### PR TITLE
Try adding text labels to block inspector icon buttons.

### DIFF
--- a/packages/block-editor/src/components/block-inspector/style.scss
+++ b/packages/block-editor/src/components/block-inspector/style.scss
@@ -27,6 +27,25 @@
 	}
 }
 
+.show-icon-labels {
+	.block-editor-block-inspector {
+		.components-button.has-icon,
+		[class*="isIconStyles"] {
+			width: auto;
+
+			// Hide the button icons when labels are set to display...
+			svg {
+				display: none;
+			}
+			// ... and display labels.
+			&::after {
+				content: attr(aria-label);
+				font-size: $helptext-font-size;
+			}
+		}
+	}
+}
+
 .block-editor-block-inspector__no-blocks,
 .block-editor-block-inspector__no-block-tools {
 	display: block;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In order for #15311 to be fully fixed, the "Show button text labels" preference must replace all interactive icons in the interface with text. This PR tries to enable this functionality for the icon buttons and toggles in the block inspector.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

As a first approach, this PR blanket adds the CSS rule that hides SVG icons and adds their aria-label as text inside an `:after` pseudo-element. Visually, the results are not always great, as can be seen in the screenshots below. We need:

* Styling changes so the text buttons look presentable (cc. @WordPress/gutenberg-design )
* A better solution to target the icons coming from the components package (the current `[class*="isIconStyles"]` is only meant to give us a preview of the effects of this change - ideally we find a less brittle way to do this - cc @ciampo @mirka )

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In the post editor, open "Options" menu on top right hand side, select "Preferences", and toggle "Show button text labels" on;
2. Select a block in the canvas and view its block settings. All icon buttons should now show text labels.
3. The same instructions can be applied in the site editor.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

Keyboard testing should work the same; Shift+Tab from the editor canvas when a block is selected should reach the "Options" button directly. Note that with text labels enabled there should be no difference for screen reader users in interacting with icon buttons (the text label being added is already their aria-label, and screen readers should ignore the text content of the pseudo element).

## Screenshots or screencast <!-- if applicable -->
  
<img width="279" alt="Screenshot 2022-12-05 at 2 32 03 pm" src="https://user-images.githubusercontent.com/8096000/205548888-29f1cf57-4e7c-4911-8554-f6602d95b718.png">

<img width="282" alt="Screenshot 2022-12-05 at 2 38 50 pm" src="https://user-images.githubusercontent.com/8096000/205548944-ff078911-d45c-49e7-a9fa-33e42effdf55.png">
