### PR TITLE
Navigation: Add a new ManageMenusButton component

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -690,6 +690,9 @@ function Navigation( {
 		/>
 	);
 
+	const isManageMenusButtonDisabled =
+		! hasManagePermissions || ! hasResolvedNavigationMenus;
+
 	if ( hasUnsavedBlocks && ! isCreatingNavigationMenu ) {
 		return (
 			<TagName { ...blockProps }>
@@ -725,7 +728,9 @@ function Navigation( {
 								<WrappedNavigationMenuSelector
 									currentMenuId={ ref }
 								/>
-								<ManageMenusButton disabled={ ! hasManagePermissions || ! hasResolvedNavigationMenus } />
+								<ManageMenusButton
+									disabled={ isManageMenusButtonDisabled }
+								/>
 							</>
 						) }
 					</PanelBody>
@@ -787,7 +792,9 @@ function Navigation( {
 								<WrappedNavigationMenuSelector
 									currentMenuId={ null }
 								/>
-								<ManageMenusButton disabled={ ! hasManagePermissions || ! hasResolvedNavigationMenus } />
+								<ManageMenusButton
+									disabled={ isManageMenusButtonDisabled }
+								/>
 							</>
 						) }
 					</PanelBody>
@@ -898,7 +905,9 @@ function Navigation( {
 								<WrappedNavigationMenuSelector
 									currentMenuId={ ref }
 								/>
-								<ManageMenusButton disabled={ ! hasManagePermissions || ! hasResolvedNavigationMenus } />
+								<ManageMenusButton
+									disabled={ isManageMenusButtonDisabled }
+								/>
 							</>
 						) }
 					</PanelBody>
@@ -928,7 +937,10 @@ function Navigation( {
 								/>
 							) }
 						{ isOffCanvasNavigationEditorEnabled && (
-							<ManageMenusButton disabled={ ! hasManagePermissions || ! hasResolvedNavigationMenus } className="wp-block-navigation-manage-menus-button" />
+							<ManageMenusButton
+								disabled={ isManageMenusButtonDisabled }
+								className="wp-block-navigation-manage-menus-button"
+							/>
 						) }
 					</InspectorControls>
 				) }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -13,7 +13,6 @@ import {
 	Platform,
 	useMemo,
 } from '@wordpress/element';
-import { addQueryArgs } from '@wordpress/url';
 import {
 	__experimentalOffCanvasEditor as OffCanvasEditor,
 	InspectorControls,
@@ -69,6 +68,7 @@ import useConvertClassicToBlockMenu, {
 import useCreateNavigationMenu from './use-create-navigation-menu';
 import { useInnerBlocks } from './use-inner-blocks';
 import { detectColors } from './utils';
+import ManageMenusButton from './manage-menus-button';
 
 function Navigation( {
 	attributes,
@@ -655,19 +655,6 @@ function Navigation( {
 		</InspectorControls>
 	);
 
-	const ManageMenusButton = ( { buttonClassName = '' } ) => (
-		<Button
-			variant="link"
-			disabled={ ! hasManagePermissions || ! hasResolvedNavigationMenus }
-			className={ buttonClassName }
-			href={ addQueryArgs( 'edit.php', {
-				post_type: 'wp_navigation',
-			} ) }
-		>
-			{ __( 'Manage menus' ) }
-		</Button>
-	);
-
 	// If the block has inner blocks, but no menu id, then these blocks are either:
 	// - inserted via a pattern.
 	// - inserted directly via Code View (or otherwise).
@@ -738,7 +725,7 @@ function Navigation( {
 								<WrappedNavigationMenuSelector
 									currentMenuId={ ref }
 								/>
-								<ManageMenusButton />
+								<ManageMenusButton disabled={ ! hasManagePermissions || ! hasResolvedNavigationMenus } />
 							</>
 						) }
 					</PanelBody>
@@ -800,7 +787,7 @@ function Navigation( {
 								<WrappedNavigationMenuSelector
 									currentMenuId={ null }
 								/>
-								<ManageMenusButton />
+								<ManageMenusButton disabled={ ! hasManagePermissions || ! hasResolvedNavigationMenus } />
 							</>
 						) }
 					</PanelBody>
@@ -911,7 +898,7 @@ function Navigation( {
 								<WrappedNavigationMenuSelector
 									currentMenuId={ ref }
 								/>
-								<ManageMenusButton />
+								<ManageMenusButton disabled={ ! hasManagePermissions || ! hasResolvedNavigationMenus } />
 							</>
 						) }
 					</PanelBody>
@@ -941,7 +928,7 @@ function Navigation( {
 								/>
 							) }
 						{ isOffCanvasNavigationEditorEnabled && (
-							<ManageMenusButton className="wp-block-navigation-manage-menus-button" />
+							<ManageMenusButton disabled={ ! hasManagePermissions || ! hasResolvedNavigationMenus } className="wp-block-navigation-manage-menus-button" />
 						) }
 					</InspectorControls>
 				) }

--- a/packages/block-library/src/navigation/edit/manage-menus-button.js
+++ b/packages/block-library/src/navigation/edit/manage-menus-button.js
@@ -3,7 +3,6 @@
  */
 import { addQueryArgs } from '@wordpress/url';
 import { Button } from '@wordpress/components';
-import { memo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 const ManageMenusButton = ( { className = '', disabled } ) => (
@@ -19,4 +18,4 @@ const ManageMenusButton = ( { className = '', disabled } ) => (
 	</Button>
 );
 
-export default memo( ManageMenusButton );
+export default ManageMenusButton;

--- a/packages/block-library/src/navigation/edit/manage-menus-button.js
+++ b/packages/block-library/src/navigation/edit/manage-menus-button.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+import { Button } from '@wordpress/components';
+import { memo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+const ManageMenusButton = ( { className = '', disabled } ) => (
+	<Button
+		variant="link"
+		disabled={ disabled }
+		className={ className }
+		href={ addQueryArgs( 'edit.php', {
+			post_type: 'wp_navigation',
+		} ) }
+	>
+		{ __( 'Manage menus' ) }
+	</Button>
+);
+
+export default memo( ManageMenusButton );


### PR DESCRIPTION
## What?
This is a follow up from https://github.com/WordPress/gutenberg/pull/45769, creating the new component in a different file to help with readability and performance.

## Why?
By extracting a disabled prop we can ensure that the component won't rerender unless necessary.

## How?
Put the component in a new file, extract the logic to determine whether to the button is disabled, and wrap it in memo.

## Testing Instructions
Check that the "manage menus" button in the inspector controls for the Navigation block, works as before.