### PR TITLE
Improve consistency across color and gradient panels

### DIFF
--- a/packages/components/src/color-palette/index.tsx
+++ b/packages/components/src/color-palette/index.tsx
@@ -304,7 +304,7 @@ function UnforwardedColorPalette(
 						<Flex
 							as={ 'button' }
 							justify="space-between"
-							align="flex-start"
+							align="center"
 							className="components-color-palette__custom-color"
 							aria-expanded={ isOpen }
 							aria-haspopup="true"

--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -3,7 +3,7 @@
 	border: none;
 	background: none;
 	border-radius: $radius-block-ui;
-	height: $grid-unit-80;
+	height: $grid-unit-60;
 	padding: $grid-unit-15;
 	font-family: inherit;
 	width: 100%;

--- a/packages/components/src/custom-gradient-picker/style.scss
+++ b/packages/components/src/custom-gradient-picker/style.scss
@@ -12,6 +12,7 @@ $components-custom-gradient-picker__padding: $grid-unit-20; // 48px container, 1
 }
 
 .components-custom-gradient-picker__gradient-bar {
+	box-shadow: inset 0 0 0 $border-width rgba(0, 0, 0, 0.2);
 	border-radius: $radius-block-ui;
 	width: 100%;
 	height: $grid-unit-60;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
- Adjust the height of the selected color UI to match that of the selected gradient UI.
- Vertically align the color name and value.
- Add the inset box-shadow that we use elsewhere in color UI

## Why?
Improve consistency across the color and gradient panels, which also reduces the UI jump when selecting the Gradient tab. 

## How?
Style tweaks.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page.
2. Insert a Heading Block. 
3. Edit the Background color 
4. See the adjusted selected color UI.
5. Switch to the Gradient tab.
6. See the box-shadow added.

## Screenshots or screencast <!-- if applicable -->
### Before
<img width="646" alt="CleanShot 2022-12-13 at 11 36 40@2x" src="https://user-images.githubusercontent.com/1813435/207391134-ec4f23c5-5ca5-4269-bf8d-2cef978d69a6.png">

### After
<img width="671" alt="CleanShot 2022-12-13 at 11 27 25@2x" src="https://user-images.githubusercontent.com/1813435/207388981-522bd4de-de2c-424e-b78d-efd73cd5a71c.png">
