### PR TITLE
E2E: Fix performance tests by making inserter search container waiting optional

### DIFF
--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -103,7 +103,13 @@ async function waitForInserterCloseAndContentFocus() {
  * Wait for the inserter search to yield results because that input is debounced.
  */
 async function waitForInserterSearch() {
-	await page.waitForSelector( '.block-editor-inserter__no-tab-container' );
+	try {
+		await page.waitForSelector(
+			'.block-editor-inserter__no-tab-container'
+		);
+	} catch ( e ) {
+		// This selector doesn't exist in older versions, so let's just continue.
+	}
 }
 
 /**

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -105,7 +105,8 @@ async function waitForInserterCloseAndContentFocus() {
 async function waitForInserterSearch() {
 	try {
 		await page.waitForSelector(
-			'.block-editor-inserter__no-tab-container'
+			'.block-editor-inserter__no-tab-container',
+			{ timeout: 2000 }
 		);
 	} catch ( e ) {
 		// This selector doesn't exist in older versions, so let's just continue.


### PR DESCRIPTION
## What?
In #46153 we broke the performance tests because we started waiting for a selector that doesn't exist in older versions. This PR fixes it by making that selector optional.

## Why?
In older versions, this wrapper doesn't exist, nor is the inserter search debounced.

## How?
We're still waiting for the selector, but catching the error if it's not found in order to continue with the e2e test execution.

## Testing Instructions
Verify all e2e tests and performance tests still pass.
