### PR TITLE
Refactor the block-editor byClientId redux state to use maps instead of plain objects.

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -775,6 +775,9 @@ export const blocks = pipe(
 	withIgnoredBlockChange,
 	withResetControlledBlocks
 )( {
+	// The state is using a Map instead of a plain object for performance reasons.
+	// You can run the "./test/performance.js" unit test to check the impact
+	// code changes can have on this reducer.
 	byClientId( state = new Map(), action ) {
 		switch ( action.type ) {
 			case 'RECEIVE_BLOCKS':

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -159,7 +159,7 @@ function buildBlockTree( state, blocks ) {
 	}
 	for ( const block of flattenedBlocks ) {
 		result[ block.clientId ] = Object.assign( result[ block.clientId ], {
-			...state.byClientId[ block.clientId ],
+			...state.byClientId.get( block.clientId ),
 			attributes: state.attributes.get( block.clientId ),
 			innerBlocks: block.innerBlocks.map(
 				( subBlock ) => result[ subBlock.clientId ]
@@ -263,7 +263,7 @@ const withBlockTree =
 						...newState.tree,
 						[ action.clientId ]: {
 							...newState.tree[ action.clientId ],
-							...newState.byClientId[ action.clientId ],
+							...newState.byClientId.get( action.clientId ),
 							attributes: newState.attributes.get(
 								action.clientId
 							),
@@ -328,7 +328,9 @@ const withBlockTree =
 					if (
 						state.parents[ clientId ] !== undefined &&
 						( state.parents[ clientId ] === '' ||
-							newState.byClientId[ state.parents[ clientId ] ] )
+							newState.byClientId.get(
+								state.parents[ clientId ]
+							) )
 					) {
 						parentsOfRemovedBlocks.push(
 							state.parents[ clientId ]
@@ -349,7 +351,9 @@ const withBlockTree =
 					if (
 						state.parents[ clientId ] !== undefined &&
 						( state.parents[ clientId ] === '' ||
-							newState.byClientId[ state.parents[ clientId ] ] )
+							newState.byClientId.get(
+								state.parents[ clientId ]
+							) )
 					) {
 						parentsOfRemovedBlocks.push(
 							state.parents[ clientId ]
@@ -405,7 +409,8 @@ const withBlockTree =
 				const updatedBlockUids = [];
 				newState.attributes.forEach( ( attributes, clientId ) => {
 					if (
-						newState.byClientId[ clientId ].name === 'core/block' &&
+						newState.byClientId.get( clientId ).name ===
+							'core/block' &&
 						attributes.ref === action.updatedId
 					) {
 						updatedBlockUids.push( clientId );
@@ -418,7 +423,7 @@ const withBlockTree =
 						...newState.tree,
 						...updatedBlockUids.reduce( ( result, clientId ) => {
 							result[ clientId ] = {
-								...newState.byClientId[ clientId ],
+								...newState.byClientId.get( clientId ),
 								attributes: newState.attributes.get( clientId ),
 								innerBlocks:
 									newState.tree[ clientId ].innerBlocks,
@@ -586,7 +591,11 @@ const withBlockReset = ( reducer ) => ( state, action ) => {
 	if ( action.type === 'RESET_BLOCKS' ) {
 		const newState = {
 			...state,
-			byClientId: getFlattenedBlocksWithoutAttributes( action.blocks ),
+			byClientId: new Map(
+				Object.entries(
+					getFlattenedBlocksWithoutAttributes( action.blocks )
+				)
+			),
 			attributes: new Map(
 				Object.entries( getFlattenedBlockAttributes( action.blocks ) )
 			),
@@ -713,7 +722,7 @@ const withSaveReusableBlock = ( reducer ) => ( state, action ) => {
 		state = { ...state };
 		state.attributes = new Map( state.attributes );
 		state.attributes.forEach( ( attributes, clientId ) => {
-			const { name } = state.byClientId[ clientId ];
+			const { name } = state.byClientId.get( clientId );
 			if ( name === 'core/block' && attributes.ref === id ) {
 				state.attributes.set( clientId, {
 					...attributes,
@@ -766,18 +775,21 @@ export const blocks = pipe(
 	withIgnoredBlockChange,
 	withResetControlledBlocks
 )( {
-	byClientId( state = {}, action ) {
+	byClientId( state = new Map(), action ) {
 		switch ( action.type ) {
 			case 'RECEIVE_BLOCKS':
-			case 'INSERT_BLOCKS':
-				return {
-					...state,
-					...getFlattenedBlocksWithoutAttributes( action.blocks ),
-				};
-
-			case 'UPDATE_BLOCK':
+			case 'INSERT_BLOCKS': {
+				const newState = new Map( state );
+				Object.entries(
+					getFlattenedBlocksWithoutAttributes( action.blocks )
+				).forEach( ( [ key, value ] ) => {
+					newState.set( key, value );
+				} );
+				return newState;
+			}
+			case 'UPDATE_BLOCK': {
 				// Ignore updates if block isn't known.
-				if ( ! state[ action.clientId ] ) {
+				if ( ! state.has( action.clientId ) ) {
 					return state;
 				}
 
@@ -787,26 +799,38 @@ export const blocks = pipe(
 					return state;
 				}
 
-				return {
-					...state,
-					[ action.clientId ]: {
-						...state[ action.clientId ],
-						...changes,
-					},
-				};
+				const newState = new Map( state );
+				newState.set( action.clientId, {
+					...state.get( action.clientId ),
+					...changes,
+				} );
+				return newState;
+			}
 
-			case 'REPLACE_BLOCKS_AUGMENTED_WITH_CHILDREN':
+			case 'REPLACE_BLOCKS_AUGMENTED_WITH_CHILDREN': {
 				if ( ! action.blocks ) {
 					return state;
 				}
 
-				return {
-					...omit( state, action.replacedClientIds ),
-					...getFlattenedBlocksWithoutAttributes( action.blocks ),
-				};
+				const newState = new Map( state );
+				action.replacedClientIds.forEach( ( clientId ) => {
+					newState.delete( clientId );
+				} );
+				Object.entries(
+					getFlattenedBlocksWithoutAttributes( action.blocks )
+				).forEach( ( [ key, value ] ) => {
+					newState.set( key, value );
+				} );
+				return newState;
+			}
 
-			case 'REMOVE_BLOCKS_AUGMENTED_WITH_CHILDREN':
-				return omit( state, action.removedClientIds );
+			case 'REMOVE_BLOCKS_AUGMENTED_WITH_CHILDREN': {
+				const newState = new Map( state );
+				action.removedClientIds.forEach( ( clientId ) => {
+					newState.delete( clientId );
+				} );
+				return newState;
+			}
 		}
 
 		return state;

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -65,7 +65,7 @@ const EMPTY_ARRAY = [];
  * @return {string} Block name.
  */
 export function getBlockName( state, clientId ) {
-	const block = state.blocks.byClientId[ clientId ];
+	const block = state.blocks.byClientId.get( clientId );
 	const socialLinkName = 'core/social-link';
 
 	if ( Platform.OS !== 'web' && block?.name === socialLinkName ) {
@@ -86,7 +86,7 @@ export function getBlockName( state, clientId ) {
  * @return {boolean} Is Valid.
  */
 export function isBlockValid( state, clientId ) {
-	const block = state.blocks.byClientId[ clientId ];
+	const block = state.blocks.byClientId.get( clientId );
 	return !! block && block.isValid;
 }
 
@@ -100,7 +100,7 @@ export function isBlockValid( state, clientId ) {
  * @return {Object?} Block attributes.
  */
 export function getBlockAttributes( state, clientId ) {
-	const block = state.blocks.byClientId[ clientId ];
+	const block = state.blocks.byClientId.get( clientId );
 	if ( ! block ) {
 		return null;
 	}
@@ -130,8 +130,7 @@ export function getBlockAttributes( state, clientId ) {
  * @return {Object} Parsed block object.
  */
 export function getBlock( state, clientId ) {
-	const block = state.blocks.byClientId[ clientId ];
-	if ( ! block ) {
+	if ( ! state.blocks.byClientId.has( clientId ) ) {
 		return null;
 	}
 
@@ -140,18 +139,17 @@ export function getBlock( state, clientId ) {
 
 export const __unstableGetBlockWithoutInnerBlocks = createSelector(
 	( state, clientId ) => {
-		const block = state.blocks.byClientId[ clientId ];
-		if ( ! block ) {
+		if ( ! state.blocks.byClientId.has( clientId ) ) {
 			return null;
 		}
 
 		return {
-			...block,
+			...state.blocks.byClientId.get( clientId ),
 			attributes: getBlockAttributes( state, clientId ),
 		};
 	},
 	( state, clientId ) => [
-		state.blocks.byClientId[ clientId ],
+		state.blocks.byClientId.get( clientId ),
 		state.blocks.attributes.get( clientId ),
 	]
 );
@@ -274,7 +272,7 @@ export const getGlobalBlockCount = createSelector(
 			return clientIds.length;
 		}
 		return clientIds.reduce( ( accumulator, clientId ) => {
-			const block = state.blocks.byClientId[ clientId ];
+			const block = state.blocks.byClientId.get( clientId );
 			return block.name === blockName ? accumulator + 1 : accumulator;
 		}, 0 );
 	},
@@ -296,7 +294,7 @@ export const __experimentalGetGlobalBlocksByName = createSelector(
 		}
 		const clientIds = getClientIdsWithDescendants( state );
 		const foundBlocks = clientIds.filter( ( clientId ) => {
-			const block = state.blocks.byClientId[ clientId ];
+			const block = state.blocks.byClientId.get( clientId );
 			return block.name === blockName;
 		} );
 		return foundBlocks.length > 0 ? foundBlocks : EMPTY_ARRAY;
@@ -1594,7 +1592,7 @@ export const canInsertBlockType = createSelector(
 	canInsertBlockTypeUnmemoized,
 	( state, blockName, rootClientId ) => [
 		state.blockListSettings[ rootClientId ],
-		state.blocks.byClientId[ rootClientId ],
+		state.blocks.byClientId.get( rootClientId ),
 		state.settings.allowedBlockTypes,
 		state.settings.templateLock,
 	]
@@ -2302,7 +2300,7 @@ export const __experimentalGetAllowedPatterns = createSelector(
 		state.settings.allowedBlockTypes,
 		state.settings.templateLock,
 		state.blockListSettings[ rootClientId ],
-		state.blocks.byClientId[ rootClientId ],
+		state.blocks.byClientId.get( rootClientId ),
 	]
 );
 

--- a/packages/block-editor/src/store/test/performance.js
+++ b/packages/block-editor/src/store/test/performance.js
@@ -29,4 +29,27 @@ describe( 'performance', () => {
 
 		expect( updatedState ).toBeDefined();
 	} );
+
+	it( 'should replace blocks (Enter in paragraphs)', () => {
+		const updatedState = reducer( preparedState, {
+			type: 'REPLACE_BLOCKS',
+			clientIds: [ 'block-10' ],
+			blocks: [
+				{
+					clientId: `block-10`,
+					attributes: { content: `paragraph 10` },
+					innerBlocks: [],
+				},
+				{
+					clientId: `block-10-2`,
+					attributes: { content: '' },
+					innerBlocks: [],
+				},
+			],
+			indexToSelect: 10,
+			initialPosition: 0,
+		} );
+
+		expect( updatedState ).toBeDefined();
+	} );
 } );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -210,18 +210,20 @@ describe( 'state', () => {
 			} );
 			it( 'can replace a child block', () => {
 				const existingState = deepFreeze( {
-					byClientId: {
-						chicken: {
-							clientId: 'chicken',
-							name: 'core/test-parent-block',
-							isValid: true,
-						},
-						'chicken-child': {
-							clientId: 'chicken-child',
-							name: 'core/test-child-block',
-							isValid: true,
-						},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							chicken: {
+								clientId: 'chicken',
+								name: 'core/test-parent-block',
+								isValid: true,
+							},
+							'chicken-child': {
+								clientId: 'chicken-child',
+								name: 'core/test-child-block',
+								isValid: true,
+							},
+						} )
+					),
 					attributes: new Map(
 						Object.entries( {
 							chicken: {},
@@ -266,18 +268,20 @@ describe( 'state', () => {
 				expect( restState ).toEqual( {
 					isPersistentChange: true,
 					isIgnoredChange: false,
-					byClientId: {
-						chicken: {
-							clientId: 'chicken',
-							name: 'core/test-parent-block',
-							isValid: true,
-						},
-						[ newChildBlockId ]: {
-							clientId: newChildBlockId,
-							name: 'core/test-child-block',
-							isValid: true,
-						},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							chicken: {
+								clientId: 'chicken',
+								name: 'core/test-parent-block',
+								isValid: true,
+							},
+							[ newChildBlockId ]: {
+								clientId: newChildBlockId,
+								name: 'core/test-child-block',
+								isValid: true,
+							},
+						} )
+					),
 					attributes: new Map(
 						Object.entries( {
 							chicken: {},
@@ -305,13 +309,15 @@ describe( 'state', () => {
 
 			it( 'can insert a child block', () => {
 				const existingState = deepFreeze( {
-					byClientId: {
-						chicken: {
-							clientId: 'chicken',
-							name: 'core/test-parent-block',
-							isValid: true,
-						},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							chicken: {
+								clientId: 'chicken',
+								name: 'core/test-parent-block',
+								isValid: true,
+							},
+						} )
+					),
 					attributes: new Map(
 						Object.entries( {
 							chicken: {},
@@ -352,18 +358,20 @@ describe( 'state', () => {
 				expect( restState ).toEqual( {
 					isPersistentChange: true,
 					isIgnoredChange: false,
-					byClientId: {
-						chicken: {
-							clientId: 'chicken',
-							name: 'core/test-parent-block',
-							isValid: true,
-						},
-						[ newChildBlockId ]: {
-							clientId: newChildBlockId,
-							name: 'core/test-child-block',
-							isValid: true,
-						},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							chicken: {
+								clientId: 'chicken',
+								name: 'core/test-parent-block',
+								isValid: true,
+							},
+							[ newChildBlockId ]: {
+								clientId: newChildBlockId,
+								name: 'core/test-child-block',
+								isValid: true,
+							},
+						} )
+					),
 					attributes: new Map(
 						Object.entries( {
 							chicken: {},
@@ -407,23 +415,25 @@ describe( 'state', () => {
 
 			it( 'can replace multiple child blocks', () => {
 				const existingState = deepFreeze( {
-					byClientId: {
-						chicken: {
-							clientId: 'chicken',
-							name: 'core/test-parent-block',
-							isValid: true,
-						},
-						'chicken-child': {
-							clientId: 'chicken-child',
-							name: 'core/test-child-block',
-							isValid: true,
-						},
-						'chicken-child-2': {
-							clientId: 'chicken-child',
-							name: 'core/test-child-block',
-							isValid: true,
-						},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							chicken: {
+								clientId: 'chicken',
+								name: 'core/test-parent-block',
+								isValid: true,
+							},
+							'chicken-child': {
+								clientId: 'chicken-child',
+								name: 'core/test-child-block',
+								isValid: true,
+							},
+							'chicken-child-2': {
+								clientId: 'chicken-child',
+								name: 'core/test-child-block',
+								isValid: true,
+							},
+						} )
+					),
 					attributes: new Map(
 						Object.entries( {
 							chicken: {},
@@ -480,28 +490,30 @@ describe( 'state', () => {
 				expect( restState ).toEqual( {
 					isPersistentChange: true,
 					isIgnoredChange: false,
-					byClientId: {
-						chicken: {
-							clientId: 'chicken',
-							name: 'core/test-parent-block',
-							isValid: true,
-						},
-						[ newChildBlockId1 ]: {
-							clientId: newChildBlockId1,
-							name: 'core/test-child-block',
-							isValid: true,
-						},
-						[ newChildBlockId2 ]: {
-							clientId: newChildBlockId2,
-							name: 'core/test-child-block',
-							isValid: true,
-						},
-						[ newChildBlockId3 ]: {
-							clientId: newChildBlockId3,
-							name: 'core/test-child-block',
-							isValid: true,
-						},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							chicken: {
+								clientId: 'chicken',
+								name: 'core/test-parent-block',
+								isValid: true,
+							},
+							[ newChildBlockId1 ]: {
+								clientId: newChildBlockId1,
+								name: 'core/test-child-block',
+								isValid: true,
+							},
+							[ newChildBlockId2 ]: {
+								clientId: newChildBlockId2,
+								name: 'core/test-child-block',
+								isValid: true,
+							},
+							[ newChildBlockId3 ]: {
+								clientId: newChildBlockId3,
+								name: 'core/test-child-block',
+								isValid: true,
+							},
+						} )
+					),
 					attributes: new Map(
 						Object.entries( {
 							chicken: {},
@@ -564,23 +576,25 @@ describe( 'state', () => {
 
 			it( 'can replace a child block that has other children', () => {
 				const existingState = deepFreeze( {
-					byClientId: {
-						chicken: {
-							clientId: 'chicken',
-							name: 'core/test-parent-block',
-							isValid: true,
-						},
-						'chicken-child': {
-							clientId: 'chicken-child',
-							name: 'core/test-child-block',
-							isValid: true,
-						},
-						'chicken-grand-child': {
-							clientId: 'chicken-child',
-							name: 'core/test-block',
-							isValid: true,
-						},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							chicken: {
+								clientId: 'chicken',
+								name: 'core/test-parent-block',
+								isValid: true,
+							},
+							'chicken-child': {
+								clientId: 'chicken-child',
+								name: 'core/test-child-block',
+								isValid: true,
+							},
+							'chicken-grand-child': {
+								clientId: 'chicken-child',
+								name: 'core/test-block',
+								isValid: true,
+							},
+						} )
+					),
 					attributes: new Map(
 						Object.entries( {
 							chicken: {},
@@ -621,18 +635,20 @@ describe( 'state', () => {
 				expect( restState ).toEqual( {
 					isPersistentChange: true,
 					isIgnoredChange: false,
-					byClientId: {
-						chicken: {
-							clientId: 'chicken',
-							name: 'core/test-parent-block',
-							isValid: true,
-						},
-						[ newChildBlockId ]: {
-							clientId: newChildBlockId,
-							name: 'core/test-block',
-							isValid: true,
-						},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							chicken: {
+								clientId: 'chicken',
+								name: 'core/test-parent-block',
+								isValid: true,
+							},
+							[ newChildBlockId ]: {
+								clientId: newChildBlockId,
+								name: 'core/test-block',
+								isValid: true,
+							},
+						} )
+					),
 					attributes: new Map(
 						Object.entries( {
 							chicken: {},
@@ -662,7 +678,7 @@ describe( 'state', () => {
 			const state = blocks( undefined, {} );
 
 			expect( state ).toEqual( {
-				byClientId: {},
+				byClientId: new Map(),
 				attributes: new Map(),
 				order: {},
 				parents: {},
@@ -680,8 +696,8 @@ describe( 'state', () => {
 					blocks: [ { clientId: 'bananas', innerBlocks: [] } ],
 				} );
 
-				expect( Object.keys( state.byClientId ) ).toHaveLength( 1 );
-				expect( Object.values( state.byClientId )[ 0 ].clientId ).toBe(
+				expect( state.byClientId.size ).toBe( 1 );
+				expect( state.byClientId.get( 'bananas' ).clientId ).toBe(
 					'bananas'
 				);
 				expect( state.order ).toEqual( {
@@ -712,7 +728,7 @@ describe( 'state', () => {
 				],
 			} );
 
-			expect( Object.keys( state.byClientId ) ).toHaveLength( 2 );
+			expect( state.byClientId.size ).toBe( 2 );
 			expect( state.order ).toEqual( {
 				'': [ 'bananas' ],
 				apples: [],
@@ -743,10 +759,8 @@ describe( 'state', () => {
 				],
 			} );
 
-			expect( Object.keys( state.byClientId ) ).toHaveLength( 2 );
-			expect( Object.values( state.byClientId )[ 1 ].clientId ).toBe(
-				'ribs'
-			);
+			expect( state.byClientId.size ).toBe( 2 );
+			expect( state.byClientId.get( 'ribs' ).clientId ).toBe( 'ribs' );
 			expect( state.order ).toEqual( {
 				'': [ 'chicken', 'ribs' ],
 				chicken: [],
@@ -789,13 +803,11 @@ describe( 'state', () => {
 				],
 			} );
 
-			expect( Object.keys( state.byClientId ) ).toHaveLength( 1 );
-			expect( Object.values( state.byClientId )[ 0 ].name ).toBe(
+			expect( state.byClientId.size ).toBe( 1 );
+			expect( state.byClientId.get( 'wings' ).name ).toBe(
 				'core/freeform'
 			);
-			expect( Object.values( state.byClientId )[ 0 ].clientId ).toBe(
-				'wings'
-			);
+			expect( state.byClientId.get( 'wings' ).clientId ).toBe( 'wings' );
 			expect( state.order ).toEqual( {
 				'': [ 'wings' ],
 				wings: [],
@@ -831,7 +843,7 @@ describe( 'state', () => {
 				blocks: [],
 			} );
 
-			expect( Object.keys( state.byClientId ) ).toHaveLength( 0 );
+			expect( state.byClientId.size ).toBe( 0 );
 			expect( state.tree[ '' ].innerBlocks ).toHaveLength( 0 );
 		} );
 
@@ -866,7 +878,7 @@ describe( 'state', () => {
 				],
 			} );
 
-			expect( Object.keys( state.byClientId ) ).toHaveLength( 1 );
+			expect( state.byClientId.size ).toBe( 1 );
 			expect( state.order ).toEqual( {
 				'': [ 'wings' ],
 				wings: [],
@@ -948,16 +960,16 @@ describe( 'state', () => {
 				],
 			} );
 
-			expect( Object.keys( replacedState.byClientId ) ).toHaveLength( 1 );
-			expect( Object.values( originalState.byClientId )[ 0 ].name ).toBe(
+			expect( replacedState.byClientId.size ).toBe( 1 );
+			expect( originalState.byClientId.get( 'chicken' ).name ).toBe(
 				'core/test-block'
 			);
-			expect( Object.values( replacedState.byClientId )[ 0 ].name ).toBe(
+			expect( replacedState.byClientId.get( 'chicken' ).name ).toBe(
 				'core/freeform'
 			);
-			expect(
-				Object.values( replacedState.byClientId )[ 0 ].clientId
-			).toBe( 'chicken' );
+			expect( replacedState.byClientId.get( 'chicken' ).clientId ).toBe(
+				'chicken'
+			);
 			expect( replacedState.order ).toEqual( {
 				'': [ 'chicken' ],
 				chicken: [],
@@ -999,10 +1011,10 @@ describe( 'state', () => {
 				[ replacementNestedBlock.clientId ]: [],
 			} );
 
-			expect( originalNestedState.byClientId.chicken.name ).toBe(
+			expect( originalNestedState.byClientId.get( 'chicken' ).name ).toBe(
 				'core/test-block'
 			);
-			expect( replacedNestedState.byClientId.chicken.name ).toBe(
+			expect( replacedNestedState.byClientId.get( 'chicken' ).name ).toBe(
 				'core/freeform'
 			);
 		} );
@@ -1029,7 +1041,7 @@ describe( 'state', () => {
 				},
 			} );
 
-			expect( state.byClientId.chicken ).toEqual( {
+			expect( state.byClientId.get( 'chicken' ) ).toEqual( {
 				clientId: 'chicken',
 				name: 'core/test-block',
 				isValid: true,
@@ -1074,7 +1086,7 @@ describe( 'state', () => {
 				updatedId: 3,
 			} );
 
-			expect( state.byClientId.chicken ).toEqual( {
+			expect( state.byClientId.get( 'chicken' ) ).toEqual( {
 				clientId: 'chicken',
 				name: 'core/block',
 				isValid: false,
@@ -1437,7 +1449,7 @@ describe( 'state', () => {
 			expect( state.parents ).toEqual( {
 				ribs: '',
 			} );
-			expect( state.byClientId ).toEqual( {
+			expect( Object.fromEntries( state.byClientId ) ).toEqual( {
 				ribs: {
 					clientId: 'ribs',
 					name: 'core/test-block',
@@ -1484,7 +1496,7 @@ describe( 'state', () => {
 			expect( state.parents ).toEqual( {
 				ribs: '',
 			} );
-			expect( state.byClientId ).toEqual( {
+			expect( Object.fromEntries( state.byClientId ) ).toEqual( {
 				ribs: {
 					clientId: 'ribs',
 					name: 'core/test-block',
@@ -1512,7 +1524,7 @@ describe( 'state', () => {
 				clientIds: [ block.clientId ],
 			} );
 
-			expect( state.byClientId ).toEqual( {} );
+			expect( state.byClientId ).toEqual( new Map() );
 			expect( state.order ).toEqual( {
 				'': [],
 			} );
@@ -1550,7 +1562,7 @@ describe( 'state', () => {
 				],
 			} );
 
-			expect( Object.keys( state.byClientId ) ).toHaveLength( 3 );
+			expect( state.byClientId.size ).toBe( 3 );
 			expect( state.order[ '' ] ).toEqual( [
 				'kumquat',
 				'persimmon',
@@ -2169,23 +2181,25 @@ describe( 'state', () => {
 				} );
 				it( 'should preserve the controlled blocks in state and re-attach them in other pieces of state(order, tree, etc..), when we replace inner blocks', () => {
 					const initialState = {
-						byClientId: {
-							'group-id': {
-								clientId: 'group-id',
-								name: 'core/group',
-								isValid: true,
-							},
-							'reusable-id': {
-								clientId: 'reusable-id',
-								name: 'core/block',
-								isValid: true,
-							},
-							'paragraph-id': {
-								clientId: 'paragraph-id',
-								name: 'core/paragraph',
-								isValid: true,
-							},
-						},
+						byClientId: new Map(
+							Object.entries( {
+								'group-id': {
+									clientId: 'group-id',
+									name: 'core/group',
+									isValid: true,
+								},
+								'reusable-id': {
+									clientId: 'reusable-id',
+									name: 'core/block',
+									isValid: true,
+								},
+								'paragraph-id': {
+									clientId: 'paragraph-id',
+									name: 'core/paragraph',
+									isValid: true,
+								},
+							} )
+						),
 						order: {
 							'': [ 'group-id' ],
 							'group-id': [ 'reusable-id' ],

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -202,7 +202,7 @@ describe( 'selectors', () => {
 		it( 'returns null if no block by clientId', () => {
 			const state = {
 				blocks: {
-					byClientId: {},
+					byClientId: new Map(),
 					attributes: {},
 					order: {},
 					parents: {},
@@ -220,15 +220,20 @@ describe( 'selectors', () => {
 		it( 'returns block name', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': {
-							clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
-							name: 'core/paragraph',
-						},
-					},
-					attributes: {
-						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': {
+								clientId:
+									'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+								name: 'core/paragraph',
+							},
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': {},
+						} )
+					),
 					order: {
 						'': [ 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' ],
 						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': [],
@@ -252,14 +257,18 @@ describe( 'selectors', () => {
 		it( 'should return the block', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						123: { clientId: 123, name: 'core/paragraph' },
-					},
-					attributes: {
-						123: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							123: { clientId: '123', name: 'core/paragraph' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							123: {},
+						} )
+					),
 					order: {
-						'': [ 123 ],
+						'': [ '123' ],
 						123: [],
 					},
 					parents: {
@@ -267,7 +276,7 @@ describe( 'selectors', () => {
 					},
 					tree: {
 						123: {
-							clientId: 123,
+							clientId: '123',
 							name: 'core/paragraph',
 							attributes: {},
 							innerBlocks: [],
@@ -277,19 +286,19 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getBlock( state, 123 ) ).toBe( state.blocks.tree[ 123 ] );
+			expect( getBlock( state, '123' ) ).toBe( state.blocks.tree[ 123 ] );
 		} );
 
 		it( 'should return null if the block is not present in state', () => {
 			const state = {
 				blocks: {
-					byClientId: {},
-					attributes: {},
+					byClientId: new Map(),
+					attributes: new Map(),
 					order: {},
 					parents: {},
 					tree: {
 						123: {
-							clientId: 123,
+							clientId: '123',
 							name: 'core/paragraph',
 							attributes: {},
 							innerBlocks: [],
@@ -299,7 +308,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getBlock( state, 123 ) ).toBe( null );
+			expect( getBlock( state, '123' ) ).toBe( null );
 		} );
 	} );
 
@@ -307,16 +316,20 @@ describe( 'selectors', () => {
 		it( 'should return the ordered blocks', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						23: { clientId: 23, name: 'core/heading' },
-						123: { clientId: 123, name: 'core/paragraph' },
-					},
-					attributes: {
-						23: {},
-						123: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							23: { clientId: '23', name: 'core/heading' },
+							123: { clientId: '123', name: 'core/paragraph' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							23: {},
+							123: {},
+						} )
+					),
 					order: {
-						'': [ 123, 23 ],
+						'': [ '123', '23' ],
 					},
 					parents: {
 						123: '',
@@ -326,13 +339,13 @@ describe( 'selectors', () => {
 						'': {
 							innerBlocks: [
 								{
-									clientId: 123,
+									clientId: '123',
 									name: 'core/paragraph',
 									attributes: {},
 									innerBlocks: [],
 								},
 								{
-									clientId: 23,
+									clientId: '23',
 									name: 'core/heading',
 									attributes: {},
 									innerBlocks: [],
@@ -362,24 +375,26 @@ describe( 'selectors', () => {
 						'client-id-03': 'client-id-02',
 						'client-id-04': 'client-id-03',
 					},
-					byClientId: {
-						'client-id-01': {
-							clientId: 'client-id-01',
-							name: 'core/columns',
-						},
-						'client-id-02': {
-							clientId: 'client-id-02',
-							name: 'core/navigation',
-						},
-						'client-id-03': {
-							clientId: 'client-id-03',
-							name: 'core/navigation-link',
-						},
-						'client-id-04': {
-							clientId: 'client-id-04',
-							name: 'core/paragraph',
-						},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							'client-id-01': {
+								clientId: 'client-id-01',
+								name: 'core/columns',
+							},
+							'client-id-02': {
+								clientId: 'client-id-02',
+								name: 'core/navigation',
+							},
+							'client-id-03': {
+								clientId: 'client-id-03',
+								name: 'core/navigation-link',
+							},
+							'client-id-04': {
+								clientId: 'client-id-04',
+								name: 'core/paragraph',
+							},
+						} )
+					),
 					cache: {
 						'client-id-01': {},
 						'client-id-02': {},
@@ -410,28 +425,30 @@ describe( 'selectors', () => {
 					'client-id-04': 'client-id-03',
 					'client-id-05': 'client-id-04',
 				},
-				byClientId: {
-					'client-id-01': {
-						clientId: 'client-id-01',
-						name: 'core/navigation',
-					},
-					'client-id-02': {
-						clientId: 'client-id-02',
-						name: 'core/columns',
-					},
-					'client-id-03': {
-						clientId: 'client-id-03',
-						name: 'core/navigation',
-					},
-					'client-id-04': {
-						clientId: 'client-id-04',
-						name: 'core/navigation-link',
-					},
-					'client-id-05': {
-						clientId: 'client-id-05',
-						name: 'core/navigation-link',
-					},
-				},
+				byClientId: new Map(
+					Object.entries( {
+						'client-id-01': {
+							clientId: 'client-id-01',
+							name: 'core/navigation',
+						},
+						'client-id-02': {
+							clientId: 'client-id-02',
+							name: 'core/columns',
+						},
+						'client-id-03': {
+							clientId: 'client-id-03',
+							name: 'core/navigation',
+						},
+						'client-id-04': {
+							clientId: 'client-id-04',
+							name: 'core/navigation-link',
+						},
+						'client-id-05': {
+							clientId: 'client-id-05',
+							name: 'core/navigation-link',
+						},
+					} )
+				),
 				cache: {
 					'client-id-01': {},
 					'client-id-02': {},
@@ -487,58 +504,89 @@ describe( 'selectors', () => {
 		it( 'should return the ids of any descendants in sequential order, given an array of clientIds', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						'uuid-2': { clientId: 'uuid-2', name: 'core/image' },
-						'uuid-4': {
-							clientId: 'uuid-4',
-							name: 'core/paragraph',
-						},
-						'uuid-6': {
-							clientId: 'uuid-6',
-							name: 'core/paragraph',
-						},
-						'uuid-8': { clientId: 'uuid-8', name: 'core/block' },
-						'uuid-10': {
-							clientId: 'uuid-10',
-							name: 'core/columns',
-						},
-						'uuid-12': { clientId: 'uuid-12', name: 'core/column' },
-						'uuid-14': { clientId: 'uuid-14', name: 'core/column' },
-						'uuid-16': { clientId: 'uuid-16', name: 'core/quote' },
-						'uuid-18': { clientId: 'uuid-18', name: 'core/block' },
-						'uuid-20': {
-							clientId: 'uuid-20',
-							name: 'core/gallery',
-						},
-						'uuid-22': { clientId: 'uuid-22', name: 'core/block' },
-						'uuid-24': {
-							clientId: 'uuid-24',
-							name: 'core/columns',
-						},
-						'uuid-26': { clientId: 'uuid-26', name: 'core/column' },
-						'uuid-28': { clientId: 'uuid-28', name: 'core/column' },
-						'uuid-30': {
-							clientId: 'uuid-30',
-							name: 'core/paragraph',
-						},
-					},
-					attributes: {
-						'uuid-2': {},
-						'uuid-4': {},
-						'uuid-6': {},
-						'uuid-8': {},
-						'uuid-10': {},
-						'uuid-12': {},
-						'uuid-14': {},
-						'uuid-16': {},
-						'uuid-18': {},
-						'uuid-20': {},
-						'uuid-22': {},
-						'uuid-24': {},
-						'uuid-26': {},
-						'uuid-28': {},
-						'uuid-30': {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							'uuid-2': {
+								clientId: 'uuid-2',
+								name: 'core/image',
+							},
+							'uuid-4': {
+								clientId: 'uuid-4',
+								name: 'core/paragraph',
+							},
+							'uuid-6': {
+								clientId: 'uuid-6',
+								name: 'core/paragraph',
+							},
+							'uuid-8': {
+								clientId: 'uuid-8',
+								name: 'core/block',
+							},
+							'uuid-10': {
+								clientId: 'uuid-10',
+								name: 'core/columns',
+							},
+							'uuid-12': {
+								clientId: 'uuid-12',
+								name: 'core/column',
+							},
+							'uuid-14': {
+								clientId: 'uuid-14',
+								name: 'core/column',
+							},
+							'uuid-16': {
+								clientId: 'uuid-16',
+								name: 'core/quote',
+							},
+							'uuid-18': {
+								clientId: 'uuid-18',
+								name: 'core/block',
+							},
+							'uuid-20': {
+								clientId: 'uuid-20',
+								name: 'core/gallery',
+							},
+							'uuid-22': {
+								clientId: 'uuid-22',
+								name: 'core/block',
+							},
+							'uuid-24': {
+								clientId: 'uuid-24',
+								name: 'core/columns',
+							},
+							'uuid-26': {
+								clientId: 'uuid-26',
+								name: 'core/column',
+							},
+							'uuid-28': {
+								clientId: 'uuid-28',
+								name: 'core/column',
+							},
+							'uuid-30': {
+								clientId: 'uuid-30',
+								name: 'core/paragraph',
+							},
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							'uuid-2': {},
+							'uuid-4': {},
+							'uuid-6': {},
+							'uuid-8': {},
+							'uuid-10': {},
+							'uuid-12': {},
+							'uuid-14': {},
+							'uuid-16': {},
+							'uuid-18': {},
+							'uuid-20': {},
+							'uuid-22': {},
+							'uuid-24': {},
+							'uuid-26': {},
+							'uuid-28': {},
+							'uuid-30': {},
+						} )
+					),
 					order: {
 						'': [ 'uuid-6', 'uuid-8', 'uuid-10', 'uuid-22' ],
 						'uuid-2': [],
@@ -592,58 +640,89 @@ describe( 'selectors', () => {
 		it( 'should return the ids for top-level blocks and their descendants of any depth (for nested blocks) in sequential order.', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						'uuid-2': { clientId: 'uuid-2', name: 'core/image' },
-						'uuid-4': {
-							clientId: 'uuid-4',
-							name: 'core/paragraph',
-						},
-						'uuid-6': {
-							clientId: 'uuid-6',
-							name: 'core/paragraph',
-						},
-						'uuid-8': { clientId: 'uuid-8', name: 'core/block' },
-						'uuid-10': {
-							clientId: 'uuid-10',
-							name: 'core/columns',
-						},
-						'uuid-12': { clientId: 'uuid-12', name: 'core/column' },
-						'uuid-14': { clientId: 'uuid-14', name: 'core/column' },
-						'uuid-16': { clientId: 'uuid-16', name: 'core/quote' },
-						'uuid-18': { clientId: 'uuid-18', name: 'core/block' },
-						'uuid-20': {
-							clientId: 'uuid-20',
-							name: 'core/gallery',
-						},
-						'uuid-22': { clientId: 'uuid-22', name: 'core/block' },
-						'uuid-24': {
-							clientId: 'uuid-24',
-							name: 'core/columns',
-						},
-						'uuid-26': { clientId: 'uuid-26', name: 'core/column' },
-						'uuid-28': { clientId: 'uuid-28', name: 'core/column' },
-						'uuid-30': {
-							clientId: 'uuid-30',
-							name: 'core/paragraph',
-						},
-					},
-					attributes: {
-						'uuid-2': {},
-						'uuid-4': {},
-						'uuid-6': {},
-						'uuid-8': {},
-						'uuid-10': {},
-						'uuid-12': {},
-						'uuid-14': {},
-						'uuid-16': {},
-						'uuid-18': {},
-						'uuid-20': {},
-						'uuid-22': {},
-						'uuid-24': {},
-						'uuid-26': {},
-						'uuid-28': {},
-						'uuid-30': {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							'uuid-2': {
+								clientId: 'uuid-2',
+								name: 'core/image',
+							},
+							'uuid-4': {
+								clientId: 'uuid-4',
+								name: 'core/paragraph',
+							},
+							'uuid-6': {
+								clientId: 'uuid-6',
+								name: 'core/paragraph',
+							},
+							'uuid-8': {
+								clientId: 'uuid-8',
+								name: 'core/block',
+							},
+							'uuid-10': {
+								clientId: 'uuid-10',
+								name: 'core/columns',
+							},
+							'uuid-12': {
+								clientId: 'uuid-12',
+								name: 'core/column',
+							},
+							'uuid-14': {
+								clientId: 'uuid-14',
+								name: 'core/column',
+							},
+							'uuid-16': {
+								clientId: 'uuid-16',
+								name: 'core/quote',
+							},
+							'uuid-18': {
+								clientId: 'uuid-18',
+								name: 'core/block',
+							},
+							'uuid-20': {
+								clientId: 'uuid-20',
+								name: 'core/gallery',
+							},
+							'uuid-22': {
+								clientId: 'uuid-22',
+								name: 'core/block',
+							},
+							'uuid-24': {
+								clientId: 'uuid-24',
+								name: 'core/columns',
+							},
+							'uuid-26': {
+								clientId: 'uuid-26',
+								name: 'core/column',
+							},
+							'uuid-28': {
+								clientId: 'uuid-28',
+								name: 'core/column',
+							},
+							'uuid-30': {
+								clientId: 'uuid-30',
+								name: 'core/paragraph',
+							},
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							'uuid-2': {},
+							'uuid-4': {},
+							'uuid-6': {},
+							'uuid-8': {},
+							'uuid-10': {},
+							'uuid-12': {},
+							'uuid-14': {},
+							'uuid-16': {},
+							'uuid-18': {},
+							'uuid-20': {},
+							'uuid-22': {},
+							'uuid-24': {},
+							'uuid-26': {},
+							'uuid-28': {},
+							'uuid-30': {},
+						} )
+					),
 					order: {
 						'': [ 'uuid-6', 'uuid-8', 'uuid-10', 'uuid-22' ],
 						'uuid-2': [],
@@ -698,16 +777,20 @@ describe( 'selectors', () => {
 		it( 'should return the number of top-level blocks in the post', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						23: { clientId: 23, name: 'core/heading' },
-						123: { clientId: 123, name: 'core/paragraph' },
-					},
-					attributes: {
-						23: {},
-						123: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							23: { clientId: '23', name: 'core/heading' },
+							123: { clientId: '123', name: 'core/paragraph' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							23: {},
+							123: {},
+						} )
+					),
 					order: {
-						'': [ 123, 23 ],
+						'': [ '123', '23' ],
 					},
 				},
 			};
@@ -718,24 +801,28 @@ describe( 'selectors', () => {
 		it( 'should return the number of blocks in a nested context', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						123: { clientId: 123, name: 'core/columns' },
-						456: { clientId: 456, name: 'core/paragraph' },
-						789: { clientId: 789, name: 'core/paragraph' },
-					},
-					attributes: {
-						123: {},
-						456: {},
-						789: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							123: { clientId: '123', name: 'core/columns' },
+							456: { clientId: '456', name: 'core/paragraph' },
+							789: { clientId: '789', name: 'core/paragraph' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							123: {},
+							456: {},
+							789: {},
+						} )
+					),
 					order: {
-						'': [ 123 ],
-						123: [ 456, 789 ],
+						'': [ '123' ],
+						123: [ '456', '789' ],
 					},
 					parents: {
 						123: '',
-						456: 123,
-						789: 123,
+						456: '123',
+						789: '123',
 					},
 				},
 			};
@@ -790,18 +877,22 @@ describe( 'selectors', () => {
 	describe( 'getGlobalBlockCount', () => {
 		const state = {
 			blocks: {
-				byClientId: {
-					123: { clientId: 123, name: 'core/heading' },
-					456: { clientId: 456, name: 'core/paragraph' },
-					789: { clientId: 789, name: 'core/paragraph' },
-				},
-				attributes: {
-					123: {},
-					456: {},
-					789: {},
-				},
+				byClientId: new Map(
+					Object.entries( {
+						123: { clientId: '123', name: 'core/heading' },
+						456: { clientId: '456', name: 'core/paragraph' },
+						789: { clientId: '789', name: 'core/paragraph' },
+					} )
+				),
+				attributes: new Map(
+					Object.entries( {
+						123: {},
+						456: {},
+						789: {},
+					} )
+				),
 				order: {
-					'': [ 123, 456 ],
+					'': [ '123', '456' ],
 				},
 				parents: {
 					123: '',
@@ -821,8 +912,8 @@ describe( 'selectors', () => {
 		it( 'should return 0 if no blocks exist', () => {
 			const emptyState = {
 				blocks: {
-					byClientId: {},
-					attributes: {},
+					byClientId: new Map(),
+					attributes: new Map(),
 					order: {},
 					parents: {},
 				},
@@ -837,32 +928,36 @@ describe( 'selectors', () => {
 	describe( '__experimentalGetGlobalBlocksByName', () => {
 		const state = {
 			blocks: {
-				byClientId: {
-					123: { clientId: 123, name: 'core/heading' },
-					456: { clientId: 456, name: 'core/paragraph' },
-					789: { clientId: 789, name: 'core/paragraph' },
-					1011: { clientId: 1011, name: 'core/group' },
-					1213: { clientId: 1213, name: 'core/paragraph' },
-					1415: { clientId: 1213, name: 'core/paragraph' },
-				},
-				attributes: {
-					123: {},
-					456: {},
-					789: {},
-					1011: {},
-					1213: {},
-					1415: {},
-				},
+				byClientId: new Map(
+					Object.entries( {
+						123: { clientId: '123', name: 'core/heading' },
+						456: { clientId: '456', name: 'core/paragraph' },
+						789: { clientId: '789', name: 'core/paragraph' },
+						1011: { clientId: '1011', name: 'core/group' },
+						1213: { clientId: '1213', name: 'core/paragraph' },
+						1415: { clientId: '1213', name: 'core/paragraph' },
+					} )
+				),
+				attributes: new Map(
+					Object.entries( {
+						123: {},
+						456: {},
+						789: {},
+						1011: {},
+						1213: {},
+						1415: {},
+					} )
+				),
 				order: {
-					'': [ 123, 456, 1011 ],
-					1011: [ 1415, 1213 ],
+					'': [ '123', '456', '1011' ],
+					1011: [ '1415', '1213' ],
 				},
 				parents: {
 					123: '',
 					456: '',
 					1011: '',
-					1213: 1011,
-					1415: 1011,
+					1213: '1011',
+					1415: '1011',
 				},
 			},
 		};
@@ -870,13 +965,13 @@ describe( 'selectors', () => {
 		it( 'should return the clientIds of blocks of a given type', () => {
 			expect(
 				__experimentalGetGlobalBlocksByName( state, 'core/heading' )
-			).toStrictEqual( [ 123 ] );
+			).toStrictEqual( [ '123' ] );
 		} );
 
 		it( 'should return the clientIds of blocks of a given type even if blocks are nested', () => {
 			expect(
 				__experimentalGetGlobalBlocksByName( state, 'core/paragraph' )
-			).toStrictEqual( [ 456, 1415, 1213 ] );
+			).toStrictEqual( [ '456', '1415', '1213' ] );
 		} );
 
 		it( 'Should return empty array if no blocks match. The empty array should be the same reference', () => {
@@ -911,8 +1006,8 @@ describe( 'selectors', () => {
 		it( 'should return null if there is multi selection', () => {
 			const state = {
 				selection: {
-					selectionStart: { clientId: 23 },
-					selectionEnd: { clientId: 123 },
+					selectionStart: { clientId: '23' },
+					selectionEnd: { clientId: '123' },
 				},
 			};
 
@@ -922,19 +1017,21 @@ describe( 'selectors', () => {
 		it( 'should return the selected block ClientId', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						23: {
-							name: 'fake block',
-						},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							23: {
+								name: 'fake block',
+							},
+						} )
+					),
 				},
 				selection: {
-					selectionStart: { clientId: 23 },
-					selectionEnd: { clientId: 23 },
+					selectionStart: { clientId: '23' },
+					selectionEnd: { clientId: '23' },
 				},
 			};
 
-			expect( getSelectedBlockClientId( state ) ).toEqual( 23 );
+			expect( getSelectedBlockClientId( state ) ).toEqual( '23' );
 		} );
 	} );
 
@@ -942,16 +1039,20 @@ describe( 'selectors', () => {
 		it( 'should return null if no block is selected', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						23: { clientId: 23, name: 'core/heading' },
-						123: { clientId: 123, name: 'core/paragraph' },
-					},
-					attributes: {
-						23: {},
-						123: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							23: { clientId: '23', name: 'core/heading' },
+							123: { clientId: '123', name: 'core/paragraph' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							23: {},
+							123: {},
+						} )
+					),
 					order: {
-						'': [ 23, 123 ],
+						'': [ '23', '123' ],
 						23: [],
 						123: [],
 					},
@@ -961,7 +1062,7 @@ describe( 'selectors', () => {
 					},
 					tree: {
 						23: {
-							clientId: 23,
+							clientId: '23',
 							name: 'core/heading',
 							attributes: {},
 							innerBlocks: [],
@@ -980,16 +1081,20 @@ describe( 'selectors', () => {
 		it( 'should return null if there is multi selection', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						23: { clientId: 23, name: 'core/heading' },
-						123: { clientId: 123, name: 'core/paragraph' },
-					},
-					attributes: {
-						23: {},
-						123: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							23: { clientId: '23', name: 'core/heading' },
+							123: { clientId: '123', name: 'core/paragraph' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							23: {},
+							123: {},
+						} )
+					),
 					order: {
-						'': [ 23, 123 ],
+						'': [ '23', '123' ],
 						23: [],
 						123: [],
 					},
@@ -999,7 +1104,7 @@ describe( 'selectors', () => {
 					},
 					tree: {
 						23: {
-							clientId: 23,
+							clientId: '23',
 							name: 'core/heading',
 							attributes: {},
 							innerBlocks: [],
@@ -1007,8 +1112,8 @@ describe( 'selectors', () => {
 					},
 				},
 				selection: {
-					selectionStart: { clientId: 23 },
-					selectionEnd: { clientId: 123 },
+					selectionStart: { clientId: '23' },
+					selectionEnd: { clientId: '123' },
 				},
 			};
 
@@ -1018,16 +1123,20 @@ describe( 'selectors', () => {
 		it( 'should return the selected block', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						23: { clientId: 23, name: 'core/heading' },
-						123: { clientId: 123, name: 'core/paragraph' },
-					},
-					attributes: {
-						23: {},
-						123: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							23: { clientId: '23', name: 'core/heading' },
+							123: { clientId: '123', name: 'core/paragraph' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							23: {},
+							123: {},
+						} )
+					),
 					order: {
-						'': [ 23, 123 ],
+						'': [ '23', '123' ],
 						23: [],
 						123: [],
 					},
@@ -1037,7 +1146,7 @@ describe( 'selectors', () => {
 					},
 					tree: {
 						23: {
-							clientId: 23,
+							clientId: '23',
 							name: 'core/heading',
 							attributes: {},
 							innerBlocks: [],
@@ -1046,13 +1155,13 @@ describe( 'selectors', () => {
 					controlledInnerBlocks: {},
 				},
 				selection: {
-					selectionStart: { clientId: 23 },
-					selectionEnd: { clientId: 23 },
+					selectionStart: { clientId: '23' },
+					selectionEnd: { clientId: '23' },
 				},
 			};
 
 			expect( getSelectedBlock( state ) ).toEqual(
-				getBlock( state, 23 )
+				getBlock( state, '23' )
 			);
 		} );
 	} );
@@ -1073,19 +1182,19 @@ describe( 'selectors', () => {
 			const state = {
 				blocks: {
 					order: {
-						'': [ 123, 23 ],
-						123: [ 456, 56 ],
+						'': [ '123', '23' ],
+						123: [ '456', '56' ],
 					},
 					parents: {
 						123: '',
 						23: '',
-						456: 123,
-						56: 123,
+						456: '123',
+						56: '123',
 					},
 				},
 			};
 
-			expect( getBlockRootClientId( state, 56 ) ).toBe( 123 );
+			expect( getBlockRootClientId( state, '56' ) ).toBe( '123' );
 		} );
 	} );
 
@@ -1147,7 +1256,7 @@ describe( 'selectors', () => {
 			const state = {
 				blocks: {
 					order: {
-						'': [ 123, 23 ],
+						'': [ '123', '23' ],
 					},
 					parents: {
 						123: '',
@@ -1167,7 +1276,7 @@ describe( 'selectors', () => {
 			const state = {
 				blocks: {
 					order: {
-						'': [ 5, 4, 3, 2, 1 ],
+						'': [ '5', '4', '3', '2', '1' ],
 					},
 					parents: {
 						1: '',
@@ -1178,19 +1287,19 @@ describe( 'selectors', () => {
 					},
 				},
 				selection: {
-					selectionStart: { clientId: 2 },
-					selectionEnd: { clientId: 2 },
+					selectionStart: { clientId: '2' },
+					selectionEnd: { clientId: '2' },
 				},
 			};
 
-			expect( getSelectedBlockClientIds( state ) ).toEqual( [ 2 ] );
+			expect( getSelectedBlockClientIds( state ) ).toEqual( [ '2' ] );
 		} );
 
 		it( 'should return selected block clientIds if there is multi selection', () => {
 			const state = {
 				blocks: {
 					order: {
-						'': [ 5, 4, 3, 2, 1 ],
+						'': [ '5', '4', '3', '2', '1' ],
 					},
 					parents: {
 						1: '',
@@ -1201,20 +1310,24 @@ describe( 'selectors', () => {
 					},
 				},
 				selection: {
-					selectionStart: { clientId: 2 },
-					selectionEnd: { clientId: 4 },
+					selectionStart: { clientId: '2' },
+					selectionEnd: { clientId: '4' },
 				},
 			};
 
-			expect( getSelectedBlockClientIds( state ) ).toEqual( [ 4, 3, 2 ] );
+			expect( getSelectedBlockClientIds( state ) ).toEqual( [
+				'4',
+				'3',
+				'2',
+			] );
 		} );
 
 		it( 'should return selected block clientIds if there is multi selection (nested context)', () => {
 			const state = {
 				blocks: {
 					order: {
-						'': [ 5, 4, 3, 2, 1 ],
-						4: [ 9, 8, 7, 6 ],
+						'': [ '5', '4', '3', '2', '1' ],
+						4: [ '9', '8', '7', '6' ],
 					},
 					parents: {
 						1: '',
@@ -1222,19 +1335,23 @@ describe( 'selectors', () => {
 						3: '',
 						4: '',
 						5: '',
-						6: 4,
-						7: 4,
-						8: 4,
-						9: 4,
+						6: '4',
+						7: '4',
+						8: '4',
+						9: '4',
 					},
 				},
 				selection: {
-					selectionStart: { clientId: 7 },
-					selectionEnd: { clientId: 9 },
+					selectionStart: { clientId: '7' },
+					selectionEnd: { clientId: '9' },
 				},
 			};
 
-			expect( getSelectedBlockClientIds( state ) ).toEqual( [ 9, 8, 7 ] );
+			expect( getSelectedBlockClientIds( state ) ).toEqual( [
+				'9',
+				'8',
+				'7',
+			] );
 		} );
 	} );
 
@@ -1243,7 +1360,7 @@ describe( 'selectors', () => {
 			const state = {
 				blocks: {
 					order: {
-						'': [ 123, 23 ],
+						'': [ '123', '23' ],
 					},
 					parents: {
 						23: '',
@@ -1263,7 +1380,7 @@ describe( 'selectors', () => {
 			const state = {
 				blocks: {
 					order: {
-						'': [ 5, 4, 3, 2, 1 ],
+						'': [ '5', '4', '3', '2', '1' ],
 					},
 					parents: {
 						1: '',
@@ -1274,13 +1391,15 @@ describe( 'selectors', () => {
 					},
 				},
 				selection: {
-					selectionStart: { clientId: 2 },
-					selectionEnd: { clientId: 4 },
+					selectionStart: { clientId: '2' },
+					selectionEnd: { clientId: '4' },
 				},
 			};
 
 			expect( getMultiSelectedBlockClientIds( state ) ).toEqual( [
-				4, 3, 2,
+				'4',
+				'3',
+				'2',
 			] );
 		} );
 
@@ -1288,8 +1407,8 @@ describe( 'selectors', () => {
 			const state = {
 				blocks: {
 					order: {
-						'': [ 5, 4, 3, 2, 1 ],
-						4: [ 9, 8, 7, 6 ],
+						'': [ '5', '4', '3', '2', '1' ],
+						4: [ '9', '8', '7', '6' ],
 					},
 					parents: {
 						1: '',
@@ -1297,20 +1416,22 @@ describe( 'selectors', () => {
 						3: '',
 						4: '',
 						5: '',
-						6: 4,
-						7: 4,
-						8: 4,
-						9: 4,
+						6: '4',
+						7: '4',
+						8: '4',
+						9: '4',
 					},
 				},
 				selection: {
-					selectionStart: { clientId: 7 },
-					selectionEnd: { clientId: 9 },
+					selectionStart: { clientId: '7' },
+					selectionEnd: { clientId: '9' },
 				},
 			};
 
 			expect( getMultiSelectedBlockClientIds( state ) ).toEqual( [
-				9, 8, 7,
+				'9',
+				'8',
+				'7',
 			] );
 		} );
 	} );
@@ -1319,8 +1440,8 @@ describe( 'selectors', () => {
 		it( 'should return the same reference on subsequent invocations of empty selection', () => {
 			const state = {
 				blocks: {
-					byClientId: {},
-					attributes: {},
+					byClientId: new Map(),
+					attributes: new Map(),
 					order: {},
 					parents: {},
 				},
@@ -1351,12 +1472,12 @@ describe( 'selectors', () => {
 		it( 'returns multi selection start', () => {
 			const state = {
 				selection: {
-					selectionStart: { clientId: 2 },
-					selectionEnd: { clientId: 4 },
+					selectionStart: { clientId: '2' },
+					selectionEnd: { clientId: '4' },
 				},
 			};
 
-			expect( getMultiSelectedBlocksStartClientId( state ) ).toBe( 2 );
+			expect( getMultiSelectedBlocksStartClientId( state ) ).toBe( '2' );
 		} );
 	} );
 
@@ -1375,12 +1496,12 @@ describe( 'selectors', () => {
 		it( 'returns multi selection end', () => {
 			const state = {
 				selection: {
-					selectionStart: { clientId: 2 },
-					selectionEnd: { clientId: 4 },
+					selectionStart: { clientId: '2' },
+					selectionEnd: { clientId: '4' },
 				},
 			};
 
-			expect( getMultiSelectedBlocksEndClientId( state ) ).toBe( 4 );
+			expect( getMultiSelectedBlocksEndClientId( state ) ).toBe( '4' );
 		} );
 	} );
 
@@ -1389,7 +1510,7 @@ describe( 'selectors', () => {
 			const state = {
 				blocks: {
 					order: {
-						'': [ 123, 23 ],
+						'': [ '123', '23' ],
 					},
 					parents: {
 						23: '',
@@ -1398,25 +1519,25 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getBlockOrder( state ) ).toEqual( [ 123, 23 ] );
+			expect( getBlockOrder( state ) ).toEqual( [ '123', '23' ] );
 		} );
 
 		it( 'should return the ordered block ClientIds at a specified rootClientId', () => {
 			const state = {
 				blocks: {
 					order: {
-						'': [ 123, 23 ],
-						123: [ 456 ],
+						'': [ '123', '23' ],
+						123: [ '456' ],
 					},
 					parents: {
 						23: '',
 						123: '',
-						456: 123,
+						456: '123',
 					},
 				},
 			};
 
-			expect( getBlockOrder( state, '123' ) ).toEqual( [ 456 ] );
+			expect( getBlockOrder( state, '123' ) ).toEqual( [ '456' ] );
 		} );
 	} );
 
@@ -1425,7 +1546,7 @@ describe( 'selectors', () => {
 			const state = {
 				blocks: {
 					order: {
-						'': [ 123, 23 ],
+						'': [ '123', '23' ],
 					},
 					parents: {
 						23: '',
@@ -1434,26 +1555,26 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getBlockIndex( state, 23 ) ).toBe( 1 );
+			expect( getBlockIndex( state, '23' ) ).toBe( 1 );
 		} );
 
 		it( 'should return the block order (nested context)', () => {
 			const state = {
 				blocks: {
 					order: {
-						'': [ 123, 23 ],
-						123: [ 456, 56 ],
+						'': [ '123', '23' ],
+						123: [ '456', '56' ],
 					},
 					parents: {
 						23: '',
 						123: '',
-						56: 123,
-						456: 123,
+						56: '123',
+						456: '123',
 					},
 				},
 			};
 
-			expect( getBlockIndex( state, 56 ) ).toBe( 1 );
+			expect( getBlockIndex( state, '56' ) ).toBe( 1 );
 		} );
 	} );
 
@@ -1462,7 +1583,7 @@ describe( 'selectors', () => {
 			const state = {
 				blocks: {
 					order: {
-						'': [ 123, 23 ],
+						'': [ '123', '23' ],
 					},
 					parents: {
 						23: '',
@@ -1471,27 +1592,27 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getPreviousBlockClientId( state, 23 ) ).toEqual( 123 );
+			expect( getPreviousBlockClientId( state, '23' ) ).toEqual( '123' );
 		} );
 
 		it( 'should return the previous block (nested context)', () => {
 			const state = {
 				blocks: {
 					order: {
-						'': [ 123, 23 ],
-						123: [ 456, 56 ],
+						'': [ '123', '23' ],
+						123: [ '456', '56' ],
 					},
 					parents: {
 						23: '',
 						123: '',
-						456: 123,
-						56: 123,
+						456: '123',
+						56: '123',
 					},
 				},
 			};
 
-			expect( getPreviousBlockClientId( state, 56, '123' ) ).toEqual(
-				456
+			expect( getPreviousBlockClientId( state, '56', '123' ) ).toEqual(
+				'456'
 			);
 		} );
 
@@ -1499,7 +1620,7 @@ describe( 'selectors', () => {
 			const state = {
 				blocks: {
 					order: {
-						'': [ 123, 23 ],
+						'': [ '123', '23' ],
 					},
 					parents: {
 						23: '',
@@ -1508,26 +1629,28 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getPreviousBlockClientId( state, 123 ) ).toBeNull();
+			expect( getPreviousBlockClientId( state, '123' ) ).toBeNull();
 		} );
 
 		it( 'should return null for the first block (nested context)', () => {
 			const state = {
 				blocks: {
 					order: {
-						'': [ 123, 23 ],
-						123: [ 456, 56 ],
+						'': [ '123', '23' ],
+						123: [ '456', '56' ],
 					},
 					parents: {
 						23: '',
 						123: '',
-						456: 123,
-						56: 123,
+						456: '123',
+						56: '123',
 					},
 				},
 			};
 
-			expect( getPreviousBlockClientId( state, 456, '123' ) ).toBeNull();
+			expect(
+				getPreviousBlockClientId( state, '456', '123' )
+			).toBeNull();
 		} );
 	} );
 
@@ -1536,7 +1659,7 @@ describe( 'selectors', () => {
 			const state = {
 				blocks: {
 					order: {
-						'': [ 123, 23 ],
+						'': [ '123', '23' ],
 					},
 					parents: {
 						23: '',
@@ -1545,33 +1668,35 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getNextBlockClientId( state, 123 ) ).toEqual( 23 );
+			expect( getNextBlockClientId( state, '123' ) ).toEqual( '23' );
 		} );
 
 		it( 'should return the following block (nested context)', () => {
 			const state = {
 				blocks: {
 					order: {
-						'': [ 123, 23 ],
-						123: [ 456, 56 ],
+						'': [ '123', '23' ],
+						123: [ '456', '56' ],
 					},
 					parents: {
 						23: '',
 						123: '',
-						456: 123,
-						56: 123,
+						456: '123',
+						56: '123',
 					},
 				},
 			};
 
-			expect( getNextBlockClientId( state, 456, '123' ) ).toEqual( 56 );
+			expect( getNextBlockClientId( state, '456', '123' ) ).toEqual(
+				'56'
+			);
 		} );
 
 		it( 'should return null for the last block', () => {
 			const state = {
 				blocks: {
 					order: {
-						'': [ 123, 23 ],
+						'': [ '123', '23' ],
 					},
 					parents: {
 						23: '',
@@ -1580,26 +1705,26 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getNextBlockClientId( state, 23 ) ).toBeNull();
+			expect( getNextBlockClientId( state, '23' ) ).toBeNull();
 		} );
 
 		it( 'should return null for the last block (nested context)', () => {
 			const state = {
 				blocks: {
 					order: {
-						'': [ 123, 23 ],
-						123: [ 456, 56 ],
+						'': [ '123', '23' ],
+						123: [ '456', '56' ],
 					},
 					parents: {
 						23: '',
 						123: '',
-						456: 123,
-						56: 123,
+						456: '123',
+						56: '123',
 					},
 				},
 			};
 
-			expect( getNextBlockClientId( state, 56, '123' ) ).toBeNull();
+			expect( getNextBlockClientId( state, '56', '123' ) ).toBeNull();
 		} );
 	} );
 
@@ -1607,23 +1732,23 @@ describe( 'selectors', () => {
 		it( 'should return true if the block is selected', () => {
 			const state = {
 				selection: {
-					selectionStart: { clientId: 123 },
-					selectionEnd: { clientId: 123 },
+					selectionStart: { clientId: '123' },
+					selectionEnd: { clientId: '123' },
 				},
 			};
 
-			expect( isBlockSelected( state, 123 ) ).toBe( true );
+			expect( isBlockSelected( state, '123' ) ).toBe( true );
 		} );
 
 		it( 'should return false if a multi-selection range exists', () => {
 			const state = {
 				selection: {
-					selectionStart: { clientId: 123 },
-					selectionEnd: { clientId: 124 },
+					selectionStart: { clientId: '123' },
+					selectionEnd: { clientId: '124' },
 				},
 			};
 
-			expect( isBlockSelected( state, 123 ) ).toBe( false );
+			expect( isBlockSelected( state, '123' ) ).toBe( false );
 		} );
 
 		it( 'should return false if the block is not selected', () => {
@@ -1634,7 +1759,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isBlockSelected( state, 23 ) ).toBe( false );
+			expect( isBlockSelected( state, '23' ) ).toBe( false );
 		} );
 	} );
 
@@ -1642,87 +1767,87 @@ describe( 'selectors', () => {
 		it( 'should return false if the selected block is a child of the given ClientId', () => {
 			const state = {
 				selection: {
-					selectionStart: { clientId: 5 },
-					selectionEnd: { clientId: 5 },
+					selectionStart: { clientId: '5' },
+					selectionEnd: { clientId: '5' },
 				},
 				blocks: {
 					order: {
-						4: [ 3, 2, 1 ],
+						4: [ '3', '2', '1' ],
 					},
 					parents: {
-						1: 4,
-						2: 4,
-						3: 4,
+						1: '4',
+						2: '4',
+						3: '4',
 					},
 				},
 			};
 
-			expect( hasSelectedInnerBlock( state, 4 ) ).toBe( false );
+			expect( hasSelectedInnerBlock( state, '4' ) ).toBe( false );
 		} );
 
 		it( 'should return true if the selected block is a child of the given ClientId', () => {
 			const state = {
 				selection: {
-					selectionStart: { clientId: 3 },
-					selectionEnd: { clientId: 3 },
+					selectionStart: { clientId: '3' },
+					selectionEnd: { clientId: '3' },
 				},
 				blocks: {
 					order: {
-						4: [ 3, 2, 1 ],
+						4: [ '3', '2', '1' ],
 					},
 					parents: {
-						1: 4,
-						2: 4,
-						3: 4,
+						1: '4',
+						2: '4',
+						3: '4',
 					},
 				},
 			};
 
-			expect( hasSelectedInnerBlock( state, 4 ) ).toBe( true );
+			expect( hasSelectedInnerBlock( state, '4' ) ).toBe( true );
 		} );
 
 		it( 'should return true if a multi selection exists that contains children of the block with the given ClientId', () => {
 			const state = {
 				blocks: {
 					order: {
-						6: [ 5, 4, 3, 2, 1 ],
+						6: [ '5', '4', '3', '2', '1' ],
 					},
 					parents: {
-						1: 6,
-						2: 6,
-						3: 6,
-						4: 6,
-						5: 6,
+						1: '6',
+						2: '6',
+						3: '6',
+						4: '6',
+						5: '6',
 					},
 				},
 				selection: {
-					selectionStart: { clientId: 2 },
-					selectionEnd: { clientId: 4 },
+					selectionStart: { clientId: '2' },
+					selectionEnd: { clientId: '4' },
 				},
 			};
-			expect( hasSelectedInnerBlock( state, 6 ) ).toBe( true );
+			expect( hasSelectedInnerBlock( state, '6' ) ).toBe( true );
 		} );
 
 		it( 'should return false if a multi selection exists bot does not contains children of the block with the given ClientId', () => {
 			const state = {
 				blocks: {
 					order: {
-						3: [ 2, 1 ],
-						6: [ 5, 4 ],
+						3: [ '2', '1' ],
+						6: [ '5', '4' ],
 					},
 					parents: {
-						1: 3,
-						2: 3,
-						4: 6,
-						5: 6,
+						1: '3',
+						2: '3',
+						4: '6',
+						5: '6',
 					},
 				},
 				selection: {
-					selectionStart: { clientId: 5 },
-					selectionEnd: { clientId: 4 },
+					selectionStart: { clientId: '5' },
+					selectionEnd: { clientId: '4' },
 				},
 			};
-			expect( hasSelectedInnerBlock( state, 3 ) ).toBe( false );
+			expect( hasSelectedInnerBlock( state, '3' ) ).toBe( false );
 		} );
 	} );
 
@@ -1730,12 +1855,12 @@ describe( 'selectors', () => {
 		it( 'should return true if the block is selected but not the last', () => {
 			const state = {
 				selection: {
-					selectionStart: { clientId: 5 },
-					selectionEnd: { clientId: 3 },
+					selectionStart: { clientId: '5' },
+					selectionEnd: { clientId: '3' },
 				},
 				blocks: {
 					order: {
-						'': [ 5, 4, 3, 2, 1 ],
+						'': [ '5', '4', '3', '2', '1' ],
 					},
 					parents: {
 						1: '',
@@ -1747,18 +1872,18 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isBlockWithinSelection( state, 4 ) ).toBe( true );
+			expect( isBlockWithinSelection( state, '4' ) ).toBe( true );
 		} );
 
 		it( 'should return false if the block is the last selected', () => {
 			const state = {
 				selection: {
-					selectionStart: { clientId: 5 },
-					selectionEnd: { clientId: 3 },
+					selectionStart: { clientId: '5' },
+					selectionEnd: { clientId: '3' },
 				},
 				blocks: {
 					order: {
-						'': [ 5, 4, 3, 2, 1 ],
+						'': [ '5', '4', '3', '2', '1' ],
 					},
 					parents: {
 						1: '',
@@ -1770,18 +1895,18 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isBlockWithinSelection( state, 3 ) ).toBe( false );
+			expect( isBlockWithinSelection( state, '3' ) ).toBe( false );
 		} );
 
 		it( 'should return false if the block is not selected', () => {
 			const state = {
 				selection: {
-					selectionStart: { clientId: 5 },
-					selectionEnd: { clientId: 3 },
+					selectionStart: { clientId: '5' },
+					selectionEnd: { clientId: '3' },
 				},
 				blocks: {
 					order: {
-						'': [ 5, 4, 3, 2, 1 ],
+						'': [ '5', '4', '3', '2', '1' ],
 					},
 					parents: {
 						1: '',
@@ -1793,7 +1918,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isBlockWithinSelection( state, 2 ) ).toBe( false );
+			expect( isBlockWithinSelection( state, '2' ) ).toBe( false );
 		} );
 
 		it( 'should return false if there is no selection', () => {
@@ -1804,7 +1929,7 @@ describe( 'selectors', () => {
 				},
 				blocks: {
 					order: {
-						'': [ 5, 4, 3, 2, 1 ],
+						'': [ '5', '4', '3', '2', '1' ],
 					},
 					parents: {
 						1: '',
@@ -1816,7 +1941,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isBlockWithinSelection( state, 4 ) ).toBe( false );
+			expect( isBlockWithinSelection( state, '4' ) ).toBe( false );
 		} );
 	} );
 
@@ -1867,7 +1992,7 @@ describe( 'selectors', () => {
 		const state = {
 			blocks: {
 				order: {
-					'': [ 5, 4, 3, 2, 1 ],
+					'': [ '5', '4', '3', '2', '1' ],
 				},
 				parents: {
 					1: '',
@@ -1878,17 +2003,17 @@ describe( 'selectors', () => {
 				},
 			},
 			selection: {
-				selectionStart: { clientId: 2 },
-				selectionEnd: { clientId: 4 },
+				selectionStart: { clientId: '2' },
+				selectionEnd: { clientId: '4' },
 			},
 		};
 
 		it( 'should return true if the block is multi selected', () => {
-			expect( isBlockMultiSelected( state, 3 ) ).toBe( true );
+			expect( isBlockMultiSelected( state, '3' ) ).toBe( true );
 		} );
 
 		it( 'should return false if the block is not multi selected', () => {
-			expect( isBlockMultiSelected( state, 5 ) ).toBe( false );
+			expect( isBlockMultiSelected( state, '5' ) ).toBe( false );
 		} );
 	} );
 
@@ -1896,7 +2021,7 @@ describe( 'selectors', () => {
 		const state = {
 			blocks: {
 				order: {
-					'': [ 5, 4, 3, 2, 1 ],
+					'': [ '5', '4', '3', '2', '1' ],
 				},
 				parents: {
 					1: '',
@@ -1907,17 +2032,17 @@ describe( 'selectors', () => {
 				},
 			},
 			selection: {
-				selectionStart: { clientId: 2 },
-				selectionEnd: { clientId: 4 },
+				selectionStart: { clientId: '2' },
+				selectionEnd: { clientId: '4' },
 			},
 		};
 
 		it( 'should return true if the block is first in multi selection', () => {
-			expect( isFirstMultiSelectedBlock( state, 4 ) ).toBe( true );
+			expect( isFirstMultiSelectedBlock( state, '4' ) ).toBe( true );
 		} );
 
 		it( 'should return false if the block is not first in multi selection', () => {
-			expect( isFirstMultiSelectedBlock( state, 3 ) ).toBe( false );
+			expect( isFirstMultiSelectedBlock( state, '3' ) ).toBe( false );
 		} );
 	} );
 
@@ -1927,7 +2052,7 @@ describe( 'selectors', () => {
 				blocksMode: {},
 			};
 
-			expect( getBlockMode( state, 123 ) ).toEqual( 'visual' );
+			expect( getBlockMode( state, '123' ) ).toEqual( 'visual' );
 		} );
 
 		it( 'should return the block mode', () => {
@@ -1937,7 +2062,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getBlockMode( state, 123 ) ).toEqual( 'html' );
+			expect( getBlockMode( state, '123' ) ).toEqual( 'html' );
 		} );
 	} );
 
@@ -2093,14 +2218,18 @@ describe( 'selectors', () => {
 					selectionEnd: { clientId: 'clientId2' },
 				},
 				blocks: {
-					byClientId: {
-						clientId1: { clientId: 'clientId1' },
-						clientId2: { clientId: 'clientId2' },
-					},
-					attributes: {
-						clientId1: {},
-						clientId2: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							clientId1: { clientId: 'clientId1' },
+							clientId2: { clientId: 'clientId2' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							clientId1: {},
+							clientId2: {},
+						} )
+					),
 					order: {
 						'': [ 'clientId1' ],
 						clientId1: [ 'clientId2' ],
@@ -2130,12 +2259,16 @@ describe( 'selectors', () => {
 					selectionEnd: { clientId: 'clientId1' },
 				},
 				blocks: {
-					byClientId: {
-						clientId1: { clientId: 'clientId1' },
-					},
-					attributes: {
-						clientId1: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							clientId1: { clientId: 'clientId1' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							clientId1: {},
+						} )
+					),
 					order: {
 						'': [ 'clientId1' ],
 						clientId1: [],
@@ -2160,14 +2293,18 @@ describe( 'selectors', () => {
 					selectionEnd: { clientId: 'clientId2' },
 				},
 				blocks: {
-					byClientId: {
-						clientId1: { clientId: 'clientId1' },
-						clientId2: { clientId: 'clientId2' },
-					},
-					attributes: {
-						clientId1: {},
-						clientId2: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							clientId1: { clientId: 'clientId1' },
+							clientId2: { clientId: 'clientId2' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							clientId1: {},
+							clientId2: {},
+						} )
+					),
 					order: {
 						'': [ 'clientId1' ],
 						clientId1: [ 'clientId2' ],
@@ -2194,14 +2331,18 @@ describe( 'selectors', () => {
 					selectionEnd: { clientId: 'clientId2' },
 				},
 				blocks: {
-					byClientId: {
-						clientId1: { clientId: 'clientId1' },
-						clientId2: { clientId: 'clientId2' },
-					},
-					attributes: {
-						clientId1: {},
-						clientId2: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							clientId1: { clientId: 'clientId1' },
+							clientId2: { clientId: 'clientId2' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							clientId1: {},
+							clientId2: {},
+						} )
+					),
 					order: {
 						'': [ 'clientId1', 'clientId2' ],
 						clientId1: [],
@@ -2228,14 +2369,18 @@ describe( 'selectors', () => {
 					selectionEnd: {},
 				},
 				blocks: {
-					byClientId: {
-						clientId1: { clientId: 'clientId1' },
-						clientId2: { clientId: 'clientId2' },
-					},
-					attributes: {
-						clientId1: {},
-						clientId2: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							clientId1: { clientId: 'clientId1' },
+							clientId2: { clientId: 'clientId2' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							clientId1: {},
+							clientId2: {},
+						} )
+					),
 					order: {
 						'': [ 'clientId1', 'clientId2' ],
 						clientId1: [],
@@ -2281,8 +2426,8 @@ describe( 'selectors', () => {
 		it( 'should deny blocks that are not registered', () => {
 			const state = {
 				blocks: {
-					byClientId: {},
-					attributes: {},
+					byClientId: new Map(),
+					attributes: new Map(),
 				},
 				blockListSettings: {},
 				settings: {},
@@ -2293,8 +2438,8 @@ describe( 'selectors', () => {
 		it( 'should deny blocks that are not allowed by the editor', () => {
 			const state = {
 				blocks: {
-					byClientId: {},
-					attributes: {},
+					byClientId: new Map(),
+					attributes: new Map(),
 				},
 				blockListSettings: {},
 				settings: {
@@ -2309,8 +2454,8 @@ describe( 'selectors', () => {
 		it( 'should allow blocks that are allowed by the editor', () => {
 			const state = {
 				blocks: {
-					byClientId: {},
-					attributes: {},
+					byClientId: new Map(),
+					attributes: new Map(),
 				},
 				blockListSettings: {},
 				settings: {
@@ -2325,8 +2470,8 @@ describe( 'selectors', () => {
 		it( 'should deny blocks when the editor has a template lock', () => {
 			const state = {
 				blocks: {
-					byClientId: {},
-					attributes: {},
+					byClientId: new Map(),
+					attributes: new Map(),
 				},
 				blockListSettings: {},
 				settings: {
@@ -2341,8 +2486,8 @@ describe( 'selectors', () => {
 		it( 'should deny blocks that restrict parent from being inserted into the root', () => {
 			const state = {
 				blocks: {
-					byClientId: {},
-					attributes: {},
+					byClientId: new Map(),
+					attributes: new Map(),
 				},
 				blockListSettings: {},
 				settings: {},
@@ -2355,12 +2500,16 @@ describe( 'selectors', () => {
 		it( 'should deny blocks that restrict parent from being inserted into a restricted parent', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						block1: { name: 'core/test-block-a' },
-					},
-					attributes: {
-						block1: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							block1: { name: 'core/test-block-a' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							block1: {},
+						} )
+					),
 				},
 				blockListSettings: {},
 				settings: {},
@@ -2373,12 +2522,16 @@ describe( 'selectors', () => {
 		it( 'should allow blocks to be inserted into an allowed parent', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						block1: { name: 'core/test-block-b' },
-					},
-					attributes: {
-						block1: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							block1: { name: 'core/test-block-b' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							block1: {},
+						} )
+					),
 				},
 				blockListSettings: {
 					block1: {},
@@ -2393,12 +2546,16 @@ describe( 'selectors', () => {
 		it( 'should deny blocks from being inserted into a block that does not allow inner blocks', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						block1: { name: 'core/test-block-b' },
-					},
-					attributes: {
-						block1: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							block1: { name: 'core/test-block-b' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							block1: {},
+						} )
+					),
 				},
 				blockListSettings: {
 					block1: {},
@@ -2413,12 +2570,16 @@ describe( 'selectors', () => {
 		it( 'should deny restricted blocks from being inserted into a block that restricts allowedBlocks', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						block1: { name: 'core/test-block-a' },
-					},
-					attributes: {
-						block1: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							block1: { name: 'core/test-block-a' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							block1: {},
+						} )
+					),
 				},
 				blockListSettings: {
 					block1: {
@@ -2435,12 +2596,16 @@ describe( 'selectors', () => {
 		it( 'should allow allowed blocks to be inserted into a block that restricts allowedBlocks', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						block1: { name: 'core/test-block-a' },
-					},
-					attributes: {
-						block1: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							block1: { name: 'core/test-block-a' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							block1: {},
+						} )
+					),
 				},
 				blockListSettings: {
 					block1: {
@@ -2457,12 +2622,16 @@ describe( 'selectors', () => {
 		it( 'should prioritise parent over allowedBlocks', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						block1: { name: 'core/test-block-b' },
-					},
-					attributes: {
-						block1: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							block1: { name: 'core/test-block-b' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							block1: {},
+						} )
+					),
 				},
 				blockListSettings: {
 					block1: {
@@ -2479,12 +2648,16 @@ describe( 'selectors', () => {
 		it( 'should deny blocks that restrict parent to core/post-content when not in editor root', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						block1: { name: 'core/test-block-c' },
-					},
-					attributes: {
-						block1: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							block1: { name: 'core/test-block-c' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							block1: {},
+						} )
+					),
 				},
 				blockListSettings: {},
 				settings: {},
@@ -2497,8 +2670,8 @@ describe( 'selectors', () => {
 		it( 'should allow blocks that restrict parent to core/post-content when in editor root', () => {
 			const state = {
 				blocks: {
-					byClientId: {},
-					attributes: {},
+					byClientId: new Map(),
+					attributes: new Map(),
 				},
 				blockListSettings: {},
 				settings: {},
@@ -2511,14 +2684,18 @@ describe( 'selectors', () => {
 		it( 'should allow blocks to be inserted in a descendant of a required ancestor', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						block1: { name: 'core/test-block-ancestor' },
-						block2: { name: 'core/block' },
-					},
-					attributes: {
-						block1: {},
-						block2: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							block1: { name: 'core/test-block-ancestor' },
+							block2: { name: 'core/block' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							block1: {},
+							block2: {},
+						} )
+					),
 					parents: {
 						block2: 'block1',
 					},
@@ -2541,16 +2718,20 @@ describe( 'selectors', () => {
 		it( 'should allow blocks to be inserted if both parent and ancestor restrictions are met', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						block1: { name: 'core/test-block-ancestor' },
-						block2: { name: 'core/block' },
-						block3: { name: 'core/test-block-parent' },
-					},
-					attributes: {
-						block1: {},
-						block2: {},
-						block3: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							block1: { name: 'core/test-block-ancestor' },
+							block2: { name: 'core/block' },
+							block3: { name: 'core/test-block-parent' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							block1: {},
+							block2: {},
+							block3: {},
+						} )
+					),
 					parents: {
 						block2: 'block1',
 						block3: 'block2',
@@ -2575,16 +2756,20 @@ describe( 'selectors', () => {
 		it( 'should deny blocks from being inserted outside a required ancestor', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						block1: { name: 'core/test-block-ancestor' },
-						block2: { name: 'core/block' },
-						block3: { name: 'core/block' },
-					},
-					attributes: {
-						block1: {},
-						block2: {},
-						block3: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							block1: { name: 'core/test-block-ancestor' },
+							block2: { name: 'core/block' },
+							block3: { name: 'core/block' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							block1: {},
+							block2: {},
+							block3: {},
+						} )
+					),
 					parents: {
 						block3: 'block2',
 					},
@@ -2608,16 +2793,20 @@ describe( 'selectors', () => {
 		it( 'should deny blocks from being inserted outside of a required ancestor, even if parent matches', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						block1: { name: 'core/test-block-ancestor' },
-						block2: { name: 'core/block' },
-						block3: { name: 'core/test-block-parent' },
-					},
-					attributes: {
-						block1: {},
-						block2: {},
-						block3: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							block1: { name: 'core/test-block-ancestor' },
+							block2: { name: 'core/block' },
+							block3: { name: 'core/test-block-parent' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							block1: {},
+							block2: {},
+							block3: {},
+						} )
+					),
 					parents: {
 						block3: 'block2',
 					},
@@ -2641,14 +2830,18 @@ describe( 'selectors', () => {
 		it( 'should deny blocks from being inserted inside ancestor if parent restricts allowedBlocks', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						block1: { name: 'core/test-block-ancestor' },
-						block2: { name: 'core/block' },
-					},
-					attributes: {
-						block1: {},
-						block2: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							block1: { name: 'core/test-block-ancestor' },
+							block2: { name: 'core/block' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							block1: {},
+							block2: {},
+						} )
+					),
 					parents: {
 						block2: 'block1',
 					},
@@ -2673,14 +2866,18 @@ describe( 'selectors', () => {
 		it( 'should deny blocks from being inserted inside ancestor if parent restriction is not met', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						block1: { name: 'core/test-block-ancestor' },
-						block2: { name: 'core/block' },
-					},
-					attributes: {
-						block1: {},
-						block2: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							block1: { name: 'core/test-block-ancestor' },
+							block2: { name: 'core/block' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							block1: {},
+							block2: {},
+						} )
+					),
 					parents: {
 						block2: 'block1',
 					},
@@ -2705,16 +2902,20 @@ describe( 'selectors', () => {
 		it( 'should allow blocks', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						1: { name: 'core/test-block-a' },
-						2: { name: 'core/test-block-b' },
-						3: { name: 'core/test-block-c' },
-					},
-					attributes: {
-						1: {},
-						2: {},
-						3: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							1: { name: 'core/test-block-a' },
+							2: { name: 'core/test-block-b' },
+							3: { name: 'core/test-block-c' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							1: {},
+							2: {},
+							3: {},
+						} )
+					),
 				},
 				blockListSettings: {
 					1: {
@@ -2732,16 +2933,20 @@ describe( 'selectors', () => {
 		it( 'should deny blocks', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						1: { name: 'core/test-block-a' },
-						2: { name: 'core/test-block-b' },
-						3: { name: 'core/test-block-c' },
-					},
-					attributes: {
-						1: {},
-						2: {},
-						3: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							1: { name: 'core/test-block-a' },
+							2: { name: 'core/test-block-b' },
+							3: { name: 'core/test-block-c' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							1: {},
+							2: {},
+							3: {},
+						} )
+					),
 				},
 				blockListSettings: {
 					1: {
@@ -2758,8 +2963,8 @@ describe( 'selectors', () => {
 		it( 'should properly list block type and reusable block items', () => {
 			const state = {
 				blocks: {
-					byClientId: {},
-					attributes: {},
+					byClientId: new Map(),
+					attributes: new Map(),
 					order: {},
 					parents: {},
 					tree: {
@@ -2827,14 +3032,18 @@ describe( 'selectors', () => {
 		it( 'should correctly cache the return values', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						block3: { name: 'core/test-block-a' },
-						block4: { name: 'core/test-block-a' },
-					},
-					attributes: {
-						block3: {},
-						block4: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							block3: { name: 'core/test-block-a' },
+							block4: { name: 'core/test-block-a' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							block3: {},
+							block4: {},
+						} )
+					),
 					order: {
 						'': [ 'block3', 'block4' ],
 					},
@@ -2934,15 +3143,19 @@ describe( 'selectors', () => {
 		it( 'should set isDisabled when a block with `multiple: false` has been used', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						block1: {
-							clientId: 'block1',
-							name: 'core/test-block-b',
-						},
-					},
-					attributes: {
-						block1: { attribute: {} },
-					},
+					byClientId: new Map(
+						Object.entries( {
+							block1: {
+								clientId: 'block1',
+								name: 'core/test-block-b',
+							},
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							block1: { attribute: {} },
+						} )
+					),
 					order: {
 						'': [ 'block1' ],
 					},
@@ -2973,8 +3186,8 @@ describe( 'selectors', () => {
 		it( 'should set a frecency', () => {
 			const state = {
 				blocks: {
-					byClientId: {},
-					attributes: {},
+					byClientId: new Map(),
+					attributes: new Map(),
 					order: {},
 					parents: {},
 					cache: {},
@@ -3068,8 +3281,8 @@ describe( 'selectors', () => {
 		it( 'should properly return block type items', () => {
 			const state = {
 				blocks: {
-					byClientId: {},
-					attributes: {},
+					byClientId: new Map(),
+					attributes: new Map(),
 					order: {},
 					parents: {},
 					cache: {},
@@ -3108,8 +3321,8 @@ describe( 'selectors', () => {
 		it( 'should support single block object', () => {
 			const state = {
 				blocks: {
-					byClientId: {},
-					attributes: {},
+					byClientId: new Map(),
+					attributes: new Map(),
 					order: {},
 					parents: {},
 					cache: {},
@@ -3125,14 +3338,18 @@ describe( 'selectors', () => {
 		it( 'should return only eligible blocks for transformation - `allowedBlocks`', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						block1: { name: 'core/with-tranforms-b' },
-						block2: { name: 'core/with-tranforms-a' },
-					},
-					attributes: {
-						block1: {},
-						block2: {},
-					},
+					byClientId: new Map(
+						Object.entries( {
+							block1: { name: 'core/with-tranforms-b' },
+							block2: { name: 'core/with-tranforms-a' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							block1: {},
+							block2: {},
+						} )
+					),
 					order: {},
 					parents: {
 						block1: '',
@@ -3160,15 +3377,19 @@ describe( 'selectors', () => {
 		it( 'should take into account the usage of blocks settings `multiple` - if multiple blocks of the same type are allowed', () => {
 			const state = {
 				blocks: {
-					byClientId: {
-						block1: {
-							clientId: 'block1',
-							name: 'core/with-tranforms-c',
-						},
-					},
-					attributes: {
-						block1: { attribute: {} },
-					},
+					byClientId: new Map(
+						Object.entries( {
+							block1: {
+								clientId: 'block1',
+								name: 'core/with-tranforms-c',
+							},
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							block1: { attribute: {} },
+						} )
+					),
 					order: {
 						'': [ 'block1' ],
 					},
@@ -3208,8 +3429,8 @@ describe( 'selectors', () => {
 		it( 'should set frecency', () => {
 			const state = {
 				blocks: {
-					byClientId: {},
-					attributes: {},
+					byClientId: new Map(),
+					attributes: new Map(),
 					order: {},
 					parents: {},
 					cache: {},
@@ -3548,28 +3769,30 @@ describe( 'selectors', () => {
 					'client-id-04': 'client-id-03',
 					'client-id-05': 'client-id-03',
 				},
-				byClientId: {
-					'client-id-01': {
-						clientId: 'client-id-01',
-						name: 'core/columns',
-					},
-					'client-id-02': {
-						clientId: 'client-id-02',
-						name: 'core/navigation',
-					},
-					'client-id-03': {
-						clientId: 'client-id-03',
-						name: 'core/navigation-link',
-					},
-					'client-id-04': {
-						clientId: 'client-id-04',
-						name: 'core/navigation-link',
-					},
-					'client-id-05': {
-						clientId: 'client-id-05',
-						name: 'core/navigation-link',
-					},
-				},
+				byClientId: new Map(
+					Object.entries( {
+						'client-id-01': {
+							clientId: 'client-id-01',
+							name: 'core/columns',
+						},
+						'client-id-02': {
+							clientId: 'client-id-02',
+							name: 'core/navigation',
+						},
+						'client-id-03': {
+							clientId: 'client-id-03',
+							name: 'core/navigation-link',
+						},
+						'client-id-04': {
+							clientId: 'client-id-04',
+							name: 'core/navigation-link',
+						},
+						'client-id-05': {
+							clientId: 'client-id-05',
+							name: 'core/navigation-link',
+						},
+					} )
+				),
 				cache: {
 					'client-id-01': {},
 					'client-id-02': {},
@@ -3611,14 +3834,18 @@ describe( 'selectors', () => {
 	describe( '__experimentalGetAllowedPatterns', () => {
 		const state = {
 			blocks: {
-				byClientId: {
-					block1: { name: 'core/test-block-a' },
-					block2: { name: 'core/test-block-b' },
-				},
-				attributes: {
-					block1: {},
-					block2: {},
-				},
+				byClientId: new Map(
+					Object.entries( {
+						block1: { name: 'core/test-block-a' },
+						block2: { name: 'core/test-block-b' },
+					} )
+				),
+				attributes: new Map(
+					Object.entries( {
+						block1: {},
+						block2: {},
+					} )
+				),
 			},
 			blockListSettings: {
 				block1: {
@@ -3670,7 +3897,7 @@ describe( 'selectors', () => {
 		it( 'should return empty array if only patterns hidden from UI exist', () => {
 			expect(
 				__experimentalGetAllowedPatterns( {
-					blocks: { byClientId: {} },
+					blocks: { byClientId: new Map() },
 					blockListSettings: {},
 					settings: {
 						__experimentalBlockPatterns: [
@@ -3742,9 +3969,11 @@ describe( 'selectors', () => {
 	describe( '__experimentalGetPatternsByBlockTypes', () => {
 		const state = {
 			blocks: {
-				byClientId: {
-					block1: { name: 'core/test-block-a' },
-				},
+				byClientId: new Map(
+					Object.entries( {
+						block1: { name: 'core/test-block-a' },
+					} )
+				),
 			},
 			blockListSettings: {
 				block1: {
@@ -3816,10 +4045,12 @@ describe( 'selectors', () => {
 	describe( '__experimentalGetPatternTransformItems', () => {
 		const state = {
 			blocks: {
-				byClientId: {
-					block1: { name: 'core/test-block-a' },
-					block2: { name: 'core/test-block-b' },
-				},
+				byClientId: new Map(
+					Object.entries( {
+						block1: { name: 'core/test-block-a' },
+						block2: { name: 'core/test-block-b' },
+					} )
+				),
 				controlledInnerBlocks: { 'block2-clientId': true },
 			},
 			blockListSettings: {
@@ -4073,8 +4304,8 @@ describe( 'getInserterItems with core blocks prioritization', () => {
 	it( 'should prioritize core blocks by sorting them at the top of the returned list', () => {
 		const state = {
 			blocks: {
-				byClientId: {},
-				attributes: {},
+				byClientId: new Map(),
+				attributes: new Map(),
 				order: {},
 				parents: {},
 				cache: {},

--- a/packages/reusable-blocks/src/store/test/actions.js
+++ b/packages/reusable-blocks/src/store/test/actions.js
@@ -178,9 +178,7 @@ describe( 'Actions', () => {
 
 			await registry
 				.dispatch( reusableBlocksStore )
-				.__experimentalConvertBlockToStatic( [
-					associatedBlock.clientId,
-				] );
+				.__experimentalConvertBlockToStatic( associatedBlock.clientId );
 
 			// Check that blocks were converted to reusable.
 			const updatedBlocks = registry


### PR DESCRIPTION
Follow-up to #46146

## What?

Following a similar approach to #46146 I've added a test to simulate what happens when you hit "Enter" on a paragraph block in the editor. It's also a common behavior.

And while doing so, I tried to see how refactoring the byClientId state from plain objects to maps could impact the performance. Here are the results I got:

 - plain objects: 450ms
 - Maps: 380ms

I think we can improve the metric more if also refactor the "tree" state to maps but I wanted to leave that to its dedicated PR.
