### PR TITLE
Adds Github Action to validate Gradle Wrapper

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,10 @@
+name: 'Validate Gradle Wrapper'
+on: [push, pull_request]
+
+jobs:
+    validation:
+        name: 'Validation'
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR adds the [official Github Action](https://github.com/gradle/wrapper-validation-action) to validate the [Gradle Wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html)'s in the project.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

These binaries are subject to supply chain attacks. You can find more information about them in the [README of the Github Action](https://github.com/gradle/wrapper-validation-action/blob/master/README.md).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Verify that the new Github Action - labeled as `Validate Gradle Wrapper` - is successful.
