### PR TITLE
Use @wordpress/escape-html escapeHTML in Link UI in preference to Lodash method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17546,6 +17546,7 @@
 				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/dom": "file:packages/dom",
 				"@wordpress/element": "file:packages/element",
+				"@wordpress/escape-html": "file:packages/escape-html",
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/html-entities": "file:packages/html-entities",
 				"@wordpress/i18n": "file:packages/i18n",
@@ -19528,7 +19529,7 @@
 		"app-root-dir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/app-root-dir/-/app-root-dir-1.0.2.tgz",
-			"integrity": "sha1-OBh+wt6nV3//Az/8sSFyaS/24Rg=",
+			"integrity": "sha512-jlpIfsOoNoafl92Sz//64uQHGSyMrD2vYG5d8o2a4qGvyNCvXur7bzIsWtAC/6flI2RYAp3kv8rsfBtaLm7w0g==",
 			"dev": true
 		},
 		"app-root-path": {
@@ -26180,7 +26181,7 @@
 		"array-flatten": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-			"integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
 			"dev": true
 		},
 		"array-ify": {
@@ -27810,7 +27811,7 @@
 		"babel-plugin-add-react-displayname": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.5.tgz",
-			"integrity": "sha1-M51M3be2X9YtHfnbn+BN4TQSK9U=",
+			"integrity": "sha512-LY3+Y0XVDYcShHHorshrDbt4KFWL4bSeniCtl4SYZbask+Syngk1uMPCeN9+nSiZo6zX5s0RTq/J9Pnaaf/KHw==",
 			"dev": true
 		},
 		"babel-plugin-apply-mdx-type-prop": {
@@ -28233,7 +28234,7 @@
 		"batch-processor": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/batch-processor/-/batch-processor-1.0.0.tgz",
-			"integrity": "sha1-dclcMrdI4IUNEMKxaPa9vpiRrOg=",
+			"integrity": "sha512-xoLQD8gmmR32MeuBHgH0Tzd5PuSZx71ZsbhVxOCRbgktZEPe4SQy7s9Z50uPp0F/f7iw2XmkHN2xkgbMfckMDA==",
 			"dev": true
 		},
 		"bcrypt-pbkdf": {
@@ -30750,7 +30751,7 @@
 		"cookie-signature": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-			"integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
 			"dev": true
 		},
 		"copy-concurrently": {
@@ -37045,7 +37046,7 @@
 		"has-glob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-glob/-/has-glob-1.0.0.tgz",
-			"integrity": "sha1-mqqe7b/7G6OZCnsAEPtnjuAIEgc=",
+			"integrity": "sha512-D+8A457fBShSEI3tFCj65PAbT++5sKiFtdCdOam0gnfBgw9D277OERk+HM9qYJXmdVLZ/znez10SqHN0BBQ50g==",
 			"dev": true,
 			"requires": {
 				"is-glob": "^3.0.0"
@@ -37054,7 +37055,7 @@
 				"is-glob": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
 					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.0"
@@ -38941,7 +38942,7 @@
 		"is-window": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-window/-/is-window-1.0.2.tgz",
-			"integrity": "sha1-LIlspT25feRdPDMTOmXYyfVjSA0=",
+			"integrity": "sha512-uj00kdXyZb9t9RcAUAwMZAnkBUwdYGhYlt7djMXhfyhUCzwNba50tIiBKR7q0l7tdoBtFVw/3JmLY6fI3rmZmg==",
 			"dev": true
 		},
 		"is-windows": {
@@ -42318,7 +42319,7 @@
 		"js-string-escape": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-			"integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=",
+			"integrity": "sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==",
 			"dev": true
 		},
 		"js-tokens": {
@@ -44519,7 +44520,7 @@
 		"media-typer": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-			"integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
 			"dev": true
 		},
 		"mem": {
@@ -44783,7 +44784,7 @@
 		"merge-descriptors": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
 			"dev": true
 		},
 		"merge-stream": {
@@ -44800,7 +44801,7 @@
 		"methods": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-			"integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
 			"dev": true
 		},
 		"metro": {
@@ -47251,7 +47252,7 @@
 		"num2fraction": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-			"integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+			"integrity": "sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg==",
 			"dev": true
 		},
 		"number-is-nan": {
@@ -48729,7 +48730,7 @@
 		"p-defer": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+			"integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
 			"dev": true
 		},
 		"p-event": {
@@ -49368,7 +49369,7 @@
 		"path-to-regexp": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-			"integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
 			"dev": true
 		},
 		"path-type": {
@@ -50303,7 +50304,7 @@
 		"pretty-hrtime": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-			"integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
+			"integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==",
 			"dev": true
 		},
 		"prismjs": {
@@ -52609,7 +52610,7 @@
 		"relateurl": {
 			"version": "0.2.7",
 			"resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+			"integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
 			"dev": true
 		},
 		"remark": {

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -45,6 +45,7 @@
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",
 		"@wordpress/element": "file:../element",
+		"@wordpress/escape-html": "file:../escape-html",
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",

--- a/packages/block-library/src/navigation-link/update-attributes.js
+++ b/packages/block-library/src/navigation-link/update-attributes.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import escapeHtml from 'escape-html';
-
-/**
  * WordPress dependencies
  */
 import { safeDecodeURI } from '@wordpress/url';
+import { escapeHTML } from '@wordpress/escape-html';
 
 /**
  * @typedef {'post-type'|'custom'|'taxonomy'|'post-type-archive'} WPNavigationLinkKind
@@ -78,8 +74,8 @@ export const updateAttributes = (
 	// - https://github.com/WordPress/gutenberg/pull/41063
 	// - https://github.com/WordPress/gutenberg/pull/18617.
 	const label = useNewLabel
-		? escapeHtml( newLabel )
-		: originalLabel || escapeHtml( newUrlWithoutHttp );
+		? escapeHTML( newLabel )
+		: originalLabel || escapeHTML( newUrlWithoutHttp );
 
 	// In https://github.com/WordPress/gutenberg/pull/24670 we decided to use "tag" in favor of "post_tag"
 	const type = newType === 'post_tag' ? 'tag' : newType.replace( '-', '_' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In https://github.com/WordPress/gutenberg/pull/46013 we moved to using `@wordpress/escape-html`'s `escapeHTML` method in preference to `lodash` to avoid coupling lodash to the editor.

This PR mirrors that change in the original code location within the Nav Link Block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Code consistency in case we need to refactor to a single instance of the Link UI code in future.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds package to block lib. Uses functino. Removes lodash.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Create a link that includes `&` or any other chars requiring escaping.
- Add link
- Edit link text to include `&`.
- Click on link to bring up link preview
- Check link text and link URL both display escaped.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
