### PR TITLE
Fix template title in `summary` panel and requests for low privileged users

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-template/index.js
+++ b/packages/edit-post/src/components/sidebar/post-template/index.js
@@ -85,9 +85,14 @@ function PostTemplateToggle( { isOpen, onClick } ) {
 		if ( ! supportsTemplateMode && availableTemplates[ templateSlug ] ) {
 			return availableTemplates[ templateSlug ];
 		}
-
-		const template = select( editPostStore ).getEditedPostTemplate();
-		return template?.title ?? template?.slug;
+		const template =
+			select( coreStore ).canUser( 'create', 'templates' ) &&
+			select( editPostStore ).getEditedPostTemplate();
+		return (
+			template?.title ||
+			template?.slug ||
+			availableTemplates?.[ templateSlug ]
+		);
 	}, [] );
 
 	return (


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/46293

See more info on the issue. 
In this PR I also added a fallback to show the template title if exists, for low privileged users like `editor` in the summary panel. I've read quite a few discussions about that panel, so I'm not 100% sure if there some other nuances with classic themes or the `availableTemplates` from the settings. I'd need a sanity check from @Mamaduka or @noisysocks maybe, as they have worked a lot in these parts. 
<!-- In a few words, what is the PR actually doing? -->

## Testing Instructions
1. Log in with an `editor` user
2. Open the dev tools and observe that there are no failing `403` requests
3. Observe that if we have selected a template available from settings the proper title is used.


