### PR TITLE
@wordpress/create-block: Allow dynamic construction of configs

### DIFF
--- a/packages/create-block/docs/external-template.md
+++ b/packages/create-block/docs/external-template.md
@@ -104,3 +104,20 @@ The following configurable variables are used with the template files. Template 
 -   `style` (default: `'file:./style-index.css'`) – a frontend and editor style definition.
 -   `render` (no default) – a path to the PHP file used when rendering the block type on the server before presenting on the front end.
 -   `customBlockJSON` (no default) - allows definition of additional properties for the generated block.json file.
+
+### Dynamic Configs
+
+Configurations can be dynamically constructed to allow for asynchronous functions.
+
+_Example:_
+
+```js
+module.exports = ( async function () {
+	const title = await getAsyncTitle();
+	return {
+		defaultValues: {
+			title,
+		},
+	};
+} )();
+```

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -161,9 +161,11 @@ const getPluginTemplate = async ( templateName ) => {
 
 	try {
 		if ( existsSync( resolve( templateName ) ) ) {
-			return await configToTemplate( require( resolve( templateName ) ) );
+			return await configToTemplate(
+				await require( resolve( templateName ) )
+			);
 		}
-		return await configToTemplate( require( templateName ) );
+		return await configToTemplate( await require( templateName ) );
 	} catch ( error ) {
 		if ( error instanceof CLIError ) {
 			throw error;
@@ -198,7 +200,7 @@ const getPluginTemplate = async ( templateName ) => {
 
 		const { name } = npmPackageArg( templateName );
 		return await configToTemplate(
-			require( require.resolve( name, {
+			await require( require.resolve( name, {
 				paths: [ tempCwd ],
 			} ) )
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

`@wordpress/create-block` can be used to create [External Project Templates](https://github.com/WordPress/gutenberg/blob/5544df110c528521719180548d2dcd6198a2ef61/packages/create-block/docs/external-template.md) which are project scaffolds for uses other than Blocks. This pull request adds `await` before the `require` statements pulling in the Template configurations. This allows `module.exports` to be a self invoked async function that returns a configuration object.

The motivation is to be able to make asynchronous requests before finalising the configuration. For example, [this WooCommerce pull request to a project template](https://github.com/woocommerce/woocommerce/pull/35922) configures `wp-env` with the latest version of WooCommerce. The latest version is derived from an asynchronous call to wordpress.org API. 

## Why?

When scaffolding out a project depends on data that is required at run time, changes in this PR allow use of `async` API calls before gathering a Project Template's configuration data.

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The `require` calls gathering Project Template modules are already wrapped in `async` functions, so I've added the `wait` keyword to allow consumption of async functions.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

These testing instruction require the use of an outside template. You can create one or use the one from this pull request https://github.com/woocommerce/woocommerce/pull/35922.

1. Pull down WooCommerce Monorepo.
2. Checkout branch `add/create-extensions-dynamic-config` from https://github.com/woocommerce/woocommerce/pull/35922
3. `pnpm install`
4. In a separate folder run the following command:

```
npx ../gutenberg/packages/create-block -t ../woocommerce/packages/js/create-extension my-extension-name
```
5. See the resulting project `my-extension-name` have a `.wp-env.json` file correctly configured with a download link pointing to the latest version of WooCommerce, which is `7.1.1` as of this writing.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

This is entirely keyboard instructions.

## Screenshots or screencast <!-- if applicable -->
