### PR TITLE
Components: Fix `no-node-access` in `Text` tests

### DIFF
--- a/packages/components/src/text/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/text/test/__snapshots__/index.tsx.snap
@@ -36,6 +36,7 @@ exports[`Text should render highlighted words with highlightCaseSensitive 1`] = 
     class="components-truncate components-text emotion-0 emotion-1"
     data-wp-c16t="true"
     data-wp-component="Text"
+    role="heading"
   >
     <span
       class=""

--- a/packages/components/src/text/test/index.tsx
+++ b/packages/components/src/text/test/index.tsx
@@ -19,133 +19,185 @@ describe( 'Text', () => {
 	} );
 
 	test( 'should render optimizeReadabilityFor', () => {
-		const { container } = render(
-			<Text optimizeReadabilityFor="blue">Lorem ipsum.</Text>
+		render(
+			<Text role="heading" optimizeReadabilityFor="blue">
+				Lorem ipsum.
+			</Text>
 		);
-		expect( container.firstChild ).toHaveStyle( {
+		expect( screen.getByRole( 'heading' ) ).toHaveStyle( {
 			color: COLORS.white,
 		} );
 	} );
 
 	test( 'should render truncate', () => {
-		const { container } = render( <Text truncate>Lorem ipsum.</Text> );
-		expect( container.firstChild ).toHaveStyle( {
+		render(
+			<Text role="heading" truncate>
+				Lorem ipsum.
+			</Text>
+		);
+		expect( screen.getByRole( 'heading' ) ).toHaveStyle( {
 			textOverflow: 'ellipsis',
 		} );
 	} );
 
 	test( 'should render size', () => {
-		const { container } = render( <Text size="title">Lorem ipsum.</Text> );
-		expect( container.firstChild ).toHaveStyle( {
+		render(
+			<Text role="heading" size="title">
+				Lorem ipsum.
+			</Text>
+		);
+		expect( screen.getByRole( 'heading' ) ).toHaveStyle( {
 			fontSize: getFontSize( 'title' ),
 		} );
 	} );
 
 	test( 'should render custom size', () => {
-		const { container } = render( <Text size={ 15 }>Lorem ipsum.</Text> );
-		expect( container.firstChild ).toHaveStyle( {
+		render(
+			<Text role="heading" size={ 15 }>
+				Lorem ipsum.
+			</Text>
+		);
+		expect( screen.getByRole( 'heading' ) ).toHaveStyle( {
 			fontSize: getFontSize( 15 ),
 		} );
 	} );
 
 	test( 'should render variant', () => {
-		const { container } = render(
-			<Text variant="muted">Lorem ipsum.</Text>
+		render(
+			<Text role="heading" variant="muted">
+				Lorem ipsum.
+			</Text>
 		);
-		expect( container.firstChild ).toHaveStyle( {
+		expect( screen.getByRole( 'heading' ) ).toHaveStyle( {
 			color: COLORS.gray[ 700 ],
 		} );
 	} );
 
 	test( 'should render as another element', () => {
-		const { container } = render( <Text as="div">Lorem ipsum.</Text> );
-		expect( container.firstChild?.nodeName ).toBe( 'DIV' );
+		render(
+			<Text role="heading" as="div">
+				Lorem ipsum.
+			</Text>
+		);
+		expect( screen.getByRole( 'heading' )?.nodeName ).toBe( 'DIV' );
 	} );
 
 	test( 'should render align', () => {
-		const { container: centerAlignedContainer } = render(
-			<Text align="center">Lorem ipsum.</Text>
-		);
-		const { container: defaultAlignedContainer } = render(
-			<Text>Lorem ipsum.</Text>
+		render(
+			<>
+				<Text role="heading" align="center">
+					Lorem ipsum.
+				</Text>
+				<Text role="note">Lorem ipsum.</Text>
+			</>
 		);
 
-		expect(
-			defaultAlignedContainer.children[ 0 ]
-		).toMatchStyleDiffSnapshot( centerAlignedContainer.children[ 0 ] );
+		expect( screen.getByRole( 'note' ) ).toMatchStyleDiffSnapshot(
+			screen.getByRole( 'heading' )
+		);
 	} );
 
 	test( 'should render color', () => {
-		const { container } = render(
-			<Text color="orange">Lorem ipsum.</Text>
+		render(
+			<Text role="heading" color="orange">
+				Lorem ipsum.
+			</Text>
 		);
-		expect( container.firstChild ).toHaveStyle( { color: 'orange' } );
+		expect( screen.getByRole( 'heading' ) ).toHaveStyle( {
+			color: 'orange',
+		} );
 	} );
 
 	test( 'should render display', () => {
-		const { container } = render(
-			<Text display="inline-flex">Lorem ipsum.</Text>
+		render(
+			<Text role="heading" display="inline-flex">
+				Lorem ipsum.
+			</Text>
 		);
-		expect( container.firstChild ).toHaveStyle( {
+		expect( screen.getByRole( 'heading' ) ).toHaveStyle( {
 			display: 'inline-flex',
 		} );
 	} );
 
 	test( 'should render highlighted words', async () => {
-		const { container } = render(
-			<Text highlightWords={ [ 'm' ] }>Lorem ipsum.</Text>
+		render(
+			<Text role="heading" highlightWords={ [ 'm' ] }>
+				Lorem ipsum.
+			</Text>
 		);
-		expect( container.firstChild?.childNodes ).toHaveLength( 5 );
+		expect( screen.getByRole( 'heading' )?.childNodes ).toHaveLength( 5 );
 		const words = await screen.findAllByText( 'm' );
 		expect( words ).toHaveLength( 2 );
 		words.forEach( ( word ) => expect( word.tagName ).toEqual( 'MARK' ) );
 	} );
 
 	test( 'should render highlighted words with undefined passed', () => {
-		const { container } = render(
-			<Text highlightWords={ undefined }>Lorem ipsum.</Text>
+		render(
+			<Text role="heading" highlightWords={ undefined }>
+				Lorem ipsum.
+			</Text>
 		);
 		// It'll have a length of 1 because there shouldn't be anything but the single span being rendered.
-		expect( container.firstChild?.childNodes ).toHaveLength( 1 );
+		expect( screen.getByRole( 'heading' )?.childNodes ).toHaveLength( 1 );
 	} );
 
 	test( 'should render highlighted words with highlightCaseSensitive', () => {
 		const { container } = render(
-			<Text highlightCaseSensitive highlightWords={ [ 'IPSUM' ] }>
+			<Text
+				role="heading"
+				highlightCaseSensitive
+				highlightWords={ [ 'IPSUM' ] }
+			>
 				Lorem ipsum.
 			</Text>
 		);
 
 		expect( container ).toMatchSnapshot();
 		// It'll have a length of 1 because there shouldn't be anything but the single span being rendered.
-		expect( container.firstChild?.childNodes ).toHaveLength( 1 );
+		expect( screen.getByRole( 'heading' )?.childNodes ).toHaveLength( 1 );
 	} );
 
 	test( 'should render isBlock', () => {
-		const { container } = render( <Text isBlock>Lorem ipsum.</Text> );
-		expect( container.firstChild ).toHaveStyle( {
+		render(
+			<Text role="heading" isBlock>
+				Lorem ipsum.
+			</Text>
+		);
+		expect( screen.getByRole( 'heading' ) ).toHaveStyle( {
 			display: 'block',
 		} );
 	} );
 
 	test( 'should render lineHeight', () => {
-		const { container } = render(
-			<Text lineHeight={ 1.5 }>Lorem ipsum.</Text>
+		render(
+			<Text role="heading" lineHeight={ 1.5 }>
+				Lorem ipsum.
+			</Text>
 		);
-		expect( container.firstChild ).toHaveStyle( { lineHeight: '1.5' } );
+		expect( screen.getByRole( 'heading' ) ).toHaveStyle( {
+			lineHeight: '1.5',
+		} );
 	} );
 
 	test( 'should render upperCase', () => {
-		const { container } = render( <Text upperCase>Lorem ipsum.</Text> );
-		expect( container.firstChild ).toHaveStyle( {
+		render(
+			<Text role="heading" upperCase>
+				Lorem ipsum.
+			</Text>
+		);
+		expect( screen.getByRole( 'heading' ) ).toHaveStyle( {
 			textTransform: 'uppercase',
 		} );
 	} );
 
 	test( 'should render weight', () => {
-		const { container } = render(
-			<Text weight={ 700 }>Lorem ipsum.</Text>
+		render(
+			<Text role="heading" weight={ 700 }>
+				Lorem ipsum.
+			</Text>
 		);
-		expect( container.firstChild ).toHaveStyle( { fontWeight: '700' } );
+		expect( screen.getByRole( 'heading' ) ).toHaveStyle( {
+			fontWeight: '700',
+		} );
 	} );
 } );


### PR DESCRIPTION
## What?
With the recent work to improve the quality of tests, we fixed a bunch of ESLint rule violations. This PR fixes a few (`17`) [`no-node-access`](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-node-access.md) rule violations in the `Text` component. 

## Why?
The end goal is to enable that ESLint rule once all violations have been fixed.

## How?
We're adding a role to the test fixtures in order to be able to use `screen.getByRole()`. We're also combining a couple of renders within the single test into a single render, and just using different roles.

## Testing Instructions
Verify all tests still pass.