### PR TITLE
Block Editor: Refactor the block-editor parents state to use maps instead of objects.

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -54,15 +54,18 @@ function mapBlockOrder( blocks, rootClientId = '' ) {
  * @return {Object} Block order map object.
  */
 function mapBlockParents( blocks, rootClientId = '' ) {
-	return blocks.reduce(
-		( result, block ) =>
-			Object.assign(
-				result,
-				{ [ block.clientId ]: rootClientId },
-				mapBlockParents( block.innerBlocks, block.clientId )
-			),
-		{}
-	);
+	const result = [];
+	const stack = [ [ rootClientId, blocks ] ];
+	while ( stack.length ) {
+		const [ parent, currentBlocks ] = stack.shift();
+		currentBlocks.forEach( ( { innerBlocks, ...block } ) => {
+			result.push( [ block.clientId, parent ] );
+			if ( innerBlocks?.length ) {
+				stack.push( [ block.clientId, innerBlocks ] );
+			}
+		} );
+	}
+	return result;
 }
 
 /**
@@ -184,7 +187,7 @@ function updateParentInnerBlocksInTree(
 	for ( const clientId of updatedClientIds ) {
 		let current = updateChildrenOfUpdatedClientIds
 			? clientId
-			: state.parents[ clientId ];
+			: state.parents.get( clientId );
 		do {
 			if ( state.controlledInnerBlocks[ current ] ) {
 				// Should stop on controlled blocks.
@@ -194,7 +197,7 @@ function updateParentInnerBlocksInTree(
 			} else {
 				// Else continue traversing up through parents.
 				uncontrolledParents.add( current );
-				current = state.parents[ current ];
+				current = state.parents.get( current );
 			}
 		} while ( current !== undefined );
 	}
@@ -329,14 +332,14 @@ const withBlockTree =
 				const parentsOfRemovedBlocks = [];
 				for ( const clientId of action.clientIds ) {
 					if (
-						state.parents[ clientId ] !== undefined &&
-						( state.parents[ clientId ] === '' ||
+						state.parents.get( clientId ) !== undefined &&
+						( state.parents.get( clientId ) === '' ||
 							newState.byClientId.get(
-								state.parents[ clientId ]
+								state.parents.get( clientId )
 							) )
 					) {
 						parentsOfRemovedBlocks.push(
-							state.parents[ clientId ]
+							state.parents.get( clientId )
 						);
 					}
 				}
@@ -352,14 +355,14 @@ const withBlockTree =
 				const parentsOfRemovedBlocks = [];
 				for ( const clientId of action.clientIds ) {
 					if (
-						state.parents[ clientId ] !== undefined &&
-						( state.parents[ clientId ] === '' ||
+						state.parents.get( clientId ) !== undefined &&
+						( state.parents.get( clientId ) === '' ||
 							newState.byClientId.get(
-								state.parents[ clientId ]
+								state.parents.get( clientId )
 							) )
 					) {
 						parentsOfRemovedBlocks.push(
-							state.parents[ clientId ]
+							state.parents.get( clientId )
 						);
 					}
 				}
@@ -599,7 +602,7 @@ const withBlockReset = ( reducer ) => ( state, action ) => {
 			),
 			attributes: new Map( getFlattenedBlockAttributes( action.blocks ) ),
 			order: mapBlockOrder( action.blocks ),
-			parents: mapBlockParents( action.blocks ),
+			parents: new Map( mapBlockParents( action.blocks ) ),
 			controlledInnerBlocks: {},
 		};
 
@@ -1129,44 +1132,55 @@ export const blocks = pipe(
 
 	// While technically redundant data as the inverse of `order`, it serves as
 	// an optimization for the selectors which derive the ancestry of a block.
-	parents( state = {}, action ) {
+	parents( state = new Map(), action ) {
 		switch ( action.type ) {
-			case 'RECEIVE_BLOCKS':
-				return {
-					...state,
-					...mapBlockParents( action.blocks ),
-				};
-
-			case 'INSERT_BLOCKS':
-				return {
-					...state,
-					...mapBlockParents(
-						action.blocks,
-						action.rootClientId || ''
-					),
-				};
-
+			case 'RECEIVE_BLOCKS': {
+				const newState = new Map( state );
+				mapBlockParents( action.blocks ).forEach(
+					( [ key, value ] ) => {
+						newState.set( key, value );
+					}
+				);
+				return newState;
+			}
+			case 'INSERT_BLOCKS': {
+				const newState = new Map( state );
+				mapBlockParents(
+					action.blocks,
+					action.rootClientId || ''
+				).forEach( ( [ key, value ] ) => {
+					newState.set( key, value );
+				} );
+				return newState;
+			}
 			case 'MOVE_BLOCKS_TO_POSITION': {
-				return {
-					...state,
-					...action.clientIds.reduce( ( accumulator, id ) => {
-						accumulator[ id ] = action.toRootClientId || '';
-						return accumulator;
-					}, {} ),
-				};
+				const newState = new Map( state );
+				action.clientIds.forEach( ( id ) => {
+					newState.set( id, action.toRootClientId || '' );
+				} );
+				return newState;
 			}
 
-			case 'REPLACE_BLOCKS_AUGMENTED_WITH_CHILDREN':
-				return {
-					...omit( state, action.replacedClientIds ),
-					...mapBlockParents(
-						action.blocks,
-						state[ action.clientIds[ 0 ] ]
-					),
-				};
-
-			case 'REMOVE_BLOCKS_AUGMENTED_WITH_CHILDREN':
-				return omit( state, action.removedClientIds );
+			case 'REPLACE_BLOCKS_AUGMENTED_WITH_CHILDREN': {
+				const newState = new Map( state );
+				action.replacedClientIds.forEach( ( clientId ) => {
+					newState.delete( clientId );
+				} );
+				mapBlockParents(
+					action.blocks,
+					state.get( action.clientIds[ 0 ] )
+				).forEach( ( [ key, value ] ) => {
+					newState.set( key, value );
+				} );
+				return newState;
+			}
+			case 'REMOVE_BLOCKS_AUGMENTED_WITH_CHILDREN': {
+				const newState = new Map( state );
+				action.removedClientIds.forEach( ( clientId ) => {
+					newState.delete( clientId );
+				} );
+				return newState;
+			}
 		}
 
 		return state;

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -73,16 +73,16 @@ function mapBlockParents( blocks, rootClientId = '' ) {
  * @param {Array}    blocks    Blocks to flatten.
  * @param {Function} transform Transforming function to be applied to each block.
  *
- * @return {Object} Flattened object.
+ * @return {Array} Flattened object.
  */
 function flattenBlocks( blocks, transform = identity ) {
-	const result = {};
+	const result = [];
 
 	const stack = [ ...blocks ];
 	while ( stack.length ) {
 		const { innerBlocks, ...block } = stack.shift();
 		stack.push( ...innerBlocks );
-		result[ block.clientId ] = transform( block );
+		result.push( [ block.clientId, transform( block ) ] );
 	}
 
 	return result;
@@ -95,7 +95,7 @@ function flattenBlocks( blocks, transform = identity ) {
  *
  * @param {Array} blocks Blocks to flatten.
  *
- * @return {Object} Flattened block attributes object.
+ * @return {Array} Flattened block attributes object.
  */
 function getFlattenedBlocksWithoutAttributes( blocks ) {
 	return flattenBlocks( blocks, ( block ) => omit( block, 'attributes' ) );
@@ -108,7 +108,7 @@ function getFlattenedBlocksWithoutAttributes( blocks ) {
  *
  * @param {Array} blocks Blocks to flatten.
  *
- * @return {Object} Flattened block attributes object.
+ * @return {Array} Flattened block attributes object.
  */
 function getFlattenedBlockAttributes( blocks ) {
 	return flattenBlocks( blocks, ( block ) => block.attributes );
@@ -595,13 +595,9 @@ const withBlockReset = ( reducer ) => ( state, action ) => {
 		const newState = {
 			...state,
 			byClientId: new Map(
-				Object.entries(
-					getFlattenedBlocksWithoutAttributes( action.blocks )
-				)
+				getFlattenedBlocksWithoutAttributes( action.blocks )
 			),
-			attributes: new Map(
-				Object.entries( getFlattenedBlockAttributes( action.blocks ) )
-			),
+			attributes: new Map( getFlattenedBlockAttributes( action.blocks ) ),
 			order: mapBlockOrder( action.blocks ),
 			parents: mapBlockParents( action.blocks ),
 			controlledInnerBlocks: {},
@@ -784,11 +780,11 @@ export const blocks = pipe(
 			case 'RECEIVE_BLOCKS':
 			case 'INSERT_BLOCKS': {
 				const newState = new Map( state );
-				Object.entries(
-					getFlattenedBlocksWithoutAttributes( action.blocks )
-				).forEach( ( [ key, value ] ) => {
-					newState.set( key, value );
-				} );
+				getFlattenedBlocksWithoutAttributes( action.blocks ).forEach(
+					( [ key, value ] ) => {
+						newState.set( key, value );
+					}
+				);
 				return newState;
 			}
 			case 'UPDATE_BLOCK': {
@@ -820,11 +816,12 @@ export const blocks = pipe(
 				action.replacedClientIds.forEach( ( clientId ) => {
 					newState.delete( clientId );
 				} );
-				Object.entries(
-					getFlattenedBlocksWithoutAttributes( action.blocks )
-				).forEach( ( [ key, value ] ) => {
-					newState.set( key, value );
-				} );
+
+				getFlattenedBlocksWithoutAttributes( action.blocks ).forEach(
+					( [ key, value ] ) => {
+						newState.set( key, value );
+					}
+				);
 				return newState;
 			}
 
@@ -848,11 +845,11 @@ export const blocks = pipe(
 			case 'RECEIVE_BLOCKS':
 			case 'INSERT_BLOCKS': {
 				const newState = new Map( state );
-				Object.entries(
-					getFlattenedBlockAttributes( action.blocks )
-				).forEach( ( [ key, value ] ) => {
-					newState.set( key, value );
-				} );
+				getFlattenedBlockAttributes( action.blocks ).forEach(
+					( [ key, value ] ) => {
+						newState.set( key, value );
+					}
+				);
 				return newState;
 			}
 
@@ -920,11 +917,11 @@ export const blocks = pipe(
 				action.replacedClientIds.forEach( ( clientId ) => {
 					newState.delete( clientId );
 				} );
-				Object.entries(
-					getFlattenedBlockAttributes( action.blocks )
-				).forEach( ( [ key, value ] ) => {
-					newState.set( key, value );
-				} );
+				getFlattenedBlockAttributes( action.blocks ).forEach(
+					( [ key, value ] ) => {
+						newState.set( key, value );
+					}
+				);
 				return newState;
 			}
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -461,8 +461,8 @@ export function getSelectedBlock( state ) {
  * @return {?string} Root client ID, if exists
  */
 export function getBlockRootClientId( state, clientId ) {
-	return state.blocks.parents[ clientId ] !== undefined
-		? state.blocks.parents[ clientId ]
+	return state.blocks.parents.has( clientId )
+		? state.blocks.parents.get( clientId )
 		: null;
 }
 
@@ -479,8 +479,8 @@ export const getBlockParents = createSelector(
 	( state, clientId, ascending = false ) => {
 		const parents = [];
 		let current = clientId;
-		while ( !! state.blocks.parents[ current ] ) {
-			current = state.blocks.parents[ current ];
+		while ( !! state.blocks.parents.get( current ) ) {
+			current = state.blocks.parents.get( current );
 			parents.push( current );
 		}
 
@@ -534,7 +534,7 @@ export function getBlockHierarchyRootClientId( state, clientId ) {
 	let parent;
 	do {
 		parent = current;
-		current = state.blocks.parents[ current ];
+		current = state.blocks.parents.get( current );
 	} while ( current );
 	return parent;
 }

--- a/packages/block-editor/src/store/test/performance.js
+++ b/packages/block-editor/src/store/test/performance.js
@@ -13,9 +13,15 @@ describe( 'performance', () => {
 			innerBlocks: [],
 		} );
 	}
-	const preparedState = reducer( state, {
-		type: 'RESET_BLOCKS',
-		blocks,
+
+	let preparedState;
+
+	it( 'should reset blocks', () => {
+		preparedState = reducer( state, {
+			type: 'RESET_BLOCKS',
+			blocks,
+		} );
+		expect( preparedState ).toBeDefined();
 	} );
 
 	it( 'should update blocks', () => {

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -239,10 +239,12 @@ describe( 'state', () => {
 							'chicken-child': [],
 						} )
 					),
-					parents: {
-						chicken: '',
-						'chicken-child': 'chicken',
-					},
+					parents: new Map(
+						Object.entries( {
+							chicken: '',
+							'chicken-child': 'chicken',
+						} )
+					),
 					tree: {
 						'': {},
 						chicken: {},
@@ -300,10 +302,12 @@ describe( 'state', () => {
 							[ newChildBlockId ]: [],
 						} )
 					),
-					parents: {
-						[ newChildBlockId ]: 'chicken',
-						chicken: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							[ newChildBlockId ]: 'chicken',
+							chicken: '',
+						} )
+					),
 					controlledInnerBlocks: {},
 				} );
 				expect( state.tree.chicken ).not.toBe(
@@ -333,9 +337,11 @@ describe( 'state', () => {
 							chicken: [],
 						} )
 					),
-					parents: {
-						chicken: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							chicken: '',
+						} )
+					),
 					tree: {
 						'': {
 							innerBlocks: [],
@@ -394,10 +400,12 @@ describe( 'state', () => {
 							[ newChildBlockId ]: [],
 						} )
 					),
-					parents: {
-						[ newChildBlockId ]: 'chicken',
-						chicken: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							[ newChildBlockId ]: 'chicken',
+							chicken: '',
+						} )
+					),
 					controlledInnerBlocks: {},
 				} );
 				expect( state.tree.chicken ).not.toBe(
@@ -461,11 +469,13 @@ describe( 'state', () => {
 							'chicken-child-2': [],
 						} )
 					),
-					parents: {
-						chicken: '',
-						'chicken-child': 'chicken',
-						'chicken-child-2': 'chicken',
-					},
+					parents: new Map(
+						Object.entries( {
+							chicken: '',
+							'chicken-child': 'chicken',
+							'chicken-child-2': 'chicken',
+						} )
+					),
 					tree: {},
 					controlledInnerBlocks: {},
 				} );
@@ -553,12 +563,14 @@ describe( 'state', () => {
 							[ newChildBlockId3 ]: [],
 						} )
 					),
-					parents: {
-						chicken: '',
-						[ newChildBlockId1 ]: 'chicken',
-						[ newChildBlockId2 ]: 'chicken',
-						[ newChildBlockId3 ]: 'chicken',
-					},
+					parents: new Map(
+						Object.entries( {
+							chicken: '',
+							[ newChildBlockId1 ]: 'chicken',
+							[ newChildBlockId2 ]: 'chicken',
+							[ newChildBlockId3 ]: 'chicken',
+						} )
+					),
 					controlledInnerBlocks: {},
 				} );
 
@@ -622,11 +634,13 @@ describe( 'state', () => {
 							'chicken-grand-child': [],
 						} )
 					),
-					parents: {
-						chicken: '',
-						'chicken-child': 'chicken',
-						'chicken-grand-child': 'chicken-child',
-					},
+					parents: new Map(
+						Object.entries( {
+							chicken: '',
+							'chicken-child': 'chicken',
+							'chicken-grand-child': 'chicken-child',
+						} )
+					),
 					tree: {
 						chicken: {},
 					},
@@ -676,10 +690,12 @@ describe( 'state', () => {
 							[ newChildBlockId ]: [],
 						} )
 					),
-					parents: {
-						chicken: '',
-						[ newChildBlockId ]: 'chicken',
-					},
+					parents: new Map(
+						Object.entries( {
+							chicken: '',
+							[ newChildBlockId ]: 'chicken',
+						} )
+					),
 					controlledInnerBlocks: {},
 				} );
 
