### PR TITLE
Plugin: Navigation menu doesn't appear when hamburger clicked on

### DIFF
--- a/lib/compat/wordpress-6.1/blocks.php
+++ b/lib/compat/wordpress-6.1/blocks.php
@@ -71,12 +71,12 @@ function gutenberg_block_type_metadata_view_script( $settings, $metadata ) {
 		! isset( $metadata['viewScript'] ) ||
 		! empty( $settings['view_script'] ) ||
 		! isset( $metadata['file'] ) ||
-		! str_starts_with( $metadata['file'], gutenberg_dir_path() )
+		! str_starts_with( $metadata['file'], wp_normalize_path( gutenberg_dir_path() ) )
 	) {
 		return $settings;
 	}
 
-	$view_script_path = realpath( dirname( $metadata['file'] ) . '/' . remove_block_asset_path_prefix( $metadata['viewScript'] ) );
+	$view_script_path = wp_normalize_path( realpath( dirname( $metadata['file'] ) . '/' . remove_block_asset_path_prefix( $metadata['viewScript'] ) ) );
 
 	if ( file_exists( $view_script_path ) ) {
 		$view_script_id     = str_replace( array( '.min.js', '.js' ), '', basename( remove_block_asset_path_prefix( $metadata['viewScript'] ) ) );
@@ -90,7 +90,7 @@ function gutenberg_block_type_metadata_view_script( $settings, $metadata ) {
 		$view_script_version      = isset( $view_asset['version'] ) ? $view_asset['version'] : false;
 		$result                   = wp_register_script(
 			$view_script_handle,
-			gutenberg_url( str_replace( gutenberg_dir_path(), '', $view_script_path ) ),
+			gutenberg_url( str_replace( wp_normalize_path( gutenberg_dir_path() ), '', $view_script_path ) ),
 			$view_script_dependencies,
 			$view_script_version
 		);


### PR DESCRIPTION
Fixed reopened #33273

## What?
This PR fixes a problem with the Gutenberg plugin enabled in a Windows environment where the modal doesn't appear when the navigation hamburger is clicked.

## Why?
This problem is caused by[ /lib/compat/wordpress-6.1/blocks.php](https://github.com/WordPress/gutenberg/blob/eb3faf6ffac764ef9b7293750c45fa94d1d6c348/lib/compat/wordpress-6.1/blocks.php) for backward compatibility.

My understanding is that the `gutenberg_block_type_metadata_view_script` function exists to load multiple `viewScripts` in the old WordPress version. And in the navigation block, `view.min.js` and `view-modal.min.js`, are specified as `viewScripts`.

In this function, the forward slash and backslash are mixed as path delimiters, which causes the problem that `view-modal.min.js` in the above script is not loaded.

@bobbingwide's analysis of this issue in [this comment](https://github.com/bobbingwide/written/issues/19#issuecomment-1315267873) may also be helpful.

## How?
Within this function, all path delimiters have been unified into forward slashes.
I will explain the details in turn in the comments that follow.

## Testing Instructions
- Fork this PR into the plugin directory of your local Windows environment and build it.
- Confirm that both `view.min.js` and `view-modal.min.js` are loaded.
- Confirm that the modal is displayed when the hamburger is clicked.

## Screenshots or screencast <!-- if applicable -->
