### PR TITLE
Template Parts: Fix modal search stacking context

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -13,7 +13,7 @@ $z-layers: (
 	".edit-site-code-editor__toolbar": 1,
 
 	// These next three share a stacking context
-	".block-library-template-part__selection-search": 1, // higher sticky element
+	".block-library-template-part__selection-search": 2, // higher sticky element
 
 	// These next two share a stacking context
 	".interface-complementary-area .components-panel" : 0, // lower scrolling content


### PR DESCRIPTION
## What?
PR fixes the stacking context of the Search component in the "Choose template part" modal.

## Why?
I noticed that I couldn't focus on searching while scrolling through the template parts. Clicking on the search field was selecting the template part.

## How?
Updating the `z-index` to 2 seems to resolve the issue.

## Testing Instructions
1. Open the Site Editor.
2. Insert Template Part.
3. Click the "Choose" button in the placeholder.
4. Scroll through the results.
5. Confirm that the search field is focusable.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/206655551-a50fbe9b-ae8a-4ecb-bcce-92f6335a4657.mp4

