### PR TITLE
PHP: backport from 6.1 again. 

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-data-gutenberg.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-data-gutenberg.php
@@ -55,4 +55,5 @@ class WP_Theme_JSON_Data_Gutenberg {
 	public function get_data() {
 		return $this->theme_json->get_raw_data();
 	}
+
 }

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-data-gutenberg.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-data-gutenberg.php
@@ -25,14 +25,6 @@ class WP_Theme_JSON_Data_Gutenberg {
 	private $origin = '';
 
 	/**
-	 * Container for data coming from the blocks.
-	 *
-	 * @since 6.1.0
-	 * @var WP_Theme_JSON
-	 */
-	protected static $blocks = null;
-
-	/**
 	 * Constructor.
 	 *
 	 * @param array  $data   Array following the theme.json specification.

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-data-gutenberg.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-data-gutenberg.php
@@ -25,6 +25,27 @@ class WP_Theme_JSON_Data_Gutenberg {
 	private $origin = '';
 
 	/**
+	 * Container for keep track of registered blocks.
+	 *
+	 * @since 6.1.0
+	 * @var array
+	 */
+	protected static $blocks_cache = array(
+		'core'   => array(),
+		'blocks' => array(),
+		'theme'  => array(),
+		'user'   => array(),
+	);
+
+	/**
+	 * Container for data coming from the blocks.
+	 *
+	 * @since 6.1.0
+	 * @var WP_Theme_JSON
+	 */
+	protected static $blocks = null;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param array  $data   Array following the theme.json specification.
@@ -54,6 +75,37 @@ class WP_Theme_JSON_Data_Gutenberg {
 	 */
 	public function get_data() {
 		return $this->theme_json->get_raw_data();
+	}
+
+	/**
+	 * Checks whether the registered blocks were already processed for this origin.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param string $origin Data source for which to cache the blocks.
+	 *                       Valid values are 'core', 'blocks', 'theme', and 'user'.
+	 * @return bool True on success, false otherwise.
+	 */
+	protected static function has_same_registered_blocks( $origin ) {
+		// Bail out if the origin is invalid.
+		if ( ! isset( static::$blocks_cache[ $origin ] ) ) {
+			return false;
+		}
+
+		$registry = WP_Block_Type_Registry::get_instance();
+		$blocks   = $registry->get_all_registered();
+
+		// Is there metadata for all currently registered blocks?
+		$block_diff = array_diff_key( $blocks, static::$blocks_cache[ $origin ] );
+		if ( empty( $block_diff ) ) {
+			return true;
+		}
+
+		foreach ( $blocks as $block_name => $block_type ) {
+			static::$blocks_cache[ $origin ][ $block_name ] = true;
+		}
+
+		return false;
 	}
 
 }

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-data-gutenberg.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-data-gutenberg.php
@@ -25,19 +25,6 @@ class WP_Theme_JSON_Data_Gutenberg {
 	private $origin = '';
 
 	/**
-	 * Container for keep track of registered blocks.
-	 *
-	 * @since 6.1.0
-	 * @var array
-	 */
-	protected static $blocks_cache = array(
-		'core'   => array(),
-		'blocks' => array(),
-		'theme'  => array(),
-		'user'   => array(),
-	);
-
-	/**
 	 * Container for data coming from the blocks.
 	 *
 	 * @since 6.1.0
@@ -76,36 +63,4 @@ class WP_Theme_JSON_Data_Gutenberg {
 	public function get_data() {
 		return $this->theme_json->get_raw_data();
 	}
-
-	/**
-	 * Checks whether the registered blocks were already processed for this origin.
-	 *
-	 * @since 6.1.0
-	 *
-	 * @param string $origin Data source for which to cache the blocks.
-	 *                       Valid values are 'core', 'blocks', 'theme', and 'user'.
-	 * @return bool True on success, false otherwise.
-	 */
-	protected static function has_same_registered_blocks( $origin ) {
-		// Bail out if the origin is invalid.
-		if ( ! isset( static::$blocks_cache[ $origin ] ) ) {
-			return false;
-		}
-
-		$registry = WP_Block_Type_Registry::get_instance();
-		$blocks   = $registry->get_all_registered();
-
-		// Is there metadata for all currently registered blocks?
-		$block_diff = array_diff_key( $blocks, static::$blocks_cache[ $origin ] );
-		if ( empty( $block_diff ) ) {
-			return true;
-		}
-
-		foreach ( $blocks as $block_name => $block_type ) {
-			static::$blocks_cache[ $origin ][ $block_name ] = true;
-		}
-
-		return false;
-	}
-
 }

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-resolver-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-resolver-6-1.php
@@ -50,7 +50,7 @@ class WP_Theme_JSON_Resolver_6_1 extends WP_Theme_JSON_Resolver_6_0 {
 	 * @return WP_Theme_JSON_Gutenberg Entity that holds core data.
 	 */
 	public static function get_core_data() {
-		if ( null !== static::$core ) {
+		if ( null !== static::$core && static::has_same_registered_blocks( 'core' ) ) {
 			return static::$core;
 		}
 
@@ -74,7 +74,7 @@ class WP_Theme_JSON_Resolver_6_1 extends WP_Theme_JSON_Resolver_6_0 {
 	 * @return WP_Theme_JSON_Gutenberg Entity that holds styles for user data.
 	 */
 	public static function get_user_data() {
-		if ( null !== static::$user ) {
+		if ( null !== static::$user && static::has_same_registered_blocks( 'user' ) ) {
 			return static::$user;
 		}
 

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-resolver-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-resolver-6-1.php
@@ -26,6 +26,19 @@ class WP_Theme_JSON_Resolver_6_1 extends WP_Theme_JSON_Resolver_6_0 {
 	protected static $core = null;
 
 	/**
+	 * Container for keep track of registered blocks.
+	 *
+	 * @since 6.1.0
+	 * @var array
+	 */
+	protected static $blocks_cache = array(
+		'core'   => array(),
+		'blocks' => array(),
+		'theme'  => array(),
+		'user'   => array(),
+	);
+
+	/**
 	 * Given a theme.json structure modifies it in place
 	 * to update certain values by its translated strings
 	 * according to the language set by the user.
@@ -187,5 +200,36 @@ class WP_Theme_JSON_Resolver_6_1 extends WP_Theme_JSON_Resolver_6_0 {
 		}
 
 		return $user_cpt;
+	}
+
+	/**
+	 * Checks whether the registered blocks were already processed for this origin.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param string $origin Data source for which to cache the blocks.
+	 *                       Valid values are 'core', 'blocks', 'theme', and 'user'.
+	 * @return bool True on success, false otherwise.
+	 */
+	protected static function has_same_registered_blocks( $origin ) {
+		// Bail out if the origin is invalid.
+		if ( ! isset( static::$blocks_cache[ $origin ] ) ) {
+			return false;
+		}
+
+		$registry = WP_Block_Type_Registry::get_instance();
+		$blocks   = $registry->get_all_registered();
+
+		// Is there metadata for all currently registered blocks?
+		$block_diff = array_diff_key( $blocks, static::$blocks_cache[ $origin ] );
+		if ( empty( $block_diff ) ) {
+			return true;
+		}
+
+		foreach ( $blocks as $block_name => $block_type ) {
+			static::$blocks_cache[ $origin ][ $block_name ] = true;
+		}
+
+		return false;
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Change from https://github.com/WordPress/wordpress-develop/commit/4be76617b9502f59e5977c1ac5d800b9b4bedd6f by @hellofromtonya. 

Fixes issue reported by https://github.com/WordPress/gutenberg/pull/46250#issuecomment-1340953291 by @mirka

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
