### PR TITLE
ComboboxControl: add new opt-in prop

### DIFF
--- a/packages/block-library/src/avatar/user-control.js
+++ b/packages/block-library/src/avatar/user-control.js
@@ -33,6 +33,7 @@ function UserControl( { value, onChange } ) {
 
 	return (
 		<ComboboxControl
+			__nextHasNoMarginBottom
 			label={ __( 'User' ) }
 			help={ __(
 				'Select the avatar user to display, if it is blank it will use the post/page author.'

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -103,6 +103,7 @@ function PostAuthorEdit( {
 						authorOptions.length &&
 						( ( showCombobox && (
 							<ComboboxControl
+								__nextHasNoMarginBottom
 								label={ __( 'Author' ) }
 								options={ authorOptions }
 								value={ authorId }

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -158,6 +158,7 @@ export function PageAttributesParent() {
 
 	return (
 		<ComboboxControl
+			__nextHasNoMarginBottom
 			className="editor-page-attributes__parent"
 			label={ parentPageLabel }
 			value={ parentPostId }

--- a/packages/editor/src/components/post-author/combobox.js
+++ b/packages/editor/src/components/post-author/combobox.js
@@ -95,6 +95,7 @@ function PostAuthorCombobox() {
 
 	return (
 		<ComboboxControl
+			__nextHasNoMarginBottom
 			label={ __( 'Author' ) }
 			options={ authorOptions }
 			value={ authorId }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

Adding new opt-in prop `__nextHasNoMarginBottom` to usages of `ComboboxControl` in the Gutenberg codebase. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Part of this project: https://github.com/WordPress/gutenberg/issues/38730
The tl;dr is `BaseControl` has a `margin-bottom` which makes it difficult to reuse and results in inconsistent use. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding the prop `__nextHasNoMarginBottom`.

## Additional Notes

There is a bottom margin for `UserControl` in trunk. However, this is causing inconsistent spacing, so I believe this is a positive change. Here you can see how the title has no margin above and touches the padding. Whereas, at the bottom it has extra space (other sections aren't like this). See the orange outline below the text and above the padding to see the inconsistent margin that is removed in this PR:

<img width="310" alt="Screen Shot 2022-11-15 at 6 48 01 PM" src="https://user-images.githubusercontent.com/35543432/202092365-2be54e39-5115-4a6c-bc7c-ea8f7c2f6486.png">

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

To test this, you'll need to look for the following `ComboboxComponent` (dropdowns) and ensure that the margin is the same as before (`margin-bottom` of 0) for the `div` with class `components-base-control__field`. Screenshots below are how it looks in core right now. 

Before going through the steps, ensure you have at least two published pages and then you can complete all the steps from a single page editor. 

### **For `UserControl`**

1. Add the 'Avatar' block to the page editor
2. Click on the dropdown under 'User' in the Block settings in the right sidebar
3. Make sure the bottom margin looks the same as before

<img width="1181" alt="Screen Shot 2022-11-15 at 9 49 42 PM" src="https://user-images.githubusercontent.com/35543432/202094854-055a98cb-a0cc-4954-82a0-998f19f65970.png">

### **For`PostAuthorEdit` (block library)**

For this to work, you need at least 25 editors on the site (same with the component below). Or you can edit **line 26** `const minimumUsersForCombobox = 25;` and change the value 25 to 1 in `packages/block-library/src/post-author/edit.js`. Then:

1. Add the 'Post Author' block to the page editor
2. Click on the dropdown under 'Author' in the Block settings in the right sidebar
3. Make sure the bottom margin looks the same as before

<img width="1181" alt="Screen Shot 2022-11-15 at 9 49 27 PM" src="https://user-images.githubusercontent.com/35543432/202094887-eefd5c0a-6659-4c81-8fe3-3bba9476f897.png">

### **For  `PostAuthorComboBox` (editor)**

For this to work, you need at least 25 editors on the site. Or you can edit **line 14** `const minimumUsersForCombobox = 25;` and change the value 25 to 1 in `packages/editor/src/components/post-author/index.js`. Then:

1. Navigate to a page editor if you aren't there already 
2. Search for 'Author' title in Page Settings in the right sidebar 
3. Make sure the bottom margin looks the same as before

<img width="297" alt="Screen Shot 2022-11-15 at 9 50 23 PM" src="https://user-images.githubusercontent.com/35543432/202095020-74a0baa0-1b31-4f12-acf9-16dd014e0077.png">


### **For `PageAtttributesParent`**
1. Ensure you have more than one page published
3. Edit a page
7. Click on 'Page Attributes' in the Page settings in the right sidebar
8. Make sure the bottom margin looks the same as before

<img width="293" alt="Screen Shot 2022-11-15 at 9 50 32 PM" src="https://user-images.githubusercontent.com/35543432/202094985-1f452022-b4db-4ae0-8248-f0dc9405d95d.png">


