### PR TITLE
Fix the editor area height.

### DIFF
--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -73,7 +73,13 @@ html.interface-interface-skeleton__html-container {
 
 .interface-interface-skeleton__content {
 	.interface-navigable-region__stacker {
+		// It's a flex item within a flex container with flex-direction column.
+		// Make sure it takes all the available height.
 		flex-grow: 1;
+		// Allow its flex items (the visual editor area) to take all the available
+		// height by making it also a flex container.
+		display: flex;
+		flex-direction: column;
 	}
 
 	flex-grow: 1;
@@ -92,7 +98,6 @@ html.interface-interface-skeleton__html-container {
 	// to "bleed" through the header.
 	// See https://github.com/WordPress/gutenberg/issues/32631
 	z-index: z-index(".interface-interface-skeleton__content");
-
 }
 
 .interface-interface-skeleton__secondary-sidebar,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/45778

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes the editor area height after https://github.com/WordPress/gutenberg/pull/45369

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The editor content area didn't take all the available height any longer.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- #45369 introduced a new container around the content area.
- This PR just adds the CSS flex properties that were used on the previous container to the new container.
- In fact, the new container needs to be a flex item and also a flex container:
  - A flex item, to take all the available height: it does have a flex container with flex-direction `column`.
  - A flex container with flex-direction `column`, to make its flex items take all the available height.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Activate Twenty Twenty-two.
- Go to the Post editor.
- Open the Template editor by clicking the template name in the settings sidebar and then by clicking 'Edit template'.
- Check the template editor content is not cut off.
- Activate a theme that uses a non-white background e.g. Twenty Twenty-One.
- Create a new post with short content e.g. only one paragraph.
- Check the non-white background takes all the available height (which means the editor content area is full height, as expected).

## Screenshots or screencast <!-- if applicable -->
