### PR TITLE
Enable easier drag and drop for navigation building

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -543,11 +543,14 @@ export default function NavigationLinkEdit( {
 		if ( ! url ) {
 			setIsLinkOpen( true );
 		}
+	}, [ url ] );
+
+	useEffect( () => {
 		// If block has inner blocks, transform to Submenu.
 		if ( hasChildren ) {
 			transformToSubmenu();
 		}
-	} );
+	}, [ hasChildren ] );
 
 	/**
 	 * The hook shouldn't be necessary but due to a focus loss happening

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -32,6 +32,7 @@ import {
 	useBlockProps,
 	store as blockEditorStore,
 	getColorClassName,
+	useInnerBlocksProps,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP, safeDecodeURI } from '@wordpress/url';
 import {
@@ -527,7 +528,9 @@ export default function NavigationLinkEdit( {
 		const newSubmenu = createBlock(
 			'core/navigation-submenu',
 			attributes,
-			innerBlocks
+			innerBlocks.length > 0
+				? innerBlocks
+				: [ createBlock( 'core/navigation-link' ) ]
 		);
 		replaceBlock( clientId, newSubmenu );
 	}
@@ -544,7 +547,7 @@ export default function NavigationLinkEdit( {
 		if ( hasChildren ) {
 			transformToSubmenu();
 		}
-	}, [] );
+	} );
 
 	/**
 	 * The hook shouldn't be necessary but due to a focus loss happening
@@ -673,6 +676,20 @@ export default function NavigationLinkEdit( {
 			backgroundColor: ! backgroundColor && customBackgroundColor,
 		},
 		onKeyDown,
+	} );
+
+	const ALLOWED_BLOCKS = [
+		'core/navigation-link',
+		'core/navigation-submenu',
+	];
+	const DEFAULT_BLOCK = {
+		name: 'core/navigation-link',
+	};
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		allowedBlocks: ALLOWED_BLOCKS,
+		__experimentalDefaultBlock: DEFAULT_BLOCK,
+		__experimentalDirectInsert: true,
+		renderAppender: false,
 	} );
 
 	if ( ! url || isInvalid || isDraft ) {
@@ -915,6 +932,7 @@ export default function NavigationLinkEdit( {
 						</Popover>
 					) }
 				</a>
+				<div { ...innerBlocksProps } />
 			</div>
 		</Fragment>
 	);

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -546,7 +546,7 @@ export default function NavigationSubmenuEdit( {
 		if ( ! hasChildren ) {
 			transformToLink();
 		}
-	} );
+	}, [ hasChildren ] );
 
 	const canConvertToLink =
 		! selectedBlockHasChildren || onlyDescendantIsEmptyLink;

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -541,6 +541,13 @@ export default function NavigationSubmenuEdit( {
 		replaceBlock( clientId, newLinkBlock );
 	}
 
+	useEffect( () => {
+		// If block is empty, transform to Navigation Link.
+		if ( ! hasChildren ) {
+			transformToLink();
+		}
+	} );
+
 	const canConvertToLink =
 		! selectedBlockHasChildren || onlyDescendantIsEmptyLink;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR makes the drag and drop of navigation inner blocks more seamless.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

With the addition of a list view in the navigation block's inspector drag and drop should work seamlessly for its allowed inner blocks. This isn't the case now:

- one can drag and drop
- but one can only nest a link in a submenu
- not a link in another link
- or a submenu inside a link

This is unexpected and makes the UX cumbersome. We have some items that were stop gap solutions such as:

- a convert to link button for submenus
- an auto-magic conversion of nested links to submenus but only on mount

These are also in need of simplification.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

1. Allow navigation links to have inner blocks, without an appender and only links and submenus.
2. Automatically transform nested links to submenus on render
3. Automatically transform empty submenus to links on render

To do:

- [ ] Remove the conver to link toolbar button

## Testing Instructions

1. In a post or template
2. Add a navigation block
3. Add some links
4. Using the list view
5. Try to nest them as you see fit
6. It should work any way you try

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/107534/202740392-e6fbd004-c00f-4ca9-b745-94a09df3f473.mp4


