### PR TITLE
Add `name` to `wp_register_webfonts`

### DIFF
--- a/lib/experimental/class-wp-webfonts.php
+++ b/lib/experimental/class-wp-webfonts.php
@@ -205,6 +205,7 @@ class WP_Webfonts {
 			$webfont,
 			array(
 				'provider'     => 'local',
+				'name'         => '',
 				'font-family'  => '',
 				'font-style'   => 'normal',
 				'font-weight'  => '400',
@@ -215,6 +216,12 @@ class WP_Webfonts {
 		// Check the font-family.
 		if ( empty( $webfont['font-family'] ) || ! is_string( $webfont['font-family'] ) ) {
 			trigger_error( __( 'Webfont font family must be a non-empty string.', 'gutenberg' ) );
+			return false;
+		}
+
+		// Check the name.
+		if ( isset( $webfont['name'] ) && ! is_string( $webfont['name'] ) ) {
+			trigger_error( __( 'Webfont name must be a string.', 'gutenberg' ) );
 			return false;
 		}
 
@@ -260,6 +267,7 @@ class WP_Webfonts {
 			'font-feature-settings',
 			'font-variation-settings',
 			'line-gap-override',
+			'name',
 			'size-adjust',
 			'src',
 			'unicode-range',

--- a/lib/experimental/register-webfonts-from-theme-json.php
+++ b/lib/experimental/register-webfonts-from-theme-json.php
@@ -152,7 +152,8 @@ function gutenberg_add_registered_webfonts_to_theme_json( $data ) {
 
 	foreach ( $to_add as $slug ) {
 		$font_faces_for_family = $font_families_registered[ $slug ];
-		$family_name           = $font_faces_for_family[0]['font-family'];
+		$font_family           = $font_faces_for_family[0]['font-family'];
+		$name           = ! empty( $font_faces_for_family[0]['name'] ) ? $font_faces_for_family[0]['name'] : $font_faces_for_family[0]['font-family'];
 		$font_faces            = array();
 
 		foreach ( $font_faces_for_family as $font_face ) {
@@ -164,8 +165,8 @@ function gutenberg_add_registered_webfonts_to_theme_json( $data ) {
 		}
 
 		$data['settings']['typography']['fontFamilies'][] = array(
-			'fontFamily' => str_contains( $family_name, ' ' ) ? "'{$family_name}'" : $family_name,
-			'name'       => $family_name,
+			'fontFamily' => str_contains( $font_family, ' ' ) ? "'{$font_family}'" : $font_family,
+			'name'       => $name,
 			'slug'       => $slug,
 			'fontFace'   => $font_faces,
 		);

--- a/lib/experimental/register-webfonts-from-theme-json.php
+++ b/lib/experimental/register-webfonts-from-theme-json.php
@@ -153,7 +153,7 @@ function gutenberg_add_registered_webfonts_to_theme_json( $data ) {
 	foreach ( $to_add as $slug ) {
 		$font_faces_for_family = $font_families_registered[ $slug ];
 		$font_family           = $font_faces_for_family[0]['font-family'];
-		$name           = ! empty( $font_faces_for_family[0]['name'] ) ? $font_faces_for_family[0]['name'] : $font_faces_for_family[0]['font-family'];
+		$name                  = ! empty( $font_faces_for_family[0]['name'] ) ? $font_faces_for_family[0]['name'] : $font_faces_for_family[0]['font-family'];
 		$font_faces            = array();
 
 		foreach ( $font_faces_for_family as $font_face ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Solves https://github.com/WordPress/gutenberg/issues/46398

Adds support for `name` attribute in `wp_register_webfonts`:

```php
array(
	'name'         => 'Example (Japanese)',
	'font-family'  => 'Example',

	'font-style'   => 'normal',
	'font-weight'  => '200 900',
	'font-stretch' => 'normal',
	'src'          => 'https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2',
	'font-display' => 'fallback',
	'provider'     => 'local',
)
```

## Why?
I'm describing use case in detail at https://github.com/WordPress/gutenberg/issues/46398, but essentially to match how `theme.json` already works.

## How?
Allows passing `name` attribute as part of font family array.

I'm not entirely happy with solution as conceptually "Name" would belong to higher up, not necessarily inside font-family definition. I also didn't see better alternative.

## Testing Instructions

Add this to mu-plugins or elsewhere:

```php
function register_example_font() {
	$font_family = "Example";
	$font_name = "Example (Japanese)";
	
	wp_register_webfonts(
		array(
			array(
				'provider'     => 'local',
				'name'         => $font_name,
				'font-family'  => $font_family,
				'font-style'   => 'normal',
				'font-weight'  => '200 900',
				'font-stretch' => 'normal',
				'src'          => 'https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2',
				'font-display' => 'fallback',
			),
			array(
				'provider'     => 'local',
				'name'         => $font_name,
				'font-family'  => $font_family,
				'font-style'   => 'italic',
				'font-weight'  => '200 900',
				'font-stretch' => 'normal',
				'src'          => 'https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2',
				'font-display' => 'fallback',
			),
		)
	);
}
add_filter( 'init', 'register_example_font' );
```

Open site editor and note font families:

<img width="740" alt="Screenshot 2022-12-08 at 15 11 40" src="https://user-images.githubusercontent.com/87168/206455357-c6c03b54-b1e5-4a99-a7d9-e33feeb25f30.png">


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
