### PR TITLE
Fix the `upgrader_process_complete` hook for `wp_theme_has_theme_json`

### DIFF
--- a/lib/compat/wordpress-6.2/default-filters.php
+++ b/lib/compat/wordpress-6.2/default-filters.php
@@ -19,4 +19,4 @@
 
 add_action( 'switch_theme', 'wp_theme_has_theme_json_clean_cache' );
 add_action( 'start_previewing_theme', 'wp_theme_has_theme_json_clean_cache' );
-add_action( 'upgrader_process_complete', '_wp_theme_has_theme_json_clean_cache_upon_upgrading_active_theme' );
+add_action( 'upgrader_process_complete', '_wp_theme_has_theme_json_clean_cache_upon_upgrading_active_theme', 10, 2 );


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/45543

## What

This properly sets up the hook `upgrader_process_complete`, given it all the info it needs about.

## Why

Without this, the upgrade process (translations, plugins, themes, core) will report a fatal in the logs (although it will proceed and complete).

## How

Telling the hook the callback will receive two parameters (note the last parameter, it'll be 1 by default):

```php
add_action( 'hook_name', 'callback', 10, 2 );
```

## Test instructions

Verify the bug exists:

- Check out the 14.5.3 branch (it should also happen in `trunk`): `git checkout -b 14.5.3 14.5.3`.
- Go to a site.
- Downgrade any plugin you have to a previous version. I've used `create-block-theme` and the wp-cli: `wp plugin update create-block-theme --version=1.3.7`. See how to use the [wp-cli with the bundled wp-env](https://github.com/WordPress/gutenberg/blob/80dfef805e74b1856f40d61bfb1ddd4fa93292c7/packages/env/README.md#wp-env-run-container-command).
- Go to the plugins admin page and upgrade the plugin.
- The expected result is that it works as expected and no notices are shown. Instead, what happens is that the upgrade is completed, but a notice is shown in the screen. If you inspect the logs you'll see something like:

```log
[18-Nov-2022 09:21:15 UTC] PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function _wp_theme_has_theme_json_clean_cache_upon_upgrading_active_theme(), 1 passed in /home/andre/flywheel-sites/wordpress-nightly/app/public/wp-includes/class-wp-hook.php on line 310 and exactly 2 expected in /home/andre/src/gutenberg/lib/compat/wordpress-6.2/get-global-styles-and-settings.php:67
Stack trace:
#0 /home/andre/flywheel-sites/wordpress-nightly/app/public/wp-includes/class-wp-hook.php(310): _wp_theme_has_theme_json_clean_cache_upon_upgrading_active_theme(Object(Plugin_Upgrader))
#1 /home/andre/flywheel-sites/wordpress-nightly/app/public/wp-includes/class-wp-hook.php(332): WP_Hook->apply_filters('', Array)
#2 /home/andre/flywheel-sites/wordpress-nightly/app/public/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#3 /home/andre/flywheel-sites/wordpress-nightly/app/public/wp-admin/includes/class-plugin-upgrader.php(371): do_action('upgrader_proces...', Object(Plugin_Upgrader), Array)
#4 /home/andre/flywheel-sites/wordpress-nightly/app/public in /home/andre/src/gutenberg/lib/compat/wordpress-6.2/get-global-styles-and-settings.php on line 67
```

Verify this PR fixes it:

- Reproduce the same instructions using this PR.
- Verify that there's no fatal errors reported (in the screen and the log).
