### PR TITLE
Add basic edit button UI to Nav block offcanvas editor

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/block-edit-button.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-edit-button.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import { edit } from '@wordpress/icons';
+import { Button } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
+const BlockEditButton = ( { label, clientId } ) => {
+	const { selectBlock } = useDispatch( blockEditorStore );
+
+	const onClick = () => {
+		selectBlock( clientId );
+	};
+
+	return <Button icon={ edit } label={ label } onClick={ onClick } />;
+};
+
+export default BlockEditButton;

--- a/packages/block-editor/src/components/off-canvas-editor/block.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block.js
@@ -33,6 +33,7 @@ import {
 } from '../block-mover/button';
 import ListViewBlockContents from './block-contents';
 import BlockSettingsDropdown from '../block-settings-menu/block-settings-dropdown';
+import BlockEditButton from './block-edit-button';
 import { useListViewContext } from './context';
 import { getBlockPositionDescription } from './utils';
 import { store as blockEditorStore } from '../../store';
@@ -132,6 +133,14 @@ function ListViewBlock( {
 		  )
 		: __( 'Options' );
 
+	const editAriaLabel = blockInformation
+		? sprintf(
+				// translators: %s: The title of the block.
+				__( 'Edit %s block' ),
+				blockInformation.title
+		  )
+		: __( 'Edit' );
+
 	const { isTreeGridMounted, expand, collapse } = useListViewContext();
 
 	const hasSiblings = siblingBlockCount > 0;
@@ -142,6 +151,11 @@ function ListViewBlock( {
 	);
 
 	const listViewBlockSettingsClassName = classnames(
+		'block-editor-list-view-block__menu-cell',
+		{ 'is-visible': isHovered || isFirstSelectedBlock }
+	);
+
+	const listViewBlockEditClassName = classnames(
 		'block-editor-list-view-block__menu-cell',
 		{ 'is-visible': isHovered || isFirstSelectedBlock }
 	);
@@ -307,26 +321,44 @@ function ListViewBlock( {
 			) }
 
 			{ showBlockActions && (
-				<TreeGridCell
-					className={ listViewBlockSettingsClassName }
-					aria-selected={ !! isSelected || forceSelectionContentLock }
-				>
-					{ ( { ref, tabIndex, onFocus } ) => (
-						<BlockSettingsDropdown
-							clientIds={ dropdownClientIds }
-							icon={ moreVertical }
-							label={ settingsAriaLabel }
-							toggleProps={ {
-								ref,
-								className: 'block-editor-list-view-block__menu',
-								tabIndex,
-								onFocus,
-							} }
-							disableOpenOnArrowDown
-							__experimentalSelectBlock={ updateSelection }
-						/>
-					) }
-				</TreeGridCell>
+				<>
+					<TreeGridCell
+						className={ listViewBlockEditClassName }
+						aria-selected={
+							!! isSelected || forceSelectionContentLock
+						}
+					>
+						{ () => (
+							<BlockEditButton
+								label={ editAriaLabel }
+								clientId={ clientId }
+							/>
+						) }
+					</TreeGridCell>
+					<TreeGridCell
+						className={ listViewBlockSettingsClassName }
+						aria-selected={
+							!! isSelected || forceSelectionContentLock
+						}
+					>
+						{ ( { ref, tabIndex, onFocus } ) => (
+							<BlockSettingsDropdown
+								clientIds={ dropdownClientIds }
+								icon={ moreVertical }
+								label={ settingsAriaLabel }
+								toggleProps={ {
+									ref,
+									className:
+										'block-editor-list-view-block__menu',
+									tabIndex,
+									onFocus,
+								} }
+								disableOpenOnArrowDown
+								__experimentalSelectBlock={ updateSelection }
+							/>
+						) }
+					</TreeGridCell>
+				</>
 			) }
 		</ListViewLeaf>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds an "Edit" icon button to the off canvas editor list view for each block node which when clicked selects the given block.

This is a **stepping stone** on the path towards [the "drill down" panels system](https://github.com/WordPress/gutenberg/issues/45439) (see also [the mockup](https://github.com/WordPress/gutenberg/issues/42257#issuecomment-1284797475).

Please don't worry - this is not the final product 😄 

Built on foundation laid down in https://github.com/WordPress/gutenberg/pull/45575.

Co-authored-by: George Hotelling <george@hotelling.net>

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We need the edit button UI in place for basic interactions.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds add new button component and displays on hover.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Turn on offcanvas experiment
- Add Nav block
- Have some menu items (or the fallback Page List)
- Select the parent Nav block
- Open inspector controls
- In offcanvas editor hover over some menu items
- See "Edit" icon.
- Click on icon. See block is selected.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/444434/202237158-35411b9e-7f4f-42ee-bec6-30c61702dcaf.mp4

