### PR TITLE
TextareaControl: add new opt-in prop

### DIFF
--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -180,6 +180,7 @@ export default function CoverInspectorControls( {
 							isImageBackground &&
 							isImgElement && (
 								<TextareaControl
+									__nextHasNoMarginBottom
 									label={ __(
 										'Alt text (alternative text)'
 									) }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -413,6 +413,7 @@ export default function Image( {
 				<PanelBody title={ __( 'Settings' ) }>
 					{ ! multiImageSelection && (
 						<TextareaControl
+							__nextHasNoMarginBottom
 							label={ __( 'Alt text (alternative text)' ) }
 							value={ alt }
 							onChange={ updateAlt }

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -281,6 +281,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes, clientId } ) {
 			) }
 			{ mediaType === 'image' && (
 				<TextareaControl
+					__nextHasNoMarginBottom
 					label={ __( 'Alt text (alternative text)' ) }
 					value={ mediaAlt }
 					onChange={ onMediaAltChange }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -495,6 +495,7 @@ export default function NavigationLinkEdit( {
 						autoComplete="off"
 					/>
 					<TextareaControl
+						__nextHasNoMarginBottom
 						value={ description || '' }
 						onChange={ ( descriptionValue ) => {
 							setAttributes( { description: descriptionValue } );

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -481,6 +481,7 @@ export default function NavigationSubmenuEdit( {
 						autoComplete="off"
 					/>
 					<TextareaControl
+						__nextHasNoMarginBottom
 						value={ description || '' }
 						onChange={ ( descriptionValue ) => {
 							setAttributes( {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -31,6 +31,7 @@
 -   Lighten the border color on control components ([#46252](https://github.com/WordPress/gutenberg/pull/46252)).
 -   `Popover`: Prevent unnecessary paint when scrolling by using transform instead of top/left positionning ([#46187](https://github.com/WordPress/gutenberg/pull/46187)).
 -   `CircularOptionPicker`: Prevent unecessary paint on hover ([#46197](https://github.com/WordPress/gutenberg/pull/46197)).
+-   `Disabled`: Replace bottom margin overrides with `__nextHasNoMarginBottom` ([#46559](https://github.com/WordPress/gutenberg/pull/46559)).
 
 ### Experimental
 
@@ -62,6 +63,7 @@
 -   `TabPanel`: Add ability to set icon only tab buttons ([#45005](https://github.com/WordPress/gutenberg/pull/45005)).
 
 ### Internal
+
 -   `AnglePickerControl`: remove `:focus-visible' outline on `CircleOutlineWrapper` ([#45758](https://github.com/WordPress/gutenberg/pull/45758))
 
 ### Bug Fix

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -31,7 +31,6 @@
 -   Lighten the border color on control components ([#46252](https://github.com/WordPress/gutenberg/pull/46252)).
 -   `Popover`: Prevent unnecessary paint when scrolling by using transform instead of top/left positionning ([#46187](https://github.com/WordPress/gutenberg/pull/46187)).
 -   `CircularOptionPicker`: Prevent unecessary paint on hover ([#46197](https://github.com/WordPress/gutenberg/pull/46197)).
--   `Disabled`: Replace bottom margin overrides with `__nextHasNoMarginBottom` ([#46559](https://github.com/WordPress/gutenberg/pull/46559)).
 
 ### Experimental
 
@@ -63,7 +62,6 @@
 -   `TabPanel`: Add ability to set icon only tab buttons ([#45005](https://github.com/WordPress/gutenberg/pull/45005)).
 
 ### Internal
-
 -   `AnglePickerControl`: remove `:focus-visible' outline on `CircleOutlineWrapper` ([#45758](https://github.com/WordPress/gutenberg/pull/45758))
 
 ### Bug Fix

--- a/packages/components/src/disabled/stories/index.tsx
+++ b/packages/components/src/disabled/stories/index.tsx
@@ -15,6 +15,7 @@ import Disabled from '../';
 import SelectControl from '../../select-control/';
 import TextControl from '../../text-control/';
 import TextareaControl from '../../textarea-control/';
+import { VStack } from '../../v-stack/';
 
 const meta: ComponentMeta< typeof Disabled > = {
 	title: 'Components/Disabled',
@@ -37,18 +38,21 @@ const Form = () => {
 	const [ textControlValue, setTextControlValue ] = useState( '' );
 	const [ textAreaValue, setTextAreaValue ] = useState( '' );
 	return (
-		<div>
+		<VStack>
 			<TextControl
+				__nextHasNoMarginBottom
 				label="Text Control"
 				value={ textControlValue }
 				onChange={ setTextControlValue }
 			/>
 			<TextareaControl
+				__nextHasNoMarginBottom
 				label="TextArea Control"
 				value={ textAreaValue }
 				onChange={ setTextAreaValue }
 			/>
 			<SelectControl
+				__nextHasNoMarginBottom
 				label="Select Control"
 				onChange={ () => {} }
 				options={ [
@@ -58,7 +62,7 @@ const Form = () => {
 					{ value: 'c', label: 'Option C' },
 				] }
 			/>
-		</div>
+		</VStack>
 	);
 };
 

--- a/packages/edit-site/src/components/global-styles/custom-css.js
+++ b/packages/edit-site/src/components/global-styles/custom-css.js
@@ -42,6 +42,7 @@ function CustomCSSControl() {
 	return (
 		<>
 			<TextareaControl
+				__nextHasNoMarginBottom
 				value={
 					customCSS?.replace( ignoreThemeCustomCSS, '' ) ||
 					themeCustomCSS

--- a/packages/editor/src/components/post-excerpt/index.js
+++ b/packages/editor/src/components/post-excerpt/index.js
@@ -15,6 +15,7 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 	return (
 		<div className="editor-post-excerpt">
 			<TextareaControl
+				__nextHasNoMarginBottom
 				label={ __( 'Write an excerpt (optional)' ) }
 				className="editor-post-excerpt__textarea"
 				onChange={ ( value ) => onUpdateExcerpt( value ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

Adding new opt-in prop `__nextHasNoMarginBottom` to usages of `TextareaControl` in the Gutenberg codebase. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Part of this project: https://github.com/WordPress/gutenberg/issues/38730
The tl;dr is `BaseControl` has a `margin-bottom` which makes it difficult to reuse and results in inconsistent use. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding the prop `__nextHasNoMarginBottom`.

## Additional Notes

The prop needs to be added to the story for the `Disabled` component which is why this PR includes updates to that component for all three `SelectControl`, `TextControl`, and `TextareaControl`. This is so future warnings of the margin-bottom deprecation won't show up in its default state. 

If this PR is merged first, https://github.com/WordPress/gutenberg/pull/46448 will need to be rebased to include this change. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

### **Test in the Block Editor (a Post)**

- ### PostExcerpt

	1. Edit a post
	2. Click on 'Excerpt' in the block inspector and look for the 'Write an Excerpt (optional)' label
	3. Ensure that spacing below the text area is the same as before
	
	![Screen Shot 2022-12-13 at 11 46 20 PM](https://user-images.githubusercontent.com/35543432/207751595-7ed7f343-c9ec-43ae-88ea-17a9ce73ed74.png)

**Quick steps: the next three (cover, image, media & text blocks) all check for the image alt text areas. Continue for step-by-step or jump down to Site Editor steps after testing these three**

- ### CoverInspector 

	1. Add a Cover block
	2. Add/upload an image to block
	3. Look for the 'Alt Text (Alternative Text)' label in the block inspector
	5. Ensure that spacing below the 'Alt Text' text area is the same as before
	
	![Screen Shot 2022-12-13 at 11 52 58 PM](https://user-images.githubusercontent.com/35543432/207751322-740c1ac3-ecc1-44d3-ada7-5f59896ce756.png)

- ### Image

	1. Add an Image block
	2. Add/upload an image to block
	3. Look for the 'Alt Text (Alternative Text)' label in the block inspector
	5. Ensure that spacing below the 'Alt Text' text area is the same as before
	
	![Screen Shot 2022-12-13 at 11 52 58 PM](https://user-images.githubusercontent.com/35543432/207751322-740c1ac3-ecc1-44d3-ada7-5f59896ce756.png)

- ### MediaTextEdt

	1. Add Media & Text block
	2. Add/upload an image to block
	3. Look for the 'Alt Text (Alternative Text)' label in the block inspector
	5. Ensure that spacing below the 'Alt Text' text area is the same as before
	
	![Screen Shot 2022-12-13 at 11 52 58 PM](https://user-images.githubusercontent.com/35543432/207751322-740c1ac3-ecc1-44d3-ada7-5f59896ce756.png)

### **Test in the Site Editor**

- ### NavigationLinkEdit & NavigationSubmenuEdit

	1. Add/edit Navigation in the Site Editor
	2. Add an empty or custom link
	3. Look for the 'Description' text area in the block inspector and ensure the space is the same as before
	4. Add a Submenu item to the Navigation block
	6. Repeat Step 3
	
	![Screen Shot 2022-12-14 at 12 07 55 AM](https://user-images.githubusercontent.com/35543432/207751175-2d022e71-27f0-47f1-bda0-e221ead809d7.png)

- ### CustomCSSControl

	1. Open the Site Editor
	2. Click on the 'Global Styles' icon 
	3. Click on 'Custom' at the bottom of the panel
	4. Ensure that spacing below the 'Additional CSS' text area is the same as before
	
 	![Screen Shot 2022-12-14 at 12 14 26 AM](https://user-images.githubusercontent.com/35543432/207751083-97816f59-6c11-425b-a302-c0def4b72e00.png)

### **Test in the Storybook**

- ### Disabled 

	1. Run storybook with this branch checked out
	2. See that the bottom margin has been removed for each of the inputs
	 
	<img width="1261" alt="Screen Shot 2022-12-14 at 5 14 58 PM" src="https://user-images.githubusercontent.com/35543432/207750992-baf7e0be-4cd4-4770-9b2f-927916639652.png">

