### PR TITLE
Tooltip: add readme and unit tests for `shortcut` prop

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 -   NumberControl: refactor styles/tests/stories to TypeScript, replace fireEvent with user-event ([#45990](https://github.com/WordPress/gutenberg/pull/45990)).
 
+### Documentation
+
+-   `Tooltip`: Add readme and unit tests for `shortcut` prop ([#46092](https://github.com/WordPress/gutenberg/pull/46092)).
+
 ## 22.1.0 (2022-11-16)
 
 ### Enhancements

--- a/packages/components/src/tooltip/README.md
+++ b/packages/components/src/tooltip/README.md
@@ -46,6 +46,13 @@ The tooltip text to show on focus or hover.
 -   Type: `String`
 -   Required: No
 
+### `shortcut`
+
+-   Type: `string` or `object`
+-   Required: No
+
+If shortcut is a string, it is expecting the display text. If shortcut is an object, it will accept the properties of `display` (string) and `ariaLabel` (string).
+
 ### delay (web only)
 
 Time in milliseconds to wait before showing tooltip after the tooltip's visibility is toggled. This prop is currently only available for the web platforms.

--- a/packages/components/src/tooltip/README.md
+++ b/packages/components/src/tooltip/README.md
@@ -46,7 +46,7 @@ The tooltip text to show on focus or hover.
 -   Type: `String`
 -   Required: No
 
-### shortcut
+### shortcut (web only)
 
 -   Type: `string` or `object`
 -   Required: No

--- a/packages/components/src/tooltip/README.md
+++ b/packages/components/src/tooltip/README.md
@@ -46,7 +46,7 @@ The tooltip text to show on focus or hover.
 -   Type: `String`
 -   Required: No
 
-### `shortcut`
+### shortcut
 
 -   Type: `string` or `object`
 -   Required: No

--- a/packages/components/src/tooltip/test/index.js
+++ b/packages/components/src/tooltip/test/index.js
@@ -276,5 +276,39 @@ describe( 'Tooltip', () => {
 			// Tooltip won't show, since the mouse has left the anchor
 			expect( screen.queryByText( 'Help text' ) ).not.toBeInTheDocument();
 		} );
+
+		it( 'should render the shortcut display text when a string is passed as the shortcut', async () => {
+			render(
+				<Tooltip text="Help text" shortcut="shortcut text">
+					<button>Hover Me!</button>
+				</Tooltip>
+			);
+
+			const button = screen.getByRole( 'button', { name: 'Hover Me!' } );
+			button.focus();
+
+			expect( screen.getByText( 'shortcut text' ) ).toBeInTheDocument();
+		} );
+
+		it( 'should render the shortcut display text and aria-label when an object is passed as the shortcut with the correct properties', async () => {
+			render(
+				<Tooltip
+					text="Help text"
+					shortcut={ {
+						display: 'shortcut text',
+						ariaLabel: 'shortcut label',
+					} }
+				>
+					<button>Hover Me!</button>
+				</Tooltip>
+			);
+
+			const button = screen.getByRole( 'button', { name: 'Hover Me!' } );
+			button.focus();
+
+			expect(
+				screen.getByLabelText( 'shortcut label' )
+			).toHaveTextContent( 'shortcut text' );
+		} );
 	} );
 } );

