### PR TITLE
Block Editor: Refactor the "order" state in the block editor reducer to use a map instead of a plain object

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -611,7 +611,7 @@ export function getAdjacentBlockClientId( state, startClientId, modifier = 1 ) {
 	}
 
 	const { order } = state.blocks;
-	const orderSet = order[ rootClientId ];
+	const orderSet = order.get( rootClientId );
 	const index = orderSet.indexOf( startClientId );
 	const nextIndex = index + 1 * modifier;
 
@@ -1126,7 +1126,7 @@ export const __unstableGetSelectedBlocksWithPartialSelection = ( state ) => {
  * @return {Array} Ordered client IDs of editor blocks.
  */
 export function getBlockOrder( state, rootClientId ) {
-	return state.blocks.order[ rootClientId || '' ] || EMPTY_ARRAY;
+	return state.blocks.order.get( rootClientId || '' ) || EMPTY_ARRAY;
 }
 
 /**

--- a/packages/block-editor/src/store/test/performance.js
+++ b/packages/block-editor/src/store/test/performance.js
@@ -52,4 +52,14 @@ describe( 'performance', () => {
 
 		expect( updatedState ).toBeDefined();
 	} );
+
+	it( 'should move blocks', () => {
+		const updatedState = reducer( preparedState, {
+			type: 'MOVE_BLOCKS_DOWN',
+			clientIds: [ 'block-10' ],
+			rootClientId: '',
+		} );
+
+		expect( updatedState ).toBeDefined();
+	} );
 } );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -232,11 +232,13 @@ describe( 'state', () => {
 							},
 						} )
 					),
-					order: {
-						'': [ 'chicken' ],
-						chicken: [ 'chicken-child' ],
-						'chicken-child': [],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ 'chicken' ],
+							chicken: [ 'chicken-child' ],
+							'chicken-child': [],
+						} )
+					),
 					parents: {
 						chicken: '',
 						'chicken-child': 'chicken',
@@ -291,11 +293,13 @@ describe( 'state', () => {
 							},
 						} )
 					),
-					order: {
-						'': [ 'chicken' ],
-						chicken: [ newChildBlockId ],
-						[ newChildBlockId ]: [],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ 'chicken' ],
+							chicken: [ newChildBlockId ],
+							[ newChildBlockId ]: [],
+						} )
+					),
 					parents: {
 						[ newChildBlockId ]: 'chicken',
 						chicken: '',
@@ -323,10 +327,12 @@ describe( 'state', () => {
 							chicken: {},
 						} )
 					),
-					order: {
-						'': [ 'chicken' ],
-						chicken: [],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ 'chicken' ],
+							chicken: [],
+						} )
+					),
 					parents: {
 						chicken: '',
 					},
@@ -381,11 +387,13 @@ describe( 'state', () => {
 							},
 						} )
 					),
-					order: {
-						'': [ 'chicken' ],
-						chicken: [ newChildBlockId ],
-						[ newChildBlockId ]: [],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ 'chicken' ],
+							chicken: [ newChildBlockId ],
+							[ newChildBlockId ]: [],
+						} )
+					),
 					parents: {
 						[ newChildBlockId ]: 'chicken',
 						chicken: '',
@@ -445,12 +453,14 @@ describe( 'state', () => {
 							},
 						} )
 					),
-					order: {
-						'': [ 'chicken' ],
-						chicken: [ 'chicken-child', 'chicken-child-2' ],
-						'chicken-child': [],
-						'chicken-child-2': [],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ 'chicken' ],
+							chicken: [ 'chicken-child', 'chicken-child-2' ],
+							'chicken-child': [],
+							'chicken-child-2': [],
+						} )
+					),
 					parents: {
 						chicken: '',
 						'chicken-child': 'chicken',
@@ -530,17 +540,19 @@ describe( 'state', () => {
 							},
 						} )
 					),
-					order: {
-						'': [ 'chicken' ],
-						chicken: [
-							newChildBlockId1,
-							newChildBlockId2,
-							newChildBlockId3,
-						],
-						[ newChildBlockId1 ]: [],
-						[ newChildBlockId2 ]: [],
-						[ newChildBlockId3 ]: [],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ 'chicken' ],
+							chicken: [
+								newChildBlockId1,
+								newChildBlockId2,
+								newChildBlockId3,
+							],
+							[ newChildBlockId1 ]: [],
+							[ newChildBlockId2 ]: [],
+							[ newChildBlockId3 ]: [],
+						} )
+					),
 					parents: {
 						chicken: '',
 						[ newChildBlockId1 ]: 'chicken',
@@ -602,12 +614,14 @@ describe( 'state', () => {
 							'chicken-grand-child': {},
 						} )
 					),
-					order: {
-						'': [ 'chicken' ],
-						chicken: [ 'chicken-child' ],
-						'chicken-child': [ 'chicken-grand-child' ],
-						'chicken-grand-child': [],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ 'chicken' ],
+							chicken: [ 'chicken-child' ],
+							'chicken-child': [ 'chicken-grand-child' ],
+							'chicken-grand-child': [],
+						} )
+					),
 					parents: {
 						chicken: '',
 						'chicken-child': 'chicken',
@@ -655,11 +669,13 @@ describe( 'state', () => {
 							[ newChildBlockId ]: {},
 						} )
 					),
-					order: {
-						'': [ 'chicken' ],
-						chicken: [ newChildBlockId ],
-						[ newChildBlockId ]: [],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ 'chicken' ],
+							chicken: [ newChildBlockId ],
+							[ newChildBlockId ]: [],
+						} )
+					),
 					parents: {
 						chicken: '',
 						[ newChildBlockId ]: 'chicken',
@@ -680,7 +696,7 @@ describe( 'state', () => {
 			expect( state ).toEqual( {
 				byClientId: new Map(),
 				attributes: new Map(),
-				order: {},
+				order: new Map(),
 				parents: {},
 				isPersistentChange: true,
 				isIgnoredChange: false,
@@ -700,7 +716,7 @@ describe( 'state', () => {
 				expect( state.byClientId.get( 'bananas' ).clientId ).toBe(
 					'bananas'
 				);
-				expect( state.order ).toEqual( {
+				expect( Object.fromEntries( state.order ) ).toEqual( {
 					'': [ 'bananas' ],
 					bananas: [],
 				} );
@@ -729,7 +745,7 @@ describe( 'state', () => {
 			} );
 
 			expect( state.byClientId.size ).toBe( 2 );
-			expect( state.order ).toEqual( {
+			expect( Object.fromEntries( state.order ) ).toEqual( {
 				'': [ 'bananas' ],
 				apples: [],
 				bananas: [ 'apples' ],
@@ -761,7 +777,7 @@ describe( 'state', () => {
 
 			expect( state.byClientId.size ).toBe( 2 );
 			expect( state.byClientId.get( 'ribs' ).clientId ).toBe( 'ribs' );
-			expect( state.order ).toEqual( {
+			expect( Object.fromEntries( state.order ) ).toEqual( {
 				'': [ 'chicken', 'ribs' ],
 				chicken: [],
 				ribs: [],
@@ -808,7 +824,7 @@ describe( 'state', () => {
 				'core/freeform'
 			);
 			expect( state.byClientId.get( 'wings' ).clientId ).toBe( 'wings' );
-			expect( state.order ).toEqual( {
+			expect( Object.fromEntries( state.order ) ).toEqual( {
 				'': [ 'wings' ],
 				wings: [],
 			} );
@@ -879,7 +895,7 @@ describe( 'state', () => {
 			} );
 
 			expect( state.byClientId.size ).toBe( 1 );
-			expect( state.order ).toEqual( {
+			expect( Object.fromEntries( state.order ) ).toEqual( {
 				'': [ 'wings' ],
 				wings: [],
 			} );
@@ -913,7 +929,7 @@ describe( 'state', () => {
 				blocks: [ replacementBlock ],
 			} );
 
-			expect( state.order ).toEqual( {
+			expect( Object.fromEntries( state.order ) ).toEqual( {
 				'': [ wrapperBlock.clientId ],
 				[ wrapperBlock.clientId ]: [ replacementBlock.clientId ],
 				[ replacementBlock.clientId ]: [],
@@ -970,7 +986,7 @@ describe( 'state', () => {
 			expect( replacedState.byClientId.get( 'chicken' ).clientId ).toBe(
 				'chicken'
 			);
-			expect( replacedState.order ).toEqual( {
+			expect( Object.fromEntries( replacedState.order ) ).toEqual( {
 				'': [ 'chicken' ],
 				chicken: [],
 			} );
@@ -1005,7 +1021,7 @@ describe( 'state', () => {
 				blocks: [ replacementNestedBlock ],
 			} );
 
-			expect( replacedNestedState.order ).toEqual( {
+			expect( Object.fromEntries( replacedNestedState.order ) ).toEqual( {
 				'': [ wrapperBlock.clientId ],
 				[ wrapperBlock.clientId ]: [ replacementNestedBlock.clientId ],
 				[ replacementNestedBlock.clientId ]: [],
@@ -1133,7 +1149,7 @@ describe( 'state', () => {
 				clientIds: [ 'ribs' ],
 			} );
 
-			expect( state.order[ '' ] ).toEqual( [ 'ribs', 'chicken' ] );
+			expect( state.order.get( '' ) ).toEqual( [ 'ribs', 'chicken' ] );
 			expect( state.tree[ '' ].innerBlocks[ 0 ] ).toBe( state.tree.ribs );
 			expect( state.tree[ '' ].innerBlocks[ 1 ] ).toBe(
 				state.tree.chicken
@@ -1158,7 +1174,7 @@ describe( 'state', () => {
 				rootClientId: wrapperBlock.clientId,
 			} );
 
-			expect( state.order ).toEqual( {
+			expect( Object.fromEntries( state.order ) ).toEqual( {
 				'': [ wrapperBlock.clientId ],
 				[ wrapperBlock.clientId ]: [
 					movedBlock.clientId,
@@ -1208,7 +1224,7 @@ describe( 'state', () => {
 				clientIds: [ 'ribs', 'veggies' ],
 			} );
 
-			expect( state.order[ '' ] ).toEqual( [
+			expect( state.order.get( '' ) ).toEqual( [
 				'ribs',
 				'veggies',
 				'chicken',
@@ -1234,7 +1250,7 @@ describe( 'state', () => {
 				rootClientId: wrapperBlock.clientId,
 			} );
 
-			expect( state.order ).toEqual( {
+			expect( Object.fromEntries( state.order ) ).toEqual( {
 				'': [ wrapperBlock.clientId ],
 				[ wrapperBlock.clientId ]: [
 					movedBlockA.clientId,
@@ -1296,7 +1312,7 @@ describe( 'state', () => {
 				clientIds: [ 'chicken' ],
 			} );
 
-			expect( state.order[ '' ] ).toEqual( [ 'ribs', 'chicken' ] );
+			expect( state.order.get( '' ) ).toEqual( [ 'ribs', 'chicken' ] );
 		} );
 
 		it( 'should move the nested block down', () => {
@@ -1316,7 +1332,7 @@ describe( 'state', () => {
 				rootClientId: wrapperBlock.clientId,
 			} );
 
-			expect( state.order ).toEqual( {
+			expect( Object.fromEntries( state.order ) ).toEqual( {
 				'': [ wrapperBlock.clientId ],
 				[ wrapperBlock.clientId ]: [
 					siblingBlock.clientId,
@@ -1356,7 +1372,7 @@ describe( 'state', () => {
 				clientIds: [ 'chicken', 'ribs' ],
 			} );
 
-			expect( state.order[ '' ] ).toEqual( [
+			expect( state.order.get( '' ) ).toEqual( [
 				'veggies',
 				'chicken',
 				'ribs',
@@ -1382,7 +1398,7 @@ describe( 'state', () => {
 				rootClientId: wrapperBlock.clientId,
 			} );
 
-			expect( state.order ).toEqual( {
+			expect( Object.fromEntries( state.order ) ).toEqual( {
 				'': [ wrapperBlock.clientId ],
 				[ wrapperBlock.clientId ]: [
 					siblingBlock.clientId,
@@ -1444,8 +1460,10 @@ describe( 'state', () => {
 				clientIds: [ 'chicken' ],
 			} );
 
-			expect( state.order[ '' ] ).toEqual( [ 'ribs' ] );
-			expect( state.order ).not.toHaveProperty( 'chicken' );
+			expect( state.order.get( '' ) ).toEqual( [ 'ribs' ] );
+			expect( Object.fromEntries( state.order ) ).not.toHaveProperty(
+				'chicken'
+			);
 			expect( state.parents ).toEqual( {
 				ribs: '',
 			} );
@@ -1490,9 +1508,13 @@ describe( 'state', () => {
 				clientIds: [ 'chicken', 'veggies' ],
 			} );
 
-			expect( state.order[ '' ] ).toEqual( [ 'ribs' ] );
-			expect( state.order ).not.toHaveProperty( 'chicken' );
-			expect( state.order ).not.toHaveProperty( 'veggies' );
+			expect( state.order.get( '' ) ).toEqual( [ 'ribs' ] );
+			expect( Object.fromEntries( state.order ) ).not.toHaveProperty(
+				'chicken'
+			);
+			expect( Object.fromEntries( state.order ) ).not.toHaveProperty(
+				'veggies'
+			);
 			expect( state.parents ).toEqual( {
 				ribs: '',
 			} );
@@ -1525,7 +1547,7 @@ describe( 'state', () => {
 			} );
 
 			expect( state.byClientId ).toEqual( new Map() );
-			expect( state.order ).toEqual( {
+			expect( Object.fromEntries( state.order ) ).toEqual( {
 				'': [],
 			} );
 			expect( state.parents ).toEqual( {} );
@@ -1563,7 +1585,7 @@ describe( 'state', () => {
 			} );
 
 			expect( state.byClientId.size ).toBe( 3 );
-			expect( state.order[ '' ] ).toEqual( [
+			expect( state.order.get( '' ) ).toEqual( [
 				'kumquat',
 				'persimmon',
 				'loquat',
@@ -1600,7 +1622,7 @@ describe( 'state', () => {
 				index: 0,
 			} );
 
-			expect( state.order[ '' ] ).toEqual( [
+			expect( state.order.get( '' ) ).toEqual( [
 				'ribs',
 				'chicken',
 				'veggies',
@@ -1637,7 +1659,7 @@ describe( 'state', () => {
 				index: 2,
 			} );
 
-			expect( state.order[ '' ] ).toEqual( [
+			expect( state.order.get( '' ) ).toEqual( [
 				'chicken',
 				'veggies',
 				'ribs',
@@ -1674,7 +1696,7 @@ describe( 'state', () => {
 				index: 1,
 			} );
 
-			expect( state.order[ '' ] ).toEqual( [
+			expect( state.order.get( '' ) ).toEqual( [
 				'chicken',
 				'ribs',
 				'veggies',
@@ -1711,7 +1733,7 @@ describe( 'state', () => {
 				index: 0,
 			} );
 
-			expect( state.order[ '' ] ).toEqual( [
+			expect( state.order.get( '' ) ).toEqual( [
 				'ribs',
 				'veggies',
 				'chicken',
@@ -1750,8 +1772,11 @@ describe( 'state', () => {
 				index: 0,
 			} );
 
-			expect( state.order[ '' ] ).toEqual( [ 'chicken' ] );
-			expect( state.order.chicken ).toEqual( [ 'ribs', 'veggies' ] );
+			expect( state.order.get( '' ) ).toEqual( [ 'chicken' ] );
+			expect( state.order.get( 'chicken' ) ).toEqual( [
+				'ribs',
+				'veggies',
+			] );
 		} );
 
 		describe( 'blocks', () => {
@@ -2200,12 +2225,14 @@ describe( 'state', () => {
 								},
 							} )
 						),
-						order: {
-							'': [ 'group-id' ],
-							'group-id': [ 'reusable-id' ],
-							'reusable-id': [ 'paragraph-id' ],
-							'paragraph-id': [],
-						},
+						order: new Map(
+							Object.entries( {
+								'': [ 'group-id' ],
+								'group-id': [ 'reusable-id' ],
+								'reusable-id': [ 'paragraph-id' ],
+								'paragraph-id': [],
+							} )
+						),
 						controlledInnerBlocks: {
 							'reusable-id': true,
 						},
@@ -2298,8 +2325,10 @@ describe( 'state', () => {
 						updateSelection: false,
 					};
 					const state = blocks( initialState, action );
-					expect( state.order ).toEqual(
-						expect.objectContaining( initialState.order )
+					expect( Object.fromEntries( state.order ) ).toEqual(
+						expect.objectContaining(
+							Object.fromEntries( initialState.order )
+						)
 					);
 					expect( state.tree ).toEqual(
 						expect.objectContaining( initialState.tree )

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -204,7 +204,7 @@ describe( 'selectors', () => {
 				blocks: {
 					byClientId: new Map(),
 					attributes: {},
-					order: {},
+					order: new Map(),
 					parents: {},
 				},
 			};
@@ -234,10 +234,12 @@ describe( 'selectors', () => {
 							'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': {},
 						} )
 					),
-					order: {
-						'': [ 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' ],
-						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': [],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' ],
+							'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': [],
+						} )
+					),
 					parents: {
 						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': '',
 					},
@@ -267,10 +269,12 @@ describe( 'selectors', () => {
 							123: {},
 						} )
 					),
-					order: {
-						'': [ '123' ],
-						123: [],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '123' ],
+							123: [],
+						} )
+					),
 					parents: {
 						123: '',
 					},
@@ -294,7 +298,7 @@ describe( 'selectors', () => {
 				blocks: {
 					byClientId: new Map(),
 					attributes: new Map(),
-					order: {},
+					order: new Map(),
 					parents: {},
 					tree: {
 						123: {
@@ -328,9 +332,11 @@ describe( 'selectors', () => {
 							123: {},
 						} )
 					),
-					order: {
-						'': [ '123', '23' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '123', '23' ],
+						} )
+					),
 					parents: {
 						123: '',
 						23: '',
@@ -587,23 +593,25 @@ describe( 'selectors', () => {
 							'uuid-30': {},
 						} )
 					),
-					order: {
-						'': [ 'uuid-6', 'uuid-8', 'uuid-10', 'uuid-22' ],
-						'uuid-2': [],
-						'uuid-4': [],
-						'uuid-6': [],
-						'uuid-8': [],
-						'uuid-10': [ 'uuid-12', 'uuid-14' ],
-						'uuid-12': [ 'uuid-16' ],
-						'uuid-14': [ 'uuid-18' ],
-						'uuid-16': [],
-						'uuid-18': [ 'uuid-24' ],
-						'uuid-20': [],
-						'uuid-22': [],
-						'uuid-24': [ 'uuid-26', 'uuid-28' ],
-						'uuid-26': [],
-						'uuid-28': [ 'uuid-30' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ 'uuid-6', 'uuid-8', 'uuid-10', 'uuid-22' ],
+							'uuid-2': [],
+							'uuid-4': [],
+							'uuid-6': [],
+							'uuid-8': [],
+							'uuid-10': [ 'uuid-12', 'uuid-14' ],
+							'uuid-12': [ 'uuid-16' ],
+							'uuid-14': [ 'uuid-18' ],
+							'uuid-16': [],
+							'uuid-18': [ 'uuid-24' ],
+							'uuid-20': [],
+							'uuid-22': [],
+							'uuid-24': [ 'uuid-26', 'uuid-28' ],
+							'uuid-26': [],
+							'uuid-28': [ 'uuid-30' ],
+						} )
+					),
 					parents: {
 						'uuid-6': '',
 						'uuid-8': '',
@@ -723,23 +731,25 @@ describe( 'selectors', () => {
 							'uuid-30': {},
 						} )
 					),
-					order: {
-						'': [ 'uuid-6', 'uuid-8', 'uuid-10', 'uuid-22' ],
-						'uuid-2': [],
-						'uuid-4': [],
-						'uuid-6': [],
-						'uuid-8': [],
-						'uuid-10': [ 'uuid-12', 'uuid-14' ],
-						'uuid-12': [ 'uuid-16' ],
-						'uuid-14': [ 'uuid-18' ],
-						'uuid-16': [],
-						'uuid-18': [ 'uuid-24' ],
-						'uuid-20': [],
-						'uuid-22': [],
-						'uuid-24': [ 'uuid-26', 'uuid-28' ],
-						'uuid-26': [],
-						'uuid-28': [ 'uuid-30' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ 'uuid-6', 'uuid-8', 'uuid-10', 'uuid-22' ],
+							'uuid-2': [],
+							'uuid-4': [],
+							'uuid-6': [],
+							'uuid-8': [],
+							'uuid-10': [ 'uuid-12', 'uuid-14' ],
+							'uuid-12': [ 'uuid-16' ],
+							'uuid-14': [ 'uuid-18' ],
+							'uuid-16': [],
+							'uuid-18': [ 'uuid-24' ],
+							'uuid-20': [],
+							'uuid-22': [],
+							'uuid-24': [ 'uuid-26', 'uuid-28' ],
+							'uuid-26': [],
+							'uuid-28': [ 'uuid-30' ],
+						} )
+					),
 					parents: {
 						'uuid-6': '',
 						'uuid-8': '',
@@ -789,9 +799,11 @@ describe( 'selectors', () => {
 							123: {},
 						} )
 					),
-					order: {
-						'': [ '123', '23' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '123', '23' ],
+						} )
+					),
 				},
 			};
 
@@ -815,10 +827,12 @@ describe( 'selectors', () => {
 							789: {},
 						} )
 					),
-					order: {
-						'': [ '123' ],
-						123: [ '456', '789' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '123' ],
+							123: [ '456', '789' ],
+						} )
+					),
 					parents: {
 						123: '',
 						456: '123',
@@ -891,9 +905,11 @@ describe( 'selectors', () => {
 						789: {},
 					} )
 				),
-				order: {
-					'': [ '123', '456' ],
-				},
+				order: new Map(
+					Object.entries( {
+						'': [ '123', '456' ],
+					} )
+				),
 				parents: {
 					123: '',
 					456: '',
@@ -914,7 +930,7 @@ describe( 'selectors', () => {
 				blocks: {
 					byClientId: new Map(),
 					attributes: new Map(),
-					order: {},
+					order: new Map(),
 					parents: {},
 				},
 			};
@@ -948,10 +964,12 @@ describe( 'selectors', () => {
 						1415: {},
 					} )
 				),
-				order: {
-					'': [ '123', '456', '1011' ],
-					1011: [ '1415', '1213' ],
-				},
+				order: new Map(
+					Object.entries( {
+						'': [ '123', '456', '1011' ],
+						1011: [ '1415', '1213' ],
+					} )
+				),
 				parents: {
 					123: '',
 					456: '',
@@ -1051,11 +1069,13 @@ describe( 'selectors', () => {
 							123: {},
 						} )
 					),
-					order: {
-						'': [ '23', '123' ],
-						23: [],
-						123: [],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '23', '123' ],
+							23: [],
+							123: [],
+						} )
+					),
 					parents: {
 						23: '',
 						123: '',
@@ -1093,11 +1113,13 @@ describe( 'selectors', () => {
 							123: {},
 						} )
 					),
-					order: {
-						'': [ '23', '123' ],
-						23: [],
-						123: [],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '23', '123' ],
+							23: [],
+							123: [],
+						} )
+					),
 					parents: {
 						123: '',
 						23: '',
@@ -1135,11 +1157,13 @@ describe( 'selectors', () => {
 							123: {},
 						} )
 					),
-					order: {
-						'': [ '23', '123' ],
-						23: [],
-						123: [],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '23', '123' ],
+							23: [],
+							123: [],
+						} )
+					),
 					parents: {
 						123: '',
 						23: '',
@@ -1170,7 +1194,7 @@ describe( 'selectors', () => {
 		it( 'should return null if the block does not exist', () => {
 			const state = {
 				blocks: {
-					order: {},
+					order: new Map(),
 					parents: {},
 				},
 			};
@@ -1181,10 +1205,12 @@ describe( 'selectors', () => {
 		it( 'should return root ClientId relative the block ClientId', () => {
 			const state = {
 				blocks: {
-					order: {
-						'': [ '123', '23' ],
-						123: [ '456', '56' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '123', '23' ],
+							123: [ '456', '56' ],
+						} )
+					),
 					parents: {
 						123: '',
 						23: '',
@@ -1202,7 +1228,7 @@ describe( 'selectors', () => {
 		it( 'should return the given block if the block has no parents', () => {
 			const state = {
 				blocks: {
-					order: {},
+					order: new Map(),
 					parents: {},
 				},
 			};
@@ -1213,10 +1239,12 @@ describe( 'selectors', () => {
 		it( 'should return root ClientId relative the block ClientId', () => {
 			const state = {
 				blocks: {
-					order: {
-						'': [ 'a', 'b' ],
-						a: [ 'c', 'd' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ 'a', 'b' ],
+							a: [ 'c', 'd' ],
+						} )
+					),
 					parents: {
 						a: '',
 						b: '',
@@ -1232,11 +1260,13 @@ describe( 'selectors', () => {
 		it( 'should return the top level root ClientId relative the block ClientId', () => {
 			const state = {
 				blocks: {
-					order: {
-						'': [ 'a', 'b' ],
-						a: [ 'c', 'd' ],
-						d: [ 'e' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ 'a', 'b' ],
+							a: [ 'c', 'd' ],
+							d: [ 'e' ],
+						} )
+					),
 					parents: {
 						a: '',
 						b: '',
@@ -1255,9 +1285,11 @@ describe( 'selectors', () => {
 		it( 'should return empty if there is no selection', () => {
 			const state = {
 				blocks: {
-					order: {
-						'': [ '123', '23' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '123', '23' ],
+						} )
+					),
 					parents: {
 						123: '',
 						23: '',
@@ -1275,9 +1307,11 @@ describe( 'selectors', () => {
 		it( 'should return the selected block clientId if there is a selection', () => {
 			const state = {
 				blocks: {
-					order: {
-						'': [ '5', '4', '3', '2', '1' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '5', '4', '3', '2', '1' ],
+						} )
+					),
 					parents: {
 						1: '',
 						2: '',
@@ -1298,9 +1332,11 @@ describe( 'selectors', () => {
 		it( 'should return selected block clientIds if there is multi selection', () => {
 			const state = {
 				blocks: {
-					order: {
-						'': [ '5', '4', '3', '2', '1' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '5', '4', '3', '2', '1' ],
+						} )
+					),
 					parents: {
 						1: '',
 						2: '',
@@ -1325,10 +1361,12 @@ describe( 'selectors', () => {
 		it( 'should return selected block clientIds if there is multi selection (nested context)', () => {
 			const state = {
 				blocks: {
-					order: {
-						'': [ '5', '4', '3', '2', '1' ],
-						4: [ '9', '8', '7', '6' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '5', '4', '3', '2', '1' ],
+							4: [ '9', '8', '7', '6' ],
+						} )
+					),
 					parents: {
 						1: '',
 						2: '',
@@ -1359,9 +1397,11 @@ describe( 'selectors', () => {
 		it( 'should return empty if there is no multi selection', () => {
 			const state = {
 				blocks: {
-					order: {
-						'': [ '123', '23' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '123', '23' ],
+						} )
+					),
 					parents: {
 						23: '',
 						123: '',
@@ -1379,9 +1419,11 @@ describe( 'selectors', () => {
 		it( 'should return selected block clientIds if there is multi selection', () => {
 			const state = {
 				blocks: {
-					order: {
-						'': [ '5', '4', '3', '2', '1' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '5', '4', '3', '2', '1' ],
+						} )
+					),
 					parents: {
 						1: '',
 						2: '',
@@ -1406,10 +1448,12 @@ describe( 'selectors', () => {
 		it( 'should return selected block clientIds if there is multi selection (nested context)', () => {
 			const state = {
 				blocks: {
-					order: {
-						'': [ '5', '4', '3', '2', '1' ],
-						4: [ '9', '8', '7', '6' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '5', '4', '3', '2', '1' ],
+							4: [ '9', '8', '7', '6' ],
+						} )
+					),
 					parents: {
 						1: '',
 						2: '',
@@ -1442,7 +1486,7 @@ describe( 'selectors', () => {
 				blocks: {
 					byClientId: new Map(),
 					attributes: new Map(),
-					order: {},
+					order: new Map(),
 					parents: {},
 				},
 				selection: {
@@ -1509,9 +1553,11 @@ describe( 'selectors', () => {
 		it( 'should return the ordered block ClientIds of top-level blocks by default', () => {
 			const state = {
 				blocks: {
-					order: {
-						'': [ '123', '23' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '123', '23' ],
+						} )
+					),
 					parents: {
 						23: '',
 						123: '',
@@ -1525,10 +1571,12 @@ describe( 'selectors', () => {
 		it( 'should return the ordered block ClientIds at a specified rootClientId', () => {
 			const state = {
 				blocks: {
-					order: {
-						'': [ '123', '23' ],
-						123: [ '456' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '123', '23' ],
+							123: [ '456' ],
+						} )
+					),
 					parents: {
 						23: '',
 						123: '',
@@ -1545,9 +1593,11 @@ describe( 'selectors', () => {
 		it( 'should return the block order', () => {
 			const state = {
 				blocks: {
-					order: {
-						'': [ '123', '23' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '123', '23' ],
+						} )
+					),
 					parents: {
 						23: '',
 						123: '',
@@ -1561,10 +1611,12 @@ describe( 'selectors', () => {
 		it( 'should return the block order (nested context)', () => {
 			const state = {
 				blocks: {
-					order: {
-						'': [ '123', '23' ],
-						123: [ '456', '56' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '123', '23' ],
+							123: [ '456', '56' ],
+						} )
+					),
 					parents: {
 						23: '',
 						123: '',
@@ -1582,9 +1634,11 @@ describe( 'selectors', () => {
 		it( 'should return the previous block', () => {
 			const state = {
 				blocks: {
-					order: {
-						'': [ '123', '23' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '123', '23' ],
+						} )
+					),
 					parents: {
 						23: '',
 						123: '',
@@ -1598,10 +1652,12 @@ describe( 'selectors', () => {
 		it( 'should return the previous block (nested context)', () => {
 			const state = {
 				blocks: {
-					order: {
-						'': [ '123', '23' ],
-						123: [ '456', '56' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '123', '23' ],
+							123: [ '456', '56' ],
+						} )
+					),
 					parents: {
 						23: '',
 						123: '',
@@ -1619,9 +1675,11 @@ describe( 'selectors', () => {
 		it( 'should return null for the first block', () => {
 			const state = {
 				blocks: {
-					order: {
-						'': [ '123', '23' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '123', '23' ],
+						} )
+					),
 					parents: {
 						23: '',
 						123: '',
@@ -1635,10 +1693,12 @@ describe( 'selectors', () => {
 		it( 'should return null for the first block (nested context)', () => {
 			const state = {
 				blocks: {
-					order: {
-						'': [ '123', '23' ],
-						123: [ '456', '56' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '123', '23' ],
+							123: [ '456', '56' ],
+						} )
+					),
 					parents: {
 						23: '',
 						123: '',
@@ -1658,9 +1718,11 @@ describe( 'selectors', () => {
 		it( 'should return the following block', () => {
 			const state = {
 				blocks: {
-					order: {
-						'': [ '123', '23' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '123', '23' ],
+						} )
+					),
 					parents: {
 						23: '',
 						123: '',
@@ -1674,10 +1736,12 @@ describe( 'selectors', () => {
 		it( 'should return the following block (nested context)', () => {
 			const state = {
 				blocks: {
-					order: {
-						'': [ '123', '23' ],
-						123: [ '456', '56' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '123', '23' ],
+							123: [ '456', '56' ],
+						} )
+					),
 					parents: {
 						23: '',
 						123: '',
@@ -1695,9 +1759,11 @@ describe( 'selectors', () => {
 		it( 'should return null for the last block', () => {
 			const state = {
 				blocks: {
-					order: {
-						'': [ '123', '23' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '123', '23' ],
+						} )
+					),
 					parents: {
 						23: '',
 						123: '',
@@ -1711,10 +1777,12 @@ describe( 'selectors', () => {
 		it( 'should return null for the last block (nested context)', () => {
 			const state = {
 				blocks: {
-					order: {
-						'': [ '123', '23' ],
-						123: [ '456', '56' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '123', '23' ],
+							123: [ '456', '56' ],
+						} )
+					),
 					parents: {
 						23: '',
 						123: '',
@@ -1771,9 +1839,11 @@ describe( 'selectors', () => {
 					selectionEnd: { clientId: '5' },
 				},
 				blocks: {
-					order: {
-						4: [ '3', '2', '1' ],
-					},
+					order: new Map(
+						Object.entries( {
+							4: [ '3', '2', '1' ],
+						} )
+					),
 					parents: {
 						1: '4',
 						2: '4',
@@ -1792,9 +1862,11 @@ describe( 'selectors', () => {
 					selectionEnd: { clientId: '3' },
 				},
 				blocks: {
-					order: {
-						4: [ '3', '2', '1' ],
-					},
+					order: new Map(
+						Object.entries( {
+							4: [ '3', '2', '1' ],
+						} )
+					),
 					parents: {
 						1: '4',
 						2: '4',
@@ -1809,9 +1881,11 @@ describe( 'selectors', () => {
 		it( 'should return true if a multi selection exists that contains children of the block with the given ClientId', () => {
 			const state = {
 				blocks: {
-					order: {
-						6: [ '5', '4', '3', '2', '1' ],
-					},
+					order: new Map(
+						Object.entries( {
+							6: [ '5', '4', '3', '2', '1' ],
+						} )
+					),
 					parents: {
 						1: '6',
 						2: '6',
@@ -1831,10 +1905,12 @@ describe( 'selectors', () => {
 		it( 'should return false if a multi selection exists bot does not contains children of the block with the given ClientId', () => {
 			const state = {
 				blocks: {
-					order: {
-						3: [ '2', '1' ],
-						6: [ '5', '4' ],
-					},
+					order: new Map(
+						Object.entries( {
+							3: [ '2', '1' ],
+							6: [ '5', '4' ],
+						} )
+					),
 					parents: {
 						1: '3',
 						2: '3',
@@ -1859,9 +1935,11 @@ describe( 'selectors', () => {
 					selectionEnd: { clientId: '3' },
 				},
 				blocks: {
-					order: {
-						'': [ '5', '4', '3', '2', '1' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '5', '4', '3', '2', '1' ],
+						} )
+					),
 					parents: {
 						1: '',
 						2: '',
@@ -1882,9 +1960,11 @@ describe( 'selectors', () => {
 					selectionEnd: { clientId: '3' },
 				},
 				blocks: {
-					order: {
-						'': [ '5', '4', '3', '2', '1' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '5', '4', '3', '2', '1' ],
+						} )
+					),
 					parents: {
 						1: '',
 						2: '',
@@ -1905,9 +1985,11 @@ describe( 'selectors', () => {
 					selectionEnd: { clientId: '3' },
 				},
 				blocks: {
-					order: {
-						'': [ '5', '4', '3', '2', '1' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '5', '4', '3', '2', '1' ],
+						} )
+					),
 					parents: {
 						1: '',
 						2: '',
@@ -1928,9 +2010,11 @@ describe( 'selectors', () => {
 					selectionEnd: {},
 				},
 				blocks: {
-					order: {
-						'': [ '5', '4', '3', '2', '1' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ '5', '4', '3', '2', '1' ],
+						} )
+					),
 					parents: {
 						1: '',
 						2: '',
@@ -1991,9 +2075,11 @@ describe( 'selectors', () => {
 	describe( 'isBlockMultiSelected', () => {
 		const state = {
 			blocks: {
-				order: {
-					'': [ '5', '4', '3', '2', '1' ],
-				},
+				order: new Map(
+					Object.entries( {
+						'': [ '5', '4', '3', '2', '1' ],
+					} )
+				),
 				parents: {
 					1: '',
 					2: '',
@@ -2020,9 +2106,11 @@ describe( 'selectors', () => {
 	describe( 'isFirstMultiSelectedBlock', () => {
 		const state = {
 			blocks: {
-				order: {
-					'': [ '5', '4', '3', '2', '1' ],
-				},
+				order: new Map(
+					Object.entries( {
+						'': [ '5', '4', '3', '2', '1' ],
+					} )
+				),
 				parents: {
 					1: '',
 					2: '',
@@ -2230,11 +2318,13 @@ describe( 'selectors', () => {
 							clientId2: {},
 						} )
 					),
-					order: {
-						'': [ 'clientId1' ],
-						clientId1: [ 'clientId2' ],
-						clientId2: [],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ 'clientId1' ],
+							clientId1: [ 'clientId2' ],
+							clientId2: [],
+						} )
+					),
 					parents: {
 						clientId1: '',
 						clientId2: 'clientId1',
@@ -2269,10 +2359,12 @@ describe( 'selectors', () => {
 							clientId1: {},
 						} )
 					),
-					order: {
-						'': [ 'clientId1' ],
-						clientId1: [],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ 'clientId1' ],
+							clientId1: [],
+						} )
+					),
 					parents: {
 						clientId1: '',
 					},
@@ -2305,11 +2397,13 @@ describe( 'selectors', () => {
 							clientId2: {},
 						} )
 					),
-					order: {
-						'': [ 'clientId1' ],
-						clientId1: [ 'clientId2' ],
-						clientId2: [],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ 'clientId1' ],
+							clientId1: [ 'clientId2' ],
+							clientId2: [],
+						} )
+					),
 					parents: {
 						clientId1: '',
 						clientId2: 'clientId1',
@@ -2343,11 +2437,13 @@ describe( 'selectors', () => {
 							clientId2: {},
 						} )
 					),
-					order: {
-						'': [ 'clientId1', 'clientId2' ],
-						clientId1: [],
-						clientId2: [],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ 'clientId1', 'clientId2' ],
+							clientId1: [],
+							clientId2: [],
+						} )
+					),
 					parents: {
 						clientId1: '',
 						clientId2: '',
@@ -2381,11 +2477,13 @@ describe( 'selectors', () => {
 							clientId2: {},
 						} )
 					),
-					order: {
-						'': [ 'clientId1', 'clientId2' ],
-						clientId1: [],
-						clientId2: [],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ 'clientId1', 'clientId2' ],
+							clientId1: [],
+							clientId2: [],
+						} )
+					),
 					parents: {
 						clientId1: '',
 						clientId2: '',
@@ -2965,7 +3063,7 @@ describe( 'selectors', () => {
 				blocks: {
 					byClientId: new Map(),
 					attributes: new Map(),
-					order: {},
+					order: new Map(),
 					parents: {},
 					tree: {
 						'': {
@@ -3044,9 +3142,11 @@ describe( 'selectors', () => {
 							block4: {},
 						} )
 					),
-					order: {
-						'': [ 'block3', 'block4' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ 'block3', 'block4' ],
+						} )
+					),
 					parents: {
 						block3: '',
 						block4: '',
@@ -3156,9 +3256,11 @@ describe( 'selectors', () => {
 							block1: { attribute: {} },
 						} )
 					),
-					order: {
-						'': [ 'block1' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ 'block1' ],
+						} )
+					),
 					tree: {
 						block1: {
 							clientId: 'block1',
@@ -3188,7 +3290,7 @@ describe( 'selectors', () => {
 				blocks: {
 					byClientId: new Map(),
 					attributes: new Map(),
-					order: {},
+					order: new Map(),
 					parents: {},
 					cache: {},
 				},
@@ -3283,7 +3385,7 @@ describe( 'selectors', () => {
 				blocks: {
 					byClientId: new Map(),
 					attributes: new Map(),
-					order: {},
+					order: new Map(),
 					parents: {},
 					cache: {},
 				},
@@ -3323,7 +3425,7 @@ describe( 'selectors', () => {
 				blocks: {
 					byClientId: new Map(),
 					attributes: new Map(),
-					order: {},
+					order: new Map(),
 					parents: {},
 					cache: {},
 				},
@@ -3350,7 +3452,7 @@ describe( 'selectors', () => {
 							block2: {},
 						} )
 					),
-					order: {},
+					order: new Map(),
 					parents: {
 						block1: '',
 						block2: 'block1',
@@ -3390,9 +3492,11 @@ describe( 'selectors', () => {
 							block1: { attribute: {} },
 						} )
 					),
-					order: {
-						'': [ 'block1' ],
-					},
+					order: new Map(
+						Object.entries( {
+							'': [ 'block1' ],
+						} )
+					),
 					tree: {
 						block1: {
 							clientId: 'block1',
@@ -3431,7 +3535,7 @@ describe( 'selectors', () => {
 				blocks: {
 					byClientId: new Map(),
 					attributes: new Map(),
-					order: {},
+					order: new Map(),
 					parents: {},
 					cache: {},
 				},
@@ -3650,12 +3754,14 @@ describe( 'selectors', () => {
 
 	describe( 'getLowestCommonAncestorWithSelectedBlock', () => {
 		const blocks = {
-			order: {
-				'': [ 'a', 'b' ],
-				a: [ 'c', 'd' ],
-				d: [ 'e' ],
-				b: [ 'f' ],
-			},
+			order: new Map(
+				Object.entries( {
+					'': [ 'a', 'b' ],
+					a: [ 'c', 'd' ],
+					d: [ 'e' ],
+					b: [ 'f' ],
+				} )
+			),
 			parents: {
 				a: '',
 				b: '',
@@ -3800,9 +3906,11 @@ describe( 'selectors', () => {
 					'client-id-04': {},
 					'client-id-05': {},
 				},
-				order: {
-					'client-id-03': [ 'client-id-04', 'client-id-05' ],
-				},
+				order: new Map(
+					Object.entries( {
+						'client-id-03': [ 'client-id-04', 'client-id-05' ],
+					} )
+				),
 				controlledInnerBlocks: {},
 			},
 		};
@@ -4306,7 +4414,7 @@ describe( 'getInserterItems with core blocks prioritization', () => {
 			blocks: {
 				byClientId: new Map(),
 				attributes: new Map(),
-				order: {},
+				order: new Map(),
 				parents: {},
 				cache: {},
 			},
@@ -4335,11 +4443,13 @@ describe( '__unstableGetClientIdWithClientIdsTree', () => {
 	it( "should return a stripped down block object containing only its client ID and its inner blocks' client IDs", () => {
 		const state = {
 			blocks: {
-				order: {
-					'': [ 'foo' ],
-					foo: [ 'bar', 'baz' ],
-					bar: [ 'qux' ],
-				},
+				order: new Map(
+					Object.entries( {
+						'': [ 'foo' ],
+						foo: [ 'bar', 'baz' ],
+						bar: [ 'qux' ],
+					} )
+				),
 			},
 		};
 
@@ -4361,11 +4471,13 @@ describe( '__unstableGetClientIdsTree', () => {
 	it( "should return the full content tree starting from the given root, consisting of stripped down block object containing only its client ID and its inner blocks' client IDs", () => {
 		const state = {
 			blocks: {
-				order: {
-					'': [ 'foo' ],
-					foo: [ 'bar', 'baz' ],
-					bar: [ 'qux' ],
-				},
+				order: new Map(
+					Object.entries( {
+						'': [ 'foo' ],
+						foo: [ 'bar', 'baz' ],
+						bar: [ 'qux' ],
+					} )
+				),
 			},
 		};
 
@@ -4381,11 +4493,13 @@ describe( '__unstableGetClientIdsTree', () => {
 	it( "should return the full content tree starting from the root, consisting of stripped down block object containing only its client ID and its inner blocks' client IDs", () => {
 		const state = {
 			blocks: {
-				order: {
-					'': [ 'foo' ],
-					foo: [ 'bar', 'baz' ],
-					bar: [ 'qux' ],
-				},
+				order: new Map(
+					Object.entries( {
+						'': [ 'foo' ],
+						foo: [ 'bar', 'baz' ],
+						bar: [ 'qux' ],
+					} )
+				),
 			},
 		};
 


### PR DESCRIPTION
Similar to #46204 and #46146

Following a similar approach to the previous PRs, I've added a test to simulate what happens when you click the block mover to move a block up/down.

And while doing so, I tried to see how refactoring the order state from plain objects to maps could impact the performance. Here are the results I got:

Before:

<img width="492" alt="Screenshot 2022-12-01 at 10 31 23 AM" src="https://user-images.githubusercontent.com/272444/205017600-117ff341-6b54-4b02-b054-10a27390f044.png">

After:

<img width="485" alt="Screenshot 2022-12-01 at 10 30 37 AM" src="https://user-images.githubusercontent.com/272444/205017580-fb2b0522-22f9-4fd6-8ae5-de3a284fbcac.png">

As you can see:

 - The "update block" metric is stable (no impact on this PR)
 - The "hit enter to create a new block" metric improved from 378ms to 271ms
 - The "move block" metric metric improved from 62ms to 23ms

I think we can improve these metrics further if also refactor the "tree" (and other) state to maps on follow-up PRs.
