### PR TITLE
Reduce prop drilling in Block Card component

### DIFF
--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -10,20 +10,15 @@ import deprecated from '@wordpress/deprecated';
 import { Button } from '@wordpress/components';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { __, isRTL } from '@wordpress/i18n';
+import { useSelect, useDispatch } from '@wordpress/data';
+
 /**
  * Internal dependencies
  */
 import BlockIcon from '../block-icon';
+import { store as blockEditorStore } from '../../store';
 
-function BlockCard( {
-	title,
-	icon,
-	description,
-	blockType,
-	parentBlockClientId,
-	handleBackButton,
-	className,
-} ) {
+function BlockCard( { title, icon, description, blockType, className } ) {
 	if ( blockType ) {
 		deprecated( '`blockType` property in `BlockCard component`', {
 			since: '5.7',
@@ -35,11 +30,27 @@ function BlockCard( {
 	const isOffCanvasNavigationEditorEnabled =
 		window?.__experimentalEnableOffCanvasNavigationEditor === true;
 
+	const { parentBlockClientId } = useSelect( ( select ) => {
+		const { getSelectedBlockClientId, getBlockParents } =
+			select( blockEditorStore );
+
+		const _selectedBlockClientId = getSelectedBlockClientId();
+
+		return {
+			parentBlockClientId: getBlockParents(
+				_selectedBlockClientId,
+				true
+			)[ 0 ],
+		};
+	}, [] );
+
+	const { selectBlock } = useDispatch( blockEditorStore );
+
 	return (
 		<div className={ classnames( 'block-editor-block-card', className ) }>
 			{ isOffCanvasNavigationEditorEnabled && parentBlockClientId && (
 				<Button
-					onClick={ handleBackButton }
+					onClick={ () => selectBlock( parentBlockClientId ) }
 					label={ __( 'Navigate to parent block' ) }
 					style={
 						// TODO: This style override is also used in ToolsPanelHeader.

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -140,7 +140,6 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 		selectedBlockClientId,
 		blockType,
 		topLevelLockedBlock,
-		parentBlockClientId,
 	} = useSelect( ( select ) => {
 		const {
 			getSelectedBlockClientId,
@@ -148,7 +147,6 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			getBlockName,
 			__unstableGetContentLockingParent,
 			getTemplateLock,
-			getBlockParents,
 		} = select( blockEditorStore );
 
 		const _selectedBlockClientId = getSelectedBlockClientId();
@@ -167,10 +165,6 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 				( getTemplateLock( _selectedBlockClientId ) === 'contentOnly'
 					? _selectedBlockClientId
 					: undefined ),
-			parentBlockClientId: getBlockParents(
-				_selectedBlockClientId,
-				true
-			)[ 0 ],
 		};
 	}, [] );
 
@@ -243,16 +237,11 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 		<BlockInspectorSingleBlock
 			clientId={ selectedBlockClientId }
 			blockName={ blockType.name }
-			parentBlockClientId={ parentBlockClientId }
 		/>
 	);
 };
 
-const BlockInspectorSingleBlock = ( {
-	clientId,
-	blockName,
-	parentBlockClientId,
-} ) => {
+const BlockInspectorSingleBlock = ( { clientId, blockName } ) => {
 	const availableTabs = useInspectorControlsTabs( blockName );
 	const showTabs =
 		window?.__experimentalEnableBlockInspectorTabs &&
@@ -268,17 +257,11 @@ const BlockInspectorSingleBlock = ( {
 	);
 	const blockInformation = useBlockDisplayInformation( clientId );
 
-	const { selectBlock } = useDispatch( blockEditorStore );
-
 	return (
 		<div className="block-editor-block-inspector">
 			<BlockCard
 				{ ...blockInformation }
 				className={ blockInformation.isSynced && 'is-synced' }
-				parentBlockClientId={ parentBlockClientId }
-				handleBackButton={ () => {
-					selectBlock( parentBlockClientId );
-				} }
 			/>
 			<BlockVariationTransforms blockClientId={ clientId } />
 			{ showTabs && (


### PR DESCRIPTION
Addresses https://github.com/WordPress/gutenberg/issues/45909

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Reduces the prop drilling in Block Card component to simply it's API.

Sub PR of https://github.com/WordPress/gutenberg/pull/46037.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Prop drilling is a code smell.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Pulls selectors and code into the component rather and requiring props.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Make sure the offcanvas experiment's back button functions as on `trunk`.
2. Make sure the inspector continues to work without the offcanvas experiment active.

## Screenshots or screencast <!-- if applicable -->
