### PR TITLE
Fix broken Link Control hook

### DIFF
--- a/packages/block-editor/src/components/link-control/use-internal-input-value.js
+++ b/packages/block-editor/src/components/link-control/use-internal-input-value.js
@@ -13,8 +13,8 @@ export default function useInternalInputValue( value ) {
 		 * If the value's `text` property changes then sync this
 		 * back up with state.
 		 */
-		if ( value?.title && value.title !== internalInputValue ) {
-			setInternalInputValue( value.title );
+		if ( value && value !== internalInputValue ) {
+			setInternalInputValue( value );
 		}
 	}, [ value ] );
 

--- a/packages/block-editor/src/components/link-control/use-internal-input-value.js
+++ b/packages/block-editor/src/components/link-control/use-internal-input-value.js
@@ -10,7 +10,7 @@ export default function useInternalInputValue( value ) {
 
 	useEffect( () => {
 		/**
-		 * If the value's `text` property changes then sync this
+		 * If the value changes then sync this
 		 * back up with state.
 		 */
 		if ( value && value !== internalInputValue ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes the `useInternalInputValue` hook to be agnostic of the property it is managing.

This was a bug that was accidentally introduced in https://github.com/WordPress/gutenberg/pull/37833

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The hook is designed to manage a given value and keep internal state in sync. It was accidentally only managing the `title` property of the link `value` object.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Make the hook able to manage any property provided rather than just `title`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Check Link Control behaves in RichText
- Try adding links
- Modify the text of the link from the control
- Check everything updates

## Screenshots or screencast <!-- if applicable -->
