### PR TITLE
Page List Block: Simplify Page List convert to links function API

### DIFF
--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -108,12 +108,13 @@ export default function ConvertToLinksModal( { onClose, clientId } ) {
 				<Button
 					variant="primary"
 					disabled={ ! pagesFinished }
-					onClick={ convertSelectedBlockToNavigationLinks( {
-						pages,
-						replaceBlock,
-						clientId,
-						createBlock,
-					} ) }
+					onClick={ () => {
+						const navigationLinks =
+							convertSelectedBlockToNavigationLinks( pages );
+
+						// Replace the Page List block with the Navigation Links.
+						replaceBlock( clientId, navigationLinks );
+					} }
 				>
 					{ __( 'Customize' ) }
 				</Button>

--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -5,8 +5,11 @@ import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { useEntityRecords } from '@wordpress/core-data';
-import { createBlock } from '@wordpress/blocks';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+/**
+ * Internal dependencies
+ */
+import { convertToNavigationLinks } from './convert-to-navigation-links';
 
 /**
  * Internal dependencies
@@ -15,63 +18,6 @@ import { convertDescription } from './constants';
 
 const PAGE_FIELDS = [ 'id', 'title', 'link', 'type', 'parent' ];
 const MAX_PAGE_COUNT = 100;
-
-export const convertSelectedBlockToNavigationLinks = ( pages ) => {
-	if ( ! pages ) {
-		return;
-	}
-
-	const linkMap = {};
-	const navigationLinks = [];
-	pages.forEach( ( { id, title, link: url, type, parent } ) => {
-		// See if a placeholder exists. This is created if children appear before parents in list.
-		const innerBlocks = linkMap[ id ]?.innerBlocks ?? [];
-		linkMap[ id ] = createBlock(
-			'core/navigation-link',
-			{
-				id,
-				label: title.rendered,
-				url,
-				type,
-				kind: 'post-type',
-			},
-			innerBlocks
-		);
-
-		if ( ! parent ) {
-			navigationLinks.push( linkMap[ id ] );
-		} else {
-			if ( ! linkMap[ parent ] ) {
-				// Use a placeholder if the child appears before parent in list.
-				linkMap[ parent ] = { innerBlocks: [] };
-			}
-			const parentLinkInnerBlocks = linkMap[ parent ].innerBlocks;
-			parentLinkInnerBlocks.push( linkMap[ id ] );
-		}
-	} );
-
-	// Transform all links with innerBlocks into Submenus. This can't be done
-	// sooner because page objects have no information on their children.
-
-	const transformSubmenus = ( listOfLinks ) => {
-		listOfLinks.forEach( ( block, index, listOfLinksArray ) => {
-			const { attributes, innerBlocks } = block;
-			if ( innerBlocks.length !== 0 ) {
-				transformSubmenus( innerBlocks );
-				const transformedBlock = createBlock(
-					'core/navigation-submenu',
-					attributes,
-					innerBlocks
-				);
-				listOfLinksArray[ index ] = transformedBlock;
-			}
-		} );
-	};
-
-	transformSubmenus( navigationLinks );
-
-	return navigationLinks;
-};
 
 export default function ConvertToLinksModal( { onClose, clientId } ) {
 	const { records: pages, hasResolved: pagesFinished } = useEntityRecords(
@@ -110,7 +56,7 @@ export default function ConvertToLinksModal( { onClose, clientId } ) {
 					disabled={ ! pagesFinished }
 					onClick={ () => {
 						const navigationLinks =
-							convertSelectedBlockToNavigationLinks( pages );
+							convertToNavigationLinks( pages );
 
 						// Replace the Page List block with the Navigation Links.
 						replaceBlock( clientId, navigationLinks );

--- a/packages/block-library/src/page-list/convert-to-navigation-links.js
+++ b/packages/block-library/src/page-list/convert-to-navigation-links.js
@@ -1,0 +1,60 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+export const convertToNavigationLinks = ( pages ) => {
+	if ( ! pages ) {
+		return;
+	}
+
+	const linkMap = {};
+	const navigationLinks = [];
+	pages.forEach( ( { id, title, link: url, type, parent } ) => {
+		// See if a placeholder exists. This is created if children appear before parents in list.
+		const innerBlocks = linkMap[ id ]?.innerBlocks ?? [];
+		linkMap[ id ] = createBlock(
+			'core/navigation-link',
+			{
+				id,
+				label: title.rendered,
+				url,
+				type,
+				kind: 'post-type',
+			},
+			innerBlocks
+		);
+
+		if ( ! parent ) {
+			navigationLinks.push( linkMap[ id ] );
+		} else {
+			if ( ! linkMap[ parent ] ) {
+				// Use a placeholder if the child appears before parent in list.
+				linkMap[ parent ] = { innerBlocks: [] };
+			}
+			const parentLinkInnerBlocks = linkMap[ parent ].innerBlocks;
+			parentLinkInnerBlocks.push( linkMap[ id ] );
+		}
+	} );
+
+	// Transform all links with innerBlocks into Submenus. This can't be done
+	// sooner because page objects have no information on their children.
+	const transformSubmenus = ( listOfLinks ) => {
+		listOfLinks.forEach( ( block, index, listOfLinksArray ) => {
+			const { attributes, innerBlocks } = block;
+			if ( innerBlocks.length !== 0 ) {
+				transformSubmenus( innerBlocks );
+				const transformedBlock = createBlock(
+					'core/navigation-submenu',
+					attributes,
+					innerBlocks
+				);
+				listOfLinksArray[ index ] = transformedBlock;
+			}
+		} );
+	};
+
+	transformSubmenus( navigationLinks );
+
+	return navigationLinks;
+};

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -32,9 +32,8 @@ import { useSelect, useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import ConvertToLinksModal, {
-	convertSelectedBlockToNavigationLinks,
-} from './convert-to-links-modal';
+import ConvertToLinksModal from './convert-to-links-modal';
+import { convertToNavigationLinks } from './convert-to-navigation-links';
 import { convertDescription } from './constants';
 
 // We only show the edit option when page count is <= MAX_PAGE_COUNT
@@ -205,9 +204,7 @@ export default function PageListEdit( {
 							disabled={ ! hasResolvedPages }
 							onClick={ () => {
 								const navigationLinks =
-									convertSelectedBlockToNavigationLinks(
-										pages
-									);
+									convertToNavigationLinks( pages );
 
 								// Replace the Page List block with the Navigation Links.
 								replaceBlock( clientId, navigationLinks );

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -197,19 +197,22 @@ export default function PageListEdit( {
 	return (
 		<>
 			<InspectorControls>
-				{ isNavigationChild && (
+				{ isNavigationChild && pages?.length > 0 && (
 					<PanelBody title={ __( 'Customize this menu' ) }>
 						<p>{ convertDescription }</p>
 						<Button
 							variant="primary"
 							disabled={ ! hasResolvedPages }
 							onClick={ () => {
-								convertSelectedBlockToNavigationLinks( {
-									pages,
-									replaceBlock,
-									clientId,
-									createBlock,
-								} )();
+								const navigationLinks =
+									convertSelectedBlockToNavigationLinks(
+										pages
+									);
+
+								// Replace the Page List block with the Navigation Links.
+								replaceBlock( clientId, navigationLinks );
+
+								// Select the Navigation block to reveal the changes.
 								selectBlock( parentNavBlockClientId );
 							} }
 						>

--- a/packages/block-library/src/page-list/test/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/test/convert-to-links-modal.js
@@ -1,10 +1,28 @@
 /**
  * Internal dependencies
  */
-import { convertSelectedBlockToNavigationLinks } from '../convert-to-links-modal';
+
+import { convertToNavigationLinks } from '../convert-to-navigation-links';
+
+// Mock createBlock to avoid creating the blocks in test environment
+// as convertToNavigationLinks calls this method internally.
+jest.mock( '@wordpress/blocks', () => {
+	const blocks = jest.requireActual( '@wordpress/blocks' );
+
+	return {
+		...blocks,
+		createBlock( name, attributes, innerBlocks ) {
+			return {
+				name,
+				attributes,
+				innerBlocks,
+			};
+		},
+	};
+} );
 
 describe( 'page list convert to links', () => {
-	describe( 'convertSelectedBlockToNavigationLinks', () => {
+	describe( 'convertToNavigationLinks', () => {
 		it( 'Can create submenus', () => {
 			const pages = [
 				{
@@ -88,22 +106,10 @@ describe( 'page list convert to links', () => {
 					type: 'page',
 				},
 			];
-			const replaceBlock = jest.fn();
-			const createBlock = jest.fn(
-				( name, attributes, innerBlocks ) => ( {
-					name,
-					attributes,
-					innerBlocks,
-				} )
-			);
-			const convertLinks = convertSelectedBlockToNavigationLinks( {
-				pages,
-				clientId: 'testId',
-				replaceBlock,
-				createBlock,
-			} );
-			convertLinks();
-			expect( replaceBlock.mock.calls?.[ 0 ]?.[ 1 ] ).toEqual( [
+
+			const convertLinks = convertToNavigationLinks( pages );
+
+			expect( convertLinks ).toEqual( [
 				{
 					attributes: {
 						id: 2,
@@ -280,22 +286,10 @@ describe( 'page list convert to links', () => {
 					type: 'page',
 				},
 			];
-			const replaceBlock = jest.fn();
-			const createBlock = jest.fn(
-				( name, attributes, innerBlocks ) => ( {
-					name,
-					attributes,
-					innerBlocks,
-				} )
-			);
-			const convertLinks = convertSelectedBlockToNavigationLinks( {
-				pages,
-				clientId: 'testId',
-				replaceBlock,
-				createBlock,
-			} );
-			convertLinks();
-			expect( replaceBlock.mock.calls?.[ 0 ]?.[ 1 ] ).toEqual( [
+
+			const convertLinks = convertToNavigationLinks( pages );
+
+			expect( convertLinks ).toEqual( [
 				{
 					attributes: {
 						id: 2,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Simplifies the API of the function which converts Pages to Nav links and improves its adherence to SRP.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In https://github.com/WordPress/gutenberg/pull/46352 we used the `convert` function from the Convert Modal in a second place in the Page List code. This drew attention to the overly complex API of that function and the fact that it was unnecessarily curried (presumably to aid in the writing of tests).

The changes in this PR make the function easier to work with, reason about and test.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR 

- extracts the function to it's own file
- renames it to better signify its new single responsibility
- removes the curried API 
- simplifies the unit tests
- updates code usages

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Check that the "convert to links" functionality of the Page List inside Nav block works both when:

- clicking `Edit` in the Block Toolbar and then clicking in the Moda;
- clicking `Customize` in the Inspector Controls

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
