### PR TITLE
Fix/keyboard shortcut modal scrolling

### DIFF
--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -198,7 +198,12 @@ function UnforwardedModal(
 								) }
 							</div>
 						) }
-						{ children }
+						<div
+							className="components-modal__container"
+							tabIndex={ 0 }
+						>
+							{ children }
+						</div>
 					</div>
 				</div>
 			</StyleProvider>

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -201,6 +201,7 @@ function UnforwardedModal(
 						<div
 							className="components-modal__container"
 							tabIndex={ 0 }
+							role="region"
 						>
 							{ children }
 						</div>

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -118,6 +118,14 @@
 	}
 }
 
+// Modal container allows keyboard focus for scrolling
+.components-modal__container {
+	&:focus {
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		outline: 3px solid #0000;
+	}
+}
+
 // Modal contents.
 .components-modal__content {
 	flex: 1;

--- a/packages/e2e-tests/specs/editor/various/shortcut-help.test.js
+++ b/packages/e2e-tests/specs/editor/various/shortcut-help.test.js
@@ -44,4 +44,22 @@ describe( 'keyboard shortcut help modal', () => {
 		);
 		expect( shortcutHelpModalElements ).toHaveLength( 0 );
 	} );
+
+	it( 'should contain tabindex on modal content div to improve compatibility with scrolling in browsers', async () => {
+		await clickOnMoreMenuItem( 'Keyboard shortcuts' );
+		const shortcutHelpModalElements = await page.$$(
+			'.edit-post-keyboard-shortcut-help-modal'
+		);
+		expect( shortcutHelpModalElements ).toHaveLength( 1 );
+
+		// Confirm content container had tabinde to allow scrolling and navigation from begining of content
+		// Similiar requirement to enter panel: https://www.w3.org/WAI/ARIA/apg/example-index/tabs/tabs-automatic.html#accessibilityfeatures
+		const findTabIndex = await page.evaluate(
+			() =>
+				document
+					.querySelector( 'div.components-modal__container' )
+					.getAttribute( 'tabindex' ) === '0'
+		);
+		expect( findTabIndex ).toBe( true );
+	} );
 } );

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
@@ -45,6 +45,7 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
     </div>
     <div
       class="components-modal__container"
+      role="region"
       tabindex="0"
     >
       <section

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
@@ -43,785 +43,789 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
         </svg>
       </button>
     </div>
-    <section
-      class="edit-post-keyboard-shortcut-help-modal__section edit-post-keyboard-shortcut-help-modal__main-shortcuts"
+    <div
+      class="components-modal__container"
+      tabindex="0"
     >
-      <ul
-        class="edit-post-keyboard-shortcut-help-modal__shortcut-list"
-        role="list"
+      <section
+        class="edit-post-keyboard-shortcut-help-modal__section edit-post-keyboard-shortcut-help-modal__main-shortcuts"
       >
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        />
-      </ul>
-    </section>
-    <section
-      class="edit-post-keyboard-shortcut-help-modal__section"
-    >
-      <h2
-        class="edit-post-keyboard-shortcut-help-modal__section-title"
+        <ul
+          class="edit-post-keyboard-shortcut-help-modal__shortcut-list"
+          role="list"
+        >
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          />
+        </ul>
+      </section>
+      <section
+        class="edit-post-keyboard-shortcut-help-modal__section"
       >
-        Global shortcuts
-      </h2>
-      <ul
-        class="edit-post-keyboard-shortcut-help-modal__shortcut-list"
-        role="list"
+        <h2
+          class="edit-post-keyboard-shortcut-help-modal__section-title"
+        >
+          Global shortcuts
+        </h2>
+        <ul
+          class="edit-post-keyboard-shortcut-help-modal__shortcut-list"
+          role="list"
+        >
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Navigate to the nearest toolbar.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="Alt + F10"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Alt
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  F10
+                </kbd>
+              </kbd>
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Save your changes.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="Control + S"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  S
+                </kbd>
+              </kbd>
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Undo your last changes.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="Control + Z"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Z
+                </kbd>
+              </kbd>
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Redo your last undo.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="Control + Shift + Z"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Shift
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Z
+                </kbd>
+              </kbd>
+              <kbd
+                aria-label="Control + Y"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Y
+                </kbd>
+              </kbd>
+            </div>
+          </li>
+        </ul>
+      </section>
+      <section
+        class="edit-post-keyboard-shortcut-help-modal__section"
       >
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
+        <h2
+          class="edit-post-keyboard-shortcut-help-modal__section-title"
         >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Navigate to the nearest toolbar.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Alt + F10"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Alt
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                F10
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          Selection shortcuts
+        </h2>
+        <ul
+          class="edit-post-keyboard-shortcut-help-modal__shortcut-list"
+          role="list"
         >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
           >
-            Save your changes.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + S"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Select all text when typing. Press again to select all blocks.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
             >
               <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                aria-label="Control + A"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
               >
-                Ctrl
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  A
+                </kbd>
               </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                S
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
           >
-            Undo your last changes.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + Z"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Clear selection.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
             >
               <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                aria-label="escape"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
               >
