### PR TITLE
ESLint: Fix warning in `getBlockAttribute` documentation

### DIFF
--- a/packages/blocks/src/api/parser/get-block-attributes.js
+++ b/packages/blocks/src/api/parser/get-block-attributes.js
@@ -102,11 +102,11 @@ export function isOfTypes( value, types ) {
  * commentAttributes returns the attribute value depending on its source
  * definition of the given attribute key.
  *
- * @param {string}      attributeKey      Attribute key.
- * @param {Object}      attributeSchema   Attribute's schema.
- * @param {Node}        innerDOM          Parsed DOM of block's inner HTML.
- * @param {Object}      commentAttributes Block's comment attributes.
- * @param {string}      innerHTML         Raw HTML from block node's innerHTML property.
+ * @param {string} attributeKey      Attribute key.
+ * @param {Object} attributeSchema   Attribute's schema.
+ * @param {Node}   innerDOM          Parsed DOM of block's inner HTML.
+ * @param {Object} commentAttributes Block's comment attributes.
+ * @param {string} innerHTML         Raw HTML from block node's innerHTML property.
  *
  * @return {*} Attribute value.
  */


### PR DESCRIPTION
## What?
This PR is fixing a `jsdoc/check-line-alignment` ESLint violation in the blocks package.

## Why?
Ideally, we should have zero ESLint warnings and errors.

## How?
We're aligning the JSDoc block to conform the ESLint rule.

## Testing Instructions
Run `npm run lint:js packages/blocks/src/api/parser/get-block-attributes.js` and verify it returns no warnings.
