### PR TITLE
ListView: Avoid paint on list view item hover

### DIFF
--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -197,15 +197,13 @@
 		@include reduce-motion("transition");
 
 		> * {
+			will-change: opacity;
 			opacity: 0;
 		}
 
 		// Show on hover, visible, and show above to keep the hit area size.
 		&:hover,
 		&.is-visible {
-			position: relative;
-			z-index: 1;
-
 			> * {
 				opacity: 1;
 				@include edit-post__fade-in-animation;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Avoid paint when hovering the list view items

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When hovering the list view items, paint is triggered all over the UI because of changes in zindex and position. This will result in poor performances

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add a will-change: opacity and remove the changes in zindex/position

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the dev console and enable the paint flashing (under rendering)
2. Open the list view
3. Hover over a list item
4. There should not be any repaint

## Screenshot

### Before

https://user-images.githubusercontent.com/4660731/204815710-f7766a41-1b0e-4f3a-84d8-04850d612a52.mov


### After

https://user-images.githubusercontent.com/4660731/204815696-02810ced-316a-40c8-a720-7f74b6e5752e.mov

