### PR TITLE
Element: Fix `no-node-access` in `createInterpolateElement`

### DIFF
--- a/packages/element/src/test/create-interpolate-element.js
+++ b/packages/element/src/test/create-interpolate-element.js
@@ -209,15 +209,13 @@ describe( 'createInterpolateElement', () => {
 		};
 		const { container, rerender } = render( <TestComponent switchKey /> );
 
-		expect( container.firstChild ).toContainHTML( '<em>string!</em>' );
-		expect( container.firstChild ).not.toContainHTML( '<strong>' );
+		expect( container ).toContainHTML( '<em>string!</em>' );
+		expect( container ).not.toContainHTML( '<strong>' );
 
 		rerender( <TestComponent switchKey={ false } /> );
 
-		expect( container.firstChild ).toContainHTML(
-			'<strong>string!</strong>'
-		);
-		expect( container.firstChild ).not.toContainHTML( '<em>' );
+		expect( container ).toContainHTML( '<strong>string!</strong>' );
+		expect( container ).not.toContainHTML( '<em>' );
 	} );
 	it( 'handles parsing emojii correctly', () => {
 		const testString = '👳‍♀️<icon>🚨🤷‍♂️⛈️fully</icon> here';


### PR DESCRIPTION
## What?
With the recent work to improve the quality of tests, we fixed a bunch of ESLint rule violations. This PR fixes a few [`no-node-access`](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-node-access.md) rule violations in the `createInterpolateElement` function. 

## Why?
The end goal is to enable that ESLint rule once all violations have been fixed.

## How?
We're removing a few needless usages of `.firstChild`.

## Testing Instructions
Verify all tests still pass.