### PR TITLE
Style Book: Clear Global Styles navigation history when selecting a block

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 -   `ColorPalette`: show "Clear" button even when colors array is empty ([#46001](https://github.com/WordPress/gutenberg/pull/46001)).
 -   `InputControl`: Fix internal `Flex` wrapper usage that could add an unintended `height: 100%` ([#46213](https://github.com/WordPress/gutenberg/pull/46213)).
+-   `Navigator`: Allow calling `goTo` and `goBack` twice in one render cycle ([#46391](https://github.com/WordPress/gutenberg/pull/46391)).
 
 ### Enhancements
 

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -43,8 +43,8 @@ function UnconnectedNavigatorProvider(
 
 	const goTo: NavigatorContextType[ 'goTo' ] = useCallback(
 		( path, options = {} ) => {
-			setLocationHistory( [
-				...locationHistory,
+			setLocationHistory( ( prevLocationHistory ) => [
+				...prevLocationHistory,
 				{
 					...options,
 					path,
@@ -53,21 +53,24 @@ function UnconnectedNavigatorProvider(
 				},
 			] );
 		},
-		[ locationHistory ]
+		[]
 	);
 
 	const goBack: NavigatorContextType[ 'goBack' ] = useCallback( () => {
-		if ( locationHistory.length > 1 ) {
-			setLocationHistory( [
-				...locationHistory.slice( 0, -2 ),
+		setLocationHistory( ( prevLocationHistory ) => {
+			if ( prevLocationHistory.length <= 1 ) {
+				return prevLocationHistory;
+			}
+			return [
+				...prevLocationHistory.slice( 0, -2 ),
 				{
-					...locationHistory[ locationHistory.length - 2 ],
+					...prevLocationHistory[ prevLocationHistory.length - 2 ],
 					isBack: true,
 					hasRestoredFocus: false,
 				},
-			] );
-		}
-	}, [ locationHistory ] );
+			];
+		} );
+	}, [] );
 
 	const navigatorContextValue: NavigatorContextType = useMemo(
 		() => ( {

--- a/packages/edit-site/src/components/global-styles/palette.js
+++ b/packages/edit-site/src/components/global-styles/palette.js
@@ -49,7 +49,7 @@ function Palette( { name } ) {
 
 	const screenPath = ! name
 		? '/colors/palette'
-		: '/blocks/' + name + '/colors/palette';
+		: '/blocks/' + encodeURIComponent( name ) + '/colors/palette';
 	const paletteButtonText =
 		colors.length > 0
 			? sprintf(

--- a/packages/edit-site/src/components/global-styles/screen-block-list.js
+++ b/packages/edit-site/src/components/global-styles/screen-block-list.js
@@ -68,7 +68,7 @@ function BlockMenuItem( { block } ) {
 
 	return (
 		<NavigationButtonAsItem
-			path={ '/blocks/' + block.name }
+			path={ '/blocks/' + encodeURIComponent( block.name ) }
 			aria-label={ navigationButtonLabel }
 		>
 			<HStack justify="flex-start">

--- a/packages/edit-site/src/components/global-styles/screen-block.js
+++ b/packages/edit-site/src/components/global-styles/screen-block.js
@@ -20,7 +20,10 @@ function ScreenBlock( { name } ) {
 			<Spacer paddingX={ 4 }>
 				<BlockPreviewPanel name={ name } />
 			</Spacer>
-			<ContextMenu parentMenu={ '/blocks/' + name } name={ name } />
+			<ContextMenu
+				parentMenu={ '/blocks/' + encodeURIComponent( name ) }
+				name={ name }
+			/>
 		</>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/screen-colors.js
+++ b/packages/edit-site/src/components/global-styles/screen-colors.js
@@ -174,7 +174,8 @@ function ButtonColorItem( { name, parentMenu } ) {
 }
 
 function ScreenColors( { name } ) {
-	const parentMenu = name === undefined ? '' : '/blocks/' + name;
+	const parentMenu =
+		name === undefined ? '' : '/blocks/' + encodeURIComponent( name );
 
 	return (
 		<>

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -43,7 +43,8 @@ function GlobalStylesNavigationScreen( { className, ...props } ) {
 }
 
 function ContextScreens( { name } ) {
-	const parentMenu = name === undefined ? '' : '/blocks/' + name;
+	const parentMenu =
+		name === undefined ? '' : '/blocks/' + encodeURIComponent( name );
 
 	return (
 		<>
@@ -124,14 +125,27 @@ function ContextScreens( { name } ) {
 
 function GlobalStylesStyleBook( { onClose } ) {
 	const navigator = useNavigator();
+	const { path } = navigator.location;
 	return (
 		<StyleBook
 			isSelected={ ( blockName ) =>
-				navigator.location.path.startsWith( '/blocks/' + blockName )
+				// Match '/blocks/core%2Fbutton' and
+				// '/blocks/core%2Fbutton/typography', but not
+				// '/blocks/core%2Fbuttons'.
+				path === `/blocks/${ encodeURIComponent( blockName ) }` ||
+				path.startsWith(
+					`/blocks/${ encodeURIComponent( blockName ) }/`
+				)
 			}
-			onSelect={ ( blockName ) =>
-				navigator.goTo( '/blocks/' + blockName )
-			}
+			onSelect={ ( blockName ) => {
+				// Clear navigator history by going back to the root.
+				const depth = path.match( /\//g ).length;
+				for ( let i = 0; i < depth; i++ ) {
+					navigator.goBack();
+				}
+				// Now go to the selected block.
+				navigator.goTo( '/blocks/' + encodeURIComponent( blockName ) );
+			} }
 			onClose={ onClose }
 		/>
 	);
@@ -159,7 +173,7 @@ function GlobalStylesUI( { isStyleBookOpened, onCloseStyleBook } ) {
 			{ blocks.map( ( block ) => (
 				<GlobalStylesNavigationScreen
 					key={ 'menu-block-' + block.name }
-					path={ '/blocks/' + block.name }
+					path={ '/blocks/' + encodeURIComponent( block.name ) }
 				>
 					<ScreenBlock name={ block.name } />
 				</GlobalStylesNavigationScreen>

--- a/test/e2e/specs/site-editor/style-book.spec.js
+++ b/test/e2e/specs/site-editor/style-book.spec.js
@@ -98,6 +98,24 @@ test.describe( 'Style Book', () => {
 		).toBeVisible();
 	} );
 
+	test( 'should clear Global Styles navigator history when example is clicked', async ( {
+		page,
+	} ) => {
+		await page.click( 'role=button[name="Blocks styles"]' );
+		await page.click( 'role=button[name="Heading block styles"]' );
+		await page.click( 'role=button[name="Typography styles"]' );
+
+		await page.click(
+			'role=button[name="Open Quote styles in Styles panel"i]'
+		);
+
+		await page.click( 'role=button[name="Navigate to the previous view"]' );
+
+		await expect(
+			page.locator( 'role=button[name="Navigate to the previous view"]' )
+		).not.toBeVisible();
+	} );
+
 	test( 'should disappear when closed', async ( { page } ) => {
 		await page.click(
 			'role=region[name="Style Book"i] >> role=button[name="Close Style Book"i]'


### PR DESCRIPTION
## What?
Follows https://github.com/WordPress/gutenberg/pull/45960.

Clears out the Global Styles navigation history when selecting a block in Style Book, so that pressing the back button after selecting a block in Style Book goes back to the root instead of to wherever you were previously.

## Why?
Addressing this feedback from @javierarce in https://github.com/WordPress/gutenberg/pull/45960#issuecomment-1328875897:

> * If you click several blocks in the canvas and then use the Global Styles sidebar back button to reach the top level (or the list of blocks), you'll be presented with every single block settings panel you clicked before. I think we shouldn't stack those clicks.

## How?
To clear the history we simply call `navigator.goBack()` until we're at the root. We can tell how many times we need to do this by counting the number of `/`s in the path. For example if we're at `/typography/headings` then we need to go back twice.

One gotcha is that block names can contain `/` i.e. `/blocks/core/paragraph/typography`. To work around this I've updated Global Styles to URI encode the block name i.e. `/blocks/core%2Fparagraph/typography`. It makes sense to do this anyway since these paths approximate a URL.

An alternative approach is to add something like `navigator.clearHistory()` to the Navigator API. I'm not sure how widely useful this would be though so thought I'd start with an approach that requires minimal changes to `@wordpress/components`.

I did have to make one minimal change to `@wordpress/components` which is to update `navigator.goTo` and `navigator.goBack` to use the `setState( prevState => ... )` pattern so that multiple calls to these functions can be made in one render cycle. 

I also fixed a small bug I noticed which is that if you select _Buttons_ in Style Book then both _Button_ and _Buttons_ appear selected. This was because I was using `path.startsWith()` to determine if the block is selected and `core/buttons` starts with `core/button` 🙂

## Testing Instructions
An E2E test for this is included. 

To test manually:

1. Open Global Styles.
2. Navigate somewhere e.g. Blocks → Paragraph → Typography.
3. Open Style Book.
4. Click on an example in the Style Book.
5. Press the Back button in Global Styles.
6. You should be back at the root level, not Blocks → Paragraph → Typography.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -→

## Screenshots or screencast <!-- if applicable -->
