### PR TITLE
Navigation link: use stripHTML

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -31,13 +31,15 @@ import {
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP } from '@wordpress/url';
 import { Fragment, useState, useEffect, useRef } from '@wordpress/element';
-import { placeCaretAtHorizontalEdge } from '@wordpress/dom';
+import {
+	placeCaretAtHorizontalEdge,
+	__unstableStripHTML as stripHTML,
+} from '@wordpress/dom';
 import { link as linkIcon, addSubmenu } from '@wordpress/icons';
 import {
 	store as coreStore,
 	useResourcePermissions,
 } from '@wordpress/core-data';
-
 import { useMergeRefs } from '@wordpress/compose';
 
 /**
@@ -476,7 +478,7 @@ export default function NavigationLinkEdit( {
 			<InspectorControls>
 				<PanelBody title={ __( 'Link settings' ) }>
 					<TextControl
-						value={ label ? navStripHTML( label ) : '' }
+						value={ label ? stripHTML( label ) : '' }
 						onChange={ ( labelValue ) => {
 							setAttributes( { label: labelValue } );
 						} }


### PR DESCRIPTION
## What?
I think the PR - strip markup from link label data in inspector (#46171) - meant to use `stripHTML`

`navStripHTML` doesn't appear to exist and is causing linting errors. 


## Testing Instructions
Follow the testing instructions in https://github.com/WordPress/gutenberg/pull/46171