### PR TITLE
Navigation: Move child block inspector controls to a shared file

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -12,10 +12,7 @@ import { createBlock, switchToBlockType } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	Button,
-	PanelBody,
 	Popover,
-	TextControl,
-	TextareaControl,
 	ToolbarButton,
 	Tooltip,
 	ToolbarGroup,
@@ -26,7 +23,6 @@ import { __, sprintf } from '@wordpress/i18n';
 import {
 	BlockControls,
 	BlockIcon,
-	InspectorControls,
 	RichText,
 	__experimentalLinkControl as LinkControl,
 	useBlockProps,
@@ -54,6 +50,7 @@ import { useMergeRefs } from '@wordpress/compose';
  * Internal dependencies
  */
 import { name } from './block.json';
+import NavigationChildInspectorControls from '../navigation/edit/child-inspector-controls';
 
 /**
  * A React hook to determine if it's dragging within the target element.
@@ -714,44 +711,7 @@ export default function NavigationLinkEdit( {
 					) }
 				</ToolbarGroup>
 			</BlockControls>
-			<InspectorControls>
-				<PanelBody title={ __( 'Link settings' ) }>
-					<TextControl
-						value={ url || '' }
-						onChange={ ( urlValue ) => {
-							setAttributes( { url: urlValue } );
-						} }
-						label={ __( 'URL' ) }
-						autoComplete="off"
-					/>
-					<TextareaControl
-						value={ description || '' }
-						onChange={ ( descriptionValue ) => {
-							setAttributes( { description: descriptionValue } );
-						} }
-						label={ __( 'Description' ) }
-						help={ __(
-							'The description will be displayed in the menu if the current theme supports it.'
-						) }
-					/>
-					<TextControl
-						value={ title || '' }
-						onChange={ ( titleValue ) => {
-							setAttributes( { title: titleValue } );
-						} }
-						label={ __( 'Link title' ) }
-						autoComplete="off"
-					/>
-					<TextControl
-						value={ rel || '' }
-						onChange={ ( relValue ) => {
-							setAttributes( { rel: relValue } );
-						} }
-						label={ __( 'Link rel' ) }
-						autoComplete="off"
-					/>
-				</PanelBody>
-			</InspectorControls>
+			<NavigationChildInspectorControls setAttributes={ setAttributes } url={ url } description={ description } title={ title } rel={ rel } />
 			<div { ...blockProps }>
 				{ /* eslint-disable jsx-a11y/anchor-is-valid */ }
 				<a className={ classes }>

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -9,10 +9,7 @@ import escapeHtml from 'escape-html';
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
-	PanelBody,
 	Popover,
-	TextControl,
-	TextareaControl,
 	ToolbarButton,
 	ToolbarGroup,
 } from '@wordpress/components';
@@ -22,7 +19,6 @@ import {
 	BlockControls,
 	InnerBlocks,
 	useInnerBlocksProps,
-	InspectorControls,
 	RichText,
 	__experimentalLinkControl as LinkControl,
 	useBlockProps,
@@ -52,6 +48,7 @@ import { useMergeRefs } from '@wordpress/compose';
  */
 import { ItemSubmenuIcon } from './icons';
 import { name } from './block.json';
+import NavigationChildInspectorControls from '../navigation/edit/child-inspector-controls';
 
 const ALLOWED_BLOCKS = [ 'core/navigation-link', 'core/navigation-submenu' ];
 
@@ -568,46 +565,7 @@ export default function NavigationSubmenuEdit( {
 					/>
 				</ToolbarGroup>
 			</BlockControls>
-			<InspectorControls>
-				<PanelBody title={ __( 'Link settings' ) }>
-					<TextControl
-						value={ url || '' }
-						onChange={ ( urlValue ) => {
-							setAttributes( { url: urlValue } );
-						} }
-						label={ __( 'URL' ) }
-						autoComplete="off"
-					/>
-					<TextareaControl
-						value={ description || '' }
-						onChange={ ( descriptionValue ) => {
-							setAttributes( {
-								description: descriptionValue,
-							} );
-						} }
-						label={ __( 'Description' ) }
-						help={ __(
-							'The description will be displayed in the menu if the current theme supports it.'
-						) }
-					/>
-					<TextControl
-						value={ title || '' }
-						onChange={ ( titleValue ) => {
-							setAttributes( { title: titleValue } );
-						} }
-						label={ __( 'Link title' ) }
-						autoComplete="off"
-					/>
-					<TextControl
-						value={ rel || '' }
-						onChange={ ( relValue ) => {
-							setAttributes( { rel: relValue } );
-						} }
-						label={ __( 'Link rel' ) }
-						autoComplete="off"
-					/>
-				</PanelBody>
-			</InspectorControls>
+			<NavigationChildInspectorControls setAttributes={ setAttributes } url={ url } description={ description } title={ title } rel={ rel } />
 			<div { ...blockProps }>
 				{ /* eslint-disable jsx-a11y/anchor-is-valid */ }
 				<ParentElement className="wp-block-navigation-item__content">

--- a/packages/block-library/src/navigation/edit/child-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/child-inspector-controls.js
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	 PanelBody,
+	 TextControl,
+	 TextareaControl,
+} from '@wordpress/components';
+
+import { __ } from '@wordpress/i18n';
+import {
+	InspectorControls,
+} from '@wordpress/block-editor';
+const NavigationChildInspectorControls = ( { setAttributes, url, description, title, rel } ) => (
+	<InspectorControls>
+		<PanelBody title={ __( 'Link settings' ) }>
+			<TextControl
+				value={ url || '' }
+				onChange={ ( urlValue ) => {
+					setAttributes( { url: urlValue } );
+				} }
+				label={ __( 'URL' ) }
+				autoComplete="off"
+			/>
+			<TextareaControl
+				value={ description || '' }
+				onChange={ ( descriptionValue ) => {
+					setAttributes( { description: descriptionValue } );
+				} }
+				label={ __( 'Description' ) }
+				help={ __(
+					'The description will be displayed in the menu if the current theme supports it.'
+				) }
+			/>
+			<TextControl
+				value={ title || '' }
+				onChange={ ( titleValue ) => {
+					setAttributes( { title: titleValue } );
+				} }
+				label={ __( 'Link title' ) }
+				autoComplete="off"
+			/>
+			<TextControl
+				value={ rel || '' }
+				onChange={ ( relValue ) => {
+					setAttributes( { rel: relValue } );
+				} }
+				label={ __( 'Link rel' ) }
+				autoComplete="off"
+			/>
+		</PanelBody>
+	</InspectorControls>
+);
+
+export default NavigationChildInspectorControls;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This moves the shared code from these two files to one new file

## Why?
I recently edited one of these without updating the other, so this will stop that happening.

## How?
I'm not sure this is a great idea.

## Testing Instructions
Check that the inspector controls for both blocks still open.