### PR TITLE
Update: Use offsite navigation editor on the navigation inspector sidebar.

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/navigation-menu-sidebar/navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/navigation-menu-sidebar/navigation-menu.js
@@ -3,6 +3,7 @@
  */
 import {
 	__experimentalListView as ListView,
+	__experimentalOffCanvasEditor as OffCanvasEditor,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
@@ -48,5 +49,14 @@ export default function NavigationMenu( { innerBlocks, id } ) {
 			}
 		} );
 	}, [ updateBlockListSettings, innerBlocks ] );
+
+	if ( window?.__experimentalEnableOffCanvasNavigationEditor ) {
+		return (
+			<OffCanvasEditor
+				blocks={ innerBlocks }
+				selectBlockInCanvas={ false }
+			/>
+		);
+	}
 	return <ListView id={ id } />;
 }


### PR DESCRIPTION
This PR updates the navigation inspector sidebar to use the new navigation offsite editor being worked on:
https://github.com/orgs/WordPress/projects/60/views/1

If the navigation offsite editor is disabled, the edit button and the appended are not shown, so it behaves similarly to what we have now.
This change also allows browse mode navigation menus to take advantage of the new menu editor. After this PR, and https://github.com/WordPress/gutenberg/pull/46436 are merged.

cc: @scruffian 
## Screenshots or screencast <!-- if applicable -->
Off-canvas editor enable:
![image](https://user-images.githubusercontent.com/11271197/206756396-a8f2f093-da00-43cc-901c-1cdc769a6a74.png)

Off-canvas editor disable: 
![image](https://user-images.githubusercontent.com/11271197/206756434-824c58cc-beee-489d-9b4e-0046e9f1c161.png)

