### PR TITLE
useNestedSettingsUpdate: prevent unneeded syncing of falsy templateLock values

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -801,7 +801,7 @@ _Parameters_
 
 _Returns_
 
--   `?string`: Block Template Lock
+-   `string|false`: Block Template Lock
 
 ### hasBlockMovingClientId
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1425,19 +1425,14 @@ export function getTemplate( state ) {
  * @param {Object}  state        Editor state.
  * @param {?string} rootClientId Optional block root client ID.
  *
- * @return {?string} Block Template Lock
+ * @return {string|false} Block Template Lock
  */
 export function getTemplateLock( state, rootClientId ) {
 	if ( ! rootClientId ) {
-		return state.settings.templateLock;
+		return state.settings.templateLock ?? false;
 	}
 
-	const blockListSettings = getBlockListSettings( state, rootClientId );
-	if ( ! blockListSettings ) {
-		return undefined;
-	}
-
-	return blockListSettings.templateLock;
+	return getBlockListSettings( state, rootClientId )?.templateLock ?? false;
 }
 
 const checkAllowList = ( list, item, defaultResult = null ) => {

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -3733,7 +3733,7 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getTemplateLock', () => {
-		it( 'should return the general template lock if no clientId was set', () => {
+		it( 'should return the general template lock if no clientId was specified', () => {
 			const state = {
 				settings: { templateLock: 'all' },
 			};
@@ -3741,7 +3741,7 @@ describe( 'selectors', () => {
 			expect( getTemplateLock( state ) ).toBe( 'all' );
 		} );
 
-		it( 'should return undefined if the specified clientId was not found', () => {
+		it( 'should return false if the specified clientId was not found', () => {
 			const state = {
 				settings: { templateLock: 'all' },
 				blockListSettings: {
@@ -3751,10 +3751,10 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getTemplateLock( state, 'ribs' ) ).toBe( undefined );
+			expect( getTemplateLock( state, 'ribs' ) ).toBe( false );
 		} );
 
-		it( 'should return undefined if template lock was not set on the specified block', () => {
+		it( 'should return false if template lock was not set on the specified block', () => {
 			const state = {
 				settings: { templateLock: 'all' },
 				blockListSettings: {
@@ -3764,7 +3764,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getTemplateLock( state, 'ribs' ) ).toBe( undefined );
+			expect( getTemplateLock( state, 'chicken' ) ).toBe( false );
 		} );
 
 		it( 'should return the template lock for the specified clientId', () => {


### PR DESCRIPTION
When working on #46350 I investigated how often does `useNestedSettingsUpdate` dispatch the `updateBlockListSettings` action and how these updates are batched.

Testing on the `large-post.html` testing post, I see a big initial batch of 579 updates, one for each block, followed by a long series of approx 100 smaller batches, about 4 updates each. This is weird, where are all these small updates coming from?

It turns out they all update a `templateLock` setting from `undefined` value to `false`, and the affected block is always a `list` or `list-item`. Indeed, the `large-post.html` post hass approx 100 list with about 4 items each. That looks like wasted time, because in practice there's no behavior difference between `undefined` and `false`.

These updates happen because `templateLock` is propagated down the tree from the root to leafs. Every block's `templateLock` is either copied from parent, or sourced from the block itself, typically from a block attribute. And the `list` block [enforces a `templateLock: false` setting](https://github.com/WordPress/gutenberg/pull/43959) on all its children. Therefore, an `updateBlockListSettings` on a `list` changes the `list`'s `templateLock` from `undefined` to `false`, and that triggers an update on all children, because their `useNestedSettingsUpdate` depends on the `parentLock` value.

I'm fixing this by defaulting `parentLock` to `false`. That way, none of the redundant updates will be performed. Only the meaningful updates would be done, e.g., these that update the initial `false` value to `'all'` or `'contentOnly'`.

And alternative fix would be to patch the `getTemplateLock` selector to return `false` as the default value instead of `undefined`. We don't need it to return two distinct falsy values. What do folks think about this?

Performance tests show some significant improvements on this PR. The `firstPaint`, `firstContentfulPaint`, `loaded` and `domContentLoaded` metrics all go down.