### PR TITLE
Fix Quote block's unwrap e2e test

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/quote.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/quote.test.js
@@ -187,11 +187,13 @@ describe( 'Quote', () => {
 		await page.keyboard.press( 'Backspace' );
 
 		expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
-		"<!-- wp:quote -->
-		<blockquote class=\\"wp-block-quote\\"><!-- wp:paragraph -->
+		"<!-- wp:paragraph -->
 		<p>1</p>
-		<!-- /wp:paragraph --><cite>2</cite></blockquote>
-		<!-- /wp:quote -->"
+		<!-- /wp:paragraph -->
+
+		<!-- wp:paragraph -->
+		<p>2</p>
+		<!-- /wp:paragraph -->"
 	` );
 	} );
 } );


### PR DESCRIPTION
## What?
See #44663.

PR fixes `can be unwrapped with content on Backspace` e2e test regression introduced in #42122. 

## Why?
The unwrapped inline snapshot doesn't match the actual post content.

## Testing Instructions
```
npm run test:e2e -- packages/e2e-tests/specs/editor/blocks/quote.test.js
```