### PR TITLE
Mobile block toolbar: position next to keyboard

### DIFF
--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -131,7 +131,10 @@ export default function BlockTools( {
 				) }
 				{ ! isZoomOutMode &&
 					( hasFixedToolbar || ! isLargeViewport ) && (
-						<BlockContextualToolbar isFixed />
+						<BlockContextualToolbar
+							isFixed
+							isBottom={ ! isLargeViewport }
+						/>
 					) }
 				{ /* Even if the toolbar is fixed, the block popover is still
 					needed for navigation and zoom-out mode. */ }

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -112,6 +112,25 @@
 		.block-editor-block-toolbar .components-toolbar {
 			border-right-color: $gray-200;
 		}
+
+		&.is-bottom {
+			margin-top: auto;
+			border-top: $border-width solid $gray-200;
+			border-bottom: none;
+		}
+	}
+}
+
+.block-editor-block-contextual-toolbar-wrapper {
+	z-index: z-index(".block-editor-block-popover");
+	position: fixed;
+	top: 0;
+	display: flex;
+	flex-direction: column;
+	pointer-events: none;
+
+	> * {
+		pointer-events: all;
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

It seems finally possible to put the block toolbar next to the keyboard on iOS.

The resize event seems to be delayed, though. I'm wondering though if we'd want to keep the toolbar when the keyboard is collapsed.

In any case, we'll first want to improve writing flow a put so the editor is usable again on iOS.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/4710635/203058410-4cb93503-fedc-4d48-911f-47c476512d40.MP4


