### PR TITLE
Child Layout: Remove flex-shrink rule

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -337,9 +337,8 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 			$child_layout_styles[] = array(
 				'selector'     => ".$container_content_class",
 				'declarations' => array(
-					'flex-shrink' => '0',
-					'flex-basis'  => $block['attrs']['style']['layout']['flexSize'],
-					'box-sizing'  => 'border-box',
+					'flex-basis' => $block['attrs']['style']['layout']['flexSize'],
+					'box-sizing' => 'border-box',
 				),
 			);
 		} elseif ( 'fill' === $block['attrs']['style']['layout']['selfStretch'] ) {

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -444,7 +444,6 @@ export const withChildLayoutStyles = createHigherOrderComponent(
 
 		if ( selfStretch === 'fixed' && flexSize ) {
 			css += `${ selector } {
-				flex-shrink: 0;
 				flex-basis: ${ flexSize };
 				box-sizing: border-box;
 			}`;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR splits out the `flex-shrink` removal from #46139, in case it's desirable to land that change before dealing with the `flex-basis` default value, which is being discussed in that PR.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The change in #46139 has some nuance surrounding what to do with pre-populating `flex-basis` values, so it might be easier to try to land the `flex-shrink` removal first. Removing `flex-shrink` was discussed earlier over in: https://github.com/WordPress/gutenberg/pull/45364#issuecomment-1327736069

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Remove `flex-shrink` rule from `layout.php` and `layout.js` when outputting the `flexSize` value.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a Row block to a post and add a couple of child blocks in it;
2. Select a child block and under "Dimensions" in the sidebar select "Width";
3. Set width to "fixed", add a fixed size e.g. 500px in the input, save;
4. Verify that on a small viewport the fixed width block shrinks and doesn't overflow it.

## Screenshots or screencast <!-- if applicable -->

| Desktop (block is set to `500px`) | Mobile (block shrinks to fill available space) |
| --- | --- |
| <img width="655" alt="image" src="https://user-images.githubusercontent.com/14988353/205190211-d9aeea29-1b5e-46cc-accc-6e454662ccb9.png"> | <img width="374" alt="image" src="https://user-images.githubusercontent.com/14988353/205190244-7f1a04e6-6cef-471e-a50d-eb061607565e.png"> |
