### PR TITLE
Navigation: Add label field to navigation link and navigation submenu

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -738,6 +738,14 @@ export default function NavigationLinkEdit( {
 			<InspectorControls>
 				<PanelBody title={ __( 'Link settings' ) }>
 					<TextControl
+						value={ label || '' }
+						onChange={ ( labelValue ) => {
+							setAttributes( { label: labelValue } );
+						} }
+						label={ __( 'Label' ) }
+						autoComplete="off"
+					/>
+					<TextControl
 						value={ url || '' }
 						onChange={ ( urlValue ) => {
 							setAttributes( { url: urlValue } );

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -579,6 +579,14 @@ export default function NavigationSubmenuEdit( {
 			<InspectorControls>
 				<PanelBody title={ __( 'Link settings' ) }>
 					<TextControl
+						value={ label || '' }
+						onChange={ ( labelValue ) => {
+							setAttributes( { label: labelValue } );
+						} }
+						label={ __( 'Label' ) }
+						autoComplete="off"
+					/>
+					<TextControl
 						value={ url || '' }
 						onChange={ ( urlValue ) => {
 							setAttributes( { url: urlValue } );


### PR DESCRIPTION
## What?
Add the "Label" field to the navigation link and navigation submenu inspector controls.

## Why?
Since we are now allowing users to edit these blocks in the list view, we should add these controls to the inspector too.

## How?
I'm doing this outside the scope of the experiment as these blocks are already hard to edit on canvas, so even if the experiment fails I think this change will be useful.

## Testing Instructions
- Add a navigation block
- Add a custom link or a submenu block
- Confirm you can see the label field for these blocks in the inspector controls
- Confirm that editing the label updates in both the site editor and the frontend


## Screenshots or screencast <!-- if applicable -->
<img width="284" alt="Screenshot 2022-11-22 at 10 24 23" src="https://user-images.githubusercontent.com/275961/203290014-2f27c240-fb65-412d-8eba-9eadb9f9cc52.png">

