### PR TITLE
Page List: Render the children correctly in the editor

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -96,7 +96,10 @@ export default function PageListEdit( {
 		}, [] );
 	};
 
-	const blockList = getBlockList();
+	const blockList = useMemo( getBlockList, [
+		pagesByParentId,
+		parentPageID,
+	] );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps );
 
@@ -165,7 +168,7 @@ export default function PageListEdit( {
 		if ( blockList ) {
 			replaceInnerBlocks( clientId, blockList );
 		}
-	}, [ clientId, parentPageID, hasResolvedPages ] );
+	}, [ clientId, blockList ] );
 
 	return (
 		<>

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -6,12 +6,15 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { createBlock } from '@wordpress/blocks';
 import {
 	InspectorControls,
 	BlockControls,
 	useBlockProps,
 	useInnerBlocksProps,
 	getColorClassName,
+	store as blockEditorStore,
+	Warning,
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -20,9 +23,10 @@ import {
 	Notice,
 	ComboboxControl,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { useMemo, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { useMemo, useState, useEffect } from '@wordpress/element';
 import { useEntityRecords } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -40,7 +44,10 @@ export default function PageListEdit( {
 	setAttributes,
 } ) {
 	const { parentPageID } = attributes;
+	const [ pages ] = useGetPages();
 	const { pagesByParentId, totalPages, hasResolvedPages } = usePageData();
+	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
+		useDispatch( blockEditorStore );
 
 	const isNavigationChild = 'showSubmenuIcon' in context;
 	const allowConvertToLinks =
@@ -64,14 +71,14 @@ export default function PageListEdit( {
 		style: { ...context.style?.color },
 	} );
 
-	const makeBlockTemplate = ( parentId = 0 ) => {
-		const pages = pagesByParentId.get( parentId );
+	const getBlockList = ( parentId = parentPageID ) => {
+		const childPages = pagesByParentId.get( parentId );
 
-		if ( ! pages?.length ) {
+		if ( ! childPages?.length ) {
 			return [];
 		}
 
-		return pages.reduce( ( template, page ) => {
+		return childPages.reduce( ( template, page ) => {
 			const hasChildren = pagesByParentId.has( page.id );
 			const pageProps = {
 				id: page.id,
@@ -81,21 +88,17 @@ export default function PageListEdit( {
 				hasChildren,
 			};
 			let item = null;
-			const children = makeBlockTemplate( page.id );
-			item = [ 'core/page-list-item', pageProps, children ];
-
+			const children = getBlockList( page.id );
+			item = createBlock( 'core/page-list-item', pageProps, children );
 			template.push( item );
 
 			return template;
 		}, [] );
 	};
 
-	const pagesTemplate = useMemo( makeBlockTemplate, [ pagesByParentId ] );
+	const blockList = getBlockList();
 
-	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		template: pagesTemplate,
-		templateLock: 'all',
-	} );
+	const innerBlocksProps = useInnerBlocksProps( blockProps );
 
 	const getBlockContent = () => {
 		if ( ! hasResolvedPages ) {
@@ -126,13 +129,28 @@ export default function PageListEdit( {
 			);
 		}
 
+		if ( blockList.length === 0 ) {
+			const parentPageDetails =
+				pages && pages.find( ( page ) => page.id === parentPageID );
+			return (
+				<div { ...blockProps }>
+					<Warning>
+						{ sprintf(
+							// translators: %s: Page title.
+							__( '"%s" page has no children.' ),
+							parentPageDetails.title.rendered
+						) }
+					</Warning>
+				</div>
+			);
+		}
+
 		if ( totalPages > 0 ) {
 			return <ul { ...innerBlocksProps }></ul>;
 		}
 	};
 
 	const useParentOptions = () => {
-		const [ pages ] = useGetPages();
 		return pages?.reduce( ( accumulator, page ) => {
 			accumulator.push( {
 				value: page.id,
@@ -141,6 +159,13 @@ export default function PageListEdit( {
 			return accumulator;
 		}, [] );
 	};
+
+	useEffect( () => {
+		__unstableMarkNextChangeAsNotPersistent();
+		if ( blockList ) {
+			replaceInnerBlocks( clientId, blockList );
+		}
+	}, [ clientId, parentPageID, hasResolvedPages ] );
 
 	return (
 		<>
@@ -202,10 +227,6 @@ function usePageData( pageId = 0 ) {
 		// TODO: Once the REST API supports passing multiple values to
 		// 'orderby', this can be removed.
 		// https://core.trac.wordpress.org/ticket/39037
-
-		if ( pageId !== 0 ) {
-			return pages.find( ( page ) => page.id === pageId );
-		}
 
 		const sortedPages = [ ...( pages ?? [] ) ].sort( ( a, b ) => {
 			if ( a.menu_order === b.menu_order ) {


### PR DESCRIPTION
Co-authored-by: Andrei Draganescu <107534+draganescu@users.noreply.github.com>

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Alternative to #46122

This PR fixes a bug that appeared when merging #45861 and #45776 into trunk.

This has revealed that setting a template on inner blocks is not the right approach here. Instead we should use replaceBlocks, so avoid issues with template syncing.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To fix a bug where parent page selection is not reflected in the editor, but takes effect when the page list block is rendered.

Changes the implementation of the feature as well because fixing the bug in #46122 showed a problem with `synchronizeBlocksWithTemplate` where we always do synchronisation, but in this case we need to replace the blocks when the parent page attribute changes, irrespective of what the page list block already contains.

This implementation while less elegant impacts less things than altering how `synchronizeBlocksWithTemplate` works.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Replaces the approach where we pass a template to inner blocks, and instead use createBlock and replaceBlock.

## Testing instructions
0. Make sure to have nested pages
1. Add a page list in a post
2. From the inspector set as parent page ID one of the pages that have children
3. Save, reload
4. The page list should reflect the parent and show only its children
5. From the inspector set as parent page ID one **another one** of the pages that have children
6. The page list should reflect the parent and show only the new children
