### PR TITLE
Tests: Fix `toBePositionedPopover` matcher message function

### DIFF
--- a/test/unit/config/matchers/to-be-positioned-popover.js
+++ b/test/unit/config/matchers/to-be-positioned-popover.js
@@ -8,7 +8,7 @@ function toBePositionedPopover( element ) {
 	const pass = element.style.top !== '' && element.style.left !== '';
 	return {
 		pass,
-		message: () => `Received element is ${ pass ? '' : ' not' }positioned`,
+		message: () => `Received element is ${ pass ? '' : 'not ' }positioned`,
 	};
 }
 

--- a/test/unit/config/matchers/to-be-positioned-popover.js
+++ b/test/unit/config/matchers/to-be-positioned-popover.js
@@ -8,7 +8,7 @@ function toBePositionedPopover( element ) {
 	const pass = element.style.top !== '' && element.style.left !== '';
 	return {
 		pass,
-		message: `Received element is ${ pass ? '' : 'not ' } positioned`,
+		message: () => `Received element is ${ pass ? '' : ' not' }positioned`,
 	};
 }
 


### PR DESCRIPTION
## What?
This PR fixes the `toBePositionedPopover()` matcher message.

## Why?
It's currently broken. As per [docs](https://jestjs.io/docs/expect#custom-matchers-api) message should be a function and not a string.

## How?
We're making the message a function, and addressing the double space that was appearing in the case of error.

## Testing Instructions
* Apply this diff:

```
diff --git a/packages/components/src/toggle-group-control/test/index.tsx b/packages/components/src/toggle-group-control/test/index.tsx
index 841ca8fd6b..459c9897a7 100644
--- a/packages/components/src/toggle-group-control/test/index.tsx
+++ b/packages/components/src/toggle-group-control/test/index.tsx
@@ -125,6 +125,10 @@ describe( 'ToggleGroupControl', () => {
                        ).toBePositionedPopover()
                );

+                       expect(
+                               getWrappingPopoverElement( tooltip )
+                       ).not.toBePositionedPopover()
+
                expect( tooltip ).toBeVisible();
        } );
```
* Run `npm run test:unit packages/components/src/toggle-group-control/test/index.tsx`
* Verify you can see the proper error message as in the screenshot below.

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2022-12-01 at 17 25 31](https://user-images.githubusercontent.com/8436925/205091988-479a4628-b443-413e-a19b-5e5fdedd848e.png)
