### PR TITLE
Global Styles: Make style book label font size 11px

### DIFF
--- a/packages/edit-site/src/components/style-book/style.scss
+++ b/packages/edit-site/src/components/style-book/style.scss
@@ -61,7 +61,7 @@
 }
 
 .edit-site-style-book__example-title {
-	font-size: $default-font-size;
+	font-size: 11px;
 	font-weight: 500;
 	margin: 0;
 	text-align: left;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follows https://github.com/WordPress/gutenberg/pull/45960.

Updates the font size of labels in the Style Book to be 11px. This matches the size of labels in the Global Styles sidebar.

## Why?
See https://github.com/WordPress/gutenberg/pull/45960#issuecomment-1337005907.

## How?


## Testing Instructions


### Testing Instructions for Keyboard

## Screenshots or screencast 
<img width="1258" alt="Screenshot 2022-12-07 at 09 51 57" src="https://user-images.githubusercontent.com/612155/206042980-93b6c86c-c098-4712-aeca-cbe761b4337b.png">
