### PR TITLE
Experiment - convert LinkControl to a compound component

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -21,7 +21,7 @@ import useCreatePage from './use-create-page';
 import useInternalInputValue from './use-internal-input-value';
 import { ViewerFill } from './viewer-slot';
 import { DEFAULT_LINK_SETTINGS } from './constants';
-import { LinkControlDefault } from './link-control-default';
+import LinkControlDefault from './link-control-default';
 import LinkControlSettingsDrawer from './settings-drawer';
 import LinkControlSearchInput from './search-input';
 import LinkControlTextInput from './link-control-text-input';

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -9,23 +9,26 @@ import {
 	useContext,
 	useCallback,
 	createContext,
+	Children,
+	cloneElement,
 } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
 
 /**
  * Internal dependencies
  */
+import useCreatePage from './use-create-page';
+import useInternalInputValue from './use-internal-input-value';
+import { ViewerFill } from './viewer-slot';
+import { DEFAULT_LINK_SETTINGS } from './constants';
+import { LinkControlDefault } from './link-control-default';
 import LinkControlSettingsDrawer from './settings-drawer';
 import LinkControlSearchInput from './search-input';
 import LinkControlTextInput from './link-control-text-input';
 import LinkPreview from './link-preview';
 import LinkControlNotice from './link-control-notice';
 import LinkControlEditControls from './link-control-edit-controls';
