### PR TITLE
Mobile: Inserter - Remove `.done()` usage

### DIFF
--- a/packages/block-editor/src/components/inserter/index.native.js
+++ b/packages/block-editor/src/components/inserter/index.native.js
@@ -216,7 +216,7 @@ export class Inserter extends Component {
 	}
 
 	onInserterToggledAnnouncement( isOpen ) {
-		AccessibilityInfo.isScreenReaderEnabled().done( ( isEnabled ) => {
+		AccessibilityInfo.isScreenReaderEnabled().then( ( isEnabled ) => {
 			if ( isEnabled ) {
 				const isIOS = Platform.OS === 'ios';
 				const announcement = isOpen


### PR DESCRIPTION
## What?
This is a quick PR to remove a console warning and address a deprecation.

## Why?
After the React Native Upgrade, a new warning pops up when opening the inserter on the mobile editor.

<kbd><img src="https://user-images.githubusercontent.com/4885740/207011908-9081bd0c-8e67-4846-ba73-987f393179a7.png"  width=200 /></kbd>

## How?
By using `.then` instead of `.done`.

## Testing Instructions

- Open the editor
- Check no warning shows up about the usage of `.done()`

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A