### PR TITLE
Add submenu menu item to list view

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/block.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block.js
@@ -6,10 +6,11 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { hasBlockSupport } from '@wordpress/blocks';
+import { createBlock, hasBlockSupport } from '@wordpress/blocks';
 import {
 	__experimentalTreeGridCell as TreeGridCell,
 	__experimentalTreeGridItem as TreeGridItem,
+	MenuItem,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { moreVertical } from '@wordpress/icons';
@@ -59,7 +60,7 @@ function ListViewBlock( {
 } ) {
 	const cellRef = useRef( null );
 	const [ isHovered, setIsHovered ] = useState( false );
-	const { clientId } = block;
+	const { clientId, attributes } = block;
 
 	const { isLocked, isContentLocked } = useBlockLock( clientId );
 	const forceSelectionContentLock = useSelect(
@@ -86,7 +87,8 @@ function ListViewBlock( {
 		( isSelected &&
 			selectedClientIds[ selectedClientIds.length - 1 ] === clientId );
 
-	const { toggleBlockHighlight } = useDispatch( blockEditorStore );
+	const { replaceBlock, toggleBlockHighlight } =
+		useDispatch( blockEditorStore );
 
 	const blockInformation = useBlockDisplayInformation( clientId );
 	const blockName = useSelect(
@@ -355,7 +357,29 @@ function ListViewBlock( {
 								} }
 								disableOpenOnArrowDown
 								__experimentalSelectBlock={ updateSelection }
-							/>
+							>
+								{ ( { onClose } ) => (
+									<MenuItem
+										onClick={ () => {
+											const newLink = createBlock(
+												'core/navigation-link'
+											);
+											const newSubmenu = createBlock(
+												'core/navigation-submenu',
+												attributes,
+												[ newLink ]
+											);
+											replaceBlock(
+												clientId,
+												newSubmenu
+											);
+											onClose();
+										} }
+									>
+										{ __( 'Add a submenu item' ) }
+									</MenuItem>
+								) }
+							</BlockSettingsDropdown>
 						) }
 					</TreeGridCell>
 				</>

--- a/packages/block-editor/src/components/off-canvas-editor/block.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block.js
@@ -367,7 +367,12 @@ function ListViewBlock( {
 											const newSubmenu = createBlock(
 												'core/navigation-submenu',
 												attributes,
-												[ newLink ]
+												block.innerBlocks
+													? [
+															...block.innerBlocks,
+															newLink,
+													  ]
+													: [ newLink ]
 											);
 											replaceBlock(
 												clientId,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #45441

Adds a menu item to the list view items to add a submenu

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Ensure the `Off canvas navigation editor` experiment is enabled
2. In nav block with a list item, open list view in the block sidebar
3. Use the three dots menu to add a submenu

## Screenshots or screencast <!-- if applicable -->

<img width="320" alt="image" src="https://user-images.githubusercontent.com/5129775/202087127-d7398b8c-fac2-4c25-b375-9d0fee7ce446.png">

