### PR TITLE
Lodash: Refactor `blocks` away from `_.find()`

### DIFF
--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, get, isEmpty, map, mapValues } from 'lodash';
+import { get, isEmpty, map, mapValues } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -265,7 +265,9 @@ export function categories( state = DEFAULT_CATEGORIES, action ) {
 			if ( ! action.category || isEmpty( action.category ) ) {
 				return state;
 			}
-			const categoryToChange = find( state, [ 'slug', action.slug ] );
+			const categoryToChange = state.find(
+				( { slug } ) => slug === action.slug
+			);
 			if ( categoryToChange ) {
 				return map( state, ( category ) => {
 					if ( category.slug === action.slug ) {


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.find()` from the `blocks` package. There is a single usage in that package and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `Array.prototype.find()`, no additional checks are necessary since it's always invoked on an array. 

## Testing Instructions

* Verify all checks are still green. The changes are covered by unit tests.