### PR TITLE
Query: Remove color block supports

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -572,7 +572,7 @@ Contains the block elements used to render a post, like the title, date, feature
 
 -	**Name:** core/post-template
 -	**Category:** theme
--	**Supports:** align, typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** align, color (background, gradients, link, text), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** 
 
 ## Post Terms
@@ -617,7 +617,7 @@ An advanced block that allows displaying post types based on different query par
 
 -	**Name:** core/query
 -	**Category:** theme
--	**Supports:** align (full, wide), color (background, gradients, link, text), ~~html~~
+-	**Supports:** align (full, wide), ~~html~~
 -	**Attributes:** displayLayout, namespace, query, queryId, tagName
 
 ## No results

--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -22,6 +22,14 @@
 		"__experimentalLayout": {
 			"allowEditing": false
 		},
+		"color": {
+			"gradients": true,
+			"link": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			}
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -50,14 +50,6 @@
 	"supports": {
 		"align": [ "wide", "full" ],
 		"html": false,
-		"color": {
-			"gradients": true,
-			"link": true,
-			"__experimentalDefaultControls": {
-				"background": true,
-				"text": true
-			}
-		},
 		"__experimentalLayout": true
 	},
 	"editorStyle": "wp-block-query-editor"

--- a/packages/block-library/src/query/deprecated.js
+++ b/packages/block-library/src/query/deprecated.js
@@ -1,11 +1,17 @@
 /**
  * WordPress dependencies
  */
+import { createBlock } from '@wordpress/blocks';
 import {
 	InnerBlocks,
 	useInnerBlocksProps,
 	useBlockProps,
 } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import cleanEmptyObject from '../utils/clean-empty-object';
 
 const migrateToTaxQuery = ( attributes ) => {
 	const { query } = attributes;
@@ -25,7 +31,151 @@ const migrateToTaxQuery = ( attributes ) => {
 	};
 };
 
