### PR TITLE
Lodash: Refactor `edit-post` away from `_.filter()`

### DIFF
--- a/packages/edit-post/src/components/block-manager/index.js
+++ b/packages/edit-post/src/components/block-manager/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { filter } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { store as blocksStore } from '@wordpress/blocks';
@@ -92,15 +87,15 @@ function BlockManager( {
 					<BlockManagerCategory
 						key={ category.slug }
 						title={ category.title }
-						blockTypes={ filter( blockTypes, {
-							category: category.slug,
-						} ) }
+						blockTypes={ blockTypes.filter(
+							( blockType ) =>
+								blockType.category === category.slug
+						) }
 					/>
 				) ) }
 				<BlockManagerCategory
 					title={ __( 'Uncategorized' ) }
-					blockTypes={ filter(
-						blockTypes,
+					blockTypes={ blockTypes.filter(
 						( { category } ) => ! category
 					) }
 				/>

--- a/packages/edit-post/src/components/preferences-modal/meta-boxes-section.js
+++ b/packages/edit-post/src/components/preferences-modal/meta-boxes-section.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, map } from 'lodash';
+import { map } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -23,8 +23,7 @@ export function MetaBoxesSection( {
 	...sectionProps
 } ) {
 	// The 'Custom Fields' meta box is a special case that we handle separately.
-	const thirdPartyMetaBoxes = filter(
-		metaBoxes,
+	const thirdPartyMetaBoxes = metaBoxes.filter(
 		( { id } ) => id !== 'postcustom'
 	);
 


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.filter()` from the `edit-post` package. There are just a few simple usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `Array.prototype.filter()` with some additional checks where necessary. 

## Testing Instructions

* In the post editor, without any additional plugins, verify the Custom Fields section still loads well. If it doesn't appear, make sure to enable it from Preferences -> Panels.
* Install and activate Yoast SEO. 
* Verify that in the post Editor, the Yoast SEO section still appears properly above the Custom Fields one.
* Again in the post editor, in Preferences, play with Blocks, and verify they still appear properly categorized, you can still search for blocks and enable/disable them.
* Verify all checks are still green.