### PR TITLE
InputControl: Fix `Flex` wrapper usage

### DIFF
--- a/packages/block-editor/src/hooks/child-layout.js
+++ b/packages/block-editor/src/hooks/child-layout.js
@@ -84,7 +84,6 @@ export function ChildLayoutEdit( {
 			{ selfStretch === 'fixed' && (
 				<UnitControl
 					size={ '__unstable-large' }
-					style={ { height: 'auto' } }
 					onChange={ ( value ) => {
 						setAttributes( {
 							style: {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fix
 
 -   `ColorPalette`: show "Clear" button even when colors array is empty ([#46001](https://github.com/WordPress/gutenberg/pull/46001)).
+-   `InputControl`: Fix internal `Flex` wrapper usage that could add an unintended `height: 100%` ([#46213](https://github.com/WordPress/gutenberg/pull/46213)).
 
 ### Enhancements
 

--- a/packages/components/src/dimension-control/test/__snapshots__/index.test.js.snap
+++ b/packages/components/src/dimension-control/test/__snapshots__/index.test.js.snap
@@ -37,7 +37,6 @@ exports[`DimensionControl rendering renders with custom sizes 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
-  height: 100%;
   box-sizing: border-box;
   position: relative;
   border-radius: 2px;
@@ -309,7 +308,6 @@ exports[`DimensionControl rendering renders with defaults 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
-  height: 100%;
   box-sizing: border-box;
   position: relative;
   border-radius: 2px;
@@ -591,7 +589,6 @@ exports[`DimensionControl rendering renders with icon and custom icon label 1`] 
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
-  height: 100%;
   box-sizing: border-box;
   position: relative;
   border-radius: 2px;
@@ -885,7 +882,6 @@ exports[`DimensionControl rendering renders with icon and default icon label 1`]
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
-  height: 100%;
   box-sizing: border-box;
   position: relative;
   border-radius: 2px;

--- a/packages/components/src/input-control/input-base.tsx
+++ b/packages/components/src/input-control/input-base.tsx
@@ -33,14 +33,21 @@ function useUniqueId( idProp?: string ) {
 
 // Adapter to map props for the new ui/flex component.
 function getUIFlexProps( labelPosition?: LabelPosition ) {
-	const props: { direction?: string; gap?: number; justify?: string } = {};
+	const props: {
+		direction?: string;
+		gap?: number;
+		justify?: string;
+		expanded?: boolean;
+	} = {};
 	switch ( labelPosition ) {
 		case 'top':
 			props.direction = 'column';
+			props.expanded = false;
 			props.gap = 0;
 			break;
 		case 'bottom':
 			props.direction = 'column-reverse';
+			props.expanded = false;
 			props.gap = 0;
 			break;
 		case 'edge':


### PR DESCRIPTION
Closes #45877
Follow-up to #45364

## What?

- Fixes a subtle bug in InputControl's usage of the `Flex` component.
- Removes a [temporary workaround](https://github.com/WordPress/gutenberg/pull/45364/files/c2d0cb4728f1529426878cc6030419d77bf75976#r1026084154) merged in #45364 to address this problem.

## Why?

Normally we use either the HStack or VStack components rather than the lower-level Flex component. In InputControl however, Flex was chosen because the children need to be stacked both horizontally or vertically depending on the value of `labelPosition`.

`Flex` has a boolean prop called `expanded` that sets `width: 100%` when stacking horizontally, and `height: 100%` when stacking vertically. In the higher-level components, HStack is `expanded=true` by default, while VStack is `expanded=false` by default. This is usually what people want.

The subtle bug in InputControl was that it forgot to disable `expanded` in the vertically stacked cases. This gave the Flex wrapper an unintended `height: 100%`. Before the recently-merged #45931, this Flex was the outermost wrapper of the InputControl, causing InputControl to stretch vertically whenever its direct container was taller than the InputControl's intrinsic height.

While #45931 has suppressed any visual indications of this bug at the moment, we should fix the root bug so it doesn't subtly reemerge in the future.

## How?

Set `expanded` to false in cases where Flex is being used like a VStack.

## Testing Instructions

1. `npm run storybook:dev`
2. In the story for InputControl (or NumberControl, UnitControl), change the `labelPosition` to "top" or "bottom". It should look as expected. When you inspect the HTML, the Flex div should not have a `height: 100%` style.

### To test `child-layout.js`

1. `npm run dev`
2. In the editor, add a Row block. Add an Image block as a child of the Row block.
3. Select the Image block. From the inspector sidebar, add the Dimensions ▸ Width control.
4. Set the Width to "Fixed". The UnitControl that appears below the ToggleGroupControl should be 40px tall, as expected.