+const colorSupportedInnerBlocks = [
+	'core/post-template',
+	'core/query-pagination',
+	'core/query-no-results',
+];
+
 const deprecated = [
+	// Version with color support prior to moving it to the PostTemplate block.
+	{
+		attributes: {
+			queryId: {
+				type: 'number',
+			},
+			query: {
+				type: 'object',
+				default: {
+					perPage: null,
+					pages: 0,
+					offset: 0,
+					postType: 'post',
+					order: 'desc',
+					orderBy: 'date',
+					author: '',
+					search: '',
+					exclude: [],
+					sticky: '',
+					inherit: true,
+					taxQuery: null,
+					parents: [],
+				},
+			},
+			tagName: {
+				type: 'string',
+				default: 'div',
+			},
+			displayLayout: {
+				type: 'object',
+				default: {
+					type: 'list',
+				},
+			},
+			namespace: {
+				type: 'string',
+			},
+		},
+		supports: {
+			align: [ 'wide', 'full' ],
+			html: false,
+			color: {
+				gradients: true,
+				link: true,
+				__experimentalDefaultControls: {
+					background: true,
+					text: true,
+				},
+			},
+			__experimentalLayout: true,
+		},
+		isEligible( attributes ) {
+			const { style, backgroundColor, gradient, textColor } = attributes;
+			return (
+				backgroundColor ||
+				gradient ||
+				textColor ||
+				style?.color ||
+				style?.elements?.link
+			);
+		},
+		migrate: ( attributes, innerBlocks ) => {
+			// Remove color style attributes from the Query block.
+			const {
+				style,
+				backgroundColor,
+				gradient,
+				textColor,
+				...newAttributes
+			} = attributes;
+
+			const hasColorStyles =
+				backgroundColor ||
+				gradient ||
+				textColor ||
+				style?.color ||
+				style?.elements?.link;
+
+			// If the query block doesn't currently have any color styles,
+			// nothing needs migrating.
+			if ( ! hasColorStyles ) {
+				return [ attributes, innerBlocks ];
+			}
+
+			if ( style ) {
+				newAttributes.style = cleanEmptyObject( {
+					...style,
+					color: undefined,
+					elements: {
+						...style.elements,
+						link: undefined,
+					},
+				} );
+			}
+
+			// Apply the color styles and attributes to the inner PostTemplate,
+			// Query Pagination, and Query No Results blocks.
+			const updatedInnerBlocks = innerBlocks.map( ( innerBlock ) => {
+				if ( ! colorSupportedInnerBlocks.includes( innerBlock.name ) ) {
+					return innerBlock;
+				}
+
+				const hasStyles =
+					style?.color ||
+					style?.elements?.link ||
+					innerBlock.attributes.style;
+
+				const newStyles = hasStyles
+					? cleanEmptyObject( {
+							...innerBlock.attributes.style,
+							color: style?.color,
+							elements: style?.elements?.link
+								? { link: style?.elements?.link }
+								: undefined,
+					  } )
+					: undefined;
+
+				return createBlock(
+					innerBlock.name,
+					{
+						...innerBlock.attributes,
+						backgroundColor,
+						gradient,
+						textColor,
+						style: newStyles,
+					},
+					innerBlock.innerBlocks
+				);
+			} );
+
+			return [ newAttributes, updatedInnerBlocks ];
+		},
+		save( { attributes: { tagName: Tag = 'div' } } ) {
+			const blockProps = useBlockProps.save();
+			const innerBlocksProps = useInnerBlocksProps.save( blockProps );
+			return <Tag { ...innerBlocksProps } />;
+		},
+	},
 	// Version with `categoryIds and tagIds`.
 	{
 		attributes: {

--- a/packages/block-library/src/query/deprecated.js
+++ b/packages/block-library/src/query/deprecated.js
@@ -34,266 +34,268 @@ const migrateToTaxQuery = ( attributes ) => {
 const hasSingleInnerGroupBlock = ( innerBlocks = [] ) =>
 	innerBlocks.length === 1 && innerBlocks[ 0 ].name === 'core/group';
 
-const deprecated = [
-	// Version with color support prior to moving it to the PostTemplate block.
-	{
-		attributes: {
-			queryId: {
-				type: 'number',
-			},
-			query: {
-				type: 'object',
-				default: {
-					perPage: null,
-					pages: 0,
-					offset: 0,
-					postType: 'post',
-					order: 'desc',
-					orderBy: 'date',
-					author: '',
-					search: '',
-					exclude: [],
-					sticky: '',
-					inherit: true,
-					taxQuery: null,
-					parents: [],
-				},
-			},
-			tagName: {
-				type: 'string',
-				default: 'div',
-			},
-			displayLayout: {
-				type: 'object',
-				default: {
-					type: 'list',
-				},
-			},
-			namespace: {
-				type: 'string',
+// Version with NO wrapper `div` element.
+const v1 = {
+	attributes: {
+		queryId: {
+			type: 'number',
+		},
+		query: {
+			type: 'object',
+			default: {
+				perPage: null,
+				pages: 0,
+				offset: 0,
+				postType: 'post',
+				categoryIds: [],
+				tagIds: [],
+				order: 'desc',
+				orderBy: 'date',
+				author: '',
+				search: '',
+				exclude: [],
+				sticky: '',
+				inherit: true,
 			},
 		},
-		supports: {
-			align: [ 'wide', 'full' ],
-			html: false,
-			color: {
-				gradients: true,
-				link: true,
-				__experimentalDefaultControls: {
-					background: true,
-					text: true,
-				},
+		layout: {
+			type: 'object',
+			default: {
+				type: 'list',
 			},
-			__experimentalLayout: true,
 		},
-		isEligible( attributes ) {
-			const { style, backgroundColor, gradient, textColor } = attributes;
-			return (
-				backgroundColor ||
-				gradient ||
-				textColor ||
+	},
+	supports: {
+		html: false,
+	},
+	migrate( attributes ) {
+		const withTaxQuery = migrateToTaxQuery( attributes );
+		const { layout, ...restWithTaxQuery } = withTaxQuery;
+		return {
+			...restWithTaxQuery,
+			displayLayout: withTaxQuery.layout,
+		};
+	},
+	save() {
+		return <InnerBlocks.Content />;
+	},
+};
+
+// Version with `categoryIds and tagIds`.
+const v2 = {
+	attributes: {
+		queryId: {
+			type: 'number',
+		},
+		query: {
+			type: 'object',
+			default: {
+				perPage: null,
+				pages: 0,
+				offset: 0,
+				postType: 'post',
+				categoryIds: [],
+				tagIds: [],
+				order: 'desc',
+				orderBy: 'date',
+				author: '',
+				search: '',
+				exclude: [],
+				sticky: '',
+				inherit: true,
+			},
+		},
+		tagName: {
+			type: 'string',
+			default: 'div',
+		},
+		displayLayout: {
+			type: 'object',
+			default: {
+				type: 'list',
+			},
+		},
+	},
+	supports: {
+		align: [ 'wide', 'full' ],
+		html: false,
+		color: {
+			gradients: true,
+			link: true,
+		},
+		__experimentalLayout: true,
+	},
+	isEligible: ( { query: { categoryIds, tagIds } = {} } ) =>
+		categoryIds || tagIds,
+	migrate: migrateToTaxQuery,
+	save( { attributes: { tagName: Tag = 'div' } } ) {
+		const blockProps = useBlockProps.save();
+		const innerBlocksProps = useInnerBlocksProps.save( blockProps );
+		return <Tag { ...innerBlocksProps } />;
+	},
+};
+
+// Version with color support prior to moving it to the PostTemplate block.
+const v3 = {
+	attributes: {
+		queryId: {
+			type: 'number',
+		},
+		query: {
+			type: 'object',
+			default: {
+				perPage: null,
+				pages: 0,
+				offset: 0,
+				postType: 'post',
+				order: 'desc',
+				orderBy: 'date',
+				author: '',
+				search: '',
+				exclude: [],
+				sticky: '',
+				inherit: true,
+				taxQuery: null,
+				parents: [],
+			},
+		},
+		tagName: {
+			type: 'string',
+			default: 'div',
+		},
+		displayLayout: {
+			type: 'object',
+			default: {
+				type: 'list',
+			},
+		},
+		namespace: {
+			type: 'string',
+		},
+	},
+	supports: {
+		align: [ 'wide', 'full' ],
+		html: false,
+		color: {
+			gradients: true,
+			link: true,
+			__experimentalDefaultControls: {
+				background: true,
+				text: true,
+			},
+		},
+		__experimentalLayout: true,
+	},
+	isEligible( attributes ) {
+		const { style, backgroundColor, gradient, textColor } = attributes;
+		return (
+			backgroundColor ||
+			gradient ||
+			textColor ||
+			style?.color ||
+			style?.elements?.link
+		);
+	},
+	migrate: ( attributes, innerBlocks ) => {
+		// Remove color style attributes from the Query block.
+		const {
+			style,
+			backgroundColor,
+			gradient,
+			textColor,
+			...newAttributes
+		} = attributes;
+
+		const hasColorStyles =
+			backgroundColor ||
+			gradient ||
+			textColor ||
+			style?.color ||
+			style?.elements?.link;
+
+		// If the query block doesn't currently have any color styles,
+		// nothing needs migrating.
+		if ( ! hasColorStyles ) {
+			return [ attributes, innerBlocks ];
+		}
+
+		// Clean color values from style attribute object.
+		if ( style ) {
+			newAttributes.style = cleanEmptyObject( {
+				...style,
+				color: undefined,
+				elements: {
+					...style.elements,
+					link: undefined,
+				},
+			} );
+		}
+
+		// If the inner blocks are already wrapped in a single group
+		// block, add the color support styles to that group block.
+		if ( hasSingleInnerGroupBlock( innerBlocks ) ) {
+			const groupBlock = innerBlocks[ 0 ];
+
+			// Create new styles for the group block.
+			const hasStyles =
 				style?.color ||
-				style?.elements?.link
-			);
-		},
-		migrate: ( attributes, innerBlocks ) => {
-			// Remove color style attributes from the Query block.
-			const {
-				style,
-				backgroundColor,
-				gradient,
-				textColor,
-				...newAttributes
-			} = attributes;
+				style?.elements?.link ||
+				groupBlock.attributes.style;
 
-			const hasColorStyles =
-				backgroundColor ||
-				gradient ||
-				textColor ||
-				style?.color ||
-				style?.elements?.link;
-
-			// If the query block doesn't currently have any color styles,
-			// nothing needs migrating.
-			if ( ! hasColorStyles ) {
-				return [ attributes, innerBlocks ];
-			}
-
-			// Clean color values from style attribute object.
-			if ( style ) {
-				newAttributes.style = cleanEmptyObject( {
-					...style,
-					color: undefined,
-					elements: {
-						...style.elements,
-						link: undefined,
-					},
-				} );
-			}
-
-			// If the inner blocks are already wrapped in a single group
-			// block, add the color support styles to that group block.
-			if ( hasSingleInnerGroupBlock( innerBlocks ) ) {
-				const groupBlock = innerBlocks[ 0 ];
-
-				// Create new styles for the group block.
-				const hasStyles =
-					style?.color ||
-					style?.elements?.link ||
-					groupBlock.attributes.style;
-
-				const newStyles = hasStyles
-					? cleanEmptyObject( {
-							...groupBlock.attributes.style,
-							color: style?.color,
-							elements: style?.elements?.link
-								? { link: style?.elements?.link }
-								: undefined,
-					  } )
-					: undefined;
-
-				// Create a new Group block from the original.
-				const updatedGroupBlock = createBlock(
-					'core/group',
-					{
-						...groupBlock.attributes,
-						backgroundColor,
-						gradient,
-						textColor,
-						style: newStyles,
-					},
-					groupBlock.innerBlocks
-				);
-
-				return [ newAttributes, [ updatedGroupBlock ] ];
-			}
-
-			// When we don't have a single wrapping group block for the inner
-			// blocks, wrap the current inner blocks in a group applying the
-			// color styles to that.
-			const newGroupBlock = createBlock(
-				'core/group',
-				{
-					backgroundColor,
-					gradient,
-					textColor,
-					style: cleanEmptyObject( {
+			const newStyles = hasStyles
+				? cleanEmptyObject( {
+						...groupBlock.attributes.style,
 						color: style?.color,
 						elements: style?.elements?.link
 							? { link: style?.elements?.link }
 							: undefined,
-					} ),
+				  } )
+				: undefined;
+
+			// Create a new Group block from the original.
+			const updatedGroupBlock = createBlock(
+				'core/group',
+				{
+					...groupBlock.attributes,
+					backgroundColor,
+					gradient,
+					textColor,
+					style: newStyles,
 				},
-				innerBlocks
+				groupBlock.innerBlocks
 			);
 
-			return [ newAttributes, [ newGroupBlock ] ];
-		},
-		save( { attributes: { tagName: Tag = 'div' } } ) {
-			const blockProps = useBlockProps.save();
-			const innerBlocksProps = useInnerBlocksProps.save( blockProps );
-			return <Tag { ...innerBlocksProps } />;
-		},
+			return [ newAttributes, [ updatedGroupBlock ] ];
+		}
+
+		// When we don't have a single wrapping group block for the inner
+		// blocks, wrap the current inner blocks in a group applying the
+		// color styles to that.
+		const newGroupBlock = createBlock(
+			'core/group',
+			{
+				backgroundColor,
+				gradient,
+				textColor,
+				style: cleanEmptyObject( {
+					color: style?.color,
+					elements: style?.elements?.link
+						? { link: style?.elements?.link }
+						: undefined,
+				} ),
+			},
+			innerBlocks
+		);
+
+		return [ newAttributes, [ newGroupBlock ] ];
 	},
-	// Version with `categoryIds and tagIds`.
-	{
-		attributes: {
-			queryId: {
-				type: 'number',
-			},
-			query: {
-				type: 'object',
-				default: {
-					perPage: null,
-					pages: 0,
-					offset: 0,
-					postType: 'post',
-					categoryIds: [],
-					tagIds: [],
-					order: 'desc',
-					orderBy: 'date',
-					author: '',
-					search: '',
-					exclude: [],
-					sticky: '',
-					inherit: true,
-				},
-			},
-			tagName: {
-				type: 'string',
-				default: 'div',
-			},
-			displayLayout: {
-				type: 'object',
-				default: {
-					type: 'list',
-				},
-			},
-		},
-		supports: {
-			align: [ 'wide', 'full' ],
-			html: false,
-			color: {
-				gradients: true,
-				link: true,
-			},
-			__experimentalLayout: true,
-		},
-		isEligible: ( { query: { categoryIds, tagIds } = {} } ) =>
-			categoryIds || tagIds,
-		migrate: migrateToTaxQuery,
-		save( { attributes: { tagName: Tag = 'div' } } ) {
-			const blockProps = useBlockProps.save();
-			const innerBlocksProps = useInnerBlocksProps.save( blockProps );
-			return <Tag { ...innerBlocksProps } />;
-		},
+	save( { attributes: { tagName: Tag = 'div' } } ) {
+		const blockProps = useBlockProps.save();
+		const innerBlocksProps = useInnerBlocksProps.save( blockProps );
+		return <Tag { ...innerBlocksProps } />;
 	},
-	// Version with NO wrapper `div` element.
-	{
-		attributes: {
-			queryId: {
-				type: 'number',
-			},
-			query: {
-				type: 'object',
-				default: {
-					perPage: null,
-					pages: 0,
-					offset: 0,
-					postType: 'post',
-					categoryIds: [],
-					tagIds: [],
-					order: 'desc',
-					orderBy: 'date',
-					author: '',
-					search: '',
-					exclude: [],
-					sticky: '',
-					inherit: true,
-				},
-			},
-			layout: {
-				type: 'object',
-				default: {
-					type: 'list',
-				},
-			},
-		},
-		supports: {
-			html: false,
-		},
-		migrate( attributes ) {
-			const withTaxQuery = migrateToTaxQuery( attributes );
-			const { layout, ...restWithTaxQuery } = withTaxQuery;
-			return {
-				...restWithTaxQuery,
-				displayLayout: withTaxQuery.layout,
-			};
-		},
-		save() {
-			return <InnerBlocks.Content />;
-		},
-	},
-];
+};
+
+const deprecated = [ v3, v2, v1 ];
 
 export default deprecated;

--- a/test/integration/fixtures/blocks/core__query__deprecated-3.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-3.html
@@ -1,0 +1,23 @@
+<!-- wp:query {"queryId":3,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"flex","columns":3},"align":"wide","style":{"color":{"background":"#284d5f"},"elements":{"link":{"color":{"text":"var:preset|color|luminous-vivid-amber"}}}},"textColor":"pale-cyan-blue"} -->
+<div class="wp-block-query alignwide has-pale-cyan-blue-color has-text-color has-background has-link-color" style="background-color:#284d5f"><!-- wp:post-template {"fontSize":"large"} -->
+<!-- wp:post-title /-->
+
+<!-- wp:post-date /-->
+
+<!-- wp:post-excerpt /-->
+<!-- /wp:post-template -->
+
+<!-- wp:query-pagination -->
+<!-- wp:query-pagination-previous /-->
+
+<!-- wp:query-pagination-numbers /-->
+
+<!-- wp:query-pagination-next /-->
+<!-- /wp:query-pagination -->
+
+<!-- wp:query-no-results -->
+<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+<p>No results found.</p>
+<!-- /wp:paragraph -->
+<!-- /wp:query-no-results --></div>
+<!-- /wp:query -->

--- a/test/integration/fixtures/blocks/core__query__deprecated-3.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-3.json
@@ -1,0 +1,151 @@
+[
+	{
+		"name": "core/query",
+		"isValid": true,
+		"attributes": {
+			"queryId": 3,
+			"query": {
+				"perPage": 3,
+				"pages": 0,
+				"offset": 0,
+				"postType": "post",
+				"order": "desc",
+				"orderBy": "date",
+				"author": "",
+				"search": "",
+				"exclude": [],
+				"sticky": "",
+				"inherit": false
+			},
+			"tagName": "div",
+			"displayLayout": {
+				"type": "flex",
+				"columns": 3
+			},
+			"align": "wide"
+		},
+		"innerBlocks": [
+			{
+				"name": "core/post-template",
+				"isValid": true,
+				"attributes": {
+					"textColor": "pale-cyan-blue",
+					"fontSize": "large",
+					"style": {
+						"color": {
+							"background": "#284d5f"
+						},
+						"elements": {
+							"link": {
+								"color": {
+									"text": "var:preset|color|luminous-vivid-amber"
+								}
+							}
+						}
+					}
+				},
+				"innerBlocks": [
+					{
+						"name": "core/post-title",
+						"isValid": true,
+						"attributes": {
+							"level": 2,
+							"isLink": false,
+							"rel": "",
+							"linkTarget": "_self"
+						},
+						"innerBlocks": []
+					},
+					{
+						"name": "core/post-date",
+						"isValid": true,
+						"attributes": {
+							"isLink": false,
+							"displayType": "date"
+						},
+						"innerBlocks": []
+					},
+					{
+						"name": "core/post-excerpt",
+						"isValid": true,
+						"attributes": {
+							"showMoreOnNewLine": true
+						},
+						"innerBlocks": []
+					}
+				]
+			},
+			{
+				"name": "core/query-pagination",
+				"isValid": true,
+				"attributes": {
+					"paginationArrow": "none",
+					"textColor": "pale-cyan-blue",
+					"style": {
+						"color": {
+							"background": "#284d5f"
+						},
+						"elements": {
+							"link": {
+								"color": {
+									"text": "var:preset|color|luminous-vivid-amber"
+								}
+							}
+						}
+					}
+				},
+				"innerBlocks": [
+					{
+						"name": "core/query-pagination-previous",
+						"isValid": true,
+						"attributes": {},
+						"innerBlocks": []
+					},
+					{
+						"name": "core/query-pagination-numbers",
+						"isValid": true,
+						"attributes": {},
+						"innerBlocks": []
+					},
+					{
+						"name": "core/query-pagination-next",
+						"isValid": true,
+						"attributes": {},
+						"innerBlocks": []
+					}
+				]
+			},
+			{
+				"name": "core/query-no-results",
+				"isValid": true,
+				"attributes": {
+					"textColor": "pale-cyan-blue",
+					"style": {
+						"color": {
+							"background": "#284d5f"
+						},
+						"elements": {
+							"link": {
+								"color": {
+									"text": "var:preset|color|luminous-vivid-amber"
+								}
+							}
+						}
+					}
+				},
+				"innerBlocks": [
+					{
+						"name": "core/paragraph",
+						"isValid": true,
+						"attributes": {
+							"content": "No results found.",
+							"dropCap": false,
+							"placeholder": "Add text or blocks that will display when a query returns no results."
+						},
+						"innerBlocks": []
+					}
+				]
+			}
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__query__deprecated-3.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-3.json
@@ -26,60 +26,10 @@
 		},
 		"innerBlocks": [
 			{
-				"name": "core/post-template",
+				"name": "core/group",
 				"isValid": true,
 				"attributes": {
-					"textColor": "pale-cyan-blue",
-					"fontSize": "large",
-					"style": {
-						"color": {
-							"background": "#284d5f"
-						},
-						"elements": {
-							"link": {
-								"color": {
-									"text": "var:preset|color|luminous-vivid-amber"
-								}
-							}
-						}
-					}
-				},
-				"innerBlocks": [
-					{
-						"name": "core/post-title",
-						"isValid": true,
-						"attributes": {
-							"level": 2,
-							"isLink": false,
-							"rel": "",
-							"linkTarget": "_self"
-						},
-						"innerBlocks": []
-					},
-					{
-						"name": "core/post-date",
-						"isValid": true,
-						"attributes": {
-							"isLink": false,
-							"displayType": "date"
-						},
-						"innerBlocks": []
-					},
-					{
-						"name": "core/post-excerpt",
-						"isValid": true,
-						"attributes": {
-							"showMoreOnNewLine": true
-						},
-						"innerBlocks": []
-					}
-				]
-			},
-			{
-				"name": "core/query-pagination",
-				"isValid": true,
-				"attributes": {
-					"paginationArrow": "none",
+					"tagName": "div",
 					"textColor": "pale-cyan-blue",
 					"style": {
 						"color": {
@@ -96,53 +46,85 @@
 				},
 				"innerBlocks": [
 					{
-						"name": "core/query-pagination-previous",
-						"isValid": true,
-						"attributes": {},
-						"innerBlocks": []
-					},
-					{
-						"name": "core/query-pagination-numbers",
-						"isValid": true,
-						"attributes": {},
-						"innerBlocks": []
-					},
-					{
-						"name": "core/query-pagination-next",
-						"isValid": true,
-						"attributes": {},
-						"innerBlocks": []
-					}
-				]
-			},
-			{
-				"name": "core/query-no-results",
-				"isValid": true,
-				"attributes": {
-					"textColor": "pale-cyan-blue",
-					"style": {
-						"color": {
-							"background": "#284d5f"
-						},
-						"elements": {
-							"link": {
-								"color": {
-									"text": "var:preset|color|luminous-vivid-amber"
-								}
-							}
-						}
-					}
-				},
-				"innerBlocks": [
-					{
-						"name": "core/paragraph",
+						"name": "core/post-template",
 						"isValid": true,
 						"attributes": {
-							"content": "No results found.",
-							"dropCap": false,
-							"placeholder": "Add text or blocks that will display when a query returns no results."
+							"fontSize": "large"
 						},
-						"innerBlocks": []
+						"innerBlocks": [
+							{
+								"name": "core/post-title",
+								"isValid": true,
+								"attributes": {
+									"level": 2,
+									"isLink": false,
+									"rel": "",
+									"linkTarget": "_self"
+								},
+								"innerBlocks": []
+							},
+							{
+								"name": "core/post-date",
+								"isValid": true,
+								"attributes": {
+									"isLink": false,
+									"displayType": "date"
+								},
+								"innerBlocks": []
+							},
+							{
+								"name": "core/post-excerpt",
+								"isValid": true,
+								"attributes": {
+									"showMoreOnNewLine": true
+								},
+								"innerBlocks": []
+							}
+						]
+					},
+					{
+						"name": "core/query-pagination",
+						"isValid": true,
+						"attributes": {
+							"paginationArrow": "none"
+						},
+						"innerBlocks": [
+							{
+								"name": "core/query-pagination-previous",
+								"isValid": true,
+								"attributes": {},
+								"innerBlocks": []
+							},
+							{
+								"name": "core/query-pagination-numbers",
+								"isValid": true,
+								"attributes": {},
+								"innerBlocks": []
+							},
+							{
+								"name": "core/query-pagination-next",
+								"isValid": true,
+								"attributes": {},
+								"innerBlocks": []
+							}
+						]
+					},
+					{
+						"name": "core/query-no-results",
+						"isValid": true,
+						"attributes": {},
+						"innerBlocks": [
+							{
+								"name": "core/paragraph",
+								"isValid": true,
+								"attributes": {
+									"content": "No results found.",
+									"dropCap": false,
+									"placeholder": "Add text or blocks that will display when a query returns no results."
+								},
+								"innerBlocks": []
+							}
+						]
 					}
 				]
 			}

--- a/test/integration/fixtures/blocks/core__query__deprecated-3.parsed.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-3.parsed.json
@@ -1,0 +1,128 @@
+[
+	{
+		"blockName": "core/query",
+		"attrs": {
+			"queryId": 3,
+			"query": {
+				"perPage": 3,
+				"pages": 0,
+				"offset": 0,
+				"postType": "post",
+				"order": "desc",
+				"orderBy": "date",
+				"author": "",
+				"search": "",
+				"exclude": [],
+				"sticky": "",
+				"inherit": false
+			},
+			"displayLayout": {
+				"type": "flex",
+				"columns": 3
+			},
+			"align": "wide",
+			"style": {
+				"color": {
+					"background": "#284d5f"
+				},
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var:preset|color|luminous-vivid-amber"
+						}
+					}
+				}
+			},
+			"textColor": "pale-cyan-blue"
+		},
+		"innerBlocks": [
+			{
+				"blockName": "core/post-template",
+				"attrs": {
+					"fontSize": "large"
+				},
+				"innerBlocks": [
+					{
+						"blockName": "core/post-title",
+						"attrs": {},
+						"innerBlocks": [],
+						"innerHTML": "",
+						"innerContent": []
+					},
+					{
+						"blockName": "core/post-date",
+						"attrs": {},
+						"innerBlocks": [],
+						"innerHTML": "",
+						"innerContent": []
+					},
+					{
+						"blockName": "core/post-excerpt",
+						"attrs": {},
+						"innerBlocks": [],
+						"innerHTML": "",
+						"innerContent": []
+					}
+				],
+				"innerHTML": "\n\n\n\n\n\n",
+				"innerContent": [ "\n", null, "\n\n", null, "\n\n", null, "\n" ]
+			},
+			{
+				"blockName": "core/query-pagination",
+				"attrs": {},
+				"innerBlocks": [
+					{
+						"blockName": "core/query-pagination-previous",
+						"attrs": {},
+						"innerBlocks": [],
+						"innerHTML": "",
+						"innerContent": []
+					},
+					{
+						"blockName": "core/query-pagination-numbers",
+						"attrs": {},
+						"innerBlocks": [],
+						"innerHTML": "",
+						"innerContent": []
+					},
+					{
+						"blockName": "core/query-pagination-next",
+						"attrs": {},
+						"innerBlocks": [],
+						"innerHTML": "",
+						"innerContent": []
+					}
+				],
+				"innerHTML": "\n\n\n\n\n\n",
+				"innerContent": [ "\n", null, "\n\n", null, "\n\n", null, "\n" ]
+			},
+			{
+				"blockName": "core/query-no-results",
+				"attrs": {},
+				"innerBlocks": [
+					{
+						"blockName": "core/paragraph",
+						"attrs": {
+							"placeholder": "Add text or blocks that will display when a query returns no results."
+						},
+						"innerBlocks": [],
+						"innerHTML": "\n<p>No results found.</p>\n",
+						"innerContent": [ "\n<p>No results found.</p>\n" ]
+					}
+				],
+				"innerHTML": "\n\n",
+				"innerContent": [ "\n", null, "\n" ]
+			}
+		],
+		"innerHTML": "\n<div class=\"wp-block-query alignwide has-pale-cyan-blue-color has-text-color has-background has-link-color\" style=\"background-color:#284d5f\">\n\n\n\n</div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-query alignwide has-pale-cyan-blue-color has-text-color has-background has-link-color\" style=\"background-color:#284d5f\">",
+			null,
+			"\n\n",
+			null,
+			"\n\n",
+			null,
+			"</div>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__query__deprecated-3.serialized.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-3.serialized.html
@@ -1,5 +1,6 @@
 <!-- wp:query {"queryId":3,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"flex","columns":3},"align":"wide"} -->
-<div class="wp-block-query alignwide"><!-- wp:post-template {"textColor":"pale-cyan-blue","fontSize":"large","style":{"color":{"background":"#284d5f"},"elements":{"link":{"color":{"text":"var:preset|color|luminous-vivid-amber"}}}}} -->
+<div class="wp-block-query alignwide"><!-- wp:group {"textColor":"pale-cyan-blue","style":{"color":{"background":"#284d5f"},"elements":{"link":{"color":{"text":"var:preset|color|luminous-vivid-amber"}}}}} -->
+<div class="wp-block-group has-pale-cyan-blue-color has-text-color has-background has-link-color" style="background-color:#284d5f"><!-- wp:post-template {"fontSize":"large"} -->
 <!-- wp:post-title /-->
 
 <!-- wp:post-date /-->
@@ -7,7 +8,7 @@
 <!-- wp:post-excerpt /-->
 <!-- /wp:post-template -->
 
-<!-- wp:query-pagination {"textColor":"pale-cyan-blue","style":{"color":{"background":"#284d5f"},"elements":{"link":{"color":{"text":"var:preset|color|luminous-vivid-amber"}}}}} -->
+<!-- wp:query-pagination -->
 <!-- wp:query-pagination-previous /-->
 
 <!-- wp:query-pagination-numbers /-->
@@ -15,9 +16,10 @@
 <!-- wp:query-pagination-next /-->
 <!-- /wp:query-pagination -->
 
-<!-- wp:query-no-results {"textColor":"pale-cyan-blue","style":{"color":{"background":"#284d5f"},"elements":{"link":{"color":{"text":"var:preset|color|luminous-vivid-amber"}}}}} -->
+<!-- wp:query-no-results -->
 <!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
 <p>No results found.</p>
 <!-- /wp:paragraph -->
 <!-- /wp:query-no-results --></div>
+<!-- /wp:group --></div>
 <!-- /wp:query -->

--- a/test/integration/fixtures/blocks/core__query__deprecated-3.serialized.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-3.serialized.html
@@ -1,0 +1,23 @@
+<!-- wp:query {"queryId":3,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"flex","columns":3},"align":"wide"} -->
+<div class="wp-block-query alignwide"><!-- wp:post-template {"textColor":"pale-cyan-blue","fontSize":"large","style":{"color":{"background":"#284d5f"},"elements":{"link":{"color":{"text":"var:preset|color|luminous-vivid-amber"}}}}} -->
+<!-- wp:post-title /-->
+
+<!-- wp:post-date /-->
+
+<!-- wp:post-excerpt /-->
+<!-- /wp:post-template -->
+
+<!-- wp:query-pagination {"textColor":"pale-cyan-blue","style":{"color":{"background":"#284d5f"},"elements":{"link":{"color":{"text":"var:preset|color|luminous-vivid-amber"}}}}} -->
+<!-- wp:query-pagination-previous /-->
+
+<!-- wp:query-pagination-numbers /-->
+
+<!-- wp:query-pagination-next /-->
+<!-- /wp:query-pagination -->
+
+<!-- wp:query-no-results {"textColor":"pale-cyan-blue","style":{"color":{"background":"#284d5f"},"elements":{"link":{"color":{"text":"var:preset|color|luminous-vivid-amber"}}}}} -->
+<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+<p>No results found.</p>
+<!-- /wp:paragraph -->
+<!-- /wp:query-no-results --></div>
+<!-- /wp:query -->


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/46472

Related:
- https://github.com/WordPress/gutenberg/pull/45005
- https://github.com/WordPress/gutenberg/issues/46472


## What?

Removes the Query block's color supports, moving them to the inner blocks. 

**Note: This could be a potentially breaking change due to the potential introduction of a wrapping Group block to enable reapplying the prior Query block colors.**

## Why?

The Query block is to be a "settings only" block. Applying the colors at such a high level has inconsistent results as well.

This direction for the Query block was identified through feedback on the block inspector tabs experiment introduced in https://github.com/WordPress/gutenberg/pull/45005

## How?

- Color supports are removed from the Query block
- Deprecations were refactored to match recommendations in docs
- A new deprecation has been added to the Query block to maintain previous color styling as best possible: 
    - If the Query block has more than one inner block, the inner blocks are wrapped in a new Group block with the previous color selections applied to the Group.
    - If the Query block has a single Group block as its inner block (which can then contain the post template block etc.), the color selections are moved to the existing Group block with no new element introduced.
- A fixture for the new deprecation has also been added.

### Alternative Approach Tried: Reapply colors to all inner blocks

This approach fell short in a couple of key ways:
1. There's no guarantee the inner blocks have adopted color supports so color may not be maintained
2. Even if inner blocks all supported colors, any margins between blocks would cause a gap between background colors

It would have the benefit of not introducing additional markup though. In trialling this approach the lack of new markup doesn't make up for its failure to maintain colors.

## Testing Instructions
1. Before checking out this PR, create a post and add several Query blocks to it
3. Configure each of the Query blocks with differing color configurations
4. Save the post
5. Checkout this PR and reload the editor
6. Ensure there are no block validation errors for the query block
7. Confirm the colors appear correctly on the inner blocks and not the outer Query block
8. Check the frontend matches
9. Run the fixture tests: `npm run test:unit test/integration/full-content/full-content.test.js`
<details>
<summary>Example Deprecated Query Blocks</summary> 

The following query blocks have a mixed of applied color support styles, inner blocks, or no customization.

```html
<!-- wp:query {"queryId":1,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"flex","columns":3},"style":{"elements":{"link":{"color":{"text":"var:preset|color|vivid-green-cyan"}}},"color":{"gradient":"linear-gradient(125deg,rgb(134,199,237) 0%,rgb(255,255,255) 36%,rgb(255,255,255) 59%,rgb(187,147,224) 100%)"}},"textColor":"secondary"} -->
<div class="wp-block-query has-secondary-color has-text-color has-background has-link-color" style="background:linear-gradient(125deg,rgb(134,199,237) 0%,rgb(255,255,255) 36%,rgb(255,255,255) 59%,rgb(187,147,224) 100%)"><!-- wp:post-template -->
<!-- wp:post-title /-->

<!-- wp:post-date /-->

<!-- wp:post-excerpt /-->
<!-- /wp:post-template -->

<!-- wp:query-pagination -->
<!-- wp:query-pagination-previous /-->

<!-- wp:query-pagination-numbers /-->

<!-- wp:query-pagination-next /-->
<!-- /wp:query-pagination -->

<!-- wp:query-no-results -->
<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
<p></p>
<!-- /wp:paragraph -->
<!-- /wp:query-no-results --></div>
<!-- /wp:query -->

<!-- wp:query {"queryId":3,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"flex","columns":3},"style":{"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"backgroundColor":"vivid-cyan-blue","textColor":"pale-cyan-blue"} -->
<div class="wp-block-query has-pale-cyan-blue-color has-vivid-cyan-blue-background-color has-text-color has-background has-link-color"><!-- wp:paragraph -->
<p>Paragraph to appear within Query block.</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:post-template -->
<!-- wp:post-title /-->

<!-- wp:post-date /-->

<!-- wp:post-excerpt /-->
<!-- /wp:post-template -->

<!-- wp:query-pagination -->
<!-- wp:query-pagination-previous /-->

<!-- wp:query-pagination-numbers /-->

<!-- wp:query-pagination-next /-->
<!-- /wp:query-pagination --></div>
<!-- /wp:group -->

<!-- wp:query-no-results -->
<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
<p></p>
<!-- /wp:paragraph -->
<!-- /wp:query-no-results --></div>
<!-- /wp:query -->

<!-- wp:query {"queryId":3,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"flex","columns":3},"style":{"elements":{"link":{"color":{"text":"var:preset|color|vivid-purple"}}}},"textColor":"secondary","gradient":"pale-ocean"} -->
<div class="wp-block-query has-secondary-color has-pale-ocean-gradient-background has-text-color has-background has-link-color"><!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:post-template -->
<!-- wp:post-title /-->

<!-- wp:post-date /-->

<!-- wp:post-excerpt /-->
<!-- /wp:post-template -->

<!-- wp:query-pagination -->
<!-- wp:query-pagination-previous /-->

<!-- wp:query-pagination-numbers /-->

<!-- wp:query-pagination-next /-->
<!-- /wp:query-pagination -->

<!-- wp:query-no-results -->
<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
<p></p>
<!-- /wp:paragraph -->
<!-- /wp:query-no-results --></div>
<!-- /wp:group --></div>
<!-- /wp:query -->

<!-- wp:query {"queryId":1,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"flex","columns":3}} -->
<div class="wp-block-query"><!-- wp:post-template -->
<!-- wp:post-title /-->

<!-- wp:post-date /-->

<!-- wp:post-excerpt /-->
<!-- /wp:post-template -->

<!-- wp:query-pagination -->
<!-- wp:query-pagination-previous /-->

<!-- wp:query-pagination-numbers /-->

<!-- wp:query-pagination-next /-->
<!-- /wp:query-pagination -->

<!-- wp:query-no-results -->
<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
<p></p>
<!-- /wp:paragraph -->
<!-- /wp:query-no-results --></div>
<!-- /wp:query -->
```

</details>

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/206390132-a61a6306-636e-4b40-8534-3d04cae2bc83.mp4

