### PR TITLE
Mobile: Disable Unsupported Block Editor Tests (Android)

### DIFF
--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-unsupported-blocks.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-unsupported-blocks.test.js
@@ -2,9 +2,12 @@
  * Internal dependencies
  */
 import testData from './helpers/test-data';
+import { isAndroid } from './helpers/utils';
 
-// Disabled for now see https://github.com/wordpress-mobile/gutenberg-mobile/issues/5321
-describe.skip( 'Gutenberg Editor Unsupported Block Editor Tests', () => {
+// Disabled for now on Android see https://github.com/wordpress-mobile/gutenberg-mobile/issues/5321
+const onlyOniOS = ! isAndroid() ? describe : describe.skip;
+
+onlyOniOS( 'Gutenberg Editor Unsupported Block Editor Tests', () => {
 	it( 'should be able to open the unsupported block web view editor', async () => {
 		await editorPage.setHtmlContent( testData.unsupportedBlockHtml );
 

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-unsupported-blocks.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-unsupported-blocks.test.js
@@ -3,7 +3,8 @@
  */
 import testData from './helpers/test-data';
 
-describe( 'Gutenberg Editor Unsupported Block Editor Tests', () => {
+// Disabled for now see https://github.com/wordpress-mobile/gutenberg-mobile/issues/5321
+describe.skip( 'Gutenberg Editor Unsupported Block Editor Tests', () => {
 	it( 'should be able to open the unsupported block web view editor', async () => {
 		await editorPage.setHtmlContent( testData.unsupportedBlockHtml );
 


### PR DESCRIPTION
**Related PR:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/5322

## What?
Due to constant failures on Android, we are disabling this E2E test for that platform.

## Why?
The test is not stable and the test itself doesn't actually test for the actual functionality, we are aiming to move this in https://github.com/wordpress-mobile/gutenberg-mobile/issues/5321. For now we are keeping the iOS test enabled.

## How?
By skipping it until it is migrated to another app.

## Testing Instructions
N/A - CI checks should pass in Gutenberg Mobile

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A