-import useCreatePage from './use-create-page';
-import useInternalInputValue from './use-internal-input-value';
-import { ViewerFill } from './viewer-slot';
-import { DEFAULT_LINK_SETTINGS } from './constants';
-import { LinkControlLoading } from './link-control-loading';
+import LinkControlLoading from './link-control-loading';
 
 /**
  * Default properties associated with a link control value.
@@ -142,6 +145,7 @@ function LinkControl( {
 	hasRichPreviews = false,
 	hasTextControl = false,
 	renderControlBottom = null,
+	children,
 } ) {
 	if ( withCreateSuggestion === undefined && createSuggestion ) {
 		withCreateSuggestion = true;
@@ -308,41 +312,58 @@ function LinkControl( {
 				ref={ wrapperNode }
 				className="block-editor-link-control"
 			>
-				<LinkControlLoading />
-
-				<LinkControlEditControls>
-					<LinkControlTextInput />
-
-					<LinkControlSearchInput
-						className="block-editor-link-control__field block-editor-link-control__search-input"
-						placeholder={ searchInputPlaceholder }
+				{ children ? (
+					Children.map( children, ( child ) =>
+						cloneElement( child, {
+							searchInputPlaceholder,
+							withCreateSuggestion,
+							createPage,
+							setInternalUrlInputValue,
+							handleSelectSuggestion,
+							showInitialSuggestions,
+							noDirectEntry,
+							showSuggestions,
+							suggestionsQuery,
+							noURLSuggestion,
+							createSuggestionButtonText,
+							showTextControl,
+							renderControlBottom,
+						} )
+					)
+				) : (
+					<LinkControlDefault
+						searchInputPlaceholder={ searchInputPlaceholder }
 						withCreateSuggestion={ withCreateSuggestion }
-						onCreateSuggestion={ createPage }
-						onChange={ setInternalUrlInputValue }
-						onSelect={ handleSelectSuggestion }
+						createPage={ createPage }
+						setInternalUrlInputValue={ setInternalUrlInputValue }
+						handleSelectSuggestion={ handleSelectSuggestion }
 						showInitialSuggestions={ showInitialSuggestions }
-						allowDirectEntry={ ! noDirectEntry }
+						noDirectEntry={ noDirectEntry }
 						showSuggestions={ showSuggestions }
 						suggestionsQuery={ suggestionsQuery }
-						withURLSuggestion={ ! noURLSuggestion }
+						noURLSuggestion={ noURLSuggestion }
 						createSuggestionButtonText={
 							createSuggestionButtonText
 						}
-						useLabel={ showTextControl }
+						showTextControl={ showTextControl }
+						renderControlBottom={ renderControlBottom }
 					/>
-					<LinkControlNotice />
-				</LinkControlEditControls>
-
-				<LinkPreview />
-
-				<LinkControlSettingsDrawer />
-
-				{ renderControlBottom && renderControlBottom() }
+				) }
 			</div>
 		</LinkControlContext.Provider>
 	);
 }
 
 LinkControl.ViewerFill = ViewerFill;
+
+// Sub-components.
+LinkControl.DefaultComponents = LinkControlDefault;
+LinkControl.SettingsDrawer = LinkControlSettingsDrawer;
+LinkControl.SearchInput = LinkControlSearchInput;
+LinkControl.TextInput = LinkControlTextInput;
+LinkControl.Preview = LinkPreview;
+LinkControl.Notice = LinkControlNotice;
+LinkControl.EditControls = LinkControlEditControls;
+LinkControl.Loading = LinkControlLoading;
 
 export default LinkControl;

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -312,7 +312,7 @@ function LinkControl( {
 				<LinkControlEditControls
 					shouldShowEditControls={ shouldShowEditControls }
 				>
-					<LinkControlTextInput />
+					<LinkControlTextInput ref={ textInputRef } />
 
 					<LinkControlSearchInput
 						className="block-editor-link-control__field block-editor-link-control__search-input"

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -264,12 +264,11 @@ function LinkControl( {
 	// See https://github.com/WordPress/gutenberg/pull/33849/#issuecomment-932194927.
 	const showTextControl = value?.url?.trim()?.length > 0 && hasTextControl;
 
-	const shouldShowEditControls =
-		( isEditingLink || ! value ) && ! isCreatingPage;
-
-	const shouldShowLinkPreview = value && ! isEditingLink && ! isCreatingPage;
-
 	const isLoading = isCreatingPage;
+
+	const shouldShowLinkPreview = value && ! isEditingLink && ! isLoading;
+
+	const shouldShowEditControls = ! shouldShowLinkPreview;
 
 	// Consumers can pass in custom functions which may return
 	// a different references resulting in the context being

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -291,7 +291,7 @@ function LinkControl( {
 		currentInputIsEmpty,
 		handleSubmit,
 		currentUrlInputValue,
-		createPageErrorMessage, // needs extracting to generic error message
+		errorMsg: createPageErrorMessage,
 		shouldShowEditControls,
 		shouldShowLinkPreview,
 		showSettingsDrawer,

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -6,8 +6,8 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Button, Spinner, Notice } from '@wordpress/components';
-import { keyboardReturn } from '@wordpress/icons';
+import { Spinner, Notice } from '@wordpress/components';
+
 import { __ } from '@wordpress/i18n';
 import {
 	useRef,
@@ -312,17 +312,7 @@ function LinkControl( {
 									createSuggestionButtonText
 								}
 								useLabel={ showTextControl }
-							>
-								<div className="block-editor-link-control__search-actions">
-									<Button
-										onClick={ handleSubmit }
-										label={ __( 'Submit' ) }
-										icon={ keyboardReturn }
-										className="block-editor-link-control__search-submit"
-										disabled={ currentInputIsEmpty } // Disallow submitting empty values.
-									/>
-								</div>
-							</LinkControlSearchInput>
+							/>
 						</div>
 						{ errorMessage && (
 							<Notice

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -302,6 +302,22 @@ function LinkControl( {
 		textInputRef,
 	};
 
+	const defaultComponentProps = {
+		searchInputPlaceholder,
+		withCreateSuggestion,
+		createPage,
+		setInternalUrlInputValue,
+		handleSelectSuggestion,
+		showInitialSuggestions,
+		noDirectEntry,
+		showSuggestions,
+		suggestionsQuery,
+		noURLSuggestion,
+		createSuggestionButtonText,
+		showTextControl,
+		renderControlBottom,
+	};
+
 	const renderChildren = unwrapArray( children );
 
 	return (
@@ -312,39 +328,9 @@ function LinkControl( {
 				className="block-editor-link-control"
 			>
 				{ children ? (
-					renderChildren( {
-						searchInputPlaceholder,
-						withCreateSuggestion,
-						createPage,
-						setInternalUrlInputValue,
-						handleSelectSuggestion,
-						showInitialSuggestions,
-						noDirectEntry,
-						showSuggestions,
-						suggestionsQuery,
-						noURLSuggestion,
-						createSuggestionButtonText,
-						showTextControl,
-						renderControlBottom,
-					} )
+					renderChildren( defaultComponentProps )
 				) : (
-					<LinkControlDefault
-						searchInputPlaceholder={ searchInputPlaceholder }
-						withCreateSuggestion={ withCreateSuggestion }
-						createPage={ createPage }
-						setInternalUrlInputValue={ setInternalUrlInputValue }
-						handleSelectSuggestion={ handleSelectSuggestion }
-						showInitialSuggestions={ showInitialSuggestions }
-						noDirectEntry={ noDirectEntry }
-						showSuggestions={ showSuggestions }
-						suggestionsQuery={ suggestionsQuery }
-						noURLSuggestion={ noURLSuggestion }
-						createSuggestionButtonText={
-							createSuggestionButtonText
-						}
-						showTextControl={ showTextControl }
-						renderControlBottom={ renderControlBottom }
-					/>
+					<LinkControlDefault { ...defaultComponentProps } />
 				) }
 			</div>
 		</LinkControlContext.Provider>

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Spinner, Notice } from '@wordpress/components';
+import { Spinner } from '@wordpress/components';
 
 import { __ } from '@wordpress/i18n';
 import {
@@ -26,6 +26,7 @@ import LinkControlSettingsDrawer from './settings-drawer';
 import LinkControlSearchInput from './search-input';
 import LinkControlTextInput from './text-input';
 import LinkPreview from './link-preview';
+import LinkControlNotice from './link-control-notice';
 import useCreatePage from './use-create-page';
 import useInternalInputValue from './use-internal-input-value';
 import { ViewerFill } from './viewer-slot';
@@ -168,8 +169,11 @@ function LinkControl( {
 			: ! value || ! value.url
 	);
 
-	const { createPage, isCreatingPage, errorMessage } =
-		useCreatePage( createSuggestion );
+	const {
+		createPage,
+		isCreatingPage,
+		errorMessage: createPageErrorMessage,
+	} = useCreatePage( createSuggestion );
 
 	useEffect( () => {
 		if (
@@ -269,6 +273,7 @@ function LinkControl( {
 		currentInputIsEmpty,
 		handleSubmit,
 		currentUrlInputValue,
+		createPageErrorMessage, // needs extracting to generic error message
 	};
 
 	return (
@@ -314,15 +319,8 @@ function LinkControl( {
 								useLabel={ showTextControl }
 							/>
 						</div>
-						{ errorMessage && (
-							<Notice
-								className="block-editor-link-control__search-error"
-								status="error"
-								isDismissible={ false }
-							>
-								{ errorMessage }
-							</Notice>
-						) }
+
+						<LinkControlNotice />
 					</>
 				) }
 

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -245,6 +245,11 @@ function LinkControl( {
 		stopEditing();
 	}, [ currentUrlInputValue, value, internalTextInputValue ] );
 
+	const onEditClick = useCallback(
+		() => setIsEditingLink( true ),
+		[ setIsEditingLink ]
+	);
+
 	const currentInputIsEmpty = ! currentUrlInputValue?.trim()?.length;
 
 	const shownUnlinkControl =
@@ -264,11 +269,12 @@ function LinkControl( {
 
 	const isLoading = isCreatingPage;
 
-	// Consumers can pass in a custom function which may return
-	// a different reference resulting in the context being
+	// Consumers can pass in custom functions which may return
+	// a different references resulting in the context being
 	// invalidated causing all context consumers to re-render.
-	// Memoize the onChange callback to avoid this.
+	// Memoize these callbacks to avoid this.
 	const memoizedOnChange = useCallback( onChange, [] );
+	const memoizedOnRemove = useCallback( onRemove, [] );
 
 	// Todo
 	// - memoize context value
@@ -276,6 +282,7 @@ function LinkControl( {
 	const contextValue = {
 		value,
 		onChange: memoizedOnChange,
+		onRemove: memoizedOnRemove,
 		settings, // todo: consider memoizing
 		internalTextInputValue, // lift to standard state mechanic
 		setInternalTextInputValue, // lift to standard state mechanic
@@ -288,6 +295,9 @@ function LinkControl( {
 		shouldShowLinkPreview,
 		showSettingsDrawer,
 		isLoading,
+		hasRichPreviews,
+		shownUnlinkControl,
+		onEditClick,
 	};
 
 	return (
@@ -324,14 +334,7 @@ function LinkControl( {
 					<LinkControlNotice />
 				</LinkControlEditControls>
 
-				<LinkPreview
-					key={ value?.url } // force remount when URL changes to avoid race conditions for rich previews
-					value={ value }
-					onEditClick={ () => setIsEditingLink( true ) }
-					hasRichPreviews={ hasRichPreviews }
-					hasUnlinkControl={ shownUnlinkControl }
-					onRemove={ onRemove }
-				/>
+				<LinkPreview />
 
 				<LinkControlSettingsDrawer />
 

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { Spinner } from '@wordpress/components';
@@ -27,6 +22,7 @@ import LinkControlSearchInput from './search-input';
 import LinkControlTextInput from './text-input';
 import LinkPreview from './link-preview';
 import LinkControlNotice from './link-control-notice';
+import LinkControlEditControls from './link-control-edit-controls';
 import useCreatePage from './use-create-page';
 import useInternalInputValue from './use-internal-input-value';
 import { ViewerFill } from './viewer-slot';
@@ -262,6 +258,9 @@ function LinkControl( {
 	// See https://github.com/WordPress/gutenberg/pull/33849/#issuecomment-932194927.
 	const showTextControl = value?.url?.trim()?.length > 0 && hasTextControl;
 
+	const shouldShowEditControls =
+		( isEditingLink || ! value ) && ! isCreatingPage;
+
 	// Todo
 	// - memoize context value
 	// - create seperate context's to avoid re-renders
@@ -274,6 +273,7 @@ function LinkControl( {
 		handleSubmit,
 		currentUrlInputValue,
 		createPageErrorMessage, // needs extracting to generic error message
+		shouldShowEditControls,
 	};
 
 	return (
@@ -289,40 +289,30 @@ function LinkControl( {
 					</div>
 				) }
 
-				{ ( isEditingLink || ! value ) && ! isCreatingPage && (
-					<>
-						<div
-							className={ classnames( {
-								'block-editor-link-control__search-input-wrapper': true,
-								'has-text-control': showTextControl,
-							} ) }
-						>
-							<LinkControlTextInput />
+				<LinkControlEditControls
+					shouldShowEditControls={ shouldShowEditControls }
+				>
+					<LinkControlTextInput />
 
-							<LinkControlSearchInput
-								className="block-editor-link-control__field block-editor-link-control__search-input"
-								placeholder={ searchInputPlaceholder }
-								withCreateSuggestion={ withCreateSuggestion }
-								onCreateSuggestion={ createPage }
-								onChange={ setInternalUrlInputValue }
-								onSelect={ handleSelectSuggestion }
-								showInitialSuggestions={
-									showInitialSuggestions
-								}
-								allowDirectEntry={ ! noDirectEntry }
-								showSuggestions={ showSuggestions }
-								suggestionsQuery={ suggestionsQuery }
-								withURLSuggestion={ ! noURLSuggestion }
-								createSuggestionButtonText={
-									createSuggestionButtonText
-								}
-								useLabel={ showTextControl }
-							/>
-						</div>
-
-						<LinkControlNotice />
-					</>
-				) }
+					<LinkControlSearchInput
+						className="block-editor-link-control__field block-editor-link-control__search-input"
+						placeholder={ searchInputPlaceholder }
+						withCreateSuggestion={ withCreateSuggestion }
+						onCreateSuggestion={ createPage }
+						onChange={ setInternalUrlInputValue }
+						onSelect={ handleSelectSuggestion }
+						showInitialSuggestions={ showInitialSuggestions }
+						allowDirectEntry={ ! noDirectEntry }
+						showSuggestions={ showSuggestions }
+						suggestionsQuery={ suggestionsQuery }
+						withURLSuggestion={ ! noURLSuggestion }
+						createSuggestionButtonText={
+							createSuggestionButtonText
+						}
+						useLabel={ showTextControl }
+					/>
+					<LinkControlNotice />
+				</LinkControlEditControls>
 
 				{ value && ! isEditingLink && ! isCreatingPage && (
 					<LinkPreview

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -258,6 +258,9 @@ function LinkControl( {
 	// See https://github.com/WordPress/gutenberg/pull/33849/#issuecomment-932194927.
 	const showTextControl = value?.url?.trim()?.length > 0 && hasTextControl;
 
+	// Todo
+	// - memoize context value
+	// - create seperate context's to avoid re-renders
 	const contextValue = {
 		value,
 		internalTextInputValue, // lift to standard state mechanic
@@ -265,6 +268,7 @@ function LinkControl( {
 		showTextControl,
 		currentInputIsEmpty,
 		handleSubmit,
+		currentUrlInputValue,
 	};
 
 	return (
@@ -291,10 +295,8 @@ function LinkControl( {
 							<LinkControlTextInput />
 
 							<LinkControlSearchInput
-								currentLink={ value }
 								className="block-editor-link-control__field block-editor-link-control__search-input"
 								placeholder={ searchInputPlaceholder }
-								value={ currentUrlInputValue }
 								withCreateSuggestion={ withCreateSuggestion }
 								onCreateSuggestion={ createPage }
 								onChange={ setInternalUrlInputValue }

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -9,8 +9,6 @@ import {
 	useContext,
 	useCallback,
 	createContext,
-	Children,
-	cloneElement,
 } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
 
@@ -305,6 +303,8 @@ function LinkControl( {
 		textInputRef,
 	};
 
+	const renderChildren = unwrapArray( children );
+
 	return (
 		<LinkControlContext.Provider value={ contextValue }>
 			<div
@@ -313,23 +313,21 @@ function LinkControl( {
 				className="block-editor-link-control"
 			>
 				{ children ? (
-					Children.map( children, ( child ) =>
-						cloneElement( child, {
-							searchInputPlaceholder,
-							withCreateSuggestion,
-							createPage,
-							setInternalUrlInputValue,
-							handleSelectSuggestion,
-							showInitialSuggestions,
-							noDirectEntry,
-							showSuggestions,
-							suggestionsQuery,
-							noURLSuggestion,
-							createSuggestionButtonText,
-							showTextControl,
-							renderControlBottom,
-						} )
-					)
+					renderChildren( {
+						searchInputPlaceholder,
+						withCreateSuggestion,
+						createPage,
+						setInternalUrlInputValue,
+						handleSelectSuggestion,
+						showInitialSuggestions,
+						noDirectEntry,
+						showSuggestions,
+						suggestionsQuery,
+						noURLSuggestion,
+						createSuggestionButtonText,
+						showTextControl,
+						renderControlBottom,
+					} )
 				) : (
 					<LinkControlDefault
 						searchInputPlaceholder={ searchInputPlaceholder }
@@ -367,3 +365,15 @@ LinkControl.EditControls = LinkControlEditControls;
 LinkControl.Loading = LinkControlLoading;
 
 export default LinkControl;
+
+/**
+ * Takes an argument and if it's an array, returns the first item in the array
+ * otherwise returns the argument
+ *
+ * @param {*} arg the maybe-array
+ * @return {*} the arg or it's first item
+ */
+
+function unwrapArray( arg ) {
+	return Array.isArray( arg ) ? arg[ 0 ] : arg;
+}

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -103,6 +103,7 @@ import LinkControlLoading from './link-control-loading';
  */
 
 const noop = () => {};
