### PR TITLE
Fix for navigation anchor links to close modal

### DIFF
--- a/packages/block-library/src/navigation/view-modal.js
+++ b/packages/block-library/src/navigation/view-modal.js
@@ -27,7 +27,7 @@ function navigationToggleModal( modal ) {
 	htmlElement.classList.toggle( 'has-modal-open' );
 }
 
-function isLinkToAnchorOnSamePage( node ) {
+function isLinkToAnchorOnCurrentPage( node ) {
 	return (
 		node.hash &&
 		node.protocol === window.location.protocol &&
@@ -52,7 +52,7 @@ window.addEventListener( 'load', () => {
 	navigationLinks.forEach( function ( link ) {
 		// Ignore non-anchor links and anchor links which open on a new tab.
 		if (
-			! isLinkToAnchorOnSamePage( link ) ||
+			! isLinkToAnchorOnCurrentPage( link ) ||
 			link.attributes?.target === '_blank'
 		) {
 			return;

--- a/packages/block-library/src/navigation/view-modal.js
+++ b/packages/block-library/src/navigation/view-modal.js
@@ -27,6 +27,16 @@ function navigationToggleModal( modal ) {
 	htmlElement.classList.toggle( 'has-modal-open' );
 }
 
+function isLinkToAnchorOnSamePage( node ) {
+	return (
+		node.hash &&
+		node.protocol === window.location.protocol &&
+		node.host === window.location.host &&
+		node.pathname === window.location.pathname &&
+		node.search === window.location.search
+	);
+}
+
 window.addEventListener( 'load', () => {
 	MicroModal.init( {
 		onShow: navigationToggleModal,
@@ -42,7 +52,7 @@ window.addEventListener( 'load', () => {
 	navigationLinks.forEach( function ( link ) {
 		// Ignore non-anchor links and anchor links which open on a new tab.
 		if (
-			! link.getAttribute( 'href' )?.startsWith( '#' ) ||
+			! isLinkToAnchorOnSamePage( link ) ||
 			link.attributes?.target === '_blank'
 		) {
 			return;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Allows the navigation block modal to close if you click on an item that is linked to an anchor on the current page.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently links like `/#anchor` or `/some-page/#anchor` do not close the modal. It only closes if the `href` exactly starts with `#`. So if you are on `/some-page/` and you click the `/some-page/#anchor` link, it will scroll down to the anchor, but the modal will remain open.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Modified the link click handler to test if the `href` contains a hash and it matches the current page (protocol, host, pathname, and search).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Insert a Navigation block (in header through Site Editor for example), make sure modal is set to mobile or always.
2. Insert a navigation item to a page such as `/page/#anchor`
3. From other page (not `/page/`), open modal menu, click link. Modal should remain open as browser navigation happens.
4. From new page `/page/`, open modal menu, click link. Modal should close and you remain on page (and browser scrolls to the anchor if you've added an element with the anchor ID).
5. You can test with anchors to other websites, pages, etc to verify that the modal only closes if the exact page and query parameters are met

## Screenshots or screencast <!-- if applicable -->