### PR TITLE
RangeControl: remove margin override and add new opt-in prop

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -47,7 +47,6 @@ The following contributors merged PRs in this release:
 -   FocalPointPicker: Update the design of the focal point handle. ([45053](https://github.com/WordPress/gutenberg/pull/45053))
 -   FontSizePicker: Update hint text to match the design. ([44966](https://github.com/WordPress/gutenberg/pull/44966))
 -   CheckboxControl: Move icons out of labels. ([45535](https://github.com/WordPress/gutenberg/pull/45535))
--   RangeControl: remove margin overrides and add new opt-in prop. ([45985](https://github.com/WordPress/gutenberg/pull/45985))
 
 #### Block Editor
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -47,6 +47,7 @@ The following contributors merged PRs in this release:
 -   FocalPointPicker: Update the design of the focal point handle. ([45053](https://github.com/WordPress/gutenberg/pull/45053))
 -   FontSizePicker: Update hint text to match the design. ([44966](https://github.com/WordPress/gutenberg/pull/44966))
 -   CheckboxControl: Move icons out of labels. ([45535](https://github.com/WordPress/gutenberg/pull/45535))
+-   RangeControl: remove margin overrides and add new opt-in prop. ([45985](https://github.com/WordPress/gutenberg/pull/45985))
 
 #### Block Editor
 

--- a/packages/block-editor/src/components/image-editor/zoom-dropdown.js
+++ b/packages/block-editor/src/components/image-editor/zoom-dropdown.js
@@ -28,6 +28,7 @@ export default function ZoomDropdown() {
 			) }
 			renderContent={ () => (
 				<RangeControl
+					__nextHasNoMarginBottom
 					label={ __( 'Zoom' ) }
 					min={ MIN_ZOOM }
 					max={ MAX_ZOOM }

--- a/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
@@ -248,6 +248,7 @@ export default function SpacingInputControl( {
 						withInputField={ false }
 						onChange={ handleCustomValueSliderChange }
 						className="components-spacing-sizes-control__custom-value-range"
+						__nextHasNoMarginBottom
 					/>
 				</>
 			) }

--- a/packages/block-library/src/avatar/edit.js
+++ b/packages/block-library/src/avatar/edit.js
@@ -35,6 +35,7 @@ const AvatarInspectorControls = ( {
 	<InspectorControls>
 		<PanelBody title={ __( 'Settings' ) }>
 			<RangeControl
+				__nextHasNoMarginBottom
 				label={ __( 'Image size' ) }
 				onChange={ ( newSize ) =>
 					setAttributes( {

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -95,6 +95,7 @@ function ColumnsEditContainer( {
 			<InspectorControls>
 				<PanelBody>
 					<RangeControl
+						__nextHasNoMarginBottom
 						label={ __( 'Columns' ) }
 						value={ count }
 						onChange={ ( value ) => updateColumns( count, value ) }

--- a/packages/block-library/src/comment-author-avatar/edit.js
+++ b/packages/block-library/src/comment-author-avatar/edit.js
@@ -50,6 +50,7 @@ export default function Edit( {
 		<InspectorControls>
 			<PanelBody title={ __( 'Avatar Settings' ) }>
 				<RangeControl
+					__nextHasNoMarginBottom
 					label={ __( 'Image size' ) }
 					onChange={ ( newWidth ) =>
 						setAttributes( {

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -266,6 +266,7 @@ export default function CoverInspectorControls( {
 					panelId={ clientId }
 				>
 					<RangeControl
+						__nextHasNoMarginBottom
 						label={ __( 'Overlay opacity' ) }
 						value={ dimRatio }
 						onChange={ ( newDimRation ) =>

--- a/packages/block-library/src/file/inspector.js
+++ b/packages/block-library/src/file/inspector.js
@@ -56,6 +56,7 @@ export default function FileBlockInspector( {
 						/>
 						{ displayPreview && (
 							<RangeControl
+								__nextHasNoMarginBottom
 								label={ __( 'Height in pixels' ) }
 								min={ MIN_PREVIEW_HEIGHT }
 								max={ Math.max(

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -486,6 +486,7 @@ function GalleryEdit( props ) {
 				<PanelBody title={ __( 'Settings' ) }>
 					{ images.length > 1 && (
 						<RangeControl
+							__nextHasNoMarginBottom
 							label={ __( 'Columns' ) }
 							value={
 								columns

--- a/packages/block-library/src/gallery/v1/edit.js
+++ b/packages/block-library/src/gallery/v1/edit.js
@@ -403,6 +403,7 @@ function GalleryEdit( props ) {
 				<PanelBody title={ __( 'Settings' ) }>
 					{ images.length > 1 && (
 						<RangeControl
+							__nextHasNoMarginBottom
 							label={ __( 'Columns' ) }
 							value={ columns }
 							onChange={ setColumnsNumber }

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -161,17 +161,6 @@ figure.wp-block-image:not(.wp-block) {
 		min-width: 260px;
 		overflow: visible !important;
 	}
-
-	.components-range-control {
-		flex: 1;
-	}
-
-	.components-base-control__field {
-		display: flex;
-		margin-bottom: 0;
-		flex-direction: column;
-		align-items: flex-start;
-	}
 }
 
 .wp-block-image__aspect-ratio {

--- a/packages/block-library/src/latest-comments/edit.js
+++ b/packages/block-library/src/latest-comments/edit.js
@@ -56,6 +56,7 @@ export default function LatestComments( { attributes, setAttributes } ) {
 						}
 					/>
 					<RangeControl
+						__nextHasNoMarginBottom
 						label={ __( 'Number of comments' ) }
 						value={ commentsToShow }
 						onChange={ ( value ) =>

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -234,6 +234,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 				{ displayPostContent &&
 					displayPostContentRadio === 'excerpt' && (
 						<RangeControl
+							__nextHasNoMarginBottom
 							label={ __( 'Max number of words in excerpt' ) }
 							value={ excerptLength }
 							onChange={ ( value ) =>
@@ -355,6 +356,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 
 				{ postLayout === 'grid' && (
 					<RangeControl
+						__nextHasNoMarginBottom
 						label={ __( 'Columns' ) }
 						value={ columns }
 						onChange={ ( value ) =>

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -307,6 +307,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes, clientId } ) {
 			) }
 			{ mediaUrl && (
 				<RangeControl
+					__nextHasNoMarginBottom
 					label={ __( 'Media width' ) }
 					value={ temporaryMediaWidth || mediaWidth }
 					onChange={ commitWidthChange }

--- a/packages/block-library/src/post-featured-image/overlay.js
+++ b/packages/block-library/src/post-featured-image/overlay.js
@@ -98,6 +98,7 @@ const Overlay = ( {
 					panelId={ clientId }
 				>
 					<RangeControl
+						__nextHasNoMarginBottom
 						label={ __( 'Overlay opacity' ) }
 						value={ dimRatio }
 						onChange={ ( newDimRatio ) =>

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -141,6 +141,7 @@ export default function QueryInspectorControls( {
 						{ showColumnsControl && (
 							<>
 								<RangeControl
+									__nextHasNoMarginBottom
 									label={ __( 'Columns' ) }
 									value={ displayLayout.columns }
 									onChange={ ( value ) =>

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -111,6 +111,7 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
 					<RangeControl
+						__nextHasNoMarginBottom
 						label={ __( 'Number of items' ) }
 						value={ itemsToShow }
 						onChange={ ( value ) =>
@@ -137,6 +138,7 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 					/>
 					{ displayExcerpt && (
 						<RangeControl
+							__nextHasNoMarginBottom
 							label={ __( 'Max number of words in excerpt' ) }
 							value={ excerptLength }
 							onChange={ ( value ) =>
@@ -149,6 +151,7 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 					) }
 					{ blockLayout === 'grid' && (
 						<RangeControl
+							__nextHasNoMarginBottom
 							label={ __( 'Columns' ) }
 							value={ columns }
 							onChange={ ( value ) =>

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -298,6 +298,7 @@ const SiteLogo = ( {
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
 					<RangeControl
+						__nextHasNoMarginBottom
 						label={ __( 'Image width' ) }
 						onChange={ ( newWidth ) =>
 							setAttributes( { width: newWidth } )

--- a/packages/block-library/src/tag-cloud/edit.js
+++ b/packages/block-library/src/tag-cloud/edit.js
@@ -124,6 +124,7 @@ function TagCloudEdit( { attributes, setAttributes, taxonomies } ) {
 					}
 				/>
 				<RangeControl
+					__nextHasNoMarginBottom
 					label={ __( 'Number of tags' ) }
 					value={ numberOfTags }
 					onChange={ ( value ) =>

--- a/packages/block-library/src/text-columns/edit.js
+++ b/packages/block-library/src/text-columns/edit.js
@@ -39,6 +39,7 @@ export default function TextColumnsEdit( { attributes, setAttributes } ) {
 			<InspectorControls>
 				<PanelBody>
 					<RangeControl
+						__nextHasNoMarginBottom
 						label={ __( 'Columns' ) }
 						value={ columns }
 						onChange={ ( value ) =>

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 -   `TabPanel`: Add ability to set icon only tab buttons ([#45005](https://github.com/WordPress/gutenberg/pull/45005)).
 -   `InputControl`, `NumberControl`, `UnitControl`: Add `help` prop for additional description ([#45931](https://github.com/WordPress/gutenberg/pull/45931)).
+-   `BorderControl`, `ColorPicker` & `QueryControls`: Replace bottom margin overrides with `__nextHasNoMarginBottom` ([#45985](https://github.com/WordPress/gutenberg/pull/45985)).
 
 ### Experimental
 

--- a/packages/components/src/border-control/border-control/component.tsx
+++ b/packages/components/src/border-control/border-control/component.tsx
@@ -104,6 +104,7 @@ const UnconnectedBorderControl = (
 				/>
 				{ withSlider && (
 					<RangeControl
+						__nextHasNoMarginBottom
 						label={ __( 'Border width' ) }
 						hideLabelFromVision
 						className={ sliderClassName }

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -8,10 +8,7 @@ import { css } from '@emotion/react';
  */
 import { COLORS, CONFIG, boxSizingReset, rtl } from '../utils';
 import { space } from '../ui/utils/space';
-import {
-	StyledField,
-	StyledLabel,
-} from '../base-control/styles/base-control-styles';
+import { StyledLabel } from '../base-control/styles/base-control-styles';
 import {
 	ValueInput as UnitControlWrapper,
 	UnitSelect,
@@ -193,10 +190,4 @@ export const borderStyleButton = css`
 export const borderSlider = () => css`
 	flex: 1 1 60%;
 	${ rtl( { marginRight: space( 3 ) } )() }
-
-	${ StyledField } {
-		margin-bottom: 0;
-		font-size: 0;
-		display: flex;
-	}
 `;

--- a/packages/components/src/color-picker/input-with-slider.tsx
+++ b/packages/components/src/color-picker/input-with-slider.tsx
@@ -60,6 +60,7 @@ export const InputWithSlider = ( {
 				size="__unstable-large"
 			/>
 			<RangeControl
+				__nextHasNoMarginBottom
 				label={ label }
 				hideLabelFromVision
 				min={ min }

--- a/packages/components/src/color-picker/styles.ts
+++ b/packages/components/src/color-picker/styles.ts
@@ -38,10 +38,6 @@ export const SelectControl = styled( InnerSelectControl )`
 export const RangeControl = styled( InnerRangeControl )`
 	flex: 1;
 	margin-right: ${ space( 2 ) };
-
-	${ StyledField } {
-		margin-bottom: 0;
-	}
 `;
 
 // Make the Hue circle picker not go out of the bar.

--- a/packages/components/src/query-controls/index.js
+++ b/packages/components/src/query-controls/index.js
@@ -107,6 +107,7 @@ export default function QueryControls( {
 		),
 		onNumberOfItemsChange && (
 			<RangeControl
+				__nextHasNoMarginBottom
 				key="query-controls-range-control"
 				label={ __( 'Number of items' ) }
 				value={ numberOfItems }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

Added new opt-in prop `__nextHasNoMarginBottom` for useages of `RangeControl` in the Gutenberg codebase and removed margin override. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Part of this project: https://github.com/WordPress/gutenberg/issues/38730
The tl;dr is `BaseControl` has a `margin-bottom` which makes it difficult to reuse and results in inconsistent use. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By removing margin overrides in the CSS and adding the prop `__nextHasNoMarginBottom`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

**To note, I've included `comment-author-avatar` and `text-columns` [which have been deprecated](https://wordpress.org/support/article/blocks/#deprecated). I also have included `GalleryEdit` V1, the old version of  `GalleryEdit` (instructions below on how it can still be found and tested).**

### **For `ZoomDropdown`** 

1. Add an image block 
2. Click on the crop icon 
3. Click on the magnifying glass icon to zoom in or out
4. Check that spacing below the slider is the same as before

<img width="565" alt="Screen Shot 2022-11-22 at 6 25 11 PM" src="https://user-images.githubusercontent.com/35543432/203458165-4971691b-70b5-4a74-8917-0fa2708f5c8c.png">

### **For `SpacingInputControl`**

1. Add a group block 
2. Look for 'Dimensions' label in the block settings 
3. Check that spacing below the slider is the same as before

<img width="287" alt="Screen Shot 2022-11-22 at 6 29 37 PM" src="https://user-images.githubusercontent.com/35543432/203458661-9c0c25d1-38e3-4a5b-b535-b9a302c69d5f.png">

### **For `AvatarInspectorControls`**

1. Add an Avatar block
2. Look for 'Image Size' in block settings
3. Check that spacing below the slider is the same as before

<img width="281" alt="Screen Shot 2022-11-22 at 6 32 58 PM" src="https://user-images.githubusercontent.com/35543432/203459004-68c394c5-1a79-43a7-b8af-687450163392.png">

### **For `ColumnsEditContainer`**

1. Add Columns block to editor
2. Ensure 'Columns' is selected and not a single column
3. Look for range control slider under 'Columns' label in block settings

<img width="292" alt="Screen Shot 2022-11-22 at 6 34 10 PM" src="https://user-images.githubusercontent.com/35543432/203459088-6b413ce2-ad2e-4590-ad4b-219e7a82cc4c.png">

### **For `FileBlockInspector`**

1. Add File block
2. Upload / Add PDF from Media Library
3. Look for 'Height in Pixels' label

<img width="285" alt="Screen Shot 2022-11-22 at 6 34 57 PM" src="https://user-images.githubusercontent.com/35543432/203459153-ed5994a8-62f5-42eb-9e75-6f01830273a8.png">

### **For `GalleryEdit`**

1. Add Gallery block
2. Upload/Add two or more images from Media Library
3. Ensure 'Gallery' is selected and not a single 'Image'
4. Look for 'Columns' under 'Settings' in block settings
5. Check that spacing below the slider is the same as before

<img width="287" alt="Screen Shot 2022-11-22 at 6 36 00 PM" src="https://user-images.githubusercontent.com/35543432/203459245-67c845b0-698d-4f24-82a5-ca842c22f28b.png">

#### **For `GalleryEdit` V1**

I have tested this myself (thanks @glendaviesnz for the steps) and it's a bit involved to test, but here are the steps if using `wp-env` and Docker:

1. In `gutenberg/.wp-env.json`, change the first two lines to:

```json
"core": "WordPress/WordPress#5.9",
"plugins": [ "" ],
```

2. Then add Gutenberg 12.0 or lower to `/{DOCKER-CONTAINER}/wp-content/plugins`
3. Run `npx wp-env run cli wp option set use_balanceTags 1` to enable `useBalanceTags`
4. Activate Gutenberg in plugins
5. Add a Gallery block to the editor
6. Look for 'Columns' under 'Settings' in block settings
7. Check that spacing below the slider is the same as before

| **Before (it has a `margin-bottom` of 8px which isn't being applied):**   |  **After (when `margin-bottom` is 0, spacing stays the same):**  |
| ------------- | ------------- |
| <img width="385" alt="Screen Shot 2022-11-23 at 10 33 58 PM" src="https://user-images.githubusercontent.com/35543432/203888247-d101c0e6-7d18-4f2e-be52-2da18b9e80bd.png">  | <img width="383" alt="Screen Shot 2022-11-23 at 10 34 19 PM" src="https://user-images.githubusercontent.com/35543432/203888352-a313057b-044f-4a2f-b01a-6edcf386ae93.png">  |

### **For `LatestComments`**

1. Add Latest Comments block to the editor
2. Look for 'Number of comments' in block settings

<img width="287" alt="Screen Shot 2022-11-22 at 6 36 43 PM" src="https://user-images.githubusercontent.com/35543432/203459327-536cabfe-02df-402d-ad3c-29ff75907097.png">

### **For `LatestPostsEdit` & `QueryControls`**

1. Add Latest Posts block
2. Toggle on 'Post content' in the block settings sidebar
3. Look for range control slider under label 'Max number of words in excerpt'
<img width="281" alt="Screen Shot 2022-11-22 at 6 39 54 PM" src="https://user-images.githubusercontent.com/35543432/203459635-c5429938-5042-44d1-968a-185e167c4bc3.png">

7. Look for range control slider 'Number of Items' in the block settings sidebar
9. Click on 'Grid View' Icon in the block toolbar
10. Look for range control slider under 'Columns' label in the block settings sidebar

<img width="266" alt="Screen Shot 2022-11-22 at 6 39 58 PM" src="https://user-images.githubusercontent.com/35543432/203459763-40841ee8-370a-4606-bcea-649025b6236e.png">

### **For `MediaTextEdit`** 

1. Add Media & Text block
2. Add / upload image
3. Look for 'Media width' label in the block settings
4. Check that spacing below the slider is the same as before

<img width="272" alt="Screen Shot 2022-11-22 at 6 44 14 PM" src="https://user-images.githubusercontent.com/35543432/203460369-b6dd5808-3f43-4922-8cb6-ae611a59ab11.png">

### **For `Overlay`** 

1. Add Post Featured Image block to the editor 
2. Look for 'Overlay Opacity' label in the block settings 
4. Check that spacing below the slider is the same as before

<img width="290" alt="Screen Shot 2022-11-22 at 6 44 31 PM" src="https://user-images.githubusercontent.com/35543432/203460420-e8b3154b-7264-4a00-aba8-c3eca55e1558.png">

### **For `QueryInspectorControls`**

1. Add Query Loop block to the editor
2. Select a template or start with blank
3. Change to 'Grid View' in the block toolbar
4. Ensure parent 'Query Loop' block is selected 
6. Look for 'Settings' in the block sidebar
7. Check that spacing below the slider is the same as before

<img width="281" alt="Screen Shot 2022-11-22 at 6 47 19 PM" src="https://user-images.githubusercontent.com/35543432/203460474-6154634d-c142-41d3-831e-22f27fbd9699.png">

### **For `RSSEdit`**

1. Add RSS block to editor
2. Add RSS feed (e.g. https://developer.wordpress.com/feed/)
3. Change from 'List View' to 'Grid view' in the block toolbar
4. Toggle on 'Display excerpt'
5. Look for range control slider for 'Number of items', 'Display Excerpt', 'Columns' in block settings sidebar

<img width="290" alt="Screen Shot 2022-11-22 at 6 49 25 PM" src="https://user-images.githubusercontent.com/35543432/203460560-b6ef2bd8-14fb-4637-8058-422ae332334d.png">

### **For `SiteLogo`**

1. Add a Site Logo block to editor
2. Add / upload an image
3. See the 'Image Width' label in the block settings sidebar
4. Check that spacing below the slider is the same as before

<img width="289" alt="Screen Shot 2022-11-22 at 6 50 13 PM" src="https://user-images.githubusercontent.com/35543432/203460603-f33ed5e4-c4fe-453a-999e-4665696b0d81.png">

### **For `TagCloudEdit`** 

1. Add Tag Cloud to editor
2. Look for 'Number of tags' in block settings
3. Check that spacing below the slider is the same as before

<img width="295" alt="Screen Shot 2022-11-22 at 6 50 48 PM" src="https://user-images.githubusercontent.com/35543432/203460643-54e671f2-9678-4fa0-9fa0-713c5cf864ed.png">

### In Storybook:

#### **For `BorderControl`**:

1. Check out this branch
2. `npm run storybook:dev`
3. Search for 'BorderControl' and click on it
4. Go to 'With Slider' and 'With Slider (Custom Width)'
5. Ensure that sliders are still vertically center with input like below:

<img width="656" alt="Screen Shot 2022-11-29 at 5 34 48 PM" src="https://user-images.githubusercontent.com/35543432/204695536-baddc8cd-88bb-4a18-8018-2f242b06fa83.png">

#### **For `ColorPicker`**:

1. While still in storybook with this PR checked out from steps above, search for 'ColorPicker'
2. Click on 'Hex' and change to RGB or HSL to view range control sliders
3. Ensure that sliders are still vertically centered with color input values like below:

<img width="640" alt="Screen Shot 2022-11-29 at 5 45 19 PM" src="https://user-images.githubusercontent.com/35543432/204694998-bdfe6a53-8242-4c8b-a5a7-342402dade73.png">


 
