### PR TITLE
Components: Fix `no-node-access` in `Sandbox` tests

### DIFF
--- a/packages/components/src/sandbox/test/index.js
+++ b/packages/components/src/sandbox/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -16,15 +16,15 @@ import Sandbox from '../';
 describe( 'Sandbox', () => {
 	const TestWrapper = () => {
 		const [ html, setHtml ] = useState(
-			// MuatationObserver implementation from JSDom does not work as intended
+			// MutationObserver implementation from JSDom does not work as intended
 			// with iframes so we need to ignore it for the time being.
 			'<script type="text/javascript">window.MutationObserver = null;</script>' +
-				'<iframe class="mock-iframe" src="https://super.embed"></iframe>'
+				'<iframe title="Mock Iframe" src="https://super.embed"></iframe>'
 		);
 
 		const updateHtml = () => {
 			setHtml(
-				'<iframe class="mock-iframe" src="https://another.super.embed"></iframe>'
+				'<iframe title="Mock Iframe" src="https://another.super.embed"></iframe>'
 			);
 		};
 
@@ -33,18 +33,19 @@ describe( 'Sandbox', () => {
 				<button onClick={ updateHtml } className="mock-button">
 					Mock Button
 				</button>
-				<Sandbox html={ html } />
+				<Sandbox html={ html } title="Sandbox Title" />
 			</div>
 		);
 	};
 
 	it( 'should rerender with new emdeded content if html prop changes', () => {
-		const { container } = render( <TestWrapper /> );
+		render( <TestWrapper /> );
 
-		const iframe = container.querySelector( '.components-sandbox' );
+		const iframe = screen.getByTitle( 'Sandbox Title' );
 
-		let sandboxedIframe =
-			iframe.contentWindow.document.body.querySelector( '.mock-iframe' );
+		let sandboxedIframe = within(
+			iframe.contentWindow.document.body
+		).getByTitle( 'Mock Iframe' );
 
 		expect( sandboxedIframe ).toHaveAttribute(
 			'src',
@@ -53,8 +54,9 @@ describe( 'Sandbox', () => {
 
 		fireEvent.click( screen.getByRole( 'button' ) );
 
-		sandboxedIframe =
-			iframe.contentWindow.document.body.querySelector( '.mock-iframe' );
+		sandboxedIframe = within(
+			iframe.contentWindow.document.body
+		).getByTitle( 'Mock Iframe' );
 
 		expect( sandboxedIframe ).toHaveAttribute(
 			'src',


### PR DESCRIPTION
## What?
With the recent work to improve the quality of tests, we fixed a bunch of ESLint rule violations. This PR fixes a few (`5`) [`no-node-access`](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-node-access.md) rule violations in the `Sandbox` component. 

## Why?
The end goal is to enable that ESLint rule once all violations have been fixed.

## How?
We're updating test fixture iframes to always contain a `title` in order to be able to use `screen.getByTitle()` for querying iframes. 

We're also updating a `iframe.contentWindow.document.body.querySelector()` to `within( iframe.contentWindow.document.body ).getByRole()` since that's our best RTL-friendly way to query within an iframe.

We're also using the opportunity to fix a typo in an inline comment.

## Testing Instructions
Verify all tests still pass.