### PR TITLE
Popover: check positioning by adding and testing is-positioned class

### DIFF
--- a/packages/block-editor/src/components/url-popover/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/url-popover/test/__snapshots__/index.js.snap
@@ -4,7 +4,7 @@ exports[`URLPopover matches the snapshot in its default state 1`] = `
 <div>
   <span>
     <div
-      class="components-popover block-editor-url-popover"
+      class="components-popover block-editor-url-popover is-positioned"
       style="position: absolute; left: 0px; top: 0px;"
       tabindex="-1"
     >
@@ -52,7 +52,7 @@ exports[`URLPopover matches the snapshot when the settings are toggled open 1`] 
 <div>
   <span>
     <div
-      class="components-popover block-editor-url-popover"
+      class="components-popover block-editor-url-popover is-positioned"
       style="position: absolute; left: 0px; top: 0px;"
       tabindex="-1"
     >
@@ -107,7 +107,7 @@ exports[`URLPopover matches the snapshot when there are no settings 1`] = `
 <div>
   <span>
     <div
-      class="components-popover block-editor-url-popover"
+      class="components-popover block-editor-url-popover is-positioned"
       style="position: absolute; left: 0px; top: 0px;"
       tabindex="-1"
     >

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -472,6 +472,7 @@ const UnforwardedPopover = (
 			placement={ computedPlacement }
 			className={ classnames( 'components-popover', className, {
 				'is-expanded': isExpanded,
+				'is-positioned': x !== null && y !== null,
 				// Use the 'alternate' classname for 'toolbar' variant for back compat.
 				[ `is-${
 					computedVariant === 'toolbar'

--- a/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
@@ -3,7 +3,7 @@
 exports[`DotTip should render correctly 1`] = `
 <div
   aria-label="Editor tips"
-  class="components-popover nux-dot-tip"
+  class="components-popover nux-dot-tip is-positioned"
   role="dialog"
   style="position: absolute; opacity: 0; transform: translateX(-2em) scale(0) translateZ(0); transform-origin: 0% 50% 0; left: 0px; top: 0px;"
   tabindex="-1"

--- a/test/unit/config/matchers/to-be-positioned-popover.js
+++ b/test/unit/config/matchers/to-be-positioned-popover.js
@@ -5,7 +5,7 @@
  * @param {HTMLElement} element Popover element.
  */
 function toBePositionedPopover( element ) {
-	const pass = element.style.top !== '' && element.style.left !== '';
+	const pass = element.classList.contains( 'is-positioned' );
 	return {
 		pass,
 		message: () => `Received element is ${ pass ? '' : 'not ' }positioned`,


### PR DESCRIPTION
When a `Popover` component is finished positioning, i.e., when the `useFloating` hook from the `floating-ui` library returns valid `x` and `y` coordinates, add a `is-positioned` CSS class on the popover element.

This is then used by the `.toBePositionedPopover` helper to detect a positioned popover. We don't need to check the exact styles, which are an implementation detail that can change. Like it does in #46187.

Closes #46303.
