### PR TITLE
Navigation Block: Fixes adding a submenu

### DIFF
--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -48,7 +48,7 @@ import {
 } from '@wordpress/core-data';
 import { speak } from '@wordpress/a11y';
 import { createBlock } from '@wordpress/blocks';
-import { useMergeRefs } from '@wordpress/compose';
+import { useMergeRefs, usePrevious } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -366,6 +366,8 @@ export default function NavigationSubmenuEdit( {
 		[ clientId ]
 	);
 
+	const prevHasChildren = usePrevious( hasChildren );
+
 	// Show the LinkControl on mount if the URL is empty
 	// ( When adding a new menu item)
 	// This can't be done in the useState call because it conflicts
@@ -546,11 +548,11 @@ export default function NavigationSubmenuEdit( {
 	}
 
 	useEffect( () => {
-		// If block is empty, transform to Navigation Link.
-		if ( ! hasChildren ) {
+		// If block becomes empty, transform to Navigation Link.
+		if ( ! hasChildren && prevHasChildren ) {
 			transformToLink();
 		}
-	}, [ hasChildren ] );
+	}, [ hasChildren, prevHasChildren ] );
 
 	const canConvertToLink =
 		! selectedBlockHasChildren || onlyDescendantIsEmptyLink;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #46309

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Bugfix.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR makes the submenu block self convert to navigation link only when it _becomes_ empty - e.g. after removing the last link, not when it is just empty - because when adding it it is empty so you cannot just add a submenu block without this PR.

## Testing Instructions

1. In a post
2. Add a navigation block
3. Add a site title block
4. Using the list view panel drag the site title in to the navigation block
5. In the navigation block click the appender
6. From the popover choose submenu
7. Observe the submenu block is inserted

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

N/A