### PR TITLE
Global Styles: Fix Reset to defaults action by moving fills to be within context provider

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -172,7 +172,6 @@ export default function Editor() {
 		<>
 			{ isEditMode && <WelcomeGuide /> }
 			<KeyboardShortcuts.Register />
-			<SidebarComplementaryAreaFills />
 			<EntityProvider kind="root" type="site">
 				<EntityProvider
 					kind="postType"
@@ -181,6 +180,7 @@ export default function Editor() {
 				>
 					<GlobalStylesProvider>
 						<BlockContextProvider value={ blockContext }>
+							<SidebarComplementaryAreaFills />
 							<InterfaceSkeleton
 								className={
 									showIconLabels && 'show-icon-labels'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes: https://github.com/WordPress/gutenberg/issues/46484

Moves `<SidebarComplementaryAreaFills />` which contains the global styles sidebar to be within the global styles provider.

Kudos: @ramonjd for the idea!

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Without being inside the provider, the `Reset to defaults` action does not work.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Move `<SidebarComplementaryAreaFills />` to be within the global styles provider.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

* Follow the issue over in #46484 — without this PR, it isn't possible to Reset to defaults within global styles
* With this PR applied, you should be able to go to global styles > ellipsis menu > Reset to defaults to reset back to theme defaults
* Double check that otherwise, global styles (and the site editor) are working correctly

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![2022-12-13 10 38 51](https://user-images.githubusercontent.com/14988353/207183817-c468ee24-9ada-40a0-98df-739c31dac3f2.gif) | ![2022-12-13 11 23 27](https://user-images.githubusercontent.com/14988353/207196364-ae8117e3-30a6-4c06-bd92-22c879386a3c.gif) |
