### PR TITLE
[WIP] Layout: Try reducing specificity of layout styles

### DIFF
--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -374,7 +374,7 @@ export function getLayoutStyles( {
 							} else {
 								combinedSelector =
 									selector === ROOT_BLOCK_SELECTOR
-										? `${ selector } .${ className }${
+										? `.${ className }${
 												spacingStyle?.selector || ''
 										  }`
 										: `${ selector }.${ className }${
@@ -425,7 +425,7 @@ export function getLayoutStyles( {
 						}
 
 						if ( declarations.length ) {
-							const combinedSelector = `${ selector } .${ className }${
+							const combinedSelector = `.${ className }${
 								baseStyle?.selector || ''
 							}`;
 							ruleset += `${ combinedSelector } { ${ declarations.join(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

🚧 🚧 🚧 🚧

***Note: This is an experiment and will quite likely not be viable. It is an exploration into identifying the problems associated with mixing layout and margin rules. As of right now, this PR does not work!***

The attempted idea in this PR is to remove the selector prefix when outputting layout rules for the root selector. That is, layout rules become for example `.is-layout-flow > * + *` instead of `body .is-layout-flow`.

However, even with this change, it still looks like layout rules (e.g. the root layout rules as in the following screenshot) still take precedence even though we've lowered the specificity of the layout rules.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Ultimately it'd be good to come up with a solution for #43404 so that folks can use both Layout and Margin rules (e.g. set `blockGap` as they'd like globally, and also set margin rules in `theme.json`) and for those rules to play well together in a way that feels logical. This is necessarily vague in this PR, as I'm not too sure what the ideal state would be. Here in this PR, the goal is simply to experiment with how they work together (or currently don't).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Try removing the selector prefix from the base layout rules and spacing output, so that `body .is-layout-constrained` is now simply `.is-layout-constrained`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

TBD, but add a bunch of blocks to a post, page, or template, with a theme that has `blockGap` switched on. Then, in global styles, set one of the blocks to have a custom margin at the block-level in global styles, e.g. maybe try the Buttons block.

Ideally, the setting a user sets in global styles there would take precedence over the base layout rules, however as of right now, that is not the case.

## Screenshots or screencast <!-- if applicable -->

In the below screenshots, note how even with the lowered specificity, the layout `margin-block-start` rules still win out. Perhaps the order or rule output might need to be adjusted, too?

| Global styles | Site front end |
| --- | --- |
| <img width="1252" alt="image" src="https://user-images.githubusercontent.com/14988353/202939427-8e77c8d2-d79c-4110-b48b-93bb6b973a28.png"> | <img width="1261" alt="image" src="https://user-images.githubusercontent.com/14988353/202942815-b0e30dd8-55ea-4006-9e38-8e13071d4d26.png"> |