### PR TITLE
Only pass parentLayout to block edit if not empty

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -152,7 +152,9 @@ function BlockListBlock( {
 			isSelectionEnabled={ isSelectionEnabled }
 			toggleSelection={ toggleSelection }
 			__unstableLayoutClassNames={ layoutClassNames }
-			__unstableParentLayout={ parentLayout }
+			__unstableParentLayout={
+				Object.keys( parentLayout ).length ? parentLayout : undefined
+			}
 		/>
 	);
 

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -132,7 +132,7 @@ function BlockListBlock( {
 	const { removeBlock } = useDispatch( blockEditorStore );
 	const onRemove = useCallback( () => removeBlock( clientId ), [ clientId ] );
 
-	const parentLayout = useLayout();
+	const parentLayout = useLayout() || {};
 
 	// We wrap the BlockEdit component in a div that hides it when editing in
 	// HTML mode. This allows us to render all of the ancillary pieces

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -112,7 +112,9 @@ function UncontrolledInnerBlocks( props ) {
 				__experimentalAppenderTagName={ __experimentalAppenderTagName }
 				__experimentalLayout={ {
 					...__experimentalLayout,
-					allowSizingOnChildren,
+					...( allowSizingOnChildren && {
+						allowSizingOnChildren: true,
+					} ),
 				} }
 				wrapperRef={ wrapperRef }
 				placeholder={ placeholder }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Follow-up to #45364.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds logic so that `allowSizingOnChildren` doesn't get passed to the Edit function of every single block, even when the parent block isn't setting it explicitly. If the parent block has no layout configured, `__unstableParentLayout` should be undefined.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a Row block to a post and add a couple child blocks;
2. Select a child block, and check that the "Width" control renders under "Dimensions" in the sidebar;
3. Change the "Width" settings and make sure they still work as expected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

With a child of a Row block selected, press Tab to go into the sidebar, Tab again to go the "Block" area, and then continue tabbing until reaching the "Dimensions options" button. Press Enter to open, Tab until reaching "Width" and press Enter to select. Press Esc to close the dropdown and then press Tab again to focus the Width control. Once focused, toggle between the options with Arrow keys. If selecting "Fixed", Tab again to reach the input and fill it in with a fixed width value.

## Screenshots or screencast <!-- if applicable -->
