### PR TITLE
URLInput: keep the search results label in sync with the results list

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+- `URLInput`: the `renderSuggestions` callback prop now receives `currentInputValue` as a new parameter ([45806](https://github.com/WordPress/gutenberg/pull/45806)).
+
 ## 10.5.0 (2022-11-16)
 
 ### Enhancement

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -322,10 +322,10 @@ The following properties are provided by URLInput:
 -   suggestions
 -   selectedSuggestion
 -   suggestionsListProps
+-   currentInputValue
 
 The following extra properties are provided by LinkControlSearchInput:
 
--   currentInputValue
 -   createSuggestionButtonText
 -   handleSuggestionClick
 -   instanceId

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -81,7 +81,6 @@ const LinkControlSearchInput = forwardRef(
 				...props,
 				instanceId,
 				withCreateSuggestion,
-				currentInputValue: value,
 				createSuggestionButtonText,
 				suggestionsQuery,
 				handleSuggestionClick: ( suggestion ) => {

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -503,6 +503,10 @@ class URLInput extends Component {
 			loading,
 		} = this.state;
 
+		if ( ! showSuggestions || suggestions.length === 0 ) {
+			return null;
+		}
+
 		const suggestionsListProps = {
 			id: suggestionsListboxId,
 			ref: this.autocompleteRef,
@@ -519,11 +523,7 @@ class URLInput extends Component {
 			};
 		};
 
-		if (
-			isFunction( renderSuggestions ) &&
-			showSuggestions &&
-			!! suggestions.length
-		) {
+		if ( isFunction( renderSuggestions ) ) {
 			return renderSuggestions( {
 				suggestions,
 				selectedSuggestion,
@@ -537,46 +537,33 @@ class URLInput extends Component {
 			} );
 		}
 
-		if (
-			! isFunction( renderSuggestions ) &&
-			showSuggestions &&
-			!! suggestions.length
-		) {
-			return (
-				<Popover placement="bottom" focusOnMount={ false }>
-					<div
-						{ ...suggestionsListProps }
-						className={ classnames(
-							'block-editor-url-input__suggestions',
-							`${ className }__suggestions`
-						) }
-					>
-						{ suggestions.map( ( suggestion, index ) => (
-							<Button
-								{ ...buildSuggestionItemProps(
-									suggestion,
-									index
-								) }
-								key={ suggestion.id }
-								className={ classnames(
-									'block-editor-url-input__suggestion',
-									{
-										'is-selected':
-											index === selectedSuggestion,
-									}
-								) }
-								onClick={ () =>
-									this.handleOnClick( suggestion )
+		return (
+			<Popover placement="bottom" focusOnMount={ false }>
+				<div
+					{ ...suggestionsListProps }
+					className={ classnames(
+						'block-editor-url-input__suggestions',
+						`${ className }__suggestions`
+					) }
+				>
+					{ suggestions.map( ( suggestion, index ) => (
+						<Button
+							{ ...buildSuggestionItemProps( suggestion, index ) }
+							key={ suggestion.id }
+							className={ classnames(
+								'block-editor-url-input__suggestion',
+								{
+									'is-selected': index === selectedSuggestion,
 								}
-							>
-								{ suggestion.title }
-							</Button>
-						) ) }
-					</div>
-				</Popover>
-			);
-		}
-		return null;
+							) }
+							onClick={ () => this.handleOnClick( suggestion ) }
+						>
+							{ suggestion.title }
+						</Button>
+					) ) }
+				</div>
+			</Popover>
+		);
 	}
 }
 

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -66,6 +66,7 @@ class URLInput extends Component {
 			suggestions: [],
 			showSuggestions: false,
 			isUpdatingSuggestions: false,
+			suggestionsValue: null,
 			selectedSuggestion: null,
 			suggestionsListboxId: '',
 			suggestionOptionIdPrefix: '',
@@ -172,6 +173,7 @@ class URLInput extends Component {
 			this.setState( {
 				suggestions: [],
 				showSuggestions: false,
+				suggestionsValue: value,
 				selectedSuggestion: null,
 				loading: false,
 			} );
@@ -201,6 +203,7 @@ class URLInput extends Component {
 				this.setState( {
 					suggestions,
 					isUpdatingSuggestions: false,
+					suggestionsValue: value,
 					loading: false,
 					showSuggestions: !! suggestions.length,
 				} );
@@ -486,13 +489,12 @@ class URLInput extends Component {
 		const {
 			className,
 			__experimentalRenderSuggestions: renderSuggestions,
-			value = '',
-			__experimentalShowInitialSuggestions = false,
 		} = this.props;
 
 		const {
 			showSuggestions,
 			suggestions,
+			suggestionsValue,
 			selectedSuggestion,
 			suggestionsListboxId,
 			suggestionOptionIdPrefix,
@@ -527,9 +529,8 @@ class URLInput extends Component {
 				buildSuggestionItemProps,
 				isLoading: loading,
 				handleSuggestionClick: this.handleOnClick,
-				isInitialSuggestions:
-					__experimentalShowInitialSuggestions &&
-					! ( value && value.length ),
+				isInitialSuggestions: ! suggestionsValue?.length,
+				currentInputValue: suggestionsValue,
 			} );
 		}
 

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -60,6 +60,7 @@ class URLInput extends Component {
 
 		this.suggestionNodes = [];
 
+		this.suggestionsRequest = null;
 		this.isUpdatingSuggestions = false;
 
 		this.state = {
@@ -123,7 +124,7 @@ class URLInput extends Component {
 
 	componentWillUnmount() {
 		this.suggestionsRequest?.cancel?.();
-		delete this.suggestionsRequest;
+		this.suggestionsRequest = null;
 	}
 
 	bindSuggestionNode( index ) {
@@ -166,6 +167,9 @@ class URLInput extends Component {
 			! isInitialSuggestions &&
 			( value.length < 2 || ( ! handleURLSuggestions && isURL( value ) ) )
 		) {
+			this.suggestionsRequest?.cancel?.();
+			this.suggestionsRequest = null;
+
 			this.setState( {
 				showSuggestions: false,
 				selectedSuggestion: null,
@@ -223,12 +227,14 @@ class URLInput extends Component {
 				this.isUpdatingSuggestions = false;
 			} )
 			.catch( () => {
-				if ( this.suggestionsRequest === request ) {
-					this.setState( {
-						loading: false,
-					} );
-					this.isUpdatingSuggestions = false;
+				if ( this.suggestionsRequest !== request ) {
+					return;
 				}
+
+				this.setState( {
+					loading: false,
+				} );
+				this.isUpdatingSuggestions = false;
 			} );
 
 		// Note that this assignment is handled *before* the async search request

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -171,6 +171,7 @@ class URLInput extends Component {
 			this.suggestionsRequest = null;
 
 			this.setState( {
+				suggestions: [],
 				showSuggestions: false,
 				selectedSuggestion: null,
 				loading: false,

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -61,13 +61,12 @@ class URLInput extends Component {
 		this.suggestionNodes = [];
 
 		this.suggestionsRequest = null;
-		this.isUpdatingSuggestions = false;
 
 		this.state = {
 			suggestions: [],
 			showSuggestions: false,
+			isUpdatingSuggestions: false,
 			selectedSuggestion: null,
-
 			suggestionsListboxId: '',
 			suggestionOptionIdPrefix: '',
 		};
@@ -104,7 +103,7 @@ class URLInput extends Component {
 		if (
 			prevProps.value !== value &&
 			! this.props.disableSuggestions &&
-			! this.isUpdatingSuggestions
+			! this.state.isUpdatingSuggestions
 		) {
 			if ( value?.length ) {
 				// If the new value is not empty we need to update with suggestions for it.
@@ -180,9 +179,8 @@ class URLInput extends Component {
 			return;
 		}
 
-		this.isUpdatingSuggestions = true;
-
 		this.setState( {
+			isUpdatingSuggestions: true,
 			selectedSuggestion: null,
 			loading: true,
 		} );
@@ -202,6 +200,7 @@ class URLInput extends Component {
 
 				this.setState( {
 					suggestions,
+					isUpdatingSuggestions: false,
 					loading: false,
 					showSuggestions: !! suggestions.length,
 				} );
@@ -225,7 +224,6 @@ class URLInput extends Component {
 						'assertive'
 					);
 				}
-				this.isUpdatingSuggestions = false;
 			} )
 			.catch( () => {
 				if ( this.suggestionsRequest !== request ) {
@@ -233,9 +231,9 @@ class URLInput extends Component {
 				}
 
 				this.setState( {
+					isUpdatingSuggestions: false,
 					loading: false,
 				} );
-				this.isUpdatingSuggestions = false;
 			} );
 
 		// Note that this assignment is handled *before* the async search request
@@ -256,7 +254,7 @@ class URLInput extends Component {
 		if (
 			value &&
 			! disableSuggestions &&
-			! this.isUpdatingSuggestions &&
+			! this.state.isUpdatingSuggestions &&
 			! ( suggestions && suggestions.length )
 		) {
 			// Ensure the suggestions are updated with the current input value.

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -237,12 +237,7 @@ class URLInput extends Component {
 	}
 
 	onChange( event ) {
-		const inputValue = event.target.value;
-
-		this.props.onChange( inputValue );
-		if ( ! this.props.disableSuggestions ) {
-			this.updateSuggestions( inputValue );
-		}
+		this.props.onChange( event.target.value );
 	}
 
 	onFocus() {

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -133,14 +133,10 @@ class URLInput extends Component {
 	}
 
 	shouldShowInitialSuggestions() {
-		const { suggestions } = this.state;
 		const { __experimentalShowInitialSuggestions = false, value } =
 			this.props;
 		return (
-			! this.isUpdatingSuggestions &&
-			__experimentalShowInitialSuggestions &&
-			! ( value && value.length ) &&
-			! ( suggestions && suggestions.length )
+			__experimentalShowInitialSuggestions && ! ( value && value.length )
 		);
 	}
 


### PR DESCRIPTION
Fixes a bug in `URLInput` that I discovered when updating unit tests for the component during the React 18 migration (#45235). When typing into the input field, it displays suggestions either for the empty value ("initial suggestions", list of recently updated pages):

<img width="367" alt="Screenshot 2022-11-16 at 13 48 27" src="https://user-images.githubusercontent.com/664258/202187467-b09eb5ea-36b0-4aa0-8912-510c27ef86b0.png">

or for a non-empty value (the label is visually hidden in production, I made it visible for testing purposes):

<img width="367" alt="Screenshot 2022-11-16 at 13 48 46" src="https://user-images.githubusercontent.com/664258/202187581-78679559-297a-4ffd-b4de-c6ee9fcb5ad1.png">

The problem is that the label ("Recently updated" or "Search results for") could get out of sync with the list of results. If I change the value from `"act"` to `""`, the `URLInput`'s `value` prop changes immediately, and the label is immediately rerendered from "Search results for 'act'" to "Recently updated", but the results list changes only a while later, after a REST API fetch finishes. That means we're rendering a mis-labeled list in the meantime.

It came up when working on a unit test, because the bug makes it impossible to catch the moment when the list get updated. This would be a great way to do it but it doesn't work:
```js
// wait for the properly labeled results list to appear
const results = await screen.findByRole( 'listbox', { name: 'Recently updated' } );
// check that the number of results is as expected
expect( within( results ).getAllByRole( 'option' ) ).toHaveLength( 3 );
```

After this patch, it will start working.

There are several other drive-by changes to `URLInput`, best reviewed commit by commit:
- the `shouldShowInitialSuggestions` method runs only on mount, in `cDM`, when the state is guaranteed to have initial values. Therefore we can remove the checks that look at `this.state`.
- the `onChange` handler doesn't need to call `this.updateSuggestions`. The `cDU` lifecycle will always do it when the `value` prop changes.
- there is a special case for a single-letter `value` where we don't want to trigger suggestions search. In that case, cancel the outstanding REST request from a previous query, and set `state.suggestions` to `[]`.
- the `this.isUpdatingSuggestions` field can be moved to state, because it is part of state. There was always a `setState` call nearby when I was refactoring: I only needed to add new property to it, never add a new one.

**How to test:**
The `initialSuggestions` feature is enabled only when editing a Custom Link (`core/navigation-link`) inside the Navigation (`core/navigation`) block, so you need to open the site editor and add a block structure like:

<img width="834" alt="Screenshot 2022-11-16 at 13 49 34" src="https://user-images.githubusercontent.com/664258/202190715-d284646e-41ba-4be0-9f53-0d4aaebcfff7.png">

Then you can play with editing the input and fetching the suggestions.