@@ -697,7 +713,7 @@ describe( 'state', () => {
 				byClientId: new Map(),
 				attributes: new Map(),
 				order: new Map(),
-				parents: {},
+				parents: new Map(),
 				isPersistentChange: true,
 				isIgnoredChange: false,
 				tree: {},
@@ -828,7 +844,7 @@ describe( 'state', () => {
 				'': [ 'wings' ],
 				wings: [],
 			} );
-			expect( state.parents ).toEqual( {
+			expect( Object.fromEntries( state.parents ) ).toEqual( {
 				wings: '',
 			} );
 			expect( state.tree[ '' ].innerBlocks[ 0 ] ).toBe(
@@ -899,7 +915,7 @@ describe( 'state', () => {
 				'': [ 'wings' ],
 				wings: [],
 			} );
-			expect( state.parents ).toEqual( {
+			expect( Object.fromEntries( state.parents ) ).toEqual( {
 				wings: '',
 			} );
 			expect( state.tree[ '' ].innerBlocks[ 0 ] ).toBe(
@@ -935,7 +951,7 @@ describe( 'state', () => {
 				[ replacementBlock.clientId ]: [],
 			} );
 
-			expect( state.parents ).toEqual( {
+			expect( Object.fromEntries( state.parents ) ).toEqual( {
 				[ wrapperBlock.clientId ]: '',
 				[ replacementBlock.clientId ]: wrapperBlock.clientId,
 			} );
@@ -1464,7 +1480,7 @@ describe( 'state', () => {
 			expect( Object.fromEntries( state.order ) ).not.toHaveProperty(
 				'chicken'
 			);
-			expect( state.parents ).toEqual( {
+			expect( Object.fromEntries( state.parents ) ).toEqual( {
 				ribs: '',
 			} );
 			expect( Object.fromEntries( state.byClientId ) ).toEqual( {
@@ -1515,7 +1531,7 @@ describe( 'state', () => {
 			expect( Object.fromEntries( state.order ) ).not.toHaveProperty(
 				'veggies'
 			);
-			expect( state.parents ).toEqual( {
+			expect( Object.fromEntries( state.parents ) ).toEqual( {
 				ribs: '',
 			} );
 			expect( Object.fromEntries( state.byClientId ) ).toEqual( {
@@ -1550,7 +1566,7 @@ describe( 'state', () => {
 			expect( Object.fromEntries( state.order ) ).toEqual( {
 				'': [],
 			} );
-			expect( state.parents ).toEqual( {} );
+			expect( Object.fromEntries( state.parents ) ).toEqual( {} );
 		} );
 
 		it( 'should insert at the specified index', () => {
@@ -2236,11 +2252,13 @@ describe( 'state', () => {
 						controlledInnerBlocks: {
 							'reusable-id': true,
 						},
-						parents: {
-							'group-id': '',
-							'reusable-id': 'group-id',
-							'paragraph-id': 'reusable-id',
-						},
+						parents: new Map(
+							Object.entries( {
+								'group-id': '',
+								'reusable-id': 'group-id',
+								'paragraph-id': 'reusable-id',
+							} )
+						),
 						tree: {
 							'group-id': {
 								clientId: 'group-id',

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -205,7 +205,7 @@ describe( 'selectors', () => {
 					byClientId: new Map(),
 					attributes: {},
 					order: new Map(),
-					parents: {},
+					parents: new Map(),
 				},
 			};
 
@@ -240,9 +240,11 @@ describe( 'selectors', () => {
 							'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': [],
 						} )
 					),
-					parents: {
-						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': '',
-					},
+					parents: new Map(
+						Object.entries( {
+							'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': '',
+						} )
+					),
 				},
 			};
 
@@ -275,9 +277,11 @@ describe( 'selectors', () => {
 							123: [],
 						} )
 					),
-					parents: {
-						123: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							123: '',
+						} )
+					),
 					tree: {
 						123: {
 							clientId: '123',
@@ -299,7 +303,7 @@ describe( 'selectors', () => {
 					byClientId: new Map(),
 					attributes: new Map(),
 					order: new Map(),
-					parents: {},
+					parents: new Map(),
 					tree: {
 						123: {
 							clientId: '123',
@@ -337,10 +341,12 @@ describe( 'selectors', () => {
 							'': [ '123', '23' ],
 						} )
 					),
-					parents: {
-						123: '',
-						23: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							123: '',
+							23: '',
+						} )
+					),
 					tree: {
 						'': {
 							innerBlocks: [
@@ -375,12 +381,14 @@ describe( 'selectors', () => {
 		it( 'should return parent blocks', () => {
 			const state = {
 				blocks: {
-					parents: {
-						'client-id-01': '',
-						'client-id-02': 'client-id-01',
-						'client-id-03': 'client-id-02',
-						'client-id-04': 'client-id-03',
-					},
+					parents: new Map(
+						Object.entries( {
+							'client-id-01': '',
+							'client-id-02': 'client-id-01',
+							'client-id-03': 'client-id-02',
+							'client-id-04': 'client-id-03',
+						} )
+					),
 					byClientId: new Map(
 						Object.entries( {
 							'client-id-01': {
@@ -424,13 +432,15 @@ describe( 'selectors', () => {
 	describe( 'getBlockParentsByBlockName', () => {
 		const state = {
 			blocks: {
-				parents: {
-					'client-id-01': '',
-					'client-id-02': 'client-id-01',
-					'client-id-03': 'client-id-02',
-					'client-id-04': 'client-id-03',
-					'client-id-05': 'client-id-04',
-				},
+				parents: new Map(
+					Object.entries( {
+						'client-id-01': '',
+						'client-id-02': 'client-id-01',
+						'client-id-03': 'client-id-02',
+						'client-id-04': 'client-id-03',
+						'client-id-05': 'client-id-04',
+					} )
+				),
 				byClientId: new Map(
 					Object.entries( {
 						'client-id-01': {
@@ -612,20 +622,22 @@ describe( 'selectors', () => {
 							'uuid-28': [ 'uuid-30' ],
 						} )
 					),
-					parents: {
-						'uuid-6': '',
-						'uuid-8': '',
-						'uuid-10': '',
-						'uuid-22': '',
-						'uuid-12': 'uuid-10',
-						'uuid-14': 'uuid-10',
-						'uuid-16': 'uuid-12',
-						'uuid-18': 'uuid-14',
-						'uuid-24': 'uuid-18',
-						'uuid-26': 'uuid-24',
-						'uuid-28': 'uuid-24',
-						'uuid-30': 'uuid-28',
-					},
+					parents: new Map(
+						Object.entries( {
+							'uuid-6': '',
+							'uuid-8': '',
+							'uuid-10': '',
+							'uuid-22': '',
+							'uuid-12': 'uuid-10',
+							'uuid-14': 'uuid-10',
+							'uuid-16': 'uuid-12',
+							'uuid-18': 'uuid-14',
+							'uuid-24': 'uuid-18',
+							'uuid-26': 'uuid-24',
+							'uuid-28': 'uuid-24',
+							'uuid-30': 'uuid-28',
+						} )
+					),
 					controlledInnerBlocks: {},
 				},
 			};
@@ -750,20 +762,22 @@ describe( 'selectors', () => {
 							'uuid-28': [ 'uuid-30' ],
 						} )
 					),
-					parents: {
-						'uuid-6': '',
-						'uuid-8': '',
-						'uuid-10': '',
-						'uuid-22': '',
-						'uuid-12': 'uuid-10',
-						'uuid-14': 'uuid-10',
-						'uuid-16': 'uuid-12',
-						'uuid-18': 'uuid-14',
-						'uuid-24': 'uuid-18',
-						'uuid-26': 'uuid-24',
-						'uuid-28': 'uuid-24',
-						'uuid-30': 'uuid-28',
-					},
+					parents: new Map(
+						Object.entries( {
+							'uuid-6': '',
+							'uuid-8': '',
+							'uuid-10': '',
+							'uuid-22': '',
+							'uuid-12': 'uuid-10',
+							'uuid-14': 'uuid-10',
+							'uuid-16': 'uuid-12',
+							'uuid-18': 'uuid-14',
+							'uuid-24': 'uuid-18',
+							'uuid-26': 'uuid-24',
+							'uuid-28': 'uuid-24',
+							'uuid-30': 'uuid-28',
+						} )
+					),
 				},
 			};
 			expect( getClientIdsWithDescendants( state ) ).toEqual( [
@@ -833,11 +847,13 @@ describe( 'selectors', () => {
 							123: [ '456', '789' ],
 						} )
 					),
-					parents: {
-						123: '',
-						456: '123',
-						789: '123',
-					},
+					parents: new Map(
+						Object.entries( {
+							123: '',
+							456: '123',
+							789: '123',
+						} )
+					),
 				},
 			};
 
@@ -910,10 +926,12 @@ describe( 'selectors', () => {
 						'': [ '123', '456' ],
 					} )
 				),
-				parents: {
-					123: '',
-					456: '',
-				},
+				parents: new Map(
+					Object.entries( {
+						123: '',
+						456: '',
+					} )
+				),
 			},
 		};
 
@@ -931,7 +949,7 @@ describe( 'selectors', () => {
 					byClientId: new Map(),
 					attributes: new Map(),
 					order: new Map(),
-					parents: {},
+					parents: new Map(),
 				},
 			};
 			expect( getGlobalBlockCount( emptyState ) ).toBe( 0 );
@@ -970,13 +988,15 @@ describe( 'selectors', () => {
 						1011: [ '1415', '1213' ],
 					} )
 				),
-				parents: {
-					123: '',
-					456: '',
-					1011: '',
-					1213: '1011',
-					1415: '1011',
-				},
+				parents: new Map(
+					Object.entries( {
+						123: '',
+						456: '',
+						1011: '',
+						1213: '1011',
+						1415: '1011',
+					} )
+				),
 			},
 		};
 
@@ -1076,10 +1096,12 @@ describe( 'selectors', () => {
 							123: [],
 						} )
 					),
-					parents: {
-						23: '',
-						123: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							23: '',
+							123: '',
+						} )
+					),
 					tree: {
 						23: {
 							clientId: '23',
@@ -1120,10 +1142,12 @@ describe( 'selectors', () => {
 							123: [],
 						} )
 					),
-					parents: {
-						123: '',
-						23: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							123: '',
+							23: '',
+						} )
+					),
 					tree: {
 						23: {
 							clientId: '23',
@@ -1164,10 +1188,12 @@ describe( 'selectors', () => {
 							123: [],
 						} )
 					),
-					parents: {
-						123: '',
-						23: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							123: '',
+							23: '',
+						} )
+					),
 					tree: {
 						23: {
 							clientId: '23',
@@ -1195,7 +1221,7 @@ describe( 'selectors', () => {
 			const state = {
 				blocks: {
 					order: new Map(),
-					parents: {},
+					parents: new Map(),
 				},
 			};
 
@@ -1211,12 +1237,14 @@ describe( 'selectors', () => {
 							123: [ '456', '56' ],
 						} )
 					),
-					parents: {
-						123: '',
-						23: '',
-						456: '123',
-						56: '123',
-					},
+					parents: new Map(
+						Object.entries( {
+							123: '',
+							23: '',
+							456: '123',
+							56: '123',
+						} )
+					),
 				},
 			};
 
@@ -1229,7 +1257,7 @@ describe( 'selectors', () => {
 			const state = {
 				blocks: {
 					order: new Map(),
-					parents: {},
+					parents: new Map(),
 				},
 			};
 
@@ -1245,12 +1273,14 @@ describe( 'selectors', () => {
 							a: [ 'c', 'd' ],
 						} )
 					),
-					parents: {
-						a: '',
-						b: '',
-						c: 'a',
-						d: 'a',
-					},
+					parents: new Map(
+						Object.entries( {
+							a: '',
+							b: '',
+							c: 'a',
+							d: 'a',
+						} )
+					),
 				},
 			};
 
@@ -1267,13 +1297,15 @@ describe( 'selectors', () => {
 							d: [ 'e' ],
 						} )
 					),
-					parents: {
-						a: '',
-						b: '',
-						c: 'a',
-						d: 'a',
-						e: 'd',
-					},
+					parents: new Map(
+						Object.entries( {
+							a: '',
+							b: '',
+							c: 'a',
+							d: 'a',
+							e: 'd',
+						} )
+					),
 				},
 			};
 
@@ -1290,10 +1322,12 @@ describe( 'selectors', () => {
 							'': [ '123', '23' ],
 						} )
 					),
-					parents: {
-						123: '',
-						23: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							123: '',
+							23: '',
+						} )
+					),
 				},
 				selection: {
 					selectionStart: {},
@@ -1312,13 +1346,15 @@ describe( 'selectors', () => {
 							'': [ '5', '4', '3', '2', '1' ],
 						} )
 					),
-					parents: {
-						1: '',
-						2: '',
-						3: '',
-						4: '',
-						5: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							1: '',
+							2: '',
+							3: '',
+							4: '',
+							5: '',
+						} )
+					),
 				},
 				selection: {
 					selectionStart: { clientId: '2' },
@@ -1337,13 +1373,15 @@ describe( 'selectors', () => {
 							'': [ '5', '4', '3', '2', '1' ],
 						} )
 					),
-					parents: {
-						1: '',
-						2: '',
-						3: '',
-						4: '',
-						5: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							1: '',
+							2: '',
+							3: '',
+							4: '',
+							5: '',
+						} )
+					),
 				},
 				selection: {
 					selectionStart: { clientId: '2' },
@@ -1367,17 +1405,19 @@ describe( 'selectors', () => {
 							4: [ '9', '8', '7', '6' ],
 						} )
 					),
-					parents: {
-						1: '',
-						2: '',
-						3: '',
-						4: '',
-						5: '',
-						6: '4',
-						7: '4',
-						8: '4',
-						9: '4',
-					},
+					parents: new Map(
+						Object.entries( {
+							1: '',
+							2: '',
+							3: '',
+							4: '',
+							5: '',
+							6: '4',
+							7: '4',
+							8: '4',
+							9: '4',
+						} )
+					),
 				},
 				selection: {
 					selectionStart: { clientId: '7' },
@@ -1402,10 +1442,12 @@ describe( 'selectors', () => {
 							'': [ '123', '23' ],
 						} )
 					),
-					parents: {
-						23: '',
-						123: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							23: '',
+							123: '',
+						} )
+					),
 				},
 				selection: {
 					selectionStart: {},
@@ -1424,13 +1466,15 @@ describe( 'selectors', () => {
 							'': [ '5', '4', '3', '2', '1' ],
 						} )
 					),
-					parents: {
-						1: '',
-						2: '',
-						3: '',
-						4: '',
-						5: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							1: '',
+							2: '',
+							3: '',
+							4: '',
+							5: '',
+						} )
+					),
 				},
 				selection: {
 					selectionStart: { clientId: '2' },
@@ -1454,17 +1498,19 @@ describe( 'selectors', () => {
 							4: [ '9', '8', '7', '6' ],
 						} )
 					),
-					parents: {
-						1: '',
-						2: '',
-						3: '',
-						4: '',
-						5: '',
-						6: '4',
-						7: '4',
-						8: '4',
-						9: '4',
-					},
+					parents: new Map(
+						Object.entries( {
+							1: '',
+							2: '',
+							3: '',
+							4: '',
+							5: '',
+							6: '4',
+							7: '4',
+							8: '4',
+							9: '4',
+						} )
+					),
 				},
 				selection: {
 					selectionStart: { clientId: '7' },
@@ -1487,7 +1533,7 @@ describe( 'selectors', () => {
 					byClientId: new Map(),
 					attributes: new Map(),
 					order: new Map(),
-					parents: {},
+					parents: new Map(),
 				},
 				selection: {
 					selectionStart: {},
@@ -1558,10 +1604,12 @@ describe( 'selectors', () => {
 							'': [ '123', '23' ],
 						} )
 					),
-					parents: {
-						23: '',
-						123: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							23: '',
+							123: '',
+						} )
+					),
 				},
 			};
 
@@ -1577,11 +1625,13 @@ describe( 'selectors', () => {
 							123: [ '456' ],
 						} )
 					),
-					parents: {
-						23: '',
-						123: '',
-						456: '123',
-					},
+					parents: new Map(
+						Object.entries( {
+							23: '',
+							123: '',
+							456: '123',
+						} )
+					),
 				},
 			};
 
@@ -1598,10 +1648,12 @@ describe( 'selectors', () => {
 							'': [ '123', '23' ],
 						} )
 					),
-					parents: {
-						23: '',
-						123: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							23: '',
+							123: '',
+						} )
+					),
 				},
 			};
 
