### PR TITLE
Tests: Unmount to clear pending popover effects

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -59,7 +59,7 @@ describe( 'General media replace flow', () => {
 			advanceTimers: jest.advanceTimersByTime,
 		} );
 
-		render( <TestWrapper /> );
+		const { unmount } = render( <TestWrapper /> );
 
 		await user.click(
 			screen.getByRole( 'button', {
@@ -76,6 +76,9 @@ describe( 'General media replace flow', () => {
 		);
 
 		await waitFor( () => expect( uploadMenu ).toBeVisible() );
+
+		// Cancel any pending and currently running popover effects.
+		unmount();
 	} );
 
 	it( 'displays media URL', async () => {
@@ -83,7 +86,7 @@ describe( 'General media replace flow', () => {
 			advanceTimers: jest.advanceTimersByTime,
 		} );
 
-		render( <TestWrapper /> );
+		const { unmount } = render( <TestWrapper /> );
 
 		await user.click(
 			screen.getByRole( 'button', {
@@ -101,6 +104,9 @@ describe( 'General media replace flow', () => {
 		);
 
 		expect( link ).toHaveAttribute( 'href', 'https://example.media' );
+
+		// Cancel any pending and currently running popover effects.
+		unmount();
 	} );
 
 	it( 'edits media URL', async () => {
@@ -108,7 +114,7 @@ describe( 'General media replace flow', () => {
 			advanceTimers: jest.advanceTimersByTime,
 		} );
 
-		render( <TestWrapper /> );
+		const { unmount } = render( <TestWrapper /> );
 
 		await user.click(
 			screen.getByRole( 'button', {
@@ -152,5 +158,8 @@ describe( 'General media replace flow', () => {
 				name: 'new.example.media (opens in a new tab)',
 			} )
 		).toHaveAttribute( 'href', 'https://new.example.media' );
+
+		// Cancel any pending and currently running popover effects.
+		unmount();
 	} );
 } );

--- a/packages/components/src/color-palette/test/index.tsx
+++ b/packages/components/src/color-palette/test/index.tsx
@@ -142,7 +142,7 @@ describe( 'ColorPalette', () => {
 		} );
 		const onChange = jest.fn();
 
-		render(
+		const { unmount } = render(
 			<ColorPalette
 				colors={ EXAMPLE_COLORS }
 				value={ INITIAL_COLOR }
@@ -182,6 +182,9 @@ describe( 'ColorPalette', () => {
 				getWrappingPopoverElement( dropdownColorInput )
 			).toBePositionedPopover()
 		);
+
+		// Cancel any pending and currently running popover effects.
+		unmount();
 	} );
 
 	it( 'should show the clear button by default', () => {

--- a/packages/components/src/toggle-group-control/test/index.tsx
+++ b/packages/components/src/toggle-group-control/test/index.tsx
@@ -103,7 +103,7 @@ describe( 'ToggleGroupControl', () => {
 		const user = userEvent.setup( {
 			advanceTimers: jest.advanceTimersByTime,
 		} );
-		render(
+		const { unmount } = render(
 			<ToggleGroupControl label="Test Toggle Group Control">
 				{ optionsWithTooltip }
 			</ToggleGroupControl>
@@ -126,6 +126,9 @@ describe( 'ToggleGroupControl', () => {
 		);
 
 		expect( tooltip ).toBeVisible();
+
+		// Cancel any pending and currently running popover effects.
+		unmount();
 	} );
 
 	it( 'should not render tooltip', async () => {

--- a/packages/components/src/tooltip/test/index.js
+++ b/packages/components/src/tooltip/test/index.js
@@ -48,7 +48,7 @@ describe( 'Tooltip', () => {
 		it( 'should render children with additional tooltip when focused', async () => {
 			const mockOnFocus = jest.fn();
 
-			render(
+			const { unmount } = render(
 				<Tooltip text="Help text">
 					<button onFocus={ mockOnFocus }>Hover Me!</button>
 				</Tooltip>
@@ -77,6 +77,9 @@ describe( 'Tooltip', () => {
 					getWrappingPopoverElement( tooltip )
 				).toBePositionedPopover()
 			);
+
+			// Cancel any pending and currently running popover effects.
+			unmount();
 		} );
 
 		it( 'should render children with additional tooltip when hovered', async () => {
@@ -84,7 +87,7 @@ describe( 'Tooltip', () => {
 				advanceTimers: jest.advanceTimersByTime,
 			} );
 
-			render(
+			const { unmount } = render(
 				<Tooltip text="Help text">
 					<button>Hover Me!</button>
 				</Tooltip>
@@ -110,6 +113,9 @@ describe( 'Tooltip', () => {
 					getWrappingPopoverElement( tooltip )
 				).toBePositionedPopover()
 			);
+
+			// Cancel any pending and currently running popover effects.
+			unmount();
 		} );
 
 		it( 'should not show tooltip on focus as result of mouse click', async () => {
@@ -152,7 +158,7 @@ describe( 'Tooltip', () => {
 			const mockOnMouseEnter = jest.fn();
 			const mockOnFocus = jest.fn();
 
-			render(
+			const { unmount } = render(
 				<Tooltip text="Help text" delay={ TEST_DELAY }>
 					<button
 						onMouseEnter={ mockOnMouseEnter }
@@ -192,6 +198,9 @@ describe( 'Tooltip', () => {
 					getWrappingPopoverElement( tooltip )
 				).toBePositionedPopover()
 			);
+
+			// Cancel any pending and currently running popover effects.
+			unmount();
 		} );
 
 		it( 'should show tooltip when an element is disabled', async () => {
@@ -199,7 +208,7 @@ describe( 'Tooltip', () => {
 				advanceTimers: jest.advanceTimersByTime,
 			} );
 
-			const { container } = render(
+			const { container, unmount } = render(
 				<Tooltip text="Show helpful text here">
 					<button disabled>Click me</button>
 				</Tooltip>
@@ -236,6 +245,9 @@ describe( 'Tooltip', () => {
 					getWrappingPopoverElement( tooltip )
 				).toBePositionedPopover()
 			);
+
+			// Cancel any pending and currently running popover effects.
+			unmount();
 		} );
 
 		it( 'should not emit events back to children when they are disabled', async () => {
@@ -317,7 +329,7 @@ describe( 'Tooltip', () => {
 				advanceTimers: jest.advanceTimersByTime,
 			} );
 
-			render(
+			const { unmount } = render(
 				<Tooltip text="Help text" shortcut="shortcut text">
 					<button>Hover Me!</button>
 				</Tooltip>
@@ -335,6 +347,9 @@ describe( 'Tooltip', () => {
 					getWrappingPopoverElement( tooltip )
 				).toBePositionedPopover()
 			);
+
+			// Cancel any pending and currently running popover effects.
+			unmount();
 		} );
 
 		it( 'should render the shortcut display text and aria-label when an object is passed as the shortcut with the correct properties', async () => {
@@ -342,7 +357,7 @@ describe( 'Tooltip', () => {
 				advanceTimers: jest.advanceTimersByTime,
 			} );
 
-			render(
+			const { unmount } = render(
 				<Tooltip
 					text="Help text"
 					shortcut={ {
@@ -366,6 +381,9 @@ describe( 'Tooltip', () => {
 					getWrappingPopoverElement( tooltip )
 				).toBePositionedPopover()
 			);
+
+			// Cancel any pending and currently running popover effects.
+			unmount();
 		} );
 	} );
 } );


### PR DESCRIPTION
## What?
This PR updates the tests that open popover to unmount the components, in order to clean up any running or pending popover effects.

## Why?
The tests that include the opening of popovers are unreliable and flaky. They depend on us waiting for the popover to be fully finished, visible, and positioned, but that's not enough, since there are effects running afterward, and this may cause `act()` warnings in unexpected PRs (like #46187).

## How?
We're unmounting after such tests to specifically make sure that pending and running popover effects will be canceled on time and before the next test.

## Testing Instructions
Verify all tests still pass.
