### PR TITLE
Video: Avoid an error when removal is locked

### DIFF
--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -161,7 +161,7 @@ function VideoEdit( {
 			const embedBlock = createUpgradedEmbedBlock( {
 				attributes: { url: newSrc },
 			} );
-			if ( undefined !== embedBlock ) {
+			if ( undefined !== embedBlock && onReplace ) {
 				onReplace( embedBlock );
 				return;
 			}


### PR DESCRIPTION
## What?
Fixes #19311.
It's similar to #38282.

PR fixes an error if using the "Insert from URL" option with the Video block if block removal is locked.

## Why?
The replace action counts as original block removal; the `onReplace` prop will be `undefined` when block removal is locked.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Video Block. 
3. Lock the block removal.
4. Use the "Insert from URL" to insert any embeddable service URL. Example: https://www.youtube.com/watch?v=m6ppAe-DjvU
5. Confirm that there are no errors in the console.

### Testing Instructions for Keyboard
Doesn't affect the UI interface.
