### PR TITLE
Block Editor: Improve `act()` usage in `BlockSwitcher` tests

### DIFF
--- a/packages/block-editor/src/components/block-switcher/test/index.js
+++ b/packages/block-editor/src/components/block-switcher/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -15,12 +15,21 @@ import { copy } from '@wordpress/icons';
  * Internal dependencies
  */
 import { BlockSwitcher, BlockSwitcherDropdownMenu } from '../';
-import { act } from 'react-test-renderer';
 
 jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
 jest.mock( '../../block-title/use-block-display-title', () =>
 	jest.fn().mockReturnValue( 'Block Name' )
 );
+
+/**
+ * Returns the first found popover element up the DOM tree.
+ *
+ * @param {HTMLElement} element Element to start with.
+ * @return {HTMLElement|null} Popover element, or `null` if not found.
+ */
+function getWrappingPopoverElement( element ) {
+	return element.closest( '.components-popover' );
+}
 
 describe( 'BlockSwitcher', () => {
 	test( 'should not render block switcher without blocks', () => {
@@ -211,7 +220,18 @@ describe( 'BlockSwitcherDropdownMenu', () => {
 				} ),
 				'[ArrowDown]'
 			);
-			await act( () => Promise.resolve() );
+
+			const menu = screen.getByRole( 'menu', {
+				name: 'Block Name',
+			} );
+
+			expect( menu ).not.toBeVisible();
+
+			await waitFor( () =>
+				expect(
+					getWrappingPopoverElement( menu )
+				).toBePositionedPopover()
+			);
 
 			expect(
 				screen.getByRole( 'button', {
@@ -220,11 +240,8 @@ describe( 'BlockSwitcherDropdownMenu', () => {
 				} )
 			).toBeVisible();
 
-			const menu = screen.getByRole( 'menu', {
-				name: 'Block Name',
-			} );
 			expect( menu ).toBeInTheDocument();
-			expect( menu ).not.toBeVisible();
+			expect( menu ).toBeVisible();
 		} );
 
 		test( 'should simulate a click event, which should call onToggle.', async () => {
@@ -254,7 +271,18 @@ describe( 'BlockSwitcherDropdownMenu', () => {
 					expanded: false,
 				} )
 			);
-			await act( () => Promise.resolve() );
+
+			const menu = screen.getByRole( 'menu', {
+				name: 'Block Name',
+			} );
+
+			expect( menu ).not.toBeVisible();
+
+			await waitFor( () =>
+				expect(
+					getWrappingPopoverElement( menu )
+				).toBePositionedPopover()
+			);
 
 			expect(
 				screen.getByRole( 'button', {
@@ -263,11 +291,7 @@ describe( 'BlockSwitcherDropdownMenu', () => {
 				} )
 			).toBeVisible();
 
-			const menu = screen.getByRole( 'menu', {
-				name: 'Block Name',
-			} );
-			expect( menu ).toBeInTheDocument();
-			expect( menu ).not.toBeVisible();
+			expect( menu ).toBeVisible();
 		} );
 
 		test( 'should create the transform items for the chosen block.', async () => {
@@ -285,14 +309,19 @@ describe( 'BlockSwitcherDropdownMenu', () => {
 					expanded: false,
 				} )
 			);
-			await act( () => Promise.resolve() );
+
+			const menu = screen.getByRole( 'menu', {
+				name: 'Block Name',
+			} );
+
+			await waitFor( () =>
+				expect(
+					getWrappingPopoverElement( menu )
+				).toBePositionedPopover()
+			);
 
 			expect(
-				within(
-					screen.getByRole( 'menu', {
-						name: 'Block Name',
-					} )
-				).getByRole( 'menuitem' )
+				within( menu ).getByRole( 'menuitem' )
 			).toBeInTheDocument();
 		} );
 	} );


### PR DESCRIPTION
## What?
This PR improves the `act()` usage in `BlockSwitcher` to make the tests more precise and more expressive.

## Why?
As part of the React 18 upgrade in #45235, we added a bunch of `act()` calls that could be improved and made more specific.

## How?
Instead of going with `await act( () => Promise.resolve() )`, we change the test to wait for the popover to be positioned before continuing.

## Testing Instructions
Verify tests still pass: `npm run test:unit block-editor/src/components/block-switcher/test/index.js`

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None
