### PR TITLE
Page List Block: Move shared "convert" description to constant

### DIFF
--- a/packages/block-library/src/page-list/constants.js
+++ b/packages/block-library/src/page-list/constants.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const convertDescription = __(
+	'This menu is automatically kept in sync with pages on your site. You can manage the menu yourself by clicking customize below.'
+);

--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -8,6 +8,11 @@ import { useEntityRecords } from '@wordpress/core-data';
 import { createBlock as create } from '@wordpress/blocks';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
+/**
+ * Internal dependencies
+ */
+import { convertDescription } from './constants';
+
 const PAGE_FIELDS = [ 'id', 'title', 'link', 'type', 'parent' ];
 const MAX_PAGE_COUNT = 100;
 
@@ -96,9 +101,7 @@ export default function ConvertToLinksModal( { onClose, clientId } ) {
 			aria={ { describedby: 'wp-block-page-list-modal__description' } }
 		>
 			<p id={ 'wp-block-page-list-modal__description' }>
-				{ __(
-					'This menu is automatically kept in sync with pages on your site. You can manage the menu yourself by clicking customize below.'
-				) }
+				{ convertDescription }
 			</p>
 			<div className="wp-block-page-list-modal-buttons">
 				<Button variant="tertiary" onClick={ onClose }>

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -35,6 +35,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import ConvertToLinksModal, {
 	convertSelectedBlockToNavigationLinks,
 } from './convert-to-links-modal';
+import { convertDescription } from './constants';
 
 // We only show the edit option when page count is <= MAX_PAGE_COUNT
 // Performance of Navigation Links is not good past this value.
@@ -198,11 +199,7 @@ export default function PageListEdit( {
 			<InspectorControls>
 				{ isNavigationChild && (
 					<PanelBody title={ __( 'Customize this menu' ) }>
-						<p id={ 'wp-block-page-list-modal__description' }>
-							{ __(
-								'This menu is automatically kept in sync with pages on your site. You can manage the menu yourself by clicking customize below.'
-							) }
-						</p>
+						<p>{ convertDescription }</p>
 						<Button
 							variant="primary"
 							disabled={ ! hasResolvedPages }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Moves the description of converting page list to navigation links to a shared constant because it's used in two places

> This menu is automatically kept in sync with pages on your site. You can manage the menu yourself by clicking customize below.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because DRY.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Read code.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Check both Modal and Inspector controls version of text are the same and no errors.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
