### PR TITLE
Navigation: Move add a submenu option to the top of the list

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -226,6 +226,8 @@ export function BlockSettingsDropdown( {
 								<__unstableBlockSettingsMenuFirstItem.Slot
 									fillProps={ { onClose } }
 								/>
+							</MenuGroup>
+							<MenuGroup>
 								{ ! parentBlockIsSelected &&
 									!! firstParentClientId && (
 										<MenuItem

--- a/packages/block-editor/src/components/off-canvas-editor/block.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block.js
@@ -40,6 +40,7 @@ import { getBlockPositionDescription } from './utils';
 import { store as blockEditorStore } from '../../store';
 import useBlockDisplayInformation from '../use-block-display-information';
 import { useBlockLock } from '../block-lock';
+import __unstableBlockSettingsMenuFirstItem from '../block-settings-menu/block-settings-menu-first-item';
 
 function ListViewBlock( {
 	block,
@@ -359,30 +360,32 @@ function ListViewBlock( {
 								__experimentalSelectBlock={ updateSelection }
 							>
 								{ ( { onClose } ) => (
-									<MenuItem
-										onClick={ () => {
-											const newLink = createBlock(
-												'core/navigation-link'
-											);
-											const newSubmenu = createBlock(
-												'core/navigation-submenu',
-												attributes,
-												block.innerBlocks
-													? [
-															...block.innerBlocks,
-															newLink,
-													  ]
-													: [ newLink ]
-											);
-											replaceBlock(
-												clientId,
-												newSubmenu
-											);
-											onClose();
-										} }
-									>
-										{ __( 'Add a submenu item' ) }
-									</MenuItem>
+									<__unstableBlockSettingsMenuFirstItem>
+										<MenuItem
+											onClick={ () => {
+												const newLink = createBlock(
+													'core/navigation-link'
+												);
+												const newSubmenu = createBlock(
+													'core/navigation-submenu',
+													attributes,
+													block.innerBlocks
+														? [
+																...block.innerBlocks,
+																newLink,
+														  ]
+														: [ newLink ]
+												);
+												replaceBlock(
+													clientId,
+													newSubmenu
+												);
+												onClose();
+											} }
+										>
+											{ __( 'Add a submenu item' ) }
+										</MenuItem>
+									</__unstableBlockSettingsMenuFirstItem>
 								) }
 							</BlockSettingsDropdown>
 						) }


### PR DESCRIPTION
## What?
Moves the "Add a submenu" option to the top of the block settings dropdown. Also add a line beneath it.

## Why?
This is a primary action so it should be at the top of the list.

## How?
Using `__unstableBlockSettingsMenuFirstItem`. This also wraps `__unstableBlockSettingsMenuFirstItem` in a `MenuGroup` which adds a line beneath it, but this has the unfortunate consequence that any items added using `__unstableBlockSettingsMenuFirstItem` will also be in a different group.

We might also want to remove the "Hide more settings" option. I started doing that here: https://github.com/WordPress/gutenberg/pull/46077

## Testing Instructions
1. Add a navigation block
2. Add a custom link
3. Click on the `...` next to the custom link
4. Notice that "Add a submenu" is at the top of the list

## Screenshots or screencast <!-- if applicable -->

<img width="283" alt="Screenshot 2022-11-25 at 19 57 37" src="https://user-images.githubusercontent.com/275961/204050142-5dc9ba8c-6998-48cd-aba4-fffb9637b90b.png">
