### PR TITLE
Shadow: Add shadow presets and UI tools in global styles

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -50,7 +50,7 @@ Prompt visitors to take action with a button-style link. ([Source](https://githu
 
 -	**Name:** core/button
 -	**Category:** design
--	**Supports:** anchor, color (background, gradients, text), spacing (padding), typography (fontSize, lineHeight), ~~alignWide~~, ~~align~~, ~~reusable~~
+-	**Supports:** anchor, color (background, gradients, text), shadow, spacing (padding), typography (fontSize, lineHeight), ~~alignWide~~, ~~align~~, ~~reusable~~
 -	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, text, textAlign, textColor, title, url, width
 
 ## Buttons

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -187,6 +187,7 @@
 			"text": true
 		},
 		"shadow": {
+			"defaultPresets": true,
 			"presets": [
 				{
 					"name": "Natural",

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -190,14 +190,14 @@
 			"defaultPresets": true,
 			"presets": [
 				{
-					"name": "Natural",
-					"slug": "natural",
-					"shadow": "0 .2rem .3rem 0 rgba(0,0,0, 0.3), 0 .5rem .6rem 0 rgba(0,0,0, 0.4)"
+					"name": "Elevated",
+					"slug": "elevated",
+					"shadow": "rgba(0, 0, 0, 0.4) 0 2rem 4rem -1rem, rgba(0, 0, 0, 0.6) 0 1rem 2rem -1.5rem"
 				},
 				{
-					"name": "Sharp",
-					"slug": "sharp",
-					"shadow": ".5rem .5rem 0 0 rgba(0,0,0, 0.4)"
+					"name": "Near",
+					"slug": "near",
+					"shadow": "rgba(0, 0, 0, 0.3) 0 0.25rem 0.5rem 0, rgba(0, 0, 0, 0.4) 0 0.05rem 0.2rem 0px"
 				}
 			]
 		},

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -190,14 +190,29 @@
 			"defaultPresets": true,
 			"presets": [
 				{
-					"name": "Elevated",
-					"slug": "elevated",
-					"shadow": "rgba(0, 0, 0, 0.4) 0 2rem 4rem 0, rgba(0, 0, 0, 0.6) 0 1rem 2rem 0"
+					"name": "Natural",
+					"slug": "natural",
+					"shadow": "6px 6px 9px rgba(0, 0, 0, 0.2)"
 				},
 				{
-					"name": "Near",
-					"slug": "near",
-					"shadow": "rgba(0, 0, 0, 0.3) 0 0.25rem 0.5rem 0, rgba(0, 0, 0, 0.4) 0 0.05rem 0.2rem 0px"
+					"name": "Deep",
+					"slug": "deep",
+					"shadow": "12px 12px 50px rgba(0, 0, 0, 0.4)"
+				},
+				{
+					"name": "Sharp",
+					"slug": "sharp",
+					"shadow": "6px 6px 0px rgba(0, 0, 0, 0.2)"
+				},
+				{
+					"name": "Outlined",
+					"slug": "outlined",
+					"shadow": "6px 6px 0px -3px rgba(255, 255, 255, 1), 6px 6px rgba(0, 0, 0, 1)"
+				},
+				{
+					"name": "Crisp",
+					"slug": "crisp",
+					"shadow": "6px 6px 0px rgba(0, 0, 0, 1)"
 				}
 			]
 		},

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -192,7 +192,7 @@
 				{
 					"name": "Elevated",
 					"slug": "elevated",
-					"shadow": "rgba(0, 0, 0, 0.4) 0 2rem 4rem -1rem, rgba(0, 0, 0, 0.6) 0 1rem 2rem -1.5rem"
+					"shadow": "rgba(0, 0, 0, 0.4) 0 2rem 4rem 0, rgba(0, 0, 0, 0.6) 0 1rem 2rem 0"
 				},
 				{
 					"name": "Near",

--- a/packages/block-editor/src/components/global-styles/utils.js
+++ b/packages/block-editor/src/components/global-styles/utils.js
@@ -62,6 +62,12 @@ export const PRESET_METADATA = [
 		classes: [],
 	},
 	{
+		path: [ 'shadow', 'presets' ],
+		valueKey: 'shadow',
+		cssVarInfix: 'shadow',
+		classes: [],
+	},
+	{
 		path: [ 'typography', 'fontSizes' ],
 		valueFunc: ( preset, { typography: typographySettings } ) =>
 			getTypographyFontSizeValue( preset, typographySettings ),
@@ -127,6 +133,7 @@ export const STYLE_PATH_TO_CSS_VAR_INFIX = {
 	'elements.h6.typography.fontFamily': 'font-family',
 	'elements.h6.color.gradient': 'gradient',
 	'color.gradient': 'gradient',
+	shadow: 'shadow',
 	'typography.fontSize': 'font-size',
 	'typography.fontFamily': 'font-family',
 };

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -83,6 +83,7 @@
 			}
 		},
 		"reusable": false,
+		"shadow": true,
 		"spacing": {
 			"__experimentalSkipSerialization": true,
 			"padding": [ "horizontal", "vertical" ],

--- a/packages/edit-site/src/components/global-styles/context-menu.js
+++ b/packages/edit-site/src/components/global-styles/context-menu.js
@@ -85,9 +85,9 @@ function ContextMenu( { name, parentMenu = '' } ) {
 					<NavigationButtonAsItem
 						icon={ border }
 						path={ parentMenu + '/border' }
-						aria-label={ __( 'Border styles' ) }
+						aria-label={ __( 'Border & shadow styles' ) }
 					>
-						{ __( 'Border' ) }
+						{ __( 'Border & Shadow' ) }
 					</NavigationButtonAsItem>
 				) }
 				{ hasLayoutPanel && (

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -71,6 +71,11 @@ export function getSupportedGlobalStylesPanels( name ) {
 		supportKeys.push( 'blockGap' );
 	}
 
+	// check for shadow support
+	if ( blockType?.supports?.shadow ) {
+		supportKeys.push( 'shadow' );
+	}
+
 	Object.keys( STYLE_PROPERTY ).forEach( ( styleName ) => {
 		if ( ! STYLE_PROPERTY[ styleName ].support ) {
 			return;

--- a/packages/edit-site/src/components/global-styles/screen-border.js
+++ b/packages/edit-site/src/components/global-styles/screen-border.js
@@ -10,16 +10,21 @@ import ScreenHeader from './header';
 import BorderPanel, { useHasBorderPanel } from './border-panel';
 import BlockPreviewPanel from './block-preview-panel';
 import { getVariationClassName } from './utils';
+import ShadowPanel, { useHasShadowControl } from './shadow-panel';
 
 function ScreenBorder( { name, variation = '' } ) {
 	const hasBorderPanel = useHasBorderPanel( name );
-	const variationClassName = getVariationClassName( variation );
+	const variationClassName = getVariationClassName( variationPath );
+	const hasShadowPanel = useHasShadowControl( name );
 	return (
 		<>
-			<ScreenHeader title={ __( 'Border' ) } />
+			<ScreenHeader title={ __( 'Border & Shadow' ) } />
 			<BlockPreviewPanel name={ name } variation={ variationClassName } />
 			{ hasBorderPanel && (
 				<BorderPanel name={ name } variation={ variation } />
+			) }
+			{ hasShadowPanel && (
+				<ShadowPanel name={ name } variationPath={ variationPath } />
 			) }
 		</>
 	);

--- a/packages/edit-site/src/components/global-styles/screen-border.js
+++ b/packages/edit-site/src/components/global-styles/screen-border.js
@@ -14,7 +14,7 @@ import ShadowPanel, { useHasShadowControl } from './shadow-panel';
 
 function ScreenBorder( { name, variation = '' } ) {
 	const hasBorderPanel = useHasBorderPanel( name );
-	const variationClassName = getVariationClassName( variationPath );
+	const variationClassName = getVariationClassName( variation );
 	const hasShadowPanel = useHasShadowControl( name );
 	return (
 		<>
@@ -24,7 +24,7 @@ function ScreenBorder( { name, variation = '' } ) {
 				<BorderPanel name={ name } variation={ variation } />
 			) }
 			{ hasShadowPanel && (
-				<ShadowPanel name={ name } variationPath={ variationPath } />
+				<ShadowPanel name={ name } variation={ variation } />
 			) }
 		</>
 	);

--- a/packages/edit-site/src/components/global-styles/shadow-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadow-panel.js
@@ -21,7 +21,7 @@ import {
 	BaseControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { shadow as shadowIcon } from '@wordpress/icons';
+import { shadow as shadowIcon, Icon, check } from '@wordpress/icons';
 import { useCallback } from '@wordpress/element';
 
 /**
@@ -145,7 +145,7 @@ function ShadowPresets( { label, presets, activeShadow, onSelect } ) {
 				{ label }
 			</BaseControl.VisualLabel>
 
-			<Grid columns={ 2 }>
+			<Grid columns={ 6 }>
 				{ presets.map( ( { name, shadow }, i ) => (
 					<ShadowIndicator
 						key={ i }
@@ -156,6 +156,7 @@ function ShadowPresets( { label, presets, activeShadow, onSelect } ) {
 								shadow === activeShadow ? undefined : shadow
 							)
 						}
+						shadow={ shadow }
 					/>
 				) ) }
 			</Grid>
@@ -163,16 +164,17 @@ function ShadowPresets( { label, presets, activeShadow, onSelect } ) {
 	);
 }
 
-function ShadowIndicator( { label, isActive, onSelect } ) {
+function ShadowIndicator( { label, isActive, onSelect, shadow } ) {
 	return (
-		<Button
-			className={ classnames(
-				'edit-site-global-styles__shadow-indicator',
-				{ active: isActive }
-			) }
-			onClick={ onSelect }
-		>
-			{ label }
-		</Button>
+		<>
+			<Button
+				className="edit-site-global-styles__shadow-indicator"
+				onClick={ onSelect }
+				aria-label={ label }
+				style={ { boxShadow: shadow } }
+			>
+				{ isActive && <Icon icon={ check } /> }
+			</Button>
+		</>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/shadow-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadow-panel.js
@@ -1,0 +1,178 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+	__experimentalItemGroup as ItemGroup,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalGrid as Grid,
+	__experimentalHeading as Heading,
+	FlexItem,
+	Dropdown,
+	__experimentalDropdownContentWrapper as DropdownContentWrapper,
+	Button,
+	BaseControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { shadow as shadowIcon } from '@wordpress/icons';
+import { useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { getSupportedGlobalStylesPanels, useStyle, useSetting } from './hooks';
+import { IconWithCurrentColor } from './icon-with-current-color';
+
+export function useHasShadowControl( name ) {
+	const supports = getSupportedGlobalStylesPanels( name );
+	return supports.includes( 'shadow' );
+}
+
+export default function ShadowPanel( { name, variationPath = '' } ) {
+	const [ shadow, setShadow ] = useStyle( `${ variationPath }shadow`, name );
+	const [ userShadow ] = useStyle( `${ variationPath }shadow`, name, 'user' );
+	const hasShadow = () => !! userShadow;
+
+	const resetShadow = () => setShadow( undefined );
+	const resetAll = useCallback(
+		() => resetShadow( undefined ),
+		[ resetShadow ]
+	);
+
+	return (
+		<ToolsPanel label={ __( 'Shadow' ) } resetAll={ resetAll }>
+			<ToolsPanelItem
+				label={ __( 'Drop shadow' ) }
+				hasValue={ hasShadow }
+				onDeselect={ resetShadow }
+				isShownByDefault
+			>
+				<ItemGroup isBordered isSeparated>
+					<ShadowPopover
+						shadow={ shadow }
+						onShadowChange={ setShadow }
+					/>
+				</ItemGroup>
+			</ToolsPanelItem>
+		</ToolsPanel>
+	);
+}
+
+const ShadowPopover = ( { shadow, onShadowChange } ) => {
+	const popoverProps = {
+		placement: 'left-start',
+		offset: 36,
+		shift: true,
+	};
+
+	return (
+		<Dropdown
+			popoverProps={ popoverProps }
+			className="edit-site-global-styles__shadow-dropdown"
+			renderToggle={ renderShadowToggle() }
+			renderContent={ () => (
+				<DropdownContentWrapper paddingSize="medium">
+					<ShadowPopoverContainer
+						shadow={ shadow }
+						onShadowChange={ onShadowChange }
+					/>
+				</DropdownContentWrapper>
+			) }
+		/>
+	);
+};
+
+function renderShadowToggle() {
+	return ( { onToggle, isOpen } ) => {
+		const toggleProps = {
+			onClick: onToggle,
+			className: classnames( { 'is-open': isOpen } ),
+			'aria-expanded': isOpen,
+		};
+
+		return (
+			<Button { ...toggleProps }>
+				<HStack justify="flex-start">
+					<IconWithCurrentColor icon={ shadowIcon } size={ 24 } />
+					<FlexItem className="edit-site-global-styles__shadow-label">
+						{ __( 'Drop shadow' ) }
+					</FlexItem>
+				</HStack>
+			</Button>
+		);
+	};
+}
+
+function ShadowPopoverContainer( { shadow, onShadowChange } ) {
+	const [ defaultShadows ] = useSetting( 'shadow.presets.default' );
+	const [ themeShadows ] = useSetting( 'shadow.presets.theme' );
+	const [ defaultPresetsEnabled ] = useSetting( 'shadow.defaultPresets' );
+
+	return (
+		<div className="edit-site-global-styles__shadow-panel">
+			<VStack spacing={ 4 }>
+				<Heading level={ 5 }>{ __( 'Drop shadows' ) }</Heading>
+				{ defaultPresetsEnabled && (
+					<ShadowPresets
+						label={ __( 'Default' ) }
+						presets={ defaultShadows }
+						activeShadow={ shadow }
+						onSelect={ onShadowChange }
+					/>
+				) }
+				<ShadowPresets
+					label={ __( 'Theme' ) }
+					presets={ themeShadows }
+					activeShadow={ shadow }
+					onSelect={ onShadowChange }
+				/>
+			</VStack>
+		</div>
+	);
+}
+
+function ShadowPresets( { label, presets, activeShadow, onSelect } ) {
+	return ! presets ? null : (
+		<div>
+			<BaseControl.VisualLabel as="legend">
+				{ label }
+			</BaseControl.VisualLabel>
+
+			<Grid columns={ 2 }>
+				{ presets.map( ( { name, shadow }, i ) => (
+					<ShadowIndicator
+						key={ i }
+						label={ name }
+						isActive={ shadow === activeShadow }
+						onSelect={ () =>
+							onSelect(
+								shadow === activeShadow ? undefined : shadow
+							)
+						}
+					/>
+				) ) }
+			</Grid>
+		</div>
+	);
+}
+
+function ShadowIndicator( { label, isActive, onSelect } ) {
+	return (
+		<Button
+			className={ classnames(
+				'edit-site-global-styles__shadow-indicator',
+				{ active: isActive }
+			) }
+			onClick={ onSelect }
+		>
+			{ label }
+		</Button>
+	);
+}

--- a/packages/edit-site/src/components/global-styles/shadow-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadow-panel.js
@@ -18,7 +18,6 @@ import {
 	Dropdown,
 	__experimentalDropdownContentWrapper as DropdownContentWrapper,
 	Button,
-	BaseControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { shadow as shadowIcon, Icon, check } from '@wordpress/icons';
@@ -60,7 +59,7 @@ export default function ShadowPanel( { name, variationPath = '' } ) {
 	return (
 		<ToolsPanel label={ __( 'Shadow' ) } resetAll={ resetAll }>
 			<ToolsPanelItem
-				label={ __( 'Drop shadow' ) }
+				label={ __( 'Shadow' ) }
 				hasValue={ hasShadow }
 				onDeselect={ resetShadow }
 				isShownByDefault
@@ -113,7 +112,7 @@ function renderShadowToggle() {
 				<HStack justify="flex-start">
 					<IconWithCurrentColor icon={ shadowIcon } size={ 24 } />
 					<FlexItem className="edit-site-global-styles__shadow-label">
-						{ __( 'Drop shadow' ) }
+						{ __( 'Shadow' ) }
 					</FlexItem>
 				</HStack>
 			</Button>
@@ -128,21 +127,17 @@ function ShadowPopoverContainer( { shadow, onShadowChange } ) {
 		'shadow.defaultPresets'
 	);
 
+	const shadows = [
+		...( defaultPresetsEnabled ? defaultShadows : [] ),
+		...( themeShadows || [] ),
+	];
+
 	return (
 		<div className="edit-site-global-styles__shadow-panel">
 			<VStack spacing={ 4 }>
-				<Heading level={ 5 }>{ __( 'Drop shadows' ) }</Heading>
-				{ defaultPresetsEnabled && (
-					<ShadowPresets
-						label={ __( 'Default' ) }
-						presets={ defaultShadows }
-						activeShadow={ shadow }
-						onSelect={ onShadowChange }
-					/>
-				) }
+				<Heading level={ 5 }>{ __( 'Shadows' ) }</Heading>
 				<ShadowPresets
-					label={ __( 'Theme' ) }
-					presets={ themeShadows }
+					presets={ shadows }
 					activeShadow={ shadow }
 					onSelect={ onShadowChange }
 				/>
@@ -151,35 +146,27 @@ function ShadowPopoverContainer( { shadow, onShadowChange } ) {
 	);
 }
 
-function ShadowPresets( { label, presets, activeShadow, onSelect } ) {
+function ShadowPresets( { presets, activeShadow, onSelect } ) {
 	return ! presets ? null : (
-		<div>
-			<BaseControl.VisualLabel as="legend">
-				{ label }
-			</BaseControl.VisualLabel>
-
-			<Grid columns={ 6 }>
-				{ presets.map( ( { name, shadow }, i ) => (
-					<ShadowIndicator
-						key={ i }
-						label={ name }
-						isActive={ shadow === activeShadow }
-						onSelect={ () =>
-							onSelect(
-								shadow === activeShadow ? undefined : shadow
-							)
-						}
-						shadow={ shadow }
-					/>
-				) ) }
-			</Grid>
-		</div>
+		<Grid columns={ 6 } gap={ 0 } align="center" justify="center">
+			{ presets.map( ( { name, shadow }, i ) => (
+				<ShadowIndicator
+					key={ i }
+					label={ name }
+					isActive={ shadow === activeShadow }
+					onSelect={ () =>
+						onSelect( shadow === activeShadow ? undefined : shadow )
+					}
+					shadow={ shadow }
+				/>
+			) ) }
+		</Grid>
 	);
 }
 
 function ShadowIndicator( { label, isActive, onSelect, shadow } ) {
 	return (
-		<>
+		<div className="edit-site-global-styles__shadow-indicator-wrapper">
 			<Button
 				className="edit-site-global-styles__shadow-indicator"
 				onClick={ onSelect }
@@ -188,6 +175,6 @@ function ShadowIndicator( { label, isActive, onSelect, shadow } ) {
 			>
 				{ isActive && <Icon icon={ check } /> }
 			</Button>
-		</>
+		</div>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/shadow-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadow-panel.js
@@ -23,12 +23,16 @@ import {
 import { __ } from '@wordpress/i18n';
 import { shadow as shadowIcon, Icon, check } from '@wordpress/icons';
 import { useCallback } from '@wordpress/element';
+import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
-import { getSupportedGlobalStylesPanels, useStyle, useSetting } from './hooks';
+import { getSupportedGlobalStylesPanels } from './hooks';
 import { IconWithCurrentColor } from './icon-with-current-color';
+import { unlock } from '../../experiments';
+
+const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorExperiments );
 
 export function useHasShadowControl( name ) {
 	const supports = getSupportedGlobalStylesPanels( name );
@@ -36,8 +40,15 @@ export function useHasShadowControl( name ) {
 }
 
 export default function ShadowPanel( { name, variationPath = '' } ) {
-	const [ shadow, setShadow ] = useStyle( `${ variationPath }shadow`, name );
-	const [ userShadow ] = useStyle( `${ variationPath }shadow`, name, 'user' );
+	const [ shadow, setShadow ] = useGlobalStyle(
+		`${ variationPath }shadow`,
+		name
+	);
+	const [ userShadow ] = useGlobalStyle(
+		`${ variationPath }shadow`,
+		name,
+		'user'
+	);
 	const hasShadow = () => !! userShadow;
 
 	const resetShadow = () => setShadow( undefined );
@@ -111,9 +122,11 @@ function renderShadowToggle() {
 }
 
 function ShadowPopoverContainer( { shadow, onShadowChange } ) {
-	const [ defaultShadows ] = useSetting( 'shadow.presets.default' );
-	const [ themeShadows ] = useSetting( 'shadow.presets.theme' );
-	const [ defaultPresetsEnabled ] = useSetting( 'shadow.defaultPresets' );
+	const [ defaultShadows ] = useGlobalSetting( 'shadow.presets.default' );
+	const [ themeShadows ] = useGlobalSetting( 'shadow.presets.theme' );
+	const [ defaultPresetsEnabled ] = useGlobalSetting(
+		'shadow.defaultPresets'
+	);
 
 	return (
 		<div className="edit-site-global-styles__shadow-panel">

--- a/packages/edit-site/src/components/global-styles/shadow-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadow-panel.js
@@ -38,13 +38,13 @@ export function useHasShadowControl( name ) {
 	return supports.includes( 'shadow' );
 }
 
-export default function ShadowPanel( { name, variationPath = '' } ) {
+export default function ShadowPanel( { name, variation = '' } ) {
 	const [ shadow, setShadow ] = useGlobalStyle(
-		`${ variationPath }shadow`,
+		`${ variation }shadow`,
 		name
 	);
 	const [ userShadow ] = useGlobalStyle(
-		`${ variationPath }shadow`,
+		`${ variation }shadow`,
 		name,
 		'user'
 	);

--- a/packages/edit-site/src/components/global-styles/shadow-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadow-panel.js
@@ -39,15 +39,9 @@ export function useHasShadowControl( name ) {
 }
 
 export default function ShadowPanel( { name, variation = '' } ) {
-	const [ shadow, setShadow ] = useGlobalStyle(
-		`${ variation }shadow`,
-		name
-	);
-	const [ userShadow ] = useGlobalStyle(
-		`${ variation }shadow`,
-		name,
-		'user'
-	);
+	const prefix = variation ? `variations.${ variation }.` : '';
+	const [ shadow, setShadow ] = useGlobalStyle( `${ prefix }shadow`, name );
+	const [ userShadow ] = useGlobalStyle( `${ prefix }shadow`, name, 'user' );
 	const hasShadow = () => !! userShadow;
 
 	const resetShadow = () => setShadow( undefined );

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -209,6 +209,15 @@ $block-preview-height: 150px;
 	}
 }
 
+// wrapper to clip the shadow beyond 6px
+.edit-site-global-styles__shadow-indicator-wrapper {
+	padding: 6px;
+	overflow: hidden;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
 // These styles are similar to the color palette.
 .edit-site-global-styles__shadow-indicator {
 	color: $gray-800;
@@ -217,7 +226,6 @@ $block-preview-height: 150px;
 	cursor: pointer;
 	padding: 0;
 
-	// This should match the value of $color-palette-circle-size.
-	height: 28px;
-	width: 28px;
+	height: 24px;
+	width: 24px;
 }

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -209,17 +209,15 @@ $block-preview-height: 150px;
 	}
 }
 
+// These styles are similar to the color palette.
 .edit-site-global-styles__shadow-indicator {
 	color: $gray-800;
 	border: $gray-200 $border-width solid;
 	border-radius: $radius-block-ui;
-	padding: $grid-unit-10;
 	cursor: pointer;
+	padding: 0;
 
-	&.active,
-	&.components-button:active {
-		color: $gray-100;
-		background-color: $gray-900;
-		border-color: $gray-900;
-	}
+	// This should match the value of $color-palette-circle-size.
+	height: 28px;
+	width: 28px;
 }

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -190,3 +190,36 @@ $block-preview-height: 150px;
 	display: flex;
 	flex-direction: column;
 }
+
+.edit-site-global-styles__shadow-panel {
+	width: 230px;
+}
+
+.edit-site-global-styles__shadow-dropdown {
+	display: block;
+	padding: 0;
+
+	> button {
+		width: 100%;
+		padding: $grid-unit-10;
+
+		&.is-open {
+			background-color: $gray-100;
+		}
+	}
+}
+
+.edit-site-global-styles__shadow-indicator {
+	color: $gray-800;
+	border: $gray-200 $border-width solid;
+	border-radius: $radius-block-ui;
+	padding: $grid-unit-10;
+	cursor: pointer;
+
+	&.active,
+	&.components-button:active {
+		color: $gray-100;
+		background-color: $gray-900;
+		border-color: $gray-900;
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This adds support for shadow presets both default and theme presets.

**Default presets: (needs design inputs for the shadow values)**

* Natural
* Crisp
* Sharp
* Soft

And UI tools in global styles.

## Testing Instructions

1. Activate any block theme
2. Add shadow presets to `theme.json`. (Following is the example)

```json
"settings": {
		"shadow": {
			"palette": [
				{
					"name": "Natural",
					"slug": "theme-natural",
					"shadow": "5px 5px 0px -2px #FFFFFF, 5px 5px #000000"
				},
				{
					"name": "Crisp",
					"slug": "theme-crisp",
					"shadow": "5px 5px #000000"
				},
				{
					"name": "Sharp",
					"slug": "theme-sharp",
					"shadow": "5px 5px 0 0 #999999"
				},
				{
					"name": "Soft",
					"slug": "theme-soft",
					"shadow": "5px 5px 10px 0 #999999"
				}
			]
		}
}
```
3. Open global styles -> blocks -> button -> Border & Shadow -> Drop shadow
4. The above defined shadows should appear in the selected panel.
5. Choose any shadow and save the changes.
6. Open frontend, and verify the button for given shadow.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

![shadow-presets](https://user-images.githubusercontent.com/1935113/207322699-fc4d6c66-a069-4813-ba6c-4afa0e07e0b7.gif)

Partially fixes: #44651 