### PR TITLE
Heading: Add block classname deprecation

### DIFF
--- a/packages/block-library/src/heading/deprecated.js
+++ b/packages/block-library/src/heading/deprecated.js
@@ -64,6 +64,78 @@ const migrateTextAlign = ( attributes ) => {
 };
 
 const deprecated = [
+	// This deprecation covers the serialization of the `wp-block-heading` class
+	// into the block's markup after className support was enabled.
+	{
+		supports: {
+			align: [ 'wide', 'full' ],
+			anchor: true,
+			className: false,
+			color: {
+				gradients: true,
+				link: true,
+				__experimentalDefaultControls: {
+					background: true,
+					text: true,
+				},
+			},
+			spacing: {
+				margin: true,
+				padding: true,
+			},
+			typography: {
+				fontSize: true,
+				lineHeight: true,
+				__experimentalFontFamily: true,
+				__experimentalFontStyle: true,
+				__experimentalFontWeight: true,
+				__experimentalLetterSpacing: true,
+				__experimentalTextTransform: true,
+				__experimentalTextDecoration: true,
+				__experimentalDefaultControls: {
+					fontSize: true,
+					fontAppearance: true,
+					textTransform: true,
+				},
+			},
+			__experimentalSelector: 'h1,h2,h3,h4,h5,h6',
+			__unstablePasteTextInline: true,
+			__experimentalSlashInserter: true,
+		},
+		attributes: {
+			textAlign: {
+				type: 'string',
+			},
+			content: {
+				type: 'string',
+				source: 'html',
+				selector: 'h1,h2,h3,h4,h5,h6',
+				default: '',
+				__experimentalRole: 'content',
+			},
+			level: {
+				type: 'number',
+				default: 2,
+			},
+			placeholder: {
+				type: 'string',
+			},
+		},
+		save( { attributes } ) {
+			const { textAlign, content, level } = attributes;
+			const TagName = 'h' + level;
+
+			const className = classnames( {
+				[ `has-text-align-${ textAlign }` ]: textAlign,
+			} );
+
+			return (
+				<TagName { ...useBlockProps.save( { className } ) }>
+					<RichText.Content value={ content } />
+				</TagName>
+			);
+		},
+	},
 	{
 		supports: {
 			align: [ 'wide', 'full' ],

--- a/packages/block-library/src/heading/deprecated.js
+++ b/packages/block-library/src/heading/deprecated.js
@@ -63,227 +63,228 @@ const migrateTextAlign = ( attributes ) => {
 		: attributes;
 };
 
-const deprecated = [
-	// This deprecation covers the serialization of the `wp-block-heading` class
-	// into the block's markup after className support was enabled.
-	{
-		supports: {
-			align: [ 'wide', 'full' ],
-			anchor: true,
-			className: false,
-			color: {
-				gradients: true,
-				link: true,
-				__experimentalDefaultControls: {
-					background: true,
-					text: true,
-				},
-			},
-			spacing: {
-				margin: true,
-				padding: true,
-			},
-			typography: {
-				fontSize: true,
-				lineHeight: true,
-				__experimentalFontFamily: true,
-				__experimentalFontStyle: true,
-				__experimentalFontWeight: true,
-				__experimentalLetterSpacing: true,
-				__experimentalTextTransform: true,
-				__experimentalTextDecoration: true,
-				__experimentalDefaultControls: {
-					fontSize: true,
-					fontAppearance: true,
-					textTransform: true,
-				},
-			},
-			__experimentalSelector: 'h1,h2,h3,h4,h5,h6',
-			__unstablePasteTextInline: true,
-			__experimentalSlashInserter: true,
+const v1 = {
+	supports: blockSupports,
+	attributes: {
+		...blockAttributes,
+		customTextColor: {
+			type: 'string',
 		},
-		attributes: {
-			textAlign: {
-				type: 'string',
-			},
-			content: {
-				type: 'string',
-				source: 'html',
-				selector: 'h1,h2,h3,h4,h5,h6',
-				default: '',
-				__experimentalRole: 'content',
-			},
-			level: {
-				type: 'number',
-				default: 2,
-			},
-			placeholder: {
-				type: 'string',
-			},
-		},
-		save( { attributes } ) {
-			const { textAlign, content, level } = attributes;
-			const TagName = 'h' + level;
-
-			const className = classnames( {
-				[ `has-text-align-${ textAlign }` ]: textAlign,
-			} );
-
-			return (
-				<TagName { ...useBlockProps.save( { className } ) }>
-					<RichText.Content value={ content } />
-				</TagName>
-			);
+		textColor: {
+			type: 'string',
 		},
 	},
-	{
-		supports: {
-			align: [ 'wide', 'full' ],
-			anchor: true,
-			className: false,
-			color: { link: true },
+	migrate: ( attributes ) =>
+		migrateCustomColors( migrateTextAlign( attributes ) ),
+	save( { attributes } ) {
+		const { align, level, content, textColor, customTextColor } =
+			attributes;
+		const tagName = 'h' + level;
+
+		const textClass = getColorClassName( 'color', textColor );
+
+		const className = classnames( {
+			[ textClass ]: textClass,
+		} );
+
+		return (
+			<RichText.Content
+				className={ className ? className : undefined }
+				tagName={ tagName }
+				style={ {
+					textAlign: align,
+					color: textClass ? undefined : customTextColor,
+				} }
+				value={ content }
+			/>
+		);
+	},
+};
+const v2 = {
+	attributes: {
+		...blockAttributes,
+		customTextColor: {
+			type: 'string',
+		},
+		textColor: {
+			type: 'string',
+		},
+	},
+	migrate: ( attributes ) =>
+		migrateCustomColors( migrateTextAlign( attributes ) ),
+	save( { attributes } ) {
+		const { align, content, customTextColor, level, textColor } =
+			attributes;
+		const tagName = 'h' + level;
+
+		const textClass = getColorClassName( 'color', textColor );
+
+		const className = classnames( {
+			[ textClass ]: textClass,
+			[ `has-text-align-${ align }` ]: align,
+		} );
+
+		return (
+			<RichText.Content
+				className={ className ? className : undefined }
+				tagName={ tagName }
+				style={ {
+					color: textClass ? undefined : customTextColor,
+				} }
+				value={ content }
+			/>
+		);
+	},
+	supports: blockSupports,
+};
+const v3 = {
+	supports: blockSupports,
+	attributes: {
+		...blockAttributes,
+		customTextColor: {
+			type: 'string',
+		},
+		textColor: {
+			type: 'string',
+		},
+	},
+	migrate: ( attributes ) =>
+		migrateCustomColors( migrateTextAlign( attributes ) ),
+	save( { attributes } ) {
+		const { align, content, customTextColor, level, textColor } =
+			attributes;
+		const tagName = 'h' + level;
+
+		const textClass = getColorClassName( 'color', textColor );
+
+		const className = classnames( {
+			[ textClass ]: textClass,
+			'has-text-color': textColor || customTextColor,
+			[ `has-text-align-${ align }` ]: align,
+		} );
+
+		return (
+			<RichText.Content
+				className={ className ? className : undefined }
+				tagName={ tagName }
+				style={ {
+					color: textClass ? undefined : customTextColor,
+				} }
+				value={ content }
+			/>
+		);
+	},
+};
+const v4 = {
+	supports: {
+		align: [ 'wide', 'full' ],
+		anchor: true,
+		className: false,
+		color: { link: true },
+		fontSize: true,
+		lineHeight: true,
+		__experimentalSelector: {
+			'core/heading/h1': 'h1',
+			'core/heading/h2': 'h2',
+			'core/heading/h3': 'h3',
+			'core/heading/h4': 'h4',
+			'core/heading/h5': 'h5',
+			'core/heading/h6': 'h6',
+		},
+		__unstablePasteTextInline: true,
+	},
+	attributes: blockAttributes,
+	isEligible: ( { align } ) => TEXT_ALIGN_OPTIONS.includes( align ),
+	migrate: migrateTextAlign,
+	save( { attributes } ) {
+		const { align, content, level } = attributes;
+		const TagName = 'h' + level;
+
+		const className = classnames( {
+			[ `has-text-align-${ align }` ]: align,
+		} );
+
+		return (
+			<TagName { ...useBlockProps.save( { className } ) }>
+				<RichText.Content value={ content } />
+			</TagName>
+		);
+	},
+};
+
+// This deprecation covers the serialization of the `wp-block-heading` class
+// into the block's markup after className support was enabled.
+const v5 = {
+	supports: {
+		align: [ 'wide', 'full' ],
+		anchor: true,
+		className: false,
+		color: {
+			gradients: true,
+			link: true,
+			__experimentalDefaultControls: {
+				background: true,
+				text: true,
+			},
+		},
+		spacing: {
+			margin: true,
+			padding: true,
+		},
+		typography: {
 			fontSize: true,
 			lineHeight: true,
-			__experimentalSelector: {
-				'core/heading/h1': 'h1',
-				'core/heading/h2': 'h2',
-				'core/heading/h3': 'h3',
-				'core/heading/h4': 'h4',
-				'core/heading/h5': 'h5',
-				'core/heading/h6': 'h6',
+			__experimentalFontFamily: true,
+			__experimentalFontStyle: true,
+			__experimentalFontWeight: true,
+			__experimentalLetterSpacing: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalDefaultControls: {
+				fontSize: true,
+				fontAppearance: true,
+				textTransform: true,
 			},
-			__unstablePasteTextInline: true,
 		},
-		attributes: blockAttributes,
-		isEligible: ( { align } ) => TEXT_ALIGN_OPTIONS.includes( align ),
-		migrate: migrateTextAlign,
-		save( { attributes } ) {
-			const { align, content, level } = attributes;
-			const TagName = 'h' + level;
-
-			const className = classnames( {
-				[ `has-text-align-${ align }` ]: align,
-			} );
-
-			return (
-				<TagName { ...useBlockProps.save( { className } ) }>
-					<RichText.Content value={ content } />
-				</TagName>
-			);
+		__experimentalSelector: 'h1,h2,h3,h4,h5,h6',
+		__unstablePasteTextInline: true,
+		__experimentalSlashInserter: true,
+	},
+	attributes: {
+		textAlign: {
+			type: 'string',
+		},
+		content: {
+			type: 'string',
+			source: 'html',
+			selector: 'h1,h2,h3,h4,h5,h6',
+			default: '',
+			__experimentalRole: 'content',
+		},
+		level: {
+			type: 'number',
+			default: 2,
+		},
+		placeholder: {
+			type: 'string',
 		},
 	},
-	{
-		supports: blockSupports,
-		attributes: {
-			...blockAttributes,
-			customTextColor: {
-				type: 'string',
-			},
-			textColor: {
-				type: 'string',
-			},
-		},
-		migrate: ( attributes ) =>
-			migrateCustomColors( migrateTextAlign( attributes ) ),
-		save( { attributes } ) {
-			const { align, content, customTextColor, level, textColor } =
-				attributes;
-			const tagName = 'h' + level;
+	save( { attributes } ) {
+		const { textAlign, content, level } = attributes;
+		const TagName = 'h' + level;
 
-			const textClass = getColorClassName( 'color', textColor );
+		const className = classnames( {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} );
 
-			const className = classnames( {
-				[ textClass ]: textClass,
-				'has-text-color': textColor || customTextColor,
-				[ `has-text-align-${ align }` ]: align,
-			} );
-
-			return (
-				<RichText.Content
-					className={ className ? className : undefined }
-					tagName={ tagName }
-					style={ {
-						color: textClass ? undefined : customTextColor,
-					} }
-					value={ content }
-				/>
-			);
-		},
+		return (
+			<TagName { ...useBlockProps.save( { className } ) }>
+				<RichText.Content value={ content } />
+			</TagName>
+		);
 	},
-	{
-		attributes: {
-			...blockAttributes,
-			customTextColor: {
-				type: 'string',
-			},
-			textColor: {
-				type: 'string',
-			},
-		},
-		migrate: ( attributes ) =>
-			migrateCustomColors( migrateTextAlign( attributes ) ),
-		save( { attributes } ) {
-			const { align, content, customTextColor, level, textColor } =
-				attributes;
-			const tagName = 'h' + level;
+};
 
-			const textClass = getColorClassName( 'color', textColor );
-
-			const className = classnames( {
-				[ textClass ]: textClass,
-				[ `has-text-align-${ align }` ]: align,
-			} );
-
-			return (
-				<RichText.Content
-					className={ className ? className : undefined }
-					tagName={ tagName }
-					style={ {
-						color: textClass ? undefined : customTextColor,
-					} }
-					value={ content }
-				/>
-			);
-		},
-		supports: blockSupports,
-	},
-	{
-		supports: blockSupports,
-		attributes: {
-			...blockAttributes,
-			customTextColor: {
-				type: 'string',
-			},
-			textColor: {
-				type: 'string',
-			},
-		},
-		migrate: ( attributes ) =>
-			migrateCustomColors( migrateTextAlign( attributes ) ),
-		save( { attributes } ) {
-			const { align, level, content, textColor, customTextColor } =
-				attributes;
-			const tagName = 'h' + level;
-
-			const textClass = getColorClassName( 'color', textColor );
-
-			const className = classnames( {
-				[ textClass ]: textClass,
-			} );
-
-			return (
-				<RichText.Content
-					className={ className ? className : undefined }
-					tagName={ tagName }
-					style={ {
-						textAlign: align,
-						color: textClass ? undefined : customTextColor,
-					} }
-					value={ content }
-				/>
-			);
-		},
-	},
-];
+const deprecated = [ v5, v4, v3, v2, v1 ];
 
 export default deprecated;

--- a/test/integration/fixtures/blocks/core__heading__deprecated-5.html
+++ b/test/integration/fixtures/blocks/core__heading__deprecated-5.html
@@ -1,0 +1,3 @@
+<!-- wp:heading {"textAlign":"right","textColor":"primary"} -->
+<h2 class="has-text-align-right has-primary-color has-text-color">Text</h2>
+<!-- /wp:heading -->

--- a/test/integration/fixtures/blocks/core__heading__deprecated-5.json
+++ b/test/integration/fixtures/blocks/core__heading__deprecated-5.json
@@ -1,0 +1,13 @@
+[
+	{
+		"name": "core/heading",
+		"isValid": true,
+		"attributes": {
+			"textAlign": "right",
+			"content": "Text",
+			"level": 2,
+			"textColor": "primary"
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__heading__deprecated-5.parsed.json
+++ b/test/integration/fixtures/blocks/core__heading__deprecated-5.parsed.json
@@ -1,0 +1,14 @@
+[
+	{
+		"blockName": "core/heading",
+		"attrs": {
+			"textAlign": "right",
+			"textColor": "primary"
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<h2 class=\"has-text-align-right has-primary-color has-text-color\">Text</h2>\n",
+		"innerContent": [
+			"\n<h2 class=\"has-text-align-right has-primary-color has-text-color\">Text</h2>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__heading__deprecated-5.serialized.html
+++ b/test/integration/fixtures/blocks/core__heading__deprecated-5.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:heading {"textAlign":"right","textColor":"primary"} -->
+<h2 class="wp-block-heading has-text-align-right has-primary-color has-text-color">Text</h2>
+<!-- /wp:heading -->


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/42122

## What?

Adds missing deprecation for Heading block after adding of block classname via supports.

## Why?

Without the deprecation old heading blocks throw block validation errors.

## How?

- Add missing deprecation
- Add new fixtures for the heading block deprecation

## Testing Instructions
1. Before checking out this PR, edit a post with existing Heading blocks.
2. Note the block validation errors for the heading block both from your post content and block patterns
3. Checkout this PR, reload the editor, and note the heading blocks are successfully migrated
4. Run the fixture tests: `npm run test:unit test/integration/full-content/full-content.test.js`

Example deprecated heading content:

```html
<!-- wp:heading {"textAlign":"right","textColor":"primary"} -->
<h2 class="has-text-align-right has-primary-color has-text-color">Text</h2>
<!-- /wp:heading -->
```
**NOTE: It might be easiest to review the code changes by commit. The first commit (https://github.com/WordPress/gutenberg/pull/46138/commits/bc5fc1c7dde750885651747d149f4b867abde046) includes the new deprecation and the updated fixtures. The second commit (https://github.com/WordPress/gutenberg/pull/46138/commits/68ac06b743ee33014c929790dc350ec55de97f76) refactors the deprecations into the [currently recommended format](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-deprecation/#example).**

****