### PR TITLE
MaybeCategoryPanel: Avoid 403 requests for users with low permissions

### DIFF
--- a/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
@@ -16,17 +16,14 @@ import { store as editorStore } from '../../store';
 function MaybeCategoryPanel() {
 	const hasNoCategory = useSelect( ( select ) => {
 		const postType = select( editorStore ).getCurrentPostType();
-		const categoriesTaxonomy =
-			select( coreStore ).getTaxonomy( 'category' );
-		const defaultCategoryId = select( coreStore ).getEntityRecord(
-			'root',
-			'site'
-		)?.default_category;
-		const defaultCategory = select( coreStore ).getEntityRecord(
-			'taxonomy',
-			'category',
-			defaultCategoryId
-		);
+		const { canUser, getEntityRecord, getTaxonomy } = select( coreStore );
+		const categoriesTaxonomy = getTaxonomy( 'category' );
+		const defaultCategoryId = canUser( 'read', 'settings' )
+			? getEntityRecord( 'root', 'site' )?.default_category
+			: undefined;
+		const defaultCategory = defaultCategoryId
+			? getEntityRecord( 'taxonomy', 'category', defaultCategoryId )
+			: undefined;
 		const postTypeSupportsCategories =
 			categoriesTaxonomy &&
 			categoriesTaxonomy.types.some( ( type ) => type === postType );
@@ -45,7 +42,7 @@ function MaybeCategoryPanel() {
 			postTypeSupportsCategories &&
 			( categories?.length === 0 ||
 				( categories?.length === 1 &&
-					defaultCategory.id === categories[ 0 ] ) )
+					defaultCategory?.id === categories[ 0 ] ) )
 		);
 	}, [] );
 	const [ shouldShowPanel, setShouldShowPanel ] = useState( false );


### PR DESCRIPTION
## What?
PR fixes failing 403 requests in the `MaybeCategoryPanel` component for low permission roles like Contributor and Author.

## Why?
Currently, the panel isn't displayed for Contributor and Author roles. This is because these roles don't have permission to read the site settings, but requests are still made, failing with a 403 error code.

See #42612.

## Testing Instructions
1. Login as a Contributor or Author.
2. Create a new post
3. Click the "Publish" button.
4. Observer, there are no failing 403 requests.

### Testing Instructions for Keyboard
No UI changes.
