### PR TITLE
[Block Library - Query Loop]: Connect scoped `block` variation to `inserter` variations

### DIFF
--- a/docs/how-to-guides/block-tutorial/extending-the-query-loop-block.md
+++ b/docs/how-to-guides/block-tutorial/extending-the-query-loop-block.md
@@ -119,6 +119,12 @@ The Query Loop block determines if there is an active variation of itself and if
 
 In order for a pattern to be “connected” with a Query Loop variation, you should add the name of your variation prefixed with the Query Loop name (e.g. `core/query/$variation_name`) to the pattern's `blockTypes` property. For more details about registering patterns [see here](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-patterns/).
 
+If you have not provided `innerBlocks` in your variation, there is also a way to suggest “connected” variations when the user selects `Start blank` in the setup phase. This is handled in a similar fashion with “connected” patterns, by checking if there is an active variation of Query Loop and if there are any connected variations to suggest.
+
+In order for a variation to be connected to another Query Loop variation we need to define the `scope` attribute with `['block']` as value and the `namespace` attribute defined as an array. This array should contain the names(`name` property) of any variations they want to be connected to.
+
+For example, if we have a Query Loop variation exposed to the inserter(`scope: ['inserter']`) with the name `products`, we can connect a scoped `block` variation by setting its `namespace` attribute to `['products']`. If the user selects this variation after having clicked `Start blank`, the namespace attribute will be overridden by the main inserter variation.
+
 ### Making Gutenberg recognize your variation
 
 There is one slight problem you might have realized after implementing this variation: while it is transparent to the user as they are inserting it, Gutenberg will still recognize the variation as a Query Loop block at its core and so, after its insertion, it will show up as a Query Loop block in the tree view of the editor, for instance.

--- a/packages/block-library/src/query/edit/query-placeholder.js
+++ b/packages/block-library/src/query/edit/query-placeholder.js
@@ -16,6 +16,11 @@ import {
 import { Button, Placeholder } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { useScopedBlockVariations } from '../utils';
+
 export default function QueryPlaceholder( {
 	attributes,
 	clientId,
@@ -104,10 +109,7 @@ function QueryVariationPicker( {
 	icon,
 	label,
 } ) {
-	const variations = useSelect(
-		( select ) => select( blocksStore ).getBlockVariations( name, 'block' ),
-		[ name ]
-	);
+	const scopeVariations = useScopedBlockVariations( name, attributes );
 	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 	const blockProps = useBlockProps();
 	return (
@@ -115,24 +117,25 @@ function QueryVariationPicker( {
 			<__experimentalBlockVariationPicker
 				icon={ icon }
 				label={ label }
-				variations={ variations }
-				onSelect={ ( nextVariation ) => {
-					if ( nextVariation.attributes ) {
+				variations={ scopeVariations }
+				onSelect={ ( variation ) => {
+					if ( variation.attributes ) {
 						setAttributes( {
-							...nextVariation.attributes,
+							...variation.attributes,
 							query: {
-								...nextVariation.attributes.query,
+								...variation.attributes.query,
 								postType:
 									attributes.query.postType ||
-									nextVariation.attributes.query.postType,
+									variation.attributes.query.postType,
 							},
+							namespace: attributes.namespace,
 						} );
 					}
-					if ( nextVariation.innerBlocks ) {
+					if ( variation.innerBlocks ) {
 						replaceInnerBlocks(
 							clientId,
 							createBlocksFromInnerBlocksTemplate(
-								nextVariation.innerBlocks
+								variation.innerBlocks
 							),
 							false
 						);

--- a/packages/block-library/src/query/edit/query-placeholder.js
+++ b/packages/block-library/src/query/edit/query-placeholder.js
@@ -62,7 +62,6 @@ export default function QueryPlaceholder( {
 		return (
 			<QueryVariationPicker
 				clientId={ clientId }
-				name={ name }
 				attributes={ attributes }
 				setAttributes={ setAttributes }
 				icon={ icon }
@@ -103,13 +102,12 @@ export default function QueryPlaceholder( {
 
 function QueryVariationPicker( {
 	clientId,
-	name,
 	attributes,
 	setAttributes,
 	icon,
 	label,
 } ) {
-	const scopeVariations = useScopedBlockVariations( name, attributes );
+	const scopeVariations = useScopedBlockVariations( attributes );
 	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 	const blockProps = useBlockProps();
 	return (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/46367
Maybe alternative of: https://github.com/WordPress/gutenberg/pull/46369

Currently in Query Loop set up flow a user can choose to `start blank`, where the scoped `block` variations are suggested. If extenders of Query Loop have added scoped `inserter` variations(ex `List of Products`) and choose to `start blank` the default `block` variations will be suggested, which might make no sense or just unwanted.

For such `inserter` variations there is already in place the mechanism to suggest `connected` patterns. So this PR implements something similar for `connected` scoped `block` patterns to other Query Loop variations(`inserter`).

I have used a convention:
> Helper hook that determines if there is an active variation of the block
 and if there are available specific scoped `block` variations connected with
 this variation.
 If there are, these variations are going to be the only ones suggested
 to the user in setup flow when clicking to `start blank`, without including
 the default ones for Query Loop.
 If there are no such scoped `block` variations, the default ones for Query
Loop are going to be suggested.
The way we determine such variations is with the convention that they have the `namespace`
 attribute defined as an array. This array should contain the names(`name` property) of any
 variations they want to be connected to.
For example, if we have a `Query Loop` scoped `inserter` variation with the name `products`,
we can connect a scoped `block` variation by setting its `namespace` attribute to `['products']`.
If the user selects this variation, the `namespace` attribute will be overridden by the
main `inserter` variation.

but that was my quick first thought for the implementation and can be adjusted..


<!-- In a few words, what is the PR actually doing? -->

In general scoped `block` variation are meant to be a simple starting point that usually 

## Testing Instructions

<details>
 <summary>Register the below two variations(one `inserter` and one `scope`)</summary>
<pre> <code>{
		description: 'Variation',
		name: 'variation_query_loop',
		title: 'Variation Query Loop',
		icon: 'admin-home',
		attributes: {
			displayLayout: {
				type: 'flex',
				columns: 3,
			},
			namespace: 'inserter_namespace_variation_query_loop',
			query: {
				perPage: 9,
				pages: 0,
				offset: 0,
				postType: 'page',
				order: 'desc',
				orderBy: 'date',
				author: '',
				search: '',
				exclude: [],
				sticky: '',
				inherit: false,
			},
		},
		isActive: [ 'namespace' ],
		scope: [ 'inserter' ],
	},
	{
		description: 'Connected Variation',
		name: 'connected-block-variation',
		title: 'Connected Variation',
		icon: 'admin-home',
		attributes: {
			displayLayout: {
				type: 'flex',
				columns: 3,
			},
			namespace: ['variation_query_loop'], // This is the same with the `name` of the variation to be 'connected'
			query: {
				perPage: 1,
				pages: 0,
				offset: 0,
				postType: 'page',
				order: 'desc',
				orderBy: 'date',
				author: '',
				search: '',
				exclude: [],
				sticky: '',
				inherit: false,
			},
		},
		innerBlocks: [
			[
				'core/post-template',
				{},
				[ [ 'core/post-title' ], [ 'core/post-date' ] ],
			],
		],
		scope: [ 'block' ],
	},</code></pre>
</details>

1. Insert Query Loop block and any different variations(like the one provided above)
2. Choose to `start blank`


### Notes
Would we need to support scoped `block` variations to be connected to more than one `inserter` variation?  

<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/16275880/206489540-b411cf53-9bc1-4f6f-bccb-88bc1be294c4.mov


