### PR TITLE
List View: Use default parameters instead of defaultProps

### DIFF
--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -79,10 +79,12 @@ const countReducer =
 		return count + 1;
 	};
 
+const noop = () => {};
+
 function ListViewBranch( props ) {
 	const {
 		blocks,
-		selectBlock = () => {},
+		selectBlock = noop,
 		showBlockMovers,
 		selectedClientIds,
 		level = 1,

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -7,9 +7,6 @@ import { AsyncModeProvider, useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-/**
- * Internal dependencies
- */
 import ListViewBlock from './block';
 import { useListViewContext } from './context';
 import { isClientIdSelected } from './utils';

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -82,7 +82,7 @@ const countReducer =
 function ListViewBranch( props ) {
 	const {
 		blocks,
-		selectBlock,
+		selectBlock = () => {},
 		showBlockMovers,
 		selectedClientIds,
 		level = 1,
@@ -214,9 +214,5 @@ function ListViewBranch( props ) {
 		</>
 	);
 }
-
-ListViewBranch.defaultProps = {
-	selectBlock: () => {},
-};
 
 export default memo( ListViewBranch );

--- a/packages/block-editor/src/components/off-canvas-editor/branch.js
+++ b/packages/block-editor/src/components/off-canvas-editor/branch.js
@@ -75,10 +75,12 @@ const countReducer =
 		return count + 1;
 	};
 
+const noop = () => {};
+
 function ListViewBranch( props ) {
 	const {
 		blocks,
-		selectBlock = () => {},
+		selectBlock = noop,
 		showBlockMovers,
 		selectedClientIds,
 		level = 1,

--- a/packages/block-editor/src/components/off-canvas-editor/branch.js
+++ b/packages/block-editor/src/components/off-canvas-editor/branch.js
@@ -78,7 +78,7 @@ const countReducer =
 function ListViewBranch( props ) {
 	const {
 		blocks,
-		selectBlock,
+		selectBlock = () => {},
 		showBlockMovers,
 		selectedClientIds,
 		level = 1,
@@ -202,9 +202,5 @@ function ListViewBranch( props ) {
 		</>
 	);
 }
-
-ListViewBranch.defaultProps = {
-	selectBlock: () => {},
-};
 
 export default memo( ListViewBranch );


### PR DESCRIPTION
## What?
PR updates `ListViewBranch` to use ES6 default function parameters instead of `defaultProps`.

## Why?
All other defaults are defined using this method, and `defaultProps` for the functional components is getting deprecated. See https://github.com/facebook/react/pull/25699/.

## Testing Instructions
CI checks are green.
