### PR TITLE
Focus settings tab when editing nav item in Offcanvas experiment list view

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -11,6 +11,8 @@ import SettingsTab from './settings-tab';
 import StylesTab from './styles-tab';
 import InspectorControls from '../inspector-controls';
 import useIsListViewTabDisabled from './use-is-list-view-tab-disabled';
+import { store as blockEditorStore } from '../../store';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 export default function InspectorControlsTabs( {
 	blockName,
@@ -18,6 +20,20 @@ export default function InspectorControlsTabs( {
 	hasBlockStyles,
 	tabs,
 } ) {
+	const { selectedTab } = useSelect( ( select ) => {
+		const { __unstableGetInspectorControlsTabSelectedTab: getSelectedTab } =
+			select( blockEditorStore );
+
+		const _selectedTab = getSelectedTab();
+
+		return {
+			selectedTab: _selectedTab,
+		};
+	}, [] );
+
+	const { __unstableSetInspectorControlsTabSelectedTab: setSelectedTab } =
+		useDispatch( blockEditorStore );
+
 	// The tabs panel will mount before fills are rendered to the list view
 	// slot. This means the list view tab isn't initially included in the
 	// available tabs so the panel defaults selection to the styles tab
@@ -25,7 +41,7 @@ export default function InspectorControlsTabs( {
 	// include the list view tab to set it as the tab selected by default.
 	const initialTabName = ! useIsListViewTabDisabled( blockName )
 		? TAB_LIST_VIEW.name
-		: undefined;
+		: selectedTab;
 
 	return (
 		<TabPanel
@@ -33,6 +49,7 @@ export default function InspectorControlsTabs( {
 			tabs={ tabs }
 			initialTabName={ initialTabName }
 			key={ clientId }
+			onSelect={ setSelectedTab }
 		>
 			{ ( tab ) => {
 				if ( tab.name === TAB_SETTINGS.name ) {

--- a/packages/block-editor/src/components/off-canvas-editor/block-edit-button.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-edit-button.js
@@ -15,10 +15,15 @@ export default forwardRef( function BlockEditButton(
 	{ clientId, ...props },
 	ref
 ) {
-	const { selectBlock } = useDispatch( blockEditorStore );
+	const {
+		selectBlock,
+		__unstableSetInspectorControlsTabSelectedTab:
+			setInspectorControlsTabSelectedTab,
+	} = useDispatch( blockEditorStore );
 
 	const onClick = () => {
 		selectBlock( clientId );
+		setInspectorControlsTabSelectedTab( 'settings' );
 	};
 
 	return (

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1748,3 +1748,10 @@ export function __unstableSetTemporarilyEditingAsBlocks(
 		temporarilyEditingAsBlocks,
 	};
 }
+
+export function __unstableSetInspectorControlsTabSelectedTab( tabName ) {
+	return {
+		type: 'SET_INSPECTOR_CONTROLS_TAB_SELECTED_TAB',
+		tabName,
+	};
+}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1855,6 +1855,13 @@ export function temporarilyEditingAsBlocks( state = '', action ) {
 	return state;
 }
 
+export function inspectorControlsTabs( state = '', action ) {
+	if ( action.type === 'SET_INSPECTOR_CONTROLS_TAB_SELECTED_TAB' ) {
+		return action.tabName;
+	}
+	return state;
+}
+
 export default combineReducers( {
 	blocks,
 	isTyping,
@@ -1878,4 +1885,5 @@ export default combineReducers( {
 	lastBlockInserted,
 	temporarilyEditingAsBlocks,
 	blockVisibility,
+	inspectorControlsTabs,
 } );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2766,3 +2766,7 @@ export function __unstableIsWithinBlockOverlay( state, clientId ) {
 	}
 	return false;
 }
+
+export function __unstableGetInspectorControlsTabSelectedTab( state ) {
+	return state.inspectorControlsTabs;
+}

--- a/packages/components/src/tab-panel/index.tsx
+++ b/packages/components/src/tab-panel/index.tsx
@@ -106,7 +106,7 @@ export function TabPanel( {
 	const selectedId = `${ instanceId }-${ selectedTab?.name ?? 'none' }`;
 
 	useEffect( () => {
-		if ( ! selectedTab?.name && tabs.length > 0 ) {
+		if ( tabs.length > 0 ) {
 			handleTabSelection( initialTabName || tabs[ 0 ].name );
 		}
 	}, [ tabs, selectedTab?.name, initialTabName, handleTabSelection ] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Experiment to try allowing Offcanvas List View to select the `Settings` tab in the inspector controls for the given block when you click the `Edit` in the list view.

⚠️ This is experimental and will require changes to `TabPanel` to expose a suitable API for selecting tabs.

Closes https://github.com/WordPress/gutenberg/issues/45951

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

https://github.com/WordPress/gutenberg/issues/45951

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Hack: temp fix to allow `initialTab` prop to set the internal state of the select tab in the `TabPanel` component.
- Wire up the Inspector Controls tabs with state in the Block Editor store.
- Trigger selection of `settings` tab from Offcanvas `Edit` button.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
