### PR TITLE
useSelect: implement with useSyncExternalStore

### DIFF
--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -101,17 +101,19 @@ function Store( registry, suspense ) {
 			renderQueue.cancel( queueContext );
 		}
 
-		const listeningStores = { current: null };
-		updateValue( () =>
-			registry.__unstableMarkListeningStores(
-				selectValue,
-				listeningStores
-			)
-		);
-
-		if ( ! lastMapSelect || ( resub && mapSelect !== lastMapSelect ) ) {
+		if ( ! subscribe || ( resub && mapSelect !== lastMapSelect ) ) {
+			const listeningStores = { current: null };
+			updateValue( () =>
+				registry.__unstableMarkListeningStores(
+					selectValue,
+					listeningStores
+				)
+			);
 			subscribe = createSubscriber( listeningStores.current );
+		} else {
+			updateValue( selectValue );
 		}
+
 		lastIsAsync = isAsync;
 		lastMapSelect = mapSelect;
 

--- a/packages/data/src/components/use-select/test/index.js
+++ b/packages/data/src/components/use-select/test/index.js
@@ -118,8 +118,7 @@ describe( 'useSelect', () => {
 		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'bar' );
 	} );
 
-	// TODO: this might be impossible to pull off in React 18 without `useSyncExternalStore`
-	it( 'avoid calling nested listener after unmounted', async () => {
+	it( 'does not rerender a nested component that is to be unmounted', () => {
 		registry.registerStore( 'toggler', {
 			reducer: ( state = false, action ) =>
 				action.type === 'TOGGLE' ? ! state : state,
@@ -134,16 +133,16 @@ describe( 'useSelect', () => {
 		const mapSelect = ( select ) => select( 'toggler' ).get();
 
 		const mapSelectChild = jest.fn( mapSelect );
-		function Child() {
+		const Child = jest.fn( () => {
 			const show = useSelect( mapSelectChild, [] );
 			return show ? 'yes' : 'no';
-		}
+		} );
 
 		const mapSelectParent = jest.fn( mapSelect );
-		function Parent() {
+		const Parent = jest.fn( () => {
 			const show = useSelect( mapSelectParent, [] );
 			return show ? <Child /> : 'none';
-		}
+		} );
 
 		render(
 			<RegistryProvider value={ registry }>
@@ -155,14 +154,10 @@ describe( 'useSelect', () => {
 		expect( screen.getByText( 'none' ) ).toBeInTheDocument();
 		expect( mapSelectParent ).toHaveBeenCalledTimes( 2 );
 		expect( mapSelectChild ).toHaveBeenCalledTimes( 0 );
+		expect( Parent ).toHaveBeenCalledTimes( 1 );
+		expect( Child ).toHaveBeenCalledTimes( 0 );
 
-		// act() does batched updates internally, i.e., any scheduled setStates or effects
-		// will be executed only after the dispatch finishes. But we want to opt out of
-		// batched updates here. We want all the setStates to be done synchronously, as the
-		// store listeners are called. The async/await code is a trick to do it: do the
-		// dispatch in a different event loop tick, where the batched updates are no longer active.
-		await act( async () => {
-			await Promise.resolve();
+		act( () => {
 			registry.dispatch( 'toggler' ).toggle();
 		} );
 
@@ -170,18 +165,21 @@ describe( 'useSelect', () => {
 		expect( screen.getByText( 'yes' ) ).toBeInTheDocument();
 		expect( mapSelectParent ).toHaveBeenCalledTimes( 3 );
 		expect( mapSelectChild ).toHaveBeenCalledTimes( 2 );
+		expect( Parent ).toHaveBeenCalledTimes( 2 );
+		expect( Child ).toHaveBeenCalledTimes( 1 );
 
-		await act( async () => {
-			await Promise.resolve();
+		act( () => {
 			registry.dispatch( 'toggler' ).toggle();
 		} );
 
 		// Check that child was unmounted without any extra state update being performed on it.
-		// I.e., `mapSelectChild` was never called again, and no "state update on an unmounted
-		// component" warning was triggered.
+		// I.e., `mapSelectChild` was called again, and state update was scheduled, we cannot
+		// avoid that, but the state update is never executed and doesn't do a rerender.
 		expect( screen.getByText( 'none' ) ).toBeInTheDocument();
 		expect( mapSelectParent ).toHaveBeenCalledTimes( 4 );
-		expect( mapSelectChild ).toHaveBeenCalledTimes( 2 );
+		expect( mapSelectChild ).toHaveBeenCalledTimes( 3 );
+		expect( Parent ).toHaveBeenCalledTimes( 3 );
+		expect( Child ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	describe( 'rerenders as expected with various mapSelect return types', () => {

--- a/packages/data/src/components/use-select/test/index.js
+++ b/packages/data/src/components/use-select/test/index.js
@@ -50,9 +50,9 @@ describe( 'useSelect', () => {
 			</RegistryProvider>
 		);
 
-		// 2 times expected
+		// 2 selectSpy calls expected
 		// - 1 for initial mount
-		// - 1 for after mount before subscription set.
+		// - 1 for the subscription effect checking if value has changed
 		expect( selectSpy ).toHaveBeenCalledTimes( 2 );
 		expect( TestComponent ).toHaveBeenCalledTimes( 1 );
 
@@ -119,7 +119,7 @@ describe( 'useSelect', () => {
 	} );
 
 	// TODO: this might be impossible to pull off in React 18 without `useSyncExternalStore`
-	it.skip( 'avoid calling nested listener after unmounted', async () => {
+	it( 'avoid calling nested listener after unmounted', async () => {
 		registry.registerStore( 'toggler', {
 			reducer: ( state = false, action ) =>
 				action.type === 'TOGGLE' ? ! state : state,

--- a/packages/data/src/components/use-select/test/suspense.js
+++ b/packages/data/src/components/use-select/test/suspense.js
@@ -162,4 +162,76 @@ describe( 'useSuspenseSelect', () => {
 		expect( label ).toHaveTextContent( 'resolution failed' );
 		expect( console ).toHaveErrored();
 	} );
+
+	it( 'independent resolutions do not cause unrelated rerenders', async () => {
+		const store = createReduxStore( 'test', {
+			reducer: ( state = {}, action ) => {
+				switch ( action.type ) {
+					case 'RECEIVE':
+						return { ...state, [ action.endpoint ]: action.data };
+					default:
+						return state;
+				}
+			},
+			selectors: {
+				getData: ( state, endpoint ) => state[ endpoint ],
+			},
+			resolvers: {
+				getData:
+					( endpoint ) =>
+					async ( { dispatch } ) => {
+						const delay = endpoint === 'slow' ? 30 : 10;
+						await new Promise( ( r ) =>
+							setTimeout( () => r(), delay )
+						);
+						dispatch( {
+							type: 'RECEIVE',
+							endpoint,
+							data: endpoint,
+						} );
+					},
+			},
+		} );
+
+		const registry = createRegistry();
+		registry.register( store );
+
+		const FastUI = jest.fn( () => {
+			const data = useSuspenseSelect(
+				( select ) => select( store ).getData( 'fast' ),
+				[]
+			);
+			return <div aria-label="fast loaded">{ data }</div>;
+		} );
+
+		const SlowUI = jest.fn( () => {
+			const data = useSuspenseSelect(
+				( select ) => select( store ).getData( 'slow' ),
+				[]
+			);
+			return <div aria-label="slow loaded">{ data }</div>;
+		} );
+
+		const App = () => (
+			<RegistryProvider value={ registry }>
+				<Suspense fallback="fast loading">
+					<FastUI />
+				</Suspense>
+				<Suspense fallback="slow loading">
+					<SlowUI />
+				</Suspense>
+			</RegistryProvider>
+		);
+
+		render( <App /> );
+
+		const fastLabel = await screen.findByLabelText( 'fast loaded' );
+		expect( fastLabel ).toHaveTextContent( 'fast' );
+
+		const slowLabel = await screen.findByLabelText( 'slow loaded' );
+		expect( slowLabel ).toHaveTextContent( 'slow' );
+
+		expect( FastUI ).toHaveBeenCalledTimes( 2 );
+		expect( SlowUI ).toHaveBeenCalledTimes( 2 );
+	} );
 } );


### PR DESCRIPTION
Implementing `useSelect` with `useSyncExternalStore`. It mostly works, except async mode and the special `useSelect( storeDescriptor )` case.