### PR TITLE
Migrate a11y e2e tests to Playwright

### DIFF
--- a/test/e2e/specs/editor/various/a11y.spec.js
+++ b/test/e2e/specs/editor/various/a11y.spec.js
@@ -3,7 +3,7 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-test.describe( 'a11y', () => {
+test.describe( 'a11y (@firefox, @webkit)', () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
 	} );

--- a/test/e2e/specs/editor/various/a11y.spec.js
+++ b/test/e2e/specs/editor/various/a11y.spec.js
@@ -8,19 +8,33 @@ test.describe( 'a11y', () => {
 		await admin.createNewPost();
 	} );
 
-	test( 'tabs header bar', async ( { page, pageUtils } ) => {
+	test( 'navigating through the Editor regions four times should land on the Editor top bar region', async ( {
+		page,
+		pageUtils,
+	} ) => {
+		// On a new post, initial focus is set on the Post title.
+		await expect(
+			page.locator( 'role=textbox[name=/Add title/i]' )
+		).toBeFocused();
+		// Navigate to the 'Editor settings' region.
 		await pageUtils.pressKeyWithModifier( 'ctrl', '`' );
+		// Navigate to the 'Editor publish' region.
 		await pageUtils.pressKeyWithModifier( 'ctrl', '`' );
+		// Navigate to the 'Editor footer' region.
 		await pageUtils.pressKeyWithModifier( 'ctrl', '`' );
+		// Navigate to the 'Editor top bar' region.
 		await pageUtils.pressKeyWithModifier( 'ctrl', '`' );
-		await page.keyboard.press( 'Tab' );
 
+		// This test assumes the Editor is not in Fullscreen mode. Check the
+		// first tabbable element within the 'Editor top bar' region is the
+		// 'Toggle block inserter' button.
+		await page.keyboard.press( 'Tab' );
 		await expect(
 			page.locator( 'role=button[name=/Toggle block inserter/i]' )
 		).toBeFocused();
 	} );
 
-	test( 'constrains focus to a modal when tabbing', async ( {
+	test( 'should constrain tabbing within a modal', async ( {
 		page,
 		pageUtils,
 	} ) => {
@@ -41,7 +55,7 @@ test.describe( 'a11y', () => {
 		await expect( closeButton ).toBeFocused();
 	} );
 
-	test( 'returns focus to the first tabbable in a modal after blurring a tabbable', async ( {
+	test( 'should return focus to the first tabbable in a modal after blurring a tabbable', async ( {
 		page,
 		pageUtils,
 	} ) => {
@@ -62,7 +76,7 @@ test.describe( 'a11y', () => {
 		).toBeFocused();
 	} );
 
-	test( 'returns focus to the last tabbable in a modal after blurring a tabbable and tabbing in reverse direction', async ( {
+	test( 'should return focus to the last tabbable in a modal after blurring a tabbable and tabbing in reverse direction', async ( {
 		page,
 		pageUtils,
 	} ) => {

--- a/test/e2e/specs/editor/various/a11y.spec.js
+++ b/test/e2e/specs/editor/various/a11y.spec.js
@@ -3,7 +3,7 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-test.describe( 'a11y (@firefox, @webkit)', () => {
+test.describe( 'a11y', () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
 	} );

--- a/test/e2e/specs/editor/various/a11y.spec.js
+++ b/test/e2e/specs/editor/various/a11y.spec.js
@@ -1,0 +1,82 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'a11y', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'tabs header bar', async ( { page, pageUtils } ) => {
+		await pageUtils.pressKeyWithModifier( 'ctrl', '`' );
+		await pageUtils.pressKeyWithModifier( 'ctrl', '`' );
+		await pageUtils.pressKeyWithModifier( 'ctrl', '`' );
+		await pageUtils.pressKeyWithModifier( 'ctrl', '`' );
+		await page.keyboard.press( 'Tab' );
+
+		await expect(
+			page.locator( 'role=button[name=/Toggle block inserter/i]' )
+		).toBeFocused();
+	} );
+
+	test( 'constrains focus to a modal when tabbing', async ( {
+		page,
+		pageUtils,
+	} ) => {
+		// Open keyboard help modal.
+		await pageUtils.pressKeyWithModifier( 'access', 'h' );
+
+		const closeButton = page.locator(
+			'role=dialog[name="Keyboard shortcuts"i] >> role=button[name="Close"i]'
+		);
+		// The close button should not be focused by default; this is a strange UX
+		// experience.
+		// See: https://github.com/WordPress/gutenberg/issues/9410
+		await expect( closeButton ).not.toBeFocused();
+
+		await page.keyboard.press( 'Tab' );
+
+		// Ensure the Close button of the modal is focused after tabbing.
+		await expect( closeButton ).toBeFocused();
+	} );
+
+	test( 'returns focus to the first tabbable in a modal after blurring a tabbable', async ( {
+		page,
+		pageUtils,
+	} ) => {
+		await pageUtils.pressKeyWithModifier( 'access', 'h' );
+
+		// Click a non-focusable element after the last tabbable within the modal.
+		const last = page
+			.locator( 'role=dialog[name="Keyboard shortcuts"i] >> div' )
+			.last();
+		await last.click();
+
+		await page.keyboard.press( 'Tab' );
+
+		await expect(
+			page.locator(
+				'role=dialog[name="Keyboard shortcuts"i] >> role=button[name="Close"i]'
+			)
+		).toBeFocused();
+	} );
+
+	test( 'returns focus to the last tabbable in a modal after blurring a tabbable and tabbing in reverse direction', async ( {
+		page,
+		pageUtils,
+	} ) => {
+		await pageUtils.pressKeyWithModifier( 'access', 'h' );
+
+		// Click a non-focusable element before the first tabbable within the modal.
+		await page.click( 'role=heading[name="Keyboard shortcuts"i]' );
+
+		await pageUtils.pressKeyWithModifier( 'shift', 'Tab' );
+
+		await expect(
+			page.locator(
+				'role=dialog[name="Keyboard shortcuts"i] >> role=button[name="Close"i]'
+			)
+		).toBeFocused();
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Part of #38851.
Related: https://github.com/WordPress/gutenberg/pull/42653

## What?
<!-- In a few words, what is the PR actually doing? -->
Migrates the `a11y` E2E tests to Playwright.

For now, it's a Draft PR because running the tests also with Firefox and Webkit surfaced new failures of the Constrained tabbing component. The previous tests passed because they only ran with Chromium.

Failures appear to be related to different native browser behaviors that aren't taken into account by the current implementation. Will create a new issue.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Part of the migration plan. Also, these tests need to run on multiple browsers as the tested features rely on native browsers behavior.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Removes `packages/e2e-tests/specs/editor/various/a11y.test.js`
- Introduces `test/e2e/specs/editor/various/a11y.spec.js`
- Runs the tests also in Webkit and Firefox.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
To run the tests with a visible browser window:
`npm run test:e2e:playwright -- --headed editor/various/a11y.spec.js`

headless mode:
`npm run test:e2e:playwright -- editor/various/a11y.spec.js`

The 4 test will run in Chromium, Webkit, and Firefox (for a total of 12 tests executed).

- Observe there's one failing test with Webkit.
- Observe there are two failing tests with Firefox.

## Screenshots or screencast <!-- if applicable -->
