### PR TITLE
Mobile: Update Heading block E2E test

### DIFF
--- a/packages/block-library/src/block/test/edit.native.js
+++ b/packages/block-library/src/block/test/edit.native.js
@@ -24,7 +24,7 @@ const getMockedReusableBlock = ( id ) => ( {
 	content: {
 		raw: `
     <!-- wp:heading -->
-    <h2>First Reusable block</h2>
+    <h2 class="wp-block-heading">First Reusable block</h2>
     <!-- /wp:heading -->
 
     <!-- wp:paragraph -->

--- a/packages/block-library/src/heading/test/__snapshots__/index.native.js.snap
+++ b/packages/block-library/src/heading/test/__snapshots__/index.native.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Heading block inserts block 1`] = `
+"<!-- wp:heading -->
+<h2 class=\\"wp-block-heading\\"></h2>
+<!-- /wp:heading -->"
+`;

--- a/packages/block-library/src/heading/test/index.native.js
+++ b/packages/block-library/src/heading/test/index.native.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import {
+	fireEvent,
+	getEditorHtml,
+	initializeEditor,
+	addBlock,
+	getBlock,
+} from 'test/helpers';
+
+/**
+ * WordPress dependencies
+ */
+import { getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
+import { registerCoreBlocks } from '@wordpress/block-library';
+
+beforeAll( () => {
+	// Register all core blocks
+	registerCoreBlocks();
+} );
+
+afterAll( () => {
+	// Clean up registered blocks
+	getBlockTypes().forEach( ( block ) => {
+		unregisterBlockType( block.name );
+	} );
+} );
+
+describe( 'Heading block', () => {
+	it( 'inserts block', async () => {
+		const screen = await initializeEditor();
+
+		// Add block
+		await addBlock( screen, 'Heading' );
+
+		// Get block
+		const headingBlock = await getBlock( screen, 'Heading' );
+		fireEvent.press( headingBlock );
+		expect( headingBlock ).toBeVisible();
+
+		expect( getEditorHtml() ).toMatchSnapshot();
+	} );
+} );

--- a/packages/react-native-editor/__device-tests__/helpers/test-data.js
+++ b/packages/react-native-editor/__device-tests__/helpers/test-data.js
@@ -143,7 +143,7 @@ exports.audioBlockPlaceholder = `<!-- wp:audio {"id":5} -->
 <!-- /wp:audio -->`;
 
 exports.headerBlockEmpty = `<!-- wp:heading -->
-<h2></h2>
+<h2 class="wp-block-heading"></h2>
 <!-- /wp:heading -->`;
 
 exports.separatorBlockEmpty = `<!-- wp:separator -->


### PR DESCRIPTION
**Related PR:**
- `Gutenberg mobile` https://github.com/wordpress-mobile/gutenberg-mobile/pull/5296

## What?
This PR addresses a failure in one of the E2E tests where it uses the Heading block.

## Why?
To solve the E2E failures in CI.

## How?
By updating the empty Heading block placeholder in the test data file.

It also adds a small integration test that also does a snapshot check.

## Testing Instructions
CI checks in https://github.com/wordpress-mobile/gutenberg-mobile/pull/5296 should be green.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A