### PR TITLE
Nav offcanvas editor: add simple back button to inspector controls

### DIFF
--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -2,13 +2,22 @@
  * WordPress dependencies
  */
 import deprecated from '@wordpress/deprecated';
-
+import { Button } from '@wordpress/components';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { __, isRTL } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
 import BlockIcon from '../block-icon';
 
-function BlockCard( { title, icon, description, blockType } ) {
+function BlockCard( {
+	title,
+	icon,
+	description,
+	blockType,
+	parentBlockClientId,
+	handleBackButton,
+} ) {
 	if ( blockType ) {
 		deprecated( '`blockType` property in `BlockCard component`', {
 			since: '5.7',
@@ -16,8 +25,22 @@ function BlockCard( { title, icon, description, blockType } ) {
 		} );
 		( { title, icon, description } = blockType );
 	}
+
 	return (
 		<div className="block-editor-block-card">
+			{ parentBlockClientId && (
+				<Button
+					onClick={ handleBackButton }
+					label={ __( 'Navigate to the previous view' ) }
+					style={
+						// TODO: This style override is also used in ToolsPanelHeader.
+						// It should be supported out-of-the-box by Button.
+						{ minWidth: 24, padding: 0 }
+					}
+					icon={ isRTL() ? chevronRight : chevronLeft }
+					isSmall
+				/>
+			) }
 			<BlockIcon icon={ icon } showColors />
 			<div className="block-editor-block-card__content">
 				<h2 className="block-editor-block-card__title">{ title }</h2>

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -34,7 +34,7 @@ function BlockCard( {
 			{ isOffCanvasNavigationEditorEnabled && parentBlockClientId && (
 				<Button
 					onClick={ handleBackButton }
-					label={ __( 'Navigate to the previous view' ) }
+					label={ __( 'Navigate to parent block' ) }
 					style={
 						// TODO: This style override is also used in ToolsPanelHeader.
 						// It should be supported out-of-the-box by Button.

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -26,9 +26,12 @@ function BlockCard( {
 		( { title, icon, description } = blockType );
 	}
 
+	const isOffCanvasNavigationEditorEnabled =
+		window?.__experimentalEnableOffCanvasNavigationEditor === true;
+
 	return (
 		<div className="block-editor-block-card">
-			{ parentBlockClientId && (
+			{ isOffCanvasNavigationEditorEnabled && parentBlockClientId && (
 				<Button
 					onClick={ handleBackButton }
 					label={ __( 'Navigate to the previous view' ) }

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -136,6 +136,7 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 		selectedBlockClientId,
 		blockType,
 		topLevelLockedBlock,
+		parentBlockClientId,
 	} = useSelect( ( select ) => {
 		const {
 			getSelectedBlockClientId,
@@ -143,6 +144,7 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			getBlockName,
 			__unstableGetContentLockingParent,
 			getTemplateLock,
+			getBlockParents,
 		} = select( blockEditorStore );
 
 		const _selectedBlockClientId = getSelectedBlockClientId();
@@ -161,6 +163,10 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 				( getTemplateLock( _selectedBlockClientId ) === 'contentOnly'
 					? _selectedBlockClientId
 					: undefined ),
+			parentBlockClientId: getBlockParents(
+				_selectedBlockClientId,
+				true
+			)[ 0 ],
 		};
 	}, [] );
 
@@ -230,11 +236,16 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 		<BlockInspectorSingleBlock
 			clientId={ selectedBlockClientId }
 			blockName={ blockType.name }
+			parentBlockClientId={ parentBlockClientId }
 		/>
 	);
 };
 
-const BlockInspectorSingleBlock = ( { clientId, blockName } ) => {
+const BlockInspectorSingleBlock = ( {
+	clientId,
+	blockName,
+	parentBlockClientId,
+} ) => {
 	const showTabs = window?.__experimentalEnableBlockInspectorTabs;
 
 	const hasBlockStyles = useSelect(
@@ -247,9 +258,17 @@ const BlockInspectorSingleBlock = ( { clientId, blockName } ) => {
 	);
 	const blockInformation = useBlockDisplayInformation( clientId );
 
+	const { selectBlock } = useDispatch( blockEditorStore );
+
 	return (
 		<div className="block-editor-block-inspector">
-			<BlockCard { ...blockInformation } />
+			<BlockCard
+				{ ...blockInformation }
+				parentBlockClientId={ parentBlockClientId }
+				handleBackButton={ () => {
+					selectBlock( parentBlockClientId );
+				} }
+			/>
 			<BlockVariationTransforms blockClientId={ clientId } />
 			{ showTabs && (
 				<InspectorControlsTabs


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds a simple "Back" icon to the inspector controls of _all_ blocks when the Offcanvas Experiment is on which when clicked selects the _parent_ block.

Partially addresses https://github.com/WordPress/gutenberg/issues/45439

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When you click "edit" on a menu item in the offcanvas editor it will show the inspector controls panel for that block. However it's often the case that you will then wish to return to the Navigation block you were editing.

The back button makes that easier.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This is a simplified and intentionally naive implementation. The back button simply checks if there is a parent block of the currently selected block and when clicked it will select the parent block.

This gives the effect of showing the inspector controls for the parent.

In the future we might want to 

- utilise the `<Navigator>` component (and friends) to achieve animation between panels
- ensure the "position" in the parent inspector controls is retained in order that it's simple to move back and forth between menu editing and individual menu _item_ editing.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- _Don't_ enable experiment.
- Go to Site Editor
- Click on various blocks (nested and non-nested)
- Check that the back button does _not_ show up.
- Now enable the off canvas experiment.
- Repeat the above but this time check that the back button does show up for blocks which are nested (only).
- When clicking on back button check that it selects the parent of the current block.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/444434/202456122-3677f7f3-b8f5-49f6-9930-1b548fb21323.mp4

