### PR TITLE
Make `theme.json` object caches non persistent

### DIFF
--- a/lib/compat/wordpress-6.2/class-wp-theme-json-resolver-6-2.php
+++ b/lib/compat/wordpress-6.2/class-wp-theme-json-resolver-6-2.php
@@ -33,31 +33,6 @@ class WP_Theme_JSON_Resolver_6_2 extends WP_Theme_JSON_Resolver_6_1 {
 	}
 
 	/**
-	 * Private method to clean the cached data after an upgrade.
-	 *
-	 * It is hooked into the `upgrader_process_complete` action.
-	 *
-	 * @see default-filters.php
-	 *
-	 * @param WP_Upgrader $upgrader WP_Upgrader instance.
-	 * @param array       $options  Array of bulk item update data.
-	 */
-	public static function _clean_cached_data_upon_upgrading( $upgrader, $options ) {
-		if ( 'update' !== $options['action'] ) {
-			return;
-		}
-
-		if (
-			'core' === $options['type'] ||
-			'plugin' === $options['type'] ||
-			// Clean cache only if the active theme was updated.
-			( 'theme' === $options['type'] && ( isset( $options['themes'][ get_stylesheet() ] ) || isset( $options['themes'][ get_template() ] ) ) )
-		) {
-			static::clean_cached_data();
-		}
-	}
-
-	/**
 	 * Returns the data merged from multiple origins.
 	 *
 	 * There are four sources of data (origins) for a site:

--- a/lib/compat/wordpress-6.2/default-filters.php
+++ b/lib/compat/wordpress-6.2/default-filters.php
@@ -29,6 +29,4 @@ add_action( 'start_previewing_theme', array( 'WP_Theme_JSON_Resolver_Gutenberg',
 add_action( 'switch_theme', 'gutenberg_get_global_stylesheet_clean_cache' );
 add_action( 'switch_theme', 'wp_theme_has_theme_json_clean_cache' );
 add_action( 'switch_theme', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
-add_action( 'upgrader_process_complete', '_gutenberg_get_global_stylesheet_clean_cache_upon_upgrading', 10, 2 );
-add_action( 'upgrader_process_complete', '_wp_theme_has_theme_json_clean_cache_upon_upgrading_active_theme', 10, 2 );
 add_action( 'upgrader_process_complete', array( 'WP_Theme_JSON_Resolver_Gutenberg', '_clean_cached_data_upon_upgrading', 10, 2 ) );

--- a/lib/compat/wordpress-6.2/default-filters.php
+++ b/lib/compat/wordpress-6.2/default-filters.php
@@ -17,9 +17,7 @@
  * @package gutenberg
  */
 
