### PR TITLE
Strip markup from link label data in inspector

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -508,7 +508,7 @@ export default function NavigationLinkEdit( {
 			<InspectorControls>
 				<PanelBody title={ __( 'Link settings' ) }>
 					<TextControl
-						value={ label || '' }
+						value={ label ? navStripHTML( label ) : '' }
 						onChange={ ( labelValue ) => {
 							setAttributes( { label: labelValue } );
 						} }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

When a link is added to a navigation block it can be formatted. This PR removes the markup for formatting from being displayed in the navigation link inspector.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The editing of the label in the navigation link block's inspector was recently introduced and it erroneously displayed markup if formatting was added to the label in the canvas.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Using the same system of stripping HTML as the one used to display the link label in the LinkUI component.

## Testing Instructions

1. In a post or page
2. Add a navigation block
3. Add some links to the navigation block
4. Select one of the links' text and make it bold
5. Open the inspector via dotted menu in the block toolbar > show more settings
6. Check that the label field displays no markup
7. Edit the text
8. The label is edited by the formatting is lost - this is expected

## Screenshots or screencast <!-- if applicable -->

<img width="1277" alt="Screenshot 2022-11-29 at 21 12 32" src="https://user-images.githubusercontent.com/107534/204624093-a33ffd55-8929-45e2-8fb9-edee98c12926.png">


