### PR TITLE
`ColorPalette`: show `Clear` button even when `colors` array is empty

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   `ColorPalette`: show "Clear" button even when colors array is empty ([#46001](https://github.com/WordPress/gutenberg/pull/46001)).
+
 ### Enhancements
 
 -   `TabPanel`: Add ability to set icon only tab buttons ([#45005](https://github.com/WordPress/gutenberg/pull/45005)).

--- a/packages/components/src/color-palette/index.tsx
+++ b/packages/components/src/color-palette/index.tsx
@@ -84,10 +84,6 @@ function SinglePalette( {
 		} );
 	}, [ colors, value, onChange, clearColor ] );
 
-	if ( colors.length === 0 ) {
-		return null;
-	}
-
 	return (
 		<CircularOptionPicker
 			className={ className }

--- a/packages/components/src/color-palette/stories/index.tsx
+++ b/packages/components/src/color-palette/stories/index.tsx
@@ -15,7 +15,6 @@ import { useState } from '@wordpress/element';
 import ColorPalette from '..';
 import Popover from '../../popover';
 import { Provider as SlotFillProvider } from '../../slot-fill';
-import type { ColorObject, PaletteObject } from '../types';
 
 const meta: ComponentMeta< typeof ColorPalette > = {
 	title: 'Components/ColorPalette',

--- a/packages/components/src/color-palette/stories/index.tsx
+++ b/packages/components/src/color-palette/stories/index.tsx
@@ -43,20 +43,7 @@ const Template: ComponentStory< typeof ColorPalette > = ( {
 	onChange,
 	...args
 } ) => {
-	let initialColor;
-	if ( args.color?.length ) {
-		const asColorObject = ( args.colors as ColorObject[] )?.[ 0 ].color;
-		let asPaletteObject;
-
-		if ( ( args.colors as PaletteObject[] )[ 0 ].colors?.length ) {
-			asPaletteObject = ( args.colors as PaletteObject[] )[ 0 ]
-				.colors[ 0 ].color;
-		}
-
-		initialColor = asColorObject || asPaletteObject;
-	}
-
-	const [ color, setColor ] = useState< string | undefined >( initialColor );
+	const [ color, setColor ] = useState< string | undefined >();
 
 	return (
 		<SlotFillProvider>

--- a/packages/components/src/color-palette/stories/index.tsx
+++ b/packages/components/src/color-palette/stories/index.tsx
@@ -43,10 +43,20 @@ const Template: ComponentStory< typeof ColorPalette > = ( {
 	onChange,
 	...args
 } ) => {
-	const firstColor =
-		( args.colors as ColorObject[] )[ 0 ].color ||
-		( args.colors as PaletteObject[] )[ 0 ].colors[ 0 ].color;
-	const [ color, setColor ] = useState< string | undefined >( firstColor );
+	let initialColor;
+	if ( args.color?.length ) {
+		const asColorObject = ( args.colors as ColorObject[] )?.[ 0 ].color;
+		let asPaletteObject;
+
+		if ( ( args.colors as PaletteObject[] )[ 0 ].colors?.length ) {
+			asPaletteObject = ( args.colors as PaletteObject[] )[ 0 ]
+				.colors[ 0 ].color;
+		}
+
+		initialColor = asColorObject || asPaletteObject;
+	}
+
+	const [ color, setColor ] = useState< string | undefined >( initialColor );
 
 	return (
 		<SlotFillProvider>

--- a/packages/components/src/color-palette/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.tsx.snap
@@ -63,10 +63,10 @@ exports[`ColorPalette should allow disabling custom color picker 1`] = `
           class="components-circular-option-picker__option-wrapper"
         >
           <button
-            aria-label="Color: white"
+            aria-label="Color: green"
             aria-pressed="false"
             class="components-button components-circular-option-picker__option"
-            style="background-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"
+            style="background-color: rgb(0, 255, 0); color: rgb(0, 255, 0);"
             type="button"
           />
         </div>
@@ -235,10 +235,10 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
           class="components-circular-option-picker__option-wrapper"
         >
           <button
-            aria-label="Color: white"
+            aria-label="Color: green"
             aria-pressed="false"
             class="components-button components-circular-option-picker__option"
-            style="background-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"
+            style="background-color: rgb(0, 255, 0); color: rgb(0, 255, 0);"
             type="button"
           />
         </div>

--- a/packages/components/src/color-palette/test/index.tsx
+++ b/packages/components/src/color-palette/test/index.tsx
@@ -169,4 +169,32 @@ describe( 'ColorPalette', () => {
 			)
 		).toBeVisible();
 	} );
+
+	it( 'should show the clear button even when `colors` is an empty array', () => {
+		const onChange = jest.fn();
+
+		const { rerender } = render(
+			<ColorPalette
+				colors={ EXAMPLE_COLORS }
+				value={ INITIAL_COLOR }
+				onChange={ onChange }
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'button', { name: 'Clear' } )
+		).toBeInTheDocument();
+
+		rerender(
+			<ColorPalette
+				colors={ [] }
+				value={ INITIAL_COLOR }
+				onChange={ onChange }
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'button', { name: 'Clear' } )
+		).toBeInTheDocument();
+	} );
 } );

--- a/packages/components/src/color-palette/test/index.tsx
+++ b/packages/components/src/color-palette/test/index.tsx
@@ -17,7 +17,7 @@ describe( 'ColorPalette', () => {
 	];
 	const currentColor = '#f00';
 
-	test( 'should render a dynamic toolbar of colors', () => {
+	it( 'should render a dynamic toolbar of colors', () => {
 		const onChange = jest.fn();
 
 		const { container } = render(
@@ -31,7 +31,7 @@ describe( 'ColorPalette', () => {
 		expect( container ).toMatchSnapshot();
 	} );
 
-	test( 'should render three color button options', () => {
+	it( 'should render three color button options', () => {
 		const onChange = jest.fn();
 
 		render(
@@ -47,7 +47,7 @@ describe( 'ColorPalette', () => {
 		).toHaveLength( 3 );
 	} );
 
-	test( 'should call onClick on an active button with undefined', async () => {
+	it( 'should call onClick on an active button with undefined', async () => {
 		const user = userEvent.setup( {
 			advanceTimers: jest.advanceTimersByTime,
 		} );
@@ -69,7 +69,7 @@ describe( 'ColorPalette', () => {
 		expect( onChange ).toHaveBeenCalledWith( undefined );
 	} );
 
-	test( 'should call onClick on an inactive button', async () => {
+	it( 'should call onClick on an inactive button', async () => {
 		const user = userEvent.setup( {
 			advanceTimers: jest.advanceTimersByTime,
 		} );
@@ -94,7 +94,7 @@ describe( 'ColorPalette', () => {
 		expect( onChange ).toHaveBeenCalledWith( '#fff', 1 );
 	} );
 
-	test( 'should call onClick with undefined, when the clearButton onClick is triggered', async () => {
+	it( 'should call onClick with undefined, when the clearButton onClick is triggered', async () => {
 		const user = userEvent.setup( {
 			advanceTimers: jest.advanceTimersByTime,
 		} );
@@ -114,7 +114,7 @@ describe( 'ColorPalette', () => {
 		expect( onChange ).toHaveBeenCalledWith( undefined );
 	} );
 
-	test( 'should allow disabling custom color picker', () => {
+	it( 'should allow disabling custom color picker', () => {
 		const onChange = jest.fn();
 
 		const { container } = render(
@@ -129,7 +129,7 @@ describe( 'ColorPalette', () => {
 		expect( container ).toMatchSnapshot();
 	} );
 
-	test( 'should render dropdown and its content', async () => {
+	it( 'should render dropdown and its content', async () => {
 		const user = userEvent.setup( {
 			advanceTimers: jest.advanceTimersByTime,
 		} );

--- a/packages/components/src/color-palette/test/index.tsx
+++ b/packages/components/src/color-palette/test/index.tsx
@@ -170,10 +170,10 @@ describe( 'ColorPalette', () => {
 		).toBeVisible();
 	} );
 
-	it( 'should show the clear button even when `colors` is an empty array', () => {
+	it( 'should show the clear button by default', () => {
 		const onChange = jest.fn();
 
-		const { rerender } = render(
+		render(
 			<ColorPalette
 				colors={ EXAMPLE_COLORS }
 				value={ INITIAL_COLOR }
@@ -184,14 +184,12 @@ describe( 'ColorPalette', () => {
 		expect(
 			screen.getByRole( 'button', { name: 'Clear' } )
 		).toBeInTheDocument();
+	} );
 
-		rerender(
-			<ColorPalette
-				colors={ [] }
-				value={ INITIAL_COLOR }
-				onChange={ onChange }
-			/>
-		);
+	it( 'should show the clear button even when `colors` is an empty array', () => {
+		const onChange = jest.fn();
+
+		render( <ColorPalette colors={ [] } onChange={ onChange } /> );
 
 		expect(
 			screen.getByRole( 'button', { name: 'Clear' } )

--- a/packages/components/src/color-palette/test/index.tsx
+++ b/packages/components/src/color-palette/test/index.tsx
@@ -16,13 +16,10 @@ describe( 'ColorPalette', () => {
 		{ name: 'blue', color: '#00f' },
 	];
 	const currentColor = '#f00';
-	const onChange = jest.fn();
-
-	beforeEach( () => {
-		onChange.mockClear();
-	} );
 
 	test( 'should render a dynamic toolbar of colors', () => {
+		const onChange = jest.fn();
+
 		const { container } = render(
 			<ColorPalette
 				colors={ colors }
@@ -35,6 +32,8 @@ describe( 'ColorPalette', () => {
 	} );
 
 	test( 'should render three color button options', () => {
+		const onChange = jest.fn();
+
 		render(
 			<ColorPalette
 				colors={ colors }
@@ -52,6 +51,7 @@ describe( 'ColorPalette', () => {
 		const user = userEvent.setup( {
 			advanceTimers: jest.advanceTimersByTime,
 		} );
+		const onChange = jest.fn();
 
 		render(
 			<ColorPalette
@@ -73,6 +73,7 @@ describe( 'ColorPalette', () => {
 		const user = userEvent.setup( {
 			advanceTimers: jest.advanceTimersByTime,
 		} );
+		const onChange = jest.fn();
 
 		render(
 			<ColorPalette
@@ -97,6 +98,7 @@ describe( 'ColorPalette', () => {
 		const user = userEvent.setup( {
 			advanceTimers: jest.advanceTimersByTime,
 		} );
+		const onChange = jest.fn();
 
 		render(
 			<ColorPalette
@@ -113,6 +115,8 @@ describe( 'ColorPalette', () => {
 	} );
 
 	test( 'should allow disabling custom color picker', () => {
+		const onChange = jest.fn();
+
 		const { container } = render(
 			<ColorPalette
 				colors={ colors }
@@ -129,6 +133,7 @@ describe( 'ColorPalette', () => {
 		const user = userEvent.setup( {
 			advanceTimers: jest.advanceTimersByTime,
 		} );
+		const onChange = jest.fn();
 
 		render(
 			<ColorPalette

--- a/packages/components/src/color-palette/test/index.tsx
+++ b/packages/components/src/color-palette/test/index.tsx
@@ -9,21 +9,21 @@ import userEvent from '@testing-library/user-event';
  */
 import ColorPalette from '..';
 
-describe( 'ColorPalette', () => {
-	const colors = [
-		{ name: 'red', color: '#f00' },
-		{ name: 'white', color: '#fff' },
-		{ name: 'blue', color: '#00f' },
-	];
-	const currentColor = '#f00';
+const EXAMPLE_COLORS = [
+	{ name: 'red', color: '#f00' },
+	{ name: 'green', color: '#0f0' },
+	{ name: 'blue', color: '#00f' },
+];
+const INITIAL_COLOR = EXAMPLE_COLORS[ 0 ].color;
 
+describe( 'ColorPalette', () => {
 	it( 'should render a dynamic toolbar of colors', () => {
 		const onChange = jest.fn();
 
 		const { container } = render(
 			<ColorPalette
-				colors={ colors }
-				value={ currentColor }
+				colors={ EXAMPLE_COLORS }
+				value={ INITIAL_COLOR }
 				onChange={ onChange }
 			/>
 		);
@@ -36,8 +36,8 @@ describe( 'ColorPalette', () => {
 
 		render(
 			<ColorPalette
-				colors={ colors }
-				value={ currentColor }
+				colors={ EXAMPLE_COLORS }
+				value={ INITIAL_COLOR }
 				onChange={ onChange }
 			/>
 		);
@@ -55,8 +55,8 @@ describe( 'ColorPalette', () => {
 
 		render(
 			<ColorPalette
-				colors={ colors }
-				value={ currentColor }
+				colors={ EXAMPLE_COLORS }
+				value={ INITIAL_COLOR }
 				onChange={ onChange }
 			/>
 		);
@@ -77,12 +77,14 @@ describe( 'ColorPalette', () => {
 
 		render(
 			<ColorPalette
-				colors={ colors }
-				value={ currentColor }
+				colors={ EXAMPLE_COLORS }
+				value={ INITIAL_COLOR }
 				onChange={ onChange }
 			/>
 		);
 
+		// Click the first unpressed button
+		// (i.e. a button representing a color that is not the current color)
 		await user.click(
 			screen.getAllByRole( 'button', {
 				name: /^Color:/,
@@ -90,8 +92,9 @@ describe( 'ColorPalette', () => {
 			} )[ 0 ]
 		);
 
+		// Expect the green color to have been selected
 		expect( onChange ).toHaveBeenCalledTimes( 1 );
-		expect( onChange ).toHaveBeenCalledWith( '#fff', 1 );
+		expect( onChange ).toHaveBeenCalledWith( EXAMPLE_COLORS[ 1 ].color, 1 );
 	} );
 
 	it( 'should call onClick with undefined, when the clearButton onClick is triggered', async () => {
@@ -102,8 +105,8 @@ describe( 'ColorPalette', () => {
 
 		render(
 			<ColorPalette
-				colors={ colors }
-				value={ currentColor }
+				colors={ EXAMPLE_COLORS }
+				value={ INITIAL_COLOR }
 				onChange={ onChange }
 			/>
 		);
@@ -119,9 +122,9 @@ describe( 'ColorPalette', () => {
 
 		const { container } = render(
 			<ColorPalette
-				colors={ colors }
+				colors={ EXAMPLE_COLORS }
 				disableCustomColors
-				value={ currentColor }
+				value={ INITIAL_COLOR }
 				onChange={ onChange }
 			/>
 		);
@@ -137,8 +140,8 @@ describe( 'ColorPalette', () => {
 
 		render(
 			<ColorPalette
-				colors={ colors }
-				value={ currentColor }
+				colors={ EXAMPLE_COLORS }
+				value={ INITIAL_COLOR }
 				onChange={ onChange }
 			/>
 		);
@@ -158,11 +161,11 @@ describe( 'ColorPalette', () => {
 		expect( dropdownButton ).toBeVisible();
 
 		expect(
-			within( dropdownButton ).getByText( colors[ 0 ].name )
+			within( dropdownButton ).getByText( EXAMPLE_COLORS[ 0 ].name )
 		).toBeVisible();
 		expect(
 			within( dropdownButton ).getByText(
-				colors[ 0 ].color.replace( '#', '' )
+				EXAMPLE_COLORS[ 0 ].color.replace( '#', '' )
 			)
 		).toBeVisible();
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #45928 by showing the `Clear` button in `ColorPalette` even when the array of `colors` is empty.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixing a regression introduced in #44632 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Removed the check that was forcing the component not to render `CircularOptionPicker`, which was effectively the source of the regression
- Fixed an issue in the Storybook example, which was causing the example to crash when `colors=[]`
- Added a unit test to prevent this regression from happening again
- In the process, tidied up a little the unit tests file (including changing example colors to be less US-centric)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Try to reproduce the bug flagged in #44632 — the bug should not be reproducible
- Make sure that new test makes sense

## Screenshots

| Before (trunk) | After (this PR) |
|---|---|
| <img width="547" alt="Screenshot 2022-11-23 at 12 41 09" src="https://user-images.githubusercontent.com/1083581/203538077-dd3a4902-7cb4-48fe-a07c-cc5a6cb7cec4.png"> | <img width="540" alt="Screenshot 2022-11-23 at 12 40 33" src="https://user-images.githubusercontent.com/1083581/203537951-18f6007b-bf14-4a6c-bf24-9254cbfeb660.png"> |