### PR TITLE
Global Styles: Fix duplication of synced block colors in CSS output

### DIFF
--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -26,8 +26,3 @@ $light-gray-placeholder: rgba($white, 0.65);
 $alert-yellow: #f0b849;
 $alert-red: #cc1818;
 $alert-green: #4ab866;
-
-:root {
-	--wp-block-synced-color: #7a00df;
-	--wp-block-synced-color--rgb: #{hex-to-rgb(#7a00df)};
-}

--- a/packages/base-styles/_default-custom-properties.scss
+++ b/packages/base-styles/_default-custom-properties.scss
@@ -4,4 +4,6 @@
 // It also provides default CSS variables for npm package consumers.
 :root {
 	@include admin-scheme(#007cba);
+	--wp-block-synced-color: #7a00df;
+	--wp-block-synced-color--rgb: #{hex-to-rgb(#7a00df)};
 }


### PR DESCRIPTION
## What?
Moves the setting of the custom CSS properties for the color of the synced blocks from `_colors.scss` to `_default-custom-properties.scss`

## Why?
Because the rest of  `_colors.scss` file is just variables having custom properties there caused them to be output in [multiple block style definitions](https://github.com/WordPress/gutenberg/pull/45473#issuecomment-1336096568).

## How?
Moved the definitions from one file to another

## Testing Instructions
 - In the site editor make sure that template part outlines and icons show as purple by default in list view, etc.
 - Add a reusable block and make sure its icon also displays as purple
 - Check the page source and make sure `root: { --wp-synced-block` isn't repeated multiple times in block style outputs

**N.B** You may need to restart the watch/build process after switching to this branch to get the duplicate styles to disappear

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="422" alt="Screenshot 2022-12-05 at 1 53 11 PM" src="https://user-images.githubusercontent.com/3629020/205526942-5d5523ed-0240-4c5f-9320-45287330bd02.png">

After:

<img width="534" alt="Screenshot 2022-12-05 at 1 51 47 PM" src="https://user-images.githubusercontent.com/3629020/205526956-5ee5005e-ccd3-4491-addd-8dfecb7d3df1.png">

