### PR TITLE
Alternative: add inserter to Nav block offcanvas experiment

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/appender.js
+++ b/packages/block-editor/src/components/off-canvas-editor/appender.js
@@ -9,20 +9,23 @@ import { forwardRef } from '@wordpress/element';
 import { store as blockEditorStore } from '../../store';
 import Inserter from '../inserter';
 
-export const Appender = forwardRef( ( { rootClientId, ...props }, ref ) => {
-	const { hideInserter } = useSelect(
-		( select ) => {
-			const { getTemplateLock, __unstableGetEditorMode } =
-				select( blockEditorStore );
+export const Appender = forwardRef( ( props, ref ) => {
+	const { hideInserter, clientId } = useSelect( ( select ) => {
+		const {
+			getTemplateLock,
+			__unstableGetEditorMode,
+			getSelectedBlockClientId,
+		} = select( blockEditorStore );
 
-			return {
-				hideInserter:
-					!! getTemplateLock( rootClientId ) ||
-					__unstableGetEditorMode() === 'zoom-out',
-			};
-		},
-		[ rootClientId ]
-	);
+		const _clientId = getSelectedBlockClientId();
+
+		return {
+			clientId: getSelectedBlockClientId(),
+			hideInserter:
+				!! getTemplateLock( _clientId ) ||
+				__unstableGetEditorMode() === 'zoom-out',
+		};
+	}, [] );
 
 	if ( hideInserter ) {
 		return null;
@@ -32,7 +35,7 @@ export const Appender = forwardRef( ( { rootClientId, ...props }, ref ) => {
 		<div className="offcanvas-editor__appender">
 			<Inserter
 				ref={ ref }
-				rootClientId={ rootClientId }
+				rootClientId={ clientId }
 				position="bottom right"
 				isAppender
 				__experimentalIsQuick

--- a/packages/block-editor/src/components/off-canvas-editor/appender.js
+++ b/packages/block-editor/src/components/off-canvas-editor/appender.js
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { forwardRef } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+import Inserter from '../inserter';
+
+export const Appender = forwardRef( ( { rootClientId, ...props }, ref ) => {
+	const { hideInserter } = useSelect(
+		( select ) => {
+			const { getTemplateLock, __unstableGetEditorMode } =
+				select( blockEditorStore );
+
+			return {
+				hideInserter:
+					!! getTemplateLock( rootClientId ) ||
+					__unstableGetEditorMode() === 'zoom-out',
+			};
+		},
+		[ rootClientId ]
+	);
+
+	if ( hideInserter ) {
+		return null;
+	}
+
+	return (
+		<div className="offcanvas-editor__appender">
+			<Inserter
+				ref={ ref }
+				rootClientId={ rootClientId }
+				position="bottom right"
+				isAppender
+				__experimentalIsQuick
+				{ ...props }
+			/>
+		</div>
+	);
+} );

--- a/packages/block-editor/src/components/off-canvas-editor/index.js
+++ b/packages/block-editor/src/components/off-canvas-editor/index.js
@@ -107,9 +107,9 @@ function __ExperimentalOffCanvasEditor(
 		setExpandedState,
 	} );
 	const selectEditorBlock = useCallback(
-		( event, _clientId ) => {
-			updateBlockSelection( event, _clientId );
-			setSelectedTreeId( _clientId );
+		( event, blockClientId ) => {
+			updateBlockSelection( event, blockClientId );
+			setSelectedTreeId( blockClientId );
 		},
 		[ setSelectedTreeId, updateBlockSelection ]
 	);
@@ -131,20 +131,26 @@ function __ExperimentalOffCanvasEditor(
 	);
 
 	const expand = useCallback(
-		( _clientId ) => {
-			if ( ! _clientId ) {
+		( blockClientId ) => {
+			if ( ! blockClientId ) {
 				return;
 			}
-			setExpandedState( { type: 'expand', clientIds: [ _clientId ] } );
+			setExpandedState( {
+				type: 'expand',
+				clientIds: [ blockClientId ],
+			} );
 		},
 		[ setExpandedState ]
 	);
 	const collapse = useCallback(
-		( _clientId ) => {
-			if ( ! _clientId ) {
+		( blockClientId ) => {
+			if ( ! blockClientId ) {
 				return;
 			}
-			setExpandedState( { type: 'collapse', clientIds: [ _clientId ] } );
+			setExpandedState( {
+				type: 'collapse',
+				clientIds: [ blockClientId ],
+			} );
 		},
 		[ setExpandedState ]
 	);

--- a/packages/block-editor/src/components/off-canvas-editor/index.js
+++ b/packages/block-editor/src/components/off-canvas-editor/index.js
@@ -221,11 +221,16 @@ function __ExperimentalOffCanvasEditor(
 						shouldShowInnerBlocks={ shouldShowInnerBlocks }
 						selectBlockInCanvas={ selectBlockInCanvas }
 					/>
-					<TreeGridRow>
+					<TreeGridRow
+						level={ 1 }
+						setSize={ 1 }
+						positionInSet={ 1 }
+						isExpanded={ true }
+					>
 						<TreeGridCell>
-							{ ( props ) => (
+							{ ( treeGridCellProps ) => (
 								<Appender
-									{ ...props }
+									{ ...treeGridCellProps }
 									rootClientId={ clientId }
 								/>
 							) }

--- a/packages/block-editor/src/components/off-canvas-editor/index.js
+++ b/packages/block-editor/src/components/off-canvas-editor/index.js
@@ -32,7 +32,7 @@ import useListViewClientIds from './use-list-view-client-ids';
 import useListViewDropZone from './use-list-view-drop-zone';
 import useListViewExpandSelectedItem from './use-list-view-expand-selected-item';
 import { store as blockEditorStore } from '../../store';
-import Inserter from '../inserter';
+import { Appender } from './appender';
 
 const expanded = ( state, action ) => {
 	if ( Array.isArray( action.clientIds ) ) {
@@ -224,7 +224,7 @@ function __ExperimentalOffCanvasEditor(
 					<TreeGridRow>
 						<TreeGridCell>
 							{ ( props ) => (
-								<OffCanvasEditorAppender
+								<Appender
 									{ ...props }
 									rootClientId={ clientId }
 								/>
@@ -236,40 +236,5 @@ function __ExperimentalOffCanvasEditor(
 		</AsyncModeProvider>
 	);
 }
-
-const OffCanvasEditorAppender = forwardRef(
-	( { rootClientId, ...props }, ref ) => {
-		const { hideInserter } = useSelect(
-			( select ) => {
-				const { getTemplateLock, __unstableGetEditorMode } =
-					select( blockEditorStore );
-
-				return {
-					hideInserter:
-						!! getTemplateLock( rootClientId ) ||
-						__unstableGetEditorMode() === 'zoom-out',
-				};
-			},
-			[ rootClientId ]
-		);
-
-		if ( hideInserter ) {
-			return null;
-		}
-
-		return (
-			<div className="offcanvas-editor__appender">
-				<Inserter
-					ref={ ref }
-					rootClientId={ rootClientId }
-					position="bottom right"
-					isAppender
-					__experimentalIsQuick
-					{ ...props }
-				/>
-			</div>
-		);
-	}
-);
 
 export default forwardRef( __ExperimentalOffCanvasEditor );

--- a/packages/block-editor/src/components/off-canvas-editor/index.js
+++ b/packages/block-editor/src/components/off-canvas-editor/index.js
@@ -5,7 +5,11 @@ import {
 	useMergeRefs,
 	__experimentalUseFixedWindowList as useFixedWindowList,
 } from '@wordpress/compose';
-import { __experimentalTreeGrid as TreeGrid } from '@wordpress/components';
+import {
+	__experimentalTreeGrid as TreeGrid,
+	__experimentalTreeGridRow as TreeGridRow,
+	__experimentalTreeGridCell as TreeGridCell,
+} from '@wordpress/components';
 import { AsyncModeProvider, useSelect } from '@wordpress/data';
 import {
 	useCallback,
@@ -217,48 +221,55 @@ function __ExperimentalOffCanvasEditor(
 						shouldShowInnerBlocks={ shouldShowInnerBlocks }
 						selectBlockInCanvas={ selectBlockInCanvas }
 					/>
-					<tr>
-						<td>
-							<OffCanvasEditorAppender
-								rootClientId={ clientId }
-							/>
-						</td>
-					</tr>
+					<TreeGridRow>
+						<TreeGridCell>
+							{ ( props ) => (
+								<OffCanvasEditorAppender
+									{ ...props }
+									rootClientId={ clientId }
+								/>
+							) }
+						</TreeGridCell>
+					</TreeGridRow>
 				</ListViewContext.Provider>
 			</TreeGrid>
 		</AsyncModeProvider>
 	);
 }
 
-function OffCanvasEditorAppender( { rootClientId } ) {
-	const { hideInserter } = useSelect(
-		( select ) => {
-			const { getTemplateLock, __unstableGetEditorMode } =
-				select( blockEditorStore );
+const OffCanvasEditorAppender = forwardRef(
+	( { rootClientId, ...props }, ref ) => {
+		const { hideInserter } = useSelect(
+			( select ) => {
+				const { getTemplateLock, __unstableGetEditorMode } =
+					select( blockEditorStore );
 
-			return {
-				hideInserter:
-					!! getTemplateLock( rootClientId ) ||
-					__unstableGetEditorMode() === 'zoom-out',
-			};
-		},
-		[ rootClientId ]
-	);
+				return {
+					hideInserter:
+						!! getTemplateLock( rootClientId ) ||
+						__unstableGetEditorMode() === 'zoom-out',
+				};
+			},
+			[ rootClientId ]
+		);
 
-	if ( hideInserter ) {
-		return null;
+		if ( hideInserter ) {
+			return null;
+		}
+
+		return (
+			<div className="offcanvas-editor__appender">
+				<Inserter
+					ref={ ref }
+					rootClientId={ rootClientId }
+					position="bottom right"
+					isAppender
+					__experimentalIsQuick
+					{ ...props }
+				/>
+			</div>
+		);
 	}
-
-	return (
-		<div className="offcanvas-editor__appender">
-			<Inserter
-				rootClientId={ rootClientId }
-				position="bottom right"
-				isAppender
-				__experimentalIsQuick
-			/>
-		</div>
-	);
-}
+);
 
 export default forwardRef( __ExperimentalOffCanvasEditor );

--- a/packages/block-editor/src/components/off-canvas-editor/index.js
+++ b/packages/block-editor/src/components/off-canvas-editor/index.js
@@ -61,7 +61,6 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
  * @param {boolean} props.showBlockMovers     Flag to enable block movers
  * @param {boolean} props.isExpanded          Flag to determine whether nested levels are expanded by default.
  * @param {boolean} props.selectBlockInCanvas Flag to determine whether the list view should be a block selection mechanism,.
- * @param {string}  props.clientId            Client ID of the root navigation block.
  * @param {Object}  ref                       Forwarded ref
  */
 function __ExperimentalOffCanvasEditor(
@@ -71,7 +70,6 @@ function __ExperimentalOffCanvasEditor(
 		showBlockMovers = false,
 		isExpanded = false,
 		selectBlockInCanvas = true,
-		clientId,
 	},
 	ref
 ) {
@@ -229,10 +227,7 @@ function __ExperimentalOffCanvasEditor(
 					>
 						<TreeGridCell>
 							{ ( treeGridCellProps ) => (
-								<Appender
-									{ ...treeGridCellProps }
-									rootClientId={ clientId }
-								/>
+								<Appender { ...treeGridCellProps } />
 							) }
 						</TreeGridCell>
 					</TreeGridRow>

--- a/packages/block-editor/src/components/off-canvas-editor/style.scss
+++ b/packages/block-editor/src/components/off-canvas-editor/style.scss
@@ -1,1 +1,17 @@
-//Styles for off-canvas editor, remove this line when you add some css to this file!
+.offcanvas-editor__list-appender__toggle {
+	flex-direction: row;
+	justify-content: flex-start;
+	border: 0;
+	box-shadow: none;
+	margin-left: 24px;
+	margin-top: $grid-unit-10; // List View block SVG icon size.
+
+	&.components-button.components-button {
+		padding: 0;
+	}
+
+	&:hover,
+	&:focus {
+		box-shadow: none;
+	}
+}

--- a/packages/block-editor/src/components/off-canvas-editor/style.scss
+++ b/packages/block-editor/src/components/off-canvas-editor/style.scss
@@ -1,17 +1,15 @@
-.offcanvas-editor__list-appender__toggle {
-	flex-direction: row;
-	justify-content: flex-start;
-	border: 0;
-	box-shadow: none;
-	margin-left: 24px;
-	margin-top: $grid-unit-10; // List View block SVG icon size.
-
-	&.components-button.components-button {
-		padding: 0;
-	}
+.offcanvas-editor__appender .block-editor-inserter__toggle {
+	background-color: #1e1e1e;
+	color: #fff;
+	margin: $grid-unit-10 0 0 28px;
+	border-radius: 2px;
+	height: 24px;
+	min-width: 24px;
+	padding: 0;
 
 	&:hover,
 	&:focus {
-		box-shadow: none;
+		background: var(--wp-admin-theme-color);
+		color: #fff;
 	}
 }

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -104,6 +104,7 @@ const MenuInspectorControls = ( {
 							<p>{ __( 'Select or create a menu' ) }</p>
 						) : (
 							<OffCanvasEditor
+								clientId={ clientId }
 								blocks={ innerBlocks }
 								isExpanded={ true }
 								selectBlockInCanvas={ false }

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -104,7 +104,6 @@ const MenuInspectorControls = ( {
 							<p>{ __( 'Select or create a menu' ) }</p>
 						) : (
 							<OffCanvasEditor
-								clientId={ clientId }
 								blocks={ innerBlocks }
 								isExpanded={ true }
 								selectBlockInCanvas={ false }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Alternative to https://github.com/WordPress/gutenberg/pull/45905.

This version just uses the simple inserter `+` that looks similar to the only in the canvas.

**Please note**: this does _not_ yet colocate the inserter _popup_ with the offcanvas list view. That will be tackled in a followup.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Addresses the first part of https://github.com/WordPress/gutenberg/issues/45445.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds a customised block appender by utilising the `<Inserter>` component directly.

This implementation _deliberately_ hardcodes all `TreeGridRow` props to reflect the root level positioning. In future we may wish to have the appender at every level of the list view but that isn't currently the case so I'm working towards landing the simplest possible implementation.

## Testing Instructions
1. Enable offcanvas experiment.
2. New Post -> Add Nav block.
3. Open offcanvas
4. See appender.
5. Click appender.
6. See that it opens the inserter _in the canvas_ (that's intentional....**for now**).
7. Test that you can navigate the List View using keyboard and it's possible to access the appender using keyboard (arrows).

## Screenshots or screencast <!-- if applicable -->
<img width="1144" alt="Screen Shot 2022-11-21 at 16 10 03" src="https://user-images.githubusercontent.com/444434/203103358-bffe08d4-d512-44f9-8b92-7cb2c48a8707.png">
