### PR TITLE
Clarify inline comment about switching to `safecss_filter_attr`

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -83,9 +83,8 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		$wide_max_width_value = $wide_size ? $wide_size : $content_size;
 
 		// Make sure there is a single CSS rule, and all tags are stripped for security.
-		// TODO: Use `safecss_filter_attr` instead - once https://core.trac.wordpress.org/ticket/46197 is patched.
-		$all_max_width_value  = wp_strip_all_tags( explode( ';', $all_max_width_value )[0] );
-		$wide_max_width_value = wp_strip_all_tags( explode( ';', $wide_max_width_value )[0] );
+		$all_max_width_value  = safecss_filter_attr( explode( ';', $all_max_width_value )[0] );
+		$wide_max_width_value = safecss_filter_attr( explode( ';', $wide_max_width_value )[0] );
 
 		$margin_left  = 'left' === $justify_content ? '0 !important' : 'auto !important';
 		$margin_right = 'right' === $justify_content ? '0 !important' : 'auto !important';

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -83,6 +83,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		$wide_max_width_value = $wide_size ? $wide_size : $content_size;
 
 		// Make sure there is a single CSS rule, and all tags are stripped for security.
+		// TODO: Use `safecss_filter_attr` instead when the minimum required WP version is >= 6.1.
 		$all_max_width_value  = safecss_filter_attr( explode( ';', $all_max_width_value )[0] );
 		$wide_max_width_value = safecss_filter_attr( explode( ';', $wide_max_width_value )[0] );
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -84,8 +84,8 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 
 		// Make sure there is a single CSS rule, and all tags are stripped for security.
 		// TODO: Use `safecss_filter_attr` instead when the minimum required WP version is >= 6.1.
-		$all_max_width_value  = safecss_filter_attr( explode( ';', $all_max_width_value )[0] );
-		$wide_max_width_value = safecss_filter_attr( explode( ';', $wide_max_width_value )[0] );
+		$all_max_width_value  = wp_strip_all_tags( explode( ';', $all_max_width_value )[0] );
+		$wide_max_width_value = wp_strip_all_tags( explode( ';', $wide_max_width_value )[0] );
 
 		$margin_left  = 'left' === $justify_content ? '0 !important' : 'auto !important';
 		$margin_right = 'right' === $justify_content ? '0 !important' : 'auto !important';


### PR DESCRIPTION
## What?
~~This PR reflects changes made in the WordPress core [Changeset 52924](https://core.trac.wordpress.org/changeset/52924) to Gutenberg as well.~~

## Why?
~~Previously, `safecss_filter_attr` could not be used to sanitize layout values because it removes functions such as `calc()` and `var()`. This was filed as core ticket #[#46197](https://core.trac.wordpress.org/ticket/46197).~~

~~Later, since `calc()` and `var()` are now allowed,  `safecss_filter_attr` is now used in [Changeset 52924](https://core.trac.wordpress.org/changeset/52924). However, this change does not appear to be reflected in the latest gutenberg.~~

@update: As [this comment](https://github.com/WordPress/gutenberg/pull/46061#pullrequestreview-1202614022) states,  supports for `var()`, `calc()`, etc. was introduced in WP 6.1. Since Gutenberg still supports WordPress 6.0, It cannot be replaced now.. Therefore, I have only clarified the inline comment.

## How?
~~Made the same changes made in the core.~~