### PR TITLE
[Site Editor]: Add default white background for themes with no `background color` set

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -430,8 +430,8 @@
 	}
 }
 
-/** Zoom Out mode styles **/
 .block-editor-iframe__body {
+	background-color: $white;
 	transition: all 0.3s;
 	transform-origin: top center;
 }


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/46291
<!-- In a few words, what is the PR actually doing? -->
>If the Gutenberg plugin is enabled and the theme doesn't explicitly specify a background color for the site, a dark color will be applied to the background, making it difficult to recognize text and blocks.


## Testing Instructions
1. Use `empty` theme or a theme which doesn't set the background color
2. Open site editor, template editing and zoom out view
3. Observe that the background of the `editor` is `white`
4. Ensure everything else has the dark color it should have - for example the rest of the frame, sidebars, etc..
5. Try adding the background to the theme through theme.json or global styles UI and observe the selected color is shown instead of `white`.

### Notes
In some places it might make some time to apply the default color and that is because the css rule is applied to the iframe and needs to load. I tried at first to update in an `upper` node, but it's used in more places where we do rely on the dark color. Of course any suggestion for better placement is welcome.
