### PR TITLE
ToggleGroupControl: remove isBlock override in default Storybook args

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   `TabPanel`: Add ability to set icon only tab buttons ([#45005](https://github.com/WordPress/gutenberg/pull/45005)).
+-   `ToggleGroupControl`: remove `isBlock` override in default Storybook args ([#45890](https://github.com/WordPress/gutenberg/pull/45890)).
 
 ## 22.1.0 (2022-11-16)
 

--- a/packages/components/src/toggle-group-control/stories/index.tsx
+++ b/packages/components/src/toggle-group-control/stories/index.tsx
@@ -81,7 +81,6 @@ Default.args = {
 		{ value: 'right', label: 'Right' },
 		{ value: 'justify', label: 'Justify' },
 	].map( mapPropsToOptionComponent ),
-	isBlock: true,
 	label: 'Label',
 };
 

--- a/packages/components/src/toggle-group-control/toggle-group-control/README.md
+++ b/packages/components/src/toggle-group-control/toggle-group-control/README.md
@@ -20,7 +20,7 @@ import {
 
 function Example() {
 	return (
-		<ToggleGroupControl label="my label" value="vertical" isBlock>
+		<ToggleGroupControl label="my label" value="vertical">
 			<ToggleGroupControlOption value="horizontal" label="Horizontal" />
 			<ToggleGroupControlOption value="vertical" label="Vertical" />
 		</ToggleGroupControl>

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -107,7 +107,7 @@ function UnconnectedToggleGroupControl(
  *
  * function Example() {
  *   return (
- *     <ToggleGroupControl label="my label" value="vertical" isBlock>
+ *     <ToggleGroupControl label="my label" value="vertical">
  *       <ToggleGroupControlOption value="horizontal" label="Horizontal" />
  *       <ToggleGroupControlOption value="vertical" label="Vertical" />
  *     </ToggleGroupControl>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Removes the `isBlock: true` override from Storybook's default args.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To have the Storybook examples more closely match the default look / behaviour of the component (the `isBlock` prop has a default value of `false`)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Removing the `isBlock: true` from Storybook's default args
- Updating the example code snippets to remove `isBlock`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Check `ToggleGroupControl`'s Storybook examples

## Screenshots or screencast <!-- if applicable -->

Before

https://user-images.githubusercontent.com/1083581/202700121-8304fedb-0ad7-4d96-913c-5e9bc8d0609a.mp4

After

https://user-images.githubusercontent.com/1083581/202699955-eeaefd67-a758-492d-b983-216310f02e69.mp4
