### PR TITLE
Fix Off Canvas Editor add submenu item option

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/block.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block.js
@@ -42,7 +42,7 @@ import useBlockDisplayInformation from '../use-block-display-information';
 import { useBlockLock } from '../block-lock';
 
 function ListViewBlock( {
-	block,
+	block: { clientId },
 	isDragged,
 	isSelected,
 	isBranchSelected,
@@ -60,7 +60,6 @@ function ListViewBlock( {
 } ) {
 	const cellRef = useRef( null );
 	const [ isHovered, setIsHovered ] = useState( false );
-	const { clientId, attributes } = block;
 
 	const { isLocked, isContentLocked } = useBlockLock( clientId );
 	const forceSelectionContentLock = useSelect(
@@ -87,12 +86,12 @@ function ListViewBlock( {
 		( isSelected &&
 			selectedClientIds[ selectedClientIds.length - 1 ] === clientId );
 
-	const { replaceBlock, toggleBlockHighlight } =
+	const { insertBlock, replaceBlock, toggleBlockHighlight } =
 		useDispatch( blockEditorStore );
 
 	const blockInformation = useBlockDisplayInformation( clientId );
-	const blockName = useSelect(
-		( select ) => select( blockEditorStore ).getBlockName( clientId ),
+	const block = useSelect(
+		( select ) => select( blockEditorStore ).getBlock( clientId ),
 		[ clientId ]
 	);
 
@@ -100,7 +99,7 @@ function ListViewBlock( {
 	// since that menu is part of the toolbar in the editor canvas.
 	// List View respects this by also hiding the block settings menu.
 	const showBlockActions = hasBlockSupport(
-		blockName,
+		block.name,
 		'__experimentalToolbar',
 		true
 	);
@@ -145,7 +144,7 @@ function ListViewBlock( {
 
 	const { isTreeGridMounted, expand, collapse } = useListViewContext();
 
-	const isEditable = blockName !== 'core/page-list-item';
+	const isEditable = block.name !== 'core/page-list-item';
 	const hasSiblings = siblingBlockCount > 0;
 	const hasRenderedMovers = showBlockMovers && hasSiblings;
 	const moverCellClassName = classnames(
@@ -369,20 +368,34 @@ function ListViewBlock( {
 											const newLink = createBlock(
 												'core/navigation-link'
 											);
-											const newSubmenu = createBlock(
-												'core/navigation-submenu',
-												attributes,
-												block.innerBlocks
-													? [
-															...block.innerBlocks,
-															newLink,
-													  ]
-													: [ newLink ]
-											);
-											replaceBlock(
-												clientId,
-												newSubmenu
-											);
+											// Convert to a submenu if the block currently isn't one.
+											if (
+												block.name ===
+												'core/navigation-submenu'
+											) {
+												const updateSelectionOnInsert = false;
+												insertBlock(
+													newLink,
+													block.innerBlocks.length,
+													clientId,
+													updateSelectionOnInsert
+												);
+											} else {
+												const newSubmenu = createBlock(
+													'core/navigation-submenu',
+													block.attributes,
+													block.innerBlocks
+														? [
+																...block.innerBlocks,
+																newLink,
+														  ]
+														: [ newLink ]
+												);
+												replaceBlock(
+													clientId,
+													newSubmenu
+												);
+											}
 											onClose();
 										} }
 									>

--- a/packages/block-editor/src/components/off-canvas-editor/block.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block.js
@@ -368,7 +368,6 @@ function ListViewBlock( {
 											const newLink = createBlock(
 												'core/navigation-link'
 											);
-											// Convert to a submenu if the block currently isn't one.
 											if (
 												block.name ===
 												'core/navigation-submenu'
@@ -381,6 +380,7 @@ function ListViewBlock( {
 													updateSelectionOnInsert
 												);
 											} else {
+												// Convert to a submenu if the block currently isn't one.
 												const newSubmenu = createBlock(
 													'core/navigation-submenu',
 													block.attributes,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #46553

## Why?
This feature stopped working as a side effect of not passing the entire block data through the off canvas list view.

## How?
Use a selector to get the block information from the block editor store.

I've also changed a minor aspect of how this feature works. It was originally creating a new submenu block every time, even when the block was already a submenu block. That's a little inefficient, as it'll result in the block getting a new client id.

If the block is already a submenu, it now only inserts a new navigation link.

## Testing Instructions
1. Add a navigation block to a post
2. Open the block inspector
3. Use the + button to add a link to the navigation block
4. Open the settings menu for the link (the stacked three dots icon)
5. Choose 'Add submenu item'
6. Observe that a new submenu is created with one item.
7. Repeat steps 4-5 a few times, more submenu items should be added.

### Testing Instructions for Keyboard
1. Tab to the post content and type '/navigation' followed by enter to create a navigation block
2. Shift tab to the block toolbar and activate the 'Settings' button
3. Tab (or navigate regions) to the block inspector until you reach the 'Block navigation structure' application
4. Press the down arrow until you get to the 'Add block' button, then hit enter to add a block
5. In the resulting popover, type in a URL or page name (or use arrow keys to navigate through options) and press enter
6. Press the up arrow once to focus the block just added
7. Press right arrow once to get to the block settings dropdown and use enter to open it
8. Arrow down to the 'Add submenu item' option and press enter to use it
9. At this point there is a focus loss bug (the block is selected in the canvas). Tab back to the block inspector block navigation structure and repeat steps 4-8 a few times. The focus loss will only happen the first time through.
10. Use up and down arrows to check the blocks in list view, you should have one Navigation Submenu with multiple Navigation Links


## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/677833/207767355-39d59949-c7eb-40cb-bdd1-cf635e23cde7.mp4