+const STABLE_OBJECT = {};
 
 const LinkControlContext = createContext();
 LinkControlContext.displayName = 'LinkControlContext';
@@ -137,7 +138,7 @@ function LinkControl( {
 	createSuggestion,
 	withCreateSuggestion,
 	inputValue: propInputValue = '',
-	suggestionsQuery = {},
+	suggestionsQuery = STABLE_OBJECT,
 	noURLSuggestion = false,
 	createSuggestionButtonText,
 	hasRichPreviews = false,

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -1,9 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Spinner } from '@wordpress/components';
 
-import { __ } from '@wordpress/i18n';
 import {
 	useRef,
 	useState,
@@ -19,7 +17,7 @@ import { focus } from '@wordpress/dom';
  */
 import LinkControlSettingsDrawer from './settings-drawer';
 import LinkControlSearchInput from './search-input';
-import LinkControlTextInput from './text-input';
+import LinkControlTextInput from './link-control-text-input';
 import LinkPreview from './link-preview';
 import LinkControlNotice from './link-control-notice';
 import LinkControlEditControls from './link-control-edit-controls';
@@ -27,6 +25,7 @@ import useCreatePage from './use-create-page';
 import useInternalInputValue from './use-internal-input-value';
 import { ViewerFill } from './viewer-slot';
 import { DEFAULT_LINK_SETTINGS } from './constants';
+import { LinkControlLoading } from './link-control-loading';
 
 /**
  * Default properties associated with a link control value.
@@ -263,11 +262,21 @@ function LinkControl( {
 
 	const shouldShowLinkPreview = value && ! isEditingLink && ! isCreatingPage;
 
+	const isLoading = isCreatingPage;
+
+	// Consumers can pass in a custom function which may return
+	// a different reference resulting in the context being
+	// invalidated causing all context consumers to re-render.
+	// Memoize the onChange callback to avoid this.
+	const memoizedOnChange = useCallback( onChange, [] );
+
 	// Todo
 	// - memoize context value
 	// - create seperate context's to avoid re-renders
 	const contextValue = {
 		value,
+		onChange: memoizedOnChange,
+		settings, // todo: consider memoizing
 		internalTextInputValue, // lift to standard state mechanic
 		setInternalTextInputValue, // lift to standard state mechanic
 		showTextControl,
@@ -277,6 +286,8 @@ function LinkControl( {
 		createPageErrorMessage, // needs extracting to generic error message
 		shouldShowEditControls,
 		shouldShowLinkPreview,
+		showSettingsDrawer,
+		isLoading,
 	};
 
 	return (
@@ -286,11 +297,7 @@ function LinkControl( {
 				ref={ wrapperNode }
 				className="block-editor-link-control"
 			>
-				{ isCreatingPage && (
-					<div className="block-editor-link-control__loading">
-						<Spinner /> { __( 'Creating' ) }…
-					</div>
-				) }
+				<LinkControlLoading />
 
 				<LinkControlEditControls
 					shouldShowEditControls={ shouldShowEditControls }
@@ -326,15 +333,8 @@ function LinkControl( {
 					onRemove={ onRemove }
 				/>
 
-				{ showSettingsDrawer && (
-					<div className="block-editor-link-control__tools">
-						<LinkControlSettingsDrawer
-							value={ value }
-							settings={ settings }
-							onChange={ onChange }
-						/>
-					</div>
-				) }
+				<LinkControlSettingsDrawer />
+
 				{ renderControlBottom && renderControlBottom() }
 			</div>
 		</LinkControlContext.Provider>

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -223,13 +223,16 @@ function LinkControl( {
 		setIsEditingLink( false );
 	};
 
-	const handleSelectSuggestion = ( updatedValue ) => {
-		onChange( {
-			...updatedValue,
-			title: internalTextInputValue || updatedValue?.title,
-		} );
-		stopEditing();
-	};
+	const handleSelectSuggestion = useCallback(
+		( updatedValue ) => {
+			onChange( {
+				...updatedValue,
+				title: internalTextInputValue || updatedValue?.title,
+			} );
+			stopEditing();
+		},
+		[ onChange, stopEditing, internalTextInputValue ]
+	);
 
 	const currentUrlInputValue = propInputValue || internalUrlInputValue;
 

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -298,6 +298,7 @@ function LinkControl( {
 		hasRichPreviews,
 		shownUnlinkControl,
 		onEditClick,
+		textInputRef,
 	};
 
 	return (
@@ -309,10 +310,8 @@ function LinkControl( {
 			>
 				<LinkControlLoading />
 
-				<LinkControlEditControls
-					shouldShowEditControls={ shouldShowEditControls }
-				>
-					<LinkControlTextInput ref={ textInputRef } />
+				<LinkControlEditControls>
+					<LinkControlTextInput />
 
 					<LinkControlSearchInput
 						className="block-editor-link-control__field block-editor-link-control__search-input"

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -261,6 +261,8 @@ function LinkControl( {
 	const shouldShowEditControls =
 		( isEditingLink || ! value ) && ! isCreatingPage;
 
+	const shouldShowLinkPreview = value && ! isEditingLink && ! isCreatingPage;
+
 	// Todo
 	// - memoize context value
 	// - create seperate context's to avoid re-renders
@@ -274,6 +276,7 @@ function LinkControl( {
 		currentUrlInputValue,
 		createPageErrorMessage, // needs extracting to generic error message
 		shouldShowEditControls,
+		shouldShowLinkPreview,
 	};
 
 	return (
@@ -314,16 +317,14 @@ function LinkControl( {
 					<LinkControlNotice />
 				</LinkControlEditControls>
 
-				{ value && ! isEditingLink && ! isCreatingPage && (
-					<LinkPreview
-						key={ value?.url } // force remount when URL changes to avoid race conditions for rich previews
-						value={ value }
-						onEditClick={ () => setIsEditingLink( true ) }
-						hasRichPreviews={ hasRichPreviews }
-						hasUnlinkControl={ shownUnlinkControl }
-						onRemove={ onRemove }
-					/>
-				) }
+				<LinkPreview
+					key={ value?.url } // force remount when URL changes to avoid race conditions for rich previews
+					value={ value }
+					onEditClick={ () => setIsEditingLink( true ) }
+					hasRichPreviews={ hasRichPreviews }
+					hasUnlinkControl={ shownUnlinkControl }
+					onRemove={ onRemove }
+				/>
 
 				{ showSettingsDrawer && (
 					<div className="block-editor-link-control__tools">

--- a/packages/block-editor/src/components/link-control/link-control-default.js
+++ b/packages/block-editor/src/components/link-control/link-control-default.js
@@ -2,52 +2,19 @@
  * Internal dependencies
  */
 import LinkControlSettingsDrawer from './settings-drawer';
-import LinkControlSearchInput from './search-input';
-import LinkControlTextInput from './link-control-text-input';
 import LinkPreview from './link-preview';
-import LinkControlNotice from './link-control-notice';
 import LinkControlEditControls from './link-control-edit-controls';
 import LinkControlLoading from './link-control-loading';
 
-export default function LinkControlDefault( {
-	searchInputPlaceholder,
-	withCreateSuggestion,
-	createPage,
-	setInternalUrlInputValue,
-	handleSelectSuggestion,
-	showInitialSuggestions,
-	noDirectEntry,
-	showSuggestions,
-	suggestionsQuery,
-	noURLSuggestion,
-	createSuggestionButtonText,
-	showTextControl,
-	renderControlBottom,
-} ) {
+export default function LinkControlDefault( props ) {
+	const { renderControlBottom } = props;
+
+	// Todo: share props without using context.
 	return (
 		<>
 			<LinkControlLoading />
 
-			<LinkControlEditControls>
-				<LinkControlTextInput />
-
-				<LinkControlSearchInput
-					className="block-editor-link-control__field block-editor-link-control__search-input"
-					placeholder={ searchInputPlaceholder }
-					withCreateSuggestion={ withCreateSuggestion }
-					onCreateSuggestion={ createPage }
-					onChange={ setInternalUrlInputValue }
-					onSelect={ handleSelectSuggestion }
-					showInitialSuggestions={ showInitialSuggestions }
-					allowDirectEntry={ ! noDirectEntry }
-					showSuggestions={ showSuggestions }
-					suggestionsQuery={ suggestionsQuery }
-					withURLSuggestion={ ! noURLSuggestion }
-					createSuggestionButtonText={ createSuggestionButtonText }
-					useLabel={ showTextControl }
-				/>
-				<LinkControlNotice />
-			</LinkControlEditControls>
+			<LinkControlEditControls { ...props } />
 
 			<LinkPreview />
 

--- a/packages/block-editor/src/components/link-control/link-control-default.js
+++ b/packages/block-editor/src/components/link-control/link-control-default.js
@@ -1,0 +1,59 @@
+/**
+ * Internal dependencies
+ */
+import LinkControlSettingsDrawer from './settings-drawer';
+import LinkControlSearchInput from './search-input';
+import LinkControlTextInput from './link-control-text-input';
+import LinkPreview from './link-preview';
+import LinkControlNotice from './link-control-notice';
+import LinkControlEditControls from './link-control-edit-controls';
+import LinkControlLoading from './link-control-loading';
+
+export function LinkControlDefault( {
+	searchInputPlaceholder,
+	withCreateSuggestion,
+	createPage,
+	setInternalUrlInputValue,
+	handleSelectSuggestion,
+	showInitialSuggestions,
+	noDirectEntry,
+	showSuggestions,
+	suggestionsQuery,
+	noURLSuggestion,
+	createSuggestionButtonText,
+	showTextControl,
+	renderControlBottom,
+} ) {
+	return (
+		<>
+			<LinkControlLoading />
+
+			<LinkControlEditControls>
+				<LinkControlTextInput />
+
+				<LinkControlSearchInput
+					className="block-editor-link-control__field block-editor-link-control__search-input"
+					placeholder={ searchInputPlaceholder }
+					withCreateSuggestion={ withCreateSuggestion }
+					onCreateSuggestion={ createPage }
+					onChange={ setInternalUrlInputValue }
+					onSelect={ handleSelectSuggestion }
+					showInitialSuggestions={ showInitialSuggestions }
+					allowDirectEntry={ ! noDirectEntry }
+					showSuggestions={ showSuggestions }
+					suggestionsQuery={ suggestionsQuery }
+					withURLSuggestion={ ! noURLSuggestion }
+					createSuggestionButtonText={ createSuggestionButtonText }
+					useLabel={ showTextControl }
+				/>
+				<LinkControlNotice />
+			</LinkControlEditControls>
+
+			<LinkPreview />
+
+			<LinkControlSettingsDrawer />
+
+			{ renderControlBottom && renderControlBottom() }
+		</>
+	);
+}

--- a/packages/block-editor/src/components/link-control/link-control-default.js
+++ b/packages/block-editor/src/components/link-control/link-control-default.js
@@ -6,15 +6,16 @@ import LinkPreview from './link-preview';
 import LinkControlEditControls from './link-control-edit-controls';
 import LinkControlLoading from './link-control-loading';
 
-export default function LinkControlDefault( props ) {
-	const { renderControlBottom } = props;
-
+export default function LinkControlDefault( {
+	renderControlBottom,
+	...editControlProps
+} ) {
 	// Todo: share props without using context.
 	return (
 		<>
 			<LinkControlLoading />
 
-			<LinkControlEditControls { ...props } />
+			<LinkControlEditControls { ...editControlProps } />
 
 			<LinkPreview />
 

--- a/packages/block-editor/src/components/link-control/link-control-default.js
+++ b/packages/block-editor/src/components/link-control/link-control-default.js
@@ -9,7 +9,7 @@ import LinkControlNotice from './link-control-notice';
 import LinkControlEditControls from './link-control-edit-controls';
 import LinkControlLoading from './link-control-loading';
 
-export function LinkControlDefault( {
+export default function LinkControlDefault( {
 	searchInputPlaceholder,
 	withCreateSuggestion,
 	createPage,

--- a/packages/block-editor/src/components/link-control/link-control-edit-controls.js
+++ b/packages/block-editor/src/components/link-control/link-control-edit-controls.js
@@ -7,8 +7,25 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import { useLinkControlContext } from './';
+import LinkControlSearchInput from './search-input';
+import LinkControlTextInput from './link-control-text-input';
+import LinkControlNotice from './link-control-notice';
 
-export default function LinkControlEditControls( { children } ) {
+export default function LinkControlEditControls( { children, ...props } ) {
+	const {
+		searchInputPlaceholder,
+		withCreateSuggestion,
+		createPage,
+		setInternalUrlInputValue,
+		handleSelectSuggestion,
+		showInitialSuggestions,
+		noDirectEntry,
+		showSuggestions,
+		suggestionsQuery,
+		noURLSuggestion,
+		createSuggestionButtonText,
+	} = props;
+
 	const { showTextControl, shouldShowEditControls } = useLinkControlContext();
 
 	if ( ! shouldShowEditControls ) {
@@ -23,7 +40,32 @@ export default function LinkControlEditControls( { children } ) {
 					'has-text-control': showTextControl,
 				} ) }
 			>
-				{ children }
+				{ children ? (
+					children
+				) : (
+					<>
+						<LinkControlTextInput />
+
+						<LinkControlSearchInput
+							className="block-editor-link-control__field block-editor-link-control__search-input"
+							placeholder={ searchInputPlaceholder }
+							withCreateSuggestion={ withCreateSuggestion }
+							onCreateSuggestion={ createPage }
+							onChange={ setInternalUrlInputValue }
+							onSelect={ handleSelectSuggestion }
+							showInitialSuggestions={ showInitialSuggestions }
+							allowDirectEntry={ ! noDirectEntry }
+							showSuggestions={ showSuggestions }
+							suggestionsQuery={ suggestionsQuery }
+							withURLSuggestion={ ! noURLSuggestion }
+							createSuggestionButtonText={
+								createSuggestionButtonText
+							}
+							useLabel={ showTextControl }
+						/>
+						<LinkControlNotice />
+					</>
+				) }
 			</div>
 		</>
 	);

--- a/packages/block-editor/src/components/link-control/link-control-edit-controls.js
+++ b/packages/block-editor/src/components/link-control/link-control-edit-controls.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { useLinkControlContext } from './';
+
+export default function LinkControlEditControls( { children } ) {
+	const { showTextControl, shouldShowEditControls } = useLinkControlContext();
+
+	if ( ! shouldShowEditControls ) {
+		return null;
+	}
+
+	return (
+		<>
+			<div
+				className={ classnames( {
+					'block-editor-link-control__search-input-wrapper': true,
+					'has-text-control': showTextControl,
+				} ) }
+			>
+				{ children }
+			</div>
+		</>
+	);
+}

--- a/packages/block-editor/src/components/link-control/link-control-loading.js
+++ b/packages/block-editor/src/components/link-control/link-control-loading.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { useLinkControlContext } from './';
 
-export function LinkControlLoading() {
+export default function LinkControlLoading() {
 	const { isLoading } = useLinkControlContext();
 
 	if ( ! isLoading ) {

--- a/packages/block-editor/src/components/link-control/link-control-loading.js
+++ b/packages/block-editor/src/components/link-control/link-control-loading.js
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useLinkControlContext } from './';
+
+export function LinkControlLoading() {
+	const { isLoading } = useLinkControlContext();
+
+	if ( ! isLoading ) {
+		return;
+	}
+
+	return (
+		<div className="block-editor-link-control__loading">
+			<Spinner /> { __( 'Creating' ) }…
+		</div>
+	);
+}

--- a/packages/block-editor/src/components/link-control/link-control-notice.js
+++ b/packages/block-editor/src/components/link-control/link-control-notice.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { Notice } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { useLinkControlContext } from './';
+
+export default function LinkControlNotice() {
+	const { createPageErrorMessage } = useLinkControlContext();
+
+	if ( ! createPageErrorMessage ) {
+		return null;
+	}
+	return (
+		<Notice
+			className="block-editor-link-control__search-error"
+			status="error"
+			isDismissible={ false }
+		>
+			{ createPageErrorMessage }
+		</Notice>
+	);
+}

--- a/packages/block-editor/src/components/link-control/link-control-notice.js
+++ b/packages/block-editor/src/components/link-control/link-control-notice.js
@@ -9,9 +9,9 @@ import { Notice } from '@wordpress/components';
 import { useLinkControlContext } from './';
 
 export default function LinkControlNotice() {
-	const { createPageErrorMessage } = useLinkControlContext();
+	const { errorMsg } = useLinkControlContext();
 
-	if ( ! createPageErrorMessage ) {
+	if ( ! errorMsg ) {
 		return null;
 	}
 	return (
@@ -20,7 +20,7 @@ export default function LinkControlNotice() {
 			status="error"
 			isDismissible={ false }
 		>
-			{ createPageErrorMessage }
+			{ errorMsg }
 		</Notice>
 	);
 }

--- a/packages/block-editor/src/components/link-control/link-control-text-input.js
+++ b/packages/block-editor/src/components/link-control/link-control-text-input.js
@@ -8,9 +8,9 @@ import { ENTER } from '@wordpress/keycodes';
 /**
  * Internal dependencies
  */
-import { useLinkControlContext } from './';
+import { useLinkControlContext } from '.';
 
-export default forwardRef( ( _props, ref ) => {
+const LinkControlTextInput = forwardRef( ( _props, ref ) => {
 	const {
 		showTextControl,
 		internalTextInputValue,
@@ -45,3 +45,5 @@ export default forwardRef( ( _props, ref ) => {
 		/>
 	);
 } );
+
+export default LinkControlTextInput;

--- a/packages/block-editor/src/components/link-control/link-control-text-input.js
+++ b/packages/block-editor/src/components/link-control/link-control-text-input.js
@@ -10,6 +10,12 @@ import { ENTER } from '@wordpress/keycodes';
  */
 import { useLinkControlContext } from '.';
 
+export default function LinkControlTextInputWrapper() {
+	const { textInputRef } = useLinkControlContext();
+
+	return <LinkControlTextInput ref={ textInputRef } />;
+}
+
 const LinkControlTextInput = forwardRef( ( _props, ref ) => {
 	const {
 		showTextControl,
@@ -45,5 +51,3 @@ const LinkControlTextInput = forwardRef( ( _props, ref ) => {
 		/>
 	);
 } );
-
-export default LinkControlTextInput;

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -20,8 +20,8 @@ import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
  * Internal dependencies
  */
 import { ViewerSlot } from './viewer-slot';
-
 import useRichUrlData from './use-rich-url-data';
+import { useLinkControlContext } from './';
 
 export default function LinkPreview( {
 	value,
@@ -30,6 +30,8 @@ export default function LinkPreview( {
 	hasUnlinkControl = false,
 	onRemove,
 } ) {
+	const { shouldShowLinkPreview } = useLinkControlContext();
+
 	// Avoid fetching if rich previews are not desired.
 	const showRichPreviews = hasRichPreviews ? value?.url : null;
 
@@ -55,6 +57,10 @@ export default function LinkPreview( {
 		icon = <Icon icon={ info } size={ 32 } />;
 	} else {
 		icon = <Icon icon={ globe } />;
+	}
+
+	if ( ! shouldShowLinkPreview ) {
+		return null;
 	}
 
 	return (

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -23,14 +23,25 @@ import { ViewerSlot } from './viewer-slot';
 import useRichUrlData from './use-rich-url-data';
 import { useLinkControlContext } from './';
 
-export default function LinkPreview( {
-	value,
-	onEditClick,
-	hasRichPreviews = false,
-	hasUnlinkControl = false,
-	onRemove,
-} ) {
-	const { shouldShowLinkPreview } = useLinkControlContext();
+export default function LinkPreviewWrapper() {
+	const { value } = useLinkControlContext();
+
+	return (
+		<LinkPreview
+			key={ value?.url } // force remount when URL changes to avoid race conditions for rich previews
+		/>
+	);
+}
+
+function LinkPreview() {
+	const {
+		value,
+		shouldShowLinkPreview,
+		hasRichPreviews = false,
+		shownUnlinkControl: hasUnlinkControl = false,
+		onRemove,
+		onEditClick,
+	} = useLinkControlContext();
 
 	// Avoid fetching if rich previews are not desired.
 	const showRichPreviews = hasRichPreviews ? value?.url : null;

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -16,6 +16,7 @@ import { URLInput } from '../';
 import LinkControlSearchResults from './search-results';
 import { CREATE_TYPE } from './constants';
 import useSearchHandler from './use-search-handler';
+import { useLinkControlContext } from './';
 
 // Must be a function as otherwise URLInput will default
 // to the fetchLinkSuggestions passed in block editor settings
@@ -27,9 +28,7 @@ const noop = () => {};
 const LinkControlSearchInput = forwardRef(
 	(
 		{
-			value,
 			children,
-			currentLink = {},
 			className = null,
 			placeholder = null,
 			withCreateSuggestion = false,
@@ -50,6 +49,11 @@ const LinkControlSearchInput = forwardRef(
 		},
 		ref
 	) => {
+		// Aliasing the values to avoid confusion during
+		// refactoring of this component.
+		const { value: currentLink = {}, currentUrlInputValue: value } =
+			useLinkControlContext();
+
 		const genericSearchHandler = useSearchHandler(
 			suggestionsQuery,
 			allowDirectEntry,

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -8,6 +8,8 @@ import classnames from 'classnames';
 import { useInstanceId } from '@wordpress/compose';
 import { forwardRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { keyboardReturn } from '@wordpress/icons';
+import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -28,7 +30,6 @@ const noop = () => {};
 const LinkControlSearchInput = forwardRef(
 	(
 		{
-			children,
 			className = null,
 			placeholder = null,
 			withCreateSuggestion = false,
@@ -51,8 +52,12 @@ const LinkControlSearchInput = forwardRef(
 	) => {
 		// Aliasing the values to avoid confusion during
 		// refactoring of this component.
-		const { value: currentLink = {}, currentUrlInputValue: value } =
-			useLinkControlContext();
+		const {
+			value: currentLink = {},
+			currentUrlInputValue: value,
+			handleSubmit,
+			currentInputIsEmpty,
+		} = useLinkControlContext();
 
 		const genericSearchHandler = useSearchHandler(
 			suggestionsQuery,
@@ -158,7 +163,15 @@ const LinkControlSearchInput = forwardRef(
 					} }
 					ref={ ref }
 				/>
-				{ children }
+				<div className="block-editor-link-control__search-actions">
+					<Button
+						onClick={ handleSubmit }
+						label={ __( 'Submit' ) }
+						icon={ keyboardReturn }
+						className="block-editor-link-control__search-submit"
+						disabled={ currentInputIsEmpty } // Disallow submitting empty values.
+					/>
+				</div>
 			</div>
 		);
 	}

--- a/packages/block-editor/src/components/link-control/settings-drawer.js
+++ b/packages/block-editor/src/components/link-control/settings-drawer.js
@@ -4,10 +4,21 @@
 import { __ } from '@wordpress/i18n';
 import { ToggleControl, VisuallyHidden } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
+import { useLinkControlContext } from './';
 const noop = () => {};
 
-const LinkControlSettingsDrawer = ( { value, onChange = noop, settings } ) => {
-	if ( ! settings || ! settings.length ) {
+const LinkControlSettingsDrawer = () => {
+	const {
+		value,
+		onChange = noop,
+		settings,
+		showSettingsDrawer,
+	} = useLinkControlContext();
+
+	if ( ! showSettingsDrawer || ! settings || ! settings.length ) {
 		return null;
 	}
 
@@ -29,12 +40,14 @@ const LinkControlSettingsDrawer = ( { value, onChange = noop, settings } ) => {
 	) );
 
 	return (
-		<fieldset className="block-editor-link-control__settings">
-			<VisuallyHidden as="legend">
-				{ __( 'Currently selected link settings' ) }
-			</VisuallyHidden>
-			{ theSettings }
-		</fieldset>
+		<div className="block-editor-link-control__tools">
+			<fieldset className="block-editor-link-control__settings">
+				<VisuallyHidden as="legend">
+					{ __( 'Currently selected link settings' ) }
+				</VisuallyHidden>
+				{ theSettings }
+			</fieldset>
+		</div>
 	);
 };
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -1894,3 +1894,52 @@ describe( 'Controlling link title text', () => {
 		).not.toBeInTheDocument();
 	} );
 } );
+
+describe( 'Component composition', () => {
+	const selectedLink = fauxEntitySuggestions[ 0 ];
+	const mockOnChange = jest.fn();
+
+	it( 'exports a default component which provides standard UI', () => {
+		function MyCustomLinkControl() {
+			return (
+				<>
+					<p>Another component before.</p>
+					<LinkControl.DefaultComponents />
+					<p>Another component afterwards.</p>
+				</>
+			);
+		}
+
+		render(
+			<LinkControl
+				value={ selectedLink }
+				forceIsEditingLink
+				hasTextControl
+				onChange={ mockOnChange }
+			>
+				<MyCustomLinkControl />
+			</LinkControl>
+		);
+
+		// Check for custom components.
+		expect(
+			screen.getByText( 'Another component before.' )
+		).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Another component afterwards.' )
+		).toBeInTheDocument();
+
+		// Check for the default components.
+		expect(
+			screen.getByRole( 'combobox', { name: 'URL' } )
+		).toBeInTheDocument();
+
+		expect(
+			screen.getByRole( 'textbox', { name: 'Text' } )
+		).toBeInTheDocument();
+
+		expect(
+			screen.getByText( 'Currently selected link settings' )
+		).toBeInTheDocument();
+	} );
+} );

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -1917,7 +1917,7 @@ describe( 'Component composition', () => {
 				hasTextControl
 				onChange={ mockOnChange }
 			>
-				<MyCustomLinkControl />
+				{ () => <MyCustomLinkControl /> }
 			</LinkControl>
 		);
 
@@ -1967,7 +1967,7 @@ describe( 'Component composition', () => {
 				hasTextControl
 				onChange={ mockOnChange }
 			>
-				<MyCustomLinkControl />
+				{ () => <MyCustomLinkControl /> }
 			</LinkControl>
 		);
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -1942,4 +1942,51 @@ describe( 'Component composition', () => {
 			screen.getByText( 'Currently selected link settings' )
 		).toBeInTheDocument();
 	} );
+
+	it( 'exports subcomponents easy UI composition', () => {
+		function MyCustomLinkControl() {
+			return (
+				<>
+					<LinkControl.Loading />
+
+					<LinkControl.EditControls />
+
+					<LinkControl.Preview />
+
+					<LinkControl.SettingsDrawer />
+
+					<div>Here is custom component.</div>
+				</>
+			);
+		}
+
+		render(
+			<LinkControl
+				value={ selectedLink }
+				forceIsEditingLink
+				hasTextControl
+				onChange={ mockOnChange }
+			>
+				<MyCustomLinkControl />
+			</LinkControl>
+		);
+
+		// Check for custom components.
+		expect(
+			screen.getByText( 'Here is custom component.' )
+		).toBeInTheDocument();
+
+		// Check for the default components.
+		expect(
+			screen.getByRole( 'combobox', { name: 'URL' } )
+		).toBeInTheDocument();
+
+		expect(
+			screen.getByRole( 'textbox', { name: 'Text' } )
+		).toBeInTheDocument();
+
+		expect(
+			screen.getByText( 'Currently selected link settings' )
+		).toBeInTheDocument();
+	} );
 } );

--- a/packages/block-editor/src/components/link-control/text-input.js
+++ b/packages/block-editor/src/components/link-control/text-input.js
@@ -1,0 +1,47 @@
+/**
+ * WordPress dependencies
+ */
+import { TextControl } from '@wordpress/components';
+import { forwardRef } from '@wordpress/element';
+import { ENTER } from '@wordpress/keycodes';
+
+/**
+ * Internal dependencies
+ */
+import { useLinkControlContext } from './';
+
+export default forwardRef( ( _props, ref ) => {
+	const {
+		showTextControl,
+		internalTextInputValue,
+		setInternalTextInputValue,
+		handleSubmit,
+		currentInputIsEmpty,
+	} = useLinkControlContext();
+
+	if ( ! showTextControl ) {
+		return null;
+	}
+
+	const handleSubmitWithEnter = ( event ) => {
+		const { keyCode } = event;
+		if (
+			keyCode === ENTER &&
+			! currentInputIsEmpty // Disallow submitting empty values.
+		) {
+			event.preventDefault();
+			handleSubmit();
+		}
+	};
+
+	return (
+		<TextControl
+			ref={ ref }
+			className="block-editor-link-control__field block-editor-link-control__text-content"
+			label="Text"
+			value={ internalTextInputValue }
+			onChange={ setInternalTextInputValue }
+			onKeyDown={ handleSubmitWithEnter }
+		/>
+	);
+} );

--- a/packages/block-editor/src/components/link-control/use-create-page.js
+++ b/packages/block-editor/src/components/link-control/use-create-page.js
@@ -2,43 +2,46 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect, useState, useRef } from '@wordpress/element';
+import { useEffect, useState, useRef, useCallback } from '@wordpress/element';
 
 export default function useCreatePage( handleCreatePage ) {
 	const cancelableCreateSuggestion = useRef();
 	const [ isCreatingPage, setIsCreatingPage ] = useState( false );
 	const [ errorMessage, setErrorMessage ] = useState( null );
 
-	const createPage = async function ( suggestionTitle ) {
-		setIsCreatingPage( true );
-		setErrorMessage( null );
+	const createPage = useCallback(
+		async function ( suggestionTitle ) {
+			setIsCreatingPage( true );
+			setErrorMessage( null );
 
-		try {
-			// Make cancellable in order that we can avoid setting State
-			// if the component unmounts during the call to `createSuggestion`
-			cancelableCreateSuggestion.current = makeCancelable(
-				// Using Promise.resolve to allow createSuggestion to return a
-				// non-Promise based value.
-				Promise.resolve( handleCreatePage( suggestionTitle ) )
-			);
+			try {
+				// Make cancellable in order that we can avoid setting State
+				// if the component unmounts during the call to `createSuggestion`
+				cancelableCreateSuggestion.current = makeCancelable(
+					// Using Promise.resolve to allow createSuggestion to return a
+					// non-Promise based value.
+					Promise.resolve( handleCreatePage( suggestionTitle ) )
+				);
 
-			return await cancelableCreateSuggestion.current.promise;
-		} catch ( error ) {
-			if ( error && error.isCanceled ) {
-				return; // bail if canceled to avoid setting state
+				return await cancelableCreateSuggestion.current.promise;
+			} catch ( error ) {
+				if ( error && error.isCanceled ) {
+					return; // bail if canceled to avoid setting state
+				}
+
+				setErrorMessage(
+					error.message ||
+						__(
+							'An unknown error occurred during creation. Please try again.'
+						)
+				);
+				throw error;
+			} finally {
+				setIsCreatingPage( false );
 			}
-
-			setErrorMessage(
-				error.message ||
-					__(
-						'An unknown error occurred during creation. Please try again.'
-					)
-			);
-			throw error;
-		} finally {
-			setIsCreatingPage( false );
-		}
-	};
+		},
+		[ setIsCreatingPage, setErrorMessage, handleCreatePage ]
+	);
 
 	/**
 	 * Handles cancelling any pending Promises that have been made cancelable.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Experimental PR to convert `<LInkControl>` to be a compound component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The API for LinkControl is...quite large. Some of these props are based on the requirement to customise certain portions of the UI. Moreover, we're getting more requests to be able to add additional piece of UI to the component.

By decomposing the component in this way we have power to construct the component in a variety of configurations. A key example would be something like this:

```js
function MyCustomLinkControl() {
	return (
		<>
			<p>Another component before.</p>
			<LinkControl.DefaultComponents />
			<p>Another component afterwards.</p>
		</>
	);
}

// Later on in render
render(
	<LinkControl
		value={ selectedLink }
		forceIsEditingLink
		hasTextControl
		onChange={ mockOnChange }
	>
		<MyCustomLinkControl />
	</LinkControl>
);

```

It is also possible to consume lower level components to achieve entirely custom results. An example such as the one below completely removes the need for the existing `renderControlBottom` prop (although this remains supported):

```js
function MyCustomLinkControl() {
	return (
		<>
			<LinkControl.Loading />

			<LinkControl.EditControls />

			<LinkControl.Preview />

			<LinkControl.SettingsDrawer />

			<div>Here is custom component.</div>
		</>
	);
}
```

In this example we can render the control's standard UI but provide additional elements within the control. As there are now many sub components it is also possible to have even more control.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- using a shared context
- making all the sub components fully encapsulated (via context)
- exporting all subcomponents as properties of the parent `LinkControl` object
- exporting a shared context for consumption outside of the component

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
