### PR TITLE
Performance Tests: Only run 1 round of tests during PR commits

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -61,7 +61,7 @@ jobs:
                   WP_VERSION=$(awk -F ': ' '/^Tested up to/{print $2}' readme.txt)
                   IFS=. read -ra WP_VERSION_ARRAY <<< "$WP_VERSION"
                   WP_MAJOR="${WP_VERSION_ARRAY[0]}.${WP_VERSION_ARRAY[1]}"
-                  ./bin/plugin/cli.js perf $GITHUB_SHA debd225d007f4e441ceec80fbd6fa96653f94737 --tests-branch $GITHUB_SHA  --wp-version "$WP_MAJOR"
+                  ./bin/plugin/cli.js perf $GITHUB_SHA debd225d007f4e441ceec80fbd6fa96653f94737 --tests-branch $GITHUB_SHA --wp-version "$WP_MAJOR"
 
             - uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # v6.3.3
               if: github.event_name == 'push'

--- a/bin/plugin/cli.js
+++ b/bin/plugin/cli.js
@@ -95,6 +95,10 @@ program
 	.alias( 'perf' )
 	.option( ...ciOption )
 	.option(
+		'--rounds <count>',
+		'Run each test suite this many times for each branch; results are summarized, default = 1'
+	)
+	.option(
 		'--tests-branch <branch>',
 		"Use this branch's performance test files"
 	)

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -22,6 +22,7 @@ const config = require( '../config' );
  * @typedef WPPerformanceCommandOptions
  *
  * @property {boolean=} ci          Run on CI.
+ * @property {number=}  rounds      Run each test suite this many times for each branch.
  * @property {string=}  testsBranch The branch whose performance test files will be used for testing.
  * @property {string=}  wpVersion   The WordPress version to be used as the base install for testing.
  */
@@ -176,6 +177,7 @@ async function runTestSuite( testSuite, performanceTestDirectory ) {
  */
 async function runPerformanceTests( branches, options ) {
 	const runningInCI = !! process.env.CI || !! options.ci;
+	const TEST_ROUNDS = options.rounds || 1;
 
 	// The default value doesn't work because commander provides an array.
 	if ( branches.length === 0 ) {
@@ -330,7 +332,7 @@ async function runPerformanceTests( branches, options ) {
 		/** @type {Array<Record<string, WPPerformanceResults>>} */
 		const rawResults = [];
 		// Alternate three times between branches.
-		for ( let i = 0; i < 3; i++ ) {
+		for ( let i = 0; i < TEST_ROUNDS; i++ ) {
 			rawResults[ i ] = {};
 			for ( const branch of branches ) {
 				// @ts-ignore


### PR DESCRIPTION
## What, how, why?

In the performance tests CI workflow we have been running every test suite three times for each branch under test. The goal of this work, introduced in #33710, was to reduce variation in the reported data from the tests.

Unfortunately after measuring the data produced by our test runs, and by running experiments that run the test suites thirty times over, the overall variation is explained primarily by noise in the Github Actions container running our jobs. If running the test suites three times each reduces the variation in the results then it's not detectable above the amount of variation introduced beyond our control.

Because these additional rounds extend the perf-test runtime by around twenty minutes on each PR we're reducing the number of rounds to a single pass for PR commits. This will free up compute resources and remove the performance tests as a bottleneck in the PR workflow.

Additional work can and should be done to further remove variance in the testing results, but this practical step will remove an obstacle from developer iteration speed without reducing the quality of the numbers being reported.

![branch-compare](https://user-images.githubusercontent.com/5431237/202270144-ae2e78fc-b0d4-47f4-a0af-d5313414e967.png)

---

The following charts summarize two metrics from _*sixty runs*_ of the performance test suite, looking at the raw data returned from the test runner. In the graphs we can see that even at a sampling size of 60 we still have large variation in the metrics, _the median of which_ for the `firstBlock` still reports a difference of 160ms between the two test groups, even though they are testing the same code.

![gb-no-change-type](https://user-images.githubusercontent.com/5431237/201772410-26eacf5c-00fd-47db-89bd-3d7fca2edc62.png)

![gb-no-change-firstBlock](https://user-images.githubusercontent.com/5431237/201772519-4824e1f0-4cc8-46ff-b3c8-f83975f446b4.png)

Statistically speaking we cannot assert that these distributions are unequal, but they are close enough with a statistical significance at the `P = 0.154` level for `type` and `P = 0.232` level for `firstBlock` that we should be careful about making any assertions based on these measurements.

With three rounds, what we've been using, the spread of the distributions are higher but similarly unusable to detect changes. That is to say, we're uncomfortably close to identifying a false-positive performance impact after sixty rounds; imagine how hard at only three rounds it is to distinguish a real performance change from normal sampling variation due to factors outside our control (e.g. the GitHub Actions container).

All of this is to say that we aren't giving up much by jumping back down to a single round. Major performance changes will still appear out of the noise but changes on the order of which we typically see in the project history will remain hidden in the noise.

If we wanted to have confidence in performance changes given the data we have about our runtime environment then we might have to run the tests through a few hundred rounds. Unfortunately thirty rounds is about as high as we can push it before the test runner is cancelled at six hours of runtime. The data I collected with sixty rounds comes from two separate test runs, taking over four hours each, and a third test run which was killed at six hours and whose data was unavailable for these measurements.

Apart from that we would need to find a way to have more control over the runtime environment so that it's more deterministic. This probably implies running a self-hosted test runner. Since this isn't an option currently under discussion I propose that this change is a pragmatic mitigation to the performance test bottleneck.

## Tests

Because this is changing only the test runner for the performance test ensure that the tests continue to pass and that the results look reasonable.

Please audit the code and look for ways this is introducing unwanted complexity; ask yourself if any parts of the change are unclear or inflexible with how we know we want to use the work in the near future.