### PR TITLE
Fix fatal error by checking if block_type asset properties are set

### DIFF
--- a/lib/compat/wordpress-6.2/script-loader.php
+++ b/lib/compat/wordpress-6.2/script-loader.php
@@ -92,13 +92,13 @@ function gutenberg_resolve_assets_override() {
 	foreach ( $block_registry->get_all_registered() as $block_type ) {
 		$style_handles = array_merge(
 			$style_handles,
-			$block_type->style_handles,
-			$block_type->editor_style_handles
+			is_null( $block_type->style_handles ) ? array() : $block_type->style_handles,
+			is_null( $block_type->editor_style_handles ) ? array() : $block_type->editor_style_handles
 		);
 
 		$script_handles = array_merge(
 			$script_handles,
-			$block_type->script_handles
+			is_null( $block_type->script_handles ) ? array() : $block_type->script_handles
 		);
 	}
 

--- a/lib/compat/wordpress-6.2/script-loader.php
+++ b/lib/compat/wordpress-6.2/script-loader.php
@@ -92,15 +92,15 @@ function gutenberg_resolve_assets_override() {
 	foreach ( $block_registry->get_all_registered() as $block_type ) {
 		// In older WordPress versions, like 6.0, these properties are not defined.
 		if ( isset( $block_type->style_handles ) && is_array( $block_type->style_handles ) ) {
-			array_merge( $style_handles, $block_type->style_handles );
+			$style_handles = array_merge( $style_handles, $block_type->style_handles );
 		}
 
 		if ( isset( $block_type->editor_style_handles ) && is_array( $block_type->editor_style_handles ) ) {
-			array_merge( $style_handles, $block_type->editor_style_handles );
+			$style_handles = array_merge( $style_handles, $block_type->editor_style_handles );
 		}
 
 		if ( isset( $block_type->script_handles ) && is_array( $block_type->script_handles ) ) {
-			array_merge( $script_handles, $block_type->script_handles );
+			$script_handles = array_merge( $script_handles, $block_type->script_handles );
 		}
 	}
 

--- a/lib/compat/wordpress-6.2/script-loader.php
+++ b/lib/compat/wordpress-6.2/script-loader.php
@@ -90,16 +90,20 @@ function gutenberg_resolve_assets_override() {
 	$block_registry = WP_Block_Type_Registry::get_instance();
 
 	foreach ( $block_registry->get_all_registered() as $block_type ) {
-		$style_handles = array_merge(
-			$style_handles,
-			isset( $block_type->style_handles ) ? $block_type->style_handles : array(),
-			isset( $block_type->editor_style_handles ) ? $block_type->editor_style_handles : array()
-		);
+		if ( isset( $block_type->style_handles ) && isset( $block_type->editor_style_handles ) ) {
+			$style_handles = array_merge(
+				$style_handles,
+				$block_type->style_handles,
+				$block_type->editor_style_handles
+			);
+		}
 
-		$script_handles = array_merge(
-			$script_handles,
-			isset( $block_type->script_handles ) ? $block_type->script_handles : array()
-		);
+		if ( isset( $block_type->script_handles ) ) {
+			array_merge(
+				$script_handles,
+				$block_type->script_handles
+			);
+		}
 	}
 
 	$style_handles = array_unique( $style_handles );

--- a/lib/compat/wordpress-6.2/script-loader.php
+++ b/lib/compat/wordpress-6.2/script-loader.php
@@ -92,13 +92,13 @@ function gutenberg_resolve_assets_override() {
 	foreach ( $block_registry->get_all_registered() as $block_type ) {
 		$style_handles = array_merge(
 			$style_handles,
-			is_null( $block_type->style_handles ) ? array() : $block_type->style_handles,
-			is_null( $block_type->editor_style_handles ) ? array() : $block_type->editor_style_handles
+			isset( $block_type->style_handles ) ? $block_type->style_handles : array(),
+			isset( $block_type->editor_style_handles ) ? $block_type->editor_style_handles : array()
 		);
 
 		$script_handles = array_merge(
 			$script_handles,
-			is_null( $block_type->script_handles ) ? array() : $block_type->script_handles
+			isset( $block_type->script_handles ) ? $block_type->script_handles : array()
 		);
 	}
 

--- a/lib/compat/wordpress-6.2/script-loader.php
+++ b/lib/compat/wordpress-6.2/script-loader.php
@@ -90,6 +90,7 @@ function gutenberg_resolve_assets_override() {
 	$block_registry = WP_Block_Type_Registry::get_instance();
 
 	foreach ( $block_registry->get_all_registered() as $block_type ) {
+		// In older WordPress versions, like 6.0, these properties are not defined.
 		if ( isset( $block_type->style_handles ) && isset( $block_type->editor_style_handles ) ) {
 			$style_handles = array_merge(
 				$style_handles,

--- a/lib/compat/wordpress-6.2/script-loader.php
+++ b/lib/compat/wordpress-6.2/script-loader.php
@@ -91,24 +91,16 @@ function gutenberg_resolve_assets_override() {
 
 	foreach ( $block_registry->get_all_registered() as $block_type ) {
 		// In older WordPress versions, like 6.0, these properties are not defined.
-		if (
-			isset( $block_type->style_handles ) &&
-			is_array($block_type->style_handles) &&
-			isset( $block_type->editor_style_handles ) &&
-			is_array( $block_type->editor_style_handles )
-		) {
-			$style_handles = array_merge(
-				$style_handles,
-				$block_type->style_handles,
-				$block_type->editor_style_handles
-			);
+		if ( isset( $block_type->style_handles ) && is_array( $block_type->style_handles ) ) {
+			array_merge( $style_handles, $block_type->style_handles );
+		}
+
+		if ( isset( $block_type->editor_style_handles ) && is_array( $block_type->editor_style_handles ) ) {
+			array_merge( $style_handles, $block_type->editor_style_handles );
 		}
 
 		if ( isset( $block_type->script_handles ) && is_array( $block_type->script_handles ) ) {
-			array_merge(
-				$script_handles,
-				$block_type->script_handles
-			);
+			array_merge( $script_handles, $block_type->script_handles );
 		}
 	}
 

--- a/lib/compat/wordpress-6.2/script-loader.php
+++ b/lib/compat/wordpress-6.2/script-loader.php
@@ -91,7 +91,12 @@ function gutenberg_resolve_assets_override() {
 
 	foreach ( $block_registry->get_all_registered() as $block_type ) {
 		// In older WordPress versions, like 6.0, these properties are not defined.
-		if ( isset( $block_type->style_handles ) && isset( $block_type->editor_style_handles ) ) {
+		if (
+			isset( $block_type->style_handles ) &&
+			is_array($block_type->style_handles) &&
+			isset( $block_type->editor_style_handles ) &&
+			is_array( $block_type->editor_style_handles )
+		) {
 			$style_handles = array_merge(
 				$style_handles,
 				$block_type->style_handles,
@@ -99,7 +104,7 @@ function gutenberg_resolve_assets_override() {
 			);
 		}
 
-		if ( isset( $block_type->script_handles ) ) {
+		if ( isset( $block_type->script_handles ) && is_array( $block_type->script_handles ) ) {
 			array_merge(
 				$script_handles,
 				$block_type->script_handles


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
We've noticed the following fatal error with Gutenberg 14.71, which would be great to resolve in a patch release quickly! **Please merge this while I'm offline and create a path release if it looks like a reasonable approach! Or if you have a better idea, overwrite this branch or make a new PR with it!** _Since it's a fatal error, it'd be nice to not get blocked on async reviews ;)_

```sh
[10-Dec-2022 12:41:38 UTC] PHP Fatal error:  Uncaught TypeError: array_merge(): Argument #2 must be of type array, null given in /wordpress/plugins/gutenberg/14.7.1/lib/compat/wordpress-6.2/script-loader.php:96
Stack trace:
#0 /wordpress/plugins/gutenberg/14.7.1/lib/compat/wordpress-6.2/script-loader.php(96): array_merge(Array, NULL, NULL)
#1 /wordpress/plugins/gutenberg/14.7.1/lib/compat/wordpress-6.2/script-loader.php(138): gutenberg_resolve_assets_override()
#2 /wordpress/core/6.0.3/wp-includes/class-wp-hook.php(309): {closure}(Array)
#3 /wordpress/core/6.0.3/wp-includes/plugin.php(191): WP_Hook->apply_filters(Array, Array)
#4 /wordpress/core/6.0.3/wp-includes/block-editor.php(507): apply_filters('block_editor_se...', Array, Object(WP_Block_Editor_Context))
#5 /wordpress/core/6.0.3/wp-admin/edit-form-blocks.php(282): get_block_editor_settings(Array, Object(WP_Block_Editor_Context))
#6 /wordpress/core/6.0.3/wp-admin/post.php(187): require('/wordpress/core...')
#7 {main}
  thrown in /wordpress/plugins/gutenberg/14.7.1/lib/compat/wordpress-6.2/script-loader.php on line 96
```

This adds some safeguards in case these values are not defined or null (`isset`). Since these new asset properties were [introduced in 6.1](https://github.com/WordPress/WordPress/blob/4ffd8b005e8aef4fb3b9983232673618b71f2edb/wp-includes/class-wp-block-type.php#L168-L206), they won't work in 6.0.

~**Question:** why is the 6.2 compat lib loaded for WordPress 6.0??~

This was answered for me: 6.2 compat lib is loaded to provide compatibility with 6.2 Gutenberg features to older WordPress versions.

## Why?
To fix the fatal.

## How?
Check if properties `isset`, and use an empty array if not.

## Testing Instructions
Set your `.wp-env.override.json` file to this to get PHP 8 and WP 6.0

```json
{
	"core": "https://wordpress.org/wordpress-6.0.zip",
	"phpVersion": "8.0"
}
```

Checkout the current Gutenberg release locally: `git checkout tags/v14.7.1`.

If you build the Gutenberg plugin and start wp-env, the page will crash trying to edit a post. If you apply the change in this PR, you should be able to edit the post.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

demo of fix:

https://user-images.githubusercontent.com/6265975/207447926-32a2e5af-9b8b-4d99-9b97-e2489dfada71.mov

