### PR TITLE
Add new selector getLastInsertedBlockClientId 

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -556,6 +556,18 @@ _Properties_
 -   _isDisabled_ `boolean`: Whether or not the user should be prevented from inserting this item.
 -   _frecency_ `number`: Heuristic that combines frequency and recency.
 
+### getLastInsertedBlockClientId
+
+Gets the client id of the last inserted block.
+
+_Parameters_
+
+-   _state_ `Object`: Global application state.
+
+_Returns_
+
+-   `string|undefined`: Client Id of the last inserted block.
+
 ### getLastMultiSelectedBlockClientId
 
 Returns the client ID of the last block in the multi-selection set, or null

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2654,6 +2654,16 @@ export function wasBlockJustInserted( state, clientId, source ) {
 }
 
 /**
+ * Gets the client id of the last inserted block.
+ *
+ * @param {Object} state Global application state.
+ * @return {string|undefined} Client Id of the last inserted block.
+ */
+export function getLastInsertedBlockClientId( state ) {
+	return state?.lastBlockInserted?.clientId;
+}
+
+/**
  * Tells if the block is visible on the canvas or not.
  *
  * @param {Object} state    Global application state.

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -73,6 +73,7 @@ const {
 	__experimentalGetPatternTransformItems,
 	wasBlockJustInserted,
 	__experimentalGetGlobalBlocksByName,
+	getLastInsertedBlockClientId,
 } = selectors;
 
 describe( 'selectors', () => {
@@ -4663,5 +4664,25 @@ describe( '__unstableGetClientIdsTree', () => {
 				],
 			},
 		] );
+	} );
+} );
+
+describe( 'getLastInsertedBlockClientId', () => {
+	it( 'should return undefined if no blocks have been inserted', () => {
+		const state = {
+			lastBlockInserted: {},
+		};
+
+		expect( getLastInsertedBlockClientId( state ) ).toEqual( undefined );
+	} );
+
+	it( 'should return clientId if blocks have been inserted', () => {
+		const state = {
+			lastBlockInserted: {
+				clientId: '123456',
+			},
+		};
+
+		expect( getLastInsertedBlockClientId( state ) ).toEqual( '123456' );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds a new selector for retrieving the `clientId` of the last inserted block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Some implementations do not select the block following insertion. Indeed this eventuality is catered for by the 4th argument of `insertBlocks`.

Therefore it is important to have some means of programmatically retriving the ID of the last block that was inserted.

A case in point is the work being undertaken in the Nav block offcanvas experiment where we do not wish to immediately select a block that has been inserted as that would cause the inspector controls to switch away from those of the Navigation block which is where the offcanvas is rendered. 

See https://github.com/WordPress/gutenberg/pull/46503

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds selector and tests. Luckily the actions and reducer were already part of the code.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Run tests with

```
npm run test:unit packages/block-editor/src/store/test/selectors.js
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
