### PR TITLE
Site Editor: Keep edited entity in sync when Editor canvas isn't mounted

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -31,7 +31,6 @@ import { SidebarComplementaryAreaFills } from '../sidebar-edit-mode';
 import BlockEditor from '../block-editor';
 import CodeEditor from '../code-editor';
 import KeyboardShortcuts from '../keyboard-shortcuts';
-import useInitEditedEntityFromURL from '../sync-state-with-url/use-init-edited-entity-from-url';
 import InserterSidebar from '../secondary-sidebar/inserter-sidebar';
 import ListViewSidebar from '../secondary-sidebar/list-view-sidebar';
 import WelcomeGuide from '../welcome-guide';
@@ -52,9 +51,6 @@ const interfaceLabels = {
 };
 
 export default function Editor() {
-	// This ensures the edited entity id and type are initialized properly.
-	useInitEditedEntityFromURL();
-
 	const {
 		editedPostId,
 		editedPostType,

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -36,10 +36,14 @@ import getIsListPage from '../../utils/get-is-list-page';
 import Header from '../header-edit-mode';
 import SiteIcon from '../site-icon';
 import SiteTitle from '../site-title';
+import useInitEditedEntityFromURL from '../sync-state-with-url/use-init-edited-entity-from-url';
 
 const ANIMATION_DURATION = 0.5;
 
 export default function Layout( { onError } ) {
+	// This ensures the edited entity id and type are initialized properly.
+	useInitEditedEntityFromURL();
+
 	const { params } = useLocation();
 	const isListPage = getIsListPage( params );
 	const isEditorPage = ! isListPage;


### PR DESCRIPTION
## What?
PR fixes the issue when the edited entity stays out of sync with the URL if the Editor canvas isn't mounted.

## Why?
The Editor canvas is conditionally rendered on small screens and causes stale data in the store. Which in some cases resulted in two navigation items marked as active.

P.S. I believe this is due home page special case - https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js#L114-L117.

## How?
I moved the `useInitEditedEntityFromURL` hook from the Editor to the Layout component.

## Testing Instructions
1. Open the Site Editor.
2. Selected a Template Part in the sidebar navigation menu.

## Keyboard Testing Instructions

Doesn't change behavior here.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/207541607-2aa5323a-8ac4-43df-b1c9-3b34a95e5040.mp4

