### PR TITLE
Navigation: Remove unused clientId prop

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -667,7 +667,6 @@ function Navigation( {
 		return (
 			<TagName { ...blockProps }>
 				<MenuInspectorControls
-					clientId={ clientId }
 					convertClassicMenu={ convertClassicMenu }
 					createNavigationMenuIsSuccess={
 						createNavigationMenuIsSuccess
@@ -710,7 +709,6 @@ function Navigation( {
 		return (
 			<TagName { ...blockProps }>
 				<MenuInspectorControls
-					clientId={ clientId }
 					convertClassicMenu={ convertClassicMenu }
 					createNavigationMenuIsSuccess={
 						createNavigationMenuIsSuccess
@@ -797,7 +795,6 @@ function Navigation( {
 		<EntityProvider kind="postType" type="wp_navigation" id={ ref }>
 			<RecursionProvider uniqueId={ recursionId }>
 				<MenuInspectorControls
-					clientId={ clientId }
 					convertClassicMenu={ convertClassicMenu }
 					createNavigationMenuIsSuccess={
 						createNavigationMenuIsSuccess

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -19,7 +19,6 @@ import ManageMenusButton from './manage-menus-button';
 import NavigationMenuSelector from './navigation-menu-selector';
 
 const WrappedNavigationMenuSelector = ( {
-	clientId,
 	currentMenuId,
 	handleUpdateMenu,
 	convertClassicMenu,
@@ -29,7 +28,6 @@ const WrappedNavigationMenuSelector = ( {
 } ) => (
 	<NavigationMenuSelector
 		currentMenuId={ currentMenuId }
-		clientId={ clientId }
 		onSelectNavigationMenu={ ( menuId ) => {
 			handleUpdateMenu( menuId );
 		} }
@@ -53,7 +51,6 @@ const WrappedNavigationMenuSelector = ( {
 	/>
 );
 const MenuInspectorControls = ( {
-	clientId,
 	convertClassicMenu,
 	createNavigationMenuIsSuccess,
 	createNavigationMenuIsError,
@@ -87,7 +84,6 @@ const MenuInspectorControls = ( {
 								{ __( 'Menu' ) }
 							</Heading>
 							<WrappedNavigationMenuSelector
-								clientId={ clientId }
 								currentMenuId={ currentMenuId }
 								handleUpdateMenu={ handleUpdateMenu }
 								convertClassicMenu={ convertClassicMenu }
@@ -113,7 +109,6 @@ const MenuInspectorControls = ( {
 				) : (
 					<>
 						<WrappedNavigationMenuSelector
-							clientId={ clientId }
 							currentMenuId={ currentMenuId }
 							handleUpdateMenu={ handleUpdateMenu }
 							convertClassicMenu={ convertClassicMenu }


### PR DESCRIPTION
## What?
We pass the clientId prop down to all these components but then we never use it! This PR just removes all these unnecessary props.

## Why?
Cleaner code.

## How?
Just removing the lines that pass clientId

## Testing Instructions
Check that the navigation block inspector controls work as before.