### PR TITLE
Documentation: Adds clarifications and clears up inaccuracies

### DIFF
--- a/docs/getting-started/create-block/attributes.md
+++ b/docs/getting-started/create-block/attributes.md
@@ -23,7 +23,7 @@ Note: The text portion is equivalent to `innerText` attribute of a DOM element. 
 
 ## Edit and Save
 
-The **attributes** are passed to the `edit` and `save` functions, along with a **setAttributes** function to set the values. Additional parameters are also passed in to these functions, see [the edit/save documentation](/docs/reference-guides/block-api/block-edit-save.md) for more details.
+The **attributes** are passed to both the `edit` and `save` functions. The **setAttributes** function is also passed but only to the `edit` function. The **setAttributes** function is used to set the values. Additional parameters are also passed in to the `edit` and `save` functions, see [the edit/save documentation](/docs/reference-guides/block-api/block-edit-save.md) for more details.
 
 The `attributes` is a JavaScript object containing the values of each attribute, or default values if defined. The `setAttributes` is a function to update an attribute.
 

--- a/docs/getting-started/create-block/attributes.md
+++ b/docs/getting-started/create-block/attributes.md
@@ -23,7 +23,7 @@ Note: The text portion is equivalent to `innerText` attribute of a DOM element. 
 
 ## Edit and Save
 
-The **attributes** are passed to both the `edit` and `save` functions. The **setAttributes** function is also passed but only to the `edit` function. The **setAttributes** function is used to set the values. Additional parameters are also passed in to the `edit` and `save` functions, see [the edit/save documentation](/docs/reference-guides/block-api/block-edit-save.md) for more details.
+The **attributes** are passed to both the `edit` and `save` functions. The **setAttributes** function is also passed, but only to the `edit` function. The **setAttributes** function is used to set the values. Additional parameters are also passed in to the `edit` and `save` functions, see [the edit/save documentation](/docs/reference-guides/block-api/block-edit-save.md) for more details.
 
 The `attributes` is a JavaScript object containing the values of each attribute, or default values if defined. The `setAttributes` is a function to update an attribute.
 

--- a/docs/getting-started/create-block/block-anatomy.md
+++ b/docs/getting-started/create-block/block-anatomy.md
@@ -29,7 +29,7 @@ registerBlockType( metadata.name, {
 } );
 ```
 
-The first parameter in the **registerBlockType** function is the block name, this should match exactly to the `name` property in the `block.json` file. By importing the metadata from `block.json` and referencing the `name` property in the first parameter we ensure that they will match, and continue to match even if the name is changed in `block.json`.
+The first parameter in the **registerBlockType** function is the block name, this should match exactly to the `name` property in the `block.json` file. By importing the metadata from `block.json` and referencing the `name` property in the first parameter we ensure that they will match, and continue to match even if the name is subsecquently changed in `block.json`.
 
 The second parameter to the function is the block object. See the [block registration documentation](/docs/reference-guides/block-api/block-registration.md) for full details.
 

--- a/docs/getting-started/create-block/block-anatomy.md
+++ b/docs/getting-started/create-block/block-anatomy.md
@@ -29,7 +29,7 @@ registerBlockType( metadata.name, {
 } );
 ```
 
-The first parameter in the **registerBlockType** function is the block name, this should match exactly to the `name` property in the `block.json` file. By importing the metadata from `block.json` and referencing the `name` property in the first parameter we ensure that they will match, and continue to match even if the name is subsecquently changed in `block.json`.
+The first parameter in the **registerBlockType** function is the block name, this should match exactly to the `name` property in the `block.json` file. By importing the metadata from `block.json` and referencing the `name` property in the first parameter we ensure that they will match, and continue to match even if the name is subsequently changed in `block.json`.
 
 The second parameter to the function is the block object. See the [block registration documentation](/docs/reference-guides/block-api/block-registration.md) for full details.
 

--- a/docs/getting-started/create-block/block-anatomy.md
+++ b/docs/getting-started/create-block/block-anatomy.md
@@ -29,7 +29,7 @@ registerBlockType( metadata.name, {
 } );
 ```
 
-The first parameter in the **registerBlockType** function is the block name, this should match exactly to the name registered in the PHP file.
+The first parameter in the **registerBlockType** function is the block name, this should match exactly to the `name` property in the `block.json` file. By importing the metadata from `block.json` and referencing the `name` property in the first parameter we ensure that they will match, and continue to match even if the name is changed in `block.json`.
 
 The second parameter to the function is the block object. See the [block registration documentation](/docs/reference-guides/block-api/block-registration.md) for full details.
 
@@ -37,7 +37,7 @@ The last two block object properties are **edit** and **save**, these are the ke
 
 The results of the edit function is what the editor will render to the editor page when the block is inserted.
 
-The results of the save function is what the editor will insert into the **post_content** field when the post is saved. The post_content field is the field in the WordPress database used to store the content of the post.
+The results of the save function is what the editor will insert into the **post_content** field when the post is saved. The post_content field is the field in the **wp_posts** table in the WordPress database that is used to store the content of the post.
 
 Most of the properties are set in the `src/block.json` file.
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes inaccurate reference to the name being registered in the PHP file and corrects it to reference the `name` property in theme.json.
Fixes inaccurate implication that `setAttributes` gets passed to the `save` function.
Adds some clarifications around both items.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To remove inaccurate/misleading information and provide clarification.

