### PR TITLE
Handle innerContent too when removing innerBlocks

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -423,6 +423,9 @@ function block_core_navigation_filter_out_invalid_blocks( $parsed_blocks ) {
 			if ( isset( $block['blockName'] ) && in_array( $block['blockName'], $allowed_blocks, true ) ) {
 				if ( $block['innerBlocks'] ) {
 					$block['innerBlocks'] = block_core_navigation_filter_out_invalid_blocks( $block['innerBlocks'] );
+					if ( empty( $block['innerBlocks'] ) ) {
+						$block['innerContent'] = array( implode( $block['innerContent'] ) );
+					}
 				}
 				$carry[] = $block;
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #46371
Alternative to #46374

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In #46374 we're adding one item but we're appeasing the system to not throw a fatal error, instead of making it behave as we expect. In this PR the behavior is as expected.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In our filtering function `block_core_navigation_filter_out_invalid_blocks` if one of the innerBlocks is not in the allowed list we set the parent's `innerBlocks` to `[]`. This triggers a fatal error in `WP_Block` because it has a conflict in the parsed block between the `innerBlocks` being `[]` and `innerContent` still retaining the old shape, e.g. for a social links block with a filtered social link

```PHP
["innerContent"]=>
  array(3) {
    [0]=>string(35) "<ul class="wp-block-social-links">"
    [1]=>NULL
    [2]=>string(6) "</ul>"
  }
```

because of this we get into a spiral that ends in the fatal error.

This PR sets `innerContent` to be a string by imploding the array above. If there are no inner blocks we only care about the empty parent block.

**Caveat**

Manually unsetting `innerblocks` like we do in the navigation block (set to `[]`) is "off label" use of how blocks expect to be dealt with. We either find a nice way to remove a block from the rendering process, or we will probably hit other problems if the navigation block becomes even more complex.

The case we seem to prevent _at render time_ should not exist if the block was created in the editor, in other words allowed blocks in the editor should not be repeated in the rendering function b/c no unallowed block should be there. Generally we treat content input manually e.g. via code view "as is". The exception here is that in #46279 a possibility for infinite loop was identified - most likely via manual editing.


## Conclusion

My opinion is that we should revert #46279 and not merge neither this or #46374. We should maybe add a safeguard to avoid infinite nesting my adding a max nesting a la react, silently error and not render anything.

## Testing Instructions

1. Add a navigation block
2. Add some navigation links
3. Add a social links block
4. Add a social link
5. Save and publish
6. Check the front end
7. The social links block should not render but there should be no PHP error

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

N/A
