### PR TITLE
Block Editor: Fix ESLint warnings in `MediaUpload` tests

### DIFF
--- a/packages/block-editor/src/components/media-upload/test/index.native.js
+++ b/packages/block-editor/src/components/media-upload/test/index.native.js
@@ -1,3 +1,5 @@
+/* eslint jest/expect-expect: ["warn", { "assertFunctionNames": ["expect", "expect*"] }] */
+
 /**
  * External dependencies
  */


### PR DESCRIPTION
## What?
While working on fixing ESLint violations for our `@testing-library` tests, I discovered we have quite a few (~48) ESLint warnings. Many of them can be fixed, and this PR is fixing a few of them.

This PR refactors `@wordpress/block-editor` `MediaUpload` component tests to make assertion more explicit, to follow the [`jest/expect-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/expect-expect.md) ESLint rule.

## Why?
Ideally, we should have no ESLint warnings in the codebase at all. This PR is a step in that direction.

## How?
Since the assertions are inside large complex helper functions to avoid lots of repetition and boilerplate, we're altering the ESLint rule inline to support the additional assertion functions. We're using [`assertFunctionNames`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/expect-expect.md#assertfunctionnames) for that, and enabling any function that starts with `expect` in this test file to be a valid assertion. 

## Testing Instructions
* Verify tests still pass.
* Run `npm run lint:js` and verify the following warnings no longer appear:

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2022-11-24 at 15 21 19](https://user-images.githubusercontent.com/8436925/203794465-4d6f87d8-7ea1-4d77-887b-3855a314f1de.png)

