### PR TITLE
Extract the manage menus button to a shared component to reduce duplicate code

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -655,6 +655,19 @@ function Navigation( {
 		</InspectorControls>
 	);
 
+	const ManageMenusButton = ( { buttonClassName = '' } ) => (
+		<Button
+			variant="link"
+			disabled={ ! hasManagePermissions || ! hasResolvedNavigationMenus }
+			className={ buttonClassName }
+			href={ addQueryArgs( 'edit.php', {
+				post_type: 'wp_navigation',
+			} ) }
+		>
+			{ __( 'Manage menus' ) }
+		</Button>
+	);
+
 	// If the block has inner blocks, but no menu id, then these blocks are either:
 	// - inserted via a pattern.
 	// - inserted directly via Code View (or otherwise).
@@ -725,18 +738,7 @@ function Navigation( {
 								<WrappedNavigationMenuSelector
 									currentMenuId={ ref }
 								/>
-								<Button
-									variant="link"
-									disabled={
-										! hasManagePermissions ||
-										! hasResolvedNavigationMenus
-									}
-									href={ addQueryArgs( 'edit.php', {
-										post_type: 'wp_navigation',
-									} ) }
-								>
-									{ __( 'Manage menus' ) }
-								</Button>
+								<ManageMenusButton />
 							</>
 						) }
 					</PanelBody>
@@ -798,18 +800,7 @@ function Navigation( {
 								<WrappedNavigationMenuSelector
 									currentMenuId={ null }
 								/>
-								<Button
-									variant="link"
-									disabled={
-										! hasManagePermissions ||
-										! hasResolvedNavigationMenus
-									}
-									href={ addQueryArgs( 'edit.php', {
-										post_type: 'wp_navigation',
-									} ) }
-								>
-									{ __( 'Manage menus' ) }
-								</Button>
+								<ManageMenusButton />
 							</>
 						) }
 					</PanelBody>
@@ -920,18 +911,7 @@ function Navigation( {
 								<WrappedNavigationMenuSelector
 									currentMenuId={ ref }
 								/>
-								<Button
-									variant="link"
-									disabled={
-										! hasManagePermissions ||
-										! hasResolvedNavigationMenus
-									}
-									href={ addQueryArgs( 'edit.php', {
-										post_type: 'wp_navigation',
-									} ) }
-								>
-									{ __( 'Manage menus' ) }
-								</Button>
+								<ManageMenusButton />
 							</>
 						) }
 					</PanelBody>
@@ -961,19 +941,7 @@ function Navigation( {
 								/>
 							) }
 						{ isOffCanvasNavigationEditorEnabled && (
-							<Button
-								variant="link"
-								className="wp-block-navigation-manage-menus-button"
-								disabled={
-									! hasManagePermissions ||
-									! hasResolvedNavigationMenus
-								}
-								href={ addQueryArgs( 'edit.php', {
-									post_type: 'wp_navigation',
-								} ) }
-							>
-								{ __( 'Manage menus' ) }
-							</Button>
+							<ManageMenusButton className="wp-block-navigation-manage-menus-button" />
 						) }
 					</InspectorControls>
 				) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This refactors the manage menus button to a shared component.

## Why?
This code is reused many times, so we should only have one copy of it.

## How?
Extracts this button to a functional component so it can be reused.

## Testing Instructions
Check that the manage menus button still appears in the same place with the off canvas editing experiment enabled/disabled.

## Screenshots or screencast <!-- if applicable -->
Experiment disabled:
<img width="319" alt="Screenshot 2022-11-15 at 11 22 35" src="https://user-images.githubusercontent.com/275961/201907588-630fb307-ac1c-4771-a390-bc8d5d2140de.png">


Experiment enabled:
<img width="312" alt="Screenshot 2022-11-15 at 11 21 07" src="https://user-images.githubusercontent.com/275961/201907418-ca68b72f-4739-4c0e-b717-559976d9b5a9.png">

