### PR TITLE
Allow developing Gutenberg with NPM v7 and v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	},
 	"engines": {
 		"node": ">=14.0.0",
-		"npm": ">=6.9.0 <7"
+		"npm": ">=6.9.0"
 	},
 	"config": {
 		"IS_GUTENBERG_PLUGIN": true


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Part of [Upgrade node and npm to latest LTS versions](https://github.com/WordPress/gutenberg/issues/34801).

Remove old restriction to use only NPM 6, thus allowing use of NPM 7 and 8.

NPM 6 came with Node.js 14 which is a bit older at this point already: https://github.com/nodejs/release#release-schedule

I'd expect to be able to use at least Node.js 16 or 18 for developing Gutenberg, and thoes come with newer NPM.

It's of course possible to keep using older NPM with newer Node.js, but that's not very convenient. 

## Why?
Restriction [was added 2 years](https://github.com/WordPress/gutenberg/pull/29204) ago because of a [bug in NPM](https://github.com/npm/cli/issues/2610). Issue with NPM seems to persist, but:

- I don't know if the problem affects Gutenberg anymore; not quite sure how to test either! [There's only one `git+https` dependency](https://github.com/WordPress/gutenberg/search?q=%22git%2Bhttps%22) but it's for [react native editor](https://github.com/WordPress/gutenberg/blob/705ab44f2c2797d75740533a85030c194b4fb040/packages/react-native-editor/package.json) and I don't know how to test that.

- [Issue commenter noticed](https://github.com/npm/cli/issues/2610#issuecomment-1297494582) the bug doesn't affect NPM 6 when using older Lockfile v1 versions (which Gutenberg currently uses). This could be the case with newer NPM versions, too?

    > Running NPM 6.14.x, this is only an issue with lockfile v2. Reverting back to a v1 lockfile fixes it.

- [Issue commented offered](https://github.com/npm/cli/issues/2610#issuecomment-1295371753) a solution that seemed to help:

   > I just had success by changing from `git+https://github.com/` to `git+https://git@github.com/` —it then resolved to HTTPS in my lock file.



## How?
So far I've only removed the restriction and didn't apply the suggested `git+https://git` solution.

## Testing Instructions
`npm ci`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
