### PR TITLE
Block Editor: Fix content locked patterns

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2690,8 +2690,8 @@ export const __unstableGetContentLockingParent = createSelector(
 	( state, clientId ) => {
 		let current = clientId;
 		let result;
-		while ( !! state.blocks.parents[ current ] ) {
-			current = state.blocks.parents[ current ];
+		while ( state.blocks.parents.has( current ) ) {
+			current = state.blocks.parents.get( current );
 			if ( getTemplateLock( state, current ) === 'contentOnly' ) {
 				result = current;
 			}

--- a/test/e2e/specs/editor/various/__snapshots__/Content-only-lock-should-be-able-to-edit-the-content-of-blocks-with-content-only-lock-1-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Content-only-lock-should-be-able-to-edit-the-content-of-blocks-with-content-only-lock-1-chromium.txt
@@ -1,0 +1,5 @@
+<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>Hello World</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->

--- a/test/e2e/specs/editor/various/content-only-lock.spec.js
+++ b/test/e2e/specs/editor/various/content-only-lock.spec.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Content-only lock', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'should be able to edit the content of blocks with content-only lock', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		// Add content only locked block in the code editor
+		await pageUtils.pressKeyWithModifier( 'secondary', 'M' ); // Emulates CTRL+Shift+Alt + M => toggle code editor
+		await page.click( '.editor-post-text-editor' );
+		await page.keyboard
+			.type( `<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
+        <div class="wp-block-group"><!-- wp:paragraph -->
+        <p>Hello</p>
+        <!-- /wp:paragraph --></div>
+        <!-- /wp:group -->` );
+		await pageUtils.pressKeyWithModifier( 'secondary', 'M' );
+
+		await page.click( 'role=document[name="Paragraph block"i]' );
+		await page.keyboard.type( ' World' );
+		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
Follow-up to #46225 
Addresses https://github.com/WordPress/gutenberg/pull/46225#issuecomment-1346543589

## What?

We've refactored the reducer of the "parents" blocks, but there is a selector that was missed in the refactoring, this broke the "content locking" behavior. It became impossible to edit blocks with content only templateLock.

## Testing Instructions

1- Insert the following blocks in the code editor

```
<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column -->
<div class="wp-block-column"><!-- wp:image {"id":525,"sizeSlug":"large","linkDestination":"none"} -->
<figure class="wp-block-image size-large"><img src="https://s.w.org/patterns/files/2021/06/Iris-793x1024.jpg" alt="" class="wp-image-525"/></figure>
<!-- /wp:image -->

<!-- wp:paragraph {"style":{"typography":{"fontSize":"14px"}}} -->
<p style="font-size:14px"><strong>White Irises</strong><br>Ogawa Kazumasa</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:spacer -->
<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:paragraph {"style":{"typography":{"fontSize":"14px"}}} -->
<p style="font-size:14px"><strong>Cherry Blossom</strong><br>Ogawa Kazumasa</p>
<!-- /wp:paragraph -->

<!-- wp:image {"id":524,"sizeSlug":"large","linkDestination":"none"} -->
<figure class="wp-block-image size-large"><img src="https://s.w.org/patterns/files/2021/06/Cherry-Blossom-707x1024.jpg" alt="" class="wp-image-524"/></figure>
<!-- /wp:image --></div>
<!-- /wp:column --></div>
<!-- /wp:columns --></div>
<!-- /wp:group -->
```

2- Make sure you can edit the paragraphs text inside the children block.