### PR TITLE
Sidebar: Make display of tabs filterable

### DIFF
--- a/docs/reference-guides/filters/editor-filters.md
+++ b/docs/reference-guides/filters/editor-filters.md
@@ -6,6 +6,24 @@ To modify the behavior of the editor experience, WordPress exposes several APIs.
 
 The following filters are available to extend the editor features.
 
+### `editor.BlockInspector.showTabs`
+
+Used to filter the display of tabs in the block inspector sidebar.
+
+_Example:_
+
+```js
+var maybeDisableTabs = function ( blockName, showTabs ) {
+	return blockName === 'core/query' ? false : showTabs;
+};
+
+wp.hooks.addFilter(
+	'editor.BlockInspector.showTabs',
+	'my-plugin/maybe-disable-tabs',
+	maybeDisableTabs
+);
+```
+
 ### `editor.PostFeaturedImage.imageSize`
 
 Used to modify the image size displayed in the Post Featured Image component. It defaults to `'post-thumbnail'`, and will fail back to the `full` image size when the specified image size doesn't exist in the media object. It's modeled after the `admin_post_thumbnail_size` filter in the classic editor.

--- a/docs/reference-guides/filters/editor-filters.md
+++ b/docs/reference-guides/filters/editor-filters.md
@@ -6,24 +6,6 @@ To modify the behavior of the editor experience, WordPress exposes several APIs.
 
 The following filters are available to extend the editor features.
 
-### `editor.BlockInspector.showTabs`
-
-Used to filter the display of tabs in the block inspector sidebar.
-
-_Example:_
-
-```js
-var maybeDisableTabs = function ( blockName, showTabs ) {
-	return blockName === 'core/query' ? false : showTabs;
-};
-
-wp.hooks.addFilter(
-	'editor.BlockInspector.showTabs',
-	'my-plugin/maybe-disable-tabs',
-	maybeDisableTabs
-);
-```
-
 ### `editor.PostFeaturedImage.imageSize`
 
 Used to modify the image size displayed in the Post Featured Image component. It defaults to `'post-thumbnail'`, and will fail back to the `full` image size when the specified image size doesn't exist in the media object. It's modeled after the `admin_post_thumbnail_size` filter in the classic editor.

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -17,6 +17,7 @@ import {
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useMemo, useCallback } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -169,9 +170,12 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 	}, [] );
 
 	const availableTabs = useInspectorControlsTabs( blockType?.name );
-	const showTabs =
+	const showTabs = applyFilters(
+		'editor.BlockInspector.showTabs',
+		blockType?.name,
 		window?.__experimentalEnableBlockInspectorTabs &&
-		availableTabs.length > 1;
+			availableTabs.length > 1
+	);
 
 	if ( count > 1 ) {
 		return (
@@ -243,10 +247,12 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 
 const BlockInspectorSingleBlock = ( { clientId, blockName } ) => {
 	const availableTabs = useInspectorControlsTabs( blockName );
-	const showTabs =
+	const showTabs = applyFilters(
+		'editor.BlockInspector.showTabs',
+		blockName,
 		window?.__experimentalEnableBlockInspectorTabs &&
-		availableTabs.length > 1;
-
+			availableTabs.length > 1
+	);
 	const hasBlockStyles = useSelect(
 		( select ) => {
 			const { getBlockStyles } = select( blocksStore );


### PR DESCRIPTION
Depends on:
- https://github.com/WordPress/gutenberg/pull/45991

Related:
- https://github.com/WordPress/gutenberg/pull/45005

## What?

Adds a filter allowing plugins to disable the display of tabs in the sidebar.

## Why?

Plugins may drastically change the controls in the sidebar or even introduce their own tabs. Making the display of the sidebar tabs filterable will help provide plugins with the escape hatch they need.

## How?

- Adds new filter: `editor.BlockInspector.showTabs`
- Applies the new filter when determining if tabs should be rendered in the block inspector

## Testing Instructions
1. Edit a post, add a paragraph and a group block
2. Apply the patch in the diff below or add a filter in a new plugin to disable the tabs just for the group block
3. Select the paragraph block and ensure the tabs display
4. Select the group block and the tabs should be hidden and controls rendered directly to the sidebar

```diff
diff --git a/packages/block-library/src/group/index.js b/packages/block-library/src/group/index.js
index 2d06f1a965..44b64f7d90 100644
--- a/packages/block-library/src/group/index.js
+++ b/packages/block-library/src/group/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { group as icon } from '@wordpress/icons';
+import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -89,3 +90,9 @@ export const settings = {
 };
 
 export const init = () => initBlock( { name, metadata, settings } );
+
+addFilter(
+	'editor.BlockInspector.showTabs',
+	'test-disable-sidebar-tabs',
+	( blockName, showTabs ) => ( blockName === 'core/group' ? false : showTabs )
+);

```