### PR TITLE
Content lock: make filter hook namespace unique

### DIFF
--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -168,6 +168,6 @@ export const withBlockControls = createHigherOrderComponent(
 
 addFilter(
 	'editor.BlockEdit',
-	'core/style/with-block-controls',
+	'core/content-lock-ui/with-block-controls',
 	withBlockControls
 );


### PR DESCRIPTION
## What?

This PR is a follow up to https://github.com/WordPress/gutenberg/pull/43037

I'm renaming the filter hook namespace from  `'core/style/with-block-controls'` to `'core/content-lock-ui/with-block-controls'` because the current value is a duplicate of the equivalent in [packages/block-editor/src/hooks/style.js](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/hooks/style.js#L472)

This is especially important since using `removeFilter` will remove them both otherwise, e.g., 

```js
removeFilter( 'editor.BlockEdit', 'core/style/with-block-controls' );
```


## Why?

The assumption is that namespaces should be unique. I could be wrong about this. If so, we should probably highlight the fact in the [docs](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-hooks/), which state that:

> One notable difference between the JS and PHP hooks API is that in the JS version, addAction() and addFilter() also need to include a namespace as the second argument. Namespace uniquely identifies a callback in the form vendor/plugin/function.

I'm happy to update the docs 😄 



## Testing Instructions
- Follow the test instructions in https://github.com/WordPress/gutenberg/pull/43037
- Check that the locked content is locked 👍 

