### PR TITLE
[`customize-widgets/utils/widgetToBlock`] Initialize a widget's `raw_content.content` to an empty string if it's `undefined`

### DIFF
--- a/packages/customize-widgets/src/utils.js
+++ b/packages/customize-widgets/src/utils.js
@@ -102,6 +102,7 @@ export function widgetToBlock( { id, idBase, number, instance } ) {
 		...rest
 	} = instance;
 
+	// It's unclear why `content` is sometimes `undefined`, but it shouldn't be.
 	const rawContent = rawInstance.content || '';
 	const raw = { ...rawInstance, content: rawContent };
 

--- a/packages/customize-widgets/src/utils.js
+++ b/packages/customize-widgets/src/utils.js
@@ -102,6 +102,10 @@ export function widgetToBlock( { id, idBase, number, instance } ) {
 		...rest
 	} = instance;
 
+	if ( ! raw.content ) {
+		raw.content = '';
+	}
+
 	if ( idBase === 'block' ) {
 		const parsedBlocks = parse( raw.content, {
 			__unstableSkipAutop: true,

--- a/packages/customize-widgets/src/utils.js
+++ b/packages/customize-widgets/src/utils.js
@@ -98,13 +98,12 @@ export function widgetToBlock( { id, idBase, number, instance } ) {
 	const {
 		encoded_serialized_instance: encoded,
 		instance_hash_key: hash,
-		raw_instance: raw,
+		raw_instance: rawInstance,
 		...rest
 	} = instance;
 
-	if ( ! raw.content ) {
-		raw.content = '';
-	}
+	const rawContent = rawInstance.content || '';
+	const raw = { ...rawInstance, content: rawContent };
 
 	if ( idBase === 'block' ) {
 		const parsedBlocks = parse( raw.content, {


### PR DESCRIPTION
## What?

Follow-up to https://github.com/WordPress/gutenberg/pull/46475.

We experienced widgets with `raw_content` = `{}`, hence it doesn't contain a valid `content` property. This feeds invalid (`undefined`) data to the parser and makes it break when it gets to https://github.com/WordPress/gutenberg/blob/trunk/packages/block-serialization-default-parser/src/index.js#L441, with: `TypeError: Cannot read properties of undefined (reading 'length')`.

The exception bubbles up and breaks the widget block editor:

![Screenshot from 2022-12-12 19-11-58](https://user-images.githubusercontent.com/81248/207201765-95ee5a99-73e7-430a-a01b-2e08f662fc9c.png)

After chatting with @dmsnell and with his help (thanks!), we continued troubleshooting the issue, and eventually decided to move the fix up the stack to this function as the root issue is not in the parser. We're still unsure where the actual culprit is as it's been hard to troubleshoot, but a guard in `widgetToBlock` seems more viable and safer than modifying the lower-level parser. If anyone has any ideas on where the culprit might be, feel free to comment here. 

## Why?

I've experienced a crash in the customize widgets block editor because the widget JSON object's `raw` property has a value of `{}` (empty object). Here's a sample widget object JSON that ended up causing the issue: https://gist.github.com/fullofcaffeine/3807914297e3e836866edf6e49b61963. Notice how the `raw` property is `{}`. We have no idea how it got to this state, and that's why we decided to add the guard in the `widgetToBlock` instead.

## How?

Add a simple guard that checks if the `raw_content` property for the given widget passed over to `widgetToBlock` has an `undefined` `content` property, if so, we set its `content` property to `''` (empty string). 

## Testing Instructions

I have no idea how the widget got to the state where `raw` is `{}`, but you can manually change one of your widgets in your db and set the `raw` property to `{}` in order to reproduce it. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
