### PR TITLE
Lodash: Refactor away from `_.pick()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -143,6 +143,7 @@ module.exports = {
 							'overEvery',
 							'partial',
 							'partialRight',
+							'pick',
 							'random',
 							'reduce',
 							'reject',

--- a/packages/babel-plugin-makepot/index.js
+++ b/packages/babel-plugin-makepot/index.js
@@ -33,7 +33,7 @@
  */
 
 const { po } = require( 'gettext-parser' );
-const { pick, isEqual, merge, isEmpty } = require( 'lodash' );
+const { merge, isEmpty } = require( 'lodash' );
 const { relative, sep } = require( 'path' );
 const { writeFileSync } = require( 'fs' );
 
@@ -182,10 +182,7 @@ function isValidTranslationKey( key ) {
  * @return {boolean} Whether valid translation keys match.
  */
 function isSameTranslation( a, b ) {
-	return isEqual(
-		pick( a, VALID_TRANSLATION_KEYS ),
-		pick( b, VALID_TRANSLATION_KEYS )
-	);
+	return VALID_TRANSLATION_KEYS.every( ( key ) => a[ key ] === b[ key ] );
 }
 
 /**


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.pick()` completely and deprecates the package. There is just a single usage and conversion is pretty straightforward. 

This PR ~is~ was blocked by a few PRs:

- [x] #45940
- [x] #45942
- [x] #45943
- [x] #45944
- [x] #45945

~It's expected that the static type and linting check fails before they have landed.~

I've rebased the PR now and it is ready for review.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're refactoring the logic of the function to greatly simplify it from:

Before: Filter 2 objects by certain known keys, compare the values, and return true if they are the same, false otherwise
After: Return true if the value of every known key for object 1 is the same as for object 2, false otherwise.

This allows us to not only remove 2 `_.pick()` instances, but also one of `_.isEqual()`.

## Testing Instructions

* Verify all checks are green - the changes are covered by their corresponding tests.