### PR TITLE
Router: Skip location update if the previous and next locations are identical

### DIFF
--- a/packages/router/src/router.js
+++ b/packages/router/src/router.js
@@ -39,7 +39,14 @@ export function RouterProvider( { children } ) {
 
 	useEffect( () => {
 		return history.listen( ( { location: updatedLocation } ) => {
-			setLocation( getLocationWithParams( updatedLocation ) );
+			setLocation( ( currentLocation ) => {
+				// Skip location update if query args are identical.
+				if ( currentLocation.search === updatedLocation.search ) {
+					return currentLocation;
+				}
+
+				return getLocationWithParams( updatedLocation );
+			} );
 		} );
 	}, [] );
 


### PR DESCRIPTION
## What?
A minor performance improvement for the site `Routers` component. PR changes `setLocation` to skip an update if new and current query args are identical. 

## Why?
Clicking on the same navigation item was causing most of the Router tree to update because `updatedLocation` is always the new object reference.

**Note:** I've never built a custom router before, so there's a chance that I'm missing an important detail here 😅

## Testing Instructions
1. Open the Site Editor.
2. Select a template.
3. Enable component re-render highlights in React DevTools.
4. Confirm that clicking the selected navigation item doesn't cause re-renders

### Testing Instructions for Keyboard
Doesn't change UI.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://user-images.githubusercontent.com/240569/207555132-4d9f782d-7844-48a8-a9a3-d8293505342c.mp4

**After**

https://user-images.githubusercontent.com/240569/207555180-f80a8807-f73d-44e0-9bc7-34a4f1272023.mp4

