### PR TITLE
Link UI: Destructure the props earlier in the component

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/link-ui.js
+++ b/packages/block-editor/src/components/off-canvas-editor/link-ui.js
@@ -124,10 +124,11 @@ function LinkControlTransforms( { clientId } ) {
 }
 
 export function LinkUI( props ) {
+	const { label, url, opensInNewTab, type, kind } = props.link;
 	const link = {
-		url: props.link.url,
-		opensInNewTab: props.link.opensInNewTab,
-		title: props.link.label && stripHTML( props.link.label ),
+		url,
+		opensInNewTab,
+		title: label && stripHTML( label ),
 	};
 
 	return (
@@ -144,16 +145,13 @@ export function LinkUI( props ) {
 				value={ link }
 				showInitialSuggestions={ true }
 				withCreateSuggestion={ props.hasCreateSuggestion }
-				noDirectEntry={ !! props.link?.type }
-				noURLSuggestion={ !! props.link?.type }
-				suggestionsQuery={ getSuggestionsQuery(
-					props.link?.type,
-					props.link?.kind
-				) }
+				noDirectEntry={ !! type }
+				noURLSuggestion={ !! type }
+				suggestionsQuery={ getSuggestionsQuery( type, kind ) }
 				onChange={ props.onChange }
 				onRemove={ props.onRemove }
 				renderControlBottom={
-					! props.link?.url
+					! url
 						? () => (
 								<LinkControlTransforms
 									clientId={ props.clientId }

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -151,10 +151,11 @@ export function LinkUI( props ) {
 		};
 	}
 
+	const { label, url, opensInNewTab, type, kind } = props.link;
 	const link = {
-		url: props.link.url,
-		opensInNewTab: props.link.opensInNewTab,
-		title: props.link.label && stripHTML( props.link.label ),
+		url,
+		opensInNewTab,
+		title: label && stripHTML( label ),
 	};
 
 	return (
@@ -175,7 +176,7 @@ export function LinkUI( props ) {
 				createSuggestionButtonText={ ( searchTerm ) => {
 					let format;
 
-					if ( props.link.type === 'post' ) {
+					if ( type === 'post' ) {
 						/* translators: %s: search term. */
 						format = __( 'Create draft post: <mark>%s</mark>' );
 					} else {
@@ -190,16 +191,13 @@ export function LinkUI( props ) {
 						}
 					);
 				} }
-				noDirectEntry={ !! props.link?.type }
-				noURLSuggestion={ !! props.link?.type }
-				suggestionsQuery={ getSuggestionsQuery(
-					props.link?.type,
-					props.link?.kind
-				) }
+				noDirectEntry={ !! type }
+				noURLSuggestion={ !! type }
+				suggestionsQuery={ getSuggestionsQuery( type, kind ) }
 				onChange={ props.onChange }
 				onRemove={ props.onRemove }
 				renderControlBottom={
-					! props.link?.url
+					! url
 						? () => (
 								<LinkControlTransforms
 									clientId={ props.clientId }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This destructures the props inside Link UI, so that when we pass them around we can access them as consts directly. 

## Why?
This makes the code a bit easier to read and also means that if we change the structure of the props in the future we only need to update this one place.

## How?
`{ destructuring } = props`

## Testing Instructions
Check that Link UI in the navigation link block and the off canvas editor both function the same as each other.