### PR TITLE
Try show navigation menu name in the block inspector, toolbar, list view and breadcrumbs

### DIFF
--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -88,6 +88,8 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 	} );
 	const isReusable = blocks.length === 1 && isReusableBlock( blocks[ 0 ] );
 	const isTemplate = blocks.length === 1 && isTemplatePart( blocks[ 0 ] );
+	const isNavigation =
+		blocks.length === 1 && blocks[ 0 ].name === 'core/navigation';
 
 	function selectForMultipleBlocks( insertedBlocks ) {
 		if ( insertedBlocks.length > 1 ) {
@@ -129,7 +131,7 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 					icon={
 						<>
 							<BlockIcon icon={ icon } showColors />
-							{ ( isReusable || isTemplate ) && (
+							{ ( isReusable || isTemplate || isNavigation ) && (
 								<span className="block-editor-block-switcher__toggle-text">
 									{ blockTitle }
 								</span>
@@ -183,7 +185,9 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 									className="block-editor-block-switcher__toggle"
 									showColors
 								/>
-								{ ( isReusable || isTemplate ) && (
+								{ ( isReusable ||
+									isTemplate ||
+									isNavigation ) && (
 									<span className="block-editor-block-switcher__toggle-text">
 										{ blockTitle }
 									</span>

--- a/packages/block-library/src/navigation/index.js
+++ b/packages/block-library/src/navigation/index.js
@@ -1,8 +1,16 @@
 /**
+ * External dependencies
+ */
+import { capitalCase } from 'change-case';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { navigation as icon } from '@wordpress/icons';
+import { store as coreDataStore } from '@wordpress/core-data';
+import { select } from '@wordpress/data';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -46,6 +54,27 @@ export const settings = {
 				},
 			},
 		],
+	},
+	__experimentalLabel: ( { ref } ) => {
+		// Attempt to find entity title if block is a template part.
+		// Require slug to request, otherwise entity is uncreated and will throw 404.
+		if ( ! ref ) {
+			return;
+		}
+
+		const entity = select( coreDataStore ).getEntityRecord(
+			'postType',
+			'wp_navigation',
+			ref
+		);
+		if ( ! entity ) {
+			return;
+		}
+
+		return (
+			decodeEntities( entity.title?.rendered ) ||
+			capitalCase( entity.slug )
+		);
 	},
 	edit,
 	save,


### PR DESCRIPTION
## What?
Related #43261
Fixes #42154

Shows the navigation menu name in the block inspector, list view and breadcrumbs.

## Why?
If we explore the navigation block being considered a 'synced' block

## How?
- Implements `__experimentalLabel` for the navigation block, in much the same way as the template part block implements this.
- Adjusts the condition for showing the block title in the toolbar to include the nav block.
- Use the `useBlockDisplayTitle` hook for showing the title in the inspector. Does this for template part, reusable and navigation blocks.

A lot of this code could be improved. For example `useBlockDisplayInformation` should really return the data that `useBlockDisplayTitle` does. Hard coded checks for block types also shouldn't be necessary in the long run.

For accessibility, I think it'd be good if some of these places did still include the normal block title as part of the aria label or description. Sighted users can often infer this from the block logo and other visual clues, but that's not always possible when using a screen reader.

It's an existing bug, so a fix could be attempted in a separate PR.

## Testing Instructions
Prerequisite: Ensure your navigation block menu isn't called 'Navigation'.

1. Add a navigation block to a post/template and select it, or use a template that has an existing navigation block
2. Observe the menu name on the toolbar and breadcrumbs
3. Open the block inspector
4. See the menu name where the block name used to be
5. Open List View
6. See the menu name

### Testing Instructions for Keyboard
1. Add a navigation block by creating a new post, tabbing to the content and typing '/navigation' followed by Enter.
2. Tab to the block inspector and keep tabbing until you reach the 'Select Menu' dropdown
3. Open the dropdown, and if you have a menu called something different to 'Navigation', select that. If you have no menus, create a new one. If you then only have a menu called 'Navigation', tab to the 'Advanced' section in the Block Inspector, press space to open it, and then tab to the Menu Name field and rename the menu to something different (e.g. 'My Menu').
4. Shift tab (or navigate regions) to the editor header, and tab to the publish button and save everything.
5. Shift tab to 'Document Overview' and press enter open it
6. Find the navigation block you created earlier. It should be announced using the menu name. Use up down arrow keys to navigate blocks in List View if needed. Make sure the block is selected by using Enter to select it.
7. Shift Tab to the block toolbar, the block should be announced using the menu name.
8. Tab to the block inspector, the menu name won't be announced but will be part of the block information, the first text after the close settings button
9. Tab to the editor footer until you get to the 'Post' button that's part of the breadcrumbs. Read the text after this button, it should be the menu name.

## Screenshots or screencast <!-- if applicable -->
### Toolbar and Inspector
![Screen Shot 2022-12-12 at 3 27 36 pm](https://user-images.githubusercontent.com/677833/206994108-c6867a19-618c-4635-b225-73adb212e7d4.png)

### List View
![Screen Shot 2022-12-12 at 3 27 45 pm](https://user-images.githubusercontent.com/677833/206994136-e0e6e002-1329-4bd7-aa89-027f8733db50.png)

### Breadcrumbs
![Screen Shot 2022-12-12 at 3 27 51 pm](https://user-images.githubusercontent.com/677833/206994152-3ed46ce0-5174-4867-bcb8-cff1ff6a5959.png)

