### PR TITLE
Add placeholder to Page List block

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -11,7 +11,12 @@ import {
 	useBlockProps,
 	getColorClassName,
 } from '@wordpress/block-editor';
-import { ToolbarButton, Spinner, Notice } from '@wordpress/components';
+import {
+	ToolbarButton,
+	Spinner,
+	Notice,
+	Placeholder,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState, memo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
@@ -72,6 +77,14 @@ export default function PageListEdit( { context, clientId } ) {
 		}
 
 		if ( totalPages === 0 ) {
+			if ( isNavigationChild ) {
+				return (
+					<div { ...blockProps }>
+						<Placeholder withIllustration={ true } />
+					</div>
+				);
+			}
+
 			return (
 				<div { ...blockProps }>
 					<Notice status={ 'info' } isDismissible={ false }>

--- a/packages/block-library/src/page-list/editor.scss
+++ b/packages/block-library/src/page-list/editor.scss
@@ -57,3 +57,8 @@
 .wp-block-page-list .components-notice {
 	margin-left: 0;
 }
+
+.wp-block-page-list .components-placeholder {
+	min-width: 60px;
+	min-height: 48px;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Addresses issue #44486 — if a site has no pages, this PR adds a placeholder to the Page List block whenever it is a child of a Navigation block.

## Why?
This is to improve the user experience for folks whose main intent is to have no pages; it makes the content in the editor more closely match the published site and reduces clutter.

## How?
It adds a placeholder and styling to the Page List block.

## Testing Instructions
- Remove all pages
- Look at a Navigation block whose child is a Page List (if no such blocks exist on your page, create one)
- You should see the placeholder displayed

## Screenshots or screencast <!-- if applicable -->
<img width="1022" alt="Screen Shot 2022-11-17 at 5 19 x53 PM" src="https://user-images.githubusercontent.com/5360536/202572412-f8a106d4-a777-4e3a-a2ad-212b0398f378.png">

## Additional Notes
- The issue this PR is linked to lists having no menus as a requirement to reproduce this; however, the triggering condition is simply having no pages — as long as the Navigation block is not configured with a menu and the Page List is a child, the new placeholder will appear.
- I'm not sure if there are any accessibility considerations with this. Please let me know if so! 