### PR TITLE
PaletteEdit: add changelog

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -22,8 +22,8 @@
 -   `InputControl`, `NumberControl`, `UnitControl`: Add `help` prop for additional description ([#45931](https://github.com/WordPress/gutenberg/pull/45931)).
 -   `BorderControl`, `ColorPicker` & `QueryControls`: Replace bottom margin overrides with `__nextHasNoMarginBottom` ([#45985](https://github.com/WordPress/gutenberg/pull/45985)).
 -   `CustomSelectControl`, `UnitControl`: Add `onFocus` and `onBlur` props ([#46096](https://github.com/WordPress/gutenberg/pull/46096)).
--   `ResizableBox`: Prevent unnecessary paint on resize handles ([#46196](https://github.com/WordPress/gutenberg/pull/46196))
--   `Popover`: Prevent unnecessary paint caused by using outline ([#46201](https://github.com/WordPress/gutenberg/pull/46201))
+-   `ResizableBox`: Prevent unnecessary paint on resize handles ([#46196](https://github.com/WordPress/gutenberg/pull/46196)).
+-   `Popover`: Prevent unnecessary paint caused by using outline ([#46201](https://github.com/WordPress/gutenberg/pull/46201)).
 -   `PaletteEdit`: Global styles: add onChange actions to color palette items [#45681](https://github.com/WordPress/gutenberg/pull/45681).
 
 ### Experimental
@@ -32,8 +32,8 @@
 
 ### Internal
 
--   `useControlledValue`: let TypeScript infer the return type ([#46164](https://github.com/WordPress/gutenberg/pull/46164))
--   `LinkedButton`: remove unnecessary `span` tag ([#46063](https://github.com/WordPress/gutenberg/pull/46063))
+-   `useControlledValue`: let TypeScript infer the return type ([#46164](https://github.com/WordPress/gutenberg/pull/46164)).
+-   `LinkedButton`: remove unnecessary `span` tag ([#46063](https://github.com/WordPress/gutenberg/pull/46063)).
 -   NumberControl: refactor styles/tests/stories to TypeScript, replace fireEvent with user-event ([#45990](https://github.com/WordPress/gutenberg/pull/45990)).
 -   `useBaseField`: Convert to TypeScript ([#45712](https://github.com/WordPress/gutenberg/pull/45712)).
 -   `Dashicon`: Convert to TypeScript ([#45924](https://github.com/WordPress/gutenberg/pull/45924)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -24,6 +24,7 @@
 -   `CustomSelectControl`, `UnitControl`: Add `onFocus` and `onBlur` props ([#46096](https://github.com/WordPress/gutenberg/pull/46096)).
 -   `ResizableBox`: Prevent unnecessary paint on resize handles ([#46196](https://github.com/WordPress/gutenberg/pull/46196))
 -   `Popover`: Prevent unnecessary paint caused by using outline ([#46201](https://github.com/WordPress/gutenberg/pull/46201))
+-   `PaletteEdit`: Global styles: add onChange actions to color palette items [#45681](https://github.com/WordPress/gutenberg/pull/45681)
 
 ### Experimental
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -24,7 +24,7 @@
 -   `CustomSelectControl`, `UnitControl`: Add `onFocus` and `onBlur` props ([#46096](https://github.com/WordPress/gutenberg/pull/46096)).
 -   `ResizableBox`: Prevent unnecessary paint on resize handles ([#46196](https://github.com/WordPress/gutenberg/pull/46196))
 -   `Popover`: Prevent unnecessary paint caused by using outline ([#46201](https://github.com/WordPress/gutenberg/pull/46201))
--   `PaletteEdit`: Global styles: add onChange actions to color palette items [#45681](https://github.com/WordPress/gutenberg/pull/45681)
+-   `PaletteEdit`: Global styles: add onChange actions to color palette items [#45681](https://github.com/WordPress/gutenberg/pull/45681).
 
 ### Experimental
 
@@ -36,7 +36,8 @@
 -   `LinkedButton`: remove unnecessary `span` tag ([#46063](https://github.com/WordPress/gutenberg/pull/46063))
 -   NumberControl: refactor styles/tests/stories to TypeScript, replace fireEvent with user-event ([#45990](https://github.com/WordPress/gutenberg/pull/45990)).
 -   `useBaseField`: Convert to TypeScript ([#45712](https://github.com/WordPress/gutenberg/pull/45712)).
--  `Dashicon`: Convert to TypeScript ([#45924](https://github.com/WordPress/gutenberg/pull/45924)).
+-   `Dashicon`: Convert to TypeScript ([#45924](https://github.com/WordPress/gutenberg/pull/45924)).
+-   `PaletteEdit`: add follow up changelog for #45681 and tests [#46095](https://github.com/WordPress/gutenberg/pull/46095).
 
 ### Documentation
 

--- a/packages/components/src/palette-edit/index.js
+++ b/packages/components/src/palette-edit/index.js
@@ -89,7 +89,7 @@ export function getNameForPosition( elements, slugPrefix ) {
 	);
 }
 
-export function ColorPickerPopover( {
+function ColorPickerPopover( {
 	isGradient,
 	element,
 	onChange,

--- a/packages/components/src/palette-edit/index.js
+++ b/packages/components/src/palette-edit/index.js
@@ -101,11 +101,6 @@ export function ColorPickerPopover( {
 			offset={ 20 }
 			className="components-palette-edit__popover"
 			onClose={ onClose }
-			aria-label={
-				! isGradient
-					? __( 'Select a new color' )
-					: __( 'Select a new gradient' )
-			}
 		>
 			{ ! isGradient && (
 				<ColorPicker

--- a/packages/components/src/palette-edit/index.js
+++ b/packages/components/src/palette-edit/index.js
@@ -89,7 +89,7 @@ export function getNameForPosition( elements, slugPrefix ) {
 	);
 }
 
-function ColorPickerPopover( {
+export function ColorPickerPopover( {
 	isGradient,
 	element,
 	onChange,
@@ -101,6 +101,11 @@ function ColorPickerPopover( {
 			offset={ 20 }
 			className="components-palette-edit__popover"
 			onClose={ onClose }
+			aria-label={
+				! isGradient
+					? __( 'Select a new color' )
+					: __( 'Select a new gradient' )
+			}
 		>
 			{ ! isGradient && (
 				<ColorPicker

--- a/packages/components/src/palette-edit/test/index.js
+++ b/packages/components/src/palette-edit/test/index.js
@@ -1,7 +1,12 @@
 /**
+ * External dependencies
+ */
+import { render, fireEvent, screen } from '@testing-library/react';
+
+/**
  * Internal dependencies
  */
-import { getNameForPosition } from '../';
+import PaletteEdit, { getNameForPosition } from '../';
 
 describe( 'getNameForPosition', () => {
 	test( 'should return 1 by default', () => {
@@ -59,5 +64,24 @@ describe( 'getNameForPosition', () => {
 		expect( getNameForPosition( elements, slugPrefix ) ).toEqual(
 			'Color 151'
 		);
+	} );
+} );
+
+describe( 'PaletteEdit', () => {
+	const defaultProps = {
+		gradients: false,
+		colors: [ { color: '#ffffff', name: 'Base', slug: 'base' } ],
+		onChange: jest.fn(),
+		paletteLabel: 'Test label',
+		emptyMessage: 'Test empty message',
+		canOnlyChangeValues: true,
+		canReset: true,
+		slugPrefix: '',
+	};
+
+	it( 'opens color selector for color palettes', () => {
+		render( <PaletteEdit { ...defaultProps } /> );
+		fireEvent.click( screen.getByLabelText( 'Color: Base' ) );
+		expect( screen.getByLabelText( 'Hex color' ) ).toBeInTheDocument();
 	} );
 } );

--- a/packages/components/src/palette-edit/test/index.js
+++ b/packages/components/src/palette-edit/test/index.js
@@ -1,12 +1,7 @@
 /**
- * External dependencies
- */
-import { render, fireEvent, screen } from '@testing-library/react';
-
-/**
  * Internal dependencies
  */
-import PaletteEdit, { getNameForPosition } from '../';
+import { getNameForPosition } from '../';
 
 describe( 'getNameForPosition', () => {
 	test( 'should return 1 by default', () => {
@@ -64,54 +59,5 @@ describe( 'getNameForPosition', () => {
 		expect( getNameForPosition( elements, slugPrefix ) ).toEqual(
 			'Color 151'
 		);
-	} );
-} );
-
-describe( 'PaletteEdit', () => {
-	const defaultProps = {
-		gradients: false,
-		colors: [ { color: '#ffffff', name: 'Base', slug: 'base' } ],
-		onChange: jest.fn(),
-		paletteLabel: 'Test label',
-		emptyMessage: 'Test empty message',
-		canOnlyChangeValues: true,
-		canReset: true,
-		slugPrefix: '',
-	};
-
-	it( 'opens color selector for color palettes', () => {
-		render( <PaletteEdit { ...defaultProps } /> );
-		fireEvent.click( screen.getByLabelText( 'Color: Base' ) );
-		expect( screen.getByLabelText( 'Hex color' ) ).toBeInTheDocument();
-	} );
-
-	it( 'opens gradient selector for gradient palettes', async () => {
-		const defaultGradientProps = {
-			gradients: [
-				{
-					gradient:
-						'linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)',
-					name: 'Vivid cyan blue to vivid purple',
-					slug: 'vivid-cyan-blue-to-vivid-purple',
-				},
-			],
-			onChange: jest.fn(),
-			paletteLabel: 'Test label',
-			emptyMessage: 'Test empty message',
-			canOnlyChangeValues: true,
-			canReset: true,
-			slugPrefix: '',
-		};
-		render( <PaletteEdit { ...defaultGradientProps } /> );
-
-		fireEvent.click(
-			screen.getByLabelText( 'Gradient: Vivid cyan blue to vivid purple' )
-		);
-
-		expect(
-			await screen.findByLabelText(
-				'Gradient control point at position 0% with color code rgba(6,147,227,1).'
-			)
-		).toBeInTheDocument();
 	} );
 } );

--- a/packages/components/src/palette-edit/test/index.js
+++ b/packages/components/src/palette-edit/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, fireEvent, screen } from '@testing-library/react';
+import { act, render, fireEvent, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -68,17 +68,18 @@ describe( 'getNameForPosition', () => {
 } );
 
 describe( 'PaletteEdit', () => {
+	const defaultProps = {
+		gradients: false,
+		colors: [ { color: '#ffffff', name: 'Base', slug: 'base' } ],
+		onChange: jest.fn(),
+		paletteLabel: 'Test label',
+		emptyMessage: 'Test empty message',
+		canOnlyChangeValues: true,
+		canReset: true,
+		slugPrefix: '',
+	};
+
 	it( 'opens color selector for color palettes', () => {
-		const defaultProps = {
-			gradients: false,
-			colors: [ { color: '#ffffff', name: 'Base', slug: 'base' } ],
-			onChange: jest.fn(),
-			paletteLabel: 'Test label',
-			emptyMessage: 'Test empty message',
-			canOnlyChangeValues: true,
-			canReset: true,
-			slugPrefix: '',
-		};
 		render( <PaletteEdit { ...defaultProps } /> );
 		fireEvent.click( screen.getByLabelText( 'Color: Base' ) );
 		expect( screen.getByLabelText( 'Hex color' ) ).toBeInTheDocument();
@@ -103,13 +104,20 @@ describe( 'PaletteEdit', () => {
 		};
 		render( <PaletteEdit { ...defaultGradientProps } /> );
 
-		fireEvent.click(
-			screen.getByLabelText( 'Gradient: Vivid cyan blue to vivid purple' )
+		const paletteItem = screen.getByLabelText(
+			'Gradient: Vivid cyan blue to vivid purple'
 		);
 
-		const gradientLabel = await screen.findByLabelText(
-			'Gradient control point at position 0% with color code rgba(6,147,227,1).'
-		);
-		expect( gradientLabel ).toBeInTheDocument();
+		// eslint-disable-next-line testing-library/no-unnecessary-act
+		await act( () => {
+			fireEvent.click( paletteItem );
+			return Promise.resolve();
+		} );
+
+		expect(
+			screen.getByLabelText(
+				'Gradient control point at position 0% with color code rgba(6,147,227,1).'
+			)
+		).toBeInTheDocument();
 	} );
 } );

--- a/packages/components/src/palette-edit/test/index.js
+++ b/packages/components/src/palette-edit/test/index.js
@@ -85,7 +85,7 @@ describe( 'PaletteEdit', () => {
 		expect( screen.getByLabelText( 'Hex color' ) ).toBeInTheDocument();
 	} );
 
-	it( 'opens gradient selector for gradient palettes', () => {
+	it( 'opens gradient selector for gradient palettes', async () => {
 		const gradientProps = {
 			...defaultProps,
 			colors: undefined,
@@ -98,14 +98,17 @@ describe( 'PaletteEdit', () => {
 				},
 			],
 		};
+
 		render( <PaletteEdit { ...gradientProps } /> );
+
 		fireEvent.click(
-			screen.getByLabelText( 'Gradient: Vivid cyan blue to vivid purple' )
-		);
-		expect(
-			screen.getByLabelText(
-				'Gradient control point at position 0% with color code rgba(6,147,227,1).'
+			await screen.findByLabelText(
+				'Gradient: Vivid cyan blue to vivid purple'
 			)
-		).toBeInTheDocument();
+		);
+
+		await screen.findByLabelText(
+			'Gradient control point at position 0% with color code rgba(6,147,227,1).'
+		);
 	} );
 } );

--- a/packages/components/src/palette-edit/test/index.js
+++ b/packages/components/src/palette-edit/test/index.js
@@ -82,9 +82,7 @@ describe( 'PaletteEdit', () => {
 	it( 'opens color selector for color palettes', async () => {
 		render( <PaletteEdit { ...defaultProps } /> );
 		fireEvent.click( screen.getByLabelText( 'Color: Base' ) );
-		expect(
-			screen.getByLabelText( 'Select a new color' )
-		).toBeInTheDocument();
+		expect( screen.getByLabelText( 'Hex color' ) ).toBeInTheDocument();
 	} );
 
 	it( 'opens gradient selector for gradient palettes', () => {
@@ -105,7 +103,9 @@ describe( 'PaletteEdit', () => {
 			screen.getByLabelText( 'Gradient: Vivid cyan blue to vivid purple' )
 		);
 		expect(
-			screen.getByLabelText( 'Select a new gradient' )
+			screen.getByLabelText(
+				'Gradient control point at position 0% with color code rgba(6,147,227,1).'
+			)
 		).toBeInTheDocument();
 	} );
 } );

--- a/packages/components/src/palette-edit/test/index.js
+++ b/packages/components/src/palette-edit/test/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { render, fireEvent, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -69,30 +68,24 @@ describe( 'getNameForPosition', () => {
 } );
 
 describe( 'PaletteEdit', () => {
-	const defaultProps = {
-		gradients: false,
-		colors: [ { color: '#ffffff', name: 'Base', slug: 'base' } ],
-		onChange: jest.fn(),
-		paletteLabel: 'Test label',
-		emptyMessage: 'Test empty message',
-		canOnlyChangeValues: true,
-		canReset: true,
-		slugPrefix: '',
-	};
-
 	it( 'opens color selector for color palettes', () => {
+		const defaultProps = {
+			gradients: false,
+			colors: [ { color: '#ffffff', name: 'Base', slug: 'base' } ],
+			onChange: jest.fn(),
+			paletteLabel: 'Test label',
+			emptyMessage: 'Test empty message',
+			canOnlyChangeValues: true,
+			canReset: true,
+			slugPrefix: '',
+		};
 		render( <PaletteEdit { ...defaultProps } /> );
 		fireEvent.click( screen.getByLabelText( 'Color: Base' ) );
 		expect( screen.getByLabelText( 'Hex color' ) ).toBeInTheDocument();
 	} );
 
 	it( 'opens gradient selector for gradient palettes', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
-		const gradientProps = {
-			...defaultProps,
-			colors: undefined,
+		const defaultGradientProps = {
 			gradients: [
 				{
 					gradient:
@@ -101,16 +94,22 @@ describe( 'PaletteEdit', () => {
 					slug: 'vivid-cyan-blue-to-vivid-purple',
 				},
 			],
+			onChange: jest.fn(),
+			paletteLabel: 'Test label',
+			emptyMessage: 'Test empty message',
+			canOnlyChangeValues: true,
+			canReset: true,
+			slugPrefix: '',
 		};
-		render( <PaletteEdit { ...gradientProps } /> );
-		await user.click(
+		render( <PaletteEdit { ...defaultGradientProps } /> );
+
+		fireEvent.click(
 			screen.getByLabelText( 'Gradient: Vivid cyan blue to vivid purple' )
 		);
 
-		expect(
-			screen.getByLabelText(
-				'Gradient control point at position 0% with color code rgba(6,147,227,1).'
-			)
-		).toBeInTheDocument();
+		const gradientLabel = await screen.findByLabelText(
+			'Gradient control point at position 0% with color code rgba(6,147,227,1).'
+		);
+		expect( gradientLabel ).toBeInTheDocument();
 	} );
 } );

--- a/packages/components/src/palette-edit/test/index.js
+++ b/packages/components/src/palette-edit/test/index.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { act, render, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -86,6 +87,9 @@ describe( 'PaletteEdit', () => {
 	} );
 
 	it( 'opens gradient selector for gradient palettes', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
 		const gradientProps = {
 			...defaultProps,
 			colors: undefined,
@@ -99,11 +103,9 @@ describe( 'PaletteEdit', () => {
 			],
 		};
 		render( <PaletteEdit { ...gradientProps } /> );
-		fireEvent.click(
+		await user.click(
 			screen.getByLabelText( 'Gradient: Vivid cyan blue to vivid purple' )
 		);
-
-		await act( () => Promise.resolve() );
 
 		expect(
 			screen.getByLabelText(

--- a/packages/components/src/palette-edit/test/index.js
+++ b/packages/components/src/palette-edit/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { act, render, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -104,18 +104,12 @@ describe( 'PaletteEdit', () => {
 		};
 		render( <PaletteEdit { ...defaultGradientProps } /> );
 
-		const paletteItem = screen.getByLabelText(
-			'Gradient: Vivid cyan blue to vivid purple'
+		fireEvent.click(
+			screen.getByLabelText( 'Gradient: Vivid cyan blue to vivid purple' )
 		);
 
-		// eslint-disable-next-line testing-library/no-unnecessary-act
-		await act( () => {
-			fireEvent.click( paletteItem );
-			return Promise.resolve();
-		} );
-
 		expect(
-			screen.getByLabelText(
+			await screen.findByLabelText(
 				'Gradient control point at position 0% with color code rgba(6,147,227,1).'
 			)
 		).toBeInTheDocument();

--- a/packages/components/src/palette-edit/test/index.js
+++ b/packages/components/src/palette-edit/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, fireEvent, screen } from '@testing-library/react';
+import { act, render, fireEvent, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -98,17 +98,17 @@ describe( 'PaletteEdit', () => {
 				},
 			],
 		};
-
 		render( <PaletteEdit { ...gradientProps } /> );
-
 		fireEvent.click(
-			await screen.findByLabelText(
-				'Gradient: Vivid cyan blue to vivid purple'
-			)
+			screen.getByLabelText( 'Gradient: Vivid cyan blue to vivid purple' )
 		);
 
-		await screen.findByLabelText(
-			'Gradient control point at position 0% with color code rgba(6,147,227,1).'
-		);
+		await act( () => Promise.resolve() );
+
+		expect(
+			screen.getByLabelText(
+				'Gradient control point at position 0% with color code rgba(6,147,227,1).'
+			)
+		).toBeInTheDocument();
 	} );
 } );

--- a/packages/components/src/palette-edit/test/index.js
+++ b/packages/components/src/palette-edit/test/index.js
@@ -1,7 +1,12 @@
 /**
+ * External dependencies
+ */
+import { render, fireEvent, screen } from '@testing-library/react';
+
+/**
  * Internal dependencies
  */
-import { getNameForPosition } from '../';
+import PaletteEdit, { getNameForPosition } from '../';
 
 describe( 'getNameForPosition', () => {
 	test( 'should return 1 by default', () => {
@@ -59,5 +64,48 @@ describe( 'getNameForPosition', () => {
 		expect( getNameForPosition( elements, slugPrefix ) ).toEqual(
 			'Color 151'
 		);
+	} );
+} );
+
+describe( 'PaletteEdit', () => {
+	const defaultProps = {
+		gradients: false,
+		colors: [ { color: '#ffffff', name: 'Base', slug: 'base' } ],
+		onChange: jest.fn(),
+		paletteLabel: 'Test label',
+		emptyMessage: 'Test empty message',
+		canOnlyChangeValues: true,
+		canReset: true,
+		slugPrefix: '',
+	};
+
+	it( 'opens color selector for color palettes', async () => {
+		render( <PaletteEdit { ...defaultProps } /> );
+		fireEvent.click( screen.getByLabelText( 'Color: Base' ) );
+		expect(
+			screen.getByLabelText( 'Select a new color' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'opens gradient selector for gradient palettes', () => {
+		const gradientProps = {
+			...defaultProps,
+			colors: undefined,
+			gradients: [
+				{
+					gradient:
+						'linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)',
+					name: 'Vivid cyan blue to vivid purple',
+					slug: 'vivid-cyan-blue-to-vivid-purple',
+				},
+			],
+		};
+		render( <PaletteEdit { ...gradientProps } /> );
+		fireEvent.click(
+			screen.getByLabelText( 'Gradient: Vivid cyan blue to vivid purple' )
+		);
+		expect(
+			screen.getByLabelText( 'Select a new gradient' )
+		).toBeInTheDocument();
 	} );
 } );

--- a/packages/components/src/palette-edit/test/index.js
+++ b/packages/components/src/palette-edit/test/index.js
@@ -79,7 +79,7 @@ describe( 'PaletteEdit', () => {
 		slugPrefix: '',
 	};
 
-	it( 'opens color selector for color palettes', async () => {
+	it( 'opens color selector for color palettes', () => {
 		render( <PaletteEdit { ...defaultProps } /> );
 		fireEvent.click( screen.getByLabelText( 'Color: Base' ) );
 		expect( screen.getByLabelText( 'Hex color' ) ).toBeInTheDocument();


### PR DESCRIPTION
## What?

This PR  adds a changelog for alterations merged in #45681

It also add a test case for PaletteEdit to ensure that the correct colorpicker is displayed. Picker functionality is covered in existing tests, e.g., packages/components/src/color-palette/test/index.tsx

Update: moving JS unit tests for gradient to a follow up since there is a `"not wrapped in act(...)" warning` that results in a fail. Probably related to the Popover. Tried many available async approaches. Maybe rejigging the component, mocking Popover might work.



