### PR TITLE
Components: add `useUpdateEffect` to `exhaustive-deps` lint check

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -349,7 +349,10 @@ module.exports = {
 			files: [ 'packages/components/src/**/*.[tj]s?(x)' ],
 			excludedFiles: [ ...developmentFiles ],
 			rules: {
-				'react-hooks/exhaustive-deps': 'error',
+				'react-hooks/exhaustive-deps': [
+					'error',
+					{ additionalHooks: 'useUpdateEffect' },
+				],
 			},
 		},
 		{

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -31,6 +31,8 @@
 -   `LinkedButton`: remove unnecessary `span` tag ([#46063](https://github.com/WordPress/gutenberg/pull/46063))
 -   NumberControl: refactor styles/tests/stories to TypeScript, replace fireEvent with user-event ([#45990](https://github.com/WordPress/gutenberg/pull/45990)).
 -   `useBaseField`: Convert to TypeScript ([#45712](https://github.com/WordPress/gutenberg/pull/45712)).
+-   Add `useUpdateEffect` hook to the previously added `react-hooks/exhuastive-deps` eslint check ([#45771](https://github.com/WordPress/gutenberg/pull/45771)).
+-   `ToggleGroupControl`: Update `useUpdateEffect` usages to pass `exhaustive-deps` eslint rule ([#45771](https://github.com/WordPress/gutenberg/pull/45771)).
 
 ### Documentation
 

--- a/packages/components/src/toggle-group-control/toggle-group-control/as-button-group.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/as-button-group.tsx
@@ -12,7 +12,7 @@ import {
 	usePrevious,
 	useResizeObserver,
 } from '@wordpress/compose';
-import { forwardRef, useRef, useState } from '@wordpress/element';
+import { forwardRef, useRef, useState, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -47,11 +47,14 @@ function UnforwardedToggleGroupControlAsButtonGroup(
 		'toggle-group-control-as-button-group'
 	).toString();
 	const [ selectedValue, setSelectedValue ] = useState( value );
-	const groupContext = {
-		baseId,
-		state: selectedValue,
-		setState: setSelectedValue,
-	};
+	const groupContext = useMemo(
+		() => ( {
+			baseId,
+			state: selectedValue,
+			setState: setSelectedValue,
+		} ),
+		[ baseId, selectedValue ]
+	);
 	const previousValue = usePrevious( value );
 
 	// Propagate groupContext.state change.
@@ -61,14 +64,14 @@ function UnforwardedToggleGroupControlAsButtonGroup(
 		if ( previousValue !== groupContext.state ) {
 			onChange( groupContext.state );
 		}
-	}, [ groupContext.state ] );
+	}, [ groupContext.state, previousValue, onChange ] );
 
 	// Sync incoming value with groupContext.state.
 	useUpdateEffect( () => {
 		if ( value !== groupContext.state ) {
 			groupContext.setState( value );
 		}
-	}, [ value ] );
+	}, [ value, groupContext ] );
 
 	return (
 		<ToggleGroupControlContext.Provider

--- a/packages/components/src/toggle-group-control/toggle-group-control/as-button-group.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/as-button-group.tsx
@@ -60,9 +60,7 @@ function UnforwardedToggleGroupControlAsButtonGroup(
 		() => ( {
 			baseId,
 			state: selectedValue,
-			setState: setSelectedValue as React.Dispatch<
-				React.SetStateAction< string | number | undefined >
-			>,
+			setState: setSelectedValue,
 			isBlock: ! isAdaptiveWidth,
 			isDeselectable: true,
 			size,

--- a/packages/components/src/toggle-group-control/toggle-group-control/as-button-group.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/as-button-group.tsx
@@ -12,7 +12,7 @@ import {
 	usePrevious,
 	useResizeObserver,
 } from '@wordpress/compose';
-import { forwardRef, useRef, useState, useMemo } from '@wordpress/element';
+import { forwardRef, useRef, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -20,7 +20,7 @@ import { forwardRef, useRef, useState, useMemo } from '@wordpress/element';
 import { View } from '../../view';
 import ToggleGroupControlBackdrop from './toggle-group-control-backdrop';
 import ToggleGroupControlContext from '../context';
-import { useUpdateEffect } from '../../utils/hooks';
+import { useControlledValue } from '../../utils/hooks';
 import type { WordPressComponentProps } from '../../ui/context';
 import type {
 	ToggleGroupControlMainControlProps,
@@ -49,35 +49,25 @@ function UnforwardedToggleGroupControlAsButtonGroup(
 		ToggleGroupControlAsButtonGroup,
 		'toggle-group-control-as-button-group'
 	).toString();
-	const [ selectedValue, setSelectedValue ] = useState( value );
 	const previousValue = usePrevious( value );
-
-	// Propagate selectedValue change.
-	useUpdateEffect( () => {
-		// Avoid calling onChange if selectedValue changed
-		// from incoming value.
-		if ( previousValue !== selectedValue ) {
-			onChange( selectedValue );
-		}
-	}, [ selectedValue, previousValue, onChange ] );
-
-	// Sync incoming value with selectedValue.
-	useUpdateEffect( () => {
-		if ( previousValue !== value ) {
-			setSelectedValue( value );
-		}
-	}, [ value, previousValue ] );
+	const [ selectedValue, setSelectedValue ] = useControlledValue( {
+		defaultValue: previousValue,
+		onChange,
+		value,
+	} );
 	// Expose selectedValue getter/setter via context
 	const groupContext: ToggleGroupControlContextProps = useMemo(
 		() => ( {
 			baseId,
 			state: selectedValue,
-			setState: setSelectedValue,
+			setState: setSelectedValue as React.Dispatch<
+				React.SetStateAction< string | number | undefined >
+			>,
 			isBlock: ! isAdaptiveWidth,
 			isDeselectable: true,
 			size,
 		} ),
-		[ baseId, selectedValue, isAdaptiveWidth, size ]
+		[ baseId, selectedValue, setSelectedValue, isAdaptiveWidth, size ]
 	);
 	return (
 		<ToggleGroupControlContext.Provider value={ groupContext }>

--- a/packages/components/src/toggle-group-control/toggle-group-control/as-radio-group.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/as-radio-group.tsx
@@ -61,13 +61,16 @@ function UnforwardedToggleGroupControlAsRadioGroup(
 		if ( previousValue !== radio.state ) {
 			onChange( radio.state );
 		}
-	}, [ radio.state ] );
+	}, [ radio.state, previousValue, onChange ] );
 
 	// Sync incoming value with radio.state.
 	useUpdateEffect( () => {
 		if ( value !== radio.state ) {
 			radio.setState( value );
 		}
+		// disable reason: Adding `radio` to the dependency array causes an extra render.
+		// Memoizing it doesn't look easily doable, so we're disabling the rule for now.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ value ] );
 
 	return (

--- a/packages/components/src/toggle-group-control/toggle-group-control/as-radio-group.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/as-radio-group.tsx
@@ -64,14 +64,14 @@ function UnforwardedToggleGroupControlAsRadioGroup(
 	}, [ radio.state, previousValue, onChange ] );
 
 	// Sync incoming value with radio.state.
+	const { state: radioState, setState: setRadioState } = radio;
 	useUpdateEffect( () => {
-		if ( value !== radio.state ) {
-			radio.setState( value );
+		if ( value !== radioState ) {
+			setRadioState( value );
 		}
-		// disable reason: Adding `radio` to the dependency array causes an extra render.
-		// Memoizing it doesn't look easily doable, so we're disabling the rule for now.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ value ] );
+		// setRadioState needs to be listed even if in theory it's supposed to be a
+		// stable reference — that's an ESLint limitation.
+	}, [ value, radioState, setRadioState ] );
 
 	return (
 		<ToggleGroupControlContext.Provider


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
As discussed in #45044, now that `exhaustive-deps` is active for the Components package, it makes sense to include `useUpdateEffect` in the check. There may be other custom hooks we want to include here, but they can be addressed in separate PRs as needed.

## Why?
For [the same reason as the overall `exhaustive-deps` migration](https://github.com/WordPress/gutenberg/pull/41166), keeping hook dependencies clean can help avoid unexpected behavior creeping into components.

## How?
Fortunately, there only appears to be one component triggering warnings related to `useUpdateEffect`, and it's `ToggleGroupControl`. There are several warnings in a couple of different spots, more details to follow as this PR develops.

With just one component in play, I don't think we need a separate followup PR, so I'll manage all of the work here.

Mostly straightforward changes here. Most notable:
- `previousValue` is actually a ref value provided by the `usePrevious` hook - so changes won't cause re-renders. Normally it wouldn't be a dependency, but `eslint` can't tell that it's actually a ref.
- adding `onChange` to the dep array does cause the effect to fire more often when the function is defined/destructured, but it is not triggering any additional re-renders.
- `groupContext` is defined on each render and therefor wouldn't be referentially stable, but wrapping in `useMemo` should resolve that.
- adding `radio` to the `as-radio-group` dep array triggers an additional render as the object gets re-declared each time. I didn't see an easily viable solution, so I've ignored this error for now. It's possible there is an easy fix that I've just overlooked  due to the TypeScript of it all.

## Testing Instructions
1. Apply this PR
2. From your local gutenberg directory, run `npx eslint packages/components/src/`
3.  Confirm none of the errors displayed are caused by the `exhaustive-deps` rule, particularly related to `useUpdateEffect`


