### PR TITLE
Docs: update reference to IE 11

### DIFF
--- a/docs/explanations/faq.md
+++ b/docs/explanations/faq.md
@@ -408,9 +408,11 @@ _See:_ [Editor Styles](/docs/how-to-guides/themes/theme-support.md#editor-styles
 
 ## What browsers does Gutenberg support?
 
-Gutenberg works in modern browsers, and Internet Explorer 11.
+Gutenberg works in modern browsers.
 
-Our [list of supported browsers can be found in the Make WordPress handbook](https://make.wordpress.org/core/handbook/best-practices/browser-support/). By “modern browsers” we generally mean the _current and past two versions_ of each major browser.
+The [list of supported browsers can be found in the Make WordPress handbook](https://make.wordpress.org/core/handbook/best-practices/browser-support/). The term “modern browsers” generally refers to the _current and previous two versions_ of each major browser.
+
+Since WordPress 5.8, Gutenberg no longer supports any version of Internet Explorer. 
 
 ## Should I be concerned that Gutenberg will make my plugin obsolete?
 


### PR DESCRIPTION
Gutenberg has not supported IE 11 [since 5.8](https://make.wordpress.org/core/handbook/best-practices/browser-support/)
