### PR TITLE
Navigation List view: fix incorect class

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/index.js
+++ b/packages/block-editor/src/components/off-canvas-editor/index.js
@@ -198,7 +198,7 @@ function __ExperimentalOffCanvasEditor(
 				listViewRef={ elementRef }
 				blockDropTarget={ blockDropTarget }
 			/>
-			<div className="offcanvas-editor-list-view-tree">
+			<div className="offcanvas-editor-list-view-tree-wrapper">
 				<TreeGrid
 					id={ id }
 					className="block-editor-list-view-tree"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
During the code review fixes of https://github.com/WordPress/gutenberg/pull/45966 the final class we are using is not the correct one.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The CSS is not being applied and the list view doesn't scroll

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
With the Navigation List view experiment on, test a navigation menu that has multiple sub menus and overflows horizontally. The scroll should only affect the list view, not the whole sidebar.

## Screenshots or screencast <!-- if applicable -->

![Screen Capture on 2022-11-28 at 18-51-06](https://user-images.githubusercontent.com/3593343/204346580-227688dd-6c5b-4dbe-b9a7-c4b468fef000.gif)

