### PR TITLE
FocalPointPicker: add new opt-in prop

### DIFF
--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -162,6 +162,7 @@ export default function CoverInspectorControls( {
 						) }
 						{ showFocalPointPicker && (
 							<FocalPointPicker
+								__nextHasNoMarginBottom
 								label={ __( 'Focal point picker' ) }
 								url={ url }
 								value={ focalPoint }

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -268,6 +268,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes, clientId } ) {
 			) }
 			{ imageFill && mediaUrl && mediaType === 'image' && (
 				<FocalPointPicker
+					__nextHasNoMarginBottom
 					label={ __( 'Focal point picker' ) }
 					url={ mediaUrl }
 					value={ focalPoint }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

Adding new opt-in prop `__nextHasNoMarginBottom` to usages of `FocalPointPicker` in the Gutenberg codebase. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Part of this project: https://github.com/WordPress/gutenberg/issues/38730
The tl;dr is `BaseControl` has a `margin-bottom` which makes it difficult to reuse and results in inconsistent use. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding the prop `__nextHasNoMarginBottom`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

### **For `CoverInspectorControls`**

1. Add a **Cover** block to the editor 
2. Upload or add an image to the block from the media library
3. Go to 'Focal Point Picker' in block settings in the right sidebar 
4. Ensure the margin below looks the same as before 

<img width="301" alt="Screen Shot 2022-11-21 at 8 25 17 PM" src="https://user-images.githubusercontent.com/35543432/203221289-f880246b-9e55-481b-b13f-0a4f88a07532.png">

### **For`MediaTextEdit`**

1. Add **Media & Text** block to the editor 
2. Upload or add an image to the block from the media library
3. Toggle on 'Crop image to fill entire column' in block settings in the right sidebar
4. Go to 'Focal Point Picker' right below toggle
5. Ensure the margin below looks the same as before 

<img width="283" alt="Screen Shot 2022-11-21 at 8 25 30 PM" src="https://user-images.githubusercontent.com/35543432/203221313-809b3d89-f3f2-4dc5-b2a6-f92b2e462a4d.png">
