### PR TITLE
Tag Processor: Add bookmark system for tracking semantic locations in document

### DIFF
--- a/lib/experimental/html/class-wp-html-span.php
+++ b/lib/experimental/html/class-wp-html-span.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * HTML Span: Represents a textual span inside an HTML document.
+ *
+ * @package WordPress
+ * @subpackage HTML
+ * @since 6.2.0
+ */
+
+/**
+ * Represents a textual span inside an HTML document.
+ *
+ * This is a two-tuple in disguise, used to avoid the memory
+ * overhead involved in using an array for the same purpose.
+ *
+ * This class is for internal usage of the WP_HTML_Tag_Processor class.
+ *
+ * @access private
+ * @since 6.2.0
+ *
+ * @see WP_HTML_Tag_Processor
+ */
+class WP_HTML_Span {
+	/**
+	 * Byte offset into document where span begins.
+	 *
+	 * @since 6.2.0
+	 * @var int
+	 */
+	public $start;
+
+	/**
+	 * Byte offset into document where span ends.
+	 *
+	 * @since 6.2.0
+	 * @var int
+	 */
+	public $end;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 6.2.0
+	 *
+	 * @param int $start Byte offset into document where replacement span begins.
+	 * @param int $end   Byte offset into document where replacement span ends.
+	 */
+	public function __construct( $start, $end ) {
+		$this->start = $start;
+		$this->end   = $end;
+	}
+}

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -180,6 +180,25 @@
  * @since 6.2.0
  */
 class WP_HTML_Tag_Processor {
+	/**
+	 * The maximum number of bookmarks allowed to exist at
+	 * any given time.
+	 *
+	 * @see set_bookmark();
+	 * @since 6.2.0
+	 * @var int
+	 */
+	const MAX_BOOKMARKS = 10;
+
+	/**
+	 * Maximum number of times seek() can be called.
+	 * Prevents accidental infinite loops.
+	 *
+	 * @see seek()
+	 * @since 6.2.0
+	 * @var int
+	 */
+	const MAX_SEEK_OPS = 1000;
 
 	/**
 	 * The HTML document to parse.
@@ -349,11 +368,11 @@ class WP_HTML_Tag_Processor {
 	 *
 	 * Example:
 	 * <code>
-	 *     // Add the `WP-block-group` class, remove the `WP-group` class.
-	 *     $class_changes = [
+	 *     // Add the `wp-block-group` class, remove the `wp-group` class.
+	 *     $classname_updates = [
 	 *         // Indexed by a comparable class name
-	 *         'wp-block-group' => new WP_Class_Name_Operation( 'WP-block-group', WP_Class_Name_Operation::ADD ),
-	 *         'wp-group'       => new WP_Class_Name_Operation( 'WP-group', WP_Class_Name_Operation::REMOVE )
+	 *         'wp-block-group' => WP_HTML_Tag_Processor::ADD_CLASS,
+	 *         'wp-group'       => WP_HTML_Tag_Processor::REMOVE_CLASS
 	 *     ];
 	 * </code>
 	 *
@@ -361,6 +380,15 @@ class WP_HTML_Tag_Processor {
 	 * @var bool[]
 	 */
 	private $classname_updates = array();
+
+	/**
+	 * Tracks a semantic location in the original HTML which
+	 * shifts with updates as they are applied to the document.
+	 *
+	 * @since 6.2.0
+	 * @var WP_HTML_Span[]
+	 */
+	private $bookmarks = array();
 
 	const ADD_CLASS    = true;
 	const REMOVE_CLASS = false;
@@ -395,6 +423,16 @@ class WP_HTML_Tag_Processor {
 	 * @var WP_HTML_Text_Replacement[]
 	 */
 	private $attribute_updates = array();
+
+	/**
+	 * Tracks how many times we've performed a `seek()`
+	 * so that we can prevent accidental infinite loops.
+	 *
+	 * @see seek
+	 * @since 6.2.0
+	 * @var int
+	 */
+	private $seek_count = 0;
 
 	/**
 	 * Constructor.
@@ -478,6 +516,123 @@ class WP_HTML_Tag_Processor {
 
 		return true;
 	}
+
+
+	/**
+	 * Sets a bookmark in the HTML document.
+	 *
+	 * Bookmarks represent specific places or tokens in the HTML
+	 * document, such as a tag opener or closer. When applying
+	 * edits to a document, such as setting an attribute, the
+	 * text offsets of that token may shift; the bookmark is
+	 * kept updated with those shifts and remains stable unless
+	 * the entire span of text in which the token sits is removed.
+	 *
+	 * Release bookmarks when they are no longer needed.
+	 *
+	 * Example:
+	 * ```
+	 *     <main><h2>Surprising fact you may not know!</h2></main>
+	 *           ^  ^
+	 *            \-|-- this `H2` opener bookmark tracks the token
+	 *
+	 *     <main class="clickbait"><h2>Surprising fact you may no…
+	 *                             ^  ^
+	 *                              \-|-- it shifts with edits
+	 * ```
+	 *
+	 * Bookmarks provide the ability to seek to a previously-scanned
+	 * place in the HTML document. This avoids the need to re-scan
+	 * the entire thing.
+	 *
+	 * Example:
+	 * ```
+	 *     <ul><li>One</li><li>Two</li><li>Three</li></ul>
+	 *                                 ^^^^
+	 *                                 want to note this last item
+	 *
+	 *     $p = new WP_HTML_Tag_Processor( $html );
+	 *     $in_list = false;
+	 *     while ( $p->next_tag( [ 'tag_closers' => $in_list ? 'visit' : 'skip' ] ) ) {
+	 *         if ( 'UL' === $p->get_tag() ) {
+	 *             if ( $p->is_tag_closer() ) {
+	 *                 $in_list = false;
+	 *                 $p->set_bookmark( 'resume' );
+	 *                 if ( $p->seek( 'last-li' ) ) {
+	 *                     $p->add_class( 'last-li' );
+	 *                 }
+	 *                 $p->seek( 'resume' );
+	 *                 $p->release_bookmark( 'last-li' );
+	 *                 $p->release_bookmark( 'resume' );
+	 *             } else {
+	 *                 $in_list = true;
+	 *             }
+	 *         }
+	 *
+	 *         if ( 'LI' === $p->get_tag() ) {
+	 *             $p->set_bookmark( 'last-li' );
+	 *         }
+	 *     }
+	 * ```
+	 *
+	 * Because bookmarks maintain their position they don't
+	 * expose any internal offsets for the HTML document
+	 * and can't be used with normal string functions.
+	 *
+	 * Because bookmarks allocate memory and require processing
+	 * for every applied update they are limited and require
+	 * a name. They should not be created inside a loop.
+	 *
+	 * Bookmarks are a powerful tool to enable complicated behavior;
+	 * consider double-checking that you need this tool if you are
+	 * reaching for it, as inappropriate use could lead to broken
+	 * HTML structure or unwanted processing overhead.
+	 *
+	 * @param string $name Identifies this particular bookmark.
+	 * @return false|void
+	 * @throws Exception Throws on invalid bookmark name if WP_DEBUG set.
+	 */
+	public function set_bookmark( $name ) {
+		if ( null === $this->tag_name_starts_at ) {
+			return false;
+		}
+
+		if ( ! array_key_exists( $name, $this->bookmarks ) && count( $this->bookmarks ) >= self::MAX_BOOKMARKS ) {
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				throw new Exception( "Tried to jump to a non-existent HTML bookmark {$name}." );
+			}
+			return false;
+		}
+
+		$this->bookmarks[ $name ] = new WP_HTML_Span(
+			$this->tag_name_starts_at - 1,
+			$this->tag_ends_at
+		);
+
+		return true;
+	}
+
+
+	/**
+	 * Removes a bookmark if you no longer need to use it.
+	 *
+	 * Releasing a bookmark frees up the small performance
+	 * overhead they require, mainly in the form of compute
+	 * costs when modifying the document.
+	 *
+	 * @param string $name Name of the bookmark to remove.
+	 * @return bool
+	 */
+	public function release_bookmark( $name ) {
+		if ( ! array_key_exists( $name, $this->bookmarks ) ) {
+			return false;
+		}
+
+		unset( $this->bookmarks[ $name ] );
+
+		return true;
+	}
+
 
 	/**
 	 * Skips the contents of the title and textarea tags until an appropriate
@@ -1104,7 +1259,75 @@ class WP_HTML_Tag_Processor {
 			$this->updated_bytes = $diff->end;
 		}
 
+		foreach ( $this->bookmarks as $bookmark ) {
+			/**
+			 * As we loop through $this->attribute_updates, we keep comparing
+			 * $bookmark->start and $bookmark->end to $diff->start. We can't
+			 * change it and still expect the correct result, so let's accumulate
+			 * the deltas separately and apply them all at once after the loop.
+			 */
+			$head_delta = 0;
+			$tail_delta = 0;
+
+			foreach ( $this->attribute_updates as $diff ) {
+				$update_head = $bookmark->start >= $diff->start;
+				$update_tail = $bookmark->end >= $diff->start;
+
+				if ( ! $update_head && ! $update_tail ) {
+					break;
+				}
+
+				$delta = strlen( $diff->text ) - ( $diff->end - $diff->start );
+
+				if ( $update_head ) {
+					$head_delta += $delta;
+				}
+
+				if ( $update_tail ) {
+					$tail_delta += $delta;
+				}
+			}
+
+			$bookmark->start += $head_delta;
+			$bookmark->end   += $tail_delta;
+		}
+
 		$this->attribute_updates = array();
