### PR TITLE
Block Editor: Wait for popover positioning in `MediaReplaceFlow` tests

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -39,10 +39,7 @@ function TestWrapper() {
  * @return {HTMLElement|null} Popover element, or `null` if not found.
  */
 function getWrappingPopoverElement( element ) {
-	if ( element.classList.contains( 'components-popover' ) ) {
-		return element;
-	}
-	return getWrappingPopoverElement( element.parentElement );
+	return element.closest( '.components-popover' );
 }
 
 describe( 'General media replace flow', () => {

--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -89,7 +89,7 @@ describe( 'General media replace flow', () => {
 
 		await popoverIsPositioned( getWrappingPopoverElement( uploadMenu ) );
 
-		expect( uploadMenu ).toBeVisible();
+		await waitFor( () => expect( uploadMenu ).toBeVisible() );
 	} );
 
 	it( 'displays media URL', async () => {

--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -69,9 +69,6 @@ describe( 'General media replace flow', () => {
 		);
 		const uploadMenu = screen.getByRole( 'menu' );
 
-		expect( uploadMenu ).toBeInTheDocument();
-		expect( uploadMenu ).not.toBeVisible();
-
 		// The popover will be positioned with a slight delay.
 		await waitFor( () =>
 			expect( getWrappingPopoverElement( uploadMenu ) ).toHaveStyle( {
@@ -79,6 +76,8 @@ describe( 'General media replace flow', () => {
 				left: '0',
 			} )
 		);
+
+		expect( uploadMenu ).toBeVisible();
 	} );
 
 	it( 'displays media URL', async () => {

--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -79,8 +79,6 @@ describe( 'General media replace flow', () => {
 				left: '0',
 			} )
 		);
-
-		expect( uploadMenu ).toBeVisible();
 	} );
 
 	it( 'displays media URL', async () => {

--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -103,15 +103,13 @@ describe( 'General media replace flow', () => {
 			} )
 		);
 
-		await popoverIsPositioned(
-			getWrappingPopoverElement( screen.getByRole( 'menu' ) )
-		);
+		const link = screen.getByRole( 'link', {
+			name: 'example.media (opens in a new tab)',
+		} );
 
-		expect(
-			screen.getByRole( 'link', {
-				name: 'example.media (opens in a new tab)',
-			} )
-		).toHaveAttribute( 'href', 'https://example.media' );
+		await popoverIsPositioned( getWrappingPopoverElement( link ) );
+
+		expect( link ).toHaveAttribute( 'href', 'https://example.media' );
 	} );
 
 	it( 'edits media URL', async () => {
@@ -129,7 +127,11 @@ describe( 'General media replace flow', () => {
 		);
 
 		await popoverIsPositioned(
-			getWrappingPopoverElement( screen.getByRole( 'menu' ) )
+			getWrappingPopoverElement(
+				screen.getByRole( 'link', {
+					name: 'example.media (opens in a new tab)',
+				} )
+			)
 		);
 
 		await user.click(

--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -42,6 +42,21 @@ function getWrappingPopoverElement( element ) {
 	return element.closest( '.components-popover' );
 }
 
+/**
+ * Asserts that the specified popover has already been positioned.
+ * Necessary because it will be positioned a bit later after it's displayed.
+ *
+ * @async
+ *
+ * @param {HTMLElement} popover Popover element.
+ */
+async function popoverIsPositioned( popover ) {
+	/* eslint-disable jest-dom/prefer-to-have-style */
+	await waitFor( () => expect( popover.style.top ).not.toBe( '' ) );
+	await waitFor( () => expect( popover.style.left ).not.toBe( '' ) );
+	/* eslint-enable jest-dom/prefer-to-have-style */
+}
+
 describe( 'General media replace flow', () => {
 	it( 'renders successfully', () => {
 		render( <TestWrapper /> );
@@ -69,13 +84,7 @@ describe( 'General media replace flow', () => {
 		);
 		const uploadMenu = screen.getByRole( 'menu' );
 
-		// The popover will be positioned with a slight delay.
-		await waitFor( () =>
-			expect( getWrappingPopoverElement( uploadMenu ) ).toHaveStyle( {
-				top: '13px',
-				left: '0',
-			} )
-		);
+		await popoverIsPositioned( getWrappingPopoverElement( uploadMenu ) );
 
 		expect( uploadMenu ).toBeVisible();
 	} );
@@ -94,11 +103,8 @@ describe( 'General media replace flow', () => {
 			} )
 		);
 
-		// The popover will be positioned with a slight delay.
-		await waitFor( () =>
-			expect(
-				getWrappingPopoverElement( screen.getByRole( 'menu' ) )
-			).toHaveStyle( { top: '13px', left: '0' } )
+		await popoverIsPositioned(
+			getWrappingPopoverElement( screen.getByRole( 'menu' ) )
 		);
 
 		expect(
@@ -122,11 +128,8 @@ describe( 'General media replace flow', () => {
 			} )
 		);
 
-		// The popover will be positioned with a slight delay.
-		await waitFor( () =>
-			expect(
-				getWrappingPopoverElement( screen.getByRole( 'menu' ) )
-			).toHaveStyle( { top: '13px', left: '0' } )
+		await popoverIsPositioned(
+			getWrappingPopoverElement( screen.getByRole( 'menu' ) )
 		);
 
 		await user.click(

--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -46,6 +46,9 @@ function getWrappingPopoverElement( element ) {
  * Asserts that the specified popover has already been positioned.
  * Necessary because it will be positioned a bit later after it's displayed.
  *
+ * We're intentionally not using `.toHaveStyle()` because we want to be
+ * less specific and avoid specific values for better test flexibility.
+ *
  * @async
  *
  * @param {HTMLElement} popover Popover element.

--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -32,6 +32,19 @@ function TestWrapper() {
 	);
 }
 
+/**
+ * Returns the first found popover element up the DOM tree.
+ *
+ * @param {HTMLElement} element Element to start with.
+ * @return {HTMLElement|null} Popover element, or `null` if not found.`
+ */
+function getWrappingPopoverElement( element ) {
+	if ( element.classList.contains( 'components-popover' ) ) {
+		return element;
+	}
+	return getWrappingPopoverElement( element.parentElement );
+}
+
 describe( 'General media replace flow', () => {
 	it( 'renders successfully', () => {
 		render( <TestWrapper /> );
@@ -57,11 +70,23 @@ describe( 'General media replace flow', () => {
 				name: 'Replace',
 			} )
 		);
-
 		const uploadMenu = screen.getByRole( 'menu' );
 
 		expect( uploadMenu ).toBeInTheDocument();
 		expect( uploadMenu ).not.toBeVisible();
+
+		/**
+		 * The popover will be displayed and positioned with a slight delay,
+		 * so we're opting to wait until that happens.
+		 */
+		await waitFor( () =>
+			expect( getWrappingPopoverElement( uploadMenu ) ).toHaveStyle( {
+				top: '13px',
+				left: '0',
+			} )
+		);
+
+		expect( uploadMenu ).toBeVisible();
 	} );
 
 	it( 'displays media URL', async () => {
@@ -76,6 +101,16 @@ describe( 'General media replace flow', () => {
 				expanded: false,
 				name: 'Replace',
 			} )
+		);
+
+		/**
+		 * The popover will be displayed and positioned with a slight delay,
+		 * so we're opting to wait until that happens.
+		 */
+		await waitFor( () =>
+			expect(
+				getWrappingPopoverElement( screen.getByRole( 'menu' ) )
+			).toHaveStyle( { top: '13px', left: '0' } )
 		);
 
 		expect(
@@ -97,6 +132,16 @@ describe( 'General media replace flow', () => {
 				expanded: false,
 				name: 'Replace',
 			} )
+		);
+
+		/**
+		 * The popover will be displayed and positioned with a slight delay,
+		 * so we're opting to wait until that happens.
+		 */
+		await waitFor( () =>
+			expect(
+				getWrappingPopoverElement( screen.getByRole( 'menu' ) )
+			).toHaveStyle( { top: '13px', left: '0' } )
 		);
 
 		await user.click(

--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -36,7 +36,7 @@ function TestWrapper() {
  * Returns the first found popover element up the DOM tree.
  *
  * @param {HTMLElement} element Element to start with.
- * @return {HTMLElement|null} Popover element, or `null` if not found.`
+ * @return {HTMLElement|null} Popover element, or `null` if not found.
  */
 function getWrappingPopoverElement( element ) {
 	if ( element.classList.contains( 'components-popover' ) ) {

--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -72,10 +72,7 @@ describe( 'General media replace flow', () => {
 		expect( uploadMenu ).toBeInTheDocument();
 		expect( uploadMenu ).not.toBeVisible();
 
-		/**
-		 * The popover will be displayed and positioned with a slight delay,
-		 * so we're opting to wait until that happens.
-		 */
+		// The popover will be positioned with a slight delay.
 		await waitFor( () =>
 			expect( getWrappingPopoverElement( uploadMenu ) ).toHaveStyle( {
 				top: '13px',
@@ -100,10 +97,7 @@ describe( 'General media replace flow', () => {
 			} )
 		);
 
-		/**
-		 * The popover will be displayed and positioned with a slight delay,
-		 * so we're opting to wait until that happens.
-		 */
+		// The popover will be positioned with a slight delay.
 		await waitFor( () =>
 			expect(
 				getWrappingPopoverElement( screen.getByRole( 'menu' ) )
@@ -131,10 +125,7 @@ describe( 'General media replace flow', () => {
 			} )
 		);
 
-		/**
-		 * The popover will be displayed and positioned with a slight delay,
-		 * so we're opting to wait until that happens.
-		 */
+		// The popover will be positioned with a slight delay.
 		await waitFor( () =>
 			expect(
 				getWrappingPopoverElement( screen.getByRole( 'menu' ) )


### PR DESCRIPTION
## What?
This PR updates the `MediaReplaceFlow` tests to wait for popover positioning before using the popover contents.

An alternative solution to #45736. Closes #45736.

## Why?
Those tests are failing in React 18, see #45235. With waiting for positioning to be finished, they'll pass in both React 17 and React 18.

## How?
We're simply `await`-ing for the popover to be positioned, in other words, to have `top` and `left` specified. We're introducing a small inline helper to help locate the first popover up the DOM tree. 

In https://github.com/WordPress/gutenberg/pull/45736#discussion_r1025077124 @jsnajdr suggested that we use the `.toBePositioned()` Jest custom matcher, but I found that to be a bit of an overkill, considering that we can just go with a simple `toHaveStyle()` assertion instead. So I opted for simplicity.

## Testing Instructions
* Verify tests still pass:  `npm run test:unit packages/block-editor/src/components/media-replace-flow/test/index.js`
* Cherry-pick into #45235 and verify that tests pass.