### PR TITLE
Lodash: Refactor blocks away from `_.pick()`

### DIFF
--- a/packages/blocks/src/store/actions.js
+++ b/packages/blocks/src/store/actions.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { isPlainObject } from 'is-plain-object';
-import { pick } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -72,23 +71,24 @@ const processBlockType = ( blockType, { select } ) => {
 
 	if ( settings.deprecated ) {
 		settings.deprecated = settings.deprecated.map( ( deprecation ) =>
-			pick(
-				// Only keep valid deprecation keys.
-				applyFilters(
-					'blocks.registerBlockType',
-					// Merge deprecation keys with pre-filter settings
-					// so that filters that depend on specific keys being
-					// present don't fail.
-					{
-						// Omit deprecation keys here so that deprecations
-						// can opt out of specific keys like "supports".
-						...omit( blockType, DEPRECATED_ENTRY_KEYS ),
-						...deprecation,
-					},
-					name,
-					deprecation
-				),
-				DEPRECATED_ENTRY_KEYS
+			Object.fromEntries(
+				Object.entries(
+					// Only keep valid deprecation keys.
+					applyFilters(
+						'blocks.registerBlockType',
+						// Merge deprecation keys with pre-filter settings
+						// so that filters that depend on specific keys being
+						// present don't fail.
+						{
+							// Omit deprecation keys here so that deprecations
+							// can opt out of specific keys like "supports".
+							...omit( blockType, DEPRECATED_ENTRY_KEYS ),
+							...deprecation,
+						},
+						name,
+						deprecation
+					)
+				).filter( ( [ key ] ) => DEPRECATED_ENTRY_KEYS.includes( key ) )
 			)
 		);
 	}


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.pick()` from the `blocks` package. There's just a single usage and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using destructuring and new object composition instead of `_.pick()`.

## Testing Instructions

* Verify all blocks are still registered properly.
* Verify all checks are still green. The change is well covered by plenty of the existing test suites.