### PR TITLE
[block-serialization-default-parser][fix] Return an empty array early if doc data passed to `parse` is invalid 

### DIFF
--- a/packages/block-serialization-default-parser/parser.php
+++ b/packages/block-serialization-default-parser/parser.php
@@ -225,6 +225,10 @@ class WP_Block_Parser {
 	 * @return array[]
 	 */
 	public function parse( $document ) {
+		if ( gettype( $document ) !== 'string' ) {
+			return [];
+		}
+
 		$this->document    = $document;
 		$this->offset      = 0;
 		$this->output      = array();

--- a/packages/block-serialization-default-parser/src/index.js
+++ b/packages/block-serialization-default-parser/src/index.js
@@ -323,7 +323,6 @@ function proceed() {
 				addFreeform();
 				return false;
 			}
-
 			// If we're not nesting then this is easy - close the block.
 			if ( 1 === stackDepth ) {
 				addBlockFromStack( startOffset );
@@ -438,7 +437,8 @@ function nextToken() {
  * @param {number} [rawLength]
  */
 function addFreeform( rawLength ) {
-	const length = rawLength ? rawLength : document.length - offset;
+	// document might be undefined
+	const length = rawLength ? rawLength : ( document?.length || 0 ) - offset;
 
 	if ( 0 === length ) {
 		return;

--- a/packages/block-serialization-default-parser/src/index.js
+++ b/packages/block-serialization-default-parser/src/index.js
@@ -217,6 +217,10 @@ function Frame( block, tokenStart, tokenLength, prevOffset, leadingHtmlStart ) {
  * @return {ParsedBlock[]} A block-based representation of the input HTML.
  */
 export const parse = ( doc ) => {
+	if ( 'string' !== typeof doc ) {
+		return [];
+	}
+
 	document = doc;
 	offset = 0;
 	output = [];
@@ -437,8 +441,7 @@ function nextToken() {
  * @param {number} [rawLength]
  */
 function addFreeform( rawLength ) {
-	// document might be undefined
-	const length = rawLength ? rawLength : ( document?.length || 0 ) - offset;
+	const length = rawLength ? rawLength : document.length - offset;
 
 	if ( 0 === length ) {
 		return;


### PR DESCRIPTION
## What?

Fixes an edge case where `document` (not to confuse with the DOM's `window.document` object, in this module, `document` is a local variable) is `undefined` and causes a `TypeError`. This happens in some hard-to-reproduce edge cases, and unfortunately I didn't manage to get to the same state in a new test site, but I tested the solution in the test site with the dirty state that caused it.

It happened in the Customizer for a theme that had widget slots. Somehow it got to a state that caused the following error as soon as I opened the `Widgets->Sidebar` and after dismissing the `Welcome to Block Widgtes` welcome message in the widget block editor:

` TypeError: Cannot read properties of undefined (reading 'length')`

In: https://github.com/WordPress/gutenberg/blob/trunk/packages/block-serialization-default-parser/src/index.js#L441

Unfortunately, I don't know how to reproduce the issue consistently, and this fix, while suitable for now, probably does not fix the root issue. More investigation is needed.

## Why?

The bug is causing the widget block editor to completely break.


## How?

By handling `undefined` (js) /`null` (PHP) and returning early from `parse` with an empty array, and avoiding other functions to be called that wouldn't expect `doc` / `$document` to be nullish, which would cause an exception later on.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Testing Instructions

Apart from the ones I added in the `What` section, I don't have complete steps to reproduce now, unfortunately.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
