### PR TITLE
Block Variation Picker: adds support to declarated icon with src

### DIFF
--- a/packages/block-editor/src/components/block-variation-picker/index.js
+++ b/packages/block-editor/src/components/block-variation-picker/index.js
@@ -43,7 +43,11 @@ function BlockVariationPicker( {
 					<li key={ variation.name }>
 						<Button
 							variant="secondary"
-							icon={ variation.icon.src || variation.icon }
+							icon={
+								variation.icon && variation.icon.src
+									? variation.icon.src
+									: variation.icon
+							}
 							iconSize={ 48 }
 							onClick={ () => onSelect( variation ) }
 							className="block-editor-block-variation-picker__variation"

--- a/packages/block-editor/src/components/block-variation-picker/index.js
+++ b/packages/block-editor/src/components/block-variation-picker/index.js
@@ -43,7 +43,7 @@ function BlockVariationPicker( {
 					<li key={ variation.name }>
 						<Button
 							variant="secondary"
-							icon={ variation.icon }
+							icon={ variation.icon.src || variation.icon }
 							iconSize={ 48 }
 							onClick={ () => onSelect( variation ) }
 							className="block-editor-block-variation-picker__variation"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds the support of a declared icon with src to the `Block Variation Picker`.
## Why?
This avoids the crash of the `Block Variation Picker` when a variation has a declared icon with src. Fixes #46372.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Create a Query Loop variation that has a declared icon with src (you can use [this code](https://gist.github.com/gigitux/cf0014e4c144af2a2c0043b615f93435)).
2. Add the Query Loop block.
3. Click `Start Blank`.
4. Be sure the `Block Variation Picker` doesn't crash.


## Screenshots or screencast <!-- if applicable -->
https://user-images.githubusercontent.com/4463174/206242543-2fd0acbe-fef7-43df-8b14-ade8a85433ca.mp4

