### PR TITLE
Remove duplicate colon

### DIFF
--- a/packages/block-editor/src/components/alignment-control/README.md
+++ b/packages/block-editor/src/components/alignment-control/README.md
@@ -40,7 +40,7 @@ _Note:_ In this example that we render `AlignmentControl` as a child of the `Blo
 
 -   **Type:** `String`
 -   **Default:** `undefined`
--   **Options:**: `left`, `center`, `right`
+-   **Options:** `left`, `center`, `right`
 
 The current value of the alignment setting. You may only choose from the `Options` listed above.
 


### PR DESCRIPTION
## What?

While looking at packages/block-editor/src/components/alignment-control/README.md, I noticed a duplicate colon behind `**Options:**`.  

## Why?

This PR aims to correct this minor mistake within the documentation.

## How?

This PR simply removed the duplicate colon.

## Testing Instructions

1. Look up the changed *.md file.
2. Verify that `**Options:**:` had been changed to `**Options:**`.