### PR TITLE
[Mobile] - Deprecate Gallery V1 as an Unsupported block

### DIFF
--- a/lib/experimental/block-editor-settings-mobile.php
+++ b/lib/experimental/block-editor-settings-mobile.php
@@ -31,6 +31,8 @@ function gutenberg_get_block_editor_settings_mobile( $settings ) {
 		$settings['__experimentalEnableQuoteBlockV2'] = true;
 		// To tell mobile that the site uses list v2 (inner blocks).
 		$settings['__experimentalEnableListBlockV2'] = true;
+		// To tell mobile if it should mark the Gallery block as Unsupported for older versions of WordPress
+		$settings['__unstableGalleryWithImageBlocks'] = is_wp_version_compatible( '5.9' );
 	}
 
 	return $settings;

--- a/lib/experimental/block-editor-settings-mobile.php
+++ b/lib/experimental/block-editor-settings-mobile.php
@@ -31,7 +31,7 @@ function gutenberg_get_block_editor_settings_mobile( $settings ) {
 		$settings['__experimentalEnableQuoteBlockV2'] = true;
 		// To tell mobile that the site uses list v2 (inner blocks).
 		$settings['__experimentalEnableListBlockV2'] = true;
-		// To tell mobile if it should mark the Gallery block as Unsupported for older versions of WordPress
+		// To tell mobile if it should mark the Gallery block as Unsupported for older versions of WordPress.
 		$settings['__unstableGalleryWithImageBlocks'] = is_wp_version_compatible( '5.9' );
 	}
 

