### PR TITLE
Edit block style variations from global styles

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -661,8 +661,6 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	protected static function sanitize( $input, $valid_block_names, $valid_element_names ) {
 
-		$valid_variation_names = array( 'fill', 'outline' );
-
 		$output = array();
 
 		if ( ! is_array( $input ) ) {
@@ -712,18 +710,12 @@ class WP_Theme_JSON_Gutenberg {
 			}
 		}
 
-		$schema_styles_variations = array();
-		foreach ( $valid_variation_names as $variation ) {
-			$schema_styles_variations[ $variation ] = $styles_non_top_level;
-		}
-
 		$schema_styles_blocks   = array();
 		$schema_settings_blocks = array();
 		foreach ( $valid_block_names as $block ) {
-			$schema_settings_blocks[ $block ]             = static::VALID_SETTINGS;
-			$schema_styles_blocks[ $block ]               = $styles_non_top_level;
-			$schema_styles_blocks[ $block ]['elements']   = $schema_styles_elements;
-			$schema_styles_blocks[ $block ]['variations'] = $schema_styles_variations;
+			$schema_settings_blocks[ $block ]           = static::VALID_SETTINGS;
+			$schema_styles_blocks[ $block ]             = $styles_non_top_level;
+			$schema_styles_blocks[ $block ]['elements'] = $schema_styles_elements;
 		}
 
 		$schema['styles']             = static::VALID_STYLES;

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -661,6 +661,8 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	protected static function sanitize( $input, $valid_block_names, $valid_element_names ) {
 
+		$valid_variation_names = array( 'fill', 'outline' );
+
 		$output = array();
 
 		if ( ! is_array( $input ) ) {
@@ -710,12 +712,18 @@ class WP_Theme_JSON_Gutenberg {
 			}
 		}
 
+		$schema_styles_variations = array();
+		foreach ( $valid_variation_names as $variation ) {
+			$schema_styles_variations[ $variation ] = $styles_non_top_level;
+		}
+
 		$schema_styles_blocks   = array();
 		$schema_settings_blocks = array();
 		foreach ( $valid_block_names as $block ) {
-			$schema_settings_blocks[ $block ]           = static::VALID_SETTINGS;
-			$schema_styles_blocks[ $block ]             = $styles_non_top_level;
-			$schema_styles_blocks[ $block ]['elements'] = $schema_styles_elements;
+			$schema_settings_blocks[ $block ]             = static::VALID_SETTINGS;
+			$schema_styles_blocks[ $block ]               = $styles_non_top_level;
+			$schema_styles_blocks[ $block ]['elements']   = $schema_styles_elements;
+			$schema_styles_blocks[ $block ]['variations'] = $schema_styles_variations;
 		}
 
 		$schema['styles']             = static::VALID_STYLES;

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2165,9 +2165,16 @@ class WP_Theme_JSON_Gutenberg {
 			$variation_selectors = array();
 			if ( isset( $node['variations'] ) ) {
 				foreach ( $node['variations'] as $variation => $node ) {
+					// There might not be a selector if this is a newly created variation, so we need to provide one.
+					$variation_selector = '';
+					if ( isset( $selectors[ $name ]['styleVariations'][ $variation ] ) ) {
+						$variation_selector = $selectors[ $name ]['styleVariations'][ $variation ];
+					} elseif ( isset( $selectors[ $name ]['selector'] ) ) {
+						$variation_selector = '.is-style-' . $variation . '.is-style-' . $variation . $selectors[ $name ]['selector'];
+					}
 					$variation_selectors[] = array(
 						'path'     => array( 'styles', 'blocks', $name, 'variations', $variation ),
-						'selector' => $selectors[ $name ]['styleVariations'][ $variation ],
+						'selector' => $variation_selector,
 					);
 				}
 			}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -876,7 +876,7 @@ class WP_Theme_JSON_Gutenberg {
 			if ( ! empty( $block_type->styles ) ) {
 				$style_selectors = array();
 				foreach ( $block_type->styles as $style ) {
-					$style_selectors[ $style['name'] ] = static::append_to_selector( '.is-style-' . $style['name'], static::$blocks_metadata[ $block_name ]['selector'] );
+					$style_selectors[ $style['name'] ] = static::append_to_selector( '.is-style-' . $style['name'] . '.is-style-' . $style['name'], static::$blocks_metadata[ $block_name ]['selector'] );
 				}
 				static::$blocks_metadata[ $block_name ]['styleVariations'] = $style_selectors;
 			}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2165,16 +2165,9 @@ class WP_Theme_JSON_Gutenberg {
 			$variation_selectors = array();
 			if ( isset( $node['variations'] ) ) {
 				foreach ( $node['variations'] as $variation => $node ) {
-					// There might not be a selector if this is a newly created variation, so we need to provide one.
-					$variation_selector = '';
-					if ( isset( $selectors[ $name ]['styleVariations'][ $variation ] ) ) {
-						$variation_selector = $selectors[ $name ]['styleVariations'][ $variation ];
-					} elseif ( isset( $selectors[ $name ]['selector'] ) ) {
-						$variation_selector = '.is-style-' . $variation . '.is-style-' . $variation . $selectors[ $name ]['selector'];
-					}
 					$variation_selectors[] = array(
 						'path'     => array( 'styles', 'blocks', $name, 'variations', $variation ),
-						'selector' => $variation_selector,
+						'selector' => $selectors[ $name ]['styleVariations'][ $variation ],
 					);
 				}
 			}

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -14,6 +14,7 @@ import {
 	Popover,
 } from '@wordpress/components';
 import deprecated from '@wordpress/deprecated';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -64,7 +65,9 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 		<div className="block-editor-block-styles">
 			<div className="block-editor-block-styles__variants">
 				{ stylesToRender.map( ( style ) => {
-					const buttonText = style.label || style.name;
+					const buttonText = style.isDefault
+						? __( 'Default' )
+						: style.label || style.name;
 
 					return (
 						<Button

--- a/packages/edit-site/src/components/global-styles/block-preview-panel.js
+++ b/packages/edit-site/src/components/global-styles/block-preview-panel.js
@@ -12,13 +12,19 @@ const BlockPreviewPanel = ( { name, variation = '' } ) => {
 		{ width: containerWidth, height: containerHeight },
 	] = useResizeObserver();
 	const blockExample = getBlockType( name )?.example;
-	if ( variation ) {
-		blockExample.attributes = {
+	const blockExampleWithVariation = {
+		...blockExample,
+		attributes: {
 			...blockExample.attributes,
 			className: variation,
-		};
-	}
-	const blocks = blockExample && getBlockFromExample( name, blockExample );
+		},
+	};
+	const blocks =
+		blockExample &&
+		getBlockFromExample(
+			name,
+			variation ? blockExampleWithVariation : blockExample
+		);
 	const viewportWidth = blockExample?.viewportWidth || containerWidth;
 	const minHeight = containerHeight;
 

--- a/packages/edit-site/src/components/global-styles/block-preview-panel.js
+++ b/packages/edit-site/src/components/global-styles/block-preview-panel.js
@@ -15,7 +15,7 @@ const BlockPreviewPanel = ( { name, variation = '' } ) => {
 	const blockExampleWithVariation = {
 		...blockExample,
 		attributes: {
-			...blockExample.attributes,
+			...blockExample?.attributes,
 			className: variation,
 		},
 	};

--- a/packages/edit-site/src/components/global-styles/block-preview-panel.js
+++ b/packages/edit-site/src/components/global-styles/block-preview-panel.js
@@ -6,12 +6,18 @@ import { getBlockType, getBlockFromExample } from '@wordpress/blocks';
 import { useResizeObserver } from '@wordpress/compose';
 import { __experimentalSpacer as Spacer } from '@wordpress/components';
 
-const BlockPreviewPanel = ( { name } ) => {
+const BlockPreviewPanel = ( { name, variation = '' } ) => {
 	const [
 		containerResizeListener,
 		{ width: containerWidth, height: containerHeight },
 	] = useResizeObserver();
 	const blockExample = getBlockType( name )?.example;
+	if ( variation ) {
+		blockExample.attributes = {
+			...blockExample.attributes,
+			className: variation,
+		};
+	}
 	const blocks = blockExample && getBlockFromExample( name, blockExample );
 	const viewportWidth = blockExample?.viewportWidth || containerWidth;
 	const minHeight = containerHeight;

--- a/packages/edit-site/src/components/global-styles/border-panel.js
+++ b/packages/edit-site/src/components/global-styles/border-panel.js
@@ -97,8 +97,12 @@ function applyAllFallbackStyles( border ) {
 export default function BorderPanel( { name, variationPath = '' } ) {
 	// To better reflect if the user has customized a value we need to
 	// ensure the style value being checked is from the `user` origin.
-	const [ userBorderStyles ] = useStyle( 'border', name, 'user' );
-	const [ border, setBorder ] = useStyle( 'border', name );
+	const [ userBorderStyles ] = useStyle(
+		`${ variationPath }border`,
+		name,
+		'user'
+	);
+	const [ border, setBorder ] = useStyle( `${ variationPath }border`, name );
 	const colors = useColorsPerOrigin( name );
 
 	const showBorderColor = useHasBorderColorControl( name );

--- a/packages/edit-site/src/components/global-styles/border-panel.js
+++ b/packages/edit-site/src/components/global-styles/border-panel.js
@@ -94,7 +94,7 @@ function applyAllFallbackStyles( border ) {
 	return applyFallbackStyle( border );
 }
 
-export default function BorderPanel( { name } ) {
+export default function BorderPanel( { name, variationPath = '' } ) {
 	// To better reflect if the user has customized a value we need to
 	// ensure the style value being checked is from the `user` origin.
 	const [ userBorderStyles ] = useStyle( 'border', name, 'user' );
@@ -108,7 +108,7 @@ export default function BorderPanel( { name } ) {
 	// Border radius.
 	const showBorderRadius = useHasBorderRadiusControl( name );
 	const [ borderRadiusValues, setBorderRadius ] = useStyle(
-		'border.radius',
+		`${ variationPath }border.radius`,
 		name
 	);
 	const hasBorderRadius = () => {

--- a/packages/edit-site/src/components/global-styles/context-menu.js
+++ b/packages/edit-site/src/components/global-styles/context-menu.js
@@ -12,6 +12,7 @@ import { useHasBorderPanel } from './border-panel';
 import { useHasColorPanel } from './color-utils';
 import { useHasDimensionsPanel } from './dimensions-panel';
 import { useHasTypographyPanel } from './typography-panel';
+import { useHasVariationsPanel } from './variations-panel';
 import { NavigationButtonAsItem } from './navigation-button';
 
 function ContextMenu( { name, parentMenu = '' } ) {
@@ -20,6 +21,7 @@ function ContextMenu( { name, parentMenu = '' } ) {
 	const hasBorderPanel = useHasBorderPanel( name );
 	const hasDimensionsPanel = useHasDimensionsPanel( name );
 	const hasLayoutPanel = hasDimensionsPanel;
+	const hasVariationsPanel = useHasVariationsPanel( name, parentMenu );
 
 	return (
 		<ItemGroup>
@@ -57,6 +59,15 @@ function ContextMenu( { name, parentMenu = '' } ) {
 					aria-label={ __( 'Layout styles' ) }
 				>
 					{ __( 'Layout' ) }
+				</NavigationButtonAsItem>
+			) }
+			{ hasVariationsPanel && (
+				<NavigationButtonAsItem
+					icon={ '+' }
+					path={ parentMenu + '/variations' }
+					aria-label={ __( 'Style variations' ) }
+				>
+					{ __( 'Variations' ) }
 				</NavigationButtonAsItem>
 			) }
 		</ItemGroup>

--- a/packages/edit-site/src/components/global-styles/context-menu.js
+++ b/packages/edit-site/src/components/global-styles/context-menu.js
@@ -14,6 +14,7 @@ import { useHasDimensionsPanel } from './dimensions-panel';
 import { useHasTypographyPanel } from './typography-panel';
 import { useHasVariationsPanel } from './variations-panel';
 import { NavigationButtonAsItem } from './navigation-button';
+import { ScreenVariations } from './screen-variations';
 
 function ContextMenu( { name, parentMenu = '' } ) {
 	const hasTypographyPanel = useHasTypographyPanel( name );
@@ -62,13 +63,7 @@ function ContextMenu( { name, parentMenu = '' } ) {
 				</NavigationButtonAsItem>
 			) }
 			{ hasVariationsPanel && (
-				<NavigationButtonAsItem
-					icon={ '+' }
-					path={ parentMenu + '/variations' }
-					aria-label={ __( 'Style variations' ) }
-				>
-					{ __( 'Variations' ) }
-				</NavigationButtonAsItem>
+				<ScreenVariations name={ name } path={ parentMenu } />
 			) }
 		</ItemGroup>
 	);

--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -197,8 +197,11 @@ function useWideSizeProps( name ) {
 }
 
 // Props for managing `spacing.padding`.
-function usePaddingProps( name ) {
-	const [ rawPadding, setRawPadding ] = useStyle( 'spacing.padding', name );
+function usePaddingProps( name, variationPath = '' ) {
+	const [ rawPadding, setRawPadding ] = useStyle(
+		variationPath + 'spacing.padding',
+		name
+	);
 	const paddingValues = splitStyleValue( rawPadding );
 	const paddingSides = useCustomSides( name, 'padding' );
 	const isAxialPadding =
@@ -210,7 +213,11 @@ function usePaddingProps( name ) {
 		setRawPadding( padding );
 	};
 	const resetPaddingValue = () => setPaddingValues( {} );
-	const [ userSetPaddingValue ] = useStyle( 'spacing.padding', name, 'user' );
+	const [ userSetPaddingValue ] = useStyle(
+		variationPath + 'spacing.padding',
+		name,
+		'user'
+	);
 	// The `hasPaddingValue` check does not need a parsed value, as `userSetPaddingValue` will be `undefined` if not set.
 	const hasPaddingValue = () => !! userSetPaddingValue;
 
@@ -225,8 +232,11 @@ function usePaddingProps( name ) {
 }
 
 // Props for managing `spacing.margin`.
-function useMarginProps( name ) {
-	const [ rawMargin, setRawMargin ] = useStyle( 'spacing.margin', name );
+function useMarginProps( name, variationPath = '' ) {
+	const [ rawMargin, setRawMargin ] = useStyle(
+		variationPath + 'spacing.margin',
+		name
+	);
 	const marginValues = splitStyleValue( rawMargin );
 	const marginSides = useCustomSides( name, 'margin' );
 	const isAxialMargin =
@@ -252,14 +262,21 @@ function useMarginProps( name ) {
 }
 
 // Props for managing `spacing.blockGap`.
-function useBlockGapProps( name ) {
-	const [ gapValue, setGapValue ] = useStyle( 'spacing.blockGap', name );
+function useBlockGapProps( name, variationPath = '' ) {
+	const [ gapValue, setGapValue ] = useStyle(
+		variationPath + 'spacing.blockGap',
+		name
+	);
 	const gapValues = splitGapValue( gapValue );
 	const gapSides = useCustomSides( name, 'blockGap' );
 	const isAxialGap =
 		gapSides && gapSides.some( ( side ) => AXIAL_SIDES.includes( side ) );
 	const resetGapValue = () => setGapValue( undefined );
-	const [ userSetGapValue ] = useStyle( 'spacing.blockGap', name, 'user' );
+	const [ userSetGapValue ] = useStyle(
+		variationPath + 'spacing.blockGap',
+		name,
+		'user'
+	);
 	const hasGapValue = () => !! userSetGapValue;
 	const setGapValues = ( nextBoxGapValue ) => {
 		if ( ! nextBoxGapValue ) {
@@ -288,9 +305,9 @@ function useBlockGapProps( name ) {
 }
 
 // Props for managing `dimensions.minHeight`.
-function useMinHeightProps( name ) {
+function useMinHeightProps( name, variationPath = '' ) {
 	const [ minHeightValue, setMinHeightValue ] = useStyle(
-		'dimensions.minHeight',
+		variationPath + 'dimensions.minHeight',
 		name
 	);
 	const resetMinHeightValue = () => setMinHeightValue( undefined );
@@ -303,7 +320,7 @@ function useMinHeightProps( name ) {
 	};
 }
 
-export default function DimensionsPanel( { name } ) {
+export default function DimensionsPanel( { name, variationPath = '' } ) {
 	const showContentSizeControl = useHasContentSize( name );
 	const showWideSizeControl = useHasWideSize( name );
 	const showPaddingControl = useHasPadding( name );
@@ -345,7 +362,7 @@ export default function DimensionsPanel( { name } ) {
 		setPaddingValues,
 		resetPaddingValue,
 		hasPaddingValue,
-	} = usePaddingProps( name );
+	} = usePaddingProps( name, variationPath );
 
 	// Props for managing `spacing.margin`.
 	const {
@@ -355,7 +372,7 @@ export default function DimensionsPanel( { name } ) {
 		setMarginValues,
 		resetMarginValue,
 		hasMarginValue,
-	} = useMarginProps( name );
+	} = useMarginProps( name, variationPath );
 
 	// Props for managing `spacing.blockGap`.
 	const {
@@ -367,7 +384,7 @@ export default function DimensionsPanel( { name } ) {
 		setGapValues,
 		resetGapValue,
 		hasGapValue,
-	} = useBlockGapProps( name );
+	} = useBlockGapProps( name, variationPath );
 
 	// Props for managing `dimensions.minHeight`.
 	const {
@@ -375,7 +392,7 @@ export default function DimensionsPanel( { name } ) {
 		setMinHeightValue,
 		resetMinHeightValue,
 		hasMinHeightValue,
-	} = useMinHeightProps( name );
+	} = useMinHeightProps( name, variationPath );
 
 	const resetAll = () => {
 		resetPaddingValue();

--- a/packages/edit-site/src/components/global-styles/global-styles-provider.js
+++ b/packages/edit-site/src/components/global-styles/global-styles-provider.js
@@ -158,6 +158,7 @@ function useGlobalStylesContext() {
 		isUserConfigReady,
 		isBaseConfigReady,
 	] );
+
 	return context;
 }
 

--- a/packages/edit-site/src/components/global-styles/global-styles-provider.js
+++ b/packages/edit-site/src/components/global-styles/global-styles-provider.js
@@ -158,7 +158,6 @@ function useGlobalStylesContext() {
 		isUserConfigReady,
 		isBaseConfigReady,
 	] );
-
 	return context;
 }
 

--- a/packages/edit-site/src/components/global-styles/screen-background-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-background-color.js
@@ -16,7 +16,7 @@ import {
 	useStyle,
 } from './hooks';
 
-function ScreenBackgroundColor( { name } ) {
+function ScreenBackgroundColor( { name, variationPath = '' } ) {
 	const supports = getSupportedGlobalStylesPanels( name );
 	const [ solids ] = useSetting( 'color.palette', name );
 	const [ gradients ] = useSetting( 'color.gradients', name );
@@ -39,16 +39,23 @@ function ScreenBackgroundColor( { name } ) {
 		supports.includes( 'background' ) &&
 		( gradients.length > 0 || areCustomGradientsEnabled );
 	const [ backgroundColor, setBackgroundColor ] = useStyle(
-		'color.background',
+		variationPath + 'color.background',
 		name
 	);
 	const [ userBackgroundColor ] = useStyle(
-		'color.background',
+		variationPath + 'color.background',
 		name,
 		'user'
 	);
-	const [ gradient, setGradient ] = useStyle( 'color.gradient', name );
-	const [ userGradient ] = useStyle( 'color.gradient', name, 'user' );
+	const [ gradient, setGradient ] = useStyle(
+		variationPath + 'color.gradient',
+		name
+	);
+	const [ userGradient ] = useStyle(
+		variationPath + 'color.gradient',
+		name,
+		'user'
+	);
 
 	if ( ! hasBackgroundColor && ! hasGradientColor ) {
 		return null;

--- a/packages/edit-site/src/components/global-styles/screen-block-list.js
+++ b/packages/edit-site/src/components/global-styles/screen-block-list.js
@@ -21,6 +21,7 @@ import { useHasBorderPanel } from './border-panel';
 import { useHasColorPanel } from './color-utils';
 import { useHasDimensionsPanel } from './dimensions-panel';
 import { useHasTypographyPanel } from './typography-panel';
+import { useHasVariationsPanel } from './variations-panel';
 import ScreenHeader from './header';
 import { NavigationButtonAsItem } from './navigation-button';
 
@@ -53,8 +54,12 @@ function BlockMenuItem( { block } ) {
 	const hasBorderPanel = useHasBorderPanel( block.name );
 	const hasDimensionsPanel = useHasDimensionsPanel( block.name );
 	const hasLayoutPanel = hasBorderPanel || hasDimensionsPanel;
+	const hasVariationsPanel = useHasVariationsPanel( block.name );
 	const hasBlockMenuItem =
-		hasTypographyPanel || hasColorPanel || hasLayoutPanel;
+		hasTypographyPanel ||
+		hasColorPanel ||
+		hasLayoutPanel ||
+		hasVariationsPanel;
 
 	if ( ! hasBlockMenuItem ) {
 		return null;

--- a/packages/edit-site/src/components/global-styles/screen-border.js
+++ b/packages/edit-site/src/components/global-styles/screen-border.js
@@ -10,14 +10,15 @@ import ScreenHeader from './header';
 import BorderPanel, { useHasBorderPanel } from './border-panel';
 import BlockPreviewPanel from './block-preview-panel';
 
-function ScreenBorder( { name } ) {
+function ScreenBorder( { name, variationPath = '' } ) {
 	const hasBorderPanel = useHasBorderPanel( name );
-
 	return (
 		<>
 			<ScreenHeader title={ __( 'Border' ) } />
 			<BlockPreviewPanel name={ name } />
-			{ hasBorderPanel && <BorderPanel name={ name } /> }
+			{ hasBorderPanel && (
+				<BorderPanel name={ name } variationPath={ variationPath } />
+			) }
 		</>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/screen-border.js
+++ b/packages/edit-site/src/components/global-styles/screen-border.js
@@ -9,13 +9,15 @@ import { __ } from '@wordpress/i18n';
 import ScreenHeader from './header';
 import BorderPanel, { useHasBorderPanel } from './border-panel';
 import BlockPreviewPanel from './block-preview-panel';
+import { getVariationClassNameFromPath } from './utils';
 
 function ScreenBorder( { name, variationPath = '' } ) {
 	const hasBorderPanel = useHasBorderPanel( name );
+	const variationClassName = getVariationClassNameFromPath( variationPath );
 	return (
 		<>
 			<ScreenHeader title={ __( 'Border' ) } />
-			<BlockPreviewPanel name={ name } />
+			<BlockPreviewPanel name={ name } variation={ variationClassName } />
 			{ hasBorderPanel && (
 				<BorderPanel name={ name } variationPath={ variationPath } />
 			) }

--- a/packages/edit-site/src/components/global-styles/screen-button-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-button-color.js
@@ -15,7 +15,7 @@ import {
 	useColorsPerOrigin,
 } from './hooks';
 
-function ScreenButtonColor( { name } ) {
+function ScreenButtonColor( { name, variationPath = '' } ) {
 	const supports = getSupportedGlobalStylesPanels( name );
 	const [ solids ] = useSetting( 'color.palette', name );
 	const [ areCustomSolidsEnabled ] = useSetting( 'color.custom', name );
@@ -30,7 +30,7 @@ function ScreenButtonColor( { name } ) {
 		( solids.length > 0 || areCustomSolidsEnabled );
 
 	const [ buttonTextColor, setButtonTextColor ] = useStyle(
-		'elements.button.color.text',
+		variationPath + 'elements.button.color.text',
 		name
 	);
 	const [ userButtonTextColor ] = useStyle(

--- a/packages/edit-site/src/components/global-styles/screen-colors.js
+++ b/packages/edit-site/src/components/global-styles/screen-colors.js
@@ -22,13 +22,19 @@ import Subtitle from './subtitle';
 import ColorIndicatorWrapper from './color-indicator-wrapper';
 import BlockPreviewPanel from './block-preview-panel';
 
-function BackgroundColorItem( { name, parentMenu } ) {
+function BackgroundColorItem( { name, parentMenu, variationPath = '' } ) {
 	const supports = getSupportedGlobalStylesPanels( name );
 	const hasSupport =
 		supports.includes( 'backgroundColor' ) ||
 		supports.includes( 'background' );
-	const [ backgroundColor ] = useStyle( 'color.background', name );
-	const [ gradientValue ] = useStyle( 'color.gradient', name );
+	const [ backgroundColor ] = useStyle(
+		variationPath + 'color.background',
+		name
+	);
+	const [ gradientValue ] = useStyle(
+		variationPath + 'color.gradient',
+		name
+	);
 
 	if ( ! hasSupport ) {
 		return null;
@@ -54,10 +60,10 @@ function BackgroundColorItem( { name, parentMenu } ) {
 	);
 }
 
-function TextColorItem( { name, parentMenu } ) {
+function TextColorItem( { name, parentMenu, variationPath = '' } ) {
 	const supports = getSupportedGlobalStylesPanels( name );
 	const hasSupport = supports.includes( 'color' );
-	const [ color ] = useStyle( 'color.text', name );
+	const [ color ] = useStyle( variationPath + 'color.text', name );
 
 	if ( ! hasSupport ) {
 		return null;
@@ -83,11 +89,17 @@ function TextColorItem( { name, parentMenu } ) {
 	);
 }
 
-function LinkColorItem( { name, parentMenu } ) {
+function LinkColorItem( { name, parentMenu, variationPath = '' } ) {
 	const supports = getSupportedGlobalStylesPanels( name );
 	const hasSupport = supports.includes( 'linkColor' );
-	const [ color ] = useStyle( 'elements.link.color.text', name );
-	const [ colorHover ] = useStyle( 'elements.link.:hover.color.text', name );
+	const [ color ] = useStyle(
+		variationPath + 'elements.link.color.text',
+		name
+	);
+	const [ colorHover ] = useStyle(
+		variationPath + 'elements.link.:hover.color.text',
+		name
+	);
 
 	if ( ! hasSupport ) {
 		return null;
@@ -115,11 +127,17 @@ function LinkColorItem( { name, parentMenu } ) {
 	);
 }
 
-function HeadingColorItem( { name, parentMenu } ) {
+function HeadingColorItem( { name, parentMenu, variationPath = '' } ) {
 	const supports = getSupportedGlobalStylesPanels( name );
 	const hasSupport = supports.includes( 'color' );
-	const [ color ] = useStyle( 'elements.heading.color.text', name );
-	const [ bgColor ] = useStyle( 'elements.heading.color.background', name );
+	const [ color ] = useStyle(
+		variationPath + 'elements.heading.color.text',
+		name
+	);
+	const [ bgColor ] = useStyle(
+		variationPath + 'elements.heading.color.background',
+		name
+	);
 
 	if ( ! hasSupport ) {
 		return null;
@@ -145,11 +163,17 @@ function HeadingColorItem( { name, parentMenu } ) {
 	);
 }
 
-function ButtonColorItem( { name, parentMenu } ) {
+function ButtonColorItem( { name, parentMenu, variationPath = '' } ) {
 	const supports = getSupportedGlobalStylesPanels( name );
 	const hasSupport = supports.includes( 'buttonColor' );
-	const [ color ] = useStyle( 'elements.button.color.text', name );
-	const [ bgColor ] = useStyle( 'elements.button.color.background', name );
+	const [ color ] = useStyle(
+		variationPath + 'elements.button.color.text',
+		name
+	);
+	const [ bgColor ] = useStyle(
+		variationPath + 'elements.button.color.background',
+		name
+	);
 
 	if ( ! hasSupport ) {
 		return null;
@@ -174,7 +198,7 @@ function ButtonColorItem( { name, parentMenu } ) {
 	);
 }
 
-function ScreenColors( { name } ) {
+function ScreenColors( { name, variationPath = '' } ) {
 	const parentMenu =
 		name === undefined ? '' : '/blocks/' + encodeURIComponent( name );
 
@@ -199,22 +223,27 @@ function ScreenColors( { name } ) {
 							<BackgroundColorItem
 								name={ name }
 								parentMenu={ parentMenu }
+								variationPath={ variationPath }
 							/>
 							<TextColorItem
 								name={ name }
 								parentMenu={ parentMenu }
+								variationPath={ variationPath }
 							/>
 							<LinkColorItem
 								name={ name }
 								parentMenu={ parentMenu }
+								variationPath={ variationPath }
 							/>
 							<HeadingColorItem
 								name={ name }
 								parentMenu={ parentMenu }
+								variationPath={ variationPath }
 							/>
 							<ButtonColorItem
 								name={ name }
 								parentMenu={ parentMenu }
+								variationPath={ variationPath }
 							/>
 						</ItemGroup>
 					</VStack>

--- a/packages/edit-site/src/components/global-styles/screen-colors.js
+++ b/packages/edit-site/src/components/global-styles/screen-colors.js
@@ -23,6 +23,9 @@ import ColorIndicatorWrapper from './color-indicator-wrapper';
 import BlockPreviewPanel from './block-preview-panel';
 
 function variationPathToURL( variationPath ) {
+	if ( ! variationPath ) {
+		return '';
+	}
 	// Replace the dots with slashes, add slash at the beginning and remove the last slash.
 	return '/' + variationPath.replace( /\./g, '/' ).slice( 0, -1 );
 }

--- a/packages/edit-site/src/components/global-styles/screen-colors.js
+++ b/packages/edit-site/src/components/global-styles/screen-colors.js
@@ -21,6 +21,7 @@ import { getSupportedGlobalStylesPanels, useStyle } from './hooks';
 import Subtitle from './subtitle';
 import ColorIndicatorWrapper from './color-indicator-wrapper';
 import BlockPreviewPanel from './block-preview-panel';
+import { getVariationClassNameFromPath } from './utils';
 
 function variationPathToURL( variationPath ) {
 	if ( ! variationPath ) {
@@ -231,6 +232,7 @@ function ButtonColorItem( { name, parentMenu, variationPath = '' } ) {
 function ScreenColors( { name, variationPath = '' } ) {
 	const parentMenu =
 		name === undefined ? '' : '/blocks/' + encodeURIComponent( name );
+	const variationClassName = getVariationClassNameFromPath( variationPath );
 
 	return (
 		<>
@@ -241,7 +243,7 @@ function ScreenColors( { name, variationPath = '' } ) {
 				) }
 			/>
 
-			<BlockPreviewPanel name={ name } />
+			<BlockPreviewPanel name={ name } variation={ variationClassName } />
 
 			<div className="edit-site-global-styles-screen-colors">
 				<VStack spacing={ 10 }>

--- a/packages/edit-site/src/components/global-styles/screen-colors.js
+++ b/packages/edit-site/src/components/global-styles/screen-colors.js
@@ -22,6 +22,11 @@ import Subtitle from './subtitle';
 import ColorIndicatorWrapper from './color-indicator-wrapper';
 import BlockPreviewPanel from './block-preview-panel';
 
+function variationPathToURL( variationPath ) {
+	// Replace the dots with slashes, add slash at the beginning and remove the last slash.
+	return '/' + variationPath.replace( /\./g, '/' ).slice( 0, -1 );
+}
+
 function BackgroundColorItem( { name, parentMenu, variationPath = '' } ) {
 	const supports = getSupportedGlobalStylesPanels( name );
 	const hasSupport =
@@ -42,7 +47,11 @@ function BackgroundColorItem( { name, parentMenu, variationPath = '' } ) {
 
 	return (
 		<NavigationButtonAsItem
-			path={ parentMenu + '/colors/background' }
+			path={
+				parentMenu +
+				variationPathToURL( variationPath ) +
+				'/colors/background'
+			}
 			aria-label={ __( 'Colors background styles' ) }
 		>
 			<HStack justify="flex-start">
@@ -71,7 +80,11 @@ function TextColorItem( { name, parentMenu, variationPath = '' } ) {
 
 	return (
 		<NavigationButtonAsItem
-			path={ parentMenu + '/colors/text' }
+			path={
+				parentMenu +
+				variationPathToURL( variationPath ) +
+				'/colors/text'
+			}
 			aria-label={ __( 'Colors text styles' ) }
 		>
 			<HStack justify="flex-start">
@@ -107,7 +120,11 @@ function LinkColorItem( { name, parentMenu, variationPath = '' } ) {
 
 	return (
 		<NavigationButtonAsItem
-			path={ parentMenu + '/colors/link' }
+			path={
+				parentMenu +
+				variationPathToURL( variationPath ) +
+				'/colors/link'
+			}
 			aria-label={ __( 'Colors link styles' ) }
 		>
 			<HStack justify="flex-start">
@@ -145,7 +162,11 @@ function HeadingColorItem( { name, parentMenu, variationPath = '' } ) {
 
 	return (
 		<NavigationButtonAsItem
-			path={ parentMenu + '/colors/heading' }
+			path={
+				parentMenu +
+				variationPathToURL( variationPath ) +
+				'/colors/heading'
+			}
 			aria-label={ __( 'Colors heading styles' ) }
 		>
 			<HStack justify="flex-start">
@@ -180,7 +201,13 @@ function ButtonColorItem( { name, parentMenu, variationPath = '' } ) {
 	}
 
 	return (
-		<NavigationButtonAsItem path={ parentMenu + '/colors/button' }>
+		<NavigationButtonAsItem
+			path={
+				parentMenu +
+				variationPathToURL( variationPath ) +
+				'/colors/button'
+			}
+		>
 			<HStack justify="flex-start">
 				<ZStack isLayered={ false } offset={ -8 }>
 					<ColorIndicatorWrapper expanded={ false }>

--- a/packages/edit-site/src/components/global-styles/screen-heading-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-heading-color.js
@@ -21,7 +21,7 @@ import {
 	useGradientsPerOrigin,
 } from './hooks';
 
-function ScreenHeadingColor( { name } ) {
+function ScreenHeadingColor( { name, variationPath = '' } ) {
 	const [ selectedLevel, setCurrentTab ] = useState( 'heading' );
 
 	const supports = getSupportedGlobalStylesPanels( name );
@@ -52,30 +52,30 @@ function ScreenHeadingColor( { name } ) {
 		( gradients.length > 0 || areCustomGradientsEnabled );
 
 	const [ color, setColor ] = useStyle(
-		'elements.' + selectedLevel + '.color.text',
+		variationPath + 'elements.' + selectedLevel + '.color.text',
 		name
 	);
 	const [ userColor ] = useStyle(
-		'elements.' + selectedLevel + '.color.text',
+		variationPath + 'elements.' + selectedLevel + '.color.text',
 		name,
 		'user'
 	);
 
 	const [ backgroundColor, setBackgroundColor ] = useStyle(
-		'elements.' + selectedLevel + '.color.background',
+		variationPath + 'elements.' + selectedLevel + '.color.background',
 		name
 	);
 	const [ userBackgroundColor ] = useStyle(
-		'elements.' + selectedLevel + '.color.background',
+		variationPath + 'elements.' + selectedLevel + '.color.background',
 		name,
 		'user'
 	);
 	const [ gradient, setGradient ] = useStyle(
-		'elements.' + selectedLevel + '.color.gradient',
+		variationPath + 'elements.' + selectedLevel + '.color.gradient',
 		name
 	);
 	const [ userGradient ] = useStyle(
-		'elements.' + selectedLevel + '.color.gradient',
+		variationPath + 'elements.' + selectedLevel + '.color.gradient',
 		name,
 		'user'
 	);

--- a/packages/edit-site/src/components/global-styles/screen-layout.js
+++ b/packages/edit-site/src/components/global-styles/screen-layout.js
@@ -9,14 +9,15 @@ import { __ } from '@wordpress/i18n';
 import DimensionsPanel, { useHasDimensionsPanel } from './dimensions-panel';
 import ScreenHeader from './header';
 import BlockPreviewPanel from './block-preview-panel';
+import { getVariationClassNameFromPath } from './utils';
 
 function ScreenLayout( { name, variationPath = '' } ) {
 	const hasDimensionsPanel = useHasDimensionsPanel( name );
-
+	const variationClassName = getVariationClassNameFromPath( variationPath );
 	return (
 		<>
 			<ScreenHeader title={ __( 'Layout' ) } />
-			<BlockPreviewPanel name={ name } />
+			<BlockPreviewPanel name={ name } variation={ variationClassName } />
 			{ hasDimensionsPanel && (
 				<DimensionsPanel
 					name={ name }

--- a/packages/edit-site/src/components/global-styles/screen-layout.js
+++ b/packages/edit-site/src/components/global-styles/screen-layout.js
@@ -10,14 +10,19 @@ import DimensionsPanel, { useHasDimensionsPanel } from './dimensions-panel';
 import ScreenHeader from './header';
 import BlockPreviewPanel from './block-preview-panel';
 
-function ScreenLayout( { name } ) {
+function ScreenLayout( { name, variationPath = '' } ) {
 	const hasDimensionsPanel = useHasDimensionsPanel( name );
 
 	return (
 		<>
 			<ScreenHeader title={ __( 'Layout' ) } />
 			<BlockPreviewPanel name={ name } />
-			{ hasDimensionsPanel && <DimensionsPanel name={ name } /> }
+			{ hasDimensionsPanel && (
+				<DimensionsPanel
+					name={ name }
+					variationPath={ variationPath }
+				/>
+			) }
 		</>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/screen-link-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-link-color.js
@@ -15,7 +15,7 @@ import {
 	useColorsPerOrigin,
 } from './hooks';
 
-function ScreenLinkColor( { name } ) {
+function ScreenLinkColor( { name, variationPath = '' } ) {
 	const supports = getSupportedGlobalStylesPanels( name );
 	const [ solids ] = useSetting( 'color.palette', name );
 	const [ areCustomSolidsEnabled ] = useSetting( 'color.custom', name );
@@ -32,20 +32,32 @@ function ScreenLinkColor( { name } ) {
 	const pseudoStates = {
 		default: {
 			label: __( 'Default' ),
-			value: useStyle( 'elements.link.color.text', name )[ 0 ],
-			handler: useStyle( 'elements.link.color.text', name )[ 1 ],
+			value: useStyle(
+				variationPath + 'elements.link.color.text',
+				name
+			)[ 0 ],
+			handler: useStyle(
+				variationPath + 'elements.link.color.text',
+				name
+			)[ 1 ],
 			userValue: useStyle(
-				'elements.link.color.text',
+				variationPath + 'elements.link.color.text',
 				name,
 				'user'
 			)[ 0 ],
 		},
 		hover: {
 			label: __( 'Hover' ),
-			value: useStyle( 'elements.link.:hover.color.text', name )[ 0 ],
-			handler: useStyle( 'elements.link.:hover.color.text', name )[ 1 ],
+			value: useStyle(
+				variationPath + 'elements.link.:hover.color.text',
+				name
+			)[ 0 ],
+			handler: useStyle(
+				variationPath + 'elements.link.:hover.color.text',
+				name
+			)[ 1 ],
 			userValue: useStyle(
-				'elements.link.:hover.color.text',
+				variationPath + 'elements.link.:hover.color.text',
 				name,
 				'user'
 			)[ 0 ],

--- a/packages/edit-site/src/components/global-styles/screen-text-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-text-color.js
@@ -15,7 +15,7 @@ import {
 	useColorsPerOrigin,
 } from './hooks';
 
-function ScreenTextColor( { name } ) {
+function ScreenTextColor( { name, variationPath = '' } ) {
 	const supports = getSupportedGlobalStylesPanels( name );
 	const [ solids ] = useSetting( 'color.palette', name );
 	const [ areCustomSolidsEnabled ] = useSetting( 'color.custom', name );
@@ -28,8 +28,12 @@ function ScreenTextColor( { name } ) {
 		isTextEnabled &&
 		( solids.length > 0 || areCustomSolidsEnabled );
 
-	const [ color, setColor ] = useStyle( 'color.text', name );
-	const [ userColor ] = useStyle( 'color.text', name, 'user' );
+	const [ color, setColor ] = useStyle( variationPath + 'color.text', name );
+	const [ userColor ] = useStyle(
+		variationPath + 'color.text',
+		name,
+		'user'
+	);
 
 	if ( ! hasTextColor ) {
 		return null;

--- a/packages/edit-site/src/components/global-styles/screen-typography.js
+++ b/packages/edit-site/src/components/global-styles/screen-typography.js
@@ -18,6 +18,7 @@ import { useStyle } from './hooks';
 import Subtitle from './subtitle';
 import TypographyPanel from './typography-panel';
 import BlockPreviewPanel from './block-preview-panel';
+import { getVariationClassNameFromPath } from './utils';
 
 function Item( { name, parentMenu, element, label } ) {
 	const hasSupport = ! name;
@@ -78,7 +79,7 @@ function Item( { name, parentMenu, element, label } ) {
 
 function ScreenTypography( { name, variationPath = '' } ) {
 	const parentMenu = name === undefined ? '' : '/blocks/' + name;
-
+	const variationClassName = getVariationClassNameFromPath( variationPath );
 	return (
 		<>
 			<ScreenHeader
@@ -88,7 +89,7 @@ function ScreenTypography( { name, variationPath = '' } ) {
 				) }
 			/>
 
-			<BlockPreviewPanel name={ name } />
+			<BlockPreviewPanel name={ name } variation={ variationClassName } />
 
 			{ ! name && (
 				<div className="edit-site-global-styles-screen-typography">

--- a/packages/edit-site/src/components/global-styles/screen-typography.js
+++ b/packages/edit-site/src/components/global-styles/screen-typography.js
@@ -76,7 +76,7 @@ function Item( { name, parentMenu, element, label } ) {
 	);
 }
 
-function ScreenTypography( { name } ) {
+function ScreenTypography( { name, variationPath = '' } ) {
 	const parentMenu = name === undefined ? '' : '/blocks/' + name;
 
 	return (
@@ -124,7 +124,13 @@ function ScreenTypography( { name } ) {
 				</div>
 			) }
 			{ /* No typography elements support yet for blocks. */ }
-			{ !! name && <TypographyPanel name={ name } element="text" /> }
+			{ !! name && (
+				<TypographyPanel
+					name={ name }
+					variationPath={ variationPath }
+					element="text"
+				/>
+			) }
 		</>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/screen-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-variations.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import {
+	VariationPanel,
+	VariationsPanel,
+	useHasVariationsPanel,
+} from './variations-panel';
+import ScreenHeader from './header';
+
+export function ScreenVariations( { name, path = '' } ) {
+	const hasVariationsPanel = useHasVariationsPanel( name, path );
+
+	if ( ! hasVariationsPanel ) {
+		return null;
+	}
+	return (
+		<>
+			<ScreenHeader
+				title={ __( 'Style Variations' ) }
+				description={ __( 'Customise style variations.' ) }
+			/>
+			<VariationsPanel name={ name } />
+		</>
+	);
+}
+
+export function ScreenVariation( { blockName, styleName } ) {
+	return (
+		<>
+			<ScreenHeader title={ styleName } />
+			<VariationPanel blockName={ blockName } styleName={ styleName } />
+		</>
+	);
+}

--- a/packages/edit-site/src/components/global-styles/screen-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-variations.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { __experimentalVStack as VStack } from '@wordpress/components';
 /**
  * Internal dependencies
  */
@@ -12,6 +13,7 @@ import {
 } from './variations-panel';
 import ScreenHeader from './header';
 import BlockPreviewPanel from './block-preview-panel';
+import Subtitle from './subtitle';
 
 export function ScreenVariations( { name, path = '' } ) {
 	const hasVariationsPanel = useHasVariationsPanel( name, path );
@@ -20,20 +22,21 @@ export function ScreenVariations( { name, path = '' } ) {
 		return null;
 	}
 	return (
-		<>
-			<ScreenHeader
-				title={ __( 'Style Variations' ) }
-				description={ __( 'Customise style variations.' ) }
-			/>
-			<VariationsPanel name={ name } />
-		</>
+		<div className="edit-site-global-styles-screen-variations">
+			<VStack spacing={ 3 }>
+				<p>Manage style variations, saved block appearence presets.</p>
+				<Subtitle>{ __( 'Style Variations' ) }</Subtitle>
+				<VariationsPanel name={ name } />
+			</VStack>
+		</div>
 	);
 }
 
-export function ScreenVariation( { blockName, styleName } ) {
+export function ScreenVariation( { blockName, style } ) {
+	const { name: styleName, label: styleLabel } = style;
 	return (
 		<>
-			<ScreenHeader title={ styleName } />
+			<ScreenHeader title={ styleLabel } />
 			<BlockPreviewPanel
 				name={ blockName }
 				variation={ `is-style-${ styleName }` }

--- a/packages/edit-site/src/components/global-styles/screen-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-variations.js
@@ -11,6 +11,7 @@ import {
 	useHasVariationsPanel,
 } from './variations-panel';
 import ScreenHeader from './header';
+import BlockPreviewPanel from './block-preview-panel';
 
 export function ScreenVariations( { name, path = '' } ) {
 	const hasVariationsPanel = useHasVariationsPanel( name, path );
@@ -33,6 +34,10 @@ export function ScreenVariation( { blockName, styleName } ) {
 	return (
 		<>
 			<ScreenHeader title={ styleName } />
+			<BlockPreviewPanel
+				name={ blockName }
+				variation={ `is-style-${ styleName }` }
+			/>
 			<VariationPanel blockName={ blockName } styleName={ styleName } />
 		</>
 	);

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -146,3 +146,12 @@ $block-preview-height: 150px;
 	max-height: 200px;
 	overflow-y: scroll;
 }
+
+.edit-site-global-styles-screen-variations {
+	margin-top: $grid-unit-20;
+	border-top: 1px solid $gray-300;
+
+	& > * {
+		margin: $grid-unit-30 $grid-unit-20;
+	}
+}

--- a/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
@@ -681,7 +681,7 @@ describe( 'global styles renderer', () => {
 			const imageBlock = { name: 'core/image', supports: imageSupports };
 			const blockTypes = [ imageBlock ];
 
-			expect( getBlockSelectors( blockTypes ) ).toEqual( {
+			expect( getBlockSelectors( blockTypes, () => {} ) ).toEqual( {
 				'core/image': {
 					name: imageBlock.name,
 					selector: imageSupports.__experimentalSelector,

--- a/packages/edit-site/src/components/global-styles/typography-panel.js
+++ b/packages/edit-site/src/components/global-styles/typography-panel.js
@@ -171,7 +171,12 @@ function useFontAppearance( prefix, name ) {
 	};
 }
 
-export default function TypographyPanel( { name, element, headingLevel } ) {
+export default function TypographyPanel( {
+	name,
+	element,
+	headingLevel,
+	variationPath = '',
+} ) {
 	const supports = getSupportedGlobalStylesPanels( name );
 	let prefix = '';
 	if ( element === 'heading' ) {
@@ -210,9 +215,15 @@ export default function TypographyPanel( { name, element, headingLevel } ) {
 	}
 
 	const [ fontFamily, setFontFamily, hasFontFamily, resetFontFamily ] =
-		useStyleWithReset( prefix + 'typography.fontFamily', name );
+		useStyleWithReset(
+			variationPath + prefix + 'typography.fontFamily',
+			name
+		);
 	const { fontSize, setFontSize, hasFontSize, resetFontSize } =
-		useFontSizeWithReset( prefix + 'typography.fontSize', name );
+		useFontSizeWithReset(
+			variationPath + prefix + 'typography.fontSize',
+			name
+		);
 	const {
 		fontStyle,
 		setFontStyle,
@@ -220,27 +231,39 @@ export default function TypographyPanel( { name, element, headingLevel } ) {
 		setFontWeight,
 		hasFontAppearance,
 		resetFontAppearance,
-	} = useFontAppearance( prefix, name );
+	} = useFontAppearance( variationPath + prefix, name );
 	const [ lineHeight, setLineHeight, hasLineHeight, resetLineHeight ] =
-		useStyleWithReset( prefix + 'typography.lineHeight', name );
+		useStyleWithReset(
+			variationPath + prefix + 'typography.lineHeight',
+			name
+		);
 	const [
 		letterSpacing,
 		setLetterSpacing,
 		hasLetterSpacing,
 		resetLetterSpacing,
-	] = useStyleWithReset( prefix + 'typography.letterSpacing', name );
+	] = useStyleWithReset(
+		variationPath + prefix + 'typography.letterSpacing',
+		name
+	);
 	const [
 		textTransform,
 		setTextTransform,
 		hasTextTransform,
 		resetTextTransform,
-	] = useStyleWithReset( prefix + 'typography.textTransform', name );
+	] = useStyleWithReset(
+		variationPath + prefix + 'typography.textTransform',
+		name
+	);
 	const [
 		textDecoration,
 		setTextDecoration,
 		hasTextDecoration,
 		resetTextDecoration,
-	] = useStyleWithReset( prefix + 'typography.textDecoration', name );
+	] = useStyleWithReset(
+		variationPath + prefix + 'typography.textDecoration',
+		name
+	);
 
 	const resetAll = () => {
 		resetFontFamily();

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -47,6 +47,14 @@ function GlobalStylesNavigationScreen( { className, ...props } ) {
 }
 
 function ContextScreens( { name, parentMenu = '' } ) {
+	const hasVariationPath = parentMenu.search( 'variations' );
+	const variationPath =
+		hasVariationPath !== -1
+			? parentMenu
+					.substring( hasVariationPath )
+					.replace( '/', '.' )
+					.concat( '', '.' )
+			: '';
 	const blockStyleVariations = useSelect(
 		( select ) => {
 			const { getBlockStyles } = select( blocksStore );
@@ -136,7 +144,7 @@ function ContextScreens( { name, parentMenu = '' } ) {
 			</GlobalStylesNavigationScreen>
 
 			<GlobalStylesNavigationScreen path={ parentMenu + '/border' }>
-				<ScreenBorder name={ name } />
+				<ScreenBorder name={ name } variationPath={ variationPath } />
 			</GlobalStylesNavigationScreen>
 
 			<GlobalStylesNavigationScreen path={ parentMenu + '/layout' }>

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -80,7 +80,10 @@ function ContextScreens( { name, parentMenu = '' } ) {
 	return (
 		<>
 			<GlobalStylesNavigationScreen path={ parentMenu + '/typography' }>
-				<ScreenTypography name={ name } />
+				<ScreenTypography
+					name={ name }
+					variationPath={ variationPath }
+				/>
 			</GlobalStylesNavigationScreen>
 
 			<GlobalStylesNavigationScreen
@@ -108,7 +111,7 @@ function ContextScreens( { name, parentMenu = '' } ) {
 			</GlobalStylesNavigationScreen>
 
 			<GlobalStylesNavigationScreen path={ parentMenu + '/colors' }>
-				<ScreenColors name={ name } />
+				<ScreenColors name={ name } variationPath={ variationPath } />
 			</GlobalStylesNavigationScreen>
 
 			<GlobalStylesNavigationScreen

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -166,7 +166,7 @@ function ContextScreens( { name, parentMenu = '' } ) {
 			</GlobalStylesNavigationScreen>
 
 			<GlobalStylesNavigationScreen path={ parentMenu + '/layout' }>
-				<ScreenLayout name={ name } />
+				<ScreenLayout name={ name } variationPath={ variationPath } />
 			</GlobalStylesNavigationScreen>
 
 			<GlobalStylesNavigationScreen path={ parentMenu + '/variations' }>

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -46,6 +46,32 @@ function GlobalStylesNavigationScreen( { className, ...props } ) {
 	);
 }
 
+function BlockStyleVariationsScreens( { name } ) {
+	const blockStyleVariations = useSelect(
+		( select ) => {
+			const { getBlockStyles } = select( blocksStore );
+			return getBlockStyles( name );
+		},
+		[ name ]
+	);
+	if ( ! blockStyleVariations?.length ) {
+		return null;
+	}
+
+	return blockStyleVariations.map( ( variation ) => (
+		<ContextScreens
+			key={ variation.name + name }
+			name={ name }
+			parentMenu={
+				'/blocks/' +
+				encodeURIComponent( name ) +
+				'/variations/' +
+				encodeURIComponent( variation.name )
+			}
+		/>
+	) );
+}
+
 function ContextScreens( { name, parentMenu = '' } ) {
 	const hasVariationPath = parentMenu.search( 'variations' );
 	const variationPath =
@@ -212,9 +238,7 @@ function GlobalStylesStyleBook( { onClose } ) {
 
 function GlobalStylesUI( { isStyleBookOpened, onCloseStyleBook } ) {
 	const blocks = getBlockTypes();
-	const getBlockStyles = useSelect( ( select ) => {
-		return select( blocksStore ).getBlockStyles;
-	}, [] );
+
 	return (
 		<NavigatorProvider
 			className="edit-site-global-styles-sidebar__navigator-provider"
@@ -251,23 +275,13 @@ function GlobalStylesUI( { isStyleBookOpened, onCloseStyleBook } ) {
 				/>
 			) ) }
 
-			{ blocks.map( ( block ) => {
-				const blockStyleVariations = getBlockStyles( block.name );
-				if ( ! blockStyleVariations?.length ) {
-					return null;
-				}
-				return blockStyleVariations.map( ( variation ) => (
-					<ContextScreens
-						key={ variation.name + block.name }
+			{ blocks.map( ( block, index ) => {
+				return (
+					<BlockStyleVariationsScreens
+						key={ 'screens-block-styles-' + block.name + index }
 						name={ block.name }
-						parentMenu={
-							'/blocks/' +
-							encodeURIComponent( block.name ) +
-							'/variations/' +
-							encodeURIComponent( variation.name )
-						}
 					/>
-				) );
+				);
 			} ) }
 			{ isStyleBookOpened && (
 				<GlobalStylesStyleBook onClose={ onCloseStyleBook } />

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -27,7 +27,7 @@ import ScreenHeadingColor from './screen-heading-color';
 import ScreenButtonColor from './screen-button-color';
 import ScreenLayout from './screen-layout';
 import ScreenStyleVariations from './screen-style-variations';
-import { ScreenVariations, ScreenVariation } from './screen-variations';
+import { ScreenVariation } from './screen-variations';
 import ScreenBorder from './screen-border';
 import StyleBook from '../style-book';
 import ScreenCSS from './screen-css';
@@ -95,10 +95,7 @@ function ContextScreens( { name, parentMenu = '' } ) {
 				key={ index }
 				path={ parentMenu + '/variations/' + style.name }
 			>
-				<ScreenVariation
-					blockName={ blockName }
-					styleName={ style.name }
-				/>
+				<ScreenVariation blockName={ blockName } style={ style } />
 			</GlobalStylesNavigationScreen>
 		) );
 	};
@@ -195,9 +192,6 @@ function ContextScreens( { name, parentMenu = '' } ) {
 				<ScreenLayout name={ name } variationPath={ variationPath } />
 			</GlobalStylesNavigationScreen>
 
-			<GlobalStylesNavigationScreen path={ parentMenu + '/variations' }>
-				<ScreenVariations name={ name } path={ parentMenu } />
-			</GlobalStylesNavigationScreen>
 			{ !! blockStyleVariations?.length && (
 				<BlockStylesNavigationScreens
 					blockStyles={ blockStyleVariations }

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -123,27 +123,42 @@ function ContextScreens( { name, parentMenu = '' } ) {
 			<GlobalStylesNavigationScreen
 				path={ parentMenu + '/colors/background' }
 			>
-				<ScreenBackgroundColor name={ name } />
+				<ScreenBackgroundColor
+					name={ name }
+					variationPath={ variationPath }
+				/>
 			</GlobalStylesNavigationScreen>
 
 			<GlobalStylesNavigationScreen path={ parentMenu + '/colors/text' }>
-				<ScreenTextColor name={ name } />
+				<ScreenTextColor
+					name={ name }
+					variationPath={ variationPath }
+				/>
 			</GlobalStylesNavigationScreen>
 
 			<GlobalStylesNavigationScreen path={ parentMenu + '/colors/link' }>
-				<ScreenLinkColor name={ name } />
+				<ScreenLinkColor
+					name={ name }
+					variationPath={ variationPath }
+				/>
 			</GlobalStylesNavigationScreen>
 
 			<GlobalStylesNavigationScreen
 				path={ parentMenu + '/colors/heading' }
 			>
-				<ScreenHeadingColor name={ name } />
+				<ScreenHeadingColor
+					name={ name }
+					variationPath={ variationPath }
+				/>
 			</GlobalStylesNavigationScreen>
 
 			<GlobalStylesNavigationScreen
 				path={ parentMenu + '/colors/button' }
 			>
-				<ScreenButtonColor name={ name } />
+				<ScreenButtonColor
+					name={ name }
+					variationPath={ variationPath }
+				/>
 			</GlobalStylesNavigationScreen>
 
 			<GlobalStylesNavigationScreen path={ parentMenu + '/border' }>

--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -854,11 +854,13 @@ export const getBlockSelectors = ( blockTypes, getBlockStyles ) => {
 
 		const blockStyleVariations = getBlockStyles( name );
 		const styleVariationSelectors = {};
-		blockStyleVariations.forEach( ( variation ) => {
-			const styleVariationSelector = `.is-style-${ variation.name }${ selector }`;
-			styleVariationSelectors[ variation.name ] = styleVariationSelector;
-		} );
-
+		if ( blockStyleVariations?.length ) {
+			blockStyleVariations.forEach( ( variation ) => {
+				const styleVariationSelector = `.is-style-${ variation.name }${ selector }`;
+				styleVariationSelectors[ variation.name ] =
+					styleVariationSelector;
+			} );
+		}
 		// For each block support feature add any custom selectors.
 		const featureSelectors = {};
 		Object.entries( BLOCK_SUPPORT_FEATURE_LEVEL_SELECTORS ).forEach(

--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -192,7 +192,6 @@ export function getStylesDeclarations(
 	tree = {}
 ) {
 	const isRoot = ROOT_BLOCK_SELECTOR === selector;
-	// need to add logic here to take into account the styles nested in variations
 	const output = Object.entries( STYLE_PROPERTY ).reduce(
 		(
 			declarations,
@@ -661,6 +660,7 @@ export const toStyles = (
 			fallbackGapValue,
 			hasLayoutSupport,
 			featureSelectors,
+			styleVariationSelectors,
 		} ) => {
 			// Process styles for block support features with custom feature level
 			// CSS selectors set.
@@ -681,6 +681,29 @@ export const toStyles = (
 									`${ featureSelector }{${ featureDeclarations.join(
 										';'
 									) } }`;
+							}
+						}
+					}
+				);
+			}
+
+			if ( styleVariationSelectors ) {
+				Object.entries( styleVariationSelectors ).forEach(
+					( [ styleVariationName, styleVariationSelector ] ) => {
+						if ( styles?.variations?.[ styleVariationName ] ) {
+							const styleVariationDeclarations =
+								getStylesDeclarations(
+									styles?.variations?.[ styleVariationName ],
+									styleVariationSelector,
+									useRootPaddingAlign,
+									tree
+								);
+							if ( !! styleVariationDeclarations.length ) {
+								ruleset =
+									ruleset +
+									`${ styleVariationSelector }{${ styleVariationDeclarations.join(
+										';'
+									) }}`;
 							}
 						}
 					}
@@ -832,7 +855,7 @@ export const getBlockSelectors = ( blockTypes, getBlockStyles ) => {
 		const blockStyleVariations = getBlockStyles( name );
 		const styleVariationSelectors = {};
 		blockStyleVariations.forEach( ( variation ) => {
-			const styleVariationSelector = `${ selector } is-style-${ variation.name }`;
+			const styleVariationSelector = `.is-style-${ variation.name }${ selector }`;
 			styleVariationSelectors[ variation.name ] = styleVariationSelector;
 		} );
 

--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -691,6 +691,60 @@ export const toStyles = (
 				Object.entries( styleVariationSelectors ).forEach(
 					( [ styleVariationName, styleVariationSelector ] ) => {
 						if ( styles?.variations?.[ styleVariationName ] ) {
+							// If the block uses any custom selectors for block support, add those first.
+							if ( featureSelectors ) {
+								Object.entries( featureSelectors ).forEach(
+									( [ featureName, featureSelector ] ) => {
+										if (
+											styles?.variations?.[
+												styleVariationName
+											]?.[ featureName ]
+										) {
+											const featureStyles = {
+												[ featureName ]:
+													styles.variations[
+														styleVariationName
+													][ featureName ],
+											};
+											const featureDeclarations =
+												getStylesDeclarations(
+													featureStyles
+												);
+											delete styles.variations[
+												styleVariationName
+											][ featureName ];
+
+											if (
+												!! featureDeclarations.length
+											) {
+												const _featureSelectors =
+													featureSelector.split(
+														','
+													);
+												const combinedSelectors = [];
+												_featureSelectors.forEach(
+													( _featureSelector ) => {
+														combinedSelectors.push(
+															`${ styleVariationSelector.trim() }${ _featureSelector.trim() }`
+														);
+													}
+												);
+												const combinedSelectorString =
+													combinedSelectors.join(
+														', '
+													);
+
+												ruleset =
+													ruleset +
+													`${ combinedSelectorString }{${ featureDeclarations.join(
+														';'
+													) } }`;
+											}
+										}
+									}
+								);
+							}
+							// Otherwise add regular selectors.
 							const styleVariationDeclarations =
 								getStylesDeclarations(
 									styles?.variations?.[ styleVariationName ],

--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -192,6 +192,7 @@ export function getStylesDeclarations(
 	tree = {}
 ) {
 	const isRoot = ROOT_BLOCK_SELECTOR === selector;
+	// need to add logic here to take into account the styles nested in variations
 	const output = Object.entries( STYLE_PROPERTY ).reduce(
 		(
 			declarations,
@@ -485,6 +486,16 @@ export const getNodesWithStyles = ( tree, blockSelectors ) => {
 	Object.entries( tree.styles?.blocks ?? {} ).forEach(
 		( [ blockName, node ] ) => {
 			const blockStyles = pickStyleKeys( node );
+
+			if ( node?.variations ) {
+				const variations = {};
+				Object.keys( node.variations ).forEach( ( variation ) => {
+					variations[ variation ] = pickStyleKeys(
+						node.variations[ variation ]
+					);
+				} );
+				blockStyles.variations = variations;
+			}
 			if (
 				!! blockStyles &&
 				!! blockSelectors?.[ blockName ]?.selector
@@ -500,6 +511,8 @@ export const getNodesWithStyles = ( tree, blockSelectors ) => {
 					styles: blockStyles,
 					featureSelectors:
 						blockSelectors[ blockName ].featureSelectors,
+					styleVariationSelectors:
+						blockSelectors[ blockName ].styleVariationSelectors,
 				} );
 			}
 

--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -173,6 +173,29 @@ function flattenTree( input = {}, prefix, token ) {
 }
 
 /**
+ * Gets variation selector string from feature selector.
+ *
+ * @param {string} featureSelector        The feature selector.
+ *
+ * @param {string} styleVariationSelector The style variation selector.
+ * @return {string} Combined selector string.
+ *
+ */
+function concatFeatureVariationSelectorString(
+	featureSelector,
+	styleVariationSelector
+) {
+	const featureSelectors = featureSelector.split( ',' );
+	const combinedSelectors = [];
+	featureSelectors.forEach( ( selector ) => {
+		combinedSelectors.push(
+			`${ styleVariationSelector.trim() }${ selector.trim() }`
+		);
+	} );
+	return combinedSelectors.join( ', ' );
+}
+
+/**
  * Transform given style tree into a set of style declarations.
  *
  * @param {Object}  blockStyles         Block styles.
@@ -717,26 +740,12 @@ export const toStyles = (
 											if (
 												!! featureDeclarations.length
 											) {
-												const _featureSelectors =
-													featureSelector.split(
-														','
-													);
-												const combinedSelectors = [];
-												_featureSelectors.forEach(
-													( _featureSelector ) => {
-														combinedSelectors.push(
-															`${ styleVariationSelector.trim() }${ _featureSelector.trim() }`
-														);
-													}
-												);
-												const combinedSelectorString =
-													combinedSelectors.join(
-														', '
-													);
-
 												ruleset =
 													ruleset +
-													`${ combinedSelectorString }{${ featureDeclarations.join(
+													`${ concatFeatureVariationSelectorString(
+														featureSelector,
+														styleVariationSelector
+													) }{${ featureDeclarations.join(
 														';'
 													) } }`;
 											}

--- a/packages/edit-site/src/components/global-styles/utils.js
+++ b/packages/edit-site/src/components/global-styles/utils.js
@@ -333,3 +333,16 @@ export function scopeSelector( scope, selector ) {
 
 	return selectorsScoped.join( ', ' );
 }
+
+/**
+ *
+ * @param {string} path The variation path in the Global Styles tree.
+ *
+ * @return {string} The variation class name.
+ */
+export function getVariationClassNameFromPath( path ) {
+	if ( ! path ) {
+		return '';
+	}
+	return `is-style-${ path.split( '.' )[ 1 ] }`;
+}

--- a/packages/edit-site/src/components/global-styles/variations-panel.js
+++ b/packages/edit-site/src/components/global-styles/variations-panel.js
@@ -1,0 +1,58 @@
+/**
+ * WordPress dependencies
+ */
+import { store as blocksStore } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+
+import { NavigationButtonAsItem } from './navigation-button';
+import ContextMenu from './context-menu';
+
+export function useHasVariationsPanel( name, parentMenu = '' ) {
+	const isInsideVariationsPanel = parentMenu.includes( 'variations' );
+	const blockStyles = useSelect(
+		( select ) => {
+			const { getBlockStyles } = select( blocksStore );
+			return getBlockStyles( name );
+		},
+		[ name ]
+	);
+	return !! blockStyles?.length && ! isInsideVariationsPanel;
+}
+
+export function VariationsPanel( { name } ) {
+	const blockStyles = useSelect(
+		( select ) => {
+			const { getBlockStyles } = select( blocksStore );
+			return getBlockStyles( name );
+		},
+		[ name ]
+	);
+
+	return (
+		<>
+			{ blockStyles.map( ( style, index ) => (
+				<NavigationButtonAsItem
+					key={ index }
+					icon={ '+' }
+					path={ '/blocks/' + name + '/variations/' + style.name }
+					aria-label={ style.label }
+				>
+					{ style.label }
+				</NavigationButtonAsItem>
+			) ) }
+		</>
+	);
+}
+
+export function VariationPanel( { blockName, styleName } ) {
+	return (
+		<ContextMenu
+			parentMenu={ '/blocks/' + blockName + '/variations/' + styleName }
+			name={ blockName }
+		/>
+	);
+}

--- a/packages/edit-site/src/components/global-styles/variations-panel.js
+++ b/packages/edit-site/src/components/global-styles/variations-panel.js
@@ -38,7 +38,12 @@ export function VariationsPanel( { name } ) {
 				<NavigationButtonAsItem
 					key={ index }
 					icon={ '+' }
-					path={ '/blocks/' + name + '/variations/' + style.name }
+					path={
+						'/blocks/' +
+						encodeURIComponent( name ) +
+						'/variations/' +
+						encodeURIComponent( style.name )
+					}
 					aria-label={ style.label }
 				>
 					{ style.label }
@@ -51,7 +56,12 @@ export function VariationsPanel( { name } ) {
 export function VariationPanel( { blockName, styleName } ) {
 	return (
 		<ContextMenu
-			parentMenu={ '/blocks/' + blockName + '/variations/' + styleName }
+			parentMenu={
+				'/blocks/' +
+				encodeURIComponent( blockName ) +
+				'/variations/' +
+				encodeURIComponent( styleName )
+			}
 			name={ blockName }
 		/>
 	);

--- a/packages/edit-site/src/components/global-styles/variations-panel.js
+++ b/packages/edit-site/src/components/global-styles/variations-panel.js
@@ -1,8 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { store as blocksStore } from '@wordpress/blocks';
+import { store as blocksStore, registerBlockStyle } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
+import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -15,6 +16,10 @@ function getCoreBlockStyles( blockStyles ) {
 	return blockStyles?.filter( ( style ) => style.source === 'block' );
 }
 
+function getUserBlockStyles( blockStyles ) {
+	return blockStyles?.filter( ( style ) => style.source === 'user' );
+}
+
 export function useHasVariationsPanel( name, parentMenu = '' ) {
 	const isInsideVariationsPanel = parentMenu.includes( 'variations' );
 	const blockStyles = useSelect(
@@ -25,7 +30,11 @@ export function useHasVariationsPanel( name, parentMenu = '' ) {
 		[ name ]
 	);
 	const coreBlockStyles = getCoreBlockStyles( blockStyles );
-	return !! coreBlockStyles?.length && ! isInsideVariationsPanel;
+	const userBlockStyles = getUserBlockStyles( blockStyles );
+	return (
+		( !! coreBlockStyles?.length || !! userBlockStyles?.length ) &&
+		! isInsideVariationsPanel
+	);
 }
 
 export function VariationsPanel( { name } ) {
@@ -36,11 +45,29 @@ export function VariationsPanel( { name } ) {
 		},
 		[ name ]
 	);
-	const coreBlockStyles = getCoreBlockStyles( blockStyles );
 
+	const coreBlockStyles = getCoreBlockStyles( blockStyles );
+	const userBlockStyles = getUserBlockStyles( blockStyles );
+	const allBlockStyles = [ ...coreBlockStyles, ...userBlockStyles ];
 	return (
 		<>
-			{ coreBlockStyles.map( ( style, index ) => (
+			<p>
+				Manage and create style variations, saved block appearance
+				presets
+			</p>
+			<Button
+				variant="primary"
+				onClick={ () => {
+					registerBlockStyle( name, {
+						name: `custom-style-${ userBlockStyles?.length + 1 }`,
+						label: `Custom Style ${ userBlockStyles?.length + 1 }`,
+						source: 'user',
+					} );
+				} }
+			>
+				Create new style variation
+			</Button>
+			{ allBlockStyles.map( ( style, index ) => (
 				<NavigationButtonAsItem
 					key={ index }
 					icon={ '+' }

--- a/packages/edit-site/src/components/global-styles/variations-panel.js
+++ b/packages/edit-site/src/components/global-styles/variations-panel.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { store as blocksStore } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
@@ -40,21 +41,41 @@ export function VariationsPanel( { name } ) {
 
 	return (
 		<ItemGroup isBordered isSeparated>
-			{ coreBlockStyles.map( ( style, index ) => (
-				<NavigationButtonAsItem
-					key={ index }
-					icon={ '+' }
-					path={
-						'/blocks/' +
-						encodeURIComponent( name ) +
-						'/variations/' +
-						encodeURIComponent( style.name )
-					}
-					aria-label={ style.label }
-				>
-					{ style.label }
-				</NavigationButtonAsItem>
-			) ) }
+			{ coreBlockStyles.map( ( style, index ) => {
+				if ( style?.isDefault ) {
+					return (
+						<NavigationButtonAsItem
+							key={ index }
+							disabled={ true }
+							path={
+								'/blocks/' +
+								encodeURIComponent( name ) +
+								'/variations/' +
+								encodeURIComponent( style.name )
+							}
+							aria-label={ `${ style.label } ${ __(
+								'(Default)'
+							) }` }
+						>
+							{ `${ style.label } ${ __( '(Default)' ) }` }
+						</NavigationButtonAsItem>
+					);
+				}
+				return (
+					<NavigationButtonAsItem
+						key={ index }
+						path={
+							'/blocks/' +
+							encodeURIComponent( name ) +
+							'/variations/' +
+							encodeURIComponent( style.name )
+						}
+						aria-label={ style.label }
+					>
+						{ style.label }
+					</NavigationButtonAsItem>
+				);
+			} ) }
 		</ItemGroup>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/variations-panel.js
+++ b/packages/edit-site/src/components/global-styles/variations-panel.js
@@ -3,7 +3,7 @@
  */
 import { store as blocksStore } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
-
+import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
 /**
  * Internal dependencies
  */
@@ -39,7 +39,7 @@ export function VariationsPanel( { name } ) {
 	const coreBlockStyles = getCoreBlockStyles( blockStyles );
 
 	return (
-		<>
+		<ItemGroup isBordered isSeparated>
 			{ coreBlockStyles.map( ( style, index ) => (
 				<NavigationButtonAsItem
 					key={ index }
@@ -55,7 +55,7 @@ export function VariationsPanel( { name } ) {
 					{ style.label }
 				</NavigationButtonAsItem>
 			) ) }
-		</>
+		</ItemGroup>
 	);
 }
 

--- a/packages/edit-site/src/components/global-styles/variations-panel.js
+++ b/packages/edit-site/src/components/global-styles/variations-panel.js
@@ -1,9 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { store as blocksStore, registerBlockStyle } from '@wordpress/blocks';
+import { store as blocksStore } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
-import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -16,10 +15,6 @@ function getCoreBlockStyles( blockStyles ) {
 	return blockStyles?.filter( ( style ) => style.source === 'block' );
 }
 
-function getUserBlockStyles( blockStyles ) {
-	return blockStyles?.filter( ( style ) => style.source === 'user' );
-}
-
 export function useHasVariationsPanel( name, parentMenu = '' ) {
 	const isInsideVariationsPanel = parentMenu.includes( 'variations' );
 	const blockStyles = useSelect(
@@ -30,11 +25,7 @@ export function useHasVariationsPanel( name, parentMenu = '' ) {
 		[ name ]
 	);
 	const coreBlockStyles = getCoreBlockStyles( blockStyles );
-	const userBlockStyles = getUserBlockStyles( blockStyles );
-	return (
-		( !! coreBlockStyles?.length || !! userBlockStyles?.length ) &&
-		! isInsideVariationsPanel
-	);
+	return !! coreBlockStyles?.length && ! isInsideVariationsPanel;
 }
 
 export function VariationsPanel( { name } ) {
@@ -45,29 +36,11 @@ export function VariationsPanel( { name } ) {
 		},
 		[ name ]
 	);
-
 	const coreBlockStyles = getCoreBlockStyles( blockStyles );
-	const userBlockStyles = getUserBlockStyles( blockStyles );
-	const allBlockStyles = [ ...coreBlockStyles, ...userBlockStyles ];
+
 	return (
 		<>
-			<p>
-				Manage and create style variations, saved block appearance
-				presets
-			</p>
-			<Button
-				variant="primary"
-				onClick={ () => {
-					registerBlockStyle( name, {
-						name: `custom-style-${ userBlockStyles?.length + 1 }`,
-						label: `Custom Style ${ userBlockStyles?.length + 1 }`,
-						source: 'user',
-					} );
-				} }
-			>
-				Create new style variation
-			</Button>
-			{ allBlockStyles.map( ( style, index ) => (
+			{ coreBlockStyles.map( ( style, index ) => (
 				<NavigationButtonAsItem
 					key={ index }
 					icon={ '+' }

--- a/packages/edit-site/src/components/global-styles/variations-panel.js
+++ b/packages/edit-site/src/components/global-styles/variations-panel.js
@@ -11,6 +11,10 @@ import { useSelect } from '@wordpress/data';
 import { NavigationButtonAsItem } from './navigation-button';
 import ContextMenu from './context-menu';
 
+function getCoreBlockStyles( blockStyles ) {
+	return blockStyles?.filter( ( style ) => style.source === 'block' );
+}
+
 export function useHasVariationsPanel( name, parentMenu = '' ) {
 	const isInsideVariationsPanel = parentMenu.includes( 'variations' );
 	const blockStyles = useSelect(
@@ -20,7 +24,8 @@ export function useHasVariationsPanel( name, parentMenu = '' ) {
 		},
 		[ name ]
 	);
-	return !! blockStyles?.length && ! isInsideVariationsPanel;
+	const coreBlockStyles = getCoreBlockStyles( blockStyles );
+	return !! coreBlockStyles?.length && ! isInsideVariationsPanel;
 }
 
 export function VariationsPanel( { name } ) {
@@ -31,10 +36,11 @@ export function VariationsPanel( { name } ) {
 		},
 		[ name ]
 	);
+	const coreBlockStyles = getCoreBlockStyles( blockStyles );
 
 	return (
 		<>
-			{ blockStyles.map( ( style, index ) => (
+			{ coreBlockStyles.map( ( style, index ) => (
 				<NavigationButtonAsItem
 					key={ index }
 					icon={ '+' }

--- a/packages/edit-site/src/components/global-styles/variations-panel.js
+++ b/packages/edit-site/src/components/global-styles/variations-panel.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { store as blocksStore } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
@@ -43,23 +42,7 @@ export function VariationsPanel( { name } ) {
 		<ItemGroup isBordered isSeparated>
 			{ coreBlockStyles.map( ( style, index ) => {
 				if ( style?.isDefault ) {
-					return (
-						<NavigationButtonAsItem
-							key={ index }
-							disabled={ true }
-							path={
-								'/blocks/' +
-								encodeURIComponent( name ) +
-								'/variations/' +
-								encodeURIComponent( style.name )
-							}
-							aria-label={ `${ style.label } ${ __(
-								'(Default)'
-							) }` }
-						>
-							{ `${ style.label } ${ __( '(Default)' ) }` }
-						</NavigationButtonAsItem>
-					);
+					return null;
 				}
 				return (
 					<NavigationButtonAsItem

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1950,17 +1950,7 @@
 							"$ref": "#/definitions/stylesElementsPropertiesComplete"
 						},
 						"variations": {
-							"outline": {
-								"border": {},
-								"color": {},
-								"spacing": {},
-								"typography": {},
-								"filter": {},
-								"shadow": {},
-								"outline": {},
-								"css": {}
-							},
-							"fill": {
+							"^[a-z-]*$": {
 								"border": {},
 								"color": {},
 								"spacing": {},

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1948,6 +1948,28 @@
 						"css": {},
 						"elements": {
 							"$ref": "#/definitions/stylesElementsPropertiesComplete"
+						},
+						"variations": {
+							"outline": {
+								"border": {},
+								"color": {},
+								"spacing": {},
+								"typography": {},
+								"filter": {},
+								"shadow": {},
+								"outline": {},
+								"css": {}
+							},
+							"fill": {
+								"border": {},
+								"color": {},
+								"spacing": {},
+								"typography": {},
+								"filter": {},
+								"shadow": {},
+								"outline": {},
+								"css": {}
+							}
 						}
 					},
 					"additionalProperties": false

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1950,21 +1950,20 @@
 							"$ref": "#/definitions/stylesElementsPropertiesComplete"
 						},
 						"variations": {
-							"^[a-z-]*$": {
-								"border": {},
-								"color": {},
-								"spacing": {},
-								"typography": {},
-								"filter": {},
-								"shadow": {},
-								"outline": {},
-								"css": {}
-							}
+							"$ref": "#/definitions/stylesVariationPropertiesComplete"
 						}
 					},
 					"additionalProperties": false
 				}
 			]
+		},
+		"stylesVariationPropertiesComplete": {
+			"type": "object",
+			"patternProperties": {
+				"^[a-z][a-z0-9-]*$": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				}
+			}
 		}
 	},
 	"type": "object",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Closes #44417.

This is an initial approach to editing block style variations in global styles. It's still a work in progress and not the complete implementation for #44417.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Currently this PR only allows to edit existing variations, which works to a limited extent, given some of the classic core block variations style elements not yet available as block supports, or aren't added to every block. It also leverages the existing global styles interface for now, so the "variations" section appears as if it were another block support. 

#### Limitations

* Style variations can only make use of whatever the block supports, so their scope is much more limited than the classic CSS variations.

#### Todoes

* It should be possible to add new style variations to any block;
* "Variations" should be a section of its own, as shown in the designs in #44417.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In Global Styles, navigate to "Blocks" and then into a block that has variations, e.g. Button, Image, or Site Logo.
2. Check that a "Variations" section is rendered inside the Block screen and that clicking on that section brings up the Variations screen;
3. Check that inside the Variations screen all core variations for the block are rendered;
4. Clicking into the variations, it should be possible to change their styles and those changes should only affect that specific variation.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

Global Styles can be accessed from the Site Editor header by clicking the "Styles" button. Unfortunately keyboard navigation to the sidebar is broken, so it is necessary to tab 5-6 times after clicking "Styles" to actually arrive in the sidebar. (The first button in the sidebar is called "Open Style Book"; from then on tabbing a few more times should take us to the "Blocks" section)

## Screenshots or screencast <!-- if applicable -->

<img width="275" alt="Screenshot 2022-12-20 at 2 19 08 pm" src="https://user-images.githubusercontent.com/8096000/208573637-3359b07c-1bed-48f7-9cce-1b883ad35755.png">
<img width="281" alt="Screenshot 2022-12-20 at 2 19 37 pm" src="https://user-images.githubusercontent.com/8096000/208573646-cd199ab5-24c3-4413-a708-300035fc0b3f.png">
<img width="282" alt="Screenshot 2022-12-20 at 2 19 46 pm" src="https://user-images.githubusercontent.com/8096000/208573654-0db6744e-940b-4bc4-91ff-cefaed9b89d4.png">


