### PR TITLE
Page List Block: Fix error loading page list parent options

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -158,15 +158,13 @@ export default function PageListEdit( {
 		}
 	};
 
-	const useParentOptions = () => {
-		return pages?.reduce( ( accumulator, page ) => {
-			accumulator.push( {
-				value: page.id,
-				label: page.title.rendered,
-			} );
-			return accumulator;
-		}, [] );
-	};
+	const parentOptions = pages?.reduce( ( accumulator, page ) => {
+		accumulator.push( {
+			value: page.id,
+			label: page.title.rendered,
+		} );
+		return accumulator;
+	}, [] );
 
 	useEffect( () => {
 		__unstableMarkNextChangeAsNotPersistent();
@@ -179,18 +177,20 @@ export default function PageListEdit( {
 		<>
 			<InspectorControls>
 				<PanelBody>
-					<ComboboxControl
-						className="editor-page-attributes__parent"
-						label={ __( 'Parent page' ) }
-						value={ parentPageID }
-						options={ useParentOptions() }
-						onChange={ ( value ) =>
-							setAttributes( { parentPageID: value ?? 0 } )
-						}
-						help={ __(
-							'Choose a page to show only its subpages.'
-						) }
-					/>
+					{ parentOptions && (
+						<ComboboxControl
+							className="editor-page-attributes__parent"
+							label={ __( 'Parent page' ) }
+							value={ parentPageID }
+							options={ parentOptions }
+							onChange={ ( value ) =>
+								setAttributes( { parentPageID: value ?? 0 } )
+							}
+							help={ __(
+								'Choose a page to show only its subpages.'
+							) }
+						/>
+					) }
 				</PanelBody>
 			</InspectorControls>
 			{ allowConvertToLinks && (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This fixes a bug which crashes the page list block. Sometimes loading the pages is slower than we render the parent selector and this combobox crashes because it receives undefined as options, taking the block with it.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Bug fix.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

1. Refactor the code to remove a useless hook `useParentOptions` which is likely a leftover from all the recent updates of the page list block
2. Only render the combobox for selecting the parent if the pages are loaded and options are ready

## Testing Instructions

1. Add a page list block to a post
2. Should work fine

### Testing Instructions for Keyboard

N/A

## Screenshots or screencast <!-- if applicable -->

N/A