### PR TITLE
Components: Also ignore `no-node-access` for some components

### DIFF
--- a/packages/components/src/range-control/test/index.tsx
+++ b/packages/components/src/range-control/test/index.tsx
@@ -43,11 +43,11 @@ describe( 'RangeControl', () => {
 				/>
 			);
 
-			// eslint-disable-next-line testing-library/no-container
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 			const beforeIcon = container.querySelector(
 				'.dashicons-format-image'
 			);
-			// eslint-disable-next-line testing-library/no-container
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 			const afterIcon = container.querySelector(
 				'.dashicons-format-video'
 			);

--- a/packages/components/src/tooltip/test/index.js
+++ b/packages/components/src/tooltip/test/index.js
@@ -212,7 +212,7 @@ describe( 'Tooltip', () => {
 			// Note: this is testing for implementation details,
 			// but couldn't find a better way.
 			const buttonRect = button.getBoundingClientRect();
-			// eslint-disable-next-line testing-library/no-container
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 			const eventCatcher = container.querySelector( '.event-catcher' );
 			const eventCatcherRect = eventCatcher.getBoundingClientRect();
 			expect( buttonRect ).toEqual( eventCatcherRect );
@@ -252,7 +252,7 @@ describe( 'Tooltip', () => {
 				</Tooltip>
 			);
 
-			// eslint-disable-next-line testing-library/no-container
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 			const eventCatcher = container.querySelector( '.event-catcher' );
 			await user.click( eventCatcher );
 			expect( onClickMock ).not.toHaveBeenCalled();

--- a/packages/components/src/unit-control/test/index.tsx
+++ b/packages/components/src/unit-control/test/index.tsx
@@ -115,7 +115,7 @@ describe( 'UnitControl', () => {
 				withoutClassName.querySelector( '.components-unit-control' )
 			).not.toHaveClass( 'hello' );
 			expect(
-				// eslint-disable-next-line testing-library/no-container
+				// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 				withClassName.querySelector( '.components-unit-control' )
 			).toHaveClass( 'hello' );
 		} );


### PR DESCRIPTION
## What?
In #46160 we disabled the `no-container` rule for a few instances. We're now disabling the `no-node-access` for some of those.

## Why?
Those violations aren't fixable without a solid refactor of the components, so we're intentionally ignoring them for the time being.

## How?
We're adding the `no-node-access` ignore rule to the existing `no-container` rule.

## Testing Instructions
* Run `npm run lint:js packages/components`
* Verify you don't get any warnings other than the existing `jest/no-disabled-tests` one.
