### PR TITLE
Reduce the amount of DB queries in the query blocks

### DIFF
--- a/lib/compat/wordpress-6.2/blocks.php
+++ b/lib/compat/wordpress-6.2/blocks.php
@@ -16,12 +16,15 @@
  * @return WP_Query
  */
 function _gutenberg_get_cached_block_query_results( $query_args ) {
-	$cache_key = 'query_results_' . md5( wp_json_encode( $query_args ) );
-	$results   = wp_cache_get( $cache_key, 'block-queries' );
-	if ( false === $results ) {
-		$query   = new WP_Query( $query_args );
-		$results = $query->posts;
-		wp_cache_set( $cache_key, $results, 'block-queries' );
+	// Use a static var to cache the results of the query.
+	static $cached_queries = array();
+	// Use a hash of the query args as the cache key.
+	$cache_key = md5( wp_json_encode( $query_args ) );
+
+	// If the query hasn't been cached, run it and cache the results.
+	if ( empty( $cached_queries[ $cache_key ] ) ) {
+		$query                        = new WP_Query( $query_args );
+		$cached_queries[ $cache_key ] = $query;
 	}
-	return $results;
+	return $cached_queries[ $cache_key ];
 }

--- a/lib/compat/wordpress-6.2/blocks.php
+++ b/lib/compat/wordpress-6.2/blocks.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Temporary compatibility shims for block APIs present in Gutenberg.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Get the results of a block query.
+ *
+ * This is a simple wrapper around `WP_Query` that allows us to
+ * cache the results of a query, and avoid repeat calls to the same query,
+ * which can be expensive.
+ *
+ * @param array $query_args Query arguments.
+ * @return WP_Query
+ */
+function _gutenberg_get_cached_block_query_results( $query_args ) {
+	$cache_key = 'query_results_' . md5( wp_json_encode( $query_args ) );
+	$results   = wp_cache_get( $cache_key, 'block-queries' );
+	if ( false === $results ) {
+		$query   = new WP_Query( $query_args );
+		$results = $query->posts;
+		wp_cache_set( $cache_key, $results, 'block-queries' );
+	}
+	return $results;
+}

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -51,7 +51,7 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 		$query = clone $wp_query;
 	} else {
 		$query_args = build_query_vars_from_query_block( $block, $page );
-		$query      = new WP_Query( $query_args );
+		$query      = _gutenberg_get_cached_block_query_results( $query_args );
 	}
 
 	if ( ! $query->have_posts() ) {

--- a/packages/block-library/src/query-no-results/index.php
+++ b/packages/block-library/src/query-no-results/index.php
@@ -29,7 +29,7 @@ function render_block_core_query_no_results( $attributes, $content, $block ) {
 		$query = $wp_query;
 	} else {
 		$query_args = build_query_vars_from_query_block( $block, $page );
-		$query      = new WP_Query( $query_args );
+		$query      = _gutenberg_get_cached_block_query_results( $query_args );
 	}
 
 	if ( $query->have_posts() ) {

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -44,7 +44,8 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 		$content = get_next_posts_link( $label, $max_page );
 		remove_filter( 'next_posts_link_attributes', $filter_link_attributes );
 	} elseif ( ! $max_page || $max_page > $page ) {
-		$custom_query           = new WP_Query( build_query_vars_from_query_block( $block, $page ) );
+		$custom_query_args      = build_query_vars_from_query_block( $block, $page );
+		$custom_query           = _gutenberg_get_cached_block_query_results( $custom_query_args );
 		$custom_query_max_pages = (int) $custom_query->max_num_pages;
 		if ( $custom_query_max_pages && $custom_query_max_pages !== $page ) {
 			$content = sprintf(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/42779


## Why?
Performance improvement
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
Adds a `_gutenberg_get_cached_block_query_results` function. This function tries to get the `WP_Query` from cache if it has already ran, and adds a new cache if it's the 1st time it runs.
This will reduce the number of database queries, since repeat queries will be reused.

## Testing Instructions

Follow the instructions from #42779, and ensure that the number of queries reported has decreased.

### Testing Instructions for Keyboard
N/A

<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
