### PR TITLE
Components: Fix `no-node-access` violations in `Popover`

### DIFF
--- a/packages/components/src/popover/test/index.tsx
+++ b/packages/components/src/popover/test/index.tsx
@@ -141,11 +141,13 @@ describe( 'Popover', () => {
 
 		describe( 'focus behavior', () => {
 			it( 'should focus the popover by default when opened', async () => {
-				await renderAsync( <Popover>Popover content</Popover> );
+				await renderAsync(
+					<Popover data-testid="popover-element">
+						Popover content
+					</Popover>
+				);
 
-				expect(
-					screen.getByText( 'Popover content' ).parentElement
-				).toHaveFocus();
+				expect( screen.getByTestId( 'popover-element' ) ).toHaveFocus();
 			} );
 
 			it( 'should allow focus-on-open behavior to be disabled', async () => {


### PR DESCRIPTION
## What?
With the recent work to improve the quality of tests, we fixed a bunch of ESLint rule violations. This PR fixes a [`no-node-access`](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-node-access.md) rule violation in the `Popover` component. 

## Why?
The end goal is to enable that ESLint rule once all violations have been fixed.

## How?
We're using a screen query instead of `element.parentElement`. For this purpose, we add a `data-testid` to the `Popover` element.

## Testing Instructions
Verify all tests still pass.