### PR TITLE
Site Editor: Fix template list width

### DIFF
--- a/packages/edit-site/src/components/list/style.scss
+++ b/packages/edit-site/src/components/list/style.scss
@@ -44,8 +44,11 @@
 
 		.interface-interface-skeleton__content {
 			background: $white;
-			align-items: center;
 			padding: $grid-unit-20;
+
+			.interface-navigable-region__stacker {
+				align-items: center;
+			}
 
 			@include break-medium() {
 				padding: $grid-unit * 9;


### PR DESCRIPTION
## What?
This a follow-up to https://github.com/WordPress/gutenberg/pull/45369.

Fixes template list width in the Site Editor.

## Why?
The list table wasn't taking all the available width.

## Testing Instructions
1. Open the Site Editor.
2. Go to the Template Parts list page from the editor navigation.
3. Confirm list table can take available width up to 960px.

## Screenshots or screencast <!-- if applicable -->

**Before**
![CleanShot 2022-11-18 at 15 30 13](https://user-images.githubusercontent.com/240569/202696608-3c5487d4-4232-463c-91b5-9c2dd0340870.png)

**After**
![CleanShot 2022-11-18 at 15 30 42](https://user-images.githubusercontent.com/240569/202696614-a2ecf3bd-a8de-467b-a339-6ad81dcc855a.png)

