### PR TITLE
[Query Loop Block ] Only show the Filters panel when there are allowed controls that need to be displayed

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -110,6 +110,21 @@ export default function QueryInspectorControls( {
 		showColumnsControl ||
 		showOrderControl ||
 		showStickyControl;
+	const showTaxControl =
+		!! taxonomies?.length &&
+		isControlAllowed( allowedControls, 'taxQuery' );
+	const showAuthorControl = isControlAllowed( allowedControls, 'author' );
+	const showSearchControl = isControlAllowed( allowedControls, 'search' );
+	const showParentControl =
+		isControlAllowed( allowedControls, 'parents' ) &&
+		isPostTypeHierarchical;
+
+	const showFiltersPanel =
+		showTaxControl ||
+		showAuthorControl ||
+		showSearchControl ||
+		showParentControl;
+
 	return (
 		<>
 			{ showSettingsPanel && (
@@ -179,98 +194,80 @@ export default function QueryInspectorControls( {
 					</PanelBody>
 				</InspectorControls>
 			) }
-			{ ! inherit &&
-				( isControlAllowed( allowedControls, 'taxQuery' ) ||
-					isControlAllowed( allowedControls, 'author' ) ||
-					isControlAllowed( allowedControls, 'search' ) ||
-					isControlAllowed( allowedControls, 'parents' ) ) && (
-					<InspectorControls>
-						<ToolsPanel
-							className="block-library-query-toolspanel__filters"
-							label={ __( 'Filters' ) }
-							resetAll={ () => {
-								setQuery( {
-									author: '',
-									parents: [],
-									search: '',
-									taxQuery: null,
-								} );
-								setQuerySearch( '' );
-							} }
-						>
-							{ !! taxonomies?.length &&
-								isControlAllowed(
-									allowedControls,
-									'taxQuery'
-								) && (
-									<ToolsPanelItem
-										label={ __( 'Taxonomies' ) }
-										hasValue={ () =>
-											Object.values(
-												taxQuery || {}
-											).some(
-												( terms ) => !! terms.length
-											)
-										}
-										onDeselect={ () =>
-											setQuery( { taxQuery: null } )
-										}
-									>
-										<TaxonomyControls
-											onChange={ setQuery }
-											query={ query }
-										/>
-									</ToolsPanelItem>
-								) }
-							{ isControlAllowed( allowedControls, 'author' ) && (
-								<ToolsPanelItem
-									hasValue={ () => !! authorIds }
-									label={ __( 'Authors' ) }
-									onDeselect={ () =>
-										setQuery( { author: '' } )
-									}
-								>
-									<AuthorControl
-										value={ authorIds }
-										onChange={ setQuery }
-									/>
-								</ToolsPanelItem>
-							) }
-							{ isControlAllowed( allowedControls, 'search' ) && (
-								<ToolsPanelItem
-									hasValue={ () => !! querySearch }
+			{ ! inherit && showFiltersPanel && (
+				<InspectorControls>
+					<ToolsPanel
+						className="block-library-query-toolspanel__filters"
+						label={ __( 'Filters' ) }
+						resetAll={ () => {
+							setQuery( {
+								author: '',
+								parents: [],
+								search: '',
+								taxQuery: null,
+							} );
+							setQuerySearch( '' );
+						} }
+					>
+						{ showTaxControl && (
+							<ToolsPanelItem
+								label={ __( 'Taxonomies' ) }
+								hasValue={ () =>
+									Object.values( taxQuery || {} ).some(
+										( terms ) => !! terms.length
+									)
+								}
+								onDeselect={ () =>
+									setQuery( { taxQuery: null } )
+								}
+							>
+								<TaxonomyControls
+									onChange={ setQuery }
+									query={ query }
+								/>
+							</ToolsPanelItem>
+						) }
+						{ showAuthorControl && (
+							<ToolsPanelItem
+								hasValue={ () => !! authorIds }
+								label={ __( 'Authors' ) }
+								onDeselect={ () => setQuery( { author: '' } ) }
+							>
+								<AuthorControl
+									value={ authorIds }
+									onChange={ setQuery }
+								/>
+							</ToolsPanelItem>
+						) }
+						{ showSearchControl && (
+							<ToolsPanelItem
+								hasValue={ () => !! querySearch }
+								label={ __( 'Keyword' ) }
+								onDeselect={ () => setQuerySearch( '' ) }
+							>
+								<TextControl
 									label={ __( 'Keyword' ) }
-									onDeselect={ () => setQuerySearch( '' ) }
-								>
-									<TextControl
-										label={ __( 'Keyword' ) }
-										value={ querySearch }
-										onChange={ setQuerySearch }
-									/>
-								</ToolsPanelItem>
-							) }
-							{ isPostTypeHierarchical &&
-								isControlAllowed(
-									allowedControls,
-									'parents'
-								) && (
-									<ToolsPanelItem
-										hasValue={ () => !! parents?.length }
-										label={ __( 'Parents' ) }
-										onDeselect={ () =>
-											setQuery( { parents: [] } )
-										}
-									>
-										<ParentControl
-											parents={ parents }
-											postType={ postType }
-											onChange={ setQuery }
-										/>
-									</ToolsPanelItem>
-								) }
-						</ToolsPanel>
-					</InspectorControls>
-				) }
+									value={ querySearch }
+									onChange={ setQuerySearch }
+								/>
+							</ToolsPanelItem>
+						) }
+						{ showParentControl && (
+							<ToolsPanelItem
+								hasValue={ () => !! parents?.length }
+								label={ __( 'Parents' ) }
+								onDeselect={ () => setQuery( { parents: [] } ) }
+							>
+								<ParentControl
+									parents={ parents }
+									postType={ postType }
+									onChange={ setQuery }
+								/>
+							</ToolsPanelItem>
+						) }
+					</ToolsPanel>
+				</InspectorControls>
+			) }
 		</>
 	);
 }

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -179,84 +179,98 @@ export default function QueryInspectorControls( {
 					</PanelBody>
 				</InspectorControls>
 			) }
-			{ ! inherit && (
-				<InspectorControls>
-					<ToolsPanel
-						className="block-library-query-toolspanel__filters"
-						label={ __( 'Filters' ) }
-						resetAll={ () => {
-							setQuery( {
-								author: '',
-								parents: [],
-								search: '',
-								taxQuery: null,
-							} );
-							setQuerySearch( '' );
-						} }
-					>
-						{ !! taxonomies?.length &&
-							isControlAllowed( allowedControls, 'taxQuery' ) && (
+			{ ! inherit &&
+				( isControlAllowed( allowedControls, 'taxQuery' ) ||
+					isControlAllowed( allowedControls, 'author' ) ||
+					isControlAllowed( allowedControls, 'search' ) ||
+					isControlAllowed( allowedControls, 'parents' ) ) && (
+					<InspectorControls>
+						<ToolsPanel
+							className="block-library-query-toolspanel__filters"
+							label={ __( 'Filters' ) }
+							resetAll={ () => {
+								setQuery( {
+									author: '',
+									parents: [],
+									search: '',
+									taxQuery: null,
+								} );
+								setQuerySearch( '' );
+							} }
+						>
+							{ !! taxonomies?.length &&
+								isControlAllowed(
+									allowedControls,
+									'taxQuery'
+								) && (
+									<ToolsPanelItem
+										label={ __( 'Taxonomies' ) }
+										hasValue={ () =>
+											Object.values(
+												taxQuery || {}
+											).some(
+												( terms ) => !! terms.length
+											)
+										}
+										onDeselect={ () =>
+											setQuery( { taxQuery: null } )
+										}
+									>
+										<TaxonomyControls
+											onChange={ setQuery }
+											query={ query }
+										/>
+									</ToolsPanelItem>
+								) }
+							{ isControlAllowed( allowedControls, 'author' ) && (
 								<ToolsPanelItem
-									label={ __( 'Taxonomies' ) }
-									hasValue={ () =>
-										Object.values( taxQuery || {} ).some(
-											( terms ) => !! terms.length
-										)
-									}
+									hasValue={ () => !! authorIds }
+									label={ __( 'Authors' ) }
 									onDeselect={ () =>
-										setQuery( { taxQuery: null } )
+										setQuery( { author: '' } )
 									}
 								>
-									<TaxonomyControls
+									<AuthorControl
+										value={ authorIds }
 										onChange={ setQuery }
-										query={ query }
 									/>
 								</ToolsPanelItem>
 							) }
-						{ isControlAllowed( allowedControls, 'author' ) && (
-							<ToolsPanelItem
-								hasValue={ () => !! authorIds }
-								label={ __( 'Authors' ) }
-								onDeselect={ () => setQuery( { author: '' } ) }
-							>
-								<AuthorControl
-									value={ authorIds }
-									onChange={ setQuery }
-								/>
-							</ToolsPanelItem>
-						) }
-						{ isControlAllowed( allowedControls, 'search' ) && (
-							<ToolsPanelItem
-								hasValue={ () => !! querySearch }
-								label={ __( 'Keyword' ) }
-								onDeselect={ () => setQuerySearch( '' ) }
-							>
-								<TextControl
+							{ isControlAllowed( allowedControls, 'search' ) && (
+								<ToolsPanelItem
+									hasValue={ () => !! querySearch }
 									label={ __( 'Keyword' ) }
-									value={ querySearch }
-									onChange={ setQuerySearch }
-								/>
-							</ToolsPanelItem>
-						) }
-						{ isPostTypeHierarchical &&
-							isControlAllowed( allowedControls, 'parents' ) && (
-								<ToolsPanelItem
-									hasValue={ () => !! parents?.length }
-									label={ __( 'Parents' ) }
-									onDeselect={ () =>
-										setQuery( { parents: [] } )
-									}
+									onDeselect={ () => setQuerySearch( '' ) }
 								>
-									<ParentControl
-										parents={ parents }
-										postType={ postType }
-										onChange={ setQuery }
+									<TextControl
+										label={ __( 'Keyword' ) }
+										value={ querySearch }
+										onChange={ setQuerySearch }
 									/>
 								</ToolsPanelItem>
 							) }
-					</ToolsPanel>
-				</InspectorControls>
-			) }
+							{ isPostTypeHierarchical &&
+								isControlAllowed(
+									allowedControls,
+									'parents'
+								) && (
+									<ToolsPanelItem
+										hasValue={ () => !! parents?.length }
+										label={ __( 'Parents' ) }
+										onDeselect={ () =>
+											setQuery( { parents: [] } )
+										}
+									>
+										<ParentControl
+											parents={ parents }
+											postType={ postType }
+											onChange={ setQuery }
+										/>
+									</ToolsPanelItem>
+								) }
+						</ToolsPanel>
+					</InspectorControls>
+				) }
 		</>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR addresses https://github.com/WordPress/gutenberg/issues/45864 by checking that allowedControls contain at least one of the items that exist under the Filters panel before rendering it.

## Why?
Without this check, it is possible to render an empty Filters panel

## Testing Instructions
See steps to reproduce in https://github.com/WordPress/gutenberg/issues/45864

