### PR TITLE
Block Editor: Add initial view mode in `BlockPatternSetup`

### DIFF
--- a/packages/block-editor/src/components/block-pattern-setup/index.js
+++ b/packages/block-editor/src/components/block-pattern-setup/index.js
@@ -138,8 +138,9 @@ const BlockPatternSetup = ( {
 	blockName,
 	filterPatternsFn,
 	onBlockPatternSelect,
+	initialViewMode = VIEWMODES.carousel,
 } ) => {
-	const [ viewMode, setViewMode ] = useState( VIEWMODES.carousel );
+	const [ viewMode, setViewMode ] = useState( initialViewMode );
 	const [ activeSlide, setActiveSlide ] = useState( 0 );
 	const { replaceBlock } = useDispatch( blockEditorStore );
 	const patterns = usePatternsSetup( clientId, blockName, filterPatternsFn );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/46381

This PR simply adds an `initialViewMode` for the BlockPatternSetup component. The available values are only `carousel` and `grid`, with the former remaining the default initial view mode.

## Testing Instructions
1. Add `initialViewMode="grid"` in a place you're using `BlockPatternSetup`
2. Observe that the modal opens in the `grid` view mode
3. Ensure Query Loop block works as before with the `carousel` view mode as the initial view mode


## Screenshots or screencast <!-- if applicable -->
I have added `initialViewMode="grid"` to Query Loop to showcase the change


https://user-images.githubusercontent.com/16275880/206428135-b96d47a8-4050-48ac-bf55-19403c716837.mov


