### PR TITLE
Docs: Adds reminder to use Node.js v14 in Quick Start

### DIFF
--- a/docs/getting-started/create-block/README.md
+++ b/docs/getting-started/create-block/README.md
@@ -18,6 +18,8 @@ From your plugins directory, to create your block run:
 npx @wordpress/create-block gutenpride --template @wordpress/create-block-tutorial-template
 ```
 
+> Remember that you should use Node.js v14. Other versions may result in an error in the terminal.
+
 The [npx command](https://docs.npmjs.com/cli/v8/commands/npx) runs a command from a remote package, in this case our create-block package that will create a new directory called `gutenpride`, installs the necessary files, and builds the block plugin. If you want an interactive mode that prompts you for details, run the command without the `gutenpride` name.
 
 You now need to activate the plugin from inside wp-admin plugins page.

--- a/docs/getting-started/create-block/README.md
+++ b/docs/getting-started/create-block/README.md
@@ -18,7 +18,7 @@ From your plugins directory, to create your block run:
 npx @wordpress/create-block gutenpride --template @wordpress/create-block-tutorial-template
 ```
 
-> Remember that you should use Node.js v14. Other versions may result in an error in the terminal.
+> Remember that you should use Node.js v14. Other versions may result in an error in the terminal. See [Node Development Tools](https://developer.wordpress.org/block-editor/getting-started/devenv/#node-development-tools) for more info.
 
 The [npx command](https://docs.npmjs.com/cli/v8/commands/npx) runs a command from a remote package, in this case our create-block package that will create a new directory called `gutenpride`, installs the necessary files, and builds the block plugin. If you want an interactive mode that prompts you for details, run the command without the `gutenpride` name.
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds a reminder to the '[Quick Start](https://developer.wordpress.org/block-editor/getting-started/create-block/#quick-start)' section of the 'Create a Block Tutorial' that node.js v14 should be used.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Other versions of node.js, e.g. v16, result in an error when the `--template @wordpress/create-block-tutorial-template` command line switch is used.  Error is:

```Template found but invalid definition provided.```

Beginners may suppose that using the latest version of node is the right thing to do, so a reminder that v14 is required for block development could be useful at this point in the tutorial, especially if they've skipped most of the [Development Environment](https://developer.wordpress.org/block-editor/getting-started/devenv/) page (where this was mentioned) because they're already set up.

