### PR TITLE
Move stripHTML into LinkControl

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -10,7 +10,8 @@ import { Button, Spinner, Notice, TextControl } from '@wordpress/components';
 import { keyboardReturn } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { useRef, useState, useEffect } from '@wordpress/element';
-import { focus } from '@wordpress/dom';
+import { focus, __unstableStripHTML as stripHTML } from '@wordpress/dom';
+
 import { ENTER } from '@wordpress/keycodes';
 
 /**
@@ -274,7 +275,7 @@ function LinkControl( {
 								ref={ textInputRef }
 								className="block-editor-link-control__field block-editor-link-control__text-content"
 								label="Text"
-								value={ internalTextInputValue }
+								value={ stripHTML( internalTextInputValue ) }
 								onChange={ setInternalTextInputValue }
 								onKeyDown={ handleSubmitWithEnter }
 							/>

--- a/packages/block-editor/src/components/off-canvas-editor/link-ui.js
+++ b/packages/block-editor/src/components/off-canvas-editor/link-ui.js
@@ -3,7 +3,6 @@
 /**
  * WordPress dependencies
  */
-import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { Popover, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { switchToBlockType } from '@wordpress/blocks';

--- a/packages/block-editor/src/components/off-canvas-editor/link-ui.js
+++ b/packages/block-editor/src/components/off-canvas-editor/link-ui.js
@@ -128,7 +128,7 @@ export function LinkUI( props ) {
 	const link = {
 		url,
 		opensInNewTab,
-		title: label && stripHTML( label ),
+		title: label,
 	};
 
 	return (

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -155,7 +155,7 @@ export function LinkUI( props ) {
 	const link = {
 		url,
 		opensInNewTab,
-		title: label && stripHTML( label ),
+		title: label,
 	};
 
 	return (

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { Popover, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import {

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -37,10 +37,7 @@ import {
 	useRef,
 	createInterpolateElement,
 } from '@wordpress/element';
-import {
-	placeCaretAtHorizontalEdge,
-	__unstableStripHTML as stripHTML,
-} from '@wordpress/dom';
+import { placeCaretAtHorizontalEdge } from '@wordpress/dom';
 import { link as linkIcon, removeSubmenu } from '@wordpress/icons';
 import {
 	useResourcePermissions,
@@ -287,7 +284,7 @@ export default function NavigationSubmenuEdit( {
 	const { label, type, opensInNewTab, url, description, rel, title, kind } =
 		attributes;
 	const link = {
-		title: label && stripHTML( label ),
+		title: label,
 		url,
 		opensInNewTab,
 	};

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -287,7 +287,7 @@ export default function NavigationSubmenuEdit( {
 	const { label, type, opensInNewTab, url, description, rel, title, kind } =
 		attributes;
 	const link = {
-		title: label,
+		title: label && stripHTML( label ),
 		url,
 		opensInNewTab,
 	};

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -287,7 +287,7 @@ export default function NavigationSubmenuEdit( {
 	const { label, type, opensInNewTab, url, description, rel, title, kind } =
 		attributes;
 	const link = {
-		title: label && stripHTML( label ),
+		title: label,
 		url,
 		opensInNewTab,
 	};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

This is in draft until #46243 is merged and the base can be changed to `trunk`

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up to #46243

Refactors `LinkControl` to include the `stripHTML` call where the value is displayed in the text input.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We don't want to see the html tags in the text input if they have been set in the block editor canvas.

<!-- ## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In the navigation bold or italic links and submenus.
2. In the link UI for the navigation link, navigation submenu, and list view appender don't show the tags for italicizing or bolding the link or submenu.

<!-- ### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

![submenu link ui](https://user-images.githubusercontent.com/5129775/205103585-bc2a642a-c6c5-4370-9703-954e6e63f8ac.png)