### PR TITLE
Navigation: Add a 'open list view' button

### DIFF
--- a/packages/edit-post/src/plugins/index.js
+++ b/packages/edit-post/src/plugins/index.js
@@ -14,6 +14,7 @@ import CopyContentMenuItem from './copy-content-menu-item';
 import KeyboardShortcutsHelpMenuItem from './keyboard-shortcuts-help-menu-item';
 import ToolsMoreMenuGroup from '../components/header/tools-more-menu-group';
 import WelcomeGuideMenuItem from './welcome-guide-menu-item';
+import NavigationListViewMenuItem from './navigation-list-view-menu-item';
 
 registerPlugin( 'edit-post', {
 	render() {
@@ -55,6 +56,7 @@ registerPlugin( 'edit-post', {
 						</>
 					) }
 				</ToolsMoreMenuGroup>
+				<NavigationListViewMenuItem />
 			</>
 		);
 	},

--- a/packages/edit-post/src/plugins/navigation-list-view-menu-item.js
+++ b/packages/edit-post/src/plugins/navigation-list-view-menu-item.js
@@ -1,16 +1,14 @@
 /**
  * WordPress dependencies
  */
- import {
+import {
 	BlockEditorProvider,
-	BlockTools,
 	__unstableBlockToolbarLastItem,
 	__unstableBlockNameContext,
 } from '@wordpress/block-editor';
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { Fragment } from '@wordpress/element';
-import { ReusableBlocksMenuItems } from '@wordpress/reusable-blocks';
 import { __ } from '@wordpress/i18n';
 import { listView } from '@wordpress/icons';
 
@@ -42,18 +40,15 @@ if ( isOffCanvasNavigationEditorEnabled ) {
 const NavigationEditMenuItem = () => {
 	return (
 		<BlockEditorProvider>
-			<BlockTools>
-				<__unstableBlockToolbarLastItem>
-					<__unstableBlockNameContext.Consumer>
-						{ ( blockName ) =>
-							blockName === 'core/navigation' && (
-								<MaybeNavMenuSidebarToggle />
-							)
-						}
-					</__unstableBlockNameContext.Consumer>
-				</__unstableBlockToolbarLastItem>
-			</BlockTools>
-			<ReusableBlocksMenuItems />
+			<__unstableBlockToolbarLastItem>
+				<__unstableBlockNameContext.Consumer>
+					{ ( blockName ) =>
+						blockName === 'core/navigation' && (
+							<MaybeNavMenuSidebarToggle />
+						)
+					}
+				</__unstableBlockNameContext.Consumer>
+			</__unstableBlockToolbarLastItem>
 		</BlockEditorProvider>
 	);
 };

--- a/packages/edit-post/src/plugins/navigation-list-view-menu-item.js
+++ b/packages/edit-post/src/plugins/navigation-list-view-menu-item.js
@@ -30,9 +30,6 @@ const NavMenuSidebarToggle = () => {
 	);
 };
 
-// Conditionally include NavMenu sidebar in Plugin only.
-// Optimise for dead code elimination.
-// See https://github.com/WordPress/gutenberg/blob/trunk/docs/how-to-guides/feature-flags.md#dead-code-elimination.
 let MaybeNavMenuSidebarToggle = Fragment;
 
 const isOffCanvasNavigationEditorEnabled =

--- a/packages/edit-post/src/plugins/navigation-list-view-menu-item.js
+++ b/packages/edit-post/src/plugins/navigation-list-view-menu-item.js
@@ -1,0 +1,64 @@
+/**
+ * WordPress dependencies
+ */
+ import {
+	BlockEditorProvider,
+	BlockTools,
+	__unstableBlockToolbarLastItem,
+	__unstableBlockNameContext,
+} from '@wordpress/block-editor';
+import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { Fragment } from '@wordpress/element';
+import { ReusableBlocksMenuItems } from '@wordpress/reusable-blocks';
+import { __ } from '@wordpress/i18n';
+import { listView } from '@wordpress/icons';
+
+const NavMenuSidebarToggle = () => {
+	// eslint-disable-next-line @wordpress/data-no-store-string-literals
+	const { openGeneralSidebar } = useDispatch( 'core/edit-post' );
+
+	return (
+		<ToolbarGroup>
+			<ToolbarButton
+				className="components-toolbar__control"
+				label={ __( 'Open navigation list view' ) }
+				onClick={ () => openGeneralSidebar( 'edit-post/block' ) }
+				icon={ listView }
+			/>
+		</ToolbarGroup>
+	);
+};
+
+// Conditionally include NavMenu sidebar in Plugin only.
+// Optimise for dead code elimination.
+// See https://github.com/WordPress/gutenberg/blob/trunk/docs/how-to-guides/feature-flags.md#dead-code-elimination.
+let MaybeNavMenuSidebarToggle = Fragment;
+
+const isOffCanvasNavigationEditorEnabled =
+	window?.__experimentalEnableOffCanvasNavigationEditor === true;
+
+if ( isOffCanvasNavigationEditorEnabled ) {
+	MaybeNavMenuSidebarToggle = NavMenuSidebarToggle;
+}
+
+const NavigationEditMenuItem = () => {
+	return (
+		<BlockEditorProvider>
+			<BlockTools>
+				<__unstableBlockToolbarLastItem>
+					<__unstableBlockNameContext.Consumer>
+						{ ( blockName ) =>
+							blockName === 'core/navigation' && (
+								<MaybeNavMenuSidebarToggle />
+							)
+						}
+					</__unstableBlockNameContext.Consumer>
+				</__unstableBlockToolbarLastItem>
+			</BlockTools>
+			<ReusableBlocksMenuItems />
+		</BlockEditorProvider>
+	);
+};
+
+export default NavigationEditMenuItem;

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -56,12 +56,7 @@ const LAYOUT = {
 };
 
 export default function BlockEditor( { setIsInserterOpen } ) {
-	const {
-		storedSettings,
-		templateType,
-		page,
-		canvasMode,
-	} = useSelect(
+	const { storedSettings, templateType, page, canvasMode } = useSelect(
 		( select ) => {
 			const {
 				getSettings,

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -172,15 +172,17 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 			<ToolbarButton
 				className="components-toolbar__control"
 				label={ __( 'Open navigation list view' ) }
-				onClick={ () => enableComplementaryArea( 'core/edit-site', 'edit-site/block-inspector' ) }
+				onClick={ () =>
+					enableComplementaryArea(
+						'core/edit-site',
+						'edit-site/block-inspector'
+					)
+				}
 				icon={ listView }
 			/>
 		</ToolbarGroup>
 	);
 
-	// Conditionally include NavMenu sidebar in Plugin only.
-	// Optimise for dead code elimination.
-	// See https://github.com/WordPress/gutenberg/blob/trunk/docs/how-to-guides/feature-flags.md#dead-code-elimination.
 	let MaybeNavMenuSidebarToggle = Fragment;
 	const isOffCanvasNavigationEditorEnabled =
 		window?.__experimentalEnableOffCanvasNavigationEditor === true;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is a replacement for https://github.com/WordPress/gutenberg/pull/45853.
This updates the list view button on the navigation block in the site editor to open the inspector controls, and also adds a new button to the navigation block in the post editor to open the inspector controls.

## Why?
This is a bit controversial - on the one hand we shouldn't need a button to simply open the inspector controls. On the other hand, if users have the navigation block selected but they don't have the inspector controls open, this could be a useful prompt to open them.

## How?
Adds a plugin to the edit-post package and updates the current list view button in edit-site.

## Testing Instructions
1. Open a new post
2. Add a navigation block
3. Add some items
4. Notice that there is "Open navigation list view" button in the Block Toolbar:
<img width="293" alt="Screenshot 2022-12-06 at 16 55 15" src="https://user-images.githubusercontent.com/275961/205974002-8d1a9e8f-47aa-4ef3-a4ce-74a881cf483a.png">
5. Click the button and confirm it opens the inspector controls for the Navigation block:
<img width="296" alt="Screenshot 2022-12-06 at 16 56 50" src="https://user-images.githubusercontent.com/275961/205974384-81300127-fccc-4aea-b00e-64873f37fbb6.png">
6. Do the same test in the site editor

### Testing Instructions for Keyboard
1. Open a new post
2. Add a navigation block
3. Add some items
4. Tab to the block toolbar
5. Use the arrow keys to move tab focus in the block toolbar
6. Select the navigation block
7. Move the focus to the "open navigation list view" button
8. Select this button
9. Confirm that the inspector controls open
10. Do the same test in the site editor

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/275961/205975435-f9e98cf4-3f18-4b73-82d7-826959d5015e.mp4


