### PR TITLE
Refactor the block-editor "tree" state to use maps instead of objects

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -289,7 +289,7 @@ const withBlockTree =
 						attributes: newState.attributes.get( clientId ),
 					} );
 				} );
-				newState.tree = updateParentInnerBlocksInTree(
+				updateParentInnerBlocksInTree(
 					newState,
 					action.clientIds,
 					false

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -91,6 +91,18 @@ function flattenBlocks( blocks, transform = identity ) {
 	return result;
 }
 
+function getFlattenedClientIds( blocks ) {
+	const result = {};
+	const stack = [ ...blocks ];
+	while ( stack.length ) {
+		const { innerBlocks, ...block } = stack.shift();
+		stack.push( ...innerBlocks );
+		result[ block.clientId ] = true;
+	}
+
+	return result;
+}
+
 /**
  * Given an array of blocks, returns an object containing all blocks, without
  * attributes, recursing into inner blocks. Keys correspond to the block client
@@ -150,8 +162,8 @@ export function isUpdatingSameBlockAttribute( action, lastAction ) {
 	);
 }
 
-function buildBlockTree( state, blocks ) {
-	const result = {};
+function updateBlockTreeForBlocks( state, blocks ) {
+	const treeToUpdate = state.tree;
 	const stack = [ ...blocks ];
 	const flattenedBlocks = [ ...blocks ];
 	while ( stack.length ) {
@@ -161,27 +173,28 @@ function buildBlockTree( state, blocks ) {
 	}
 	// Create objects before mutating them, that way it's always defined.
 	for ( const block of flattenedBlocks ) {
-		result[ block.clientId ] = {};
+		treeToUpdate.set( block.clientId, {} );
 	}
 	for ( const block of flattenedBlocks ) {
-		result[ block.clientId ] = Object.assign( result[ block.clientId ], {
-			...state.byClientId.get( block.clientId ),
-			attributes: state.attributes.get( block.clientId ),
-			innerBlocks: block.innerBlocks.map(
-				( subBlock ) => result[ subBlock.clientId ]
-			),
-		} );
+		treeToUpdate.set(
+			block.clientId,
+			Object.assign( treeToUpdate.get( block.clientId ), {
+				...state.byClientId.get( block.clientId ),
+				attributes: state.attributes.get( block.clientId ),
+				innerBlocks: block.innerBlocks.map( ( subBlock ) =>
+					treeToUpdate.get( subBlock.clientId )
+				),
+			} )
+		);
 	}
-
-	return result;
 }
 
 function updateParentInnerBlocksInTree(
 	state,
-	tree,
 	updatedClientIds,
 	updateChildrenOfUpdatedClientIds = false
 ) {
+	const treeToUpdate = state.tree;
 	const uncontrolledParents = new Set( [] );
 	const controlledParents = new Set();
 	for ( const clientId of updatedClientIds ) {
@@ -205,27 +218,23 @@ function updateParentInnerBlocksInTree(
 	// To make sure the order of assignments doesn't matter,
 	// we first create empty objects and mutates the inner blocks later.
 	for ( const clientId of uncontrolledParents ) {
-		tree[ clientId ] = {
-			...tree[ clientId ],
-		};
+		treeToUpdate.set( clientId, { ...treeToUpdate.get( clientId ) } );
 	}
 	for ( const clientId of uncontrolledParents ) {
-		tree[ clientId ].innerBlocks = (
+		treeToUpdate.get( clientId ).innerBlocks = (
 			state.order.get( clientId ) || []
-		).map( ( subClientId ) => tree[ subClientId ] );
+		).map( ( subClientId ) => treeToUpdate.get( subClientId ) );
 	}
 
 	// Controlled parent blocks, need a dedicated key for their inner blocks
 	// to be used when doing getBlocks( controlledBlockClientId ).
 	for ( const clientId of controlledParents ) {
-		tree[ 'controlled||' + clientId ] = {
+		treeToUpdate.set( 'controlled||' + clientId, {
 			innerBlocks: ( state.order.get( clientId ) || [] ).map(
-				( subClientId ) => tree[ subClientId ]
+				( subClientId ) => treeToUpdate.get( subClientId )
 			),
-		};
+		} );
 	}
-
-	return tree;
 }
 
 /**
@@ -246,84 +255,70 @@ const withBlockTree =
 			return state;
 		}
 
-		newState.tree = state.tree ? state.tree : {};
+		newState.tree = state.tree ? state.tree : new Map();
 		switch ( action.type ) {
 			case 'RECEIVE_BLOCKS':
 			case 'INSERT_BLOCKS': {
-				const subTree = buildBlockTree( newState, action.blocks );
-				newState.tree = updateParentInnerBlocksInTree(
+				newState.tree = new Map( newState.tree );
+				updateBlockTreeForBlocks( newState, action.blocks );
+				updateParentInnerBlocksInTree(
 					newState,
-					{
-						...newState.tree,
-						...subTree,
-					},
 					action.rootClientId ? [ action.rootClientId ] : [ '' ],
 					true
 				);
 				break;
 			}
 			case 'UPDATE_BLOCK':
-				newState.tree = updateParentInnerBlocksInTree(
+				newState.tree = new Map( newState.tree );
+				newState.tree.set( action.clientId, {
+					...newState.tree.get( action.clientId ),
+					...newState.byClientId.get( action.clientId ),
+					attributes: newState.attributes.get( action.clientId ),
+				} );
+				updateParentInnerBlocksInTree(
 					newState,
-					{
-						...newState.tree,
-						[ action.clientId ]: {
-							...newState.tree[ action.clientId ],
-							...newState.byClientId.get( action.clientId ),
-							attributes: newState.attributes.get(
-								action.clientId
-							),
-						},
-					},
 					[ action.clientId ],
 					false
 				);
 				break;
 			case 'UPDATE_BLOCK_ATTRIBUTES': {
-				const newSubTree = action.clientIds.reduce(
-					( result, clientId ) => {
-						result[ clientId ] = {
-							...newState.tree[ clientId ],
-							attributes: newState.attributes.get( clientId ),
-						};
-						return result;
-					},
-					{}
-				);
+				newState.tree = new Map( newState.tree );
+				action.clientIds.forEach( ( clientId ) => {
+					newState.tree.set( clientId, {
+						...newState.tree.get( clientId ),
+						attributes: newState.attributes.get( clientId ),
+					} );
+				} );
 				newState.tree = updateParentInnerBlocksInTree(
 					newState,
-					{
-						...newState.tree,
-						...newSubTree,
-					},
 					action.clientIds,
 					false
 				);
 				break;
 			}
 			case 'REPLACE_BLOCKS_AUGMENTED_WITH_CHILDREN': {
-				const subTree = buildBlockTree( newState, action.blocks );
-				newState.tree = updateParentInnerBlocksInTree(
-					newState,
-					{
-						...omit(
-							newState.tree,
-							action.replacedClientIds.concat(
-								// Controlled inner blocks are only removed
-								// if the block doesn't move to another position
-								// otherwise their content will be lost.
-								action.replacedClientIds
-									.filter(
-										( clientId ) => ! subTree[ clientId ]
-									)
-									.map(
-										( clientId ) =>
-											'controlled||' + clientId
-									)
+				const inserterClientIds = getFlattenedClientIds(
+					action.blocks
+				);
+				newState.tree = new Map( newState.tree );
+				action.replacedClientIds
+					.concat(
+						// Controlled inner blocks are only removed
+						// if the block doesn't move to another position
+						// otherwise their content will be lost.
+						action.replacedClientIds
+							.filter(
+								( clientId ) => ! inserterClientIds[ clientId ]
 							)
-						),
-						...subTree,
-					},
+							.map( ( clientId ) => 'controlled||' + clientId )
+					)
+					.forEach( ( key ) => {
+						newState.tree.delete( key );
+					} );
+
+				updateBlockTreeForBlocks( newState, action.blocks );
+				updateParentInnerBlocksInTree(
+					newState,
 					action.blocks.map( ( b ) => b.clientId ),
 					false
 				);
@@ -343,9 +338,8 @@ const withBlockTree =
 						);
 					}
 				}
-				newState.tree = updateParentInnerBlocksInTree(
+				updateParentInnerBlocksInTree(
 					newState,
-					newState.tree,
 					parentsOfRemovedBlocks,
 					true
 				);
@@ -366,16 +360,18 @@ const withBlockTree =
 						);
 					}
 				}
-				newState.tree = updateParentInnerBlocksInTree(
-					newState,
-					omit(
-						newState.tree,
-						action.removedClientIds.concat(
-							action.removedClientIds.map(
-								( clientId ) => 'controlled||' + clientId
-							)
+				newState.tree = new Map( newState.tree );
+				action.removedClientIds
+					.concat(
+						action.removedClientIds.map(
+							( clientId ) => 'controlled||' + clientId
 						)
-					),
+					)
+					.forEach( ( key ) => {
+						newState.tree.delete( key );
+					} );
+				updateParentInnerBlocksInTree(
+					newState,
 					parentsOfRemovedBlocks,
 					true
 				);
@@ -390,9 +386,9 @@ const withBlockTree =
 				if ( action.toRootClientId ) {
 					updatedBlockUids.push( action.toRootClientId );
 				}
-				newState.tree = updateParentInnerBlocksInTree(
+				newState.tree = new Map( newState.tree );
+				updateParentInnerBlocksInTree(
 					newState,
-					newState.tree,
 					updatedBlockUids,
 					true
 				);
@@ -403,9 +399,9 @@ const withBlockTree =
 				const updatedBlockUids = [
 					action.rootClientId ? action.rootClientId : '',
 				];
-				newState.tree = updateParentInnerBlocksInTree(
+				newState.tree = new Map( newState.tree );
+				updateParentInnerBlocksInTree(
 					newState,
-					newState.tree,
 					updatedBlockUids,
 					true
 				);
@@ -422,21 +418,16 @@ const withBlockTree =
 						updatedBlockUids.push( clientId );
 					}
 				} );
-
-				newState.tree = updateParentInnerBlocksInTree(
+				newState.tree = new Map( newState.tree );
+				updatedBlockUids.forEach( ( clientId ) => {
+					newState.tree.set( clientId, {
+						...newState.byClientId.get( clientId ),
+						attributes: newState.attributes.get( clientId ),
+						innerBlocks: newState.tree.get( clientId ).innerBlocks,
+					} );
+				} );
+				updateParentInnerBlocksInTree(
 					newState,
-					{
-						...newState.tree,
-						...updatedBlockUids.reduce( ( result, clientId ) => {
-							result[ clientId ] = {
-								...newState.byClientId.get( clientId ),
-								attributes: newState.attributes.get( clientId ),
-								innerBlocks:
-									newState.tree[ clientId ].innerBlocks,
-							};
-							return result;
-						}, {} ),
-					},
 					updatedBlockUids,
 					false
 				);
@@ -606,16 +597,13 @@ const withBlockReset = ( reducer ) => ( state, action ) => {
 			controlledInnerBlocks: {},
 		};
 
-		const subTree = buildBlockTree( newState, action.blocks );
-		newState.tree = {
-			...subTree,
-			// Root.
-			'': {
-				innerBlocks: action.blocks.map(
-					( subBlock ) => subTree[ subBlock.clientId ]
-				),
-			},
-		};
+		newState.tree = new Map( state?.tree );
+		updateBlockTreeForBlocks( newState, action.blocks );
+		newState.tree.set( '', {
+			innerBlocks: action.blocks.map( ( subBlock ) =>
+				newState.tree.get( subBlock.clientId )
+			),
+		} );
 
 		return newState;
 	}
@@ -686,16 +674,13 @@ const withReplaceInnerBlocks = ( reducer ) => ( state, action ) => {
 			}
 		} );
 		stateAfterInsert.order = stateAfterInsertOrder;
-		stateAfterInsert.tree = {
-			...stateAfterInsert.tree,
-			...Object.keys( nestedControllers ).reduce( ( result, _key ) => {
-				const key = `controlled||${ _key }`;
-				if ( state.tree[ key ] ) {
-					result[ key ] = state.tree[ key ];
-				}
-				return result;
-			}, {} ),
-		};
+		stateAfterInsert.tree = new Map( stateAfterInsert.tree );
+		Object.keys( nestedControllers ).forEach( ( _key ) => {
+			const key = `controlled||${ _key }`;
+			if ( state.tree.has( key ) ) {
+				stateAfterInsert.tree.set( key, state.tree.get( key ) );
+			}
+		} );
 	}
 	return stateAfterInsert;
 };

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -134,7 +134,7 @@ export function getBlock( state, clientId ) {
 		return null;
 	}
 
-	return state.blocks.tree[ clientId ];
+	return state.blocks.tree.get( clientId );
 }
 
 export const __unstableGetBlockWithoutInnerBlocks = createSelector(
@@ -169,7 +169,7 @@ export function getBlocks( state, rootClientId ) {
 		! rootClientId || ! areInnerBlocksControlled( state, rootClientId )
 			? rootClientId || ''
 			: 'controlled||' + rootClientId;
-	return state.blocks.tree[ treeKey ]?.innerBlocks || EMPTY_ARRAY;
+	return state.blocks.tree.get( treeKey )?.innerBlocks || EMPTY_ARRAY;
 }
 
 /**
@@ -320,7 +320,7 @@ export const getBlocksByClientId = createSelector(
 	( state, clientIds ) =>
 		map(
 			Array.isArray( clientIds ) ? clientIds : [ clientIds ],
-			( clientId ) => state.blocks.tree[ clientId ]
+			( clientId ) => state.blocks.tree.get( clientId )
 		)
 );
 
@@ -2208,7 +2208,7 @@ export const __experimentalGetDirectInsertBlock = createSelector(
 	},
 	( state, rootClientId ) => [
 		state.blockListSettings[ rootClientId ],
-		state.blocks.tree[ rootClientId ],
+		state.blocks.tree.get( rootClientId ),
 	]
 );
 

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -245,11 +245,13 @@ describe( 'state', () => {
 							'chicken-child': 'chicken',
 						} )
 					),
-					tree: {
-						'': {},
-						chicken: {},
-						'chicken-child': {},
-					},
+					tree: new Map(
+						Object.entries( {
+							'': {},
+							chicken: {},
+							'chicken-child': {},
+						} )
+					),
 					controlledInnerBlocks: {},
 				} );
 
@@ -310,8 +312,8 @@ describe( 'state', () => {
 					),
 					controlledInnerBlocks: {},
 				} );
-				expect( state.tree.chicken ).not.toBe(
-					existingState.tree.chicken
+				expect( state.tree.get( 'chicken' ) ).not.toBe(
+					existingState.tree.get( 'chicken' )
 				);
 			} );
 
@@ -342,12 +344,14 @@ describe( 'state', () => {
 							chicken: '',
 						} )
 					),
-					tree: {
-						'': {
-							innerBlocks: [],
-						},
-						chicken: {},
-					},
+					tree: new Map(
+						Object.entries( {
+							'': {
+								innerBlocks: [],
+							},
+							chicken: {},
+						} )
+					),
 					controlledInnerBlocks: {},
 				} );
 
@@ -408,16 +412,16 @@ describe( 'state', () => {
 					),
 					controlledInnerBlocks: {},
 				} );
-				expect( state.tree.chicken ).not.toBe(
-					existingState.tree.chicken
+				expect( state.tree.get( 'chicken' ) ).not.toBe(
+					existingState.tree.get( 'chicken' )
 				);
-				expect( state.tree[ '' ].innerBlocks[ 0 ] ).toBe(
-					state.tree.chicken
+				expect( state.tree.get( '' ).innerBlocks[ 0 ] ).toBe(
+					state.tree.get( 'chicken' )
 				);
-				expect( state.tree.chicken.innerBlocks[ 0 ] ).toBe(
-					state.tree[ newChildBlockId ]
+				expect( state.tree.get( 'chicken' ).innerBlocks[ 0 ] ).toBe(
+					state.tree.get( newChildBlockId )
 				);
-				expect( state.tree[ newChildBlockId ] ).toEqual( {
+				expect( state.tree.get( newChildBlockId ) ).toEqual( {
 					clientId: newChildBlockId,
 					innerBlocks: [],
 					isValid: true,
@@ -476,7 +480,7 @@ describe( 'state', () => {
 							'chicken-child-2': 'chicken',
 						} )
 					),
-					tree: {},
+					tree: new Map(),
 					controlledInnerBlocks: {},
 				} );
 
@@ -574,19 +578,19 @@ describe( 'state', () => {
 					controlledInnerBlocks: {},
 				} );
 
-				expect( state.tree[ '' ].innerBlocks[ 0 ] ).toBe(
-					state.tree.chicken
+				expect( state.tree.get( '' ).innerBlocks[ 0 ] ).toBe(
+					state.tree.get( 'chicken' )
 				);
-				expect( state.tree.chicken.innerBlocks[ 0 ] ).toBe(
-					state.tree[ newChildBlockId1 ]
+				expect( state.tree.get( 'chicken' ).innerBlocks[ 0 ] ).toBe(
+					state.tree.get( newChildBlockId1 )
 				);
-				expect( state.tree.chicken.innerBlocks[ 1 ] ).toBe(
-					state.tree[ newChildBlockId2 ]
+				expect( state.tree.get( 'chicken' ).innerBlocks[ 1 ] ).toBe(
+					state.tree.get( newChildBlockId2 )
 				);
-				expect( state.tree.chicken.innerBlocks[ 2 ] ).toBe(
-					state.tree[ newChildBlockId3 ]
+				expect( state.tree.get( 'chicken' ).innerBlocks[ 2 ] ).toBe(
+					state.tree.get( newChildBlockId3 )
 				);
-				expect( state.tree[ newChildBlockId1 ] ).toEqual( {
+				expect( state.tree.get( newChildBlockId1 ) ).toEqual( {
 					innerBlocks: [],
 					clientId: newChildBlockId1,
 					name: 'core/test-child-block',
@@ -641,9 +645,11 @@ describe( 'state', () => {
 							'chicken-grand-child': 'chicken-child',
 						} )
 					),
-					tree: {
-						chicken: {},
-					},
+					tree: new Map(
+						Object.entries( {
+							chicken: {},
+						} )
+					),
 					controlledInnerBlocks: {},
 				} );
 
@@ -700,8 +706,8 @@ describe( 'state', () => {
 				} );
 
 				// The block object of the parent should be updated.
-				expect( state.tree.chicken ).not.toBe(
-					existingState.tree.chicken
+				expect( state.tree.get( 'chicken' ) ).not.toBe(
+					existingState.tree.get( 'chicken' )
 				);
 			} );
 		} );
@@ -716,7 +722,7 @@ describe( 'state', () => {
 				parents: new Map(),
 				isPersistentChange: true,
 				isIgnoredChange: false,
-				tree: {},
+				tree: new Map(),
 				controlledInnerBlocks: {},
 			} );
 		} );
@@ -736,12 +742,12 @@ describe( 'state', () => {
 					'': [ 'bananas' ],
 					bananas: [],
 				} );
-				expect( state.tree.bananas ).toEqual( {
+				expect( state.tree.get( 'bananas' ) ).toEqual( {
 					clientId: 'bananas',
 					innerBlocks: [],
 				} );
-				expect( state.tree[ '' ].innerBlocks[ 0 ] ).toBe(
-					state.tree.bananas
+				expect( state.tree.get( '' ).innerBlocks[ 0 ] ).toBe(
+					state.tree.get( 'bananas' )
 				);
 			} );
 		} );
@@ -799,11 +805,13 @@ describe( 'state', () => {
 				ribs: [],
 			} );
 
-			expect( state.tree[ '' ].innerBlocks[ 0 ] ).toBe(
-				state.tree.chicken
+			expect( state.tree.get( '' ).innerBlocks[ 0 ] ).toBe(
+				state.tree.get( 'chicken' )
 			);
-			expect( state.tree[ '' ].innerBlocks[ 1 ] ).toBe( state.tree.ribs );
-			expect( state.tree.chicken ).toEqual( {
+			expect( state.tree.get( '' ).innerBlocks[ 1 ] ).toBe(
+				state.tree.get( 'ribs' )
+			);
+			expect( state.tree.get( 'chicken' ) ).toEqual( {
 				clientId: 'chicken',
 				name: 'core/test-block',
 				attributes: {},
@@ -847,10 +855,10 @@ describe( 'state', () => {
 			expect( Object.fromEntries( state.parents ) ).toEqual( {
 				wings: '',
 			} );
-			expect( state.tree[ '' ].innerBlocks[ 0 ] ).toBe(
-				state.tree.wings
+			expect( state.tree.get( '' ).innerBlocks[ 0 ] ).toBe(
+				state.tree.get( 'wings' )
 			);
-			expect( state.tree.wings ).toEqual( {
+			expect( state.tree.get( 'wings' ) ).toEqual( {
 				clientId: 'wings',
 				name: 'core/freeform',
 				innerBlocks: [],
@@ -876,7 +884,7 @@ describe( 'state', () => {
 			} );
 
 			expect( state.byClientId.size ).toBe( 0 );
-			expect( state.tree[ '' ].innerBlocks ).toHaveLength( 0 );
+			expect( state.tree.get( '' ).innerBlocks ).toHaveLength( 0 );
 		} );
 
 		it( 'should replace the block and remove references to its inner blocks', () => {
@@ -918,10 +926,10 @@ describe( 'state', () => {
 			expect( Object.fromEntries( state.parents ) ).toEqual( {
 				wings: '',
 			} );
-			expect( state.tree[ '' ].innerBlocks[ 0 ] ).toBe(
-				state.tree.wings
+			expect( state.tree.get( '' ).innerBlocks[ 0 ] ).toBe(
+				state.tree.get( 'wings' )
 			);
-			expect( state.tree.wings ).toEqual( {
+			expect( state.tree.get( 'wings' ) ).toEqual( {
 				clientId: 'wings',
 				name: 'core/freeform',
 				innerBlocks: [],
@@ -956,10 +964,10 @@ describe( 'state', () => {
 				[ replacementBlock.clientId ]: wrapperBlock.clientId,
 			} );
 
-			expect( state.tree[ wrapperBlock.clientId ].innerBlocks[ 0 ] ).toBe(
-				state.tree[ replacementBlock.clientId ]
-			);
-			expect( state.tree[ replacementBlock.clientId ] ).toEqual( {
+			expect(
+				state.tree.get( wrapperBlock.clientId ).innerBlocks[ 0 ]
+			).toBe( state.tree.get( replacementBlock.clientId ) );
+			expect( state.tree.get( replacementBlock.clientId ) ).toEqual( {
 				clientId: replacementBlock.clientId,
 				name: 'core/test-block',
 				innerBlocks: [],
@@ -1006,8 +1014,8 @@ describe( 'state', () => {
 				'': [ 'chicken' ],
 				chicken: [],
 			} );
-			expect( originalState.tree.chicken ).not.toBe(
-				replacedState.tree.chicken
+			expect( originalState.tree.get( 'chicken' ) ).not.toBe(
+				replacedState.tree.get( 'chicken' )
 			);
 
 			const nestedBlock = {
@@ -1082,10 +1090,10 @@ describe( 'state', () => {
 			expect( state.attributes.get( 'chicken' ) ).toEqual( {
 				content: 'ribs',
 			} );
-			expect( state.tree[ '' ].innerBlocks[ 0 ] ).toBe(
-				state.tree.chicken
+			expect( state.tree.get( '' ).innerBlocks[ 0 ] ).toBe(
+				state.tree.get( 'chicken' )
 			);
-			expect( state.tree.chicken ).toEqual( {
+			expect( state.tree.get( 'chicken' ) ).toEqual( {
 				clientId: 'chicken',
 				name: 'core/test-block',
 				innerBlocks: [],
@@ -1128,10 +1136,10 @@ describe( 'state', () => {
 				ref: 3,
 			} );
 
-			expect( state.tree[ '' ].innerBlocks[ 0 ] ).toBe(
-				state.tree.chicken
+			expect( state.tree.get( '' ).innerBlocks[ 0 ] ).toBe(
+				state.tree.get( 'chicken' )
 			);
-			expect( state.tree.chicken ).toEqual( {
+			expect( state.tree.get( 'chicken' ) ).toEqual( {
 				clientId: 'chicken',
 				name: 'core/block',
 				isValid: false,
@@ -1166,11 +1174,15 @@ describe( 'state', () => {
 			} );
 
 			expect( state.order.get( '' ) ).toEqual( [ 'ribs', 'chicken' ] );
-			expect( state.tree[ '' ].innerBlocks[ 0 ] ).toBe( state.tree.ribs );
-			expect( state.tree[ '' ].innerBlocks[ 1 ] ).toBe(
-				state.tree.chicken
+			expect( state.tree.get( '' ).innerBlocks[ 0 ] ).toBe(
+				state.tree.get( 'ribs' )
 			);
-			expect( state.tree.chicken ).toBe( original.tree.chicken );
+			expect( state.tree.get( '' ).innerBlocks[ 1 ] ).toBe(
+				state.tree.get( 'chicken' )
+			);
+			expect( state.tree.get( 'chicken' ) ).toBe(
+				original.tree.get( 'chicken' )
+			);
 		} );
 
 		it( 'should move the nested block up', () => {
@@ -1200,14 +1212,14 @@ describe( 'state', () => {
 				[ siblingBlock.clientId ]: [],
 			} );
 
-			expect( state.tree[ wrapperBlock.clientId ].innerBlocks[ 0 ] ).toBe(
-				state.tree[ movedBlock.clientId ]
-			);
-			expect( state.tree[ wrapperBlock.clientId ].innerBlocks[ 1 ] ).toBe(
-				state.tree[ siblingBlock.clientId ]
-			);
-			expect( state.tree[ movedBlock.clientId ] ).toBe(
-				original.tree[ movedBlock.clientId ]
+			expect(
+				state.tree.get( wrapperBlock.clientId ).innerBlocks[ 0 ]
+			).toBe( state.tree.get( movedBlock.clientId ) );
+			expect(
+				state.tree.get( wrapperBlock.clientId ).innerBlocks[ 1 ]
+			).toBe( state.tree.get( siblingBlock.clientId ) );
+			expect( state.tree.get( movedBlock.clientId ) ).toBe(
+				original.tree.get( movedBlock.clientId )
 			);
 		} );
 
@@ -1492,7 +1504,7 @@ describe( 'state', () => {
 			expect( Object.fromEntries( state.attributes ) ).toEqual( {
 				ribs: {},
 			} );
-			expect( state.tree[ '' ].innerBlocks ).toHaveLength( 1 );
+			expect( state.tree.get( '' ).innerBlocks ).toHaveLength( 1 );
 		} );
 
 		it( 'should remove multiple blocks', () => {
@@ -2217,8 +2229,10 @@ describe( 'state', () => {
 					expect( state.controlledInnerBlocks.chicken ).toBe( true );
 					// The previous content of the block should be removed
 					expect( state.byClientId.child ).toBeUndefined();
-					expect( state.tree.child ).toBeUndefined();
-					expect( state.tree.chicken.innerBlocks ).toEqual( [] );
+					expect( state.tree.get( 'child' ) ).toBeUndefined();
+					expect( state.tree.get( 'chicken' ).innerBlocks ).toEqual(
+						[]
+					);
 				} );
 				it( 'should preserve the controlled blocks in state and re-attach them in other pieces of state(order, tree, etc..), when we replace inner blocks', () => {
 					const initialState = {
@@ -2259,69 +2273,71 @@ describe( 'state', () => {
 								'paragraph-id': 'reusable-id',
 							} )
 						),
-						tree: {
-							'group-id': {
-								clientId: 'group-id',
-								name: 'core/group',
-								isValid: true,
-								innerBlocks: [
-									{
-										clientId: 'reusable-id',
-										name: 'core/block',
-										isValid: true,
-										attributes: {
-											ref: 687,
-										},
-										innerBlocks: [],
-									},
-								],
-							},
-							'reusable-id': {
-								clientId: 'reusable-id',
-								name: 'core/block',
-								isValid: true,
-								attributes: {
-									ref: 687,
-								},
-								innerBlocks: [],
-							},
-							'': {
-								innerBlocks: [
-									{
-										clientId: 'group-id',
-										name: 'core/group',
-										isValid: true,
-										innerBlocks: [
-											{
-												clientId: 'reusable-id',
-												name: 'core/block',
-												isValid: true,
-												attributes: {
-													ref: 687,
-												},
-												innerBlocks: [],
+						tree: new Map(
+							Object.entries( {
+								'group-id': {
+									clientId: 'group-id',
+									name: 'core/group',
+									isValid: true,
+									innerBlocks: [
+										{
+											clientId: 'reusable-id',
+											name: 'core/block',
+											isValid: true,
+											attributes: {
+												ref: 687,
 											},
-										],
+											innerBlocks: [],
+										},
+									],
+								},
+								'reusable-id': {
+									clientId: 'reusable-id',
+									name: 'core/block',
+									isValid: true,
+									attributes: {
+										ref: 687,
 									},
-								],
-							},
-							'paragraph-id': {
-								clientId: 'paragraph-id',
-								name: 'core/paragraph',
-								isValid: true,
-								innerBlocks: [],
-							},
-							'controlled||reusable-id': {
-								innerBlocks: [
-									{
-										clientId: 'paragraph-id',
-										name: 'core/paragraph',
-										isValid: true,
-										innerBlocks: [],
-									},
-								],
-							},
-						},
+									innerBlocks: [],
+								},
+								'': {
+									innerBlocks: [
+										{
+											clientId: 'group-id',
+											name: 'core/group',
+											isValid: true,
+											innerBlocks: [
+												{
+													clientId: 'reusable-id',
+													name: 'core/block',
+													isValid: true,
+													attributes: {
+														ref: 687,
+													},
+													innerBlocks: [],
+												},
+											],
+										},
+									],
+								},
+								'paragraph-id': {
+									clientId: 'paragraph-id',
+									name: 'core/paragraph',
+									isValid: true,
+									innerBlocks: [],
+								},
+								'controlled||reusable-id': {
+									innerBlocks: [
+										{
+											clientId: 'paragraph-id',
+											name: 'core/paragraph',
+											isValid: true,
+											innerBlocks: [],
+										},
+									],
+								},
+							} )
+						),
 					};
 					// We will dispatch an action that replaces the inner
 					// blocks with the same inner blocks, which contain
@@ -2348,8 +2364,10 @@ describe( 'state', () => {
 							Object.fromEntries( initialState.order )
 						)
 					);
-					expect( state.tree ).toEqual(
-						expect.objectContaining( initialState.tree )
+					expect( Object.fromEntries( state.tree ) ).toEqual(
+						expect.objectContaining(
+							Object.fromEntries( initialState.tree )
+						)
 					);
 				} );
 			} );

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -282,19 +282,23 @@ describe( 'selectors', () => {
 							123: '',
 						} )
 					),
-					tree: {
-						123: {
-							clientId: '123',
-							name: 'core/paragraph',
-							attributes: {},
-							innerBlocks: [],
-						},
-					},
+					tree: new Map(
+						Object.entries( {
+							123: {
+								clientId: '123',
+								name: 'core/paragraph',
+								attributes: {},
+								innerBlocks: [],
+							},
+						} )
+					),
 					controlledInnerBlocks: {},
 				},
 			};
 
-			expect( getBlock( state, '123' ) ).toBe( state.blocks.tree[ 123 ] );
+			expect( getBlock( state, '123' ) ).toBe(
+				state.blocks.tree.get( '123' )
+			);
 		} );
 
 		it( 'should return null if the block is not present in state', () => {
@@ -304,14 +308,16 @@ describe( 'selectors', () => {
 					attributes: new Map(),
 					order: new Map(),
 					parents: new Map(),
-					tree: {
-						123: {
-							clientId: '123',
-							name: 'core/paragraph',
-							attributes: {},
-							innerBlocks: [],
-						},
-					},
+					tree: new Map(
+						Object.entries( {
+							123: {
+								clientId: '123',
+								name: 'core/paragraph',
+								attributes: {},
+								innerBlocks: [],
+							},
+						} )
+					),
 					controlledInnerBlocks: {},
 				},
 			};
@@ -347,32 +353,34 @@ describe( 'selectors', () => {
 							23: '',
 						} )
 					),
-					tree: {
-						'': {
-							innerBlocks: [
-								{
-									clientId: '123',
-									name: 'core/paragraph',
-									attributes: {},
-									innerBlocks: [],
-								},
-								{
-									clientId: '23',
-									name: 'core/heading',
-									attributes: {},
-									innerBlocks: [],
-								},
-							],
-						},
-						123: {},
-						23: {},
-					},
+					tree: new Map(
+						Object.entries( {
+							'': {
+								innerBlocks: [
+									{
+										clientId: '123',
+										name: 'core/paragraph',
+										attributes: {},
+										innerBlocks: [],
+									},
+									{
+										clientId: '23',
+										name: 'core/heading',
+										attributes: {},
+										innerBlocks: [],
+									},
+								],
+							},
+							123: {},
+							23: {},
+						} )
+					),
 					controlledInnerBlocks: {},
 				},
 			};
 
 			expect( getBlocks( state ) ).toBe(
-				state.blocks.tree[ '' ].innerBlocks
+				state.blocks.tree.get( '' ).innerBlocks
 			);
 		} );
 	} );
@@ -1102,14 +1110,16 @@ describe( 'selectors', () => {
 							123: '',
 						} )
 					),
-					tree: {
-						23: {
-							clientId: '23',
-							name: 'core/heading',
-							attributes: {},
-							innerBlocks: [],
-						},
-					},
+					tree: new Map(
+						Object.entries( {
+							23: {
+								clientId: '23',
+								name: 'core/heading',
+								attributes: {},
+								innerBlocks: [],
+							},
+						} )
+					),
 				},
 				selection: {
 					selectionStart: {},
@@ -1148,14 +1158,16 @@ describe( 'selectors', () => {
 							23: '',
 						} )
 					),
-					tree: {
-						23: {
-							clientId: '23',
-							name: 'core/heading',
-							attributes: {},
-							innerBlocks: [],
-						},
-					},
+					tree: new Map(
+						Object.entries( {
+							23: {
+								clientId: '23',
+								name: 'core/heading',
+								attributes: {},
+								innerBlocks: [],
+							},
+						} )
+					),
 				},
 				selection: {
 					selectionStart: { clientId: '23' },
@@ -1194,14 +1206,16 @@ describe( 'selectors', () => {
 							23: '',
 						} )
 					),
-					tree: {
-						23: {
-							clientId: '23',
-							name: 'core/heading',
-							attributes: {},
-							innerBlocks: [],
-						},
-					},
+					tree: new Map(
+						Object.entries( {
+							23: {
+								clientId: '23',
+								name: 'core/heading',
+								attributes: {},
+								innerBlocks: [],
+							},
+						} )
+					),
 					controlledInnerBlocks: {},
 				},
 				selection: {
@@ -3183,11 +3197,13 @@ describe( 'selectors', () => {
 					attributes: new Map(),
 					order: new Map(),
 					parents: new Map(),
-					tree: {
-						'': {
-							innerBlocks: [],
-						},
-					},
+					tree: new Map(
+						Object.entries( {
+							'': {
+								innerBlocks: [],
+							},
+						} )
+					),
 				},
 				settings: {
 					__experimentalReusableBlocks: [
@@ -3271,20 +3287,22 @@ describe( 'selectors', () => {
 							block4: '',
 						} )
 					),
-					tree: {
-						block3: {
-							clientId: 'block3',
-							name: 'core/test-block-a',
-							attributes: {},
-							innerBlocks: [],
-						},
-						block4: {
-							clientId: 'block4',
-							name: 'core/test-block-a',
-							attributes: {},
-							innerBlocks: [],
-						},
-					},
+					tree: new Map(
+						Object.entries( {
+							block3: {
+								clientId: 'block3',
+								name: 'core/test-block-a',
+								attributes: {},
+								innerBlocks: [],
+							},
+							block4: {
+								clientId: 'block4',
+								name: 'core/test-block-a',
+								attributes: {},
+								innerBlocks: [],
+							},
+						} )
+					),
 					controlledInnerBlocks: {},
 				},
 				settings: {
@@ -3381,14 +3399,16 @@ describe( 'selectors', () => {
 							'': [ 'block1' ],
 						} )
 					),
-					tree: {
-						block1: {
-							clientId: 'block1',
-							name: 'core/test-block-b',
-							attributes: {},
-							innerBlocks: [],
-						},
-					},
+					tree: new Map(
+						Object.entries( {
+							block1: {
+								clientId: 'block1',
+								name: 'core/test-block-b',
+								attributes: {},
+								innerBlocks: [],
+							},
+						} )
+					),
 					controlledInnerBlocks: {},
 					parents: new Map(),
 				},
@@ -3619,14 +3639,16 @@ describe( 'selectors', () => {
 							'': [ 'block1' ],
 						} )
 					),
-					tree: {
-						block1: {
-							clientId: 'block1',
-							name: 'core/with-tranforms-c',
-							attributes: {},
-							innerBlocks: [],
-						},
-					},
+					tree: new Map(
+						Object.entries( {
+							block1: {
+								clientId: 'block1',
+								name: 'core/with-tranforms-c',
+								attributes: {},
+								innerBlocks: [],
+							},
+						} )
+					),
 					controlledInnerBlocks: {},
 					parents: new Map(),
 				},


### PR DESCRIPTION
Similar to #46204 #46221 #46225 and #46146

Following a similar approach to the previous PRs, I tried to see how refactoring the parents state from plain objects to maps could impact the performance. Here are the results I got:

Before:

<img width="484" alt="Screenshot 2022-12-01 at 2 25 21 PM" src="https://user-images.githubusercontent.com/272444/205064337-d978c760-555d-4c33-b02b-94987b0ea78a.png">

After:

<img width="483" alt="Screenshot 2022-12-01 at 2 24 40 PM" src="https://user-images.githubusercontent.com/272444/205064402-91be4f07-824a-42ec-ae0a-20f2b46dc4aa.png">

