### PR TITLE
Block Selection Toolbar: Support fixed blocks by flipping toolbar when block goes out of view

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -30,6 +30,7 @@ $z-layers: (
 	".block-editor-url-input__suggestions": 30,
 	".edit-post-layout__footer": 30,
 	".interface-interface-skeleton__header": 30,
+	".edit-site-layout__header": 30,
 	".interface-interface-skeleton__content": 20,
 	".edit-widgets-header": 30,
 	".block-library-button__inline-link .block-editor-url-input__suggestions": 6, // URL suggestions for button block above sibling inserter

--- a/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
+++ b/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
@@ -13,27 +13,12 @@ import { __unstableUseBlockElement as useBlockElement } from '../block-list/use-
 
 const TOOLBAR_MARGIN = 12;
 
-const COMMON_PROPS = {
+// By default the toolbar sets the `shift` prop and flip properties.
+// If there is enough room, then once the block scrolls past the top of the screen,
+// then the toolbar is flipped to the bottom.
+const DEFAULT_PROPS = {
 	placement: 'top-start',
 	strategy: 'fixed',
-};
-
-// By default the toolbar sets the `shift` prop. If the user scrolls the page
-// down the toolbar will stay on screen by adopting a sticky position at the
-// top of the viewport.
-const DEFAULT_PROPS = {
-	...COMMON_PROPS,
-	flip: true,
-	shift: true,
-};
-
-// When there isn't enough height between the top of the block and the editor
-// canvas, the `shift` prop is set to `false`, as it will cause the block to be
-// obscured. The `flip` behavior is enabled, which positions the toolbar below
-// the block. This only happens if the block is smaller than the viewport, as
-// otherwise the toolbar will be off-screen.
-const RESTRICTED_HEIGHT_PROPS = {
-	...COMMON_PROPS,
 	flip: true,
 	shift: true,
 };
@@ -53,17 +38,11 @@ function getProps( contentElement, selectedBlockElement, toolbarHeight ) {
 	}
 
 	const blockRect = selectedBlockElement.getBoundingClientRect();
-	const contentRect = contentElement.getBoundingClientRect();
 
 	// The document element's clientHeight represents the viewport height.
 	const viewportHeight =
 		contentElement.ownerDocument.documentElement.clientHeight;
 
-	// The calculation for the following adds the two `top` values together.
-	// If an element is positioned higher than the viewport, then its `top` value will be
-	// negative, so using an addition ensures that the values are calculated appropriately.
-	const hasSpaceForToolbarAbove =
-		blockRect.top + contentRect.top > toolbarHeight;
 	const isBlockTallerThanViewport =
 		blockRect.height > viewportHeight - toolbarHeight;
 
@@ -75,16 +54,8 @@ function getProps( contentElement, selectedBlockElement, toolbarHeight ) {
 		};
 	}
 
-	if ( hasSpaceForToolbarAbove ) {
-		return {
-			...DEFAULT_PROPS,
-			flip: { padding: toolbarHeight },
-			shift: { padding: toolbarHeight - TOOLBAR_MARGIN },
-		};
-	}
-
 	return {
-		...RESTRICTED_HEIGHT_PROPS,
+		...DEFAULT_PROPS,
 		flip: { padding: toolbarHeight },
 		shift: { padding: toolbarHeight - TOOLBAR_MARGIN },
 	};

--- a/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
+++ b/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
@@ -11,6 +11,8 @@ import { useCallback, useLayoutEffect, useState } from '@wordpress/element';
 import { store as blockEditorStore } from '../../store';
 import { __unstableUseBlockElement as useBlockElement } from '../block-list/use-block-props/use-block-refs';
 
+const TOOLBAR_MARGIN = 12;
+
 const COMMON_PROPS = {
 	placement: 'top-start',
 	strategy: 'fixed',
@@ -21,7 +23,7 @@ const COMMON_PROPS = {
 // top of the viewport.
 const DEFAULT_PROPS = {
 	...COMMON_PROPS,
-	flip: false,
+	flip: true,
 	shift: true,
 };
 
@@ -33,7 +35,7 @@ const DEFAULT_PROPS = {
 const RESTRICTED_HEIGHT_PROPS = {
 	...COMMON_PROPS,
 	flip: true,
-	shift: false,
+	shift: true,
 };
 
 /**
@@ -61,15 +63,31 @@ function getProps( contentElement, selectedBlockElement, toolbarHeight ) {
 	// If an element is positioned higher than the viewport, then its `top` value will be
 	// negative, so using an addition ensures that the values are calculated appropriately.
 	const hasSpaceForToolbarAbove =
-		blockRect.top + contentRect.top > toolbarHeight; // TODO: Do we need to flip earlier?
+		blockRect.top + contentRect.top > toolbarHeight;
 	const isBlockTallerThanViewport =
 		blockRect.height > viewportHeight - toolbarHeight;
 
-	if ( hasSpaceForToolbarAbove || isBlockTallerThanViewport ) {
-		return DEFAULT_PROPS;
+	if ( isBlockTallerThanViewport ) {
+		return {
+			...DEFAULT_PROPS,
+			flip: false,
+			shift: { padding: toolbarHeight - TOOLBAR_MARGIN },
+		};
 	}
 
-	return RESTRICTED_HEIGHT_PROPS;
+	if ( hasSpaceForToolbarAbove ) {
+		return {
+			...DEFAULT_PROPS,
+			flip: { padding: toolbarHeight },
+			shift: { padding: toolbarHeight - TOOLBAR_MARGIN },
+		};
+	}
+
+	return {
+		...RESTRICTED_HEIGHT_PROPS,
+		flip: { padding: toolbarHeight },
+		shift: { padding: toolbarHeight - TOOLBAR_MARGIN },
+	};
 }
 
 /**

--- a/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
+++ b/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
@@ -111,13 +111,6 @@ export default function useBlockToolbarPopoverProps( {
 		const contentView = contentElement?.ownerDocument?.defaultView;
 		contentView?.addEventHandler?.( 'resize', updateProps );
 
-		// TODO: There must be a better way to find the scroll container for the editor than this.
-		// Unfortunately, `contentView` isn't the right element to watch for scroll events.
-		const scrollContainer = selectedBlockElement?.closest?.(
-			'.interface-interface-skeleton__content'
-		);
-		scrollContainer.addEventListener( 'scroll', updateProps );
-
 		// Update the toolbar props on block resize.
 		let resizeObserver;
 		const blockView = selectedBlockElement?.ownerDocument?.defaultView;
@@ -128,7 +121,6 @@ export default function useBlockToolbarPopoverProps( {
 
 		return () => {
 			contentView?.removeEventHandler?.( 'resize', updateProps );
-			scrollContainer?.removeEventListener?.( 'scroll', updateProps );
 
 			if ( resizeObserver ) {
 				resizeObserver.disconnect();

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -25,6 +25,7 @@
 -   `ResizableBox`: Prevent unnecessary paint on resize handles ([#46196](https://github.com/WordPress/gutenberg/pull/46196)).
 -   `Popover`: Prevent unnecessary paint caused by using outline ([#46201](https://github.com/WordPress/gutenberg/pull/46201)).
 -   `PaletteEdit`: Global styles: add onChange actions to color palette items [#45681](https://github.com/WordPress/gutenberg/pull/45681).
+-   `Popover`: Add support for padding in `flip` and `shift` props, add `strategy` prop ([#46085](https://github.com/WordPress/gutenberg/pull/46085)).
 
 ### Experimental
 

--- a/packages/components/src/popover/README.md
+++ b/packages/components/src/popover/README.md
@@ -125,13 +125,15 @@ Show the popover fullscreen on mobile viewports.
 
 -   Required: No
 
-### `flip`: `boolean`
+### `flip`: `FlipProps | boolean`
 
 Specifies whether the popover should flip across its axis if there isn't space for it in the normal placement.
 
 When the using a 'top' placement, the popover will switch to a 'bottom' placement. When using a 'left' placement, the popover will switch to a `right' placement.
 
 The popover will retain its alignment of 'start' or 'end' when flipping.
+
+When passed an object, the amount of padding before flipping can be set using a `padding` property.
 
 -   Required: No
 -   Default: `true`
@@ -223,6 +225,22 @@ Adjusts the size of the popover to prevent its contents from going out of view w
 
 -   Required: No
 -   Default: `true`
+
+### `shift`: `ShiftProps | boolean`
+
+Enables the popover to shift in order to stay in view when meeting the viewport edges.
+
+When passed an object, the amount of padding before shifting can be set using a `padding` property.
+
+-   Required: No
+-   Default: `true`
+
+### `strategy`: `'absolute' | 'fixed'`
+
+Sets the type of CSS position property to use for the popover.
+
+-   Required: No
+-   Default: `'absolute'`
 
 ### `variant`: `'toolbar' | 'unstyled'`
 

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -292,7 +292,14 @@ const UnforwardedPopover = (
 			},
 		},
 		offsetMiddleware( offsetProp ),
-		computedFlipProp ? flipMiddleware() : undefined,
+		computedFlipProp
+			? flipMiddleware( {
+					padding:
+						typeof computedFlipProp === 'object'
+							? computedFlipProp?.padding
+							: undefined,
+			  } )
+			: undefined,
 		computedResizeProp
 			? size( {
 					apply( sizeProps ) {
@@ -315,7 +322,7 @@ const UnforwardedPopover = (
 			? shiftMiddleware( {
 					crossAxis: true,
 					limiter: customLimitShift(),
-					padding: 1, // Necessary to avoid flickering at the edge of the viewport.
+					padding: typeof shift === 'object' ? shift?.padding : 1, // Necessary to avoid flickering at the edge of the viewport.
 			  } )
 			: undefined,
 		arrow( { element: arrowRef } ),

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -181,6 +181,7 @@ const UnforwardedPopover = (
 		resize = true,
 		shift = false,
 		variant,
+		strategy: strategyProp = 'absolute',
 
 		// Deprecated props
 		__unstableForcePosition,
@@ -362,6 +363,7 @@ const UnforwardedPopover = (
 		middlewareData: { arrow: arrowData },
 	} = useFloating( {
 		placement: normalizedPlacementFromProps,
+		strategy: strategyProp,
 		middleware,
 		whileElementsMounted: ( referenceParam, floatingParam, updateParam ) =>
 			autoUpdate( referenceParam, floatingParam, updateParam, {

--- a/packages/components/src/popover/types.ts
+++ b/packages/components/src/popover/types.ts
@@ -135,6 +135,12 @@ export type PopoverProps = {
 	 */
 	shift?: boolean;
 	/**
+	 * Sets the type of CSS position property to use.
+	 *
+	 * @default 'absolute'
+	 */
+	strategy?: 'absolute' | 'fixed';
+	/**
 	 * Specifies the popover's style.
 	 *
 	 * Leave undefined for the default style. Other values are:

--- a/packages/components/src/popover/types.ts
+++ b/packages/components/src/popover/types.ts
@@ -26,6 +26,14 @@ export type VirtualElement = Pick< Element, 'getBoundingClientRect' > & {
 	ownerDocument?: Document;
 };
 
+export type FlipProps = {
+	padding?: number;
+};
+
+export type ShiftProps = {
+	padding?: number;
+};
+
 export type PopoverProps = {
 	/**
 	 * The name of the Slot in which the popover should be rendered. It should
@@ -67,7 +75,7 @@ export type PopoverProps = {
 	 *
 	 * @default true
 	 */
-	flip?: boolean;
+	flip?: FlipProps | boolean;
 	/**
 	 * By default, the _first tabbable element_ in the popover will receive focus
 	 * when it mounts. This is the same as setting this prop to `"firstElement"`.
@@ -133,7 +141,7 @@ export type PopoverProps = {
 	 *
 	 * @default false
 	 */
-	shift?: boolean;
+	shift?: ShiftProps | boolean;
 	/**
 	 * Sets the type of CSS position property to use.
 	 *

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -24,6 +24,7 @@
 	grid-area: header;
 	height: $header-height;
 	display: flex;
+	z-index: z-index(".edit-site-layout__header");
 }
 
 .edit-site-layout__logo {

--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -2,6 +2,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
+	background: $white;
 	height: $header-height;
 	padding: 0 $grid-unit-20;
 	overflow: auto;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR explores whether we can update the Popover component and the block selection toolbar to support the toolbar displaying appropriately when using fixed or sticky positioned blocks (as in the exploration in https://github.com/WordPress/gutenberg/pull/46142). This is achieved by flipping the toolbar to be below the block when a block scrolls out of view, to prevent the block toolbar from obscuring the block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When support for sticky or fixed position is added to blocks, the block toolbar is not currently positioned correctly — it continues to scroll off the viewport as if the block were not sticky or fixed. Once the block toolbar is fixed in position, it then needs to be moved so that it does not obscure the fixed/sticky block content.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Popover: Add support for `strategy` in floating UI, which allows the consumer to set `fixed` or the default `absolute`
* For the block toolbar, use the `fixed` strategy, which appears to play better with fixed elements as mentioned in the floating UI docs: https://floating-ui.com/docs/computeposition#strategy
* Allow `padding` on `shift` and `flip`, and use this value to flip and shift the toolbar, while factoring in the height of the toolbar
* Update the logic in the `useBlockToolbarPopoverProps` to simplify things a little — here, we default to having `flip` always switched on, unless the block fills the viewport — this is a departure from `trunk`, but as described below, appears to be required in order to support sticky or fixed position blocks. I'm very happy for feedback on this PR, as it is quite a change — unfortunately I couldn't quite work out a way to support sticky/fixed blocks without making this change to toolbar positioning.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

* Explore how the Toolbar is positioned with regular blocks that do not fill the viewport (should flip as you scroll down the page, if there is enough room to display the Toolbar beneath the block)
* Explore how the Toolbar is positioned with blocks that fill the viewport (should be sticky at the top of the viewport, as on trunk)
* To test in conjunction with sticky positioned blocks, this PR can be tested on top of https://github.com/WordPress/gutenberg/pull/46142 — however, for the moment, it might be worth considering this change in isolation, and whether or not it is appropriate

## Screenshots or screencast <!-- if applicable -->

In the below screenshot, a Group block that is set to "sticky" is selected, and its toolbar is flipped to be displayed below the block. It stays there while the viewport is scrolled. (Note: to test this, you also need #46142 applied)

<img width="1336" alt="image" src="https://user-images.githubusercontent.com/14988353/204072285-2f7fe3dc-0504-4902-bc78-cf21d1b03f0c.png">

Ignoring sticky or fixed position for the moment, the main change in this PR is that if there is no room above a block, however there is room below the block, then we flip the controls to display underneath. For blocks that fill the height of the viewport, then we retain the sticky behaviour from before. Overall, this is a change from the behaviour on `trunk` — I couldn't quite work out a way to support sticky/fixed blocks without this change, particularly since we also need to support the children of those blocks, so we can't directly inspect if the current block is sticky or fixed in order to enable the behaviour. Here are a couple more screenshots of the behaviour in this PR:

| Enough room above | Not enough above, so flip to bottom | A tall block sticks to the top, as before |
| --- | --- | --- |
| <img width="1434" alt="image" src="https://user-images.githubusercontent.com/14988353/204118507-f6e332e1-2a9c-4717-96ad-0e99f244eb41.png"> | <img width="1434" alt="image" src="https://user-images.githubusercontent.com/14988353/204118520-b2416138-4f31-4c69-a25f-acbffa1b743e.png"> | <img width="1434" alt="image" src="https://user-images.githubusercontent.com/14988353/204118537-e8d85e3b-41f4-4da6-ade4-c80e92dcd406.png"> |

Screengrab (note that toolbar flips to be below the block when scrolling past the edge of the viewport, so that it doesn't obscure the currently selected block):

https://user-images.githubusercontent.com/14988353/205827633-b8a54352-631c-47fc-9b45-24dab4bf6d86.mp4