### PR TITLE
Template Part Block: use icon for area selection (take 2)

### DIFF
--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -57,6 +57,9 @@ export function TemplatePartAdvancedControls( {
 					/>
 
 					<ToggleGroupControl
+						help={ __(
+							'The area of a page that this block should occupy.'
+						) }
 						label={ __( 'Area' ) }
 						onChange={ setArea }
 						value={ area }

--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -2,7 +2,12 @@
  * WordPress dependencies
  */
 import { useEntityProp } from '@wordpress/core-data';
-import { SelectControl, TextControl } from '@wordpress/components';
+import {
+	SelectControl,
+	TextControl,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
+} from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
@@ -28,19 +33,14 @@ export function TemplatePartAdvancedControls( {
 		templatePartId
 	);
 
-	const { areaOptions } = useSelect( ( select ) => {
+	const areas = useSelect( ( select ) => {
 		// FIXME: @wordpress/block-library should not depend on @wordpress/editor.
 		// Blocks can be loaded into a *non-post* block editor.
 		/* eslint-disable @wordpress/data-no-store-string-literals */
-		const definedAreas =
-			select( 'core/editor' ).__experimentalGetDefaultTemplatePartAreas();
+		return select(
+			'core/editor'
+		).__experimentalGetDefaultTemplatePartAreas();
 		/* eslint-enable @wordpress/data-no-store-string-literals */
-		return {
-			areaOptions: definedAreas.map( ( { label, area: _area } ) => ( {
-				label,
-				value: _area,
-			} ) ),
-		};
 	}, [] );
 
 	return (
@@ -56,13 +56,20 @@ export function TemplatePartAdvancedControls( {
 						onFocus={ ( event ) => event.target.select() }
 					/>
 
-					<SelectControl
+					<ToggleGroupControl
 						label={ __( 'Area' ) }
-						labelPosition="top"
-						options={ areaOptions }
-						value={ area }
 						onChange={ setArea }
-					/>
+						value={ area }
+					>
+						{ areas.map( ( { area: value, icon, label } ) => (
+							<ToggleGroupControlOptionIcon
+								icon={ icon }
+								key={ value }
+								label={ label }
+								value={ value }
+							/>
+						) ) }
+					</ToggleGroupControl>
 				</>
 			) }
 			<SelectControl


### PR DESCRIPTION
Re-attempt from #30005

## What?

Changes the Template Part block "Area" setting to use icons, giving a more visual representation of the setting.

## Why?

Addresses #29295

## How?

Changes the setting to use a toggle group with icons instead of a dropdown selector.

## Testing Instructions

- Open a template in the Site editor
- Select a template part block, such as the header or footer
- Open the Advanced section of the settings in the sidebar
- See that that template part's current area is selected (General, Header, or Footer)
- Select a different area and save the template--when the page is reloaded the new area should be selected instead

## Screenshots or screencast <!-- if applicable -->

<img width="281" alt="image" src="https://user-images.githubusercontent.com/1699996/201809091-8f44d0df-6175-436f-962f-b5d8e5ee5dd7.png">

<img width="256" alt="image" src="https://user-images.githubusercontent.com/1699996/201809095-9a659658-1806-4446-9289-8da3308fb013.png">
