### PR TITLE
Sidebar Tabs: Use editor settings to override display

### DIFF
--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -168,6 +168,12 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 					'context'     => array( 'mobile' ),
 				),
 
+				'__experimentalBlockInspectorTabs'       => array(
+					'description' => __( 'Block inspector tab display overrides.', 'gutenberg' ),
+					'type'        => 'object',
+					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+				),
+
 				'alignWide'                              => array(
 					'description' => __( 'Enable/Disable Wide/Full Alignments.', 'gutenberg' ),
 					'type'        => 'boolean',

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -72,18 +72,6 @@ function getContentBlocks( blocks, isContentBlock ) {
 	return result;
 }
 
-function getShowTabs( blockName, tabSettings = {} ) {
-	if ( tabSettings[ blockName ] !== undefined ) {
-		return tabSettings[ blockName ];
-	}
-
-	if ( tabSettings.default !== undefined ) {
-		return tabSettings.default;
-	}
-
-	return window?.__experimentalEnableBlockInspectorTabs;
-}
-
 function BlockNavigationButton( { blockTypes, block, selectedBlock } ) {
 	const { selectBlock } = useDispatch( blockEditorStore );
 	const blockType = blockTypes.find( ( { name } ) => name === block.name );
@@ -152,7 +140,6 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 		selectedBlockClientId,
 		blockType,
 		topLevelLockedBlock,
-		tabSettings,
 	} = useSelect( ( select ) => {
 		const {
 			getSelectedBlockClientId,
@@ -160,7 +147,6 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			getBlockName,
 			__unstableGetContentLockingParent,
 			getTemplateLock,
-			getSettings,
 		} = select( blockEditorStore );
 
 		const _selectedBlockClientId = getSelectedBlockClientId();
@@ -168,14 +154,12 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			_selectedBlockClientId && getBlockName( _selectedBlockClientId );
 		const _blockType =
 			_selectedBlockName && getBlockType( _selectedBlockName );
-		const _tabSettings = getSettings().__experimentalBlockInspectorTabs;
 
 		return {
 			count: getSelectedBlockCount(),
 			selectedBlockClientId: _selectedBlockClientId,
 			selectedBlockName: _selectedBlockName,
 			blockType: _blockType,
-			tabSettings: _tabSettings,
 			topLevelLockedBlock:
 				__unstableGetContentLockingParent( _selectedBlockClientId ) ||
 				( getTemplateLock( _selectedBlockClientId ) === 'contentOnly'
@@ -185,8 +169,7 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 	}, [] );
 
 	const availableTabs = useInspectorControlsTabs( blockType?.name );
-	const showTabs =
-		availableTabs.length > 1 && getShowTabs( blockType?.name, tabSettings );
+	const showTabs = availableTabs.length > 1;
 
 	if ( count > 1 ) {
 		return (
@@ -257,14 +240,8 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 };
 
 const BlockInspectorSingleBlock = ( { clientId, blockName } ) => {
-	const tabSettings = useSelect( ( select ) => {
-		return select( blockEditorStore ).getSettings()
-			.__experimentalBlockInspectorTabs;
-	}, [] );
-
 	const availableTabs = useInspectorControlsTabs( blockName );
-	const showTabs =
-		availableTabs.length > 1 && getShowTabs( blockName, tabSettings );
+	const showTabs = availableTabs.length > 1;
 
 	const hasBlockStyles = useSelect(
 		( select ) => {

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __experimentalUseSlotFills as useSlotFills } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -10,6 +11,27 @@ import InspectorControlsGroups from '../inspector-controls/groups';
 import useIsListViewTabDisabled from './use-is-list-view-tab-disabled';
 import { InspectorAdvancedControls } from '../inspector-controls';
 import { TAB_LIST_VIEW, TAB_SETTINGS, TAB_STYLES } from './utils';
+import { store as blockEditorStore } from '../../store';
+
+function getShowTabs( blockName, tabSettings = {} ) {
+	// Don't allow settings to force the display of tabs if the block inspector
+	// tabs experiment hasn't been opted into.
+	if ( ! window?.__experimentalEnableBlockInspectorTabs ) {
+		return false;
+	}
+
+	// Block specific setting takes precedence over generic default.
+	if ( tabSettings[ blockName ] !== undefined ) {
+		return tabSettings[ blockName ];
+	}
+
+	// Use generic default if set over the Gutenberg experiment option.
+	if ( tabSettings.default !== undefined ) {
+		return tabSettings.default;
+	}
+
+	return true;
+}
 
 export default function useInspectorControlsTabs( blockName ) {
 	const tabs = [];
@@ -54,5 +76,12 @@ export default function useInspectorControlsTabs( blockName ) {
 		tabs.push( TAB_SETTINGS );
 	}
 
-	return tabs;
+	const tabSettings = useSelect( ( select ) => {
+		return select( blockEditorStore ).getSettings()
+			.__experimentalBlockInspectorTabs;
+	}, [] );
+
+	const showTabs = getShowTabs( blockName, tabSettings );
+
+	return showTabs ? tabs : [];
 }

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -344,3 +344,26 @@ function register_block_core_navigation_link() {
 	);
 }
 add_action( 'init', 'register_block_core_navigation_link' );
+
+/**
+ * Disables the display of tabs for the Navigation Link block.
+ *
+ * @param array $settings Default editor settings.
+ * @return array Filtered editor settings.
+ */
+function gutenberg_disable_tabs_for_navigation_link_block( $settings ) {
+	$current_tab_settings = _wp_array_get(
+		$settings,
+		array( '__experimentalBlockInspectorTabs' ),
+		array()
+	);
+
+	$settings['__experimentalBlockInspectorTabs'] = array_merge(
+		$current_tab_settings,
+		array( 'core/navigation-link' => false )
+	);
+
+	return $settings;
+}
+
+add_filter( 'block_editor_settings_all', 'gutenberg_disable_tabs_for_navigation_link_block' );

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -289,3 +289,26 @@ function register_block_core_navigation_submenu() {
 	);
 }
 add_action( 'init', 'register_block_core_navigation_submenu' );
+
+/**
+ * Disables the display of tabs for the Navigation Submenu block.
+ *
+ * @param array $settings Default editor settings.
+ * @return array Filtered editor settings.
+ */
+function gutenberg_disable_tabs_for_navigation_submenu_block( $settings ) {
+	$current_tab_settings = _wp_array_get(
+		$settings,
+		array( '__experimentalBlockInspectorTabs' ),
+		array()
+	);
+
+	$settings['__experimentalBlockInspectorTabs'] = array_merge(
+		$current_tab_settings,
+		array( 'core/navigation-submenu' => false )
+	);
+
+	return $settings;
+}
+
+add_filter( 'block_editor_settings_all', 'gutenberg_disable_tabs_for_navigation_submenu_block' );

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -135,6 +135,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 				Object.entries( settings ).filter( ( [ key ] ) =>
 					[
 						'__experimentalBlockDirectory',
+						'__experimentalBlockInspectorTabs',
 						'__experimentalDiscussionSettings',
 						'__experimentalFeatures',
 						'__experimentalPreferredStyleVariations',


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/45005

## What?

- Leverages a new block editor setting to provide a means of overriding the block inspector tabs display across all blocks or on a per-block basis.
- Uses the new block editor setting to disable tabs for the Navigation Link block

## Why?

We need a means of providing plugins and third party blocks with the ability to disable the display of block inspector tabs.

## How?

- Adds a new experimental block editor setting: `__experimentalBlockInspectorTabs`
- Adds a `block_editor_settings_all` filter to the Navigation Link block to disable tabs for it
- Updates the block inspector to take into account any overrides in the new block editor setting when rendering tabs
- Updates the item schema for the block editor settings rest controller

#### Alternative Approaches
- Using a filter: https://github.com/WordPress/gutenberg/pull/46026 
- Using the block editor store: https://github.com/WordPress/gutenberg/pull/46271
- A context approach was considered however we need to be able to set the overrides outside of components within the context.

## Testing Instructions
1. Enable both the "off canvas navigation editor" and "block inspector tabs" Gutenberg experiments
2. Edit a post
3. Add a navigation block and a navigation link
4. Ensure the navigation block is selected
5. Under the navigation block's list view tab edit the link
6. You should now have the navigation link block selected without any display of tabs in the block inspector

### Testing Instructions for Keyboard
1. Enable both the "off canvas navigation editor" and "block inspector tabs" Gutenberg experiments
2. Edit a post
3. Add a navigation block and a navigation link
4. Ensure the navigation block is selected
5. Tab through to the navigation block's list view tab and focus the navigation link's edit button
6. Press space and you should then have the navigation link block selected with no tabs displayed in the block inspector

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/205834991-c670cce5-c03e-4202-a24e-6d9fb1fcd358.mp4

