### PR TITLE
Components: Improve `Dropdown` tests

### DIFF
--- a/packages/components/src/dropdown/test/index.js
+++ b/packages/components/src/dropdown/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -16,15 +16,6 @@ function getOpenCloseButton( container, selector ) {
 }
 
 describe( 'Dropdown', () => {
-	function expectPopoverVisible( container, value ) {
-		const popover = container.querySelector( '.components-popover' );
-		if ( value ) {
-			expect( popover ).toBeTruthy();
-		} else {
-			expect( popover ).toBeFalsy();
-		}
-	}
-
 	it( 'should toggle the dropdown properly', () => {
 		const expectButtonExpanded = ( container, expanded ) => {
 			expect( container.querySelectorAll( 'button' ) ).toHaveLength( 1 );
@@ -46,17 +37,18 @@ describe( 'Dropdown', () => {
 					</button>
 				) }
 				renderContent={ () => <span>test</span> }
+				popoverProps={ { 'data-testid': 'popover' } }
 			/>
 		);
 
 		expectButtonExpanded( dropdownContainer, false );
-		expectPopoverVisible( dropdownContainer, false );
+		expect( screen.queryByTestId( 'popover' ) ).not.toBeInTheDocument();
 
 		const button = getButtonElement( dropdownContainer );
 		fireEvent.click( button );
 
 		expectButtonExpanded( dropdownContainer, true );
-		expectPopoverVisible( dropdownContainer, true );
+		expect( screen.getByTestId( 'popover' ) ).toBeVisible();
 	} );
 
 	it( 'should close the dropdown when calling onClose', () => {
@@ -83,16 +75,16 @@ describe( 'Dropdown', () => {
 			/>
 		);
 
-		expectPopoverVisible( dropdownContainer, false );
+		expect( screen.queryByTestId( 'popover' ) ).not.toBeInTheDocument();
 
 		const openButton = getOpenCloseButton( dropdownContainer, '.open' );
 		fireEvent.click( openButton );
 
-		expectPopoverVisible( dropdownContainer, true );
+		expect( screen.getByTestId( 'popover' ) ).toBeVisible();
 
 		const closeButton = getOpenCloseButton( dropdownContainer, '.close' );
 		fireEvent.click( closeButton );
 
-		expectPopoverVisible( dropdownContainer, false );
+		expect( screen.queryByTestId( 'popover' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/packages/components/src/dropdown/test/index.js
+++ b/packages/components/src/dropdown/test/index.js
@@ -17,14 +17,6 @@ function getOpenCloseButton( container, selector ) {
 
 describe( 'Dropdown', () => {
 	it( 'should toggle the dropdown properly', () => {
-		const expectButtonExpanded = ( container, expanded ) => {
-			expect( container.querySelectorAll( 'button' ) ).toHaveLength( 1 );
-			expect( getButtonElement( container ) ).toHaveAttribute(
-				'aria-expanded',
-				expanded.toString()
-			);
-		};
-
 		const {
 			container: { firstChild: dropdownContainer },
 		} = render(
@@ -41,13 +33,17 @@ describe( 'Dropdown', () => {
 			/>
 		);
 
-		expectButtonExpanded( dropdownContainer, false );
+		expect(
+			screen.getByRole( 'button', { expanded: false } )
+		).toBeVisible();
 		expect( screen.queryByTestId( 'popover' ) ).not.toBeInTheDocument();
 
 		const button = getButtonElement( dropdownContainer );
 		fireEvent.click( button );
 
-		expectButtonExpanded( dropdownContainer, true );
+		expect(
+			screen.getByRole( 'button', { expanded: true } )
+		).toBeVisible();
 		expect( screen.getByTestId( 'popover' ) ).toBeVisible();
 	} );
 

--- a/packages/components/src/dropdown/test/index.js
+++ b/packages/components/src/dropdown/test/index.js
@@ -24,7 +24,7 @@ describe( 'Dropdown', () => {
 				contentClassName="content"
 				renderToggle={ ( { isOpen, onToggle } ) => (
 					<button aria-expanded={ isOpen } onClick={ onToggle }>
-						Toggleee
+						Toggle
 					</button>
 				) }
 				renderContent={ () => <span>test</span> }
@@ -68,10 +68,10 @@ describe( 'Dropdown', () => {
 						aria-expanded={ isOpen }
 						onClick={ onToggle }
 					>
-						Toggleee
+						Toggle
 					</button>,
 					<button key="close" className="close" onClick={ onClose }>
-						closee
+						close
 					</button>,
 				] }
 				renderContent={ () => null }

--- a/packages/components/src/dropdown/test/index.js
+++ b/packages/components/src/dropdown/test/index.js
@@ -75,15 +75,13 @@ describe( 'Dropdown', () => {
 
 		expect( screen.queryByTestId( 'popover' ) ).not.toBeInTheDocument();
 
-		const openButton = screen.getByRole( 'button', { name: 'Toggle' } );
-		await user.click( openButton );
+		await user.click( screen.getByRole( 'button', { name: 'Toggle' } ) );
 
 		await waitFor( () =>
 			expect( screen.getByTestId( 'popover' ) ).toBeVisible()
 		);
 
-		const closeButton = screen.getByRole( 'button', { name: 'close' } );
-		await user.click( closeButton );
+		await user.click( screen.getByRole( 'button', { name: 'close' } ) );
 
 		expect( screen.queryByTestId( 'popover' ) ).not.toBeInTheDocument();
 	} );

--- a/packages/components/src/dropdown/test/index.js
+++ b/packages/components/src/dropdown/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -18,7 +18,7 @@ describe( 'Dropdown', () => {
 		const user = userEvent.setup( {
 			advanceTimers: jest.advanceTimersByTime,
 		} );
-		render(
+		const { unmount } = render(
 			<Dropdown
 				className="container"
 				contentClassName="content"
@@ -42,7 +42,13 @@ describe( 'Dropdown', () => {
 		expect(
 			screen.getByRole( 'button', { expanded: true } )
 		).toBeVisible();
-		expect( screen.getByTestId( 'popover' ) ).toBeVisible();
+
+		await waitFor( () =>
+			expect( screen.getByTestId( 'popover' ) ).toBeVisible()
+		);
+
+		// Cleanup remaining effects, like the popover positioning
+		unmount();
 	} );
 
 	it( 'should close the dropdown when calling onClose', async () => {
@@ -69,6 +75,7 @@ describe( 'Dropdown', () => {
 					</button>,
 				] }
 				renderContent={ () => null }
+				popoverProps={ { 'data-testid': 'popover' } }
 			/>
 		);
 
@@ -77,7 +84,9 @@ describe( 'Dropdown', () => {
 		const openButton = getOpenCloseButton( dropdownContainer, '.open' );
 		await user.click( openButton );
 
-		expect( screen.getByTestId( 'popover' ) ).toBeVisible();
+		await waitFor( () =>
+			expect( screen.getByTestId( 'popover' ) ).toBeVisible()
+		);
 
 		const closeButton = getOpenCloseButton( dropdownContainer, '.close' );
 		await user.click( closeButton );

--- a/packages/components/src/dropdown/test/index.js
+++ b/packages/components/src/dropdown/test/index.js
@@ -8,18 +8,13 @@ import { fireEvent, render, screen } from '@testing-library/react';
  */
 import Dropdown from '../';
 
-function getButtonElement( container ) {
-	return container.querySelector( 'button' );
-}
 function getOpenCloseButton( container, selector ) {
 	return container.querySelector( selector );
 }
 
 describe( 'Dropdown', () => {
 	it( 'should toggle the dropdown properly', () => {
-		const {
-			container: { firstChild: dropdownContainer },
-		} = render(
+		render(
 			<Dropdown
 				className="container"
 				contentClassName="content"
@@ -33,12 +28,11 @@ describe( 'Dropdown', () => {
 			/>
 		);
 
-		expect(
-			screen.getByRole( 'button', { expanded: false } )
-		).toBeVisible();
+		const button = screen.getByRole( 'button', { expanded: false } );
+
+		expect( button ).toBeVisible();
 		expect( screen.queryByTestId( 'popover' ) ).not.toBeInTheDocument();
 
-		const button = getButtonElement( dropdownContainer );
 		fireEvent.click( button );
 
 		expect(

--- a/packages/components/src/dropdown/test/index.js
+++ b/packages/components/src/dropdown/test/index.js
@@ -43,7 +43,7 @@ describe( 'Dropdown', () => {
 			expect( screen.getByTestId( 'popover' ) ).toBeVisible()
 		);
 
-		// Cleanup remaining effects, like the popover positioning
+		// Cleanup remaining effects, like the delayed popover positioning
 		unmount();
 	} );
 

--- a/packages/components/src/dropdown/test/index.js
+++ b/packages/components/src/dropdown/test/index.js
@@ -9,10 +9,6 @@ import userEvent from '@testing-library/user-event';
  */
 import Dropdown from '../';
 
-function getOpenCloseButton( container, selector ) {
-	return container.querySelector( selector );
-}
-
 describe( 'Dropdown', () => {
 	it( 'should toggle the dropdown properly', async () => {
 		const user = userEvent.setup( {
@@ -55,9 +51,7 @@ describe( 'Dropdown', () => {
 		const user = userEvent.setup( {
 			advanceTimers: jest.advanceTimersByTime,
 		} );
-		const {
-			container: { firstChild: dropdownContainer },
-		} = render(
+		render(
 			<Dropdown
 				className="container"
 				contentClassName="content"
@@ -81,14 +75,14 @@ describe( 'Dropdown', () => {
 
 		expect( screen.queryByTestId( 'popover' ) ).not.toBeInTheDocument();
 
-		const openButton = getOpenCloseButton( dropdownContainer, '.open' );
+		const openButton = screen.getByRole( 'button', { name: 'Toggle' } );
 		await user.click( openButton );
 
 		await waitFor( () =>
 			expect( screen.getByTestId( 'popover' ) ).toBeVisible()
 		);
 
-		const closeButton = getOpenCloseButton( dropdownContainer, '.close' );
+		const closeButton = screen.getByRole( 'button', { name: 'close' } );
 		await user.click( closeButton );
 
 		expect( screen.queryByTestId( 'popover' ) ).not.toBeInTheDocument();

--- a/packages/components/src/dropdown/test/index.js
+++ b/packages/components/src/dropdown/test/index.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -13,7 +14,10 @@ function getOpenCloseButton( container, selector ) {
 }
 
 describe( 'Dropdown', () => {
-	it( 'should toggle the dropdown properly', () => {
+	it( 'should toggle the dropdown properly', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
 		render(
 			<Dropdown
 				className="container"
@@ -33,7 +37,7 @@ describe( 'Dropdown', () => {
 		expect( button ).toBeVisible();
 		expect( screen.queryByTestId( 'popover' ) ).not.toBeInTheDocument();
 
-		fireEvent.click( button );
+		await user.click( button );
 
 		expect(
 			screen.getByRole( 'button', { expanded: true } )
@@ -41,7 +45,10 @@ describe( 'Dropdown', () => {
 		expect( screen.getByTestId( 'popover' ) ).toBeVisible();
 	} );
 
-	it( 'should close the dropdown when calling onClose', () => {
+	it( 'should close the dropdown when calling onClose', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
 		const {
 			container: { firstChild: dropdownContainer },
 		} = render(
@@ -68,12 +75,12 @@ describe( 'Dropdown', () => {
 		expect( screen.queryByTestId( 'popover' ) ).not.toBeInTheDocument();
 
 		const openButton = getOpenCloseButton( dropdownContainer, '.open' );
-		fireEvent.click( openButton );
+		await user.click( openButton );
 
 		expect( screen.getByTestId( 'popover' ) ).toBeVisible();
 
 		const closeButton = getOpenCloseButton( dropdownContainer, '.close' );
-		fireEvent.click( closeButton );
+		await user.click( closeButton );
 
 		expect( screen.queryByTestId( 'popover' ) ).not.toBeInTheDocument();
 	} );


### PR DESCRIPTION
## What?
This PR is improving the existing tests of the `Dropdown` component. Easiest to review commit-by-commit.

## Why?
My initial motivation was to just address a few pre-existing `no-node-access` ESLint violations but ended up fixing a few other issues that make the tests ultimately more readable and reliable.

## How?
We're basically doing a few improvements, which I've tried to keep in separate commits:
* Getting rid of all helper functions in favor of specific inline `screen` queries.
* Addressing all `no-node-access` violations by introducing a `data-testid` to locate the popover with `screen` queries, or simply using `screen` queries where that was directly achievable. 
* Using `userEvent` instead of `fireEvent` to simulate user events better and closer to what the user actually experiences.
* Fixing a few (maybe intentional) typos in the component test fixtures.
* Updating the test to actually wait for the popover to be displayed. 
* Cleaning up after the dropdown visibility assertion in order to cancel all other effects we're not interested in. Otherwise, the test would likely fail in React 18.
* Removing redundant variables/constants where they were used just once.

## Testing Instructions
Verify tests still pass.
