### PR TITLE
[Mobile] List/quote: Unwrap inner block when pressing Backspace at start

### DIFF
--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -20,6 +20,8 @@ import {
 	getBlockType,
 	__experimentalGetAccessibleBlockLabel as getAccessibleBlockLabel,
 	switchToBlockType,
+	getDefaultBlockName,
+	isUnmodifiedBlock,
 } from '@wordpress/blocks';
 import { useSetting } from '@wordpress/block-editor';
 
@@ -436,7 +438,71 @@ export default compose( [
 					getBlockAttributes,
 					getBlockName,
 					getBlockOrder,
+					getBlockIndex,
+					getBlockRootClientId,
+					canInsertBlockType,
 				} = registry.select( blockEditorStore );
+
+				/**
+				 * Moves the block with clientId up one level. If the block type
+				 * cannot be inserted at the new location, it will be attempted to
+				 * convert to the default block type.
+				 *
+				 * @param {string}  _clientId       The block to move.
+				 * @param {boolean} changeSelection Whether to change the selection
+				 *                                  to the moved block.
+				 */
+				function moveFirstItemUp( _clientId, changeSelection = true ) {
+					const targetRootClientId =
+						getBlockRootClientId( _clientId );
+					const blockOrder = getBlockOrder( _clientId );
+					const [ firstClientId ] = blockOrder;
+
+					if (
+						blockOrder.length === 1 &&
+						isUnmodifiedBlock( getBlock( firstClientId ) )
+					) {
+						removeBlock( _clientId );
+					} else {
+						if (
+							canInsertBlockType(
+								getBlockName( firstClientId ),
+								targetRootClientId
+							)
+						) {
+							moveBlocksToPosition(
+								[ firstClientId ],
+								_clientId,
+								targetRootClientId,
+								getBlockIndex( _clientId )
+							);
+						} else {
+							const replacement = switchToBlockType(
+								getBlock( firstClientId ),
+								getDefaultBlockName()
+							);
+
+							if ( replacement && replacement.length ) {
+								registry.batch( () => {
+									insertBlocks(
+										replacement,
+										getBlockIndex( _clientId ),
+										targetRootClientId,
+										changeSelection
+									);
+									removeBlock( firstClientId, false );
+								} );
+							}
+						}
+
+						if (
+							! getBlockOrder( _clientId ).length &&
+							isUnmodifiedBlock( getBlock( _clientId ) )
+						) {
+							removeBlock( _clientId, false );
+						}
+					}
+				}
 
 				// For `Delete` or forward merge, we should do the exact same thing
 				// as `Backspace`, but from the other block.
@@ -488,15 +554,8 @@ export default compose( [
 						return;
 					}
 
-					// Check if it's possibile to "unwrap" the following block
-					// before trying to merge.
-					const replacement = switchToBlockType(
-						getBlock( nextBlockClientId ),
-						'*'
-					);
-
-					if ( replacement && replacement.length ) {
-						replaceBlocks( nextBlockClientId, replacement );
+					if ( getBlockOrder( nextBlockClientId ).length ) {
+						moveFirstItemUp( nextBlockClientId, false );
 					} else {
 						mergeBlocks( clientId, nextBlockClientId );
 					}
@@ -541,18 +600,7 @@ export default compose( [
 							}
 						}
 
-						// Attempt to "unwrap" the block contents when there's no
-						// preceding block to merge with.
-						const replacement = switchToBlockType(
-							getBlock( rootClientId ),
-							'*'
-						);
-						if ( replacement && replacement.length ) {
-							registry.batch( () => {
-								replaceBlocks( rootClientId, replacement );
-								selectBlock( replacement[ 0 ].clientId, 0 );
-							} );
-						}
+						moveFirstItemUp( rootClientId );
 					}
 				}
 			},

--- a/packages/block-library/src/list/test/edit.native.js
+++ b/packages/block-library/src/list/test/edit.native.js
@@ -361,7 +361,7 @@ describe( 'List block', () => {
 		` );
 	} );
 
-	it( 'unwraps list items when attempting to merge with non-list block', async () => {
+	it( 'unwraps first item when attempting to merge with non-list block', async () => {
 		const initialHtml = `<!-- wp:paragraph -->
 		<p>A quick brown fox.</p>
 		<!-- /wp:paragraph -->
@@ -400,14 +400,16 @@ describe( 'List block', () => {
 		"<!-- wp:paragraph -->
 		<p>A quick brown fox.</p>
 		<!-- /wp:paragraph -->
-
+		
 		<!-- wp:paragraph -->
 		<p>One</p>
 		<!-- /wp:paragraph -->
-
-		<!-- wp:paragraph -->
-		<p>Two</p>
-		<!-- /wp:paragraph -->"
+		
+		<!-- wp:list -->
+		<ul><!-- wp:list-item -->
+		<li>Two</li>
+		<!-- /wp:list-item --></ul>
+		<!-- /wp:list -->"
 	` );
 	} );
 } );

--- a/packages/block-library/src/utils/transformation-categories.native.js
+++ b/packages/block-library/src/utils/transformation-categories.native.js
@@ -3,6 +3,7 @@ const transformationCategories = {
 		'core/paragraph',
 		'core/heading',
 		'core/list',
+		'core/list-item',
 		'core/quote',
 		'core/pullquote',
 		'core/preformatted',


### PR DESCRIPTION
## What?
This PR is a follow-up of https://github.com/WordPress/gutenberg/pull/45075 to make these changes work on mobile.

## Why?
To have the same behavior in both web and mobile when unwrapping inner blocks when pressing `Backspace` at the start of the block.

## How?
By bringing the code changes to the `onMerge` functionality in the Block list. It also adds the `List Item` block in the mobile `transformationCategories`.

It also updates a test that has an outdated functionality with the current one.

## Testing Instructions

- Open the app
- Add a list block
- Add two items
- Select the first item and move the cursor to the start
- Press the `Backspace` key
- **Expect** the List item to be a Paragraph block outside of the List block

Repeat the same with the `Quote` block.

## Screenshots or screencast <!-- if applicable -->

List block | Quote block
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/204273354-4c3ab2e1-cfb0-45ae-96ba-9f3b64c5a71d.gif" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/204273370-3cd15660-5ff8-4c4a-9861-776ead03e892.gif" width="200" /></kbd>