### PR TITLE
SelectControl: remove margin overrides and add new opt-in prop

### DIFF
--- a/packages/block-editor/src/components/default-style-picker/index.js
+++ b/packages/block-editor/src/components/default-style-picker/index.js
@@ -58,6 +58,7 @@ export default function DefaultStylePicker( { blockName } ) {
 		onUpdatePreferredStyleVariations && (
 			<div className="default-style-picker__default-switcher">
 				<SelectControl
+					__nextHasNoMarginBottom
 					options={ selectOptions }
 					value={ preferredStyle || '' }
 					label={ __( 'Default Style' ) }

--- a/packages/block-editor/src/components/font-family/index.js
+++ b/packages/block-editor/src/components/font-family/index.js
@@ -40,6 +40,7 @@ export default function FontFamilyControl( {
 	];
 	return (
 		<SelectControl
+			__nextHasNoMarginBottom
 			label={ __( 'Font' ) }
 			options={ options }
 			value={ value }

--- a/packages/block-editor/src/components/font-family/index.js
+++ b/packages/block-editor/src/components/font-family/index.js
@@ -40,7 +40,6 @@ export default function FontFamilyControl( {
 	];
 	return (
 		<SelectControl
-			__nextHasNoMarginBottom
 			label={ __( 'Font' ) }
 			options={ options }
 			value={ value }

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -41,6 +41,7 @@ export default function ImageSizeControl( {
 		<>
 			{ ! isEmpty( imageSizeOptions ) && (
 				<SelectControl
+					__nextHasNoMarginBottom
 					label={ __( 'Image size' ) }
 					value={ slug }
 					options={ imageSizeOptions }

--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -48,6 +48,7 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 						}
 					/>
 					<SelectControl
+						__nextHasNoMarginBottom
 						label={ __( 'Group by:' ) }
 						options={ [
 							{ label: __( 'Year' ), value: 'yearly' },

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -218,6 +218,7 @@ function AudioEdit( {
 						checked={ loop }
 					/>
 					<SelectControl
+						__nextHasNoMarginBottom
 						label={ _x( 'Preload', 'noun; Audio block parameter' ) }
 						value={ preload || '' }
 						// `undefined` is required for the preload attribute to be unset.

--- a/packages/block-library/src/comments/edit/comments-inspector-controls.js
+++ b/packages/block-library/src/comments/edit/comments-inspector-controls.js
@@ -13,6 +13,7 @@ export default function CommentsInspectorControls( {
 		<InspectorControls>
 			<InspectorControls __experimentalGroup="advanced">
 				<SelectControl
+					__nextHasNoMarginBottom
 					label={ __( 'HTML element' ) }
 					options={ [
 						{ label: __( 'Default (<div>)' ), value: 'div' },

--- a/packages/block-library/src/file/inspector.js
+++ b/packages/block-library/src/file/inspector.js
@@ -71,6 +71,7 @@ export default function FileBlockInspector( {
 				) }
 				<PanelBody title={ __( 'Settings' ) }>
 					<SelectControl
+						__nextHasNoMarginBottom
 						label={ __( 'Link to' ) }
 						value={ textLinkHref }
 						options={ linkDestinationOptions }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -531,6 +531,7 @@ function GalleryEdit( props ) {
 						help={ getImageCropHelp }
 					/>
 					<SelectControl
+						__nextHasNoMarginBottom
 						label={ __( 'Link to' ) }
 						value={ linkTo }
 						onChange={ setLinkTo }
@@ -546,6 +547,7 @@ function GalleryEdit( props ) {
 					) }
 					{ imageSizeOptions?.length > 0 && (
 						<SelectControl
+							__nextHasNoMarginBottom
 							label={ __( 'Image size' ) }
 							value={ sizeSlug }
 							options={ imageSizeOptions }

--- a/packages/block-library/src/gallery/v1/edit.js
+++ b/packages/block-library/src/gallery/v1/edit.js
@@ -420,6 +420,7 @@ function GalleryEdit( props ) {
 						help={ getImageCropHelp }
 					/>
 					<SelectControl
+						__nextHasNoMarginBottom
 						label={ __( 'Link to' ) }
 						value={ linkTo }
 						onChange={ setLinkTo }
@@ -428,6 +429,7 @@ function GalleryEdit( props ) {
 					/>
 					{ shouldShowSizeOptions && (
 						<SelectControl
+							__nextHasNoMarginBottom
 							label={ __( 'Image size' ) }
 							value={ sizeSlug }
 							options={ imageSizeOptions }

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -51,6 +51,7 @@ function GroupEditControls( { tagName, onSelectTagName } ) {
 	return (
 		<InspectorControls __experimentalGroup="advanced">
 			<SelectControl
+				__nextHasNoMarginBottom
 				label={ __( 'HTML element' ) }
 				options={ [
 					{ label: __( 'Default (<div>)' ), value: 'div' },

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -112,6 +112,7 @@ function PostAuthorEdit( {
 							/>
 						) ) || (
 							<SelectControl
+								__nextHasNoMarginBottom
 								label={ __( 'Author' ) }
 								value={ authorId }
 								options={ authorOptions }
@@ -127,6 +128,7 @@ function PostAuthorEdit( {
 					/>
 					{ showAvatar && (
 						<SelectControl
+							__nextHasNoMarginBottom
 							label={ __( 'Avatar size' ) }
 							value={ attributes.avatarSize }
 							options={ avatarSizes }

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -160,6 +160,7 @@ const DimensionControls = ( {
 					panelId={ clientId }
 				>
 					<SelectControl
+						__nextHasNoMarginBottom
 						label={ __( 'Image size' ) }
 						value={ sizeSlug || DEFAULT_SIZE }
 						options={ imageSizeOptions }

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -144,6 +144,7 @@ export default function QueryInspectorControls( {
 						) }
 						{ showPostTypeControl && (
 							<SelectControl
+								__nextHasNoMarginBottom
 								options={ postTypesSelectOptions }
 								value={ postType }
 								label={ __( 'Post type' ) }

--- a/packages/block-library/src/query/edit/inspector-controls/order-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/order-control.js
@@ -27,6 +27,7 @@ const orderOptions = [
 function OrderControl( { order, orderBy, onChange } ) {
 	return (
 		<SelectControl
+			__nextHasNoMarginBottom
 			label={ __( 'Order by' ) }
 			value={ `${ orderBy }/${ order }` }
 			options={ orderOptions }

--- a/packages/block-library/src/query/edit/inspector-controls/sticky-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/sticky-control.js
@@ -13,6 +13,7 @@ const stickyOptions = [
 export default function StickyControl( { value, onChange } ) {
 	return (
 		<SelectControl
+			__nextHasNoMarginBottom
 			label={ __( 'Sticky posts' ) }
 			options={ stickyOptions }
 			value={ value }

--- a/packages/block-library/src/query/edit/query-content.js
+++ b/packages/block-library/src/query/edit/query-content.js
@@ -113,6 +113,7 @@ export default function QueryContent( {
 			</BlockControls>
 			<InspectorControls __experimentalGroup="advanced">
 				<SelectControl
+					__nextHasNoMarginBottom
 					label={ __( 'HTML element' ) }
 					options={ [
 						{ label: __( 'Default (<div>)' ), value: 'div' },

--- a/packages/block-library/src/tag-cloud/edit.js
+++ b/packages/block-library/src/tag-cloud/edit.js
@@ -109,6 +109,7 @@ function TagCloudEdit( { attributes, setAttributes, taxonomies } ) {
 		<InspectorControls>
 			<PanelBody title={ __( 'Settings' ) }>
 				<SelectControl
+					__nextHasNoMarginBottom
 					label={ __( 'Taxonomy' ) }
 					options={ getTaxonomyOptions() }
 					value={ taxonomy }

--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -63,6 +63,7 @@ export function TemplatePartAdvancedControls( {
 					/>
 
 					<SelectControl
+						__nextHasNoMarginBottom
 						label={ __( 'Area' ) }
 						labelPosition="top"
 						options={ areaOptions }
@@ -72,6 +73,7 @@ export function TemplatePartAdvancedControls( {
 				</>
 			) }
 			<SelectControl
+				__nextHasNoMarginBottom
 				label={ __( 'HTML element' ) }
 				options={ [
 					{

--- a/packages/block-library/src/video/edit-common-settings.js
+++ b/packages/block-library/src/video/edit-common-settings.js
@@ -74,6 +74,7 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 				checked={ !! playsInline }
 			/>
 			<SelectControl
+				__nextHasNoMarginBottom
 				label={ __( 'Preload' ) }
 				value={ preload }
 				onChange={ onChangePreload }

--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -119,6 +119,7 @@ function SingleTrackEditor( { track, onChange, onClose, onRemove } ) {
 					/>
 				</div>
 				<SelectControl
+					__nextHasNoMarginBottom
 					className="block-library-video-tracks-editor__single-track-editor-kind-select"
 					options={ KIND_OPTIONS }
 					value={ kind }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -42,6 +42,7 @@
 -   Lighten the border color on control components ([#46252](https://github.com/WordPress/gutenberg/pull/46252)).
 -   `Popover`: Prevent unnecessary paint when scrolling by using transform instead of top/left positionning ([#46187](https://github.com/WordPress/gutenberg/pull/46187)).
 -   `CircularOptionPicker`: Prevent unecessary paint on hover ([#46197](https://github.com/WordPress/gutenberg/pull/46197)).
+-   `ColorPicker` & `QueryControls`: Replace bottom margin overrides with `__nextHasNoMarginBottom` ([#46448](https://github.com/WordPress/gutenberg/pull/46448)).
 
 ### Experimental
 
@@ -75,6 +76,7 @@
 -   `TabPanel`: Add ability to set icon only tab buttons ([#45005](https://github.com/WordPress/gutenberg/pull/45005)).
 
 ### Internal
+
 -   `AnglePickerControl`: remove `:focus-visible' outline on `CircleOutlineWrapper` ([#45758](https://github.com/WordPress/gutenberg/pull/45758))
 
 ### Bug Fix

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Internal
 
 -   `Dashicon`: remove unnecessary type for `className` prop ([46849](https://github.com/WordPress/gutenberg/pull/46849)).
+-   `ColorPicker` & `QueryControls`: Replace bottom margin overrides with `__nextHasNoMarginBottom` ([#46448](https://github.com/WordPress/gutenberg/pull/46448)).
 
 ## 23.1.0 (2023-01-02)
 
@@ -42,7 +43,6 @@
 -   Lighten the border color on control components ([#46252](https://github.com/WordPress/gutenberg/pull/46252)).
 -   `Popover`: Prevent unnecessary paint when scrolling by using transform instead of top/left positionning ([#46187](https://github.com/WordPress/gutenberg/pull/46187)).
 -   `CircularOptionPicker`: Prevent unecessary paint on hover ([#46197](https://github.com/WordPress/gutenberg/pull/46197)).
--   `ColorPicker` & `QueryControls`: Replace bottom margin overrides with `__nextHasNoMarginBottom` ([#46448](https://github.com/WordPress/gutenberg/pull/46448)).
 
 ### Experimental
 

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -97,6 +97,7 @@ const ColorPicker = (
 			<AuxiliaryColorArtefactWrapper>
 				<AuxiliaryColorArtefactHStackHeader justify="space-between">
 					<SelectControl
+						__nextHasNoMarginBottom
 						options={ options }
 						value={ colorType }
 						onChange={ ( nextColorType ) =>

--- a/packages/components/src/color-picker/styles.ts
+++ b/packages/components/src/color-picker/styles.ts
@@ -9,7 +9,6 @@ import styled from '@emotion/styled';
 import NumberControl from '../number-control';
 import InnerSelectControl from '../select-control';
 import InnerRangeControl from '../range-control';
-import { StyledField } from '../base-control/styles/base-control-styles';
 import { space } from '../ui/utils/space';
 import { boxSizingReset } from '../utils';
 import Button from '../button';
@@ -111,10 +110,6 @@ export const ColorfulWrapper = styled.div`
 	}
 
 	${ interactiveHueStyles }
-
-	${ StyledField } {
-		margin-bottom: 0;
-	}
 `;
 
 export const CopyButton = styled( Button )`

--- a/packages/components/src/query-controls/index.js
+++ b/packages/components/src/query-controls/index.js
@@ -35,6 +35,7 @@ export default function QueryControls( {
 	return [
 		onOrderChange && onOrderByChange && (
 			<SelectControl
+				__nextHasNoMarginBottom
 				key="query-controls-order-select"
 				label={ __( 'Order by' ) }
 				value={ `${ orderBy }/${ order }` }

--- a/packages/edit-post/src/components/sidebar/post-template/form.js
+++ b/packages/edit-post/src/components/sidebar/post-template/form.js
@@ -111,6 +111,7 @@ export default function PostTemplateForm( { onClose } ) {
 				</Notice>
 			) : (
 				<SelectControl
+					__nextHasNoMarginBottom
 					hideLabelFromVision
 					label={ __( 'Template' ) }
 					value={ selectedOption?.value ?? '' }

--- a/packages/edit-site/src/components/sidebar-edit-mode/navigation-menu-sidebar/navigation-inspector.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/navigation-menu-sidebar/navigation-inspector.js
@@ -3,7 +3,10 @@
  */
 import { useSelect } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
-import { SelectControl } from '@wordpress/components';
+import {
+	SelectControl,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { store as coreStore, useEntityBlockEditor } from '@wordpress/core-data';
 import {
 	store as blockEditorStore,
@@ -168,7 +171,7 @@ export default function NavigationInspector() {
 	}, [ isLoadingInnerBlocks, hasLoadedInnerBlocks ] );
 
 	return (
-		<div className="edit-site-navigation-inspector">
+		<VStack>
 			{ hasResolvedNavigationMenus && ! hasNavigationMenus && (
 				<p className="edit-site-navigation-inspector__empty-msg">
 					{ __( 'There are no Navigation Menus.' ) }
@@ -180,6 +183,7 @@ export default function NavigationInspector() {
 			) }
 			{ hasResolvedNavigationMenus && hasMoreThanOneNavigationMenu && (
 				<SelectControl
+					__nextHasNoMarginBottom
 					aria-controls={
 						// aria-controls should only apply when referenced element is in DOM
 						hasLoadedInnerBlocks ? navMenuListId : undefined
@@ -216,6 +220,6 @@ export default function NavigationInspector() {
 					{ __( 'Navigation Menu is empty.' ) }
 				</p>
 			) }
-		</div>
+		</VStack>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/navigation-menu-sidebar/navigation-inspector.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/navigation-menu-sidebar/navigation-inspector.js
@@ -3,10 +3,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
-import {
-	SelectControl,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
 import { store as coreStore, useEntityBlockEditor } from '@wordpress/core-data';
 import {
 	store as blockEditorStore,
@@ -171,7 +168,7 @@ export default function NavigationInspector() {
 	}, [ isLoadingInnerBlocks, hasLoadedInnerBlocks ] );
 
 	return (
-		<VStack>
+		<div className="edit-site-navigation-inspector">
 			{ hasResolvedNavigationMenus && ! hasNavigationMenus && (
 				<p className="edit-site-navigation-inspector__empty-msg">
 					{ __( 'There are no Navigation Menus.' ) }
@@ -184,6 +181,7 @@ export default function NavigationInspector() {
 			{ hasResolvedNavigationMenus && hasMoreThanOneNavigationMenu && (
 				<SelectControl
 					__nextHasNoMarginBottom
+					className="edit-site-navigation-inspector__select-menu"
 					aria-controls={
 						// aria-controls should only apply when referenced element is in DOM
 						hasLoadedInnerBlocks ? navMenuListId : undefined
@@ -220,6 +218,6 @@ export default function NavigationInspector() {
 					{ __( 'Navigation Menu is empty.' ) }
 				</p>
 			) }
-		</VStack>
+		</div>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/navigation-menu-sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/navigation-menu-sidebar/style.scss
@@ -22,6 +22,10 @@
 	.block-editor-list-view-block__menu-cell {
 		padding-right: 0;
 	}
+
+	.edit-site-navigation-inspector__select-menu {
+		margin-bottom: $grid-unit-10;
+	}
 }
 
 .edit-site-navigation-inspector__placeholder {

--- a/packages/edit-site/src/components/template-details/edit-template-title.js
+++ b/packages/edit-site/src/components/template-details/edit-template-title.js
@@ -17,6 +17,7 @@ export default function EditTemplateTitle( { template } ) {
 
 	return (
 		<TextControl
+			__nextHasNoMarginBottom
 			label={ __( 'Title' ) }
 			value={ forceEmpty ? '' : title }
 			help={

--- a/packages/edit-site/src/components/template-details/style.scss
+++ b/packages/edit-site/src/components/template-details/style.scss
@@ -2,6 +2,10 @@
 	.edit-site-template-details__group {
 		margin: 0;
 		padding: $grid-unit-20;
+
+		.edit-site-template-details__area-select {
+			margin-bottom: $grid-unit-10;
+		}
 	}
 
 	.edit-site-template-details__group + .edit-site-template-details__group {

--- a/packages/edit-site/src/components/template-details/style.scss
+++ b/packages/edit-site/src/components/template-details/style.scss
@@ -2,10 +2,6 @@
 	.edit-site-template-details__group {
 		margin: 0;
 		padding: $grid-unit-20;
-
-		.edit-site-template-details__area-select {
-			margin-bottom: $grid-unit-10;
-		}
 	}
 
 	.edit-site-template-details__group + .edit-site-template-details__group {

--- a/packages/edit-site/src/components/template-details/template-part-area-selector.js
+++ b/packages/edit-site/src/components/template-details/template-part-area-selector.js
@@ -28,6 +28,8 @@ export default function TemplatePartAreaSelector( { id } ) {
 
 	return (
 		<SelectControl
+			__nextHasNoMarginBottom
+			className="edit-site-template-details__area-select"
 			label={ __( 'Area' ) }
 			labelPosition="top"
 			options={ areaOptions }

--- a/packages/edit-site/src/components/template-details/template-part-area-selector.js
+++ b/packages/edit-site/src/components/template-details/template-part-area-selector.js
@@ -29,7 +29,6 @@ export default function TemplatePartAreaSelector( { id } ) {
 	return (
 		<SelectControl
 			__nextHasNoMarginBottom
-			className="edit-site-template-details__area-select"
 			label={ __( 'Area' ) }
 			labelPosition="top"
 			options={ areaOptions }

--- a/packages/editor/src/components/post-author/select.js
+++ b/packages/editor/src/components/post-author/select.js
@@ -40,6 +40,7 @@ function PostAuthorSelect() {
 
 	return (
 		<SelectControl
+			__nextHasNoMarginBottom
 			className="post-author-selector"
 			label={ __( 'Author' ) }
 			options={ authorOptions }

--- a/packages/editor/src/components/post-format/index.js
+++ b/packages/editor/src/components/post-format/index.js
@@ -76,6 +76,7 @@ export default function PostFormat() {
 		<PostFormatCheck>
 			<div className="editor-post-format">
 				<SelectControl
+					__nextHasNoMarginBottom
 					label={ __( 'Post Format' ) }
 					value={ postFormat }
 					onChange={ ( format ) => onUpdatePostFormat( format ) }

--- a/packages/editor/src/components/post-template/index.js
+++ b/packages/editor/src/components/post-template/index.js
@@ -44,6 +44,7 @@ export function PostTemplate() {
 
 	return (
 		<SelectControl
+			__nextHasNoMarginBottom
 			label={ __( 'Template:' ) }
 			value={ selectedTemplate }
 			onChange={ ( templateSlug ) => {

--- a/packages/widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/index.js
@@ -57,30 +57,32 @@ function Empty( { attributes: { id, idBase }, setAttributes } ) {
 			icon={ <BlockIcon icon={ brushIcon } /> }
 			label={ __( 'Legacy Widget' ) }
 		>
-			<WidgetTypeSelector
-				selectedId={ id ?? idBase }
-				onSelect={ ( { selectedId, isMulti } ) => {
-					if ( ! selectedId ) {
-						setAttributes( {
-							id: null,
-							idBase: null,
-							instance: null,
-						} );
-					} else if ( isMulti ) {
-						setAttributes( {
-							id: null,
-							idBase: selectedId,
-							instance: {},
-						} );
-					} else {
-						setAttributes( {
-							id: selectedId,
-							idBase: null,
-							instance: null,
-						} );
-					}
-				} }
-			/>
+			<div className="wp-block-legacy-widget__selector-container">
+				<WidgetTypeSelector
+					selectedId={ id ?? idBase }
+					onSelect={ ( { selectedId, isMulti } ) => {
+						if ( ! selectedId ) {
+							setAttributes( {
+								id: null,
+								idBase: null,
+								instance: null,
+							} );
+						} else if ( isMulti ) {
+							setAttributes( {
+								id: null,
+								idBase: selectedId,
+								instance: {},
+							} );
+						} else {
+							setAttributes( {
+								id: selectedId,
+								idBase: null,
+								instance: null,
+							} );
+						}
+					} }
+				/>
+			</div>
 		</Placeholder>
 	);
 }

--- a/packages/widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/index.js
@@ -13,7 +13,7 @@ import {
 	BlockIcon,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { Spinner, Placeholder } from '@wordpress/components';
+import { Flex, FlexBlock, Spinner, Placeholder } from '@wordpress/components';
 import { brush as brushIcon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { useState, useCallback } from '@wordpress/element';
@@ -57,32 +57,34 @@ function Empty( { attributes: { id, idBase }, setAttributes } ) {
 			icon={ <BlockIcon icon={ brushIcon } /> }
 			label={ __( 'Legacy Widget' ) }
 		>
-			<div className="wp-block-legacy-widget__selector-container">
-				<WidgetTypeSelector
-					selectedId={ id ?? idBase }
-					onSelect={ ( { selectedId, isMulti } ) => {
-						if ( ! selectedId ) {
-							setAttributes( {
-								id: null,
-								idBase: null,
-								instance: null,
-							} );
-						} else if ( isMulti ) {
-							setAttributes( {
-								id: null,
-								idBase: selectedId,
-								instance: {},
-							} );
-						} else {
-							setAttributes( {
-								id: selectedId,
-								idBase: null,
-								instance: null,
-							} );
-						}
-					} }
-				/>
-			</div>
+			<Flex>
+				<FlexBlock>
+					<WidgetTypeSelector
+						selectedId={ id ?? idBase }
+						onSelect={ ( { selectedId, isMulti } ) => {
+							if ( ! selectedId ) {
+								setAttributes( {
+									id: null,
+									idBase: null,
+									instance: null,
+								} );
+							} else if ( isMulti ) {
+								setAttributes( {
+									id: null,
+									idBase: selectedId,
+									instance: {},
+								} );
+							} else {
+								setAttributes( {
+									id: selectedId,
+									idBase: null,
+									instance: null,
+								} );
+							}
+						} }
+					/>
+				</FlexBlock>
+			</Flex>
 		</Placeholder>
 	);
 }

--- a/packages/widgets/src/blocks/legacy-widget/edit/widget-type-selector.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/widget-type-selector.js
@@ -27,6 +27,8 @@ export default function WidgetTypeSelector( { selectedId, onSelect } ) {
 
 	return (
 		<SelectControl
+			__nextHasNoMarginBottom
+			className="wp-block-legacy-widget__select-widget"
 			label={ __( 'Select a legacy widget to display:' ) }
 			value={ selectedId ?? '' }
 			options={ [

--- a/packages/widgets/src/blocks/legacy-widget/edit/widget-type-selector.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/widget-type-selector.js
@@ -28,7 +28,6 @@ export default function WidgetTypeSelector( { selectedId, onSelect } ) {
 	return (
 		<SelectControl
 			__nextHasNoMarginBottom
-			className="wp-block-legacy-widget__select-widget"
 			label={ __( 'Select a legacy widget to display:' ) }
 			value={ selectedId ?? '' }
 			options={ [

--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -164,11 +164,12 @@
 }
 
 .wp-block-legacy-widget {
-	.components-base-control {
+	.wp-block-legacy-widget__selector-container {
 		width: 100%;
 	}
-	.components-select-control__input {
-		padding: 0;
-		font-family: system-ui;
+
+	// Replaces margin on BaseControl
+	.wp-block-legacy-widget__select-widget {
+		margin-bottom: $grid-unit-10;
 	}
 }

--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -163,13 +163,3 @@
 	min-width: 400px;
 }
 
-.wp-block-legacy-widget {
-	.wp-block-legacy-widget__selector-container {
-		width: 100%;
-	}
-
-	// Replaces margin on BaseControl
-	.wp-block-legacy-widget__select-widget {
-		margin-bottom: $grid-unit-10;
-	}
-}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

Added new opt-in prop `__nextHasNoMarginBottom` for usages of `SelectControl` in the Gutenberg codebase and removed margin overrides. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Part of this project: https://github.com/WordPress/gutenberg/issues/38730
The tl;dr is `BaseControl` has a `margin-bottom` which makes it difficult to reuse and results in inconsistent use. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By removing margin overrides in the CSS and adding the prop `__nextHasNoMarginBottom`.

## Additional Notes

- `ManageLocations` wasn't updated, as I found this wasn't being used when looking at `CheckboxControl`: https://github.com/WordPress/gutenberg/issues/29102

- I've updated `PostTemplate` although it isn't being used anymore, as it was replaced by `PostTemplateForm`: https://github.com/WordPress/gutenberg/pull/41925#issuecomment-1175744394

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

<details>
<summary><h3>1. The <strong>Site Editor</strong>:</h3></summary>

* ### NavigationInspector

	1. Edit the 'Header' template part or wherever you have a Navigation block
	2. Ensure you have more than one menu created
	3. Click on the Navigation block or add one if there isn't
	4. Click on the 'Open list view' icon in the block toolbar 
	5. Ensure the space select element for menus is the same as before
	
	<img width="284" alt="Screen Shot 2022-12-12 at 2 55 27 PM" src="https://user-images.githubusercontent.com/35543432/207172711-1c58fced-187d-4b76-a53d-4c87ebbee731.png">

* ### TemplatePartAreaSelector

	1. Go to 'Template Parts'
	2. Create a custom template part by clicking 'Add New'
	3. Name it and click 'Create'
	4. Click on the name you gave at the top 
	5. Ensure the space below the select element for 'Area' is the same as before
	
	<img width="246" alt="Screen Shot 2022-12-09 at 1 20 38 PM" src="https://user-images.githubusercontent.com/35543432/206842424-9ecd025f-8b35-4b6a-82bd-3c9643d4a6e1.png">

* ### TemplatePartAdvancedControls

	1. Edit a template in the site editor
	2. Add a Template Part block 
	3. Choose a template or start blank
	4. Go to 'Advanced' in the block inspector
	5. Look for labels 'Area' and 'HTML Element' 
	6. Ensure the space below the select elements is the same as before
	
	<img width="278" alt="Screen Shot 2022-12-12 at 3 03 10 PM" src="https://user-images.githubusercontent.com/35543432/207196326-47592e57-a61e-48ca-8ffa-dd91b082e404.png">


* ### Color Picker 

	1. Open site editor 
	2. Click on the Global Styles icon → then on 'Colors'
	3. Click on Palette
	4. Click on a color 
	5. Ensure the space below the select element is the same as before

	<img width="300" alt="Screen Shot 2022-12-09 at 11 49 37 PM" src="https://user-images.githubusercontent.com/35543432/206842286-facb0c71-5a8a-4ee3-99b0-5a6bb24568c6.png">

</details><details>
<summary><h3>2. The Block Editor:</h3></summary>

* ### DefaultStylePicker

	1. Comment out the following lines: 
		https://github.com/WordPress/gutenberg/blob/b333d1d515c7fe91ec063112a6c178d5ed66b1e4/packages/block-editor/src/components/default-style-picker/index.js#L53-L55
		
	2. Add a Quote block to the editor
	3. Look for 'Default Style' label in the block inspector
	4. Ensure the space below the select element is the same as before
	
	<img width="285" alt="Screen Shot 2022-12-12 at 3 05 00 PM" src="https://user-images.githubusercontent.com/35543432/207175833-ca370ce9-07da-4075-ab47-22b0ff24d580.png">

* ### FontFamilyControl

	1. Add a block that has typography options (e.g. Paragraph block)
	2. Click on three dots menu next to 'Typography' label in the block inspector
	3. Choose 'Font Family'
	4. Ensure the space below the select element for 'Font' is the same as before
	
	<img width="286" alt="Screen Shot 2022-12-12 at 3 06 10 PM" src="https://user-images.githubusercontent.com/35543432/207176363-c7fb266b-0dcf-421e-aee4-98cd3a39e666.png">

* ### For ImageSizeControl

	1. Add image block
	2. Look for the select element under 'Image Size' label in block inspector 
	3. Ensure the space below the select element is the same as before
	
	<img width="285" alt="Screen Shot 2022-11-30 at 6 54 58 PM" src="https://user-images.githubusercontent.com/35543432/206842606-149fae40-d90e-44bc-86f9-a40a92744398.png">

* ### ArchivesEdit

	1. Add Archives block
	2.  Look for the select element under 'Group by:' label in block inspector
	3. Ensure the space below the select element is the same as before
	
	<img width="283" alt="Screen Shot 2022-11-30 at 6 54 15 PM" src="https://user-images.githubusercontent.com/35543432/207172182-ae7c99f1-79f1-4c99-a77c-fd455bced341.png">

* ### AudioEdit

	1. Add Audio block
	2. Upload or add audio from the media library 
	3. Look for the select element under the 'Preload' label in the block inspector
	4. Ensure the space below the select element is the same as before
	
	<img width="291" alt="Screen Shot 2022-11-30 at 6 54 33 PM" src="https://user-images.githubusercontent.com/35543432/207172298-adea2726-206e-4a21-a2f1-8d127981278d.png">

* ### CommentsInspectorControls

	1. Add Comments block 
	2. Open the 'Advanced' section at the bottom of the block inspector
	3. Look for the select element under the 'HTML Element' label 
	4. Ensure the space below the select element is the same as before

	<img width="278" alt="Screen Shot 2022-11-30 at 9 31 27 PM" src="https://user-images.githubusercontent.com/35543432/206842500-e17b63f1-902a-4050-84c1-47fa41d0cfe7.png">

* ### FileBlockInspector

	1. Add File block
	2. Upload / Add PDF from Media Library
	3. Look for the select element under the 'Link to' label in the block inspector
	4. Ensure the space below the select element is the same as before
	
	<img width="287" alt="Screen Shot 2022-12-12 at 3 07 46 PM" src="https://user-images.githubusercontent.com/35543432/207176808-1171d475-0e87-4e99-b3cf-2dc5a4fde803.png">

* ### GalleryEdit

	1. Add gallery block to editor and add media
	2. Ensure you have 'Gallery' selected through block navigation and not a single image
	3. Look for 'Link to' and 'Image Size' labels in block inspector
	4. Ensure space below select elements are the same as before
	
	<img width="288" alt="Screen Shot 2022-12-12 at 3 09 31 PM" src="https://user-images.githubusercontent.com/35543432/207177248-00e3ae31-256e-48cd-82c0-ddd98c1ae459.png">

* ### GalleryEdit V1

	I have tested this myself, and it's a bit involved to test, but here are the steps if using `wp-env` and Docker:
	
	1.  In `gutenberg/.wp-env.json`, change the first line to:
		`"core": "WordPress/WordPress#5.9"`
	2.  Start WordPress with `npm run wp-env start`
	3. Add Gutenberg 12.0 or lower to `/.wp-env/{DOCKER-CONTAINER}/WordPress/wp-content/plugins`
	6. Change the second line in `` to:
		`plugins": [  ],`
	10. Ensure the older version of Gutenberg is there but deactivated 
	11.  Run `npx wp-env run cli wp option set use_balanceTags 1` to enable `useBalanceTags`
	12.  Activate Gutenberg in plugins
	13.  Add a Gallery block to the editor
	14. Look for the 'Link to' and 'Image Size' labels in the block inspector
	15. Ensure the space below select elements is the same as before
	
	<img width="281" alt="Screen Shot 2022-12-09 at 5 58 30 PM" src="https://user-images.githubusercontent.com/35543432/206842373-311b5dff-9009-4a80-9d4a-e689a3851428.png">

* ### GroupEditControls

	1. Add Group block
	2. Open the 'Advanced' section at the bottom of the block inspector
	3. Look for a select element under the 'HTML Element' label 
	4. Ensure the space below the select element is the same as before
	
	<img width="278" alt="Screen Shot 2022-11-30 at 9 31 27 PM" src="https://user-images.githubusercontent.com/35543432/206842500-e17b63f1-902a-4050-84c1-47fa41d0cfe7.png">

* ### PostAuthorEdit 

	1. Add Post Author block
	2. Look for select elements under the 'Author' and 'Avatar size' labels in the block inspector
	3. Ensure the space below select elements is the same as before
	
	<img width="285" alt="Screen Shot 2022-11-30 at 6 58 15 PM" src="https://user-images.githubusercontent.com/35543432/206842595-9eb730ef-09a0-4b6f-a8e0-fa5130cef11e.png">

* ###  QueryControls

	1. Add the Latest Posts block 
	2. Look for the 'Order By' label under 'Sorting and filtering' in the block inspector
	3. Ensure the space below the select element is the same as before

	<img width="301" alt="Screen Shot 2022-12-09 at 11 33 24 PM" src="https://user-images.githubusercontent.com/35543432/206842339-d6a2eb2a-4b60-4289-9f6c-2c5e0d7080a2.png">

* ### DimensionControls

	1.  Add Post Featured Block
	2. Add/upload image to block
	3. Click on three dots menu next to the 'Dimensions' label in the block inspector
	4. Select 'Image Size'
	5. Ensure the space below the 'Image Size' select element is the same as before
	
	<img width="287" alt="Screen Shot 2022-12-12 at 3 11 21 PM" src="https://user-images.githubusercontent.com/35543432/207177774-9038f089-d5f1-4846-81ad-65503875d018.png">

* ### QueryContent & QueryInspectorControls

	**There are a few components to test in the Query loop block inspector so this can be done in one shot:** 
	
	1. Add Query Loop block and select 'Start Blank'
	2. Click any variation 
	3. Look for the following labels in the block inspector and ensure the below select elements' bottom spacing is the same as before:  
		- 'Post Type' 
		- 'Order By'
		- 'Sticky Posts'
	7. Next, go to the bottom of the block inspector and open the 'Advanced' section
	8. Look for the select element under the 'HTML ELement' label 
	9. Ensure the space below the select element is the same as before
	
		| Step 3  | Step 7-9 |
		| ------------- | ------------- |
		|  <img width="281" alt="Screen Shot 2022-12-12 at 3 14 51 PM" src="https://user-images.githubusercontent.com/35543432/207180345-08f9bbf3-2a27-44ea-a093-62e89020aaee.png"> | <img width="290" alt="Screen Shot 2022-12-12 at 3 15 09 PM" src="https://user-images.githubusercontent.com/35543432/207180359-7f2ec688-c6b1-4f93-9e3a-71336908f444.png"> |

* ### TagCloudEdit

	1. Add Tag Cloud to the editor
	2. Look for a select element under the 'Taxonomy' label in the block inspector
	3. Ensure the space below the select element is the same as before
	
	<img width="283" alt="Screen Shot 2022-12-12 at 4 25 38 PM" src="https://user-images.githubusercontent.com/35543432/207196549-d3e1e15b-0cc4-429e-bcf5-3ea9e3db4e6b.png">

* ### VideoSettings && SingleTrackEditor

	1. Add video block
	2. Upload/add video 
	3. Look for the 'Preload' label in the block inspector 
	3. Ensure the space below the select element is the same as before
	7. Click on the block and select 'Text tracks' from the toolbar
	8. Add text track (I used [a sample I found here](https://gist.github.com/samdutton/ca37f3adaf4e23679957b8083e061177))
	
		| Step 3  | Step 7-8 |
		| ------------- | ------------- |
		|  <img width="287" alt="Screen Shot 2022-12-12 at 3 22 41 PM" src="https://user-images.githubusercontent.com/35543432/207180985-267ea8d3-09c0-48bb-82d6-f3bbb8308630.png"> | <img width="382" alt="Screen Shot 2022-12-12 at 3 23 02 PM" src="https://user-images.githubusercontent.com/35543432/207180995-b490e6ae-df06-400d-9bb9-1450dafaa59b.png"> |

* ### PostTemplateForm

	1. In a page or post's inspector, look for 'Template'
	2. Click on the link to the right of it 
	3. Ensure the space below the select element in the popover is the same as before
	
	<img width="308" alt="Screen Shot 2022-12-12 at 3 24 07 PM" src="https://user-images.githubusercontent.com/35543432/207181071-a3608bdf-ccf5-4b20-bef5-2d78fa74e1f7.png">

</details><details>
<summary><h3>3. An older theme (e.g. Twenty Seventeen):</h3></summary>

* ### PostFormat && PostAuthorSelect

	1. Switch to an older theme (e.g. Twenty Seventeen)
	2. Edit a post and go to the Post settings sidebar
	3. Look for select elements under the labels 'Post Format' and 'Author'
	4. Ensure the space below select elements is the same as before
	
	<img width="288" alt="Screen Shot 2022-12-12 at 3 32 14 PM" src="https://user-images.githubusercontent.com/35543432/207182093-6db91167-9873-4d86-a305-a069d56aeff2.png">

	<img width="288" alt="Screen Shot 2022-12-09 at 3 43 51 PM" src="https://user-images.githubusercontent.com/35543432/206842397-b9379450-b4f8-4c66-bb5f-2b72e3174302.png">

* ### WidgetTypeSelector

	1. With the older theme still active, go to 'Appearance → Widgets'
	2. Click on the plus icon to add a 'Legacy Widget' block to one of the widget locations
	3. Ensure the space below the select element is the same as before
	
	<img width="683" alt="Screen Shot 2022-12-12 at 3 32 58 PM" src="https://user-images.githubusercontent.com/35543432/207182174-89a1fb1b-618a-496f-9054-628ae1137f21.png">

</details>
<details><summary><h3>Storybook</h3></summary>

* ### Disabled

	1. Run storybook with this branch checked out
	2. See that bottom margin has been removed
	
	![Screen Shot 2022-12-13 at 11 09 54 PM](https://user-images.githubusercontent.com/35543432/207529833-6ff9b76c-bf0a-4922-b848-1e05f039be7e.png)

</details>
<hr>
<details>
<summary><h4>Checklist template (if it helps for testing)</h4></summary>

### Site Editor:

- [ ] NavigationInspector
- [ ] TemplatePartAreaSelector
- [ ] TemplatePartAdvancedControls
- [ ] ColorPicker 

### Block Editor: 

- [ ] DefaultStylePicker
- [ ] FontFamilyControl
- [ ] ImageSizeControl
- [ ] ArchivesEdit
- [ ] AudioEdit
- [ ] CommentsInspectorControls
- [ ] FileBlockInspector
- [ ] GalleryEdit
- [ ] GalleryEdit V1
- [ ] GroupEditControls
- [ ] PostAuthorEdit
- [ ] QueryControls
- [ ] DimensionComtrols
- [ ] QueryContent & QueryInspectorControls
     - [ ] OrderControl
     - [ ] StickyControl
- [ ] TagCloudEdit
- [ ] VideoSettings & SingleTrackEditor
- [ ] ManageLocations
- [ ] PostTemplateForm
- [ ] PostTemplate
- [ ] TagCloudEdit

### With an older theme:

- [ ] PostFormat & PostAuthorSelect
- [ ] WidgetTypeSelector

### Storybook

- [ ] Disabled

</details>