### PR TITLE
Query Loop: use the correct PostType when the variation is picked via BlockVariationPicker component

### DIFF
--- a/packages/block-library/src/query/edit/query-placeholder.js
+++ b/packages/block-library/src/query/edit/query-placeholder.js
@@ -135,8 +135,8 @@ function QueryVariationPicker( {
 							query: {
 								...nextVariation.attributes.query,
 								postType:
-									attributes.query.postType ||
-									nextVariation.attributes.query.postType,
+									nextVariation.attributes.query.postType ||
+									attributes.query.postType,
 							},
 						} );
 					}


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->
This PR fixes a wrong behavior when a scoped `block` variation is picked via the `BlockVariationPicker` component: even if the variation uses a different post type, the post type set is always "Post". 

Fixes #46367 


## Testing Instructions
1. Create a Query Loop variation that has as post type "Page" (you can use [this code](https://gist.github.com/gigitux/10caff8854f030afbe6982a074614f94)).
2. Add the Query Loop block.
3. Click `Start Blank`.
4. Select the variation created previously. If you copy-pasted the code above, the name of the variation is "Query Loop variation".
5. In the right sidebar, be sure that the post type is the correct one. If you copy-pasted the code above, the correct post type is "Page".


## Screenshots or screencast <!-- if applicable -->
https://user-images.githubusercontent.com/4463174/206224552-ad4e8a38-d269-479a-bd51-62278b4764dc.mov

