### PR TITLE
Tag Processor: Prevent bugs from pre-PHP8 strspn/strcspn behavior

### DIFF
--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -397,6 +397,10 @@ class WP_HTML_Tag_Processor {
 		$already_found = 0;
 
 		do {
+			if ( $this->parsed_bytes >= strlen( $this->html ) ) {
+				return false;
+			}
+
 			/*
 			 * Unfortunately we can't try to search for only the tag name we want because that might
 			 * lead us to skip over other tags and lose track of our place. So we need to search for
@@ -419,10 +423,15 @@ class WP_HTML_Tag_Processor {
 			if ( 's' === $t || 'S' === $t || 't' === $t || 'T' === $t ) {
 				$tag_name = $this->get_tag();
 
-				if ( 'SCRIPT' === $tag_name ) {
-					$this->skip_script_data();
-				} elseif ( 'TEXTAREA' === $tag_name || 'TITLE' === $tag_name ) {
-					$this->skip_rcdata( $tag_name );
+				if ( 'SCRIPT' === $tag_name && ! $this->skip_script_data() ) {
+					$this->parsed_bytes = strlen( $this->html );
+					return false;
+				} elseif (
+					( 'TEXTAREA' === $tag_name || 'TITLE' === $tag_name ) &&
+					! $this->skip_rcdata( $tag_name )
+				) {
+					$this->parsed_bytes = strlen( $this->html );
+					return false;
 				}
 			}
 		} while ( $already_found < $this->sought_match_offset );
@@ -449,9 +458,9 @@ class WP_HTML_Tag_Processor {
 			$at = strpos( $this->html, '</', $at );
 
 			// If we have no possible tag closer then fail.
-			if ( false === $at || ( $at + $tag_length ) > $doc_length ) {
+			if ( false === $at || ( $at + $tag_length ) >= $doc_length ) {
 				$this->parsed_bytes = $doc_length;
-				return;
+				return false;
 			}
 
 			$at += 2;
@@ -488,10 +497,13 @@ class WP_HTML_Tag_Processor {
 
 			$this->skip_tag_closer_attributes();
 			$at = $this->parsed_bytes;
+			if ( $at >= strlen( $this->html ) ) {
+				return false;
+			}
 
 			if ( '>' === $html[ $at ] || '/' === $html[ $at ] ) {
 				++$this->parsed_bytes;
-				return;
+				return true;
 			}
 		}
 
@@ -586,6 +598,9 @@ class WP_HTML_Tag_Processor {
 			 * We also have to make sure we terminate the script tag opener/closer
 			 * to avoid making partial matches on strings like `<script123`.
 			 */
+			if ( $at + 6 >= $doc_length ) {
+				continue;
+			}
 			$at += 6;
 			$c   = $html[ $at ];
 			if ( ' ' !== $c && "\t" !== $c && "\r" !== $c && "\n" !== $c && '/' !== $c && '>' !== $c ) {
@@ -607,9 +622,13 @@ class WP_HTML_Tag_Processor {
 				$this->parsed_bytes = $at;
 				$this->skip_tag_closer_attributes();
 
+				if ( $this->parsed_bytes >= $doc_length ) {
+					return false;
+				}
+
 				if ( '>' === $html[ $this->parsed_bytes ] ) {
 					++$this->parsed_bytes;
-					return;
+					return true;
 				}
 			}
 
@@ -656,6 +675,13 @@ class WP_HTML_Tag_Processor {
 				$this->tag_name_starts_at = $at;
 				$this->parsed_bytes       = $at + $this->tag_name_length;
 				return true;
+			}
+
+			// If we didn't find a tag opener, and we can't be
+			// transitioning into different markup states, then
+			// we can abort because there aren't any more tags.
+			if ( $at + 1 >= strlen( $html ) ) {
+				return false;
 			}
 
 			// <! transitions to markup declaration open state
@@ -782,6 +808,9 @@ class WP_HTML_Tag_Processor {
 	private function parse_next_attribute( $context = 'tag-opener' ) {
 		// Skip whitespace and slashes.
 		$this->parsed_bytes += strspn( $this->html, " \t\f\r\n/", $this->parsed_bytes );
+		if ( $this->parsed_bytes >= strlen( $this->html ) ) {
+			return false;
+		}
 
 		/*
 		 * Treat the equal sign ("=") as a part of the attribute name if it is the
@@ -793,20 +822,29 @@ class WP_HTML_Tag_Processor {
 			: strcspn( $this->html, "=/> \t\f\r\n", $this->parsed_bytes );
 
 		// No attribute, just tag closer.
-		if ( 0 === $name_length ) {
+		if ( 0 === $name_length || $this->parsed_bytes + $name_length >= strlen( $this->html ) ) {
 			return false;
 		}
 
 		$attribute_start     = $this->parsed_bytes;
 		$attribute_name      = substr( $this->html, $attribute_start, $name_length );
 		$this->parsed_bytes += $name_length;
+		if ( $this->parsed_bytes >= strlen( $this->html ) ) {
+			return false;
+		}
 
 		$this->skip_whitespace();
+		if ( $this->parsed_bytes >= strlen( $this->html ) ) {
+			return false;
+		}
 
 		$has_value = '=' === $this->html[ $this->parsed_bytes ];
 		if ( $has_value ) {
 			++$this->parsed_bytes;
 			$this->skip_whitespace();
+			if ( $this->parsed_bytes >= strlen( $this->html ) ) {
+				return false;
+			}
 
 			switch ( $this->html[ $this->parsed_bytes ] ) {
 				case "'":
@@ -828,6 +866,10 @@ class WP_HTML_Tag_Processor {
 			$value_start   = $this->parsed_bytes;
 			$value_length  = 0;
 			$attribute_end = $attribute_start + $name_length;
+		}
+
+		if ( $attribute_end >= strlen( $this->html ) ) {
+			return false;
 		}
 
 		if ( 'tag-opener' !== $context ) {

--- a/phpunit/html/WP_HTML_Tag_Processor_Test.php
+++ b/phpunit/html/WP_HTML_Tag_Processor_Test.php
@@ -59,7 +59,7 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 	public function test_get_tag_returns_open_tag_name() {
 		$p = new WP_HTML_Tag_Processor( '<div>Test</div>' );
 		$this->assertTrue( $p->next_tag( 'div' ), 'Querying an existing tag did not return true' );
-		$this->assertSame( 'div', $p->get_tag(), 'Accessing an existing tag name did not return "div"' );
+		$this->assertSame( 'DIV', $p->get_tag(), 'Accessing an existing tag name did not return "div"' );
 	}
 
 	/**
@@ -759,7 +759,7 @@ HTML;
 	public function test_unclosed_script_tag_should_not_cause_an_infinite_loop() {
 		$p = new WP_HTML_Tag_Processor( '<script>' );
 		$p->next_tag();
-		$this->assertSame( 'script', $p->get_tag() );
+		$this->assertSame( 'SCRIPT', $p->get_tag() );
 		$p->next_tag();
 	}
 
@@ -773,9 +773,9 @@ HTML;
 	public function test_next_tag_ignores_the_contents_of_a_script_tag( $script_then_div ) {
 		$p = new WP_HTML_Tag_Processor( $script_then_div );
 		$p->next_tag();
-		$this->assertSame( 'script', $p->get_tag(), 'The first found tag was not "script"' );
+		$this->assertSame( 'SCRIPT', $p->get_tag(), 'The first found tag was not "script"' );
 		$p->next_tag();
-		$this->assertSame( 'div', $p->get_tag(), 'The second found tag was not "∂iv"' );
+		$this->assertSame( 'DIV', $p->get_tag(), 'The second found tag was not "∂iv"' );
 	}
 
 	/**
@@ -850,9 +850,9 @@ HTML;
 	public function test_next_tag_ignores_the_contents_of_a_rcdata_tag( $rcdata_then_div, $rcdata_tag ) {
 		$p = new WP_HTML_Tag_Processor( $rcdata_then_div );
 		$p->next_tag();
-		$this->assertSame( $rcdata_tag, $p->get_tag(), "The first found tag was not '$rcdata_tag'" );
+		$this->assertSame( strtoupper( $rcdata_tag ), $p->get_tag(), "The first found tag was not '$rcdata_tag'" );
 		$p->next_tag();
-		$this->assertSame( 'div', $p->get_tag(), "The second found tag was not 'div'" );
+		$this->assertSame( 'DIV', $p->get_tag(), "The second found tag was not 'div'" );
 	}
 
 	/**


### PR DESCRIPTION
## What?

Prevent infinite loop in `WP_HTML_Tag_Processor` when parsing truncated HTML.

## Why?

Follows #45537
Replaces #45803 

When parsing truncated HTML it was brought to our attention that when passing  out-of-bounds indices to `strspn()` and `strcspn()` that the behavior is different before and after PHP8. We also realized that when we cleaned up the problems with `substr()` we left some indices without bounds checking and that led to a different flavor of the same problem.

When parsing the following HTML we run into warnings when calling `strspn()` and `strcspn()`. For pre-PHP8 versions this also leads to an infinite loop while in later versions it simply omits a warning.

```php
<!-- wp:gallery {"linkTo":"none"} -->
<figure class="wp-block-gallery has-nested-images ...
```

In this patch we're adding proper bounds checking wherever we update the internal pointer in the Tag Processor to avoid any further out-of-bounds issues.

While this patch fixes the core issue at stake, it's worth performing a more complete audit of the index usage throughout the class and consider internalizing the string methods to avoid version inconsistencies and provide a more robust mechanism for aborting when passing the end of the provided input document.

Props to @aidvu for quickly identifying this issue.

## How?

Inserts bounds-checking wherever we read unchecked string indices.

## Testing Instructions

You can use the following script to confirm the behavior in trunk and confirm the fix. Place the script in the root directory of your Gutenberg repo.

```php
<?php
require "lib/experimental/html/index.php";

$html = <<<EOF
<!-- wp:gallery {"linkTo":"none"} -->
<figure class="wp-block-gallery has-nested-images ...
EOF;

$p = new WP_HTML_Tag_Processor( $html );
$p->next_tag();
```

In `trunk` on PHP<8 this will create an infinite loop while in the branch it will terminate.
In `trunk` this should issue a `PHP Warning:  Uninitialized string offset 92` warning while in this branch there should be no warning.