@@ -1617,12 +1669,14 @@ describe( 'selectors', () => {
 							123: [ '456', '56' ],
 						} )
 					),
-					parents: {
-						23: '',
-						123: '',
-						56: '123',
-						456: '123',
-					},
+					parents: new Map(
+						Object.entries( {
+							23: '',
+							123: '',
+							56: '123',
+							456: '123',
+						} )
+					),
 				},
 			};
 
@@ -1639,10 +1693,12 @@ describe( 'selectors', () => {
 							'': [ '123', '23' ],
 						} )
 					),
-					parents: {
-						23: '',
-						123: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							23: '',
+							123: '',
+						} )
+					),
 				},
 			};
 
@@ -1658,12 +1714,14 @@ describe( 'selectors', () => {
 							123: [ '456', '56' ],
 						} )
 					),
-					parents: {
-						23: '',
-						123: '',
-						456: '123',
-						56: '123',
-					},
+					parents: new Map(
+						Object.entries( {
+							23: '',
+							123: '',
+							456: '123',
+							56: '123',
+						} )
+					),
 				},
 			};
 
@@ -1680,10 +1738,12 @@ describe( 'selectors', () => {
 							'': [ '123', '23' ],
 						} )
 					),
-					parents: {
-						23: '',
-						123: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							23: '',
+							123: '',
+						} )
+					),
 				},
 			};
 
