### PR TITLE
PluginSidebar: show pin/unpin button on the site eitor

### DIFF
--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -92,12 +92,6 @@ body.js.site-editor-php {
 		top: 0;
 	}
 
-	// Todo: Remove this rule when edit site gets support
-	// for opening unpinned sidebar items.
-	.interface-complementary-area__pin-unpin-item.components-button {
-		display: none;
-	}
-
 	.interface-interface-skeleton__content {
 		background-color: $gray-300;
 	}


### PR DESCRIPTION
## What?
This PR displays the pin/unpin button of the `PluginSidebar` that was hidden in the site editor. This will allow pinning/unpinning of the plugin sidebar button as well as in the post editor.

## Why?
From what I could find, initially the button was temporarily hidden in #21260 because there was no way to display unpinned sidebar items in the site editor. However, #34460 added plugin support in the site editor as well, and unpinned plugins should be able to be viewed from the options menu.

## How?
Just removed the CSS that hides the button.

## Testing Instructions
Use the following code to display the plugin sidebar:

```javascript
( function ( wp ) {
	var registerPlugin = wp.plugins.registerPlugin;
	var PluginSidebar = wp.editSite.PluginSidebar;
	var el = wp.element.createElement;

	registerPlugin( 'my-plugin-sidebar', {
		render: function () {
			return el(
				PluginSidebar,
				{
					name: 'my-plugin-sidebar',
					icon: 'admin-post',
					title: 'My plugin sidebar',
				},
				'My plugin sidebar content.'
			);
		},
	} );
} )( window.wp );
```

- Confirm that the plugin icon appears in the header.
- Confirm that the plugin sidebar appears when the button is clicked.
- Confirm that the plugin button disappears from the header when the unpin button is clicked.
- Close the plugin sidebar.
- Confirm that the plugin sidebar can be displayed again from the options menu.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/54422211/204024645-ee6fc893-c0ba-43fc-a57b-5b0c836a802f.mp4