### PR TITLE
Reusable block: Pluralize the message "Convert to regular blocks" depending on the number of blocks contained.

### DIFF
--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -201,14 +201,14 @@ const BlockActionsMenu = ( {
 			onSelect: () => {
 				const successNotice =
 					innerBlockCount > 1
-						? 'converted to regular blocks'
-						: 'converted to regular block';
+						? /* translators: %s: name of the reusable block */
+						  __( '%s converted to regular blocks' )
+						: /* translators: %s: name of the reusable block */
+						  __( '%s converted to regular block' );
 				createSuccessNotice(
 					sprintf(
-						/* translators: %s: name of the reusable block */
-						__( '%1$s %2$s' ),
-						reusableBlock?.title?.raw || blockTitle,
-						successNotice
+						successNotice,
+						reusableBlock?.title?.raw || blockTitle
 					)
 				);
 				convertToRegularBlocks();

--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -23,7 +23,7 @@ import {
 	isReusableBlock,
 } from '@wordpress/blocks';
 import { __, sprintf } from '@wordpress/i18n';
-import { withDispatch, withSelect } from '@wordpress/data';
+import { withDispatch, withSelect, useSelect } from '@wordpress/data';
 import { withInstanceId, compose } from '@wordpress/compose';
 import { moreHorizontalMobile } from '@wordpress/icons';
 import { useRef, useState } from '@wordpress/element';
@@ -77,6 +77,12 @@ const BlockActionsMenu = ( {
 	const isPasteEnabled =
 		clipboardBlock &&
 		canInsertBlockType( clipboardBlock.name, rootClientId );
+
+	const innerBlockCount = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getBlockCount( selectedBlockClientId ),
+		[ selectedBlockClientId ]
+	);
 
 	const {
 		actionTitle: {
@@ -187,7 +193,10 @@ const BlockActionsMenu = ( {
 		},
 		convertToRegularBlocks: {
 			id: 'convertToRegularBlocksOption',
-			label: __( 'Convert to regular blocks' ),
+			label:
+				innerBlockCount > 1
+					? __( 'Convert to regular blocks' )
+					: __( 'Convert to regular block' ),
 			value: 'convertToRegularBlocksOption',
 			onSelect: () => {
 				createSuccessNotice(

--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -199,11 +199,16 @@ const BlockActionsMenu = ( {
 					: __( 'Convert to regular block' ),
 			value: 'convertToRegularBlocksOption',
 			onSelect: () => {
+				const successNotice =
+					innerBlockCount > 1
+						? 'converted to regular blocks'
+						: 'converted to regular block';
 				createSuccessNotice(
 					sprintf(
 						/* translators: %s: name of the reusable block */
-						__( '%s converted to regular blocks' ),
-						reusableBlock?.title?.raw || blockTitle
+						__( '%1$s %2$s' ),
+						reusableBlock?.title?.raw || blockTitle,
+						successNotice
 					)
 				);
 				convertToRegularBlocks();

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -39,13 +39,15 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 	);
 	const isMissing = hasResolved && ! record;
 
-	const canRemove = useSelect(
-		( select ) => select( blockEditorStore ).canRemoveBlock( clientId ),
-		[ clientId ]
-	);
-
-	const innerBlockCount = useSelect(
-		( select ) => select( blockEditorStore ).getBlockCount( clientId ),
+	const { canRemove, innerBlockCount } = useSelect(
+		( select ) => {
+			const { canRemoveBlock, getBlockCount } =
+				select( blockEditorStore );
+			return {
+				canRemove: canRemoveBlock( clientId ),
+				innerBlockCount: getBlockCount( clientId ),
+			};
+		},
 		[ clientId ]
 	);
 

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -44,6 +44,11 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 		[ clientId ]
 	);
 
+	const innerBlockCount = useSelect(
+		( select ) => select( blockEditorStore ).getBlockCount( clientId ),
+		[ clientId ]
+	);
+
 	const { __experimentalConvertBlockToStatic: convertBlockToStatic } =
 		useDispatch( reusableBlocksStore );
 
@@ -109,7 +114,11 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 					<ToolbarGroup>
 						<ToolbarButton
 							onClick={ () => convertBlockToStatic( clientId ) }
-							label={ __( 'Convert to regular blocks' ) }
+							label={
+								innerBlockCount > 1
+									? __( 'Convert to regular blocks' )
+									: __( 'Convert to regular block' )
+							}
 							icon={ ungroup }
 							showTooltip
 						/>

--- a/packages/block-library/src/block/edit.native.js
+++ b/packages/block-library/src/block/edit.native.js
@@ -128,16 +128,11 @@ export default function ReusableBlockEdit( {
 	const onConvertToRegularBlocks = useCallback( () => {
 		const successNotice =
 			innerBlockCount > 1
-				? 'converted to regular blocks'
-				: 'converted to regular block';
-		createSuccessNotice(
-			sprintf(
-				/* translators: %s: name of the reusable block */
-				__( '%1$s %2$s' ),
-				title,
-				successNotice
-			)
-		);
+				? /* translators: %s: name of the reusable block */
+				  __( '%s converted to regular blocks' )
+				: /* translators: %s: name of the reusable block */
+				  __( '%s converted to regular block' );
+		createSuccessNotice( sprintf( successNotice, title ) );
 
 		clearSelectedBlock();
 		// Convert action is executed at the end of the current JavaScript execution block

--- a/packages/block-library/src/block/edit.native.js
+++ b/packages/block-library/src/block/edit.native.js
@@ -126,11 +126,16 @@ export default function ReusableBlockEdit( {
 	}
 
 	const onConvertToRegularBlocks = useCallback( () => {
+		const successNotice =
+			innerBlockCount > 1
+				? 'converted to regular blocks'
+				: 'converted to regular block';
 		createSuccessNotice(
 			sprintf(
 				/* translators: %s: name of the reusable block */
-				__( '%s converted to regular blocks' ),
-				title
+				__( '%1$s %2$s' ),
+				title,
+				successNotice
 			)
 		);
 

--- a/packages/block-library/src/block/edit.native.js
+++ b/packages/block-library/src/block/edit.native.js
@@ -77,7 +77,7 @@ export default function ReusableBlockEdit( {
 		styles.spinnerDark
 	);
 
-	const { hasResolved, isEditing, isMissing } = useSelect(
+	const { hasResolved, isEditing, isMissing, innerBlockCount } = useSelect(
 		( select ) => {
 			const persistedBlock = select( coreStore ).getEntityRecord(
 				'postType',
@@ -88,6 +88,9 @@ export default function ReusableBlockEdit( {
 				'getEntityRecord',
 				[ 'postType', 'wp_block', ref ]
 			);
+
+			const { getBlockCount } = select( blockEditorStore );
+
 			return {
 				hasResolved: hasResolvedBlock,
 				isEditing:
@@ -95,14 +98,10 @@ export default function ReusableBlockEdit( {
 						reusableBlocksStore
 					).__experimentalIsEditingReusableBlock( clientId ),
 				isMissing: hasResolvedBlock && ! persistedBlock,
+				innerBlockCount: getBlockCount( clientId ),
 			};
 		},
 		[ ref, clientId ]
-	);
-
-	const innerBlockCount = useSelect(
-		( select ) => select( blockEditorStore ).getBlockCount( clientId ),
-		[ clientId ]
 	);
 
 	const { createSuccessNotice } = useDispatch( noticesStore );

--- a/packages/block-library/src/block/edit.native.js
+++ b/packages/block-library/src/block/edit.native.js
@@ -100,6 +100,11 @@ export default function ReusableBlockEdit( {
 		[ ref, clientId ]
 	);
 
+	const innerBlockCount = useSelect(
+		( select ) => select( blockEditorStore ).getBlockCount( clientId ),
+		[ clientId ]
+	);
+
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const { __experimentalConvertBlockToStatic: convertBlockToStatic } =
 		useDispatch( reusableBlocksStore );
@@ -162,12 +167,20 @@ export default function ReusableBlockEdit( {
 						{ infoTitle }
 					</Text>
 					<Text style={ [ infoTextStyle, infoDescriptionStyle ] }>
-						{ __(
-							'Alternatively, you can detach and edit these blocks separately by tapping “Convert to regular blocks”.'
-						) }
+						{ innerBlockCount > 1
+							? __(
+									'Alternatively, you can detach and edit these blocks separately by tapping “Convert to regular blocks”.'
+							  )
+							: __(
+									'Alternatively, you can detach and edit this block separately by tapping “Convert to regular block”.'
+							  ) }
 					</Text>
 					<TextControl
-						label={ __( 'Convert to regular blocks' ) }
+						label={
+							innerBlockCount > 1
+								? __( 'Convert to regular blocks' )
+								: __( 'Convert to regular block' )
+						}
 						separatorType="topFullWidth"
 						onPress={ onConvertToRegularBlocks }
 						labelStyle={ actionButtonStyle }

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -108,7 +108,7 @@ describe( 'Reusable blocks', () => {
 		await insertReusableBlock( 'Surprised greeting block' );
 
 		// Convert block to a regular block.
-		await clickBlockToolbarButton( 'Convert to regular blocks' );
+		await clickBlockToolbarButton( 'Convert to regular block' );
 
 		// Check that we have a paragraph block on the page.
 		const paragraphBlock = await page.$(
@@ -343,7 +343,7 @@ describe( 'Reusable blocks', () => {
 
 		// Convert back to regular blocks.
 		await clickBlockToolbarButton( 'Select Reusable block' );
-		await clickBlockToolbarButton( 'Convert to regular blocks' );
+		await clickBlockToolbarButton( 'Convert to regular block' );
 		await page.waitForXPath( selector, {
 			hidden: true,
 		} );

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -39,6 +39,11 @@ function ReusableBlocksManageButton( { clientId } ) {
 		[ clientId ]
 	);
 
+	const innerBlockCount = useSelect(
+		( select ) => select( blockEditorStore ).getBlockCount( clientId ),
+		[ clientId ]
+	);
+
 	const { __experimentalConvertBlockToStatic: convertBlockToStatic } =
 		useDispatch( reusableBlocksStore );
 
@@ -55,7 +60,9 @@ function ReusableBlocksManageButton( { clientId } ) {
 			</MenuItem>
 			{ canRemove && (
 				<MenuItem onClick={ () => convertBlockToStatic( clientId ) }>
-					{ __( 'Convert to regular blocks' ) }
+					{ innerBlockCount > 1
+						? __( 'Convert to regular blocks' )
+						: __( 'Convert to regular block' ) }
 				</MenuItem>
 			) }
 		</BlockSettingsMenuControls>

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -18,9 +18,10 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as reusableBlocksStore } from '../../store';
 
 function ReusableBlocksManageButton( { clientId } ) {
-	const { canRemove, isVisible } = useSelect(
+	const { canRemove, isVisible, innerBlockCount } = useSelect(
 		( select ) => {
-			const { getBlock, canRemoveBlock } = select( blockEditorStore );
+			const { getBlock, canRemoveBlock, getBlockCount } =
+				select( blockEditorStore );
 			const { canUser } = select( coreStore );
 			const reusableBlock = getBlock( clientId );
 
@@ -34,13 +35,9 @@ function ReusableBlocksManageButton( { clientId } ) {
 						'blocks',
 						reusableBlock.attributes.ref
 					),
+				innerBlockCount: getBlockCount( clientId ),
 			};
 		},
-		[ clientId ]
-	);
-
-	const innerBlockCount = useSelect(
-		( select ) => select( blockEditorStore ).getBlockCount( clientId ),
 		[ clientId ]
 	);
 


### PR DESCRIPTION
Reusable block: Pluralize the message "Convert to regular blocks" depending on the number of blocks contained

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
The action "Convert to regular blocks" is in plural form for all cases, including when the reusable block only contains a single block. It would be great if we detect the number of blocks contained and pluralize the message:
- Reusable block only contains a single block: Convert to a regular block
- Reusable block contains multiple blocks: Convert to regular blocks

This PR fixes the issue by properly pluralizing the label where necessary.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It resolves #34749. The action "Convert to regular blocks" should be in singular if the reusable block only contains a single block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Based on @fluiddot advice the block count was determined by checking the inner blocks rendered within a reusable block, and the count was use to determine if to pluralize the label.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Go to the web version of the editor.    
2. Open a post/page.
3. Add any block and click on the options button located in the toolbar (the three dots icon).
4. Click on "Add to Reusable blocks" and set a name for the block.
5. Open the app (native version of the editor).
6. Open a post/page.
7. Tap on the heavy_plus_sign button.
8. Navigate to the Reusable tab.
9. Tap on the recently created reusable block and select the block.
10. Tap on the block settings (three dots button).
11. Observe that the action "Convert to regular blocks" has correct plural form depending on the number of blocks in the reusable block.


## Screenshots or screencast <!-- if applicable -->
