### PR TITLE
Sidebar Tabs: Set default tab to first available

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -10,6 +10,7 @@ import { TAB_SETTINGS, TAB_APPEARANCE, TAB_LIST_VIEW } from './utils';
 import AppearanceTab from './appearance-tab';
 import SettingsTab from './settings-tab';
 import InspectorControls from '../inspector-controls';
+import useIsListViewTabDisabled from './use-is-list-view-tab-disabled';
 
 export default function InspectorControlsTabs( {
 	blockName,
@@ -17,8 +18,22 @@ export default function InspectorControlsTabs( {
 	hasBlockStyles,
 	tabs,
 } ) {
+	// The tabs panel will mount before fills are rendered to the list view
+	// slot. This means the list view tab isn't initially included in the
+	// available tabs so the panel defaults selection to the appearance tab
+	// which at the time is the first tab. This check allows blocks known to
+	// include the list view tab to set it as the tab selected by default.
+	const initialTabName = ! useIsListViewTabDisabled( blockName )
+		? TAB_LIST_VIEW.name
+		: undefined;
+
 	return (
-		<TabPanel className="block-editor-block-inspector__tabs" tabs={ tabs }>
+		<TabPanel
+			className="block-editor-block-inspector__tabs"
+			tabs={ tabs }
+			initialTabName={ initialTabName }
+			key={ clientId }
+		>
 			{ ( tab ) => {
 				if ( tab.name === TAB_SETTINGS.name ) {
 					return (


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/45991
- https://github.com/WordPress/gutenberg/pull/45005
- https://github.com/WordPress/gutenberg/pull/45304

## What?

Makes the block inspector sidebar tabs default to the first available tab when changing block selection.

## Why?

Before this PR, the `TabPanel` in the sidebar is mounted and then only rerendered when the block selection changes. This means the currently selected tab in its internal state is maintained across blocks. 

It's a nicer UX for the selected tab to default to the first tab after changing blocks. This helps ensure the most relevant controls, and those most sort after by users are the ones shown by default.

## How?

- The block inspector tabs are now keyed by the current `clientId`. As the block selection is already changing, we shouldn't suffer any a11y issues around a loss of focus here. More than happy to receive suggestions on a better approach, though.
- Leverages the fact we have a curated list of blocks using the list view tab to set that as the default for those blocks. Without this, the panel renders before the fills for the list view are detected and so the wrong tab becomes the default.



## Testing Instructions
1. Edit a post and add several blocks containing different tabs for the inspector controls, e.g. navigation block, file, paragraph etc.
2. Select a block and ensure its first tab is selected by default
3. Select a second tab and then select a new block. Its first tab should be selected.
4. In particular, check switching to a navigation block and that the list view tab is defaultly selected

<details>

<summary>Example block code</summary>

```html
<!-- wp:navigation {"ref":187} /-->

<!-- wp:navigation {"ref":187} /-->

<!-- wp:paragraph -->
<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. </p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
<!-- /wp:paragraph -->

<!-- wp:file /-->

<!-- wp:cover {"isDark":false} -->
<div class="wp-block-cover is-light"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"></div></div>
<!-- /wp:cover -->

<p>Classic block content.</p>
```
</details>

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/203534204-053ed46a-b5ba-4ddb-8507-b4e75325a2f6.mp4

