### PR TITLE
Block editor: rich text: return early if __experimentalUndo is not defined

### DIFF
--- a/packages/block-editor/src/components/rich-text/use-undo-automatic-change.js
+++ b/packages/block-editor/src/components/rich-text/use-undo-automatic-change.js
@@ -28,12 +28,18 @@ export function useUndoAutomaticChange() {
 				return;
 			}
 
+			const { __experimentalUndo } = getSettings();
+
+			if ( ! __experimentalUndo ) {
+				return;
+			}
+
 			if ( ! didAutomaticChange() ) {
 				return;
 			}
 
 			event.preventDefault();
-			getSettings().__experimentalUndo();
+			__experimentalUndo();
 		}
 
 		element.addEventListener( 'keydown', onKeyDown );


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What & why?
<!-- In a few words, what is the PR actually doing? -->

It looks like some editor implementations (P2) are not passing an __experimentalUndo function in block settings, which causes an error when pressing Backspace/Delete/Escape after an automatic change such as the list and quote input rules.

We should return early when this is not defined to prevent the error and fall back to default behaviour.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
