### PR TITLE
Gallery: Use unbound query when fetching image details

### DIFF
--- a/packages/block-library/src/gallery/use-get-media.js
+++ b/packages/block-library/src/gallery/use-get-media.js
@@ -28,7 +28,7 @@ export default function useGetMedia( innerBlockImages ) {
 			return (
 				select( coreStore ).getMediaItems( {
 					include: imageIds.join( ',' ),
-					per_page: imageIds.length,
+					per_page: -1,
 					orderby: 'include',
 				} ) ?? EMPTY_IMAGE_MEDIA
 			);


### PR DESCRIPTION
## What?
Fixes #46088.

PR restores the` getMediaItems` selector to use unbound query and avoid errors when the Gallery has more than 100 images.

## Why?
The core REST APIs have a `per_page` limit of 100. The block editor works around this limitation using `fetchAllMiddleware` to handle unbound queries. Unfortunately, this method [isn't supported on the native side](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2661), and we had to set a "hard" limit for the query. See #40947.

## How?
Now that there's a native variant of `useGetMedia` (#42178), I restored the previous query parameters in the web variant.

@geriux, @SiobhyB, it might be a good idea to leave an inline note in the native file regarding the limitation.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Gallery Block.
3. Selector or update more than 100 images.
4. Confirm that there's no 400 error in the console and that the image sizes are loaded correctly.
