### PR TITLE
Site Logo: Correctly set the image's natural height and width

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -123,13 +123,10 @@ const SiteLogo = ( {
 			src={ logoUrl }
 			alt={ alt }
 			onLoad={ ( event ) => {
-				setNaturalSize(
-					Object.fromEntries(
-						Object.entries( event.target ).filter( ( [ key ] ) =>
-							[ 'naturalWidth', 'naturalHeight' ].includes( key )
-						)
-					)
-				);
+				setNaturalSize( {
+					naturalWidth: event.target.naturalWidth,
+					naturalHeight: event.target.naturalHeight,
+				} );
 			} }
 		/>
 	);


### PR DESCRIPTION
## What?
Fixes #46198.
Regression after #45940.

The Site Logo block returns early without rendering any controls when an image's natural width isn't available.

## Why?
The `event.target` is an `HTMLImageElement`, and the `Object.entries` will always return an empty array.

Example:
```js
Object.entries( new Image() );
```

## How?
I've updated the `onLoad` callback to set directly `naturalWidth` and `naturalHeight`.

## Testing Instructions
1. Open a Post or Page.
2. Insert the Site Logo block.
3. Set the logo.
4. Confirm block's Settings panel is displayed in the sidebar.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-11-30 at 20 39 16](https://user-images.githubusercontent.com/240569/204856365-4e106cdf-d29a-41b2-8f1a-39ccbb51d9c5.png)
