### PR TITLE
Compose: Fix 'no-container' violations in 'useDisabled' tests

### DIFF
--- a/packages/compose/src/hooks/use-disabled/test/index.js
+++ b/packages/compose/src/hooks/use-disabled/test/index.js
@@ -21,7 +21,7 @@ describe( 'useDisabled', () => {
 			<form ref={ ref }>
 				<input />
 				<a href="https://wordpress.org/">A link</a>
-				<p contentEditable={ true } tabIndex="0"></p>
+				<p role="document" contentEditable={ true } tabIndex="0"></p>
 				{ showButton && <button>Button</button> }
 			</form>
 		);
@@ -33,11 +33,11 @@ describe( 'useDisabled', () => {
 	}
 
 	it( 'will disable all fields', () => {
-		const { container } = render( <DisabledComponent /> );
+		render( <DisabledComponent /> );
 
 		const input = screen.getByRole( 'textbox' );
 		const link = screen.getByRole( 'link' );
-		const p = container.querySelector( 'p' );
+		const p = screen.getByRole( 'document' );
 
 		expect( input ).toHaveAttribute( 'inert', 'true' );
 		expect( link ).toHaveAttribute( 'inert', 'true' );


### PR DESCRIPTION
## What?
PR fixes a [no-container](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-container.md) rule violation in the `useDisabled` hook's tests.

## Why?
The end goal is to enable that ESLint rule once all violations have been fixed.

## How?
I've replaced `querySelector` with the screen query.

## Testing Instructions
Verify tests pass as before.
