### PR TITLE
Add: Navigation menus to the browse mode sidebar.

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/block.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block.js
@@ -209,6 +209,7 @@ function ListViewBlock( {
 
 	const listViewBlockEditClassName = classnames(
 		'block-editor-list-view-block__menu-cell',
+		'block-editor-list-view-block__menu-edit',
 		{ 'is-visible': isHovered || isFirstSelectedBlock }
 	);
 

--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -3,15 +3,40 @@
 	border-width: $border-width-tab;
 
 	&:hover,
-	&:focus {
+	&:focus,
+	&[aria-current] {
 		color: $white;
 		background: $gray-800;
 		border-width: $border-width-tab;
 	}
 
 	&[aria-current] {
-		color: $white;
 		background: var(--wp-admin-theme-color);
-		border-width: $border-width-tab;
 	}
+}
+
+.edit-site-sidebar-navigation-screen__content .edit-site-navigation-inspector .components-button {
+	color: $gray-600;
+	&:hover,
+	&:focus,
+	&[aria-current] {
+		color: $white;
+	}
+}
+
+.edit-site-sidebar-navigation-screen__content .edit-site-navigation-inspector .offcanvas-editor-list-view-leaf {
+	&:hover,
+	&:focus,
+	&[aria-current] {
+		background: $gray-800;
+	}
+	.block-editor-list-view-block__menu {
+		margin-left: -$grid-unit-10;
+	}
+}
+
+.edit-site-sidebar-navigation-screen__content .block-editor-list-view-block-select-button {
+	cursor: grab;
+	width: calc(100% - #{ $border-width-focus });
+	padding: $grid-unit-10;
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -6,7 +6,9 @@ import {
 	__experimentalNavigatorButton as NavigatorButton,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { layout, symbolFilled } from '@wordpress/icons';
+import { layout, symbolFilled, navigation } from '@wordpress/icons';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -15,12 +17,33 @@ import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import SidebarNavigationItem from '../sidebar-navigation-item';
 
 export default function SidebarNavigationScreenMain() {
+	const { navigationMenus } = useSelect( ( select ) => {
+		const { getEntityRecords } = select( coreStore );
+		return {
+			navigationMenus: getEntityRecords( 'postType', 'wp_navigation', {
+				per_page: -1,
+				status: 'publish',
+			} ),
+		};
+	} );
 	return (
 		<SidebarNavigationScreen
 			path="/"
 			title={ __( 'Design' ) }
 			content={
 				<ItemGroup>
+					{ !! window?.__experimentalEnableOffCanvasNavigationEditor &&
+						!! navigationMenus &&
+						navigationMenus.length > 0 && (
+							<NavigatorButton
+								as={ SidebarNavigationItem }
+								path="/navigation"
+								withChevron
+								icon={ navigation }
+							>
+								{ __( 'Navigation' ) }
+							</NavigatorButton>
+						) }
 					<NavigatorButton
 						as={ SidebarNavigationItem }
 						path="/templates"

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import SidebarNavigationScreen from '../sidebar-navigation-screen';
+import NavigationInspector from '../sidebar-edit-mode/navigation-menu-sidebar/navigation-inspector';
+
+export default function SidebarNavigationScreenNavigationMenus() {
+	return (
+		<SidebarNavigationScreen
+			path="/navigation"
+			parentTitle={ __( 'Design' ) }
+			title={ __( 'Navigation' ) }
+			content={
+				<div className="edit-site-sidebar-navigation-screen-navigation-menus">
+					<NavigationInspector />
+				</div>
+			}
+		/>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -1,0 +1,12 @@
+.edit-site-sidebar-navigation-screen-navigation-menus {
+	.block-editor-list-view-block__menu-edit,
+	.edit-site-navigation-inspector__select-menu {
+		display: none;
+	}
+	.offcanvas-editor-list-view-leaf {
+		max-width: calc(100% - #{ $grid-unit-05 });
+	}
+	.block-editor-list-view-leaf .block-editor-list-view-block__contents-cell {
+		width: 100%;
+	}
+}

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -10,6 +10,7 @@ import { __experimentalNavigatorProvider as NavigatorProvider } from '@wordpress
 import SidebarNavigationScreenMain from '../sidebar-navigation-screen-main';
 import SidebarNavigationScreenTemplates from '../sidebar-navigation-screen-templates';
 import useSyncSidebarPathWithURL from '../sync-state-with-url/use-sync-sidebar-path-with-url';
+import SidebarNavigationScreenNavigationMenus from '../sidebar-navigation-screen-navigation-menus';
 
 function SidebarScreens() {
 	useSyncSidebarPathWithURL();
@@ -17,6 +18,7 @@ function SidebarScreens() {
 	return (
 		<>
 			<SidebarNavigationScreenMain />
+			<SidebarNavigationScreenNavigationMenus />
 			<SidebarNavigationScreenTemplates postType="wp_template" />
 			<SidebarNavigationScreenTemplates postType="wp_template_part" />
 		</>

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -24,6 +24,7 @@
 @import "./components/sidebar-navigation-screen/style.scss";
 @import "./components/sidebar-navigation-screen-templates/style.scss";
 @import "./components/site-hub/style.scss";
+@import "./components/sidebar-navigation-screen-navigation-menus/style.scss";
 @import "./components/site-icon/style.scss";
 @import "./components/style-book/style.scss";
 @import "./hooks/push-changes-to-global-styles/style.scss";


### PR DESCRIPTION
This PR adds navigation menus to the browse mode sidebar. Allowing the user to manage menus from there.
It moves the current navigation sidebar to the left.

cc: @jasmussen, @jameskoster 
## Screenhots
![image](https://user-images.githubusercontent.com/11271197/206742568-8d06e4f7-cec0-4055-bec9-f1fff5d26a9b.png)
![image](https://user-images.githubusercontent.com/11271197/206742619-af3d641f-57c0-4be1-b469-f8b08005624c.png)

## Follow up
There is a new navigation block manager being implemented at https://github.com/orgs/WordPress/projects/60/views/1. We should try to use that new component here.