### PR TITLE
fix for core/read-more block missing in schema

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -807,6 +807,9 @@
 				"core/quote": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
+				"core/read-more": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
 				"core/rss": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
fix for core/read-more block missing in schema