### PR TITLE
Fix inserter tab panel content buttons' position

### DIFF
--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -135,6 +135,10 @@ html.interface-interface-skeleton__html-container {
 }
 
 .interface-interface-skeleton__secondary-sidebar {
+	.interface-navigable-region__stacker {
+		height: 100%;
+	}
+
 	@include break-medium() {
 		border-right: $border-width solid $gray-200;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A small regression from: https://github.com/WordPress/gutenberg/pull/45369 that changed the position of the `Manage reusable blocks and Explore all patterns` buttons in the inserter respective tab panels content.


https://user-images.githubusercontent.com/16275880/202149879-f9442f5b-d5d4-42fb-90e0-e7c1094966c6.mov



