### PR TITLE
Lodash: Refactor away from `_.filter()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -101,6 +101,7 @@ module.exports = {
 							'escapeRegExp',
 							'every',
 							'extend',
+							'filter',
 							'findIndex',
 							'findKey',
 							'findLast',

--- a/packages/edit-navigation/src/components/notices/index.js
+++ b/packages/edit-navigation/src/components/notices/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { filter } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { NoticeList, SnackbarList } from '@wordpress/components';
@@ -16,17 +11,15 @@ export default function EditNavigationNotices() {
 		( select ) => select( noticesStore ).getNotices(),
 		[]
 	);
-	const dismissibleNotices = filter( notices, {
-		isDismissible: true,
-		type: 'default',
-	} );
-	const nonDismissibleNotices = filter( notices, {
-		isDismissible: false,
-		type: 'default',
-	} );
-	const snackbarNotices = filter( notices, {
-		type: 'snackbar',
-	} );
+	const dismissibleNotices = notices.filter(
+		( { isDismissible, type } ) => isDismissible && type === 'default'
+	);
+	const nonDismissibleNotices = notices.filter(
+		( { isDismissible, type } ) => ! isDismissible && type === 'default'
+	);
+	const snackbarNotices = notices.filter(
+		( { type } ) => type === 'snackbar'
+	);
 
 	return (
 		<>

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { filter } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useEffect } from '@wordpress/element';
@@ -30,10 +25,9 @@ function useGlobalStylesRenderer() {
 		}
 
 		const currentStoreSettings = getSettings();
-		const nonGlobalStyles = filter(
-			currentStoreSettings.styles,
-			( style ) => ! style.isGlobalStyles
-		);
+		const nonGlobalStyles = Object.values(
+			currentStoreSettings.styles ?? []
+		).filter( ( style ) => ! style.isGlobalStyles );
 		updateSettings( {
 			...currentStoreSettings,
 			styles: [ ...nonGlobalStyles, ...styles ],


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.filter()` completely and deprecates the function. There are just a couple of simple usages and conversion is pretty straightforward. 

~This PR is blocked by #46114 and needs to be rebased once it lands.~

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `Array.prototype.filter()` with some additional checks where necessary. 

## Testing Instructions

* Verify notices still appear well in the navigation editor.
* Verify #39091 still works as expected (cc @Mamaduka).
* Verify all checks are still green.