### PR TITLE
Navigation: Simplify the interface to NavigationMenuSelector

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -767,24 +767,11 @@ function Navigation( {
 					currentMenuId={ ref }
 					clientId={ clientId }
 					canUserCreateNavigationMenu={ canUserCreateNavigationMenu }
+					convertClassicMenu={ convertClassicMenu }
+					handleUpdateMenu={ handleUpdateMenu }
 					isResolvingCanUserCreateNavigationMenu={
 						isResolvingCanUserCreateNavigationMenu
 					}
-					onSelectNavigationMenu={ ( menuId ) => {
-						handleUpdateMenu( menuId );
-					} }
-					onSelectClassicMenu={ async ( classicMenu ) => {
-						const navMenu = await convertClassicMenu(
-							classicMenu.id,
-							classicMenu.name,
-							'draft'
-						);
-						if ( navMenu ) {
-							handleUpdateMenu( navMenu.id, {
-								focusNavigationBlock: true,
-							} );
-						}
-					} }
 					onCreateEmpty={ createUntitledEmptyNavigationMenu }
 				/>
 			</TagName>

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -27,22 +27,9 @@ const WrappedNavigationMenuSelector = ( {
 	createNavigationMenuIsError,
 } ) => (
 	<NavigationMenuSelector
+		convertClassicMenu={ convertClassicMenu }
 		currentMenuId={ currentMenuId }
-		onSelectNavigationMenu={ ( menuId ) => {
-			handleUpdateMenu( menuId );
-		} }
-		onSelectClassicMenu={ async ( classicMenu ) => {
-			const navMenu = await convertClassicMenu(
-				classicMenu.id,
-				classicMenu.name,
-				'draft'
-			);
-			if ( navMenu ) {
-				handleUpdateMenu( navMenu.id, {
-					focusNavigationBlock: true,
-				} );
-			}
-		} }
+		handleUpdateMenu={ handleUpdateMenu }
 		onCreateNew={ onCreateNew }
 		createNavigationMenuIsSuccess={ createNavigationMenuIsSuccess }
 		createNavigationMenuIsError={ createNavigationMenuIsError }

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -22,9 +22,9 @@ import useNavigationMenu from '../use-navigation-menu';
 import useNavigationEntities from '../use-navigation-entities';
 
 function NavigationMenuSelector( {
+	convertClassicMenu,
 	currentMenuId,
-	onSelectNavigationMenu,
-	onSelectClassicMenu,
+	handleUpdateMenu,
 	onCreateNew,
 	actionLabel,
 	createNavigationMenuIsSuccess,
@@ -59,6 +59,19 @@ function NavigationMenuSelector( {
 		'wp_navigation',
 		'title'
 	);
+
+	const onSelectClassicMenu = async ( classicMenu ) => {
+		const navMenu = await convertClassicMenu(
+			classicMenu.id,
+			classicMenu.name,
+			'draft'
+		);
+		if ( navMenu ) {
+			handleUpdateMenu( navMenu.id, {
+				focusNavigationBlock: true,
+			} );
+		}
+	};
 
 	const shouldEnableMenuSelector =
 		( canSwitchNavigationMenu || canUserCreateNavigationMenu ) &&
@@ -98,6 +111,10 @@ function NavigationMenuSelector( {
 	const noBlockMenus = ! hasNavigationMenus && hasResolvedNavigationMenus;
 	const menuUnavailable =
 		hasResolvedNavigationMenus && currentMenuId === null;
+
+	const onSelectNavigationMenu = ( menuId ) => {
+		handleUpdateMenu( menuId );
+	};
 
 	useEffect( () => {
 		if ( ! hasResolvedNavigationMenus ) {

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -18,10 +18,10 @@ export default function NavigationPlaceholder( {
 	isSelected,
 	currentMenuId,
 	clientId,
+	convertClassicMenu,
 	canUserCreateNavigationMenu = false,
+	handleUpdateMenu,
 	isResolvingCanUserCreateNavigationMenu,
-	onSelectNavigationMenu,
-	onSelectClassicMenu,
 	onCreateEmpty,
 } ) {
 	const { isResolvingMenus, hasResolvedMenus } = useNavigationEntities();
@@ -68,8 +68,8 @@ export default function NavigationPlaceholder( {
 						<NavigationMenuSelector
 							currentMenuId={ currentMenuId }
 							clientId={ clientId }
-							onSelectNavigationMenu={ onSelectNavigationMenu }
-							onSelectClassicMenu={ onSelectClassicMenu }
+							handleUpdateMenu={ handleUpdateMenu }
+							convertClassicMenu={ convertClassicMenu }
 							toggleProps={ {
 								variant: 'tertiary',
 								iconPosition: 'right',


### PR DESCRIPTION
## What?
When we want to use NavigationMenuSelector we need to pass it quite complex functions for how to handle updating navigation and importing classic menus. This complexity should really live within the component itself.

## Why?
Cleaner code.

## How?
Move the function definitions to the component, reducing duplicate code and removing the need for the `WrappedNavigationMenuSelector` component.

## Testing Instructions
- Switch to a classic theme
- Create a classic menu
- Switch to a block theme
- Confirm that importing classic menus still works
- Confirm that changing navigation menus using the navigation menu selector still works.