### PR TITLE
Site editor: do not remount iframe

### DIFF
--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -62,7 +62,6 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 	const {
 		storedSettings,
 		templateType,
-		templateId,
 		page,
 		isNavigationSidebarOpen,
 		canvasMode,
@@ -71,7 +70,6 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 			const {
 				getSettings,
 				getEditedPostType,
-				getEditedPostId,
 				getPage,
 				__unstableGetCanvasMode,
 			} = select( editSiteStore );
@@ -79,7 +77,6 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 			return {
 				storedSettings: getSettings( setIsInserterOpen ),
 				templateType: getEditedPostType(),
-				templateId: getEditedPostId(),
 				page: getPage(),
 				isNavigationSidebarOpen:
 					select( interfaceStore ).getActiveComplementaryArea(
@@ -257,8 +254,6 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 							<BlockEditorKeyboardShortcuts.Register />
 							<BackButton />
 							<ResizableEditor
-								// Reinitialize the editor and reset the states when the template changes.
-								key={ templateId }
 								enableResizing={ enableResizing }
 								height={ sizes.height }
 							>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This was added by #35974, but I can't see why it's necessary.
I did some testing and I can't see anything breaking.
It sounds like this was added to reset the height of the canvas, but I'm unable to find a case where it's needed.
Even if we need a reset there, we shouldn't be unmounting the whole iframe.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

|Before|After|
|-|-|
|![before](https://user-images.githubusercontent.com/4710635/206713970-d7bef4d6-de80-4ef9-aabc-5f3ee2a1de7f.gif)|![after](https://user-images.githubusercontent.com/4710635/206713996-f65e2ae5-1d2e-4859-b41b-56ec8eb4e4c9.gif)|

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
