### PR TITLE
Move post/page title to top toolbar

### DIFF
--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -40,6 +40,7 @@
 		"@wordpress/editor": "file:../editor",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",
+		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/interface": "file:../interface",

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -188,6 +188,7 @@ function HeaderToolbar() {
 							aria-expanded={ isOpen }
 							aria-haspopup="true"
 							onClick={ onToggle }
+							variant={ showIconLabels ? 'tertiary' : undefined }
 							label={ __( 'Edit document details' ) }
 						>
 							{ showIconLabels && __( 'Details' ) }

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -176,6 +176,7 @@ function HeaderToolbar() {
 							onChange={ ( newTitle ) =>
 								editPost( { title: newTitle } )
 							}
+							size={ title.length }
 						/>
 					</div>
 				</Tooltip>

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -14,15 +14,8 @@ import {
 	EditorHistoryUndo,
 	store as editorStore,
 } from '@wordpress/editor';
-import {
-	Button,
-	ToolbarItem,
-	Dropdown,
-	VisuallyHidden,
-	TextControl,
-	__experimentalText as Text,
-} from '@wordpress/components';
-import { chevronDown, listView, plus } from '@wordpress/icons';
+import { Button, ToolbarItem, TextControl } from '@wordpress/components';
+import { listView, plus } from '@wordpress/icons';
 import { useRef, useCallback } from '@wordpress/element';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -38,7 +31,6 @@ const preventDefault = ( event ) => {
 
 function HeaderToolbar() {
 	const inserterButton = useRef();
-	const centerToolbar = useRef();
 	const { editPost } = useDispatch( editorStore );
 	const { setIsInserterOpened, setIsListViewOpened } =
 		useDispatch( editPostStore );
@@ -165,45 +157,13 @@ function HeaderToolbar() {
 					</>
 				) }
 			</div>
-			<div
-				className="edit-post-header-toolbar__center"
-				ref={ centerToolbar }
-			>
-				<Text size="body" as="h1" limit={ 24 }>
-					<VisuallyHidden as="span">
-						{ __( 'Editing: ' ) }
-					</VisuallyHidden>
-					{ title !== ''
-						? decodeEntities( title )
-						: __( '(Untitled Document)' ) }
-				</Text>
-				<Dropdown
-					popoverProps={ {
-						anchor: centerToolbar.current,
-					} }
-					position="bottom center"
-					renderToggle={ ( { isOpen, onToggle } ) => (
-						<Button
-							icon={ chevronDown }
-							aria-expanded={ isOpen }
-							aria-haspopup="true"
-							onClick={ onToggle }
-							variant={ showIconLabels ? 'tertiary' : undefined }
-							label={ __( 'Edit document details' ) }
-						>
-							{ showIconLabels && __( 'Details' ) }
-						</Button>
-					) }
-					contentClassName="edit-post-header-toolbar__title-dropdown"
-					renderContent={ () => (
-						<TextControl
-							label={ __( 'Title' ) }
-							value={ title }
-							onChange={ ( newTitle ) =>
-								editPost( { title: newTitle } )
-							}
-						/>
-					) }
+			<div className="edit-post-header-toolbar__center">
+				<TextControl
+					value={
+						title !== '' ? decodeEntities( title ) : 'Untitled'
+					}
+					aria-label={ __( 'Edit title' ) }
+					onChange={ ( newTitle ) => editPost( { title: newTitle } ) }
 				/>
 			</div>
 		</NavigableToolbar>

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -14,7 +14,12 @@ import {
 	EditorHistoryUndo,
 	store as editorStore,
 } from '@wordpress/editor';
-import { Button, ToolbarItem, TextControl } from '@wordpress/components';
+import {
+	Button,
+	ToolbarItem,
+	TextControl,
+	Tooltip,
+} from '@wordpress/components';
 import { listView, plus } from '@wordpress/icons';
 import { useRef, useCallback } from '@wordpress/element';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
@@ -158,13 +163,22 @@ function HeaderToolbar() {
 				) }
 			</div>
 			<div className="edit-post-header-toolbar__center">
-				<TextControl
-					value={
-						title !== '' ? decodeEntities( title ) : 'Untitled'
-					}
-					aria-label={ __( 'Edit title' ) }
-					onChange={ ( newTitle ) => editPost( { title: newTitle } ) }
-				/>
+				<Tooltip position="bottom center" text={ __( 'Edit title' ) }>
+					<div className="edit-post-header__edit-title">
+						<TextControl
+							value={
+								title !== ''
+									? decodeEntities( title )
+									: 'Untitled'
+							}
+							label={ __( 'Edit title' ) }
+							hideLabelFromVision={ true }
+							onChange={ ( newTitle ) =>
+								editPost( { title: newTitle } )
+							}
+						/>
+					</div>
+				</Tooltip>
 			</div>
 		</NavigableToolbar>
 	);

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -58,6 +58,11 @@
 			display: none;
 		}
 	}
+
+	.edit-post-header-toolbar__center .components-button.has-icon::after {
+		content: none;
+	}
+
 }
 
 // Reduced UI.

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -110,3 +110,15 @@
 .show-icon-labels .edit-post-header-toolbar__left > * + * {
 	margin-left: $grid-unit-10;
 }
