### PR TITLE
Lodash: Refactor `core-data` away from `_.find()`

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import fastDeepEqual from 'fast-deep-equal/es6';
-import { find } from 'lodash';
 import { v4 as uuid } from 'uuid';
 
 /**
@@ -256,7 +255,9 @@ export const deleteEntityRecord =
 	) =>
 	async ( { dispatch } ) => {
 		const configs = await dispatch( getOrLoadEntitiesConfig( kind ) );
-		const entityConfig = find( configs, { kind, name } );
+		const entityConfig = configs.find(
+			( config ) => config.kind === kind && config.name === name
+		);
 		let error;
 		let deletedRecord = false;
 		if ( ! entityConfig || entityConfig?.__experimentalNoFetch ) {
@@ -451,7 +452,9 @@ export const saveEntityRecord =
 	) =>
 	async ( { select, resolveSelect, dispatch } ) => {
 		const configs = await dispatch( getOrLoadEntitiesConfig( kind ) );
-		const entityConfig = find( configs, { kind, name } );
+		const entityConfig = configs.find(
+			( config ) => config.kind === kind && config.name === name
+		);
 		if ( ! entityConfig || entityConfig?.__experimentalNoFetch ) {
 			return;
 		}
@@ -723,7 +726,9 @@ export const saveEditedEntityRecord =
 			return;
 		}
 		const configs = await dispatch( getOrLoadEntitiesConfig( kind ) );
-		const entityConfig = find( configs, { kind, name } );
+		const entityConfig = configs.find(
+			( config ) => config.kind === kind && config.name === name
+		);
 		if ( ! entityConfig ) {
 			return;
 		}

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { capitalCase, pascalCase } from 'change-case';
-import { map, find, get } from 'lodash';
+import { map, get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -288,7 +288,9 @@ export const getMethodName = (
 	prefix = 'get',
 	usePlural = false
 ) => {
-	const entityConfig = find( rootEntitiesConfig, { kind, name } );
+	const entityConfig = rootEntitiesConfig.find(
+		( config ) => config.kind === kind && config.name === name
+	);
 	const kindPrefix = kind === 'root' ? '' : pascalCase( kind );
 	const nameSuffix = pascalCase( name ) + ( usePlural ? 's' : '' );
 	const suffix =
@@ -313,7 +315,9 @@ export const getOrLoadEntitiesConfig =
 			return configs;
 		}
 
-		const loader = find( additionalEntityConfigLoaders, { kind } );
+		const loader = additionalEntityConfigLoaders.find(
+			( l ) => l.kind === kind
+		);
 		if ( ! loader ) {
 			return [];
 		}

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { set, map, find, get } from 'lodash';
+import { set, map, get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -218,7 +218,9 @@ export function getEntityConfig(
 	kind: string,
 	name: string
 ): any {
-	return find( state.entities.config, { kind, name } );
+	return state.entities.config?.find(
+		( config ) => config.kind === kind && config.name === name
+	);
 }
 
 /**
@@ -1129,7 +1131,10 @@ export function getAutosave< EntityRecord extends ET.EntityRecord< any > >(
 	}
 
 	const autosaves = state.autosaves[ postId ];
-	return find( autosaves, { author: authorId } ) as EntityRecord | undefined;
+
+	return autosaves?.find(
+		( autosave: any ) => autosave.author === authorId
+	) as EntityRecord | undefined;
 }
 
 /**


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.find()` from the `core-data` package. There are a few usages in that package and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `Array.prototype.find()` instead of `_.find()`. We're adding optional chaining where necessary.

## Testing Instructions

Verify all checks are still green. The changes are covered by unit tests.