### PR TITLE
Navigation List View: Remove empty cell when there is no edit button

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/block.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block.js
@@ -325,27 +325,28 @@ function ListViewBlock( {
 
 			{ showBlockActions && (
 				<>
-					<TreeGridCell
-						className={ listViewBlockEditClassName }
-						aria-selected={
-							!! isSelected || forceSelectionContentLock
-						}
-					>
-						{ ( props ) =>
-							isEditable && (
+					{ isEditable && (
+						<TreeGridCell
+							className={ listViewBlockEditClassName }
+							aria-selected={
+								!! isSelected || forceSelectionContentLock
+							}
+						>
+							{ ( props ) => (
 								<BlockEditButton
 									{ ...props }
 									label={ editAriaLabel }
 									clientId={ clientId }
 								/>
-							)
-						}
-					</TreeGridCell>
+							) }
+						</TreeGridCell>
+					) }
 					<TreeGridCell
 						className={ listViewBlockSettingsClassName }
 						aria-selected={
 							!! isSelected || forceSelectionContentLock
 						}
+						colSpan={ isEditable ? 1 : 2 } // When an item is not editable then we don't output the cell for the edit button, so we need to adjust the colspan so that the HTML is valid.
 					>
 						{ ( { ref, tabIndex, onFocus } ) => (
 							<BlockSettingsDropdown


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow up to https://github.com/WordPress/gutenberg/pull/46163

This removes the empty `td` element when there is no edit button present for the page list items.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The `td` element was taking extra space and it was forcing horizontal scroll in some cases, making the 3 dot menu hard to reach or even hard to discover.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The condition to check if an item is editable is now including the cell and a colspan on the 3 dot menu cell takes care of the issue of the missing cell that would render the HTML invalid.

## Screenshots or screencast <!-- if applicable -->

Before | After
--- | ---
![Screen Capture on 2022-12-09 at 17-59-35](https://user-images.githubusercontent.com/3593343/206753691-d7e25434-7dfb-4c82-849d-70e420f72d01.gif) | ![Screen Capture on 2022-12-09 at 17-58-27](https://user-images.githubusercontent.com/3593343/206753687-b716429f-fa64-4f7f-b524-50481816cac1.gif)


