### PR TITLE
[Mobile] Update React Native Android E2E runner

### DIFF
--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -20,7 +20,6 @@ jobs:
             matrix:
                 native-test-name: [gutenberg-editor-initial-html]
                 api-level: [29]
-                target: [default]
 
         steps:
             - name: checkout

--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -14,11 +14,13 @@ concurrency:
 
 jobs:
     test:
-        runs-on: macos-latest
+        runs-on: macos-12
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:
                 native-test-name: [gutenberg-editor-initial-html]
+                api-level: [29]
+                target: [default]
 
         steps:
             - name: checkout
@@ -29,7 +31,6 @@ jobs:
               with:
                   distribution: 'temurin'
                   java-version: '11'
-                  cache: 'gradle'
 
             - name: Use desired version of NodeJS
               uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
@@ -39,17 +40,39 @@ jobs:
 
             - run: npm ci
 
-            - name: Restore Gradle cache
-              uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
-              with:
-                  path: ~/.gradle/caches
-                  key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+            - name: Gradle cache
+              uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef # v2.3.3
 
-            - uses: reactivecircus/android-emulator-runner@50986b1464923454c95e261820bc626f38490ec0 # v2.27.0
+            - name: AVD cache
+              uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
+              id: avd-cache
               with:
-                  api-level: 28
-                  emulator-build: 7425822 # https://github.com/ReactiveCircus/android-emulator-runner/issues/160#issuecomment-868615730
-                  profile: pixel_xl
+                  path: |
+                      ~/.android/avd/*
+                      ~/.android/adb*
+                  key: avd-${{ matrix.api-level }}
+
+            - name: Create AVD and generate snapshot for caching
+              if: steps.avd-cache.outputs.cache-hit != 'true'
+              uses: reactivecircus/android-emulator-runner@50986b1464923454c95e261820bc626f38490ec0 # v2.27.0
+              with:
+                  api-level: ${{ matrix.api-level }}
+                  force-avd-creation: false
+                  emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+                  disable-animations: false
+                  arch: x86_64
+                  profile: Nexus 6
+                  script: echo "Generated AVD snapshot for caching."
+
+            - name: Run tests
+              uses: reactivecircus/android-emulator-runner@50986b1464923454c95e261820bc626f38490ec0 # v2.27.0
+              with:
+                  api-level: ${{ matrix.api-level }}
+                  force-avd-creation: false
+                  emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+                  disable-animations: true
+                  arch: x86_64
+                  profile: Nexus 6
                   script: npm run native test:e2e:android:local ${{ matrix.native-test-name }}
 
             - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1


### PR DESCRIPTION
## What?
This PR updates the React Native Android E2E GitHub's action, to use a newer simulator and AVD caching. It should be more stable as it no longer users an older pinned emulator version.

## Why?
There have been a lot of failures for this E2E test, some references:

- https://github.com/WordPress/gutenberg/actions/runs/3486073924/jobs/5832185302
- https://github.com/WordPress/gutenberg/actions/runs/3485539638/jobs/5831170088
- https://github.com/WordPress/gutenberg/actions/runs/3485539638/jobs/5831267245

Most of them are related to the simulator not booting.

## How?
Updates the usage of the latest simulator builds since before we were using a [pinned](https://github.com/WordPress/gutenberg/pull/45840/files#diff-c7f13afad96aa6c2fabf3cd40a4296e9acbc3a5fcf5619d4a290a04b9596b0e5L51) version.

It also adds setting up AVD snapshot caching as instructed by the action's [recommendations](https://github.com/ReactiveCircus/android-emulator-runner#usage--examples) to speed up booting the simulator, since we are no longer using a pinned one.

Removes the `Restore Gradle cache` step in favor of the `Gradle Cache` step which uses `gradle-build-action`.

Updates `macos-latest` to `macos-12` since there was a notice saying it will change automatically in December:

```
macOS-latest pipelines will use macOS-12 soon. For more details, see https://github.com/actions/runner-images/issues/6384
```

## Testing Instructions

Make sure the `React Native E2E Tests (Android) / test (gutenberg-editor-initial-html, 29, default)` check passes and maybe try to re-run it and make sure it passes.

## Screenshots or screencast <!-- if applicable -->
N/A