### PR TITLE
CircularOption: Avoid paint on circular option hover

### DIFF
--- a/packages/components/src/circular-option-picker/style.scss
+++ b/packages/components/src/circular-option-picker/style.scss
@@ -26,6 +26,7 @@ $color-palette-circle-spacing: 12px;
 	vertical-align: top;
 	transform: scale(1);
 	transition: 100ms transform ease;
+	will-change: transform;
 	@include reduce-motion("transition");
 
 	&:hover {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Avoid browser paint when hovering the circular-option-picker

## How?
A simple will-change: transform

## Testing Instructions
1. Open the dev console and enable the paint flashing (under rendering)
2. Open a color palette popover
3. Hover over a color
4. There should not be paint on the circular options

## Screenshot

### Before

https://user-images.githubusercontent.com/4660731/204817161-73b42b3a-f565-4662-a1b7-4f372e470518.mov

### After

https://user-images.githubusercontent.com/4660731/204817192-d4f0fdf8-ece0-4bce-95f2-62f412cd16e9.mov