-                Ctrl
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  escape
+                </kbd>
               </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Z
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Redo your last undo.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + Shift + Z"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Ctrl
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Shift
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Z
-              </kbd>
-            </kbd>
-            <kbd
-              aria-label="Control + Y"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Ctrl
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Y
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-      </ul>
-    </section>
-    <section
-      class="edit-post-keyboard-shortcut-help-modal__section"
-    >
-      <h2
-        class="edit-post-keyboard-shortcut-help-modal__section-title"
+            </div>
+          </li>
+        </ul>
+      </section>
+      <section
+        class="edit-post-keyboard-shortcut-help-modal__section"
       >
-        Selection shortcuts
-      </h2>
-      <ul
-        class="edit-post-keyboard-shortcut-help-modal__shortcut-list"
-        role="list"
+        <h2
+          class="edit-post-keyboard-shortcut-help-modal__section-title"
+        >
+          Block shortcuts
+        </h2>
+        <ul
+          class="edit-post-keyboard-shortcut-help-modal__shortcut-list"
+          role="list"
+        >
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Duplicate the selected block(s).
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="Control + Shift + D"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Shift
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  D
+                </kbd>
+              </kbd>
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Remove the selected block(s).
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="Shift + Alt + Z"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Shift
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Alt
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Z
+                </kbd>
+              </kbd>
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Insert a new block before the selected block(s).
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="Control + Alt + T"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Alt
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  T
+                </kbd>
+              </kbd>
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Insert a new block after the selected block(s).
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="Control + Alt + Y"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Alt
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Y
+                </kbd>
+              </kbd>
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Delete selection.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="del"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  del
+                </kbd>
+              </kbd>
+              <kbd
+                aria-label="backspace"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  backspace
+                </kbd>
+              </kbd>
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Move the selected block(s) up.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="Control + Shift + Alt + T"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Shift
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Alt
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  T
+                </kbd>
+              </kbd>
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Move the selected block(s) down.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="Control + Shift + Alt + Y"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Shift
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Alt
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Y
+                </kbd>
+              </kbd>
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Change the block type after adding a new paragraph.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="Forward-slash"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  /
+                </kbd>
+              </kbd>
+            </div>
+          </li>
+        </ul>
+      </section>
+      <section
+        class="edit-post-keyboard-shortcut-help-modal__section"
       >
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
+        <h2
+          class="edit-post-keyboard-shortcut-help-modal__section-title"
         >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Select all text when typing. Press again to select all blocks.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + A"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Ctrl
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                A
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          Text formatting
+        </h2>
+        <ul
+          class="edit-post-keyboard-shortcut-help-modal__shortcut-list"
+          role="list"
         >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
           >
-            Clear selection.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="escape"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Make the selected text bold.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
             >
               <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                aria-label="Control + B"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
               >
-                escape
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  B
+                </kbd>
               </kbd>
-            </kbd>
-          </div>
-        </li>
-      </ul>
-    </section>
-    <section
-      class="edit-post-keyboard-shortcut-help-modal__section"
-    >
-      <h2
-        class="edit-post-keyboard-shortcut-help-modal__section-title"
-      >
-        Block shortcuts
-      </h2>
-      <ul
-        class="edit-post-keyboard-shortcut-help-modal__shortcut-list"
-        role="list"
-      >
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
           >
-            Duplicate the selected block(s).
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + Shift + D"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Make the selected text italic.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
             >
               <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                aria-label="Control + I"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
               >
-                Ctrl
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  I
+                </kbd>
               </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Shift
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                D
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
           >
-            Remove the selected block(s).
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Shift + Alt + Z"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Convert the selected text into a link.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
             >
               <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                aria-label="Control + K"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
               >
-                Shift
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  K
+                </kbd>
               </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Alt
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Z
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
           >
-            Insert a new block before the selected block(s).
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + Alt + T"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Remove a link.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
             >
               <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                aria-label="Control + Shift + K"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
               >
-                Ctrl
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Shift
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  K
+                </kbd>
               </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Alt
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                T
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
           >
-            Insert a new block after the selected block(s).
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + Alt + Y"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Insert a link to a post or page
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
             >
               <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                aria-label="[["
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
               >
