### PR TITLE
E2E: Fix flaky Block Switcher tests

### DIFF
--- a/packages/e2e-tests/specs/editor/various/block-switcher.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-switcher.test.js
@@ -16,8 +16,8 @@ describe( 'Block Switcher', () => {
 
 	it( 'Should show the expected block transforms on the list block when the blocks are removed', async () => {
 		// Insert a list block.
-		await insertBlock( 'List' );
-		await page.keyboard.type( 'List content' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '- List content' );
 		await page.keyboard.press( 'ArrowUp' );
 		await pressKeyWithModifier( 'alt', 'F10' );
 
@@ -43,8 +43,8 @@ describe( 'Block Switcher', () => {
 		} );
 
 		// Insert a list block.
-		await insertBlock( 'List' );
-		await page.keyboard.type( 'List content' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '- List content' );
 		await page.keyboard.press( 'ArrowUp' );
 		await pressKeyWithModifier( 'alt', 'F10' );
 
@@ -63,6 +63,10 @@ describe( 'Block Switcher', () => {
 	} );
 
 	it( 'Should not show the block switcher if all the blocks the list block transforms into are removed', async () => {
+		// Insert a list block.
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '- List content' );
+
 		// Remove the paragraph and quote block from the list of registered blocks.
 		await page.evaluate( () => {
 			[
@@ -75,9 +79,6 @@ describe( 'Block Switcher', () => {
 			].map( ( block ) => wp.blocks.unregisterBlockType( block ) );
 		} );
 
-		// Insert a list block.
-		await insertBlock( 'List' );
-		await page.keyboard.type( 'List content' );
 		await page.keyboard.press( 'ArrowUp' );
 		await pressKeyWithModifier( 'alt', 'F10' );
 
@@ -90,8 +91,8 @@ describe( 'Block Switcher', () => {
 	describe( 'Conditional tranformation options', () => {
 		describe( 'Columns tranforms', () => {
 			it( 'Should show Columns block only if selected blocks are between limits (1-6)', async () => {
-				await insertBlock( 'List' );
-				await page.keyboard.type( 'List content' );
+				await page.keyboard.press( 'Enter' );
+				await page.keyboard.type( '- List content' );
 				await page.keyboard.press( 'ArrowUp' );
 				await insertBlock( 'Heading' );
 				await page.keyboard.type( 'I am a header' );
@@ -103,8 +104,8 @@ describe( 'Block Switcher', () => {
 				);
 			} );
 			it( 'Should NOT show Columns transform only if selected blocks are more than max limit(6)', async () => {
-				await insertBlock( 'List' );
-				await page.keyboard.type( 'List content' );
+				await page.keyboard.press( 'Enter' );
+				await page.keyboard.type( '- List content' );
 				await page.keyboard.press( 'ArrowUp' );
 				await insertBlock( 'Heading' );
 				await page.keyboard.type( 'I am a header' );


### PR DESCRIPTION
## What?

Fixes #45354

Fix flaky Block Switcher tests by typing in the List block instead of inserting it via the global inserter.

## Testing Instructions

All Block Switcher tests should be passing (packages/e2e-tests/specs/editor/various/block-switcher.test.js).