### PR TITLE
Merged data should consider origin to return early

### DIFF
--- a/lib/compat/wordpress-6.2/class-wp-theme-json-resolver-6-2.php
+++ b/lib/compat/wordpress-6.2/class-wp-theme-json-resolver-6-2.php
@@ -110,6 +110,7 @@ class WP_Theme_JSON_Resolver_6_2 extends WP_Theme_JSON_Resolver_6_1 {
 		}
 
 		$result->merge( static::get_user_data() );
+		$result->set_spacing_sizes();
 		return $result;
 	}
 }

--- a/lib/compat/wordpress-6.2/class-wp-theme-json-resolver-6-2.php
+++ b/lib/compat/wordpress-6.2/class-wp-theme-json-resolver-6-2.php
@@ -57,4 +57,62 @@ class WP_Theme_JSON_Resolver_6_2 extends WP_Theme_JSON_Resolver_6_1 {
 		}
 	}
 
+	/**
+	 * Returns the data merged from multiple origins.
+	 *
+	 * There are four sources of data (origins) for a site:
+	 *
+	 * - default => WordPress
+	 * - blocks  => each one of the blocks provides data for itself
+	 * - theme   => the active theme
+	 * - custom  => data provided by the user
+	 *
+	 * The custom's has higher priority than the theme's, the theme's higher than blocks',
+	 * and block's higher than default's.
+	 *
+	 * Unlike the getters
+	 * {@link https://developer.wordpress.org/reference/classes/wp_theme_json_resolver/get_core_data/ get_core_data},
+	 * {@link https://developer.wordpress.org/reference/classes/wp_theme_json_resolver/get_theme_data/ get_theme_data},
+	 * and {@link https://developer.wordpress.org/reference/classes/wp_theme_json_resolver/get_user_data/ get_user_data},
+	 * this method returns data after it has been merged with the previous origins.
+	 * This means that if the same piece of data is declared in different origins
+	 * (default, blocks, theme, custom), the last origin overrides the previous.
+	 *
+	 * For example, if the user has set a background color
+	 * for the paragraph block, and the theme has done it as well,
+	 * the user preference wins.
+	 *
+	 * @param string $origin Optional. To what level should we merge data:'default', 'blocks', 'theme' or 'custom'.
+	 *                       'custom' is used as default value as well as fallback value if the origin is unknown.
+	 *
+	 * @return WP_Theme_JSON
+	 */
+	public static function get_merged_data( $origin = 'custom' ) {
+		if ( is_array( $origin ) ) {
+			_deprecated_argument( __FUNCTION__, '5.9.0' );
+		}
+
+		$result = static::get_core_data();
+		if ( 'default' === $origin ) {
+			$result->set_spacing_sizes();
+			return $result;
+		}
+
+		$result->merge( static::get_block_data() );
+		if ( 'blocks' === $origin ) {
+			$result->set_spacing_sizes();
+			return $result;
+		}
+
+		$result->merge( static::get_theme_data() );
+		if ( 'theme' === $origin ) {
+			$result->set_spacing_sizes();
+			return $result;
+		}
+
+		$result->merge( static::get_user_data() );
+
+		$result->set_spacing_sizes();
+		return $result;
+	}
 }

--- a/lib/compat/wordpress-6.2/class-wp-theme-json-resolver-6-2.php
+++ b/lib/compat/wordpress-6.2/class-wp-theme-json-resolver-6-2.php
@@ -100,7 +100,6 @@ class WP_Theme_JSON_Resolver_6_2 extends WP_Theme_JSON_Resolver_6_1 {
 
 		$result->merge( static::get_block_data() );
 		if ( 'blocks' === $origin ) {
-			$result->set_spacing_sizes();
 			return $result;
 		}
 
@@ -111,8 +110,6 @@ class WP_Theme_JSON_Resolver_6_2 extends WP_Theme_JSON_Resolver_6_1 {
 		}
 
 		$result->merge( static::get_user_data() );
-
-		$result->set_spacing_sizes();
 		return $result;
 	}
 }

--- a/lib/compat/wordpress-6.2/default-filters.php
+++ b/lib/compat/wordpress-6.2/default-filters.php
@@ -18,7 +18,9 @@
  */
 
 add_action( 'switch_theme', 'wp_theme_has_theme_json_clean_cache' );
