### PR TITLE
Docs: fix missing link to `primitives` package

### DIFF
--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -252,7 +252,7 @@ The `ancestor` property makes a block available inside the specified block types
 
 An icon property should be specified to make it easier to identify a block. These can be any of WordPress' Dashicons (slug serving also as a fallback in non-js contexts).
 
-**Note:** It's also possible to override this property on the client-side with the source of the SVG element. In addition, this property can be defined with JavaScript as an object containing background and foreground colors. This colors will appear with the icon when they are applicable e.g.: in the inserter. Custom SVG icons are automatically wrapped in the [wp.primitives.SVG](/packages/packages-primitives) component to add accessibility attributes (aria-hidden, role, and focusable).
+**Note:** It's also possible to override this property on the client-side with the source of the SVG element. In addition, this property can be defined with JavaScript as an object containing background and foreground colors. This colors will appear with the icon when they are applicable e.g.: in the inserter. Custom SVG icons are automatically wrapped in the [wp.primitives.SVG](/packages/primitives/README.md) component to add accessibility attributes (aria-hidden, role, and focusable).
 
 ### Description
 

--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -35,7 +35,7 @@ A block requires a few properties to be specified before it can be registered su
 
 -   **Type:** `String`
 
-This is the display title for your block, which can be translated with our translation functions. The title will display in the Inserter and in other areas of the editor. 
+This is the display title for your block, which can be translated with our translation functions. The title will display in the Inserter and in other areas of the editor.
 
 ```js
 // Our data object
@@ -90,7 +90,7 @@ icon: 'book-alt',
 icon: <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0V0z" /><path d="M19 13H5v-2h14v2z" /></svg>,
 ```
 
-**Note:** Custom SVG icons are automatically wrapped in the [`wp.primitives.SVG` component](/packages/primitives/src/svg/) to add accessibility attributes (`aria-hidden`, `role`, and `focusable`).
+**Note:** Custom SVG icons are automatically wrapped in the [`wp.primitives.SVG` component](/packages/primitives/README.md) to add accessibility attributes (`aria-hidden`, `role`, and `focusable`).
 
 An object can also be passed as icon, in this case, icon, as specified above, should be included in the src property.
 


### PR DESCRIPTION
Fix #45804

## What?

This PR fixes missing links to the `primitives` package, which is linked from within the following two documents. When you click on the '**wp.primitives.SVG**' or '**wp.primitives.SVG component**' link, you will see that the page is missing.

- [Metadata in block.json | Block Editor Handbook](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#icon)
- [Registration | Block Editor Handbook](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/#icon-optional)

According to [the documentation about using links](https://github.com/WordPress/gutenberg/tree/trunk/docs/contributors/documentation#using-links), in order for the link to work in all contexts (handbook, GitHub repo, npm website), certain rules must be followed to describe the path.

- `/docs/*.md`
- `/packages/*/README.md`
- `/packages/components/src/**/README.md`

## Testing Instructions

Access the following readme file in this branch:

- [/docs/reference-guides/block-api/block-metadata.md](https://github.com/WordPress/gutenberg/blob/doc/fix-missing-primitives-link/docs/reference-guides/block-api/block-metadata.md#icon)
- [/docs/reference-guides/block-api/block-registration.md](https://github.com/WordPress/gutenberg/blob/doc/fix-missing-primitives-link/docs/reference-guides/block-api/block-registration.md#icon-optional)

Confirm that the expected readme file is displayed when you click on '**wp.primitives.SVG**' or '**wp.primitives.SVG component**'. And this should work correctly with other contexts as well.