### PR TITLE
[Mobile] - Disable emulator's animations on Android

### DIFF
--- a/packages/react-native-editor/__device-tests__/helpers/caps.js
+++ b/packages/react-native-editor/__device-tests__/helpers/caps.js
@@ -36,4 +36,5 @@ exports.android = {
 	deviceOrientation: 'portrait',
 	appiumVersion: '1.22.1',
 	app: undefined,
+	disableWindowAnimation: true,
 };


### PR DESCRIPTION
**Related PR:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/5320

## What?
This PR disables the Android emulator's animations in CI E2E tests.

## Why?
To speed up tests by reducing waiting time from animations.

## How?
Enabling `disableWindowAnimation` in Appium's configuration.

## Testing Instructions
CI checks should pass.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A