### PR TITLE
Block editor: iframe/writing flow: change tab index to 0

### DIFF
--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -44,7 +44,7 @@ export function useWritingFlow() {
 			useArrowNav(),
 			useRefEffect(
 				( node ) => {
-					node.tabIndex = -1;
+					node.tabIndex = 0;
 					node.contentEditable = hasMultiSelection;
 
 					if ( ! hasMultiSelection ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Tries to fix #46258. Changes the tab index of writing flow (which is the body element in case of an iframe) to 0 (from -1).

I've tested with VoiceOver on Mac, but can't really reproduce the issue, so I'm working in the dark.

@alexstine Does this resolve the issue you're experiencing?

## Why?

See https://github.com/WordPress/gutenberg/issues/46258.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

See https://github.com/WordPress/gutenberg/issues/46258 for detailed instructions.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