--- a/packages/block-library/src/gallery/test/__snapshots__/index.native.js.snap
+++ b/packages/block-library/src/gallery/test/__snapshots__/index.native.js.snap
@@ -32,6 +32,17 @@ exports[`Gallery block Columns setting does not increment due to maximum value 1
 <!-- /wp:gallery -->"
 `;
 
+exports[`Gallery block V1 deprecation shows the Gallery block as Unsupported if the flag galleryWithImageBlocks is set to false 1`] = `
+"<!-- wp:gallery {\\"ids\\":[13,15],\\"linkTo\\":\\"none\\"} -->
+<figure class=\\"wp-block-gallery columns-2 is-cropped\\">
+			<ul class=\\"blocks-gallery-grid\\"><li class=\\"blocks-gallery-item\\">
+			<figure><img src=\\"https://test-site.files.wordpress.com/local-image-1.jpeg\\" data-id=\\"13\\" class=\\"wp-image-13\\" />
+			</figure></li><li class=\\"blocks-gallery-item\\"><figure>
+			<img src=\\"https://test-site.files.wordpress.com/local-image-2.jpeg\\" data-id=\\"15\\" class=\\"wp-image-15\\" />
+			</figure></li></ul></figure>
+<!-- /wp:gallery -->"
+`;
+
 exports[`Gallery block cancels uploads 1`] = `
 "<!-- wp:gallery {\\"linkTo\\":\\"none\\"} -->
 <figure class=\\"wp-block-gallery has-nested-images columns-default is-cropped\\"><!-- wp:image {\\"id\\":null} -->

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -196,7 +196,7 @@ addFilter(
 
 // Deprecation of Gallery V1
 function galleryCheck( galleryBlock, blocksFlags ) {
-	const { galleryWithImageBlocks } = blocksFlags;
+	const { galleryWithImageBlocks } = blocksFlags || {};
 
 	if (
 		typeof galleryWithImageBlocks === 'boolean' &&

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -194,6 +194,20 @@ addFilter(
 	}
 );
 
+// Deprecation of Gallery V1
+function galleryCheck( galleryBlock, blocksFlags ) {
+	const { galleryWithImageBlocks } = blocksFlags;
+
+	if (
+		typeof galleryWithImageBlocks === 'boolean' &&
+		! galleryWithImageBlocks
+	) {
+		// Mark the Gallery block as unsupported for users using <=5.8 or without the Gutenberg plugin
+		return null;
+	}
+	return galleryBlock;
+}
+
 /**
  * Function to register core blocks provided by the block editor.
  *
@@ -203,8 +217,10 @@ addFilter(
  *
  * registerCoreBlocks();
  * ```
+ * @param {Object} [blocksFlags] Experimental flags
+ *
  */
-export const registerCoreBlocks = () => {
+export const registerCoreBlocks = ( blocksFlags ) => {
 	// When adding new blocks to this list please also consider updating /src/block-support/supported-blocks.json in the Gutenberg-Mobile repo
 	[
 		paragraph,
@@ -221,7 +237,7 @@ export const registerCoreBlocks = () => {
 		quote,
 		mediaText,
 		preformatted,
-		gallery,
+		galleryCheck( gallery, blocksFlags ),
 		columns,
 		column,
 		group,

--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -127,18 +127,18 @@ export class UnsupportedBlockEdit extends Component {
 		}
 	}
 
-	getSheetTitle( blockTitle ) {
-		if ( CUSTOM_UNSUPPORTED_BLOCK_MESSAGE[ blockTitle ] ) {
-			return CUSTOM_UNSUPPORTED_BLOCK_MESSAGE[ blockTitle ]?.title;
+	getSheetTitle( blockName ) {
+		if ( CUSTOM_UNSUPPORTED_BLOCK_MESSAGE[ blockName ] ) {
+			return CUSTOM_UNSUPPORTED_BLOCK_MESSAGE[ blockName ]?.title;
 		}
 
 		/* translators: Missing block alert title. %s: The localized block name */
 		return __( "'%s' is not fully-supported" );
 	}
 
-	getSheetDescription( blockTitle ) {
-		if ( CUSTOM_UNSUPPORTED_BLOCK_MESSAGE[ blockTitle ] ) {
-			return CUSTOM_UNSUPPORTED_BLOCK_MESSAGE[ blockTitle ]?.description;
+	getSheetDescription( blockName ) {
+		if ( CUSTOM_UNSUPPORTED_BLOCK_MESSAGE[ blockName ] ) {
+			return CUSTOM_UNSUPPORTED_BLOCK_MESSAGE[ blockName ]?.description;
 		}
 
 		return applyFilters(

--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -36,7 +36,7 @@ import styles from './style.scss';
 const UBE_INCOMPATIBLE_BLOCKS = [ 'core/block' ];
 const I18N_BLOCK_SCHEMA_TITLE = 'block title';
 const CUSTOM_UNSUPPORTED_BLOCK_MESSAGE = {
-	Gallery: {
+	'core/gallery': {
 		/* translators: Unsupported block alert title. %s: The localized block name */
 		title: __( "'%s' needs an updated version of WordPress" ),
 		description: __( 'Please update to version 5.9 or above' ),
@@ -173,9 +173,9 @@ export class UnsupportedBlockEdit extends Component {
 			styles.infoSheetIconDark
 		);
 
-		const titleFormat = this.getSheetTitle( blockTitle );
+		const titleFormat = this.getSheetTitle( blockName );
 		const infoTitle = sprintf( titleFormat, blockTitle );
-		const missingBlockDetail = this.getSheetDescription( blockTitle );
+		const missingBlockDetail = this.getSheetDescription( blockName );
 		const missingBlockActionButton = applyFilters(
 			'native.missing_block_action_button',
 			__( 'Edit using web editor' )

--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -35,6 +35,10 @@ import styles from './style.scss';
 // Blocks that can't be edited through the Unsupported block editor identified by their name.
 const UBE_INCOMPATIBLE_BLOCKS = [ 'core/block' ];
 const I18N_BLOCK_SCHEMA_TITLE = 'block title';
+const CUSTOM_BLOCK_TITLES = {
+	/* translators: Unsupported block alert title. %s: The localized block name */
+	Gallery: __( "'%s' needs an updated version of WordPress" ),
+};
 
 export class UnsupportedBlockEdit extends Component {
 	constructor( props ) {
@@ -120,6 +124,15 @@ export class UnsupportedBlockEdit extends Component {
 		}
 	}
 
+	getSheetTitle( blockTitle ) {
+		if ( CUSTOM_BLOCK_TITLES[ blockTitle ] ) {
+			return CUSTOM_BLOCK_TITLES[ blockTitle ];
+		}
+
+		/* translators: Missing block alert title. %s: The localized block name */
+		return __( "'%s' is not fully-supported" );
+	}
+
 	renderSheet( blockTitle, blockName ) {
 		const {
 			getStylesFromColorScheme,
@@ -146,8 +159,7 @@ export class UnsupportedBlockEdit extends Component {
 			styles.infoSheetIconDark
 		);
 
-		/* translators: Missing block alert title. %s: The localized block name */
-		const titleFormat = __( "'%s' is not fully-supported" );
+		const titleFormat = this.getSheetTitle( blockTitle );
 		const infoTitle = sprintf( titleFormat, blockTitle );
 		const missingBlockDetail = applyFilters(
 			'native.missing_block_detail',

--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -35,9 +35,12 @@ import styles from './style.scss';
 // Blocks that can't be edited through the Unsupported block editor identified by their name.
 const UBE_INCOMPATIBLE_BLOCKS = [ 'core/block' ];
 const I18N_BLOCK_SCHEMA_TITLE = 'block title';
-const CUSTOM_BLOCK_TITLES = {
-	/* translators: Unsupported block alert title. %s: The localized block name */
-	Gallery: __( "'%s' needs an updated version of WordPress" ),
+const CUSTOM_UNSUPPORTED_BLOCK_MESSAGE = {
+	Gallery: {
+		/* translators: Unsupported block alert title. %s: The localized block name */
+		title: __( "'%s' needs an updated version of WordPress" ),
+		description: __( 'Please update to version 5.9 or above' ),
+	},
 };
 
 export class UnsupportedBlockEdit extends Component {
@@ -125,12 +128,23 @@ export class UnsupportedBlockEdit extends Component {
 	}
 
 	getSheetTitle( blockTitle ) {
-		if ( CUSTOM_BLOCK_TITLES[ blockTitle ] ) {
-			return CUSTOM_BLOCK_TITLES[ blockTitle ];
+		if ( CUSTOM_UNSUPPORTED_BLOCK_MESSAGE[ blockTitle ] ) {
+			return CUSTOM_UNSUPPORTED_BLOCK_MESSAGE[ blockTitle ]?.title;
 		}
 
 		/* translators: Missing block alert title. %s: The localized block name */
 		return __( "'%s' is not fully-supported" );
+	}
+
+	getSheetDescription( blockTitle ) {
+		if ( CUSTOM_UNSUPPORTED_BLOCK_MESSAGE[ blockTitle ] ) {
+			return CUSTOM_UNSUPPORTED_BLOCK_MESSAGE[ blockTitle ]?.description;
+		}
+
+		return applyFilters(
+			'native.missing_block_detail',
+			__( 'We are working hard to add more blocks with each release.' )
+		);
 	}
 
 	renderSheet( blockTitle, blockName ) {
@@ -161,10 +175,7 @@ export class UnsupportedBlockEdit extends Component {
 
 		const titleFormat = this.getSheetTitle( blockTitle );
 		const infoTitle = sprintf( titleFormat, blockTitle );
-		const missingBlockDetail = applyFilters(
-			'native.missing_block_detail',
-			__( 'We are working hard to add more blocks with each release.' )
-		);
+		const missingBlockDetail = this.getSheetDescription( blockTitle );
 		const missingBlockActionButton = applyFilters(
 			'native.missing_block_action_button',
 			__( 'Edit using web editor' )

--- a/packages/react-native-editor/src/setup.js
+++ b/packages/react-native-editor/src/setup.js
@@ -60,8 +60,11 @@ const gutenbergSetup = () => {
 const setupInitHooks = () => {
 	addAction( 'native.pre-render', 'core/react-native-editor', ( props ) => {
 		const capabilities = props.capabilities ?? {};
+		const blocksFlags = {
+			galleryWithImageBlocks: props?.galleryWithImageBlocks,
+		};
 
-		registerBlocks();
+		registerBlocks( blocksFlags );
 
 		// Unregister non-supported blocks by capabilities
 		if (
@@ -119,12 +122,12 @@ const setupInitHooks = () => {
 };
 
 let blocksRegistered = false;
-const registerBlocks = () => {
+const registerBlocks = ( blocksFlags ) => {
 	if ( blocksRegistered ) {
 		return;
 	}
 
-	registerCoreBlocks();
+	registerCoreBlocks( blocksFlags );
 
 	blocksRegistered = true;
 };


### PR DESCRIPTION
## What?
Deprecates the V1 of the Gallery block since three versions of WordPress have been released since version 2 was released in `5.9`.

## Why?
To avoid maintaining old code that is no longer supported for too long.

## How?
Since there is still some usage we will use the current `__unstableGalleryWithImageBlocks` flag that was previously pulled from `gutenberg_experiments_editor_settings` but now it will be in the mobile block editor settings endpoint, to show users that have this flag as `false` an unsupported version of the Gallery block.

It will provide hints to upgrade to a newer version of WordPress and editing capability using a WebView in some specific cases.

Users that have this flag as `false` **won't see the Gallery block button in the inserter**. We could provide a hint every time they open the inserter or the editor but maybe it could be annoying for users that might not even use this block?

## Testing Instructions

**Precondition:**

- Use a self-hosted site
- Install the Gutenberg plugin and activate it
- Using the Plugin file editor, go to the Gutenberg plugin and update [this line](https://github.com/WordPress/gutenberg/blob/trunk/lib/experiments-page.php#L141-L143) to: 
 ```
	$experiments_settings = array(
		'__unstableGalleryWithImageBlocks' => false,
	);
```
- Using the web editor create a post with a Gallery block

On the mobile app:

- Log into your self-hosted site
- Open the draft post you created
- Expect to see the Gallery block as `Unsupported` if you don't see this, re-open the editor
- Tap on the `?` button
- Expect to see a description of why this block is unsupported

## Screenshots or screencast <!-- if applicable -->
<kbd><img src="https://user-images.githubusercontent.com/4885740/204553680-793a3937-b257-4a27-94b1-28a38831a727.png" width=250 /></kbd>

