### PR TITLE
Style engine: trim multiple selector strings

### DIFF
--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -113,8 +113,10 @@ class WP_Style_Engine_CSS_Rule {
 		$declarations_indent = $should_prettify ? $indent_count + 1 : 0;
 		$suffix              = $should_prettify ? "\n" : '';
 		$spacer              = $should_prettify ? ' ' : '';
-		$selector            = $should_prettify ? str_replace( ',', ",\n", $this->get_selector() ) : $this->get_selector();
-		$css_declarations    = $this->declarations->get_declarations_string( $should_prettify, $declarations_indent );
+		// Trims any multiple selectors strings.
+		$selector_trimmed = implode( ',', array_map( 'trim', explode( ',', $this->get_selector() ) ) );
+		$selector         = $should_prettify ? str_replace( array( ',' ), ",\n", $selector_trimmed ) : $selector_trimmed;
+		$css_declarations = $this->declarations->get_declarations_string( $should_prettify, $declarations_indent );
 
 		if ( empty( $css_declarations ) ) {
 			return '';

--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -114,8 +114,8 @@ class WP_Style_Engine_CSS_Rule {
 		$suffix              = $should_prettify ? "\n" : '';
 		$spacer              = $should_prettify ? ' ' : '';
 		// Trims any multiple selectors strings.
-		$selector_trimmed = implode( ',', array_map( 'trim', explode( ',', $this->get_selector() ) ) );
-		$selector         = $should_prettify ? str_replace( array( ',' ), ",\n", $selector_trimmed ) : $selector_trimmed;
+		$selector         = $should_prettify ? implode( ',', array_map( 'trim', explode( ',', $this->get_selector() ) ) ) : $this->get_selector();
+		$selector         = $should_prettify ? str_replace( array( ',' ), ",\n", $selector ) : $selector;
 		$css_declarations = $this->declarations->get_declarations_string( $should_prettify, $declarations_indent );
 
 		if ( empty( $css_declarations ) ) {

--- a/phpunit/style-engine/class-wp-style-engine-css-rule-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-rule-test.php
@@ -156,7 +156,7 @@ class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
 		);
 		$css_declarations   = new WP_Style_Engine_CSS_Declarations_Gutenberg( $input_declarations );
 		$css_rule           = new WP_Style_Engine_CSS_Rule_Gutenberg( $selector, $css_declarations );
-		$expected           = '.poirot,.poirot:active,#miss-marple > .st-mary-mead{margin-left:0;font-family:Detective Sans;}';
+		$expected           = '.poirot, .poirot:active, #miss-marple > .st-mary-mead {margin-left:0;font-family:Detective Sans;}';
 
 		$this->assertSame( $expected, $css_rule->get_css(), 'Return value should be not prettified.' );
 

--- a/phpunit/style-engine/class-wp-style-engine-css-rule-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-rule-test.php
@@ -142,4 +142,31 @@ class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
 
 		$this->assertSame( $expected, $css_rule->get_css( true ) );
 	}
+
+	/**
+	 * Tests that a string of multiple selectors is trimmed.
+	 *
+	 * @covers ::get_css
+	 */
+	public function test_should_trim_multiple_selectors() {
+		$selector           = '.poirot, .poirot:active, #miss-marple > .st-mary-mead ';
+		$input_declarations = array(
+			'margin-left' => '0',
+			'font-family' => 'Detective Sans',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations_Gutenberg( $input_declarations );
+		$css_rule           = new WP_Style_Engine_CSS_Rule_Gutenberg( $selector, $css_declarations );
+		$expected           = '.poirot,.poirot:active,#miss-marple > .st-mary-mead{margin-left:0;font-family:Detective Sans;}';
+
+		$this->assertSame( $expected, $css_rule->get_css(), 'Return value should be not prettified.' );
+
+		$expected_prettified = '.poirot,
+.poirot:active,
+#miss-marple > .st-mary-mead {
+	margin-left: 0;
+	font-family: Detective Sans;
+}';
+
+		$this->assertSame( $expected_prettified, $css_rule->get_css( true ), 'Return value should be prettified with new lines and indents.' );
+	}
 }


### PR DESCRIPTION

## What?
This PR trims multiple selector string, that is a string of selectors separated by a comma, passed to the style engine.

Basically removing spaces between selectors in a given string. A "selector" is defined by a comma boundary: `','`.

For example, let's say we pass a selector of `.poirot, .poirot:active, #miss-marple > .st-mary-mead` for a given set of CSS declarations.

**Before**

`.poirot, .poirot:active, #miss-marple > .st-mary-mead{margin-left:0;font-family:Detective Sans;}`

**After**

`.poirot,.poirot:active,#miss-marple > .st-mary-mead{margin-left:0;font-family:Detective Sans;}'`

And, prettified, this:

```css
.poirot,
 .poirot:active,
 #miss-marple > .st-mary-mead {
	margin-left: 0;
	font-family: Detective Sans;
}
```

Becomes this:


```css
.poirot,
.poirot:active,
#miss-marple > .st-mary-mead {
	margin-left: 0;
	font-family: Detective Sans;
}
```



## Why?
This is so we can correctly align prettified content, and remove spaces between multiple selectors with the same styles.


## How?
Exploding, mapping, trimming, imploding.

## Testing Instructions

Run the tests!

`npm run test:unit:php -- --filter WP_Style_Engine_CSS_Rule_Test`


If you're feeling really keen, try adding multiple selectors to a block supports style. Layouts is a good place to test.

Here's a diff:

```diff
diff --git a/lib/block-supports/layout.php b/lib/block-supports/layout.php
index a50e1fb883..2f9a882e2e 100644
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -54,11 +54,11 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support
 					$slug            = _wp_to_kebab_case( substr( $gap_value, $index_to_splice ) );
 					$gap_value       = "var(--wp--preset--spacing--$slug)";
 				}
-
+				$test_id = wp_unique_id( 'pachycephalosaurus-' );
 				array_push(
 					$layout_styles,
 					array(
-						'selector'     => "$selector > *",
+						'selector'     => "$selector > *, .$test_id",
 						'declarations' => array(
 							'margin-block-start' => '0',
 							'margin-block-end'   => '0',
```

For any page with a default layout (e.g., add a simple group block to a page), the styles should be printed out neatly:

```html
<style id='core-block-supports-inline-css'>
.wp-container-16.wp-container-16 > *,
.pachycephalosaurus-17,
.wp-container-19.wp-container-19 > *,
.pachycephalosaurus-20 {
	margin-block-start: 0;
	margin-block-end: 0;
}
</style>
```