+	}
+
+	/**
+	 * Move the current pointer in the Tag Processor to a given bookmark's location.
+	 *
+	 * In order to prevent accidental infinite loops, there's a
+	 * maximum limit on the number of times seek() can be called.
+	 *
+	 * @param string $bookmark_name Jump to the place in the document identified by this bookmark name.
+	 * @return bool
+	 * @throws Exception Throws on invalid bookmark name if WP_DEBUG set.
+	 */
+	public function seek( $bookmark_name ) {
+		if ( ! array_key_exists( $bookmark_name, $this->bookmarks ) ) {
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				throw new Exception( 'Invalid bookmark name' );
+			}
+			return false;
+		}
+
+		if ( ++$this->seek_count > self::MAX_SEEK_OPS ) {
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				throw new Exception( 'Too many calls to seek() - this can lead to performance issues.' );
+			}
+			return false;
+		}
+
+		// Flush out any pending updates to the document.
+		$this->get_updated_html();
+
+		// Point this tag processor before the sought tag opener and consume it.
+		$this->parsed_bytes  = $this->bookmarks[ $bookmark_name ]->start;
+		$this->updated_bytes = $this->parsed_bytes;
+		$this->updated_html  = substr( $this->html, 0, $this->updated_bytes );
+		return $this->next_tag();
 	}
 
 	/**
@@ -1411,47 +1634,31 @@ class WP_HTML_Tag_Processor {
 	 * @return string The processed HTML.
 	 */
 	public function get_updated_html() {
-		// Short-circuit if there are no updates to apply.
+		// Short-circuit if there are no new updates to apply.
 		if ( ! count( $this->classname_updates ) && ! count( $this->attribute_updates ) ) {
 			return $this->updated_html . substr( $this->html, $this->updated_bytes );
 		}
 
-		/*
-		 * Parsing is in progress – let's apply the attribute updates without moving on to the next tag.
-		 *
-		 * In practice:
-		 * 1. Apply the attributes updates to the original HTML
-		 * 2. Replace the original HTML with the updated HTML
-		 * 3. Point this tag processor to the current tag name's end in that updated HTML
-		 */
+		// Otherwise: apply the updates, rewind before the current tag, and parse it again.
+		$delta_between_updated_html_end_and_current_tag_end = substr(
+			$this->html,
+			$this->updated_bytes,
+			$this->tag_name_starts_at + $this->tag_name_length - $this->updated_bytes
+		);
+		$updated_html_up_to_current_tag_name_end            = $this->updated_html . $delta_between_updated_html_end_and_current_tag_end;
 
-		// Find tag name's end in the updated markup.
-		$markup_updated_up_to_a_tag_name_end = $this->updated_html . substr( $this->html, $this->updated_bytes, $this->tag_name_starts_at + $this->tag_name_length - $this->updated_bytes );
-		$updated_tag_name_ends_at            = strlen( $markup_updated_up_to_a_tag_name_end );
-		$updated_tag_name_starts_at          = $updated_tag_name_ends_at - $this->tag_name_length;
-
-		// Apply attributes updates.
-		$this->updated_html  = $markup_updated_up_to_a_tag_name_end;
-		$this->updated_bytes = $this->tag_name_starts_at + $this->tag_name_length;
+		// 1. Apply the attributes updates to the original HTML
 		$this->class_name_updates_to_attributes_updates();
 		$this->apply_attributes_updates();
 
-		// Replace $this->html with the updated markup.
-		$this->html = $this->updated_html . substr( $this->html, $this->updated_bytes );
+		// 2. Replace the original HTML with the updated HTML
+		$this->html          = $this->updated_html . substr( $this->html, $this->updated_bytes );
+		$this->updated_html  = $updated_html_up_to_current_tag_name_end;
+		$this->updated_bytes = strlen( $this->updated_html );
 
-		// Rewind this processor to the tag name's end.
-		$this->tag_name_starts_at = $updated_tag_name_starts_at;
-		$this->parsed_bytes       = $updated_tag_name_ends_at;
-
-		// Restore the previous version of the updated_html as we are not finished with the current_tag yet.
-		$this->updated_html  = $markup_updated_up_to_a_tag_name_end;
-		$this->updated_bytes = $updated_tag_name_ends_at;
-
-		// Parse the attributes in the updated markup.
-		$this->attributes = array();
-		while ( $this->parse_next_attribute() ) {
-			continue;
-		}
+		// 3. Point this tag processor at the original tag opener and consume it
+		$this->parsed_bytes = strlen( $updated_html_up_to_current_tag_name_end ) - $this->tag_name_length - 2;
+		$this->next_tag();
 
 		return $this->html;
 	}

