### PR TITLE
Update the synced block hover styles in Inserter

### DIFF
--- a/packages/block-editor/src/components/inserter-list-item/style.scss
+++ b/packages/block-editor/src/components/inserter-list-item/style.scss
@@ -17,13 +17,13 @@
 						color: var(--wp-block-synced-color) !important;
 						filter: brightness(0.95);
 					}
-		
+
 					svg {
 						color: var(--wp-block-synced-color) !important;
 					}
 				}
 
-				&:after {
+				&::after {
 					background: var(--wp-block-synced-color);
 				}
 			}

--- a/packages/block-editor/src/components/inserter-list-item/style.scss
+++ b/packages/block-editor/src/components/inserter-list-item/style.scss
@@ -1,11 +1,32 @@
+
 .block-editor-block-types-list__list-item {
 	display: block;
 	width: 33.33%;
 	padding: 0;
 	margin: 0;
+
 	&.is-synced {
-		.block-editor-block-icon.has-colors {
-			color: var(--wp-block-synced-color);
+		.components-button.block-editor-block-types-list__item {
+			&:not(:disabled) {
+				.block-editor-block-icon.has-colors {
+					color: var(--wp-block-synced-color);
+				}
+
+				&:hover {
+					.block-editor-block-types-list__item-title {
+						color: var(--wp-block-synced-color) !important;
+						filter: brightness(0.95);
+					}
+		
+					svg {
+						color: var(--wp-block-synced-color) !important;
+					}
+				}
+
+				&:after {
+					background: var(--wp-block-synced-color);
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Before


https://user-images.githubusercontent.com/846565/206763919-42cf7f25-ce99-4dd8-83d9-82e654bbe959.mp4

Note that synced blocks share the blue accents on hover with regular blocks. 

### After

https://user-images.githubusercontent.com/846565/206763969-75c8d570-5467-4bb1-8f18-baea90d95e6d.mp4

This PR updates the hover styles to utilise the purple accents (`var(--wp-block-synced-color)`) instead.

It also updates the `disabled` styles for synced blocks to remove all color.