### PR TITLE
Add page list to Link UI transforms in Nav block

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/link-ui.js
+++ b/packages/block-editor/src/components/off-canvas-editor/link-ui.js
@@ -75,10 +75,13 @@ function LinkControlTransforms( { clientId } ) {
 	const { replaceBlock } = useDispatch( blockEditorStore );
 
 	const featuredBlocks = [
+		'core/page-list',
 		'core/site-logo',
 		'core/social-links',
 		'core/search',
 	];
+
+	console.log( { blockTransforms } );
 
 	const transforms = blockTransforms.filter( ( item ) => {
 		return featuredBlocks.includes( item.name );

--- a/packages/block-editor/src/components/off-canvas-editor/link-ui.js
+++ b/packages/block-editor/src/components/off-canvas-editor/link-ui.js
@@ -81,8 +81,6 @@ function LinkControlTransforms( { clientId } ) {
 		'core/search',
 	];
 
-	console.log( { blockTransforms } );
-
 	const transforms = blockTransforms.filter( ( item ) => {
 		return featuredBlocks.includes( item.name );
 	} );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1971,7 +1971,7 @@ export const getInserterItems = createSelector(
 			};
 		};
 
-		const blockTypeInserterItems = getBlockTransformItems()
+		const blockTypeInserterItems = getBlockTypes()
 			.filter( ( blockType ) =>
 				canIncludeBlockTypeInInserter( state, blockType, rootClientId )
 			)

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1755,7 +1755,6 @@ function getInsertUsage( state, id ) {
  * @return {boolean} Whether the given block type is allowed to be shown in the inserter.
  */
 const canIncludeBlockTypeInInserter = ( state, blockType, rootClientId ) => {
-	console.log( { blockType } );
 	if ( ! hasBlockSupport( blockType, 'inserter', true ) ) {
 		return false;
 	}
@@ -2063,7 +2062,6 @@ export const getBlockTransformItems = createSelector(
 		const buildBlockTypeTransformItem = buildBlockTypeItem( state, {
 			buildScope: 'transform',
 		} );
-		debugger;
 		const blockTypeTransformItems = getBlockTypes()
 			.filter( ( blockType ) =>
 				canIncludeBlockTypeInInserter( state, blockType, rootClientId )

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1755,6 +1755,7 @@ function getInsertUsage( state, id ) {
  * @return {boolean} Whether the given block type is allowed to be shown in the inserter.
  */
 const canIncludeBlockTypeInInserter = ( state, blockType, rootClientId ) => {
+	console.log( { blockType } );
 	if ( ! hasBlockSupport( blockType, 'inserter', true ) ) {
 		return false;
 	}
@@ -1971,7 +1972,7 @@ export const getInserterItems = createSelector(
 			};
 		};
 
-		const blockTypeInserterItems = getBlockTypes()
+		const blockTypeInserterItems = getBlockTransformItems()
 			.filter( ( blockType ) =>
 				canIncludeBlockTypeInInserter( state, blockType, rootClientId )
 			)
@@ -2062,6 +2063,7 @@ export const getBlockTransformItems = createSelector(
 		const buildBlockTypeTransformItem = buildBlockTypeItem( state, {
 			buildScope: 'transform',
 		} );
+		debugger;
 		const blockTypeTransformItems = getBlockTypes()
 			.filter( ( blockType ) =>
 				canIncludeBlockTypeInInserter( state, blockType, rootClientId )

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -424,6 +424,7 @@ export default function NavigationLinkEdit( {
 	const ALLOWED_BLOCKS = [
 		'core/navigation-link',
 		'core/navigation-submenu',
+		'core/page-list',
 	];
 	const DEFAULT_BLOCK = {
 		name: 'core/navigation-link',

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -74,10 +74,12 @@ function LinkControlTransforms( { clientId } ) {
 	const { replaceBlock } = useDispatch( blockEditorStore );
 
 	const featuredBlocks = [
+		'core/page-list',
 		'core/site-logo',
 		'core/social-links',
 		'core/search',
 	];
+
 	const transforms = blockTransforms.filter( ( item ) => {
 		return featuredBlocks.includes( item.name );
 	} );

--- a/packages/block-library/src/navigation-link/transforms.js
+++ b/packages/block-library/src/navigation-link/transforms.js
@@ -40,6 +40,13 @@ const transforms = {
 				return createBlock( 'core/navigation-link' );
 			},
 		},
+		{
+			type: 'block',
+			blocks: [ 'core/page-list' ],
+			transform: () => {
+				return createBlock( 'core/navigation-link' );
+			},
+		},
 	],
 	to: [
 		{
@@ -89,6 +96,13 @@ const transforms = {
 					buttonUseIcon: true,
 					buttonPosition: 'button-inside',
 				} );
+			},
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/page-list' ],
+			transform: () => {
+				return createBlock( 'core/page-list' );
 			},
 		},
 	],

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -43,7 +43,11 @@ import { name } from './block.json';
 import { LinkUI } from '../navigation-link/link-ui';
 import { updateAttributes } from '../navigation-link/update-attributes';
 
-const ALLOWED_BLOCKS = [ 'core/navigation-link', 'core/navigation-submenu' ];
+const ALLOWED_BLOCKS = [
+	'core/navigation-link',
+	'core/navigation-submenu',
+	'core/page-list',
+];
 
 const DEFAULT_BLOCK = {
 	name: 'core/navigation-link',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

<img width="484" alt="Screen Shot 2022-12-13 at 10 42 37" src="https://user-images.githubusercontent.com/444434/207296522-73d00974-4f07-4392-81cb-8d2d8527bd19.png">

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds Page List as a transform to link item blocks on the Nav block. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Enables flow where user wants to insert a Page List. Currently this isn't possible as the Custom Link block is always auto inserted when using the offcanvas.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds relevant transforms.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Enable experiment
- Delete all Nav Menus
- New Post
- Add Nav block
- Click `+` in inserter.
- See `Link UI`
- See `Transforms` at bottom of Link UI
- Click `Page List`.
- See added block has been transformed into a Page List.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/444434/207296389-88b721ce-56c3-4742-8c91-a3978cdac5d3.mp4



