### PR TITLE
Add "Testing Instructions for Keyboard" to PR template to encourage accessibility testing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,4 +16,7 @@ https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
 <!-- 2. Insert a Heading Block. -->
 <!-- 3. etc. -->
 
+### Testing Instructions for Keyboard
+<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
+
 ## Screenshots or screencast <!-- if applicable -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR adds a new heading 3 to the PR template, "Testing Instructions for Keyboard".

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It is my thinking that if users are forced to think about keyboard testing for user interface (UI) changes, some accessibility regressions could be prevented and new features could go out with fewer A11Y concerns. This also comes with the added benefit that it is more inclusive for everyone. Different people learn in different ways and also have different abilities. For example, someone may really benefit from being able to see the changes in a screenshot where I as a reviewer need to understand how I can test with my screen reader. This requires following a certain pattern on the keyboard that may not be obvious from the standard "Testing Instructions" heading 2 as they could be steps more geared towards sighted reviewers.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

A quick edit to the pull request template file.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Check the code diff. That is the best way for this. I will include the new sample template in a comment.

## Screenshots or screencast <!-- if applicable -->
