### PR TITLE
Post Featured Image: Only get the post title when rendering alt text

### DIFF
--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -27,12 +27,11 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 
 	$is_link        = isset( $attributes['isLink'] ) && $attributes['isLink'];
 	$size_slug      = isset( $attributes['sizeSlug'] ) ? $attributes['sizeSlug'] : 'post-thumbnail';
-	$post_title     = trim( strip_tags( get_the_title( $post_ID ) ) );
 	$attr           = get_block_core_post_featured_image_border_attributes( $attributes );
 	$overlay_markup = get_block_core_post_featured_image_overlay_element_markup( $attributes );
 
 	if ( $is_link ) {
-		$attr['alt'] = $post_title;
+		$attr['alt'] = trim( strip_tags( get_the_title( $post_ID ) ) );
 	}
 
 	if ( ! empty( $attributes['height'] ) ) {


### PR DESCRIPTION
## What?
PR updates logic in Featured Image render callback to only call `get_the_title` when the value is used.

## Why?
It's a small code quality improvement.

## Testing Instructions
 1. Open a Post or Page.
2. Insert a Post Featured Image block.
3. Enabled "Link to post" settings.
4. Confirm that the image alt is set to a post title.
