### PR TITLE
Group: Remove unnecessary 'useCallback'

### DIFF
--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -12,7 +12,6 @@ import {
 } from '@wordpress/block-editor';
 import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -123,13 +122,10 @@ function GroupEdit( {
 	);
 
 	const { selectBlock } = useDispatch( blockEditorStore );
-	const updateSelection = useCallback(
-		( newClientId ) => selectBlock( newClientId, -1 ),
-		[ selectBlock ]
-	);
+
 	const selectVariation = ( nextVariation ) => {
 		setAttributes( nextVariation.attributes );
-		updateSelection( clientId );
+		selectBlock( clientId, -1 );
 		setShowPlaceholder( false );
 	};
 


### PR DESCRIPTION
## What?
PR inlines block selection update function and removes unnecessary `useCallback` usage.

## Why?
The `updateSelection` function wasn't passed to any hook or memoized component that might require a stable reference.

## Testing Instructions
Confirm that the Group variation picker works as before.
