### PR TITLE
Navigation Submenu: Use a different icon for the submenu when in the list view

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/block-select-button.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-select-button.js
@@ -12,7 +12,7 @@ import {
 	__experimentalTruncate as Truncate,
 } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
-import { Icon, lock } from '@wordpress/icons';
+import { Icon, lock, customLink } from '@wordpress/icons';
 import { SPACE, ENTER } from '@wordpress/keycodes';
 
 /**
@@ -27,7 +27,7 @@ import { useBlockLock } from '../block-lock';
 function ListViewBlockSelectButton(
 	{
 		className,
-		block: { clientId },
+		block,
 		onClick,
 		onToggleExpanded,
 		tabIndex,
@@ -38,6 +38,7 @@ function ListViewBlockSelectButton(
 	},
 	ref
 ) {
+	const { clientId } = block;
 	const blockInformation = useBlockDisplayInformation( clientId );
 	const blockTitle = useBlockDisplayTitle( {
 		clientId,
@@ -58,6 +59,13 @@ function ListViewBlockSelectButton(
 		if ( event.keyCode === ENTER || event.keyCode === SPACE ) {
 			onClick( event );
 		}
+	}
+
+	// This is a very annoying kind of exception.
+	// Maybe we need to have a config that allows blocks
+	// to have a different icon in the list view?
+	if ( block.name === 'core/navigation-submenu' ) {
+		blockInformation.icon = customLink;
 	}
 
 	return (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Replaces the icon for the submenu block in the navigation list view

Fixes https://github.com/WordPress/gutenberg/issues/46065

## Why?
Because this block is also a link, it makes more sense to use a link icon.

## How?
By adding a per-block exception in the list view. This is obviously not an ideal solution, but maybe this is ok while the off canvas editing experience is still an experiment? Can we return to it after we decide whether to proceed with the experiment?

## Testing Instructions
1. Add a navigation block to a post
2. Add a custom link
3. Convert it to a submenu
4. Add a custom link to the submenu
5. Confirm that the custom link and the submenu blocks have the same icon in the list view in the inspector controls

## Screenshots or screencast <!-- if applicable -->
<img width="292" alt="Screenshot 2022-11-25 at 19 33 25" src="https://user-images.githubusercontent.com/275961/204046077-e72f8882-6df3-4e7e-aefa-d39c98bf2d06.png">

