### PR TITLE
Update copy of off canvas editor 'add submenu item' option

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/block.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block.js
@@ -386,7 +386,7 @@ function ListViewBlock( {
 											onClose();
 										} }
 									>
-										{ __( 'Add a submenu item' ) }
+										{ __( 'Add submenu item' ) }
 									</MenuItem>
 								) }
 							</BlockSettingsDropdown>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Makes the copy in the off canvas editor's Add submenu item option consistent with other options (like 'Create reusable block' / 'Add block').

## Why?
Copy for buttons avoids using ['article' words](https://en.wikipedia.org/wiki/Article_(grammar)).

## How?
1. Add a navigation block to a post
2. Open the block inspector
3. Use the + button to add a link to the navigation block
4. Open the settings menu for the link (the stacked three dots icon)
5. See that the menu item text is now 'Add submenu item'.

### Testing Instructions for Keyboard
1. Tab to the post content and type '/navigation' followed by enter to create a navigation block
2. Shift tab to the block toolbar and activate the 'Settings' button
3. Tab (or navigate regions) to the block inspector until you reach the 'Block navigation structure' application
4. Press the down arrow until you get to the 'Add block' button, then hit enter to add a block
5. In the resulting popover, type in a URL or page name (or use arrow keys to navigate through options) and press enter
6. Press the up arrow once to focus the block just added
7. Press right arrow once to get to the block settings dropdown and use enter to open it
8. Arrow down to the 'Add submenu item' option, and note that the text is now different.

## Screenshots or screencast <!-- if applicable -->
### Before

![Screen Shot 2022-12-15 at 12 17 01 pm](https://user-images.githubusercontent.com/677833/207771413-6cd43cd0-27de-45d9-85ac-880d04880569.png)


### After

![Screen Shot 2022-12-15 at 12 17 24 pm](https://user-images.githubusercontent.com/677833/207771428-e7b62bc7-4c87-4198-b842-a80915172aab.png)

