### PR TITLE
Patterns: Add new pattern categories

### DIFF
--- a/lib/compat/wordpress-6.1/class-gutenberg-rest-block-patterns-controller-6-1.php
+++ b/lib/compat/wordpress-6.1/class-gutenberg-rest-block-patterns-controller-6-1.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * REST API: Gutenberg_REST_Block_Patterns_Controller class
+ * REST API: Gutenberg_REST_Block_Patterns_Controller_6_1 class
  *
  * @package    Gutenberg
  * @subpackage REST_API

--- a/lib/compat/wordpress-6.1/class-gutenberg-rest-block-patterns-controller-6-1.php
+++ b/lib/compat/wordpress-6.1/class-gutenberg-rest-block-patterns-controller-6-1.php
@@ -13,104 +13,12 @@
  *
  * @see WP_REST_Controller
  */
-class Gutenberg_REST_Block_Patterns_Controller extends WP_REST_Controller {
-
-	/**
-	 * Defines whether remote patterns should be loaded.
-	 *
-	 * @since 6.0.0
-	 * @var bool
-	 */
-	private $remote_patterns_loaded;
-
-	/**
-	 * Constructs the controller.
-	 *
-	 * @since 6.0.0
-	 */
-	public function __construct() {
-		$this->namespace = 'wp/v2';
-		$this->rest_base = 'block-patterns/patterns';
-	}
-
-	/**
-	 * Registers the routes for the objects of the controller.
-	 *
-	 * @since 6.0.0
-	 */
-	public function register_routes() {
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base,
-			array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_items' ),
-					'permission_callback' => array( $this, 'get_items_permissions_check' ),
-				),
-				'schema' => array( $this, 'get_public_item_schema' ),
-			),
-			true
-		);
-	}
-
-	/**
-	 * Checks whether a given request has permission to read block patterns.
-	 *
-	 * @since 6.0.0
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
-	 */
-	public function get_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		if ( current_user_can( 'edit_posts' ) ) {
-			return true;
-		}
-
-		foreach ( get_post_types( array( 'show_in_rest' => true ), 'objects' ) as $post_type ) {
-			if ( current_user_can( $post_type->cap->edit_posts ) ) {
-				return true;
-			}
-		}
-
-		return new WP_Error(
-			'rest_cannot_view',
-			__( 'Sorry, you are not allowed to view the registered block patterns.', 'gutenberg' ),
-			array( 'status' => rest_authorization_required_code() )
-		);
-	}
-
-	/**
-	 * Retrieves all block patterns.
-	 *
-	 * @since 6.0.0
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
-	 */
-	public function get_items( $request ) {
-		if ( ! $this->remote_patterns_loaded ) {
-			// Load block patterns from w.org.
-			_load_remote_block_patterns(); // Patterns with the `core` keyword.
-			_load_remote_featured_patterns(); // Patterns in the `featured` category.
-			_register_remote_theme_patterns(); // Patterns requested by current theme.
-
-			$this->remote_patterns_loaded = true;
-		}
-
-		$response = array();
-		$patterns = WP_Block_Patterns_Registry::get_instance()->get_all_registered();
-		foreach ( $patterns as $pattern ) {
-			$prepared_pattern = $this->prepare_item_for_response( $pattern, $request );
-			$response[]       = $this->prepare_response_for_collection( $prepared_pattern );
-		}
-		return rest_ensure_response( $response );
-	}
-
+class Gutenberg_REST_Block_Patterns_Controller_6_1 extends WP_REST_Block_Patterns_Controller {
 	/**
 	 * Prepare a raw block pattern before it gets output in a REST API response.
 	 *
 	 * @since 6.0.0
+	 * @since 6.1.0 Added `postTypes` property.
 	 *
 	 * @param array           $item    Raw pattern as registered, before any changes.
 	 * @param WP_REST_Request $request Request object.
@@ -147,6 +55,7 @@ class Gutenberg_REST_Block_Patterns_Controller extends WP_REST_Controller {
 	 * Retrieves the block pattern schema, conforming to JSON Schema.
 	 *
 	 * @since 6.0.0
+	 * @since 6.1.0 Added `post_types` property.
 	 *
 	 * @return array Item schema data.
 	 */

--- a/lib/compat/wordpress-6.1/rest-api.php
+++ b/lib/compat/wordpress-6.1/rest-api.php
@@ -36,15 +36,6 @@ function gutenberg_update_post_types_rest_response( $response, $post_type ) {
 add_filter( 'rest_prepare_post_type', 'gutenberg_update_post_types_rest_response', 10, 2 );
 
 /**
- * Registers the block patterns REST API routes.
- */
-function gutenberg_register_gutenberg_rest_block_patterns() {
-	$block_patterns = new Gutenberg_REST_Block_Patterns_Controller();
-	$block_patterns->register_routes();
-}
-add_action( 'rest_api_init', 'gutenberg_register_gutenberg_rest_block_patterns', 100 );
-
-/**
  * Exposes the site logo URL through the WordPress REST API.
  *
  * This is used for fetching this information when user has no rights

--- a/lib/compat/wordpress-6.2/block-patterns.php
+++ b/lib/compat/wordpress-6.2/block-patterns.php
@@ -30,27 +30,6 @@ function gutenberg_register_core_block_patterns_and_categories() {
 		)
 	);
 	register_block_pattern_category(
-		'footer',
-		array(
-			'label'       => _x( 'Footers', 'Block pattern category', 'gutenberg' ),
-			'description' => __( 'A variety of footer designs displaying information and site navigation.', 'gutenberg' ),
-		)
-	);
-	register_block_pattern_category(
-		'gallery',
-		array(
-			'label'       => _x( 'Gallery', 'Block pattern category', 'gutenberg' ),
-			'description' => __( 'Patterns containing mostly images or other media.', 'gutenberg' ),
-		)
-	);
-	register_block_pattern_category(
-		'header',
-		array(
-			'label'       => _x( 'Headers', 'Block pattern category', 'gutenberg' ),
-			'description' => __( 'A variety of header designs displaying your site title and navigation.', 'gutenberg' ),
-		)
-	);
-	register_block_pattern_category(
 		'text',
 		array(
 			'label'       => _x( 'Text', 'Block pattern category', 'gutenberg' ),
@@ -69,6 +48,149 @@ function gutenberg_register_core_block_patterns_and_categories() {
 		array(
 			'label'       => _x( 'Featured', 'Block pattern category', 'gutenberg' ),
 			'description' => __( 'A set of high quality curated patterns.', 'gutenberg' ),
+		)
+	);
+
+	// Register new core block pattern categories.
+	register_block_pattern_category(
+		'call-to-action',
+		array(
+			'label'       => _x( 'Call to Action', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'Sections whose purpose is to trigger a specific action.', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'team',
+		array(
+			'label'       => _x( 'Team', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'A variety of designs to display your team members.', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'testimonials',
+		array(
+			'label'       => _x( 'Testimonials', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'Share reviews and feedback about your brand/business.', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'services',
+		array(
+			'label'       => _x( 'Services', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'Briefly describe what your business does and how you can help.', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'contact',
+		array(
+			'label'       => _x( 'Contact', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'Display your contact information.', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'about',
+		array(
+			'label'       => _x( 'About', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'Introduce yourself.', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'portfolio',
+		array(
+			'label'       => _x( 'Portfolio', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'Showcase your latest work.', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'gallery',
+		array(
+			'label'       => _x( 'Gallery', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'Different layouts for displaying images.', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'media',
+		array(
+			'label'       => _x( 'Media', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'Different layouts containing video or audio.', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'posts',
+		array(
+			'label'       => _x( 'Posts', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'Display your latest posts in lists, grids or other layouts.', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'products',
+		array(
+			'label'       => _x( 'Products', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'Display your store’s products in lists, grids or other layouts.', 'gutenberg' ),
+		)
+	);
+	// Site building pattern categories.
+	register_block_pattern_category(
+		'footer',
+		array(
+			'label'       => _x( 'Footers', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'A variety of footer designs displaying information and site navigation.', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'header',
+		array(
+			'label'       => _x( 'Headers', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'A variety of header designs displaying your site title and navigation.', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'post-content',
+		array(
+			'label'       => _x( 'Post Content', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'Your post and page content.', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'comments',
+		array(
+			'label'       => _x( 'Comments', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'Different ways of displaying your post or page\'s comments.', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'pagination',
+		array(
+			'label'       => _x( 'Pagination', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'A variety of designs for navigating your posts.', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'comment-pagination',
+		array(
+			'label'       => _x( 'Comment Pagination', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'A variety of designs to browse through a big list of comments.', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'archive-headings',
+		array(
+			'label'       => _x( 'Archive Headings', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'A variety of designs for your archive heading.', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'404',
+		array(
+			'label'       => _x( '404', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'A variety of designs for when a page cannot be found.', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'search',
+		array(
+			'label'       => _x( 'Search', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'Different layouts to display search results.', 'gutenberg' ),
 		)
 	);
 }

--- a/lib/compat/wordpress-6.2/block-patterns.php
+++ b/lib/compat/wordpress-6.2/block-patterns.php
@@ -122,13 +122,6 @@ function gutenberg_register_core_block_patterns_and_categories() {
 			'description' => __( 'Display your latest posts in lists, grids or other layouts.', 'gutenberg' ),
 		)
 	);
-	register_block_pattern_category(
-		'products',
-		array(
-			'label'       => _x( 'Products', 'Block pattern category', 'gutenberg' ),
-			'description' => __( 'Display your store’s products in lists, grids or other layouts.', 'gutenberg' ),
-		)
-	);
 	// Site building pattern categories.
 	register_block_pattern_category(
 		'footer',
@@ -142,55 +135,6 @@ function gutenberg_register_core_block_patterns_and_categories() {
 		array(
 			'label'       => _x( 'Headers', 'Block pattern category', 'gutenberg' ),
 			'description' => __( 'A variety of header designs displaying your site title and navigation.', 'gutenberg' ),
-		)
-	);
-	register_block_pattern_category(
-		'post-content',
-		array(
-			'label'       => _x( 'Post Content', 'Block pattern category', 'gutenberg' ),
-			'description' => __( 'Your post and page content.', 'gutenberg' ),
-		)
-	);
-	register_block_pattern_category(
-		'comments',
-		array(
-			'label'       => _x( 'Comments', 'Block pattern category', 'gutenberg' ),
-			'description' => __( 'Different ways of displaying your post or page\'s comments.', 'gutenberg' ),
-		)
-	);
-	register_block_pattern_category(
-		'pagination',
-		array(
-			'label'       => _x( 'Pagination', 'Block pattern category', 'gutenberg' ),
-			'description' => __( 'A variety of designs for navigating your posts.', 'gutenberg' ),
-		)
-	);
-	register_block_pattern_category(
-		'comment-pagination',
-		array(
-			'label'       => _x( 'Comment Pagination', 'Block pattern category', 'gutenberg' ),
-			'description' => __( 'A variety of designs to browse through a big list of comments.', 'gutenberg' ),
-		)
-	);
-	register_block_pattern_category(
-		'archive-headings',
-		array(
-			'label'       => _x( 'Archive Headings', 'Block pattern category', 'gutenberg' ),
-			'description' => __( 'A variety of designs for your archive heading.', 'gutenberg' ),
-		)
-	);
-	register_block_pattern_category(
-		'404',
-		array(
-			'label'       => _x( '404', 'Block pattern category', 'gutenberg' ),
-			'description' => __( 'A variety of designs for when a page cannot be found.', 'gutenberg' ),
-		)
-	);
-	register_block_pattern_category(
-		'search',
-		array(
-			'label'       => _x( 'Search', 'Block pattern category', 'gutenberg' ),
-			'description' => __( 'Different layouts to display search results.', 'gutenberg' ),
 		)
 	);
 }

--- a/lib/compat/wordpress-6.2/block-patterns.php
+++ b/lib/compat/wordpress-6.2/block-patterns.php
@@ -8,7 +8,7 @@
 /**
  * Registers the block pattern categories.
  */
-function gutenberg_register_core_block_patterns_and_categories() {
+function gutenberg_register_core_block_patterns_categories() {
 	register_block_pattern_category(
 		'banner',
 		array(
@@ -138,7 +138,7 @@ function gutenberg_register_core_block_patterns_and_categories() {
 		)
 	);
 }
-add_action( 'init', 'gutenberg_register_core_block_patterns_and_categories' );
+add_action( 'init', 'gutenberg_register_core_block_patterns_categories' );
 
 /**
  * Registers Gutenberg-bundled patterns, with a focus on headers and footers

--- a/lib/compat/wordpress-6.2/class-gutenberg-rest-block-patterns-controller-6-2.php
+++ b/lib/compat/wordpress-6.2/class-gutenberg-rest-block-patterns-controller-6-2.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Block_Patterns_Controller_6_2 class
+ *
+ * @package    Gutenberg
+ * @subpackage REST_API
+ */
+
+/**
+ * Core class used to access block patterns via the REST API.
+ *
+ * @since 6.0.0
+ *
+ * @see WP_REST_Controller
+ */
+class Gutenberg_REST_Block_Patterns_Controller_6_2 extends Gutenberg_REST_Block_Patterns_Controller_6_1 {
+	/**
+	 * Defines whether remote patterns should be loaded.
+	 *
+	 * @since 6.0.0
+	 * @var bool
+	 */
+	private $remote_patterns_loaded;
+
+	/**
+	 * An array that maps old categories names to new ones.
+	 *
+	 * @since 6.2.0
+	 * @var array
+	 */
+	protected static $categories_migration = array(
+		'buttons' => 'call-to-action',
+		'query'   => 'posts',
+	);
+
+	/**
+	 * Registers the routes for the objects of the controller.
+	 *
+	 * @since 6.0.0
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			),
+			true
+		);
+	}
+	/**
+	 * Retrieves all block patterns.
+	 *
+	 * @since 6.0.0
+	 * @since 6.2.0 Added migration for old pattern categories.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_items( $request ) {
+		if ( ! $this->remote_patterns_loaded ) {
+			// Load block patterns from w.org.
+			_load_remote_block_patterns(); // Patterns with the `core` keyword.
+			_load_remote_featured_patterns(); // Patterns in the `featured` category.
+			_register_remote_theme_patterns(); // Patterns requested by current theme.
+
+			$this->remote_patterns_loaded = true;
+		}
+
+		$response = array();
+		$patterns = WP_Block_Patterns_Registry::get_instance()->get_all_registered();
+		foreach ( $patterns as $pattern ) {
+			$migrated_pattern = $this->migrate_pattern_categories( $pattern );
+			$prepared_pattern = $this->prepare_item_for_response( $migrated_pattern, $request );
+			$response[]       = $this->prepare_response_for_collection( $prepared_pattern );
+		}
+		return rest_ensure_response( $response );
+	}
+
+	protected static function migrate_pattern_categories( $pattern ) {
+		if ( isset( $pattern['categories'] ) && is_array( $pattern['categories'] ) ) {
+			$new_categories = array();
+			foreach ( $pattern['categories'] as $category ) {
+				if ( isset( static::$categories_migration[ $category ] ) ) {
+					$new_categories[] = static::$categories_migration[ $category ];
+				} else {
+					$new_categories[] = $category;
+				}
+			}
+			$pattern['categories'] = $new_categories;
+		}
+		return $pattern;
+	}
+}

--- a/lib/compat/wordpress-6.2/class-gutenberg-rest-block-patterns-controller-6-2.php
+++ b/lib/compat/wordpress-6.2/class-gutenberg-rest-block-patterns-controller-6-2.php
@@ -84,17 +84,10 @@ class Gutenberg_REST_Block_Patterns_Controller_6_2 extends Gutenberg_REST_Block_
 	 */
 	protected function migrate_pattern_categories( $pattern ) {
 		if ( isset( $pattern['categories'] ) && is_array( $pattern['categories'] ) ) {
-			$old_categories = array_intersect( $pattern['categories'], array_keys( static::$categories_migration ) );
-			if ( ! empty( $old_categories ) ) {
-				$pattern['categories'] = array_merge(
-					array_diff( $pattern['categories'], $old_categories ),
-					array_map(
-						function( $category ) {
-							return static::$categories_migration[ $category ];
-						},
-						$old_categories
-					)
-				);
+			foreach ( $pattern['categories'] as $i => $category ) {
+				if ( array_key_exists( $category, static::$categories_migration ) ) {
+					$pattern['categories'][ $i ] = static::$categories_migration[ $category ];
+				}
 			}
 		}
 		return $pattern;

--- a/lib/compat/wordpress-6.2/class-gutenberg-rest-block-patterns-controller-6-2.php
+++ b/lib/compat/wordpress-6.2/class-gutenberg-rest-block-patterns-controller-6-2.php
@@ -30,8 +30,7 @@ class Gutenberg_REST_Block_Patterns_Controller_6_2 extends Gutenberg_REST_Block_
 	 */
 	protected static $categories_migration = array(
 		'buttons' => 'call-to-action',
-		'columns' => 'media',
-		'text'    => 'media',
+		'columns' => 'text',
 		'query'   => 'posts',
 	);
 

--- a/lib/compat/wordpress-6.2/class-gutenberg-rest-block-patterns-controller-6-2.php
+++ b/lib/compat/wordpress-6.2/class-gutenberg-rest-block-patterns-controller-6-2.php
@@ -15,6 +15,14 @@
  */
 class Gutenberg_REST_Block_Patterns_Controller_6_2 extends Gutenberg_REST_Block_Patterns_Controller_6_1 {
 	/**
+	 * Defines whether remote patterns should be loaded.
+	 *
+	 * @since 6.0.0
+	 * @var bool
+	 */
+	private $remote_patterns_loaded;
+
+	/**
 	 * An array that maps old categories names to new ones.
 	 *
 	 * @since 6.2.0

--- a/lib/compat/wordpress-6.2/class-gutenberg-rest-block-patterns-controller-6-2.php
+++ b/lib/compat/wordpress-6.2/class-gutenberg-rest-block-patterns-controller-6-2.php
@@ -58,7 +58,7 @@ class Gutenberg_REST_Block_Patterns_Controller_6_2 extends Gutenberg_REST_Block_
 	 * Retrieves all block patterns.
 	 *
 	 * @since 6.0.0
-	 * @since 6.2.0 Added migration for old pattern categories.
+	 * @since 6.2.0 Added migration for old core pattern categories to the new ones.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
@@ -84,11 +84,14 @@ class Gutenberg_REST_Block_Patterns_Controller_6_2 extends Gutenberg_REST_Block_
 	}
 
 	/**
-	 * Migrates old pattern categories to new ones.
+	 * Migrates old core pattern categories to new ones.
+	 *
+	 * Core pattern categories are being revamped and we need to handle the migration
+	 * to the new ones and ensure backwards compatibility.
 	 *
 	 * @since 6.2.0
 	 *
-	 * @param array $pattern Raw pattern as registered, before any changes.
+	 * @param array $pattern Raw pattern as registered, before applying any changes.
 	 * @return array Migrated pattern.
 	 */
 	protected function migrate_pattern_categories( $pattern ) {

--- a/lib/compat/wordpress-6.2/class-gutenberg-rest-block-patterns-controller-6-2.php
+++ b/lib/compat/wordpress-6.2/class-gutenberg-rest-block-patterns-controller-6-2.php
@@ -15,14 +15,6 @@
  */
 class Gutenberg_REST_Block_Patterns_Controller_6_2 extends Gutenberg_REST_Block_Patterns_Controller_6_1 {
 	/**
-	 * Defines whether remote patterns should be loaded.
-	 *
-	 * @since 6.0.0
-	 * @var bool
-	 */
-	private $remote_patterns_loaded;
-
-	/**
 	 * An array that maps old categories names to new ones.
 	 *
 	 * @since 6.2.0
@@ -82,17 +74,28 @@ class Gutenberg_REST_Block_Patterns_Controller_6_2 extends Gutenberg_REST_Block_
 		return rest_ensure_response( $response );
 	}
 
-	protected static function migrate_pattern_categories( $pattern ) {
+	/**
+	 * Migrates old pattern categories to new ones.
+	 *
+	 * @since 6.2.0
+	 *
+	 * @param array $pattern Raw pattern as registered, before any changes.
+	 * @return array Migrated pattern.
+	 */
+	protected function migrate_pattern_categories( $pattern ) {
 		if ( isset( $pattern['categories'] ) && is_array( $pattern['categories'] ) ) {
-			$new_categories = array();
-			foreach ( $pattern['categories'] as $category ) {
-				if ( isset( static::$categories_migration[ $category ] ) ) {
-					$new_categories[] = static::$categories_migration[ $category ];
-				} else {
-					$new_categories[] = $category;
-				}
+			$old_categories = array_intersect( $pattern['categories'], array_keys( static::$categories_migration ) );
+			if ( ! empty( $old_categories ) ) {
+				$pattern['categories'] = array_merge(
+					array_diff( $pattern['categories'], $old_categories ),
+					array_map(
+						function( $category ) {
+							return static::$categories_migration[ $category ];
+						},
+						$old_categories
+					)
+				);
 			}
-			$pattern['categories'] = $new_categories;
 		}
 		return $pattern;
 	}

--- a/lib/compat/wordpress-6.2/class-gutenberg-rest-block-patterns-controller-6-2.php
+++ b/lib/compat/wordpress-6.2/class-gutenberg-rest-block-patterns-controller-6-2.php
@@ -30,6 +30,8 @@ class Gutenberg_REST_Block_Patterns_Controller_6_2 extends Gutenberg_REST_Block_
 	 */
 	protected static $categories_migration = array(
 		'buttons' => 'call-to-action',
+		'columns' => 'media',
+		'text'    => 'media',
 		'query'   => 'posts',
 	);
 

--- a/lib/compat/wordpress-6.2/rest-api.php
+++ b/lib/compat/wordpress-6.2/rest-api.php
@@ -30,7 +30,7 @@ function gutenberg_register_rest_block_patterns() {
 	$block_patterns = new Gutenberg_REST_Block_Patterns_Controller_6_2();
 	$block_patterns->register_routes();
 }
-add_action( 'rest_api_init', 'gutenberg_register_rest_block_patterns', 100 );
+add_action( 'rest_api_init', 'gutenberg_register_rest_block_patterns' );
 
 /**
  * Add extra collection params to pattern directory requests.

--- a/lib/compat/wordpress-6.2/rest-api.php
+++ b/lib/compat/wordpress-6.2/rest-api.php
@@ -24,6 +24,15 @@ function gutenberg_register_rest_pattern_directory() {
 add_action( 'rest_api_init', 'gutenberg_register_rest_pattern_directory' );
 
 /**
+ * Registers the block patterns REST API routes.
+ */
+function gutenberg_register_rest_block_patterns() {
+	$block_patterns = new Gutenberg_REST_Block_Patterns_Controller_6_2();
+	$block_patterns->register_routes();
+}
+add_action( 'rest_api_init', 'gutenberg_register_rest_block_patterns', 100 );
+
+/**
  * Add extra collection params to pattern directory requests.
  *
  * @param array $query_params JSON Schema-formatted collection parameters.

--- a/lib/load.php
+++ b/lib/load.php
@@ -36,11 +36,12 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	}
 
 	// WordPress 6.1 compat.
-	require_once __DIR__ . '/compat/wordpress-6.1/class-gutenberg-rest-block-patterns-controller.php';
+	require_once __DIR__ . '/compat/wordpress-6.1/class-gutenberg-rest-block-patterns-controller-6-1.php';
 	require_once __DIR__ . '/compat/wordpress-6.1/class-gutenberg-rest-templates-controller.php';
 	require_once __DIR__ . '/compat/wordpress-6.1/rest-api.php';
 
 	// WordPress 6.2 compat.
+	require_once __DIR__ . '/compat/wordpress-6.2/class-gutenberg-rest-block-patterns-controller-6-2.php';
 	require_once __DIR__ . '/compat/wordpress-6.2/class-gutenberg-rest-block-pattern-categories-controller.php';
 	require_once __DIR__ . '/compat/wordpress-6.2/class-gutenberg-rest-pattern-directory-controller-6-2.php';
 	require_once __DIR__ . '/compat/wordpress-6.2/rest-api.php';

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -53,10 +53,17 @@ function usePatternsCategories() {
 				)
 			)
 			.sort( ( { name: currentName }, { name: nextName } ) => {
-				if ( ! [ currentName, nextName ].includes( 'featured' ) ) {
+				if (
+					! [ currentName, nextName ].some( ( categoryName ) =>
+						[ 'featured', 'text' ].includes( categoryName )
+					)
+				) {
 					return 0;
 				}
-				return currentName === 'featured' ? -1 : 1;
+				// Move `featured` category to the top and `text` to the bottom.
+				return currentName === 'featured' || nextName === 'text'
+					? -1
+					: 1;
 			} );
 
 		if (

--- a/phpunit/class-gutenberg-rest-block-patterns-controller-test.php
+++ b/phpunit/class-gutenberg-rest-block-patterns-controller-test.php
@@ -11,7 +11,6 @@
  *
  * @group restapi
  * @covers Gutenberg_REST_Block_Patterns_Controller_6_2
- * @group something
  */
 class Gutenberg_REST_Block_Patterns_Controller_6_2_Test extends WP_Test_REST_Controller_Testcase {
 	/**

--- a/phpunit/class-gutenberg-rest-block-patterns-controller-test.php
+++ b/phpunit/class-gutenberg-rest-block-patterns-controller-test.php
@@ -10,27 +10,55 @@
  * Unit tests for REST API for Block Patterns.
  *
  * @group restapi
- * @covers Gutenberg_REST_Block_Patterns_Controller
+ * @covers Gutenberg_REST_Block_Patterns_Controller_6_2
+ * @group something
  */
-class Gutenberg_REST_Block_Patterns_Controller_Test extends WP_Test_REST_Controller_Testcase {
+class Gutenberg_REST_Block_Patterns_Controller_6_2_Test extends WP_Test_REST_Controller_Testcase {
+	/**
+	 * Admin user ID.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @var int
+	 */
 	protected static $admin_id;
+
+	/**
+	 * Original instance of WP_Block_Patterns_Registry.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @var WP_Block_Patterns_Registry
+	 */
 	protected static $orig_registry;
 
-	public function set_up() {
-		parent::set_up();
-		switch_theme( 'emptytheme' );
-	}
+	/**
+	 * Instance of the reflected `instance` property.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @var ReflectionProperty
+	 */
+	private static $registry_instance_property;
+
+	/**
+	 * The REST API route.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @var string
+	 */
+	const REQUEST_ROUTE = '/wp/v2/block-patterns/patterns';
 
 	public static function wpSetUpBeforeClass( $factory ) {
-		// Create a test user.
 		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
 
 		// Setup an empty testing instance of `WP_Block_Patterns_Registry` and save the original.
-		$reflection = new ReflectionClass( 'WP_Block_Patterns_Registry' );
-		$reflection->getProperty( 'instance' )->setAccessible( true );
-		self::$orig_registry = $reflection->getStaticPropertyValue( 'instance' );
-		$test_registry       = new WP_Block_Patterns_Registry();
-		$reflection->setStaticPropertyValue( 'instance', $test_registry );
+		self::$orig_registry              = WP_Block_Patterns_Registry::get_instance();
+		self::$registry_instance_property = new ReflectionProperty( 'WP_Block_Patterns_Registry', 'instance' );
+		self::$registry_instance_property->setAccessible( true );
+		$test_registry = new WP_Block_Pattern_Categories_Registry();
+		self::$registry_instance_property->setValue( $test_registry );
 
 		// Register some patterns in the test registry.
 		$test_registry->register(
@@ -51,47 +79,77 @@ class Gutenberg_REST_Block_Patterns_Controller_Test extends WP_Test_REST_Control
 				'content'    => '<!-- wp:paragraph --><p>Two</p><!-- /wp:paragraph -->',
 			)
 		);
-	}
 
-	public static function wpTearDownAfterClass() {
-		// Delete the test user.
-		self::delete_user( self::$admin_id );
-
-		// Restore the original registry instance.
-		$reflection = new ReflectionClass( 'WP_Block_Patterns_Registry' );
-		$reflection->setStaticPropertyValue( 'instance', self::$orig_registry );
-	}
-
-	public function test_register_routes() {
-		$routes = rest_get_server()->get_routes();
-		$this->assertArrayHasKey(
-			'/wp/v2/block-patterns/patterns',
-			$routes,
-			'The patterns route does not exist'
+		$test_registry->register(
+			'test/three',
+			array(
+				'title'      => 'Pattern Three',
+				'categories' => array( 'test', 'buttons', 'query' ),
+				'content'    => '<!-- wp:paragraph --><p>Three</p><!-- /wp:paragraph -->',
+			)
 		);
 	}
 
-	public function test_get_items() {
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_id );
+
+		// Restore the original registry instance.
+		self::$registry_instance_property->setValue( self::$orig_registry );
+		self::$registry_instance_property->setAccessible( false );
+		self::$registry_instance_property = null;
+		self::$orig_registry              = null;
+	}
+
+	public function set_up() {
+		parent::set_up();
+		switch_theme( 'emptytheme' );
+	}
+
+	public function test_get_items_migrate_pattern_categories() {
 		wp_set_current_user( self::$admin_id );
 
-		$expected_names  = array( 'test/one', 'test/two' );
-		$expected_fields = array( 'name', 'content' );
-
-		$request            = new WP_REST_Request( 'GET', '/wp/v2/block-patterns/patterns' );
-		$request['_fields'] = 'name,content';
+		$request            = new WP_REST_Request( 'GET', static::REQUEST_ROUTE );
+		$request['_fields'] = 'name,categories';
 		$response           = rest_get_server()->dispatch( $request );
 		$data               = $response->get_data();
 
-		$this->assertCount( count( $expected_names ), $data );
-		foreach ( $data as $idx => $item ) {
-			$this->assertEquals( $expected_names[ $idx ], $item['name'] );
-			$this->assertEquals( $expected_fields, array_keys( $item ) );
-		}
+		$this->assertIsArray( $data, 'WP_REST_Block_Patterns_Controller::get_items() should return an array' );
+		$this->assertGreaterThanOrEqual( 3, count( $data ), 'WP_REST_Block_Patterns_Controller::get_items() should return at least 3 items' );
+		$this->assertSame(
+			array(
+				'name'       => 'test/one',
+				'categories' => array( 'test' ),
+			),
+			$data[0],
+			'WP_REST_Block_Patterns_Controller::get_items() should return test/one'
+		);
+		$this->assertSame(
+			array(
+				'name'       => 'test/two',
+				'categories' => array( 'test' ),
+			),
+			$data[1],
+			'WP_REST_Block_Patterns_Controller::get_items() should return test/two'
+		);
+		$this->assertSame(
+			array(
+				'name'       => 'test/three',
+				'categories' => array( 'test', 'call-to-action', 'posts' ),
+			),
+			$data[2],
+			'WP_REST_Block_Patterns_Controller::get_items() should return test/three'
+		);
 	}
 
 	/**
 	 * Abstract methods that we must implement.
 	 */
+	public function test_register_routes() {
+		$this->markTestIncomplete();
+	}
+	public function test_get_items() {
+		$this->markTestIncomplete();
+	}
 	public function test_context_param() {
 		$this->markTestIncomplete();
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of code extracted from: https://github.com/WordPress/gutenberg/pull/45548
Part of: https://github.com/WordPress/gutenberg/issues/44501

This PR adds some new pattern categories and adds a migration step for patterns that use old categories. For now I've mapped only `'buttons' => 'call-to-action' and 'query'   => 'posts'`.  Also the php code will be updated, as I wanted to move things forward with this..

### Notes
1. Do we want to map more categories?
2. Do we want to add all the other categories from #44501 ?
<!-- In a few words, what is the PR actually doing? -->

## Testing Instructions
1. In the post editor open the inserter `Patterns` tab
2. Observe that the patterns previously shown in `buttons` are shown in `call to action`.
3. The other categories are not visible, because there are no patterns using them, so you can register on pattern with any of the new categories

## Screenshots or screencast <!-- if applicable -->