+add_action( 'switch_theme', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
 add_action( 'start_previewing_theme', 'wp_theme_has_theme_json_clean_cache' );
+add_action( 'start_previewing_theme', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
 add_action( 'upgrader_process_complete', '_wp_theme_has_theme_json_clean_cache_upon_upgrading_active_theme', 10, 2 );
 add_action( 'save_post_wp_global_styles', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
 add_action( 'activated_plugin', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );

--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -165,47 +165,4 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_2 {
 		return $array;
 	}
 
-	/**
-	 * Returns the data merged from multiple origins.
-	 *
-	 * There are three sources of data (origins) for a site:
-	 * default, theme, and custom. The custom's has higher priority
-	 * than the theme's, and the theme's higher than default's.
-	 *
-	 * Unlike the getters {@link get_core_data},
-	 * {@link get_theme_data}, and {@link get_user_data},
-	 * this method returns data after it has been merged
-	 * with the previous origins. This means that if the same piece of data
-	 * is declared in different origins (user, theme, and core),
-	 * the last origin overrides the previous.
-	 *
-	 * For example, if the user has set a background color
-	 * for the paragraph block, and the theme has done it as well,
-	 * the user preference wins.
-	 *
-	 * @since 5.8.0
-	 * @since 5.9.0 Added user data, removed the `$settings` parameter,
-	 *              added the `$origin` parameter.
-	 *
-	 * @param string $origin Optional. To what level should we merge data.
-	 *                       Valid values are 'theme' or 'custom'. Default 'custom'.
-	 * @return WP_Theme_JSON
-	 */
-	public static function get_merged_data( $origin = 'custom' ) {
-		if ( is_array( $origin ) ) {
-			_deprecated_argument( __FUNCTION__, '5.9' );
-		}
-
-		$result = new WP_Theme_JSON_Gutenberg();
-		$result->merge( static::get_core_data() );
-		$result->merge( static::get_block_data() );
-		$result->merge( static::get_theme_data() );
-		if ( 'custom' === $origin ) {
-			$result->merge( static::get_user_data() );
-		}
-		// Generate the default spacing sizes presets.
-		$result->set_spacing_sizes();
-
-		return $result;
-	}
 }

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -379,22 +379,22 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-			),
+			)
 		);
 	}
 
 	public function register_user_data() {
 		wp_set_current_user( self::$administrator_id );
 		$user_cpt = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( wp_get_theme(), true );
-		$config = json_decode( $user_cpt['post_content'], true );
+		$config   = json_decode( $user_cpt['post_content'], true );
 		$config['settings']['color']['palette']['custom'] = array(
 			array(
 				'color' => 'hotpink',
 				'name'  => 'My color',
-				'slug'  => 'my-color'
-			)
+				'slug'  => 'my-color',
+			),
 		);
-		$user_cpt['post_content'] = wp_json_encode( $config );
+		$user_cpt['post_content']                         = wp_json_encode( $config );
 		wp_update_post( $user_cpt, true, false );
 	}
 
@@ -415,10 +415,13 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		$settings   = $theme_json->get_settings();
 		$styles     = $theme_json->get_styles_block_nodes();
 		$this->assertTrue( isset( $settings['color']['palette']['default'] ), 'core palette is present' );
-		$block_styles = array_filter( $styles, function( $element ) {
-			return isset( $element['name'] ) && $element['name'] === 'my/block-with-styles';
-		} );
-		$this->assertTrue( count( $block_styles ) === 0 , 'block styles are not present' );
+		$block_styles = array_filter(
+			$styles,
+			function( $element ) {
+				return isset( $element['name'] ) && 'my/block-with-styles' === $element['name'];
+			}
+		);
+		$this->assertTrue( count( $block_styles ) === 0, 'block styles are not present' );
 		$this->assertFalse( isset( $settings['color']['palette']['theme'] ), 'theme palette is not present' );
 		$this->assertFalse( isset( $settings['color']['palette']['custom'] ), 'user palette is not present' );
 
@@ -442,10 +445,13 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		$settings   = $theme_json->get_settings();
 		$styles     = $theme_json->get_styles_block_nodes();
 		$this->assertTrue( isset( $settings['color']['palette']['default'] ), 'core palette is present' );
