### PR TITLE
BlockVariationPicker: Remove Unnecessary ARIA Role

### DIFF
--- a/packages/block-editor/src/components/block-variation-picker/index.js
+++ b/packages/block-editor/src/components/block-variation-picker/index.js
@@ -49,10 +49,7 @@ function BlockVariationPicker( {
 							className="block-editor-block-variation-picker__variation"
 							label={ variation.description || variation.title }
 						/>
-						<span
-							className="block-editor-block-variation-picker__variation-label"
-							role="presentation"
-						>
+						<span className="block-editor-block-variation-picker__variation-label">
 							{ variation.title }
 						</span>
 					</li>


### PR DESCRIPTION
## What?
Removes an unnecessary `role=presentation` attribute from the a `span` within the `BlockVariationPicker` component. 

## Why?
As described in #45753, the ARIA `role=presentation` attribute is not necessary on an element that doesn't have a native role (in this case, a `span` containing the label for the variation). 

## How?
This change removes the extraneous attribute, which is currently not serving any particular purpose. This change also _does not_ hide the label from assistive technology. 

## Testing Instructions
Reproduction from the [original issue](https://github.com/WordPress/gutenberg/issues/45753):

1. Add a Columns or Query loop block
2. Note: to make the block variations appear in the Query loop block, click 'Start empty'.
3. Inspect the source of the visible text below the variation buttons.
4. <del>observe the role="presentation" attribute is present.</del> Ensure the attribute is **not** present
5. Optionally test with a screen reader.
6. Navigate the variations using the screen reader arrows navigation (ie. with VoiceOver it's Control+Option+Right (or Left) arrow)
7. Observe the visible text is read out

Tested with Safari+VoiceOver and Chrome+VoiceOver.

## Screenshots or screencast
**Before:**

![before image](https://user-images.githubusercontent.com/1682452/201684156-fb82b97a-3117-4dab-83de-c8544e3f0306.png)

**After:** 

![image](https://user-images.githubusercontent.com/85708316/202798270-f318a878-c931-411f-883d-cd6f161211ca.png)


