### PR TITLE
Child Layout controls: Fix help text for height

### DIFF
--- a/packages/block-editor/src/hooks/child-layout.js
+++ b/packages/block-editor/src/hooks/child-layout.js
@@ -14,15 +14,19 @@ import { useEffect } from '@wordpress/element';
  */
 import useSetting from '../components/use-setting';
 
-function helpText( selfStretch ) {
-	switch ( selfStretch ) {
-		case 'fill':
-			return __( 'Stretch to fill available space.' );
-		case 'fixed':
-			return __( 'Specify a fixed width.' );
-		default:
-			return __( 'Fit contents.' );
+function helpText( selfStretch, parentLayout ) {
+	const { orientation = 'horizontal' } = parentLayout;
+
+	if ( selfStretch === 'fill' ) {
+		return __( 'Stretch to fill available space.' );
 	}
+	if ( selfStretch === 'fixed' ) {
+		if ( orientation === 'horizontal' ) {
+			return __( 'Specify a fixed width.' );
+		}
+		return __( 'Specify a fixed height.' );
+	}
+	return __( 'Fit contents.' );
 }
 
 /**
@@ -64,7 +68,7 @@ export function ChildLayoutEdit( {
 				size={ '__unstable-large' }
 				label={ childLayoutOrientation( parentLayout ) }
 				value={ selfStretch || 'fit' }
-				help={ helpText( selfStretch ) }
+				help={ helpText( selfStretch, parentLayout ) }
 				onChange={ ( value ) => {
 					const newFlexSize = value !== 'fixed' ? null : flexSize;
 					setAttributes( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix help text for child layout size controls in the vertical orientation (e.g. Stack block) so that the help text refers to 'height' instead of 'width' when `Fixed` is selected.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Looks like we missed adding in a conditional for the help text based on orientation.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In the `helpText` function, also pass in the parent layout so that we can determine the orientation. Default to horizontal.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

* With this PR applied, add a Stack block, and under Dimensions, add the Height control. Check that the help text for `Fit`, `Fill`, and `Fixed` all read correctly.
* Add a Row block, and double check that the same help text looks correct in the horizontal orientation (e.g. the help text for `Fixed` refers to `width`.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/205780836-878fa041-6474-40f1-b8ef-1720cb1fc8c8.png) | ![image](https://user-images.githubusercontent.com/14988353/205780857-28c1861b-5703-49ea-9ff6-6a717d8cfb24.png) | ![image](https://user-images.githubusercontent.com/14988353/205781704-9a5758a9-cb89-4062-bb8a-dd4ffe438fef.png) |
