### PR TITLE
Prepublish: suggest uploading external images

### DIFF
--- a/lib/experimental/rest-api.php
+++ b/lib/experimental/rest-api.php
@@ -111,3 +111,12 @@ function gutenberg_auto_draft_get_sample_permalink( $permalink, $id, $title, $na
 	return $permalink;
 }
 add_filter( 'get_sample_permalink', 'gutenberg_auto_draft_get_sample_permalink', 10, 5 );
+
+add_action( 'wp_ajax_gutenberg_fetch_media', 'gutenberg_fetch_media' );
+
+function gutenberg_fetch_media() {
+	$response = wp_remote_get( $_GET['url'] );
+	header( 'Content-Type: ' . $response['headers']['content-type'] );
+	echo wp_remote_retrieve_body( $response );
+	wp_die();
+}

--- a/lib/experimental/rest-api.php
+++ b/lib/experimental/rest-api.php
@@ -111,12 +111,3 @@ function gutenberg_auto_draft_get_sample_permalink( $permalink, $id, $title, $na
 	return $permalink;
 }
 add_filter( 'get_sample_permalink', 'gutenberg_auto_draft_get_sample_permalink', 10, 5 );
-
-add_action( 'wp_ajax_gutenberg_fetch_media', 'gutenberg_fetch_media' );
-
-function gutenberg_fetch_media() {
-	$response = wp_safe_remote_get( $_GET['url'] );
-	header( 'Content-Type: ' . $response['headers']['content-type'] );
-	echo wp_remote_retrieve_body( $response );
-	wp_die();
-}

