### PR TITLE
WP Webfonts: avoid duplicated font families if the font family name was defined using fallback values.

### DIFF
--- a/lib/experimental/class-wp-webfonts.php
+++ b/lib/experimental/class-wp-webfonts.php
@@ -188,6 +188,11 @@ class WP_Webfonts {
 			}
 		}
 
+		// If the font-family is a comma-separated list (example: "Inter, sans-serif" ), use just the first font.
+		if ( strpos($to_convert, ",") !== false ) {
+			$to_convert = explode(",", $to_convert)[0];
+		}
+
 		return sanitize_title( $to_convert );
 	}
 

--- a/lib/experimental/class-wp-webfonts.php
+++ b/lib/experimental/class-wp-webfonts.php
@@ -189,8 +189,8 @@ class WP_Webfonts {
 		}
 
 		// If the font-family is a comma-separated list (example: "Inter, sans-serif" ), use just the first font.
-		if ( strpos($to_convert, ",") !== false ) {
-			$to_convert = explode(",", $to_convert)[0];
+		if ( strpos( $to_convert, ',' ) !== false ) {
+			$to_convert = explode( ',', $to_convert )[0];
 		}
 
 		return sanitize_title( $to_convert );

--- a/lib/experimental/class-wp-webfonts.php
+++ b/lib/experimental/class-wp-webfonts.php
@@ -178,7 +178,7 @@ class WP_Webfonts {
 	 */
 	public static function get_font_slug( $to_convert ) {
 		if ( is_array( $to_convert ) ) {
-			if ( isset ( $to_convert['slug'] ) ) {
+			if ( isset( $to_convert['slug'] ) ) {
 				return $to_convert['slug'];
 			} elseif ( isset( $to_convert['font-family'] ) ) {
 				$to_convert = $to_convert['font-family'];

--- a/lib/experimental/class-wp-webfonts.php
+++ b/lib/experimental/class-wp-webfonts.php
@@ -178,7 +178,9 @@ class WP_Webfonts {
 	 */
 	public static function get_font_slug( $to_convert ) {
 		if ( is_array( $to_convert ) ) {
-			if ( isset( $to_convert['font-family'] ) ) {
+			if ( isset ( $to_convert['slug'] ) ) {
+				return $to_convert['slug'];
+			} elseif ( isset( $to_convert['font-family'] ) ) {
 				$to_convert = $to_convert['font-family'];
 			} elseif ( isset( $to_convert['fontFamily'] ) ) {
 				$to_convert = $to_convert['fontFamily'];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
WP Webfonts: avoid duplicated font families if the font family name was defined using fallback values

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Because of https://github.com/WordPress/gutenberg/issues/46376

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The function `gutenberg_add_registered_webfonts_to_theme_json` is adding the fonts twice when the font family name has fallback values. This is because how are we compairing the slug of the fonts.

In this PR, we change the `get_font_slug function` to return the family slug if it is already defined. If it's not defined, the function returns the font family name. If the font family has fallback values, it creates the slug using the first font family name.




## Testing Instructions

Follow test instructions from: https://github.com/WordPress/gutenberg/issues/46376
And see that the font is no longer repeated

Fixes: https://github.com/WordPress/gutenberg/issues/46376
