### PR TITLE
Sidebar Tabs: Refine use of inspector tabs and disable filters for Nav blocks

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -169,7 +169,7 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 	}, [] );
 
 	const availableTabs = useInspectorControlsTabs( blockType?.name );
-	const showTabs = availableTabs.length > 1;
+	const showTabs = availableTabs?.length > 1;
 
 	if ( count > 1 ) {
 		return (
@@ -241,7 +241,7 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 
 const BlockInspectorSingleBlock = ( { clientId, blockName } ) => {
 	const availableTabs = useInspectorControlsTabs( blockName );
-	const showTabs = availableTabs.length > 1;
+	const showTabs = availableTabs?.length > 1;
 
 	const hasBlockStyles = useSelect(
 		( select ) => {

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -13,6 +13,8 @@ import { InspectorAdvancedControls } from '../inspector-controls';
 import { TAB_LIST_VIEW, TAB_SETTINGS, TAB_STYLES } from './utils';
 import { store as blockEditorStore } from '../../store';
 
+const EMPTY_ARRAY = [];
+
 function getShowTabs( blockName, tabSettings = {} ) {
 	// Don't allow settings to force the display of tabs if the block inspector
 	// tabs experiment hasn't been opted into.
@@ -83,5 +85,5 @@ export default function useInspectorControlsTabs( blockName ) {
 
 	const showTabs = getShowTabs( blockName, tabSettings );
 
-	return showTabs ? tabs : [];
+	return showTabs ? tabs : EMPTY_ARRAY;
 }

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -346,7 +346,16 @@ function register_block_core_navigation_link() {
 add_action( 'init', 'register_block_core_navigation_link' );
 
 /**
- * Disables the display of tabs for the Navigation Link block.
+ * Disables the display of block inspector tabs for the Navigation Link block.
+ *
+ * This is only a temporary measure until we have a TabPanel and mechanism that
+ * will allow the Navigation Link to programmatically select a tab when edited
+ * via a specific context.
+ *
+ * See:
+ * - https://github.com/WordPress/gutenberg/issues/45951
+ * - https://github.com/WordPress/gutenberg/pull/46321
+ * - https://github.com/WordPress/gutenberg/pull/46271
  *
  * @param array $settings Default editor settings.
  * @return array Filtered editor settings.

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -291,7 +291,16 @@ function register_block_core_navigation_submenu() {
 add_action( 'init', 'register_block_core_navigation_submenu' );
 
 /**
- * Disables the display of tabs for the Navigation Submenu block.
+ * Disables display of block inspector tabs for the Navigation Submenu block.
+ *
+ * This is only a temporary measure until we have a TabPanel and mechanism that
+ * will allow the Navigation Submenu to programmatically select a tab when
+ * edited via a specific context.
+ *
+ * See:
+ * - https://github.com/WordPress/gutenberg/issues/45951
+ * - https://github.com/WordPress/gutenberg/pull/46321
+ * - https://github.com/WordPress/gutenberg/pull/46271
  *
  * @param array $settings Default editor settings.
  * @return array Filtered editor settings.


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/46321

## What?

- Makes the checking of available block inspector tabs a little more robust
- Adds more context via inline comments to navigation link & submenu filters disabling tabs

## Why?

More robust = good
More clarity = good

## How?

- Add optional chaining to the checks for `availableTabs` length
- Return stable reference for "no tabs" result from `useInspectorControlsTabs`
- Add inline comments with links to discussions on why we are disabling tabs for Navigation Link & Submenu blocks

## Testing Instructions
1. Enable both the "off canvas navigation editor" and "block inspector tabs" Gutenberg experiments
2. Edit a post
3. Add a navigation block and a navigation link
4. Ensure the navigation block is selected
5. Under the navigation block's list view tab edit the link
6. You should now have the navigation link block selected without any display of tabs in the block inspector

### Testing Instructions for Keyboard
1. Enable both the "off canvas navigation editor" and "block inspector tabs" Gutenberg experiments
2. Edit a post
3. Add a navigation block and a navigation link
4. Ensure the navigation block is selected
5. Tab through to the navigation block's list view tab and focus the navigation link's edit button
6. Press space and you should then have the navigation link block selected with no tabs displayed in the block inspector