--- a/lib/experimental/html/index.php
+++ b/lib/experimental/html/index.php
@@ -7,5 +7,6 @@
 
 // All class files necessary for the HTML Tag Processor.
 require_once __DIR__ . '/class-wp-html-attribute-token.php';
+require_once __DIR__ . '/class-wp-html-span.php';
 require_once __DIR__ . '/class-wp-html-text-replacement.php';
 require_once __DIR__ . '/class-wp-html-tag-processor.php';

--- a/phpunit/html/wp-html-tag-processor-bookmark-test.php
+++ b/phpunit/html/wp-html-tag-processor-bookmark-test.php
@@ -1,0 +1,370 @@
+<?php
+/**
+ * Unit tests covering WP_HTML_Tag_Processor bookmark functionality.
+ *
+ * @package WordPress
+ * @subpackage HTML
+ */
+
+require_once __DIR__ . '/../../lib/experimental/html/index.php';
+
+/**
+ * @group html
+ *
+ * @coversDefaultClass WP_HTML_Tag_Processor
+ */
+class WP_HTML_Tag_Processor_Bookmark_Test extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 56299
+	 *
+	 * @covers set_bookmark
+	 */
+	public function test_set_bookmark() {
+		$p = new WP_HTML_Tag_Processor( '<ul><li>One</li><li>Two</li><li>Three</li></ul>' );
+		$p->next_tag( 'li' );
+		$this->assertTrue( $p->set_bookmark( 'first li' ), 'Could not allocate a "first li" bookmark.' );
+		$p->next_tag( 'li' );
+		$this->assertTrue( $p->set_bookmark( 'second li' ), 'Could not allocate a "second li" bookmark.' );
+		$this->assertTrue( $p->set_bookmark( 'first li' ), 'Could not move the "first li" bookmark.' );
+	}
+
+	/**
+	 * @ticket 56299
+	 *
+	 * @covers release_bookmark
+	 */
+	public function test_release_bookmark() {
+		$p = new WP_HTML_Tag_Processor( '<ul><li>One</li><li>Two</li><li>Three</li></ul>' );
+		$p->next_tag( 'li' );
+		$this->assertFalse( $p->release_bookmark( 'first li' ), 'Released a non-existing bookmark.' );
+		$p->set_bookmark( 'first li' );
+		$this->assertTrue( $p->release_bookmark( 'first li' ), 'Could not release a bookmark.' );
+	}
+
+	/**
+	 * @ticket 56299
+	 *
+	 * @covers seek
+	 * @covers set_bookmark
+	 */
+	public function test_seek() {
+		$p = new WP_HTML_Tag_Processor( '<ul><li>One</li><li>Two</li><li>Three</li></ul>' );
+		$p->next_tag( 'li' );
+		$p->set_bookmark( 'first li' );
+
+		$p->next_tag( 'li' );
+		$p->set_attribute( 'foo-2', 'bar-2' );
+
+		$p->seek( 'first li' );
+		$p->set_attribute( 'foo-1', 'bar-1' );
+
+		$this->assertEquals(
+			'<ul><li foo-1="bar-1">One</li><li foo-2="bar-2">Two</li><li>Three</li></ul>',
+			$p->get_updated_html()
+		);
+	}
+
+	/**
+	 * WP_HTML_Tag_Processor used to test for the diffs affecting
+	 * the adjusted bookmark position while simultaneously adjusting
+	 * the bookmark in question. As a result, updating the bookmarks
+	 * of a next tag while removing two subsequent attributes in
+	 * a previous tag unfolded like this:
+	 *
+	 * 1. Check if the first removed attribute is before the bookmark:
+	 *
+	 * <button twenty_one_characters 7_chars></button><button></button>
+	 *         ^-------------------^                  ^
+	 *           diff applied here           the bookmark is here
+	 *
+	 *    (Yes it is)
+	 *
+	 * 2. Move the bookmark to the left by the attribute length:
+	 *
+	 * <button twenty_one_characters 7_chars></button><button></button>
+	 *                           ^
+	 *                   the bookmark is here
+	 *
+	 * 3. Check if the second removed attribute is before the bookmark:
+	 *
+	 * <button twenty_one_characters 7_chars></button><button></button>
+	 *                           ^   ^-----^
+	 *                    bookmark    diff
+	 *
+	 *    This time, it isn't!
+	 *
+	 * The fix in the WP_HTML_Tag_Processor involves doing all the checks
+	 * before moving the bookmark. This test is here to guard us from
+	 * the erroneous behavior accidentally returning one day.
+	 *
+	 * @ticket 56299
+	 *
+	 * @covers seek
+	 * @covers set_bookmark
+	 * @covers apply_attributes_updates
+	 */
+	public function test_removing_long_attributes_doesnt_break_seek() {
+		$input = <<<HTML
+		<button twenty_one_characters 7_chars></button><button></button>
+HTML;
+		$p     = new WP_HTML_Tag_Processor( $input );
+		$p->next_tag( 'button' );
+		$p->set_bookmark( 'first' );
+		$p->next_tag( 'button' );
+		$p->set_bookmark( 'second' );
+
+		$this->assertTrue(
+			$p->seek( 'first' ),
+			'Seek() to the first button has failed'
+		);
+		$p->remove_attribute( 'twenty_one_characters' );
+		$p->remove_attribute( '7_chars' );
+
+		$this->assertTrue(
+			$p->seek( 'second' ),
+			'Seek() to the second button has failed'
+		);
+	}
+
+	/**
+	 * @ticket 56299
+	 *
+	 * @covers seek
+	 * @covers set_bookmark
+	 */
+	public function test_bookmarks_complex_use_case() {
+		$input           = <<<HTML
+<div selected class="merge-message" checked>
+	<div class="select-menu d-inline-block">
+		<div checked class="BtnGroup MixedCaseHTML position-relative" />
+		<div checked class="BtnGroup MixedCaseHTML position-relative">
+			<button type="button" class="merge-box-button btn-group-merge rounded-left-2 btn  BtnGroup-item js-details-target hx_create-pr-button" aria-expanded="false" data-details-container=".js-merge-pr" disabled="">
+			  Merge pull request
+			</button>
+
+			<button type="button" class="merge-box-button btn-group-squash rounded-left-2 btn  BtnGroup-item js-details-target hx_create-pr-button" aria-expanded="false" data-details-container=".js-merge-pr" disabled="">
+			  Squash and merge
+			</button>
+
+			<button type="button" class="merge-box-button btn-group-rebase rounded-left-2 btn  BtnGroup-item js-details-target hx_create-pr-button" aria-expanded="false" data-details-container=".js-merge-pr" disabled="">
+			  Rebase and merge
+			</button>
+
+			<button aria-label="Select merge method" disabled="disabled" type="button" data-view-component="true" class="select-menu-button btn BtnGroup-item"></button>
+		</div>
+	</div>
+</div>
+HTML;
+		$expected_output = <<<HTML
+<div selected class="merge-message" checked>
+	<div class="select-menu d-inline-block">
+		<div  class="BtnGroup MixedCaseHTML position-relative" />
+		<div checked class="BtnGroup MixedCaseHTML position-relative">
+			<button type="submit" class="merge-box-button btn-group-merge rounded-left-2 btn  BtnGroup-item js-details-target hx_create-pr-button" aria-expanded="false" data-details-container=".js-merge-pr" disabled="">
+			  Merge pull request
+			</button>
+
+			<button  class="hx_create-pr-button" aria-expanded="false" data-details-container=".js-merge-pr" disabled="">
+			  Squash and merge
+			</button>
+
+			<button id="rebase-and-merge"     disabled="">
+			  Rebase and merge
+			</button>
+
+			<button id="last-button"     ></button>
+		</div>
+	</div>
+</div>
+HTML;
+		$p               = new WP_HTML_Tag_Processor( $input );
+		$p->next_tag( 'div' );
+		$p->next_tag( 'div' );
+		$p->next_tag( 'div' );
+		$p->set_bookmark( 'first div' );
+		$p->next_tag( 'button' );
+		$p->set_bookmark( 'first button' );
+		$p->next_tag( 'button' );
+		$p->set_bookmark( 'second button' );
+		$p->next_tag( 'button' );
+		$p->set_bookmark( 'third button' );
+		$p->next_tag( 'button' );
+		$p->set_bookmark( 'fourth button' );
+
+		$p->seek( 'first button' );
+		$p->set_attribute( 'type', 'submit' );
+
+		$this->assertTrue(
+			$p->seek( 'third button' ),
+			'Seek() to the third button failed'
+		);
+		$p->remove_attribute( 'class' );
+		$p->remove_attribute( 'type' );
+		$p->remove_attribute( 'aria-expanded' );
+		$p->set_attribute( 'id', 'rebase-and-merge' );
+		$p->remove_attribute( 'data-details-container' );
+
+		$this->assertTrue(
+			$p->seek( 'first div' ),
+			'Seek() to the first div failed'
+		);
+		$p->set_attribute( 'checked', false );
+
+		$this->assertTrue(
+			$p->seek( 'fourth button' ),
+			'Seek() to the fourth button failed'
+		);
+		$p->set_attribute( 'id', 'last-button' );
+		$p->remove_attribute( 'class' );
+		$p->remove_attribute( 'type' );
+		$p->remove_attribute( 'checked' );
+		$p->remove_attribute( 'aria-label' );
+		$p->remove_attribute( 'disabled' );
+		$p->remove_attribute( 'data-view-component' );
+
+		$this->assertTrue(
+			$p->seek( 'second button' ),
+			'Seek() to the second button failed'
+		);
+		$p->remove_attribute( 'type' );
+		$p->set_attribute( 'class', 'hx_create-pr-button' );
+
+		$this->assertEquals(
+			$expected_output,
+			$p->get_updated_html()
+		);
+	}
+
+	/**
+	 * @ticket 56299
+	 *
+	 * @covers seek
+	 * @covers set_bookmark
+	 */
+	public function test_updates_bookmark_for_additions_after_both_sides() {
+		$p = new WP_HTML_Tag_Processor( '<div>First</div><div>Second</div>' );
+		$p->next_tag();
+		$p->set_bookmark( 'first' );
+		$p->next_tag();
+		$p->add_class( 'second' );
+
+		$p->seek( 'first' );
+		$p->add_class( 'first' );
+
+		$this->assertEquals(
+			'<div class="first">First</div><div class="second">Second</div>',
+			$p->get_updated_html()
+		);
+	}
+
+	/**
+	 * @ticket 56299
+	 *
+	 * @covers seek
+	 * @covers set_bookmark
+	 */
+	public function test_updates_bookmark_for_additions_before_both_sides() {
+		$p = new WP_HTML_Tag_Processor( '<div>First</div><div>Second</div>' );
+		$p->next_tag();
+		$p->set_bookmark( 'first' );
+		$p->next_tag();
+		$p->set_bookmark( 'second' );
+
+		$p->seek( 'first' );
+		$p->add_class( 'first' );
+
+		$p->seek( 'second' );
+		$p->add_class( 'second' );
+
+		$this->assertEquals(
+			'<div class="first">First</div><div class="second">Second</div>',
+			$p->get_updated_html()
+		);
+	}
+
+	/**
+	 * @ticket 56299
+	 *
+	 * @covers seek
+	 * @covers set_bookmark
+	 */
+	public function test_updates_bookmark_for_deletions_after_both_sides() {
+		$p = new WP_HTML_Tag_Processor( '<div>First</div><div disabled>Second</div>' );
+		$p->next_tag();
+		$p->set_bookmark( 'first' );
+		$p->next_tag();
+		$p->remove_attribute( 'disabled' );
+
+		$p->seek( 'first' );
+		$p->set_attribute( 'untouched', true );
+
+		$this->assertEquals(
+			/** @TODO: we shouldn't have to assert the extra space after removing the attribute. */
+			'<div untouched>First</div><div >Second</div>',
+			$p->get_updated_html()
+		);
+	}
+
+	/**
+	 * @ticket 56299
+	 *
+	 * @covers seek
+	 * @covers set_bookmark
+	 */
+	public function test_updates_bookmark_for_deletions_before_both_sides() {
+		$p = new WP_HTML_Tag_Processor( '<div disabled>First</div><div>Second</div>' );
+		$p->next_tag();
+		$p->set_bookmark( 'first' );
+		$p->next_tag();
+		$p->set_bookmark( 'second' );
+
+		$p->seek( 'first' );
+		$p->remove_attribute( 'disabled' );
+
+		$p->seek( 'second' );
+		$p->set_attribute( 'safe', true );
+
+		$this->assertEquals(
+			/** @TODO: we shouldn't have to assert the extra space after removing the attribute. */
+			'<div >First</div><div safe>Second</div>',
+			$p->get_updated_html()
+		);
+	}
+
+	/**
+	 * @ticket 56299
+	 *
+	 * @covers set_bookmark
+	 */
+	public function test_limits_the_number_of_bookmarks() {
+		$p = new WP_HTML_Tag_Processor( '<ul><li>One</li><li>Two</li><li>Three</li></ul>' );
+		$p->next_tag( 'li' );
+
+		$this->expectException( Exception::class );
+
+		for ( $i = 0;$i < WP_HTML_Tag_Processor::MAX_BOOKMARKS;$i++ ) {
+			$this->assertTrue( $p->set_bookmark( "bookmark $i" ), "Could not allocate the bookmark #$i" );
+		}
+
+		$this->assertFalse( $p->set_bookmark( 'final bookmark' ), "Allocated $i bookmarks, which is one above the limit." );
+	}
+
+	/**
+	 * @ticket 56299
+	 *
+	 * @covers seek
+	 */
+	public function test_limits_the_number_of_seek_calls() {
+		$p = new WP_HTML_Tag_Processor( '<ul><li>One</li><li>Two</li><li>Three</li></ul>' );
+		$p->next_tag( 'li' );
+		$p->set_bookmark( 'bookmark' );
+
+		$this->expectException( Exception::class );
+
+		for ( $i = 0; $i < WP_HTML_Tag_Processor::MAX_SEEK_OPS; $i++ ) {
+			$this->assertTrue( $p->seek( 'bookmark' ), 'Could not seek to the "bookmark"' );
+		}
+		$this->assertFalse( $p->seek( 'bookmark' ), "$i-th seek() to the bookmark succeeded, even though it should exceed the allowed limit." );
+	}
+}

