### PR TITLE
Hide  block toolbar when focusing items in Inspector panel

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -16,7 +16,7 @@ import {
 	Button,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useMemo, useCallback } from '@wordpress/element';
+import { useMemo, useCallback, useRef, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -257,8 +257,35 @@ const BlockInspectorSingleBlock = ( { clientId, blockName } ) => {
 	);
 	const blockInformation = useBlockDisplayInformation( clientId );
 
+	const inspectorElement = useRef();
+	const {
+		__experimentalHideBlockInterface: hideBlockInterface,
+		__experimentalShowBlockInterface: showBlockInterface,
+	} = useDispatch( blockEditorStore );
+
+	function handleOnFocus() {
+		hideBlockInterface();
+	}
+	function handleOnBlur() {
+		showBlockInterface();
+	}
+	useEffect( () => {
+		inspectorElement?.current?.addEventListener( 'focusin', handleOnFocus );
+		inspectorElement?.current?.addEventListener( 'focusout', handleOnBlur );
+		return () => {
+			inspectorElement?.current?.removeEventListener(
+				'focusin',
+				handleOnFocus
+			);
+			inspectorElement?.current?.removeEventListener(
+				'focusout',
+				handleOnBlur
+			);
+		};
+	}, [ inspectorElement.current ] );
+
 	return (
-		<div className="block-editor-block-inspector">
+		<div className="block-editor-block-inspector" ref={ inspectorElement }>
 			<BlockCard
 				{ ...blockInformation }
 				className={ blockInformation.isSynced && 'is-synced' }

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -258,28 +258,19 @@ const BlockInspectorSingleBlock = ( { clientId, blockName } ) => {
 	const blockInformation = useBlockDisplayInformation( clientId );
 
 	const inspectorElement = useRef();
-	const {
-		__experimentalHideBlockInterface: hideBlockInterface,
-		__experimentalShowBlockInterface: showBlockInterface,
-	} = useDispatch( blockEditorStore );
+	const { __experimentalHideBlockInterface: hideBlockInterface } =
+		useDispatch( blockEditorStore );
 
 	function handleOnFocus() {
 		hideBlockInterface();
 	}
-	function handleOnBlur() {
-		showBlockInterface();
-	}
+
 	useEffect( () => {
 		inspectorElement?.current?.addEventListener( 'focusin', handleOnFocus );
-		inspectorElement?.current?.addEventListener( 'focusout', handleOnBlur );
 		return () => {
 			inspectorElement?.current?.removeEventListener(
 				'focusin',
 				handleOnFocus
-			);
-			inspectorElement?.current?.removeEventListener(
-				'focusout',
-				handleOnBlur
 			);
 		};
 	}, [ inspectorElement.current ] );

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
@@ -17,11 +17,7 @@ import { store as blockEditorStore } from '../../../store';
  */
 export function useFocusHandler( clientId ) {
 	const { isBlockSelected } = useSelect( blockEditorStore );
-	const {
-		selectBlock,
-		selectionChange,
-		__experimentalShowBlockInterface: showBlockInterface,
-	} = useDispatch( blockEditorStore );
+	const { selectBlock, selectionChange } = useDispatch( blockEditorStore );
 
 	return useRefEffect(
 		( node ) => {
@@ -34,7 +30,6 @@ export function useFocusHandler( clientId ) {
 			 * @param {FocusEvent} event Focus event.
 			 */
 			function onFocus( event ) {
-				showBlockInterface();
 				// When the whole editor is editable, let writing flow handle
 				// selection.
 				if (

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
@@ -17,7 +17,11 @@ import { store as blockEditorStore } from '../../../store';
  */
 export function useFocusHandler( clientId ) {
 	const { isBlockSelected } = useSelect( blockEditorStore );
-	const { selectBlock, selectionChange } = useDispatch( blockEditorStore );
+	const {
+		selectBlock,
+		selectionChange,
+		__experimentalShowBlockInterface: showBlockInterface,
+	} = useDispatch( blockEditorStore );
 
 	return useRefEffect(
 		( node ) => {
@@ -30,6 +34,7 @@ export function useFocusHandler( clientId ) {
 			 * @param {FocusEvent} event Focus event.
 			 */
 			function onFocus( event ) {
+				showBlockInterface();
 				// When the whole editor is editable, let writing flow handle
 				// selection.
 				if (

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -55,7 +55,13 @@ function MaybeIframe( {
 	style,
 } ) {
 	const ref = useMouseMoveTypingReset();
-
+	const { __experimentalShowBlockInterface: showBlockInterface } =
+		useDispatch( blockEditorStore );
+	function handleMouseOver( e ) {
+		if ( e?.target?.classList.contains( 'editor-styles-wrapper' ) ) {
+			showBlockInterface();
+		}
+	}
 	if ( ! shouldIframe ) {
 		return (
 			<>
@@ -65,6 +71,7 @@ function MaybeIframe( {
 					className="editor-styles-wrapper"
 					style={ { flex: '1', ...style } }
 					tabIndex={ -1 }
+					onMouseOver={ handleMouseOver }
 				>
 					{ children }
 				</WritingFlow>

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -34,7 +34,7 @@ import {
 import { useEffect, useRef, useMemo } from '@wordpress/element';
 import { Button, __unstableMotion as motion } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useMergeRefs } from '@wordpress/compose';
+import { useMergeRefs, debounce } from '@wordpress/compose';
 import { arrowLeft } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { parse } from '@wordpress/blocks';
@@ -55,13 +55,24 @@ function MaybeIframe( {
 	style,
 } ) {
 	const ref = useMouseMoveTypingReset();
+	const isBlockInterfaceHidden = useSelect( ( select ) => {
+		const { __experimentalIsBlockInterfaceHidden } =
+			select( blockEditorStore );
+		return __experimentalIsBlockInterfaceHidden();
+	} );
+
 	const { __experimentalShowBlockInterface: showBlockInterface } =
 		useDispatch( blockEditorStore );
 	function handleMouseOver( e ) {
-		if ( e?.target?.classList.contains( 'editor-styles-wrapper' ) ) {
+		if (
+			isBlockInterfaceHidden &&
+			( e?.target?.classList.contains( 'editor-styles-wrapper' ) ||
+				e?.target?.classList.contains( 'is-root-container' ) )
+		) {
 			showBlockInterface();
 		}
 	}
+
 	if ( ! shouldIframe ) {
 		return (
 			<>
@@ -71,7 +82,7 @@ function MaybeIframe( {
 					className="editor-styles-wrapper"
 					style={ { flex: '1', ...style } }
 					tabIndex={ -1 }
-					onMouseOver={ handleMouseOver }
+					onMouseOver={ debounce( handleMouseOver, 200 ) }
 				>
 					{ children }
 				</WritingFlow>


### PR DESCRIPTION
## What?
Hide the block toolbar if focusing any controls in the Inspector

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 70941eb</samp>

Added a feature to toggle the block interface visibility in the block editor and the visual editor. Refactored some components to use hooks and the block editor store.

## Why?
To see if we can.

Fixes: #46192 - maybe

## How?
Using the store actions added here https://github.com/WordPress/gutenberg/pull/45131

## Testing Instructions

- Add a paragraph block and change the font settings in Inspector panel and see if block toolbar disappears
- Click back on paragraph block and check toolbar appears again

Currently block will appear again if Inspector control has popups

## Screenshots or screencast <!-- if applicable -→
