### PR TITLE
Sidebar: Expand advanced panel if only item in settings tab

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/advanced-controls-panel.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/advanced-controls-panel.js
@@ -14,10 +14,17 @@ import {
 	default as InspectorControls,
 	InspectorAdvancedControls,
 } from '../inspector-controls';
+import InspectorControlsGroups from '../inspector-controls/groups';
 
 const AdvancedControls = () => {
 	const fills = useSlotFills( InspectorAdvancedControls.slotName );
 	const hasFills = Boolean( fills && fills.length );
+
+	// Check fills in settings tab to determine initial open state for panel.
+	const tabsEnabled = window?.__experimentalEnableBlockInspectorTabs;
+	const { default: defaultGroup } = InspectorControlsGroups;
+	const settingFills = useSlotFills( defaultGroup.Slot.__unstableName ) || [];
+	const open = !! tabsEnabled && ! settingFills.length;
 
 	if ( ! hasFills ) {
 		return null;
@@ -27,7 +34,7 @@ const AdvancedControls = () => {
 		<PanelBody
 			className="block-editor-block-inspector__advanced"
 			title={ __( 'Advanced' ) }
-			initialOpen={ false }
+			initialOpen={ open }
 		>
 			<InspectorControls.Slot __experimentalGroup="advanced" />
 		</PanelBody>


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/45005

## What?

Expands the Advanced controls panel by default when it is the only item under the sidebar settings tab.

## Why?

Having the advanced controls panel remain collapsed when it is the only item in the tab looks odd. Expanding it in this scenario may also save the user a click.

## How?

If there are no fills being rendered within the `default` inspector controls slot, the advanced controls panel has its `initialOpen` prop set to `true`.

## Known Issues

Conditionally rendered fills within the default inspector controls slot pose a problem. For example;

```
<InspectorControls>
    { !! url && ... }
</InspectorControls>
```

The above code still adds a fill to the slot. I haven't yet found a reliable means of determining that nothing is actually being rendered by the example above to still allow the auto-expansion of the advanced controls panel.

#### Alternative Approach

I did try setting a flag within a new SettingsTabContext and having any fills toggle that as they render however I couldn't get that working.

## Testing Instructions

1. Add a navigation block to a post and edit it
2. Select the "Settings" tab in the sidebar and ensure the advanced controls panel is collapsed by default
3. Add a paragraph block and select it
4. Under the "Settings" tab the advanced controls panel should be expanded
5. Add a cover block and leave it in the placeholder state or select a solid background color
6. Select the cover block and the Settings tab. The advanced controls here will still be collapsed due to the known issue noted above.



## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/203728129-fd8edf43-32c2-4b66-aafa-f95e37ff4b01.mp4