--- a/phpunit/html/wp-html-tag-processor-test.php
+++ b/phpunit/html/wp-html-tag-processor-test.php
@@ -1296,18 +1296,24 @@ HTML;
 		);
 
 		$examples['Multiple unclosed tags treated as a single tag'] = array(
-			'<hr id=">"code
-<hr id="value>"code
-<hr id="/>"code
-<hr id="value/>"code
-/>
-<span>test</span>',
-			'<hr foo="bar" class="firstTag" id=">"code
-<hr id="value>"code
-<hr id="/>"code
-<hr id="value/>"code
-/>
-<span class="secondTag">test</span>',
+			<<<HTML
+			<hr id=">"code
+			<hr id="value>"code
+			<hr id="/>"code
+			<hr id="value/>"code
+			/>
+			<span>test</span>
+HTML
+			,
+			<<<HTML
+			<hr foo="bar" class="firstTag" id=">"code
+			<hr id="value>"code
+			<hr id="/>"code
+			<hr id="value/>"code
+			/>
+			<span class="secondTag">test</span>
+HTML
+		,
 		);
 
 		$examples['27'] = array(


### PR DESCRIPTION
## What?

Introduces "bookmarks" to the `WP_HTML_Tag_Processor` which allow seeking to previously-scanned parts of the document, if they still exist, while maintaining the integrity of the HTML syntax.

## Why?

It can be helpful to track a location in an HTML document while updates are being made to it such that we can instruct the Tag Processor to seek to the location of one of the bookmarks.

In this patch we're introducing a bookmarks system to do just that. Bookmarks are referenced by name and handled internally by a tracking object which will follow all updates made to the document. It will be possible to rewind or jump around a document by setting a bookmark and then calling `seek( $bookmark_name )` to move there.

## How?

The bookmarks are tracked internally to the tag processor. Every time we update the document through `set_attribute()` or related functions, the trackers are updated to follow those edits.

Bookmarks are two-sided, tracking the start and end of an HTML token. We do this so that we can never accidentally reset a string offset into the middle of a tag or attribute.