### PR TITLE
Navigation List view: scroll horizontally when table overflows

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/index.js
+++ b/packages/block-editor/src/components/off-canvas-editor/index.js
@@ -198,41 +198,43 @@ function __ExperimentalOffCanvasEditor(
 				listViewRef={ elementRef }
 				blockDropTarget={ blockDropTarget }
 			/>
-			<TreeGrid
-				id={ id }
-				className="block-editor-list-view-tree"
-				aria-label={ __( 'Block navigation structure' ) }
-				ref={ treeGridRef }
-				onCollapseRow={ collapseRow }
-				onExpandRow={ expandRow }
-				onFocusRow={ focusRow }
-				applicationAriaLabel={ __( 'Block navigation structure' ) }
-			>
-				<ListViewContext.Provider value={ contextValue }>
-					<ListViewBranch
-						blocks={ clientIdsTree }
-						selectBlock={ selectEditorBlock }
-						showBlockMovers={ showBlockMovers }
-						fixedListWindow={ fixedListWindow }
-						selectedClientIds={ selectedClientIds }
-						isExpanded={ isExpanded }
-						shouldShowInnerBlocks={ shouldShowInnerBlocks }
-						selectBlockInCanvas={ selectBlockInCanvas }
-					/>
-					<TreeGridRow
-						level={ 1 }
-						setSize={ 1 }
-						positionInSet={ 1 }
-						isExpanded={ true }
-					>
-						<TreeGridCell>
-							{ ( treeGridCellProps ) => (
-								<Appender { ...treeGridCellProps } />
-							) }
-						</TreeGridCell>
-					</TreeGridRow>
-				</ListViewContext.Provider>
-			</TreeGrid>
+			<div className="offcanvas-editor-list-view-tree-wrapper">
+				<TreeGrid
+					id={ id }
+					className="block-editor-list-view-tree"
+					aria-label={ __( 'Block navigation structure' ) }
+					ref={ treeGridRef }
+					onCollapseRow={ collapseRow }
+					onExpandRow={ expandRow }
+					onFocusRow={ focusRow }
+					applicationAriaLabel={ __( 'Block navigation structure' ) }
+				>
+					<ListViewContext.Provider value={ contextValue }>
+						<ListViewBranch
+							blocks={ clientIdsTree }
+							selectBlock={ selectEditorBlock }
+							showBlockMovers={ showBlockMovers }
+							fixedListWindow={ fixedListWindow }
+							selectedClientIds={ selectedClientIds }
+							isExpanded={ isExpanded }
+							shouldShowInnerBlocks={ shouldShowInnerBlocks }
+							selectBlockInCanvas={ selectBlockInCanvas }
+						/>
+						<TreeGridRow
+							level={ 1 }
+							setSize={ 1 }
+							positionInSet={ 1 }
+							isExpanded={ true }
+						>
+							<TreeGridCell>
+								{ ( treeGridCellProps ) => (
+									<Appender { ...treeGridCellProps } />
+								) }
+							</TreeGridCell>
+						</TreeGridRow>
+					</ListViewContext.Provider>
+				</TreeGrid>
+			</div>
 		</AsyncModeProvider>
 	);
 }

