### PR TITLE
Lodash: Refactor editor away from `_.filter()`

### DIFF
--- a/packages/editor/src/components/document-outline/check.js
+++ b/packages/editor/src/components/document-outline/check.js
@@ -1,17 +1,11 @@
 /**
- * External dependencies
- */
-import { filter } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { withSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 function DocumentOutlineCheck( { blocks, children } ) {
-	const headings = filter(
-		blocks,
+	const headings = blocks.filter(
 		( block ) => block.name === 'core/heading'
 	);
 

--- a/packages/editor/src/components/editor-notices/index.js
+++ b/packages/editor/src/components/editor-notices/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { filter } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { NoticeList } from '@wordpress/components';
@@ -17,14 +12,12 @@ import { store as noticesStore } from '@wordpress/notices';
 import TemplateValidationNotice from '../template-validation-notice';
 
 export function EditorNotices( { notices, onRemove } ) {
-	const dismissibleNotices = filter( notices, {
-		isDismissible: true,
-		type: 'default',
-	} );
-	const nonDismissibleNotices = filter( notices, {
-		isDismissible: false,
-		type: 'default',
-	} );
+	const dismissibleNotices = notices.filter(
+		( { isDismissible, type } ) => isDismissible && type === 'default'
+	);
+	const nonDismissibleNotices = notices.filter(
+		( { isDismissible, type } ) => ! isDismissible && type === 'default'
+	);
 
 	return (
 		<>

--- a/packages/editor/src/components/editor-snackbars/index.js
+++ b/packages/editor/src/components/editor-snackbars/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { filter } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { SnackbarList } from '@wordpress/components';
@@ -16,9 +11,9 @@ export default function EditorSnackbars() {
 		[]
 	);
 	const { removeNotice } = useDispatch( noticesStore );
-	const snackbarNotices = filter( notices, {
-		type: 'snackbar',
-	} );
+	const snackbarNotices = notices.filter(
+		( { type } ) => type === 'snackbar'
+	);
 
 	return (
 		<SnackbarList

--- a/packages/editor/src/components/post-taxonomies/index.js
+++ b/packages/editor/src/components/post-taxonomies/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { filter } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { Fragment } from '@wordpress/element';
@@ -25,11 +20,10 @@ export function PostTaxonomies( {
 	taxonomies,
 	taxonomyWrapper = identity,
 } ) {
-	const availableTaxonomies = filter( taxonomies, ( taxonomy ) =>
+	const availableTaxonomies = ( taxonomies ?? [] ).filter( ( taxonomy ) =>
 		taxonomy.types.includes( postType )
 	);
-	const visibleTaxonomies = filter(
-		availableTaxonomies,
+	const visibleTaxonomies = availableTaxonomies.filter(
 		// In some circumstances .visibility can end up as undefined so optional chaining operator required.
 		// https://github.com/WordPress/gutenberg/issues/40326
 		( taxonomy ) => taxonomy.visibility?.show_ui

--- a/packages/editor/src/components/post-taxonomies/test/index.js
+++ b/packages/editor/src/components/post-taxonomies/test/index.js
@@ -85,7 +85,7 @@ describe( 'PostTaxonomies', () => {
 	} );
 
 	it( 'should render no children if taxonomy data not available', () => {
-		const taxonomies = {};
+		const taxonomies = null;
 
 		const { container } = render(
 			<PostTaxonomies postType="page" taxonomies={ taxonomies } />


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.filter()` from the `editor` package. There are just a few simple usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `Array.prototype.filter()` with some additional checks where necessary. 

## Testing Instructions

* Insert a `h2` and a `h4` headings into a post.
* Click on Document Overview, and open the Outline tab.
* Verify you can still see the "(Incorrect heading level)" warnings below the h4, and it's yellow in color.
* In a file block, try dropping a large file, or an unallowed extension (e.g. `.php`) and verify you can still see the notices appear.
* Verify you can still set a category and tags to a post, and the ones already set load correctly.
* Verify all checks are still green.