### PR TITLE
Width of LinkControl in the sidebar

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -24,6 +24,15 @@ $preview-image-height: 140px;
 	}
 }
 
+// When Link control is being used is the settings sidebar it doesn't cause
+// scrolling and will fit it with the max width still being the same.
+.interface-interface-skeleton__sidebar {
+    .block-editor-link-control {
+        min-width: 100%;
+        max-width: $modal-min-width;
+    }
+}
+
 // Provides positioning context for reset button. Without this then when an
 // error notice is displayed the input's reset button is incorrectly positioned.
 .block-editor-link-control__search-input-wrapper {


### PR DESCRIPTION
SCSS that ensures that LinkControl doesn't cause horizontal scrolling when being used in the side bar.

Chose the .interface-interface-skeleton__sidebar class as that seems to make the most logical sense but open to having a better class suggested


## What?
Changes to fix #45812

## Why?
Horizontal scrolling isn't very user friendly when it isn't desired

## How?
Targets the wrapper class of the settings sidebar and then the LinkControl settings to control the width

## Testing Instructions

1. Copy the below code for demo block
2. Visit: [gutenberg.run/45813](http://gutenberg.run/45813)
3. Open the JavaScript Console
4. Paste and execute the copied code
5. Insert the "Test 45812" block
6. Examine block settings in the sidebar
7. Verify there’s no horizontal overflow from the link control
8. Add a link using the control
9. Edit the link again and verify there is no horizontal overflow

### Code for demo block
```js
( ( {
  blocks: { registerBlockType },
  blockEditor: { InspectorControls, __experimentalLinkControl: LinkControl },
  components: { PanelBody },
  element: { createElement: el, Fragment },
  i18n: { __ },
} ) => {
  registerBlockType( 'tester/issue-45812', {
    title: 'Test 45812',
    edit: Edit,
    save: () => null,
  } );

  function Edit( { attributes: { post }, setAttributes } ) {
    var setLink = ( value ) => setAttributes( { post : value } );

    return (
      el( Fragment, null,
        el( InspectorControls, null,
          el( PanelBody, {title: 'Additional Link'},
            el( LinkControl, {
              searchInputPlaceholder: "Search here...", value: post, onChange: setLink, settings: [
                {
                  id: 'opensInNewTab',
                  title: 'Open card link in new tab?',
                }
              ], suggestionsQuery: {
                type: 'post',
                subtype: 'page',
              } }
            ),
          )
        ),
        el( 'p', null, "See block settings…" )
      )
    );
  };
} )( wp );
```
