### PR TITLE
Components: Fix `no-node-access` violations in `Theme`

### DIFF
--- a/packages/components/src/theme/test/index.tsx
+++ b/packages/components/src/theme/test/index.tsx
@@ -68,21 +68,13 @@ describe( 'Theme', () => {
 	describe( 'background color', () => {
 		it( 'it does not define the background color (and its dependent colors) as a CSS variable when the `background` prop is undefined', () => {
 			render(
-				<Theme>
+				<Theme data-testid="theme">
 					<MyThemableComponent>Inner</MyThemableComponent>
 				</Theme>
 			);
 
-			const inner = screen.getByText( 'Inner' );
-
-			if ( inner?.parentElement === null ) {
-				throw new Error(
-					'Somehow the `Theme` component does not render a DOM element?'
-				);
-			}
-
 			const innerElementStyles = window.getComputedStyle(
-				inner?.parentElement
+				screen.getByTestId( 'theme' )
 			);
 
 			[
@@ -101,14 +93,12 @@ describe( 'Theme', () => {
 
 		it( 'it defines the background color (and its dependent colors) as a CSS variable', () => {
 			render(
-				<Theme background="#ffffff">
+				<Theme background="#ffffff" data-testid="theme">
 					<MyThemableComponent>Inner</MyThemableComponent>
 				</Theme>
 			);
 
-			const inner = screen.getByText( 'Inner' );
-
-			expect( inner?.parentElement ).toHaveStyle( {
+			expect( screen.getByTestId( 'theme' ) ).toHaveStyle( {
 				'--wp-components-color-background': '#ffffff',
 				'--wp-components-color-foreground': '#1e1e1e',
 				'--wp-components-color-foreground-inverted': '#fff',


### PR DESCRIPTION
## What?
With the recent work to improve the quality of tests, we fixed a bunch of ESLint rule violations. This PR fixes a few (4) [`no-node-access`](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-node-access.md) rule violations in the `Theme` component. 

## Why?
The end goal is to enable that ESLint rule once all violations have been fixed.

## How?
We're using a screen query instead of `container.parentElement`. For this purpose, we add a `data-testid` to the `Theme` element. We're also cleaning up an unnecessary error handling in a test.

## Testing Instructions
Verify all tests still pass.