### PR TITLE
Layout child fixed size should not be fixed by default and should always have a value set

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -334,10 +334,11 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$child_layout_styles = array();
 
 		if ( 'fixed' === $block['attrs']['style']['layout']['selfStretch'] && isset( $block['attrs']['style']['layout']['flexSize'] ) ) {
+			$has_shrink            = isset( $block['attrs']['style']['layout']['breakOutOfLayout'] ) && $block['attrs']['style']['layout']['breakOutOfLayout'];
 			$child_layout_styles[] = array(
 				'selector'     => ".$container_content_class",
 				'declarations' => array(
-					'flex-shrink' => '0',
+					'flex-shrink' => $has_shrink ? '0' : '1',
 					'flex-basis'  => $block['attrs']['style']['layout']['flexSize'],
 					'box-sizing'  => 'border-box',
 				),

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -334,13 +334,11 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$child_layout_styles = array();
 
 		if ( 'fixed' === $block['attrs']['style']['layout']['selfStretch'] && isset( $block['attrs']['style']['layout']['flexSize'] ) ) {
-			$has_shrink            = isset( $block['attrs']['style']['layout']['breakOutOfLayout'] ) && $block['attrs']['style']['layout']['breakOutOfLayout'];
 			$child_layout_styles[] = array(
 				'selector'     => ".$container_content_class",
 				'declarations' => array(
-					'flex-shrink' => $has_shrink ? '0' : '1',
-					'flex-basis'  => $block['attrs']['style']['layout']['flexSize'],
-					'box-sizing'  => 'border-box',
+					'flex-basis' => $block['attrs']['style']['layout']['flexSize'],
+					'box-sizing' => 'border-box',
 				),
 			);
 		} elseif ( 'fill' === $block['attrs']['style']['layout']['selfStretch'] ) {

--- a/packages/block-editor/src/hooks/child-layout.js
+++ b/packages/block-editor/src/hooks/child-layout.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import {
-	ToggleControl,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	__experimentalUnitControl as UnitControl,
@@ -43,7 +42,7 @@ export function ChildLayoutEdit( {
 } ) {
 	const { style = {} } = attributes;
 	const { layout: childLayout = {} } = style;
-	const { selfStretch, flexSize, breakOutOfLayout = false } = childLayout;
+	const { selfStretch, flexSize } = childLayout;
 
 	useEffect( () => {
 		if ( selfStretch === 'fixed' && ! flexSize ) {
@@ -98,39 +97,22 @@ export function ChildLayoutEdit( {
 				/>
 			</ToggleGroupControl>
 			{ selfStretch === 'fixed' && (
-				<>
-					<UnitControl
-						size={ '__unstable-large' }
-						style={ { height: 'auto' } }
-						onChange={ ( value ) => {
-							setAttributes( {
-								style: {
-									...style,
-									layout: {
-										...childLayout,
-										flexSize: value,
-									},
+				<UnitControl
+					size={ '__unstable-large' }
+					style={ { height: 'auto' } }
+					onChange={ ( value ) => {
+						setAttributes( {
+							style: {
+								...style,
+								layout: {
+									...childLayout,
+									flexSize: value,
 								},
-							} );
-						} }
-						value={ flexSize }
-					/>
-					<ToggleControl
-						label={ __( 'Allow block to break out of layout' ) }
-						onChange={ ( value ) => {
-							setAttributes( {
-								style: {
-									...style,
-									layout: {
-										...childLayout,
-										breakOutOfLayout: value,
-									},
-								},
-							} );
-						} }
-						checked={ breakOutOfLayout }
-					/>
-				</>
+							},
+						} );
+					} }
+					value={ flexSize }
+				/>
 			) }
 		</>
 	);

--- a/packages/block-editor/src/hooks/child-layout.js
+++ b/packages/block-editor/src/hooks/child-layout.js
@@ -7,11 +7,11 @@ import {
 	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { __unstableUseBlockElement as useBlockElement } from '../components/block-list/use-block-props/use-block-refs';
 import useSetting from '../components/use-setting';
 
 function helpText( selfStretch ) {
@@ -29,7 +29,6 @@ function helpText( selfStretch ) {
  * Inspector controls containing the child layout related configuration.
  *
  * @param {Object} props                        Block props.
- * @param {string} props.clientId               Block client id.
  * @param {Object} props.attributes             Block attributes.
  * @param {Object} props.setAttributes          Function to set block attributes.
  * @param {Object} props.__unstableParentLayout
@@ -37,7 +36,6 @@ function helpText( selfStretch ) {
  * @return {WPElement} child layout edit element.
  */
 export function ChildLayoutEdit( {
-	clientId,
 	attributes,
 	setAttributes,
 	__unstableParentLayout: parentLayout,
@@ -46,12 +44,19 @@ export function ChildLayoutEdit( {
 	const { layout: childLayout = {} } = style;
 	const { selfStretch, flexSize } = childLayout;
 
-	const blockElement = useBlockElement( clientId );
-	const { orientation = 'horizontal' } = parentLayout;
-	const blockSize =
-		orientation === 'horizontal'
-			? `${ blockElement?.offsetWidth }px`
-			: `${ blockElement?.offsetHeight }px`;
+	useEffect( () => {
+		if ( selfStretch === 'fixed' && ! flexSize ) {
+			setAttributes( {
+				style: {
+					...style,
+					layout: {
+						...childLayout,
+						selfStretch: 'fit',
+					},
+				},
+			} );
+		}
+	}, [] );
 
 	return (
 		<>
@@ -61,9 +66,7 @@ export function ChildLayoutEdit( {
 				value={ selfStretch || 'fit' }
 				help={ helpText( selfStretch ) }
 				onChange={ ( value ) => {
-					const defaultFlexSize = flexSize || blockSize;
-					const newFlexSize =
-						value !== 'fixed' ? null : defaultFlexSize;
+					const newFlexSize = value !== 'fixed' ? null : flexSize;
 					setAttributes( {
 						style: {
 							...style,
@@ -108,7 +111,7 @@ export function ChildLayoutEdit( {
 							},
 						} );
 					} }
-					value={ flexSize || blockSize }
+					value={ flexSize }
 				/>
 			) }
 		</>

--- a/packages/block-editor/src/hooks/child-layout.js
+++ b/packages/block-editor/src/hooks/child-layout.js
@@ -7,11 +7,11 @@ import {
 	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
+import { __unstableUseBlockElement as useBlockElement } from '../components/block-list/use-block-props/use-block-refs';
 import useSetting from '../components/use-setting';
 
 function helpText( selfStretch ) {
@@ -29,6 +29,7 @@ function helpText( selfStretch ) {
  * Inspector controls containing the child layout related configuration.
  *
  * @param {Object} props                        Block props.
+ * @param {string} props.clientId               Block client id.
  * @param {Object} props.attributes             Block attributes.
  * @param {Object} props.setAttributes          Function to set block attributes.
  * @param {Object} props.__unstableParentLayout
@@ -36,6 +37,7 @@ function helpText( selfStretch ) {
  * @return {WPElement} child layout edit element.
  */
 export function ChildLayoutEdit( {
+	clientId,
 	attributes,
 	setAttributes,
 	__unstableParentLayout: parentLayout,
@@ -44,19 +46,12 @@ export function ChildLayoutEdit( {
 	const { layout: childLayout = {} } = style;
 	const { selfStretch, flexSize } = childLayout;
 
-	useEffect( () => {
-		if ( selfStretch === 'fixed' && ! flexSize ) {
-			setAttributes( {
-				style: {
-					...style,
-					layout: {
-						...childLayout,
-						selfStretch: 'fit',
-					},
-				},
-			} );
-		}
-	}, [] );
+	const blockElement = useBlockElement( clientId );
+	const { orientation = 'horizontal' } = parentLayout;
+	const blockSize =
+		orientation === 'horizontal'
+			? `${ blockElement?.offsetWidth }px`
+			: `${ blockElement?.offsetHeight }px`;
 
 	return (
 		<>
@@ -66,7 +61,9 @@ export function ChildLayoutEdit( {
 				value={ selfStretch || 'fit' }
 				help={ helpText( selfStretch ) }
 				onChange={ ( value ) => {
-					const newFlexSize = value !== 'fixed' ? null : flexSize;
+					const defaultFlexSize = flexSize || blockSize;
+					const newFlexSize =
+						value !== 'fixed' ? null : defaultFlexSize;
 					setAttributes( {
 						style: {
 							...style,
@@ -111,7 +108,7 @@ export function ChildLayoutEdit( {
 							},
 						} );
 					} }
-					value={ flexSize }
+					value={ flexSize || blockSize }
 				/>
 			) }
 		</>

--- a/packages/block-editor/src/hooks/child-layout.js
+++ b/packages/block-editor/src/hooks/child-layout.js
@@ -8,6 +8,7 @@ import {
 	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -23,14 +24,6 @@ function helpText( selfStretch ) {
 		default:
 			return __( 'Fit contents.' );
 	}
-}
-
-function checkSelfStretchForInvalidValues( selfStretch, flexSize ) {
-	if ( selfStretch === 'fixed' && ! flexSize ) {
-		// If there's no defined size we shouldn't keep the fixed setting.
-		return 'fit';
-	}
-	return selfStretch;
 }
 
 /**
@@ -52,18 +45,27 @@ export function ChildLayoutEdit( {
 	const { layout: childLayout = {} } = style;
 	const { selfStretch, flexSize, breakOutOfLayout = false } = childLayout;
 
-	const validatedSelfStretch = checkSelfStretchForInvalidValues(
-		selfStretch,
-		flexSize
-	);
+	useEffect( () => {
+		if ( selfStretch === 'fixed' && ! flexSize ) {
+			setAttributes( {
+				style: {
+					...style,
+					layout: {
+						...childLayout,
+						selfStretch: 'fit',
+					},
+				},
+			} );
+		}
+	}, [] );
 
 	return (
 		<>
 			<ToggleGroupControl
 				size={ '__unstable-large' }
 				label={ childLayoutOrientation( parentLayout ) }
-				value={ validatedSelfStretch || 'fit' }
-				help={ helpText( validatedSelfStretch ) }
+				value={ selfStretch || 'fit' }
+				help={ helpText( selfStretch ) }
 				onChange={ ( value ) => {
 					const newFlexSize = value !== 'fixed' ? null : flexSize;
 					setAttributes( {
@@ -95,7 +97,7 @@ export function ChildLayoutEdit( {
 					label={ __( 'Fixed' ) }
 				/>
 			</ToggleGroupControl>
-			{ validatedSelfStretch === 'fixed' && (
+			{ selfStretch === 'fixed' && (
 				<>
 					<UnitControl
 						size={ '__unstable-large' }

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -427,7 +427,7 @@ export const withChildLayoutStyles = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
 		const { attributes } = props;
 		const { style: { layout = {} } = {} } = attributes;
-		const { selfStretch, flexSize, breakOutOfLayout } = layout;
+		const { selfStretch, flexSize } = layout;
 		const hasChildLayout = selfStretch || flexSize;
 		const disableLayoutStyles = useSelect( ( select ) => {
 			const { getSettings } = select( blockEditorStore );
@@ -443,9 +443,7 @@ export const withChildLayoutStyles = createHigherOrderComponent(
 		let css = '';
 
 		if ( selfStretch === 'fixed' && flexSize ) {
-			const hasShrink = !! breakOutOfLayout;
 			css += `${ selector } {
-				flex-shrink: ${ hasShrink ? 0 : 1 };
 				flex-basis: ${ flexSize };
 				box-sizing: border-box;
 			}`;

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -427,7 +427,7 @@ export const withChildLayoutStyles = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
 		const { attributes } = props;
 		const { style: { layout = {} } = {} } = attributes;
-		const { selfStretch, flexSize } = layout;
+		const { selfStretch, flexSize, breakOutOfLayout } = layout;
 		const hasChildLayout = selfStretch || flexSize;
 		const disableLayoutStyles = useSelect( ( select ) => {
 			const { getSettings } = select( blockEditorStore );
@@ -443,8 +443,9 @@ export const withChildLayoutStyles = createHigherOrderComponent(
 		let css = '';
 
 		if ( selfStretch === 'fixed' && flexSize ) {
+			const hasShrink = !! breakOutOfLayout;
 			css += `${ selector } {
-				flex-shrink: 0;
+				flex-shrink: ${ hasShrink ? 0 : 1 };
 				flex-basis: ${ flexSize };
 				box-sizing: border-box;
 			}`;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #46116 and addresses [this discussion](https://github.com/WordPress/gutenberg/pull/45364#issuecomment-1327736069)

Makes fixed flex child size shrinkable by default, with optional toggle to un-shrink it. Also makes sure that a value for 'fixed' setting exists.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

`flex-shrink` should only be `0` if the block is explicitly set to unshrinkable.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a Row block to a post and add a couple of child blocks in it;
2. Select a child block and under "Dimensions" in the sidebar select "Width";
3. Set width to "fixed", add a fixed size e.g. `500px` in the input, save;
4. Verify that on a small viewport the fixed width block shrinks and doesn't overflow it.
5. Check the "Allow block to break out of layout" toggle, save;
6. Verify that now the fixed width block is always the same width independently of viewport size.
7. Remove fixed width completely from block;
8. Deselect then reselect the block;
9. Verify that width toggle has been set back to 'fit'.

## Screenshots or screencast <!-- if applicable -->
<img width="832" alt="Screenshot 2022-11-29 at 3 13 48 pm" src="https://user-images.githubusercontent.com/8096000/204437220-94d49bcd-9020-4335-853d-371e41c76b28.png">


