### PR TITLE
Block editor: hide fixed contextual toolbar

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -18,8 +18,8 @@ import BlockToolbar from '../block-toolbar';
 import { store as blockEditorStore } from '../../store';
 
 function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
-	const { blockClientIds, blockType, hasParents, showParentSelector } =
-		useSelect( ( select ) => {
+	const { blockType, hasParents, showParentSelector } = useSelect(
+		( select ) => {
 			const {
 				getBlockName,
 				getBlockParents,
@@ -35,7 +35,6 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 			const parentBlockType = getBlockType( parentBlockName );
 
 			return {
-				blockClientIds: selectedBlockClientIds,
 				blockType:
 					selectedBlockClientId &&
 					getBlockType( getBlockName( selectedBlockClientId ) ),
@@ -52,16 +51,14 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 						selectedBlockClientId
 					),
 			};
-		}, [] );
+		},
+		[]
+	);
 
 	if ( blockType ) {
 		if ( ! hasBlockSupport( blockType, '__experimentalToolbar', true ) ) {
 			return null;
 		}
-	}
-
-	if ( blockClientIds.length === 0 ) {
-		return null;
 	}
 
 	// Shifts the toolbar to make room for the parent block selector.

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -18,8 +18,8 @@ import BlockToolbar from '../block-toolbar';
 import { store as blockEditorStore } from '../../store';
 
 function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
-	const { blockType, hasParents, showParentSelector } = useSelect(
-		( select ) => {
+	const { blockClientIds, blockType, hasParents, showParentSelector } =
+		useSelect( ( select ) => {
 			const {
 				getBlockName,
 				getBlockParents,
@@ -35,6 +35,7 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 			const parentBlockType = getBlockType( parentBlockName );
 
 			return {
+				blockClientIds: selectedBlockClientIds,
 				blockType:
 					selectedBlockClientId &&
 					getBlockType( getBlockName( selectedBlockClientId ) ),
@@ -51,14 +52,16 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 						selectedBlockClientId
 					),
 			};
-		},
-		[]
-	);
+		}, [] );
 
 	if ( blockType ) {
 		if ( ! hasBlockSupport( blockType, '__experimentalToolbar', true ) ) {
 			return null;
 		}
+	}
+
+	if ( blockClientIds.length === 0 ) {
+		return null;
 	}
 
 	// Shifts the toolbar to make room for the parent block selector.

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -180,6 +180,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 		canvasMode !== 'view' &&
 		// Disable resizing in mobile viewport.
 		! isMobileViewport;
+	const isViewMode = canvasMode === 'view';
 
 	const NavMenuSidebarToggle = () => (
 		<ToolbarGroup>
@@ -243,6 +244,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 						<BlockTools
 							className={ classnames( 'edit-site-visual-editor', {
 								'is-focus-mode': isTemplatePart || !! styleBook,
+								'is-view-mode': isViewMode,
 							} ) }
 							__unstableContentRef={ contentRef }
 							onClick={ ( event ) => {

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -49,6 +49,19 @@
 		// Removing this will cancel the bottom margins in the iframe.
 		overflow: auto;
 	}
+
+	/*
+		Temporary to hide the contextual toolbar in view mode.
+		See: https://github.com/WordPress/gutenberg/pull/46298
+		This rule can possibly be removed once the
+		contextual toolbar has been redesigned.
+		See: https://github.com/WordPress/gutenberg/issues/40450
+	*/
+	&.is-view-mode {
+		.block-editor-block-contextual-toolbar {
+			display: none;
+		}
+	}
 }
 
 .edit-site-visual-editor__back-button {


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/41047 (maybe)

## What?
A temporary CSS fix to hide the contextual tool bar in view mode, and only for the site editor.

## Why?
This is because it creates a large, empty space at the top of the page in the site editor view mode.

## How?
Checking for view mode, then displaying "none".

## Testing Instructions
Before testing, ensure you have fixed the toolbar using the editor settings accessible via the dots menu.

<img width="290" alt="Screen Shot 2022-12-06 at 7 33 10 am" src="https://user-images.githubusercontent.com/6458278/205737528-b1154cf1-14a6-4cbd-b8c5-c4a879e8df2f.png">


Open the site editor, check that the contextual toolbar does not show in view mode:

| Before  | After |
| ------------- | ------------- |
| <img width="863" alt="Screen Shot 2022-12-05 at 1 14 50 pm" src="https://user-images.githubusercontent.com/6458278/205535012-a35be312-d42c-4ddc-b8a9-ff9caa65da85.png">  | <img width="858" alt="Screen Shot 2022-12-05 at 1 16 58 pm" src="https://user-images.githubusercontent.com/6458278/205535038-61323c02-c83d-4e10-8965-f5f4df607199.png">  |

Ensure that no other views are affected, e.g., in edit mode, selecting blocks...