--- a/lib/experimental/rest-api.php
+++ b/lib/experimental/rest-api.php
@@ -115,7 +115,7 @@ add_filter( 'get_sample_permalink', 'gutenberg_auto_draft_get_sample_permalink',
 add_action( 'wp_ajax_gutenberg_fetch_media', 'gutenberg_fetch_media' );
 
 function gutenberg_fetch_media() {
-	$response = wp_remote_get( $_GET['url'] );
+	$response = wp_safe_remote_get( $_GET['url'] );
 	header( 'Content-Type: ' . $response['headers']['content-type'] );
 	echo wp_remote_retrieve_body( $response );
 	wp_die();

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -10,6 +10,7 @@ import {
 	TextareaControl,
 	TextControl,
 	ToolbarButton,
+	ToolbarGroup,
 } from '@wordpress/components';
 import { useViewportMatch, usePrevious } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -395,13 +396,17 @@ export default function Image( {
 						onSelectURL={ onSelectURL }
 						onError={ onUploadError }
 					/>
-					{ externalBlob && (
+				</BlockControls>
+			) }
+			{ ! multiImageSelection && externalBlob && (
+				<BlockControls>
+					<ToolbarGroup>
 						<ToolbarButton
 							onClick={ uploadExternal }
 							icon={ upload }
 							label={ __( 'Upload external image' ) }
 						/>
-					) }
+					</ToolbarGroup>
 				</BlockControls>
 			) }
 			<InspectorControls>

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -183,13 +183,8 @@ export default function Image( {
 		}
 
 		window
-			.fetch(
-				`${
-					window.ajaxurl
-				}?action=gutenberg_fetch_media&url=${ encodeURIComponent(
-					url
-				) }`
-			)
+			// Avoid cache, which seems to help avoid CORS problems.
+			.fetch( url.includes( '?' ) ? url : url + '?' )
 			.then( ( response ) => response.blob() )
 			.then( ( blob ) => setExternalBlob( blob ) )
 			// Do nothing, cannot upload.

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -176,11 +176,13 @@ export default function Image( {
 		if (
 			! isExternalImage( id, url ) ||
 			! isSelected ||
-			! canUploadMedia ||
-			externalBlob
+			! canUploadMedia
 		) {
+			setExternalBlob();
 			return;
 		}
+
+		if ( externalBlob ) return;
 
 		window
 			// Avoid cache, which seems to help avoid CORS problems.

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -182,7 +182,13 @@ export default function Image( {
 		}
 
 		window
-			.fetch( url )
+			.fetch(
+				`${
+					window.ajaxurl
+				}?action=gutenberg_fetch_media&url=${ encodeURIComponent(
+					url
+				) }`
+			)
 			.then( ( response ) => response.blob() )
 			.then( ( blob ) => setExternalBlob( blob ) )
 			// Do nothing, cannot upload.
@@ -370,13 +376,6 @@ export default function Image( {
 						label={ __( 'Crop' ) }
 					/>
 				) }
-				{ externalBlob && (
-					<ToolbarButton
-						onClick={ uploadExternal }
-						icon={ upload }
-						label={ __( 'Upload external image' ) }
-					/>
-				) }
 				{ ! multiImageSelection && canInsertCover && (
 					<ToolbarButton
 						icon={ overlayText }
@@ -396,6 +395,13 @@ export default function Image( {
 						onSelectURL={ onSelectURL }
 						onError={ onUploadError }
 					/>
+					{ externalBlob && (
+						<ToolbarButton
+							onClick={ uploadExternal }
+							icon={ upload }
+							label={ __( 'Upload external image' ) }
+						/>
+					) }
 				</BlockControls>
 			) }
 			<InspectorControls>

--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -135,17 +135,15 @@ export default function PostFormatPanel() {
 				{ externalImages.map( ( image ) => {
 					return <Image key={ image.clientId } { ...image } />;
 				} ) }
-			</div>
-			<p>
 				<Button
 					icon={ upload }
-					variant="secondary"
+					variant="primary"
 					onClick={ uploadImages }
 				>
 					{ __( 'Upload all' ) }
 				</Button>
-				{ isUploading && <Spinner /> }
-			</p>
+			</div>
+			{ isUploading && <Spinner /> }
 		</PanelBody>
 	);
 }

--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -34,10 +34,18 @@ function flattenBlocks( blocks ) {
 function Image( block ) {
 	const { selectBlock } = useDispatch( blockEditorStore );
 	return (
-		// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
 		<motion.img
+			tabIndex={ 0 }
+			role="button"
+			aria-label={ __( 'Select image block.' ) }
 			onClick={ () => {
 				selectBlock( block.clientId );
+			} }
+			onKeyDown={ ( event ) => {
+				if ( event.key === 'Enter' || event.key === ' ' ) {
+					selectBlock( block.clientId );
+					event.preventDefault();
+				}
 			} }
 			key={ block.clientId }
 			alt={ block.attributes.alt }

--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -1,0 +1,159 @@
+/**
+ * WordPress dependencies
+ */
+import { PanelBody, Button, Spinner } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { upload } from '@wordpress/icons';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useEffect, useState } from '@wordpress/element';
+import { isBlobURL } from '@wordpress/blob';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
+function flattenBlocks( blocks ) {
+	const result = [];
+
+	blocks.forEach( ( block ) => {
+		result.push( block );
+		result.push( ...flattenBlocks( block.innerBlocks ) );
+	} );
+
+	return result;
+}
+
+function Image( block ) {
+	const { selectBlock } = useDispatch( blockEditorStore );
+	return (
+		// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
+		<img
+			onClick={ () => {
+				selectBlock( block.clientId );
+			} }
+			key={ block.clientId }
+			alt={ block.attributes.alt }
+			src={ block.attributes.url }
+			style={ {
+				width: '30px',
+				height: '30px',
+				objectFit: 'cover',
+				margin: '5px',
+			} }
+		/>
+	);
+}
+
+export default function PostFormatPanel() {
+	const [ blobUrls, setBlobUrls ] = useState( [] );
+	const [ isUploading, setIsUploading ] = useState( false );
+	const externalImages = useSelect( ( select ) => {
+		const { getEditorBlocks } = select( editorStore );
+		return flattenBlocks( getEditorBlocks() ).filter( ( block ) => {
+			return (
+				block.name === 'core/image' &&
+				block.attributes.url &&
+				! block.attributes.id
+			);
+		} );
+	}, [] );
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	const mediaUpload = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+
+		return getSettings().mediaUpload;
+	}, [] );
+	const panelBodyTitle = [
+		__( 'Suggestion:' ),
+		<span className="editor-post-publish-panel__link" key="label">
+			{ __( 'Upload external media' ) }
+		</span>,
+	];
+
+	useEffect( () => {
+		externalImages.forEach( ( image ) => {
+			if ( ! blobUrls[ image.attributes.url ] ) {
+				window
+					.fetch( image.attributes.url )
+					.then( ( response ) => response.blob() )
+					.then( ( blob ) =>
+						setBlobUrls( ( blobs ) => [
+							...blobs,
+							{ clientId: image.clientId, blob },
+						] )
+					)
+					// Do nothing, cannot upload.
+					.catch( () => {} );
+			}
+		} );
+	}, [ externalImages ] );
+
+	const nonUploadableImages = externalImages.filter(
+		( image ) =>
+			! blobUrls.find( ( { clientId } ) => image.clientId === clientId )
+	);
+
+	function uploadImages() {
+		setIsUploading( true );
+		Promise.all(
+			blobUrls.map( ( { clientId, blob } ) => {
+				return new Promise( ( resolve, reject ) => {
+					mediaUpload( {
+						filesList: [ blob ],
+						onFileChange: ( [ media ] ) => {
+							if ( isBlobURL( media.url ) ) {
+								return;
+							}
+
+							setBlobUrls( ( blobs ) =>
+								blobs.filter(
+									( { clientId: id } ) => id !== clientId
+								)
+							);
+							updateBlockAttributes( clientId, {
+								id: media.id,
+								url: media.url,
+							} );
+							resolve();
+						},
+						onError() {
+							reject();
+						},
+					} );
+				} );
+			} )
+		).then( () => {
+			setIsUploading( false );
+		} );
+	}
+
+	return (
+		<PanelBody initialOpen={ true } title={ panelBodyTitle }>
+			<div>
+				{ blobUrls.map( ( { clientId: _clientId } ) => {
+					const image = externalImages.find(
+						( { clientId } ) => clientId === _clientId
+					);
+					return <Image key={ _clientId } { ...image } />;
+				} ) }
+			</div>
+			<Button
+				icon={ upload }
+				variant="secondary"
+				onClick={ uploadImages }
+			>
+				{ __( 'Upload All' ) }
+			</Button>
+			{ isUploading && <Spinner /> }
+			<hr />
+			<p>{ __( 'Some images can only be uploaded manually.' ) }</p>
+			<div>
+				{ nonUploadableImages.map( ( image ) => (
+					<Image key={ image.clientId } { ...image } />
+				) ) }
+			</div>
+		</PanelBody>
+	);
+}

--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -75,7 +75,7 @@ export default function PostFormatPanel() {
 		return getSettings().mediaUpload;
 	}, [] );
 
-	if ( ! externalImages.length ) {
+	if ( ! mediaUpload || ! externalImages.length ) {
 		return null;
 	}
 

--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -66,22 +66,20 @@ function Image( block ) {
 
 export default function PostFormatPanel() {
 	const [ isUploading, setIsUploading ] = useState( false );
-	const externalImages = useSelect( ( select ) => {
-		const { getEditorBlocks } = select( editorStore );
-		return flattenBlocks( getEditorBlocks() ).filter( ( block ) => {
-			return (
-				block.name === 'core/image' &&
-				block.attributes.url &&
-				! block.attributes.id
-			);
-		} );
-	}, [] );
+	const { editorBlocks, mediaUpload } = useSelect(
+		( select ) => ( {
+			editorBlocks: select( editorStore ).getEditorBlocks(),
+			mediaUpload: select( blockEditorStore ).getSettings().mediaUpload,
+		} ),
+		[]
+	);
+	const externalImages = flattenBlocks( editorBlocks ).filter(
+		( block ) =>
+			block.name === 'core/image' &&
+			block.attributes.url &&
+			! block.attributes.id
+	);
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
-	const mediaUpload = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-
-		return getSettings().mediaUpload;
-	}, [] );
 
 	if ( ! mediaUpload || ! externalImages.length ) {
 		return null;

--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -120,7 +120,7 @@ export default function PostFormatPanel() {
 							} )
 					)
 			)
-		).then( () => {
+		).finally( () => {
 			setIsUploading( false );
 		} );
 	}
@@ -144,15 +144,18 @@ export default function PostFormatPanel() {
 						return <Image key={ image.clientId } { ...image } />;
 					} ) }
 				</AnimatePresence>
-				<Button
-					icon={ upload }
-					variant="primary"
-					onClick={ uploadImages }
-				>
-					{ __( 'Upload all' ) }
-				</Button>
+				{ isUploading ? (
+					<Spinner />
+				) : (
+					<Button
+						icon={ upload }
+						variant="primary"
+						onClick={ uploadImages }
+					>
+						{ __( 'Upload all' ) }
+					</Button>
+				) }
 			</div>
-			{ isUploading && <Spinner /> }
 		</PanelBody>
 	);
 }

