### PR TITLE
Allow post updates on an edited post with no content

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Updated `isEditedPostSaveable` to return `true` when the post was edited (is "dirty") regardless of whether the editor is empty (has no blocks). Previously you could not save after removing the final block.
+
 ## 12.21.0 (2022-11-16)
 
 ## 12.20.0 (2022-11-02)

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Updated `isEditedPostSaveable` to return `true` when the post was edited (is "dirty") regardless of whether the editor is empty (has no blocks). Previously you could not save after removing the final block.
+- Updated `isEditedPostSaveable` to return `true` when the post was edited (is "dirty") regardless of whether the editor is empty (has no blocks). Previously you could not save after removing the final block ([#45917](https://github.com/WordPress/gutenberg/pull/45917)).
 
 ## 12.21.0 (2022-11-16)
 

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -493,7 +493,8 @@ export function isEditedPostSaveable( state ) {
 	return (
 		!! getEditedPostAttribute( state, 'title' ) ||
 		!! getEditedPostAttribute( state, 'excerpt' ) ||
-		! isEditedPostEmpty( state ) ||
+		// Post is not saveable if empty, unless it's "dirty" (has edits).
+		! ( isEditedPostEmpty( state ) && ! isEditedPostDirty( state ) ) ||
 		Platform.OS === 'native'
 	);
 }

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -61,7 +61,7 @@ selectorNames.forEach( ( name ) => {
 					};
 				}
 
-				return edits;
+				return edits ?? {};
 			},
 
 			hasEditsForEntityRecord() {
@@ -1226,6 +1226,7 @@ describe( 'selectors', () => {
 				editor: {
 					present: {
 						blocks: {
+							isDirty: false,
 							value: [],
 						},
 						edits: {},
@@ -1336,6 +1337,7 @@ describe( 'selectors', () => {
 				editor: {
 					present: {
 						blocks: {
+							isDirty: false,
 							value: [
 								{
 									clientId: 123,
@@ -1363,6 +1365,7 @@ describe( 'selectors', () => {
 				editor: {
 					present: {
 						blocks: {
+							isDirty: false,
 							value: [
 								{
 									clientId: 123,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This allows a user to delete the final block and still save the post. Currently you cannot save it and a refresh attempt prompts the user ("Are you sure you want to reload?") and reloading restores content (since it wasn't saved)

## Why?
Personally, I open a new page for testing blocks as I develop. Remove the block, reload, add it again, rinse and repeat. I also think it's intuitive that you should be able to save here regardless of the use case.

More mentioned in this issue:

closes: https://github.com/WordPress/gutenberg/issues/17346

## How?
```js
// Post is not saveable if empty, unless it's "dirty" (has edits).
! ( isEditedPostEmpty( state ) && ! isEditedPostDirty( state ) ) ||
```

Additionally, I've updated some of the mocked functions in the tests. If someone more familiar with the tests can take a look please. Essentially, I added `isDirty` to the state config to be explicit as otherwise it was adding edits like `{ blocks: [] }`. Alternatively I could update the mocked function to account for it. 

## Testing Instructions
Add a new post, add a few blocks (or one), save, remove blocks, press save.

Outside of this PR, you cannot save. In this PR, you can.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/1478421/202830276-a83a8416-4fcd-4e21-aa7a-700674c28350.mov

This PR:


https://user-images.githubusercontent.com/1478421/202830318-13a2dc09-0b3a-490e-bbac-ef579c224177.mov

