### PR TITLE
Add rough animation to navigation and links

### DIFF
--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -177,7 +177,7 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 				'__experimentalBlockInspectorAnimation'  => array(
 					'description' => __( 'Whether to enable animation when showing and hiding the block inspector.', 'gutenberg' ),
 					'type'        => 'object',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					'context'     => array( 'site-editor' ),
 				),
 
 				'alignWide'                              => array(

--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -174,6 +174,12 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 				),
 
+				'__experimentalBlockInspectorAnimation'       => array(
+					'description' => __( 'Whether to enable animation when showing and hiding the block inspector.', 'gutenberg' ),
+					'type'        => 'object',
+					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+				),
+
 				'alignWide'                              => array(
 					'description' => __( 'Enable/Disable Wide/Full Alignments.', 'gutenberg' ),
 					'type'        => 'boolean',

--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -174,7 +174,7 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 				),
 
-				'__experimentalBlockInspectorAnimation'       => array(
+				'__experimentalBlockInspectorAnimation'  => array(
 					'description' => __( 'Whether to enable animation when showing and hiding the block inspector.', 'gutenberg' ),
 					'type'        => 'object',
 					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -66,7 +66,6 @@
 		"diff": "^4.0.2",
 		"dom-scroll-into-view": "^1.2.1",
 		"fast-deep-equal": "^3.1.3",
-		"framer-motion": "^7.6.1",
 		"inherits": "^2.0.3",
 		"lodash": "^4.17.21",
 		"react-autosize-textarea": "^7.1.0",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -66,6 +66,7 @@
 		"diff": "^4.0.2",
 		"dom-scroll-into-view": "^1.2.1",
 		"fast-deep-equal": "^3.1.3",
+		"framer-motion": "^7.6.1",
 		"inherits": "^2.0.3",
 		"lodash": "^4.17.21",
 		"react-autosize-textarea": "^7.1.0",

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -177,10 +177,13 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 
 	const blockInspectorAnimationSettings = useSelect(
 		( select ) => {
-			const globalBlockInspectorAnimationSettings =
-				select( blockEditorStore ).getSettings()
-					.__experimentalBlockInspectorAnimation;
-			return globalBlockInspectorAnimationSettings[ blockType.name ];
+			if ( isOffCanvasNavigationEditorEnabled ) {
+				const globalBlockInspectorAnimationSettings =
+					select( blockEditorStore ).getSettings()
+						.__experimentalBlockInspectorAnimation;
+				return globalBlockInspectorAnimationSettings[ blockType.name ];
+			}
+			return null;
 		},
 		[ selectedBlockClientId ]
 	);

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -21,7 +21,7 @@ import { useMemo, useCallback } from '@wordpress/element';
 /**
  * External dependencies
  */
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 
 /**
  * Internal dependencies
@@ -228,34 +228,30 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 		const animationOrigin =
 			blockInspectorAnimationSettings &&
 			blockInspectorAnimationSettings.enterDirection === 'leftToRight'
-				? 50
-				: -50;
+				? -50
+				: 50;
 
 		return (
-			<div>
-				<AnimatePresence>
-					<motion.div
-						animate={ {
-							x: 0,
-							opacity: 1,
-							transition: {
-								ease: 'easeInOut',
-								duration: 0.14,
-							},
-						} }
-						initial={ {
-							x: animationOrigin,
-							opacity: 0,
-						} }
-						key={ selectedBlockClientId }
-					>
-						<BlockInspectorSingleBlock
-							clientId={ selectedBlockClientId }
-							blockName={ blockType.name }
-						/>
-					</motion.div>
-				</AnimatePresence>
-			</div>
+			<motion.div
+				animate={ {
+					x: 0,
+					opacity: 1,
+					transition: {
+						ease: 'easeInOut',
+						duration: 0.14,
+					},
+				} }
+				initial={ {
+					x: animationOrigin,
+					opacity: 0,
+				} }
+				key={ selectedBlockClientId }
+			>
+				<BlockInspectorSingleBlock
+					clientId={ selectedBlockClientId }
+					blockName={ blockType.name }
+				/>
+			</motion.div>
 		);
 	}
 

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -21,6 +21,8 @@ import { useMemo, useCallback } from '@wordpress/element';
 /**
  * External dependencies
  */
+
+// eslint-disable-next-line no-restricted-imports
 import { motion } from 'framer-motion';
 
 /**

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -17,7 +17,7 @@ import {
 	__unstableMotion as motion,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useMemo, useCallback } from '@wordpress/element';
+import { useMemo, useCallback, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -185,7 +185,11 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			}
 			return null;
 		},
-		[ selectedBlockClientId ]
+		[
+			selectedBlockClientId,
+			isOffCanvasNavigationEditorEnabled,
+			blockType.name,
+		]
 	);
 
 	if ( count > 1 ) {
@@ -220,40 +224,6 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 		);
 	}
 
-	if (
-		isOffCanvasNavigationEditorEnabled &&
-		blockInspectorAnimationSettings
-	) {
-		const animationOrigin =
-			blockInspectorAnimationSettings &&
-			blockInspectorAnimationSettings.enterDirection === 'leftToRight'
-				? -50
-				: 50;
-
-		return (
-			<motion.div
-				animate={ {
-					x: 0,
-					opacity: 1,
-					transition: {
-						ease: 'easeInOut',
-						duration: 0.14,
-					},
-				} }
-				initial={ {
-					x: animationOrigin,
-					opacity: 0,
-				} }
-				key={ selectedBlockClientId }
-			>
-				<BlockInspectorSingleBlock
-					clientId={ selectedBlockClientId }
-					blockName={ blockType.name }
-				/>
-			</motion.div>
-		);
-	}
-
 	const isSelectedBlockUnregistered =
 		selectedBlockName === getUnregisteredTypeHandlerName();
 
@@ -282,11 +252,67 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			/>
 		);
 	}
+
 	return (
-		<BlockInspectorSingleBlock
-			clientId={ selectedBlockClientId }
-			blockName={ blockType.name }
-		/>
+		<BlockInspectorSingleBlockWrapper
+			animate={
+				isOffCanvasNavigationEditorEnabled &&
+				blockInspectorAnimationSettings
+			}
+			wrapper={ ( children ) => (
+				<AnimatedContainer
+					blockInspectorAnimationSettings={
+						blockInspectorAnimationSettings
+					}
+					selectedBlockClientId={ selectedBlockClientId }
+				>
+					{ children }
+				</AnimatedContainer>
+			) }
+		>
+			<Fragment>
+				<BlockInspectorSingleBlock
+					clientId={ selectedBlockClientId }
+					blockName={ blockType.name }
+				/>
+			</Fragment>
+		</BlockInspectorSingleBlockWrapper>
+	);
+};
+
+const BlockInspectorSingleBlockWrapper = ( { animate, wrapper, children } ) => {
+	return animate ? wrapper( children ) : children;
+};
+
+const AnimatedContainer = ( {
+	blockInspectorAnimationSettings,
+	selectedBlockClientId,
+	children,
+} ) => {
+	const animationOrigin =
+		blockInspectorAnimationSettings &&
+		blockInspectorAnimationSettings.enterDirection === 'leftToRight'
+			? -50
+			: 50;
+
+	return (
+		<motion.div
+			animate={ {
+				x: 0,
+				opacity: 1,
+				transition: {
+					ease: 'easeInOut',
+					duration: 0.14,
+				},
+			} }
+			initial={ {
+				x: animationOrigin,
+				opacity: 0,
+			} }
+			key={ selectedBlockClientId }
+		>
+			{ children }
+		</motion.div>
 	);
 };
 

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -185,11 +185,7 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			}
 			return null;
 		},
-		[
-			selectedBlockClientId,
-			isOffCanvasNavigationEditorEnabled,
-			blockType.name,
-		]
+		[ selectedBlockClientId, isOffCanvasNavigationEditorEnabled, blockType ]
 	);
 
 	if ( count > 1 ) {

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -14,16 +14,10 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	Button,
+	__unstableMotion as motion,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useMemo, useCallback } from '@wordpress/element';
-
-/**
- * External dependencies
- */
-
-// eslint-disable-next-line no-restricted-imports
-import { motion } from 'framer-motion';
 
 /**
  * Internal dependencies

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -378,17 +378,16 @@ function gutenberg_disable_tabs_for_navigation_link_block( $settings ) {
 add_filter( 'block_editor_settings_all', 'gutenberg_disable_tabs_for_navigation_link_block' );
 
 function gutenberg_enable_animation_for_navigation_link_inspector( $settings ) {
-	$current_tab_settings = _wp_array_get(
+	$current_animation_settings = _wp_array_get(
 		$settings,
 		array( '__experimentalBlockInspectorAnimation' ),
 		array()
 	);
 
 	$settings['__experimentalBlockInspectorAnimation'] = array_merge(
-		$current_tab_settings,
+		$current_animation_settings,
 		array( 'core/navigation-link' => array(
-			'enterDirection' => 'rightToLeft',
-			'exitDirection' => 'leftToRight'
+			'enterDirection' => 'rightToLeft'
 		) )
 	);
 

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -377,6 +377,16 @@ function gutenberg_disable_tabs_for_navigation_link_block( $settings ) {
 
 add_filter( 'block_editor_settings_all', 'gutenberg_disable_tabs_for_navigation_link_block' );
 
+/**
+ * Enables animation of the block inspector for the Navigation Link block.
+ *
+ * See:
+ * - https://github.com/WordPress/gutenberg/pull/46342
+ * - https://github.com/WordPress/gutenberg/issues/45884
+ *
+ * @param array $settings Default editor settings.
+ * @return array Filtered editor settings.
+ */
 function gutenberg_enable_animation_for_navigation_link_inspector( $settings ) {
 	$current_animation_settings = _wp_array_get(
 		$settings,
@@ -386,9 +396,12 @@ function gutenberg_enable_animation_for_navigation_link_inspector( $settings ) {
 
 	$settings['__experimentalBlockInspectorAnimation'] = array_merge(
 		$current_animation_settings,
-		array( 'core/navigation-link' => array(
-			'enterDirection' => 'rightToLeft'
-		) )
+		array(
+			'core/navigation-link' =>
+				array(
+					'enterDirection' => 'rightToLeft',
+				),
+		)
 	);
 
 	return $settings;

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -376,3 +376,23 @@ function gutenberg_disable_tabs_for_navigation_link_block( $settings ) {
 }
 
 add_filter( 'block_editor_settings_all', 'gutenberg_disable_tabs_for_navigation_link_block' );
+
+function gutenberg_enable_animation_for_navigation_link_inspector( $settings ) {
+	$current_tab_settings = _wp_array_get(
+		$settings,
+		array( '__experimentalBlockInspectorAnimation' ),
+		array()
+	);
+
+	$settings['__experimentalBlockInspectorAnimation'] = array_merge(
+		$current_tab_settings,
+		array( 'core/navigation-link' => array(
+			'enterDirection' => 'rightToLeft',
+			'exitDirection' => 'leftToRight'
+		) )
+	);
+
+	return $settings;
+}
+
+add_filter( 'block_editor_settings_all', 'gutenberg_enable_animation_for_navigation_link_inspector' );

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -323,17 +323,16 @@ function gutenberg_disable_tabs_for_navigation_submenu_block( $settings ) {
 add_filter( 'block_editor_settings_all', 'gutenberg_disable_tabs_for_navigation_submenu_block' );
 
 function gutenberg_enable_animation_for_navigation_submenu_inspector( $settings ) {
-	$current_tab_settings = _wp_array_get(
+	$current_animation_settings = _wp_array_get(
 		$settings,
 		array( '__experimentalBlockInspectorAnimation' ),
 		array()
 	);
 
 	$settings['__experimentalBlockInspectorAnimation'] = array_merge(
-		$current_tab_settings,
+		$current_animation_settings,
 		array( 'core/navigation-submenu' => array(
-			'enterDirection' => 'rightToLeft',
-			'exitDirection' => 'leftToRight'
+			'enterDirection' => 'rightToLeft'
 		) )
 	);
 

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -321,3 +321,23 @@ function gutenberg_disable_tabs_for_navigation_submenu_block( $settings ) {
 }
 
 add_filter( 'block_editor_settings_all', 'gutenberg_disable_tabs_for_navigation_submenu_block' );
+
+function gutenberg_enable_animation_for_navigation_submenu_inspector( $settings ) {
+	$current_tab_settings = _wp_array_get(
+		$settings,
+		array( '__experimentalBlockInspectorAnimation' ),
+		array()
+	);
+
+	$settings['__experimentalBlockInspectorAnimation'] = array_merge(
+		$current_tab_settings,
+		array( 'core/navigation-submenu' => array(
+			'enterDirection' => 'rightToLeft',
+			'exitDirection' => 'leftToRight'
+		) )
+	);
+
+	return $settings;
+}
+
+add_filter( 'block_editor_settings_all', 'gutenberg_enable_animation_for_navigation_submenu_inspector' );

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -322,6 +322,16 @@ function gutenberg_disable_tabs_for_navigation_submenu_block( $settings ) {
 
 add_filter( 'block_editor_settings_all', 'gutenberg_disable_tabs_for_navigation_submenu_block' );
 
+/**
+ * Enables animation of the block inspector for the Navigation Submenu block.
+ *
+ * See:
+ * - https://github.com/WordPress/gutenberg/pull/46342
+ * - https://github.com/WordPress/gutenberg/issues/45884
+ *
+ * @param array $settings Default editor settings.
+ * @return array Filtered editor settings.
+ */
 function gutenberg_enable_animation_for_navigation_submenu_inspector( $settings ) {
 	$current_animation_settings = _wp_array_get(
 		$settings,
@@ -331,9 +341,12 @@ function gutenberg_enable_animation_for_navigation_submenu_inspector( $settings 
 
 	$settings['__experimentalBlockInspectorAnimation'] = array_merge(
 		$current_animation_settings,
-		array( 'core/navigation-submenu' => array(
-			'enterDirection' => 'rightToLeft'
-		) )
+		array(
+			'core/navigation-submenu' =>
+				array(
+					'enterDirection' => 'rightToLeft',
+				),
+		)
 	);
 
 	return $settings;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -857,6 +857,16 @@ function block_core_navigation_typographic_presets_backcompatibility( $parsed_bl
 
 add_filter( 'render_block_data', 'block_core_navigation_typographic_presets_backcompatibility' );
 
+/**
+ * Enables animation of the block inspector for the Navigation block.
+ *
+ * See:
+ * - https://github.com/WordPress/gutenberg/pull/46342
+ * - https://github.com/WordPress/gutenberg/issues/45884
+ *
+ * @param array $settings Default editor settings.
+ * @return array Filtered editor settings.
+ */
 function gutenberg_enable_animation_for_navigation_inspector( $settings ) {
 	$current_animation_settings = _wp_array_get(
 		$settings,
@@ -866,9 +876,12 @@ function gutenberg_enable_animation_for_navigation_inspector( $settings ) {
 
 	$settings['__experimentalBlockInspectorAnimation'] = array_merge(
 		$current_animation_settings,
-		array( 'core/navigation' => array(
-			'enterDirection' => 'leftToRight'
-		) )
+		array(
+			'core/navigation' =>
+				array(
+					'enterDirection' => 'leftToRight',
+				),
+		)
 	);
 
 	return $settings;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -858,17 +858,16 @@ function block_core_navigation_typographic_presets_backcompatibility( $parsed_bl
 add_filter( 'render_block_data', 'block_core_navigation_typographic_presets_backcompatibility' );
 
 function gutenberg_enable_animation_for_navigation_inspector( $settings ) {
-	$current_tab_settings = _wp_array_get(
+	$current_animation_settings = _wp_array_get(
 		$settings,
 		array( '__experimentalBlockInspectorAnimation' ),
 		array()
 	);
 
 	$settings['__experimentalBlockInspectorAnimation'] = array_merge(
-		$current_tab_settings,
+		$current_animation_settings,
 		array( 'core/navigation' => array(
-			'enterDirection' => 'leftToRight',
-			'exitDirection' => 'rightToLeft'
+			'enterDirection' => 'leftToRight'
 		) )
 	);
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -856,3 +856,23 @@ function block_core_navigation_typographic_presets_backcompatibility( $parsed_bl
 }
 
 add_filter( 'render_block_data', 'block_core_navigation_typographic_presets_backcompatibility' );
+
+function gutenberg_enable_animation_for_navigation_inspector( $settings ) {
+	$current_tab_settings = _wp_array_get(
+		$settings,
+		array( '__experimentalBlockInspectorAnimation' ),
+		array()
+	);
+
+	$settings['__experimentalBlockInspectorAnimation'] = array_merge(
+		$current_tab_settings,
+		array( 'core/navigation' => array(
+			'enterDirection' => 'leftToRight',
+			'exitDirection' => 'rightToLeft'
+		) )
+	);
+
+	return $settings;
+}
+
+add_filter( 'block_editor_settings_all', 'gutenberg_enable_animation_for_navigation_inspector' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This pull request is an exploration of how we might add animation to the navigation block and related links in the off canvas editor, related to https://github.com/WordPress/gutenberg/issues/45884

## Why?
The slide animations can help with the orient the user and overall provide a better experience.

## How?
Currently, this PR adds a very rough implementation of the animation using Framer Motion so we can have something to look at as we continue discussions.

## Testing Instructions
1. Open the Full Site Editor
2. Open the Navigation block
3. In the off-canvas editor, click the edit button on one of the navigation links
4. Click the back button on the navigation link's Block Card

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
I believe the same as above, except tab over to the buttons. Since this is just for a user test though, I can look at accessibility more closely once we have a better handle on the approach we're going to take.

## Additional Notes and Question for Discussion

Note: The code currently activates the animation whenever the previously selected block is a navigation block, navigation link, or navigation submenu, so it's not a real implementation yet, so the code is very rough, though I'm happy to take any suggestions.

That being said, I'm looking for feedback on the animation itself — is this how we want it to look, or do we want to show an exit animation on the previously selected block before showing the entry animation of the newly selected one?

## Screen shots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/5360536/206072115-c7de6087-cfed-4696-aee8-a9bff5d2b8d7.mov


