### PR TITLE
Media & Text Block: create undo history when media width is changed

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -199,7 +199,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes, clientId } ) {
 		setAttributes( {
 			mediaWidth: applyWidthConstraints( width ),
 		} );
-		setTemporaryMediaWidth( applyWidthConstraints( width ) );
+		setTemporaryMediaWidth( null );
 	};
 
 	const classNames = classnames( {


### PR DESCRIPTION
Fixes #45933

## What?
This PR ensures that undo history is successfully created in the media text block when the media size is changed.

## Why?

This block holds a temporary width as a state to prevent unnecessary updates of attributes. Then, when a resize operation is performed, there are two change events:

- [onWidthChange](https://github.com/WordPress/gutenberg/blob/40aa5e62ed7f517c1d45548227d4e1845aae850a/packages/block-library/src/media-text/edit.js#L195-L197): It is executed each time you move the drag handle with the mouse. This event updates only the state, which is a temporary width.
- [commitWidthChange](https://github.com/WordPress/gutenberg/blob/40aa5e62ed7f517c1d45548227d4e1845aae850a/packages/block-library/src/media-text/edit.js#L198-L203): It is executed when the drag handle operation is completed. This event updates both attributes and temporary state.

In the current implementation, when attirbutes are "committed", the state is also updated with the same value. However, the undo operation doesn'ot change the state. The value of state (the value before undo) is preferentially set, making it appear that the value has not changed.

https://github.com/WordPress/gutenberg/blob/40aa5e62ed7f517c1d45548227d4e1845aae850a/packages/block-library/src/media-text/edit.js#L212

https://github.com/WordPress/gutenberg/blob/40aa5e62ed7f517c1d45548227d4e1845aae850a/packages/block-library/src/media-text/edit.js#L311

When a width change is committed, we need to reset the state value to display the attribute value preferentially.

This is also the implementation seen in [the spacer block](https://github.com/WordPress/gutenberg/blob/40aa5e62ed7f517c1d45548227d4e1845aae850a/packages/block-library/src/spacer/edit.js#L102).

## Testing Instructions
- Insert a media & text block.
- Change the media width from the drag handle, range control, or input control.
- In any operation, confirm that the undo function works  properly.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/54422211/204071884-4774bbfb-5816-4758-a847-db8a298751cc.mp4