### PR TITLE
[RNMobile] Prevent error message from unneccesarily firing when uploading to Gallery block

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -217,9 +217,17 @@ function GalleryEdit( props ) {
 	}
 
 	function isValidFileType( file ) {
+		// It's necessary to retrieve the media type from the raw image data for uploaded images on native.
+		const image =
+			Platform.isNative && file.id
+				? find( imageData, { id: file.id } )
+				: null;
+
+		const mediaTypeSelector = image ? image?.media_type : file.type;
+
 		return (
 			ALLOWED_MEDIA_TYPES.some(
-				( mediaType ) => file.type?.indexOf( mediaType ) === 0
+				( mediaType ) => mediaTypeSelector?.indexOf( mediaType ) === 0
 			) || file.url?.indexOf( 'blob:' ) === 0
 		);
 	}

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -217,13 +217,15 @@ function GalleryEdit( props ) {
 	}
 
 	function isValidFileType( file ) {
-		// It's necessary to retrieve the media type from the raw image data for uploaded images on native.
-		const image =
+		// It's necessary to retrieve the media type from the raw image data for already-uploaded images on native.
+		const nativeBlockData =
 			Platform.isNative && file.id
 				? find( imageData, { id: file.id } )
 				: null;
 
-		const mediaTypeSelector = image ? image?.media_type : file.type;
+		const mediaTypeSelector = nativeBlockData
+			? nativeBlockData?.media_type
+			: file.type;
 
 		return (
 			ALLOWED_MEDIA_TYPES.some(

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -218,13 +218,13 @@ function GalleryEdit( props ) {
 
 	function isValidFileType( file ) {
 		// It's necessary to retrieve the media type from the raw image data for already-uploaded images on native.
-		const nativeBlockData =
+		const nativeFileData =
 			Platform.isNative && file.id
 				? find( imageData, { id: file.id } )
 				: null;
 
-		const mediaTypeSelector = nativeBlockData
-			? nativeBlockData?.media_type
+		const mediaTypeSelector = nativeFileData
+			? nativeFileData?.media_type
 			: file.type;
 
 		return (

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,6 +11,7 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 
+-   [**] Prevent error message from unneccesarily firing when uploading to Gallery block [#46175]
 ## 1.85.0
 -   [*] [iOS] Fixed iOS Voice Control support within Image block captions. [#44850]
 

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,8 +10,8 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
-
 -   [**] Prevent error message from unneccesarily firing when uploading to Gallery block [#46175]
+
 ## 1.85.0
 -   [*] [iOS] Fixed iOS Voice Control support within Image block captions. [#44850]
 


### PR DESCRIPTION
## What?

This PR ensures that any valid image uploaded to the Gallery block within the mobile apps is correctly marked as valid. 

## Why?

Following the updates to the Gallery block's error notices in https://github.com/WordPress/gutenberg/pull/43946, the following error began displaying when uploading images to an existing Gallery block: `If uploading to a gallery all files need to be image formats`

Note, the previous implementation of the error notices had not been supported on mobile. The referenced PR exposed a previously 'silent' issue by introducing an error notice that worked within the apps.

## How?

The error began firing as the `isValidFileType` function was returning `false` for existing images in a Gallery block on native:

https://github.com/WordPress/gutenberg/blob/f1dd9e1b80b780ed6b286dbe9f386cedafe87d1b/packages/block-library/src/gallery/edit.js#L219-L225

The above function works for newly uploaded images, as those images return a `file` object similar to the following:

```
{"alt":"","caption":"","id":3373,"title":"hello-world.png","type":"image","url":"https://example.com/2022/10/hello-world.png"}
```

However, on native, images that are already uploaded to a Gallery block return a `file` object similar to the following:

```
{"clientId":"45c8e5a2-d20d-4d77-a224-88c426e93878","id":2255,"url":"https://example.com/2022/10/hello-world.jpg?w=473","attributes":{"url":"https://example.com/2022/10/hello-world.jpg?w=473","alt":"","caption":"","id":2255,"link":"https://example.com/hello-world/","fullUrl":"https://example.com/2022/10/hello-world.jpg","linkDestination":"none","sizeSlug":"large"},"fromSavedContent":false}
```

To account for the different data that's retrieved for already-uploaded images on native, the `isValidFileType` function has been updated to gather the `media_type` details from the file's raw image data:

https://github.com/WordPress/gutenberg/blob/54decbe79c13ec461a57d512884bddb56cbe915b/packages/block-library/src/gallery/edit.js#L219-L235

## Testing Instructions

1. Navigate to the editor in the iOS or Android app.
2. Add a Gallery block with multiple images and save the post.
3. Tap the appender to add a new image to the block.
4. Try a few different methods for adding the image, such as from your device or from your site's Media Library.
5. Confirm that the `If uploading to a gallery all files need to be image formats` doesn't fire unexpectedly after uploading valid images.

## Screenshots or screencast <!-- if applicable -->

From these screenshots taken immediately after uploading an image to the gallery, you'll see that the first screenshot shows an error message despite the fact a valid image had been uploaded:

| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/2998162/204662211-a40d48f1-ac3d-4d73-b376-527694ae0fc5.png" width="100%"> | <img src="https://user-images.githubusercontent.com/2998162/204649578-e0fc774d-1fd0-47dc-be4a-84bc56ee1326.png" width="100%"> |


