### PR TITLE
Summary panel: Try improving spacing and grid.

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-schedule/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-schedule/style.scss
@@ -7,13 +7,14 @@
 		display: block;
 		width: 45%;
 		flex-shrink: 0;
+		// Match padding on tertiary buttons for alignment.
+		padding: $grid-unit-15 * 0.5 0;
 	}
 }
 
 .components-button.edit-post-post-schedule__toggle {
 	text-align: left;
 	white-space: normal;
-	height: auto;
 
 	// This span is added by the Popover in Tooltip when no anchor is
 	// provided. We set its width to 0 so that it does not cause the button text

--- a/packages/edit-post/src/components/sidebar/post-status/index.js
+++ b/packages/edit-post/src/components/sidebar/post-status/index.js
@@ -40,8 +40,8 @@ function PostStatus( { isOpened, onTogglePanel } ) {
 					<>
 						<PostVisibility />
 						<PostSchedule />
-						<PostURL />
 						<PostTemplate />
+						<PostURL />
 						<PostSticky />
 						<PostPendingStatus />
 						<PostFormat />

--- a/packages/edit-post/src/components/sidebar/post-template/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-template/style.scss
@@ -5,6 +5,8 @@
 	span {
 		display: block;
 		width: 45%;
+		// Match padding on tertiary buttons for alignment.
+		padding: $grid-unit-15 * 0.5 0;
 	}
 }
 

--- a/packages/edit-post/src/components/sidebar/post-url/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-url/style.scss
@@ -1,11 +1,14 @@
 .edit-post-post-url {
 	width: 100%;
 	justify-content: flex-start;
+	align-items: flex-start;
 
 	span {
 		display: block;
 		width: 45%;
 		flex-shrink: 0;
+		// Match padding on tertiary buttons for alignment.
+		padding: $grid-unit-15 * 0.5 0;
 	}
 }
 

--- a/packages/edit-post/src/components/sidebar/post-visibility/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-visibility/style.scss
@@ -5,6 +5,8 @@
 	span {
 		display: block;
 		width: 45%;
+		// Match padding on tertiary buttons for alignment.
+		padding: $grid-unit-15 * 0.5 0;
 	}
 }
 


### PR DESCRIPTION
## What?

The grid of items in the Summary grid are not spaced evenly:

![summary before](https://user-images.githubusercontent.com/1204802/205258224-8c65d390-94d2-4a28-9d98-90c01a388e07.gif)

* The URL item is vertically centered against a wrapping URL
* The button padding for status items is uneven

This PR tries to improve that to space things better:

![after](https://user-images.githubusercontent.com/1204802/205258370-f7c099ab-c77d-40d6-a08f-19bc473a2910.gif)

* The URL label is aligned to the top, to match the first line of the URL
* A uniform padding is added to labels, so they optically align with the text inside the buttons
* The padding on buttons is unified across
* The URL item is moved to below the Template item, so as to not cause a jump in spacing

## Why?

It's a small improvement over what's there, to better visually balance things.

## Testing Instructions

Test the Summary panel in the post and page inspector, and note that visibility, publish, template, and URL items behave as intended.

### Testing Instructions for Keyboard

Same instructions for keyboard.