### PR TITLE
BlockListAppender: with custom appender, don't react to nested list settings changes

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -56,7 +56,7 @@ function useAppender( rootClientId, CustomAppender ) {
 					__unstableGetEditorMode() === 'zoom-out',
 				isParentSelected:
 					rootClientId === selectedBlockClientId ||
-					( rootClientId === '' && ! selectedBlockClientId ),
+					( ! rootClientId && ! selectedBlockClientId ),
 			};
 		},
 		[ rootClientId ]

--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -16,67 +16,78 @@ import DefaultBlockAppender from '../default-block-appender';
 import ButtonBlockAppender from '../button-block-appender';
 import { store as blockEditorStore } from '../../store';
 
-function BlockListAppender( {
-	rootClientId,
-	renderAppender: CustomAppender,
-	className,
-	tagName: TagName = 'div',
-} ) {
-	const { hideInserter, canInsertDefaultBlock, selectedBlockClientId } =
-		useSelect(
-			( select ) => {
-				const {
-					canInsertBlockType,
-					getTemplateLock,
-					getSelectedBlockClientId,
-					__unstableGetEditorMode,
-				} = select( blockEditorStore );
+function DefaultAppender( { rootClientId } ) {
+	const canInsertDefaultBlock = useSelect( ( select ) =>
+		select( blockEditorStore ).canInsertBlockType(
+			getDefaultBlockName(),
+			rootClientId
+		)
+	);
 
-				return {
-					hideInserter:
-						!! getTemplateLock( rootClientId ) ||
-						__unstableGetEditorMode() === 'zoom-out',
-					canInsertDefaultBlock: canInsertBlockType(
-						getDefaultBlockName(),
-						rootClientId
-					),
-					selectedBlockClientId: getSelectedBlockClientId(),
-				};
-			},
-			[ rootClientId ]
-		);
+	if ( canInsertDefaultBlock ) {
+		// Render the default block appender if the context supports use
+		// of the default appender.
+		return <DefaultBlockAppender rootClientId={ rootClientId } />;
+	}
+
+	// Fallback in case the default block can't be inserted.
+	return (
+		<ButtonBlockAppender
+			rootClientId={ rootClientId }
+			className="block-list-appender__toggle"
+		/>
+	);
+}
+
+function useAppender( rootClientId, CustomAppender ) {
+	const { hideInserter, isParentSelected } = useSelect(
+		( select ) => {
+			const {
+				getTemplateLock,
+				getSelectedBlockClientId,
+				__unstableGetEditorMode,
+			} = select( blockEditorStore );
+
+			const selectedBlockClientId = getSelectedBlockClientId();
+
+			return {
+				hideInserter:
+					!! getTemplateLock( rootClientId ) ||
+					__unstableGetEditorMode() === 'zoom-out',
+				isParentSelected:
+					rootClientId === selectedBlockClientId ||
+					( rootClientId === '' && ! selectedBlockClientId ),
+			};
+		},
+		[ rootClientId ]
+	);
 
 	if ( hideInserter || CustomAppender === false ) {
 		return null;
 	}
 
-	let appender;
 	if ( CustomAppender ) {
 		// Prefer custom render prop if provided.
-		appender = <CustomAppender />;
-	} else {
-		const isParentSelected =
-			selectedBlockClientId === rootClientId ||
-			( ! rootClientId && ! selectedBlockClientId );
+		return <CustomAppender />;
+	}
 
-		if ( ! isParentSelected ) {
-			return null;
-		}
+	if ( ! isParentSelected ) {
+		return null;
+	}
 
-		if ( canInsertDefaultBlock ) {
-			// Render the default block appender when renderAppender has not been
-			// provided and the context supports use of the default appender.
-			appender = <DefaultBlockAppender rootClientId={ rootClientId } />;
-		} else {
-			// Fallback in the case no renderAppender has been provided and the
-			// default block can't be inserted.
-			appender = (
-				<ButtonBlockAppender
-					rootClientId={ rootClientId }
-					className="block-list-appender__toggle"
-				/>
-			);
-		}
+	return <DefaultAppender rootClientId={ rootClientId } />;
+}
+
+function BlockListAppender( {
+	rootClientId,
+	renderAppender,
+	className,
+	tagName: TagName = 'div',
+} ) {
+	const appender = useAppender( rootClientId, renderAppender );
+
+	if ( ! appender ) {
+		return null;
 	}
 
 	return (


### PR DESCRIPTION
Unit tests written with React Testing Library don't like situations where:
- a state update is performed asynchronously, like in a `Promise.then` handler
- causes a rerender of a component (because the state value has changed)
- doesn't lead to any observable UI change (because the component didn't really use the changed state value and rendered the same thing as before)

In such a case the "update not wrapped in `act()`" warning is triggered -- something has changed asychronously and the test didn't catch it by waiting for the change to happen.

This situation happens when testing the mobile columns block. You create a new column block, synchronously perform the test actions on it (like changing vertical alignment) and then finish the test. However, there is another process going on: the column block initially has no `blockListSettings`, and `updateBlockListSettings` dispatch for it gets async scheduled. This dispatch affects rendering of the block inserter (the + icon in the mobile toolbar):

![IMG_3904](https://user-images.githubusercontent.com/664258/207004908-ca571e89-113f-4810-963c-a1afddd4b60d.PNG)

Because this inserter asks whether it can insert the default block (`canInsertDefaultBlock`). Initially this is `false` because the column block doesn't yet have any list settings, and later becomes `true`. That leads to rerender of the inserter.

But when the inserter is rendered with custom UI (`renderAppender`) it doesn't really use the `canInsertDefaultBlock` value. Therefore, a state update that has no UI effect.

This PR fixes that by splitting `BlockListAppender` into multiple components. The outer checks the custom UI and returns immediately when custom UI is requested. Only when custom UI is not requested, does it render an inner component which does the `useSelect` with `canInsertDefaultBlock`.