### PR TITLE
Social Links mobile test: wait for URL bottom sheet to appear

### DIFF
--- a/packages/block-library/src/social-links/test/edit.native.js
+++ b/packages/block-library/src/social-links/test/edit.native.js
@@ -104,7 +104,6 @@ describe( 'Social links block', () => {
 
 	it( 'shows the social links bottom sheet when tapping on the inline appender', async () => {
 		const screen = await initializeEditor();
-		const { getByTestId, getByText } = screen;
 
 		// Add block
 		await addBlock( screen, 'Social Icons' );
@@ -131,7 +130,7 @@ describe( 'Social links block', () => {
 		fireEvent.press( appenderButton );
 
 		// Find a social link in the inserter
-		const blockList = getByTestId( 'InserterUI-Blocks' );
+		const blockList = screen.getByTestId( 'InserterUI-Blocks' );
 
 		// onScroll event used to force the FlatList to render all items
 		fireEvent.scroll( blockList, {
@@ -143,10 +142,12 @@ describe( 'Social links block', () => {
 		} );
 
 		// Add the Amazon link
-		const amazonBlock = await waitFor( () => getByText( 'Amazon' ) );
+		const amazonBlock = await screen.findByText( 'Amazon' );
 		expect( amazonBlock ).toBeVisible();
 
 		fireEvent.press( amazonBlock );
+
+		await screen.findByTestId( 'navigation-screen-LinkSettingsScreen' );
 
 		expect( getEditorHtml() ).toMatchSnapshot();
 	} );


### PR DESCRIPTION
Fixes a "not wrapped in `act()`" warning when testing adding a social icon block on mobile.

The test adds an Amazon social icon, then verifies that the edited HTML is as expected: contains a `core/social-link` block with a `service: 'amazon'` attribute, and empty `url`.

But at the moment when the test ends and checks the edited HTML snapshot, the insertion is not yet fully finished: it shows a bottom sheet like this:

![IMG_5AAFDCFB3373-1 2](https://user-images.githubusercontent.com/664258/205664680-c0fe6b9a-88bf-4047-880c-0a29c9ad3dcb.jpeg)

Showing this bottom sheet is async, with a `useEffect` + `queueMicrotask` combination. Coming from the `ReactNavigationContainer` component. And it triggers the "not wrapped in `act()`" warning.

The solution is to wait for the bottom sheet to appear, referencing it with its test ID.