### PR TITLE
Components: Fix ESLint warning for Dashicon

### DIFF
--- a/packages/components/src/dashicon/index.js
+++ b/packages/components/src/dashicon/index.js
@@ -3,7 +3,7 @@
  *
  * @property {import('./types').IconKey} icon        Icon name
  * @property {string}                    [className] Class name
- * @property {number}                    [size] Size of the icon
+ * @property {number}                    [size]      Size of the icon
  */
 /** @typedef {import('react').ComponentPropsWithoutRef<'span'> & OwnProps} Props */
 


### PR DESCRIPTION
## What?
PR fixes following ESLint warning the Dashicon component.

```
Expected JSDoc block lines to be aligned
```

## Why?
I noticed while running `lint` on the project.

## Testing Instructions
CI checks should be green.
