### PR TITLE
Always update the current render state of uncontrolled navigation block unless the block is selected

### DIFF
--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -46,10 +46,10 @@ export default function UnsavedInnerBlocks( {
 	useEffect( () => {
 		// Initially store the uncontrolled inner blocks for
 		// dirty state comparison.
-		if ( ! originalBlocks?.current ) {
+		if ( ! hasSelection ) {
 			originalBlocks.current = blocks;
 		}
-	}, [ blocks ] );
+	}, [ blocks, hasSelection ] );
 
 	// If the current inner blocks object is different in any way
 	// from the original inner blocks from the post content then the


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Naive alternative to #46223

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because the logic behind fixing the way we automatically create the navigation block when it has uncontrolled blocks was complex and now it's more complex since the page list block has inner blocks. 

In #46223 we fix a situation when the navigation block only has one page list block, but not if there are other blocks and a navigation block. Plus any new allowed block that can have inner blocks loaded async will break the navigation block's auto-creation from uncontrolled contents.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

So far it's a naive solution: until the block is selected we keep updating the state. This works b/c generally blocks with uncontrolled blocks render instantly.

However, with the page list block loading the list of pages via rest a user may select the block while loading, and, being selected, the current state is not updated anymore. So this has to be tweaked a bit.

## Testing Instructions

- / -

### Testing Instructions for Keyboard

- / -

## Screenshots or screencast <!-- if applicable -->

N/A