### PR TITLE
Navigation Block: Add social link singular to list of blocks to be allowed

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -409,6 +409,7 @@ function block_core_navigation_filter_out_invalid_blocks( $parsed_blocks ) {
 		'core/navigation-link',
 		'core/search',
 		'core/social-links',
+		'core/social-link',
 		'core/page-list',
 		'core/spacer',
 		'core/home-link',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/46371 by allowing singular Social Link block within the Social Links block.

This bug was introduced by https://github.com/WordPress/gutenberg/pull/46279.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Singular social links blocks should be allowed in a social links plural block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add to whitelist.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Add Nav block. Add social links block. Add one or more social link (singular) blocks.

Check no errors on front end as reported on Issue https://github.com/WordPress/gutenberg/issues/46371.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
