### PR TITLE
Navigation: Add link URL to the navigation submenu inspector controls

### DIFF
--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -570,6 +570,14 @@ export default function NavigationSubmenuEdit( {
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Link settings' ) }>
+					<TextControl
+						value={ url || '' }
+						onChange={ ( urlValue ) => {
+							setAttributes( { url: urlValue } );
+						} }
+						label={ __( 'URL' ) }
+						autoComplete="off"
+					/>
 					<TextareaControl
 						value={ description || '' }
 						onChange={ ( descriptionValue ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This adds a URL field to the Navigation Submenu block.

## Why?
As part of https://github.com/WordPress/gutenberg/issues/41549, we need to add the URL to the inspector controls for this block.

## How?
Just adds the field, following the example of the other fields.

## Testing Instructions
1. Add a navigation block to a post
2. Add a submenu block
3. Add a URL to the submenu block using both the link controls and the inspector controls
4. Confirm that the changes save and are reflected on the frontend

## Screenshots or screencast <!-- if applicable -->
<img width="289" alt="Screenshot 2022-11-16 at 17 07 20" src="https://user-images.githubusercontent.com/275961/202246534-f06cad76-e0aa-44fe-9c54-cffd6ba3cd90.png">

