### PR TITLE
resolve twenty-twenty three theme search block border issue

### DIFF
--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -69,6 +69,9 @@ function render_block_core_search( $attributes ) {
 		if ( $is_button_inside ) {
 			$input_classes[] = $border_color_classes;
 		}
+		if ( ! $is_button_inside && ! empty( $border_color_classes ) ) {
+			$input_classes[]  = $border_color_classes;
+		}
 		if ( ! empty( $typography_classes ) ) {
 			$input_classes[] = $typography_classes;
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Twenty Twenty-Three: Search block border-color css not applying to input box on front-end.
Trac ticket: https://core.trac.wordpress.org/ticket/57115

<!-- In a few words, what is the PR actually doing? -->
This PR will resolve the mentioned ticket issue.