### PR TITLE
Fix invalid attribute markup in core/home-link block

### DIFF
--- a/packages/block-library/src/home-link/index.php
+++ b/packages/block-library/src/home-link/index.php
@@ -128,7 +128,7 @@ function render_block_core_home_link( $attributes, $content, $block ) {
 	$aria_current = is_home() || ( is_front_page() && 'page' === get_option( 'show_on_front' ) ) ? ' aria-current="page"' : '';
 
 	return sprintf(
-		'<li %1$s><a class="wp-block-home-link__content wp-block-navigation-item__content" href="%2$s" "rel="home"%3$s>%4$s</a></li>',
+		'<li %1$s><a class="wp-block-home-link__content wp-block-navigation-item__content" href="%2$s" rel="home"%3$s>%4$s</a></li>',
 		block_core_home_link_build_li_wrapper_attributes( $block->context ),
 		esc_url( home_url() ),
 		$aria_current,


### PR DESCRIPTION
The `core/home-link` block produces invalid HTML markup, after f4e4ac25151175ae229d1a2f4a0d6129f9738801 introduced a stray `"` in front of the `rel` attribute.

This PR removes that wrong quotation mark.