### PR TITLE
Prevent edit-post from being loaded in edit-site

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -200,6 +200,26 @@ module.exports = {
 						message:
 							'Please use `@emotion/react` and `@emotion/styled` in order to maintain iframe support. As a replacement for the `cx` function, please use the `useCx` hook defined in `@wordpress/components` instead.',
 					},
+					{
+						name: '@wordpress/edit-post',
+						message:
+							"edit-post is a WordPress top level package that shouldn't be imported into other packages",
+					},
+					{
+						name: '@wordpress/edit-site',
+						message:
+							"edit-site is a WordPress top level package that shouldn't be imported into other packages",
+					},
+					{
+						name: '@wordpress/edit-widgets',
+						message:
+							"edit-widgets is a WordPress top level package that shouldn't be imported into other packages",
+					},
+					{
+						name: '@wordpress/edit-navigation',
+						message:
+							"edit-navigation is a WordPress top level package that shouldn't be imported into other packages",
+					},
 				],
 			},
 		],

--- a/packages/block-directory/src/plugins/installed-blocks-pre-publish-panel/index.js
+++ b/packages/block-directory/src/plugins/installed-blocks-pre-publish-panel/index.js
@@ -13,7 +13,7 @@ import { store as blockDirectoryStore } from '../../store';
 
 // We shouldn't import the edit-post package directly
 // because it would include the wp-edit-post in all pages loading the block-directory script.
-const { PluginPrePublishPanel } = window.wp.editPost;
+const { PluginPrePublishPanel } = window?.wp?.editPost ?? {};
 
 export default function InstalledBlocksPrePublishPanel() {
 	const newBlockTypes = useSelect(

--- a/packages/block-directory/src/plugins/installed-blocks-pre-publish-panel/index.js
+++ b/packages/block-directory/src/plugins/installed-blocks-pre-publish-panel/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { _n, sprintf } from '@wordpress/i18n';
-import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { useSelect } from '@wordpress/data';
 import { blockDefault } from '@wordpress/icons';
 
@@ -11,6 +10,10 @@ import { blockDefault } from '@wordpress/icons';
  */
 import CompactList from '../../components/compact-list';
 import { store as blockDirectoryStore } from '../../store';
+
+// We shouldn't import the edit-post package directly
+// because it would include the wp-edit-post in all pages loading the block-directory script.
+const { PluginPrePublishPanel } = window.wp.editPost;
 
 export default function InstalledBlocksPrePublishPanel() {
 	const newBlockTypes = useSelect(

--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -31,6 +31,7 @@ import {
 	useMobileGlobalStylesColors,
 } from '@wordpress/components';
 import { link } from '@wordpress/icons';
+// eslint-disable-next-line no-restricted-imports
 import { store as editPostStore } from '@wordpress/edit-post';
 
 /**

--- a/packages/block-library/src/cover/edit.native.js
+++ b/packages/block-library/src/cover/edit.native.js
@@ -58,6 +58,7 @@ import {
 } from '@wordpress/element';
 import { cover as icon, replace, image, warning } from '@wordpress/icons';
 import { getProtocol } from '@wordpress/url';
+// eslint-disable-next-line no-restricted-imports
 import { store as editPostStore } from '@wordpress/edit-post';
 
 /**

--- a/packages/block-library/src/embed/embed-controls.native.js
+++ b/packages/block-library/src/embed/embed-controls.native.js
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
 import { PanelBody, ToggleControl } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
 import { useDispatch } from '@wordpress/data';
+// eslint-disable-next-line no-restricted-imports
 import { store as editPostStore } from '@wordpress/edit-post';
 
 function getResponsiveHelp( checked ) {

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -61,8 +61,9 @@ import {
 	textColor,
 } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
-import { store as editPostStore } from '@wordpress/edit-post';
 import { store as noticesStore } from '@wordpress/notices';
+// eslint-disable-next-line no-restricted-imports
+import { store as editPostStore } from '@wordpress/edit-post';
 
 /**
  * Internal dependencies

--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -56,6 +56,7 @@ const postTypeEntities = [
 import { EditorHelpTopics, store as editorStore } from '@wordpress/editor';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
+// eslint-disable-next-line no-restricted-imports
 import { store as editPostStore } from '@wordpress/edit-post';
 
 /**

--- a/packages/eslint-plugin/rules/__tests__/data-no-store-string-literals.js
+++ b/packages/eslint-plugin/rules/__tests__/data-no-store-string-literals.js
@@ -112,11 +112,6 @@ const invalid = [
 		`import { select } from '@wordpress/data'; select( 'core/notices' );`,
 		`import { select } from '@wordpress/data';\nimport { store as noticesStore } from '@wordpress/notices'; select( noticesStore );`
 	),
-	// Replace edit-post with editPostStore.
-	createSuggestionTestCase(
-		`import { select } from '@wordpress/data'; select( 'core/edit-post' );`,
-		`import { select } from '@wordpress/data';\nimport { store as editPostStore } from '@wordpress/edit-post'; select( editPostStore );`
-	),
 ];
 const errors = [
 	{

--- a/packages/react-native-editor/src/setup.js
+++ b/packages/react-native-editor/src/setup.js
@@ -9,8 +9,9 @@ import { I18nManager, LogBox } from 'react-native';
 import { unregisterBlockType, getBlockType } from '@wordpress/blocks';
 import { addAction, addFilter } from '@wordpress/hooks';
 import * as wpData from '@wordpress/data';
-import { initializeEditor } from '@wordpress/edit-post';
 import { registerCoreBlocks } from '@wordpress/block-library';
+// eslint-disable-next-line no-restricted-imports
+import { initializeEditor } from '@wordpress/edit-post';
 
 /**
  * Internal dependencies

--- a/test/native/integration-test-helpers/initialize-editor.js
+++ b/test/native/integration-test-helpers/initialize-editor.js
@@ -7,8 +7,9 @@ import { v4 as uuid } from 'uuid';
 /**
  * WordPress dependencies
  */
-import { initializeEditor as internalInitializeEditor } from '@wordpress/edit-post';
 import { createElement, cloneElement } from '@wordpress/element';
+// eslint-disable-next-line no-restricted-imports
+import { initializeEditor as internalInitializeEditor } from '@wordpress/edit-post';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
## What?

I noticed that when loading the site editor, the edit-post script was also being loaded there. This loads useless kbytes into the site editor and might have some unexpected consequences (like running side effects in the edit-post script).

## How?

The problem was that the block-directory package has a plugin that is specific to edit-post but it was importing the package directly causing a wp dependency to be added to the script. This PR uses the global variable directly and also adds some lint rules to prevent top level packages from being imported in other packages.

Note that there are some remaining imports in "native" files, I preferred to leave these untouched for now, folks from the mobile team might know better what's the best approach there.

## Testing Instructions

1- load the site editor
2- Ensure that the edit-post script is not loaded.
