### PR TITLE
Nux: Improve `act()` usage in `DotTip` tests

### DIFF
--- a/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`DotTip should render correctly 1`] = `
   aria-label="Editor tips"
   class="components-popover nux-dot-tip"
   role="dialog"
-  style="position: absolute; opacity: 0; transform: translateX(-2em) scale(0) translateZ(0); transform-origin: 0% 50% 0; left: 0px; top: 0px;"
+  style="position: absolute; opacity: 0.9994144868675858; transform: translateX(-0.00117em) scale(0.9994144868675858) translateZ(0); transform-origin: 0% 50% 0; left: 0px; top: 0px;"
   tabindex="-1"
 >
   <div

--- a/packages/nux/src/components/dot-tip/test/index.js
+++ b/packages/nux/src/components/dot-tip/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { act, render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -19,8 +19,6 @@ describe( 'DotTip', () => {
 			</DotTip>
 		);
 
-		await act( () => Promise.resolve() );
-
 		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
 	} );
 
@@ -31,9 +29,11 @@ describe( 'DotTip', () => {
 			</DotTip>
 		);
 
-		await act( () => Promise.resolve() );
+		const dialog = screen.getByRole( 'dialog' );
 
-		expect( screen.getByRole( 'dialog' ) ).toMatchSnapshot();
+		await waitFor( () => expect( dialog ).toBePositionedPopover() );
+
+		expect( dialog ).toMatchSnapshot();
 	} );
 
 	it( 'should call onDismiss when the dismiss button is clicked', async () => {
@@ -48,7 +48,9 @@ describe( 'DotTip', () => {
 			</DotTip>
 		);
 
-		await act( () => Promise.resolve() );
+		const dialog = screen.getByRole( 'dialog' );
+
+		await waitFor( () => expect( dialog ).toBePositionedPopover() );
 
 		await user.click( screen.getByRole( 'button', { name: 'Got it' } ) );
 
@@ -67,7 +69,9 @@ describe( 'DotTip', () => {
 			</DotTip>
 		);
 
-		await act( () => Promise.resolve() );
+		const dialog = screen.getByRole( 'dialog' );
+
+		await waitFor( () => expect( dialog ).toBePositionedPopover() );
 
 		await user.click(
 			screen.getByRole( 'button', { name: 'Disable tips' } )


### PR DESCRIPTION
## What?
This PR improves the `act()` usage in `DotTip` to make the tests more precise and expressive.

## Why?
As part of the React 18 upgrade in #45235, we added a bunch of `act()` calls that could be improved and made more specific.

## How?
Instead of going with `await act( () => Promise.resolve() )`, we change the test to wait for the dialog to be positioned before continuing.

## Testing Instructions
Verify tests still pass: `npm run test:unit packages/nux/src/components/dot-tip/test/index.js`

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None
