### PR TITLE
Inserter: Update mobile tab navigation styles

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -175,7 +175,16 @@ function BlockPatternsTabs( {
 	const [ showPatternsExplorer, setShowPatternsExplorer ] = useState( false );
 	const categories = usePatternsCategories();
 	const isMobile = useViewportMatch( 'medium', '<' );
-
+	const getBlockPatternsCategoryPanel = useCallback(
+		( category ) => (
+			<BlockPatternsCategoryPanel
+				onInsert={ onInsert }
+				rootClientId={ rootClientId }
+				category={ category }
+			/>
+		),
+		[ onInsert, rootClientId ]
+	);
 	return (
 		<>
 			{ ! isMobile && (
@@ -229,10 +238,7 @@ function BlockPatternsTabs( {
 			) }
 			{ isMobile && (
 				<MobileTabNavigation categories={ categories }>
-					<BlockPatternsCategoryPanel
-						onInsert={ onInsert }
-						rootClientId={ rootClientId }
-					/>
+					{ getBlockPatternsCategoryPanel }
 				</MobileTabNavigation>
 			) }
 			{ showPatternsExplorer && (

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -8,20 +8,16 @@ import {
 	useRef,
 	useEffect,
 } from '@wordpress/element';
-import { _x, __, isRTL } from '@wordpress/i18n';
+import { _x, __ } from '@wordpress/i18n';
 import { useAsyncList, useViewportMatch } from '@wordpress/compose';
 import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
 	__experimentalHStack as HStack,
-	__experimentalNavigatorProvider as NavigatorProvider,
-	__experimentalNavigatorScreen as NavigatorScreen,
-	__experimentalNavigatorButton as NavigatorButton,
-	__experimentalNavigatorBackButton as NavigatorBackButton,
 	FlexBlock,
 	Button,
 } from '@wordpress/components';
-import { Icon, chevronRight, chevronLeft } from '@wordpress/icons';
+import { Icon, chevronRight } from '@wordpress/icons';
 import { focus } from '@wordpress/dom';
 
 /**
@@ -30,6 +26,7 @@ import { focus } from '@wordpress/dom';
 import usePatternsState from './hooks/use-patterns-state';
 import BlockPatternList from '../block-patterns-list';
 import PatternsExplorerModal from './block-patterns-explorer/explorer';
+import MobileTabNavigation from './mobile-tab-navigation';
 
 function usePatternsCategories() {
 	const [ allPatterns, allCategories ] = usePatternsState();
@@ -100,7 +97,7 @@ export function BlockPatternsCategoryDialog( {
 	return (
 		<div
 			ref={ container }
-			className="block-editor-inserter__patterns-category-panel"
+			className="block-editor-inserter__patterns-category-dialog"
 		>
 			<BlockPatternsCategoryPanel
 				rootClientId={ rootClientId }
@@ -151,7 +148,7 @@ export function BlockPatternsCategoryPanel( {
 	}
 
 	return (
-		<div>
+		<div className="block-editor-inserter__patterns-category-panel">
 			<div className="block-editor-inserter__patterns-category-panel-title">
 				{ category.label }
 			</div>
@@ -231,10 +228,12 @@ function BlockPatternsTabs( {
 				</div>
 			) }
 			{ isMobile && (
-				<BlockPatternsTabNavigation
-					onInsert={ onInsert }
-					rootClientId={ rootClientId }
-				/>
+				<MobileTabNavigation categories={ categories }>
+					<BlockPatternsCategoryPanel
+						onInsert={ onInsert }
+						rootClientId={ rootClientId }
+					/>
+				</MobileTabNavigation>
 			) }
 			{ showPatternsExplorer && (
 				<PatternsExplorerModal
@@ -244,56 +243,6 @@ function BlockPatternsTabs( {
 				/>
 			) }
 		</>
-	);
-}
-
-function BlockPatternsTabNavigation( { onInsert, rootClientId } ) {
-	const categories = usePatternsCategories();
-
-	return (
-		<NavigatorProvider initialPath="/">
-			<NavigatorScreen path="/">
-				<ItemGroup>
-					{ categories.map( ( category ) => (
-						<NavigatorButton
-							key={ category.name }
-							path={ `/category/${ category.name }` }
-							as={ Item }
-							isAction
-						>
-							<HStack>
-								<FlexBlock>{ category.label }</FlexBlock>
-								<Icon
-									icon={
-										isRTL() ? chevronLeft : chevronRight
-									}
-								/>
-							</HStack>
-						</NavigatorButton>
-					) ) }
-				</ItemGroup>
-			</NavigatorScreen>
-
-			{ categories.map( ( category ) => (
-				<NavigatorScreen
-					key={ category.name }
-					path={ `/category/${ category.name }` }
-				>
-					<NavigatorBackButton
-						icon={ isRTL() ? chevronRight : chevronLeft }
-						isSmall
-						aria-label={ __( 'Navigate to the categories list' ) }
-					>
-						{ __( 'Back' ) }
-					</NavigatorBackButton>
-					<BlockPatternsCategoryPanel
-						category={ category }
-						rootClientId={ rootClientId }
-						onInsert={ onInsert }
-					/>
-				</NavigatorScreen>
-			) ) }
-		</NavigatorProvider>
 	);
 }
 

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -175,16 +175,6 @@ function BlockPatternsTabs( {
 	const [ showPatternsExplorer, setShowPatternsExplorer ] = useState( false );
 	const categories = usePatternsCategories();
 	const isMobile = useViewportMatch( 'medium', '<' );
-	const getBlockPatternsCategoryPanel = useCallback(
-		( category ) => (
-			<BlockPatternsCategoryPanel
-				onInsert={ onInsert }
-				rootClientId={ rootClientId }
-				category={ category }
-			/>
-		),
-		[ onInsert, rootClientId ]
-	);
 	return (
 		<>
 			{ ! isMobile && (
@@ -238,7 +228,13 @@ function BlockPatternsTabs( {
 			) }
 			{ isMobile && (
 				<MobileTabNavigation categories={ categories }>
-					{ getBlockPatternsCategoryPanel }
+					{ ( category ) => (
+						<BlockPatternsCategoryPanel
+							onInsert={ onInsert }
+							rootClientId={ rootClientId }
+							category={ category }
+						/>
+					) }
 				</MobileTabNavigation>
 			) }
 			{ showPatternsExplorer && (

--- a/packages/block-editor/src/components/inserter/media-tab/media-tab.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-tab.js
@@ -49,6 +49,16 @@ function MediaTab( {
 		},
 		[ onInsert ]
 	);
+	const getMediaCategoryPanel = useCallback(
+		( category ) => (
+			<MediaCategoryPanel
+				onInsert={ onInsert }
+				rootClientId={ rootClientId }
+				category={ category }
+			/>
+		),
+		[ onInsert, rootClientId ]
+	);
 	return (
 		<>
 			{ ! isMobile && (
@@ -119,10 +129,7 @@ function MediaTab( {
 			) }
 			{ isMobile && (
 				<MobileTabNavigation categories={ mediaCategories }>
-					<MediaCategoryPanel
-						onInsert={ onInsert }
-						rootClientId={ rootClientId }
-					/>
+					{ getMediaCategoryPanel }
 				</MobileTabNavigation>
 			) }
 		</>

--- a/packages/block-editor/src/components/inserter/media-tab/media-tab.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-tab.js
@@ -6,21 +6,17 @@ import classNames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __, isRTL } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
 import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
 	__experimentalHStack as HStack,
-	__experimentalNavigatorProvider as NavigatorProvider,
-	__experimentalNavigatorScreen as NavigatorScreen,
-	__experimentalNavigatorButton as NavigatorButton,
-	__experimentalNavigatorBackButton as NavigatorBackButton,
 	FlexBlock,
 	Button,
 } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
-import { Icon, chevronRight, chevronLeft } from '@wordpress/icons';
+import { Icon, chevronRight } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -30,6 +26,7 @@ import MediaUploadCheck from '../../media-upload/check';
 import MediaUpload from '../../media-upload';
 import { useMediaCategories } from './hooks';
 import { getBlockAndPreviewFromMedia } from './utils';
+import MobileTabNavigation from '../mobile-tab-navigation';
 
 const ALLOWED_MEDIA_TYPES = [ 'image', 'video', 'audio' ];
 
@@ -121,61 +118,14 @@ function MediaTab( {
 				</div>
 			) }
 			{ isMobile && (
-				<MediaTabNavigation
-					onInsert={ onInsert }
-					rootClientId={ rootClientId }
-					mediaCategories={ mediaCategories }
-				/>
+				<MobileTabNavigation categories={ mediaCategories }>
+					<MediaCategoryPanel
+						onInsert={ onInsert }
+						rootClientId={ rootClientId }
+					/>
+				</MobileTabNavigation>
 			) }
 		</>
-	);
-}
-
-function MediaTabNavigation( { onInsert, rootClientId, mediaCategories } ) {
-	return (
-		<NavigatorProvider initialPath="/">
-			<NavigatorScreen path="/">
-				<ItemGroup>
-					{ mediaCategories.map( ( category ) => (
-						<NavigatorButton
-							key={ category.name }
-							path={ `/category/${ category.name }` }
-							as={ Item }
-							isAction
-						>
-							<HStack>
-								<FlexBlock>{ category.label }</FlexBlock>
-								<Icon
-									icon={
-										isRTL() ? chevronLeft : chevronRight
-									}
-								/>
-							</HStack>
-						</NavigatorButton>
-					) ) }
-				</ItemGroup>
-			</NavigatorScreen>
-			{ mediaCategories.map( ( category ) => (
-				<NavigatorScreen
-					key={ category.name }
-					path={ `/category/${ category.name }` }
-				>
-					<NavigatorBackButton
-						className="rigatonious"
-						icon={ isRTL() ? chevronRight : chevronLeft }
-						isSmall
-						aria-label={ __( 'Navigate to the categories list' ) }
-					>
-						{ __( 'Back' ) }
-					</NavigatorBackButton>
-					<MediaCategoryPanel
-						rootClientId={ rootClientId }
-						onInsert={ onInsert }
-						category={ category }
-					/>
-				</NavigatorScreen>
-			) ) }
-		</NavigatorProvider>
 	);
 }
 

--- a/packages/block-editor/src/components/inserter/media-tab/media-tab.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-tab.js
@@ -49,16 +49,6 @@ function MediaTab( {
 		},
 		[ onInsert ]
 	);
-	const getMediaCategoryPanel = useCallback(
-		( category ) => (
-			<MediaCategoryPanel
-				onInsert={ onInsert }
-				rootClientId={ rootClientId }
-				category={ category }
-			/>
-		),
-		[ onInsert, rootClientId ]
-	);
 	return (
 		<>
 			{ ! isMobile && (
@@ -129,7 +119,13 @@ function MediaTab( {
 			) }
 			{ isMobile && (
 				<MobileTabNavigation categories={ mediaCategories }>
-					{ getMediaCategoryPanel }
+					{ ( category ) => (
+						<MediaCategoryPanel
+							onInsert={ onInsert }
+							rootClientId={ rootClientId }
+							category={ category }
+						/>
+					) }
 				</MobileTabNavigation>
 			) }
 		</>

--- a/packages/block-editor/src/components/inserter/mobile-tab-navigation.js
+++ b/packages/block-editor/src/components/inserter/mobile-tab-navigation.js
@@ -1,0 +1,88 @@
+/**
+ * WordPress dependencies
+ */
+import { __, isRTL } from '@wordpress/i18n';
+import {
+	__experimentalItemGroup as ItemGroup,
+	__experimentalItem as Item,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalSpacer as Spacer,
+	__experimentalHeading as Heading,
+	__experimentalView as View,
+	__experimentalNavigatorProvider as NavigatorProvider,
+	__experimentalNavigatorScreen as NavigatorScreen,
+	__experimentalNavigatorButton as NavigatorButton,
+	__experimentalNavigatorBackButton as NavigatorBackButton,
+	FlexBlock,
+} from '@wordpress/components';
+import { Icon, chevronRight, chevronLeft } from '@wordpress/icons';
+import { Children, cloneElement } from '@wordpress/element';
+
+function ScreenHeader( { title } ) {
+	return (
+		<VStack spacing={ 0 }>
+			<View>
+				<Spacer marginBottom={ 0 } paddingX={ 4 } paddingY={ 3 }>
+					<HStack spacing={ 2 }>
+						<NavigatorBackButton
+							style={
+								// TODO: This style override is also used in ToolsPanelHeader.
+								// It should be supported out-of-the-box by Button.
+								{ minWidth: 24, padding: 0 }
+							}
+							icon={ isRTL() ? chevronRight : chevronLeft }
+							isSmall
+							aria-label={ __( 'Navigate to the previous view' ) }
+						/>
+						<Spacer>
+							<Heading level={ 5 }>{ title }</Heading>
+						</Spacer>
+					</HStack>
+				</Spacer>
+			</View>
+		</VStack>
+	);
+}
+
+export default function MobileTabNavigation( { categories, children } ) {
+	return (
+		<NavigatorProvider
+			initialPath="/"
+			className="block-editor-inserter__mobile-tab-navigation"
+		>
+			<NavigatorScreen path="/">
+				<ItemGroup>
+					{ categories.map( ( category ) => (
+						<NavigatorButton
+							key={ category.name }
+							path={ `/category/${ category.name }` }
+							as={ Item }
+							isAction
+						>
+							<HStack>
+								<FlexBlock>{ category.label }</FlexBlock>
+								<Icon
+									icon={
+										isRTL() ? chevronLeft : chevronRight
+									}
+								/>
+							</HStack>
+						</NavigatorButton>
+					) ) }
+				</ItemGroup>
+			</NavigatorScreen>
+			{ categories.map( ( category ) => (
+				<NavigatorScreen
+					key={ category.name }
+					path={ `/category/${ category.name }` }
+				>
+					<ScreenHeader title={ __( 'Back' ) } />
+					{ Children.map( children, ( child ) =>
+						cloneElement( child, { category } )
+					) }
+				</NavigatorScreen>
+			) ) }
+		</NavigatorProvider>
+	);
+}

--- a/packages/block-editor/src/components/inserter/mobile-tab-navigation.js
+++ b/packages/block-editor/src/components/inserter/mobile-tab-navigation.js
@@ -17,7 +17,6 @@ import {
 	FlexBlock,
 } from '@wordpress/components';
 import { Icon, chevronRight, chevronLeft } from '@wordpress/icons';
-import { Children, cloneElement } from '@wordpress/element';
 
 function ScreenHeader( { title } ) {
 	return (
@@ -78,9 +77,7 @@ export default function MobileTabNavigation( { categories, children } ) {
 					path={ `/category/${ category.name }` }
 				>
 					<ScreenHeader title={ __( 'Back' ) } />
-					{ Children.map( children, ( child ) =>
-						cloneElement( child, { category } )
-					) }
+					{ children( category ) }
 				</NavigatorScreen>
 			) ) }
 		</NavigatorProvider>

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -575,18 +575,14 @@ $block-inserter-tabs-height: 44px;
 		padding: 0;
 	}
 
-	&-title {
-		font-size: calc(1.25 * 13px);
-	}
-
-	&-spinner {
+	.block-editor-inserter__media-panel-spinner {
 		height: 100%;
 		display: flex;
 		align-items: center;
 		justify-content: center;
 	}
 
-	&-search {
+	.block-editor-inserter__media-panel-search {
 		&.components-search-control {
 			input[type="search"].components-search-control__input {
 				background: $white;

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -287,7 +287,7 @@ $block-inserter-tabs-height: 44px;
 	}
 }
 
-.block-editor-inserter__patterns-category-panel {
+.block-editor-inserter__patterns-category-dialog {
 	background: $gray-100;
 	border-left: $border-width solid $gray-200;
 	border-right: $border-width solid $gray-200;
@@ -319,6 +319,14 @@ $block-inserter-tabs-height: 44px;
 
 	.block-editor-block-patterns-list__item-title {
 		display: none;
+	}
+}
+
+.block-editor-inserter__patterns-category-panel {
+	padding: 0 $grid-unit-20;
+
+	@include break-medium {
+		padding: 0;
 	}
 }
 
@@ -557,26 +565,31 @@ $block-inserter-tabs-height: 44px;
 			box-shadow: 0 0 0 2px $gray-900, 0 15px 25px rgb(0 0 0 / 7%);
 		}
 	}
+}
 
-	.block-editor-inserter__media-panel {
+.block-editor-inserter__media-panel {
+	height: 100%;
+	padding: 0 $grid-unit-20;
+
+	@include break-medium {
+		padding: 0;
+	}
+
+	&-title {
+		font-size: calc(1.25 * 13px);
+	}
+
+	&-spinner {
 		height: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
 
-		&-title {
-			font-size: calc(1.25 * 13px);
-		}
-
-		&-spinner {
-			height: 100%;
-			display: flex;
-			align-items: center;
-			justify-content: center;
-		}
-
-		&-search {
-			&.components-search-control {
-				input[type="search"].components-search-control__input {
-					background: $white;
-				}
+	&-search {
+		&.components-search-control {
+			input[type="search"].components-search-control__input {
+				background: $white;
 			}
 		}
 	}
@@ -622,5 +635,15 @@ $block-inserter-tabs-height: 44px;
 			// Windows High Contrast mode will show this outline, but not the box-shadow.
 			outline: 2px solid transparent;
 		}
+	}
+}
+
+
+.block-editor-inserter__mobile-tab-navigation {
+	padding: $grid-unit-20;
+	height: 100%;
+
+	> * {
+		height: 100%;
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
With the introduction of the new design in inserter's `patterns and media` tabs we use a different view on 'mobile' devices which needs improvements.

This PR:
1. updates the styles for the mobile view of these tabs' content with some padding mostly and by following suit with the Global Styles `back` button styles.
2. extracts the navigation tab component for this view in an internal reusable component.
<!-- In a few words, what is the PR actually doing? -->


## Testing Instructions
1. Ensure that not in mobile view everything is styled and works as before, both in post and site editors
2. Make the window smaller or by any other means to be presented with the mobile view and open the inserter
3. Ensure that everything works as before

### Before

https://user-images.githubusercontent.com/16275880/204771644-8c349c53-6bf1-4521-a86b-b3bc224f52eb.mov



### After

https://user-images.githubusercontent.com/16275880/204770764-0e78f062-1da4-4506-acf7-bddd3d8fb282.mov



