### PR TITLE
Paste handler: remove styles on inline paste

### DIFF
--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -47,6 +47,7 @@ const { console } = window;
  */
 function filterInlineHTML( HTML, preserveWhiteSpace ) {
 	HTML = deepFilterHTML( HTML, [
+		headRemover,
 		googleDocsUIDRemover,
 		phrasingContentReducer,
 		commentRemover,

--- a/test/integration/__snapshots__/blocks-raw-handling.test.js.snap
+++ b/test/integration/__snapshots__/blocks-raw-handling.test.js.snap
@@ -1,5 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Blocks raw handling pasteHandler apple 1`] = `"<strong>This is a </strong>title<br><br><br><strong>This is a <em>heading</em></strong><br><br><br>This is a <strong>paragraph</strong> with a <a href=\\"https://w.org\\">link</a>.<br><br><br>A<br>Bulleted<br>Indented<br>List<br><br><br>One<br>Two<br>Three<br><br><br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III<br><br><br>An image:<br>"`;
+
+exports[`Blocks raw handling pasteHandler classic 1`] = `"First paragraph<br><br>Second paragraph<br>Third paragraph<br>Fourth paragraph<br>Fifth paragraph<br>Sixth paragraph"`;
+
+exports[`Blocks raw handling pasteHandler evernote 1`] = `"This is a <em>paragraph</em>.<br><br><br>This is a <a href=\\"https://w.org\\">link</a>.<br><br><br>An<br>Unordered<br>Indented<br>List<br><br><br>One<br>Two<br>Indented<br>Three<br><br><br><br><br><br><br>One<br>Two<br>Three<br>Four<br>Five<br>Six<br><img src=\\"data:image/jpeg;base64,###\\">"`;
+
+exports[`Blocks raw handling pasteHandler google-docs 1`] = `"This is a <strong>title</strong><br><br>This is a <em>heading</em><br><br>Formatting test: <strong>bold</strong>, <em>italic</em>, <a href=\\"https://w.org/\\">link</a>, <s>strikethrough</s>, <sup>superscript</sup>, <sub>subscript</sub>, <strong><em>nested</em></strong>.<br><br>A<br>Bulleted<br>Indented<br>List<br><br>One<br>Two<br>Three<br><br><br><br><br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III<br><br><br><br><br><br>An image:<br><br><img src=\\"https://lh4.googleusercontent.com/ID\\" width=\\"544\\" height=\\"184\\"><br>"`;
+
+exports[`Blocks raw handling pasteHandler google-docs-list-only 1`] = `"My first list item<br>A sub list item<br>A second sub list item<br>My second list item<br>My third list item"`;
+
+exports[`Blocks raw handling pasteHandler google-docs-table 1`] = `"<br><br><br><br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III"`;
+
+exports[`Blocks raw handling pasteHandler google-docs-table-with-comments 1`] = `"<br><br><br><br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III"`;
+
+exports[`Blocks raw handling pasteHandler google-docs-with-comments 1`] = `"This is a <strong>title</strong><br><br>This is a <em>heading</em><br><br>Formatting test: <strong>bold</strong>, <em>italic</em>, <a href=\\"https://w.org/\\">link</a>, <s>strikethrough</s>, <sup>superscript</sup>, <sub>subscript</sub>, <strong><em>nested</em></strong>.<br><br>A<br>Bulleted<br>Indented<br>List<br><br>One<br>Two<br>Three<br><br><br><br><br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III<br><br><br><br><br><br>An image:<br><br><img src=\\"https://lh4.googleusercontent.com/ID\\" width=\\"544\\" height=\\"184\\"><br><br>"`;
+
+exports[`Blocks raw handling pasteHandler gutenberg 1`] = `"Test"`;
+
+exports[`Blocks raw handling pasteHandler iframe-embed 1`] = `""`;
+
+exports[`Blocks raw handling pasteHandler markdown 1`] = `"This is a heading with <em>italic</em><br>This is a paragraph with a <a href=\\"https://w.org/\\">link</a>, <strong>bold</strong>, and <del>strikethrough</del>.<br>Preserve<br>line breaks please.<br>Lists<br>A<br>Bulleted Indented<br>List<br>One<br>Two<br>Three<br>Table<br>First Header<br>Second Header<br>Content from cell 1<br>Content from cell 2<br>Content in the first column<br>Content in the second column<br><br><br><br>Table with empty cells.<br>Quote<br>First<br>Second<br>Code<br>Inline <code>code</code> tags should work.<br><code>This is a code block.</code>"`;
+
+exports[`Blocks raw handling pasteHandler ms-word 1`] = `"This is a title<br>&nbsp;<br>This is a subtitle<br>&nbsp;<br>This is a heading level 1<br>&nbsp;<br>This is a heading level 2<br>&nbsp;<br>This is a <strong>paragraph</strong> with a <a href=\\"https://w.org/\\">link</a>.<br>&nbsp;<br>·&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; A<br>·&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Bulleted<br>o&nbsp;&nbsp; Indented<br>·&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; List<br>&nbsp;<br>1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; One<br>2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Two<br>3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Three<br>&nbsp;<br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III<br>&nbsp;<br>An image:<br>&nbsp;<br><img width=\\"451\\" height=\\"338\\" src=\\"file:LOW-RES.png\\"><br><a href=\\"#anchor\\">This is an anchor link</a> that leads to the next paragraph.<br><a id=\\"anchor\\">This is the paragraph with the anchor.</a><br><a href=\\"#nowhere\\">This is an anchor link</a> that leads nowhere.<br><a>This is a paragraph with an anchor with no link pointing to it.</a><br>This is a reference to a footnote<a href=\\"#_ftn1\\" id=\\"_ftnref1\\">[1]</a>.<br>This is a reference to an endnote<a href=\\"#_edn1\\" id=\\"_ednref1\\">[i]</a>.<br><br><br><a href=\\"#_ftnref1\\" id=\\"_ftn1\\">[1]</a> This is a footnote.<br><br><br><a href=\\"#_ednref1\\" id=\\"_edn1\\">[i]</a> This is an endnote."`;
+
+exports[`Blocks raw handling pasteHandler ms-word-online 1`] = `"This is a <em>heading</em>&nbsp;<br>This is a <strong>paragraph </strong>with a <a href=\\"https://w.org/\\" target=\\"_blank\\" rel=\\"noreferrer noopener\\">link</a>.&nbsp;<br>A&nbsp;<br>Bulleted&nbsp;<br>Indented&nbsp;<br>List&nbsp;<br>&nbsp;<br>One&nbsp;<br>Two&nbsp;<br>Three&nbsp;<br><br>One&nbsp;<br>Two&nbsp;<br>Three&nbsp;<br>1&nbsp;<br>2&nbsp;<br>3&nbsp;<br>I&nbsp;<br>II&nbsp;<br>III&nbsp;<br>&nbsp;<br>An image:&nbsp;<br><img src=\\"data:image/jpeg;base64,###\\">&nbsp;"`;
+
+exports[`Blocks raw handling pasteHandler ms-word-styled 1`] = `"<br><strong>Lorem ipsum dolor sit amet, consectetur adipiscing elit&nbsp;</strong><br><br><br>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque aliquet hendrerit auctor. Nam lobortis, est vel lacinia tincidunt, purus tellus vehicula ex, nec pharetra justo dui sed lorem. Nam congue laoreet massa, quis varius est tincidunt ut."`;
+
+exports[`Blocks raw handling pasteHandler nested-divs 1`] = `"First paragraph<br><br>Second paragraph<br>Third paragraph<br>Fourth paragraph<br>Fifth paragraph<br>Sixth paragraph"`;
+
+exports[`Blocks raw handling pasteHandler one-image 1`] = `"<img src=\\"http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif\\" alt=\\"\\" width=\\"300\\" height=\\"137\\">"`;
+
+exports[`Blocks raw handling pasteHandler plain 1`] = `"test<br>test<br><br>test"`;
+
+exports[`Blocks raw handling pasteHandler shortcode-matching 1`] = `"[gallery ids=\\"40,41,42\\"]<br>[gallery ids=\\"1000\\"]<br>[gallery ids=\\"42\\"]"`;
+
 exports[`Blocks raw handling pasteHandler should remove extra blank lines 1`] = `
 "<!-- wp:paragraph -->
 <p>1</p>
@@ -27,6 +63,14 @@ exports[`Blocks raw handling pasteHandler should strip windows data 1`] = `
 <p>Paragraph Win</p>
 <!-- /wp:paragraph -->"
 `;
+
+exports[`Blocks raw handling pasteHandler slack-paragraphs 1`] = `"test with&nbsp;<a target=\\"_blank\\" href=\\"http://w.org/\\" rel=\\"noreferrer noopener\\">link</a><br>a new linea new paragraph<br>another new lineanother paragraph"`;
+
+exports[`Blocks raw handling pasteHandler slack-quote 1`] = `"Test with&nbsp;<a target=\\"_blank\\" href=\\"http://w.org/\\" rel=\\"noreferrer noopener\\">link</a>."`;
+
+exports[`Blocks raw handling pasteHandler two-images 1`] = `"<img src=\\"http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif\\" alt=\\"\\" width=\\"300\\" height=\\"137\\"> <img src=\\"http://localhost/wp-content/uploads/2018/01/Dec-05-2017-17-52-09-9-300x248.gif\\" alt=\\"\\" width=\\"300\\" height=\\"248\\">"`;
+
+exports[`Blocks raw handling pasteHandler wordpress 1`] = `"Howdy<br>This is a paragraph.<br>More tag<br><br>Shortcode<br>[gallery ids=\\"1\\"]<br><img src=\\"block.png\\" alt=\\"\\"><br><img src=\\"aligned.png\\" alt=\\"\\"> test<br><img src=\\"not-aligned.png\\" alt=\\"\\"> test"`;
 
 exports[`Blocks raw handling should correctly handle quotes with mixed content 1`] = `
 "<!-- wp:quote -->

--- a/test/integration/blocks-raw-handling.test.js
+++ b/test/integration/blocks-raw-handling.test.js
@@ -427,10 +427,14 @@ describe( 'Blocks raw handling', () => {
 
 				expect( serialized ).toBe( output );
 
-				if ( type !== 'gutenberg' ) {
-					// eslint-disable-next-line jest/no-conditional-expect
-					expect( console ).toHaveLogged();
-				}
+				const convertedInline = pasteHandler( {
+					HTML,
+					plainText,
+					mode: 'INLINE',
+				} );
+
+				expect( convertedInline ).toMatchSnapshot();
+				expect( console ).toHaveLogged();
 			} );
 		} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #19197.
Fixes #16986.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?

Head tag is not removed on inline paste.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
