### PR TITLE
Element: enable concurrent mode by implementing mount/unmount with createRoot

### DIFF
--- a/packages/block-editor/src/components/block-tools/selected-block-popover.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-popover.js
@@ -35,6 +35,7 @@ function selector( select ) {
 
 	return {
 		editorMode: __unstableGetEditorMode(),
+		hasMultiSelection: hasMultiSelection(),
 		isMultiSelecting: isMultiSelecting(),
 		isTyping: isTyping(),
 		isBlockInterfaceHidden: isBlockInterfaceHidden(),
@@ -57,6 +58,7 @@ function SelectedBlockPopover( {
 } ) {
 	const {
 		editorMode,
+		hasMultiSelection,
 		isMultiSelecting,
 		isTyping,
 		isBlockInterfaceHidden,
@@ -89,7 +91,8 @@ function SelectedBlockPopover( {
 	const showEmptyBlockSideInserter =
 		! isTyping && editorMode === 'edit' && isEmptyDefaultBlock;
 	const shouldShowBreadcrumb =
-		editorMode === 'navigation' || editorMode === 'zoom-out';
+		! hasMultiSelection &&
+		( editorMode === 'navigation' || editorMode === 'zoom-out' );
 	const shouldShowContextualToolbar =
 		editorMode === 'edit' &&
 		! hasFixedToolbar &&
@@ -129,86 +132,79 @@ function SelectedBlockPopover( {
 		clientId,
 	} );
 
-	if (
-		! shouldShowBreadcrumb &&
-		! shouldShowContextualToolbar &&
-		! showEmptyBlockSideInserter
-	) {
-		return null;
+	if ( showEmptyBlockSideInserter ) {
+		return (
+			<BlockPopover
+				clientId={ capturingClientId || clientId }
+				__unstableCoverTarget
+				bottomClientId={ lastClientId }
+				className={ classnames(
+					'block-editor-block-list__block-side-inserter-popover',
+					{
+						'is-insertion-point-visible': isInsertionPointVisible,
+					}
+				) }
+				__unstablePopoverSlot={ __unstablePopoverSlot }
+				__unstableContentRef={ __unstableContentRef }
+				resize={ false }
+				shift={ false }
+				{ ...popoverProps }
+			>
+				<div className="block-editor-block-list__empty-block-inserter">
+					<Inserter
+						position="bottom right"
+						rootClientId={ rootClientId }
+						clientId={ clientId }
+						__experimentalIsQuick
+					/>
+				</div>
+			</BlockPopover>
+		);
 	}
 
-	return (
-		<>
-			{ showEmptyBlockSideInserter && (
-				<BlockPopover
-					clientId={ capturingClientId || clientId }
-					__unstableCoverTarget
-					bottomClientId={ lastClientId }
-					className={ classnames(
-						'block-editor-block-list__block-side-inserter-popover',
-						{
-							'is-insertion-point-visible':
-								isInsertionPointVisible,
+	if ( shouldShowBreadcrumb || shouldShowContextualToolbar ) {
+		return (
+			<BlockPopover
+				clientId={ capturingClientId || clientId }
+				bottomClientId={ lastClientId }
+				className={ classnames(
+					'block-editor-block-list__block-popover',
+					{
+						'is-insertion-point-visible': isInsertionPointVisible,
+					}
+				) }
+				__unstablePopoverSlot={ __unstablePopoverSlot }
+				__unstableContentRef={ __unstableContentRef }
+				resize={ false }
+				{ ...popoverProps }
+			>
+				{ shouldShowContextualToolbar && showContents && (
+					<BlockContextualToolbar
+						// If the toolbar is being shown because of being forced
+						// it should focus the toolbar right after the mount.
+						focusOnMount={ isToolbarForced.current }
+						__experimentalInitialIndex={
+							initialToolbarItemIndexRef.current
 						}
-					) }
-					__unstablePopoverSlot={ __unstablePopoverSlot }
-					__unstableContentRef={ __unstableContentRef }
-					resize={ false }
-					shift={ false }
-					{ ...popoverProps }
-				>
-					<div className="block-editor-block-list__empty-block-inserter">
-						<Inserter
-							position="bottom right"
-							rootClientId={ rootClientId }
-							clientId={ clientId }
-							__experimentalIsQuick
-						/>
-					</div>
-				</BlockPopover>
-			) }
-			{ ( shouldShowBreadcrumb || shouldShowContextualToolbar ) && (
-				<BlockPopover
-					clientId={ capturingClientId || clientId }
-					bottomClientId={ lastClientId }
-					className={ classnames(
-						'block-editor-block-list__block-popover',
-						{
-							'is-insertion-point-visible':
-								isInsertionPointVisible,
-						}
-					) }
-					__unstablePopoverSlot={ __unstablePopoverSlot }
-					__unstableContentRef={ __unstableContentRef }
-					resize={ false }
-					{ ...popoverProps }
-				>
-					{ shouldShowContextualToolbar && showContents && (
-						<BlockContextualToolbar
-							// If the toolbar is being shown because of being forced
-							// it should focus the toolbar right after the mount.
-							focusOnMount={ isToolbarForced.current }
-							__experimentalInitialIndex={
-								initialToolbarItemIndexRef.current
-							}
-							__experimentalOnIndexChange={ ( index ) => {
-								initialToolbarItemIndexRef.current = index;
-							} }
-							// Resets the index whenever the active block changes so
-							// this is not persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
-							key={ clientId }
-						/>
-					) }
-					{ shouldShowBreadcrumb && (
-						<BlockSelectionButton
-							clientId={ clientId }
-							rootClientId={ rootClientId }
-						/>
-					) }
-				</BlockPopover>
-			) }
-		</>
-	);
+						__experimentalOnIndexChange={ ( index ) => {
+							initialToolbarItemIndexRef.current = index;
+						} }
+						// Resets the index whenever the active block changes so
+						// this is not persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
+						key={ clientId }
+					/>
+				) }
+				{ shouldShowBreadcrumb && (
+					<BlockSelectionButton
+						clientId={ clientId }
+						rootClientId={ rootClientId }
+					/>
+				) }
+			</BlockPopover>
+		);
+	}
+
+	return null;
 }
 
 function wrapperSelector( select ) {

--- a/packages/block-editor/src/components/rich-text/use-before-input-rules.js
+++ b/packages/block-editor/src/components/rich-text/use-before-input-rules.js
@@ -77,9 +77,17 @@ export function useBeforeInputRules( props ) {
 			const { defaultView } = ownerDocument;
 			const newEvent = new defaultView.InputEvent( 'input', init );
 
-			// Dispatch an input event with the new data. This will trigger the
+			// Dispatch an `input` event with the new data. This will trigger the
 			// input rules.
-			event.target.dispatchEvent( newEvent );
+			// Postpone the `input` to the next event loop tick so that the dispatch
+			// doesn't happen synchronously in the middle of `beforeinput` dispatch.
+			// This is closer to how native `input` event would be timed, and also
+			// makes sure that the `input` event is dispatched only after the `onChange`
+			// call few lines above has fully updated the data store state and rerendered
+			// all affected components.
+			window.queueMicrotask( () => {
+				event.target.dispatchEvent( newEvent );
+			} );
 			event.preventDefault();
 		}
 

--- a/packages/components/src/slot-fill/bubbles-virtually/fill.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/fill.js
@@ -15,6 +15,7 @@ function useForceUpdate() {
 	const mounted = useRef( true );
 
 	useEffect( () => {
+		mounted.current = true;
 		return () => {
 			mounted.current = false;
 		};

--- a/packages/components/src/slot-fill/slot.js
+++ b/packages/components/src/slot-fill/slot.js
@@ -34,7 +34,7 @@ class SlotComponent extends Component {
 
 	componentDidMount() {
 		const { registerSlot } = this.props;
-
+		this.isUnmounted = false;
 		registerSlot( this.props.name, this );
 	}
 

--- a/packages/components/src/slot-fill/use-slot.js
+++ b/packages/components/src/slot-fill/use-slot.js
@@ -2,7 +2,7 @@
 /**
  * WordPress dependencies
  */
-import { useContext, useState, useEffect } from '@wordpress/element';
+import { useContext, useSyncExternalStore } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -17,21 +17,11 @@ import SlotFillContext from './context';
  */
 const useSlot = ( name ) => {
 	const { getSlot, subscribe } = useContext( SlotFillContext );
-	const [ slot, setSlot ] = useState( getSlot( name ) );
-
-	useEffect( () => {
-		setSlot( getSlot( name ) );
-		const unsubscribe = subscribe( () => {
-			setSlot( getSlot( name ) );
-		} );
-
-		return unsubscribe;
-		// Ignore reason: Modifying this dep array could introduce unexpected changes in behavior,
-		// so we'll leave it as=is until the hook can be properly refactored for exhaustive-deps.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ name ] );
-
-	return slot;
+	return useSyncExternalStore(
+		subscribe,
+		() => getSlot( name ),
+		() => getSlot( name )
+	);
 };
 
 export default useSlot;

--- a/packages/compose/src/hooks/use-async-list/index.ts
+++ b/packages/compose/src/hooks/use-async-list/index.ts
@@ -44,7 +44,7 @@ function useAsyncList< T >(
 	config: AsyncListConfig = { step: 1 }
 ): T[] {
 	const { step = 1 } = config;
-	const [ current, setCurrent ] = useState( [] as T[] );
+	const [ current, setCurrent ] = useState< T[] >( [] );
 
 	useEffect( () => {
 		// On reset, we keep the first items that were previously rendered.
@@ -55,10 +55,9 @@ function useAsyncList< T >(
 			);
 		}
 		setCurrent( firstItems );
-		let nextIndex = firstItems.length;
 
 		const asyncQueue = createQueue();
-		const append = () => {
+		const append = ( nextIndex: number ) => () => {
 			if ( list.length <= nextIndex ) {
 				return;
 			}
@@ -66,10 +65,9 @@ function useAsyncList< T >(
 				...state,
 				...list.slice( nextIndex, nextIndex + step ),
 			] );
-			nextIndex += step;
-			asyncQueue.add( {}, append );
+			asyncQueue.add( {}, append( nextIndex + step ) );
 		};
-		asyncQueue.add( {}, append );
+		asyncQueue.add( {}, append( firstItems.length ) );
 
 		return () => asyncQueue.reset();
 	}, [ list ] );

--- a/packages/e2e-tests/specs/editor/various/rich-text.test.js
+++ b/packages/e2e-tests/specs/editor/various/rich-text.test.js
@@ -515,11 +515,15 @@ describe( 'RichText', () => {
 		// text in the DOM directly, setting selection in the right place, and
 		// firing `compositionend`.
 		// See https://github.com/puppeteer/puppeteer/issues/4981.
-		await page.evaluate( () => {
+		await page.evaluate( async () => {
 			document.activeElement.textContent = '`a`';
 			const selection = window.getSelection();
+			// The `selectionchange` and `compositionend` events should run in separate event
+			// loop ticks to process all data store updates in time. Native events would be
+			// scheduled the same way.
 			selection.selectAllChildren( document.activeElement );
 			selection.collapseToEnd();
+			await new Promise( ( r ) => setTimeout( r, 0 ) );
 			document.activeElement.dispatchEvent(
 				new CompositionEvent( 'compositionend' )
 			);

--- a/packages/edit-post/README.md
+++ b/packages/edit-post/README.md
@@ -478,17 +478,7 @@ _Returns_
 
 ### reinitializeEditor
 
-Reinitializes the editor after the user chooses to reboot the editor after
-an unhandled error occurs, replacing previously mounted editor element using
-an initial state from prior to the crash.
-
-_Parameters_
-
--   _postType_ `Object`: Post type of the post to edit.
--   _postId_ `Object`: ID of the post to edit.
--   _target_ `Element`: DOM node in which editor is rendered.
--   _settings_ `?Object`: Editor settings object.
--   _initialEdits_ `Object`: Programmatic edits to apply initially, to be considered as non-user-initiated (bypass for unsaved changes prompt).
+Used to reinitialize the editor after an error. Now it's a deprecated noop function.
 
 ### store
 

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -9,7 +9,7 @@ import {
 	store as editorStore,
 	experiments as editorExperiments,
 } from '@wordpress/editor';
-import { StrictMode, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { SlotFillProvider } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
@@ -180,28 +180,24 @@ function Editor( {
 	}
 
 	return (
-		<StrictMode>
-			<ShortcutProvider>
-				<SlotFillProvider>
-					<ExperimentalEditorProvider
-						settings={ editorSettings }
-						post={ post }
-						initialEdits={ initialEdits }
-						useSubRegistry={ false }
-						__unstableTemplate={
-							isTemplateMode ? template : undefined
-						}
-						{ ...props }
-					>
-						<ErrorBoundary onError={ onError }>
-							<EditorInitialization postId={ postId } />
-							<Layout styles={ styles } />
-						</ErrorBoundary>
-						<PostLockedModal />
-					</ExperimentalEditorProvider>
-				</SlotFillProvider>
-			</ShortcutProvider>
-		</StrictMode>
+		<ShortcutProvider>
+			<SlotFillProvider>
+				<ExperimentalEditorProvider
+					settings={ editorSettings }
+					post={ post }
+					initialEdits={ initialEdits }
+					useSubRegistry={ false }
+					__unstableTemplate={ isTemplateMode ? template : undefined }
+					{ ...props }
+				>
+					<ErrorBoundary onError={ onError }>
+						<EditorInitialization postId={ postId } />
+						<Layout styles={ styles } />
+					</ErrorBoundary>
+					<PostLockedModal />
+				</ExperimentalEditorProvider>
+			</SlotFillProvider>
+		</ShortcutProvider>
 	);
 }
 

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -25,14 +25,7 @@ import { unlock } from './experiments';
 
 const { ExperimentalEditorProvider } = unlock( editorExperiments );
 
-function Editor( {
-	postId,
-	postType,
-	settings,
-	initialEdits,
-	onError,
-	...props
-} ) {
+function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 	const {
 		hasFixedToolbar,
 		focusMode,
@@ -190,7 +183,7 @@ function Editor( {
 					__unstableTemplate={ isTemplateMode ? template : undefined }
 					{ ...props }
 				>
-					<ErrorBoundary onError={ onError }>
+					<ErrorBoundary>
 						<EditorInitialization postId={ postId } />
 						<Layout styles={ styles } />
 					</ErrorBoundary>

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -6,7 +6,8 @@ import {
 	registerCoreBlocks,
 	__experimentalRegisterExperimentalCoreBlocks,
 } from '@wordpress/block-library';
-import { render, unmountComponentAtNode } from '@wordpress/element';
+import deprecated from '@wordpress/deprecated';
+import { createRoot } from '@wordpress/element';
 import { dispatch, select } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
 import { store as preferencesStore } from '@wordpress/preferences';
@@ -19,49 +20,6 @@ import './hooks';
 import './plugins';
 import Editor from './editor';
 import { store as editPostStore } from './store';
-
-/**
- * Reinitializes the editor after the user chooses to reboot the editor after
- * an unhandled error occurs, replacing previously mounted editor element using
- * an initial state from prior to the crash.
- *
- * @param {Object}  postType     Post type of the post to edit.
- * @param {Object}  postId       ID of the post to edit.
- * @param {Element} target       DOM node in which editor is rendered.
- * @param {?Object} settings     Editor settings object.
- * @param {Object}  initialEdits Programmatic edits to apply initially, to be
- *                               considered as non-user-initiated (bypass for
- *                               unsaved changes prompt).
- */
-export function reinitializeEditor(
-	postType,
-	postId,
-	target,
-	settings,
-	initialEdits
-) {
-	unmountComponentAtNode( target );
-	const reboot = reinitializeEditor.bind(
-		null,
-		postType,
-		postId,
-		target,
-		settings,
-		initialEdits
-	);
-
-	render(
-		<Editor
-			settings={ settings }
-			onError={ reboot }
-			postId={ postId }
-			postType={ postType }
-			initialEdits={ initialEdits }
-			recovery
-		/>,
-		target
-	);
-}
 
 /**
  * Initializes and returns an instance of Editor.
@@ -82,14 +40,7 @@ export function initializeEditor(
 	initialEdits
 ) {
 	const target = document.getElementById( id );
-	const reboot = reinitializeEditor.bind(
-		null,
-		postType,
-		postId,
-		target,
-		settings,
-		initialEdits
-	);
+	const root = createRoot( target );
 
 	dispatch( preferencesStore ).setDefaults( 'core/edit-post', {
 		editorMode: 'visual',
@@ -187,16 +138,26 @@ export function initializeEditor(
 	window.addEventListener( 'dragover', ( e ) => e.preventDefault(), false );
 	window.addEventListener( 'drop', ( e ) => e.preventDefault(), false );
 
-	render(
+	root.render(
 		<Editor
 			settings={ settings }
-			onError={ reboot }
 			postId={ postId }
 			postType={ postType }
 			initialEdits={ initialEdits }
-		/>,
-		target
+		/>
 	);
+
+	return root;
+}
+
+/**
+ * Used to reinitialize the editor after an error. Now it's a deprecated noop function.
+ */
+export function reinitializeEditor() {
+	deprecated( 'wp.editPost.reinitializeEditor', {
+		since: '6.2',
+		version: '6.3',
+	} );
 }
 
 export { default as PluginBlockSettingsMenuItem } from './components/block-settings-menu/plugin-block-settings-menu-item';

--- a/packages/edit-site/src/components/app/index.js
+++ b/packages/edit-site/src/components/app/index.js
@@ -15,7 +15,7 @@ import { PluginArea } from '@wordpress/plugins';
 import { Routes } from '../routes';
 import Layout from '../layout';
 
-export default function App( { onError } ) {
+export default function App() {
 	const { createErrorNotice } = useDispatch( noticesStore );
 
 	function onPluginAreaError( name ) {
@@ -37,7 +37,7 @@ export default function App( { onError } ) {
 				<UnsavedChangesWarning />
 
 				<Routes>
-					<Layout onError={ onError } />
+					<Layout />
 					<PluginArea onError={ onPluginAreaError } />
 				</Routes>
 			</SlotFillProvider>

--- a/packages/edit-site/src/components/app/index.js
+++ b/packages/edit-site/src/components/app/index.js
@@ -15,7 +15,7 @@ import { PluginArea } from '@wordpress/plugins';
 import { Routes } from '../routes';
 import Layout from '../layout';
 
-export default function App( { reboot } ) {
+export default function App( { onError } ) {
 	const { createErrorNotice } = useDispatch( noticesStore );
 
 	function onPluginAreaError( name ) {
@@ -37,7 +37,7 @@ export default function App( { reboot } ) {
 				<UnsavedChangesWarning />
 
 				<Routes>
-					<Layout onError={ reboot } />
+					<Layout onError={ onError } />
 					<PluginArea onError={ onPluginAreaError } />
 				</Routes>
 			</SlotFillProvider>

--- a/packages/edit-site/src/components/error-boundary/index.js
+++ b/packages/edit-site/src/components/error-boundary/index.js
@@ -14,8 +14,6 @@ export default class ErrorBoundary extends Component {
 	constructor() {
 		super( ...arguments );
 
-		this.reboot = this.reboot.bind( this );
-
 		this.state = {
 			error: null,
 		};
@@ -29,13 +27,8 @@ export default class ErrorBoundary extends Component {
 		return { error };
 	}
 
-	reboot() {
-		this.props.onError();
-	}
-
 	render() {
-		const { error } = this.state;
-		if ( ! error ) {
+		if ( ! this.state.error ) {
 			return this.props.children;
 		}
 
@@ -44,8 +37,8 @@ export default class ErrorBoundary extends Component {
 				message={ __(
 					'The editor has encountered an unexpected error.'
 				) }
-				error={ error }
-				reboot={ this.reboot }
+				error={ this.state.error }
+				reboot={ this.props.onError }
 			/>
 		);
 	}

--- a/packages/edit-site/src/components/error-boundary/index.js
+++ b/packages/edit-site/src/components/error-boundary/index.js
@@ -38,7 +38,6 @@ export default class ErrorBoundary extends Component {
 					'The editor has encountered an unexpected error.'
 				) }
 				error={ this.state.error }
-				reboot={ this.props.onError }
 			/>
 		);
 	}

--- a/packages/edit-site/src/components/error-boundary/warning.js
+++ b/packages/edit-site/src/components/error-boundary/warning.js
@@ -15,41 +15,12 @@ function CopyButton( { text, children } ) {
 	);
 }
 
-export default function ErrorBoundaryWarning( {
-	message,
-	error,
-	reboot,
-	dashboardLink,
-} ) {
-	const actions = [];
-
-	if ( reboot ) {
-		actions.push(
-			<Button key="recovery" onClick={ reboot } variant="secondary">
-				{ __( 'Attempt Recovery' ) }
-			</Button>
-		);
-	}
-
-	if ( error ) {
-		actions.push(
-			<CopyButton key="copy-error" text={ error.stack }>
-				{ __( 'Copy Error' ) }
-			</CopyButton>
-		);
-	}
-
-	if ( dashboardLink ) {
-		actions.push(
-			<Button
-				key="back-to-dashboard"
-				variant="secondary"
-				href={ dashboardLink }
-			>
-				{ __( 'Back to dashboard' ) }
-			</Button>
-		);
-	}
+export default function ErrorBoundaryWarning( { message, error } ) {
+	const actions = [
+		<CopyButton key="copy-error" text={ error.stack }>
+			{ __( 'Copy Error' ) }
+		</CopyButton>,
+	];
 
 	return (
 		<Warning className="editor-error-boundary" actions={ actions }>

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -52,7 +52,7 @@ const emptyResizeHandleStyles = {
 	left: undefined,
 };
 
-export default function Layout( { onError } ) {
+export default function Layout() {
 	// This ensures the edited entity id and type are initialized properly.
 	useInitEditedEntityFromURL();
 	useSyncCanvasModeWithURL();
@@ -314,7 +314,7 @@ export default function Layout( { onError } ) {
 											ease: 'easeOut',
 										} }
 									>
-										<ErrorBoundary onError={ onError }>
+										<ErrorBoundary>
 											{ isEditorPage && <Editor /> }
 											{ isListPage && <ListPage /> }
 										</ErrorBoundary>

--- a/packages/edit-widgets/src/components/error-boundary/index.js
+++ b/packages/edit-widgets/src/components/error-boundary/index.js
@@ -17,11 +17,35 @@ function CopyButton( { text, children } ) {
 	);
 }
 
+function ErrorBoundaryWarning( { message, error, reboot } ) {
+	const actions = [];
+
+	if ( reboot ) {
+		actions.push(
+			<Button key="recovery" onClick={ reboot } variant="secondary">
+				{ __( 'Attempt Recovery' ) }
+			</Button>
+		);
+	}
+
+	if ( error ) {
+		actions.push(
+			<CopyButton key="copy-error" text={ error.stack }>
+				{ __( 'Copy Error' ) }
+			</CopyButton>
+		);
+	}
+
+	return (
+		<Warning className="edit-widgets-error-boundary" actions={ actions }>
+			{ message }
+		</Warning>
+	);
+}
+
 export default class ErrorBoundary extends Component {
 	constructor() {
 		super( ...arguments );
-
-		this.reboot = this.reboot.bind( this );
 
 		this.state = {
 			error: null,
@@ -29,39 +53,26 @@ export default class ErrorBoundary extends Component {
 	}
 
 	componentDidCatch( error ) {
-		this.setState( { error } );
-
 		doAction( 'editor.ErrorBoundary.errorLogged', error );
 	}
 
-	reboot() {
-		this.props.onError();
+	static getDerivedStateFromError( error ) {
+		return { error };
 	}
 
 	render() {
-		const { error } = this.state;
-		if ( ! error ) {
+		if ( ! this.state.error ) {
 			return this.props.children;
 		}
 
 		return (
-			<Warning
-				className="edit-widgets-error-boundary"
-				actions={ [
-					<Button
-						key="recovery"
-						onClick={ this.reboot }
-						variant="secondary"
-					>
-						{ __( 'Attempt Recovery' ) }
-					</Button>,
-					<CopyButton key="copy-error" text={ error.stack }>
-						{ __( 'Copy Error' ) }
-					</CopyButton>,
-				] }
-			>
-				{ __( 'The editor has encountered an unexpected error.' ) }
-			</Warning>
+			<ErrorBoundaryWarning
+				message={ __(
+					'The editor has encountered an unexpected error.'
+				) }
+				error={ this.state.error }
+				reboot={ this.props.onError }
+			/>
 		);
 	}
 }

--- a/packages/edit-widgets/src/components/error-boundary/index.js
+++ b/packages/edit-widgets/src/components/error-boundary/index.js
@@ -17,24 +17,12 @@ function CopyButton( { text, children } ) {
 	);
 }
 
-function ErrorBoundaryWarning( { message, error, reboot } ) {
-	const actions = [];
-
-	if ( reboot ) {
-		actions.push(
-			<Button key="recovery" onClick={ reboot } variant="secondary">
-				{ __( 'Attempt Recovery' ) }
-			</Button>
-		);
-	}
-
-	if ( error ) {
-		actions.push(
-			<CopyButton key="copy-error" text={ error.stack }>
-				{ __( 'Copy Error' ) }
-			</CopyButton>
-		);
-	}
+function ErrorBoundaryWarning( { message, error } ) {
+	const actions = [
+		<CopyButton key="copy-error" text={ error.stack }>
+			{ __( 'Copy Error' ) }
+		</CopyButton>,
+	];
 
 	return (
 		<Warning className="edit-widgets-error-boundary" actions={ actions }>
@@ -71,7 +59,6 @@ export default class ErrorBoundary extends Component {
 					'The editor has encountered an unexpected error.'
 				) }
 				error={ this.state.error }
-				reboot={ this.props.onError }
 			/>
 		);
 	}

--- a/packages/edit-widgets/src/components/layout/index.js
+++ b/packages/edit-widgets/src/components/layout/index.js
@@ -17,7 +17,7 @@ import Interface from './interface';
 import UnsavedChangesWarning from './unsaved-changes-warning';
 import WelcomeGuide from '../welcome-guide';
 
-function Layout( { blockEditorSettings, onError } ) {
+function Layout( { blockEditorSettings } ) {
 	const { createErrorNotice } = useDispatch( noticesStore );
 
 	function onPluginAreaError( name ) {
@@ -33,7 +33,7 @@ function Layout( { blockEditorSettings, onError } ) {
 	}
 
 	return (
-		<ErrorBoundary onError={ onError }>
+		<ErrorBoundary>
 			<WidgetAreasBlockEditorProvider
 				blockEditorSettings={ blockEditorSettings }
 			>

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -8,7 +8,8 @@ import {
 	store as blocksStore,
 } from '@wordpress/blocks';
 import { dispatch } from '@wordpress/data';
-import { render, unmountComponentAtNode } from '@wordpress/element';
+import deprecated from '@wordpress/deprecated';
+import { createRoot } from '@wordpress/element';
 import {
 	registerCoreBlocks,
 	__experimentalGetCoreBlocks,
@@ -43,31 +44,15 @@ const disabledBlocks = [
 ];
 
 /**
- * Reinitializes the editor after the user chooses to reboot the editor after
- * an unhandled error occurs, replacing previously mounted editor element using
- * an initial state from prior to the crash.
- *
- * @param {Element} target   DOM node in which editor is rendered.
- * @param {?Object} settings Editor settings object.
- */
-export function reinitializeEditor( target, settings ) {
-	unmountComponentAtNode( target );
-	const reboot = reinitializeEditor.bind( null, target, settings );
-	render(
-		<Layout blockEditorSettings={ settings } onError={ reboot } />,
-		target
-	);
-}
-
-/**
  * Initializes the block editor in the widgets screen.
  *
  * @param {string} id       ID of the root element to render the screen in.
  * @param {Object} settings Block editor settings.
  */
-export function initialize( id, settings ) {
+export function initializeEditor( id, settings ) {
 	const target = document.getElementById( id );
-	const reboot = reinitializeEditor.bind( null, target, settings );
+	const root = createRoot( target );
+
 	const coreBlocks = __experimentalGetCoreBlocks().filter( ( block ) => {
 		return ! (
 			disabledBlocks.includes( block.name ) ||
@@ -105,10 +90,22 @@ export function initialize( id, settings ) {
 	// do this will result in errors in the default block parser.
 	// see: https://github.com/WordPress/gutenberg/issues/33097
 	setFreeformContentHandlerName( 'core/html' );
-	render(
-		<Layout blockEditorSettings={ settings } onError={ reboot } />,
-		target
-	);
+
+	root.render( <Layout blockEditorSettings={ settings } /> );
+
+	return root;
+}
+
+/**
+ * Compatibility export under the old `initialize` name.
+ */
+export const initialize = initializeEditor;
+
+export function reinitializeEditor() {
+	deprecated( 'wp.editWidgets.reinitializeEditor', {
+		since: '6.2',
+		version: '6.3',
+	} );
 }
 
 /**

--- a/packages/editor/src/components/error-boundary/index.js
+++ b/packages/editor/src/components/error-boundary/index.js
@@ -14,6 +14,18 @@ import { doAction } from '@wordpress/hooks';
  */
 import { store as editorStore } from '../../store';
 
+function getContent() {
+	try {
+		// While `select` in a component is generally discouraged, it is
+		// used here because it (a) reduces the chance of data loss in the
+		// case of additional errors by performing a direct retrieval and
+		// (b) avoids the performance cost associated with unnecessary
+		// content serialization throughout the lifetime of a non-erroring
+		// application.
+		return select( editorStore ).getEditedPostContent();
+	} catch ( error ) {}
+}
+
 function CopyButton( { text, children } ) {
 	const ref = useCopyToClipboard( text );
 	return (
@@ -27,7 +39,6 @@ class ErrorBoundary extends Component {
 	constructor() {
 		super( ...arguments );
 
-		this.reboot = this.reboot.bind( this );
 		this.getContent = this.getContent.bind( this );
 
 		this.state = {
@@ -36,25 +47,11 @@ class ErrorBoundary extends Component {
 	}
 
 	componentDidCatch( error ) {
-		this.setState( { error } );
-
 		doAction( 'editor.ErrorBoundary.errorLogged', error );
 	}
 
-	reboot() {
-		this.props.onError();
-	}
-
-	getContent() {
-		try {
-			// While `select` in a component is generally discouraged, it is
-			// used here because it (a) reduces the chance of data loss in the
-			// case of additional errors by performing a direct retrieval and
-			// (b) avoids the performance cost associated with unnecessary
-			// content serialization throughout the lifetime of a non-erroring
-			// application.
-			return select( editorStore ).getEditedPostContent();
-		} catch ( error ) {}
+	static getDerivedStateFromError( error ) {
+		return { error };
 	}
 
 	render() {
@@ -63,25 +60,34 @@ class ErrorBoundary extends Component {
 			return this.props.children;
 		}
 
+		const actions = [];
+
+		if ( this.props.onError ) {
+			actions.push(
+				<Button
+					key="recovery"
+					onClick={ this.props.onError }
+					variant="secondary"
+				>
+					{ __( 'Attempt Recovery' ) }
+				</Button>
+			);
+		}
+
+		actions.push(
+			<CopyButton key="copy-post" text={ getContent }>
+				{ __( 'Copy Post Text' ) }
+			</CopyButton>
+		);
+
+		actions.push(
+			<CopyButton key="copy-error" text={ error.stack }>
+				{ __( 'Copy Error' ) }
+			</CopyButton>
+		);
+
 		return (
-			<Warning
-				className="editor-error-boundary"
-				actions={ [
-					<Button
-						key="recovery"
-						onClick={ this.reboot }
-						variant="secondary"
-					>
-						{ __( 'Attempt Recovery' ) }
-					</Button>,
-					<CopyButton key="copy-post" text={ this.getContent }>
-						{ __( 'Copy Post Text' ) }
-					</CopyButton>,
-					<CopyButton key="copy-error" text={ error.stack }>
-						{ __( 'Copy Error' ) }
-					</CopyButton>,
-				] }
-			>
+			<Warning className="editor-error-boundary" actions={ actions }>
 				{ __( 'The editor has encountered an unexpected error.' ) }
 			</Warning>
 		);

--- a/packages/editor/src/components/error-boundary/index.js
+++ b/packages/editor/src/components/error-boundary/index.js
@@ -39,8 +39,6 @@ class ErrorBoundary extends Component {
 	constructor() {
 		super( ...arguments );
 
-		this.getContent = this.getContent.bind( this );
-
 		this.state = {
 			error: null,
 		};
@@ -60,31 +58,14 @@ class ErrorBoundary extends Component {
 			return this.props.children;
 		}
 
-		const actions = [];
-
-		if ( this.props.onError ) {
-			actions.push(
-				<Button
-					key="recovery"
-					onClick={ this.props.onError }
-					variant="secondary"
-				>
-					{ __( 'Attempt Recovery' ) }
-				</Button>
-			);
-		}
-
-		actions.push(
+		const actions = [
 			<CopyButton key="copy-post" text={ getContent }>
 				{ __( 'Copy Post Text' ) }
-			</CopyButton>
-		);
-
-		actions.push(
+			</CopyButton>,
 			<CopyButton key="copy-error" text={ error.stack }>
 				{ __( 'Copy Error' ) }
-			</CopyButton>
-		);
+			</CopyButton>,
+		];
 
 		return (
 			<Warning className="editor-error-boundary" actions={ actions }>

--- a/test/e2e/specs/editor/various/font-size-picker.spec.js
+++ b/test/e2e/specs/editor/various/font-size-picker.spec.js
@@ -8,6 +8,16 @@ test.describe( 'Font Size Picker', () => {
 		await admin.createNewPost();
 	} );
 
+	test.afterEach( async ( { page } ) => {
+		const closeButton = page.locator(
+			'role=region[name="Editor settings"i] >> role=button[name^="Close settings"i]'
+		);
+
+		if ( await closeButton.isVisible() ) {
+			await closeButton.click();
+		}
+	} );
+
 	test.describe( 'Common', () => {
 		test( 'should apply a named font size using the font size input', async ( {
 			editor,

--- a/test/e2e/specs/editor/various/font-size-picker.spec.js
+++ b/test/e2e/specs/editor/various/font-size-picker.spec.js
@@ -193,6 +193,7 @@ test.describe( 'Font Size Picker', () => {
 
 			await page.click( 'role=button[name="Typography options"i]' );
 			await page.click( 'role=menuitem[name="Reset Font size"i]' );
+			await page.keyboard.press( 'Escape' ); // Close the menu
 
 			await expect.poll( editor.getEditedPostContent )
 				.toBe( `<!-- wp:paragraph -->
@@ -273,6 +274,7 @@ test.describe( 'Font Size Picker', () => {
 
 			await page.click( 'role=button[name="Typography options"i]' );
 			await page.click( 'role=menuitem[name="Reset Font size"i]' );
+			await page.keyboard.press( 'Escape' ); // Close the menu
 
 			await expect.poll( editor.getEditedPostContent )
 				.toBe( `<!-- wp:paragraph -->


### PR DESCRIPTION
Reimplement the `render`, `hydrate` and `unmountComponentAtNode` helpers in `@wordpress/element` using the new `createRoot` and `hydrateRoot` APIs from React 18, instead of using the legacy React 17 implementations.

The side effect of this is switching the entire production editor to concurrent mode. Let's see if this breaks the editor or not.

In his original [React 18 upgrade PR](https://github.com/WordPress/gutenberg/pull/32765), @youknowriad did many changes to various components (summarized [here](https://github.com/WordPress/gutenberg/pull/32765#issuecomment-1266819588)) which were not included in the React 18 upgrade that got eventually merged. Maybe we'll need to merge these changes, too, after all, because otherwise concurrent mode will break? Let's test this hypothesis 🙂 