### PR TITLE
Site Editor: Move the edit button on top of the frame

### DIFF
--- a/packages/e2e-test-utils-playwright/src/site-editor/toggle-canvas-mode.js
+++ b/packages/e2e-test-utils-playwright/src/site-editor/toggle-canvas-mode.js
@@ -4,5 +4,5 @@
  * @this {import('.').SiteEditor}
  */
 export async function enterEditMode() {
-	await this.page.click( '.edit-site-layout__edit-button' );
+	await this.page.click( '.edit-site-layout__edit-button-canvas-header' );
 }

--- a/packages/e2e-test-utils/src/site-editor.js
+++ b/packages/e2e-test-utils/src/site-editor.js
@@ -166,11 +166,13 @@ export async function openPreviousGlobalStylesPanel() {
  * Enters edit mode.
  */
 export async function enterEditMode() {
-	const editSiteToggle = await page.$( '.edit-site-layout__edit-button' );
+	const editSiteToggle = await page.$(
+		'.edit-site-layout__edit-button-canvas-header'
+	);
 	// This check is necessary for the performance tests in old branches
 	// where the site editor toggle was not implemented yet.
 	if ( ! editSiteToggle ) {
 		return;
 	}
-	await page.click( '.edit-site-layout__edit-button' );
+	await page.click( '.edit-site-layout__edit-button-canvas-header' );
 }

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -110,6 +110,7 @@ export default function Layout( { onError } ) {
 							canvasMode === 'edit' &&
 							! isMobileViewport ) ||
 						isMobileCanvasVisible,
+					'is-editor-page': isEditorPage,
 				} ) }
 			>
 				<div className="edit-site-layout__header">
@@ -217,14 +218,26 @@ export default function Layout( { onError } ) {
 				</AnimatePresence>
 
 				{ showCanvas && (
-					<div
-						className="edit-site-layout__canvas-container"
-						style={ {
-							paddingTop: showFrame ? canvasPadding : 0,
-							paddingBottom: showFrame ? canvasPadding : 0,
-						} }
-					>
+					<div className="edit-site-layout__canvas-container">
 						{ canvasResizer }
+						{ isEditorPage &&
+							canvasMode === 'view' &&
+							! isMobileViewport && (
+								<HStack
+									className="edit-site-layout__canvas-header"
+									alignment="right"
+								>
+									<Button
+										isPrimary
+										label={ __( 'Open the editor' ) }
+										onClick={ () => {
+											__unstableSetCanvasMode( 'edit' );
+										} }
+									>
+										{ __( 'Edit' ) }
+									</Button>
+								</HStack>
+							) }
 						{ !! canvasSize.width && (
 							<motion.div
 								initial={ false }

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -228,6 +228,7 @@ export default function Layout( { onError } ) {
 									alignment="right"
 								>
 									<Button
+										className="edit-site-layout__edit-button-canvas-header"
 										isPrimary
 										label={ __( 'Open the editor' ) }
 										onClick={ () => {

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -75,10 +75,6 @@
 	position: relative;
 	flex-grow: 1;
 	z-index: 2;
-
-	.edit-site-layout:not(.is-full-canvas) & {
-		padding-top: $grid-unit-10;
-	}
 }
 
 .edit-site-layout__canvas {
@@ -118,13 +114,18 @@
 
 	.edit-site-layout.is-editor-page:not(.is-full-canvas) & {
 		@include break-small {
-			top: $button-size + $grid-unit-20;
+			top: $header-height;
 		}
 	}
 }
 
 .edit-site-layout__canvas-header {
 	padding-right: $canvas-padding;
+	height: $header-height;
+}
+
+.edit-site-layout__edit-button-canvas-header {
+	height: 32px;
 }
 
 // This shouldn't be necessary (we should have a way to say that a skeletton is relative

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -75,6 +75,10 @@
 	position: relative;
 	flex-grow: 1;
 	z-index: 2;
+
+	.edit-site-layout:not(.is-full-canvas) & {
+		padding-top: $grid-unit-10;
+	}
 }
 
 .edit-site-layout__canvas {
@@ -111,6 +115,16 @@
 		width: 100%;
 		border-radius: 0;
 	}
+
+	.edit-site-layout.is-editor-page:not(.is-full-canvas) & {
+		@include break-small {
+			top: $button-size + $grid-unit-20;
+		}
+	}
+}
+
+.edit-site-layout__canvas-header {
+	padding-right: $canvas-padding;
 }
 
 // This shouldn't be necessary (we should have a way to say that a skeletton is relative

--- a/packages/edit-site/src/components/sidebar-navigation-root/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-root/index.js
@@ -5,12 +5,9 @@ import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
-	Button,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { layout, symbolFilled } from '@wordpress/icons';
-import { useDispatch } from '@wordpress/data';
-import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -19,13 +16,9 @@ import SidebarNavigationTitle from '../sidebar-navigation-title';
 import { useLink } from '../routes/link';
 import SidebarNavigationItem from '../sidebar-navigation-item';
 import { useLocation } from '../routes';
-import { store as editSiteStore } from '../../store';
-import getIsListPage from '../../utils/get-is-list-page';
 
 export default function SidebarNavigationRoot() {
 	const { params } = useLocation();
-	const isListPage = getIsListPage( params );
-	const isEditorPage = ! isListPage;
 	const templatesLink = useLink( {
 		postType: 'wp_template',
 		postId: undefined,
@@ -34,8 +27,6 @@ export default function SidebarNavigationRoot() {
 		postType: 'wp_template_part',
 		postId: undefined,
 	} );
-	const { __unstableSetCanvasMode } = useDispatch( editSiteStore );
-	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const isTemplatesPage =
 		params.postType === 'wp_template' && ! params.postId;
 	const isTemplatePartsPage =
@@ -47,17 +38,6 @@ export default function SidebarNavigationRoot() {
 				title={
 					<HStack style={ { minHeight: 36 } }>
 						<div>{ __( 'Design' ) }</div>
-						{ ! isMobileViewport && isEditorPage && (
-							<Button
-								className="edit-site-layout__edit-button"
-								label={ __( 'Open the editor' ) }
-								onClick={ () => {
-									__unstableSetCanvasMode( 'edit' );
-								} }
-							>
-								{ __( 'Edit' ) }
-							</Button>
-						) }
 					</HStack>
 				}
 			/>


### PR DESCRIPTION
Related #36667

## What?

After the initial implementation of the site editor "frame", there has been some feedback that the "edit" button is not visible and not well placed. Per some designs in https://github.com/WordPress/gutenberg/pull/44770 this PR moves the edit button on top of the frame.

For now I've just moved the button, but we may be adding more information like the template name.

<img width="1434" alt="Screenshot 2022-12-02 at 11 15 18 AM" src="https://user-images.githubusercontent.com/272444/205269822-feb77d8f-b41c-44f1-8fe1-029e35a2dca9.png">

