### PR TITLE
Nav offcanvas - handle non-direct insert block inserter

### DIFF
--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -39,7 +39,7 @@ function useInsertionPoint( {
 	isAppender,
 	onSelect,
 	shouldFocusBlock = true,
-	selectBlockOnInsert = false,
+	selectBlockOnInsert = true,
 } ) {
 	const { getSelectedBlock } = useSelect( blockEditorStore );
 	const { destinationRootClientId, destinationIndex } = useSelect(

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -110,7 +110,6 @@ function useInsertionPoint( {
 					destinationIndex,
 					destinationRootClientId,
 					selectBlockOnInsert,
-					false,
 					shouldFocusBlock || shouldForceFocusBlock ? 0 : null,
 					meta
 				);

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -39,6 +39,7 @@ function useInsertionPoint( {
 	isAppender,
 	onSelect,
 	shouldFocusBlock = true,
+	selectBlockOnInsert = false,
 } ) {
 	const { getSelectedBlock } = useSelect( blockEditorStore );
 	const { destinationRootClientId, destinationIndex } = useSelect(
@@ -108,7 +109,7 @@ function useInsertionPoint( {
 					blocks,
 					destinationIndex,
 					destinationRootClientId,
-					// true,
+					selectBlockOnInsert,
 					false,
 					shouldFocusBlock || shouldForceFocusBlock ? 0 : null,
 					meta

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -108,7 +108,8 @@ function useInsertionPoint( {
 					blocks,
 					destinationIndex,
 					destinationRootClientId,
-					true,
+					// true,
+					false,
 					shouldFocusBlock || shouldForceFocusBlock ? 0 : null,
 					meta
 				);
@@ -122,7 +123,7 @@ function useInsertionPoint( {
 			speak( message );
 
 			if ( onSelect ) {
-				onSelect();
+				onSelect( blocks );
 			}
 		},
 		[

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -144,6 +144,7 @@ class Inserter extends Component {
 			__experimentalIsQuick: isQuick,
 			prioritizePatterns,
 			onSelectOrClose,
+			selectBlockOnInsert,
 		} = this.props;
 
 		if ( isQuick ) {
@@ -166,6 +167,7 @@ class Inserter extends Component {
 					clientId={ clientId }
 					isAppender={ isAppender }
 					prioritizePatterns={ prioritizePatterns }
+					selectBlockOnInsert={ selectBlockOnInsert }
 				/>
 			);
 		}

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -143,12 +143,18 @@ class Inserter extends Component {
 			// Feel free to make them stable after a few releases.
 			__experimentalIsQuick: isQuick,
 			prioritizePatterns,
+			onSelectOrClose,
 		} = this.props;
 
 		if ( isQuick ) {
 			return (
 				<QuickInserter
-					onSelect={ () => {
+					onSelect={ ( blocks ) => {
+						const firstBlock =
+							Array.isArray( blocks ) && blocks?.length
+								? blocks[ 0 ]
+								: blocks;
+						onSelectOrClose( firstBlock );
 						onClose();
 					} }
 					rootClientId={ rootClientId }
@@ -380,7 +386,7 @@ export default compose( [
 
 				if ( onSelectOrClose ) {
 					onSelectOrClose( {
-						insertedBlockId: blockToInsert?.clientId,
+						clientId: blockToInsert?.clientId,
 					} );
 				}
 

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -154,7 +154,12 @@ class Inserter extends Component {
 							Array.isArray( blocks ) && blocks?.length
 								? blocks[ 0 ]
 								: blocks;
-						onSelectOrClose( firstBlock );
+						if (
+							onSelectOrClose &&
+							typeof onSelectOrClose === 'function'
+						) {
+							onSelectOrClose( firstBlock );
+						}
 						onClose();
 					} }
 					rootClientId={ rootClientId }

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -31,6 +31,7 @@ export default function QuickInserter( {
 	clientId,
 	isAppender,
 	prioritizePatterns,
+	selectBlockOnInsert,
 } ) {
 	const [ filterValue, setFilterValue ] = useState( '' );
 	const [ destinationRootClientId, onInsertBlocks ] = useInsertionPoint( {
@@ -38,6 +39,7 @@ export default function QuickInserter( {
 		rootClientId,
 		clientId,
 		isAppender,
+		selectBlockOnInsert,
 	} );
 	const [ blockTypes ] = useBlockTypesState(
 		destinationRootClientId,

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -123,6 +123,7 @@ export default function QuickInserter( {
 					maxBlockTypes={ SHOWN_BLOCK_TYPES }
 					isDraggable={ false }
 					prioritizePatterns={ prioritizePatterns }
+					selectBlockOnInsert={ selectBlockOnInsert }
 				/>
 			</div>
 

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -50,6 +50,7 @@ function InserterSearchResults( {
 	isDraggable = true,
 	shouldFocusBlock = true,
 	prioritizePatterns,
+	selectBlockOnInsert,
 } ) {
 	const debouncedSpeak = useDebounce( speak, 500 );
 
@@ -60,6 +61,7 @@ function InserterSearchResults( {
 		isAppender,
 		insertionIndex: __experimentalInsertionIndex,
 		shouldFocusBlock,
+		selectBlockOnInsert,
 	} );
 	const [
 		blockTypes,

--- a/packages/block-editor/src/components/off-canvas-editor/appender.js
+++ b/packages/block-editor/src/components/off-canvas-editor/appender.js
@@ -12,7 +12,7 @@ import { LinkUI } from './link-ui';
 import { updateAttributes } from './update-attributes';
 
 export const Appender = forwardRef( ( props, ref ) => {
-	const [ insertedBlock, setInsertedBlock ] = useState();
+	const [ insertedBlockClientId, setInsertedBlockClientId ] = useState();
 
 	const { hideInserter, clientId } = useSelect( ( select ) => {
 		const {
@@ -31,43 +31,47 @@ export const Appender = forwardRef( ( props, ref ) => {
 		};
 	}, [] );
 
-	const { insertedBlockAttributes } = useSelect(
+	const { insertedBlockAttributes, insertedBlockName } = useSelect(
 		( select ) => {
-			const { getBlockAttributes } = select( blockEditorStore );
+			const { getBlockName, getBlockAttributes } =
+				select( blockEditorStore );
 
 			return {
-				insertedBlockAttributes: getBlockAttributes( insertedBlock ),
+				insertedBlockAttributes: getBlockAttributes(
+					insertedBlockClientId
+				),
+				insertedBlockName: getBlockName( insertedBlockClientId ),
 			};
 		},
-		[ insertedBlock ]
+		[ insertedBlockClientId ]
 	);
 
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
 	const setAttributes =
-		( insertedBlockClientId ) => ( _updatedAttributes ) => {
-			updateBlockAttributes( insertedBlockClientId, _updatedAttributes );
+		( _insertedBlockClientId ) => ( _updatedAttributes ) => {
+			updateBlockAttributes( _insertedBlockClientId, _updatedAttributes );
 		};
 
 	let maybeLinkUI;
 
 	if (
-		insertedBlock &&
-		insertedBlockAttributes?.name === 'core/navigation-link'
+		insertedBlockClientId &&
+		insertedBlockName === 'core/navigation-link'
 	) {
 		maybeLinkUI = (
 			<LinkUI
-				clientId={ insertedBlock }
+				clientId={ insertedBlockClientId }
 				link={ insertedBlockAttributes }
-				onClose={ () => setInsertedBlock( null ) }
+				onClose={ () => setInsertedBlockClientId( null ) }
 				hasCreateSuggestion={ false }
 				onChange={ ( updatedValue ) => {
 					updateAttributes(
 						updatedValue,
-						setAttributes( insertedBlock ),
+						setAttributes( insertedBlockClientId ),
 						insertedBlockAttributes
 					);
-					setInsertedBlock( null );
+					setInsertedBlockClientId( null );
 				} }
 			/>
 		);
@@ -81,7 +85,7 @@ export const Appender = forwardRef( ( props, ref ) => {
 		<div className="offcanvas-editor__appender">
 			{ maybeLinkUI }
 
-			{ ! insertedBlock && (
+			{ ! insertedBlockClientId && (
 				<Inserter
 					ref={ ref }
 					rootClientId={ clientId }
@@ -90,7 +94,9 @@ export const Appender = forwardRef( ( props, ref ) => {
 					selectBlockOnInsert={ false }
 					onSelectOrClose={ ( _insertedBlock ) => {
 						if ( _insertedBlock?.clientId ) {
-							setInsertedBlock( _insertedBlock?.clientId );
+							setInsertedBlockClientId(
+								_insertedBlock?.clientId
+							);
 						}
 					} }
 					__experimentalIsQuick

--- a/packages/block-editor/src/components/off-canvas-editor/appender.js
+++ b/packages/block-editor/src/components/off-canvas-editor/appender.js
@@ -58,6 +58,14 @@ export const Appender = forwardRef( ( props, ref ) => {
 			updateBlockAttributes( _insertedBlockClientId, _updatedAttributes );
 		};
 
+	const maybeSetInsertedBlockOnInsertion = ( _insertedBlock ) => {
+		if ( ! _insertedBlock?.clientId ) {
+			return;
+		}
+
+		setInsertedBlockClientId( _insertedBlock?.clientId );
+	};
+
 	let maybeLinkUI;
 
 	if (
@@ -96,11 +104,7 @@ export const Appender = forwardRef( ( props, ref ) => {
 				position="bottom right"
 				isAppender={ true }
 				selectBlockOnInsert={ false }
-				onSelectOrClose={ ( _insertedBlock ) => {
-					if ( _insertedBlock?.clientId ) {
-						setInsertedBlockClientId( _insertedBlock?.clientId );
-					}
-				} }
+				onSelectOrClose={ maybeSetInsertedBlockOnInsertion }
 				__experimentalIsQuick
 				{ ...props }
 			/>

--- a/packages/block-editor/src/components/off-canvas-editor/appender.js
+++ b/packages/block-editor/src/components/off-canvas-editor/appender.js
@@ -51,7 +51,10 @@ export const Appender = forwardRef( ( props, ref ) => {
 
 	let maybeLinkUI;
 
-	if ( insertedBlock ) {
+	if (
+		insertedBlock &&
+		insertedBlockAttributes?.name === 'core/navigation-link'
+	) {
 		maybeLinkUI = (
 			<LinkUI
 				clientId={ insertedBlock }
@@ -77,17 +80,23 @@ export const Appender = forwardRef( ( props, ref ) => {
 	return (
 		<div className="offcanvas-editor__appender">
 			{ maybeLinkUI }
-			<Inserter
-				ref={ ref }
-				rootClientId={ clientId }
-				position="bottom right"
-				isAppender={ true }
-				selectBlockOnInsert={ false }
-				onSelectOrClose={ ( { insertedBlockId } ) => {
-					setInsertedBlock( insertedBlockId );
-				} }
-				{ ...props }
-			/>
+
+			{ ! insertedBlock && (
+				<Inserter
+					ref={ ref }
+					rootClientId={ clientId }
+					position="bottom right"
+					isAppender={ true }
+					selectBlockOnInsert={ false }
+					onSelectOrClose={ ( _insertedBlock ) => {
+						if ( _insertedBlock?.clientId ) {
+							setInsertedBlock( _insertedBlock?.clientId );
+						}
+					} }
+					__experimentalIsQuick
+					{ ...props }
+				/>
+			) }
 		</div>
 	);
 } );

--- a/packages/block-editor/src/components/off-canvas-editor/appender.js
+++ b/packages/block-editor/src/components/off-canvas-editor/appender.js
@@ -11,6 +11,11 @@ import Inserter from '../inserter';
 import { LinkUI } from './link-ui';
 import { updateAttributes } from './update-attributes';
 
+const BLOCKS_WITH_LINK_UI_SUPPORT = [
+	'core/navigation-link',
+	'core/navigation-submenu',
+];
+
 export const Appender = forwardRef( ( props, ref ) => {
 	const [ insertedBlockClientId, setInsertedBlockClientId ] = useState();
 
@@ -57,7 +62,7 @@ export const Appender = forwardRef( ( props, ref ) => {
 
 	if (
 		insertedBlockClientId &&
-		insertedBlockName === 'core/navigation-link'
+		BLOCKS_WITH_LINK_UI_SUPPORT?.includes( insertedBlockName )
 	) {
 		maybeLinkUI = (
 			<LinkUI
@@ -85,24 +90,20 @@ export const Appender = forwardRef( ( props, ref ) => {
 		<div className="offcanvas-editor__appender">
 			{ maybeLinkUI }
 
-			{ ! insertedBlockClientId && (
-				<Inserter
-					ref={ ref }
-					rootClientId={ clientId }
-					position="bottom right"
-					isAppender={ true }
-					selectBlockOnInsert={ false }
-					onSelectOrClose={ ( _insertedBlock ) => {
-						if ( _insertedBlock?.clientId ) {
-							setInsertedBlockClientId(
-								_insertedBlock?.clientId
-							);
-						}
-					} }
-					__experimentalIsQuick
-					{ ...props }
-				/>
-			) }
+			<Inserter
+				ref={ ref }
+				rootClientId={ clientId }
+				position="bottom right"
+				isAppender={ true }
+				selectBlockOnInsert={ false }
+				onSelectOrClose={ ( _insertedBlock ) => {
+					if ( _insertedBlock?.clientId ) {
+						setInsertedBlockClientId( _insertedBlock?.clientId );
+					}
+				} }
+				__experimentalIsQuick
+				{ ...props }
+			/>
 		</div>
 	);
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Handles the offcanvas UX block insertion flow in the Nav offcanvas experiment when the Nav block contains blocks other than `core/navigation-link` thus triggering the "full" inserter UI (i.e. no direct-insert). The flow becomes:

1. Select block type
2. (Optional/conditional) Create link

⚠️ Note this does _not_:

- fully migrate the flow to become two-step (as suggested by @draganescu) but it might be possible to modify (in a follow up) to allow for this behaviour also.
- handle the fact that some "allowed blocks" of the Nav block are not shown in the Quick Inserter
- solve the problem that clicking `Browse` in the quick inserter triggers the full block inserter and closes the off canvas 🤔 

Closes https://github.com/WordPress/gutenberg/issues/46203

## Why?

The two-step insertion behaviour is what already happens in the editor canvas when the Nav block has non-`core/navigation-link` blocks in it. Therefore we need to handle the same use case in the offcanvas.

Having a two step process affords the user greater control over the type of block they wish to insert into their Navigation. 

Whilst this does introduce _some_ friction for those users wishing simply to add links, it does afford full power to insert any of the block types without having to rely on obfuscated/convoluted  UX such as:

- adding block transforms to the Link UI.
- clicking the "Add submenu" within the 3 dots menu on each Nav Link item.

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The key changes are:

- add `__experimentalIsQuick` to the `<Inserter>` component to trigger the `<QuickInserter>` style (as per block canvas)
- prop drill `selectBlockOnInsert` and conditionally set the 4th argument of calls to `insertBlock` within the hooks consumed by the `<QuickInserter>`
- prop drill `onSelectOrClose` and have the `<QuickInserter>` call this when defined with the blocks that were inserted (if any).
- conditionally display the Link UI in the offcanvas based on whether the inserted block supports that interface (e.g. we don't need a Link UI showing when we insert a Site Logo block).


### Future plans

In the future I imagine we can refactor some of this callback code around the Link UI:

- ~add a reducer to keep track of the inserted blocks as a flattened array~ see https://github.com/WordPress/gutenberg/pull/46531
- ~add a selector to retrieve the most recently inserted block (e.g. `getLastInsertedBlock()`)~ see https://github.com/WordPress/gutenberg/pull/46531
- move the LinkUI component up to the `ListViewBlockContents` component
- conditionally trigger the Link UI based on the result of calling the new `getLastInsertedBlock` selector

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Enable experiment
- New Post
- Add Nav block
- Click on appender to add a custom link as usual - note: so long as all your current nav items are `core/navigation-link` this should work as per `trunk` and immediately insert the block and show the Link UI. That is _expected_.
- Now click appender and use the `Transforms` in the Link UI to add a social icons block.
- Now click the appender _again_. This time you should see the full (quick) inserter.
- Click on Custom Link and check that the Link UI shows correctly.
- Now click the appender _again_. This time choose Submenu and check that the Link UI shows correctly.
- Now click the appender _again_. This time choose Page List or Social or whatever. Check that the block is inserted and that the Link UI does _not_ show.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/444434/207336737-458ed7a0-db35-4dae-8cd6-17a878e01c74.mp4

