### PR TITLE
Add a starting page for page list block's hierarchy

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -429,7 +429,7 @@ Display a list of all pages. ([Source](https://github.com/WordPress/gutenberg/tr
 -	**Name:** core/page-list
 -	**Category:** widgets
 -	**Supports:** ~~html~~, ~~reusable~~
--	**Attributes:** 
+-	**Attributes:** rootPageID
 
 ## Paragraph
 

--- a/packages/block-library/src/page-list/block.json
+++ b/packages/block-library/src/page-list/block.json
@@ -7,7 +7,12 @@
 	"description": "Display a list of all pages.",
 	"keywords": [ "menu", "navigation" ],
 	"textdomain": "default",
-	"attributes": {},
+	"attributes": {
+		"rootPageID": {
+			"type": "integer",
+			"default": 0
+		}
+	},
 	"usesContext": [
 		"textColor",
 		"customTextColor",

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -40,7 +40,7 @@ export default function PageListEdit( {
 	attributes,
 	setAttributes,
 } ) {
-	const { rootPageID } = attributes;
+	const { parentPageID } = attributes;
 	const { pagesByParentId, totalPages, hasResolvedPages } = usePageData();
 
 	const isNavigationChild = 'showSubmenuIcon' in context;
@@ -99,7 +99,7 @@ export default function PageListEdit( {
 				<ul { ...blockProps }>
 					<PageItems
 						context={ context }
-						parentId={ rootPageID }
+						parentId={ parentPageID }
 						pagesByParentId={ pagesByParentId }
 					/>
 				</ul>
@@ -107,7 +107,7 @@ export default function PageListEdit( {
 		}
 	};
 
-	const useRootOptions = () => {
+	const useParentOptions = () => {
 		const [ pages ] = useGetPages();
 		return pages?.reduce( ( accumulator, page ) => {
 			accumulator.push( {
@@ -124,14 +124,14 @@ export default function PageListEdit( {
 				<PanelBody>
 					<ComboboxControl
 						className="editor-page-attributes__parent"
-						label={ __( 'Root page' ) }
-						value={ rootPageID }
-						options={ useRootOptions() }
+						label={ __( 'Parent page' ) }
+						value={ parentPageID }
+						options={ useParentOptions() }
 						onChange={ ( value ) =>
-							setAttributes( { rootPageID: value ?? 0 } )
+							setAttributes( { parentPageID: value ?? 0 } )
 						}
 						help={ __(
-							'Setting a page here will restrict the block to show only the children of that'
+							'Choose a page to show only its subpages.'
 						) }
 					/>
 				</PanelBody>

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -7,11 +7,17 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import {
+	InspectorControls,
 	BlockControls,
 	useBlockProps,
 	getColorClassName,
 } from '@wordpress/block-editor';
-import { ToolbarButton, Spinner, Notice } from '@wordpress/components';
+import {
+	PanelBody,
+	ToolbarButton,
+	Spinner,
+	Notice,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState, memo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
@@ -27,7 +33,8 @@ import { ItemSubmenuIcon } from '../navigation-link/icons';
 // Performance of Navigation Links is not good past this value.
 const MAX_PAGE_COUNT = 100;
 
-export default function PageListEdit( { context, clientId } ) {
+export default function PageListEdit( { context, clientId, attributes } ) {
+	const { rootPageID } = attributes;
 	const { pagesByParentId, totalPages, hasResolvedPages } = usePageData();
 
 	const isNavigationChild = 'showSubmenuIcon' in context;
@@ -86,6 +93,7 @@ export default function PageListEdit( { context, clientId } ) {
 				<ul { ...blockProps }>
 					<PageItems
 						context={ context }
+						parentId={ rootPageID }
 						pagesByParentId={ pagesByParentId }
 					/>
 				</ul>
@@ -95,6 +103,9 @@ export default function PageListEdit( { context, clientId } ) {
 
 	return (
 		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Root page' ) }></PanelBody>
+			</InspectorControls>
 			{ allowConvertToLinks && (
 				<BlockControls group="other">
 					<ToolbarButton title={ __( 'Edit' ) } onClick={ openModal }>
@@ -129,7 +140,7 @@ function useFrontPageId() {
 	}, [] );
 }
 
-function usePageData() {
+function usePageData( pageId = 0 ) {
 	const { records: pages, hasResolved: hasResolvedPages } = useEntityRecords(
 		'postType',
 		'page',
@@ -146,6 +157,11 @@ function usePageData() {
 		// TODO: Once the REST API supports passing multiple values to
 		// 'orderby', this can be removed.
 		// https://core.trac.wordpress.org/ticket/39037
+
+		if ( pageId !== 0 ) {
+			return pages.find( ( page ) => page.id === pageId );
+		}
+
 		const sortedPages = [ ...( pages ?? [] ) ].sort( ( a, b ) => {
 			if ( a.menu_order === b.menu_order ) {
 				return a.title.rendered.localeCompare( b.title.rendered );
@@ -167,7 +183,7 @@ function usePageData() {
 			hasResolvedPages,
 			totalPages: pages?.length ?? null,
 		};
-	}, [ pages, hasResolvedPages ] );
+	}, [ pageId, pages, hasResolvedPages ] );
 }
 
 const PageItems = memo( function PageItems( {
@@ -176,7 +192,10 @@ const PageItems = memo( function PageItems( {
 	parentId = 0,
 	depth = 0,
 } ) {
-	const pages = pagesByParentId.get( parentId );
+	const parentPage = usePageData( parentId );
+	const pages = pagesByParentId.get( parentId )
+		? pagesByParentId.get( parentId )
+		: [ parentPage ];
 	const frontPageId = useFrontPageId();
 
 	if ( ! pages?.length ) {

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -252,6 +252,8 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	static $block_id = 0;
 	++$block_id;
 
+	$rootPageID = $attributes['rootPageID'];
+
 	$all_pages = get_pages(
 		array(
 			'sort_column' => 'menu_order,post_title',
@@ -305,6 +307,13 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	$css_classes     = trim( implode( ' ', $classes ) );
 
 	$nested_pages = block_core_page_list_nest_pages( $top_level_pages, $pages_with_children );
+
+	if( $rootPageID !== 0 ) {
+		$nested_pages = block_core_page_list_nest_pages(
+			$pages_with_children[ $rootPageID ],
+			$pages_with_children
+		);
+	}
 
 	$is_navigation_child = array_key_exists( 'showSubmenuIcon', $block->context );
 

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -252,7 +252,7 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	static $block_id = 0;
 	++$block_id;
 
-	$parentPageID = $attributes['parentPageID'];
+	$parent_page_id = $attributes['parentPageID'];
 
 	$all_pages = get_pages(
 		array(
@@ -308,9 +308,9 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 
 	$nested_pages = block_core_page_list_nest_pages( $top_level_pages, $pages_with_children );
 
-	if( $parentPageID !== 0 ) {
+	if( $parent_page_id !== 0 ) {
 		$nested_pages = block_core_page_list_nest_pages(
-			$pages_with_children[ $parentPageID ],
+			$pages_with_children[ $parent_page_id ],
 			$pages_with_children
 		);
 	}

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -252,7 +252,7 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	static $block_id = 0;
 	++$block_id;
 
-	$rootPageID = $attributes['rootPageID'];
+	$parentPageID = $attributes['parentPageID'];
 
 	$all_pages = get_pages(
 		array(
@@ -308,9 +308,9 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 
 	$nested_pages = block_core_page_list_nest_pages( $top_level_pages, $pages_with_children );
 
-	if( $rootPageID !== 0 ) {
+	if( $parentPageID !== 0 ) {
 		$nested_pages = block_core_page_list_nest_pages(
-			$pages_with_children[ $rootPageID ],
+			$pages_with_children[ $parentPageID ],
 			$pages_with_children
 		);
 	}

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -308,7 +308,7 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 
 	$nested_pages = block_core_page_list_nest_pages( $top_level_pages, $pages_with_children );
 
-	if( $parent_page_id !== 0 ) {
+	if ( 0 !== $parent_page_id ) {
 		$nested_pages = block_core_page_list_nest_pages(
 			$pages_with_children[ $parent_page_id ],
 			$pages_with_children

--- a/test/integration/fixtures/blocks/core__page-list.json
+++ b/test/integration/fixtures/blocks/core__page-list.json
@@ -2,7 +2,9 @@
 	{
 		"name": "core/page-list",
 		"isValid": true,
-		"attributes": {},
+		"attributes": {
+			"rootPageID": 0
+		},
 		"innerBlocks": []
 	}
 ]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR adds the ability to the Page List block to only render a subset of the page hierarchy.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

1. Sometimes a user may need to display only a subset of a page hierarchy
2. To be able to have only parts of a navigation block track only parts of the site's page hierarchy

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Set up a `rootPageID` attribute for the Page List block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Check out this PR
3. Make sure to have pages with parents setup
4. In a new post add a page list block
5. Select the page list block
6. Click on Settings (cog) in the top right corner
7. In the input called Root page search for a page with children
8. Select it
9. Notice the page list only shows its children 

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/107534/202670872-3b9970b7-c893-4dcb-935c-25bf86324c94.mp4


## To do

- [ ] Regenerate fixtures for new attribute
- [ ] Edit copy