### PR TITLE
Site Editor: Remove invalid CSS

### DIFF
--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -116,7 +116,6 @@
 // This shouldn't be necessary (we should have a way to say that a skeletton is relative
 .edit-site-layout__canvas .interface-interface-skeleton {
 	position: relative !important;
-	max-height: auto !important;
 	min-height: 100% !important;
 }
 


### PR DESCRIPTION
## What?
This PR removes incorrect styles from CSS defined as site editor styles. Since this style is not interpreted by the browser, I think there is no problem removing it.

![css](https://user-images.githubusercontent.com/54422211/205445385-8582e737-28e3-4f72-8296-9ded7e08b3dd.png)

## Testing Instructions

On each screen of the site editor, check that the layout has not changed. (In particular, the height of the editor area, whether it scrolls, etc.)