### PR TITLE
Removed: Remove small APIs marked to be removed in WP 6.2

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -98,7 +98,6 @@ function RichTextWrapper(
 		onReplace,
 		placeholder,
 		allowedFormats,
-		formattingControls,
 		withoutInteractiveFormatting,
 		onRemove,
 		onMerge,
@@ -166,7 +165,6 @@ function RichTextWrapper(
 	const multilineTag = getMultilineTag( multiline );
 	const adjustedAllowedFormats = getAllowedFormats( {
 		allowedFormats,
-		formattingControls,
 		disableFormats,
 	} );
 	const hasFormats =

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -75,7 +75,6 @@ function RichTextWrapper(
 		onReplace,
 		placeholder,
 		allowedFormats,
-		formattingControls,
 		withoutInteractiveFormatting,
 		onRemove,
 		onMerge,
@@ -194,7 +193,6 @@ function RichTextWrapper(
 	const multilineTag = getMultilineTag( multiline );
 	const adjustedAllowedFormats = getAllowedFormats( {
 		allowedFormats,
-		formattingControls,
 		disableFormats,
 	} );
 	const hasFormats =

--- a/packages/block-editor/src/components/rich-text/utils.js
+++ b/packages/block-editor/src/components/rich-text/utils.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { regexp } from '@wordpress/shortcode';
-import deprecated from '@wordpress/deprecated';
 import { renderToString } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
 
@@ -34,30 +33,16 @@ export function getMultilineTag( multiline ) {
 	return multiline === true ? 'p' : multiline;
 }
 
-export function getAllowedFormats( {
-	allowedFormats,
-	formattingControls,
-	disableFormats,
-} ) {
+export function getAllowedFormats( { allowedFormats, disableFormats } ) {
 	if ( disableFormats ) {
 		return getAllowedFormats.EMPTY_ARRAY;
 	}
 
-	if ( ! allowedFormats && ! formattingControls ) {
+	if ( ! allowedFormats ) {
 		return;
 	}
 
-	if ( allowedFormats ) {
-		return allowedFormats;
-	}
-
-	deprecated( 'wp.blockEditor.RichText formattingControls prop', {
-		since: '5.4',
-		alternative: 'allowedFormats',
-		version: '6.2',
-	} );
-
-	return formattingControls.map( ( name ) => `core/${ name }` );
+	return allowedFormats;
 }
 
 getAllowedFormats.EMPTY_ARRAY = [];

--- a/packages/block-editor/src/components/rich-text/utils.js
+++ b/packages/block-editor/src/components/rich-text/utils.js
@@ -38,10 +38,6 @@ export function getAllowedFormats( { allowedFormats, disableFormats } ) {
 		return getAllowedFormats.EMPTY_ARRAY;
 	}
 
-	if ( ! allowedFormats ) {
-		return;
-	}
-
 	return allowedFormats;
 }
 

--- a/packages/server-side-render/src/index.js
+++ b/packages/server-side-render/src/index.js
@@ -1,9 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { useMemo, forwardRef } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
-import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -46,16 +45,5 @@ const ExportedServerSideRender = withSelect( ( select ) => {
 
 	return <ServerSideRender urlQueryArgs={ newUrlQueryArgs } { ...props } />;
 } );
-
-if ( window && window.wp && window.wp.components ) {
-	window.wp.components.ServerSideRender = forwardRef( ( props, ref ) => {
-		deprecated( 'wp.components.ServerSideRender', {
-			version: '6.2',
-			since: '5.3',
-			alternative: 'wp.serverSideRender',
-		} );
-		return <ExportedServerSideRender { ...props } ref={ ref } />;
-	} );
-}
 
 export default ExportedServerSideRender;


### PR DESCRIPTION
Some APIs from different packages are marked for removal for the WP 6.2 version. This PR removes them:

 - formattingControls prop of the RichText component.
 - wp.components.ServerSideRender component.

These are relatively non impactful.