-		$block_styles = array_filter( $styles, function( $element ) {
-			return isset( $element['name'] ) && $element['name'] === 'my/block-with-styles';
-		} );
-		$this->assertTrue( count( $block_styles ) === 1 , 'block styles are present' );
+		$block_styles = array_filter(
+			$styles,
+			function( $element ) {
+				return isset( $element['name'] ) && 'my/block-with-styles' === $element['name'];
+			}
+		);
+		$this->assertTrue( count( $block_styles ) === 1, 'block styles are present' );
 		$this->assertFalse( isset( $settings['color']['palette']['theme'] ), 'theme palette is not present' );
 		$this->assertFalse( isset( $settings['color']['palette']['custom'] ), 'user palette is not present' );
 
@@ -469,10 +475,13 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		$settings   = $theme_json->get_settings();
 		$styles     = $theme_json->get_styles_block_nodes();
 		$this->assertTrue( isset( $settings['color']['palette']['default'] ), 'core palette is present' );
-		$block_styles = array_filter( $styles, function( $element ) {
-			return isset( $element['name'] ) && $element['name'] === 'my/block-with-styles';
-		} );
-		$this->assertTrue( count( $block_styles ) === 1 , 'block styles are present' );
+		$block_styles = array_filter(
+			$styles,
+			function( $element ) {
+				return isset( $element['name'] ) && 'my/block-with-styles' === $element['name'];
+			}
+		);
+		$this->assertTrue( count( $block_styles ) === 1, 'block styles are present' );
 		$this->assertTrue( isset( $settings['color']['palette']['theme'] ), 'theme palette is present' );
 		$this->assertFalse( isset( $settings['color']['palette']['custom'] ), 'user palette is not present' );
 
@@ -496,10 +505,13 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		$settings   = $theme_json->get_settings();
 		$styles     = $theme_json->get_styles_block_nodes();
 		$this->assertTrue( isset( $settings['color']['palette']['default'] ), 'core palette is present' );
-		$block_styles = array_filter( $styles, function( $element ) {
-			return isset( $element['name'] ) && $element['name'] === 'my/block-with-styles';
-		} );
-		$this->assertTrue( count( $block_styles ) === 1 , 'block styles are present' );
+		$block_styles = array_filter(
+			$styles,
+			function( $element ) {
+				return isset( $element['name'] ) && 'my/block-with-styles' === $element['name'];
+			}
+		);
+		$this->assertTrue( count( $block_styles ) === 1, 'block styles are present' );
 		$this->assertTrue( isset( $settings['color']['palette']['theme'] ), 'theme palette is present' );
 		$this->assertTrue( isset( $settings['color']['palette']['custom'] ), 'user palette is present' );
 

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -370,7 +370,7 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 	 * @param bool   $core_palette      Whether the core palette is present.
 	 * @param string $core_palette_text Message.
 	 * @param string $block_styles      Whether the block styles are present.
-	 * @param string $block_styles_text Message
+	 * @param string $block_styles_text Message.
 	 * @param bool   $theme_palette      Whether the theme palette is present.
 	 * @param string $theme_palette_text Message.
 	 * @param bool   $user_palette      Whether the user palette is present.
@@ -452,7 +452,7 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 				'user_palette'       => false,
 				'user_palette_text'  => 'User palette should not be present',
 			),
