### PR TITLE
BaseControl: Add convenience hook to generate id-related props

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Feature
 
 -   `TabPanel`: support manual tab activation ([#46004](https://github.com/WordPress/gutenberg/pull/46004)).
+-   `BaseControl`: Add `useBaseControlProps` hook to help generate id-releated props ([#46170](https://github.com/WordPress/gutenberg/pull/46170)).
 
 ### Bug Fix
 

--- a/packages/components/src/base-control/README.md
+++ b/packages/components/src/base-control/README.md
@@ -44,9 +44,9 @@ If true, the label will only be visible to screen readers.
 
 ### help
 
-If this property is added, a help text will be generated using help property as the content.
+Additional description for the control. It is preferable to use plain text for `help`, as it can be accessibly associated with the control using `aria-describedby`. When the `help` contains links, or otherwise non-plain text content, it will be associated with the control using `aria-details`.
 
--   Type: `String|WPElement`
+-   Type: `ReactNode`
 -   Required: No
 
 ### className

--- a/packages/components/src/base-control/README.md
+++ b/packages/components/src/base-control/README.md
@@ -4,16 +4,23 @@
 
 ## Usage
 
-Render a `BaseControl` for a textarea input:
-
 ```jsx
-import { BaseControl } from '@wordpress/components';
+import { BaseControl, useBaseControlProps } from '@wordpress/components';
 
-// The `id` prop is necessary to accessibly associate the label with the textarea
-const MyBaseControl = () => (
-	<BaseControl id="textarea-1" label="Text" help="Enter some text" __nextHasNoMarginBottom={ true }>
-		<textarea id="textarea-1" />
-	</BaseControl>
+// Render a `BaseControl` for a textarea input
+const MyCustomTextareaControl = ({ children, ...baseProps }) => (
+	// `useBaseControlProps` is a convenience hook to get the props for the `BaseControl`
+	// and the inner control itself. Namely, it takes care of generating a unique `id`,
+	// properly associating it with the `label` and `help` elements.
+	const { baseControlProps, controlProps } = useBaseControlProps( baseProps );
+
+	return (
+		<BaseControl { ...baseControlProps } __nextHasNoMarginBottom={ true }>
+			<textarea { ...controlProps }>
+			  { children }
+			</textarea>
+		</BaseControl>
+	);
 );
 ```
 
@@ -23,7 +30,9 @@ The component accepts the following props:
 
 ### id
 
-The HTML `id` of the element (passed in as a child to `BaseControl`) to which labels and help text are being generated. This is necessary to accessibly associate the label with that element.
+The HTML `id` of the control element (passed in as a child to `BaseControl`) to which labels and help text are being generated. This is necessary to accessibly associate the label with that element.
+
+The recommended way is to use the `useBaseControlProps` hook, which takes care of generating a unique `id` for you. Otherwise, if you choose to pass an explicit `id` to this prop, you are responsible for ensuring the uniqueness of the `id`.
 
 -   Type: `String`
 -   Required: No
@@ -45,6 +54,8 @@ If true, the label will only be visible to screen readers.
 ### help
 
 Additional description for the control. It is preferable to use plain text for `help`, as it can be accessibly associated with the control using `aria-describedby`. When the `help` contains links, or otherwise non-plain text content, it will be associated with the control using `aria-details`.
+
+The recommended way is to use the `useBaseControlProps` hook, which takes care of setting an appropriate `aria-describedby` or `aria-details` based on the auto-generated unique `id` and the `help` value type.
 
 -   Type: `ReactNode`
 -   Required: No

--- a/packages/components/src/base-control/README.md
+++ b/packages/components/src/base-control/README.md
@@ -55,8 +55,6 @@ If true, the label will only be visible to screen readers.
 
 Additional description for the control. It is preferable to use plain text for `help`, as it can be accessibly associated with the control using `aria-describedby`. When the `help` contains links, or otherwise non-plain text content, it will be associated with the control using `aria-details`.
 
-The recommended way is to use the `useBaseControlProps` hook, which takes care of setting an appropriate `aria-describedby` or `aria-details` based on the auto-generated unique `id` and the `help` value type.
-
 -   Type: `ReactNode`
 -   Required: No
 

--- a/packages/components/src/base-control/hooks.ts
+++ b/packages/components/src/base-control/hooks.ts
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import type { ReactNode } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { useInstanceId } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import BaseControl from '.';
+
+export function useBaseControlProps( {
+	help,
+	preferredId,
+}: {
+	/** The `help` value to pass to the BaseControl. */
+	help: ReactNode;
+	/** Optionally specify an explicit `id`. If you do this, you are responsible for ensuring its uniqueness. */
+	preferredId?: string;
+} ) {
+	const uniqueId = useInstanceId(
+		BaseControl,
+		'components-base-control',
+		preferredId
+	);
+
+	// ARIA descriptions can only contain plain text, so fall back to aria-details if not.
+	const helpPropName =
+		typeof help === 'string' ? 'aria-describedby' : 'aria-details';
+	const helpProp = !! help ? { [ helpPropName ]: `${ uniqueId }__help` } : {};
+
+	return {
+		baseControlProps: {
+			id: uniqueId,
+			help,
+		},
+		controlProps: {
+			id: uniqueId,
+			...helpProp,
+		},
+	};
+}

--- a/packages/components/src/base-control/hooks.ts
+++ b/packages/components/src/base-control/hooks.ts
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import type { ReactNode } from 'react';
-
-/**
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
@@ -12,35 +7,32 @@ import { useInstanceId } from '@wordpress/compose';
  * Internal dependencies
  */
 import BaseControl from '.';
+import type { BaseControlProps } from './types';
 
 export function useBaseControlProps( {
 	help,
-	preferredId,
-}: {
-	/** The `help` value to pass to the BaseControl. */
-	help: ReactNode;
-	/** Optionally specify an explicit `id`. If you do this, you are responsible for ensuring its uniqueness. */
-	preferredId?: string;
-} ) {
+	id: preferredId,
+	...restProps
+}: Omit< BaseControlProps, 'children' > ) {
 	const uniqueId = useInstanceId(
 		BaseControl,
-		'components-base-control',
+		'wp-components-base-control',
 		preferredId
 	);
 
 	// ARIA descriptions can only contain plain text, so fall back to aria-details if not.
 	const helpPropName =
 		typeof help === 'string' ? 'aria-describedby' : 'aria-details';
-	const helpProp = !! help ? { [ helpPropName ]: `${ uniqueId }__help` } : {};
 
 	return {
 		baseControlProps: {
 			id: uniqueId,
 			help,
+			...restProps,
 		},
 		controlProps: {
 			id: uniqueId,
-			...helpProp,
+			...( !! help ? { [ helpPropName ]: `${ uniqueId }__help` } : {} ),
 		},
 	};
 }

--- a/packages/components/src/base-control/hooks.ts
+++ b/packages/components/src/base-control/hooks.ts
@@ -9,11 +9,18 @@ import { useInstanceId } from '@wordpress/compose';
 import BaseControl from '.';
 import type { BaseControlProps } from './types';
 
-export function useBaseControlProps( {
-	help,
-	id: preferredId,
-	...restProps
-}: Omit< BaseControlProps, 'children' > ) {
+/**
+ * Generate props for the `BaseControl` and the inner control itself.
+ *
+ * Namely, it takes care of generating a unique `id`, properly associating it with the `label` and `help` elements.
+ *
+ * @param  props
+ */
+export function useBaseControlProps(
+	props: Omit< BaseControlProps, 'children' >
+) {
+	const { help, id: preferredId, ...restProps } = props;
+
 	const uniqueId = useInstanceId(
 		BaseControl,
 		'wp-components-base-control',

--- a/packages/components/src/base-control/index.tsx
+++ b/packages/components/src/base-control/index.tsx
@@ -17,6 +17,8 @@ import {
 } from './styles/base-control-styles';
 import type { WordPressComponentProps } from '../ui/context';
 
+export { useBaseControlProps } from './hooks';
+
 /**
  * `BaseControl` is a component used to generate labels and help text for components handling user inputs.
  *

--- a/packages/components/src/base-control/index.tsx
+++ b/packages/components/src/base-control/index.tsx
@@ -20,16 +20,25 @@ import type { WordPressComponentProps } from '../ui/context';
 /**
  * `BaseControl` is a component used to generate labels and help text for components handling user inputs.
  *
- * @example
- * // Render a `BaseControl` for a textarea input
- * import { BaseControl } from '@wordpress/components';
+ * ```jsx
+ * import { BaseControl, useBaseControlProps } from '@wordpress/components';
  *
- * // The `id` prop is necessary to accessibly associate the label with the textarea
- * const MyBaseControl = () => (
- *   <BaseControl id="textarea-1" label="Text" help="Enter some text" __nextHasNoMarginBottom={ true }>
- *     <textarea id="textarea-1" />
- *   </BaseControl>
+ * // Render a `BaseControl` for a textarea input
+ * const MyCustomTextareaControl = ({ children, ...baseProps }) => (
+ * 	// `useBaseControlProps` is a convenience hook to get the props for the `BaseControl`
+ * 	// and the inner control itself. Namely, it takes care of generating a unique `id`,
+ * 	// properly associating it with the `label` and `help` elements.
+ * 	const { baseControlProps, controlProps } = useBaseControlProps( baseProps );
+ *
+ * 	return (
+ * 		<BaseControl { ...baseControlProps } __nextHasNoMarginBottom={ true }>
+ * 			<textarea { ...controlProps }>
+ * 			  { children }
+ * 			</textarea>
+ * 		</BaseControl>
+ * 	);
  * );
+ * ```
  */
 export const BaseControl = ( {
 	__nextHasNoMarginBottom = false,

--- a/packages/components/src/base-control/stories/index.tsx
+++ b/packages/components/src/base-control/stories/index.tsx
@@ -6,7 +6,7 @@ import type { ComponentMeta, ComponentStory } from '@storybook/react';
 /**
  * Internal dependencies
  */
-import BaseControl from '..';
+import BaseControl, { useBaseControlProps } from '..';
 import Button from '../../button';
 
 const meta: ComponentMeta< typeof BaseControl > = {
@@ -24,13 +24,14 @@ const meta: ComponentMeta< typeof BaseControl > = {
 };
 export default meta;
 
-const BaseControlWithTextarea: ComponentStory< typeof BaseControl > = ( {
-	id,
-	...props
-} ) => {
+const BaseControlWithTextarea: ComponentStory< typeof BaseControl > = (
+	props
+) => {
+	const { baseControlProps, controlProps } = useBaseControlProps( props );
+
 	return (
-		<BaseControl id={ id } { ...props }>
-			<textarea style={ { display: 'block' } } id={ id } />
+		<BaseControl { ...baseControlProps }>
+			<textarea style={ { display: 'block' } } { ...controlProps } />
 		</BaseControl>
 	);
 };
@@ -39,14 +40,12 @@ export const Default: ComponentStory< typeof BaseControl > =
 	BaseControlWithTextarea.bind( {} );
 Default.args = {
 	__nextHasNoMarginBottom: true,
-	id: 'textarea-default-1',
 	label: 'Label text',
 };
 
 export const WithHelpText = BaseControlWithTextarea.bind( {} );
 WithHelpText.args = {
 	...Default.args,
-	id: 'textarea-with-help-text-1',
 	help: 'Help text adds more explanation.',
 };
 
@@ -75,6 +74,5 @@ export const WithVisualLabel: ComponentStory< typeof BaseControl > = (
 WithVisualLabel.args = {
 	...Default.args,
 	help: 'This button is already accessibly labeled.',
-	id: undefined,
 	label: undefined,
 };

--- a/packages/components/src/base-control/test/index.tsx
+++ b/packages/components/src/base-control/test/index.tsx
@@ -10,22 +10,11 @@ import BaseControl from '..';
 import { useBaseControlProps } from '../hooks';
 import type { BaseControlProps } from '../types';
 
-const MyBaseControl = ( {
-	id,
-	help,
-	...props
-}: Omit< BaseControlProps, 'children' > ) => {
-	const { baseControlProps, controlProps } = useBaseControlProps( {
-		help,
-		preferredId: id,
-	} );
+const MyBaseControl = ( props: Omit< BaseControlProps, 'children' > ) => {
+	const { baseControlProps, controlProps } = useBaseControlProps( props );
 
 	return (
-		<BaseControl
-			{ ...props }
-			{ ...baseControlProps }
-			__nextHasNoMarginBottom={ true }
-		>
+		<BaseControl { ...baseControlProps } __nextHasNoMarginBottom={ true }>
 			<textarea { ...controlProps } />
 		</BaseControl>
 	);

--- a/packages/components/src/base-control/test/index.tsx
+++ b/packages/components/src/base-control/test/index.tsx
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import BaseControl from '..';
+import { useBaseControlProps } from '../hooks';
+import type { BaseControlProps } from '../types';
+
+const MyBaseControl = ( {
+	id,
+	help,
+	...props
+}: Omit< BaseControlProps, 'children' > ) => {
+	const { baseControlProps, controlProps } = useBaseControlProps( {
+		help,
+		preferredId: id,
+	} );
+
+	return (
+		<BaseControl
+			{ ...props }
+			{ ...baseControlProps }
+			__nextHasNoMarginBottom={ true }
+		>
+			<textarea { ...controlProps } />
+		</BaseControl>
+	);
+};
+
+describe( 'BaseControl', () => {
+	it( 'should render help text as description', () => {
+		render( <MyBaseControl label="Text" help="My help text" /> );
+
+		expect(
+			screen.getByRole( 'textbox', {
+				description: 'My help text',
+			} )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should render help as aria-details when not plain text', () => {
+		render(
+			<MyBaseControl
+				label="Text"
+				help={ <a href="/foo">My help text</a> }
+			/>
+		);
+
+		const textarea = screen.getByRole( 'textbox' );
+		const help = screen.getByRole( 'link', {
+			name: 'My help text',
+		} );
+
+		expect( textarea ).toHaveAttribute( 'aria-details' );
+		expect(
+			help.closest( `#${ textarea.getAttribute( 'aria-details' ) }` )
+		).toBeVisible();
+	} );
+} );

--- a/packages/components/src/base-control/types.ts
+++ b/packages/components/src/base-control/types.ts
@@ -11,8 +11,11 @@ export type BaseControlProps = {
 	 */
 	__nextHasNoMarginBottom?: boolean;
 	/**
-	 * The HTML `id` of the element (passed in as a child to `BaseControl`) to which labels and help text are being generated.
+	 * The HTML `id` of the control element (passed in as a child to `BaseControl`) to which labels and help text are being generated.
 	 * This is necessary to accessibly associate the label with that element.
+	 *
+	 * The recommended way is to use the `useBaseControlProps` hook, which takes care of generating a unique `id` for you.
+	 * Otherwise, if you choose to pass an explicit `id` to this prop, you are responsible for ensuring the uniqueness of the `id`.
 	 */
 	id?: string;
 	/**
@@ -20,6 +23,9 @@ export type BaseControlProps = {
 	 *
 	 * It is preferable to use plain text for `help`, as it can be accessibly associated with the control using `aria-describedby`.
 	 * When the `help` contains links, or otherwise non-plain text content, it will be associated with the control using `aria-details`.
+	 *
+	 * The recommended way is to use the `useBaseControlProps` hook, which takes care of setting an appropriate `aria-describedby` or
+	 * `aria-details` based on the auto-generated unique `id` and the `help` value type.
 	 */
 	help?: ReactNode;
 	/**

--- a/packages/components/src/base-control/types.ts
+++ b/packages/components/src/base-control/types.ts
@@ -23,9 +23,6 @@ export type BaseControlProps = {
 	 *
 	 * It is preferable to use plain text for `help`, as it can be accessibly associated with the control using `aria-describedby`.
 	 * When the `help` contains links, or otherwise non-plain text content, it will be associated with the control using `aria-details`.
-	 *
-	 * The recommended way is to use the `useBaseControlProps` hook, which takes care of setting an appropriate `aria-describedby` or
-	 * `aria-details` based on the auto-generated unique `id` and the `help` value type.
 	 */
 	help?: ReactNode;
 	/**

--- a/packages/components/src/base-control/types.ts
+++ b/packages/components/src/base-control/types.ts
@@ -16,7 +16,10 @@ export type BaseControlProps = {
 	 */
 	id?: string;
 	/**
-	 * If this property is added, a help text will be generated using help property as the content.
+	 * Additional description for the control.
+	 *
+	 * It is preferable to use plain text for `help`, as it can be accessibly associated with the control using `aria-describedby`.
+	 * When the `help` contains links, or otherwise non-plain text content, it will be associated with the control using `aria-details`.
 	 */
 	help?: ReactNode;
 	/**

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -23,7 +23,7 @@ export {
 	default as Autocomplete,
 	useAutocompleteProps as __unstableUseAutocompleteProps,
 } from './autocomplete';
-export { default as BaseControl } from './base-control';
+export { default as BaseControl, useBaseControlProps } from './base-control';
 export {
 	BorderBoxControl as __experimentalBorderBoxControl,
 	hasSplitBorders as __experimentalHasSplitBorders,


### PR DESCRIPTION
Follow-up to #45931

## What?

Adds a `useBaseControlProps` to help generate id-related props for both the BaseControl and the inner control itself.

See the updated docs for how it's supposed to be used.

## Why?

Right now, consumers of BaseControl are forced to generate their own unique ids, and associate the `help` text manually with `aria-describedby` in a way that depends on an internal implementation detail (i.e. that the `help` element has an `${id}__help` id).

I feel like the only clean way to address this would be to provide a convenience hook that would be responsible for these things. Obviously the manual way would still work, but it would be easier and less hacky if you use this hook instead.

The hook also includes the [conditional logic](https://github.com/WordPress/gutenberg/pull/45931#discussion_r1033711421) to switch between `aria-describedby` and `aria-details` depending on the `help` value.

## Next steps

It isn't super high priority to migrate all the existing usage, but it would be nice to use this hook in new components, or when adding better `help` semantics to existing components that don't add an `aria-describedby` at the moment (e.g. ToggleGroupControl).

## Testing Instructions

- Checks that the docs makes sense.
- ✅ Tests pass
