### PR TITLE
Navigation Block: Update attribute test for `are-blocks-dirty.js`

### DIFF
--- a/packages/block-library/src/navigation/edit/test/are-blocks-dirty.js
+++ b/packages/block-library/src/navigation/edit/test/are-blocks-dirty.js
@@ -25,8 +25,11 @@ describe( 'areBlocksDirty', () => {
 	it( `should be dirty if the blocks' attributes don't match`, () => {
 		expect(
 			areBlocksDirty(
-				[ { name: 'core/paragraph' } ],
-				[ { name: 'core/paragraph', dropCap: false } ]
+				[ { name: 'core/paragraph' }, { dropCap: false } ],
+				[
+					{ name: 'core/paragraph' },
+					{ content: 'I am actually dirty.' },
+				]
 			)
 		).toBe( true );
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Updates the "should be dirty if the blocks' attributes don't match" unit test for the `are-blocks-dirty.js` file.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This update ensures that this file has 100% test coverage, as we were only missing coverage for [line 44](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/navigation/edit/are-blocks-dirty.js#L44).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds more attributes to the mock objects so we can compare the attributes in the first array to the second.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Run the following command to check coverage and ensure tests are passing: 

`npm run test:unit are-blocks-dirty.js -- --coverage`

With this PR, this file should have 100% coverage.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
