### PR TITLE
Try: Adopt a simpler tab focus style

### DIFF
--- a/packages/components/src/tab-panel/style.scss
+++ b/packages/components/src/tab-panel/style.scss
@@ -55,8 +55,8 @@
 	&:focus::after {
 		left: $grid-unit-20;
 		right: $grid-unit-20;
-		height: calc(2 * var(--wp-admin-border-width-focus));
-		border-radius: calc(2 * var(--wp-admin-border-width-focus));
+		height: $radius-block-ui;
+		border-radius: $radius-block-ui $radius-block-ui 0 0;
 	}
 
 	&.is-active {

--- a/packages/components/src/tab-panel/style.scss
+++ b/packages/components/src/tab-panel/style.scss
@@ -7,27 +7,60 @@
 	}
 }
 
+// This tab style CSS is duplicated verbatim in
+// /packages/edit-post/src/components/sidebar/settings-header/style.scss
 .components-tab-panel__tabs-item {
+	position: relative;
+	border-radius: 0;
+	height: $grid-unit-60;
 	background: transparent;
 	border: none;
 	box-shadow: none;
-	border-radius: 0;
 	cursor: pointer;
-	height: $grid-unit-60;
 	padding: 3px $grid-unit-20; // Use padding to offset the is-active border, this benefits Windows High Contrast mode
 	margin-left: 0;
 	font-weight: 500;
-	transition: box-shadow 0.1s linear;
-	box-sizing: border-box;
 
 	&:focus:not(:disabled) {
-		box-shadow: inset 0 var(--wp-admin-border-width-focus) $components-color-accent;
+		position: relative;
+		z-index: z-index(".edit-post-sidebar__panel-tab.is-active");
+		box-shadow: none;
+	}
+
+	// Tab indicator
+	&::after {
+		content: "";
+		position: absolute;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		pointer-events: none;
+
+		// Draw the indicator.
+		background: var(--wp-admin-theme-color);
+		height: calc(0 * var(--wp-admin-border-width-focus));
+		border-radius: 0;
+
+		// Animation
+		transition: all 0.1s linear;
+		@include reduce-motion("transition");
+	}
+
+	// Active.
+	&.is-active::after {
+		height: calc(1 * var(--wp-admin-border-width-focus));
+	}
+
+	// Focus.
+	&:focus::after {
+		left: $grid-unit-20;
+		right: $grid-unit-20;
+		height: calc(2 * var(--wp-admin-border-width-focus));
+		border-radius: calc(2 * var(--wp-admin-border-width-focus));
 	}
 
 	&.is-active {
-		// The transparent shadow ensures no jumpiness when focus animates on an active tab.
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) transparent, inset 0 0 -$border-width-tab 0 0 $components-color-accent;
-		position: relative;
+		z-index: z-index(".edit-post-sidebar__panel-tab.is-active");
 
 		// This border appears in Windows High Contrast mode instead of the box-shadow.
 		&::before {
@@ -37,15 +70,8 @@
 			bottom: 1px;
 			right: 0;
 			left: 0;
-			border-bottom: $border-width-tab solid transparent;
+			border-bottom: 3px solid transparent;
+			z-index: z-index(".edit-post-sidebar__panel-tab.is-active");
 		}
-	}
-
-	&:focus {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
-	}
-
-	&.is-active:focus {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent, inset 0 -#{$border-width-tab * 2} 0 0 $components-color-accent;
 	}
 }

--- a/packages/components/src/tab-panel/style.scss
+++ b/packages/components/src/tab-panel/style.scss
@@ -20,18 +20,6 @@
 	transition: box-shadow 0.1s linear;
 	box-sizing: border-box;
 
-	// This pseudo-element "duplicates" the tab label and sets the text to bold.
-	// This ensures that the tab doesn't change width when selected.
-	// See: https://github.com/WordPress/gutenberg/pull/9793
-	&::after {
-		content: attr(data-label);
-		display: block;
-		height: 0;
-		overflow: hidden;
-		speak: none;
-		visibility: hidden;
-	}
-
 	&:focus:not(:disabled) {
 		box-shadow: inset 0 var(--wp-admin-border-width-focus) $components-color-accent;
 	}

