### PR TITLE
Perf Tests: Fetch all revisions in one command and assign to local branches

### DIFF
--- a/bin/plugin/cli.js
+++ b/bin/plugin/cli.js
@@ -99,8 +99,8 @@ program
 		'Run each test suite this many times for each branch; results are summarized, default = 1'
 	)
 	.option(
-		'--tests-branch <branch>',
-		"Use this branch's performance test files"
+		'--tests-branch <rev>',
+		"Use this revision's performance test files"
 	)
 	.option(
 		'--wp-version <version>',


### PR DESCRIPTION
## What?

In the performance tests fetch all revisions in a single command and assign them to local branches.

> In a wild twist of events, this not only is failing to show significant reduction in test runtime, but it's showing a clearly more variable and longer runtime. After around thirty runs of the test suite on each branch, `trunk` is significantly faster, and the measured reduction in mean test runtime was on the order of seven minutes 😕 

![branch-compare-45780-44907](https://user-images.githubusercontent.com/5431237/203462661-338281b0-75c8-4ae4-8d14-126da4b36974.png)


## Why?

Sometimes it gets confusing in the performance test code trying to make sense of the distinctions between git shas, branches, and refs. When shallow fetching we don't even always get the branches associated with the revisions we fetch, such as with `trunk`.

In this patch we're doing three things:
 - Combining all of the revision fetches into a single call, which should reduce variation in the test runs due to network issues.
 - Passing a refspec to assign each fetched object to a local branch so that we can reliablly deal only with branches that definitely exist in the local copy of the repository.
 - Small cleanups to strings and namings to make it clear that this script will allow testing against any git revision, which could be a sha, a branch name, a tag name, or any other ref.

## How?

We're passing a list of `refspec`s to the `fetch` command which will tell the remote repository to send all of the listed objects and then it will assign them to a new local branch.

Under normal PR commits this will eliminate a couple of network fetches - one for each branch that we've been fetching. This will hopefully reduce the variability in the test runtimes and result in faster test runs.

## Testing Instructions

There are only changes to the test runner in this patch; no code changes on the project or the test suites themselves. Please audit the code and look for things that might be wrong or confusing.

If the Performance Test workflow passes then this should be working. Verify that the output of the performance test shows the normal table of measured test results.