### PR TITLE
withFilters: Use 'act' from React Testing Library

### DIFF
--- a/packages/components/src/higher-order/with-filters/test/index.js
+++ b/packages/components/src/higher-order/with-filters/test/index.js
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 /**
  * WordPress dependencies
  */
 import { addFilter, removeAllFilters, removeFilter } from '@wordpress/hooks';
-import { act } from 'react-test-renderer';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
## What?
Updates `withFilters` HOC tests to use `act` from RTL

## Why?
Since the RTL is our main testing library we should use the `act` method provided by it.

## Testing Instructions

```
packages/components/src/higher-order/with-filters/test/index.js
```