### PR TITLE
InputControl: Add `help` prop

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   `TabPanel`: Add ability to set icon only tab buttons ([#45005](https://github.com/WordPress/gutenberg/pull/45005)).
+-   `InputControl`, `NumberControl`, `UnitControl`: Add `help` prop for additional description ([#45931](https://github.com/WordPress/gutenberg/pull/45931)).
 
 ## 22.1.0 (2022-11-16)
 

--- a/packages/components/src/input-control/index.tsx
+++ b/packages/components/src/input-control/index.tsx
@@ -18,7 +18,7 @@ import InputField from './input-field';
 import type { InputControlProps } from './types';
 import { space } from '../ui/utils/space';
 import { useDraft } from './utils';
-import { StyledHelp } from '../base-control/styles/base-control-styles';
+import BaseControl from '../base-control';
 
 const noop = () => {};
 
@@ -58,7 +58,6 @@ export function UnforwardedInputControl(
 
 	const id = useUniqueId( idProp );
 	const classes = classNames( 'components-input-control', className );
-	const helpTextId = `${ id }__help`;
 
 	const draftHookProps = useDraft( {
 		value,
@@ -67,7 +66,12 @@ export function UnforwardedInputControl(
 	} );
 
 	return (
-		<div className={ classes }>
+		<BaseControl
+			className={ classes }
+			help={ help }
+			id={ id }
+			__nextHasNoMarginBottom
+		>
 			<InputBase
 				__next36pxDefaultSize={ __next36pxDefaultSize }
 				__unstableInputWidth={ __unstableInputWidth }
@@ -87,7 +91,7 @@ export function UnforwardedInputControl(
 				<InputField
 					{ ...props }
 					__next36pxDefaultSize={ __next36pxDefaultSize }
-					aria-describedby={ !! help ? helpTextId : undefined }
+					aria-describedby={ !! help ? `${ id }__help` : undefined }
 					className="components-input-control__input"
 					disabled={ disabled }
 					id={ id }
@@ -104,12 +108,7 @@ export function UnforwardedInputControl(
 					{ ...draftHookProps }
 				/>
 			</InputBase>
-			{ !! help && (
-				<StyledHelp id={ helpTextId } __nextHasNoMarginBottom>
-					{ help }
-				</StyledHelp>
-			) }
-		</div>
+		</BaseControl>
 	);
 }
 

--- a/packages/components/src/input-control/index.tsx
+++ b/packages/components/src/input-control/index.tsx
@@ -18,6 +18,7 @@ import InputField from './input-field';
 import type { InputControlProps } from './types';
 import { space } from '../ui/utils/space';
 import { useDraft } from './utils';
+import { StyledHelp } from '../base-control/styles/base-control-styles';
 
 const noop = () => {};
 
@@ -35,6 +36,7 @@ export function UnforwardedInputControl(
 		__unstableInputWidth,
 		className,
 		disabled = false,
+		help,
 		hideLabelFromVision = false,
 		id: idProp,
 		isPressEnterToChange = false,
@@ -56,6 +58,7 @@ export function UnforwardedInputControl(
 
 	const id = useUniqueId( idProp );
 	const classes = classNames( 'components-input-control', className );
+	const helpTextId = `${ id }__help`;
 
 	const draftHookProps = useDraft( {
 		value,
@@ -64,42 +67,49 @@ export function UnforwardedInputControl(
 	} );
 
 	return (
-		<InputBase
-			__next36pxDefaultSize={ __next36pxDefaultSize }
-			__unstableInputWidth={ __unstableInputWidth }
-			className={ classes }
-			disabled={ disabled }
-			gap={ 3 }
-			hideLabelFromVision={ hideLabelFromVision }
-			id={ id }
-			isFocused={ isFocused }
-			justify="left"
-			label={ label }
-			labelPosition={ labelPosition }
-			prefix={ prefix }
-			size={ size }
-			style={ style }
-			suffix={ suffix }
-		>
-			<InputField
-				{ ...props }
+		<div className={ classes }>
+			<InputBase
 				__next36pxDefaultSize={ __next36pxDefaultSize }
-				className="components-input-control__input"
+				__unstableInputWidth={ __unstableInputWidth }
 				disabled={ disabled }
+				gap={ 3 }
+				hideLabelFromVision={ hideLabelFromVision }
 				id={ id }
 				isFocused={ isFocused }
-				isPressEnterToChange={ isPressEnterToChange }
-				onKeyDown={ onKeyDown }
-				onValidate={ onValidate }
-				paddingInlineStart={ prefix ? space( 2 ) : undefined }
-				paddingInlineEnd={ suffix ? space( 2 ) : undefined }
-				ref={ ref }
-				setIsFocused={ setIsFocused }
+				justify="left"
+				label={ label }
+				labelPosition={ labelPosition }
+				prefix={ prefix }
 				size={ size }
-				stateReducer={ stateReducer }
-				{ ...draftHookProps }
-			/>
-		</InputBase>
+				style={ style }
+				suffix={ suffix }
+			>
+				<InputField
+					{ ...props }
+					__next36pxDefaultSize={ __next36pxDefaultSize }
+					aria-describedby={ !! help ? helpTextId : undefined }
+					className="components-input-control__input"
+					disabled={ disabled }
+					id={ id }
+					isFocused={ isFocused }
+					isPressEnterToChange={ isPressEnterToChange }
+					onKeyDown={ onKeyDown }
+					onValidate={ onValidate }
+					paddingInlineStart={ prefix ? space( 2 ) : undefined }
+					paddingInlineEnd={ suffix ? space( 2 ) : undefined }
+					ref={ ref }
+					setIsFocused={ setIsFocused }
+					size={ size }
+					stateReducer={ stateReducer }
+					{ ...draftHookProps }
+				/>
+			</InputBase>
+			{ !! help && (
+				<StyledHelp id={ helpTextId } __nextHasNoMarginBottom>
+					{ help }
+				</StyledHelp>
+			) }
+		</div>
 	);
 }
 

--- a/packages/components/src/input-control/index.tsx
+++ b/packages/components/src/input-control/index.tsx
@@ -65,6 +65,11 @@ export function UnforwardedInputControl(
 		onChange,
 	} );
 
+	// ARIA descriptions can only contain plain text, so fall back to aria-details if not.
+	const helpPropName =
+		typeof help === 'string' ? 'aria-describedby' : 'aria-details';
+	const helpProp = !! help ? { [ helpPropName ]: `${ id }__help` } : {};
+
 	return (
 		<BaseControl
 			className={ classes }
@@ -90,8 +95,8 @@ export function UnforwardedInputControl(
 			>
 				<InputField
 					{ ...props }
+					{ ...helpProp }
 					__next36pxDefaultSize={ __next36pxDefaultSize }
-					aria-describedby={ !! help ? `${ id }__help` : undefined }
 					className="components-input-control__input"
 					disabled={ disabled }
 					id={ id }

--- a/packages/components/src/input-control/stories/index.tsx
+++ b/packages/components/src/input-control/stories/index.tsx
@@ -40,6 +40,12 @@ Default.args = {
 	placeholder: 'Placeholder',
 };
 
+export const WithHelpText = Template.bind( {} );
+WithHelpText.args = {
+	...Default.args,
+	help: 'Help text to describe the control.',
+};
+
 /**
  * A `prefix` can be inserted before the input. By default, the prefix is aligned with the edge of the input border,
  * with no padding. If you want to apply standard padding in accordance with the size variant, use the provided

--- a/packages/components/src/input-control/test/index.js
+++ b/packages/components/src/input-control/test/index.js
@@ -50,6 +50,13 @@ describe( 'InputControl', () => {
 
 			expect( input ).toBeInTheDocument();
 		} );
+
+		it( 'should render help text as description', () => {
+			render( <InputControl help="My help text" /> );
+			expect(
+				screen.getByRole( 'textbox', { description: 'My help text' } )
+			).toBeInTheDocument();
+		} );
 	} );
 
 	describe( 'Ensurance of focus for number inputs', () => {

--- a/packages/components/src/input-control/test/index.js
+++ b/packages/components/src/input-control/test/index.js
@@ -57,6 +57,17 @@ describe( 'InputControl', () => {
 				screen.getByRole( 'textbox', { description: 'My help text' } )
 			).toBeInTheDocument();
 		} );
+
+		it( 'should render help as aria-details when not plain text', () => {
+			render( <InputControl help={ <a href="/foo">My help text</a> } /> );
+
+			const input = screen.getByRole( 'textbox' );
+			const help = screen.getByRole( 'link', { name: 'My help text' } );
+
+			expect(
+				help.closest( `#${ input.getAttribute( 'aria-details' ) }` )
+			).toBeVisible();
+		} );
 	} );
 
 	describe( 'Ensurance of focus for number inputs', () => {

--- a/packages/components/src/input-control/types.ts
+++ b/packages/components/src/input-control/types.ts
@@ -191,6 +191,10 @@ export interface InputControlProps
 			| 'paddingInlineEnd'
 		> {
 	__unstableStateReducer?: InputFieldProps[ 'stateReducer' ];
+	/**
+	 * An additional description for the control.
+	 */
+	help?: string;
 }
 
 export interface InputControlLabelProps {

--- a/packages/components/src/input-control/types.ts
+++ b/packages/components/src/input-control/types.ts
@@ -15,6 +15,7 @@ import type { useDrag } from '@use-gesture/react';
 import type { StateReducer } from './reducer/state';
 import type { WordPressComponentProps } from '../ui/context';
 import type { FlexProps } from '../flex/types';
+import type { BaseControlProps } from '../base-control/types';
 
 export type LabelPosition = 'top' | 'bottom' | 'side' | 'edge';
 
@@ -171,6 +172,7 @@ export interface InputBaseProps extends BaseProps, FlexProps {
 
 export interface InputControlProps
 	extends Omit< InputBaseProps, 'children' | 'isFocused' | keyof FlexProps >,
+		Pick< BaseControlProps, 'help' >,
 		/**
 		 * The `prefix` prop in `WordPressComponentProps< InputFieldProps, 'input', false >` comes from the
 		 * `HTMLInputAttributes` and clashes with the one from `InputBaseProps`. So we have to omit it from
@@ -191,10 +193,6 @@ export interface InputControlProps
 			| 'paddingInlineEnd'
 		> {
 	__unstableStateReducer?: InputFieldProps[ 'stateReducer' ];
-	/**
-	 * An additional description for the control.
-	 */
-	help?: string;
 }
 
 export interface InputControlLabelProps {


### PR DESCRIPTION
Required for https://github.com/WordPress/gutenberg/pull/45364#issuecomment-1321320586

## What?

Adds a `help` prop, similar to the one for BaseControl, on the InputControl component and friends (NumberControl, UnitControl).

## Why?

InputControl does not use the standard BaseControl, in order to support the `labelPosition` feature. Therefore, it needs its own `help` implementation.

## How?

Reuse the `StyledHelp` from BaseControl and add semantics.

## Testing Instructions

1. `npm run storybook:dev`
2. See the "With Help Text" story for InputControl. The help text should be in the correct place, regardless of the `labelPosition` prop's value.
3. The same should work for NumberControl and UnitControl as well.

## Screenshots or screencast <!-- if applicable -->

<img width="281" alt="InputControl with help text below it" src="https://user-images.githubusercontent.com/555336/202984396-7bb91602-db3b-4e14-b29c-f35557451440.png">
