### PR TITLE
Components: Fix ESLint violations in `NoticeList` tests

### DIFF
--- a/packages/components/src/notice/test/list.js
+++ b/packages/components/src/notice/test/list.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -10,11 +10,14 @@ import NoticeList from '../list';
 
 describe( 'NoticeList', () => {
 	it( 'should merge className', () => {
-		const { container } = render(
-			<NoticeList notices={ [] } className="is-ok" />
+		render(
+			<NoticeList notices={ [] } className="is-ok">
+				List of notices
+			</NoticeList>
 		);
 
-		expect( container.firstChild ).toHaveClass( 'is-ok' );
-		expect( container.firstChild ).toHaveClass( 'components-notice-list' );
+		const noticeList = screen.getByText( 'List of notices' );
+		expect( noticeList ).toHaveClass( 'is-ok' );
+		expect( noticeList ).toHaveClass( 'components-notice-list' );
 	} );
 } );


### PR DESCRIPTION
## What?
With the recent work to improve the quality of tests, we fixed a bunch of ESLint rule violations. This PR fixes a few [`no-node-access`](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-node-access.md) rule violations in the `NoticeList` component. 

## Why?
The end goal is to enable that ESLint rule once all violations have been fixed.

## How?
We're using a screen query instead of `container.firstChild`.

## Testing Instructions
Verify all tests still pass.