### PR TITLE
Global Styles: Add "custom-css" as an acceptable value in the docs for gutenberg_get_global_stylesheet

### DIFF
--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -63,7 +63,7 @@ if ( ! function_exists( 'wp_theme_has_theme_json_clean_cache' ) ) {
  * Returns the stylesheet resulting of merging core, theme, and user data.
  *
  * @param array $types Types of styles to load. Optional.
- *                     It accepts 'variables', 'styles', 'presets' as values.
+ *                     It accepts 'variables', 'styles', 'presets', 'custom-css' as values.
  *                     If empty, it'll load all for themes with theme.json support
  *                     and only [ 'variables', 'presets' ] for themes without theme.json support.
  *


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/46141

## What?

In https://github.com/WordPress/gutenberg/pull/46141/files#diff-cedd84c7ed1db0edc59408b4ee36590a340ed11b5c36a77732026518db0f3e7aR88 we added `custom-css` in `gutenberg_get_global_stylesheet`. However, the function's docs were not updated to mirror that change. This PR adds the `custom-css` value as an acceptable value in the function's docs.
