### PR TITLE
Autocomplete: only show UI on user input

### DIFF
--- a/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
+++ b/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
@@ -409,4 +409,32 @@ test.describe( 'Autocomplete', () => {
 <p>@ringbearer +thebetterhobbit</p>
 <!-- /wp:paragraph -->` );
 	} );
+
+	test( 'should hide UI when selection changes (by keyboard)', async ( {
+		page,
+	} ) => {
+		await page.click( 'role=button[name="Add default block"i]' );
+		await page.keyboard.type( '@fr' );
+		await expect(
+			page.locator( 'role=option', { hasText: 'Frodo Baggins' } )
+		).toBeVisible();
+		await page.keyboard.press( 'ArrowLeft' );
+		await expect(
+			page.locator( 'role=option', { hasText: 'Frodo Baggins' } )
+		).not.toBeVisible();
+	} );
+
+	test( 'should hide UI when selection changes (by mouse)', async ( {
+		page,
+	} ) => {
+		await page.click( 'role=button[name="Add default block"i]' );
+		await page.keyboard.type( '@fr' );
+		await expect(
+			page.locator( 'role=option', { hasText: 'Frodo Baggins' } )
+		).toBeVisible();
+		await page.click( '[data-type="core/paragraph"]' );
+		await expect(
+			page.locator( 'role=option', { hasText: 'Frodo Baggins' } )
+		).not.toBeVisible();
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What & why?

One extremely annoying issue with the current autocomplete UI is that it keeps showing up even when there has been no user input. I tested several other sites like Slack, Github and Twitter, and Autocomplete only shows up after user input. When the selection changes, it hides.

## How?

Adds an input and selection change listener to show & hide the autocomplete UI.

## Testing Instructions

There's quite a lot of scenarios.

1) Start typing an @admin and move the selection a bit back either by mouse or keyboard. The UI should hide.
2) Start typing @admin and complete it. Clicking within @admin shouldn't show the UI, but when typing again within "@admin" (for example: "@ad|dmin", where | is the caret), the UI should show again.

## Screenshots or screencast <!-- if applicable -->
