### PR TITLE
Perf Tests: Fix test build process to call wp-scripts

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -276,7 +276,7 @@ async function runPerformanceTests( branches, options ) {
 
 			log( `        >> Building the ${ fancyBranch } branch` );
 			await runShellScript(
-				'npm ci && node ./bin/packages/build.js',
+				'npm ci && npm run prebuild:packages && node ./bin/packages/build.js && npx wp-scripts build',
 				buildPath
 			);
 		}


### PR DESCRIPTION
## What?

Call full build without generating types during the performance tests.

![branch-compare-45922-44907](https://user-images.githubusercontent.com/5431237/202959998-e6e7c9c1-2726-4904-99bf-89ffe2347381.png)


## Why?

In #45284 we started skipping the generate-types phase of the build when running the performance tests. This was done to avoid the time it takes to generate those types when they are ignored by the rest of the test suite.

In that patch we accidentally skipped running `wp-scripts build`, and in this patch we're bringing that back to fix the mistake.

## How?

We're replacing the simpler call to `node ./bin/packages/build.js` with the full build without the types generation.

## Testing Instructions

Ensure that the test suite passes as expected.