### PR TITLE
Remove Nav block specific classes from Nav offcanvas Link UI

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/link-ui.js
+++ b/packages/block-editor/src/components/off-canvas-editor/link-ui.js
@@ -131,9 +131,9 @@ export function LinkUI( props ) {
 			shift
 		>
 			<LinkControl
+				className={ props.className }
 				hasTextControl
 				hasRichPreviews
-				className="wp-block-navigation-link__inline-link-input"
 				value={ props?.value }
 				showInitialSuggestions={ true }
 				withCreateSuggestion={ props?.hasCreateSuggestion }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -654,6 +654,7 @@ export default function NavigationLinkEdit( {
 					) }
 					{ isLinkOpen && (
 						<LinkUI
+							className="wp-block-navigation-link__inline-link-input"
 							clientId={ clientId }
 							value={ link }
 							linkAttributes={ { type, url, kind } }

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -156,7 +156,7 @@ export function LinkUI( props ) {
 			<LinkControl
 				hasTextControl
 				hasRichPreviews
-				className="wp-block-navigation-link__inline-link-input"
+				className={ props.className }
 				value={ props.value }
 				showInitialSuggestions={ true }
 				withCreateSuggestion={ props.hasCreateSuggestion }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In https://github.com/WordPress/gutenberg/pull/46013 we accidentally included Nav block specific classes on the Link UI that appears in the Nav offcanvas experiment.

Thus PR removes those and makes all instances of the Link UI configure classes via props.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because the classes should be related to the placement of the Link UI.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Props.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Check that both experiment offcanvas and standard Nav Link block "on canvas" Link UI's behave as per `trunk`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