--- a/packages/components/src/tooltip/test/index.js
+++ b/packages/components/src/tooltip/test/index.js
@@ -291,15 +291,7 @@ describe( 'Tooltip', () => {
 			const button = screen.getByRole( 'button', { name: 'Hover Me!' } );
 			await user.hover( button );
 
-			// Tooltip with the shortcut text hasn't appeared yet
-			expect(
-				screen.queryByText( 'shortcut text' )
-			).not.toBeInTheDocument();
-
-			act( () => jest.advanceTimersByTime( TOOLTIP_DELAY ) );
-
-			// Tooltip with the shortcut text shows after the delay
-			expect( screen.getByText( 'shortcut text' ) ).toBeVisible();
+			expect( await screen.findByText( 'shortcut text' ) ).toBeVisible();
 		} );
 
 		it( 'should render the shortcut display text and aria-label when an object is passed as the shortcut with the correct properties', async () => {
@@ -322,16 +314,8 @@ describe( 'Tooltip', () => {
 			const button = screen.getByRole( 'button', { name: 'Hover Me!' } );
 			await user.hover( button );
 
-			// Tooltip with the shortcut text hasn't appeared yet
 			expect(
-				screen.queryByText( 'shortcut text' )
-			).not.toBeInTheDocument();
-
-			act( () => jest.advanceTimersByTime( TOOLTIP_DELAY ) );
-
-			// Tooltip with the shortcut text shows after the delay
-			expect(
-				screen.getByLabelText( 'shortcut label' )
+				await screen.findByLabelText( 'shortcut label' )
 			).toHaveTextContent( 'shortcut text' );
 		} );
 	} );

--- a/packages/components/src/tooltip/test/index.js
+++ b/packages/components/src/tooltip/test/index.js
@@ -37,7 +37,7 @@ describe( 'Tooltip', () => {
 
 			expect(
 				screen.getByRole( 'button', { name: 'Hover Me!' } )
-			).toBeInTheDocument();
+			).toBeVisible();
 			expect( screen.queryByText( 'Help text' ) ).not.toBeInTheDocument();
 		} );
 
