### PR TITLE
Modal: Fix unexpected modal closing in IME Composition

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 -   `ColorPalette`: show "Clear" button even when colors array is empty ([#46001](https://github.com/WordPress/gutenberg/pull/46001)).
 -   `InputControl`: Fix internal `Flex` wrapper usage that could add an unintended `height: 100%` ([#46213](https://github.com/WordPress/gutenberg/pull/46213)).
+-   `Modal`: Fix unexpected modal closing in IME Composition ([#46453](https://github.com/WordPress/gutenberg/pull/46453)).
 
 ### Enhancements
 

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -99,6 +99,17 @@ function UnforwardedModal(
 
 	function handleEscapeKeyDown( event: KeyboardEvent< HTMLDivElement > ) {
 		if (
+			// Ignore keydowns from IMEs
+			event.nativeEvent.isComposing ||
+			// Workaround for Mac Safari where the final Enter/Backspace of an IME composition
+			// is `isComposing=false`, even though it's technically still part of the composition.
+			// These can only be detected by keyCode.
+			event.keyCode === 229
+		) {
+			return;
+		}
+
+		if (
 			shouldCloseOnEsc &&
 			event.code === 'Escape' &&
 			! event.defaultPrevented

--- a/packages/components/src/modal/stories/index.tsx
+++ b/packages/components/src/modal/stories/index.tsx
@@ -12,6 +12,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import Button from '../../button';
+import InputControl from '../../input-control';
 import Modal from '../';
 import type { ModalProps } from '../types';
 
@@ -74,6 +75,8 @@ const Template: ComponentStory< typeof Modal > = ( {
 						non proident, sunt in culpa qui officia deserunt mollit
 						anim id est laborum.
 					</p>
+
+					<InputControl style={ { marginBottom: '20px' } } />
 
 					<Button variant="secondary" onClick={ closeModal }>
 						Close Modal

--- a/packages/components/src/modal/test/index.tsx
+++ b/packages/components/src/modal/test/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -68,5 +69,19 @@ describe( 'Modal', () => {
 		const dialog = screen.getByRole( 'dialog' );
 		const title = within( dialog ).queryByText( 'Test Title' );
 		expect( title ).not.toBeInTheDocument();
+	} );
+
+	it( 'should call onRequestClose when the escape key is pressed', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
+		const onRequestClose = jest.fn();
+		render(
+			<Modal onRequestClose={ onRequestClose }>
+				<p>Modal content</p>
+			</Modal>
+		);
+		await user.keyboard( '[Escape]' );
+		expect( onRequestClose ).toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
Part of #45605

## What?
This PR fixes unexpected modal closing in IME Composition.

## Why?
In IME composition, the `escape` key is used to cancel character committing. This event is detected as a modal close action, causing unexpected modal close processing.


https://user-images.githubusercontent.com/54422211/206904110-3982efa0-792e-4c10-a4b7-04b8f0eb5ae0.mp4

## How?
Added determination of whether or not the compose is in progress, as was done with #45607 and #45626.

At the same time, I added a unit test to confirm that the modal should be closed with the `escape` key.

## Testing Instructions
- Build the storybook and access the modal page (Or, open a modal with an input element, such as Add New Template Part.).
- Focus on the input element and enter text in an IME composition.
- Press the escape key while the input is not confirmed (a wavy line is displayed under the character).
- Pressing the escape key for **the first time** will erase the candidate list for conversion.
- Pressing the escape key for **the second time** will cancel the input of a character and makes it disappear.
- Pressing the escape key for **the third time** will hide the modal as intended.

In addition, I have confirmed that the following browsers work as expected in Windows 11:

- ✅ Google Chrome Version 108.0.5359.99
- ✅ Microsoft Edge Version 108.0.1462.46
- ✅ FireFox Version 107.0.1 

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/54422211/206887404-ac7239b9-911d-437d-8e87-7da9eef6829d.mp4



