### PR TITLE
[Inserter]: Replace text in `Reusable` tab with an icon

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -127,6 +127,9 @@ $block-inserter-tabs-height: 44px;
 			margin-bottom: -$border-width;
 			&[id$="reusable"] {
 				flex-grow: inherit;
+				// These are to align the `reusable` icon with the search icon.
+				margin-right: 16px;
+				width: 63px;
 			}
 		}
 	}

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -128,8 +128,8 @@ $block-inserter-tabs-height: 44px;
 			&[id$="reusable"] {
 				flex-grow: inherit;
 				// These are to align the `reusable` icon with the search icon.
-				margin-right: $grid-unit-20;
-				width: $grid-unit-80;
+				padding-left: $grid-unit-20;
+				padding-right: $grid-unit-40 + $grid-unit-05;
 			}
 		}
 	}

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -128,8 +128,8 @@ $block-inserter-tabs-height: 44px;
 			&[id$="reusable"] {
 				flex-grow: inherit;
 				// These are to align the `reusable` icon with the search icon.
-				margin-right: 16px;
-				width: 63px;
+				margin-right: $grid-unit-20;
+				width: $grid-unit-80;
 			}
 		}
 	}

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -125,6 +125,9 @@ $block-inserter-tabs-height: 44px;
 		.components-tab-panel__tabs-item {
 			flex-grow: 1;
 			margin-bottom: -$border-width;
+			&[id$="reusable"] {
+				flex-grow: inherit;
+			}
 		}
 	}
 

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -129,7 +129,7 @@ $block-inserter-tabs-height: 44px;
 				flex-grow: inherit;
 				// These are to align the `reusable` icon with the search icon.
 				padding-left: $grid-unit-20;
-				padding-right: $grid-unit-40 + $grid-unit-05;
+				padding-right: $grid-unit-20;
 			}
 		}
 	}

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -6,11 +6,6 @@ import { useMemo } from '@wordpress/element';
 import { TabPanel } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-/**
- * Internal dependencies
- */
-import BlockIcon from '../block-icon';
-
 const blocksTab = {
 	name: 'blocks',
 	/* translators: Blocks tab title in the block inserter. */
@@ -23,7 +18,9 @@ const patternsTab = {
 };
 const reusableBlocksTab = {
 	name: 'reusable',
-	title: <BlockIcon icon={ reusableBlockIcon } />,
+	/* translators: Reusable blocks tab title in the block inserter. */
+	title: __( 'Reusable' ),
+	icon: reusableBlockIcon,
 };
 
 function InserterTabs( {

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -1,9 +1,15 @@
 /**
  * WordPress dependencies
  */
+import { symbol as reusableBlockIcon } from '@wordpress/icons';
 import { useMemo } from '@wordpress/element';
 import { TabPanel } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import BlockIcon from '../block-icon';
 
 const blocksTab = {
 	name: 'blocks',
@@ -17,8 +23,7 @@ const patternsTab = {
 };
 const reusableBlocksTab = {
 	name: 'reusable',
-	/* translators: Reusable blocks tab title in the block inserter. */
-	title: __( 'Reusable' ),
+	title: <BlockIcon icon={ reusableBlockIcon } />,
 };
 
 function InserterTabs( {

--- a/packages/components/src/search-control/style.scss
+++ b/packages/components/src/search-control/style.scss
@@ -10,6 +10,10 @@
 		width: 100%;
 		height: $grid-unit-60;
 
+		// Unset inherited values.
+		margin-left: 0;
+		margin-right: 0;
+
 		/* Fonts smaller than 16px causes mobile safari to zoom. */
 		font-size: $mobile-text-min-font-size;
 		@include break-small {

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -142,12 +142,12 @@ export async function searchForReusableBlock( searchTerm ) {
 	// fetched. They aren't fetched until an inserter is used or the post
 	// already contains reusable blocks, so wait for the tab to appear.
 	await page.waitForXPath(
-		'//div[contains(@class, "block-editor-inserter__tabs")]//button[text()="Reusable"]'
+		'//div[contains(@class, "block-editor-inserter__tabs")]//button[@aria-label="Reusable"]'
 	);
 
 	// Select the reusable blocks tab.
 	const tab = await page.waitForXPath(
-		'//div[contains(@class, "block-editor-inserter__tabs")]//button[text()="Reusable"]'
+		'//div[contains(@class, "block-editor-inserter__tabs")]//button[@aria-label="Reusable"]'
 	);
 	await tab.click();
 	await page.waitForSelector( INSERTER_SEARCH_SELECTOR );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Alternative of https://github.com/WordPress/gutenberg/pull/45847

If we go forward with this one, it will need some design input for the change of the width in the `reusable` tabpanel button, if needed.


## Screenshots or screencast <!-- if applicable -->
<img width="396" alt="Screenshot 2022-11-18 at 12 13 27 PM" src="https://user-images.githubusercontent.com/16275880/202678703-fb7b390c-fe8a-4477-928b-693fa8fcba89.png">