@@ -1699,12 +1759,14 @@ describe( 'selectors', () => {
 							123: [ '456', '56' ],
 						} )
 					),
-					parents: {
-						23: '',
-						123: '',
-						456: '123',
-						56: '123',
-					},
+					parents: new Map(
+						Object.entries( {
+							23: '',
+							123: '',
+							456: '123',
+							56: '123',
+						} )
+					),
 				},
 			};
 
@@ -1723,10 +1785,12 @@ describe( 'selectors', () => {
 							'': [ '123', '23' ],
 						} )
 					),
-					parents: {
-						23: '',
-						123: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							23: '',
+							123: '',
+						} )
+					),
 				},
 			};
 
@@ -1742,12 +1806,14 @@ describe( 'selectors', () => {
 							123: [ '456', '56' ],
 						} )
 					),
-					parents: {
-						23: '',
-						123: '',
-						456: '123',
-						56: '123',
-					},
+					parents: new Map(
+						Object.entries( {
+							23: '',
+							123: '',
+							456: '123',
+							56: '123',
+						} )
+					),
 				},
 			};
 
@@ -1764,10 +1830,12 @@ describe( 'selectors', () => {
 							'': [ '123', '23' ],
 						} )
 					),
-					parents: {
-						23: '',
-						123: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							23: '',
+							123: '',
+						} )
+					),
 				},
 			};
 
