### PR TITLE
Change SpacingSizesControl ARIA from region to group

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -8,7 +8,11 @@
 
 ### Enhancements
 
-- `URLInput`: the `renderSuggestions` callback prop now receives `currentInputValue` as a new parameter ([45806](https://github.com/WordPress/gutenberg/pull/45806)).
+-   `URLInput`: the `renderSuggestions` callback prop now receives `currentInputValue` as a new parameter ([45806](https://github.com/WordPress/gutenberg/pull/45806)).
+
+### Bug Fix
+
+-   `SpacingSizesControl`: Change ARIA role from `region` to `group` to avoid unwanted ARIA landmark regions ([#46530](https://github.com/WordPress/gutenberg/pull/46530)).
 
 ## 10.5.0 (2022-11-16)
 

--- a/packages/block-editor/src/components/spacing-sizes-control/index.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/index.js
@@ -78,7 +78,6 @@ export default function SpacingSizesControl( {
 
 	return (
 		<fieldset
-			role="region"
 			className={ classnames( 'component-spacing-sizes-control', {
 				'is-unlinked': ! isLinked,
 			} ) }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,6 +17,7 @@
 -   `InputControl`: Fix internal `Flex` wrapper usage that could add an unintended `height: 100%` ([#46213](https://github.com/WordPress/gutenberg/pull/46213)).
 -   `Navigator`: Allow calling `goTo` and `goBack` twice in one render cycle ([#46391](https://github.com/WordPress/gutenberg/pull/46391)).
 -   `Modal`: Fix unexpected modal closing in IME Composition ([#46453](https://github.com/WordPress/gutenberg/pull/46453)).
+-   `SpacingSizesControl`: Change ARIA role from `region` to `group` to avoid unwanted ARIA landmark regions ([#46530](https://github.com/WordPress/gutenberg/pull/46530)).
 
 ### Enhancements
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,7 +17,6 @@
 -   `InputControl`: Fix internal `Flex` wrapper usage that could add an unintended `height: 100%` ([#46213](https://github.com/WordPress/gutenberg/pull/46213)).
 -   `Navigator`: Allow calling `goTo` and `goBack` twice in one render cycle ([#46391](https://github.com/WordPress/gutenberg/pull/46391)).
 -   `Modal`: Fix unexpected modal closing in IME Composition ([#46453](https://github.com/WordPress/gutenberg/pull/46453)).
--   `SpacingSizesControl`: Change ARIA role from `region` to `group` to avoid unwanted ARIA landmark regions ([#46530](https://github.com/WordPress/gutenberg/pull/46530)).
 
 ### Enhancements
 


### PR DESCRIPTION
## What?
See https://github.com/WordPress/gutenberg/pull/42173#discussion_r1046955545.

PR updates `SpacingSizesControl` ARIA from region to group.

## Why?
Borrowed from https://github.com/WordPress/gutenberg/pull/42094

- we don't want this component to be an ARIA landmark
- the group role is more appropriate, as it logically groups the form elements within SpacingSizesControl

## How?
I removed the hardcoded `region` role since `<fieldset>` has the [implicit role of the group](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset#technical_summary).

## Testing Instructions
1. Open a post or page.
2. Insert Group block.
3. Ensure the "Padding" or "Margin" controls are rendered.
4. Search for the control element in the DevTools - `fieldset.component-spacing-sizes-control`.
5. Confirm it has the implicit role of the group in the a11y tree computed properties.

### Testing Instructions for Keyboard
_Props to @afercia_

1. Cmd + F5 to launch VoiceOver
2. Go to the edited post you used for testing
3. Select the Group block
4. Ensure the 'Padding' or 'Margin' controls are rendered in the block inspector sidebar.
5. Press Control + Option + U to launch the VoiceOver 'rotor'
6. Use the Left or Right arrow keys to switch the 'rotor' to the Landmarks list
7. Observe the spacing size controls are no longer listed in the Landmarks list.
