### PR TITLE
Post Author: Avoid errors when the user avatars are disabled

### DIFF
--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -62,7 +62,7 @@ function PostAuthorEdit( {
 		attributes;
 	const avatarSizes = [];
 	const authorName = authorDetails?.name || __( 'Post Author' );
-	if ( authorDetails ) {
+	if ( authorDetails?.avatar_urls ) {
 		Object.keys( authorDetails.avatar_urls ).forEach( ( size ) => {
 			avatarSizes.push( {
 				value: size,
@@ -172,7 +172,7 @@ function PostAuthorEdit( {
 			</BlockControls>
 
 			<div { ...blockProps }>
-				{ showAvatar && authorDetails && (
+				{ showAvatar && authorDetails?.avatar_urls && (
 					<div className="wp-block-post-author__avatar">
 						<img
 							width={ attributes.avatarSize }


### PR DESCRIPTION
## What?
Fixes #45980.

PR fixes the JS error when the user avatar display is disabled for the site.

## Why?
The user avatars can be disabled on the site level. The blocks should respect that.

## How?
Update logic to guard for missing `avatar_urls` property.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Post Author block
3. Confirm that the user avatar is displayed.
4. Disable avatars from Settings -> Discussion
5. Go back to the post and confirm that the user avatar isn't displayed. There are no errors.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2022-11-23 at 11 32 07](https://user-images.githubusercontent.com/240569/203492655-05eb9c82-9b23-48f2-b0b3-5e6823f7d192.png)
