### PR TITLE
Add a `has_class` method to the public WP_HTML_Tag_Processor API

### DIFF
--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1386,7 +1386,9 @@ class WP_HTML_Tag_Processor {
 			return false;
 		}
 
-		return $this->string_contains_a_class_name( $sought_class_name, $classes );
+		$escaped_sought_class_name = preg_quote( $sought_class_name );
+
+		return 1 === preg_match( "#(?:[\n\r\f\t ]|^)$escaped_sought_class_name(?:[\n\r\f\t ]|$)#", $classes );
 	}
 
 	/**
@@ -1589,96 +1591,61 @@ class WP_HTML_Tag_Processor {
 
 		// Do we match a byte-for-byte (case-sensitive and encoding-form-sensitive) class name?
 		if ( $needs_class_name ) {
-			return $this->string_contains_a_class_name(
-				$this->sought_class_name,
-				$this->html,
-				$this->attributes['class']->value_starts_at,
-				$this->attributes['class']->value_starts_at + $this->attributes['class']->value_length
-			);
+			$class_start = $this->attributes['class']->value_starts_at;
+			$class_end   = $class_start + $this->attributes['class']->value_length;
+			$class_at    = $class_start;
+
+			/*
+			 * We're going to have to jump through potential matches here because
+			 * it's possible that we have classes containing the class name we're
+			 * looking for. For instance, if we are looking for "even" we don't
+			 * want to be confused when we come to the class "not-even." This is
+			 * secured by ensuring that we find our sought-after class and that
+			 * it's surrounded on both sides by proper boundaries.
+			 *
+			 * See https://html.spec.whatwg.org/#attributes-3
+			 * See https://html.spec.whatwg.org/#space-separated-tokens
+			 */
+			while (
+				// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+				false !== ( $class_at = strpos( $this->html, $this->sought_class_name, $class_at ) ) &&
+				$class_at < $class_end
+			) {
+				/*
+				 * Verify this class starts at a boundary. If it were at 0 we'd be at
+				 * the start of the string and that would be fine, otherwise we have
+				 * to start at a place where the preceding character is whitespace.
+				 */
+				if ( $class_at > $class_start ) {
+					$character = $this->html[ $class_at - 1 ];
+
+					if ( ' ' !== $character && "\t" !== $character && "\f" !== $character && "\r" !== $character && "\n" !== $character ) {
+						$class_at += strlen( $this->sought_class_name );
+						continue;
+					}
+				}
+
+				/*
+				 * Similarly, verify this class ends at a boundary as well. Here we
+				 * can end at the very end of the string value, otherwise we have
+				 * to end at a place where the next character is whitespace.
+				 */
+				if ( $class_at + strlen( $this->sought_class_name ) < $class_end ) {
+					$character = $this->html[ $class_at + strlen( $this->sought_class_name ) ];
+
+					if ( ' ' !== $character && "\t" !== $character && "\f" !== $character && "\r" !== $character && "\n" !== $character ) {
+						$class_at += strlen( $this->sought_class_name );
+						continue;
+					}
+				}
+
+				return true;
+			}
+
+			return false;
 		}
 
 		return true;
-	}
-
-	/**
-	 * Tests whether the HTML class attribute contains a given CSS class name.
-	 *
-	 * Example:
-	 * ```php
-	 *     $this->string_contains_a_class_name( 'bold', 'button bold' );
-	 *     // true
-	 *
-	 *     $this->string_contains_a_class_name( 'italic', 'button bold' );
-	 *     // false
-	 *
-	 *     $this->string_contains_a_class_name( 'bold', '<a class="button bold"></a>', 10, 21 );
-	 *     // true
-	 *
-	 *     $this->string_contains_a_class_name( 'a', '<a class="button bold"></a>', 10, 21 );
-	 *     // false
-	 * ```
-	 *
-	 * @param string $sought_class_name The class name to test for.
-	 * @param string $lookup_string     The string to search in. This could be just the value of an HTML
-	 *                                  class" attribute, or an entire HTML markup if the $start_lookup_at
-	 *                                  and $end_lookup_at arguments are used.
-	 * @param string $start_lookup_at   Optional. The string offset to consider as a start of the HTML "class"
-	 *                                  attribute value. Default: 0.
-	 * @param string $end_lookup_at     Optional. The string offset to consider as an end of the HTML "class"
-	 *                                  attribute value. Defaults to the length of $class_attribute_value.
-	 */
-	private function string_contains_a_class_name( $sought_class_name, $lookup_string, $start_lookup_at = 0, $end_lookup_at = null ) {
-		/*
-		 * We're going to have to jump through potential matches here because
-		 * it's possible that we have classes containing the class name we're
-		 * looking for. For instance, if we are looking for "even" we don't
-		 * want to be confused when we come to the class "not-even." This is
-		 * secured by ensuring that we find our sought-after class and that
-		 * it's surrounded on both sides by proper boundaries.
-		 *
-		 * See https://html.spec.whatwg.org/#attributes-3
-		 * See https://html.spec.whatwg.org/#space-separated-tokens
-		 */
-		$class_at    = $start_lookup_at;
-		$class_start = $start_lookup_at;
-		$class_end   = null === $end_lookup_at ? strlen( $lookup_string ) : $end_lookup_at;
-		while (
-			// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
-			false !== ( $class_at = strpos( $lookup_string, $sought_class_name, $class_at ) ) &&
-			$class_at < $class_end
-		) {
-			/*
-			 * Verify this class starts at a boundary. If it were at 0 we'd be at
-			 * the start of the string and that would be fine, otherwise we have
-			 * to start at a place where the preceding character is whitespace.
-			 */
-			if ( $class_at > $class_start ) {
-				$character = $lookup_string[ $class_at - 1 ];
-
-				if ( ' ' !== $character && "\t" !== $character && "\f" !== $character && "\r" !== $character && "\n" !== $character ) {
-					$class_at += strlen( $sought_class_name );
-					continue;
-				}
-			}
-
-			/*
-			 * Similarly, verify this class ends at a boundary as well. Here we
-			 * can end at the very end of the string value, otherwise we have
-			 * to end at a place where the next character is whitespace.
-			 */
-			if ( $class_at + strlen( $sought_class_name ) < $class_end ) {
-				$character = $lookup_string[ $class_at + strlen( $sought_class_name ) ];
-
-				if ( ' ' !== $character && "\t" !== $character && "\f" !== $character && "\r" !== $character && "\n" !== $character ) {
-					$class_at += strlen( $sought_class_name );
-					continue;
-				}
-			}
-
-			return true;
-		}
-
-		return false;
 	}
 
 }

