### PR TITLE
[RNMobile] Temporarily skip failing copy/paste tests

### DIFF
--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-drag-and-drop.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-drag-and-drop.test.js
@@ -12,8 +12,9 @@ import {
 } from './helpers/utils';
 import testData from './helpers/test-data';
 
-// Used to skip some tests on iOS
-const onlyOnAndroid = isAndroid() ? it : it.skip;
+// Tests associated with this const are temporarily off for both platforms due to failures.
+// They should be enabled for Android-only when a fix is in place.
+const onlyOnAndroid = it.skip;
 
 describe( 'Gutenberg Editor Drag & Drop blocks tests', () => {
 	beforeEach( async () => {

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-paste.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-paste.test.js
@@ -25,7 +25,7 @@ describe( 'Gutenberg Editor paste tests', () => {
 		await clearClipboard( editorPage.driver );
 	} );
 
-	it( 'copies plain text from one paragraph block and pastes in another', async () => {
+	it.skip( 'copies plain text from one paragraph block and pastes in another', async () => {
 		await editorPage.addNewBlock( blockNames.paragraph );
 		const paragraphBlockElement = await editorPage.getTextBlockAtPosition(
 			blockNames.paragraph
@@ -68,7 +68,7 @@ describe( 'Gutenberg Editor paste tests', () => {
 		await editorPage.removeBlockAtPosition( blockNames.paragraph, 1 );
 	} );
 
-	it( 'copies styled text from one paragraph block and pastes in another', async () => {
+	it.skip( 'copies styled text from one paragraph block and pastes in another', async () => {
 		// Create paragraph block with styled text by editing html.
 		await editorPage.setHtmlContent( testData.pasteHtmlText );
 		const paragraphBlockElement = await editorPage.getTextBlockAtPosition(


### PR DESCRIPTION
## What?

This PR manually skips some E2E tests that are currently failing.

## Why?

The following E2E tests have been failing since https://github.com/WordPress/gutenberg/pull/45235 was merged into `trunk`:

* [should be able to long-press on a text-based block to paste a text in a focused textinput](https://github.com/WordPress/gutenberg/blob/d52854559a3130764e8a431863298ed032d3ecb0/packages/react-native-editor/__device-tests__/gutenberg-editor-drag-and-drop.test.js#L58-L88)
* [should be able to long-press on a text-based block using the PlainText component to paste a text in a focused textinput](https://github.com/WordPress/gutenberg/blob/d52854559a3130764e8a431863298ed032d3ecb0/packages/react-native-editor/__device-tests__/gutenberg-editor-drag-and-drop.test.js#L91-L122)
* [copies plain text from one paragraph block and pastes in another](https://github.com/WordPress/gutenberg/blob/d52854559a3130764e8a431863298ed032d3ecb0/packages/react-native-editor/__device-tests__/gutenberg-editor-paste.test.js#L28-L69)
* [copies styled text from one paragraph block and pastes in another](https://github.com/WordPress/gutenberg/blob/d52854559a3130764e8a431863298ed032d3ecb0/packages/react-native-editor/__device-tests__/gutenberg-editor-paste.test.js#L71-L98) 

Despite the fact that these tests are failing, copy/paste appears to still be working as expected. To verify this, a test build can be found at https://github.com/wordpress-mobile/WordPress-Android/pull/17612.

While we work on a more permanent fix for the E2E tests, this PR will temporarily skip them in the interest of reducing the noise that's coming from these incorrect failures.

## How?

`.skip` is called in order to achieve what we want. The plan is for this to be a temporary solution while we work towards a more permanent fix.

## Testing Instructions

With this branch checked out, verify that the tests pass via the following commands:

* `npm run native test:e2e:android:local gutenberg-editor-paste`
* `npm run native test:e2e:android:local gutenberg-editor-drag-and-drop`

It would also be useful to verify that these failures are in fact false by manually testing the installable build available at https://github.com/wordpress-mobile/WordPress-Android/pull/17612.