### PR TITLE
Add `editSite.NewTemplate.defaultTemplateSlugs` filter

### DIFF
--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -250,7 +250,7 @@ function useMissingTemplates(
 	setShowCustomTemplateModal
 ) {
 	const DEFAULT_TEMPLATE_SLUGS = applyFilters(
-		'newTemplate.defaultTemplateSlugs',
+		'editSite.NewTemplate.defaultTemplateSlugs',
 		[
 			'front-page',
 			'single',

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -47,21 +47,7 @@ import AddCustomGenericTemplateModal from './add-custom-generic-template-modal';
 import TemplateActionsLoadingScreen from './template-actions-loading-screen';
 import { useHistory } from '../routes';
 import { store as editSiteStore } from '../../store';
-
-const DEFAULT_TEMPLATE_SLUGS = [
-	'front-page',
-	'single',
-	'page',
-	'index',
-	'archive',
-	'author',
-	'category',
-	'date',
-	'tag',
-	'taxonomy',
-	'search',
-	'404',
-];
+import { applyFilters } from '@wordpress/hooks';
 
 const TEMPLATE_ICONS = {
 	'front-page': home,
@@ -263,6 +249,24 @@ function useMissingTemplates(
 	setEntityForSuggestions,
 	setShowCustomTemplateModal
 ) {
+	const DEFAULT_TEMPLATE_SLUGS = applyFilters(
+		'newTemplate.defaultTemplateSlugs',
+		[
+			'front-page',
+			'single',
+			'page',
+			'index',
+			'archive',
+			'author',
+			'category',
+			'date',
+			'tag',
+			'taxonomy',
+			'search',
+			'404',
+		]
+	);
+
 	const existingTemplates = useExistingTemplates();
 	const defaultTemplateTypes = useDefaultTemplateTypes();
 	const existingTemplateSlugs = ( existingTemplates || [] ).map(


### PR DESCRIPTION
## What?
This PR adds the new `editSite.NewTemplate.defaultTemplateSlugs` filter which will allow plugins to extend the list of default template slugs.

## Why?
Currently, it is possible to extend the list of default templates via the [`default_template_types`](https://developer.wordpress.org/reference/hooks/default_template_types/) hook, but since there's no way to extend the [`DEFAULT_TEMPLATE_SLUGS`](https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-site/src/components/add-new-template/new-template.js#L51) in Gutenberg, the templates are [filtered out](https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-site/src/components/add-new-template/new-template.js#L275-L279) from the `Add new` dropdown menu.

For example, via the WooCommerce plugin, we want to make a block template available in the `Add menu` user interface that will apply to all product attributes pages, which wouldn't be possible right now.


## How?
This PRs is introducing a new filter that allows other plugins to modify the `DEFAULT_TEMPLATE_SLUGS` list.
```js
const DEFAULT_TEMPLATE_SLUGS = applyFilters(
	'editSite.NewTemplate.defaultTemplateSlugs',
	[
		'front-page',
		'single',
		'page',
		'index',
		'archive',
		'author',
		'category',
		'date',
		'tag',
		'taxonomy',
		'search',
		'404',
	]
);
```

## Testing Instructions
1. Add a new template to the list of default templates:
```php
public function extend_default_block_template_types( $default_template_types ) {
	$default_template_types['my_new_template'] = array(
		'title'       => 'My new template',
		'description' => 'Displays my new template',
	);
	return $default_template_types;
}
```
2. Use the new filter to extend the list with the same template:
```js
addFilter(
	'editSite.NewTemplate.defaultTemplateSlugs',
	'my-plugin/extend-default-template-slugs',
	( slugs ) => {
		return slugs.concat( [ 'my_new_template' ] );
	}
);
```
3. Go to the `Site Editor` > `Browse all templates` (`/wp-admin/site-editor.php?postType=wp_template`)
4. Click on the `Add new` button and make sure you see an item in the dropdown for the `My new template` template.

## Screenshots
| Before | After |
|------|------|
| <img width="327" alt="before" src="https://user-images.githubusercontent.com/186112/205266186-2f925fa1-192f-46dd-b43e-7a9b22291111.png"> | <img width="347" alt="after" src="https://user-images.githubusercontent.com/186112/205266384-1fa838ce-7583-412d-bc58-4c9d15bc44a5.png"> |
