### PR TITLE
Add filter to site edit titles

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Added filter `entitiesSavedStates.siteEditsAsEntities.title` to allow developers to modify label output.
+- Added filter `entitiesSavedStates.siteEditsAsEntities.title` to allow developers to modify title output ([#45918](https://github.com/WordPress/gutenberg/pull/45918)).
 
 ## 12.21.0 (2022-11-16)
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added filter `entitiesSavedStates.siteEditsAsEntities.title` to allow developers to modify label output.
+
 ## 12.21.0 (2022-11-16)
 
 ## 12.20.0 (2022-11-02)

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -14,6 +14,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { __experimentalUseDialog as useDialog } from '@wordpress/compose';
 import { store as noticesStore } from '@wordpress/notices';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -57,7 +58,11 @@ export default function EntitiesSavedStates( { close } ) {
 			siteEditsAsEntities.push( {
 				kind: 'root',
 				name: 'site',
-				title: TRANSLATED_SITE_PROPERTIES[ property ] || property,
+				title: applyFilters(
+					'entitiesSavedStates.siteEditsAsEntities.title',
+					TRANSLATED_SITE_PROPERTIES[ property ] || property,
+					property
+				),
 				property,
 			} );
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This allows developers to override title property in `siteEditsAsEntities`

closes https://github.com/WordPress/gutenberg/issues/41637

## Why?
More flexibility to the developer who wants to avoid showing "computer language" to the user (e.g. custom_site_option)

## How?
```js
title: applyFilters(
    'entitiesSavedStates.siteEditsAsEntities.title',
    TRANSLATED_SITE_PROPERTIES[ property ] || property,
    property
),
```

## Testing Instructions
- Visit the site editor
- Change the title
- Save the post.
 
On the confirmation page you will see mention that the `Title` was changed. Add the following code to the console:

```js
wp.hooks.addFilter('entitiesSavedStates.siteEditsAsEntities.title', 'kb', () => 'hey')
```

- Close and re-open the confirmation panel (i.e. trigger a re render)
- See 'hey'

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/1478421/202834305-933e554d-c429-48ce-b97a-e549a3be0d1d.mov