--- a/packages/block-editor/src/components/off-canvas-editor/index.js
+++ b/packages/block-editor/src/components/off-canvas-editor/index.js
@@ -198,7 +198,7 @@ function __ExperimentalOffCanvasEditor(
 				listViewRef={ elementRef }
 				blockDropTarget={ blockDropTarget }
 			/>
-			<div className="offcanvas-editor-list-view-tree-wrapper">
+			<div className="offcanvas-editor-list-view-tree">
 				<TreeGrid
 					id={ id }
 					className="block-editor-list-view-tree"

--- a/packages/block-editor/src/components/off-canvas-editor/leaf.js
+++ b/packages/block-editor/src/components/off-canvas-editor/leaf.js
@@ -36,7 +36,11 @@ export default function ListViewLeaf( {
 	return (
 		<AnimatedTreeGridRow
 			ref={ ref }
-			className={ classnames( 'block-editor-list-view-leaf', className ) }
+			className={ classnames(
+				'block-editor-list-view-leaf',
+				'offcanvas-editor-list-view-leaf',
+				className
+			) }
 			level={ level }
 			positionInSet={ position }
 			setSize={ rowCount }

--- a/packages/block-editor/src/components/off-canvas-editor/style.scss
+++ b/packages/block-editor/src/components/off-canvas-editor/style.scss
@@ -12,4 +12,7 @@
 		background: var(--wp-admin-theme-color);
 		color: #fff;
 	}
+.offcanvas-editor-list-view-tree-wrapper {
+	max-width: 100%;
+	overflow-x: auto;
 }

--- a/packages/block-editor/src/components/off-canvas-editor/style.scss
+++ b/packages/block-editor/src/components/off-canvas-editor/style.scss
@@ -14,7 +14,7 @@
 	}
 }
 
-.offcanvas-editor-list-view-tree{
+.offcanvas-editor-list-view-tree {
 	max-width: 100%;
 	overflow-x: auto;
 	.block-editor-list-view-block__menu-cell:last-child {

--- a/packages/block-editor/src/components/off-canvas-editor/style.scss
+++ b/packages/block-editor/src/components/off-canvas-editor/style.scss
@@ -22,6 +22,8 @@
 }
 
 .block-editor-list-view-leaf {
+	display: block;
+	max-width: $sidebar-width - (2 * $grid-unit-20);
 	.block-editor-block-icon {
 		margin-right: 4px;
 	}

--- a/packages/block-editor/src/components/off-canvas-editor/style.scss
+++ b/packages/block-editor/src/components/off-canvas-editor/style.scss
@@ -16,3 +16,13 @@
 	max-width: 100%;
 	overflow-x: auto;
 }
+
+.block-editor-list-view-block__menu-cell:last-child {
+	padding-right: 0;
+}
+
+.block-editor-list-view-leaf {
+	.block-editor-block-icon {
+		margin-right: 4px;
+	}
+}

--- a/packages/block-editor/src/components/off-canvas-editor/style.scss
+++ b/packages/block-editor/src/components/off-canvas-editor/style.scss
@@ -14,20 +14,13 @@
 	}
 }
 
-.offcanvas-editor-list-view-tree {
+.offcanvas-editor-list-view-tree-wrapper {
 	max-width: 100%;
 	overflow-x: auto;
-	
-	.block-editor-list-view-block__menu-cell:last-child {
-		padding-right: 0;
-	}
+}
 
-	.block-editor-list-view-leaf {
-		display: block;
-		max-width: $sidebar-width - (2 * $grid-unit-20);
-		
-		.block-editor-block-icon {
-			margin-right: 4px;
-		}
-	}
+.offcanvas-editor-list-view-leaf {
+	display: block;
+	// sidebar width - tab panel padding
+	max-width: $sidebar-width - (2 * $grid-unit-20);
 }

--- a/packages/block-editor/src/components/off-canvas-editor/style.scss
+++ b/packages/block-editor/src/components/off-canvas-editor/style.scss
@@ -24,6 +24,7 @@
 	.block-editor-list-view-leaf {
 		display: block;
 		max-width: $sidebar-width - (2 * $grid-unit-20);
+		
 		.block-editor-block-icon {
 			margin-right: 4px;
 		}

--- a/packages/block-editor/src/components/off-canvas-editor/style.scss
+++ b/packages/block-editor/src/components/off-canvas-editor/style.scss
@@ -12,7 +12,9 @@
 		background: var(--wp-admin-theme-color);
 		color: #fff;
 	}
-.offcanvas-editor-list-view-tree-wrapper {
+}
+
+.offcanvas-editor-list-view-tree{
 	max-width: 100%;
 	overflow-x: auto;
 	.block-editor-list-view-block__menu-cell:last-child {

--- a/packages/block-editor/src/components/off-canvas-editor/style.scss
+++ b/packages/block-editor/src/components/off-canvas-editor/style.scss
@@ -15,16 +15,15 @@
 .offcanvas-editor-list-view-tree-wrapper {
 	max-width: 100%;
 	overflow-x: auto;
-}
+	.block-editor-list-view-block__menu-cell:last-child {
+		padding-right: 0;
+	}
 
-.block-editor-list-view-block__menu-cell:last-child {
-	padding-right: 0;
-}
-
-.block-editor-list-view-leaf {
-	display: block;
-	max-width: $sidebar-width - (2 * $grid-unit-20);
-	.block-editor-block-icon {
-		margin-right: 4px;
+	.block-editor-list-view-leaf {
+		display: block;
+		max-width: $sidebar-width - (2 * $grid-unit-20);
+		.block-editor-block-icon {
+			margin-right: 4px;
+		}
 	}
 }

--- a/packages/block-editor/src/components/off-canvas-editor/style.scss
+++ b/packages/block-editor/src/components/off-canvas-editor/style.scss
@@ -17,6 +17,7 @@
 .offcanvas-editor-list-view-tree {
 	max-width: 100%;
 	overflow-x: auto;
+	
 	.block-editor-list-view-block__menu-cell:last-child {
 		padding-right: 0;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
When we have menu sub menus the whole sidebar will have a scrollbar. This PR makes the list view the only part of the sidebar that will overflow because of this and makes some adjustments to keep spacing tight and improve UX like forcing the max width of each menu item to be the same as the sidebar width. That allows for us to see the edit buttons on the items you don't need to scroll to see without actually having to scroll :D

Closes #45446

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It was a bad user experience to force the user to scroll the whole sidebar in these cases.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I'm adding an extra class to target the table for the overflow and forcing a max width on the rows so the edit icon doesn't always appear at the far end of however width the table is.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Create a Menu with multiple sub menus nested and hover over them. Check that the scroll only affects the list view.

## Screenshots or screencast <!-- if applicable -->


Before |  After
--- | ---
![Screen Capture on 2022-11-23 at 10-04-57](https://user-images.githubusercontent.com/3593343/203507551-8a3ca22f-e218-4942-8f37-42ef257f2956.gif) | ![Screen Capture on 2022-11-23 at 09-59-01](https://user-images.githubusercontent.com/3593343/203507258-308b5598-8493-430d-b0cd-e73b66494ce3.gif)