@@ -51,7 +51,7 @@ describe( 'Tooltip', () => {
 			);
 
 			const button = screen.getByRole( 'button', { name: 'Hover Me!' } );
-			expect( button ).toBeInTheDocument();
+			expect( button ).toBeVisible();
 
 			// Before focus, the tooltip is not shown.
 			expect( screen.queryByText( 'Help text' ) ).not.toBeInTheDocument();
@@ -59,7 +59,7 @@ describe( 'Tooltip', () => {
 			button.focus();
 
 			// Tooltip is shown after focusing the anchor.
-			expect( screen.getByText( 'Help text' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Help text' ) ).toBeVisible();
 			expect( mockOnFocus ).toHaveBeenCalledWith(
 				expect.objectContaining( {
 					type: 'focus',
@@ -79,7 +79,7 @@ describe( 'Tooltip', () => {
 			);
 
 			const button = screen.getByRole( 'button', { name: 'Hover Me!' } );
-			expect( button ).toBeInTheDocument();
+			expect( button ).toBeVisible();
 
 			await user.hover( button );
 
@@ -89,7 +89,7 @@ describe( 'Tooltip', () => {
 			act( () => jest.advanceTimersByTime( TOOLTIP_DELAY ) );
 
 			// Tooltip shows after the delay
-			expect( screen.getByText( 'Help text' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Help text' ) ).toBeVisible();
 		} );
 
 		it( 'should not show tooltip on focus as result of mouse click', async () => {
@@ -105,7 +105,7 @@ describe( 'Tooltip', () => {
 			);
 
 			const button = screen.getByRole( 'button', { text: 'Hover Me!' } );
-			expect( button ).toBeInTheDocument();
+			expect( button ).toBeVisible();
 
 			await user.click( button );
 
@@ -144,7 +144,7 @@ describe( 'Tooltip', () => {
 			);
 
 			const button = screen.getByRole( 'button', { name: 'Hover Me!' } );
-			expect( button ).toBeInTheDocument();
+			expect( button ).toBeVisible();
 
 			await user.hover( button );
 
@@ -161,7 +161,7 @@ describe( 'Tooltip', () => {
 			act( () => jest.advanceTimersByTime( TEST_DELAY - TOOLTIP_DELAY ) );
 
 			// Tooltip shows after TEST_DELAY time
-			expect( screen.getByText( 'Help text' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Help text' ) ).toBeVisible();
 
 			expect( mockOnFocus ).not.toHaveBeenCalled();
 		} );
@@ -178,7 +178,7 @@ describe( 'Tooltip', () => {
 			);
 
 			const button = screen.getByRole( 'button', { name: 'Click me' } );
-			expect( button ).toBeInTheDocument();
+			expect( button ).toBeVisible();
 			expect( button ).toBeDisabled();
 
 			// Note: this is testing for implementation details,
@@ -200,7 +200,7 @@ describe( 'Tooltip', () => {
 			// Tooltip shows after the delay
 			expect(
 				screen.getByText( 'Show helpful text here' )
-			).toBeInTheDocument();
+			).toBeVisible();
 		} );
 
 		it( 'should not emit events back to children when they are disabled', async () => {
@@ -287,7 +287,7 @@ describe( 'Tooltip', () => {
 			const button = screen.getByRole( 'button', { name: 'Hover Me!' } );
 			button.focus();
 
-			expect( screen.getByText( 'shortcut text' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'shortcut text' ) ).toBeVisible();
 		} );
 
 		it( 'should render the shortcut display text and aria-label when an object is passed as the shortcut with the correct properties', async () => {

--- a/packages/components/src/tooltip/test/index.js
+++ b/packages/components/src/tooltip/test/index.js
@@ -278,6 +278,10 @@ describe( 'Tooltip', () => {
 		} );
 
 		it( 'should render the shortcut display text when a string is passed as the shortcut', async () => {
+			const user = userEvent.setup( {
+				advanceTimers: jest.advanceTimersByTime,
+			} );
+
 			render(
 				<Tooltip text="Help text" shortcut="shortcut text">
 					<button>Hover Me!</button>
@@ -285,12 +289,24 @@ describe( 'Tooltip', () => {
 			);
 
 			const button = screen.getByRole( 'button', { name: 'Hover Me!' } );
-			button.focus();
+			await user.hover( button );
 
+			// Tooltip with the shortcut text hasn't appeared yet
+			expect(
+				screen.queryByText( 'shortcut text' )
+			).not.toBeInTheDocument();
+
+			act( () => jest.advanceTimersByTime( TOOLTIP_DELAY ) );
+
+			// Tooltip with the shortcut text shows after the delay
 			expect( screen.getByText( 'shortcut text' ) ).toBeVisible();
 		} );
 
 		it( 'should render the shortcut display text and aria-label when an object is passed as the shortcut with the correct properties', async () => {
+			const user = userEvent.setup( {
+				advanceTimers: jest.advanceTimersByTime,
+			} );
+
 			render(
 				<Tooltip
 					text="Help text"
@@ -304,8 +320,16 @@ describe( 'Tooltip', () => {
 			);
 
 			const button = screen.getByRole( 'button', { name: 'Hover Me!' } );
-			button.focus();
+			await user.hover( button );
 
+			// Tooltip with the shortcut text hasn't appeared yet
+			expect(
+				screen.queryByText( 'shortcut text' )
+			).not.toBeInTheDocument();
+
+			act( () => jest.advanceTimersByTime( TOOLTIP_DELAY ) );
+
+			// Tooltip with the shortcut text shows after the delay
 			expect(
 				screen.getByLabelText( 'shortcut label' )
 			).toHaveTextContent( 'shortcut text' );


### PR DESCRIPTION
Related to: #42753

## What?
This PR adds a description of the `shortcut` prop to the readme in the `Tooltip` component.
Also add unit tests for this prop.

## Why?
When I was investigating #42753, which rewrites the tooltip component, I noticed that the `shortcut` prop was missing in the README file.

This prop seems to have been updated by #9582 as a component with `aria-label`.

![shortcut](https://user-images.githubusercontent.com/54422211/204141419-94c3d0f7-280f-4fbf-a60e-934c872cedce.png)

## How?
The prop description was taken directly from the [MenuItem](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/menu-item/README.md#shortcut) component. 

Unit tests were added as needed, referring to the [unit test for the Shortcut component](https://github.com/WordPress/gutenberg/blob/0b1998cf997d866bc1eca182fedb1abb42e337fd/packages/components/src/shortcut/test/index.tsx).

## Testing Instructions

Confirm that the unit test passes successfully:

`npm run test:unit packages/components/src/tooltip/test/index.js`