### PR TITLE
Remove 'response.deleted' check

### DIFF
--- a/packages/e2e-test-utils-playwright/src/request-utils/templates.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/templates.ts
@@ -35,10 +35,8 @@ async function deleteAllTemplates( this: RequestUtils, type: TemplateType ) {
 			continue;
 		}
 
-		let response;
-
 		try {
-			response = await this.rest( {
+			await this.rest( {
 				method: 'DELETE',
 				path: `${ path }/${ template.id }`,
 				params: { force: true },
@@ -49,15 +47,6 @@ async function deleteAllTemplates( this: RequestUtils, type: TemplateType ) {
 			console.warn(
 				`deleteAllTemplates failed to delete template (id: ${ template.wp_id }) with the following error`,
 				responseError
-			);
-		}
-
-		if ( ! response.deleted ) {
-			// Disable reason - the error provides valuable feedback about issues with tests.
-			// eslint-disable-next-line no-console
-			console.warn(
-				`deleteAllTemplates failed to delete template (id: ${ template.wp_id }) with the following response`,
-				response
 			);
 		}
 	}

--- a/packages/e2e-test-utils/src/templates.js
+++ b/packages/e2e-test-utils/src/templates.js
@@ -46,14 +46,5 @@ export async function deleteAllTemplates( type ) {
 				responseError
 			);
 		}
-
-		if ( ! response?.deleted ) {
-			// Disable reason - the error provides valuable feedback about issues with tests.
-			// eslint-disable-next-line no-console
-			console.warn(
-				`deleteAllTemplates failed to delete template (id: ${ template.wp_id }) with the following response`,
-				response
-			);
-		}
 	}
 }

--- a/packages/e2e-test-utils/src/templates.js
+++ b/packages/e2e-test-utils/src/templates.js
@@ -47,7 +47,7 @@ export async function deleteAllTemplates( type ) {
 			);
 		}
 
-		if ( ! response.deleted ) {
+		if ( ! response?.deleted ) {
 			// Disable reason - the error provides valuable feedback about issues with tests.
 			// eslint-disable-next-line no-console
 			console.warn(

--- a/packages/e2e-test-utils/src/templates.js
+++ b/packages/e2e-test-utils/src/templates.js
@@ -31,10 +31,8 @@ export async function deleteAllTemplates( type ) {
 			continue;
 		}
 
-		let response;
-
 		try {
-			response = await rest( {
+			await rest( {
 				path: `${ path }/${ template.id }?force=true`,
 				method: 'DELETE',
 			} );


### PR DESCRIPTION
## What?
The goal of this change is to prevent the tests using the `deteleAllTemplates` from failing when the `response` is undefined or null.

## Why?
When a template couldn't be deleted the `response` variable is `null`, but the code is trying to access the `deleted` property on it, and giving this error:
```
TypeError: Cannot read properties of undefined (reading 'deleted')
```

## How?
Removing the `response.deleted` check. if `deleted` is present it [will be always true](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php#LL484), any other error will make the request fail and it'll go on the catch.
