### PR TITLE
Block Editor: Fix memoized pattern selector dependant arguments

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2333,7 +2333,7 @@ export const __experimentalGetPatternsByBlockTypes = createSelector(
 			)
 		);
 	},
-	( state, rootClientId ) => [
+	( state, blockNames, rootClientId ) => [
 		...__experimentalGetAllowedPatterns.getDependants(
 			state,
 			rootClientId
@@ -2394,7 +2394,7 @@ export const __experimentalGetPatternTransformItems = createSelector(
 			rootClientId
 		);
 	},
-	( state, rootClientId ) => [
+	( state, blocks, rootClientId ) => [
 		...__experimentalGetPatternsByBlockTypes.getDependants(
 			state,
 			rootClientId


### PR DESCRIPTION
## What?
I noticed while reviewing #46226.

PR fixes `__experimentalGetPatternsByBlockTypes` and `__experimentalGetPatternTransformItems` to use the correct argument for `rootClientId`.

## Testing Instructions
```
npm run test:unit packages/block-editor/src/store/test/selectors.js
```