--- a/phpunit/html/wp-html-tag-processor-test.php
+++ b/phpunit/html/wp-html-tag-processor-test.php
@@ -1094,6 +1094,102 @@ HTML;
 		);
 	}
 
+
+	/**
+	 * @ticket 56299
+	 *
+	 * @dataProvider data_has_class
+	 * @covers has_class
+	 */
+	public function test_has_class_checks_whether_a_css_class_is_found_in_the_class_attribute( $html_input, $is_found ) {
+		$p = new WP_HTML_Tag_Processor( $html_input );
+		$p->next_tag();
+		if ( $is_found ) {
+			$this->assertTrue( $p->has_class( 'is-foo' ) );
+		} else {
+			$this->assertFalse( $p->has_class( 'is-foo' ) );
+		}
+	}
+
+	/**
+	 * Data provider for test_updates_when_malformed_tag().
+	 *
+	 * @return array {
+	 *     @type array {
+	 *         @type string $html_input  The HTML snippet where the first element will be tested for the presence of a is-foo CSS class.
+	 *         @type boolean $is_found   Whether the is-foo CSS class should be found.
+	 *     }
+	 * }
+	 */
+	public function data_has_class() {
+		$examples                                  = array();
+		$examples['A single class name, matching'] = array(
+			'<div class="is-foo"></div>',
+			true,
+		);
+
+		$examples['A single class names, non-matching'] = array(
+			'<div class="is-bar"></div>',
+			false,
+		);
+
+		$examples['Two class name, match class at the start boundary'] = array(
+			'<div class="is-foo is-bar"></div>',
+			true,
+		);
+
+		$examples['Two class name, match class at the end boundary'] = array(
+			'<div class="is-foo is-bar"></div>',
+			true,
+		);
+
+		$examples['Two class names, none matching'] = array(
+			'<div class="is-bar is-none"></div>',
+			false,
+		);
+
+		$examples['A single class name, non-matching, is-foo in the class name'] = array(
+			'<div class="is-foo-bar"></div>',
+			false,
+		);
+
+		$examples['Two class names, non-matching, is-foo in the class name at the start boundary'] = array(
+			'<div class="is-foo-bar is-bar"></div>',
+			false,
+		);
+
+		$examples['Two class names, non-matching, is-foo in the class name at the end boundary'] = array(
+			'<div class="is-bar is-foo-bar"></div>',
+			false,
+		);
+
+		$examples['Two class names, non-matching, separated by a tab character'] = array(
+			"<div class='is-bar\tis-foo-bar'></div>",
+			false,
+		);
+
+		$examples['Two class names, matching, separated by a tab character'] = array(
+			"<div class='is-bar\tis-foo'></div>",
+			true,
+		);
+
+		$examples['Three class names, matching, using \\t and \\r as class separators'] = array(
+			"<div class='is-bar\tis-foo\ris-another-class'></div>",
+			true,
+		);
+
+		$examples['Three class names, matching, using \\f and \\n as class separators'] = array(
+			"<div class='is-bar\tis-foo\ris-another-class'></div>",
+			true,
+		);
+
+		$examples['Three class names, matching, using a space and \\r as class separators'] = array(
+			"<div class='is-bar is-foo\ris-another-class'></div>",
+			true,
+		);
+		return $examples;
+	}
+
 	/**
 	 * @ticket 56299
 	 *


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/44410

## What?

Adds a `has_class` method to WP_HTML_Tag_Processor to provide an idiomatic, nuance-aware way of testing for the presence of a CSS class name:

```php
// <div class="is-foo"></div>
$tags->has_class( 'is-foo' ); // true

// <div class="is-foo"></div>
$tags->has_class( 'not-is-foo' ); // false

// <div class="is-bar"></div>
$tags->has_class( 'is-foo' ); // false

// is-bar\tis-foo\ris-another-class'></div>
$tags->has_class( 'is-foo' ); // true
```

## Testing Instructions

* Confirm the unit tests pass
* Confirm the code is sound

cc @dmsnell @getdave @aristath 