### PR TITLE
Page List Block: Adds a longdash tree to the parent selector

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -236,8 +236,8 @@ export default function PageListEdit( {
 						</Button>
 					</PanelBody>
 				) }
-				<PanelBody>
-					{ pagesTree.length > 0 && (
+				{ pagesTree.length > 0 && (
+					<PanelBody>
 						<ComboboxControl
 							className="editor-page-attributes__parent"
 							label={ __( 'Parent page' ) }
@@ -250,8 +250,8 @@ export default function PageListEdit( {
 								'Choose a page to show only its subpages.'
 							) }
 						/>
-					) }
-				</PanelBody>
+					</PanelBody>
+				) }
 			</InspectorControls>
 			{ allowConvertToLinks && totalPages > 0 && (
 				<BlockControls group="other">


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Formats the parent selector in the page list block to show a long dash tree.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To make it similar to how the parent selector is formatted in the inspector's page attributes panel for pages parent setting.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Reusing the same routine we have for creating the inner blocks of the pages block.

## Testing Instructions

1. Make sure to have a page hierarchy (some pages with some having parents)
2. Remove all block and classic menus
3. Add a new page
4. Insert a navigation block
5. It should default to a page list
6. Select the page list
7. Try to change the parent
8. Observe the tree representation

### Testing Instructions for Keyboard

N/A

## Screenshots or screencast <!-- if applicable -->



https://user-images.githubusercontent.com/107534/205984435-29ac8f5c-f852-4f6d-abd9-e5bffecc7dd6.mp4

