### PR TITLE
Lodash: Refactor post editor away from `_.find()`

### DIFF
--- a/packages/edit-post/src/hooks/validate-multiple-use/index.js
+++ b/packages/edit-post/src/hooks/validate-multiple-use/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { find } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -44,8 +39,7 @@ const enhance = compose(
 		// Otherwise, only pass `originalBlockClientId` if it refers to a different
 		// block from the current one.
 		const blocks = select( blockEditorStore ).getBlocks();
-		const firstOfSameType = find(
-			blocks,
+		const firstOfSameType = blocks.find(
 			( { name } ) => block.name === name
 		);
 		const isInvalid =


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.find()` from the `edit-post` package. There is a single usage in that package and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `Array.prototype.find()`, no additional checks are necessary since it's always invoked on an array. 

## Testing Instructions

* There's not a core block with `multiple`, so try adding `multiple` to the block metadata of any block, and verify that you can't insert it more than once without getting a warning.
* Verify all checks are still green.