### PR TITLE
ESLint: Fix minor ESLint warning in `LinkUI`

### DIFF
--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -47,8 +47,8 @@ export function getSuggestionsQuery( type, kind ) {
 /**
  * Add transforms to Link Control
  *
- * @param {Object} props					Component props.
- * @param {string} props.clientId			Block client ID.
+ * @param {Object} props          Component props.
+ * @param {string} props.clientId Block client ID.
  */
 function LinkControlTransforms( { clientId } ) {
 	const { getBlock, blockTransforms } = useSelect(


### PR DESCRIPTION
## What?
While working on #46160 I noticed a new ESLint warning that we seem to have introduced in #46031. This PR fixes it.

## Why?
Ideally, we should have no ESLint warnings in the entire codebase.

## How?
I ran `npm run lint:js -- --fix` to auto-fix it.

## Testing Instructions
Run `npm run lint:js` and verify the warning from the screenshot below is gone.

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2022-11-29 at 16 40 06](https://user-images.githubusercontent.com/8436925/204559452-1a6797e0-0a8b-4844-8f04-70c5bfc8e3dd.png)