+
+.edit-post-header-toolbar__center {
+	flex-grow: 1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.edit-post-header-toolbar__title-dropdown > .components-popover__content {
+	min-width: 240px;
+	padding: 16px;
+}

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -118,17 +118,27 @@
 	align-items: center;
 	justify-content: center;
 
-	.components-base-control {
-		width: 50%;
+	.edit-post-header__edit-title {
+		width: 98%;
 
-		.css-10urnh1-StyledField-deprecatedMarginField {
-			margin-bottom: 0;
+		.components-base-control {
+			width: 100%;
 
-			.components-text-control__input {
-				text-align: center;
+			.css-10urnh1-StyledField-deprecatedMarginField {
+				margin-bottom: 0;
+
+				.components-text-control__input {
+					text-align: center;
+					color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
+					border: none;
+
+					&:focus {
+						background: #ececec;
+						box-shadow: none;
+						color: var(--wp--preset--color--contrast);
+					}
+				}
 			}
 		}
-
 	}
-
 }

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -119,11 +119,7 @@
 	justify-content: center;
 
 	.edit-post-header__edit-title {
-		width: 98%;
-
 		.components-base-control {
-			width: 100%;
-
 			.css-10urnh1-StyledField-deprecatedMarginField {
 				margin-bottom: 0;
 
@@ -131,11 +127,21 @@
 					text-align: center;
 					color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
 					border: none;
+					width: auto;
+					min-height: $button-size;
+					&:hover {
+						cursor: pointer;
+					}
 
 					&:focus {
-						background: #ececec;
+						background: $gray-100;
 						box-shadow: none;
 						color: var(--wp--preset--color--contrast);
+						cursor: text;
+
+						@include break-xlarge() {
+							width: 400px;
+						}
 					}
 				}
 			}

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -1,6 +1,7 @@
 .edit-post-header-toolbar {
 	display: inline-flex;
 	flex-grow: 1;
+	flex-basis: min-content;
 	align-items: center;
 	border: none;
 
@@ -8,7 +9,7 @@
 	.edit-post-header-toolbar__left > .components-button {
 		display: none;
 
-		@include break-small() {
+		@include break-medium() {
 			display: inline-flex;
 		}
 	}
@@ -127,8 +128,9 @@
 					text-align: center;
 					color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
 					border: none;
-					width: auto;
 					min-height: $button-size;
+					text-overflow: ellipsis;
+					max-width: 800px;
 					&:hover {
 						cursor: pointer;
 					}
@@ -138,10 +140,6 @@
 						box-shadow: none;
 						color: var(--wp--preset--color--contrast);
 						cursor: text;
-
-						@include break-xlarge() {
-							width: 400px;
-						}
 					}
 				}
 			}

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -59,10 +59,6 @@
 		}
 	}
 
-	.edit-post-header-toolbar__center .components-button.has-icon::after {
-		content: none;
-	}
-
 }
 
 // Reduced UI.
@@ -121,9 +117,18 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-}
 
-.edit-post-header-toolbar__title-dropdown > .components-popover__content {
-	min-width: 240px;
-	padding: 16px;
+	.components-base-control {
+		width: 50%;
+
+		.css-10urnh1-StyledField-deprecatedMarginField {
+			margin-bottom: 0;
+
+			.components-text-control__input {
+				text-align: center;
+			}
+		}
+
+	}
+
 }

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -64,6 +64,14 @@
 	@include break-small() {
 		gap: $grid-unit-10;
 	}
+
+	.interface-pinned-items .components-button {
+		display: none;
+
+		@include break-medium {
+			display: block;
+		}
+	}
 }
 
 .edit-post-header-preview__grouping-external {

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -34,6 +34,7 @@
 .edit-post-header__toolbar {
 	display: flex;
 	flex-grow: 1;
+	flex-basis: min-content;
 
 	.table-of-contents {
 		display: none;

--- a/packages/edit-post/src/components/text-editor/index.js
+++ b/packages/edit-post/src/components/text-editor/index.js
@@ -3,7 +3,6 @@
  */
 import {
 	PostTextEditor,
-	PostTitle,
 	TextEditorGlobalKeyboardShortcuts,
 	store as editorStore,
 } from '@wordpress/editor';
@@ -39,7 +38,6 @@ export default function TextEditor() {
 				</div>
 			) }
 			<div className="edit-post-text-editor__body">
-				<PostTitle />
 				<PostTextEditor />
 			</div>
 		</div>

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -8,7 +8,6 @@ import classnames from 'classnames';
  */
 import {
 	VisualEditorGlobalKeyboardShortcuts,
-	PostTitle,
 	store as editorStore,
 } from '@wordpress/editor';
 import {
@@ -376,9 +375,7 @@ export default function VisualEditor( { styles } ) {
 									}
 								) }
 								contentEditable={ false }
-							>
-								<PostTitle ref={ titleRef } />
-							</div>
+							></div>
 						) }
 						<RecursionProvider
 							blockName={ wrapperBlockName }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR addresses #27093 and moves the post/page title to the top toolbar.

## Why?
Block themes and template editing give authors freedom on how to display titles of posts and pages on the frontend, and so, the previous implementation of the title — displaying it in the canvas — was increasingly unlikely to be an accurate representation of the frontend.

## How?
It largely duplicates the implementation of the toolbar from Full Site Editing mode, placing a button and dropdown into the header of the post and page edit window.

## Testing Instructions

Default view
1. Open a Post or Page.
2. See the title in the top toolbar
3. Click the dropdown button
4. Edit the title

"Show button text labels" view
1. Open a Post or Page
2. Open Gutenberg preferences
3. Enable "Show button text labels"
5. See updated dropdown button
6. Edit the title

## Screenshots or screencast <!-- if applicable -->
<img width="1688" alt="Screen Shot 2022-11-28 at 3 12 45 PM" src="https://user-images.githubusercontent.com/5360536/204386227-c22d799d-5c06-4e13-8e61-1bbd8369f75f.png">
<img width="1689" alt="Screen Shot 2022-11-28 at 4 35 39 PM" src="https://user-images.githubusercontent.com/5360536/204386249-55267af3-9a1f-4ec3-b6ec-30350a75afb0.png">

