### PR TITLE
Allow for passing stylesheet to `wp_theme_has_theme_json`.

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -237,9 +237,9 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		$options = wp_parse_args( $options, array( 'with_supports' => true ) );
 
 		if ( null === static::$theme || ! static::has_same_registered_blocks( 'theme' ) ) {
-			$theme_json_file = static::get_file_path_from_theme( 'theme.json' );
-			$wp_theme        = wp_get_theme();
-			if ( '' !== $theme_json_file ) {
+			$wp_theme = wp_get_theme();
+			if ( wp_theme_has_theme_json( $wp_theme->get_stylesheet() ) ) {
+				$theme_json_file = static::get_file_path_from_theme( 'theme.json' );
 				$theme_json_data = static::read_json_file( $theme_json_file );
 				$theme_json_data = static::translate( $theme_json_data, $wp_theme->get( 'TextDomain' ) );
 			} else {
@@ -262,8 +262,8 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 
 			if ( $wp_theme->parent() ) {
 				// Get parent theme.json.
-				$parent_theme_json_file = static::get_file_path_from_theme( 'theme.json', true );
-				if ( '' !== $parent_theme_json_file ) {
+				if ( wp_theme_has_theme_json( $wp_theme->parent()->get_stylesheet() ) ) {
+					$parent_theme_json_file = static::get_file_path_from_theme( 'theme.json', true );
 					$parent_theme_json_data = static::read_json_file( $parent_theme_json_file );
 					$parent_theme_json_data = static::translate( $parent_theme_json_data, $wp_theme->parent()->get( 'TextDomain' ) );
 					// BEGIN OF EXPERIMENTAL CODE. Not to backport to core.
@@ -422,7 +422,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		 * theme, the extra condition for whether $theme is the active theme is
 		 * present here.
 		 */
-		if ( $theme->get_stylesheet() === get_stylesheet() && ! wp_theme_has_theme_json() ) {
+		if ( ! wp_theme_has_theme_json( $theme->get_stylesheet() ) ) {
 			return array();
 		}
 

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -12,11 +12,16 @@ if ( ! function_exists( 'wp_theme_has_theme_json' ) ) {
 	 * The result would be cached via the WP_Object_Cache.
 	 * It can be cleared by calling wp_theme_has_theme_json_clean_cache().
 	 *
+	 * @param string $stylesheet Directory name for the theme. Optional. Defaults to current theme.
+	 *
 	 * @return boolean
 	 */
-	function wp_theme_has_theme_json() {
+	function wp_theme_has_theme_json( $stylesheet = '' ) {
 		$cache_group       = 'theme_json';
-		$cache_key         = 'wp_theme_has_theme_json';
+		if ( empty( $stylesheet ) ) {
+			$stylesheet = get_stylesheet();
+		}
+		$cache_key         = sprintf( 'wp_theme_has_theme_json_%s', $stylesheet );
 		$theme_has_support = wp_cache_get( $cache_key, $cache_group );
 
 		/**
@@ -32,15 +37,13 @@ if ( ! function_exists( 'wp_theme_has_theme_json' ) ) {
 			return (bool) $theme_has_support;
 		}
 
-		// Has the own theme a theme.json?
-		$theme_has_support = is_readable( get_stylesheet_directory() . '/theme.json' );
-
-		// Look up the parent if the child does not have a theme.json.
-		if ( ! $theme_has_support ) {
-			$theme_has_support = is_readable( get_template_directory() . '/theme.json' );
+		$wp_theme = wp_get_theme( $stylesheet );
+		if ( ! $wp_theme->exists() ) {
+			return false;
 		}
 
-		$theme_has_support = $theme_has_support ? 1 : 0;
+		// Has the own theme a theme.json?
+		$theme_has_support = is_readable( $wp_theme->get_file_path( 'theme.json' ) ) ? 1 : 0;
 
 		wp_cache_set( $cache_key, $theme_has_support, $cache_group );
 
@@ -53,9 +56,15 @@ if ( ! function_exists( 'wp_theme_has_theme_json_clean_cache' ) ) {
 	 * Function to clean the cache used by wp_theme_has_theme_json method.
 	 *
 	 * Not to backport to core. Delete it instead.
+	 *
+	 * @param string $stylesheet Directory name for the theme. Optional. Defaults to current theme.
 	 */
-	function wp_theme_has_theme_json_clean_cache() {
-		_deprecated_function( __METHOD__, '14.7' );
+	function wp_theme_has_theme_json_clean_cache( $stylesheet = '' ) {
+		if ( empty( $stylesheet ) ) {
+			$stylesheet = get_stylesheet();
+		}
+		$cache_key = sprintf( 'wp_theme_has_theme_json_%s', $stylesheet );
+		wp_cache_delete( $cache_key, 'theme_json' );
 	}
 }
 
@@ -190,7 +199,12 @@ function gutenberg_get_global_settings( $path = array(), $context = array() ) {
  * @access private
  */
 function _gutenberg_clean_theme_json_caches() {
-	wp_cache_delete( 'wp_theme_has_theme_json', 'theme_json' );
+	$stylesheet = get_stylesheet();
+	$template   = get_template();
+	wp_theme_has_theme_json_clean_cache( $stylesheet );
+	if( $stylesheet !== $template ){
+		wp_theme_has_theme_json_clean_cache( $template );
+	}
 	wp_cache_delete( 'gutenberg_get_global_stylesheet', 'theme_json' );
 	wp_cache_delete( 'gutenberg_get_global_settings_custom', 'theme_json' );
 	wp_cache_delete( 'gutenberg_get_global_settings_theme', 'theme_json' );


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/45171

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Allow stylesheet to `wp_theme_has_theme_json`. This allows for the developers to check if none active themes support theme json. This also improves caching, as caches are no longer depending on current theme. 

See https://github.com/WordPress/gutenberg/pull/45950 https://github.com/WordPress/gutenberg/pull/45831

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
