### PR TITLE
Block Library: Fix ESLint warnings in tests

### DIFF
--- a/packages/block-library/test/babel-plugin.js
+++ b/packages/block-library/test/babel-plugin.js
@@ -12,56 +12,56 @@ function join( ...strings ) {
 	return strings.join( '\n' );
 }
 
-function compare( input, output, isExperimental, options = {} ) {
+function transformCode( input, isExperimental, options = {} ) {
 	const blockLibraryPlugin = createBabelPlugin( isExperimental, false );
 	const { code } = transform( input, {
 		configFile: false,
 		plugins: [ [ blockLibraryPlugin, options ] ],
 	} );
-	expect( code ).toEqual( output );
+	return code;
 }
 
 describe( 'babel-plugin', () => {
 	it( 'should ignore stable blocks', () => {
-		compare(
-			join(
-				'import * as experimentalBlock from "./experimental-block";',
-				'const blocks = [ experimentalBlock ];'
-			),
-			join(
-				'import * as experimentalBlock from "./experimental-block";',
-				'const blocks = [experimentalBlock];'
-			),
-			() => false
+		const input = join(
+			'import * as experimentalBlock from "./experimental-block";',
+			'const blocks = [ experimentalBlock ];'
 		);
+		const expected = join(
+			'import * as experimentalBlock from "./experimental-block";',
+			'const blocks = [experimentalBlock];'
+		);
+
+		expect( transformCode( input, () => false ) ).toEqual( expected );
 	} );
+
 	it( 'should transform experimental blocks', () => {
-		compare(
-			join(
-				'import * as experimentalBlock from "./experimental-block";',
-				'const blocks = [ experimentalBlock ];'
-			),
-			join(
-				'const experimentalBlock = null;',
-				'const blocks = [experimentalBlock];'
-			),
-			() => true
+		const input = join(
+			'import * as experimentalBlock from "./experimental-block";',
+			'const blocks = [ experimentalBlock ];'
 		);
+		const expected = join(
+			'const experimentalBlock = null;',
+			'const blocks = [experimentalBlock];'
+		);
+
+		expect( transformCode( input, () => true ) ).toEqual( expected );
 	} );
+
 	it( 'should work with mixed imports blocks', () => {
-		compare(
-			join(
-				'import * as stableBlock from "./stable-block";',
-				'import * as experimentalBlock from "./experimental-block";',
-				'const blocks = [ stableBlock, experimentalBlock ];'
-			),
-			join(
-				'import * as stableBlock from "./stable-block";',
-				'const experimentalBlock = null;',
-				'const blocks = [stableBlock, experimentalBlock];'
-			),
-			( path ) =>
-				path.node.specifiers[ 0 ].local.name === 'experimentalBlock'
+		const input = join(
+			'import * as stableBlock from "./stable-block";',
+			'import * as experimentalBlock from "./experimental-block";',
+			'const blocks = [ stableBlock, experimentalBlock ];'
 		);
+		const expected = join(
+			'import * as stableBlock from "./stable-block";',
+			'const experimentalBlock = null;',
+			'const blocks = [stableBlock, experimentalBlock];'
+		);
+		const isExperimental = ( path ) =>
+			path.node.specifiers[ 0 ].local.name === 'experimentalBlock';
+
+		expect( transformCode( input, isExperimental ) ).toEqual( expected );
 	} );
 } );


### PR DESCRIPTION
## What?
While working on fixing ESLint violations for our `@testing-library` tests, I discovered we have quite a few (~48) ESLint warnings. Many of them can be fixed, and this PR is fixing a few of them.

This PR refactors `@wordpress/block-library` tests to make assertion more explicit, to follow the [`jest/expect-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/expect-expect.md) ESLint rule.

## Why?
Ideally, we should have no ESLint warnings in the codebase at all. This PR is a step in that direction.

## How?
We're altering the `compare()` helper to just be responsible for code transformation only, and we're moving the actual comparison assertion inline in each of the tests.

## Testing Instructions
* Verify tests still pass.
* Run `npm run lint:js` and verify the following warnings no longer appear:

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2022-11-24 at 15 16 43](https://user-images.githubusercontent.com/8436925/203793597-63f903b2-f85e-4cb0-9e5e-0bc8bc518dee.png)

