### PR TITLE
Warning: Fix ESLint warnings in tests

### DIFF
--- a/packages/warning/test/babel-plugin.js
+++ b/packages/warning/test/babel-plugin.js
@@ -12,88 +12,92 @@ function join( ...strings ) {
 	return strings.join( '\n' );
 }
 
-function compare( input, output, options = {} ) {
+function transformCode( input, options = {} ) {
 	const { code } = transform( input, {
 		configFile: false,
 		plugins: [ [ babelPlugin, options ] ],
 	} );
-	expect( code ).toEqual( output );
+	return code;
 }
 
 describe( 'babel-plugin', () => {
 	it( 'should replace warning calls with import declaration', () => {
-		compare(
-			join(
-				'import warning from "@wordpress/warning";',
-				'warning("a");'
-			),
-			join(
-				'import warning from "@wordpress/warning";',
-				'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warning("a") : void 0;'
-			)
+		const input = join(
+			'import warning from "@wordpress/warning";',
+			'warning("a");'
 		);
+		const expected = join(
+			'import warning from "@wordpress/warning";',
+			'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warning("a") : void 0;'
+		);
+
+		expect( transformCode( input ) ).toEqual( expected );
 	} );
 
 	it( 'should not replace warning calls without import declaration', () => {
-		compare( 'warning("a");', 'warning("a");' );
+		const input = 'warning("a");';
+		const expected = 'warning("a");';
+
+		expect( transformCode( input ) ).toEqual( expected );
 	} );
 
 	it( 'should replace warning calls without import declaration with plugin options', () => {
-		compare(
-			'warning("a");',
-			'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warning("a") : void 0;',
-			{ callee: 'warning' }
-		);
+		const input = 'warning("a");';
+		const options = { callee: 'warning' };
+		const expected =
+			'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warning("a") : void 0;';
+
+		expect( transformCode( input, options ) ).toEqual( expected );
 	} );
 
 	it( 'should replace multiple warning calls', () => {
-		compare(
-			join(
-				'import warning from "@wordpress/warning";',
-				'warning("a");',
-				'warning("b");',
-				'warning("c");'
-			),
-			join(
-				'import warning from "@wordpress/warning";',
-				'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warning("a") : void 0;',
-				'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warning("b") : void 0;',
-				'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warning("c") : void 0;'
-			)
+		const input = join(
+			'import warning from "@wordpress/warning";',
+			'warning("a");',
+			'warning("b");',
+			'warning("c");'
 		);
+		const expected = join(
+			'import warning from "@wordpress/warning";',
+			'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warning("a") : void 0;',
+			'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warning("b") : void 0;',
+			'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warning("c") : void 0;'
+		);
+
+		expect( transformCode( input ) ).toEqual( expected );
 	} );
 
 	it( 'should identify warning callee name', () => {
-		compare(
-			join(
-				'import warn from "@wordpress/warning";',
-				'warn("a");',
-				'warn("b");',
-				'warn("c");'
-			),
-			join(
-				'import warn from "@wordpress/warning";',
-				'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warn("a") : void 0;',
-				'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warn("b") : void 0;',
-				'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warn("c") : void 0;'
-			)
+		const input = join(
+			'import warn from "@wordpress/warning";',
+			'warn("a");',
+			'warn("b");',
+			'warn("c");'
 		);
+		const expected = join(
+			'import warn from "@wordpress/warning";',
+			'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warn("a") : void 0;',
+			'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warn("b") : void 0;',
+			'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warn("c") : void 0;'
+		);
+
+		expect( transformCode( input ) ).toEqual( expected );
 	} );
 
 	it( 'should identify warning callee name by', () => {
-		compare(
-			join(
-				'import warn from "@wordpress/warning";',
-				'warn("a");',
-				'warn("b");',
-				'warn("c");'
-			),
-			join(
-				'import warn from "@wordpress/warning";',
-				'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warn("a") : void 0;',
-				'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warn("b") : void 0;',
-				'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warn("c") : void 0;'
-			)
+		const input = join(
+			'import warn from "@wordpress/warning";',
+			'warn("a");',
+			'warn("b");',
+			'warn("c");'
 		);
+		const expected = join(
+			'import warn from "@wordpress/warning";',
+			'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warn("a") : void 0;',
+			'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warn("b") : void 0;',
+			'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warn("c") : void 0;'
+		);
+
+		expect( transformCode( input ) ).toEqual( expected );
 	} );
 } );


### PR DESCRIPTION
## What?
While working on fixing ESLint violations for our `@testing-library` tests, I discovered we have quite a few (~48) ESLint warnings. Many of them can be fixed, and this PR is fixing a few of them.

This PR refactors `@wordpress/warning` tests to make assertion more explicit, to follow the [`jest/expect-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/expect-expect.md) ESLint rule.

## Why?
Ideally, we should have no ESLint warnings in the codebase at all. This PR is a step in that direction.

## How?
We're altering the `compare()` helper to just be responsible for code transformation only, and we're moving the actual comparison assertion inline in each of the tests.

## Testing Instructions
* Verify tests still pass.
* Run `npm run lint:js` and verify the following warnings no longer appear:

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2022-11-24 at 15 11 12](https://user-images.githubusercontent.com/8436925/203793161-c35ac22f-59b2-496c-a24e-3bd86d773c3c.png)
