### PR TITLE
Update offcanvas back button to select parent Nav block and limited to Nav block only

### DIFF
--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -30,15 +30,16 @@ function BlockCard( { title, icon, description, blockType, className } ) {
 	const isOffCanvasNavigationEditorEnabled =
 		window?.__experimentalEnableOffCanvasNavigationEditor === true;
 
-	const { parentBlockClientId } = useSelect( ( select ) => {
-		const { getSelectedBlockClientId, getBlockParents } =
+	const { parentNavBlockClientId } = useSelect( ( select ) => {
+		const { getSelectedBlockClientId, getBlockParentsByBlockName } =
 			select( blockEditorStore );
 
 		const _selectedBlockClientId = getSelectedBlockClientId();
 
 		return {
-			parentBlockClientId: getBlockParents(
+			parentNavBlockClientId: getBlockParentsByBlockName(
 				_selectedBlockClientId,
+				'core/navigation',
 				true
 			)[ 0 ],
 		};
@@ -48,10 +49,10 @@ function BlockCard( { title, icon, description, blockType, className } ) {
 
 	return (
 		<div className={ classnames( 'block-editor-block-card', className ) }>
-			{ isOffCanvasNavigationEditorEnabled && parentBlockClientId && (
+			{ isOffCanvasNavigationEditorEnabled && parentNavBlockClientId && (
 				<Button
-					onClick={ () => selectBlock( parentBlockClientId ) }
-					label={ __( 'Navigate to parent block' ) }
+					onClick={ () => selectBlock( parentNavBlockClientId ) }
+					label={ __( 'Go to parent Navigation block' ) }
 					style={
 						// TODO: This style override is also used in ToolsPanelHeader.
 						// It should be supported out-of-the-box by Button.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In https://github.com/WordPress/gutenberg/pull/45852 we added a simple back button to the offcanvas Nav block experiment which renders in the block inspector controls.

When clicked this selects the parent block. This PR updates this in two ways:

- limits the button to the Nav block only
- ensures that when clicked it will select the closest ancestor Navigation block

~This PR also reduces the prop drilling that was introduced in https://github.com/WordPress/gutenberg/pull/45852 as per~ resolved in https://github.com/WordPress/gutenberg/pull/46052.

Closes https://github.com/WordPress/gutenberg/issues/46036



## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

1. We agreed this feature should be limited to the Nav block 
2. Because when you edit a nested nav item in the offcanvas and then click back you expect to return to the Nav block and _not_ the immediate parent. 
3. ~Because excessive prop drilling is a code smell.~ (see https://github.com/WordPress/gutenberg/pull/46052)


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We use [`getBlockParentsByBlockName` ](https://developer.wordpress.org/block-editor/reference-guides/data/data-core-block-editor/#getblockparentsbyblockname) to select the closest Nav block. As the button will only display if a Nav block is detected it is therefore also only shown if the selector returns a blockId.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Enable offcanvas experiment
- Create Nav Menu with several nested levels of menu item
- Select Nav. block
- Open offcanvas
- click "edit" on a deeply nested block
- see back button in the inspector controls
- click button and see that the parent Nav block is selected
- test the back button does _not_ display for other types of blocks

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/444434/203800839-61c6abbc-79e0-4d16-b20d-79c7cc60f3f8.mp4

