### PR TITLE
Navigation Block: Recursively remove Navigation block’s from appearing inside Navigation block on front of site

### DIFF
--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -15,6 +15,7 @@ import { useMemo } from '@wordpress/element';
  */
 import PlaceholderPreview from './placeholder/placeholder-preview';
 
+// This list is duplicated in packages/block-library/src/navigation/index.php
 const ALLOWED_BLOCKS = [
 	'core/navigation-link',
 	'core/search',

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -609,7 +609,6 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 			// it encounters whitespace. This code strips it.
 			$compacted_blocks = block_core_navigation_filter_out_invalid_blocks( $parsed_blocks );
 
-
 			// TODO - this uses the full navigation block attributes for the
 			// context which could be refined.
 			$inner_blocks = new WP_Block_List( $compacted_blocks, $attributes );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -384,20 +384,31 @@ function block_core_navigation_get_most_recently_published_navigation() {
 }
 
 /**
- * Filter out empty "null" blocks from the block list.
- * 'parse_blocks' includes a null block with '\n\n' as the content when
+ * Recursively filter out blocks from the block list that are considered invalid inside Navigation.
+ * This list includes:
+ * - The Navigation block itself (results in recursion).
+ * - empty "null" blocks from the block list.
+ *
+ * Note: 'parse_blocks' includes a null block with '\n\n' as the content when
  * it encounters whitespace. This is not a bug but rather how the parser
  * is designed.
  *
- * @param array $parsed_blocks the parsed blocks to be normalized.
- * @return array the normalized parsed blocks.
+ * @param array $parsed_blocks the parsed blocks to be filtered.
+ * @return array the filtered parsed blocks.
  */
-function block_core_navigation_filter_out_empty_blocks( $parsed_blocks ) {
-	$filtered = array_filter(
+function block_core_navigation_filter_out_invalid_blocks( $parsed_blocks ) {
+	$filtered = array_reduce(
 		$parsed_blocks,
-		function( $block ) {
-			return isset( $block['blockName'] );
-		}
+		function( $carry, $block ) {
+			if ( isset( $block['blockName'] ) && 'core/navigation' !== $block['blockName'] ) {
+				if ( $block['innerBlocks'] ) {
+					$block['innerBlocks'] = block_core_navigation_filter_out_invalid_blocks( $block['innerBlocks'] );
+				}
+				$carry[] = $block;
+			}
+			return $carry;
+		},
+		array()
 	);
 
 	// Reset keys.
@@ -437,7 +448,8 @@ function block_core_navigation_get_fallback_blocks() {
 
 	// Use the first non-empty Navigation as fallback if available.
 	if ( $navigation_post ) {
-		$maybe_fallback = block_core_navigation_filter_out_empty_blocks( parse_blocks( $navigation_post->post_content ) );
+
+		$maybe_fallback = block_core_navigation_filter_out_invalid_blocks( parse_blocks( $navigation_post->post_content ) );
 
 		// Normalizing blocks may result in an empty array of blocks if they were all `null` blocks.
 		// In this case default to the (Page List) fallback.
@@ -595,7 +607,8 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 			// 'parse_blocks' includes a null block with '\n\n' as the content when
 			// it encounters whitespace. This code strips it.
-			$compacted_blocks = block_core_navigation_filter_out_empty_blocks( $parsed_blocks );
+			$compacted_blocks = block_core_navigation_filter_out_invalid_blocks( $parsed_blocks );
+
 
 			// TODO - this uses the full navigation block attributes for the
 			// context which could be refined.

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -398,7 +398,7 @@ function block_core_navigation_get_most_recently_published_navigation() {
  * @return array the filtered parsed blocks.
  */
 function block_core_navigation_filter_out_invalid_blocks( $parsed_blocks ) {
-
+	// This list is duplicated in /packages/block-library/src/navigation/edit/inner-blocks.js
 	$allowed_blocks = array(
 		'core/navigation-link',
 		'core/search',

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -384,10 +384,11 @@ function block_core_navigation_get_most_recently_published_navigation() {
 }
 
 /**
- * Recursively filter out blocks from the block list that are considered invalid inside Navigation.
- * This list includes:
+ * Recursively filter out blocks from the block list that are not whitelisted.
+ * This list of exclusions includes:
  * - The Navigation block itself (results in recursion).
  * - empty "null" blocks from the block list.
+ * - other blocks that are not yet handled.
  *
  * Note: 'parse_blocks' includes a null block with '\n\n' as the content when
  * it encounters whitespace. This is not a bug but rather how the parser
@@ -397,10 +398,23 @@ function block_core_navigation_get_most_recently_published_navigation() {
  * @return array the filtered parsed blocks.
  */
 function block_core_navigation_filter_out_invalid_blocks( $parsed_blocks ) {
+
+	$allowed_blocks = array(
+		'core/navigation-link',
+		'core/search',
+		'core/social-links',
+		'core/page-list',
+		'core/spacer',
+		'core/home-link',
+		'core/site-title',
+		'core/site-logo',
+		'core/navigation-submenu',
+	);
+
 	$filtered = array_reduce(
 		$parsed_blocks,
-		function( $carry, $block ) {
-			if ( isset( $block['blockName'] ) && 'core/navigation' !== $block['blockName'] ) {
+		function( $carry, $block ) use ( $allowed_blocks ) {
+			if ( isset( $block['blockName'] ) && in_array( $block['blockName'], $allowed_blocks, true ) ) {
 				if ( $block['innerBlocks'] ) {
 					$block['innerBlocks'] = block_core_navigation_filter_out_invalid_blocks( $block['innerBlocks'] );
 				}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -398,7 +398,7 @@ function block_core_navigation_get_most_recently_published_navigation() {
  * @return array the filtered parsed blocks.
  */
 function block_core_navigation_filter_out_invalid_blocks( $parsed_blocks ) {
-	// This list is duplicated in /packages/block-library/src/navigation/edit/inner-blocks.js
+	// This list is duplicated in /packages/block-library/src/navigation/edit/inner-blocks.js.
 	$allowed_blocks = array(
 		'core/navigation-link',
 		'core/search',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes potential rendering recursion (infinite loop) whereby `core/navigation` blocks appear within the post_content of `wp_navigation` posts.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It shouldn't be possible for this to happen as Navigation block's aren't valid as inner blocks of Navigation block's

However things do happen...

When this occurs it results in the potential scenario whereby the block recursively renders because it parses the block's from the `wp_navigation` which contain a reference to itself.

For example if I created a `wp_navigation` post containing a `core/navigation` block with its `ref` attribute set to the ID of the `wp_navigation` post I just created then it will continually re-render itself.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR recursively filters out `core/navigation` from the list of block's that are allowed to be parsed from `wp_navigation` posts. This ensures this scenario cannot occur as the block is removed before it can be rendered.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->


#### Before (validate the bug)

- Remove all your `wp_navigation` posts and Classic Menus from your site
- Create a brand new Navigation using the Navigation block. Be sure to save it.
- Now open your MySQL client and update the `post_content` of your `wp_navigation` post with the following content, being sure to replace `%%REPLACE_ME%%` with the ID of the `wp_navigation` post _**YOU**_ just created:
```
<!-- wp:navigation {"ref":%%REPLACE_ME%%,"__unstableLocation":"primary","className":"social-links","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
```
- Open your Post on the front of your site.
- See that the page will not load due to memory being exhausted!

#### After (validate the bug)

- Now apply this PR to your working copy.
- Reload the same Post.
- See that it loads ok and the Navigation block is not rendered (because there are no blocks).

Please try this with variations of content being sure that it contains the self-referential Nav block issue.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
