### PR TITLE
Components: Fix `no-node-access` violation in `ControlLabel` tests

### DIFF
--- a/packages/components/src/ui/control-label/test/index.js
+++ b/packages/components/src/ui/control-label/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -16,11 +16,9 @@ describe( 'props', () => {
 	} );
 
 	test( 'should render htmlFor', () => {
-		const { container } = render(
-			<ControlLabel htmlFor="Field">Label</ControlLabel>
-		);
+		render( <ControlLabel htmlFor="Field">Label</ControlLabel> );
 
-		expect( container.firstChild ).toHaveAttribute( 'for', 'Field' );
+		expect( screen.getByText( 'Label' ) ).toHaveAttribute( 'for', 'Field' );
 	} );
 
 	test( 'should render size', () => {


### PR DESCRIPTION
## What?
With the recent work to improve the quality of tests, we fixed a bunch of ESLint rule violations. This PR fixes a [`no-node-access`](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-node-access.md) rule violation in the `ControlLabel` component. 

## Why?
The end goal is to enable that ESLint rule once all violations have been fixed.

## How?
We're using a screen query instead of `container.firstChild`.

## Testing Instructions
Verify all tests still pass.