### PR TITLE
Components: Bump `DateTimePicker` deprecated prop removal version

### DIFF
--- a/packages/components/src/date-time/date-time/index.tsx
+++ b/packages/components/src/date-time/date-time/index.tsx
@@ -43,14 +43,14 @@ function UnforwardedDateTimePicker(
 	if ( ! __nextRemoveHelpButton ) {
 		deprecated( 'Help button in wp.components.DateTimePicker', {
 			since: '13.4',
-			version: '14.6', // Six months of plugin releases.
+			version: '15.8', // One year of plugin releases.
 			hint: 'Set the `__nextRemoveHelpButton` prop to `true` to remove this warning and opt in to the new behaviour, which will become the default in a future version.',
 		} );
 	}
 	if ( ! __nextRemoveResetButton ) {
 		deprecated( 'Reset button in wp.components.DateTimePicker', {
 			since: '13.4',
-			version: '14.6', // Six months of plugin releases.
+			version: '15.8', // One year of plugin releases.
 			hint: 'Set the `__nextRemoveResetButton` prop to `true` to remove this warning and opt in to the new behaviour, which will become the default in a future version.',
 		} );
 	}


### PR DESCRIPTION
## What?
This PR bumps the version in which the deprecated props of `DateTimePicker` will be removed in 6 more months of Gutenberg releases.

This is an alternative to #45999. 

Closes #45999.

## Why?
The `DateTimePicker` calendar help has been deprecated since Version 13.4 and was scheduled to be removed for 14.6.

Bumping the removal version of the deprecated props fixes the Static Analysis check which is currently failing in `trunk`.

## How?
Simply bumping the deprecated props removal version.

## Testing Instructions
Verify all checks are green.

## ✍️ Dev Note

The removal of the `__nextRemoveHelpButton` and `__nextRemoveResetButton` props on the `DateTimePicker` component in `@wordpress/components`, initially scheduled for Gutenberg  14.6, has been postponed to the Gutenberg 15.8 release.