### PR TITLE
Page List: Prevent users from adding inner blocks to Page List

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -105,6 +105,7 @@ export default function PageListEdit( {
 		allowedBlocks: [ 'core/page-list-item' ],
 		renderAppender: false,
 		__unstableDisableDropZone: true,
+		templateLock: 'all',
 	} );
 
 	const getBlockContent = () => {

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -101,7 +101,11 @@ export default function PageListEdit( {
 		parentPageID,
 	] );
 
-	const innerBlocksProps = useInnerBlocksProps( blockProps );
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		allowedBlocks: [ 'core/page-list-item' ],
+		renderAppender: false,
+		__unstableDisableDropZone: true,
+	} );
 
 	const getBlockContent = () => {
 		if ( ! hasResolvedPages ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This prevents users from modifying the content of the Page List block.
Fixes https://github.com/WordPress/gutenberg/issues/46224.

## Why?
Page List is a controlled block - it shouldn't allow users to add blocks to it in any way. 

## How?
We apply locking to the innerblocks, disabled the appender and turn off drag and drop.

## Testing Instructions
Add a Page List block
Try to find a way of modifying the content of the block

### Testing Instructions for Keyboard
As above

Co-authored-by: Maggie <3593343+MaggieCabrera@users.noreply.github.com>
Co-authored-by: Dave Smith <444434+getdave@users.noreply.github.com>
