### PR TITLE
Global Styles REST API endpoint: check custom CSS is included before attempting to validate

### DIFF
--- a/lib/compat/wordpress-6.2/class-gutenberg-rest-global-styles-controller-6-2.php
+++ b/lib/compat/wordpress-6.2/class-gutenberg-rest-global-styles-controller-6-2.php
@@ -151,7 +151,7 @@ class Gutenberg_REST_Global_Styles_Controller_6_2 extends WP_REST_Global_Styles_
 		if ( isset( $request['styles'] ) || isset( $request['settings'] ) ) {
 			$config = array();
 			if ( isset( $request['styles'] ) ) {
-				$config['styles']    = $request['styles'];
+				$config['styles'] = $request['styles'];
 				if ( isset( $request['styles']['css'] ) ) {
 					$validate_custom_css = $this->validate_custom_css( $request['styles']['css'] );
 					if ( is_wp_error( $validate_custom_css ) ) {

--- a/lib/compat/wordpress-6.2/class-gutenberg-rest-global-styles-controller-6-2.php
+++ b/lib/compat/wordpress-6.2/class-gutenberg-rest-global-styles-controller-6-2.php
@@ -152,9 +152,11 @@ class Gutenberg_REST_Global_Styles_Controller_6_2 extends WP_REST_Global_Styles_
 			$config = array();
 			if ( isset( $request['styles'] ) ) {
 				$config['styles']    = $request['styles'];
-				$validate_custom_css = $this->validate_custom_css( $request['styles']['css'] );
-				if ( is_wp_error( $validate_custom_css ) ) {
-					return $validate_custom_css;
+				if ( isset( $request['styles']['css'] ) ) {
+					$validate_custom_css = $this->validate_custom_css( $request['styles']['css'] );
+					if ( is_wp_error( $validate_custom_css ) ) {
+						return $validate_custom_css;
+					}
 				}
 			} elseif ( isset( $existing_config['styles'] ) ) {
 				$config['styles'] = $existing_config['styles'];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow up to https://github.com/WordPress/gutenberg/pull/46141 to make sure that `$request['styles']['css']` is set before attempting to validate it.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Without an additional check, saving global styles without custom CSS values resulted in a PHP warning being thrown:

![image](https://user-images.githubusercontent.com/14988353/207763955-ac022ba6-c2e4-4b52-8324-5044d8642c65.png)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add an `isset()` check before attempting to validate the custom CSS in global styles.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

* In a blocks theme go to make an update to global styles without adding any custom CSS
* Add custom CSS and ensure that the CSS saves
* In both cases there shouldn't be any PHP warnings logged