### PR TITLE
Min Height: Add height control component with slider

### DIFF
--- a/packages/block-editor/src/components/height-control/index.js
+++ b/packages/block-editor/src/components/height-control/index.js
@@ -25,7 +25,7 @@ const CUSTOM_VALUE_SETTINGS = {
 	vw: { max: 100, steps: 1 },
 	vh: { max: 100, steps: 1 },
 	em: { max: 50, steps: 0.1 },
-	rm: { max: 50, steps: 0.1 },
+	rem: { max: 50, steps: 0.1 },
 };
 
 export default function HeightControl( {

--- a/packages/block-editor/src/components/height-control/index.js
+++ b/packages/block-editor/src/components/height-control/index.js
@@ -1,0 +1,94 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import {
+	BaseControl,
+	RangeControl,
+	Flex,
+	FlexItem,
+	__experimentalSpacer as Spacer,
+	__experimentalUseCustomUnits as useCustomUnits,
+	__experimentalUnitControl as UnitControl,
+	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import useSetting from '../use-setting';
+
+const CUSTOM_VALUE_SETTINGS = {
+	px: { max: 1000, steps: 1 },
+	'%': { max: 100, steps: 1 },
+	vw: { max: 100, steps: 1 },
+	vh: { max: 100, steps: 1 },
+	em: { max: 50, steps: 0.1 },
+	rm: { max: 50, steps: 0.1 },
+};
+
+export default function HeightControl( {
+	onChange,
+	label = __( 'Height' ),
+	value,
+} ) {
+	const customRangeValue = parseFloat( value );
+
+	const units = useCustomUnits( {
+		availableUnits: useSetting( 'spacing.units' ) || [
+			'%',
+			'px',
+			'em',
+			'rem',
+			'vh',
+			'vw',
+		],
+	} );
+
+	const selectedUnit =
+		useMemo(
+			() => parseQuantityAndUnitFromRawValue( value ),
+			[ value ]
+		)[ 1 ] || units[ 0 ].value;
+
+	const handleSliderChange = ( next ) => {
+		onChange( [ next, selectedUnit ].join( '' ) );
+	};
+
+	return (
+		<fieldset className="component-height-control">
+			<BaseControl.VisualLabel as="legend">
+				{ label }
+			</BaseControl.VisualLabel>
+			<Flex>
+				<FlexItem isBlock>
+					<UnitControl
+						value={ value }
+						units={ units }
+						onChange={ onChange }
+						min={ 0 }
+						size={ '__unstable-large' }
+					/>
+				</FlexItem>
+				<FlexItem isBlock>
+					<Spacer marginX={ 2 } marginBottom={ 0 }>
+						<RangeControl
+							value={ customRangeValue }
+							min={ 0 }
+							max={
+								CUSTOM_VALUE_SETTINGS[ selectedUnit ]?.max ?? 10
+							}
+							step={
+								CUSTOM_VALUE_SETTINGS[ selectedUnit ]?.steps ??
+								0.1
+							}
+							withInputField={ false }
+							onChange={ handleSliderChange }
+						/>
+					</Spacer>
+				</FlexItem>
+			</Flex>
+		</fieldset>
+	);
+}

--- a/packages/block-editor/src/components/height-control/index.js
+++ b/packages/block-editor/src/components/height-control/index.js
@@ -83,7 +83,7 @@ export default function HeightControl( {
 	};
 
 	return (
-		<fieldset className="component-height-control">
+		<fieldset className="block-editor-height-control">
 			<BaseControl.VisualLabel as="legend">
 				{ label }
 			</BaseControl.VisualLabel>
@@ -113,6 +113,7 @@ export default function HeightControl( {
 							}
 							withInputField={ false }
 							onChange={ handleSliderChange }
+							__nextHasNoMarginBottom
 						/>
 					</Spacer>
 				</FlexItem>

--- a/packages/block-editor/src/components/height-control/stories/index.js
+++ b/packages/block-editor/src/components/height-control/stories/index.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import HeightControl from '../';
+
+export default {
+	component: HeightControl,
+	title: 'BlockEditor/HeightControl',
+};
+
+const Template = ( props ) => {
+	const [ value, setValue ] = useState();
+	return <HeightControl onChange={ setValue } value={ value } { ...props } />;
+};
+
+export const Default = Template.bind( {} );

--- a/packages/block-editor/src/components/height-control/style.scss
+++ b/packages/block-editor/src/components/height-control/style.scss
@@ -1,0 +1,5 @@
+.block-editor-height-control {
+	border: 0;
+	margin: 0;
+	padding: 0;
+}

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -53,6 +53,7 @@ export { default as __experimentalColorGradientControl } from './colors-gradient
 export { default as __experimentalColorGradientSettingsDropdown } from './colors-gradients/dropdown';
 export { default as __experimentalPanelColorGradientSettings } from './colors-gradients/panel-color-gradient-settings';
 export { default as __experimentalUseMultipleOriginColorsAndGradients } from './colors-gradients/use-multiple-origin-colors-and-gradients';
+export { default as __experimentalHeightControl } from './height-control';
 export {
 	default as __experimentalImageEditor,
 	ImageEditingProvider as __experimentalImageEditingProvider,

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -182,7 +182,6 @@ export function DimensionsPanel( props ) {
 				) }
 				{ ! isMinHeightDisabled && (
 					<ToolsPanelItem
-						className="single-column"
 						hasValue={ () => hasMinHeightValue( props ) }
 						label={ __( 'Min. height' ) }
 						onDeselect={ () => resetMinHeight( props ) }

--- a/packages/block-editor/src/hooks/min-height.js
+++ b/packages/block-editor/src/hooks/min-height.js
@@ -2,16 +2,13 @@
  * WordPress dependencies
  */
 import { getBlockSupport } from '@wordpress/blocks';
-import {
-	__experimentalUseCustomUnits as useCustomUnits,
-	__experimentalUnitControl as UnitControl,
-} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import useSetting from '../components/use-setting';
+import HeightControl from '../components/height-control';
 import { DIMENSIONS_SUPPORT_KEY } from './dimensions';
 import { cleanEmptyObject } from './utils';
 
@@ -81,17 +78,6 @@ export function MinHeightEdit( props ) {
 		setAttributes,
 	} = props;
 
-	const units = useCustomUnits( {
-		availableUnits: useSetting( 'dimensions.units' ) || [
-			'%',
-			'px',
-			'em',
-			'rem',
-			'vh',
-			'vw',
-		],
-	} );
-
 	if ( useIsMinHeightDisabled( props ) ) {
 		return null;
 	}
@@ -109,13 +95,10 @@ export function MinHeightEdit( props ) {
 	};
 
 	return (
-		<UnitControl
+		<HeightControl
 			label={ __( 'Min. height' ) }
 			value={ style?.dimensions?.minHeight }
-			units={ units }
 			onChange={ onChange }
-			min={ 0 }
-			size={ '__unstable-large' }
 		/>
 	);
 }

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -32,6 +32,7 @@
 @import "./components/date-format-picker/style.scss";
 @import "./components/duotone-control/style.scss";
 @import "./components/font-appearance-control/style.scss";
+@import "./components/height-control/style.scss";
 @import "./components/image-size-control/style.scss";
 @import "./components/inner-blocks/style.scss";
 @import "./components/inserter-list-item/style.scss";

--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -18,6 +18,7 @@ import {
 } from '@wordpress/components';
 import {
 	__experimentalUseCustomSides as useCustomSides,
+	__experimentalHeightControl as HeightControl,
 	__experimentalSpacingSizesControl as SpacingSizesControl,
 } from '@wordpress/block-editor';
 import { Icon, positionCenter, stretchWide } from '@wordpress/icons';
@@ -556,19 +557,15 @@ export default function DimensionsPanel( { name } ) {
 			) }
 			{ showMinHeightControl && (
 				<ToolsPanelItem
-					className="single-column"
 					hasValue={ hasMinHeightValue }
 					label={ __( 'Min. height' ) }
 					onDeselect={ resetMinHeightValue }
 					isShownByDefault={ true }
 				>
-					<UnitControl
+					<HeightControl
 						label={ __( 'Min. height' ) }
 						value={ minHeightValue }
 						onChange={ setMinHeightValue }
-						units={ units }
-						min={ 0 }
-						size={ '__unstable-large' }
 					/>
 				</ToolsPanelItem>
 			) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #45501 and a follow-up to #45300

Add a `HeightControl` component to the block editor package, to be used for the Minimum Height control. It pairs a `UnitControl` and a `RangeControl` together, along with some default maximum values for units, which are suitable for the height control. These values are necessarily much higher than those used for the spacing controls like padding and margin, as it's likely that folks will be setting larger values for minimum heights.

Note: higher `step` values are also included for the range control only. This allows pressing left/right arrows with the range control focused to have a more immediate visual effect on the minimum height in use. The higher values are only applied to the range control so that the unit control can still support more granular / precise values.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For consistency with design tools, and to implement the feedback as raised in https://github.com/WordPress/gutenberg/pull/45300#issuecomment-1296975201 — also, a slider control will be easier for folks to interact with to see immediate adjustments to height values.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add a `HeightControl` component that pairs a `UnitControl` with a `RangeControl` component, and that provides default maximum values for the slider. Use this new component at both the individual block level and within global styles, for the minimum height control.
* Add a Storybook example.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Test the using the minimum height control on the Group block works correctly in the post editor
2. Check that using the minimum height control at the block level in global styles works correctly (e.g. select Group or Post Content blocks from within global styles)
3. Try out using different units, and see if the provided min/max values for the range control for those units feels suitable for the minimum height control. Do they feel okay, or should they be adjusted? (e.g. what makes for a good maximum position for `px`, `em`, or `rem` values?)

You can also test out the included storybook example by running `npm run storybook:dev` locally, and then navigating to: http://localhost:50240/?path=/story/blockeditor-heightcontrol--default

## Screenshots or screencast <!-- if applicable -->

<img width="1096" alt="image" src="https://user-images.githubusercontent.com/14988353/202630801-e6680da1-d349-4529-807b-95d1294c9c8d.png">
