### PR TITLE
Block Editor: Improve inserter search performance

### DIFF
--- a/packages/block-editor/src/components/inserter/hooks/use-debounced-input.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-debounced-input.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+import { useDebounce } from '@wordpress/compose';
+
+export default function useDebouncedInput( defaultValue = '' ) {
+	const [ input, setInput ] = useState( defaultValue );
+	const [ debounced, setter ] = useState( defaultValue );
+	const setDebounced = useDebounce( setter, 250 );
+	useEffect( () => {
+		if ( debounced !== input ) {
+			setDebounced( input );
+		}
+	}, [ debounced, input ] );
+	return [ input, setInput, debounced ];
+}

--- a/packages/block-editor/src/components/inserter/media-tab/hooks.js
+++ b/packages/block-editor/src/components/inserter/media-tab/hooks.js
@@ -4,24 +4,11 @@
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import { useDebounce } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../../store';
-
-export function useDebouncedInput() {
-	const [ input, setInput ] = useState( '' );
-	const [ debounced, setter ] = useState( '' );
-	const setDebounced = useDebounce( setter, 250 );
-	useEffect( () => {
-		if ( debounced !== input ) {
-			setDebounced( input );
-		}
-	}, [ debounced, input ] );
-	return [ input, setInput, debounced ];
-}
 
 export function useMediaResults( options = {} ) {
 	const [ results, setResults ] = useState();

--- a/packages/block-editor/src/components/inserter/media-tab/media-panel.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-panel.js
@@ -10,7 +10,8 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import MediaList from './media-list';
-import { useMediaResults, useDebouncedInput } from './hooks';
+import useDebouncedInput from '../hooks/use-debounced-input';
+import { useMediaResults } from './hooks';
 import InserterNoResults from '../no-results';
 
 const INITIAL_MEDIA_ITEMS_PER_PAGE = 10;

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -16,7 +16,6 @@ import {
 } from '@wordpress/element';
 import { VisuallyHidden, SearchControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useDebounce } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -31,6 +30,7 @@ import BlockPatternsTabs, {
 import ReusableBlocksTab from './reusable-blocks-tab';
 import { MediaTab, MediaCategoryDialog, useMediaCategories } from './media-tab';
 import InserterSearchResults from './search-results';
+import useDebouncedInput from './hooks/use-debounced-input';
 import useInsertionPoint from './hooks/use-insertion-point';
 import InserterTabs from './tabs';
 import { store as blockEditorStore } from '../../store';
@@ -50,15 +50,8 @@ function InserterMenu(
 	},
 	ref
 ) {
-	// Used for the search field only.
-	const [ filterValue, setFilterValue ] = useState(
-		__experimentalFilterValue
-	);
-	// Used for the rest of the inserter, debounced for performance reasons.
-	const [ delayedFilterValue, setDelayedFilterValue ] = useState(
-		__experimentalFilterValue
-	);
-	const debouncedSetFilterValue = useDebounce( setDelayedFilterValue, 100 );
+	const [ filterValue, setFilterValue, delayedFilterValue ] =
+		useDebouncedInput( __experimentalFilterValue );
 	const [ hoveredItem, setHoveredItem ] = useState( null );
 	const [ selectedPatternCategory, setSelectedPatternCategory ] =
 		useState( null );
@@ -244,7 +237,6 @@ function InserterMenu(
 					className="block-editor-inserter__search"
 					onChange={ ( value ) => {
 						if ( hoveredItem ) setHoveredItem( null );
-						debouncedSetFilterValue( value );
 						setFilterValue( value );
 					} }
 					value={ filterValue }

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -136,6 +136,7 @@ export async function searchForPattern( searchTerm ) {
 	await page.focus( INSERTER_SEARCH_SELECTOR );
 	await pressKeyWithModifier( 'primary', 'a' );
 	await page.keyboard.type( searchTerm );
+	await waitForInserterSearch();
 }
 
 /**

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -99,10 +99,11 @@ async function waitForInserterCloseAndContentFocus() {
 	);
 }
 
+/**
+ * Wait for the inserter search to yield results because that input is debounced.
+ */
 async function waitForInserterSearch() {
-	// Inserter search results are debounced, let's wait a bit after typing.
-	// eslint-disable-next-line no-restricted-syntax
-	await page.waitForTimeout( 200 );
+	await page.waitForSelector( '.block-editor-inserter__no-tab-container' );
 }
 
 /**

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -99,6 +99,12 @@ async function waitForInserterCloseAndContentFocus() {
 	);
 }
 
+async function waitForInserterSearch() {
+	// Inserter search results are debounced, let's wait a bit after typing.
+	// eslint-disable-next-line no-restricted-syntax
+	await page.waitForTimeout( 200 );
+}
+
 /**
  * Search for block in the global inserter
  *
@@ -110,9 +116,7 @@ export async function searchForBlock( searchTerm ) {
 	await page.focus( INSERTER_SEARCH_SELECTOR );
 	await pressKeyWithModifier( 'primary', 'a' );
 	await page.keyboard.type( searchTerm );
-	// Inserter search results are debounced, let's wait a bit after typing.
-	// eslint-disable-next-line no-restricted-syntax
-	await page.waitForTimeout( 200 );
+	await waitForInserterSearch();
 }
 
 /**
@@ -157,6 +161,7 @@ export async function searchForReusableBlock( searchTerm ) {
 	await page.focus( INSERTER_SEARCH_SELECTOR );
 	await pressKeyWithModifier( 'primary', 'a' );
 	await page.keyboard.type( searchTerm );
+	await waitForInserterSearch();
 }
 
 /**

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -110,6 +110,9 @@ export async function searchForBlock( searchTerm ) {
 	await page.focus( INSERTER_SEARCH_SELECTOR );
 	await pressKeyWithModifier( 'primary', 'a' );
 	await page.keyboard.type( searchTerm );
+	// Inserter search results are debounced, let's wait a bit after typing.
+	// eslint-disable-next-line no-restricted-syntax
+	await page.waitForTimeout( 200 );
 }
 
 /**


### PR DESCRIPTION
## What?
This PR aims to improve **inserter search performance**. 

The change should not only impact measured performance but user-perceived performance because we're making **much fewer requests** while the user is inputting the inserter search query. 

The impact I measured locally with the performance tests indicates **an improvement of inserter search performance by ~5 times**. 

## Why?
Inserter search is currently slow because there's a lot going on - every time we search for something, on every search field input change, we re-render all blocks and block patterns, and each of them has a bunch going on. For example, each block pattern has its own preview iframe with corresponding scripts and styles that get reloaded on every search field change.

## How?
We're reusing the `useDebouncedInput` hook to debounce the inserter search input. That way we save a bunch of unnecessary rerenders and style/script fetches that happen in the meantime.

We're updating e2e tests to be aware of the denounced search and waiting for the search results wrapper to appear before inserting blocks and patterns.

## Testing Instructions
* Open the block inserter in the edit post header.
* Search for something, e.g. `para` or `imag`.
* Verify that results are almost immediately shown and everything works the same as before.
* To run the performance tests of the `trunk` branch vs this one, checkout the branch and apply this locally:

```
diff --git a/packages/e2e-tests/specs/performance/post-editor.test.js b/packages/e2e-tests/specs/performance/post-editor.test.js
index 933b4973fb..ea85a6fe55 100644
--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -221,7 +221,7 @@ describe( 'Post Editor Performance', () => {
                }
        } );

-       it( 'Searching the inserter', async () => {
+       it.only( 'Searching the inserter', async () => {
                function sum( arr ) {
                        return arr.reduce( ( a, b ) => a + b, 0 );
                }
```
* Run `npm run test:performance post-editor.test.js`, wait for ~half a minute and observe the results.

## Screenshots or screencast <!-- if applicable -->

Before:
![Screenshot 2022-11-29 at 13 39 30](https://user-images.githubusercontent.com/8436925/204520080-d9af5ddc-303c-4898-99fb-af9245ceea5d.png)

After:
![Screenshot 2022-11-29 at 13 40 52](https://user-images.githubusercontent.com/8436925/204520086-35774eb0-7809-43e6-b397-a6e98b4b49c1.png)
