### PR TITLE
Remove clearable from link ColorPanel item

### DIFF
--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -522,8 +522,6 @@ export function ColorEdit( props ) {
 									allSolids,
 									style?.elements?.link?.color?.text
 								),
-								clearable:
-									!! style?.elements?.link?.color?.text,
 								isShownByDefault: defaultColorControls?.link,
 								resetAllFilter: resetAllLinkFilter,
 							},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #42689 by removing the excess "Clear" action that exists on the Link ColorPanel item. 

## Why?
Consistency. The text and background ColorPanel items do not have a "Clear" action, but all have an action within the ellipsis menu to reset the applied color.  

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Open a page or post
2. Add a paragraph block 
3. Click on the "Link" ColorPanel item
4. Apply a color
5. See no "Clear" action

## Screenshots or screencast <!-- if applicable -->

Before:

<img width="648" alt="CleanShot 2022-12-13 at 09 53 59@2x" src="https://user-images.githubusercontent.com/1813435/207366546-6aae02d3-4b9d-4d52-a9ba-512d1104202d.png">

After:

<img width="595" alt="CleanShot 2022-12-13 at 09 50 43@2x" src="https://user-images.githubusercontent.com/1813435/207366382-658b859a-8a3b-41ae-a8c3-bee4434eef96.png">