-			'origin_blocks' => array(
+			'origin_blocks'  => array(
 				'origin'             => 'blocks',
 				'core_palette'       => true,
 				'core_palette_text'  => 'Core palette must be present',
@@ -463,7 +463,7 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 				'user_palette'       => false,
 				'user_palette_text'  => 'User palette should not be present',
 			),
-			'origin_theme' => array(
+			'origin_theme'   => array(
 				'origin'             => 'theme',
 				'core_palette'       => true,
 				'core_palette_text'  => 'Core palette must be present',
@@ -474,7 +474,7 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 				'user_palette'       => false,
 				'user_palette_text'  => 'User palette should not be present',
 			),
-			'origin_custom' => array(
+			'origin_custom'  => array(
 				'origin'             => 'custom',
 				'core_palette'       => true,
 				'core_palette_text'  => 'Core palette must be present',

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -415,7 +415,10 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		$settings   = $theme_json->get_settings();
 		$styles     = $theme_json->get_styles_block_nodes();
 		$this->assertTrue( isset( $settings['color']['palette']['default'] ), 'core palette is present' );
-		$this->assertFalse( isset( $styles[4] ) , 'block styles are not present' );
+		$block_styles = array_filter( $styles, function( $element ) {
+			return isset( $element['name'] ) && $element['name'] === 'my/block-with-styles';
+		} );
+		$this->assertTrue( count( $block_styles ) === 0 , 'block styles are not present' );
 		$this->assertFalse( isset( $settings['color']['palette']['theme'] ), 'theme palette is not present' );
 		$this->assertFalse( isset( $settings['color']['palette']['custom'] ), 'user palette is not present' );
 
@@ -439,7 +442,10 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		$settings   = $theme_json->get_settings();
 		$styles     = $theme_json->get_styles_block_nodes();
 		$this->assertTrue( isset( $settings['color']['palette']['default'] ), 'core palette is present' );
-		$this->assertSame( $styles[4]['name'], 'my/block-with-styles' , 'block styles are present' );
+		$block_styles = array_filter( $styles, function( $element ) {
+			return isset( $element['name'] ) && $element['name'] === 'my/block-with-styles';
+		} );
+		$this->assertTrue( count( $block_styles ) === 1 , 'block styles are present' );
 		$this->assertFalse( isset( $settings['color']['palette']['theme'] ), 'theme palette is not present' );
 		$this->assertFalse( isset( $settings['color']['palette']['custom'] ), 'user palette is not present' );
 
@@ -463,7 +469,10 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		$settings   = $theme_json->get_settings();
 		$styles     = $theme_json->get_styles_block_nodes();
 		$this->assertTrue( isset( $settings['color']['palette']['default'] ), 'core palette is present' );
-		$this->assertSame( $styles[4]['name'], 'my/block-with-styles' , 'block styles are present' );
+		$block_styles = array_filter( $styles, function( $element ) {
+			return isset( $element['name'] ) && $element['name'] === 'my/block-with-styles';
+		} );
+		$this->assertTrue( count( $block_styles ) === 1 , 'block styles are present' );
 		$this->assertTrue( isset( $settings['color']['palette']['theme'] ), 'theme palette is present' );
 		$this->assertFalse( isset( $settings['color']['palette']['custom'] ), 'user palette is not present' );
 
@@ -487,7 +496,10 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		$settings   = $theme_json->get_settings();
 		$styles     = $theme_json->get_styles_block_nodes();
 		$this->assertTrue( isset( $settings['color']['palette']['default'] ), 'core palette is present' );
-		$this->assertSame( $styles[4]['name'], 'my/block-with-styles' , 'block styles are present' );
+		$block_styles = array_filter( $styles, function( $element ) {
+			return isset( $element['name'] ) && $element['name'] === 'my/block-with-styles';
+		} );
+		$this->assertTrue( count( $block_styles ) === 1 , 'block styles are present' );
 		$this->assertTrue( isset( $settings['color']['palette']['theme'] ), 'theme palette is present' );
 		$this->assertTrue( isset( $settings['color']['palette']['custom'] ), 'user palette is present' );
 

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -383,7 +383,7 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		);
 	}
 
-	public function register_user_data() {
+	private function register_user_data() {
 		wp_set_current_user( self::$administrator_id );
 		$user_cpt = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( wp_get_theme(), true );
 		$config   = json_decode( $user_cpt['post_content'], true );
@@ -403,13 +403,13 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_merged_data_returns_origin_default() {
 		// Make sure there is data from the blocks origin.
-		self::register_block_data( 'my/block-with-styles' );
+		$this->register_block_data( 'my/block-with-styles' );
 
 		// Make sure there is data from the theme origin.
 		switch_theme( 'block-theme' );
 
 		// Make sure there is data from the user origin.
-		self::register_user_data();
+		$this->register_user_data();
 
 		$theme_json = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( 'default' );
 		$settings   = $theme_json->get_settings();
@@ -417,7 +417,7 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertTrue( isset( $settings['color']['palette']['default'] ), 'core palette is present' );
 		$block_styles = array_filter(
 			$styles,
-			function( $element ) {
+			static function( $element ) {
 				return isset( $element['name'] ) && 'my/block-with-styles' === $element['name'];
 			}
 		);
@@ -433,25 +433,25 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_merged_data_returns_origin_blocks() {
 		// Make sure there is data from the blocks origin.
-		self::register_block_data( 'my/block-with-styles' );
+		$this->register_block_data( 'my/block-with-styles' );
 
 		// Make sure there is data from the theme origin.
 		switch_theme( 'block-theme' );
 
 		// Make sure there is data from the user origin.
-		self::register_user_data();
+		$this->register_user_data();
 
 		$theme_json = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( 'blocks' );
 		$settings   = $theme_json->get_settings();
 		$styles     = $theme_json->get_styles_block_nodes();
-		$this->assertTrue( isset( $settings['color']['palette']['default'] ), 'core palette is present' );
+		$this->assertTrue( isset( $settings['color']['palette']['default'] ), 'core palette must be present' );
 		$block_styles = array_filter(
 			$styles,
-			function( $element ) {
+			static function( $element ) {
 				return isset( $element['name'] ) && 'my/block-with-styles' === $element['name'];
 			}
 		);
-		$this->assertTrue( count( $block_styles ) === 1, 'block styles are present' );
+		$this->assertTrue( count( $block_styles ) === 1, 'block styles must be defined' );
 		$this->assertFalse( isset( $settings['color']['palette']['theme'] ), 'theme palette is not present' );
 		$this->assertFalse( isset( $settings['color']['palette']['custom'] ), 'user palette is not present' );
 
@@ -463,26 +463,26 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_merged_data_returns_origin_theme() {
 		// Make sure there is data from the blocks origin.
-		self::register_block_data( 'my/block-with-styles' );
+		$this::register_block_data( 'my/block-with-styles' );
 
 		// Make sure there is data from the theme origin.
 		switch_theme( 'block-theme' );
 
 		// Make sure there is data from the user origin.
-		self::register_user_data();
+		$this->register_user_data();
 
 		$theme_json = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( 'theme' );
 		$settings   = $theme_json->get_settings();
 		$styles     = $theme_json->get_styles_block_nodes();
-		$this->assertTrue( isset( $settings['color']['palette']['default'] ), 'core palette is present' );
+		$this->assertTrue( isset( $settings['color']['palette']['default'] ), 'core palette must be defined' );
 		$block_styles = array_filter(
 			$styles,
-			function( $element ) {
+			static function( $element ) {
 				return isset( $element['name'] ) && 'my/block-with-styles' === $element['name'];
 			}
 		);
 		$this->assertTrue( count( $block_styles ) === 1, 'block styles are present' );
-		$this->assertTrue( isset( $settings['color']['palette']['theme'] ), 'theme palette is present' );
+		$this->assertTrue( isset( $settings['color']['palette']['theme'] ), 'theme palette must be defined' );
 		$this->assertFalse( isset( $settings['color']['palette']['custom'] ), 'user palette is not present' );
 
 		unregister_block_type( 'my/block-with-styles' );
@@ -493,27 +493,27 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_merged_data_returns_origin_custom() {
 		// Make sure there is data from the blocks origin.
-		self::register_block_data( 'my/block-with-styles' );
+		$this->register_block_data( 'my/block-with-styles' );
 
 		// Make sure there is data from the theme origin.
 		switch_theme( 'block-theme' );
 
 		// Make sure there is data from the user origin.
-		self::register_user_data();
+		$this->register_user_data();
 
 		$theme_json = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
 		$settings   = $theme_json->get_settings();
 		$styles     = $theme_json->get_styles_block_nodes();
-		$this->assertTrue( isset( $settings['color']['palette']['default'] ), 'core palette is present' );
+		$this->assertTrue( isset( $settings['color']['palette']['default'] ), 'core palette isn\'t defined' );
 		$block_styles = array_filter(
 			$styles,
-			function( $element ) {
+			static function( $element ) {
 				return isset( $element['name'] ) && 'my/block-with-styles' === $element['name'];
 			}
 		);
 		$this->assertTrue( count( $block_styles ) === 1, 'block styles are present' );
 		$this->assertTrue( isset( $settings['color']['palette']['theme'] ), 'theme palette is present' );
-		$this->assertTrue( isset( $settings['color']['palette']['custom'] ), 'user palette is present' );
+		$this->assertTrue( isset( $settings['color']['palette']['custom'] ), 'user palette isn\'t defined' );
 
 		unregister_block_type( 'my/block-with-styles' );
 	}

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -359,7 +359,7 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEmpty( $user_cpt, 'User CPT is expected to be empty.' );
 	}
 
-	public function register_block_data( $block_name ) {
+	private function register_block_data( $block_name ) {
 		register_block_type(
 			$block_name,
 			array(
@@ -451,7 +451,7 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 				return isset( $element['name'] ) && 'my/block-with-styles' === $element['name'];
 			}
 		);
-		$this->assertTrue( count( $block_styles ) === 1, 'block styles must be defined' );
+		$this->assertTrue( count( $block_styles ) === 1, 'block styles must be present' );
 		$this->assertFalse( isset( $settings['color']['palette']['theme'] ), 'theme palette is not present' );
 		$this->assertFalse( isset( $settings['color']['palette']['custom'] ), 'user palette is not present' );
 
@@ -463,7 +463,7 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_merged_data_returns_origin_theme() {
 		// Make sure there is data from the blocks origin.
-		$this::register_block_data( 'my/block-with-styles' );
+		$this->register_block_data( 'my/block-with-styles' );
 
 		// Make sure there is data from the theme origin.
 		switch_theme( 'block-theme' );
@@ -474,15 +474,15 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		$theme_json = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( 'theme' );
 		$settings   = $theme_json->get_settings();
 		$styles     = $theme_json->get_styles_block_nodes();
-		$this->assertTrue( isset( $settings['color']['palette']['default'] ), 'core palette must be defined' );
+		$this->assertTrue( isset( $settings['color']['palette']['default'] ), 'core palette must be present' );
 		$block_styles = array_filter(
 			$styles,
 			static function( $element ) {
 				return isset( $element['name'] ) && 'my/block-with-styles' === $element['name'];
 			}
 		);
-		$this->assertTrue( count( $block_styles ) === 1, 'block styles are present' );
-		$this->assertTrue( isset( $settings['color']['palette']['theme'] ), 'theme palette must be defined' );
+		$this->assertTrue( count( $block_styles ) === 1, 'block styles must be present' );
+		$this->assertTrue( isset( $settings['color']['palette']['theme'] ), 'theme palette must be present' );
 		$this->assertFalse( isset( $settings['color']['palette']['custom'] ), 'user palette is not present' );
 
 		unregister_block_type( 'my/block-with-styles' );
@@ -504,16 +504,16 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		$theme_json = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
 		$settings   = $theme_json->get_settings();
 		$styles     = $theme_json->get_styles_block_nodes();
-		$this->assertTrue( isset( $settings['color']['palette']['default'] ), 'core palette isn\'t defined' );
+		$this->assertTrue( isset( $settings['color']['palette']['default'] ), 'core palette must be present' );
 		$block_styles = array_filter(
 			$styles,
 			static function( $element ) {
 				return isset( $element['name'] ) && 'my/block-with-styles' === $element['name'];
 			}
 		);
-		$this->assertTrue( count( $block_styles ) === 1, 'block styles are present' );
-		$this->assertTrue( isset( $settings['color']['palette']['theme'] ), 'theme palette is present' );
-		$this->assertTrue( isset( $settings['color']['palette']['custom'] ), 'user palette isn\'t defined' );
+		$this->assertTrue( count( $block_styles ) === 1, 'block styles must be present' );
+		$this->assertTrue( isset( $settings['color']['palette']['theme'] ), 'theme palette must be present' );
+		$this->assertTrue( isset( $settings['color']['palette']['custom'] ), 'user palette must be present' );
 
 		unregister_block_type( 'my/block-with-styles' );
 	}


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/45171
Related https://github.com/WordPress/gutenberg/pull/45971

## What?

This makes the `WP_Theme_JSON_Resolver::get_merged_data` consider the origin the consumers wants to retrieve, preventing it from calculating data consumers don't need.

## Why?

This PR is a preparation for https://github.com/WordPress/gutenberg/pull/45372/ and other public high-level methods. The consumer should be responsible to know which origin needs to be queried, and the resolver should return data based on that.

## How?

- This makes the `get_merged_data` method use the `$origin` parameter and bail early.
- Adds some test to clarify behavior.
- Brings back a couple of filters that were missing.

## Testing Instructions

- Verify that automated test pass.
- Test [scaling presets work as expected](https://github.com/WordPress/gutenberg/pull/45969#issuecomment-1324292280).
