### PR TITLE
E2E tests: Add width and color test to button block

### DIFF
--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -255,13 +255,21 @@ test.describe( 'Buttons', () => {
 		await page.click( COLOR_INPUT_FIELD_SELECTOR );
 		await pageUtils.pressKeyWithModifier( 'primary', 'a' );
 		await page.keyboard.type( 'ff0000' );
+		await page.keyboard.press( 'Escape' );
+		await page.click(
+			'role=button[name=/^Gradient control point at position 100% with color code/]'
+		);
+		await page.waitForSelector( COLOR_INPUT_FIELD_SELECTOR );
+		await page.click( COLOR_INPUT_FIELD_SELECTOR );
+		await pageUtils.pressKeyWithModifier( 'primary', 'a' );
+		await page.keyboard.type( '00ff00' );
 
 		// Check the content.
 		const content = await editor.getEditedPostContent();
 		expect( content ).toBe(
 			`<!-- wp:buttons -->
-<div class=\"wp-block-buttons\"><!-- wp:button {\"style\":{\"color\":{\"gradient\":\"linear-gradient(135deg,rgb(255,0,0) 0%,rgb(155,81,224) 100%)\"}}} -->
-<div class=\"wp-block-button\"><a class=\"wp-block-button__link has-background wp-element-button\" style=\"background:linear-gradient(135deg,rgb(255,0,0) 0%,rgb(155,81,224) 100%)\">Content</a></div>
+<div class=\"wp-block-buttons\"><!-- wp:button {\"style\":{\"color\":{\"gradient\":\"linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,255,0) 100%)\"}}} -->
+<div class=\"wp-block-button\"><a class=\"wp-block-button__link has-background wp-element-button\" style=\"background:linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,255,0) 100%)\">Content</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->`
 		);

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -220,6 +220,12 @@ test.describe( 'Buttons', () => {
 			'role=region[name="Editor settings"i] >> role=button[name="Background"i]'
 		);
 		await page.click( 'role=tab[name="Gradient"i]' );
+
+		// eslint-disable-next-line no-console
+		console.log(
+			await page.innerHTML( '.components-tab-panel__tab-content' )
+		);
+
 		await page.click(
 			'role=button[name="Gradient: Vivid cyan blue to vivid purple"i]'
 		);

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -220,22 +220,14 @@ test.describe( 'Buttons', () => {
 			'role=region[name="Editor settings"i] >> role=button[name="Background"i]'
 		);
 		await page.click( 'role=tab[name="Gradient"i]' );
-
-		// eslint-disable-next-line no-console
-		console.log(
-			await page.innerHTML( '.components-tab-panel__tab-content' )
-		);
-
-		await page.click(
-			'role=button[name="Gradient: Vivid cyan blue to vivid purple"i]'
-		);
+		await page.click( 'role=button[name="Gradient: Purple to yellow"i]' );
 
 		// Check the content.
 		const content = await editor.getEditedPostContent();
 		expect( content ).toBe(
 			`<!-- wp:buttons -->
-<div class=\"wp-block-buttons\"><!-- wp:button {\"gradient\":\"vivid-cyan-blue-to-vivid-purple\"} -->
-<div class=\"wp-block-button\"><a class=\"wp-block-button__link has-vivid-cyan-blue-to-vivid-purple-gradient-background has-background wp-element-button\">Content</a></div>
+<div class=\"wp-block-buttons\"><!-- wp:button {\"gradient\":\"purple-to-yellow\"} -->
+<div class=\"wp-block-button\"><a class=\"wp-block-button__link has-purple-to-yellow-gradient-background has-background wp-element-button\">Content</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->`
 		);

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -4,6 +4,9 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Buttons', () => {
+	const COLOR_INPUT_FIELD_SELECTOR =
+		'.components-color-picker .components-input-control__input';
+
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
 	} );
@@ -122,6 +125,143 @@ test.describe( 'Buttons', () => {
 			`<!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button -->
 <div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="https://www.wordpress.org/">WordPress</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->`
+		);
+	} );
+
+	test( 'can resize width', async ( { editor, page } ) => {
+		await editor.insertBlock( { name: 'core/buttons' } );
+		await page.keyboard.type( 'Content' );
+		await editor.openDocumentSettingsSidebar();
+		await page.click(
+			'role=group[name="Button width"i] >> role=button[name="25%"i]'
+		);
+
+		// Check the content.
+		const content = await editor.getEditedPostContent();
+		expect( content ).toBe(
+			`<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"width":25} -->
+<div class="wp-block-button has-custom-width wp-block-button__width-25"><a class="wp-block-button__link wp-element-button">Content</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->`
+		);
+	} );
+
+	test( 'can apply named colors', async ( { editor, page } ) => {
+		await editor.insertBlock( { name: 'core/buttons' } );
+		await page.keyboard.type( 'Content' );
+		await editor.openDocumentSettingsSidebar();
+
+		await page.click(
+			'role=region[name="Editor settings"i] >> button:has-text("Text")'
+		);
+		await page.click( 'role=button[name="Color: White"i]' );
+		await page.click(
+			'role=region[name="Editor settings"i] >> button:has-text("Background")'
+		);
+		await page.click( 'role=button[name="Color: Vivid red"i]' );
+
+		// Check the content.
+		const content = await editor.getEditedPostContent();
+		expect( content ).toBe(
+			`<!-- wp:buttons -->
+<div class=\"wp-block-buttons\"><!-- wp:button {\"backgroundColor\":\"vivid-red\",\"textColor\":\"base\"} -->
+<div class=\"wp-block-button\"><a class=\"wp-block-button__link has-base-color has-vivid-red-background-color has-text-color has-background wp-element-button\">Content</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->`
+		);
+	} );
+
+	test( 'can apply custom colors', async ( { editor, page, pageUtils } ) => {
+		await editor.insertBlock( { name: 'core/buttons' } );
+		await page.keyboard.type( 'Content' );
+		await editor.openDocumentSettingsSidebar();
+
+		await page.click(
+			'role=region[name="Editor settings"i] >> button:has-text("Text")'
+		);
+		await page.click( 'role=button[name="Custom color picker."i]' );
+		await page.waitForSelector( COLOR_INPUT_FIELD_SELECTOR );
+		await page.click( COLOR_INPUT_FIELD_SELECTOR );
+		await pageUtils.pressKeyWithModifier( 'primary', 'a' );
+		await page.keyboard.type( 'ff0000' );
+
+		await page.click(
+			'role=region[name="Editor settings"i] >> button:has-text("Background")'
+		);
+		await page.click( 'role=button[name="Custom color picker."i]' );
+		await page.waitForSelector( COLOR_INPUT_FIELD_SELECTOR );
+		await page.click( COLOR_INPUT_FIELD_SELECTOR );
+		await pageUtils.pressKeyWithModifier( 'primary', 'a' );
+		await page.keyboard.type( '00ff00' );
+
+		// Check the content.
+		const content = await editor.getEditedPostContent();
+		expect( content ).toBe(
+			`<!-- wp:buttons -->
+<div class=\"wp-block-buttons\"><!-- wp:button {\"style\":{\"color\":{\"text\":\"#ff0000\",\"background\":\"#00ff00\"}}} -->
+<div class=\"wp-block-button\"><a class=\"wp-block-button__link has-text-color has-background wp-element-button\" style=\"color:#ff0000;background-color:#00ff00\">Content</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->`
+		);
+	} );
+
+	test( 'can apply named gradient background color', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( { name: 'core/buttons' } );
+		await page.keyboard.type( 'Content' );
+		await editor.openDocumentSettingsSidebar();
+
+		await page.click(
+			'role=region[name="Editor settings"i] >> button:has-text("Background")'
+		);
+		await page.click( 'role=tab[name="Gradient"i]' );
+		await page.click(
+			'role=button[name="Gradient: Vivid cyan blue to vivid purple"i]'
+		);
+
+		// Check the content.
+		const content = await editor.getEditedPostContent();
+		expect( content ).toBe(
+			`<!-- wp:buttons -->
+<div class=\"wp-block-buttons\"><!-- wp:button {\"gradient\":\"vivid-cyan-blue-to-vivid-purple\"} -->
+<div class=\"wp-block-button\"><a class=\"wp-block-button__link has-vivid-cyan-blue-to-vivid-purple-gradient-background has-background wp-element-button\">Content</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->`
+		);
+	} );
+
+	test( 'can apply custom gradient background color', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( { name: 'core/buttons' } );
+		await page.keyboard.type( 'Content' );
+		await editor.openDocumentSettingsSidebar();
+
+		await page.click(
+			'role=region[name="Editor settings"i] >> button:has-text("Background")'
+		);
+		await page.click( 'role=tab[name="Gradient"i]' );
+		await page.click(
+			'role=button[name=/^Gradient control point at position 0% with color code/]'
+		);
+		await page.waitForSelector( COLOR_INPUT_FIELD_SELECTOR );
+		await page.click( COLOR_INPUT_FIELD_SELECTOR );
+		await pageUtils.pressKeyWithModifier( 'primary', 'a' );
+		await page.keyboard.type( 'ff0000' );
+
+		// Check the content.
+		const content = await editor.getEditedPostContent();
+		expect( content ).toBe(
+			`<!-- wp:buttons -->
+<div class=\"wp-block-buttons\"><!-- wp:button {\"style\":{\"color\":{\"gradient\":\"linear-gradient(135deg,rgb(255,0,0) 0%,rgb(155,81,224) 100%)\"}}} -->
+<div class=\"wp-block-button\"><a class=\"wp-block-button__link has-background wp-element-button\" style=\"background:linear-gradient(135deg,rgb(255,0,0) 0%,rgb(155,81,224) 100%)\">Content</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->`
 		);

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -4,9 +4,6 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Buttons', () => {
-	const COLOR_INPUT_FIELD_SELECTOR =
-		'.components-color-picker .components-input-control__input';
-
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
 	} );
