### PR TITLE
Navigation: Remove "Hide more settings" from block settings dropdown

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -30,6 +30,7 @@ import {
 	__experimentalRecursionProvider as RecursionProvider,
 	__experimentaluseLayoutClasses as useLayoutClasses,
 	__experimentaluseLayoutStyles as useLayoutStyles,
+	__unstableBlockNameContext,
 } from '@wordpress/block-editor';
 import { useEffect, useRef, useMemo } from '@wordpress/element';
 import { Button, __unstableMotion as motion } from '@wordpress/components';
@@ -398,7 +399,14 @@ export default function VisualEditor( { styles } ) {
 			</motion.div>
 			<__unstableBlockSettingsMenuFirstItem>
 				{ ( { onClose } ) => (
-					<BlockInspectorButton onClick={ onClose } />
+					<__unstableBlockNameContext.Consumer>
+						{ ( blockName ) =>
+							blockName !== 'core/navigation-link' &&
+							blockName !== 'core/navigation-submenu' && (
+								<BlockInspectorButton onClick={ onClose } />
+							)
+						}
+					</__unstableBlockNameContext.Consumer>
 				) }
 			</__unstableBlockSettingsMenuFirstItem>
 		</BlockTools>

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -246,9 +246,17 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 				</ResizableEditor>
 				<__unstableBlockSettingsMenuFirstItem>
 					{ ( { onClose } ) => (
-						<BlockInspectorButton onClick={ onClose } />
+						<__unstableBlockNameContext.Consumer>
+							{ ( blockName ) =>
+								blockName !== 'core/navigation-link' &&
+								blockName !== 'core/navigation-submenu' && (
+									<BlockInspectorButton onClick={ onClose } />
+								)
+							}
+						</__unstableBlockNameContext.Consumer>
 					) }
 				</__unstableBlockSettingsMenuFirstItem>
+
 				<__unstableBlockToolbarLastItem>
 					<__unstableBlockNameContext.Consumer>
 						{ ( blockName ) =>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Removes the "Hide more settings" from block settings dropdown in the Navigation Link and Navigation Submenu blocks.

## Why?
These options don't make sense in these blocks when in the Navigation List View as they close the inspector controls.

## How?
This approach doesn't work!

## Testing Instructions
1. Add a navigation block
2. Add a custom link
3. Open the block settings dropdown in the Navigation list view
4. See if the "Hide more settings" option is there.

<img width="299" alt="Screenshot 2022-11-25 at 20 42 18" src="https://user-images.githubusercontent.com/275961/204053639-ea9f11a9-44a7-4f61-85b1-6540a458f053.png">