--- a/packages/edit-post/src/components/sidebar/settings-header/style.scss
+++ b/packages/edit-post/src/components/sidebar/settings-header/style.scss
@@ -1,3 +1,5 @@
+// This tab style CSS is duplicated verbatim in
+// /packages/components/src/tab-panel/style.scss
 .components-button.edit-post-sidebar__panel-tab {
 	position: relative;
 	border-radius: 0;
@@ -6,12 +8,11 @@
 	border: none;
 	box-shadow: none;
 	cursor: pointer;
-	display: inline-block;
 	padding: 3px $grid-unit-20; // Use padding to offset the is-active border, this benefits Windows High Contrast mode
 	margin-left: 0;
 	font-weight: 500;
 
-	&:focus {
+	&:focus:not(:disabled) {
 		position: relative;
 		z-index: z-index(".edit-post-sidebar__panel-tab.is-active");
 		box-shadow: none;

--- a/packages/edit-post/src/components/sidebar/settings-header/style.scss
+++ b/packages/edit-post/src/components/sidebar/settings-header/style.scss
@@ -46,8 +46,8 @@
 	&:focus::after {
 		left: $grid-unit-20;
 		right: $grid-unit-20;
-		height: calc(2 * var(--wp-admin-border-width-focus));
-		border-radius: calc(2 * var(--wp-admin-border-width-focus));
+		height: $radius-block-ui;
+		border-radius: $radius-block-ui $radius-block-ui 0 0;
 	}
 
 	&.is-active {

--- a/packages/edit-post/src/components/sidebar/settings-header/style.scss
+++ b/packages/edit-post/src/components/sidebar/settings-header/style.scss
@@ -21,30 +21,32 @@
 	&::after {
 		content: "";
 		position: absolute;
-		top: 0;
 		right: 0;
 		bottom: 0;
 		left: 0;
 		pointer-events: none;
 
-		// Animation
-		transition: all 0.2s linear;
-		@include reduce-motion("transition");
+		// Draw the indicator.
+		background: var(--wp-admin-theme-color);
+		height: calc(0 * var(--wp-admin-border-width-focus));
+		border-radius: 0;
 
-		// The transparent shadow ensures no jumpiness when focus animates on an active tab.
-		box-shadow: inset 0 calc(0 * var(--wp-admin-border-width-focus)) 0 0 var(--wp-admin-theme-color);
+		// Animation
+		transition: all 0.1s linear;
+		@include reduce-motion("transition");
 	}
 
 	// Active.
 	&.is-active::after {
-		box-shadow: inset 0 calc(-1 * var(--wp-admin-border-width-focus)) 0 0 var(--wp-admin-theme-color);
+		height: calc(1 * var(--wp-admin-border-width-focus));
 	}
 
 	// Focus.
 	&:focus::after {
-		box-shadow: inset 0 calc(-2 * var(--wp-admin-border-width-focus)) 0 0 var(--wp-admin-theme-color);
 		left: $grid-unit-20;
 		right: $grid-unit-20;
+		height: calc(2 * var(--wp-admin-border-width-focus));
+		border-radius: calc(2 * var(--wp-admin-border-width-focus));
 	}
 
 	&.is-active {

--- a/packages/edit-post/src/components/sidebar/settings-header/style.scss
+++ b/packages/edit-post/src/components/sidebar/settings-header/style.scss
@@ -1,4 +1,5 @@
 .components-button.edit-post-sidebar__panel-tab {
+	position: relative;
 	border-radius: 0;
 	height: $grid-unit-60;
 	background: transparent;
@@ -6,27 +7,47 @@
 	box-shadow: none;
 	cursor: pointer;
 	display: inline-block;
-	padding: 3px 15px; // Use padding to offset the is-active border, this benefits Windows High Contrast mode
+	padding: 3px $grid-unit-20; // Use padding to offset the is-active border, this benefits Windows High Contrast mode
 	margin-left: 0;
 	font-weight: 500;
 
-	// This pseudo-element "duplicates" the tab label and sets the text to bold.
-	// This ensures that the tab doesn't change width when selected.
-	// See: https://github.com/WordPress/gutenberg/pull/9793
+	&:focus {
+		position: relative;
+		z-index: z-index(".edit-post-sidebar__panel-tab.is-active");
+		box-shadow: none;
+	}
+
+	// Tab indicator
 	&::after {
-		content: attr(data-label);
-		display: block;
-		font-weight: 600;
-		height: 0;
-		overflow: hidden;
-		speak: none;
-		visibility: hidden;
+		content: "";
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		pointer-events: none;
+
+		// Animation
+		transition: all 0.2s linear;
+		@include reduce-motion("transition");
+
+		// The transparent shadow ensures no jumpiness when focus animates on an active tab.
+		box-shadow: inset 0 calc(0 * var(--wp-admin-border-width-focus)) 0 0 var(--wp-admin-theme-color);
+	}
+
+	// Active.
+	&.is-active::after {
+		box-shadow: inset 0 calc(-1 * var(--wp-admin-border-width-focus)) 0 0 var(--wp-admin-theme-color);
+	}
+
+	// Focus.
+	&:focus::after {
+		box-shadow: inset 0 calc(-2 * var(--wp-admin-border-width-focus)) 0 0 var(--wp-admin-theme-color);
+		left: $grid-unit-20;
+		right: $grid-unit-20;
 	}
 
 	&.is-active {
-		// The transparent shadow ensures no jumpiness when focus animates on an active tab.
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) transparent, inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
-		position: relative;
 		z-index: z-index(".edit-post-sidebar__panel-tab.is-active");
 
 		// This border appears in Windows High Contrast mode instead of the box-shadow.
@@ -37,17 +58,8 @@
 			bottom: 1px;
 			right: 0;
 			left: 0;
-			border-bottom: $border-width-tab solid transparent;
+			border-bottom: 3px solid transparent;
+			z-index: z-index(".edit-post-sidebar__panel-tab.is-active");
 		}
-	}
-
-	&:focus {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-		position: relative;
-		z-index: z-index(".edit-post-sidebar__panel-tab.is-active");
-	}
-
-	&.is-active:focus {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 -#{$border-width-tab * 2} 0 0 var(--wp-admin-theme-color);
 	}
 }


### PR DESCRIPTION
## What?

The current focus style for tabs is both complex and very heavy, and makes the tab look like a button instead of a tab:

<img width="434" alt="before" src="https://user-images.githubusercontent.com/1204802/203772657-d2103fce-e231-405a-88b1-267d2e560f4c.png">

This PR tries to simplify the focus style while still making it look like a tab:

<img width="404" alt="after" src="https://user-images.githubusercontent.com/1204802/203772738-a4bcfb15-11ce-45cb-965d-590c916137d1.png">

Here's a GIF showing the tab focus between inspector and inserter:

![tab focus](https://user-images.githubusercontent.com/1204802/203772849-30f29d57-eb03-4370-823d-af4310032ce8.gif)

In addition to the new style, it also simplifies the code a little bit, unifies it in the two places I found it used, and makes the tab indicator into a pseudo element. That should also let us animate it between the two tabs in the future, like how the segmented control backdrop is animated.

## Testing Instructions

Please test the focus style of tabs in inspector, inserter, and anywhere else the tabpanel component is used.