### PR TITLE
useBlockEditorSettings: return const empty array to avoid rerenders

### DIFF
--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -17,6 +17,8 @@ import { __ } from '@wordpress/i18n';
 import { mediaUpload } from '../../utils';
 import { store as editorStore } from '../../store';
 
+const EMPTY_BLOCKS_LIST = [];
+
 /**
  * React hook used to compute the block editor settings to use for the post editor.
  *
@@ -51,7 +53,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 						'wp_block',
 						{ per_page: -1 }
 				  )
-				: [], // Reusable blocks are fetched in the native version of this hook.
+				: EMPTY_BLOCKS_LIST, // Reusable blocks are fetched in the native version of this hook.
 			hasUploadPermissions: canUser( 'create', 'media' ) ?? true,
 			userCanCreatePages: canUser( 'create', 'pages' ),
 			pageOnFront: siteSettings?.page_on_front,

--- a/packages/editor/src/components/provider/use-block-editor-settings.native.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.native.js
@@ -11,6 +11,8 @@ import { store as coreStore } from '@wordpress/core-data';
 import useBlockEditorSettings from './use-block-editor-settings.js';
 import { store as editorStore } from '../../store';
 
+const EMPTY_BLOCKS_LIST = [];
+
 function useNativeBlockEditorSettings( settings, hasTemplate ) {
 	const capabilities = settings.capabilities ?? {};
 	const editorSettings = useBlockEditorSettings( settings, hasTemplate );
@@ -27,7 +29,7 @@ function useNativeBlockEditorSettings( settings, hasTemplate ) {
 							// Related issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2661
 							{ per_page: 100 }
 					  )
-					: [],
+					: EMPTY_BLOCKS_LIST,
 				isTitleSelected: select( editorStore ).isPostTitleSelected(),
 			};
 		},


### PR DESCRIPTION
Fixes a performance bug that I found when debugging the React 18 migration in #45235. The `useBlockEditorSettings` hook selects a `reusableBlocks` array by querying posts with the `wp_block` post type. When the selector returns `null`, it defaults to an empty array. But that empty array is a new object on every call, leading to `useSelect` always returning a different result, triggering a component rerender on each action dispatch.

This PR fixes that by extracing a constant empty array. That should avoid a lot of editor rerenders.