### PR TITLE
Block Editor: Fix some usages of useSelect that return unstable results

### DIFF
--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -293,6 +293,8 @@ const BlockActionsMenu = ( {
 	);
 };
 
+const EMPTY_BLOCK_LIST = [];
+
 export default compose(
 	withSelect( ( select, { clientIds } ) => {
 		const {
@@ -345,8 +347,8 @@ export default compose(
 			? getBlocksByClientId( selectedBlockClientId )[ 0 ]
 			: undefined;
 		const selectedBlockPossibleTransformations = selectedBlock
-			? getBlockTransformItems( [ selectedBlock ], rootClientId )
-			: [];
+			? getBlockTransformItems( selectedBlock, rootClientId )
+			: EMPTY_BLOCK_LIST;
 
 		const isReusableBlockType = block ? isReusableBlock( block ) : false;
 		const reusableBlock = isReusableBlockType

--- a/packages/block-editor/src/components/ungroup-button/index.native.js
+++ b/packages/block-editor/src/components/ungroup-button/index.native.js
@@ -14,6 +14,7 @@ import UngroupIcon from './icon';
 import { store as blockEditorStore } from '../../store';
 
 const noop = () => {};
+const EMPTY_BLOCKS_LIST = [];
 
 export function UngroupButton( { onConvertFromGroup, isUngroupable = false } ) {
 	if ( ! isUngroupable ) {
@@ -45,9 +46,12 @@ export default compose( [
 		const isUngroupable =
 			selectedBlock &&
 			selectedBlock.innerBlocks &&
-			!! selectedBlock.innerBlocks.length &&
+			selectedBlock.innerBlocks.length > 0 &&
 			selectedBlock.name === groupingBlockName;
-		const innerBlocks = isUngroupable ? selectedBlock.innerBlocks : [];
+
+		const innerBlocks = isUngroupable
+			? selectedBlock.innerBlocks
+			: EMPTY_BLOCKS_LIST;
 
 		return {
 			isUngroupable,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2107,7 +2107,7 @@ export const getBlockTransformItems = createSelector(
 			'desc'
 		);
 	},
-	( state, rootClientId ) => [
+	( state, blocks, rootClientId ) => [
 		state.blockListSettings[ rootClientId ],
 		state.blocks.byClientId,
 		state.preferences.insertUsage,


### PR DESCRIPTION
When fixing unit tests for the React 18 migration, I discovered there are some unwanted component rerenders. They happen after editing rich text, when there is a debounced (after 1s) creation of an undo level and dispatch of the `MARK_LAST_CHANGE_AS_PERSISTENT` action. The only selector that changes return value after this action should ever be only `isLastBlockChangePersistent`, and the `useBlockSync` hook that uses it. Nothing else.

But there are a few components that rerender:

The `UngroupButton` component has a select call that returns an empty `innerBlocks` array if the `isUngroupable` value is `false`. This array is a new instance on each call, leading to rerenders. I extracted it to a module-level constant.

The `BlockActionsMenu` component does something similar with `selectedBlockPossibleTransformations` when there is no selected block. Also, it disables memoization of the `getBlockTransformItems` selection because it passes a new `[ selectedBlock ]` array to it on every call. `rememo` returns a memoized value only if all the args are exactly the same. I fixed this by passing only the stable `selectedBlock` object to the selector. The selector will normalize the value to an one-item array internally.

The `getBlockTransformItems` selector also has a little bug in the dependants callback. There are wrong args. The `blocks` arg was interpreted as `rootClientId` and the of course the `state.blockListSettings[ rootClientId ]` is invalid, always returning `undefined`.

**How to test:**
Run React Native unit tests for the list block:
```
npm run native test packages/block-library/src/list
```
Before this patch, it would report "update not wrapped in `act()`" warnings. Because the `useSelect` hook detected changes and forced rerender of a component. After this patch, these warnings disappear.