@@ -1783,12 +1851,14 @@ describe( 'selectors', () => {
 							123: [ '456', '56' ],
 						} )
 					),
-					parents: {
-						23: '',
-						123: '',
-						456: '123',
-						56: '123',
-					},
+					parents: new Map(
+						Object.entries( {
+							23: '',
+							123: '',
+							456: '123',
+							56: '123',
+						} )
+					),
 				},
 			};
 
@@ -1844,11 +1914,13 @@ describe( 'selectors', () => {
 							4: [ '3', '2', '1' ],
 						} )
 					),
-					parents: {
-						1: '4',
-						2: '4',
-						3: '4',
-					},
+					parents: new Map(
+						Object.entries( {
+							1: '4',
+							2: '4',
+							3: '4',
+						} )
+					),
 				},
 			};
 
@@ -1867,11 +1939,13 @@ describe( 'selectors', () => {
 							4: [ '3', '2', '1' ],
 						} )
 					),
-					parents: {
-						1: '4',
-						2: '4',
-						3: '4',
-					},
+					parents: new Map(
+						Object.entries( {
+							1: '4',
+							2: '4',
+							3: '4',
+						} )
+					),
 				},
 			};
 
@@ -1886,13 +1960,15 @@ describe( 'selectors', () => {
 							6: [ '5', '4', '3', '2', '1' ],
 						} )
 					),
