### PR TITLE
Navigation: Hide the create new menu button if the experiment is enabled

### DIFF
--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -143,7 +143,11 @@ function NavigationMenuSelector( {
 		},
 	};
 
-	if ( ! hasNavigationMenus && ! hasClassicMenus ) {
+	if (
+		! hasNavigationMenus &&
+		! hasClassicMenus &&
+		! isOffCanvasNavigationEditorEnabled
+	) {
 		return (
 			<Button
 				className="wp-block-navigation__navigation-selector-button--createnew"


### PR DESCRIPTION
## What?
This moves the "create new menu" option to the navigation menu selector, when in the offcanvas editing experiment.

Before:
<img width="284" alt="Screenshot 2022-11-22 at 13 21 17" src="https://user-images.githubusercontent.com/275961/203324347-646967d8-729e-4ca8-a535-76ebe7d9ad0c.png">

After:
<img width="284" alt="Screenshot 2022-11-24 at 15 17 01" src="https://user-images.githubusercontent.com/275961/203818007-8089c228-8417-4570-8c7a-317432842114.png">


## Why?
Because before looks bad!

## How?
Doing this in the simplest possible way based on the feedback in https://github.com/WordPress/gutenberg/pull/45983

## Testing Instructions
1. Delete all classic menus and all wp_navigation menus
2. Enable the offcanvas editing experiment
3. Add a navigation block
4. Confirm that the "Create new menu" button is not alongside the "Menu" heading.

