### PR TITLE
SearchControl: remove margin overrides and add new opt-in prop

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/sidebar.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/sidebar.js
@@ -36,6 +36,7 @@ function PatternsExplorerSearch( { filterValue, setFilterValue } ) {
 	return (
 		<div className={ baseClassName }>
 			<SearchControl
+				__nextHasNoMarginBottom
 				onChange={ setFilterValue }
 				value={ filterValue }
 				label={ __( 'Search for patterns' ) }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -228,6 +228,7 @@ function InserterMenu(
 				} ) }
 			>
 				<SearchControl
+					__nextHasNoMarginBottom
 					className="block-editor-inserter__search"
 					onChange={ ( value ) => {
 						if ( hoveredItem ) setHoveredItem( null );

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -99,6 +99,7 @@ export default function QuickInserter( {
 		>
 			{ showSearch && (
 				<SearchControl
+					__nextHasNoMarginBottom
 					className="block-editor-inserter__search"
 					value={ filterValue }
 					onChange={ ( value ) => {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -107,10 +107,6 @@ $block-inserter-tabs-height: 44px;
 	.components-search-control__icon {
 		right: $grid-unit-10 + ($grid-unit-60 - $icon-size) * 0.5;
 	}
-
-	.components-base-control__field {
-		margin-bottom: 0;
-	}
 }
 
 .block-editor-inserter__tabs {

--- a/packages/block-library/src/template-part/edit/selection-modal.js
+++ b/packages/block-library/src/template-part/edit/selection-modal.js
@@ -88,6 +88,7 @@ export default function TemplatePartSelectionModal( {
 		<div className="block-library-template-part__selection-content">
 			<div className="block-library-template-part__selection-search">
 				<SearchControl
+					__nextHasNoMarginBottom
 					onChange={ setSearchValue }
 					value={ searchValue }
 					label={ __( 'Search for replacements' ) }

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -21,7 +21,7 @@
 	background: $white;
 	position: sticky;
 	top: 0;
-	padding: $grid-unit-20 0;
+	padding: $grid-unit-20 0 $grid-unit-30;
 	z-index: z-index(".block-library-template-part__selection-search");
 }
 

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -21,7 +21,7 @@
 	background: $white;
 	position: sticky;
 	top: 0;
-	padding: $grid-unit-20 0 $grid-unit-30;
+	padding: $grid-unit-20 0;
 	z-index: z-index(".block-library-template-part__selection-search");
 }
 

--- a/packages/edit-post/src/components/block-manager/index.js
+++ b/packages/edit-post/src/components/block-manager/index.js
@@ -66,6 +66,7 @@ function BlockManager( {
 				</div>
 			) }
 			<SearchControl
+				__nextHasNoMarginBottom
 				label={ __( 'Search for a block' ) }
 				placeholder={ __( 'Search for a block' ) }
 				value={ search }

--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
@@ -131,6 +131,7 @@ function SuggestionList( { entityForSuggestions, onSelect } ) {
 		<>
 			{ showSearchControl && (
 				<SearchControl
+					__nextHasNoMarginBottom
 					onChange={ setSearch }
 					value={ search }
 					label={ labels.search_items }

--- a/packages/edit-site/src/components/global-styles/screen-block-list.js
+++ b/packages/edit-site/src/components/global-styles/screen-block-list.js
@@ -129,6 +129,7 @@ function ScreenBlockList() {
 				) }
 			/>
 			<SearchControl
+				__nextHasNoMarginBottom
 				className="edit-site-block-types-search"
 				onChange={ setFilterValue }
 				value={ filterValue }

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -61,7 +61,6 @@
 	padding: 0 $grid-unit-20;
 }
 
-
 .edit-site-global-styles-subtitle {
 	// Need to override the too specific styles for complementary areas.
 	margin-bottom: 0 !important;

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -52,10 +52,15 @@
 	}
 }
 
-.edit-site-global-styles-header__description,
-.edit-site-block-types-search {
+.edit-site-global-styles-header__description {
 	padding: 0 $grid-unit-20;
 }
+
+.edit-site-block-types-search {
+	margin-bottom: $grid-unit-10;
+	padding: 0 $grid-unit-20;
+}
+
 
 .edit-site-global-styles-subtitle {
 	// Need to override the too specific styles for complementary areas.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

Added new opt-in prop `__nextHasNoMarginBottom` for useages of `SearchControl` in the Gutenberg codebase and removed margin overrides. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Part of this project: https://github.com/WordPress/gutenberg/issues/38730
The tl;dr is `BaseControl` has a `margin-bottom` which makes it difficult to reuse and results in inconsistent use. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By removing margin overrides in the CSS and adding the prop `__nextHasNoMarginBottom`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

### Testing steps done in the **block editor**:

* ### For `InserterMenu`

1. Open page or post 
2. Click on block inserter in top left corner of main toolbar 
3. Ensure spacing below search bar is the same as before

<img width="362" alt="Screen Shot 2022-11-25 at 2 29 08 PM" src="https://user-images.githubusercontent.com/35543432/204060324-ad05b761-b7b3-4ae0-ad6a-f12e4ef95635.png">

* ### For `QuickInserter`

**! Note: Currently, the border around the quick inserter is broken due to the added margin (see gaps in border on left and right side of search). The change here will fix it.**

1. Open page or post
2. Click on plus icon to add block in editor
3. See that removed margin fixes border

| Before  | After |
| ------------- | ------------- |
| <img width="360" alt="Screen Shot 2022-11-24 at 7 51 00 PM" src="https://user-images.githubusercontent.com/35543432/204059424-046ac831-2493-4ed1-ac4f-9fd2c1d03ee3.png">  |  <img width="356" alt="Screen Shot 2022-11-24 at 7 52 59 PM" src="https://user-images.githubusercontent.com/35543432/204059422-8472ef18-33ff-45ba-884b-94bad909f8dc.png"> |

* ### PatternsExplorerSearch

1. Open page or post 
2. Click on block inserter in top left corner of main toolbar 
3. Click on 'Patterns' tab
5. Click on 'Explore all patterns' button at the bottom to open modal
6. Ensure spacing below search bar is the same as before

<img width="475" alt="Screen Shot 2022-11-25 at 2 29 49 PM" src="https://user-images.githubusercontent.com/35543432/204060450-caad4cac-dda1-4afa-8c32-720168100c92.png">

* ### For `BlockManager`

1. Open page or post 
2. Click on three dots in top right corner
3. Go to 'Preferences' at the bottom of the dropdown
5. Click on 'Blocks'
6. Ensure spacing below search bar is the same as before

<img width="763" alt="Screen Shot 2022-11-24 at 8 35 15 PM" src="https://user-images.githubusercontent.com/35543432/204058888-9ce9c522-aa00-435f-88e2-c8c0789b07d7.png">

<hr>

### Testing steps done in the **site editor**:

* ### For `TemplatePartSelectionModal`

**! Note: I think it looks better with a smaller margin to match the top, but in this PR I've added padding to make it look the same as before. I'd be happy to remove it, though, if anyone agrees.** 

1. Open the site editor via 'Appearance → Editor'
2. Select any template part (e.g. header)
3. Click on the three dots in the block toolbar
4. Select 'Replace {templatePartName}' in block options dropdown
5. Ensure spacing below search bar is the same as before

| Before  | After with extra margin removed |
| ------------- | ------------- |
| <img width="765" alt="Screen Shot 2022-11-24 at 8 11 22 PM" src="https://user-images.githubusercontent.com/35543432/204059114-c80ecd62-63af-45ea-807b-10453de9178d.png"> | <img width="763" alt="Screen Shot 2022-11-24 at 8 11 36 PM" src="https://user-images.githubusercontent.com/35543432/204059113-b203ff8c-7863-42f3-a07c-eae2e8435786.png"> |

* ### For `SuggestionList`

**! Note:For this, you need to have at least 10 or more categories / authors / tags etc or you could edit the following line 127 to have a length greater than 0:**

`if ( ! showSearchControl && suggestions?.length > 9 ) {`

1. Open the site editor via 'Appearance → Editor'
2. Click on WordPress logo in left corner
3. Go to 'Templates'
4. Click on button 'Add New' in top right corner
5. Select 'Category' (or 'Author' or whatever you have more than 10 of if you didn't edit the code above)
7. Click right option, 'Category for a specific item'
8. Ensure spacing below search bar is the same as before

<img width="471" alt="Screen Shot 2022-11-25 at 2 28 31 PM" src="https://user-images.githubusercontent.com/35543432/204060379-f0b2af6b-45a0-48a3-a988-1acdf5b94205.png">

* ### For `ScreenBlockList`

1. Open the site editor via 'Appearance → Editor'
2. Click on global 'Styles' icon in top right of main toolbar
3. Click on 'Blocks'
4. Ensure spacing below search bar is the same as before

<img width="279" alt="Screen Shot 2022-11-24 at 9 40 28 PM" src="https://user-images.githubusercontent.com/35543432/204058867-fcbb5287-0d42-45c0-bd9a-fb94f2bb82b9.png">