-					parents: {
-						1: '6',
-						2: '6',
-						3: '6',
-						4: '6',
-						5: '6',
-					},
+					parents: new Map(
+						Object.entries( {
+							1: '6',
+							2: '6',
+							3: '6',
+							4: '6',
+							5: '6',
+						} )
+					),
 				},
 				selection: {
 					selectionStart: { clientId: '2' },
@@ -1911,12 +1987,14 @@ describe( 'selectors', () => {
 							6: [ '5', '4' ],
 						} )
 					),
-					parents: {
-						1: '3',
-						2: '3',
-						4: '6',
-						5: '6',
-					},
+					parents: new Map(
+						Object.entries( {
+							1: '3',
+							2: '3',
+							4: '6',
+							5: '6',
+						} )
+					),
 				},
 				selection: {
 					selectionStart: { clientId: '5' },
@@ -1940,13 +2018,15 @@ describe( 'selectors', () => {
 							'': [ '5', '4', '3', '2', '1' ],
 						} )
 					),
-					parents: {
-						1: '',
-						2: '',
-						3: '',
-						4: '',
-						5: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							1: '',
+							2: '',
+							3: '',
+							4: '',
+							5: '',
+						} )
+					),
 				},
 			};
 
@@ -1965,13 +2045,15 @@ describe( 'selectors', () => {
 							'': [ '5', '4', '3', '2', '1' ],
 						} )
 					),
