### PR TITLE
Fix: PHP Warnings caused by `array_key_exists()`.

### DIFF
--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -834,6 +834,11 @@ class WP_HTML_Tag_Processor {
 			return true;
 		}
 
+		// Continue parsing if no attribute name. No point in storing something as ''/false.
+		if ( ! is_string( $attribute_name ) || strlen( $attribute_name ) === 0 ) {
+			return true;
+		}
+		
 		// If an attribute is listed many times, only use the first declaration and ignore the rest.
 		if ( ! array_key_exists( $attribute_name, $this->attributes ) ) {
 			$this->attributes[ $attribute_name ] = new WP_HTML_Attribute_Token(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When this happens logs are filled with warnings and hit 70+GBs in less than 15 minutes. This makes the filesystem sluggish because of constant writes.

```
Warning: array_key_exists(): The first argument should be either a string or an integer in /home/test/wp-content/plugins/gutenberg-core/v14.5.1/lib/experimental/html/class-wp-html-tag-processor.php on line 838
```

Another good reason to add some checks for `$attribute_name` is the difference in behavior in PHP 7 and 8: https://3v4l.org/FNWJn

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It never tries to set an array value if the key is not a string or an empty string.

Based on my skill of code-reading, this one shouldn't loop endlessly because worst-case `$this->parsed_bytes` will be increased by `$name_length` which is disallowed to be 0. The other case is when it `$has_value === true`, where it also gets incremented by at least 1.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Sadly, I couldn't get the whole string, and haven't managed to reproduce it manually.

