### PR TITLE
Refactor link creation UI to standalone component/file

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -762,11 +762,11 @@ export default function NavigationLinkEdit( {
 							url={ url }
 							kind={ kind }
 							linkValue={ link }
-							setIsLinkOpen={ setIsLinkOpen }
-							popoverAnchor={ popoverAnchor }
+							onClose={ () => setIsLinkOpen( false ) }
+							anchor={ popoverAnchor }
 							hasCreateSuggestion={ userCanCreate }
 							onRemove={ removeLink }
-						></LinkUI>
+						/>
 					) }
 				</a>
 				<div { ...innerBlocksProps } />

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -47,6 +47,7 @@ import { useMergeRefs } from '@wordpress/compose';
  */
 import { name } from './block.json';
 import { LinkUI } from './link-ui';
+import { updateAttributes } from './update-attributes';
 
 /**
  * A React hook to determine if it's dragging within the target element.
@@ -755,8 +756,6 @@ export default function NavigationLinkEdit( {
 					) }
 					{ isLinkOpen && (
 						<LinkUI
-							attributes={ attributes }
-							setAttributes={ setAttributes }
 							clientId={ clientId }
 							type={ type }
 							url={ url }
@@ -766,6 +765,13 @@ export default function NavigationLinkEdit( {
 							anchor={ popoverAnchor }
 							hasCreateSuggestion={ userCanCreate }
 							onRemove={ removeLink }
+							updateAttributes={ ( updatedValue ) => {
+								updateAttributes(
+									updatedValue,
+									setAttributes,
+									attributes
+								);
+							} }
 						/>
 					) }
 				</a>

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -99,36 +99,6 @@ const useIsDraggingWithin = ( elementRef ) => {
 };
 
 /**
- * Given the Link block's type attribute, return the query params to give to
- * /wp/v2/search.
- *
- * @param {string} type Link block's type attribute.
- * @param {string} kind Link block's entity of kind (post-type|taxonomy)
- * @return {{ type?: string, subtype?: string }} Search query params.
- */
-export function getSuggestionsQuery( type, kind ) {
-	switch ( type ) {
-		case 'post':
-		case 'page':
-			return { type: 'post', subtype: type };
-		case 'category':
-			return { type: 'term', subtype: 'category' };
-		case 'tag':
-			return { type: 'term', subtype: 'post_tag' };
-		case 'post_format':
-			return { type: 'post-format' };
-		default:
-			if ( kind === 'taxonomy' ) {
-				return { type: 'term', subtype: type };
-			}
-			if ( kind === 'post-type' ) {
-				return { type: 'post', subtype: type };
-			}
-			return {};
-	}
-}
-
-/**
  * Determine the colors for a menu.
  *
  * Order of priority is:

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -663,7 +663,7 @@ export default function NavigationLinkEdit( {
 							anchor={ popoverAnchor }
 							hasCreateSuggestion={ userCanCreate }
 							onRemove={ removeLink }
-							updateAttributes={ ( updatedValue ) => {
+							onChange={ ( updatedValue ) => {
 								updateAttributes(
 									updatedValue,
 									setAttributes,

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -759,11 +759,11 @@ export default function NavigationLinkEdit( {
 							type={ type }
 							url={ url }
 							kind={ kind }
-							link={ link }
+							linkValue={ link }
 							replaceBlock={ replaceBlock }
 							setIsLinkOpen={ setIsLinkOpen }
 							popoverAnchor={ popoverAnchor }
-							userCanCreate={ userCanCreate }
+							hasCreateSuggestion={ userCanCreate }
 							onRemove={ removeLink }
 						></LinkUI>
 					) }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -262,7 +262,7 @@ function navStripHTML( html ) {
  * Add transforms to Link Control
  */
 
