### PR TITLE
List View - Stop child item selecting a parent which is already selected

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -189,6 +189,11 @@ export function BlockSettingsDropdown( {
 		},
 	} );
 
+	// This can occur when the selected block (the parent)
+	// displays child blocks within a List View.
+	const parentBlockIsSelected =
+		selectedBlockClientIds?.includes( firstParentClientId );
+
 	return (
 		<BlockActions
 			clientIds={ clientIds }
@@ -221,26 +226,33 @@ export function BlockSettingsDropdown( {
 								<__unstableBlockSettingsMenuFirstItem.Slot
 									fillProps={ { onClose } }
 								/>
-								{ !! firstParentClientId && (
-									<MenuItem
-										{ ...showParentOutlineGestures }
-										ref={ selectParentButtonRef }
-										icon={
-											<BlockIcon
-												icon={ parentBlockType.icon }
-											/>
-										}
-										onClick={ () =>
-											selectBlock( firstParentClientId )
-										}
-									>
-										{ sprintf(
-											/* translators: %s: Name of the block's parent. */
-											__( 'Select parent block (%s)' ),
-											parentBlockType.title
-										) }
-									</MenuItem>
-								) }
+								{ ! parentBlockIsSelected &&
+									!! firstParentClientId && (
+										<MenuItem
+											{ ...showParentOutlineGestures }
+											ref={ selectParentButtonRef }
+											icon={
+												<BlockIcon
+													icon={
+														parentBlockType.icon
+													}
+												/>
+											}
+											onClick={ () =>
+												selectBlock(
+													firstParentClientId
+												)
+											}
+										>
+											{ sprintf(
+												/* translators: %s: Name of the block's parent. */
+												__(
+													'Select parent block (%s)'
+												),
+												parentBlockType.title
+											) }
+										</MenuItem>
+									) }
 								{ count === 1 && (
 									<BlockHTMLConvertButton
 										clientId={ firstBlockClientId }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes a bug observed in the Offcanvas Navigation Editor to stop allowing list view child items' settings menu providing an option to select a parent block if that parent is _already_ selected. 

This was manifesting as the popover disappearing when attempting to mouseover the option. See screenshots.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Rendering a List View within a block is a new pattern. This has exposed the above bug whereby the menu says `Select parent block` but the parent block is _already_ selected. That's not something we wish to expose.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This checks whether the currently selected block matches the parent block ID and if it does then it doesn't show the Select Parent option.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Enable offcanvas experiment
- Site Editor
- Click Nav block
- Go to offcanvas sidebar
- Select 3 dots menu on any menu item in sidebar
- See that no "select parent" is available.
- Check you can mouse over and select all the items

Also check that the "Select parent" feature still works for the main list view for normal blocks.

## Screenshots or screencast <!-- if applicable -->

#### Before

https://user-images.githubusercontent.com/444434/202495245-a99c2043-b9a7-4e50-a955-57157f1908a8.mp4



#### After
<img width="506" alt="Screen Shot 2022-11-17 at 15 56 06" src="https://user-images.githubusercontent.com/444434/202494857-bf3b3b52-b4ae-4b90-8cfe-d43ec50a733b.png">
