### PR TITLE
updateBlockListSettings: convert state to Map, do all updates in one action

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1829,12 +1829,12 @@ export function preferences( state = PREFERENCES_DEFAULTS, action ) {
  * Reducer returning an object where each key is a block client ID, its value
  * representing the settings for its nested blocks.
  *
- * @param {Object} state  Current state.
+ * @param {Map}    state  Current state.
  * @param {Object} action Dispatched action.
  *
  * @return {Object} Updated state.
  */
-export const blockListSettings = ( state = {}, action ) => {
+export const blockListSettings = ( state = new Map(), action ) => {
 	switch ( action.type ) {
 		case 'REPLACE_BLOCKS': {
 			// Collect all clientIds from replacement blocks. If a clientId
@@ -1849,53 +1849,48 @@ export const blockListSettings = ( state = {}, action ) => {
 				replacementIds.add( block.clientId );
 				stack.push( ...block.innerBlocks );
 			}
-			return Object.fromEntries(
-				Object.entries( state ).filter(
-					( [ id ] ) =>
-						! action.clientIds.includes( id ) ||
-						replacementIds.has( id )
-				)
-			);
+			const newState = new Map( state );
+			for ( const clientId of action.clientIds ) {
+				if ( ! replacementIds.has( clientId ) ) {
+					newState.delete( clientId );
+				}
+			}
+			return newState;
 		}
 		case 'REMOVE_BLOCKS': {
-			return Object.fromEntries(
-				Object.entries( state ).filter(
-					( [ id ] ) => ! action.clientIds.includes( id )
-				)
-			);
+			const newState = new Map( state );
+			for ( const clientId of action.clientIds ) {
+				newState.delete( clientId );
+			}
+			return newState;
 		}
 		case 'UPDATE_BLOCK_LIST_SETTINGS': {
 			const updates =
 				typeof action.clientId === 'string'
-					? { [ action.clientId ]: action.settings }
-					: action.clientId;
+					? [ [ action.clientId, action.settings ] ]
+					: Object.entries( action.clientId );
 
-			// Remove settings that are the same as the current state.
-			for ( const clientId in updates ) {
-				if ( ! updates[ clientId ] ) {
-					if ( ! state[ clientId ] ) {
-						delete updates[ clientId ];
-					}
-				} else if (
-					fastDeepEqual( state[ clientId ], updates[ clientId ] )
-				) {
-					delete updates[ clientId ];
-				}
-			}
+			const relevantUpdates = updates.filter(
+				( [ clientId, nextSettings ] ) =>
+					! nextSettings
+						? state.has( clientId )
+						: ! fastDeepEqual( state.get( clientId ), nextSettings )
+			);
 
-			if ( Object.keys( updates ).length === 0 ) {
+			if ( ! relevantUpdates.length ) {
 				return state;
 			}
 
-			const merged = { ...state, ...updates };
-
-			for ( const clientId in updates ) {
-				if ( ! updates[ clientId ] ) {
-					delete merged[ clientId ];
+			const newState = new Map( state );
+			for ( const [ clientId, nextSettings ] of relevantUpdates ) {
+				if ( ! nextSettings ) {
+					newState.delete( clientId );
+				} else {
+					newState.set( clientId, nextSettings );
 				}
 			}
 
-			return merged;
+			return newState;
 		}
 	}
 	return state;
@@ -2480,12 +2475,14 @@ function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 			syncedPatternClientIds.push( clientId );
 		}
 	} );
-	const contentOnlyTemplateLockedClientIds = Object.keys(
-		state.blockListSettings
-	).filter(
-		( clientId ) =>
-			state.blockListSettings[ clientId ]?.templateLock === 'contentOnly'
-	);
+	const contentOnlyTemplateLockedClientIds = Array.from(
+		state.blockListSettings.entries()
+	)
+		.filter(
+			( [ , listSettings ] ) =>
+				listSettings?.templateLock === 'contentOnly'
+		)
+		.map( ( [ clientId ] ) => clientId );
 
 	// When in an isolated editing context (e.g., editing a template part or pattern directly),
 	// don't apply contentOnly mode to nested unsynced patterns or template parts.
@@ -2890,15 +2887,15 @@ export function withDerivedBlockEditingModes( reducer ) {
 
 				for ( const clientId in updates ) {
 					const isNewContentOnlyBlock =
-						state.blockListSettings[ clientId ]?.templateLock !==
-							'contentOnly' &&
-						nextState.blockListSettings[ clientId ]
+						state.blockListSettings.get( clientId )
+							?.templateLock !== 'contentOnly' &&
+						nextState.blockListSettings.get( clientId )
 							?.templateLock === 'contentOnly';
 
 					const wasContentOnlyBlock =
-						state.blockListSettings[ clientId ]?.templateLock ===
-							'contentOnly' &&
-						nextState.blockListSettings[ clientId ]
+						state.blockListSettings.get( clientId )
+							?.templateLock === 'contentOnly' &&
+						nextState.blockListSettings.get( clientId )
 							?.templateLock !== 'contentOnly';
 
 					if ( isNewContentOnlyBlock ) {

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2476,13 +2476,10 @@ function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 		}
 	} );
 	const contentOnlyTemplateLockedClientIds = Array.from(
-		state.blockListSettings.entries()
-	)
-		.filter(
-			( [ , listSettings ] ) =>
-				listSettings?.templateLock === 'contentOnly'
-		)
-		.map( ( [ clientId ] ) => clientId );
+		state.blockListSettings
+	).flatMap( ( [ clientId, listSettings ] ) =>
+		listSettings?.templateLock === 'contentOnly' ? [ clientId ] : []
+	);
 
 	// When in an isolated editing context (e.g., editing a template part or pattern directly),
 	// don't apply contentOnly mode to nested unsynced patterns or template parts.

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2636,7 +2636,7 @@ export function getDirectInsertBlock( state, rootClientId = null ) {
 		return;
 	}
 	const { defaultBlock, directInsert } =
-		state.blockListSettings[ rootClientId ] ?? {};
+		state.blockListSettings.get( rootClientId ) ?? {};
 	if ( ! defaultBlock || ! directInsert ) {
 		return;
 	}
@@ -2869,7 +2869,7 @@ export const __experimentalGetPatternTransformItems = createRegistrySelector(
  * @return {?Object} Block settings of the block if set.
  */
 export function getBlockListSettings( state, clientId ) {
-	return state.blockListSettings[ clientId ];
+	return state.blockListSettings.get( clientId );
 }
 
 /**
@@ -2907,16 +2907,14 @@ export function isLastBlockChangePersistent( state ) {
  */
 export const __experimentalGetBlockListSettingsForBlocks = createSelector(
 	( state, clientIds = [] ) => {
-		return clientIds.reduce( ( blockListSettingsForBlocks, clientId ) => {
-			if ( ! state.blockListSettings[ clientId ] ) {
-				return blockListSettingsForBlocks;
+		const blockListSettingsForBlocks = {};
+		for ( const clientId of clientIds ) {
+			const settings = getBlockListSettings( state, clientId );
+			if ( settings ) {
+				blockListSettingsForBlocks[ clientId ] = settings;
 			}
-
-			return {
-				...blockListSettingsForBlocks,
-				[ clientId ]: state.blockListSettings[ clientId ],
-			};
-		}, {} );
+		}
+		return blockListSettingsForBlocks;
 	},
 	( state ) => [ state.blockListSettings ]
 );

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -131,13 +131,13 @@ describe( 'private selectors', () => {
 						'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f',
 					],
 				] ),
-				blockEditingModes: new Map( [] ),
+				blockEditingModes: new Map(),
 			},
-			blockListSettings: {
-				'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337': {},
-				'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f': {},
-			},
-			derivedBlockEditingModes: new Map( [] ),
+			blockListSettings: new Map( [
+				[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', {} ],
+				[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', {} ],
+			] ),
+			derivedBlockEditingModes: new Map(),
 		};
 
 		const hasContentRoleAttribute = jest.fn( () => false );
@@ -154,9 +154,9 @@ describe( 'private selectors', () => {
 				...baseState,
 				blocks: {
 					...baseState.blocks,
-					blockEditingModes: new Map( [] ),
+					blockEditingModes: new Map(),
 				},
-				derivedBlockEditingModes: new Map( [] ),
+				derivedBlockEditingModes: new Map(),
 			};
 			expect(
 				isBlockSubtreeDisabled(
@@ -349,10 +349,10 @@ describe( 'private selectors', () => {
 					],
 				] ),
 			},
-			blockListSettings: {
-				'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337': {},
-				'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f': {},
-			},
+			blockListSettings: new Map( [
+				[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', {} ],
+				[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', {} ],
+			] ),
 		};
 		getEnabledClientIdsTree.registry = {
 			select: jest.fn( () => ( {} ) ),
@@ -363,9 +363,9 @@ describe( 'private selectors', () => {
 				...baseState,
 				blocks: {
 					...baseState.blocks,
-					blockEditingModes: new Map( [] ),
+					blockEditingModes: new Map(),
 				},
-				derivedBlockEditingModes: new Map( [] ),
+				derivedBlockEditingModes: new Map(),
 			};
 			expect( getEnabledClientIdsTree( state ) ).toEqual( [
 				{
@@ -404,9 +404,9 @@ describe( 'private selectors', () => {
 				...baseState,
 				blocks: {
 					...baseState.blocks,
-					blockEditingModes: new Map( [] ),
+					blockEditingModes: new Map(),
 				},
-				derivedBlockEditingModes: new Map( [] ),
+				derivedBlockEditingModes: new Map(),
 			};
 			expect(
 				getEnabledClientIdsTree(
@@ -545,7 +545,7 @@ describe( 'private selectors', () => {
 					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
 					[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'disabled' ],
 				] ),
-				blockListSettings: {},
+				blockListSettings: new Map(),
 			};
 			expect(
 				getEnabledBlockParents(
@@ -597,7 +597,7 @@ describe( 'private selectors', () => {
 				derivedBlockEditingModes: new Map( [
 					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
 				] ),
-				blockListSettings: {},
+				blockListSettings: new Map(),
 			};
 			expect(
 				getEnabledBlockParents(
@@ -799,9 +799,9 @@ describe( 'private selectors', () => {
 				] ),
 			},
 			settings: {},
-			blockListSettings: {
-				'parent-block': templateLock ? { templateLock } : {},
-			},
+			blockListSettings: new Map( [
+				[ 'parent-block', templateLock ? { templateLock } : {} ],
+			] ),
 		} );
 
 		it( 'returns false when block has no lock and no templateLock', () => {
@@ -852,9 +852,9 @@ describe( 'private selectors', () => {
 				] ),
 			},
 			settings: {},
-			blockListSettings: {
-				'parent-block': templateLock ? { templateLock } : {},
-			},
+			blockListSettings: new Map( [
+				[ 'parent-block', templateLock ? { templateLock } : {} ],
+			] ),
 		} );
 
 		it( 'returns false when block has no lock and no templateLock', () => {
@@ -910,9 +910,9 @@ describe( 'private selectors', () => {
 				] ),
 			},
 			settings: {},
-			blockListSettings: {
-				'parent-block': templateLock ? { templateLock } : {},
-			},
+			blockListSettings: new Map( [
+				[ 'parent-block', templateLock ? { templateLock } : {} ],
+			] ),
 		} );
 
 		it( 'returns false when block is not locked in any way', () => {
@@ -1395,12 +1395,15 @@ describe( 'private selectors', () => {
 					attributes: new Map( [ [ clientId, attributes ] ] ),
 					parents: new Map( [ [ clientId, rootClientId ] ] ),
 				},
-				blockListSettings: {
-					[ clientId ]: templateLock ? { templateLock } : {},
-					'': rootTemplateLock
-						? { templateLock: rootTemplateLock }
-						: {},
-				},
+				blockListSettings: new Map( [
+					[ clientId, templateLock ? { templateLock } : {} ],
+					[
+						'',
+						rootTemplateLock
+							? { templateLock: rootTemplateLock }
+							: {},
+					],
+				] ),
 				settings:
 					disableContentOnlyForUnsyncedPatterns !== undefined
 						? { disableContentOnlyForUnsyncedPatterns }
@@ -1470,7 +1473,7 @@ describe( 'private selectors', () => {
 						[ 'inner-pattern', 'outer-pattern' ],
 					] ),
 				},
-				blockListSettings: {},
+				blockListSettings: new Map(),
 				settings: {},
 				editedContentOnlySection: undefined,
 			};
@@ -1509,7 +1512,7 @@ describe( 'private selectors', () => {
 						[ 'block-1', 'outer-pattern' ],
 					] ),
 				},
-				blockListSettings: {},
+				blockListSettings: new Map(),
 				settings: {},
 				editedContentOnlySection: 'outer-pattern',
 			};
@@ -1535,7 +1538,7 @@ describe( 'private selectors', () => {
 						[ 'pattern-b', '' ],
 					] ),
 				},
-				blockListSettings: {},
+				blockListSettings: new Map(),
 				settings: {},
 				editedContentOnlySection: 'pattern-a',
 			};
@@ -1554,7 +1557,7 @@ describe( 'private selectors', () => {
 					attributes: new Map( [ [ 'block-1', {} ] ] ),
 					parents: new Map( [ [ 'block-1', '' ] ] ),
 				},
-				blockListSettings: {},
+				blockListSettings: new Map(),
 				settings: {},
 				editedContentOnlySection: undefined,
 			};
@@ -1580,7 +1583,7 @@ describe( 'private selectors', () => {
 						[ 'inner-block', 'pattern-block' ],
 					] ),
 				},
-				blockListSettings: {},
+				blockListSettings: new Map(),
 				settings: {},
 				editedContentOnlySection: undefined,
 			};
@@ -1608,7 +1611,7 @@ describe( 'private selectors', () => {
 						[ 'inner-block', 'pattern-block' ],
 					] ),
 				},
-				blockListSettings: {},
+				blockListSettings: new Map(),
 				settings: {},
 				editedContentOnlySection: 'pattern-block',
 			};
@@ -1645,7 +1648,7 @@ describe( 'private selectors', () => {
 						[ 'deep-block', 'nested-pattern' ],
 					] ),
 				},
-				blockListSettings: {},
+				blockListSettings: new Map(),
 				settings: {},
 				editedContentOnlySection: 'outer-pattern',
 			};
@@ -1676,7 +1679,7 @@ describe( 'private selectors', () => {
 						[ 'pattern-b', '' ],
 					] ),
 				},
-				blockListSettings: {},
+				blockListSettings: new Map(),
 				settings: {},
 				editedContentOnlySection: 'pattern-b',
 			};

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -3391,7 +3391,7 @@ describe( 'state', () => {
 
 	describe( 'blockListSettings', () => {
 		it( 'should add new settings', () => {
-			const original = deepFreeze( {} );
+			const original = deepFreeze( new Map() );
 
 			const state = blockListSettings( original, {
 				type: 'UPDATE_BLOCK_LIST_SETTINGS',
@@ -3401,19 +3401,29 @@ describe( 'state', () => {
 				},
 			} );
 
-			expect( state ).toEqual( {
-				'9db792c6-a25a-495d-adbd-97d56a4c4189': {
-					allowedBlocks: [ 'core/paragraph' ],
-				},
-			} );
+			expect( state ).toEqual(
+				new Map( [
+					[
+						'9db792c6-a25a-495d-adbd-97d56a4c4189',
+						{
+							allowedBlocks: [ 'core/paragraph' ],
+						},
+					],
+				] )
+			);
 		} );
 
 		it( 'should return same reference if updated as the same', () => {
-			const original = deepFreeze( {
-				'9db792c6-a25a-495d-adbd-97d56a4c4189': {
-					allowedBlocks: [ 'core/paragraph' ],
-				},
-			} );
+			const original = deepFreeze(
+				new Map( [
+					[
+						'9db792c6-a25a-495d-adbd-97d56a4c4189',
+						{
+							allowedBlocks: [ 'core/paragraph' ],
+						},
+					],
+				] )
+			);
 
 			const state = blockListSettings( original, {
 				type: 'UPDATE_BLOCK_LIST_SETTINGS',
@@ -3427,7 +3437,7 @@ describe( 'state', () => {
 		} );
 
 		it( 'should return same reference if updated settings not assigned and id not exists', () => {
-			const original = deepFreeze( {} );
+			const original = deepFreeze( new Map() );
 
 			const state = blockListSettings( original, {
 				type: 'UPDATE_BLOCK_LIST_SETTINGS',
@@ -3438,14 +3448,22 @@ describe( 'state', () => {
 		} );
 
 		it( 'should update the settings of a block', () => {
-			const original = deepFreeze( {
-				'9db792c6-a25a-495d-adbd-97d56a4c4189': {
-					allowedBlocks: [ 'core/paragraph' ],
-				},
-				'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': {
-					allowedBlocks: true,
-				},
-			} );
+			const original = deepFreeze(
+				new Map( [
+					[
+						'9db792c6-a25a-495d-adbd-97d56a4c4189',
+						{
+							allowedBlocks: [ 'core/paragraph' ],
+						},
+					],
+					[
+						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+						{
+							allowedBlocks: true,
+						},
+					],
+				] )
+			);
 
 			const state = blockListSettings( original, {
 				type: 'UPDATE_BLOCK_LIST_SETTINGS',
@@ -3455,40 +3473,61 @@ describe( 'state', () => {
 				},
 			} );
 
-			expect( state ).toEqual( {
-				'9db792c6-a25a-495d-adbd-97d56a4c4189': {
-					allowedBlocks: [ 'core/list' ],
-				},
-				'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': {
-					allowedBlocks: true,
-				},
-			} );
+			expect( state ).toEqual(
+				new Map( [
+					[
+						'9db792c6-a25a-495d-adbd-97d56a4c4189',
+						{
+							allowedBlocks: [ 'core/list' ],
+						},
+					],
+					[
+						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+						{
+							allowedBlocks: true,
+						},
+					],
+				] )
+			);
 		} );
 
 		it( 'should remove existing settings if updated settings not assigned', () => {
-			const original = deepFreeze( {
-				'9db792c6-a25a-495d-adbd-97d56a4c4189': {
-					allowedBlocks: [ 'core/paragraph' ],
-				},
-			} );
+			const original = deepFreeze(
+				new Map( [
+					[
+						'9db792c6-a25a-495d-adbd-97d56a4c4189',
+						{
+							allowedBlocks: [ 'core/paragraph' ],
+						},
+					],
+				] )
+			);
 
 			const state = blockListSettings( original, {
 				type: 'UPDATE_BLOCK_LIST_SETTINGS',
 				clientId: '9db792c6-a25a-495d-adbd-97d56a4c4189',
 			} );
 
-			expect( state ).toEqual( {} );
+			expect( state ).toEqual( new Map() );
 		} );
 
 		it( 'should remove the settings of a block when it is replaced', () => {
-			const original = deepFreeze( {
-				'9db792c6-a25a-495d-adbd-97d56a4c4189': {
-					allowedBlocks: [ 'core/paragraph' ],
-				},
-				'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': {
-					allowedBlocks: true,
-				},
-			} );
+			const original = deepFreeze(
+				new Map( [
+					[
+						'9db792c6-a25a-495d-adbd-97d56a4c4189',
+						{
+							allowedBlocks: [ 'core/paragraph' ],
+						},
+					],
+					[
+						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+						{
+							allowedBlocks: true,
+						},
+					],
+				] )
+			);
 
 			const state = blockListSettings( original, {
 				type: 'REPLACE_BLOCKS',
@@ -3496,22 +3535,35 @@ describe( 'state', () => {
 				blocks: [],
 			} );
 
-			expect( state ).toEqual( {
-				'9db792c6-a25a-495d-adbd-97d56a4c4189': {
-					allowedBlocks: [ 'core/paragraph' ],
-				},
-			} );
+			expect( state ).toEqual(
+				new Map( [
+					[
+						'9db792c6-a25a-495d-adbd-97d56a4c4189',
+						{
+							allowedBlocks: [ 'core/paragraph' ],
+						},
+					],
+				] )
+			);
 		} );
 
 		it( 'should preserve the settings of a block when its clientId is reused in replacement', () => {
-			const original = deepFreeze( {
-				'9db792c6-a25a-495d-adbd-97d56a4c4189': {
-					allowedBlocks: [ 'core/paragraph' ],
-				},
-				'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': {
-					allowedBlocks: true,
-				},
-			} );
+			const original = deepFreeze(
+				new Map( [
+					[
+						'9db792c6-a25a-495d-adbd-97d56a4c4189',
+						{
+							allowedBlocks: [ 'core/paragraph' ],
+						},
+					],
+					[
+						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+						{
+							allowedBlocks: true,
+						},
+					],
+				] )
+			);
 
 			const state = blockListSettings( original, {
 				type: 'REPLACE_BLOCKS',
@@ -3524,29 +3576,42 @@ describe( 'state', () => {
 				],
 			} );
 
-			expect( state ).toEqual( {
-				'9db792c6-a25a-495d-adbd-97d56a4c4189': {
-					allowedBlocks: [ 'core/paragraph' ],
-				},
-				'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': {
-					allowedBlocks: true,
-				},
-			} );
+			expect( state ).toEqual(
+				new Map( [
+					[
+						'9db792c6-a25a-495d-adbd-97d56a4c4189',
+						{
+							allowedBlocks: [ 'core/paragraph' ],
+						},
+					],
+					[
+						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+						{
+							allowedBlocks: true,
+						},
+					],
+				] )
+			);
 		} );
 
 		it( 'should remove the settings of a block when it is removed', () => {
-			const original = deepFreeze( {
-				'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': {
-					allowedBlocks: true,
-				},
-			} );
+			const original = deepFreeze(
+				new Map( [
+					[
+						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+						{
+							allowedBlocks: true,
+						},
+					],
+				] )
+			);
 
 			const state = blockListSettings( original, {
 				type: 'REMOVE_BLOCKS',
 				clientIds: [ 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' ],
 			} );
 
-			expect( state ).toEqual( {} );
+			expect( state ).toEqual( new Map() );
 		} );
 	} );
 

--- a/packages/block-editor/src/store/test/registry-selectors.js
+++ b/packages/block-editor/src/store/test/registry-selectors.js
@@ -104,7 +104,7 @@ describe( 'selectors', () => {
 			expect(
 				select( store ).__experimentalGetAllowedPatterns( {
 					blocks: { byClientId: new Map() },
-					blockListSettings: {},
+					blockListSettings: new Map(),
 					settings: {
 						__experimentalBlockPatterns: [
 							{

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -2700,7 +2700,7 @@ describe( 'selectors', () => {
 					parents: new Map(),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {},
+				blockListSettings: new Map(),
 				settings: {},
 			};
 			expect( canInsertBlockType( state, 'core/invalid' ) ).toBe( false );
@@ -2715,7 +2715,7 @@ describe( 'selectors', () => {
 					parents: new Map(),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {},
+				blockListSettings: new Map(),
 				settings: {
 					allowedBlockTypes: [],
 				},
@@ -2734,7 +2734,7 @@ describe( 'selectors', () => {
 					order: new Map(),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {},
+				blockListSettings: new Map(),
 				settings: {
 					allowedBlockTypes: [ 'core/test-block-a' ],
 				},
@@ -2753,7 +2753,7 @@ describe( 'selectors', () => {
 					parents: new Map(),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {},
+				blockListSettings: new Map(),
 				settings: {
 					templateLock: 'all',
 				},
@@ -2776,7 +2776,7 @@ describe( 'selectors', () => {
 						} )
 					),
 				},
-				blockListSettings: {},
+				blockListSettings: new Map(),
 				settings: {},
 			};
 			expect( canInsertBlockType( state, 'core/test-block-a' ) ).toBe(
@@ -2793,7 +2793,7 @@ describe( 'selectors', () => {
 					order: new Map(),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {},
+				blockListSettings: new Map(),
 				settings: {},
 			};
 			expect( canInsertBlockType( state, 'core/test-block-c' ) ).toBe(
@@ -2818,7 +2818,7 @@ describe( 'selectors', () => {
 					order: new Map(),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {},
+				blockListSettings: new Map(),
 				settings: {},
 			};
 			expect(
@@ -2843,9 +2843,11 @@ describe( 'selectors', () => {
 					order: new Map(),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {
-					block1: {},
-				},
+				blockListSettings: new Map(
+					Object.entries( {
+						block1: {},
+					} )
+				),
 				settings: {},
 			};
 			expect(
@@ -2870,9 +2872,11 @@ describe( 'selectors', () => {
 					order: new Map(),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {
-					block1: {},
-				},
+				blockListSettings: new Map(
+					Object.entries( {
+						block1: {},
+					} )
+				),
 				settings: {},
 			};
 			expect(
@@ -2897,11 +2901,13 @@ describe( 'selectors', () => {
 					order: new Map(),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {
-					block1: {
-						allowedBlocks: [ 'core/test-block-c' ],
-					},
-				},
+				blockListSettings: new Map(
+					Object.entries( {
+						block1: {
+							allowedBlocks: [ 'core/test-block-c' ],
+						},
+					} )
+				),
 				settings: {},
 			};
 			expect(
@@ -2926,11 +2932,13 @@ describe( 'selectors', () => {
 					order: new Map(),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {
-					block1: {
-						allowedBlocks: [ 'core/test-block-b' ],
-					},
-				},
+				blockListSettings: new Map(
+					Object.entries( {
+						block1: {
+							allowedBlocks: [ 'core/test-block-b' ],
+						},
+					} )
+				),
 				settings: {},
 			};
 			expect(
@@ -2959,7 +2967,7 @@ describe( 'selectors', () => {
 						} )
 					),
 				},
-				blockListSettings: {},
+				blockListSettings: new Map(),
 				settings: {},
 			};
 			expect(
@@ -2984,11 +2992,13 @@ describe( 'selectors', () => {
 					order: new Map(),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {
-					block1: {
-						allowedBlocks: [],
-					},
-				},
+				blockListSettings: new Map(
+					Object.entries( {
+						block1: {
+							allowedBlocks: [],
+						},
+					} )
+				),
 				settings: {},
 			};
 			expect(
@@ -3013,7 +3023,7 @@ describe( 'selectors', () => {
 					order: new Map(),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {},
+				blockListSettings: new Map(),
 				settings: {},
 			};
 			expect(
@@ -3030,7 +3040,7 @@ describe( 'selectors', () => {
 					order: new Map(),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {},
+				blockListSettings: new Map(),
 				settings: {},
 			};
 			expect(
@@ -3058,16 +3068,20 @@ describe( 'selectors', () => {
 							block2: 'block1',
 						} )
 					),
-					order: new Map( [
-						[ '', [ 'block1' ] ],
-						[ 'block1', [ 'block2' ] ],
-					] ),
+					order: new Map(
+						Object.entries( {
+							'': [ 'block1' ],
+							block1: [ 'block2' ],
+						} )
+					),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {
-					block1: {},
-					block2: {},
-				},
+				blockListSettings: new Map(
+					Object.entries( {
+						block1: {},
+						block2: {},
+					} )
+				),
 				settings: {},
 			};
 			expect(
@@ -3100,9 +3114,11 @@ describe( 'selectors', () => {
 					order: new Map( [ [ '', [ 'block1' ] ] ] ),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {
-					block1: {},
-				},
+				blockListSettings: new Map(
+					Object.entries( {
+						block1: {},
+					} )
+				),
 				settings: {},
 			};
 			expect(
@@ -3134,19 +3150,25 @@ describe( 'selectors', () => {
 							child: 'parent',
 						} )
 					),
-					order: new Map( [
-						[ '', [ 'parent' ] ],
-						[ 'parent', [ 'child' ] ],
-					] ),
+					order: new Map(
+						Object.entries( {
+							'': [ 'parent' ],
+							parent: [ 'child' ],
+						} )
+					),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {
-					parent: {},
-				},
+				blockListSettings: new Map(
+					Object.entries( {
+						parent: {},
+					} )
+				),
 				settings: {},
-				derivedBlockEditingModes: new Map( [
-					[ 'parent', 'contentOnly' ],
-				] ),
+				derivedBlockEditingModes: new Map(
+					Object.entries( {
+						parent: 'contentOnly',
+					} )
+				),
 			};
 			expect(
 				canInsertBlockType( state, 'core/test-block-b', 'parent' )
@@ -3189,10 +3211,10 @@ describe( 'selectors', () => {
 					] ),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {
-					section: {},
-					container: {},
-				},
+				blockListSettings: new Map( [
+					[ 'section', {} ],
+					[ 'container', {} ],
+				] ),
 				settings: {
 					[ sectionRootClientIdKey ]: '',
 				},
@@ -3247,10 +3269,10 @@ describe( 'selectors', () => {
 					] ),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {
-					section: {},
-					container: {},
-				},
+				blockListSettings: new Map( [
+					[ 'section', {} ],
+					[ 'container', {} ],
+				] ),
 				settings: {
 					[ sectionRootClientIdKey ]: '',
 				},
@@ -3297,11 +3319,11 @@ describe( 'selectors', () => {
 					] ),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {
-					block1: {},
-					block2: {},
-					block3: {},
-				},
+				blockListSettings: new Map( [
+					[ 'block1', {} ],
+					[ 'block2', {} ],
+					[ 'block3', {} ],
+				] ),
 				settings: {},
 			};
 			expect(
@@ -3342,11 +3364,11 @@ describe( 'selectors', () => {
 					] ),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {
-					block1: {},
-					block2: {},
-					block3: {},
-				},
+				blockListSettings: new Map( [
+					[ 'block1', {} ],
+					[ 'block2', {} ],
+					[ 'block3', {} ],
+				] ),
 				settings: {},
 			};
 			expect(
@@ -3387,11 +3409,11 @@ describe( 'selectors', () => {
 					] ),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {
-					block1: {},
-					block2: {},
-					block3: {},
-				},
+				blockListSettings: new Map( [
+					[ 'block1', {} ],
+					[ 'block2', {} ],
+					[ 'block3', {} ],
+				] ),
 				settings: {},
 			};
 			expect(
@@ -3428,12 +3450,15 @@ describe( 'selectors', () => {
 					] ),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {
-					block1: {},
-					block2: {
-						allowedBlocks: [],
-					},
-				},
+				blockListSettings: new Map( [
+					[ 'block1', {} ],
+					[
+						'block2',
+						{
+							allowedBlocks: [],
+						},
+					],
+				] ),
 				settings: {},
 			};
 			expect(
@@ -3471,10 +3496,10 @@ describe( 'selectors', () => {
 					] ),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {
-					block1: {},
-					block2: {},
-				},
+				blockListSettings: new Map( [
+					[ 'block1', {} ],
+					[ 'block2', {} ],
+				] ),
 				settings: {},
 			};
 			expect(
@@ -3509,14 +3534,17 @@ describe( 'selectors', () => {
 					order: new Map(),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {
-					1: {
-						allowedBlocks: [
-							'core/test-block-b',
-							'core/test-block-c',
-						],
-					},
-				},
+				blockListSettings: new Map( [
+					[
+						'1',
+						{
+							allowedBlocks: [
+								'core/test-block-b',
+								'core/test-block-c',
+							],
+						},
+					],
+				] ),
 				settings: {},
 			};
 			expect( canInsertBlocks( state, [ '2' ], '1' ) ).toBe( true );
@@ -3543,11 +3571,13 @@ describe( 'selectors', () => {
 					order: new Map(),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {
-					1: {
-						allowedBlocks: [ 'core/test-block-c' ],
-					},
-				},
+				blockListSettings: new Map(
+					Object.entries( {
+						1: {
+							allowedBlocks: [ 'core/test-block-c' ],
+						},
+					} )
+				),
 				settings: {},
 			};
 			expect( canInsertBlocks( state, [ '2', '3' ], '1' ) ).toBe( false );
@@ -3824,7 +3854,7 @@ describe( 'selectors', () => {
 				},
 				settings: {},
 				preferences: {},
-				blockListSettings: {},
+				blockListSettings: new Map(),
 			};
 			const blocks = [ { name: 'core/with-tranforms-a' } ];
 			const items = getBlockTransformItems( state, blocks );
@@ -3865,7 +3895,7 @@ describe( 'selectors', () => {
 				},
 				settings: {},
 				preferences: {},
-				blockListSettings: {},
+				blockListSettings: new Map(),
 			};
 			const block = { name: 'core/with-tranforms-a' };
 			const items = getBlockTransformItems( state, block );
@@ -3899,12 +3929,15 @@ describe( 'selectors', () => {
 				},
 				settings: {},
 				preferences: {},
-				blockListSettings: {
-					block1: {
-						allowedBlocks: [ 'core/with-tranforms-c' ],
-					},
-					block2: {},
-				},
+				blockListSettings: new Map( [
+					[
+						'block1',
+						{
+							allowedBlocks: [ 'core/with-tranforms-c' ],
+						},
+					],
+					[ 'block2', {} ],
+				] ),
 			};
 			const blocks = [
 				{ clientId: 'block2', name: 'core/with-tranforms-a' },
@@ -3951,7 +3984,7 @@ describe( 'selectors', () => {
 				preferences: {
 					insertUsage: {},
 				},
-				blockListSettings: {},
+				blockListSettings: new Map(),
 				settings: {},
 			};
 			const blocks = [ { name: 'core/with-tranforms-a' } ];
@@ -3985,7 +4018,7 @@ describe( 'selectors', () => {
 						'core/with-tranforms-a': { count: 10, time: 1000 },
 					},
 				},
-				blockListSettings: {},
+				blockListSettings: new Map(),
 				settings: {},
 			};
 			const blocks = [ { name: 'core/with-tranforms-c' } ];
@@ -4041,11 +4074,14 @@ describe( 'selectors', () => {
 		it( 'should return false if the specified clientId was not found', () => {
 			const state = {
 				settings: { templateLock: 'all' },
-				blockListSettings: {
-					chicken: {
-						templateLock: 'insert',
-					},
-				},
+				blockListSettings: new Map( [
+					[
+						'chicken',
+						{
+							templateLock: 'insert',
+						},
+					],
+				] ),
 			};
 
 			expect( getTemplateLock( state, 'ribs' ) ).toBe( false );
@@ -4054,11 +4090,14 @@ describe( 'selectors', () => {
 		it( 'should return false if template lock was not set on the specified block', () => {
 			const state = {
 				settings: { templateLock: 'all' },
-				blockListSettings: {
-					chicken: {
-						test: 'tes1t',
-					},
-				},
+				blockListSettings: new Map( [
+					[
+						'chicken',
+						{
+							test: 'tes1t',
+						},
+					],
+				] ),
 			};
 
 			expect( getTemplateLock( state, 'chicken' ) ).toBe( false );
@@ -4067,11 +4106,14 @@ describe( 'selectors', () => {
 		it( 'should return the template lock for the specified clientId', () => {
 			const state = {
 				settings: { templateLock: 'all' },
-				blockListSettings: {
-					chicken: {
-						templateLock: 'insert',
-					},
-				},
+				blockListSettings: new Map( [
+					[
+						'chicken',
+						{
+							templateLock: 'insert',
+						},
+					],
+				] ),
 			};
 
 			expect( getTemplateLock( state, 'chicken' ) ).toBe( 'insert' );
@@ -4080,11 +4122,14 @@ describe( 'selectors', () => {
 		it( 'should return false if the block has contentOnly template lock and is an edited section', () => {
 			const state = {
 				editedContentOnlySection: 'chicken',
-				blockListSettings: {
-					chicken: {
-						templateLock: 'contentOnly',
-					},
-				},
+				blockListSettings: new Map( [
+					[
+						'chicken',
+						{
+							templateLock: 'contentOnly',
+						},
+					],
+				] ),
 			};
 
 			expect( getTemplateLock( state, 'chicken' ) ).toBe( false );
@@ -4094,14 +4139,20 @@ describe( 'selectors', () => {
 	describe( 'getBlockListSettings', () => {
 		it( 'should return the settings of a block', () => {
 			const state = {
-				blockListSettings: {
-					chicken: {
-						setting1: false,
-					},
-					ribs: {
-						setting2: true,
-					},
-				},
+				blockListSettings: new Map( [
+					[
+						'chicken',
+						{
+							setting1: false,
+						},
+					],
+					[
+						'ribs',
+						{
+							setting2: true,
+						},
+					],
+				] ),
 			};
 
 			expect( getBlockListSettings( state, 'chicken' ) ).toEqual( {
@@ -4111,7 +4162,7 @@ describe( 'selectors', () => {
 
 		it( 'should return undefined if settings for the block don’t exist', () => {
 			const state = {
-				blockListSettings: {},
+				blockListSettings: new Map(),
 			};
 
 			expect( getBlockListSettings( state, 'chicken' ) ).toBe(
@@ -4123,22 +4174,34 @@ describe( 'selectors', () => {
 	describe( '__experimentalGetBlockListSettingsForBlocks', () => {
 		it( 'should return the settings for a set of blocks', () => {
 			const state = {
-				blockListSettings: {
-					'test-1-dummy-clientId': {
-						setting1: false,
-					},
-					'test-2-dummy-clientId': {
-						setting1: true,
-						setting2: false,
-					},
-					'test-3-dummy-clientId': {
-						setting1: true,
-						setting2: false,
-					},
-					'test-4-dummy-clientId': {
-						setting1: true,
-					},
-				},
+				blockListSettings: new Map( [
+					[
+						'test-1-dummy-clientId',
+						{
+							setting1: false,
+						},
+					],
+					[
+						'test-2-dummy-clientId',
+						{
+							setting1: true,
+							setting2: false,
+						},
+					],
+					[
+						'test-3-dummy-clientId',
+						{
+							setting1: true,
+							setting2: false,
+						},
+					],
+					[
+						'test-4-dummy-clientId',
+						{
+							setting1: true,
+						},
+					],
+				] ),
 			};
 
 			const targetBlocksClientIds = [
@@ -4165,15 +4228,21 @@ describe( 'selectors', () => {
 		it( 'should return empty object if settings for the blocks don’t exist', () => {
 			// Does not include target Block clientIds.
 			const state = {
-				blockListSettings: {
-					'test-2-dummy-clientId': {
-						setting1: true,
-						setting2: false,
-					},
-					'test-4-dummy-clientId': {
-						setting1: true,
-					},
-				},
+				blockListSettings: new Map( [
+					[
+						'test-2-dummy-clientId',
+						{
+							setting1: true,
+							setting2: false,
+						},
+					],
+					[
+						'test-4-dummy-clientId',
+						{
+							setting1: true,
+						},
+					],
+				] ),
 			};
 
 			const targetBlocksClientIds = [
@@ -4478,9 +4547,7 @@ describe( 'selectors', () => {
 					] ),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {
-					parent: {},
-				},
+				blockListSettings: new Map( [ [ 'parent', {} ] ] ),
 				settings: {},
 				derivedBlockEditingModes: new Map( [
 					[ 'parent', 'contentOnly' ],
@@ -4528,10 +4595,10 @@ describe( 'selectors', () => {
 					] ),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {
-					section: {},
-					container: {},
-				},
+				blockListSettings: new Map( [
+					[ 'section', {} ],
+					[ 'container', {} ],
+				] ),
 				settings: {
 					[ sectionRootClientIdKey ]: '',
 				},
@@ -4581,10 +4648,10 @@ describe( 'selectors', () => {
 					] ),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {
-					section: {},
-					container: {},
-				},
+				blockListSettings: new Map( [
+					[ 'section', {} ],
+					[ 'container', {} ],
+				] ),
 				settings: {
 					[ sectionRootClientIdKey ]: '',
 				},
@@ -4643,10 +4710,10 @@ describe( 'selectors', () => {
 					] ),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {
-					section: {},
-					container: {},
-				},
+				blockListSettings: new Map( [
+					[ 'section', {} ],
+					[ 'container', {} ],
+				] ),
 				settings: {
 					[ sectionRootClientIdKey ]: '',
 				},
@@ -4690,9 +4757,7 @@ describe( 'selectors', () => {
 					] ),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {
-					parent: {},
-				},
+				blockListSettings: new Map( [ [ 'parent', {} ] ] ),
 				settings: {},
 				derivedBlockEditingModes: new Map( [
 					[ 'parent', 'contentOnly' ],
@@ -4740,10 +4805,10 @@ describe( 'selectors', () => {
 					] ),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {
-					section: {},
-					container: {},
-				},
+				blockListSettings: new Map( [
+					[ 'section', {} ],
+					[ 'container', {} ],
+				] ),
 				settings: {
 					[ sectionRootClientIdKey ]: '',
 				},
@@ -4793,10 +4858,10 @@ describe( 'selectors', () => {
 					] ),
 					blockEditingModes: new Map(),
 				},
-				blockListSettings: {
-					section: {},
-					container: {},
-				},
+				blockListSettings: new Map( [
+					[ 'section', {} ],
+					[ 'container', {} ],
+				] ),
 				settings: {
 					[ sectionRootClientIdKey ]: '',
 				},
@@ -4973,9 +5038,9 @@ describe( '__unstableGetClientIdsTree', () => {
 describe( 'getBlockEditingMode', () => {
 	const baseState = {
 		blocks: {
-			blockEditingModes: new Map( [] ),
+			blockEditingModes: new Map(),
 		},
-		derivedBlockEditingModes: new Map( [] ),
+		derivedBlockEditingModes: new Map(),
 	};
 
 	const hasContentRoleAttribute = jest.fn( () => false );

--- a/packages/block-editor/src/store/utils.js
+++ b/packages/block-editor/src/store/utils.js
@@ -138,7 +138,7 @@ export const getAllPatternsDependants = ( select ) => ( state ) => {
 
 export const getInsertBlockTypeDependants = () => ( state, rootClientId ) => {
 	return [
-		state.blockListSettings[ rootClientId ],
+		state.blockListSettings.get( rootClientId ),
 		state.blocks.byClientId.get( rootClientId ),
 		state.blocks.order.get( rootClientId || '' ),
 		state.settings.allowedBlockTypes,


### PR DESCRIPTION
Converts the `state.blockListSettings` state to a `Map`, hoping to make it faster. And when there are multiple pending updates for block list settings, do them inside one `updateBlockListSettings` action. That should be much faster that `registry.batch()`, because we're not creating a new state tree for the entire store for each update.