### PR TITLE
Site Editor: Fix the top bar 'exit' animation

### DIFF
--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -177,7 +177,7 @@ export default function Layout( { onError } ) {
 								as={ motion.div }
 								initial={ { y: -60 } }
 								animate={ { y: 0 } }
-								edit={ { y: -60 } }
+								exit={ { y: -60 } }
 								transition={ {
 									type: 'tween',
 									duration: disableMotion


### PR DESCRIPTION
## What?
PR fixes the "exit" animation for the Site Editor top bar.

## Why?
The was a typo in the property name.

## Testing Instructions
1. Open the Site Editor.
2. Toggle between the Browse and Edit modes.
3. Confirm that the "exit" animation is working.

### Testing Instructions for Keyboard
Doesn't change the UI structure.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://user-images.githubusercontent.com/240569/207590204-0007be4a-595b-45d5-8d56-e94b2cf70029.mp4


**After**

https://user-images.githubusercontent.com/240569/207590155-a15af9b7-5192-4ac1-9b67-78f6602b8498.mp4

