### PR TITLE
Navigation Block: Prevent circular references in navigation block rendering

### DIFF
--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -15,7 +15,6 @@ import { useMemo } from '@wordpress/element';
  */
 import PlaceholderPreview from './placeholder/placeholder-preview';
 
-// This list is duplicated in packages/block-library/src/navigation/index.php
 const ALLOWED_BLOCKS = [
 	'core/navigation-link',
 	'core/search',

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -409,7 +409,6 @@ function block_core_navigation_filter_out_invalid_blocks( $parsed_blocks ) {
 		'core/navigation-link',
 		'core/search',
 		'core/social-links',
-		'core/social-link',
 		'core/page-list',
 		'core/spacer',
 		'core/home-link',

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -511,6 +511,7 @@ function block_core_navigation_from_block_get_post_ids( $block ) {
 function render_block_core_navigation( $attributes, $content, $block ) {
 
 	static $seen_menu_names = array();
+	static $seen_ref = array();
 
 	// Flag used to indicate whether the rendered output is considered to be
 	// a fallback (i.e. the block has no menu associated with it).
@@ -581,6 +582,11 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 	// Load inner blocks from the navigation post.
 	if ( array_key_exists( 'ref', $attributes ) ) {
+		if ( in_array( $attributes['ref'], $seen_ref, true ) ) {
+			return '';
+		}
+		$seen_ref[] = $attributes['ref'];
+
 		$navigation_post = get_post( $attributes['ref'] );
 		if ( ! isset( $navigation_post ) ) {
 			return '';

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -681,6 +681,11 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		'core/navigation-submenu',
 	);
 
+	$needs_list_item_wrapper = array(
+		'core/site-title',
+		'core/site-logo',
+	);
+
 	$inner_blocks_html = '';
 	$is_list_open      = false;
 	foreach ( $inner_blocks as $inner_block ) {
@@ -697,14 +702,12 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		}
 
 		$inner_block_content = $inner_block->render();
-
-		if (
-			'core/site-title' === $inner_block->name ||
-			( 'core/site-logo' === $inner_block->name && $inner_block_content )
-		) {
-			$inner_blocks_html .= '<li class="wp-block-navigation-item">' . $inner_block_content . '</li>';
-		} else {
-			$inner_blocks_html .= $inner_block_content;
+		if ( ! empty( $inner_block_content ) ) {
+			if ( in_array( $inner_block->name, $needs_list_item_wrapper, true ) ) {
+				$inner_blocks_html .= '<li class="wp-block-navigation-item">' . $inner_block_content . '</li>';
+			} else {
+				$inner_blocks_html .= $inner_block_content;
+			}
 		}
 	}
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -673,19 +673,35 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		_prime_post_caches( $post_ids, false, false );
 	}
 
+	$list_item_nav_blocks = array(
+		'core/navigation-link',
+		'core/home-link',
+		'core/site-title',
+		'core/site-logo',
+		'core/navigation-submenu',
+	);
+
 	$inner_blocks_html = '';
 	$is_list_open      = false;
 	foreach ( $inner_blocks as $inner_block ) {
-		if ( ( 'core/navigation-link' === $inner_block->name || 'core/home-link' === $inner_block->name || 'core/site-title' === $inner_block->name || 'core/site-logo' === $inner_block->name || 'core/navigation-submenu' === $inner_block->name ) && ! $is_list_open ) {
+		$is_list_item = in_array( $inner_block->name, $list_item_nav_blocks, true );
+
+		if ( $is_list_item && ! $is_list_open ) {
 			$is_list_open       = true;
 			$inner_blocks_html .= '<ul class="wp-block-navigation__container">';
 		}
-		if ( 'core/navigation-link' !== $inner_block->name && 'core/home-link' !== $inner_block->name && 'core/site-title' !== $inner_block->name && 'core/site-logo' !== $inner_block->name && 'core/navigation-submenu' !== $inner_block->name && $is_list_open ) {
+
+		if ( ! $is_list_item && $is_list_open ) {
 			$is_list_open       = false;
 			$inner_blocks_html .= '</ul>';
 		}
+
 		$inner_block_content = $inner_block->render();
-		if ( 'core/site-title' === $inner_block->name || ( 'core/site-logo' === $inner_block->name && $inner_block_content ) ) {
+
+		if (
+			'core/site-title' === $inner_block->name ||
+			( 'core/site-logo' === $inner_block->name && $inner_block_content )
+		) {
 			$inner_blocks_html .= '<li class="wp-block-navigation-item">' . $inner_block_content . '</li>';
 		} else {
 			$inner_blocks_html .= $inner_block_content;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -511,7 +511,7 @@ function block_core_navigation_from_block_get_post_ids( $block ) {
 function render_block_core_navigation( $attributes, $content, $block ) {
 
 	static $seen_menu_names = array();
-	static $seen_ref = array();
+	static $seen_ref        = array();
 
 	// Flag used to indicate whether the rendered output is considered to be
 	// a fallback (i.e. the block has no menu associated with it).

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -390,45 +390,20 @@ function block_core_navigation_get_most_recently_published_navigation() {
 }
 
 /**
- * Recursively filter out blocks from the block list that are not whitelisted.
- * This list of exclusions includes:
- * - The Navigation block itself (results in recursion).
- * - empty "null" blocks from the block list.
- * - other blocks that are not yet handled.
- *
- * Note: 'parse_blocks' includes a null block with '\n\n' as the content when
+ * Filter out empty "null" blocks from the block list.
+ * 'parse_blocks' includes a null block with '\n\n' as the content when
  * it encounters whitespace. This is not a bug but rather how the parser
  * is designed.
  *
- * @param array $parsed_blocks the parsed blocks to be filtered.
- * @return array the filtered parsed blocks.
+ * @param array $parsed_blocks the parsed blocks to be normalized.
+ * @return array the normalized parsed blocks.
  */
-function block_core_navigation_filter_out_invalid_blocks( $parsed_blocks ) {
-	// This list is duplicated in /packages/block-library/src/navigation/edit/inner-blocks.js.
-	$allowed_blocks = array(
-		'core/navigation-link',
-		'core/search',
-		'core/social-links',
-		'core/page-list',
-		'core/spacer',
-		'core/home-link',
-		'core/site-title',
-		'core/site-logo',
-		'core/navigation-submenu',
-	);
-
-	$filtered = array_reduce(
+function block_core_navigation_filter_out_empty_blocks( $parsed_blocks ) {
+	$filtered = array_filter(
 		$parsed_blocks,
-		function( $carry, $block ) use ( $allowed_blocks ) {
-			if ( isset( $block['blockName'] ) && in_array( $block['blockName'], $allowed_blocks, true ) ) {
-				if ( $block['innerBlocks'] ) {
-					$block['innerBlocks'] = block_core_navigation_filter_out_invalid_blocks( $block['innerBlocks'] );
-				}
-				$carry[] = $block;
-			}
-			return $carry;
-		},
-		array()
+		function( $block ) {
+			return isset( $block['blockName'] );
+		}
 	);
 
 	// Reset keys.
@@ -468,8 +443,7 @@ function block_core_navigation_get_fallback_blocks() {
 
 	// Use the first non-empty Navigation as fallback if available.
 	if ( $navigation_post ) {
-
-		$maybe_fallback = block_core_navigation_filter_out_invalid_blocks( parse_blocks( $navigation_post->post_content ) );
+		$maybe_fallback = block_core_navigation_filter_out_empty_blocks( parse_blocks( $navigation_post->post_content ) );
 
 		// Normalizing blocks may result in an empty array of blocks if they were all `null` blocks.
 		// In this case default to the (Page List) fallback.
@@ -627,7 +601,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 			// 'parse_blocks' includes a null block with '\n\n' as the content when
 			// it encounters whitespace. This code strips it.
-			$compacted_blocks = block_core_navigation_filter_out_invalid_blocks( $parsed_blocks );
+			$compacted_blocks = block_core_navigation_filter_out_empty_blocks( $parsed_blocks );
 
 			// TODO - this uses the full navigation block attributes for the
 			// context which could be refined.

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -424,9 +424,6 @@ function block_core_navigation_filter_out_invalid_blocks( $parsed_blocks ) {
 			if ( isset( $block['blockName'] ) && in_array( $block['blockName'], $allowed_blocks, true ) ) {
 				if ( $block['innerBlocks'] ) {
 					$block['innerBlocks'] = block_core_navigation_filter_out_invalid_blocks( $block['innerBlocks'] );
-					if ( empty( $block['innerBlocks'] ) ) {
-						$block['innerContent'] = array( implode( $block['innerContent'] ) );
-					}
 				}
 				$carry[] = $block;
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Alternative to #46279. Fixes potential infinite recursion due to a circular reference while rendering `core/navigation` blocks that reference themselves within the post_content of the `wp_navigation` post.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This approach doesn't modify block content while rendering.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Reverts changes made by #46279 and follow-up PRs (#46374 and #46377).
- Keeps track of the refs seen and silently ignores ones that have already been rendered.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

#### Before (validate the bug)

- Remove all your `wp_navigation` posts and Classic Menus from your site
- Create a brand new Navigation using the Navigation block. Be sure to save it.
- Now open your MySQL client and update the `post_content` of your `wp_navigation` post with the following content, being sure to replace `%%REPLACE_ME%%` with the ID of the `wp_navigation` post _**YOU**_ just created:
```
<!-- wp:navigation {"ref":%%REPLACE_ME%%,"__unstableLocation":"primary","className":"social-links","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
```
- Open your Post on the front of your site.
- See that the page will not load due to memory being exhausted!

#### After (validate the bug)

- Now apply this PR to your working copy.
- Reload the same Post.
- See that it loads ok and the Navigation block is not rendered (because there are no blocks).

Please try this with variations of content being sure that it contains the self-referential Nav block issue.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
