### PR TITLE
Lodash: Refactor away from `_.pick()` in block library

### DIFF
--- a/packages/block-library/src/gallery/shared.js
+++ b/packages/block-library/src/gallery/shared.js
@@ -13,8 +13,11 @@ export function defaultColumnsNumber( imageCount ) {
 }
 
 export const pickRelevantMediaFiles = ( image, sizeSlug = 'large' ) => {
-	const { alt, id, link } = image;
-	const imageProps = { alt, id, link };
+	const imageProps = Object.fromEntries(
+		Object.entries( image ).filter( ( [ key ] ) =>
+			[ 'alt', 'id', 'link' ].includes( key )
+		)
+	);
 
 	imageProps.url =
 		get( image, [ 'sizes', sizeSlug, 'url' ] ) ||

--- a/packages/block-library/src/gallery/shared.js
+++ b/packages/block-library/src/gallery/shared.js
@@ -14,7 +14,7 @@ export function defaultColumnsNumber( imageCount ) {
 
 export const pickRelevantMediaFiles = ( image, sizeSlug = 'large' ) => {
 	const imageProps = Object.fromEntries(
-		Object.entries( image ).filter( ( [ key ] ) =>
+		Object.entries( image ?? {} ).filter( ( [ key ] ) =>
 			[ 'alt', 'id', 'link' ].includes( key )
 		)
 	);

--- a/packages/block-library/src/gallery/shared.js
+++ b/packages/block-library/src/gallery/shared.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, pick } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -13,7 +13,9 @@ export function defaultColumnsNumber( imageCount ) {
 }
 
 export const pickRelevantMediaFiles = ( image, sizeSlug = 'large' ) => {
-	const imageProps = pick( image, [ 'alt', 'id', 'link' ] );
+	const { alt, id, link } = image;
+	const imageProps = { alt, id, link };
+
 	imageProps.url =
 		get( image, [ 'sizes', sizeSlug, 'url' ] ) ||
 		get( image, [ 'media_details', 'sizes', sizeSlug, 'source_url' ] ) ||

--- a/packages/block-library/src/gallery/v1/shared.js
+++ b/packages/block-library/src/gallery/v1/shared.js
@@ -1,10 +1,12 @@
 /**
  * External dependencies
  */
-import { get, pick } from 'lodash';
+import { get } from 'lodash';
 
 export const pickRelevantMediaFiles = ( image, sizeSlug = 'large' ) => {
-	const imageProps = pick( image, [ 'alt', 'id', 'link', 'caption' ] );
+	const { alt, id, link, caption } = image;
+	const imageProps = { alt, id, link, caption };
+
 	imageProps.url =
 		get( image, [ 'sizes', sizeSlug, 'url' ] ) ||
 		get( image, [ 'media_details', 'sizes', sizeSlug, 'source_url' ] ) ||

--- a/packages/block-library/src/gallery/v1/shared.js
+++ b/packages/block-library/src/gallery/v1/shared.js
@@ -4,8 +4,11 @@
 import { get } from 'lodash';
 
 export const pickRelevantMediaFiles = ( image, sizeSlug = 'large' ) => {
-	const { alt, id, link, caption } = image;
-	const imageProps = { alt, id, link, caption };
+	const imageProps = Object.fromEntries(
+		Object.entries( image ).filter( ( [ key ] ) =>
+			[ 'alt', 'id', 'link', 'caption' ].includes( key )
+		)
+	);
 
 	imageProps.url =
 		get( image, [ 'sizes', sizeSlug, 'url' ] ) ||

--- a/packages/block-library/src/gallery/v1/shared.js
+++ b/packages/block-library/src/gallery/v1/shared.js
@@ -5,7 +5,7 @@ import { get } from 'lodash';
 
 export const pickRelevantMediaFiles = ( image, sizeSlug = 'large' ) => {
 	const imageProps = Object.fromEntries(
-		Object.entries( image ).filter( ( [ key ] ) =>
+		Object.entries( image ?? {} ).filter( ( [ key ] ) =>
 			[ 'alt', 'id', 'link', 'caption' ].includes( key )
 		)
 	);

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { get, isEmpty, pick } from 'lodash';
+import { get, isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -58,7 +58,9 @@ import {
 } from './constants';
 
 export const pickRelevantMediaFiles = ( image, size ) => {
-	const imageProps = pick( image, [ 'alt', 'id', 'link', 'caption' ] );
+	const { alt, id, link, caption } = image;
+	const imageProps = { alt, id, link, caption };
+
 	imageProps.url =
 		get( image, [ 'sizes', size, 'url' ] ) ||
 		get( image, [ 'media_details', 'sizes', size, 'source_url' ] ) ||

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -59,7 +59,7 @@ import {
 
 export const pickRelevantMediaFiles = ( image, size ) => {
 	const imageProps = Object.fromEntries(
-		Object.entries( image ).filter( ( [ key ] ) =>
+		Object.entries( image ?? {} ).filter( ( [ key ] ) =>
 			[ 'alt', 'id', 'link', 'caption' ].includes( key )
 		)
 	);

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -58,8 +58,11 @@ import {
 } from './constants';
 
 export const pickRelevantMediaFiles = ( image, size ) => {
-	const { alt, id, link, caption } = image;
-	const imageProps = { alt, id, link, caption };
+	const imageProps = Object.fromEntries(
+		Object.entries( image ).filter( ( [ key ] ) =>
+			[ 'alt', 'id', 'link', 'caption' ].includes( key )
+		)
+	);
 
 	imageProps.url =
 		get( image, [ 'sizes', size, 'url' ] ) ||

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -135,13 +135,16 @@ export default function Image( {
 				} = select( blockEditorStore );
 
 				const rootClientId = getBlockRootClientId( clientId );
-				const blockEditorSettings = getSettings();
-				const settings = {
-					imageEditing: blockEditorSettings.imageEditing,
-					imageSizes: blockEditorSettings.imageSizes,
-					maxWidth: blockEditorSettings.maxWidth,
-					mediaUpload: blockEditorSettings.mediaUpload,
-				};
+				const settings = Object.fromEntries(
+					Object.entries( getSettings() ).filter( ( [ key ] ) =>
+						[
+							'imageEditing',
+							'imageSizes',
+							'maxWidth',
+							'mediaUpload',
+						].includes( key )
+					)
+				);
 
 				return {
 					...settings,

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, filter, isEmpty, map, pick } from 'lodash';
+import { get, filter, isEmpty, map } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -135,12 +135,13 @@ export default function Image( {
 				} = select( blockEditorStore );
 
 				const rootClientId = getBlockRootClientId( clientId );
-				const settings = pick( getSettings(), [
-					'imageEditing',
-					'imageSizes',
-					'maxWidth',
-					'mediaUpload',
-				] );
+				const blockEditorSettings = getSettings();
+				const settings = {
+					imageEditing: blockEditorSettings.imageEditing,
+					imageSizes: blockEditorSettings.imageSizes,
+					maxWidth: blockEditorSettings.maxWidth,
+					mediaUpload: blockEditorSettings.mediaUpload,
+				};
 
 				return {
 					...settings,

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { pick } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -85,9 +84,11 @@ const SiteLogo = ( {
 			'root',
 			'__unstableBase'
 		);
+		const blockEditorSettings = getSettings();
 		return {
 			title: siteEntities?.name,
-			...pick( getSettings(), [ 'imageEditing', 'maxWidth' ] ),
+			imageEditing: blockEditorSettings.imageEditing,
+			maxWidth: blockEditorSettings.maxWidth,
 		};
 	}, [] );
 
@@ -120,9 +121,10 @@ const SiteLogo = ( {
 			src={ logoUrl }
 			alt={ alt }
 			onLoad={ ( event ) => {
-				setNaturalSize(
-					pick( event.target, [ 'naturalWidth', 'naturalHeight' ] )
-				);
+				setNaturalSize( {
+					naturalWidth: event.target.naturalWidth,
+					naturalHeight: event.target.naturalHeight,
+				} );
 			} }
 		/>
 	);

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -84,11 +84,13 @@ const SiteLogo = ( {
 			'root',
 			'__unstableBase'
 		);
-		const blockEditorSettings = getSettings();
 		return {
 			title: siteEntities?.name,
-			imageEditing: blockEditorSettings.imageEditing,
-			maxWidth: blockEditorSettings.maxWidth,
+			...Object.fromEntries(
+				Object.entries( getSettings() ).filter( ( [ key ] ) =>
+					[ 'imageEditing', 'maxWidth' ].includes( key )
+				)
+			),
 		};
 	}, [] );
 
@@ -121,10 +123,13 @@ const SiteLogo = ( {
 			src={ logoUrl }
 			alt={ alt }
 			onLoad={ ( event ) => {
-				setNaturalSize( {
-					naturalWidth: event.target.naturalWidth,
-					naturalHeight: event.target.naturalHeight,
-				} );
+				setNaturalSize(
+					Object.fromEntries(
+						Object.entries( event.target ).filter( ( [ key ] ) =>
+							[ 'naturalWidth', 'naturalHeight' ].includes( key )
+						)
+					)
+				);
 			} }
 		/>
 	);

--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -82,11 +82,6 @@ export function updateSelectedCell( state, selection, updateCell ) {
 		selection;
 
 	return mapValues( tableSections, ( section, sectionName ) => {
-		// Bail early if the table section is empty.
-		if ( isEmptyTableSection( section ) ) {
-			return section;
-		}
-
 		if ( selectionSectionName && selectionSectionName !== sectionName ) {
 			return section;
 		}

--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -1,9 +1,7 @@
 /**
  * External dependencies
  */
-import { get, mapValues, pick } from 'lodash';
-
-const INHERITED_COLUMN_ATTRIBUTES = [ 'align' ];
+import { get, mapValues } from 'lodash';
 
 /**
  * Creates a table state.
@@ -78,7 +76,8 @@ export function updateSelectedCell( state, selection, updateCell ) {
 		return state;
 	}
 
-	const tableSections = pick( state, [ 'head', 'body', 'foot' ] );
+	const { head, body, foot } = state;
+	const tableSections = { head, body, foot };
 	const { sectionName: selectionSectionName, rowIndex: selectionRowIndex } =
 		selection;
 
@@ -174,10 +173,10 @@ export function insertRow( state, { sectionName, rowIndex, columnCount } ) {
 							[ 'cells', index ],
 							{}
 						);
-						const inheritedAttributes = pick(
-							firstCellInColumn,
-							INHERITED_COLUMN_ATTRIBUTES
-						);
+
+						const inheritedAttributes = {
+							align: firstCellInColumn.align,
+						};
 
 						return {
 							...inheritedAttributes,
@@ -220,7 +219,8 @@ export function deleteRow( state, { sectionName, rowIndex } ) {
  * @return {Object} New table state.
  */
 export function insertColumn( state, { columnIndex } ) {
-	const tableSections = pick( state, [ 'head', 'body', 'foot' ] );
+	const { head, body, foot } = state;
+	const tableSections = { head, body, foot };
 
 	return mapValues( tableSections, ( section, sectionName ) => {
 		// Bail early if the table section is empty.
@@ -259,7 +259,8 @@ export function insertColumn( state, { columnIndex } ) {
  * @return {Object} New table state.
  */
 export function deleteColumn( state, { columnIndex } ) {
-	const tableSections = pick( state, [ 'head', 'body', 'foot' ] );
+	const { head, body, foot } = state;
+	const tableSections = { head, body, foot };
 
 	return mapValues( tableSections, ( section ) => {
 		// Bail early if the table section is empty.

--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -3,6 +3,8 @@
  */
 import { get, mapValues } from 'lodash';
 
+const INHERITED_COLUMN_ATTRIBUTES = [ 'align' ];
+
 /**
  * Creates a table state.
  *
@@ -76,8 +78,11 @@ export function updateSelectedCell( state, selection, updateCell ) {
 		return state;
 	}
 
-	const { head, body, foot } = state;
-	const tableSections = { head, body, foot };
+	const tableSections = Object.fromEntries(
+		Object.entries( state ).filter( ( [ key ] ) =>
+			[ 'head', 'body', 'foot' ].includes( key )
+		)
+	);
 	const { sectionName: selectionSectionName, rowIndex: selectionRowIndex } =
 		selection;
 
@@ -174,9 +179,12 @@ export function insertRow( state, { sectionName, rowIndex, columnCount } ) {
 							{}
 						);
 
-						const inheritedAttributes = {
-							align: firstCellInColumn.align,
-						};
+						const inheritedAttributes = Object.fromEntries(
+							Object.entries( firstCellInColumn ).filter(
+								( [ key ] ) =>
+									INHERITED_COLUMN_ATTRIBUTES.includes( key )
+							)
+						);
 
 						return {
 							...inheritedAttributes,
@@ -219,8 +227,11 @@ export function deleteRow( state, { sectionName, rowIndex } ) {
  * @return {Object} New table state.
  */
 export function insertColumn( state, { columnIndex } ) {
-	const { head, body, foot } = state;
-	const tableSections = { head, body, foot };
+	const tableSections = Object.fromEntries(
+		Object.entries( state ).filter( ( [ key ] ) =>
+			[ 'head', 'body', 'foot' ].includes( key )
+		)
+	);
 
 	return mapValues( tableSections, ( section, sectionName ) => {
 		// Bail early if the table section is empty.
@@ -259,8 +270,11 @@ export function insertColumn( state, { columnIndex } ) {
  * @return {Object} New table state.
  */
 export function deleteColumn( state, { columnIndex } ) {
-	const { head, body, foot } = state;
-	const tableSections = { head, body, foot };
+	const tableSections = Object.fromEntries(
+		Object.entries( state ).filter( ( [ key ] ) =>
+			[ 'head', 'body', 'foot' ].includes( key )
+		)
+	);
 
 	return mapValues( tableSections, ( section ) => {
 		// Bail early if the table section is empty.

--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -82,6 +82,11 @@ export function updateSelectedCell( state, selection, updateCell ) {
 		selection;
 
 	return mapValues( tableSections, ( section, sectionName ) => {
+		// Bail early if the table section is empty.
+		if ( isEmptyTableSection( section ) ) {
+			return section;
+		}
+
 		if ( selectionSectionName && selectionSectionName !== sectionName ) {
 			return section;
 		}


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.pick()` from the `block-library` package. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're converting the object to entries, filtering the entries, and converting back to an object.

## Testing Instructions

* Verify inserting a new gallery block with a few images still works well.
* Verify selecting different images in an existing gallery block still works well.
* Verify that when you select an image in an image block, its caption and alt are still considered.
* Smoke test editing of the site icon block, particularly with changing the image. Try with a very large size image as well.
* Create a 2x2 table block and change the alignment of the left column rows to the center, then to the right column rows to right. Insert a new row and verify alignment inside the cells is the same.
* Verify all checks are still green.