### PR TITLE
Update BlockCard to pass className instead of isSynced prop

### DIFF
--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -22,7 +22,7 @@ function BlockCard( {
 	blockType,
 	parentBlockClientId,
 	handleBackButton,
-	isSynced,
+	className,
 } ) {
 	if ( blockType ) {
 		deprecated( '`blockType` property in `BlockCard component`', {
@@ -36,11 +36,7 @@ function BlockCard( {
 		window?.__experimentalEnableOffCanvasNavigationEditor === true;
 
 	return (
-		<div
-			className={ classnames( 'block-editor-block-card', {
-				'is-synced': isSynced,
-			} ) }
-		>
+		<div className={ classnames( 'block-editor-block-card', className ) }>
 			{ isOffCanvasNavigationEditorEnabled && parentBlockClientId && (
 				<Button
 					onClick={ handleBackButton }

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -106,7 +106,10 @@ function BlockInspectorLockedBlocks( { topLevelLockedBlock } ) {
 	const contentBlocks = useContentBlocks( blockTypes, block );
 	return (
 		<div className="block-editor-block-inspector">
-			<BlockCard { ...blockInformation } />
+			<BlockCard
+				{ ...blockInformation }
+				className={ blockInformation.isSynced && 'is-synced' }
+			/>
 			<BlockVariationTransforms blockClientId={ topLevelLockedBlock } />
 			<VStack
 				spacing={ 1 }
@@ -264,6 +267,7 @@ const BlockInspectorSingleBlock = ( {
 		<div className="block-editor-block-inspector">
 			<BlockCard
 				{ ...blockInformation }
+				className={ blockInformation.isSynced && 'is-synced' }
 				parentBlockClientId={ parentBlockClientId }
 				handleBackButton={ () => {
 					selectBlock( parentBlockClientId );


### PR DESCRIPTION
## What?
Replaces the `isSynced` prop on the BlockCard component with a `className` prop

## Why?
As [suggested here](https://github.com/WordPress/gutenberg/pull/45473#pullrequestreview-1191212049) this could save us possible deprecations and we could also accommodate more use cases for styles in the future.

## How?
Swaps the props

## Testing Instructions

- Add a reusable block to a page and make sure the icon in the BlockCard in right inspector panel is colored purple
- Lock the block and make sure the icon remains purple
- Add a standard block and check that the icon is black
