### PR TITLE
Page List Item: hide edit button

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/block-edit-button.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-edit-button.js
@@ -4,20 +4,24 @@
 import { edit } from '@wordpress/icons';
 import { Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
 
-const BlockEditButton = ( { label, clientId } ) => {
+export default forwardRef( function BlockEditButton(
+	{ clientId, ...props },
+	ref
+) {
 	const { selectBlock } = useDispatch( blockEditorStore );
 
 	const onClick = () => {
 		selectBlock( clientId );
 	};
 
-	return <Button icon={ edit } label={ label } onClick={ onClick } />;
-};
-
-export default BlockEditButton;
+	return (
+		<Button { ...props } ref={ ref } icon={ edit } onClick={ onClick } />
+	);
+} );

--- a/packages/block-editor/src/components/off-canvas-editor/block.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block.js
@@ -145,6 +145,7 @@ function ListViewBlock( {
 
 	const { isTreeGridMounted, expand, collapse } = useListViewContext();
 
+	const isEditable = block.name !== 'core/page-list-item';
 	const hasSiblings = siblingBlockCount > 0;
 	const hasRenderedMovers = showBlockMovers && hasSiblings;
 	const moverCellClassName = classnames(
@@ -331,10 +332,14 @@ function ListViewBlock( {
 						}
 					>
 						{ () => (
-							<BlockEditButton
-								label={ editAriaLabel }
-								clientId={ clientId }
-							/>
+							<>
+								{ isEditable && (
+									<BlockEditButton
+										label={ editAriaLabel }
+										clientId={ clientId }
+									/>
+								) }
+							</>
 						) }
 					</TreeGridCell>
 					<TreeGridCell

--- a/packages/block-editor/src/components/off-canvas-editor/block.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block.js
@@ -331,16 +331,15 @@ function ListViewBlock( {
 							!! isSelected || forceSelectionContentLock
 						}
 					>
-						{ () => (
-							<>
-								{ isEditable && (
-									<BlockEditButton
-										label={ editAriaLabel }
-										clientId={ clientId }
-									/>
-								) }
-							</>
-						) }
+						{ ( props ) =>
+							isEditable && (
+								<BlockEditButton
+									{ ...props }
+									label={ editAriaLabel }
+									clientId={ clientId }
+								/>
+							)
+						}
 					</TreeGridCell>
 					<TreeGridCell
 						className={ listViewBlockSettingsClassName }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Closes https://github.com/WordPress/gutenberg/issues/46051
Hides the edit buttons for Page list items in the off canvas list view

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
These blocks are just meant to convey the page structure 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I added a new variable to control when we want the edit button to be present or not

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Insert a Page list block inside a navigation block and check that the pencil icon is not present

## Screenshots or screencast <!-- if applicable -->
![ezgif-5-b2c1a837b9](https://user-images.githubusercontent.com/3593343/204565472-53924d71-8ff8-4c73-a0a4-87e69519106c.gif)