-					parents: {
-						1: '',
-						2: '',
-						3: '',
-						4: '',
-						5: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							1: '',
+							2: '',
+							3: '',
+							4: '',
+							5: '',
+						} )
+					),
 				},
 			};
 
@@ -1990,13 +2072,15 @@ describe( 'selectors', () => {
 							'': [ '5', '4', '3', '2', '1' ],
 						} )
 					),
-					parents: {
-						1: '',
-						2: '',
-						3: '',
-						4: '',
-						5: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							1: '',
+							2: '',
+							3: '',
+							4: '',
+							5: '',
+						} )
+					),
 				},
 			};
 
@@ -2015,13 +2099,15 @@ describe( 'selectors', () => {
 							'': [ '5', '4', '3', '2', '1' ],
 						} )
 					),
-					parents: {
-						1: '',
-						2: '',
-						3: '',
-						4: '',
-						5: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							1: '',
+							2: '',
+							3: '',
+							4: '',
+							5: '',
+						} )
+					),
 				},
 			};
 
@@ -2080,13 +2166,15 @@ describe( 'selectors', () => {
 						'': [ '5', '4', '3', '2', '1' ],
 					} )
 				),
-				parents: {
-					1: '',
-					2: '',
-					3: '',
-					4: '',
-					5: '',
-				},
+				parents: new Map(
+					Object.entries( {
+						1: '',
+						2: '',
+						3: '',
+						4: '',
+						5: '',
+					} )
+				),
 			},
 			selection: {
 				selectionStart: { clientId: '2' },
@@ -2111,13 +2199,15 @@ describe( 'selectors', () => {
 						'': [ '5', '4', '3', '2', '1' ],
 					} )
 				),
-				parents: {
-					1: '',
-					2: '',
-					3: '',
-					4: '',
-					5: '',
-				},
+				parents: new Map(
+					Object.entries( {
+						1: '',
+						2: '',
+						3: '',
+						4: '',
+						5: '',
+					} )
+				),
 			},
 			selection: {
 				selectionStart: { clientId: '2' },
@@ -2244,10 +2334,12 @@ describe( 'selectors', () => {
 			const state = {
 				draggedBlocks: [ 'block-1_grandparent' ],
 				blocks: {
-					parents: {
-						'block-1': 'block-1_parent',
-						'block-1_parent': 'block-1_grandparent',
-					},
+					parents: new Map(
+						Object.entries( {
+							'block-1': 'block-1_parent',
+							'block-1_parent': 'block-1_grandparent',
+						} )
+					),
 				},
 			};
 			expect( isAncestorBeingDragged( state, 'block-1' ) ).toBe( true );
@@ -2257,10 +2349,12 @@ describe( 'selectors', () => {
 			const state = {
 				draggedBlocks: [ 'block-2_grandparent' ],
 				blocks: {
-					parents: {
-						'block-1': 'block-1_parent',
-						'block-1_parent': 'block-1_grandparent',
-					},
+					parents: new Map(
+						Object.entries( {
+							'block-1': 'block-1_parent',
+							'block-1_parent': 'block-1_grandparent',
+						} )
+					),
 				},
 			};
 			expect( isAncestorBeingDragged( state, 'block-1' ) ).toBe( false );
@@ -2270,10 +2364,12 @@ describe( 'selectors', () => {
 			const state = {
 				draggedBlocks: [],
 				blocks: {
-					parents: {
-						'block-1': 'block-1_parent',
-						'block-1_parent': 'block-1_grandparent',
-					},
+					parents: new Map(
+						Object.entries( {
+							'block-1': 'block-1_parent',
+							'block-1_parent': 'block-1_grandparent',
+						} )
+					),
 				},
 			};
 			expect( isAncestorBeingDragged( state, 'block-1' ) ).toBe( false );
@@ -2325,10 +2421,12 @@ describe( 'selectors', () => {
 							clientId2: [],
 						} )
 					),
-					parents: {
-						clientId1: '',
-						clientId2: 'clientId1',
-					},
+					parents: new Map(
+						Object.entries( {
+							clientId1: '',
+							clientId2: 'clientId1',
+						} )
+					),
 				},
 				insertionPoint: {
 					rootClientId: undefined,
@@ -2365,9 +2463,11 @@ describe( 'selectors', () => {
 							clientId1: [],
 						} )
 					),
-					parents: {
-						clientId1: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							clientId1: '',
+						} )
+					),
 				},
 				insertionPoint: null,
 			};
@@ -2404,10 +2504,12 @@ describe( 'selectors', () => {
 							clientId2: [],
 						} )
 					),
-					parents: {
-						clientId1: '',
-						clientId2: 'clientId1',
-					},
+					parents: new Map(
+						Object.entries( {
+							clientId1: '',
+							clientId2: 'clientId1',
+						} )
+					),
 				},
 				insertionPoint: null,
 			};
@@ -2444,10 +2546,12 @@ describe( 'selectors', () => {
 							clientId2: [],
 						} )
 					),
-					parents: {
-						clientId1: '',
-						clientId2: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							clientId1: '',
+							clientId2: '',
+						} )
+					),
 				},
 				insertionPoint: null,
 			};
@@ -2484,10 +2588,12 @@ describe( 'selectors', () => {
 							clientId2: [],
 						} )
 					),
-					parents: {
-						clientId1: '',
-						clientId2: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							clientId1: '',
+							clientId2: '',
+						} )
+					),
 				},
 				insertionPoint: null,
 			};
@@ -2794,9 +2900,11 @@ describe( 'selectors', () => {
 							block2: {},
 						} )
 					),
-					parents: {
-						block2: 'block1',
-					},
+					parents: new Map(
+						Object.entries( {
+							block2: 'block1',
+						} )
+					),
 				},
 				blockListSettings: {
 					block1: {},
@@ -2830,10 +2938,12 @@ describe( 'selectors', () => {
 							block3: {},
 						} )
 					),
