### PR TITLE
Try making page list a controlled block

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -25,7 +25,7 @@ import {
 	Button,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { useMemo, useState, useEffect } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import { useEntityRecords } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 
@@ -39,6 +39,7 @@ import { convertDescription } from './constants';
 // We only show the edit option when page count is <= MAX_PAGE_COUNT
 // Performance of Navigation Links is not good past this value.
 const MAX_PAGE_COUNT = 100;
+const NOOP = () => {};
 
 export default function PageListEdit( {
 	context,
@@ -49,8 +50,6 @@ export default function PageListEdit( {
 	const { parentPageID } = attributes;
 	const [ pages ] = useGetPages();
 	const { pagesByParentId, totalPages, hasResolvedPages } = usePageData();
-	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
-		useDispatch( blockEditorStore );
 
 	const isNavigationChild = 'showSubmenuIcon' in context;
 	const allowConvertToLinks =
@@ -133,6 +132,9 @@ export default function PageListEdit( {
 		renderAppender: false,
 		__unstableDisableDropZone: true,
 		templateLock: 'all',
+		onInput: NOOP,
+		onChange: NOOP,
+		value: blockList,
 	} );
 
 	const getBlockContent = () => {
@@ -184,13 +186,6 @@ export default function PageListEdit( {
 			return <ul { ...innerBlocksProps }></ul>;
 		}
 	};
-
-	useEffect( () => {
-		__unstableMarkNextChangeAsNotPersistent();
-		if ( blockList ) {
-			replaceInnerBlocks( clientId, blockList );
-		}
-	}, [ clientId, blockList ] );
 
 	const { replaceBlock, selectBlock } = useDispatch( blockEditorStore );
 


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/issues/46330

## What?
Tries making Page List a controlled block, as an alternative to using an effect to call `replaceInnerBlocks`. 

## Why?
This is mostly a code quality change, it reduces some complexity by removing an effect.

## How?
Set the `value` of the inner blocks instead of using `replaceInnerBlocks`. `onInput` and `onChange` are set to a noop because the block is not editable.

Making this change also exposed an issue with the off-canvas editor, which is fixed here. It wasn't showing the controlled children of Page List. The implementation now uses `__unstableGetClientIdsTree` to match what the main List View implementation does.

## Testing Instructions
Everything should be the same as `trunk`.

1. First create some pages on your WordPress site, make some of the pages have a parent page (it's easiest to do this in the Quick Editor)
2. Open up the site editor. Optionally go to a Header template part and edit that.
3. Add a navigation block and add a Page List to your navigation block. This can be tricky to do, first add a normal link to your nav block, then select that link and use the main block library to add the Page List. Then optionally go back and delete the link.
4. The added Page List should show all your published pages.
5. Select the Page List block and open the block inspector. Try setting a Parent Page. The Page List block should update to show the only the children of the parent page
6. Select the navigation block, open the block inspector and check that the correct blocks are shown in the navigation block's off-canvas editor / list view.

### Testing Instructions for Keyboard
The steps should be keyboard friendly. For keyboard testing, it may be easiest to use List View to select blocks, as selecting blocks in the canvas is still difficult.
