### PR TITLE
Block Editor: Fix block alignment tests for React 18

### DIFF
--- a/packages/block-editor/src/components/alignment-control/test/index.js
+++ b/packages/block-editor/src/components/alignment-control/test/index.js
@@ -52,7 +52,7 @@ describe( 'AlignmentUI', () => {
 			advanceTimers: jest.advanceTimersByTime,
 		} );
 
-		render(
+		const { unmount } = render(
 			<AlignmentUI
 				isToolbar
 				value={ alignment }
@@ -77,6 +77,9 @@ describe( 'AlignmentUI', () => {
 				name: /^Align text \w+$/,
 			} )
 		).toHaveLength( 3 );
+
+		// Cancel running effects, like delayed dropdown menu popover positioning.
+		unmount();
 	} );
 
 	test( 'should call on change with undefined when a control is already active', async () => {

--- a/packages/block-editor/src/components/block-alignment-control/test/index.js
+++ b/packages/block-editor/src/components/block-alignment-control/test/index.js
@@ -47,7 +47,7 @@ describe( 'BlockAlignmentUI', () => {
 			advanceTimers: jest.advanceTimersByTime,
 		} );
 
-		render(
+		const { unmount } = render(
 			<BlockAlignmentUI
 				value={ alignment }
 				onChange={ onChange }
@@ -72,6 +72,9 @@ describe( 'BlockAlignmentUI', () => {
 				name: /^Align \w+$/,
 			} )
 		).toHaveLength( 3 );
+
+		// Cancel running effects, like delayed dropdown menu popover positioning.
+		unmount();
 	} );
 
 	test( 'should call onChange with undefined, when the control is already active', async () => {

--- a/packages/block-editor/src/components/block-vertical-alignment-control/test/index.js
+++ b/packages/block-editor/src/components/block-vertical-alignment-control/test/index.js
@@ -45,7 +45,7 @@ describe( 'BlockVerticalAlignmentUI', () => {
 			advanceTimers: jest.advanceTimersByTime,
 		} );
 
-		render(
+		const { unmount } = render(
 			<BlockVerticalAlignmentUI
 				isToolbar
 				value={ alignment }
@@ -70,6 +70,9 @@ describe( 'BlockVerticalAlignmentUI', () => {
 				name: /^Align \w+$/,
 			} )
 		).toHaveLength( 3 );
+
+		// Cancel running effects, like delayed dropdown menu popover positioning.
+		unmount();
 	} );
 
 	it( 'should call onChange with undefined, when the control is already active', async () => {


### PR DESCRIPTION
## What?
This PR is fixing the block alignment component tests so they pass in React 18.

## Why?
We need the tests to pass in React 18 in order to unblock the upgrade. See #45235.

## How?
We're `unmount`-ing at the end of the component before the test ends, in order to specifically cancel any running or scheduled effects. In this case, it's about the dropdown menu popover positioning, so we're adding a comment to ensure that the intention is clear.

## Testing Instructions
* Verify tests still pass:  `npm run test:unit:watch alignment-control`
* Cherry-pick into https://github.com/WordPress/gutenberg/pull/45235 and verify that the tests pass.