-					parents: {
-						block2: 'block1',
-						block3: 'block2',
-					},
+					parents: new Map(
+						Object.entries( {
+							block2: 'block1',
+							block3: 'block2',
+						} )
+					),
 				},
 				blockListSettings: {
 					block1: {},
@@ -2868,9 +2978,11 @@ describe( 'selectors', () => {
 							block3: {},
 						} )
 					),
-					parents: {
-						block3: 'block2',
-					},
+					parents: new Map(
+						Object.entries( {
+							block3: 'block2',
+						} )
+					),
 				},
 				blockListSettings: {
 					block1: {},
@@ -2905,9 +3017,11 @@ describe( 'selectors', () => {
 							block3: {},
 						} )
 					),
-					parents: {
-						block3: 'block2',
-					},
+					parents: new Map(
+						Object.entries( {
+							block3: 'block2',
+						} )
+					),
 				},
 				blockListSettings: {
 					block1: {},
@@ -2940,9 +3054,11 @@ describe( 'selectors', () => {
 							block2: {},
 						} )
 					),
-					parents: {
-						block2: 'block1',
-					},
+					parents: new Map(
+						Object.entries( {
+							block2: 'block1',
+						} )
+					),
 				},
 				blockListSettings: {
 					block1: {},
@@ -2976,9 +3092,11 @@ describe( 'selectors', () => {
 							block2: {},
 						} )
 					),
-					parents: {
-						block2: 'block1',
-					},
+					parents: new Map(
+						Object.entries( {
+							block2: 'block1',
+						} )
+					),
 				},
 				blockListSettings: {
 					block1: {},
@@ -3064,7 +3182,7 @@ describe( 'selectors', () => {
 					byClientId: new Map(),
 					attributes: new Map(),
 					order: new Map(),
-					parents: {},
+					parents: new Map(),
 					tree: {
 						'': {
 							innerBlocks: [],
@@ -3147,10 +3265,12 @@ describe( 'selectors', () => {
 							'': [ 'block3', 'block4' ],
 						} )
 					),
-					parents: {
-						block3: '',
-						block4: '',
-					},
+					parents: new Map(
+						Object.entries( {
+							block3: '',
+							block4: '',
+						} )
+					),
 					tree: {
 						block3: {
 							clientId: 'block3',
@@ -3270,7 +3390,7 @@ describe( 'selectors', () => {
 						},
 					},
 					controlledInnerBlocks: {},
-					parents: {},
+					parents: new Map(),
 				},
 				preferences: {
 					insertUsage: {},
@@ -3291,7 +3411,7 @@ describe( 'selectors', () => {
 					byClientId: new Map(),
 					attributes: new Map(),
 					order: new Map(),
-					parents: {},
+					parents: new Map(),
 					cache: {},
 				},
 				preferences: {
@@ -3386,7 +3506,7 @@ describe( 'selectors', () => {
 					byClientId: new Map(),
 					attributes: new Map(),
 					order: new Map(),
-					parents: {},
+					parents: new Map(),
 					cache: {},
 				},
 				settings: {},
@@ -3426,7 +3546,7 @@ describe( 'selectors', () => {
 					byClientId: new Map(),
 					attributes: new Map(),
 					order: new Map(),
-					parents: {},
+					parents: new Map(),
 					cache: {},
 				},
 				settings: {},
@@ -3453,10 +3573,12 @@ describe( 'selectors', () => {
 						} )
 					),
 					order: new Map(),
-					parents: {
-						block1: '',
-						block2: 'block1',
-					},
+					parents: new Map(
+						Object.entries( {
+							block1: '',
+							block2: 'block1',
+						} )
+					),
 					cache: {},
 					controlledInnerBlocks: {},
 				},
@@ -3506,7 +3628,7 @@ describe( 'selectors', () => {
 						},
 					},
 					controlledInnerBlocks: {},
-					parents: {},
+					parents: new Map(),
 				},
 				preferences: {
 					insertUsage: {},
@@ -3536,7 +3658,7 @@ describe( 'selectors', () => {
 					byClientId: new Map(),
 					attributes: new Map(),
 					order: new Map(),
-					parents: {},
+					parents: new Map(),
 					cache: {},
 				},
 				preferences: {
@@ -3762,14 +3884,16 @@ describe( 'selectors', () => {
 					b: [ 'f' ],
 				} )
 			),
-			parents: {
-				a: '',
-				b: '',
-				c: 'a',
-				d: 'a',
-				e: 'd',
-				f: 'b',
-			},
+			parents: new Map(
+				Object.entries( {
+					a: '',
+					b: '',
+					c: 'a',
+					d: 'a',
+					e: 'd',
+					f: 'b',
+				} )
+			),
 		};
 
 		it( 'should not be defined if there is no block selected', () => {
@@ -3868,13 +3992,15 @@ describe( 'selectors', () => {
 				},
 			},
 			blocks: {
-				parents: {
-					'client-id-01': '',
-					'client-id-02': 'client-id-01',
-					'client-id-03': 'client-id-02',
-					'client-id-04': 'client-id-03',
-					'client-id-05': 'client-id-03',
-				},
+				parents: new Map(
+					Object.entries( {
+						'client-id-01': '',
+						'client-id-02': 'client-id-01',
+						'client-id-03': 'client-id-02',
+						'client-id-04': 'client-id-03',
+						'client-id-05': 'client-id-03',
+					} )
+				),
 				byClientId: new Map(
 					Object.entries( {
 						'client-id-01': {
@@ -4415,7 +4541,7 @@ describe( 'getInserterItems with core blocks prioritization', () => {
 				byClientId: new Map(),
 				attributes: new Map(),
 				order: new Map(),
-				parents: {},
+				parents: new Map(),
 				cache: {},
 			},
 			settings: {},


### PR DESCRIPTION
Similar to #46204 #46221 and #46146

Following a similar approach to the previous PRs, I tried to see how refactoring the parents state from plain objects to maps could impact the performance. Here are the results I got:

Before:

<img width="515" alt="Screenshot 2022-12-01 at 12 32 39 PM" src="https://user-images.githubusercontent.com/272444/205042881-40fe9321-4085-4048-9cf3-6f5536ab5f64.png">

After:

<img width="515" alt="Screenshot 2022-12-01 at 12 31 51 PM" src="https://user-images.githubusercontent.com/272444/205042775-486fe568-adda-441a-9c52-ad2f0ab31a37.png">
