### PR TITLE
Display inserter popover in offcanvas UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17498,6 +17498,7 @@
 				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/dom": "file:packages/dom",
 				"@wordpress/element": "file:packages/element",
+				"@wordpress/escape-html": "file:packages/escape-html",
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/html-entities": "file:packages/html-entities",
 				"@wordpress/i18n": "file:packages/i18n",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -44,6 +44,7 @@
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",
 		"@wordpress/element": "file:../element",
+		"@wordpress/escape-html": "file:../escape-html",
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -380,7 +380,7 @@ export default compose( [
 
 				if ( onSelectOrClose ) {
 					onSelectOrClose( {
-						insertedBlock: blockToInsert,
+						insertedBlockId: blockToInsert?.clientId,
 					} );
 				}
 

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -379,7 +379,9 @@ export default compose( [
 				);
 
 				if ( onSelectOrClose ) {
-					onSelectOrClose();
+					onSelectOrClose( {
+						insertedBlock: blockToInsert,
+					} );
 				}
 
 				const message = sprintf(

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -260,6 +260,7 @@ export default compose( [
 					allowedBlockType,
 					directInsertBlock,
 					onSelectOrClose,
+					selectBlockOnInsert,
 				} = ownProps;
 
 				if ( ! hasSingleBlockType && ! directInsertBlock ) {
@@ -370,7 +371,12 @@ export default compose( [
 					blockToInsert = createBlock( allowedBlockType.name );
 				}
 
-				insertBlock( blockToInsert, getInsertionIndex(), rootClientId );
+				insertBlock(
+					blockToInsert,
+					getInsertionIndex(),
+					rootClientId,
+					selectBlockOnInsert
+				);
 
 				if ( onSelectOrClose ) {
 					onSelectOrClose();

--- a/packages/block-editor/src/components/off-canvas-editor/appender.js
+++ b/packages/block-editor/src/components/off-canvas-editor/appender.js
@@ -54,7 +54,8 @@ export const Appender = forwardRef( ( props, ref ) => {
 	if ( insertedBlock ) {
 		const link = {
 			url: insertedBlockAttributes.url,
-			opensInNewTab: insertedBlockAttributes.target === '_blank',
+			opensInNewTab: insertedBlockAttributes.opensInNewTab,
+			title: insertedBlockAttributes.label,
 		};
 		maybeLinkUI = (
 			<LinkUI

--- a/packages/block-editor/src/components/off-canvas-editor/appender.js
+++ b/packages/block-editor/src/components/off-canvas-editor/appender.js
@@ -74,6 +74,7 @@ export const Appender = forwardRef( ( props, ref ) => {
 						setAttributes( insertedBlock ),
 						insertedBlockAttributes
 					);
+					setInsertedBlock( null );
 				} }
 			/>
 		);

--- a/packages/block-editor/src/components/off-canvas-editor/appender.js
+++ b/packages/block-editor/src/components/off-canvas-editor/appender.js
@@ -37,8 +37,7 @@ export const Appender = forwardRef( ( props, ref ) => {
 				ref={ ref }
 				rootClientId={ clientId }
 				position="bottom right"
-				isAppender
-				__experimentalIsQuick
+				isAppender={ true }
 				selectBlockOnInsert={ false }
 				{ ...props }
 			/>

--- a/packages/block-editor/src/components/off-canvas-editor/appender.js
+++ b/packages/block-editor/src/components/off-canvas-editor/appender.js
@@ -31,6 +31,17 @@ export const Appender = forwardRef( ( props, ref ) => {
 		};
 	}, [] );
 
+	const { insertedBlockAttributes } = useSelect(
+		( select ) => {
+			const { getBlockAttributes } = select( blockEditorStore );
+
+			return {
+				insertedBlockAttributes: getBlockAttributes( insertedBlock ),
+			};
+		},
+		[ insertedBlock ]
+	);
+
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
 	const setAttributes =
@@ -42,25 +53,25 @@ export const Appender = forwardRef( ( props, ref ) => {
 
 	if ( insertedBlock ) {
 		const link = {
-			url: insertedBlock.attributes.url,
-			opensInNewTab: insertedBlock.attributes.target === '_blank',
+			url: insertedBlockAttributes.url,
+			opensInNewTab: insertedBlockAttributes.target === '_blank',
 		};
 		maybeLinkUI = (
 			<LinkUI
-				clientId={ insertedBlock.clientId }
+				clientId={ insertedBlock }
 				value={ link }
 				linkAttributes={ {
-					type: insertedBlock.attributes.type,
-					url: insertedBlock.attributes.url,
-					kind: insertedBlock.attributes.kind,
+					type: insertedBlockAttributes.type,
+					url: insertedBlockAttributes.url,
+					kind: insertedBlockAttributes.kind,
 				} }
 				onClose={ () => setInsertedBlock( null ) }
 				hasCreateSuggestion={ false }
 				onChange={ ( updatedValue ) => {
 					updateAttributes(
 						updatedValue,
-						setAttributes( insertedBlock.clientId ),
-						insertedBlock.attributes
+						setAttributes( insertedBlock ),
+						insertedBlockAttributes
 					);
 				} }
 			/>
@@ -80,8 +91,8 @@ export const Appender = forwardRef( ( props, ref ) => {
 				position="bottom right"
 				isAppender={ true }
 				selectBlockOnInsert={ false }
-				onSelectOrClose={ ( { insertedBlock: _insertedBlock } ) => {
-					setInsertedBlock( _insertedBlock );
+				onSelectOrClose={ ( { insertedBlockId } ) => {
+					setInsertedBlock( insertedBlockId );
 				} }
 				{ ...props }
 			/>

--- a/packages/block-editor/src/components/off-canvas-editor/appender.js
+++ b/packages/block-editor/src/components/off-canvas-editor/appender.js
@@ -39,6 +39,7 @@ export const Appender = forwardRef( ( props, ref ) => {
 				position="bottom right"
 				isAppender
 				__experimentalIsQuick
+				selectBlockOnInsert={ false }
 				{ ...props }
 			/>
 		</div>

--- a/packages/block-editor/src/components/off-canvas-editor/appender.js
+++ b/packages/block-editor/src/components/off-canvas-editor/appender.js
@@ -1,15 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
-import { forwardRef } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { forwardRef, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
 import Inserter from '../inserter';
+import { LinkUI } from './link-ui';
+import { updateAttributes } from './update-attributes';
 
 export const Appender = forwardRef( ( props, ref ) => {
+	const [ insertedBlock, setInsertedBlock ] = useState();
+
 	const { hideInserter, clientId } = useSelect( ( select ) => {
 		const {
 			getTemplateLock,
@@ -27,18 +31,58 @@ export const Appender = forwardRef( ( props, ref ) => {
 		};
 	}, [] );
 
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	const setAttributes =
+		( insertedBlockClientId ) => ( _updatedAttributes ) => {
+			updateBlockAttributes( insertedBlockClientId, _updatedAttributes );
+		};
+
+	let maybeLinkUI;
+
+	if ( insertedBlock ) {
+		const link = {
+			url: insertedBlock.attributes.url,
+			opensInNewTab: insertedBlock.attributes.target === '_blank',
+		};
+		maybeLinkUI = (
+			<LinkUI
+				clientId={ insertedBlock.clientId }
+				value={ link }
+				linkAttributes={ {
+					type: insertedBlock.attributes.type,
+					url: insertedBlock.attributes.url,
+					kind: insertedBlock.attributes.kind,
+				} }
+				onClose={ () => setInsertedBlock( null ) }
+				hasCreateSuggestion={ false }
+				onChange={ ( updatedValue ) => {
+					updateAttributes(
+						updatedValue,
+						setAttributes( insertedBlock.clientId ),
+						insertedBlock.attributes
+					);
+				} }
+			/>
+		);
+	}
+
 	if ( hideInserter ) {
 		return null;
 	}
 
 	return (
 		<div className="offcanvas-editor__appender">
+			{ maybeLinkUI }
 			<Inserter
 				ref={ ref }
 				rootClientId={ clientId }
 				position="bottom right"
 				isAppender={ true }
 				selectBlockOnInsert={ false }
+				onSelectOrClose={ ( { insertedBlock: _insertedBlock } ) => {
+					setInsertedBlock( _insertedBlock );
+				} }
 				{ ...props }
 			/>
 		</div>

--- a/packages/block-editor/src/components/off-canvas-editor/link-ui.js
+++ b/packages/block-editor/src/components/off-canvas-editor/link-ui.js
@@ -12,11 +12,9 @@ import { useSelect, useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import {
-	__experimentalLinkControl as LinkControl,
-	BlockIcon,
-	store as blockEditorStore,
-} from '../../';
+import { store as blockEditorStore } from '../../store';
+import LinkControl from '../link-control';
+import BlockIcon from '../block-icon';
 
 /**
  * Given the Link block's type attribute, return the query params to give to

--- a/packages/block-editor/src/components/off-canvas-editor/link-ui.js
+++ b/packages/block-editor/src/components/off-canvas-editor/link-ui.js
@@ -1,4 +1,3 @@
-
 // Note: this file is copied directly from packages/block-library/src/navigation-link/link-ui.js
 
 /**

--- a/packages/block-editor/src/components/off-canvas-editor/link-ui.js
+++ b/packages/block-editor/src/components/off-canvas-editor/link-ui.js
@@ -1,0 +1,209 @@
+/**
+ * WordPress dependencies
+ */
+import { Popover, Button } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { store as coreStore } from '@wordpress/core-data';
+import { decodeEntities } from '@wordpress/html-entities';
+import { switchToBlockType } from '@wordpress/blocks';
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import {
+	__experimentalLinkControl as LinkControl,
+	BlockIcon,
+	store as blockEditorStore,
+} from '../../';
+
+/**
+ * Given the Link block's type attribute, return the query params to give to
+ * /wp/v2/search.
+ *
+ * @param {string} type Link block's type attribute.
+ * @param {string} kind Link block's entity of kind (post-type|taxonomy)
+ * @return {{ type?: string, subtype?: string }} Search query params.
+ */
+export function getSuggestionsQuery( type, kind ) {
+	switch ( type ) {
+		case 'post':
+		case 'page':
+			return { type: 'post', subtype: type };
+		case 'category':
+			return { type: 'term', subtype: 'category' };
+		case 'tag':
+			return { type: 'term', subtype: 'post_tag' };
+		case 'post_format':
+			return { type: 'post-format' };
+		default:
+			if ( kind === 'taxonomy' ) {
+				return { type: 'term', subtype: type };
+			}
+			if ( kind === 'post-type' ) {
+				return { type: 'post', subtype: type };
+			}
+			return {};
+	}
+}
+
+/**
+ * Add transforms to Link Control
+ *
+ * @param {Object} props          Component props.
+ * @param {string} props.clientId Block client ID.
+ */
+function LinkControlTransforms( { clientId } ) {
+	if ( ! clientId ) {
+		return null;
+	}
+	const { getBlock, blockTransforms } = useSelect(
+		( select ) => {
+			const {
+				getBlock: _getBlock,
+				getBlockRootClientId,
+				getBlockTransformItems,
+			} = select( blockEditorStore );
+
+			return {
+				getBlock: _getBlock,
+				blockTransforms: getBlockTransformItems(
+					_getBlock( clientId ),
+					getBlockRootClientId( clientId )
+				),
+			};
+		},
+		[ clientId ]
+	);
+
+	const { replaceBlock } = useDispatch( blockEditorStore );
+
+	const featuredBlocks = [
+		'core/site-logo',
+		'core/social-links',
+		'core/search',
+	];
+	const transforms = blockTransforms.filter( ( item ) => {
+		return featuredBlocks.includes( item?.name );
+	} );
+
+	if ( ! transforms?.length ) {
+		return null;
+	}
+
+	return (
+		<div className="link-control-transform">
+			<h3 className="link-control-transform__subheading">
+				{ __( 'Transform' ) }
+			</h3>
+			<div className="link-control-transform__items">
+				{ transforms.map( ( item, index ) => {
+					return (
+						<Button
+							key={ `transform-${ index }` }
+							onClick={ () =>
+								replaceBlock(
+									clientId,
+									switchToBlockType(
+										getBlock( clientId ),
+										item.name
+									)
+								)
+							}
+							className="link-control-transform__item"
+						>
+							<BlockIcon icon={ item.icon } />
+							{ item.title }
+						</Button>
+					);
+				} ) }
+			</div>
+		</div>
+	);
+}
+
+export function LinkUI( props ) {
+	const { saveEntityRecord } = useDispatch( coreStore );
+
+	async function handleCreate( pageTitle ) {
+		const postType = props?.linkAttributes?.type || 'page';
+
+		const page = await saveEntityRecord( 'postType', postType, {
+			title: pageTitle,
+			status: 'draft',
+		} );
+
+		return {
+			id: page.id,
+			type: postType,
+			// Make `title` property consistent with that in `fetchLinkSuggestions` where the `rendered` title (containing HTML entities)
+			// is also being decoded. By being consistent in both locations we avoid having to branch in the rendering output code.
+			// Ideally in the future we will update both APIs to utilise the "raw" form of the title which is better suited to edit contexts.
+			// e.g.
+			// - title.raw = "Yes & No"
+			// - title.rendered = "Yes &#038; No"
+			// - decodeEntities( title.rendered ) = "Yes & No"
+			// See:
+			// - https://github.com/WordPress/gutenberg/pull/41063
+			// - https://github.com/WordPress/gutenberg/blob/a1e1fdc0e6278457e9f4fc0b31ac6d2095f5450b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js#L212-L218
+			title: decodeEntities( page.title.rendered ),
+			url: page.link,
+			kind: 'post-type',
+		};
+	}
+
+	return (
+		<Popover
+			placement="bottom"
+			onClose={ props?.onClose }
+			anchor={ props?.anchor }
+			shift
+		>
+			<LinkControl
+				hasTextControl
+				hasRichPreviews
+				className="wp-block-navigation-link__inline-link-input"
+				value={ props?.value }
+				showInitialSuggestions={ true }
+				withCreateSuggestion={ props?.hasCreateSuggestion }
+				createSuggestion={ handleCreate }
+				createSuggestionButtonText={ ( searchTerm ) => {
+					let format;
+
+					if ( props?.linkAttributes.type === 'post' ) {
+						/* translators: %s: search term. */
+						format = __( 'Create draft post: <mark>%s</mark>' );
+					} else {
+						/* translators: %s: search term. */
+						format = __( 'Create draft page: <mark>%s</mark>' );
+					}
+
+					return createInterpolateElement(
+						sprintf( format, searchTerm ),
+						{
+							mark: <mark />,
+						}
+					);
+				} }
+				noDirectEntry={ !! props?.linkAttributes?.type }
+				noURLSuggestion={ !! props?.linkAttributes?.type }
+				suggestionsQuery={ getSuggestionsQuery(
+					props?.linkAttributes?.type,
+					props?.linkAttributes?.kind
+				) }
+				onChange={ props.onChange }
+				onRemove={ props.onRemove }
+				renderControlBottom={
+					! props?.linkAttributes?.url
+						? () => (
+								<LinkControlTransforms
+									clientId={ props?.clientId }
+								/>
+						  )
+						: null
+				}
+			/>
+		</Popover>
+	);
+}

--- a/packages/block-editor/src/components/off-canvas-editor/link-ui.js
+++ b/packages/block-editor/src/components/off-canvas-editor/link-ui.js
@@ -1,3 +1,6 @@
+
+// Note: this file is copied directly from packages/block-library/src/navigation-link/link-ui.js
+
 /**
  * WordPress dependencies
  */

--- a/packages/block-editor/src/components/off-canvas-editor/update-attributes.js
+++ b/packages/block-editor/src/components/off-canvas-editor/update-attributes.js
@@ -1,0 +1,103 @@
+/**
+ * External dependencies
+ */
+import escapeHtml from 'escape-html';
+
+/**
+ * WordPress dependencies
+ */
+import { safeDecodeURI } from '@wordpress/url';
+
+/**
+ * @typedef {'post-type'|'custom'|'taxonomy'|'post-type-archive'} WPNavigationLinkKind
+ */
+/**
+ * Navigation Link Block Attributes
+ *
+ * @typedef {Object} WPNavigationLinkBlockAttributes
+ *
+ * @property {string}               [label]         Link text.
+ * @property {WPNavigationLinkKind} [kind]          Kind is used to differentiate between term and post ids to check post draft status.
+ * @property {string}               [type]          The type such as post, page, tag, category and other custom types.
+ * @property {string}               [rel]           The relationship of the linked URL.
+ * @property {number}               [id]            A post or term id.
+ * @property {boolean}              [opensInNewTab] Sets link target to _blank when true.
+ * @property {string}               [url]           Link href.
+ * @property {string}               [title]         Link title attribute.
+ */
+/**
+ * Link Control onChange handler that updates block attributes when a setting is changed.
+ *
+ * @param {Object}                          updatedValue    New block attributes to update.
+ * @param {Function}                        setAttributes   Block attribute update function.
+ * @param {WPNavigationLinkBlockAttributes} blockAttributes Current block attributes.
+ *
+ */
+
+export const updateAttributes = (
+	updatedValue = {},
+	setAttributes,
+	blockAttributes = {}
+) => {
+	const {
+		label: originalLabel = '',
+		kind: originalKind = '',
+		type: originalType = '',
+	} = blockAttributes;
+
+	const {
+		title: newLabel = '', // the title of any provided Post.
+		url: newUrl = '',
+		opensInNewTab,
+		id,
+		kind: newKind = originalKind,
+		type: newType = originalType,
+	} = updatedValue;
+
+	const newLabelWithoutHttp = newLabel.replace( /http(s?):\/\//gi, '' );
+	const newUrlWithoutHttp = newUrl.replace( /http(s?):\/\//gi, '' );
+
+	const useNewLabel =
+		newLabel &&
+		newLabel !== originalLabel &&
+		// LinkControl without the title field relies
+		// on the check below. Specifically, it assumes that
+		// the URL is the same as a title.
+		// This logic a) looks suspicious and b) should really
+		// live in the LinkControl and not here. It's a great
+		// candidate for future refactoring.
+		newLabelWithoutHttp !== newUrlWithoutHttp;
+
+	// Unfortunately this causes the escaping model to be inverted.
+	// The escaped content is stored in the block attributes (and ultimately in the database),
+	// and then the raw data is "recovered" when outputting into the DOM.
+	// It would be preferable to store the **raw** data in the block attributes and escape it in JS.
+	// Why? Because there isn't one way to escape data. Depending on the context, you need to do
+	// different transforms. It doesn't make sense to me to choose one of them for the purposes of storage.
+	// See also:
+	// - https://github.com/WordPress/gutenberg/pull/41063
+	// - https://github.com/WordPress/gutenberg/pull/18617.
+	const label = useNewLabel
+		? escapeHtml( newLabel )
+		: originalLabel || escapeHtml( newUrlWithoutHttp );
+
+	// In https://github.com/WordPress/gutenberg/pull/24670 we decided to use "tag" in favor of "post_tag"
+	const type = newType === 'post_tag' ? 'tag' : newType.replace( '-', '_' );
+
+	const isBuiltInType =
+		[ 'post', 'page', 'tag', 'category' ].indexOf( type ) > -1;
+
+	const isCustomLink =
+		( ! newKind && ! isBuiltInType ) || newKind === 'custom';
+	const kind = isCustomLink ? 'custom' : newKind;
+
+	setAttributes( {
+		// Passed `url` may already be encoded. To prevent double encoding, decodeURI is executed to revert to the original string.
+		...( newUrl && { url: encodeURI( safeDecodeURI( newUrl ) ) } ),
+		...( label && { label } ),
+		...( undefined !== opensInNewTab && { opensInNewTab } ),
+		...( id && Number.isInteger( id ) && { id } ),
+		...( kind && { kind } ),
+		...( type && type !== 'URL' && { type } ),
+	} );
+};

--- a/packages/block-editor/src/components/off-canvas-editor/update-attributes.js
+++ b/packages/block-editor/src/components/off-canvas-editor/update-attributes.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { escapeHtml } from '@wordpress/escape-html';
+import { escapeHTML } from '@wordpress/escape-html';
 import { safeDecodeURI } from '@wordpress/url';
 
 /**
@@ -74,8 +74,8 @@ export const updateAttributes = (
 	// - https://github.com/WordPress/gutenberg/pull/41063
 	// - https://github.com/WordPress/gutenberg/pull/18617.
 	const label = useNewLabel
-		? escapeHtml( newLabel )
-		: originalLabel || escapeHtml( newUrlWithoutHttp );
+		? escapeHTML( newLabel )
+		: originalLabel || escapeHTML( newUrlWithoutHttp );
 
 	// In https://github.com/WordPress/gutenberg/pull/24670 we decided to use "tag" in favor of "post_tag"
 	const type = newType === 'post_tag' ? 'tag' : newType.replace( '-', '_' );

--- a/packages/block-editor/src/components/off-canvas-editor/update-attributes.js
+++ b/packages/block-editor/src/components/off-canvas-editor/update-attributes.js
@@ -1,11 +1,7 @@
 /**
- * External dependencies
- */
-import escapeHtml from 'escape-html';
-
-/**
  * WordPress dependencies
  */
+import { escapeHtml } from '@wordpress/escape-html';
 import { safeDecodeURI } from '@wordpress/url';
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Shows the block inserter popover within the offcanvas UI area. Currently on `trunk` this displays next to the block in question.

🙏 🙏 Please read the `How` section below _before_ reviewing this PR. 🙏🙏

Closes https://github.com/WordPress/gutenberg/issues/45996

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The user has clicked the appender in the offcanvas and thus the interaction of choosing the block should remain inline within the offcanvas.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

To make this PR work there is a precondition of the UX that we need to be aware of - namely that when a block is inserted using the appender we need to **disable the selection of the block being inserted**.

Why? Because if we allow the block to be selected then the sidebar (inspector controls) will update to display the settings of _that [inserted] block_ rather than remaining on the Navigation block. This would immediately hide the offcanvas menu and pull the user out of the context of creating their Menu which we believe would _not_ be a good flow.

This PR adds a new prop to the global `<Inserter>` to allow configuring whether or not to select the block upon insertion.

## Caveats

- Doesn't handle the case when a non `core/navigation-link` block is inserted. We should tackle that in a follow up.
- The Link UI doesn't anchor itself to the inserted block in the list view. We have **no reference** to that DOM node in this context. Perhaps in future if the Inserter is displayed at each branch level we will be able to achieve this.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Turn on experiment
- Add Nav block and create a menu.
- Toggle open Offcanvas List View
- See inserter
- Click inserter and see Link UI
- Add a standard link
- See that link created
- Try editing the link (before you close the Link UI). See the updates reflected once commited.


## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/444434/204263246-75f7df66-7cea-428c-8cba-6218cb3b4e44.mp4