-export function LinkControlTransforms( { clientId, replace } ) {
+export function LinkControlTransforms( { clientId } ) {
 	const { getBlock, blockTransforms } = useSelect(
 		( select ) => {
 			const {
@@ -281,6 +281,8 @@ export function LinkControlTransforms( { clientId, replace } ) {
 		},
 		[ clientId ]
 	);
+
+	const { replaceBlock } = useDispatch( blockEditorStore );
 
 	const featuredBlocks = [
 		'core/site-logo',
@@ -306,7 +308,7 @@ export function LinkControlTransforms( { clientId, replace } ) {
 						<Button
 							key={ `transform-${ index }` }
 							onClick={ () =>
-								replace(
+								replaceBlock(
 									clientId,
 									switchToBlockType(
 										getBlock( clientId ),
@@ -760,7 +762,6 @@ export default function NavigationLinkEdit( {
 							url={ url }
 							kind={ kind }
 							linkValue={ link }
-							replaceBlock={ replaceBlock }
 							setIsLinkOpen={ setIsLinkOpen }
 							popoverAnchor={ popoverAnchor }
 							hasCreateSuggestion={ userCanCreate }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -7,10 +7,9 @@ import { unescape } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { createBlock, switchToBlockType } from '@wordpress/blocks';
+import { createBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
-	Button,
 	PanelBody,
 	TextControl,
 	TextareaControl,
@@ -23,7 +22,6 @@ import { displayShortcut, isKeyboardEvent, ENTER } from '@wordpress/keycodes';
 import { __ } from '@wordpress/i18n';
 import {
 	BlockControls,
-	BlockIcon,
 	InspectorControls,
 	RichText,
 	useBlockProps,
@@ -257,76 +255,6 @@ function navStripHTML( html ) {
 	const doc = document.implementation.createHTMLDocument( '' );
 	doc.body.innerHTML = html;
 	return doc.body.textContent || '';
-}
-
-/**
- * Add transforms to Link Control
- */
-
-export function LinkControlTransforms( { clientId } ) {
-	const { getBlock, blockTransforms } = useSelect(
-		( select ) => {
-			const {
-				getBlock: _getBlock,
-				getBlockRootClientId,
-				getBlockTransformItems,
-			} = select( blockEditorStore );
-
-			return {
-				getBlock: _getBlock,
-				blockTransforms: getBlockTransformItems(
-					_getBlock( clientId ),
-					getBlockRootClientId( clientId )
-				),
-			};
-		},
-		[ clientId ]
-	);
-
-	const { replaceBlock } = useDispatch( blockEditorStore );
-
-	const featuredBlocks = [
-		'core/site-logo',
-		'core/social-links',
-		'core/search',
-	];
-	const transforms = blockTransforms.filter( ( item ) => {
-		return featuredBlocks.includes( item.name );
-	} );
-
-	if ( ! transforms?.length ) {
-		return null;
-	}
-
-	return (
-		<div className="link-control-transform">
-			<h3 className="link-control-transform__subheading">
-				{ __( 'Transform' ) }
-			</h3>
-			<div className="link-control-transform__items">
-				{ transforms.map( ( item, index ) => {
-					return (
-						<Button
-							key={ `transform-${ index }` }
-							onClick={ () =>
-								replaceBlock(
-									clientId,
-									switchToBlockType(
-										getBlock( clientId ),
-										item.name
-									)
-								)
-							}
-							className="link-control-transform__item"
-						>
-							<BlockIcon icon={ item.icon } />
-							{ item.title }
-						</Button>
-					);
-				} ) }
-			</div>
-		</div>
-	);
 }
 
 export default function NavigationLinkEdit( {

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -655,10 +655,8 @@ export default function NavigationLinkEdit( {
 					{ isLinkOpen && (
 						<LinkUI
 							clientId={ clientId }
-							type={ type }
-							url={ url }
-							kind={ kind }
-							linkValue={ link }
+							value={ link }
+							linkAttributes={ { type, url, kind } }
 							onClose={ () => setIsLinkOpen( false ) }
 							anchor={ popoverAnchor }
 							hasCreateSuggestion={ userCanCreate }

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -97,7 +97,6 @@ export function LinkUI( props ) {
 						? () => (
 								<LinkControlTransforms
 									clientId={ props.clientId }
-									replace={ props.replaceBlock }
 								/>
 						  )
 						: null

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -48,8 +48,8 @@ export function LinkUI( props ) {
 	return (
 		<Popover
 			placement="bottom"
-			onClose={ () => props.setIsLinkOpen( false ) }
-			anchor={ props.popoverAnchor }
+			onClose={ props.onClose }
+			anchor={ props.anchor }
 			shift
 		>
 			<LinkControl

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -56,9 +56,9 @@ export function LinkUI( props ) {
 				hasTextControl
 				hasRichPreviews
 				className="wp-block-navigation-link__inline-link-input"
-				value={ props.link }
+				value={ props.linkValue }
 				showInitialSuggestions={ true }
-				withCreateSuggestion={ props.userCanCreate }
+				withCreateSuggestion={ props.hasCreateSuggestion }
 				createSuggestion={ handleCreate }
 				createSuggestionButtonText={ ( searchTerm ) => {
 					let format;

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -185,7 +185,7 @@ export function LinkUI( props ) {
 					props.type,
 					props.kind
 				) }
-				onChange={ props.updateAttributes }
+				onChange={ props.onChange }
 				onRemove={ props.onRemove }
 				renderControlBottom={
 					! props.url

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -1,0 +1,108 @@
+/**
+ * WordPress dependencies
+ */
+import { Popover } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { __experimentalLinkControl as LinkControl } from '@wordpress/block-editor';
+import { createInterpolateElement } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * Internal dependencies
+ */
+import { getSuggestionsQuery, LinkControlTransforms } from './edit';
+import { updateAttributes } from './update-attributes';
+
+export function LinkUI( props ) {
+	const { saveEntityRecord } = useDispatch( coreStore );
+
+	async function handleCreate( pageTitle ) {
+		const postType = props.type || 'page';
+
+		const page = await saveEntityRecord( 'postType', postType, {
+			title: pageTitle,
+			status: 'draft',
+		} );
+
+		return {
+			id: page.id,
+			type: postType,
+			// Make `title` property consistent with that in `fetchLinkSuggestions` where the `rendered` title (containing HTML entities)
+			// is also being decoded. By being consistent in both locations we avoid having to branch in the rendering output code.
+			// Ideally in the future we will update both APIs to utilise the "raw" form of the title which is better suited to edit contexts.
+			// e.g.
+			// - title.raw = "Yes & No"
+			// - title.rendered = "Yes &#038; No"
+			// - decodeEntities( title.rendered ) = "Yes & No"
+			// See:
+			// - https://github.com/WordPress/gutenberg/pull/41063
+			// - https://github.com/WordPress/gutenberg/blob/a1e1fdc0e6278457e9f4fc0b31ac6d2095f5450b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js#L212-L218
+			title: decodeEntities( page.title.rendered ),
+			url: page.link,
+			kind: 'post-type',
+		};
+	}
+
+	return (
+		<Popover
+			placement="bottom"
+			onClose={ () => props.setIsLinkOpen( false ) }
+			anchor={ props.popoverAnchor }
+			shift
+		>
+			<LinkControl
+				hasTextControl
+				hasRichPreviews
+				className="wp-block-navigation-link__inline-link-input"
+				value={ props.link }
+				showInitialSuggestions={ true }
+				withCreateSuggestion={ props.userCanCreate }
+				createSuggestion={ handleCreate }
+				createSuggestionButtonText={ ( searchTerm ) => {
+					let format;
+
+					if ( props.type === 'post' ) {
+						/* translators: %s: search term. */
+						format = __( 'Create draft post: <mark>%s</mark>' );
+					} else {
+						/* translators: %s: search term. */
+						format = __( 'Create draft page: <mark>%s</mark>' );
+					}
+
+					return createInterpolateElement(
+						sprintf( format, searchTerm ),
+						{
+							mark: <mark />,
+						}
+					);
+				} }
+				noDirectEntry={ !! props.type }
+				noURLSuggestion={ !! props.type }
+				suggestionsQuery={ getSuggestionsQuery(
+					props.type,
+					props.kind
+				) }
+				onChange={ ( updatedValue ) =>
+					updateAttributes(
+						updatedValue,
+						props.setAttributes,
+						props.attributes
+					)
+				}
+				onRemove={ props.onRemove }
+				renderControlBottom={
+					! props.url
+						? () => (
+								<LinkControlTransforms
+									clientId={ props.clientId }
+									replace={ props.replaceBlock }
+								/>
+						  )
+						: null
+				}
+			/>
+		</Popover>
+	);
+}

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -120,7 +120,7 @@ export function LinkUI( props ) {
 	const { saveEntityRecord } = useDispatch( coreStore );
 
 	async function handleCreate( pageTitle ) {
-		const postType = props.type || 'page';
+		const postType = props.linkAttributes.type || 'page';
 
 		const page = await saveEntityRecord( 'postType', postType, {
 			title: pageTitle,
@@ -157,14 +157,14 @@ export function LinkUI( props ) {
 				hasTextControl
 				hasRichPreviews
 				className="wp-block-navigation-link__inline-link-input"
-				value={ props.linkValue }
+				value={ props.value }
 				showInitialSuggestions={ true }
 				withCreateSuggestion={ props.hasCreateSuggestion }
 				createSuggestion={ handleCreate }
 				createSuggestionButtonText={ ( searchTerm ) => {
 					let format;
 
-					if ( props.type === 'post' ) {
+					if ( props.linkAttributes.type === 'post' ) {
 						/* translators: %s: search term. */
 						format = __( 'Create draft post: <mark>%s</mark>' );
 					} else {
@@ -179,16 +179,16 @@ export function LinkUI( props ) {
 						}
 					);
 				} }
-				noDirectEntry={ !! props.type }
-				noURLSuggestion={ !! props.type }
+				noDirectEntry={ !! props.linkAttributes.type }
+				noURLSuggestion={ !! props.linkAttributes.type }
 				suggestionsQuery={ getSuggestionsQuery(
-					props.type,
-					props.kind
+					props.linkAttributes.type,
+					props.linkAttributes.kind
 				) }
 				onChange={ props.onChange }
 				onRemove={ props.onRemove }
 				renderControlBottom={
-					! props.url
+					! props.linkAttributes.url
 						? () => (
 								<LinkControlTransforms
 									clientId={ props.clientId }

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -13,7 +13,6 @@ import { decodeEntities } from '@wordpress/html-entities';
  * Internal dependencies
  */
 import { getSuggestionsQuery, LinkControlTransforms } from './edit';
-import { updateAttributes } from './update-attributes';
 
 export function LinkUI( props ) {
 	const { saveEntityRecord } = useDispatch( coreStore );
@@ -84,13 +83,7 @@ export function LinkUI( props ) {
 					props.type,
 					props.kind
 				) }
-				onChange={ ( updatedValue ) =>
-					updateAttributes(
-						updatedValue,
-						props.setAttributes,
-						props.attributes
-					)
-				}
+				onChange={ props.updateAttributes }
 				onRemove={ props.onRemove }
 				renderControlBottom={
 					! props.url

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -13,10 +13,36 @@ import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { switchToBlockType } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
+
 /**
- * Internal dependencies
+ * Given the Link block's type attribute, return the query params to give to
+ * /wp/v2/search.
+ *
+ * @param {string} type Link block's type attribute.
+ * @param {string} kind Link block's entity of kind (post-type|taxonomy)
+ * @return {{ type?: string, subtype?: string }} Search query params.
  */
-import { getSuggestionsQuery } from './edit';
+export function getSuggestionsQuery( type, kind ) {
+	switch ( type ) {
+		case 'post':
+		case 'page':
+			return { type: 'post', subtype: type };
+		case 'category':
+			return { type: 'term', subtype: 'category' };
+		case 'tag':
+			return { type: 'term', subtype: 'post_tag' };
+		case 'post_format':
+			return { type: 'post-format' };
+		default:
+			if ( kind === 'taxonomy' ) {
+				return { type: 'term', subtype: type };
+			}
+			if ( kind === 'post-type' ) {
+				return { type: 'post', subtype: type };
+			}
+			return {};
+	}
+}
 
 /**
  * Add transforms to Link Control

--- a/packages/block-library/src/navigation-link/test/edit.js
+++ b/packages/block-library/src/navigation-link/test/edit.js
@@ -1,10 +1,10 @@
 /**
  * Internal dependencies
  */
-import { updateNavigationLinkBlockAttributes } from '../edit';
+import { updateAttributes } from '../update-attributes';
 
 describe( 'edit', () => {
-	describe( 'updateNavigationLinkBlockAttributes', () => {
+	describe( 'updateAttributes', () => {
 		// Data shapes are linked to fetchLinkSuggestions from
 		// core-data/src/fetch/__experimental-fetch-link-suggestions.js.
 		it( 'can update a post link', () => {
@@ -18,10 +18,7 @@ describe( 'edit', () => {
 				type: 'post',
 			};
 
-			updateNavigationLinkBlockAttributes(
-				linkSuggestion,
-				setAttributes
-			);
+			updateAttributes( linkSuggestion, setAttributes );
 			expect( setAttributes ).toHaveBeenCalledWith( {
 				id: 1337,
 				label: 'Menu Test',
@@ -42,10 +39,7 @@ describe( 'edit', () => {
 				type: 'page',
 				url: 'http://wordpress.local/sample-page/',
 			};
-			updateNavigationLinkBlockAttributes(
-				linkSuggestion,
-				setAttributes
-			);
+			updateAttributes( linkSuggestion, setAttributes );
 			expect( setAttributes ).toHaveBeenCalledWith( {
 				id: 2,
 				kind: 'post-type',
@@ -66,10 +60,7 @@ describe( 'edit', () => {
 				type: 'post_tag',
 				url: 'http://wordpress.local/tag/bar/',
 			};
-			updateNavigationLinkBlockAttributes(
-				linkSuggestion,
-				setAttributes
-			);
+			updateAttributes( linkSuggestion, setAttributes );
 			expect( setAttributes ).toHaveBeenCalledWith( {
 				id: 15,
 				kind: 'taxonomy',
@@ -90,10 +81,7 @@ describe( 'edit', () => {
 				type: 'category',
 				url: 'http://wordpress.local/category/cats/',
 			};
-			updateNavigationLinkBlockAttributes(
-				linkSuggestion,
-				setAttributes
-			);
+			updateAttributes( linkSuggestion, setAttributes );
 			expect( setAttributes ).toHaveBeenCalledWith( {
 				id: 9,
 				kind: 'taxonomy',
@@ -114,10 +102,7 @@ describe( 'edit', () => {
 				type: 'portfolio',
 				url: 'http://wordpress.local/portfolio/fall/',
 			};
-			updateNavigationLinkBlockAttributes(
-				linkSuggestion,
-				setAttributes
-			);
+			updateAttributes( linkSuggestion, setAttributes );
 			expect( setAttributes ).toHaveBeenCalledWith( {
 				id: 131,
 				kind: 'post-type',
@@ -138,10 +123,7 @@ describe( 'edit', () => {
 				type: 'portfolio_tag',
 				url: 'http://wordpress.local/portfolio_tag/PortfolioTag/',
 			};
-			updateNavigationLinkBlockAttributes(
-				linkSuggestion,
-				setAttributes
-			);
+			updateAttributes( linkSuggestion, setAttributes );
 			expect( setAttributes ).toHaveBeenCalledWith( {
 				id: 4,
 				kind: 'taxonomy',
@@ -162,10 +144,7 @@ describe( 'edit', () => {
 				type: 'portfolio_category',
 				url: 'http://wordpress.local/portfolio_category/Portfolio-category/',
 			};
-			updateNavigationLinkBlockAttributes(
-				linkSuggestion,
-				setAttributes
-			);
+			updateAttributes( linkSuggestion, setAttributes );
 			expect( setAttributes ).toHaveBeenCalledWith( {
 				id: 2,
 				kind: 'taxonomy',
@@ -186,10 +165,7 @@ describe( 'edit', () => {
 				type: 'post-format',
 				url: 'http://wordpress.local/type/video/',
 			};
-			updateNavigationLinkBlockAttributes(
-				linkSuggestion,
-				setAttributes
-			);
+			updateAttributes( linkSuggestion, setAttributes );
 			// post_format returns a slug ID value from the Search API
 			// we do not persist this ID since we expect this value to be a post or term ID.
 			expect( setAttributes ).toHaveBeenCalledWith( {
@@ -208,10 +184,7 @@ describe( 'edit', () => {
 					opensInNewTab: false,
 					url: 'www.wordpress.org',
 				};
-				updateNavigationLinkBlockAttributes(
-					linkSuggestion,
-					setAttributes
-				);
+				updateAttributes( linkSuggestion, setAttributes );
 				expect( setAttributes ).toHaveBeenCalledWith( {
 					opensInNewTab: false,
 					url: 'www.wordpress.org',
@@ -229,10 +202,7 @@ describe( 'edit', () => {
 					type: 'URL',
 					url: 'http://www.wordpress.org',
 				};
-				updateNavigationLinkBlockAttributes(
-					linkSuggestion,
-					setAttributes
-				);
+				updateAttributes( linkSuggestion, setAttributes );
 				expect( setAttributes ).toHaveBeenCalledWith( {
 					opensInNewTab: false,
 					label: 'www.wordpress.org',
@@ -250,10 +220,7 @@ describe( 'edit', () => {
 					type: 'mailto',
 					url: 'mailto:foo@example.com',
 				};
-				updateNavigationLinkBlockAttributes(
-					linkSuggestion,
-					setAttributes
-				);
+				updateAttributes( linkSuggestion, setAttributes );
 				expect( setAttributes ).toHaveBeenCalledWith( {
 					opensInNewTab: false,
 					label: 'mailto:foo@example.com',
@@ -272,10 +239,7 @@ describe( 'edit', () => {
 					type: 'internal',
 					url: '#foo',
 				};
-				updateNavigationLinkBlockAttributes(
-					linkSuggestion,
-					setAttributes
-				);
+				updateAttributes( linkSuggestion, setAttributes );
 				expect( setAttributes ).toHaveBeenCalledWith( {
 					opensInNewTab: false,
 					label: '#foo',
@@ -294,10 +258,7 @@ describe( 'edit', () => {
 					type: 'tel',
 					url: 'tel:5555555',
 				};
-				updateNavigationLinkBlockAttributes(
-					linkSuggestion,
-					setAttributes
-				);
+				updateAttributes( linkSuggestion, setAttributes );
 				expect( setAttributes ).toHaveBeenCalledWith( {
 					opensInNewTab: false,
 					label: 'tel:5555555',
@@ -319,10 +280,7 @@ describe( 'edit', () => {
 					type: 'URL',
 					url: 'https://www.wordpress.org',
 				};
-				updateNavigationLinkBlockAttributes(
-					linkSuggestion,
-					setAttributes
-				);
+				updateAttributes( linkSuggestion, setAttributes );
 				expect( setAttributes ).toHaveBeenCalledWith( {
 					opensInNewTab: false,
 					label: 'www.wordpress.org',
@@ -339,10 +297,7 @@ describe( 'edit', () => {
 					type: 'URL',
 					url: 'wordpress.org',
 				};
-				updateNavigationLinkBlockAttributes(
-					linkSuggestion,
-					setAttributes
-				);
+				updateAttributes( linkSuggestion, setAttributes );
 				expect( setAttributes ).toHaveBeenCalledWith( {
 					opensInNewTab: false,
 					label: 'Custom Title',
@@ -359,10 +314,7 @@ describe( 'edit', () => {
 					type: 'URL',
 					url: 'https://wordpress.org',
 				};
-				updateNavigationLinkBlockAttributes(
-					linkSuggestion,
-					setAttributes
-				);
+				updateAttributes( linkSuggestion, setAttributes );
 				expect( setAttributes ).toHaveBeenCalledWith( {
 					opensInNewTab: false,
 					label: 'Custom Title',
@@ -380,10 +332,7 @@ describe( 'edit', () => {
 					type: 'URL',
 					url: 'http://wordpress.org/?s=<>',
 				};
-				updateNavigationLinkBlockAttributes(
-					linkSuggestion,
-					setAttributes
-				);
+				updateAttributes( linkSuggestion, setAttributes );
 				expect( setAttributes ).toHaveBeenCalledWith( {
 					opensInNewTab: false,
 					label: 'Custom Title',
@@ -408,11 +357,7 @@ describe( 'edit', () => {
 					type: 'post',
 				};
 
-				updateNavigationLinkBlockAttributes(
-					linkSuggestion,
-					setAttributes,
-					mockState
-				);
+				updateAttributes( linkSuggestion, setAttributes, mockState );
 				expect( mockState ).toEqual( {
 					id: 1337,
 					label: 'Menu Test',
@@ -422,7 +367,7 @@ describe( 'edit', () => {
 					url: 'https://wordpress.local/menu-test/',
 				} );
 				// Click on the existing link control, and toggle opens new tab.
-				updateNavigationLinkBlockAttributes(
+				updateAttributes(
 					{
 						url: 'https://wordpress.local/menu-test/',
 						opensInNewTab: true,
@@ -453,11 +398,7 @@ describe( 'edit', () => {
 					type: 'post',
 				};
 
-				updateNavigationLinkBlockAttributes(
-					linkSuggestion,
-					setAttributes,
-					mockState
-				);
+				updateAttributes( linkSuggestion, setAttributes, mockState );
 				expect( mockState ).toEqual( {
 					id: 1337,
 					label: 'Menu Test',
@@ -467,7 +408,7 @@ describe( 'edit', () => {
 					url: 'https://wordpress.local/menu-test/',
 				} );
 				// Click on the existing link control, and toggle opens new tab.
-				updateNavigationLinkBlockAttributes(
+				updateAttributes(
 					{
 						url: 'https://wordpress.local/foo/',
 						opensInNewTab: false,

--- a/packages/block-library/src/navigation-link/update-attributes.js
+++ b/packages/block-library/src/navigation-link/update-attributes.js
@@ -1,0 +1,103 @@
+/**
+ * External dependencies
+ */
+import escapeHtml from 'escape-html';
+
+/**
+ * WordPress dependencies
+ */
+import { safeDecodeURI } from '@wordpress/url';
+
+/**
+ * @typedef {'post-type'|'custom'|'taxonomy'|'post-type-archive'} WPNavigationLinkKind
+ */
+/**
+ * Navigation Link Block Attributes
+ *
+ * @typedef {Object} WPNavigationLinkBlockAttributes
+ *
+ * @property {string}               [label]         Link text.
+ * @property {WPNavigationLinkKind} [kind]          Kind is used to differentiate between term and post ids to check post draft status.
+ * @property {string}               [type]          The type such as post, page, tag, category and other custom types.
+ * @property {string}               [rel]           The relationship of the linked URL.
+ * @property {number}               [id]            A post or term id.
+ * @property {boolean}              [opensInNewTab] Sets link target to _blank when true.
+ * @property {string}               [url]           Link href.
+ * @property {string}               [title]         Link title attribute.
+ */
+/**
+ * Link Control onChange handler that updates block attributes when a setting is changed.
+ *
+ * @param {Object}                          updatedValue    New block attributes to update.
+ * @param {Function}                        setAttributes   Block attribute update function.
+ * @param {WPNavigationLinkBlockAttributes} blockAttributes Current block attributes.
+ *
+ */
+
+export const updateAttributes = (
+	updatedValue = {},
+	setAttributes,
+	blockAttributes = {}
+) => {
+	const {
+		label: originalLabel = '',
+		kind: originalKind = '',
+		type: originalType = '',
+	} = blockAttributes;
+
+	const {
+		title: newLabel = '', // the title of any provided Post.
+		url: newUrl = '',
+		opensInNewTab,
+		id,
+		kind: newKind = originalKind,
+		type: newType = originalType,
+	} = updatedValue;
+
+	const newLabelWithoutHttp = newLabel.replace( /http(s?):\/\//gi, '' );
+	const newUrlWithoutHttp = newUrl.replace( /http(s?):\/\//gi, '' );
+
+	const useNewLabel =
+		newLabel &&
+		newLabel !== originalLabel &&
+		// LinkControl without the title field relies
+		// on the check below. Specifically, it assumes that
+		// the URL is the same as a title.
+		// This logic a) looks suspicious and b) should really
+		// live in the LinkControl and not here. It's a great
+		// candidate for future refactoring.
+		newLabelWithoutHttp !== newUrlWithoutHttp;
+
+	// Unfortunately this causes the escaping model to be inverted.
+	// The escaped content is stored in the block attributes (and ultimately in the database),
+	// and then the raw data is "recovered" when outputting into the DOM.
+	// It would be preferable to store the **raw** data in the block attributes and escape it in JS.
+	// Why? Because there isn't one way to escape data. Depending on the context, you need to do
+	// different transforms. It doesn't make sense to me to choose one of them for the purposes of storage.
+	// See also:
+	// - https://github.com/WordPress/gutenberg/pull/41063
+	// - https://github.com/WordPress/gutenberg/pull/18617.
+	const label = useNewLabel
+		? escapeHtml( newLabel )
+		: originalLabel || escapeHtml( newUrlWithoutHttp );
+
+	// In https://github.com/WordPress/gutenberg/pull/24670 we decided to use "tag" in favor of "post_tag"
+	const type = newType === 'post_tag' ? 'tag' : newType.replace( '-', '_' );
+
+	const isBuiltInType =
+		[ 'post', 'page', 'tag', 'category' ].indexOf( type ) > -1;
+
+	const isCustomLink =
+		( ! newKind && ! isBuiltInType ) || newKind === 'custom';
+	const kind = isCustomLink ? 'custom' : newKind;
+
+	setAttributes( {
+		// Passed `url` may already be encoded. To prevent double encoding, decodeURI is executed to revert to the original string.
+		...( newUrl && { url: encodeURI( safeDecodeURI( newUrl ) ) } ),
+		...( label && { label } ),
+		...( undefined !== opensInNewTab && { opensInNewTab } ),
+		...( id && Number.isInteger( id ) && { id } ),
+		...( kind && { kind } ),
+		...( type && type !== 'URL' && { type } ),
+	} );
+};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Refactors all the link creation components and utilities in `core/navigaiton-link` to a single component/file.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is a step towards goals set out in https://github.com/WordPress/gutenberg/issues/45996#issuecomment-1326255824.

The idea is that we'll need to display the same link ui interface within the Nav block offcanvas experiment as is currently used within the block in the editor canvas.

By extracting everything to a single file it will be easier to see what we have copied/pasted (reused) within the offcanvas.

This also has the additional benefit of cleaning up the code of the Nav Link block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Extracts all the Link UI specific stuff to a separate standalone file which can be fed props to configure it for a specific block and link instance.

This should mean we can feed it block data from the offcanvas experiment and it will "just work".

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

The goal here is to check the link creation UI within the Nav block has not be effected at all. It should remain _exactly_ as it is on `trunk`. Whatever bugs you find here please be sure to cross check them with `trunk`.

- Create some links
- Search for posts/pages ...etc
- Try creating a page directly from within the Link UI (clue: type in a very long page name and it will give you the option to "create").
- Test all the things.

## Screenshots or screencast <!-- if applicable -->