@@ -174,7 +171,7 @@ test.describe( 'Buttons', () => {
 		);
 	} );
 
-	test( 'can apply custom colors', async ( { editor, page, pageUtils } ) => {
+	test( 'can apply custom colors', async ( { editor, page } ) => {
 		await editor.insertBlock( { name: 'core/buttons' } );
 		await page.keyboard.type( 'Content' );
 		await editor.openDocumentSettingsSidebar();
@@ -183,17 +180,13 @@ test.describe( 'Buttons', () => {
 			'role=region[name="Editor settings"i] >> role=button[name="Text"i]'
 		);
 		await page.click( 'role=button[name="Custom color picker."i]' );
-		await page.click( COLOR_INPUT_FIELD_SELECTOR );
-		await pageUtils.pressKeyWithModifier( 'primary', 'a' );
-		await page.keyboard.type( 'ff0000' );
+		await page.fill( 'role=textbox[name="Hex color"i]', 'ff0000' );
 
 		await page.click(
 			'role=region[name="Editor settings"i] >> role=button[name="Background"i]'
 		);
 		await page.click( 'role=button[name="Custom color picker."i]' );
-		await page.click( COLOR_INPUT_FIELD_SELECTOR );
-		await pageUtils.pressKeyWithModifier( 'primary', 'a' );
-		await page.keyboard.type( '00ff00' );
+		await page.fill( 'role=textbox[name="Hex color"i]', '00ff00' );
 
 		// Check the content.
 		const content = await editor.getEditedPostContent();
@@ -234,7 +227,6 @@ test.describe( 'Buttons', () => {
 	test( 'can apply custom gradient background color', async ( {
 		editor,
 		page,
-		pageUtils,
 	} ) => {
 		await editor.insertBlock( { name: 'core/buttons' } );
 		await page.keyboard.type( 'Content' );
@@ -247,16 +239,12 @@ test.describe( 'Buttons', () => {
 		await page.click(
 			'role=button[name=/^Gradient control point at position 0% with color code/]'
 		);
-		await page.click( COLOR_INPUT_FIELD_SELECTOR );
-		await pageUtils.pressKeyWithModifier( 'primary', 'a' );
-		await page.keyboard.type( 'ff0000' );
+		await page.fill( 'role=textbox[name="Hex color"i]', 'ff0000' );
 		await page.keyboard.press( 'Escape' );
 		await page.click(
 			'role=button[name=/^Gradient control point at position 100% with color code/]'
 		);
-		await page.click( COLOR_INPUT_FIELD_SELECTOR );
-		await pageUtils.pressKeyWithModifier( 'primary', 'a' );
-		await page.keyboard.type( '00ff00' );
+		await page.fill( 'role=textbox[name="Hex color"i]', '00ff00' );
 
 		// Check the content.
 		const content = await editor.getEditedPostContent();

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -155,11 +155,11 @@ test.describe( 'Buttons', () => {
 		await editor.openDocumentSettingsSidebar();
 
 		await page.click(
-			'role=region[name="Editor settings"i] >> button:has-text("Text")'
+			'role=region[name="Editor settings"i] >> role=button[name="Text"i]'
 		);
 		await page.click( 'role=button[name="Color: White"i]' );
 		await page.click(
-			'role=region[name="Editor settings"i] >> button:has-text("Background")'
+			'role=region[name="Editor settings"i] >> role=button[name="Background"i]'
 		);
 		await page.click( 'role=button[name="Color: Vivid red"i]' );
 
@@ -180,7 +180,7 @@ test.describe( 'Buttons', () => {
 		await editor.openDocumentSettingsSidebar();
 
 		await page.click(
-			'role=region[name="Editor settings"i] >> button:has-text("Text")'
+			'role=region[name="Editor settings"i] >> role=button[name="Text"i]'
 		);
 		await page.click( 'role=button[name="Custom color picker."i]' );
 		await page.waitForSelector( COLOR_INPUT_FIELD_SELECTOR );
@@ -189,7 +189,7 @@ test.describe( 'Buttons', () => {
 		await page.keyboard.type( 'ff0000' );
 
 		await page.click(
-			'role=region[name="Editor settings"i] >> button:has-text("Background")'
+			'role=region[name="Editor settings"i] >> role=button[name="Background"i]'
 		);
 		await page.click( 'role=button[name="Custom color picker."i]' );
 		await page.waitForSelector( COLOR_INPUT_FIELD_SELECTOR );
@@ -217,7 +217,7 @@ test.describe( 'Buttons', () => {
 		await editor.openDocumentSettingsSidebar();
 
 		await page.click(
-			'role=region[name="Editor settings"i] >> button:has-text("Background")'
+			'role=region[name="Editor settings"i] >> role=button[name="Background"i]'
 		);
 		await page.click( 'role=tab[name="Gradient"i]' );
 		await page.click(
@@ -245,7 +245,7 @@ test.describe( 'Buttons', () => {
 		await editor.openDocumentSettingsSidebar();
 
 		await page.click(
-			'role=region[name="Editor settings"i] >> button:has-text("Background")'
+			'role=region[name="Editor settings"i] >> role=button[name="Background"i]'
 		);
 		await page.click( 'role=tab[name="Gradient"i]' );
 		await page.click(

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -157,7 +157,7 @@ test.describe( 'Buttons', () => {
 		await page.click(
 			'role=region[name="Editor settings"i] >> role=button[name="Text"i]'
 		);
-		await page.click( 'role=button[name="Color: White"i]' );
+		await page.click( 'role=button[name="Color: Cyan bluish gray"i]' );
 		await page.click(
 			'role=region[name="Editor settings"i] >> role=button[name="Background"i]'
 		);
@@ -167,8 +167,8 @@ test.describe( 'Buttons', () => {
 		const content = await editor.getEditedPostContent();
 		expect( content ).toBe(
 			`<!-- wp:buttons -->
-<div class=\"wp-block-buttons\"><!-- wp:button {\"backgroundColor\":\"vivid-red\",\"textColor\":\"base\"} -->
-<div class=\"wp-block-button\"><a class=\"wp-block-button__link has-base-color has-vivid-red-background-color has-text-color has-background wp-element-button\">Content</a></div>
+<div class=\"wp-block-buttons\"><!-- wp:button {\"backgroundColor\":\"vivid-red\",\"textColor\":\"cyan-bluish-gray\"} -->
+<div class=\"wp-block-button\"><a class=\"wp-block-button__link has-cyan-bluish-gray-color has-vivid-red-background-color has-text-color has-background wp-element-button\">Content</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->`
 		);

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -183,7 +183,6 @@ test.describe( 'Buttons', () => {
 			'role=region[name="Editor settings"i] >> role=button[name="Text"i]'
 		);
 		await page.click( 'role=button[name="Custom color picker."i]' );
-		await page.waitForSelector( COLOR_INPUT_FIELD_SELECTOR );
 		await page.click( COLOR_INPUT_FIELD_SELECTOR );
 		await pageUtils.pressKeyWithModifier( 'primary', 'a' );
 		await page.keyboard.type( 'ff0000' );
@@ -192,7 +191,6 @@ test.describe( 'Buttons', () => {
 			'role=region[name="Editor settings"i] >> role=button[name="Background"i]'
 		);
 		await page.click( 'role=button[name="Custom color picker."i]' );
-		await page.waitForSelector( COLOR_INPUT_FIELD_SELECTOR );
 		await page.click( COLOR_INPUT_FIELD_SELECTOR );
 		await pageUtils.pressKeyWithModifier( 'primary', 'a' );
 		await page.keyboard.type( '00ff00' );
@@ -249,7 +247,6 @@ test.describe( 'Buttons', () => {
 		await page.click(
 			'role=button[name=/^Gradient control point at position 0% with color code/]'
 		);
-		await page.waitForSelector( COLOR_INPUT_FIELD_SELECTOR );
 		await page.click( COLOR_INPUT_FIELD_SELECTOR );
 		await pageUtils.pressKeyWithModifier( 'primary', 'a' );
 		await page.keyboard.type( 'ff0000' );
@@ -257,7 +254,6 @@ test.describe( 'Buttons', () => {
 		await page.click(
 			'role=button[name=/^Gradient control point at position 100% with color code/]'
 		);
-		await page.waitForSelector( COLOR_INPUT_FIELD_SELECTOR );
 		await page.click( COLOR_INPUT_FIELD_SELECTOR );
 		await pageUtils.pressKeyWithModifier( 'primary', 'a' );
 		await page.keyboard.type( '00ff00' );


### PR DESCRIPTION
Closes: #29992

## What?
This PR adds a test for width and colors (text, background color, gradient color) to the E2E test for the button block.

## Why?
To cover more test cases and to prevent regressions reported in #29992.

## How?
This test adds the following five test cases:

- can resize width
- can apply named colors
- can apply custom colors
- can apply named gradient background color
- can apply custom gradient background color

## Testing Instructions
Run either of the following:

- `npm run test:e2e:playwright test/e2e/specs/editor/blocks/buttons.spec.js`
- `npm run test:e2e:playwright test/e2e/specs/editor/blocks/buttons.spec.js -- --headed`

> **Note**
> To run the test locally, you may need to change the active theme to Twenty Twenty One beforehand. As far as I know, [GitHub Actions uses Twnety Twenty One to test blocks](https://github.com/WordPress/gutenberg/blob/b333d1d515c7fe91ec063112a6c178d5ed66b1e4/packages/e2e-test-utils-playwright/src/test.ts#L143). For other themes, the test will fail because the selectors in the gradient palette don’t match. I would appreciate any advice on a good solution to this.