### PR TITLE
Image Block: Ensure drag handle matches cursor position when resizing a center aligned image

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -611,6 +611,7 @@ export default function Image( {
 						height: parseInt( currentHeight + delta.height, 10 ),
 					} );
 				} }
+				resizeRatio={ align === 'center' ? 2 : 1 }
 			>
 				{ img }
 			</ResizableBox>


### PR DESCRIPTION
## What?
This fixes a small bug when resizing a center aligned image. Previously the drag handle wasn't following the mouse position for center aligned images. 

## Why?
The reason the bug happens is that for a center aligned image, the width is resized on both the left and the right sides of the image, so the drag handle only moves at half the speed of the cursor.

## How?
The ResizableBox component accepts a `resizeRatio` prop for fixing this issue. For center aligned images it's set to `2` to indicate that the drag handle should move at double its normal speed. In all other instances this is set to the default of `1`.

## Testing Instructions
1. Create a new post and add an image block
2. Add an image to the image block
3. Center align the image
4. Resize the image using the drag handle

In this PR - the drag handle follows the cursor position
In trunk - the drag handle doesn't follow the cursor position

### Testing Instructions for Keyboard
This particular feature can't be accessed via a keyboard, so there's no way to test it. There are keyboard accessible ways to resize an image, but they don't have this bug.

## Screenshots or screencast <!-- if applicable -->
### Before

https://user-images.githubusercontent.com/677833/207273374-c2ddd47c-0727-4353-9320-c5fb035c4d8d.mp4

### After

https://user-images.githubusercontent.com/677833/207273013-60e4db9b-9be3-47a2-a412-9a305506f1f0.mp4

