### PR TITLE
Update: Improve performance of gutenberg_render_layout_support_flag.

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -380,7 +380,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	$used_layout          = isset( $block['attrs']['layout'] ) ? $block['attrs']['layout'] : $default_block_layout;
 
 	if ( isset( $used_layout['inherit'] ) && $used_layout['inherit'] && ! $global_layout_settings ) {
-			return $block_content;
+		return $block_content;
 	}
 
 	$class_names        = array();

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -378,7 +378,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$global_settings               = gutenberg_get_global_settings();
 		$block_gap                     = _wp_array_get( $global_settings, array( 'spacing', 'blockGap' ), $global_settings );
 		$has_block_gap_support         = isset( $block_gap );
-		$global_layout_settings        = _wp_array_get( $global_settings, array( 'layout' ), $global_settings );
+		$global_layout_settings        = _wp_array_get( $global_settings, array( 'layout' ), null );
 		$root_padding_aware_alignments = _wp_array_get( $global_settings, array( 'useRootPaddingAwareAlignments' ), false );
 		$static_information_computed   = true;
 	}

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -370,25 +370,18 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		return (string) $content;
 	}
 
-	static $static_information_computed   = false;
-	static $has_block_gap_support         = false;
-	static $global_layout_settings        = null;
-	static $root_padding_aware_alignments = false;
-	if ( ! $static_information_computed ) {
-		$global_settings               = gutenberg_get_global_settings();
-		$block_gap                     = _wp_array_get( $global_settings, array( 'spacing', 'blockGap' ), $global_settings );
-		$has_block_gap_support         = isset( $block_gap );
-		$global_layout_settings        = _wp_array_get( $global_settings, array( 'layout' ), null );
-		$root_padding_aware_alignments = _wp_array_get( $global_settings, array( 'useRootPaddingAwareAlignments' ), false );
-		$static_information_computed   = true;
-	}
+	$global_settings               = gutenberg_get_global_settings();
+	$block_gap                     = _wp_array_get( $global_settings, array( 'spacing', 'blockGap' ), null );
+	$has_block_gap_support         = isset( $block_gap );
+	$global_layout_settings        = _wp_array_get( $global_settings, array( 'layout' ), null );
+	$root_padding_aware_alignments = _wp_array_get( $global_settings, array( 'useRootPaddingAwareAlignments' ), false );
 
-	$default_block_layout   = _wp_array_get( $block_type->supports, array( '__experimentalLayout', 'default' ), array() );
-	$used_layout            = isset( $block['attrs']['layout'] ) ? $block['attrs']['layout'] : $default_block_layout;
+	$default_block_layout = _wp_array_get( $block_type->supports, array( '__experimentalLayout', 'default' ), array() );
+	$used_layout          = isset( $block['attrs']['layout'] ) ? $block['attrs']['layout'] : $default_block_layout;
 
 	if ( isset( $used_layout['inherit'] ) && $used_layout['inherit'] && ! $global_layout_settings ) {
 			return $block_content;
-		}
+	}
 
 	$class_names        = array();
 	$layout_definitions = _wp_array_get( $global_layout_settings, array( 'definitions' ), array() );

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -379,7 +379,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$block_gap                     = _wp_array_get( $global_settings, array( 'spacing', 'blockGap' ), $global_settings );
 		$has_block_gap_support         = isset( $block_gap );
 		$global_layout_settings        = _wp_array_get( $global_settings, array( 'layout' ), $global_settings );
-		$root_padding_aware_alignments = _wp_array_get( $global_settings, array( 'useRootPaddingAwareAlignments' ), $global_settings );
+		$root_padding_aware_alignments = _wp_array_get( $global_settings, array( 'useRootPaddingAwareAlignments' ), false );
 		$static_information_computed   = true;
 	}
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -370,17 +370,25 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		return (string) $content;
 	}
 
-	$block_gap              = gutenberg_get_global_settings( array( 'spacing', 'blockGap' ) );
-	$global_layout_settings = gutenberg_get_global_settings( array( 'layout' ) );
-	$has_block_gap_support  = isset( $block_gap ) ? null !== $block_gap : false;
+	static $static_information_computed   = false;
+	static $has_block_gap_support         = false;
+	static $global_layout_settings        = null;
+	static $root_padding_aware_alignments = false;
+	if ( ! $static_information_computed ) {
+		$global_settings               = gutenberg_get_global_settings();
+		$block_gap                     = _wp_array_get( $global_settings, array( 'spacing', 'blockGap' ), $global_settings );
+		$has_block_gap_support         = isset( $block_gap );
+		$global_layout_settings        = _wp_array_get( $global_settings, array( 'layout' ), $global_settings );
+		$root_padding_aware_alignments = _wp_array_get( $global_settings, array( 'useRootPaddingAwareAlignments' ), $global_settings );
+		$static_information_computed   = true;
+	}
+
 	$default_block_layout   = _wp_array_get( $block_type->supports, array( '__experimentalLayout', 'default' ), array() );
 	$used_layout            = isset( $block['attrs']['layout'] ) ? $block['attrs']['layout'] : $default_block_layout;
 
-	if ( isset( $used_layout['inherit'] ) && $used_layout['inherit'] ) {
-		if ( ! $global_layout_settings ) {
+	if ( isset( $used_layout['inherit'] ) && $used_layout['inherit'] && ! $global_layout_settings ) {
 			return $block_content;
 		}
-	}
 
 	$class_names        = array();
 	$layout_definitions = _wp_array_get( $global_layout_settings, array( 'definitions' ), array() );
@@ -393,7 +401,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	}
 
 	if (
-		gutenberg_get_global_settings( array( 'useRootPaddingAwareAlignments' ) ) &&
+		$root_padding_aware_alignments &&
 		isset( $used_layout['type'] ) &&
 		'constrained' === $used_layout['type']
 	) {


### PR DESCRIPTION
On https://github.com/WordPress/gutenberg/pull/45372#issuecomment-1327313449, it was possible to see that get_merge_data was being called hundreds of times inside render_layout_support_flag.

render_layout_support_flag is run per block, and inside we were calling gutenberg_get_global_settings three times. gutenberg_get_global_settings calls get_merged_data. render_layout_support_flag is a filter called during the block render. When the blocks start rendering, there is no expectation that the theme.json settings change during the block render so I think the settings and their derived information should all be static information of this function.
This simple change removes 3*NUMBER_OF_BLOCKS calls of get_merged_data to just one call.

We should still add caching to the settings in https://github.com/WordPress/gutenberg/pull/45372. But even with caching, there is a cost in retrieving information from the cache, so we should include this PR.



## Testing Instructions
Verify the block styles continue to work as expected.
