### PR TITLE
Components: Fix ESLint violations in `ContextSystemProvider` tests

### DIFF
--- a/packages/components/src/ui/context/test/context-system-provider.js
+++ b/packages/components/src/ui/context/test/context-system-provider.js
@@ -61,7 +61,7 @@ describe( 'props', () => {
 		);
 
 		expect( container ).toMatchSnapshot();
-		expect( container.firstChild.innerHTML ).toContain( 'Code is Poetry' );
+		expect( screen.getByText( 'Code is Poetry' ) ).toBeVisible();
 	} );
 
 	test( 'should render _override props', () => {
@@ -100,10 +100,11 @@ describe( 'props', () => {
 
 		expect( container ).toMatchSnapshot();
 
-		const el = container.querySelector( '.test-component' );
+		const element = screen.getByText( 'Code is Poetry' );
+		expect( element ).toBeVisible();
+		expect( element ).toHaveClass( 'test-component' );
 
-		expect( el.innerHTML ).toContain( 'Code is Poetry' );
-		expect( el.innerHTML ).not.toContain( 'WordPress.org' );
+		expect( screen.queryByText( 'WordPress.org' ) ).not.toBeInTheDocument();
 	} );
 } );
 


### PR DESCRIPTION
## What?
With the recent work to improve the quality of tests, we fixed a bunch of ESLint rule violations. This PR fixes a few [`no-node-access`](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-node-access.md) and [`no-container`](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-container.md) rule violations in the `ContextSystemProvider` component tests.  

## Why?
The end goal is to enable that ESLint rule once all violations have been fixed.

## How?
We're altering tests to use screen queries and inverting the assertions to be screen-query-centric.

## Testing Instructions
Verify all tests still pass.