### PR TITLE
Update: Show default template name on template picker list.

### DIFF
--- a/lib/compat/wordpress-6.2/additional-filters.php
+++ b/lib/compat/wordpress-6.2/additional-filters.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Filters used by Gutenberg to extend core functionality.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Filters the title of the default page template displayed in the drop-down on the post editor
+ *
+ * @param string $label   The display value for the default page template title.
+ * @param string $context Where the option label is displayed.
+ * @return string The new display value for the default page template title.
+ */
+function gutenberg_add_template_to_default_template_title( $label, $context = '' ) {
+	global $post_type, $post;
+	if (
+		__( 'Default template', 'gutenberg' ) !== $label ||
+		empty( $post ) || empty( $post_type ) ||
+		! current_theme_supports( 'block-templates' ) ||
+		'meta-box' === $context
+	) {
+		return $label;
+	}
+
+	$block_template = '';
+	if ( 'page' === $post_type ) {
+		$templates = array();
+		if ( ! empty( $post->post_name ) ) {
+			$templates[] = "page-{$post->post_name}";
+		}
+		if ( ! empty( $post->ID ) ) {
+			$templates[] = "page-{$post->ID}";
+		}
+		$templates[] = 'page';
+
+		$block_template = resolve_block_template( 'page', $templates, '' );
+	} else {
+		$templates = array();
+		if ( ! empty( $post->post_name ) ) {
+			$templates[] = "single-{$post_type}-{$post->post_name}";
+		}
+		$templates[] = "single-{$post_type}";
+		$templates[] = 'single';
+
+		$block_template = resolve_block_template( 'single', $templates, '' );
+	}
+	if ( empty( $block_template ) ) {
+		$block_template = resolve_block_template( 'singular', array(), '' );
+	}
+
+	if ( ! empty( $block_template ) ) {
+		$title = $block_template->title;
+		if ( empty( $title ) ) {
+			$title = $block_template->slug;
+		}
+		if ( ! empty( $title ) ) {
+			return sprintf(
+				// translators: %s is the template name e.g.: Single, Page, etc.
+				__( '%s (default)', 'gutenberg' ),
+				$title
+			);
+		}
+	}
+	return $label;
+}
+add_filter( 'default_page_template_title', 'gutenberg_add_template_to_default_template_title' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -101,6 +101,7 @@ require __DIR__ . '/compat/wordpress-6.1/template-parts-screen.php';
 require __DIR__ . '/compat/wordpress-6.1/theme.php';
 
 // WordPress 6.2 compat.
+require __DIR__ . '/compat/wordpress-6.2/additional-filters.php';
 require __DIR__ . '/compat/wordpress-6.2/script-loader.php';
 require __DIR__ . '/compat/wordpress-6.2/get-global-styles-and-settings.php';
 require __DIR__ . '/compat/wordpress-6.2/default-filters.php';


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/41449

This PR updates the default template label to say what the default template name is. This makes the user aware of what the default template is.
## What?
The implementation was a little complex as we needed to compute the default template for the post if it had no template assigned to it. I followed the logic in get_single_template, get_page_template, and get_singular_template.

## Screenshots or screencast <!-- if applicable -->
![image](https://user-images.githubusercontent.com/11271197/202545670-8c3134e2-68c1-4f55-bcc8-041263f3dcb9.png)
![image](https://user-images.githubusercontent.com/11271197/202546227-2f464874-1038-4314-b1aa-d77236b98412.png)
