### PR TITLE
Add: Template types to the patterns API.

### DIFF
--- a/docs/reference-guides/block-api/block-patterns.md
+++ b/docs/reference-guides/block-api/block-patterns.md
@@ -34,6 +34,7 @@ The properties available for block patterns are:
 -   `viewportWidth` (optional): An integer specifying the intended width of the pattern to allow for a scaled preview of the pattern in the inserter.
 -   `blockTypes` (optional): An array of block types that the pattern is intended to be used with. Each value needs to be the declared block's `name`.
 -   `postTypes` (optional): An array of post types that the pattern is restricted to be used with. The pattern will only be available when editing one of the post types passed on the array, for all the other post types the pattern is not available at all.
+-   `templateTypes` (optional): An array of template types where the pattern makes sense e.g: '404' if the pattern is for a 404 page, single-post if the pattern is for showing a single post.
 -   `inserter` (optional): By default, all patterns will appear in the inserter. To hide a pattern so that it can only be inserted programmatically, set the `inserter` to `false`.
 
 The following code sample registers a block pattern named 'my-plugin/my-awesome-pattern':

--- a/lib/compat/wordpress-6.2/block-patterns.php
+++ b/lib/compat/wordpress-6.2/block-patterns.php
@@ -225,6 +225,7 @@ function gutenberg_register_theme_block_patterns() {
 		'blockTypes'    => 'Block Types',
 		'postTypes'     => 'Post Types',
 		'inserter'      => 'Inserter',
+		'templateTypes' => 'Template Types',
 	);
 
 	/*
@@ -294,7 +295,7 @@ function gutenberg_register_theme_block_patterns() {
 					}
 
 					// For properties of type array, parse data as comma-separated.
-					foreach ( array( 'categories', 'keywords', 'blockTypes', 'postTypes' ) as $property ) {
+					foreach ( array( 'categories', 'keywords', 'blockTypes', 'postTypes', 'templateTypes' ) as $property ) {
 						if ( ! empty( $pattern_data[ $property ] ) ) {
 							$pattern_data[ $property ] = array_filter(
 								preg_split(

--- a/lib/compat/wordpress-6.2/class-gutenberg-rest-block-patterns-controller-6-2.php
+++ b/lib/compat/wordpress-6.2/class-gutenberg-rest-block-patterns-controller-6-2.php
@@ -35,6 +35,128 @@ class Gutenberg_REST_Block_Patterns_Controller_6_2 extends Gutenberg_REST_Block_
 	);
 
 	/**
+	 * Prepare a raw block pattern before it gets output in a REST API response.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @param array           $item    Raw pattern as registered, before any changes.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$fields = $this->get_fields_for_response( $request );
+		$keys   = array(
+			'name'          => 'name',
+			'title'         => 'title',
+			'description'   => 'description',
+			'viewportWidth' => 'viewport_width',
+			'blockTypes'    => 'block_types',
+			'postTypes'     => 'post_types',
+			'categories'    => 'categories',
+			'keywords'      => 'keywords',
+			'content'       => 'content',
+			'inserter'      => 'inserter',
+			'templateTypes' => 'template_types',
+		);
+		$data   = array();
+		foreach ( $keys as $item_key => $rest_key ) {
+			if ( isset( $item[ $item_key ] ) && rest_is_field_included( $rest_key, $fields ) ) {
+				$data[ $rest_key ] = $item[ $item_key ];
+			}
+		}
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Retrieves the block pattern schema, conforming to JSON Schema.
+	 *
+	 * @since 6.0.0
+	 * @since 6.1.0 Added `post_types` property.
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'block-pattern',
+			'type'       => 'object',
+			'properties' => array(
+				'name'           => array(
+					'description' => __( 'The pattern name.', 'gutenberg' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'title'          => array(
+					'description' => __( 'The pattern title, in human readable format.', 'gutenberg' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'description'    => array(
+					'description' => __( 'The pattern detailed description.', 'gutenberg' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'viewport_width' => array(
+					'description' => __( 'The pattern viewport width for inserter preview.', 'gutenberg' ),
+					'type'        => 'number',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'block_types'    => array(
+					'description' => __( 'Block types that the pattern is intended to be used with.', 'gutenberg' ),
+					'type'        => 'array',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'post_types'     => array(
+					'description' => __( 'An array of post types that the pattern is restricted to be used with.', 'gutenberg' ),
+					'type'        => 'array',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'categories'     => array(
+					'description' => __( 'The pattern category slugs.', 'gutenberg' ),
+					'type'        => 'array',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'keywords'       => array(
+					'description' => __( 'The pattern keywords.', 'gutenberg' ),
+					'type'        => 'array',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'template_types' => array(
+					'description' => __( 'An array of template types where the pattern fits.', 'gutenberg' ),
+					'type'        => 'array',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'content'        => array(
+					'description' => __( 'The pattern content.', 'gutenberg' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'inserter'       => array(
+					'description' => __( 'Determines whether the pattern is visible in inserter.', 'gutenberg' ),
+					'type'        => 'boolean',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
 	 * Registers the routes for the objects of the controller.
 	 *
 	 * @since 6.0.0

--- a/lib/compat/wordpress-6.2/rest-api.php
+++ b/lib/compat/wordpress-6.2/rest-api.php
@@ -116,3 +116,15 @@ function gutenberg_modify_rest_sidebars_response( $response ) {
 	return $response;
 }
 add_filter( 'rest_prepare_sidebar', 'gutenberg_modify_rest_sidebars_response' );
+
+
+register_block_pattern(
+	'query/template-type-test',
+	array(
+		'title'         => __( 'Template type test', 'gutenberg' ),
+		'templateTypes' => array( '404' ),
+		'content'       => '<!-- wp:paragraph {"align":"center","fontSize":"x-large"} -->
+							<p class="has-text-align-center has-x-large-font-size">404</p>
+							<!-- /wp:paragraph -->',
+	)
+);

--- a/phpunit/class-gutenberg-rest-block-patterns-controller-test.php
+++ b/phpunit/class-gutenberg-rest-block-patterns-controller-test.php
@@ -67,24 +67,27 @@ class Gutenberg_REST_Block_Patterns_Controller_6_2_Test extends WP_Test_REST_Con
 				'categories'    => array( 'test' ),
 				'viewportWidth' => 1440,
 				'content'       => '<!-- wp:heading {"level":1} --><h1>One</h1><!-- /wp:heading -->',
+				'templateTypes' => array( 'page' ),
 			)
 		);
 
 		$test_registry->register(
 			'test/two',
 			array(
-				'title'      => 'Pattern Two',
-				'categories' => array( 'test' ),
-				'content'    => '<!-- wp:paragraph --><p>Two</p><!-- /wp:paragraph -->',
+				'title'         => 'Pattern Two',
+				'categories'    => array( 'test' ),
+				'content'       => '<!-- wp:paragraph --><p>Two</p><!-- /wp:paragraph -->',
+				'templateTypes' => array( 'single' ),
 			)
 		);
 
 		$test_registry->register(
 			'test/three',
 			array(
-				'title'      => 'Pattern Three',
-				'categories' => array( 'test', 'buttons', 'query' ),
-				'content'    => '<!-- wp:paragraph --><p>Three</p><!-- /wp:paragraph -->',
+				'title'         => 'Pattern Three',
+				'categories'    => array( 'test', 'buttons', 'query' ),
+				'content'       => '<!-- wp:paragraph --><p>Three</p><!-- /wp:paragraph -->',
+				'templateTypes' => array( '404' ),
 			)
 		);
 	}
@@ -147,7 +150,21 @@ class Gutenberg_REST_Block_Patterns_Controller_6_2_Test extends WP_Test_REST_Con
 		$this->markTestIncomplete();
 	}
 	public function test_get_items() {
-		$this->markTestIncomplete();
+		wp_set_current_user( self::$admin_id );
+
+		$expected_names  = array( 'test/one', 'test/two', 'test/three' );
+		$expected_fields = array( 'name', 'content', 'template_types' );
+
+		$request            = new WP_REST_Request( 'GET', '/wp/v2/block-patterns/patterns' );
+		$request['_fields'] = 'name,content,template_types';
+		$response           = rest_get_server()->dispatch( $request );
+		$data               = $response->get_data();
+
+		$this->assertCount( count( $expected_names ), $data );
+		foreach ( $data as $idx => $item ) {
+			$this->assertEquals( $expected_names[ $idx ], $item['name'] );
+			$this->assertEquals( $expected_fields, array_keys( $item ) );
+		}
 	}
 	public function test_context_param() {
 		$this->markTestIncomplete();


### PR DESCRIPTION
This PR adds a new templateType property to the patterns registration API.
This property allows a pattern to specify which template it makes sense on e.g.: 404, single-post, single-product, category.

This is required by https://github.com/WordPress/gutenberg/issues/42325 in order to when creating a template show all the relevant patterns that exist for it.
It may also allow users on the pattern directory to explore patterns by the template where they are supposed to be used.

## Testing
I pasted the following sample pattern on lib/compat/wordpress-6.2/block-patterns.php.
```
register_block_pattern(
	'query/template-type-test',
	array(
		'title'      => __( 'Template type test', 'gutenberg' ),
		'templateTypes' => array( '404' ),
		'content'    => '<!-- wp:paragraph {"align":"center","fontSize":"x-large"} -->
						<p class="has-text-align-center has-x-large-font-size">404</p>
						<!-- /wp:paragraph -->',
	)
);
```
I opened the post editor and the developer tools and pasted `wp.apiFetch( { path: '/wp/v2/block-patterns/patterns' } ).then( console.log );`on the browser console.
I verified that the API response for included query/template-type-test include 404 in the templateTypes.