### PR TITLE
Fix: Correct font slug before calculating $to_add

### DIFF
--- a/lib/experimental/register-webfonts-from-theme-json.php
+++ b/lib/experimental/register-webfonts-from-theme-json.php
@@ -118,7 +118,7 @@ function gutenberg_add_registered_webfonts_to_theme_json( $data ) {
 	$get_families = static function( $families_data ) {
 		$families = array();
 		foreach ( $families_data as $family ) {
-			$families[] = WP_Webfonts::get_font_slug( $family );
+			$families[] = $family['slug'];
 		}
 
 		// Micro-optimization: Use array_flip( array_flip( $array ) )


### PR DESCRIPTION
## What?
Incorrect font-family slug is being used while registering theme webfonts.

## Why?
Solves #46289 

## How?
Passing `$family` to `WP_Webfonts::get_font_slug( $family )` returns sanitized font-family. This is OK for webfonts, but not OK when used on `settings.typography.fontFamilies`. Also, there's already `$family['slug']` available to check against.

