### PR TITLE
Columns mobile edit: remove unused updateBlockSettings action bind

### DIFF
--- a/packages/block-library/src/columns/edit.native.js
+++ b/packages/block-library/src/columns/edit.native.js
@@ -332,11 +332,6 @@ const ColumnsEditContainerWrapper = withDispatch(
 				width: value,
 			} );
 		},
-		updateBlockSettings( settings ) {
-			const { clientId } = ownProps;
-			const { updateBlockListSettings } = dispatch( blockEditorStore );
-			updateBlockListSettings( clientId, settings );
-		},
 		/**
 		 * Updates the column columnCount, including necessary revisions to child Column
 		 * blocks to grant required or redistribute available space.


### PR DESCRIPTION
A simple code cleanup PR that removes an unused bind of the `updateBlockListSettings` action. Found this when searching the codebase for places where block list settings get updated.