### PR TITLE
Page List Block: Hide page list edit button if no pages available

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -193,16 +193,11 @@ export default function PageListEdit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			{ allowConvertToLinks && (
+			{ allowConvertToLinks && totalPages > 0 && (
 				<BlockControls group="other">
-					{ totalPages > 0 && (
-						<ToolbarButton
-							title={ __( 'Edit' ) }
-							onClick={ openModal }
-						>
-							{ __( 'Edit' ) }
-						</ToolbarButton>
-					) }
+					<ToolbarButton title={ __( 'Edit' ) } onClick={ openModal }>
+						{ __( 'Edit' ) }
+					</ToolbarButton>
 				</BlockControls>
 			) }
 			{ allowConvertToLinks && isOpen && (

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -195,9 +195,14 @@ export default function PageListEdit( {
 			</InspectorControls>
 			{ allowConvertToLinks && (
 				<BlockControls group="other">
-					<ToolbarButton title={ __( 'Edit' ) } onClick={ openModal }>
-						{ __( 'Edit' ) }
-					</ToolbarButton>
+					{ totalPages > 0 && (
+						<ToolbarButton
+							title={ __( 'Edit' ) }
+							onClick={ openModal }
+						>
+							{ __( 'Edit' ) }
+						</ToolbarButton>
+					) }
 				</BlockControls>
 			) }
 			{ allowConvertToLinks && isOpen && (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #46301

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When the page list has no pages to retrieve, clicking "edit" when the block is a child of navigation is confusing as nothing really happens.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Only show the button if there are pages.

## Testing Instructions

1. Remove all pages
2. Remove all navigation menus and classic menus
3. Add a navigation block
4. The block should default to a page list block
5. Select the page list block
6. No edit button should be visible in the block's toolbar.

### Testing Instructions for Keyboard

N/A

## Screenshots or screencast <!-- if applicable -->

N/A