### PR TITLE
Fix typing performance issue for container blocks

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useViewportMatch, useMergeRefs } from '@wordpress/compose';
-import { forwardRef } from '@wordpress/element';
+import { forwardRef, useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import {
 	getBlockSupport,
@@ -102,6 +102,16 @@ function UncontrolledInnerBlocks( props ) {
 	const { allowSizingOnChildren = false } =
 		getBlockSupport( name, '__experimentalLayout' ) || {};
 
+	const layout = useMemo(
+		() => ( {
+			...__experimentalLayout,
+			...( allowSizingOnChildren && {
+				allowSizingOnChildren: true,
+			} ),
+		} ),
+		[ __experimentalLayout, allowSizingOnChildren ]
+	);
+
 	// This component needs to always be synchronous as it's the one changing
 	// the async mode depending on the block selection.
 	return (
@@ -110,12 +120,7 @@ function UncontrolledInnerBlocks( props ) {
 				rootClientId={ clientId }
 				renderAppender={ renderAppender }
 				__experimentalAppenderTagName={ __experimentalAppenderTagName }
-				__experimentalLayout={ {
-					...__experimentalLayout,
-					...( allowSizingOnChildren && {
-						allowSizingOnChildren: true,
-					} ),
-				} }
+				__experimentalLayout={ layout }
 				wrapperRef={ wrapperRef }
 				placeholder={ placeholder }
 			/>


### PR DESCRIPTION
## What?

There has been several recent reports of typing performance issues, after some digging it seems it was something in #45364 

## How?

The "layout" object passed to InnerBlocks was generating a new instance on each render causing too many re-renders on type. So this PR just memoizes that particular prop.

To confirm this, I've slowed down the CPU x 4 using Chrome tools and used the performance monitoring tools to compare the length of the "keypress" event when typing inside a paragraph within container blocks. In my tests, this PR is twice faster than trunk.

I've also noticed that our typing performance metric only considers typing at the root level of the block editor. Separately, I'm going to explore adding a metric to monitor the typing performance within a container block.