### PR TITLE
Navigation: Fix the display of the create new menu option

### DIFF
--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
  */
 import ManageMenusButton from './manage-menus-button';
 import NavigationMenuSelector from './navigation-menu-selector';
+import useMoreNavigationMenu from './use-more-navigation-menu';
 
 const WrappedNavigationMenuSelector = ( {
 	clientId,
@@ -70,6 +71,36 @@ const MenuInspectorControls = ( {
 		? 'list'
 		: undefined;
 
+	const displayMoreNavigationMenu = useMoreNavigationMenu();
+
+	let headingContent = (
+		<>
+			<Heading
+				className="wp-block-navigation-off-canvas-editor__title"
+				level={ 2 }
+			>
+				{ __( 'Menu' ) }
+			</Heading>
+			<WrappedNavigationMenuSelector
+				clientId={ clientId }
+				currentMenuId={ currentMenuId }
+				handleUpdateMenu={ handleUpdateMenu }
+				convertClassicMenu={ convertClassicMenu }
+				onCreateNew={ onCreateNew }
+				createNavigationMenuIsSuccess={ createNavigationMenuIsSuccess }
+				createNavigationMenuIsError={ createNavigationMenuIsError }
+			/>
+		</>
+	);
+
+	if ( displayMoreNavigationMenu ) {
+		headingContent = (
+			<HStack className="wp-block-navigation-off-canvas-editor__header">
+				{ headingContent }
+			</HStack>
+		);
+	}
+
 	return (
 		<InspectorControls __experimentalGroup={ menuControlsSlot }>
 			<PanelBody
@@ -79,27 +110,7 @@ const MenuInspectorControls = ( {
 			>
 				{ isOffCanvasNavigationEditorEnabled ? (
 					<>
-						<HStack className="wp-block-navigation-off-canvas-editor__header">
-							<Heading
-								className="wp-block-navigation-off-canvas-editor__title"
-								level={ 2 }
-							>
-								{ __( 'Menu' ) }
-							</Heading>
-							<WrappedNavigationMenuSelector
-								clientId={ clientId }
-								currentMenuId={ currentMenuId }
-								handleUpdateMenu={ handleUpdateMenu }
-								convertClassicMenu={ convertClassicMenu }
-								onCreateNew={ onCreateNew }
-								createNavigationMenuIsSuccess={
-									createNavigationMenuIsSuccess
-								}
-								createNavigationMenuIsError={
-									createNavigationMenuIsError
-								}
-							/>
-						</HStack>
+						{ headingContent }
 						{ currentMenuId && isNavigationMenuMissing ? (
 							<p>{ __( 'Select or create a menu' ) }</p>
 						) : (

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -20,6 +20,7 @@ import { useEffect, useMemo, useState } from '@wordpress/element';
  */
 import useNavigationMenu from '../use-navigation-menu';
 import useNavigationEntities from '../use-navigation-entities';
+import useMoreNavigationMenu from './use-more-navigation-menu';
 
 function NavigationMenuSelector( {
 	currentMenuId,
@@ -59,6 +60,8 @@ function NavigationMenuSelector( {
 		'wp_navigation',
 		'title'
 	);
+
+	const displayMoreNavigationMenu = useMoreNavigationMenu();
 
 	const shouldEnableMenuSelector =
 		( canSwitchNavigationMenu || canUserCreateNavigationMenu ) &&
@@ -143,7 +146,7 @@ function NavigationMenuSelector( {
 		},
 	};
 
-	if ( ! hasNavigationMenus && ! hasClassicMenus ) {
+	if ( ! displayMoreNavigationMenu ) {
 		return (
 			<Button
 				className="wp-block-navigation__navigation-selector-button--createnew"

--- a/packages/block-library/src/navigation/edit/use-more-navigation-menu.js
+++ b/packages/block-library/src/navigation/edit/use-more-navigation-menu.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import useNavigationMenu from '../use-navigation-menu';
+import useNavigationEntities from '../use-navigation-entities';
+
+const useMoreNavigationMenu = () => {
+	const { menus: classicMenus } = useNavigationEntities();
+	const { navigationMenus } = useNavigationMenu();
+	const hasNavigationMenus = !! navigationMenus?.length;
+	const hasClassicMenus = !! classicMenus?.length;
+	return hasClassicMenus || hasNavigationMenus;
+};
+
+export default useMoreNavigationMenu;

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -540,9 +540,6 @@ body.editor-styles-wrapper
 	color: inherit;
 }
 
-.components-heading.wp-block-navigation-off-canvas-editor__title {
-	margin: 0;
-}
 .wp-block-navigation-off-canvas-editor__header {
 	margin-bottom: $grid-unit-10;
 }


### PR DESCRIPTION
## What?
This handles the case where the "create new menu" option is displayed as a button, when in the offcanvas editing experiment.

Before:
<img width="284" alt="Screenshot 2022-11-22 at 13 21 17" src="https://user-images.githubusercontent.com/275961/203324347-646967d8-729e-4ca8-a535-76ebe7d9ad0c.png">

After:
<img width="290" alt="Screenshot 2022-11-22 at 13 14 34" src="https://user-images.githubusercontent.com/275961/203323969-3e05704c-d16e-4521-b16b-e39049b3ad1f.png">

## Why?
Because before looks bad!

## How?
I tried to do some refactoring to avoid us having too much duplicated logic for the condition which determines which state we are in. Ideally the header would become its own component, but we'd need to pass all the props down through it to `WrappedNavigationMenuSelector`. I'll try to clean some of this up in a followup PR and see if we can get everything we need inside WrappedNavigationMenuSelector without passing so many props.

## Testing Instructions
1. Delete all classic menus and all wp_navigation menus
2. Enable the offcanvas editing experiment
3. Add a navigation block
4. Confirm that the "Create new menu" button is not alongside the "Menu" heading.

