### PR TITLE
Page List: If no parent page is set, still render all children

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -429,7 +429,7 @@ Display a list of all pages. ([Source](https://github.com/WordPress/gutenberg/tr
 -	**Name:** core/page-list
 -	**Category:** widgets
 -	**Supports:** ~~html~~, ~~reusable~~
--	**Attributes:** rootPageID
+-	**Attributes:** parentPageID
 
 ## Paragraph
 

--- a/packages/block-library/src/page-list/block.json
+++ b/packages/block-library/src/page-list/block.json
@@ -8,7 +8,7 @@
 	"keywords": [ "menu", "navigation" ],
 	"textdomain": "default",
 	"attributes": {
-		"rootPageID": {
+		"parentPageID": {
 			"type": "integer",
 			"default": 0
 		}

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -307,7 +307,8 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	$css_classes     = trim( implode( ' ', $classes ) );
 
 	$nested_pages = block_core_page_list_nest_pages( $top_level_pages, $pages_with_children );
-	if ( 0 < $parent_page_id ) {
+
+	if ( 0 !== $parent_page_id ) {
 		$nested_pages = block_core_page_list_nest_pages(
 			$pages_with_children[ $parent_page_id ],
 			$pages_with_children

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -307,8 +307,7 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	$css_classes     = trim( implode( ' ', $classes ) );
 
 	$nested_pages = block_core_page_list_nest_pages( $top_level_pages, $pages_with_children );
-
-	if ( 0 !== $parent_page_id ) {
+	if ( 0 < $parent_page_id ) {
 		$nested_pages = block_core_page_list_nest_pages(
 			$pages_with_children[ $parent_page_id ],
 			$pages_with_children

--- a/test/integration/fixtures/blocks/core__page-list.json
+++ b/test/integration/fixtures/blocks/core__page-list.json
@@ -3,7 +3,7 @@
 		"name": "core/page-list",
 		"isValid": true,
 		"attributes": {
-			"rootPageID": 0
+			"parentPageID": 0
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
## What?
Changes the condition to display child pages, to assume that NULL is not a valid parentPageID value.

## Why?
If no `parentPageID` attribute is set, then we should display all the child pages. 

## How?
Change `!==0` to `0<`. This is maybe not ideal, as it makes some assumptions about the default value of parentPageID. Alternatively we could add an is_empty check.

## Testing Instructions
1. Add a Page List block to your post without a parent ID
2. Check the front end display all page.