-                Ctrl
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  [[
+                </kbd>
               </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Alt
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Y
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
           >
-            Delete selection.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="del"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Underline the selected text.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
             >
               <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                aria-label="Control + U"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
               >
-                del
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  U
+                </kbd>
               </kbd>
-            </kbd>
-            <kbd
-              aria-label="backspace"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Strikethrough the selected text.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
             >
               <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                aria-label="Shift + Alt + D"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
               >
-                backspace
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Shift
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Alt
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  D
+                </kbd>
               </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
           >
-            Move the selected block(s) up.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + Shift + Alt + T"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Make the selected text inline code.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
             >
               <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                aria-label="Shift + Alt + X"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
               >
-                Ctrl
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Shift
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Alt
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  X
+                </kbd>
               </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Shift
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Alt
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                T
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Move the selected block(s) down.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + Shift + Alt + Y"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Ctrl
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Shift
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Alt
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Y
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Change the block type after adding a new paragraph.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Forward-slash"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                /
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-      </ul>
-    </section>
-    <section
-      class="edit-post-keyboard-shortcut-help-modal__section"
-    >
-      <h2
-        class="edit-post-keyboard-shortcut-help-modal__section-title"
-      >
-        Text formatting
-      </h2>
-      <ul
-        class="edit-post-keyboard-shortcut-help-modal__shortcut-list"
-        role="list"
-      >
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Make the selected text bold.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + B"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Ctrl
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                B
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Make the selected text italic.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + I"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Ctrl
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                I
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Convert the selected text into a link.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + K"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Ctrl
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                K
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Remove a link.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + Shift + K"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Ctrl
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Shift
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                K
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Insert a link to a post or page
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="[["
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                [[
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Underline the selected text.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + U"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Ctrl
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                U
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Strikethrough the selected text.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Shift + Alt + D"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Shift
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Alt
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                D
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Make the selected text inline code.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Shift + Alt + X"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Shift
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Alt
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                X
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
+            </div>
+          </li>
+          <li
           class="edit-post-keyboard-shortcut-help-modal__shortcut"
         >
           <div
@@ -892,7 +896,8 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
           </div>
         </li>
       </ul>
-    </section>
+      </section>
+    </div>
   </div>
 </div>
 `;

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -93,6 +93,7 @@ exports[`EditPostPreferencesModal should match snapshot when the modal is active
     </div>
     <div
       class="components-modal__container"
+      role="region"
       tabindex="0"
     >
       <div
@@ -702,6 +703,7 @@ exports[`EditPostPreferencesModal should match snapshot when the modal is active
     </div>
     <div
       class="components-modal__container"
+      role="region"
       tabindex="0"
     >
       <div

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -92,410 +92,415 @@ exports[`EditPostPreferencesModal should match snapshot when the modal is active
       </button>
     </div>
     <div
-      class="interface-preferences__tabs"
+      class="components-modal__container"
+      tabindex="0"
     >
       <div
-        aria-orientation="vertical"
-        class="components-tab-panel__tabs"
-        role="tablist"
+        class="interface-preferences__tabs"
       >
-        <button
-          aria-controls="tab-panel-0-general-view"
-          aria-selected="true"
-          class="components-button components-tab-panel__tabs-item is-active"
-          id="tab-panel-0-general"
-          role="tab"
-          type="button"
+        <div
+          aria-orientation="vertical"
+          class="components-tab-panel__tabs"
+          role="tablist"
         >
-          General
-        </button>
-        <button
-          aria-controls="tab-panel-0-blocks-view"
-          aria-selected="false"
-          class="components-button components-tab-panel__tabs-item"
-          id="tab-panel-0-blocks"
-          role="tab"
-          tabindex="-1"
-          type="button"
+          <button
+            aria-controls="tab-panel-0-general-view"
+            aria-selected="true"
+            class="components-button components-tab-panel__tabs-item is-active"
+            id="tab-panel-0-general"
+            role="tab"
+            type="button"
+          >
+            General
+          </button>
+          <button
+            aria-controls="tab-panel-0-blocks-view"
+            aria-selected="false"
+            class="components-button components-tab-panel__tabs-item"
+            id="tab-panel-0-blocks"
+            role="tab"
+            tabindex="-1"
+            type="button"
+          >
+            Blocks
+          </button>
+          <button
+            aria-controls="tab-panel-0-panels-view"
+            aria-selected="false"
+            class="components-button components-tab-panel__tabs-item"
+            id="tab-panel-0-panels"
+            role="tab"
+            tabindex="-1"
+            type="button"
+          >
+            Panels
+          </button>
+        </div>
+        <div
+          aria-labelledby="tab-panel-0-general"
+          class="components-tab-panel__tab-content"
+          id="tab-panel-0-general-view"
+          role="tabpanel"
         >
-          Blocks
-        </button>
-        <button
-          aria-controls="tab-panel-0-panels-view"
-          aria-selected="false"
-          class="components-button components-tab-panel__tabs-item"
-          id="tab-panel-0-panels"
-          role="tab"
-          tabindex="-1"
-          type="button"
-        >
-          Panels
-        </button>
-      </div>
-      <div
-        aria-labelledby="tab-panel-0-general"
-        class="components-tab-panel__tab-content"
-        id="tab-panel-0-general-view"
-        role="tabpanel"
-      >
-        <fieldset
-          class="interface-preferences-modal__section"
-        >
-          <legend
-            class="interface-preferences-modal__section-legend"
+          <fieldset
+            class="interface-preferences-modal__section"
           >
-            <h2
-              class="interface-preferences-modal__section-title"
+            <legend
+              class="interface-preferences-modal__section-legend"
             >
-              Publishing
-            </h2>
-            <p
-              class="interface-preferences-modal__section-description"
-            >
-              Change options related to publishing.
-            </p>
-          </legend>
-          <div
-            class="interface-preferences-modal__option"
-          >
+              <h2
+                class="interface-preferences-modal__section-title"
+              >
+                Publishing
+              </h2>
+              <p
+                class="interface-preferences-modal__section-description"
+              >
+                Change options related to publishing.
+              </p>
+            </legend>
             <div
-              class="components-base-control components-toggle-control emotion-0 emotion-1"
+              class="interface-preferences-modal__option"
             >
               <div
-                class="components-base-control__field emotion-2 emotion-3"
+                class="components-base-control components-toggle-control emotion-0 emotion-1"
               >
                 <div
-                  class="components-flex components-h-stack emotion-4 emotion-5"
-                  data-wp-c16t="true"
-                  data-wp-component="HStack"
+                  class="components-base-control__field emotion-2 emotion-3"
                 >
-                  <span
-                    class="components-form-toggle"
+                  <div
+                    class="components-flex components-h-stack emotion-4 emotion-5"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      aria-describedby="inspector-toggle-control-0__help"
-                      class="components-form-toggle__input"
-                      id="inspector-toggle-control-0"
-                      type="checkbox"
-                    />
                     <span
-                      class="components-form-toggle__track"
-                    />
-                    <span
-                      class="components-form-toggle__thumb"
-                    />
-                  </span>
-                  <label
-                    class="components-toggle-control__label"
-                    for="inspector-toggle-control-0"
-                  >
-                    Include pre-publish checklist
-                  </label>
+                      class="components-form-toggle"
+                    >
+                      <input
+                        aria-describedby="inspector-toggle-control-0__help"
+                        class="components-form-toggle__input"
+                        id="inspector-toggle-control-0"
+                        type="checkbox"
+                      />
+                      <span
+                        class="components-form-toggle__track"
+                      />
+                      <span
+                        class="components-form-toggle__thumb"
+                      />
+                    </span>
+                    <label
+                      class="components-toggle-control__label"
+                      for="inspector-toggle-control-0"
+                    >
+                      Include pre-publish checklist
+                    </label>
+                  </div>
                 </div>
+                <p
+                  class="components-base-control__help emotion-6 emotion-7"
+                  id="inspector-toggle-control-0__help"
+                >
+                  Review settings, such as visibility and tags.
+                </p>
               </div>
-              <p
-                class="components-base-control__help emotion-6 emotion-7"
-                id="inspector-toggle-control-0__help"
-              >
-                Review settings, such as visibility and tags.
-              </p>
             </div>
-          </div>
-        </fieldset>
-        <fieldset
-          class="interface-preferences-modal__section"
-        >
-          <legend
-            class="interface-preferences-modal__section-legend"
+          </fieldset>
+          <fieldset
+            class="interface-preferences-modal__section"
           >
-            <h2
-              class="interface-preferences-modal__section-title"
+            <legend
+              class="interface-preferences-modal__section-legend"
             >
-              Appearance
-            </h2>
-            <p
-              class="interface-preferences-modal__section-description"
-            >
-              Customize options related to the block editor interface and editing flow.
-            </p>
-          </legend>
-          <div
-            class="interface-preferences-modal__option"
-          >
+              <h2
+                class="interface-preferences-modal__section-title"
+              >
+                Appearance
+              </h2>
+              <p
+                class="interface-preferences-modal__section-description"
+              >
+                Customize options related to the block editor interface and editing flow.
+              </p>
+            </legend>
             <div
-              class="components-base-control components-toggle-control emotion-0 emotion-1"
+              class="interface-preferences-modal__option"
             >
               <div
-                class="components-base-control__field emotion-2 emotion-3"
+                class="components-base-control components-toggle-control emotion-0 emotion-1"
               >
                 <div
-                  class="components-flex components-h-stack emotion-4 emotion-5"
-                  data-wp-c16t="true"
-                  data-wp-component="HStack"
+                  class="components-base-control__field emotion-2 emotion-3"
                 >
-                  <span
-                    class="components-form-toggle"
+                  <div
+                    class="components-flex components-h-stack emotion-4 emotion-5"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      aria-describedby="inspector-toggle-control-1__help"
-                      class="components-form-toggle__input"
-                      id="inspector-toggle-control-1"
-                      type="checkbox"
-                    />
                     <span
-                      class="components-form-toggle__track"
-                    />
-                    <span
-                      class="components-form-toggle__thumb"
-                    />
-                  </span>
-                  <label
-                    class="components-toggle-control__label"
-                    for="inspector-toggle-control-1"
-                  >
-                    Distraction free
-                  </label>
+                      class="components-form-toggle"
+                    >
+                      <input
+                        aria-describedby="inspector-toggle-control-1__help"
+                        class="components-form-toggle__input"
+                        id="inspector-toggle-control-1"
+                        type="checkbox"
+                      />
+                      <span
+                        class="components-form-toggle__track"
+                      />
+                      <span
+                        class="components-form-toggle__thumb"
+                      />
+                    </span>
+                    <label
+                      class="components-toggle-control__label"
+                      for="inspector-toggle-control-1"
+                    >
+                      Distraction free
+                    </label>
+                  </div>
                 </div>
+                <p
+                  class="components-base-control__help emotion-6 emotion-7"
+                  id="inspector-toggle-control-1__help"
+                >
+                  Reduce visual distractions by hiding the toolbar and other elements to focus on writing.
+                </p>
               </div>
-              <p
-                class="components-base-control__help emotion-6 emotion-7"
-                id="inspector-toggle-control-1__help"
-              >
-                Reduce visual distractions by hiding the toolbar and other elements to focus on writing.
-              </p>
             </div>
-          </div>
-          <div
-            class="interface-preferences-modal__option"
-          >
             <div
-              class="components-base-control components-toggle-control emotion-0 emotion-1"
+              class="interface-preferences-modal__option"
             >
               <div
-                class="components-base-control__field emotion-2 emotion-3"
+                class="components-base-control components-toggle-control emotion-0 emotion-1"
               >
                 <div
-                  class="components-flex components-h-stack emotion-4 emotion-5"
-                  data-wp-c16t="true"
-                  data-wp-component="HStack"
+                  class="components-base-control__field emotion-2 emotion-3"
                 >
-                  <span
-                    class="components-form-toggle"
+                  <div
+                    class="components-flex components-h-stack emotion-4 emotion-5"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      aria-describedby="inspector-toggle-control-2__help"
-                      class="components-form-toggle__input"
-                      id="inspector-toggle-control-2"
-                      type="checkbox"
-                    />
                     <span
-                      class="components-form-toggle__track"
-                    />
-                    <span
-                      class="components-form-toggle__thumb"
-                    />
-                  </span>
-                  <label
-                    class="components-toggle-control__label"
-                    for="inspector-toggle-control-2"
-                  >
-                    Spotlight mode
-                  </label>
+                      class="components-form-toggle"
+                    >
+                      <input
+                        aria-describedby="inspector-toggle-control-2__help"
+                        class="components-form-toggle__input"
+                        id="inspector-toggle-control-2"
+                        type="checkbox"
+                      />
+                      <span
+                        class="components-form-toggle__track"
+                      />
+                      <span
+                        class="components-form-toggle__thumb"
+                      />
+                    </span>
+                    <label
+                      class="components-toggle-control__label"
+                      for="inspector-toggle-control-2"
+                    >
+                      Spotlight mode
+                    </label>
+                  </div>
                 </div>
+                <p
+                  class="components-base-control__help emotion-6 emotion-7"
+                  id="inspector-toggle-control-2__help"
+                >
+                  Highlights the current block and fades other content.
+                </p>
               </div>
-              <p
-                class="components-base-control__help emotion-6 emotion-7"
-                id="inspector-toggle-control-2__help"
-              >
-                Highlights the current block and fades other content.
-              </p>
             </div>
-          </div>
-          <div
-            class="interface-preferences-modal__option"
-          >
             <div
-              class="components-base-control components-toggle-control emotion-0 emotion-1"
+              class="interface-preferences-modal__option"
             >
               <div
-                class="components-base-control__field emotion-2 emotion-3"
+                class="components-base-control components-toggle-control emotion-0 emotion-1"
               >
                 <div
-                  class="components-flex components-h-stack emotion-4 emotion-5"
-                  data-wp-c16t="true"
-                  data-wp-component="HStack"
+                  class="components-base-control__field emotion-2 emotion-3"
                 >
-                  <span
-                    class="components-form-toggle"
+                  <div
+                    class="components-flex components-h-stack emotion-4 emotion-5"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      aria-describedby="inspector-toggle-control-3__help"
-                      class="components-form-toggle__input"
-                      id="inspector-toggle-control-3"
-                      type="checkbox"
-                    />
                     <span
-                      class="components-form-toggle__track"
-                    />
-                    <span
-                      class="components-form-toggle__thumb"
-                    />
-                  </span>
-                  <label
-                    class="components-toggle-control__label"
-                    for="inspector-toggle-control-3"
-                  >
-                    Show button text labels
-                  </label>
+                      class="components-form-toggle"
+                    >
+                      <input
+                        aria-describedby="inspector-toggle-control-3__help"
+                        class="components-form-toggle__input"
+                        id="inspector-toggle-control-3"
+                        type="checkbox"
+                      />
+                      <span
+                        class="components-form-toggle__track"
+                      />
+                      <span
+                        class="components-form-toggle__thumb"
+                      />
+                    </span>
+                    <label
+                      class="components-toggle-control__label"
+                      for="inspector-toggle-control-3"
+                    >
+                      Show button text labels
+                    </label>
+                  </div>
                 </div>
+                <p
+                  class="components-base-control__help emotion-6 emotion-7"
+                  id="inspector-toggle-control-3__help"
+                >
+                  Show text instead of icons on buttons.
+                </p>
               </div>
-              <p
-                class="components-base-control__help emotion-6 emotion-7"
-                id="inspector-toggle-control-3__help"
-              >
-                Show text instead of icons on buttons.
-              </p>
             </div>
-          </div>
-          <div
-            class="interface-preferences-modal__option"
-          >
             <div
-              class="components-base-control components-toggle-control emotion-0 emotion-1"
+              class="interface-preferences-modal__option"
             >
               <div
-                class="components-base-control__field emotion-2 emotion-3"
+                class="components-base-control components-toggle-control emotion-0 emotion-1"
               >
                 <div
-                  class="components-flex components-h-stack emotion-4 emotion-5"
-                  data-wp-c16t="true"
-                  data-wp-component="HStack"
+                  class="components-base-control__field emotion-2 emotion-3"
                 >
-                  <span
-                    class="components-form-toggle"
+                  <div
+                    class="components-flex components-h-stack emotion-4 emotion-5"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      aria-describedby="inspector-toggle-control-4__help"
-                      class="components-form-toggle__input"
-                      id="inspector-toggle-control-4"
-                      type="checkbox"
-                    />
                     <span
-                      class="components-form-toggle__track"
-                    />
-                    <span
-                      class="components-form-toggle__thumb"
-                    />
-                  </span>
-                  <label
-                    class="components-toggle-control__label"
-                    for="inspector-toggle-control-4"
-                  >
-                    Always open list view
-                  </label>
+                      class="components-form-toggle"
+                    >
+                      <input
+                        aria-describedby="inspector-toggle-control-4__help"
+                        class="components-form-toggle__input"
+                        id="inspector-toggle-control-4"
+                        type="checkbox"
+                      />
+                      <span
+                        class="components-form-toggle__track"
+                      />
+                      <span
+                        class="components-form-toggle__thumb"
+                      />
+                    </span>
+                    <label
+                      class="components-toggle-control__label"
+                      for="inspector-toggle-control-4"
+                    >
+                      Always open list view
+                    </label>
+                  </div>
                 </div>
+                <p
+                  class="components-base-control__help emotion-6 emotion-7"
+                  id="inspector-toggle-control-4__help"
+                >
+                  Opens the block list view sidebar by default.
+                </p>
               </div>
-              <p
-                class="components-base-control__help emotion-6 emotion-7"
-                id="inspector-toggle-control-4__help"
-              >
-                Opens the block list view sidebar by default.
-              </p>
             </div>
-          </div>
-          <div
-            class="interface-preferences-modal__option"
-          >
             <div
-              class="components-base-control components-toggle-control emotion-0 emotion-1"
+              class="interface-preferences-modal__option"
             >
               <div
-                class="components-base-control__field emotion-2 emotion-3"
+                class="components-base-control components-toggle-control emotion-0 emotion-1"
               >
                 <div
-                  class="components-flex components-h-stack emotion-4 emotion-5"
-                  data-wp-c16t="true"
-                  data-wp-component="HStack"
+                  class="components-base-control__field emotion-2 emotion-3"
                 >
-                  <span
-                    class="components-form-toggle"
+                  <div
+                    class="components-flex components-h-stack emotion-4 emotion-5"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      aria-describedby="inspector-toggle-control-5__help"
-                      class="components-form-toggle__input"
-                      id="inspector-toggle-control-5"
-                      type="checkbox"
-                    />
                     <span
-                      class="components-form-toggle__track"
-                    />
-                    <span
-                      class="components-form-toggle__thumb"
-                    />
-                  </span>
-                  <label
-                    class="components-toggle-control__label"
-                    for="inspector-toggle-control-5"
-                  >
-                    Use theme styles
-                  </label>
+                      class="components-form-toggle"
+                    >
+                      <input
+                        aria-describedby="inspector-toggle-control-5__help"
+                        class="components-form-toggle__input"
+                        id="inspector-toggle-control-5"
+                        type="checkbox"
+                      />
+                      <span
+                        class="components-form-toggle__track"
+                      />
+                      <span
+                        class="components-form-toggle__thumb"
+                      />
+                    </span>
+                    <label
+                      class="components-toggle-control__label"
+                      for="inspector-toggle-control-5"
+                    >
+                      Use theme styles
+                    </label>
+                  </div>
                 </div>
+                <p
+                  class="components-base-control__help emotion-6 emotion-7"
+                  id="inspector-toggle-control-5__help"
+                >
+                  Make the editor look like your theme.
+                </p>
               </div>
-              <p
-                class="components-base-control__help emotion-6 emotion-7"
-                id="inspector-toggle-control-5__help"
-              >
-                Make the editor look like your theme.
-              </p>
             </div>
-          </div>
-          <div
-            class="interface-preferences-modal__option"
-          >
             <div
-              class="components-base-control components-toggle-control emotion-0 emotion-1"
+              class="interface-preferences-modal__option"
             >
               <div
-                class="components-base-control__field emotion-2 emotion-3"
+                class="components-base-control components-toggle-control emotion-0 emotion-1"
               >
                 <div
-                  class="components-flex components-h-stack emotion-4 emotion-5"
-                  data-wp-c16t="true"
-                  data-wp-component="HStack"
+                  class="components-base-control__field emotion-2 emotion-3"
                 >
-                  <span
-                    class="components-form-toggle"
+                  <div
+                    class="components-flex components-h-stack emotion-4 emotion-5"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      aria-describedby="inspector-toggle-control-6__help"
-                      class="components-form-toggle__input"
-                      id="inspector-toggle-control-6"
-                      type="checkbox"
-                    />
                     <span
-                      class="components-form-toggle__track"
-                    />
-                    <span
-                      class="components-form-toggle__thumb"
-                    />
-                  </span>
-                  <label
-                    class="components-toggle-control__label"
-                    for="inspector-toggle-control-6"
-                  >
-                    Display block breadcrumbs
-                  </label>
+                      class="components-form-toggle"
+                    >
+                      <input
+                        aria-describedby="inspector-toggle-control-6__help"
+                        class="components-form-toggle__input"
+                        id="inspector-toggle-control-6"
+                        type="checkbox"
+                      />
+                      <span
+                        class="components-form-toggle__track"
+                      />
+                      <span
+                        class="components-form-toggle__thumb"
+                      />
+                    </span>
+                    <label
+                      class="components-toggle-control__label"
+                      for="inspector-toggle-control-6"
+                    >
+                      Display block breadcrumbs
+                    </label>
+                  </div>
                 </div>
+                <p
+                  class="components-base-control__help emotion-6 emotion-7"
+                  id="inspector-toggle-control-6__help"
+                >
+                  Shows block breadcrumbs at the bottom of the editor.
+                </p>
               </div>
-              <p
-                class="components-base-control__help emotion-6 emotion-7"
-                id="inspector-toggle-control-6__help"
-              >
-                Shows block breadcrumbs at the bottom of the editor.
-              </p>
             </div>
-          </div>
-        </fieldset>
+          </fieldset>
+        </div>
       </div>
     </div>
   </div>
@@ -696,197 +701,202 @@ exports[`EditPostPreferencesModal should match snapshot when the modal is active
       </button>
     </div>
     <div
-      class="components-navigator-provider interface-preferences__provider emotion-0 emotion-1"
-      data-wp-c16t="true"
-      data-wp-component="NavigatorProvider"
+      class="components-modal__container"
+      tabindex="0"
     >
       <div
-        class="emotion-2 components-navigator-screen"
+        class="components-navigator-provider interface-preferences__provider emotion-0 emotion-1"
         data-wp-c16t="true"
-        data-wp-component="NavigatorScreen"
-        style="opacity: 0; transform: translateX(50px) translateZ(0);"
+        data-wp-component="NavigatorProvider"
       >
         <div
-          class="components-surface components-card emotion-3 emotion-1"
+          class="emotion-2 components-navigator-screen"
           data-wp-c16t="true"
-          data-wp-component="Card"
+          data-wp-component="NavigatorScreen"
+          style="opacity: 0; transform: translateX(50px) translateZ(0);"
         >
           <div
-            class="emotion-5 emotion-1"
+            class="components-surface components-card emotion-3 emotion-1"
+            data-wp-c16t="true"
+            data-wp-component="Card"
           >
             <div
-              class="components-card__body components-card-body emotion-7 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="CardBody"
+              class="emotion-5 emotion-1"
             >
               <div
-                class="components-item-group emotion-9 emotion-1"
+                class="components-card__body components-card-body emotion-7 emotion-1"
                 data-wp-c16t="true"
-                data-wp-component="ItemGroup"
-                role="list"
+                data-wp-component="CardBody"
               >
                 <div
-                  class="emotion-11"
-                  role="listitem"
+                  class="components-item-group emotion-9 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="ItemGroup"
+                  role="list"
                 >
-                  <button
-                    class="components-item components-navigator-button emotion-1 emotion-13 emotion-1"
-                    data-wp-c16t="true"
-                    data-wp-component="NavigatorButton"
-                    id="general"
+                  <div
+                    class="emotion-11"
+                    role="listitem"
                   >
-                    <div
-                      class="components-flex components-h-stack emotion-15 emotion-1"
+                    <button
+                      class="components-item components-navigator-button emotion-1 emotion-13 emotion-1"
                       data-wp-c16t="true"
-                      data-wp-component="HStack"
+                      data-wp-component="NavigatorButton"
+                      id="general"
                     >
                       <div
-                        class="components-flex-item emotion-17 emotion-1"
+                        class="components-flex components-h-stack emotion-15 emotion-1"
                         data-wp-c16t="true"
-                        data-wp-component="FlexItem"
+                        data-wp-component="HStack"
                       >
-                        <span
-                          class="components-truncate emotion-19 emotion-1"
+                        <div
+                          class="components-flex-item emotion-17 emotion-1"
                           data-wp-c16t="true"
-                          data-wp-component="Truncate"
+                          data-wp-component="FlexItem"
                         >
-                          General
-                        </span>
-                      </div>
-                      <div
-                        class="components-flex-item emotion-17 emotion-1"
-                        data-wp-c16t="true"
-                        data-wp-component="FlexItem"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          focusable="false"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="components-truncate emotion-19 emotion-1"
+                            data-wp-c16t="true"
+                            data-wp-component="Truncate"
+                          >
+                            General
+                          </span>
+                        </div>
+                        <div
+                          class="components-flex-item emotion-17 emotion-1"
+                          data-wp-c16t="true"
+                          data-wp-component="FlexItem"
                         >
-                          <path
-                            d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z"
-                          />
-                        </svg>
+                          <svg
+                            aria-hidden="true"
+                            focusable="false"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z"
+                            />
+                          </svg>
+                        </div>
                       </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="emotion-11"
-                  role="listitem"
-                >
-                  <button
-                    class="components-item components-navigator-button emotion-1 emotion-13 emotion-1"
-                    data-wp-c16t="true"
-                    data-wp-component="NavigatorButton"
-                    id="blocks"
+                    </button>
+                  </div>
+                  <div
+                    class="emotion-11"
+                    role="listitem"
                   >
-                    <div
-                      class="components-flex components-h-stack emotion-15 emotion-1"
+                    <button
+                      class="components-item components-navigator-button emotion-1 emotion-13 emotion-1"
                       data-wp-c16t="true"
-                      data-wp-component="HStack"
+                      data-wp-component="NavigatorButton"
+                      id="blocks"
                     >
                       <div
-                        class="components-flex-item emotion-17 emotion-1"
+                        class="components-flex components-h-stack emotion-15 emotion-1"
                         data-wp-c16t="true"
-                        data-wp-component="FlexItem"
+                        data-wp-component="HStack"
                       >
-                        <span
-                          class="components-truncate emotion-19 emotion-1"
+                        <div
+                          class="components-flex-item emotion-17 emotion-1"
                           data-wp-c16t="true"
-                          data-wp-component="Truncate"
+                          data-wp-component="FlexItem"
                         >
-                          Blocks
-                        </span>
-                      </div>
-                      <div
-                        class="components-flex-item emotion-17 emotion-1"
-                        data-wp-c16t="true"
-                        data-wp-component="FlexItem"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          focusable="false"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="components-truncate emotion-19 emotion-1"
+                            data-wp-c16t="true"
+                            data-wp-component="Truncate"
+                          >
+                            Blocks
+                          </span>
+                        </div>
+                        <div
+                          class="components-flex-item emotion-17 emotion-1"
+                          data-wp-c16t="true"
+                          data-wp-component="FlexItem"
                         >
-                          <path
-                            d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z"
-                          />
-                        </svg>
+                          <svg
+                            aria-hidden="true"
+                            focusable="false"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z"
+                            />
+                          </svg>
+                        </div>
                       </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="emotion-11"
-                  role="listitem"
-                >
-                  <button
-                    class="components-item components-navigator-button emotion-1 emotion-13 emotion-1"
-                    data-wp-c16t="true"
-                    data-wp-component="NavigatorButton"
-                    id="panels"
+                    </button>
+                  </div>
+                  <div
+                    class="emotion-11"
+                    role="listitem"
                   >
-                    <div
-                      class="components-flex components-h-stack emotion-15 emotion-1"
+                    <button
+                      class="components-item components-navigator-button emotion-1 emotion-13 emotion-1"
                       data-wp-c16t="true"
-                      data-wp-component="HStack"
+                      data-wp-component="NavigatorButton"
+                      id="panels"
                     >
                       <div
-                        class="components-flex-item emotion-17 emotion-1"
+                        class="components-flex components-h-stack emotion-15 emotion-1"
                         data-wp-c16t="true"
-                        data-wp-component="FlexItem"
+                        data-wp-component="HStack"
                       >
-                        <span
-                          class="components-truncate emotion-19 emotion-1"
+                        <div
+                          class="components-flex-item emotion-17 emotion-1"
                           data-wp-c16t="true"
-                          data-wp-component="Truncate"
+                          data-wp-component="FlexItem"
                         >
-                          Panels
-                        </span>
-                      </div>
-                      <div
-                        class="components-flex-item emotion-17 emotion-1"
-                        data-wp-c16t="true"
-                        data-wp-component="FlexItem"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          focusable="false"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="components-truncate emotion-19 emotion-1"
+                            data-wp-c16t="true"
+                            data-wp-component="Truncate"
+                          >
+                            Panels
+                          </span>
+                        </div>
+                        <div
+                          class="components-flex-item emotion-17 emotion-1"
+                          data-wp-c16t="true"
+                          data-wp-component="FlexItem"
                         >
-                          <path
-                            d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z"
-                          />
-                        </svg>
+                          <svg
+                            aria-hidden="true"
+                            focusable="false"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z"
+                            />
+                          </svg>
+                        </div>
                       </div>
-                    </div>
-                  </button>
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation emotion-47 emotion-1"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation emotion-47 emotion-1"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
           </div>
-          <div
-            aria-hidden="true"
-            class="components-elevation emotion-47 emotion-1"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation emotion-47 emotion-1"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What?
Fixes #41500 

## Why?
Users are unable to scroll inside the keyboard shortcut modal

## How?
Adds a container with tabindex to the modal content to allow focus on content div to allow scrolling.

## Testing Instructions
1. Open keyboard shortcut modal
2. Press tab to highlight the "Close" Button
3. Press tab again to focus on the shortcut container
4. Use down and up arrow keys to scroll

Note: This may need an aria-label for the new region. It does not seem to be required to pass or function, but would be helpful to have a non-empty tab stop for screenreader users. I am unsure of how that would work with internationalization so I have not added it yet. This would be inserted at line 204 in packages/components/src/modal/index.tsx

## References
https://www.tpgi.com/short-note-on-improving-usability-of-scrollable-regions/
https://dequeuniversity.com/rules/axe/3.5/scrollable-region-focusable
https://accessibilityinsights.io/info-examples/web/scrollable-region-focusable/

Tested:
Safari: Version 16.0 (17614.1.25.9.10, 17614)
Firefox: Version 106.0.5 
Chrome: Version 107.0.5304.110
