### PR TITLE
Serialize the map objects properly in the Redux dev tools

### DIFF
--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -43,6 +43,15 @@ const trimUndefinedValues = ( array ) => {
 	return result;
 };
 
+// Convert Map objects to plain objects
+const mapToObject = ( key, state ) => {
+	if ( state instanceof Map ) {
+		return Object.fromEntries( state );
+	}
+
+	return state;
+};
+
 /**
  * Create a cache to track whether resolvers started running or not.
  *
@@ -256,6 +265,9 @@ function instantiateReduxStore( key, options, registry, thunkArgs ) {
 			window.__REDUX_DEVTOOLS_EXTENSION__( {
 				name: key,
 				instanceId: key,
+				serialize: {
+					replacer: mapToObject,
+				},
 			} )
 		);
 	}


### PR DESCRIPTION
## What?

Ref: https://github.com/WordPress/gutenberg/pull/46146#discussion_r1038231000

After the recent refactoring of the block editor store to use maps instead of plain objects, the redux dev tools stopped showing the state properly. This PR transforms back the "maps" into "objects" in the Redux dev tools to show the updates properly there.

## Testing Instructions

 - Install the Redux Dev Tools
 - Add some blocks
 - Check that the "block-editor" store is showing its state content properly (blocks.attributes for instance) in the Redux Dev Tools tab.
