### PR TITLE
Docs: Add ancestor property to block-registration.md doc

### DIFF
--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -258,6 +258,18 @@ Setting `parent` lets a block require that it is only available when nested with
 parent: [ 'core/columns' ],
 ```
 
+#### ancestor (optional)
+
+-   **Type:** `Array`
+
+The `ancestor` property makes a block available inside the specified block types at any position of the ancestor block subtree. That allows, for example, to place a ‘Comment Content’ block inside a ‘Column’ block, as long as ‘Column’ is somewhere within a ‘Comment Template’ block. In comparrison to the `parent` property blocks that specify their `ancestor` can be placed anywhere in the subtree whilst blocks with a specified `parent` need to be direct children.
+
+
+```js
+// Only allow this block when it is nested in a Columns block
+parent: [ 'core/columns' ],
+```
+
 ## Block Collections
 
 ## `registerBlockCollection`

--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -262,12 +262,12 @@ parent: [ 'core/columns' ],
 
 -   **Type:** `Array`
 
-The `ancestor` property makes a block available inside the specified block types at any position of the ancestor block subtree. That allows, for example, to place a ‘Comment Content’ block inside a ‘Column’ block, as long as ‘Column’ is somewhere within a ‘Comment Template’ block. In comparrison to the `parent` property blocks that specify their `ancestor` can be placed anywhere in the subtree whilst blocks with a specified `parent` need to be direct children.
+The `ancestor` property makes a block available inside the specified block types at any position of the ancestor block subtree. That allows, for example, to place a 'Comment Content' block inside a 'Column' block, as long as 'Column' is somewhere within a 'Comment Template' block. In comparison to the `parent` property blocks that specify their `ancestor` can be placed anywhere in the subtree whilst blocks with a specified `parent` need to be direct children.
 
 
 ```js
-// Only allow this block when it is nested in a Columns block
-parent: [ 'core/columns' ],
+// Only allow this block when it is nested at any level in a Columns block.
+ancestor: [ 'core/columns' ],
 ```
 
 ## Block Collections


### PR DESCRIPTION
In #39894, the `ancestor` property had been added to the schema. In #40027, the docs [docs/how-to-guides/block-tutorial/nested-blocks-inner-blocks.md](https://github.com/WordPress/gutenberg/blob/0921a493c47c499f70eaab7c7c7eb710e19521d1/docs/how-to-guides/block-tutorial/nested-blocks-inner-blocks.md) and [docs/reference-guides/block-api/block-metadata.md](https://github.com/WordPress/gutenberg/blob/0921a493c47c499f70eaab7c7c7eb710e19521d1/docs/reference-guides/block-api/block-metadata.md) have been updated accordingly. Looking at https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/, I noticed that the new property hasn't been added there.

## What?

This PR aims to document the `ancestor` property on https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/.

## Why?

This PR is necessary as the `ancestor` property is missing on this particular doc.

## How?

This PR only contains textual changes within one particular *.md file.

## Testing Instructions

1. Look up the changed *.md file.
2. Verify that the information is accurate.