### PR TITLE
Add `'GPL-3.0-or-later'` to allowed licenses in `wp-scripts lint-pkg-json`

### DIFF
--- a/packages/npm-package-json-lint-config/index.js
+++ b/packages/npm-package-json-lint-config/index.js
@@ -103,7 +103,10 @@ const defaultConfig = {
 		'require-version': 'error',
 		'scripts-type': 'error',
 		'valid-values-author': 'off',
-		'valid-values-license': [ 'error', [ 'GPL-2.0-or-later' ] ],
+		'valid-values-license': [
+			'error',
+			[ 'GPL-2.0-or-later', 'GPL-3.0-or-later' ],
+		],
 		'valid-values-private': 'off',
 		'version-format': 'error',
 		'version-type': 'error',


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add `'GPL-3.0-or-later'` to allowed licenses in `wp-scripts lint-pkg-json`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
As it is `GPL-2.0-or-later` compliant, and this is a version many WooCommerce extensions use

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Create a project with `	"license": "GPL-3.0-or-later",` in its `package.json`
2. run `wp-scripts lint-pkg-json`

## Screenshots or screencast <!-- if applicable -->
![image](https://user-images.githubusercontent.com/17435/202266183-fbf4460d-74e0-4b33-8ff2-c9494c0704a6.png)