-add_action( 'activated_plugin', 'gutenberg_get_global_stylesheet_clean_cache' );
 add_action( 'activated_plugin', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
-add_action( 'deactivated_plugin', 'gutenberg_get_global_stylesheet_clean_cache' );
 add_action( 'deactivated_plugin', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
 add_action( 'save_post_wp_global_styles', 'gutenberg_get_global_stylesheet_clean_cache' );
 add_action( 'save_post_wp_global_styles', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );

--- a/lib/compat/wordpress-6.2/default-filters.php
+++ b/lib/compat/wordpress-6.2/default-filters.php
@@ -17,18 +17,18 @@
  * @package gutenberg
  */
 
-add_action( 'switch_theme', 'wp_theme_has_theme_json_clean_cache' );
-add_action( 'switch_theme', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
+add_action( 'activated_plugin', 'gutenberg_get_global_stylesheet_clean_cache' );
+add_action( 'activated_plugin', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
+add_action( 'deactivated_plugin', 'gutenberg_get_global_stylesheet_clean_cache' );
+add_action( 'deactivated_plugin', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
+add_action( 'save_post_wp_global_styles', 'gutenberg_get_global_stylesheet_clean_cache' );
+add_action( 'save_post_wp_global_styles', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
+add_action( 'start_previewing_theme', 'gutenberg_get_global_stylesheet_clean_cache' );
 add_action( 'start_previewing_theme', 'wp_theme_has_theme_json_clean_cache' );
 add_action( 'start_previewing_theme', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
-add_action( 'upgrader_process_complete', '_wp_theme_has_theme_json_clean_cache_upon_upgrading_active_theme', 10, 2 );
-add_action( 'save_post_wp_global_styles', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
-add_action( 'activated_plugin', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
-add_action( 'deactivated_plugin', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
-add_action( 'upgrader_process_complete', array( 'WP_Theme_JSON_Resolver_Gutenberg', '_clean_cached_data_upon_upgrading', 10, 2 ) );
-add_action( 'save_post_wp_global_styles', 'gutenberg_get_global_stylesheet_clean_cache' );
 add_action( 'switch_theme', 'gutenberg_get_global_stylesheet_clean_cache' );
-add_action( 'start_previewing_theme', 'gutenberg_get_global_stylesheet_clean_cache' );
-add_action( 'activated_plugin', 'gutenberg_get_global_stylesheet_clean_cache' );
-add_action( 'deactivated_plugin', 'gutenberg_get_global_stylesheet_clean_cache' );
+add_action( 'switch_theme', 'wp_theme_has_theme_json_clean_cache' );
+add_action( 'switch_theme', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
 add_action( 'upgrader_process_complete', '_gutenberg_get_global_stylesheet_clean_cache_upon_upgrading', 10, 2 );
+add_action( 'upgrader_process_complete', '_wp_theme_has_theme_json_clean_cache_upon_upgrading_active_theme', 10, 2 );
+add_action( 'upgrader_process_complete', array( 'WP_Theme_JSON_Resolver_Gutenberg', '_clean_cached_data_upon_upgrading', 10, 2 ) );

--- a/lib/compat/wordpress-6.2/default-filters.php
+++ b/lib/compat/wordpress-6.2/default-filters.php
@@ -17,9 +17,9 @@
  * @package gutenberg
  */
 
-add_action( 'start_previewing_theme', 'gutenberg_get_global_stylesheet_clean_cache' );
-add_action( 'start_previewing_theme', 'wp_theme_has_theme_json_clean_cache' );
-add_action( 'start_previewing_theme', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
-add_action( 'switch_theme', 'gutenberg_get_global_stylesheet_clean_cache' );
-add_action( 'switch_theme', 'wp_theme_has_theme_json_clean_cache' );
-add_action( 'switch_theme', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
+/**
+ * When backporting to core, the existing filters hooked to WP_Theme_JSON_Resolver::clean_cached_data()
+ * need to be removed.
+ */
+add_action( 'start_previewing_theme', '_gutenberg_clean_theme_json_caches' );
+add_action( 'switch_theme', '_gutenberg_clean_theme_json_caches' );

--- a/lib/compat/wordpress-6.2/default-filters.php
+++ b/lib/compat/wordpress-6.2/default-filters.php
@@ -17,13 +17,9 @@
  * @package gutenberg
  */
 
-add_action( 'activated_plugin', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
-add_action( 'deactivated_plugin', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
-add_action( 'save_post_wp_global_styles', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
 add_action( 'start_previewing_theme', 'gutenberg_get_global_stylesheet_clean_cache' );
 add_action( 'start_previewing_theme', 'wp_theme_has_theme_json_clean_cache' );
 add_action( 'start_previewing_theme', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
 add_action( 'switch_theme', 'gutenberg_get_global_stylesheet_clean_cache' );
 add_action( 'switch_theme', 'wp_theme_has_theme_json_clean_cache' );
 add_action( 'switch_theme', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
-add_action( 'upgrader_process_complete', array( 'WP_Theme_JSON_Resolver_Gutenberg', '_clean_cached_data_upon_upgrading', 10, 2 ) );

--- a/lib/compat/wordpress-6.2/default-filters.php
+++ b/lib/compat/wordpress-6.2/default-filters.php
@@ -19,7 +19,6 @@
 
 add_action( 'activated_plugin', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
 add_action( 'deactivated_plugin', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
-add_action( 'save_post_wp_global_styles', 'gutenberg_get_global_stylesheet_clean_cache' );
 add_action( 'save_post_wp_global_styles', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
 add_action( 'start_previewing_theme', 'gutenberg_get_global_stylesheet_clean_cache' );
 add_action( 'start_previewing_theme', 'wp_theme_has_theme_json_clean_cache' );

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -227,3 +227,29 @@ function gutenberg_get_global_settings( $path = array(), $context = array() ) {
 	$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_settings();
 	return _wp_array_get( $settings, $path, $settings );
 }
+
+/**
+ * Tell the cache mechanisms not to persist theme.json data across requests.
+ * The data stored under this cache group:
+ *
+ * - wp_theme_has_theme_json
+ * - gutenberg_get_global_stylesheet
+ *
+ * There is some hooks consumers can use to modify parts
+ * of the theme.json logic.
+ * See https://make.wordpress.org/core/2022/10/10/filters-for-theme-json-data/
+ *
+ * The rationale to make this cache group non persistent is to make sure derived data
+ * from theme.json is always fresh from the potential modifications done via hooks
+ * that can use dynamic data (modify the stylesheet depending on some option,
+ * or settings depending on user permissions, etc.).
+ *
+ * A different alternative considered was to invalidate the cache upon certain
+ * events such as options add/update/delete, user meta, etc.
+ * It was judged not enough, hence this approach.
+ * See https://github.com/WordPress/gutenberg/pull/45372
+ */
+function _gutenberg_add_non_persistent_theme_json_cache_group() {
+	wp_cache_add_non_persistent_groups( 'theme_json' );
+}
+add_action( 'init', '_gutenberg_add_non_persistent_theme_json_cache_group' );

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -137,15 +137,6 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 }
 
 /**
- * Clean the cache used by the `gutenberg_get_global_stylesheet` function.
- *
- * Not to backport to core. Delete it instead.
- */
-function gutenberg_get_global_stylesheet_clean_cache() {
-	_deprecated_function( __METHOD__, '14.7' );
-}
-
-/**
  * Function to get the settings resulting of merging core, theme, and user data.
  *
  * @param array $path    Path to the specific setting to retrieve. Optional.

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -211,4 +211,4 @@ function _gutenberg_clean_theme_json_caches() {
 function _gutenberg_add_non_persistent_theme_json_cache_group() {
 	wp_cache_add_non_persistent_groups( 'theme_json' );
 }
-add_action( 'init', '_gutenberg_add_non_persistent_theme_json_cache_group' );
+add_action( 'plugins_loaded', '_gutenberg_add_non_persistent_theme_json_cache_group' );

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -57,29 +57,6 @@ if ( ! function_exists( 'wp_theme_has_theme_json_clean_cache' ) ) {
 	}
 }
 
-if ( ! function_exists( '_wp_theme_has_theme_json_clean_cache_upon_upgrading_active_theme' ) ) {
-	/**
-	 * Private function to clean the cache used by wp_theme_has_theme_json method.
-	 *
-	 * It is hooked into the `upgrader_process_complete` action.
-	 *
-	 * @see default-filters.php
-	 *
-	 * @param WP_Upgrader $upgrader Instance of WP_Upgrader class.
-	 * @param array       $options Metadata that identifies the data that is updated.
-	 */
-	function _wp_theme_has_theme_json_clean_cache_upon_upgrading_active_theme( $upgrader, $options ) {
-		// The cache only needs cleaning when the active theme was updated.
-		if (
-			'update' === $options['action'] &&
-			'theme' === $options['type'] &&
-			( isset( $options['themes'][ get_stylesheet() ] ) || isset( $options['themes'][ get_template() ] ) )
-		) {
-			wp_theme_has_theme_json_clean_cache();
-		}
-	}
-}
-
 /**
  * Returns the stylesheet resulting of merging core, theme, and user data.
  *
@@ -162,31 +139,6 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
  */
 function gutenberg_get_global_stylesheet_clean_cache() {
 	wp_cache_delete( 'gutenberg_get_global_stylesheet', 'theme_json' );
-}
-
-/**
- * Private function to clean the cache used by the `gutenberg_get_global_stylesheet` function after an upgrade.
- *
- * It is hooked into the `upgrader_process_complete` action.
- *
- * @see default-filters.php
- *
- * @param WP_Upgrader $upgrader WP_Upgrader instance.
- * @param array       $options  Array of bulk item update data.
- */
-function _gutenberg_get_global_stylesheet_clean_cache_upon_upgrading( $upgrader, $options ) {
-	if ( 'update' !== $options['action'] ) {
-		return;
-	}
-
-	if (
-		'core' === $options['type'] ||
-		'plugin' === $options['type'] ||
-		// Clean cache only if the active theme was updated.
-		( 'theme' === $options['type'] && ( isset( $options['themes'][ get_stylesheet() ] ) || isset( $options['themes'][ get_template() ] ) ) )
-	) {
-		gutenberg_get_global_stylesheet_clean_cache();
-	}
 }
 
 /**

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -51,9 +51,11 @@ if ( ! function_exists( 'wp_theme_has_theme_json' ) ) {
 if ( ! function_exists( 'wp_theme_has_theme_json_clean_cache' ) ) {
 	/**
 	 * Function to clean the cache used by wp_theme_has_theme_json method.
+	 *
+	 * Not to backport to core. Delete it instead.
 	 */
 	function wp_theme_has_theme_json_clean_cache() {
-		wp_cache_delete( 'wp_theme_has_theme_json', 'theme_json' );
+		_deprecated_function( __METHOD__, '14.7' );
 	}
 }
 
@@ -136,9 +138,11 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 
 /**
  * Clean the cache used by the `gutenberg_get_global_stylesheet` function.
+ *
+ * Not to backport to core. Delete it instead.
  */
 function gutenberg_get_global_stylesheet_clean_cache() {
-	wp_cache_delete( 'gutenberg_get_global_stylesheet', 'theme_json' );
+	_deprecated_function( __METHOD__, '14.7' );
 }
 
 /**
@@ -178,6 +182,18 @@ function gutenberg_get_global_settings( $path = array(), $context = array() ) {
 
 	$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_settings();
 	return _wp_array_get( $settings, $path, $settings );
+}
+
+/**
+ * Private function to clean the caches used by gutenberg_get_global_settings method.
+ *
+ * @access private
+ */
+function _gutenberg_clean_theme_json_caches() {
+	wp_cache_delete( 'wp_theme_has_theme_json', 'theme_json' );
+	wp_cache_delete( 'gutenberg_get_global_stylesheet', 'theme_json' );
+	wp_cache_delete( 'gutenberg_get_global_settings_theme', 'theme_json' );
+	WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data();
 }
 
 /**


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/pull/45372
Part of https://github.com/WordPress/gutenberg/issues/45171

## What?

This PR makes the object caches in use for theme.json related data non-persistent.

## Why?

Upon some conversations at https://github.com/WordPress/gutenberg/pull/45372 people find that there are a couple of cases for which the invalidation of cache may be not enough:

- Consumers that hook into theme.json data using dynamic data (hooking or not based on an options or user meta value). The alternative would be to invalidate the cache upon certain events (plugin de/activation, option ad/update/delete, etc.).
- Updates that are not done via the regular WordPress mechanism (FTP updates, updates managed via git repositories, etc.). The alternative is asking consumers to clear the cache manually if they use a persistent cache plugin.

To unblock that PR, this makes the data non-persistent.

## How?

- Adds `theme_json` to the list of cache groups not to persist.
- Removes the existing filters that took care of invalidating the cache for across-request situations: plugin de/activation, global styles post update.

## Testing Instructions

- Go to the global styles sidebar in site editor, do some changes (e.g.: change background color) and save.
- Go to the front-end and verify that the changes are reflected immediately.
