### PR TITLE
Verse: Prevent default styles overriding theme.json font family

### DIFF
--- a/packages/block-library/src/verse/style.scss
+++ b/packages/block-library/src/verse/style.scss
@@ -1,5 +1,8 @@
 pre.wp-block-verse {
-	font-family: inherit;
 	overflow: auto;
 	white-space: pre-wrap;
+}
+
+:where(pre.wp-block-verse) {
+	font-family: inherit;
 }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/46181

## What?

Prevents default block styles from overriding theme.json set font family.

## Why?

The block's default style's purpose appears to be to remove the standard `pre` monospaced font and match the primary font family. It isn't intended to override anything set by the theme.json.

## How?

Lowers the specificity of the font family style.

#### Alternative Approaches

1. We could add a custom selector to the Verse block that overrides the `pre.wp-block-verse` selector in the default styles. This would have a more wide-ranging impact, so I opted for a simpler tweak to the block's CSS.
2. The font family style could be moved to the `__experimentalStyle` property within the block.json. The catch here is that these styles aren't included for classic themes.

## Testing Instructions

1. Set a font family for the verse block in your theme.json
2. Edit a post, add a verse block, and save
4. Note that the verse block has your set font family in the editor
5. Switch to the frontend and note that your font family selection hasn't been applied
6. Checkout this PR, reload the editor and confirm the correct font family
7. Check the frontend now reflects the correct font family
8. Switch to the site editor and set a different font family, then confirm it is applied appropriately

### Testing Instructions for Keyboard

No changes to the UI. 

## Screenshots or screencast <!-- if applicable -->

<img width="1510" alt="Screenshot 2022-12-15 at 9 37 23 am" src="https://user-images.githubusercontent.com/60436221/207753246-731475c1-cf39-47f4-ae5f-ddf76f94f4ea.png">

