### PR TITLE
Always run initialization code before Playwright e2e tests

### DIFF
--- a/packages/e2e-test-utils-playwright/src/test.ts
+++ b/packages/e2e-test-utils-playwright/src/test.ts
@@ -153,7 +153,7 @@ const test = base.extend<
 
 			await use( requestUtils );
 		},
-		{ scope: 'worker' },
+		{ scope: 'worker', auto: true },
 	],
 	// An automatic fixture to configure snapshot settings globally.
 	snapshotConfig: [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Discovered in https://github.com/WordPress/gutenberg/pull/46452 by @t-hamano. The `requestUtils` fixture is not initialized if the test doesn't use it.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We need to run some initialization steps before any e2e tests (switching themes for instance), hence the `requestUtils` fixture needs to be initialize even when it's not used in tests.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add `{ auto: true }` to the fixture options.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Publish a random post in the test WP instance.
2. On trunk, run the buttons tests only via `npm run test:e2e:playwright -- buttons` (it doesn't use `requestUtils`)
3. The post should still be there.
4. Apply this PR, and repeat the same. After the tests, the post should be deleted.

