### PR TITLE
Lodash: Refactor blocks away from `_.filter()`

### DIFF
--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, find, get, isEmpty, map, mapValues } from 'lodash';
+import { find, get, isEmpty, map, mapValues } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -144,8 +144,11 @@ export function blockStyles( state = {}, action ) {
 		case 'REMOVE_BLOCK_STYLES':
 			return {
 				...state,
-				[ action.blockName ]: filter(
-					get( state, [ action.blockName ], [] ),
+				[ action.blockName ]: get(
+					state,
+					[ action.blockName ],
+					[]
+				).filter(
 					( style ) => action.styleNames.indexOf( style.name ) === -1
 				),
 			};
@@ -195,8 +198,11 @@ export function blockVariations( state = {}, action ) {
 		case 'REMOVE_BLOCK_VARIATIONS':
 			return {
 				...state,
-				[ action.blockName ]: filter(
-					get( state, [ action.blockName ], [] ),
+				[ action.blockName ]: get(
+					state,
+					[ action.blockName ],
+					[]
+				).filter(
 					( variation ) =>
 						action.variationNames.indexOf( variation.name ) === -1
 				),

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -3,7 +3,7 @@
  */
 import createSelector from 'rememo';
 import removeAccents from 'remove-accents';
-import { filter, get, map } from 'lodash';
+import { get, map } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -554,7 +554,7 @@ export function getGroupingBlockName( state ) {
 export const getChildBlockNames = createSelector(
 	( state, blockName ) => {
 		return map(
-			filter( state.blockTypes, ( blockType ) => {
+			getBlockTypes( state ).filter( ( blockType ) => {
 				return blockType.parent?.includes( blockName );
 			} ),
 			( { name } ) => name

--- a/packages/blocks/src/store/test/selectors.js
+++ b/packages/blocks/src/store/test/selectors.js
@@ -86,26 +86,28 @@ describe( 'selectors', () => {
 
 	describe( 'getChildBlockNames', () => {
 		it( 'should return an empty array if state is empty', () => {
-			const state = {};
+			const state = {
+				blockTypes: {},
+			};
 
 			expect( getChildBlockNames( state, 'parent1' ) ).toHaveLength( 0 );
 		} );
 
 		it( 'should return an empty array if no children exist', () => {
 			const state = {
-				blockTypes: [
-					{
+				blockTypes: {
+					child1: {
 						name: 'child1',
 						parent: [ 'parent1' ],
 					},
-					{
+					child2: {
 						name: 'child2',
 						parent: [ 'parent2' ],
 					},
-					{
+					parent3: {
 						name: 'parent3',
 					},
-				],
+				},
 			};
 
 			expect( getChildBlockNames( state, 'parent3' ) ).toHaveLength( 0 );
@@ -113,15 +115,15 @@ describe( 'selectors', () => {
 
 		it( 'should return an empty array if the parent block is not found', () => {
 			const state = {
-				blockTypes: [
-					{
+				blockTypes: {
+					child1: {
 						name: 'child1',
 						parent: [ 'parent1' ],
 					},
-					{
+					parent1: {
 						name: 'parent1',
 					},
-				],
+				},
 			};
 
 			expect( getChildBlockNames( state, 'parent3' ) ).toHaveLength( 0 );
@@ -129,29 +131,29 @@ describe( 'selectors', () => {
 
 		it( 'should return an array with the child block names', () => {
 			const state = {
-				blockTypes: [
-					{
+				blockTypes: {
+					child1: {
 						name: 'child1',
 						parent: [ 'parent1' ],
 					},
-					{
+					child2: {
 						name: 'child2',
 						parent: [ 'parent2' ],
 					},
-					{
+					child3: {
 						name: 'child3',
 						parent: [ 'parent1' ],
 					},
-					{
+					child4: {
 						name: 'child4',
 					},
-					{
+					parent1: {
 						name: 'parent1',
 					},
-					{
+					parent2: {
 						name: 'parent2',
 					},
-				],
+				},
 			};
 
 			expect( getChildBlockNames( state, 'parent1' ) ).toEqual( [
@@ -162,25 +164,25 @@ describe( 'selectors', () => {
 
 		it( 'should return an array with the child block names even if only one child exists', () => {
 			const state = {
-				blockTypes: [
-					{
+				blockTypes: {
+					child1: {
 						name: 'child1',
 						parent: [ 'parent1' ],
 					},
-					{
+					child2: {
 						name: 'child2',
 						parent: [ 'parent2' ],
 					},
-					{
+					child4: {
 						name: 'child4',
 					},
-					{
+					parent1: {
 						name: 'parent1',
 					},
-					{
+					parent2: {
 						name: 'parent2',
 					},
-				],
+				},
 			};
 
 			expect( getChildBlockNames( state, 'parent1' ) ).toEqual( [
@@ -190,29 +192,29 @@ describe( 'selectors', () => {
 
 		it( 'should return an array with the child block names even if children have multiple parents', () => {
 			const state = {
-				blockTypes: [
-					{
+				blockTypes: {
+					child1: {
 						name: 'child1',
 						parent: [ 'parent1' ],
 					},
-					{
+					child2: {
 						name: 'child2',
 						parent: [ 'parent1', 'parent2' ],
 					},
-					{
+					child3: {
 						name: 'child3',
 						parent: [ 'parent1' ],
 					},
-					{
+					child4: {
 						name: 'child4',
 					},
-					{
+					parent1: {
 						name: 'parent1',
 					},
-					{
+					parent2: {
 						name: 'parent2',
 					},
-				],
+				},
 			};
 
 			expect( getChildBlockNames( state, 'parent1' ) ).toEqual( [


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.filter()` from the `blocks` package. There are just a few simple usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `Array.prototype.filter()` with some additional checks where necessary. 

We're also fixing some bad tests in the meantime - see my self-review.

My fingers were itching to fix those `get()` calls, but I'd like to take it one step at a time.

## Testing Instructions

Verify all checks are still green. The changes are well covered by unit tests.