### PR TITLE
ESLint: Fix warnings in the data package

### DIFF
--- a/packages/data/src/plugins/persistence/test/index.js
+++ b/packages/data/src/plugins/persistence/test/index.js
@@ -26,9 +26,10 @@ describe( 'persistence', () => {
 	} );
 
 	it( 'should not mutate options', () => {
-		const options = Object.freeze( { persist: true, reducer() {} } );
-
-		registry.registerStore( 'test', options );
+		expect( () => {
+			const options = Object.freeze( { persist: true, reducer() {} } );
+			registry.registerStore( 'test', options );
+		} ).not.toThrowError( /object is not extensible/ );
 	} );
 
 	it( 'should load a persisted value as initialState', () => {

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -1,3 +1,5 @@
+/* eslint jest/expect-expect: ["warn", { "assertFunctionNames": ["expect", "subscribeUntil"] }] */
+
 /**
  * Internal dependencies
  */


### PR DESCRIPTION
## What?
This PR fixes a few ESLint warnings in the `@wordpress/data` package.

## Why?
Ideally, we should have zero ESLint warnings and errors.

## How?
* We're adding an assertion in one of the tests so it's more accurately expressing what it actually tests.
* We're customizing the allowed assertion functions to reflect the existing test cases.

## Testing Instructions
* Verify tests still pass.
* Run `npm run lint:js packages/data` and verify that there are no `jest/expect-expect` warnings remaining.
