### PR TITLE
Compose: Fix ESLint violations in `withGlobalEvents` tests

### DIFF
--- a/packages/compose/src/higher-order/with-global-events/test/index.js
+++ b/packages/compose/src/higher-order/with-global-events/test/index.js
@@ -36,7 +36,8 @@ describe( 'withGlobalEvents', () => {
 		}
 
 		render() {
-			return <div>{ this.props.children }</div>;
+			const { children } = this.props;
+			return <div>{ children }</div>;
 		}
 	}
 


### PR DESCRIPTION
## What?
With the recent work to improve the quality of tests, we fixed a bunch of ESLint rule violations. This PR fixes a few [`no-node-access`](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-node-access.md) rule violations in the `withGlobalEvents` high-order component. 

## Why?
The end goal is to enable that ESLint rule once all violations have been fixed.

## How?
We're altering the syntax to beat the ESLint rule 😅 

## Testing Instructions
Verify all tests still pass.