### PR TITLE
Navigation block: update fallback nav creation to most recently created menu

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -292,7 +292,7 @@ function Navigation( {
 		// If there's non fallback navigation menus and
 		// a classic menu with a `primary` location or slug,
 		// then create a new navigation menu based on it.
-		// Otherwise, use the first classic menu.
+		// Otherwise, use the most recently created classic menu.
 		const primaryMenus = classicMenus.filter(
 			( classicMenu ) =>
 				classicMenu.locations.includes( 'primary' ) ||
@@ -300,23 +300,20 @@ function Navigation( {
 		);
 
 		if ( primaryMenus.length ) {
-			// Sort by location to allow the menu assigned to primary location to take precedence.
-			primaryMenus.sort( ( a, b ) => {
-				if ( a.locations < b.locations ) {
-					return 1;
-				}
-				// If no locations are assigned, we compare the term_id to determine and sort by the most recently created.
-				else if ( a.locations > b.locations || a.term_id < b.term_id ) {
-					return -1;
-				}
-				return 0;
-			} );
 			convertClassicMenu(
 				primaryMenus[ 0 ].id,
 				primaryMenus[ 0 ].name,
 				'publish'
 			);
 		} else {
+			classicMenus.sort( ( a, b ) => {
+				if ( a.term_id < b.term_id ) {
+					return 1;
+				} else if ( a.term_id > b.term_id ) {
+					return -1;
+				}
+				return 0;
+			} );
 			convertClassicMenu(
 				classicMenus[ 0 ].id,
 				classicMenus[ 0 ].name,

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -305,7 +305,8 @@ function Navigation( {
 				if ( a.locations < b.locations ) {
 					return 1;
 				}
-				if ( a.locations > b.locations ) {
+				// If no locations are assigned, we compare the term_id to determine and sort by the most recently created.
+				else if ( a.locations > b.locations || a.term_id < b.term_id ) {
 					return -1;
 				}
 				return 0;

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -307,12 +307,7 @@ function Navigation( {
 			);
 		} else {
 			classicMenus.sort( ( a, b ) => {
-				if ( a.term_id < b.term_id ) {
-					return 1;
-				} else if ( a.term_id > b.term_id ) {
-					return -1;
-				}
-				return 0;
+				return b.id - a.id;
 			} );
 			convertClassicMenu(
 				classicMenus[ 0 ].id,

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -275,13 +275,14 @@ function block_core_navigation_get_classic_menu_fallback() {
 				return $classic_nav_menu;
 			}
 		}
-		
+
 		// Otherwise return the most recently created classic menu.
-		usort( $classic_nav_menus, 
-			function($a, $b) {
-				if ($a->term_id < $b->term_id) {
+		usort(
+			$classic_nav_menus,
+			function( $a, $b ) {
+				if ( $a->term_id < $b->term_id ) {
 					return 1;
-				} elseif ($a->term_id > $b->term_id) {
+				} elseif ( $a->term_id > $b->term_id ) {
 					return -1;
 				} else {
 					return 0;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -277,6 +277,7 @@ function block_core_navigation_get_classic_menu_fallback() {
 		}
 
 		// Otherwise return the most recently created classic menu.
+		usort( $classic_nav_menus, fn( $a, $b) => $b->term_id - $a->term_id );
 		return $classic_nav_menus[0];
 	}
 }

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -280,13 +280,7 @@ function block_core_navigation_get_classic_menu_fallback() {
 		usort(
 			$classic_nav_menus,
 			function( $a, $b ) {
-				if ( $a->term_id < $b->term_id ) {
-					return 1;
-				} elseif ( $a->term_id > $b->term_id ) {
-					return -1;
-				} else {
-					return 0;
-				}
+				return $b->term_id - $a->term_id;
 			}
 		);
 		return $classic_nav_menus[0];

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -275,9 +275,19 @@ function block_core_navigation_get_classic_menu_fallback() {
 				return $classic_nav_menu;
 			}
 		}
-
+		
 		// Otherwise return the most recently created classic menu.
-		usort( $classic_nav_menus, fn( $a, $b) => $b->term_id - $a->term_id );
+		usort( $classic_nav_menus, 
+			function($a, $b) {
+				if ($a->term_id < $b->term_id) {
+					return 1;
+				} elseif ($a->term_id > $b->term_id) {
+					return -1;
+				} else {
+					return 0;
+				}
+			}
+		);
 		return $classic_nav_menus[0];
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR sorts the classic menus so the most recently created menu is used in the series of fallback nav creation.

If there is a menu named primary or has a primary location, that menu still takes precedence.
 
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Before https://github.com/WordPress/gutenberg/pull/45976, a navigation would only be created if the site had a single classic menu. Now that the fallback system can handle multiple cases, we need to consider which menu should be prioritized in the fallback order.

The WP function that get classic menus returns an array of menus sorted by name, alphabetically by default. So we need to instead sort by their `term_id` if we want the most recently created.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

See above. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Activate a classic theme like TT1 and create two or more menus (none named primary)
2. Switch to a block theme like TT3
3. Verify you have no `wp_navigation`s previously
4. Visit the editor, verify the most recently created menu is used as the fallback. Verify the same shows on the front-end.
5. Delete the `wp_navigation`, repeat step 4 but visiting the front-end first, then the editor.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
