### PR TITLE
Global styles: Offer a way to view a document containing all blocks and styles

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1748,3 +1748,12 @@ export function __unstableSetTemporarilyEditingAsBlocks(
 		temporarilyEditingAsBlocks,
 	};
 }
+
+export function __unstableSetGlobalStylesPreviewPageVisibility(
+	globalStylesPreviewPageVisibility
+) {
+	return {
+		type: 'SET_GLOBAL_STYLES_PREVIEW_PAGE_VISIBILITY',
+		globalStylesPreviewPageVisibility,
+	};
+}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1815,6 +1815,13 @@ export function temporarilyEditingAsBlocks( state = '', action ) {
 	return state;
 }
 
+export function globalStylesPreviewPageVisibility( state = false, action ) {
+	if ( action.type === 'SET_GLOBAL_STYLES_PREVIEW_PAGE_VISIBILITY' ) {
+		return action.globalStylesPreviewPageVisibility;
+	}
+	return state;
+}
+
 export default combineReducers( {
 	blocks,
 	isTyping,
@@ -1838,4 +1845,5 @@ export default combineReducers( {
 	lastBlockInserted,
 	temporarilyEditingAsBlocks,
 	blockVisibility,
+	globalStylesPreviewPageVisibility,
 } );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -27,6 +27,7 @@ import deprecated from '@wordpress/deprecated';
  * Internal dependencies
  */
 import { mapRichTextSettings } from './utils';
+import {globalStylesPreviewPageVisibility} from "./reducer";
 
 /**
  * A block selection object.
@@ -2772,4 +2773,8 @@ export function __unstableIsWithinBlockOverlay( state, clientId ) {
 		parent = state.blocks.parents[ parent ];
 	}
 	return false;
+}
+
+export function __unstableIsGlobalStylesPreviewPageVisible( state ) {
+	return state.globalStylesPreviewPageVisibility;
 }

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -28,6 +28,11 @@ import { listView } from '@wordpress/icons';
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { store as interfaceStore } from '@wordpress/interface';
+import {
+	getBlockType,
+	getBlockFromExample,
+	createBlock,
+} from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -45,6 +50,62 @@ const LAYOUT = {
 	// At the root level of the site editor, no alignments should be allowed.
 	alignments: [],
 };
+
+/* @TEST */
+
+function getGlobalStylesPreviewBlocks() {
+	const group = getBlockType( 'core/group' );
+	const heading = getBlockType( 'core/heading' );
+	const paragraph = getBlockType( 'core/paragraph' );
+	const image = getBlockType( 'core/image' );
+
+	if (
+		! group?.name ||
+		! heading?.name ||
+		! paragraph?.name ||
+		! image?.name
+	) {
+		return null;
+	}
+
+	const headings = [ 1, 2, 3, 4, 5, 6 ].map( ( level ) =>
+		createBlock( heading?.name, {
+			content: `Heading H${ level }`,
+			level,
+		} )
+	);
+
+	const paragraphBlock = getBlockFromExample( paragraph?.name, {
+		attributes: paragraph?.example?.attributes,
+		innerBlocks: paragraph?.example?.innerBlocks,
+	} );
+
+	const imageBlock = getBlockFromExample( image?.name, {
+		attributes: image?.example?.attributes,
+		innerBlocks: image?.example?.innerBlocks,
+	} );
+
+	// const headingBlock = createBlock(
+	// 	heading?.name,
+	// 	heading?.example?.attributes,
+	// 	heading?.example?.innerBlocks
+	// );
+	// const paragraphBlock = createBlock(
+	// 	paragraph?.name,
+	// 	paragraph?.example?.attributes,
+	// 	paragraph?.example?.innerBlocks
+	// );
+
+	const blocks = createBlock( group?.name, group?.example?.attributes, [
+		...headings,
+		paragraphBlock,
+		imageBlock,
+	] );
+
+	return [ blocks ];
+}
+
+/* @TEST */
 
 const NAVIGATION_SIDEBAR_NAME = 'edit-site/navigation-menu';
 
@@ -73,7 +134,6 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 		},
 		[ setIsInserterOpen ]
 	);
-
 	const settingsBlockPatterns =
 		storedSettings.__experimentalAdditionalBlockPatterns ?? // WP 6.0
 		storedSettings.__experimentalBlockPatterns; // WP 5.9
@@ -181,11 +241,16 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 	if ( process.env.IS_GUTENBERG_PLUGIN ) {
 		MaybeNavMenuSidebarToggle = NavMenuSidebarToggle;
 	}
+const isGlobalStylesPreviewOn = false;
 
 	return (
 		<BlockEditorProvider
 			settings={ settings }
-			value={ blocks }
+			value={
+				isGlobalStylesPreviewOn
+					? getGlobalStylesPreviewBlocks()
+					: blocks
+			}
 			onInput={ onInput }
 			onChange={ onChange }
 			useSubRegistry={ false }

--- a/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
@@ -4,8 +4,9 @@
 import { DropdownMenu, FlexItem, FlexBlock, Flex } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { styles, moreVertical } from '@wordpress/icons';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -16,7 +17,25 @@ import { GlobalStylesUI, useGlobalStylesReset } from '../global-styles';
 export default function GlobalStylesSidebar() {
 	const [ canReset, onReset ] = useGlobalStylesReset();
 	const { toggle } = useDispatch( preferencesStore );
+	const {
+		__unstableSetEditorMode,
+		__unstableSetGlobalStylesPreviewPageVisibility,
+	} = useDispatch( blockEditorStore );
+	const { isZoomOutMode, isGlobalStylesPreviewPageVisible } = useSelect(
+		( select ) => {
+			const {
+				__unstableGetEditorMode,
+				__unstableIsGlobalStylesPreviewPageVisible,
+			} = select( blockEditorStore );
 
+			return {
+				isZoomOutMode: __unstableGetEditorMode() === 'zoom-out',
+				isGlobalStylesPreviewPageVisible:
+					__unstableIsGlobalStylesPreviewPageVisible() === true,
+			};
+		},
+		[]
+	);
 	return (
 		<DefaultSidebar
 			className="edit-site-global-styles-sidebar"
@@ -39,6 +58,23 @@ export default function GlobalStylesSidebar() {
 									title: __( 'Reset to defaults' ),
 									onClick: onReset,
 									isDisabled: ! canReset,
+								},
+								{
+									title: isZoomOutMode
+										? __(
+												'Hide Global Styles Preview Page'
+										  )
+										: __(
+												'Show Global Styles Preview Page'
+										  ),
+									onClick: () => {
+										__unstableSetGlobalStylesPreviewPageVisibility(
+											! isGlobalStylesPreviewPageVisible
+										);
+										__unstableSetEditorMode(
+											isZoomOutMode ? 'edit' : 'zoom-out'
+										);
+									},
 								},
 								{
 									title: __( 'Welcome Guide' ),


### PR DESCRIPTION


## What?
A hacky experiment inspired by https://github.com/WordPress/gutenberg/issues/44420

## Why?
Yes, why.

## How?
You don't want to know right now.

## Testing Instructions
https://user-images.githubusercontent.com/6458278/202622257-8f2824bc-bdd8-4c48-9832-f8cb7becaf65.mp4
