### PR TITLE
Fix auto Nav menu creation due to page list inner blocks

### DIFF
--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -60,7 +60,7 @@ export default function UnsavedInnerBlocks( {
 
 	if (
 		originalBlocks.current &&
-		blocks?.length &&
+		blocks?.length === 1 &&
 		blocks[ 0 ]?.name === 'core/page-list'
 	) {
 		// If the blocks are a page list, we need to ignore

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -90,8 +90,8 @@ export default function UnsavedInnerBlocks( {
 			currentPageListBlockWithoutInnerBlocks
 		);
 	} else {
-		// If the current inner blocks object is different in any way
-		// from the original inner blocks from the post content then the
+		// If the current inner blocks object does not display referential equality
+		// with the original inner blocks from the post content then the
 		// user has made changes to the inner blocks. At this point the inner
 		// blocks can be considered "dirty".
 		// We also make sure the current innerBlocks had a chance to be set.

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEqual } from 'lodash';
+import fastDeepEqual from 'fast-deep-equal/es6';
 
 /**
  * WordPress dependencies
@@ -85,7 +85,7 @@ export default function UnsavedInnerBlocks( {
 			...currentPageListBlockWithoutInnerBlocks
 		} = currentPageListBlock;
 
-		innerBlocksAreDirty = ! isEqual(
+		innerBlocksAreDirty = ! fastDeepEqual(
 			originalPageListBlockWithoutInnerBlocks,
 			currentPageListBlockWithoutInnerBlocks
 		);

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -99,9 +99,6 @@ export default function UnsavedInnerBlocks( {
 			!! originalBlocks.current && blocks !== originalBlocks.current;
 	}
 
-	// if ( innerBlocksAreDirty ) {
-	// 	debugger;
-	// }
 	const shouldDirectInsert = useMemo(
 		() =>
 			blocks.every(

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -91,8 +91,8 @@ export default function UnsavedInnerBlocks( {
 		}
 	}, [ blocks ] );
 
-	// If the current inner blocks is different  from the original inner blocks
-	// from the post content then then the user has made changes to the inner blocks.
+	// If the current inner blocks are different from the original inner blocks
+	// from the post content then the user has made changes to the inner blocks.
 	// At this point the inner blocks can be considered "dirty".
 	// Note: referential equality is not sufficient for comparison as the inner blocks
 	// of the page list are controlled and may be updated async due to syncing with

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -91,13 +91,21 @@ export default function UnsavedInnerBlocks( {
 		}
 	}, [ blocks ] );
 
+	// If the current inner blocks is different  from the original inner blocks
+	// from the post content then then the user has made changes to the inner blocks.
+	// At this point the inner blocks can be considered "dirty".
+	// Note: referential equality is not sufficient for comparison as the inner blocks
+	// of the page list are controlled and may be updated async due to syncing with
+	// entity records. As a result we need to perform a deep equality check skipping
+	// the page list's inner blocks.
 	const innerBlocksAreDirty = ! isDeepEqual(
 		originalBlocks.current,
 		blocks,
 		( prop, x ) => {
-			// skip inner blocks of page list during comparison as they
-			// are always controlled and may be updated async due to
-			// syncing with enitiy records.
+			// Skip inner blocks of page list during comparison as they
+			// are **always** controlled and may be updated async due to
+			// syncing with enitiy records. Left unchecked this would
+			// inadvertently trigger the dirty state.
 			if ( x?.name && prop === 'innerBlocks' ) {
 				return true;
 			}

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -63,9 +63,15 @@ export default function UnsavedInnerBlocks( {
 		blocks?.length &&
 		blocks[ 0 ]?.name === 'core/page-list'
 	) {
-		// ignore changes to inner blocks
-		// track changes to attributes changing
-
+		// If the blocks are a page list, we need to ignore
+		// inner blocks and compare remaining attributes only.
+		// Why? Because Page List block dynamically sets its
+		// child inner blocks async following a REST API request.
+		// This means that the inner blocks are empty when the
+		// block is first inserted, and then populated later once
+		// the REST API request resolves. This causes the original
+		// check to always return dirty as the inner blocks change.
+		// This is a workaround for this specific scenario.
 		const originalPageListBlock = originalBlocks.current[ 0 ];
 		const currentPageListBlock = blocks[ 0 ];
 

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { isEqual } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { useInnerBlocksProps } from '@wordpress/block-editor';
@@ -51,14 +56,46 @@ export default function UnsavedInnerBlocks( {
 		}
 	}, [ blocks ] );
 
-	// If the current inner blocks object is different in any way
-	// from the original inner blocks from the post content then the
-	// user has made changes to the inner blocks. At this point the inner
-	// blocks can be considered "dirty".
-	// We also make sure the current innerBlocks had a chance to be set.
-	const innerBlocksAreDirty =
-		!! originalBlocks.current && blocks !== originalBlocks.current;
+	let innerBlocksAreDirty = false;
 
+	if (
+		originalBlocks.current &&
+		blocks?.length &&
+		blocks[ 0 ]?.name === 'core/page-list'
+	) {
+		// ignore changes to inner blocks
+		// track changes to attributes changing
+
+		const originalPageListBlock = originalBlocks.current[ 0 ];
+		const currentPageListBlock = blocks[ 0 ];
+
+		const {
+			innerBlocks: discardedOriginalInnerBlocks,
+			...originalPageListBlockWithoutInnerBlocks
+		} = originalPageListBlock;
+
+		const {
+			innerBlocks: discardedCurrentInnerBlocks,
+			...currentPageListBlockWithoutInnerBlocks
+		} = currentPageListBlock;
+
+		innerBlocksAreDirty = ! isEqual(
+			originalPageListBlockWithoutInnerBlocks,
+			currentPageListBlockWithoutInnerBlocks
+		);
+	} else {
+		// If the current inner blocks object is different in any way
+		// from the original inner blocks from the post content then the
+		// user has made changes to the inner blocks. At this point the inner
+		// blocks can be considered "dirty".
+		// We also make sure the current innerBlocks had a chance to be set.
+		innerBlocksAreDirty =
+			!! originalBlocks.current && blocks !== originalBlocks.current;
+	}
+
+	// if ( innerBlocksAreDirty ) {
+	// 	debugger;
+	// }
 	const shouldDirectInsert = useMemo(
 		() =>
 			blocks.every(

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -106,7 +106,7 @@ export default function UnsavedInnerBlocks( {
 			// are **always** controlled and may be updated async due to
 			// syncing with enitiy records. Left unchecked this would
 			// inadvertently trigger the dirty state.
-			if ( x?.name && prop === 'innerBlocks' ) {
+			if ( x?.name === 'core/page-list' && prop === 'innerBlocks' ) {
 				return true;
 			}
 		}

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -91,9 +91,7 @@ export default function UnsavedInnerBlocks( {
 		}
 	}, [ blocks ] );
 
-	let innerBlocksAreDirty = false;
-
-	innerBlocksAreDirty = ! isDeepEqual(
+	const innerBlocksAreDirty = ! isDeepEqual(
 		originalBlocks.current,
 		blocks,
 		( prop, x ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes bug whereby the fallback Page List in the Navigation block was automatically creating a new Navigation Menu (post) on load.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This was happening because Page List has now been converted to use InnerBlocks. It is dynamic in the sense that the Page List Items are loaded from the REST API and thus the `.innerBlocks` property changes as the data is received.

- initial render `innerBlocks` is `[]`
- once pages data is received `innerBlocks` is an array of blocks

[The `UncontrolledInnerBlocks` component in the Nav block checks for changes to the uncontrolled inner blocks](https://github.com/WordPress/gutenberg/blob/149c3a37d70d44ae8a99c7ca0e172935f9ab77a0/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js#L59) and if there are any changes it considers the blocks to have become "dirty" and triggers the creation of a Navigation Menu.

Unfortunately due to the dynamic population of inner blocks in the Page List block (as described above) this behaviour now caused the auto creation of a menu on insertion.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The fix is currently achieved by adding a specific condition for Page List to ignore the inner blocks and only check for changes to the block's _other_ properties (i.e.: we ignore changes to inner blocks of the Page List block).

This results in the dynamic changes to `innerBlocks` being ignored and thus the Nav Men is _not_ auto created. However if you make other changes to the Nav block's inner blocks such as:

- adding another block type
- adjusting the parent of the Page List block

...the Nav Menu _will_ be correctly auto created as before.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

This needs careful testing.

Before all tests please clear your Nav Menus at http://localhost:8888/wp-admin/edit.php?post_type=wp_navigation.

#### Test Page List

- Add Nav block
- See Page List
- Do _not_ see Nav Menu auto-creation.
- Select Page List
- Click `Edit`
- See Nav Menu auto created

#### Test Adding New Block

- Add Nav block
- See Page List
- Do _not_ see Nav Menu auto-creation.
- Select Nav Block
- Append new block within Nav block 
- See Nav Menu auto created

#### Existing Inner Blocks
- Open code editor mode
- Paste in the following (or your inner blocks of choice)
```
<!-- wp:navigation -->
<!-- wp:navigation-link {"label":"Menu Test","type":"post","id":669,"url":"http://localhost:8888/menu-test/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Laborum ducimus","type":"page","id":609,"url":"http://localhost:8888/laborum-ducimus-voluptatibus-officia-soluta-impedit/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:site-logo {"shouldSyncIcon":true} /-->

<!-- wp:navigation-link {"label":"Quas facere est ","type":"post","id":593,"url":"http://localhost:8888/quas-facere-est-doloribus-vel-consequuntur/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"isTopLevelLink":true} /-->
<!-- /wp:navigation -->
```
- Switch to visual mode
- See Nav block
- See uncontrolled inner blocks
- Modify the inner blocks in any way
- See Nav Menu auto created



### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


Co-authored-by: Maggie <[maggie@onemaggie.com](mailto:maggie@onemaggie.com)>
Co-authored-by: Ben Dwyer <[275961+scruffian@users.noreply.github.com](mailto:275961+scruffian@users.noreply.github.com)>