### PR TITLE
Navigation block: add location->primary to fallback nav creation for classic menus.

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -118,8 +118,7 @@ function Navigation( {
 
 	// Preload classic menus, so that they don't suddenly pop-in when viewing
 	// the Select Menu dropdown.
-	const { menus: classicMenus, menuLocations: menuLocations } =
-		useNavigationEntities();
+	const { menus: classicMenus } = useNavigationEntities();
 
 	const [ showNavigationMenuStatusNotice, hideNavigationMenuStatusNotice ] =
 		useNavigationNotice( {
@@ -291,16 +290,15 @@ function Navigation( {
 		}
 
 		// If there's non fallback navigation menus and
-		// a classic menu with a location set to primary,
+		// a classic menu with a `primary` location or slug,
 		// then create a new navigation menu based on it.
 		// Otherwise, use the first classic menu.
-		const hasPrimaryMenuLocation = menuLocations.filter(
-			( location ) => location.name === 'primary'
-		).length;
-		const primaryMenus = classicMenus.filter( ( classicMenu ) =>
-			classicMenu.locations.includes( 'primary' )
+		const primaryMenus = classicMenus.filter(
+			( classicMenu ) =>
+				classicMenu.locations.includes( 'primary' ) ||
+				classicMenu.slug.indexOf( 'primary' ) !== -1
 		);
-		if ( hasPrimaryMenuLocation && primaryMenus.length ) {
+		if ( primaryMenus.length ) {
 			convertClassicMenu(
 				primaryMenus[ 0 ].id,
 				primaryMenus[ 0 ].name,

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -118,7 +118,8 @@ function Navigation( {
 
 	// Preload classic menus, so that they don't suddenly pop-in when viewing
 	// the Select Menu dropdown.
-	const { menus: classicMenus } = useNavigationEntities();
+	const { menus: classicMenus, menuLocations: menuLocations } =
+		useNavigationEntities();
 
 	const [ showNavigationMenuStatusNotice, hideNavigationMenuStatusNotice ] =
 		useNavigationNotice( {
@@ -284,18 +285,34 @@ function Navigation( {
 			! hasResolvedNavigationMenus ||
 			isConvertingClassicMenu ||
 			fallbackNavigationMenus?.length > 0 ||
-			classicMenus?.length !== 1
+			! classicMenus?.length
 		) {
 			return;
 		}
 
 		// If there's non fallback navigation menus and
-		// only one classic menu then create a new navigation menu based on it.
-		convertClassicMenu(
-			classicMenus[ 0 ].id,
-			classicMenus[ 0 ].name,
-			'publish'
+		// a classic menu with a location set to primary,
+		// then create a new navigation menu based on it.
+		// Otherwise, use the first classic menu.
+		const hasPrimaryMenuLocation = menuLocations.filter(
+			( location ) => location.name === 'primary'
+		).length;
+		const primaryMenus = classicMenus.filter( ( classicMenu ) =>
+			classicMenu.locations.includes( 'primary' )
 		);
+		if ( hasPrimaryMenuLocation && primaryMenus.length ) {
+			convertClassicMenu(
+				primaryMenus[ 0 ].id,
+				primaryMenus[ 0 ].name,
+				'publish'
+			);
+		} else {
+			convertClassicMenu(
+				classicMenus[ 0 ].id,
+				classicMenus[ 0 ].name,
+				'publish'
+			);
+		}
 	}, [ hasResolvedNavigationMenus ] );
 
 	const navRef = useRef();

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -296,9 +296,20 @@ function Navigation( {
 		const primaryMenus = classicMenus.filter(
 			( classicMenu ) =>
 				classicMenu.locations.includes( 'primary' ) ||
-				classicMenu.slug.indexOf( 'primary' ) !== -1
+				classicMenu.slug === 'primary'
 		);
+
 		if ( primaryMenus.length ) {
+			// Sort by location to allow the menu assigned to primary location to take precedence.
+			primaryMenus.sort( ( a, b ) => {
+				if ( a.locations < b.locations ) {
+					return 1;
+				}
+				if ( a.locations > b.locations ) {
+					return -1;
+				}
+				return 0;
+			} );
 			convertClassicMenu(
 				primaryMenus[ 0 ].id,
 				primaryMenus[ 0 ].name,

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -257,10 +257,16 @@ function block_core_navigation_get_classic_menu_fallback() {
 	$classic_nav_menus = wp_get_nav_menus();
 
 	// If menus exist.
-	if ( $classic_nav_menus && ! is_wp_error( $classic_nav_menus ) && count( $classic_nav_menus ) === 1 ) {
-		// Use the first classic menu only. Handles simple use case where user has a single
-		// classic menu and switches to a block theme. In future this maybe expanded to
-		// determine the most appropriate classic menu to be used based on location.
+	if ( $classic_nav_menus && ! is_wp_error( $classic_nav_menus ) ) {
+		// Handles simple use case where user has a classic menu and switches to a block theme.
+
+		// Attempts to return the menu assigned to location `primary` (a convention many classic themes follow).
+		$locations = get_nav_menu_locations();
+		if ( isset( $locations[ 'primary' ] ) ) {
+			return wp_get_nav_menu_object( $locations[ 'primary' ] );
+		}
+
+		// Otherwise return the most first classic menu.
 		return $classic_nav_menus[0];
 	}
 }
@@ -410,7 +416,6 @@ function block_core_navigation_get_fallback_blocks() {
 	$fallback_blocks = $registry->is_registered( 'core/page-list' ) ? $page_list_fallback : array();
 
 	// Default to a list of Pages.
-
 	$navigation_post = block_core_navigation_get_most_recently_published_navigation();
 
 	// If there are no navigation posts then try to find a classic menu

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -416,6 +416,7 @@ function block_core_navigation_get_fallback_blocks() {
 	$fallback_blocks = $registry->is_registered( 'core/page-list' ) ? $page_list_fallback : array();
 
 	// Default to a list of Pages.
+
 	$navigation_post = block_core_navigation_get_most_recently_published_navigation();
 
 	// If there are no navigation posts then try to find a classic menu

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -270,7 +270,7 @@ function block_core_navigation_get_classic_menu_fallback() {
 		}
 
 		// Returns a menu if it contains `primary` in its name/slug.
-		foreach ($classic_nav_menus as $classic_nav_menu) {
+		foreach ( $classic_nav_menus as $classic_nav_menu ) {
 			if ( str_contains( $classic_nav_menu->slug, 'primary' ) ) {
 				return $classic_nav_menu;
 			}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -262,8 +262,8 @@ function block_core_navigation_get_classic_menu_fallback() {
 
 		// Attempts to return the menu assigned to location `primary` (a convention many classic themes follow).
 		$locations = get_nav_menu_locations();
-		if ( isset( $locations[ 'primary' ] ) ) {
-			return wp_get_nav_menu_object( $locations[ 'primary' ] );
+		if ( isset( $locations['primary'] ) ) {
+			return wp_get_nav_menu_object( $locations['primary'] );
 		}
 
 		// Otherwise return the most first classic menu.

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -269,9 +269,9 @@ function block_core_navigation_get_classic_menu_fallback() {
 			}
 		}
 
-		// Returns a menu if it contains `primary` in its name/slug.
+		// Returns a menu if `primary` is its slug.
 		foreach ( $classic_nav_menus as $classic_nav_menu ) {
-			if ( str_contains( $classic_nav_menu->slug, 'primary' ) ) {
+			if ( 'primary' === $classic_nav_menu->slug ) {
 				return $classic_nav_menu;
 			}
 		}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -260,13 +260,23 @@ function block_core_navigation_get_classic_menu_fallback() {
 	if ( $classic_nav_menus && ! is_wp_error( $classic_nav_menus ) ) {
 		// Handles simple use case where user has a classic menu and switches to a block theme.
 
-		// Attempts to return the menu assigned to location `primary` (a convention many classic themes follow).
+		// Returns the menu assigned to location `primary`.
 		$locations = get_nav_menu_locations();
 		if ( isset( $locations['primary'] ) ) {
-			return wp_get_nav_menu_object( $locations['primary'] );
+			$primary_menu = wp_get_nav_menu_object( $locations['primary'] );
+			if ( $primary_menu ) {
+				return $primary_menu;
+			}
 		}
 
-		// Otherwise return the most first classic menu.
+		// Returns a menu if it contains `primary` in its name/slug.
+		foreach ($classic_nav_menus as $classic_nav_menu) {
+			if ( str_contains( $classic_nav_menu->slug, 'primary' ) ) {
+				return $classic_nav_menu;
+			}
+		}
+
+		// Otherwise return the most recently created classic menu.
 		return $classic_nav_menus[0];
 	}
 }

--- a/packages/block-library/src/navigation/use-navigation-entities.js
+++ b/packages/block-library/src/navigation/use-navigation-entities.js
@@ -5,18 +5,16 @@ import { useEntityRecords } from '@wordpress/core-data';
 
 /**
  * @typedef {Object} NavigationEntitiesData
- * @property {Array|undefined} pages                    - a collection of WP Post entity objects of post type "Page".
- * @property {boolean}         isResolvingPages         - indicates whether the request to fetch pages is currently resolving.
- * @property {boolean}         hasResolvedPages         - indicates whether the request to fetch pages has finished resolving.
- * @property {Array|undefined} menus                    - a collection of Menu entity objects.
- * @property {boolean}         isResolvingMenus         - indicates whether the request to fetch menus is currently resolving.
- * @property {boolean}         hasResolvedMenus         - indicates whether the request to fetch menus has finished resolving.
- * @property {Array|undefined} menusItems               - a collection of Menu Item entity objects for the current menuId.
- * @property {boolean}         hasResolvedMenuItems     - indicates whether the request to fetch menuItems has finished resolving.
- * @property {boolean}         hasPages                 - indicates whether there is currently any data for pages.
- * @property {boolean}         hasMenus                 - indicates whether there is currently any data for menus.
- * @property {Array|undefined} menuLocations            - a collection of Menu Location entity objects for the active theme.
- * @property {boolean}         hasResolvedMenuLocations - indicates whether the request to fetch MenuLocations has finished resolving.
+ * @property {Array|undefined} pages                - a collection of WP Post entity objects of post type "Page".
+ * @property {boolean}         isResolvingPages     - indicates whether the request to fetch pages is currently resolving.
+ * @property {boolean}         hasResolvedPages     - indicates whether the request to fetch pages has finished resolving.
+ * @property {Array|undefined} menus                - a collection of Menu entity objects.
+ * @property {boolean}         isResolvingMenus     - indicates whether the request to fetch menus is currently resolving.
+ * @property {boolean}         hasResolvedMenus     - indicates whether the request to fetch menus has finished resolving.
+ * @property {Array|undefined} menusItems           - a collection of Menu Item entity objects for the current menuId.
+ * @property {boolean}         hasResolvedMenuItems - indicates whether the request to fetch menuItems has finished resolving.
+ * @property {boolean}         hasPages             - indicates whether there is currently any data for pages.
+ * @property {boolean}         hasMenus             - indicates whether there is currently any data for menus.
  */
 
 /**
@@ -57,12 +55,6 @@ export default function useNavigationEntities( menuId ) {
 			{ enabled: !! menuId }
 		);
 
-	const { records: menuLocations, hasResolved: hasResolvedMenuLocations } =
-		useEntityRecords( 'root', 'menuLocation', {
-			per_page: -1,
-			context: 'view',
-		} );
-
 	return {
 		pages,
 		isResolvingPages,
@@ -76,8 +68,5 @@ export default function useNavigationEntities( menuId ) {
 
 		menuItems,
 		hasResolvedMenuItems,
-
-		menuLocations,
-		hasResolvedMenuLocations,
 	};
 }

--- a/packages/block-library/src/navigation/use-navigation-entities.js
+++ b/packages/block-library/src/navigation/use-navigation-entities.js
@@ -5,16 +5,18 @@ import { useEntityRecords } from '@wordpress/core-data';
 
 /**
  * @typedef {Object} NavigationEntitiesData
- * @property {Array|undefined} pages                - a collection of WP Post entity objects of post type "Page".
- * @property {boolean}         isResolvingPages     - indicates whether the request to fetch pages is currently resolving.
- * @property {boolean}         hasResolvedPages     - indicates whether the request to fetch pages has finished resolving.
- * @property {Array|undefined} menus                - a collection of Menu entity objects.
- * @property {boolean}         isResolvingMenus     - indicates whether the request to fetch menus is currently resolving.
- * @property {boolean}         hasResolvedMenus     - indicates whether the request to fetch menus has finished resolving.
- * @property {Array|undefined} menusItems           - a collection of Menu Item entity objects for the current menuId.
- * @property {boolean}         hasResolvedMenuItems - indicates whether the request to fetch menuItems has finished resolving.
- * @property {boolean}         hasPages             - indicates whether there is currently any data for pages.
- * @property {boolean}         hasMenus             - indicates whether there is currently any data for menus.
+ * @property {Array|undefined} pages                    - a collection of WP Post entity objects of post type "Page".
+ * @property {boolean}         isResolvingPages         - indicates whether the request to fetch pages is currently resolving.
+ * @property {boolean}         hasResolvedPages         - indicates whether the request to fetch pages has finished resolving.
+ * @property {Array|undefined} menus                    - a collection of Menu entity objects.
+ * @property {boolean}         isResolvingMenus         - indicates whether the request to fetch menus is currently resolving.
+ * @property {boolean}         hasResolvedMenus         - indicates whether the request to fetch menus has finished resolving.
+ * @property {Array|undefined} menusItems               - a collection of Menu Item entity objects for the current menuId.
+ * @property {boolean}         hasResolvedMenuItems     - indicates whether the request to fetch menuItems has finished resolving.
+ * @property {boolean}         hasPages                 - indicates whether there is currently any data for pages.
+ * @property {boolean}         hasMenus                 - indicates whether there is currently any data for menus.
+ * @property {Array|undefined} menuLocations            - a collection of Menu Location entity objects for the active theme.
+ * @property {boolean}         hasResolvedMenuLocations - indicates whether the request to fetch MenuLocations has finished resolving.
  */
 
 /**
@@ -55,6 +57,12 @@ export default function useNavigationEntities( menuId ) {
 			{ enabled: !! menuId }
 		);
 
+	const { records: menuLocations, hasResolved: hasResolvedMenuLocations } =
+		useEntityRecords( 'root', 'menuLocation', {
+			per_page: -1,
+			context: 'view',
+		} );
+
 	return {
 		pages,
 		isResolvingPages,
@@ -68,5 +76,8 @@ export default function useNavigationEntities( menuId ) {
 
 		menuItems,
 		hasResolvedMenuItems,
+
+		menuLocations,
+		hasResolvedMenuLocations,
 	};
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds a check for a classic menu whose location is set to `primary`, to the series of fallbacks.

## Why?
Many themes ([for example TT1](https://github.com/WordPress/twentytwentyone/blob/trunk/functions.php#L76)) use `primary` slug as a convention for the location for the main classic menu, so this is slightly more friendly to upgrade from a classic theme / menu if the `primary` location is assigned.

## How?
See above.

## Testing Instructions
1. Ensure you have no navigation posts created (/wp-admin/edit.php?post_type=wp_navigation)
2. Activate a block theme with a `primary` location defined eg [Zoologist](https://github.com/Automattic/themes/tree/trunk/zoologist) and create + assign a menu to that location.  
4. Visit the front-end, verify the expected menu is used.
5. Visit the site editor, verify the expected menu is used. 

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
