### PR TITLE
Fix the navigate regions focus style on Safari

### DIFF
--- a/packages/components/src/higher-order/navigate-regions/style.scss
+++ b/packages/components/src/higher-order/navigate-regions/style.scss
@@ -75,6 +75,11 @@
 			z-index: -1;
 		}
 	}
+
+	// Fix for Safari bug where the focus style is not visible on the content area.
+	.interface-interface-skeleton__content:focus {
+		z-index: initial;
+	}
 }
 
 // Fixes for edge cases.

--- a/packages/components/src/higher-order/navigate-regions/style.scss
+++ b/packages/components/src/higher-order/navigate-regions/style.scss
@@ -11,11 +11,12 @@
 		.interface-navigable-region__stacker {
 			position: relative;
 			z-index: z-index(".is-focusing-regions [role='region']:focus .interface-navigable-region__stacker");
-			// Fix for Safari bug where the focus style is not visible on the content area.
-			// See https://github.com/WordPress/gutenberg/issues/46111
-			.interface-interface-skeleton__content & {
-				transform: translateZ(0);
-			}
+		}
+
+		// Fix for Safari bug where the focus style is not visible on the content area.
+		// See https://github.com/WordPress/gutenberg/issues/46111
+		&.interface-interface-skeleton__content .interface-navigable-region__stacker {
+			transform: translateZ(0);
 		}
 	}
 

--- a/packages/components/src/higher-order/navigate-regions/style.scss
+++ b/packages/components/src/higher-order/navigate-regions/style.scss
@@ -13,7 +13,9 @@
 			z-index: z-index(".is-focusing-regions [role='region']:focus .interface-navigable-region__stacker");
 			// Fix for Safari bug where the focus style is not visible on the content area.
 			// See https://github.com/WordPress/gutenberg/issues/46111
-			transform: translateZ(0);
+			.interface-interface-skeleton__content & {
+				transform: translateZ(0);
+			}
 		}
 	}
 

--- a/packages/components/src/higher-order/navigate-regions/style.scss
+++ b/packages/components/src/higher-order/navigate-regions/style.scss
@@ -11,6 +11,9 @@
 		.interface-navigable-region__stacker {
 			position: relative;
 			z-index: z-index(".is-focusing-regions [role='region']:focus .interface-navigable-region__stacker");
+			// Fix for Safari bug where the focus style is not visible on the content area.
+			// See https://github.com/WordPress/gutenberg/issues/46111
+			transform: translateZ(0);
 		}
 	}
 
@@ -74,11 +77,6 @@
 		.edit-site-navigation-toggle__button {
 			z-index: -1;
 		}
-	}
-
-	// Fix for Safari bug where the focus style is not visible on the content area.
-	.interface-interface-skeleton__content:focus {
-		z-index: initial;
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/46111

## What?
<!-- In a few words, what is the PR actually doing? -->
Under some conditions, Safari exhibits a bug where the Navigate regions focus style is not visible on the content area. This appears to be a browser issue, as Safari is known to have problems with z-indexes.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The Navigate regions focus style must be visible.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Uses `transform: translateZ(0);`, which is known to fix some painting issues in Safari. This new CSS rule shouldn't affect anything as it basically doesn't do anything.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Repeat the instructions from the issue https://github.com/WordPress/gutenberg/issues/46111
- Check the focus style on the content area is visible also when the post has some long content.
- Check with the editor in various states, e.g. List view, sidebar opened and closed, Distraction free mode on and off, Full screen mode on and off, etc.
- Optionally: check the navigate regions focus style also in the Site editor and Widgets editor.

## Screenshots or screencast <!-- if applicable -->
