### PR TITLE
Comments Block: Remove unnecessary `editorStyle` prop in legacy metadata

### DIFF
--- a/packages/block-library/src/comments/index.php
+++ b/packages/block-library/src/comments/index.php
@@ -202,7 +202,6 @@ function register_legacy_post_comments_block() {
 			'wp-block-buttons',
 			'wp-block-button',
 		),
-		'editorStyle'       => 'wp-block-post-comments-editor',
 		'render_callback'   => 'render_block_core_comments',
 		'skip_inner_blocks' => true,
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What and why?

This PR removes an `editorStyle` property defined in the legacy Post Comments block's metadata.

Reasons:
1. the property is not correctly defined; it should be `editor_style` instead.
2. the property is not actually needed ―as mentioned [here](https://github.com/WordPress/gutenberg/issues/45677#issuecomment-1326576827)― because the legacy block is never rendered in the editor.

Note that nothing was going wrong from the user's perspective, so this fix could be considered a code-quality fix.

## How?

Simply removing the offending line of code. 🙂 

## Testing Instructions
1. Install a theme that uses the old Post Comments block (e.g., [TT1 Blocks](https://wordpress.org/themes/tt1-blocks/))
2. Go to the Single template
4. Ensure that the block being rendered is the Comments block. You can do so by either:
  3.1. checking the class used by the rendered element (it should be `wp-block-comments`) or
  3.2. opening the code editor (the block markup should be `<!-- wp:comments {"legacy":true} /--></div>`
5. The styles used by the block come from `editor.css` and are applied correctly, with and without this PR.

## Screenshots or screencast

This is how it should look, before and after.

![Screenshot 2022-12-13 at 19 39 10](https://user-images.githubusercontent.com/6917969/207424084-189e2fa8-f7de-42dd-b821-4b8c34da930a.png)

