### PR TITLE
Fix page list parent page setting

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -64,7 +64,7 @@ export default function PageListEdit( {
 		style: { ...context.style?.color },
 	} );
 
-	const makeBlockTemplate = ( parentId = 0 ) => {
+	const makeBlockTemplate = ( parentId = parentPageID ) => {
 		const pages = pagesByParentId.get( parentId );
 
 		if ( ! pages?.length ) {
@@ -90,7 +90,10 @@ export default function PageListEdit( {
 		}, [] );
 	};
 
-	const pagesTemplate = useMemo( makeBlockTemplate, [ pagesByParentId ] );
+	const pagesTemplate = useMemo( makeBlockTemplate, [
+		parentPageID,
+		pagesByParentId,
+	] );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: pagesTemplate,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR fixes a bug that appeared when merging #45861 and #45776 into trunk. Independently they worked but on conflict resolution some code is not ported correctly.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To fix a bug where parent page selection is not reflected in the editor, but takes effect when the page list block is rendered.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds parent page ID to be the starting point when building the block template made of page list item blocls.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

0. Make sure to have nested pages
1. Add a page list in a post
2. From the inspector set as parent page ID one of the pages that have children
3. Save, reload
4. The page list should reflect the parent and show only its children
5. From the inspector set as parent page ID one **another one** of the pages that have children
6. The page list should reflect the parent and show only the new children

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/107534/204295343-4c080bee-de3d-4bf9-aed3-96d7aaa6eb68.mp4


## To do

- [ ] Currently the page list respects the parent ID only on mount but garbles the page list when the parent is changed. The rendering is unaffected.