### PR TITLE
Permalink: Hide edit field for users without publishing capabilities

### DIFF
--- a/packages/editor/src/components/post-url/index.js
+++ b/packages/editor/src/components/post-url/index.js
@@ -23,16 +23,20 @@ export default function PostURL( { onClose } ) {
 		permalinkPrefix,
 		permalinkSuffix,
 	} = useSelect( ( select ) => {
+		const post = select( editorStore ).getCurrentPost();
 		const postTypeSlug = select( editorStore ).getCurrentPostType();
 		const postType = select( coreStore ).getPostType( postTypeSlug );
 		const permalinkParts = select( editorStore ).getPermalinkParts();
+		const hasPublishAction = post?._links?.[ 'wp:action-publish' ] ?? false;
+
 		return {
-			isEditable: select( editorStore ).isPermalinkEditable(),
+			isEditable:
+				select( editorStore ).isPermalinkEditable() && hasPublishAction,
 			postSlug: safeDecodeURIComponent(
 				select( editorStore ).getEditedPostSlug()
 			),
 			viewPostLabel: postType?.labels.view_item,
-			postLink: select( editorStore ).getCurrentPost().link,
+			postLink: post.link,
 			permalinkPrefix: permalinkParts?.prefix,
 			permalinkSuffix: permalinkParts?.suffix,
 		};


### PR DESCRIPTION
## What?
Fixes #13857.

PR updates URL popover to hide the slug edit field if a user doesn't have post-publishing capabilities.

## Why?
The core doesn't allow [contributors to set a post slug](https://github.com/WordPress/wordpress-develop/blob/6.1/src/wp-includes/post.php#L4170-L4183) and will always use the post title to generate it. So changing it in the editor has no effect.

This is an attempt to match UI to backend logic.

Trac ticket that introduced this logic in core: https://core.trac.wordpress.org/ticket/7805.

## How?
Updates `isEditable` to check for the right capabilities as well.

## Testing Instructions
1. Login as a Contributor.
2. Add a new post.
3. Confirm edit field isn't visible in the URL popover.
4. Login with a different role that has post-publishing capabilities.
5. Confirm the edit field is displayed.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-12-07 at 17 08 18](https://user-images.githubusercontent.com/240569/206187444-a7b3874a-d4be-47d9-bcaa-3baa866b8c52.png)
