### PR TITLE
Update which origins are queried for `gutenberg_get_global_settings`

### DIFF
--- a/lib/compat/wordpress-6.0/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.0/get-global-styles-and-settings.php
@@ -6,35 +6,6 @@
  */
 
 /**
- * Function to get the settings resulting of merging core, theme, and user data.
- *
- * @param array $path    Path to the specific setting to retrieve. Optional.
- *                       If empty, will return all settings.
- * @param array $context {
- *     Metadata to know where to retrieve the $path from. Optional.
- *
- *     @type string $block_name Which block to retrieve the settings from.
- *                              If empty, it'll return the settings for the global context.
- *     @type string $origin     Which origin to take data from.
- *                              Valid values are 'all' (core, theme, and user) or 'base' (core and theme).
- *                              If empty or unknown, 'all' is used.
- * }
- *
- * @return array The settings to retrieve.
- */
-function gutenberg_get_global_settings( $path = array(), $context = array() ) {
-	if ( ! empty( $context['block_name'] ) ) {
-		$path = array_merge( array( 'blocks', $context['block_name'] ), $path );
-	}
-	$origin = 'custom';
-	if ( isset( $context['origin'] ) && 'base' === $context['origin'] ) {
-		$origin = 'theme';
-	}
-	$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_settings();
-	return _wp_array_get( $settings, $path, $settings );
-}
-
-/**
  * Function to get the styles resulting of merging core, theme, and user data.
  *
  * @param array $path    Path to the specific style to retrieve. Optional.

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -211,14 +211,13 @@ function gutenberg_get_global_settings( $path = array(), $context = array() ) {
 		$path = array_merge( array( 'blocks', $context['block_name'] ), $path );
 	}
 
+	// This is the default value when no origin is provided or when it is 'all'.
 	$origin = 'custom';
 	if ( ! wp_theme_has_theme_json() ) {
 		// For themes with no theme.json skip querying the database for user data (custom origin).
 		$origin = 'theme';
 	} elseif ( isset( $context['origin'] ) && 'base' === $context['origin'] ) {
 		$origin = 'theme';
-	} elseif ( isset( $context['origin'] ) && 'all' === $context['all'] ) {
-		$origin = 'custom';
 	}
 
 	$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_settings();

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -209,7 +209,7 @@ function _gutenberg_get_global_stylesheet_clean_cache_upon_upgrading( $upgrader,
 function gutenberg_get_global_settings( $path = array(), $context = array() ) {
 	if ( ! empty( $context['block_name'] ) ) {
 		$new_path = array( 'blocks', $context['block_name'] );
-		foreach( $path as $subpath ) {
+		foreach ( $path as $subpath ) {
 			$new_path[] = $subpath;
 		}
 		$path = $new_path;

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -208,7 +208,11 @@ function _gutenberg_get_global_stylesheet_clean_cache_upon_upgrading( $upgrader,
  */
 function gutenberg_get_global_settings( $path = array(), $context = array() ) {
 	if ( ! empty( $context['block_name'] ) ) {
-		$path = array_merge( array( 'blocks', $context['block_name'] ), $path );
+		$new_path = array( 'blocks', $context['block_name'] );
+		foreach( $path as $subpath ) {
+			$new_path[] = $subpath;
+		}
+		$path = $new_path;
 	}
 
 	// This is the default value when no origin is provided or when it is 'all'.

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -213,10 +213,10 @@ function gutenberg_get_global_settings( $path = array(), $context = array() ) {
 
 	// This is the default value when no origin is provided or when it is 'all'.
 	$origin = 'custom';
-	if ( ! wp_theme_has_theme_json() ) {
-		// For themes with no theme.json skip querying the database for user data (custom origin).
-		$origin = 'theme';
-	} elseif ( isset( $context['origin'] ) && 'base' === $context['origin'] ) {
+	if (
+		! wp_theme_has_theme_json() ||
+		( isset( $context['origin'] ) && 'base' === $context['origin'] )
+	) {
 		$origin = 'theme';
 	}
 

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -189,7 +189,7 @@ function _gutenberg_get_global_stylesheet_clean_cache_upon_upgrading( $upgrader,
 	}
 }
 
-/*
+/**
  * Function to get the settings resulting of merging core, theme, and user data.
  *
  * @param array $path    Path to the specific setting to retrieve. Optional.
@@ -210,10 +210,17 @@ function gutenberg_get_global_settings( $path = array(), $context = array() ) {
 	if ( ! empty( $context['block_name'] ) ) {
 		$path = array_merge( array( 'blocks', $context['block_name'] ), $path );
 	}
+
 	$origin = 'custom';
-	if ( isset( $context['origin'] ) && 'base' === $context['origin'] ) {
+	if ( ! wp_theme_has_theme_json() ) {
+		// For themes with no theme.json skip querying the database for user data (custom origin).
 		$origin = 'theme';
+	} elseif ( isset( $context['origin'] ) && 'base' === $context['origin'] ) {
+		$origin = 'theme';
+	} elseif ( isset( $context['origin'] ) && 'all' === $context['all'] ) {
+		$origin = 'custom';
 	}
+
 	$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_settings();
 	return _wp_array_get( $settings, $path, $settings );
 }

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -189,3 +189,31 @@ function _gutenberg_get_global_stylesheet_clean_cache_upon_upgrading( $upgrader,
 	}
 }
 
+/*
+ * Function to get the settings resulting of merging core, theme, and user data.
+ *
+ * @param array $path    Path to the specific setting to retrieve. Optional.
+ *                       If empty, will return all settings.
+ * @param array $context {
+ *     Metadata to know where to retrieve the $path from. Optional.
+ *
+ *     @type string $block_name Which block to retrieve the settings from.
+ *                              If empty, it'll return the settings for the global context.
+ *     @type string $origin     Which origin to take data from.
+ *                              Valid values are 'all' (core, theme, and user) or 'base' (core and theme).
+ *                              If empty or unknown, 'all' is used.
+ * }
+ *
+ * @return array The settings to retrieve.
+ */
+function gutenberg_get_global_settings( $path = array(), $context = array() ) {
+	if ( ! empty( $context['block_name'] ) ) {
+		$path = array_merge( array( 'blocks', $context['block_name'] ), $path );
+	}
+	$origin = 'custom';
+	if ( isset( $context['origin'] ) && 'base' === $context['origin'] ) {
+		$origin = 'theme';
+	}
+	$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_settings();
+	return _wp_array_get( $settings, $path, $settings );
+}


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/45171
Related https://github.com/WordPress/gutenberg/pull/45969

## What?

This PR makes sure the settings only query for the data they need.

## Why?

We should not do operations that are unnecessary (such as database calls when there is no need).

## How?

- By making the settings method to manage properly the origins.
- Adding a new condition for themes that do not have `theme.json` (there is no user data in this case).

## Testing Instructions

Make sure automated tests pass.
