### PR TITLE
Lodash: Refactor `core-data` away from `_.filter()`

### DIFF
--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map, omit, filter, mapValues } from 'lodash';
+import { map, omit, mapValues } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -233,7 +233,7 @@ const queries = ( state = {}, action ) => {
 
 			return mapValues( state, ( contextQueries ) => {
 				return mapValues( contextQueries, ( queryItems ) => {
-					return filter( queryItems, ( queryId ) => {
+					return queryItems.filter( ( queryId ) => {
 						return ! removedItems[ queryId ];
 					} );
 				} );

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { set, map, find, get, filter } from 'lodash';
+import { set, map, find, get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -183,7 +183,7 @@ export function getEntitiesByKind( state: State, kind: string ): Array< any > {
  * @return Array of entities with config matching kind.
  */
 export function getEntitiesConfig( state: State, kind: string ): Array< any > {
-	return filter( state.entities.config, { kind } );
+	return state.entities.config.filter( ( entity ) => entity.kind === kind );
 }
 
 /**


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.filter()` from the `core-data` package. There are just a few simple usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `Array.prototype.filter()` with some additional checks where necessary. 

## Testing Instructions

* Verify all checks are still green. All changes are covered by unit tests.