### PR TITLE
Popover: remove box shadow on quick inserter introduced in #46201

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -33,8 +33,6 @@ $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter__popover.is-quick {
 	.components-popover__content {
-		border: none;
-		outline: none;
 		box-shadow: $shadow-popover;
 
 		.block-editor-inserter__quick-inserter > * {


### PR DESCRIPTION
## What?
Fix the quick inserter popover border

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
#46201 changed outlines in favour of box shadows to avoid paint issues but the .is-quick class was reseting border and outline and not box shadow

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Reset the value to the default shadow : `box-shadow: $shadow-popover;`

## Screenshots

### Before
<img width="374" alt="Screenshot 2022-12-12 at 14 44 40" src="https://user-images.githubusercontent.com/4660731/207060176-8ab154c7-7704-45ad-b547-90fddb05ddd7.png">

### After
<img width="376" alt="Screenshot 2022-12-12 at 14 44 21" src="https://user-images.githubusercontent.com/4660731/207060198-e72e1ed3-74cc-4602-9966-2fda99eae578.png">