--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -137,12 +137,7 @@ export default function PostFormatPanel() {
 		<PanelBody initialOpen={ true } title={ panelBodyTitle }>
 			<p>
 				{ __(
-					'There are some external images in the post. You can upload them to the media library.'
-				) }
-			</p>
-			<p>
-				{ __(
-					'Images from different domains may not always load correctly, load slowly, or be removed unexpectedly.'
+					'There are some external images in the post which can be uploaded to the media library. Images coming from different domains may not always display correctly, load slowly for visitors, or be removed unexpectedly.'
 				) }
 			</p>
 			<div

--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -6,7 +6,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { upload } from '@wordpress/icons';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { useEffect, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { isBlobURL } from '@wordpress/blob';
 
 /**
@@ -48,7 +48,6 @@ function Image( block ) {
 }
 
 export default function PostFormatPanel() {
-	const [ blobUrls, setBlobUrls ] = useState( [] );
 	const [ isUploading, setIsUploading ] = useState( false );
 	const externalImages = useSelect( ( select ) => {
 		const { getEditorBlocks } = select( editorStore );
@@ -66,36 +65,17 @@ export default function PostFormatPanel() {
 
 		return getSettings().mediaUpload;
 	}, [] );
+
+	if ( ! externalImages.length ) {
+		return null;
+	}
+
 	const panelBodyTitle = [
 		__( 'Suggestion:' ),
 		<span className="editor-post-publish-panel__link" key="label">
 			{ __( 'External media' ) }
 		</span>,
 	];
-
-	useEffect( () => {
-		externalImages.forEach( ( image ) => {
-			if ( ! blobUrls[ image.attributes.url ] ) {
-				window
-					.fetch(
-						`${
-							window.ajaxurl
-						}?action=gutenberg_fetch_media&url=${ encodeURIComponent(
-							image.attributes.url
-						) }`
-					)
-					.then( ( response ) => response.blob() )
-					.then( ( blob ) =>
-						setBlobUrls( ( blobs ) => [
-							...blobs,
-							{ clientId: image.clientId, blob },
-						] )
-					)
-					// Do nothing, cannot upload.
-					.catch( () => {} );
-			}
-		} );
-	}, [ externalImages ] );
 
 	function uploadImages() {
 		setIsUploading( true );
@@ -148,7 +128,7 @@ export default function PostFormatPanel() {
 			<div
 				style={ {
 					display: 'inline-flex',
-					flexWrap: 'wrap',
+					'flex-wrap': 'wrap',
 					gap: '8px',
 				} }
 			>

--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -140,6 +140,11 @@ export default function PostFormatPanel() {
 					'There are some external images in the post. You can upload them to the media library.'
 				) }
 			</p>
+			<p>
+				{ __(
+					'Images from different domains may not always load correctly, load slowly, or be removed unexpectedly.'
+				) }
+			</p>
 			<div
 				style={ {
 					display: 'inline-flex',

--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -92,11 +92,9 @@ export default function PostFormatPanel() {
 			externalImages.map( ( image ) =>
 				window
 					.fetch(
-						`${
-							window.ajaxurl
-						}?action=gutenberg_fetch_media&url=${ encodeURIComponent(
-							image.attributes.url
-						) }`
+						image.attributes.url.includes( '?' )
+							? image.attributes.url
+							: image.attributes.url + '?'
 					)
 					.then( ( response ) => response.blob() )
 					.then(
@@ -137,7 +135,7 @@ export default function PostFormatPanel() {
 			<div
 				style={ {
 					display: 'inline-flex',
-					'flex-wrap': 'wrap',
+					flexWrap: 'wrap',
 					gap: '8px',
 				} }
 			>

--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -37,10 +37,11 @@ function Image( block ) {
 			alt={ block.attributes.alt }
 			src={ block.attributes.url }
 			style={ {
-				width: '30px',
-				height: '30px',
+				width: '36px',
+				height: '36px',
 				objectFit: 'cover',
-				margin: '5px',
+				borderRadius: '2px',
+				cursor: 'pointer',
 			} }
 		/>
 	);
@@ -68,7 +69,7 @@ export default function PostFormatPanel() {
 	const panelBodyTitle = [
 		__( 'Suggestion:' ),
 		<span className="editor-post-publish-panel__link" key="label">
-			{ __( 'Upload external media' ) }
+			{ __( 'External media' ) }
 		</span>,
 	];
 
@@ -131,25 +132,44 @@ export default function PostFormatPanel() {
 
 	return (
 		<PanelBody initialOpen={ true } title={ panelBodyTitle }>
-			<div>
+			<p>
+				{ __(
+					'There are some external images in the post. You can upload them to the media library.'
+				) }
+			</p>
+			<div
+				style={ {
+					display: 'inline-flex',
+					'flex-wrap': 'wrap',
+					gap: '8px',
+				} }
+			>
 				{ blobUrls.map( ( { clientId: _clientId } ) => {
 					const image = externalImages.find(
 						( { clientId } ) => clientId === _clientId
 					);
 					return <Image key={ _clientId } { ...image } />;
 				} ) }
+				<Button
+					icon={ upload }
+					variant="secondary"
+					onClick={ uploadImages }
+				>
+					{ __( 'Upload all' ) }
+				</Button>
 			</div>
-			<Button
-				icon={ upload }
-				variant="secondary"
-				onClick={ uploadImages }
-			>
-				{ __( 'Upload All' ) }
-			</Button>
+
 			{ isUploading && <Spinner /> }
-			<hr />
-			<p>{ __( 'Some images can only be uploaded manually.' ) }</p>
-			<div>
+			<p>
+				{ __( 'The following images can only be uploaded manually.' ) }
+			</p>
+			<div
+				style={ {
+					display: 'inline-flex',
+					'flex-wrap': 'wrap',
+					gap: '8px',
+				} }
+			>
 				{ nonUploadableImages.map( ( image ) => (
 					<Image key={ image.clientId } { ...image } />
 				) ) }

--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -1,7 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { PanelBody, Button, Spinner } from '@wordpress/components';
+import {
+	PanelBody,
+	Button,
+	Spinner,
+	__unstableMotion as motion,
+	__unstableAnimatePresence as AnimatePresence,
+} from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { upload } from '@wordpress/icons';
@@ -29,13 +35,15 @@ function Image( block ) {
 	const { selectBlock } = useDispatch( blockEditorStore );
 	return (
 		// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
-		<img
+		<motion.img
 			onClick={ () => {
 				selectBlock( block.clientId );
 			} }
 			key={ block.clientId }
 			alt={ block.attributes.alt }
 			src={ block.attributes.url }
+			animate={ { opacity: 1 } }
+			exit={ { opacity: 0, scale: 0 } }
 			style={ {
 				width: '36px',
 				height: '36px',
@@ -43,6 +51,7 @@ function Image( block ) {
 				borderRadius: '2px',
 				cursor: 'pointer',
 			} }
+			whileHover={ { scale: 1.08 } }
 		/>
 	);
 }
@@ -132,9 +141,11 @@ export default function PostFormatPanel() {
 					gap: '8px',
 				} }
 			>
-				{ externalImages.map( ( image ) => {
-					return <Image key={ image.clientId } { ...image } />;
-				} ) }
+				<AnimatePresence>
+					{ externalImages.map( ( image ) => {
+						return <Image key={ image.clientId } { ...image } />;
+					} ) }
+				</AnimatePresence>
 				<Button
 					icon={ upload }
 					variant="primary"

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -20,6 +20,7 @@ import MaybeTagsPanel from './maybe-tags-panel';
 import MaybePostFormatPanel from './maybe-post-format-panel';
 import { store as editorStore } from '../../store';
 import MaybeCategoryPanel from './maybe-category-panel';
+import MaybeUploadMedia from './maybe-upload-media';
 
 function PostPublishPanelPrepublish( { children } ) {
 	const {
@@ -103,6 +104,7 @@ function PostPublishPanelPrepublish( { children } ) {
 					<span className="components-site-home">{ siteHome }</span>
 				</div>
 			</div>
+			<MaybeUploadMedia />
 			{ hasPublishAction && (
 				<>
 					<PanelBody

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -6,7 +6,7 @@
 	// Ensure the post-publish panel accounts for the header and footer height.
 	min-height: calc(100% - #{$header-height + 84px});
 
-	.components-spinner {
+	> .components-spinner {
 		display: block;
 		margin: 100px auto 0;
 	}

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -825,6 +825,52 @@ test.describe( 'Image', () => {
 		await expect( linkDom ).toBeVisible();
 		await expect( linkDom ).toHaveAttribute( 'href', url );
 	} );
+
+	test( 'should upload external image', async ( { editor } ) => {
+		await editor.insertBlock( {
+			name: 'core/image',
+			attributes: {
+				url: 'https://cldup.com/cXyG__fTLN.jpg',
+			},
+		} );
+
+		await editor.clickBlockToolbarButton( 'Upload external image' );
+
+		const imageBlock = editor.canvas.locator(
+			'role=document[name="Block: Image"i]'
+		);
+		const image = imageBlock.locator( 'img[src^="http"]' );
+		const src = await image.getAttribute( 'src' );
+
+		expect( src ).toMatch( /\/wp-content\/uploads\// );
+	} );
+
+	test( 'should upload through prepublish panel', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/image',
+			attributes: {
+				url: 'https://cldup.com/cXyG__fTLN.jpg',
+			},
+		} );
+
+		await page
+			.getByRole( 'button', { name: 'Publish', exact: true } )
+			.click();
+		await page.getByRole( 'button', { name: 'Upload all' } ).click();
+
+		await expect( page.locator( '.components-spinner' ) ).toHaveCount( 0 );
+
+		const imageBlock = editor.canvas.locator(
+			'role=document[name="Block: Image"i]'
+		);
+		const image = imageBlock.locator( 'img[src^="http"]' );
+		const src = await image.getAttribute( 'src' );
+
+		expect( src ).toMatch( /\/wp-content\/uploads\// );
+	} );
 } );
 
 test.describe( 'Image - interactivity', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Adds a prepublish panel suggesting to upload external images.

I'm not great at making a good UI, so feel free to tweak. :)

As for the technical bit: I think ideally we need a slot where block types can hook in and add custom logic, but this is a good start.

## Why?

Make it more discoverable that you can upload them.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

Go to the demo content and publish.

## Screenshots or screencast <!-- if applicable -->

![upload-panel](https://user-images.githubusercontent.com/4710635/203638483-15d749df-fd84-4238-b1a7-032cc791c1a1.gif)

