### PR TITLE
Fixed a bug that List block attributes were reset in 6.1.1

### DIFF
--- a/packages/block-library/src/list/utils.js
+++ b/packages/block-library/src/list/utils.js
@@ -56,7 +56,8 @@ export function createListBlockFromDOMElement( listElement ) {
 }
 
 export function migrateToListV2( attributes ) {
-	const { values, start, reversed, ordered, type } = attributes;
+	const { values, start, reversed, ordered, type, ...othorAttrs } =
+		attributes;
 
 	const list = document.createElement( ordered ? 'ol' : 'ul' );
 	list.innerHTML = values;
@@ -72,5 +73,8 @@ export function migrateToListV2( attributes ) {
 
 	const [ listBlock ] = rawHandler( { HTML: list.outerHTML } );
 
-	return [ listBlock.attributes, listBlock.innerBlocks ];
+	return [
+		{ ...othorAttrs, ...listBlock.attributes },
+		listBlock.innerBlocks,
+	];
 }

--- a/packages/block-library/src/list/utils.js
+++ b/packages/block-library/src/list/utils.js
@@ -56,7 +56,7 @@ export function createListBlockFromDOMElement( listElement ) {
 }
 
 export function migrateToListV2( attributes ) {
-	const { values, start, reversed, ordered, type, ...othorAttrs } =
+	const { values, start, reversed, ordered, type, ...otherAttributes } =
 		attributes;
 
 	const list = document.createElement( ordered ? 'ol' : 'ul' );
@@ -74,7 +74,7 @@ export function migrateToListV2( attributes ) {
 	const [ listBlock ] = rawHandler( { HTML: list.outerHTML } );
 
 	return [
-		{ ...othorAttrs, ...listBlock.attributes },
+		{ ...otherAttributes, ...listBlock.attributes },
 		listBlock.innerBlocks,
 	];
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is a PR that fixes #45987.

## How?
Inherited data such as className, fontSize, textColor, etc. that were not inherited in 6.1.1.

## Testing Instructions
1. Prepare an environment with a version of 6.1 or earlier and use the list. (e.g., 6.0.3)
2. Change the background color and font size of the list block.
3. Save the article.
4. Update to 6.1.1 and open the edit window for that article again.
