### PR TITLE
Block Selection Toolbar: Support fixed and sticky blocks by flipping when there is not enough space above the block

### DIFF
--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useMergeRefs } from '@wordpress/compose';
+import { getScrollContainer } from '@wordpress/dom';
 import { Popover } from '@wordpress/components';
 import {
 	forwardRef,
@@ -74,6 +75,31 @@ function BlockPopover(
 			observer.disconnect();
 		};
 	}, [ selectedElement ] );
+
+	const scrollContainer = useMemo( () => {
+		if ( ! __unstableContentRef?.current ) {
+			return;
+		}
+		return getScrollContainer( __unstableContentRef?.current );
+	}, [ __unstableContentRef?.current ] );
+
+	useLayoutEffect( () => {
+		if ( ! scrollContainer ) {
+			return;
+		}
+
+		scrollContainer?.addEventListener?.(
+			'scroll',
+			forceRecomputePopoverDimensions
+		);
+
+		return () => {
+			scrollContainer?.removeEventHandler?.(
+				'scroll',
+				forceRecomputePopoverDimensions
+			);
+		};
+	}, [ scrollContainer ] );
 
 	const style = useMemo( () => {
 		if (

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -76,6 +76,7 @@ function BlockPopover(
 		};
 	}, [ selectedElement ] );
 
+	// Get the scrollable container that the block popover appears within.
 	const scrollContainer = useMemo( () => {
 		if ( ! __unstableContentRef?.current ) {
 			return;
@@ -83,6 +84,8 @@ function BlockPopover(
 		return getScrollContainer( __unstableContentRef?.current );
 	}, [ __unstableContentRef?.current ] );
 
+	// Force the block popover to re-render whenever the content area is scrolled.
+	// This ensures that the position of the popover is accurate for fixed or sticky blocks.
 	useLayoutEffect( () => {
 		if ( ! scrollContainer ) {
 			return;

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -7,7 +7,6 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useMergeRefs } from '@wordpress/compose';
-import { getScrollContainer } from '@wordpress/dom';
 import { Popover } from '@wordpress/components';
 import {
 	forwardRef,
@@ -75,34 +74,6 @@ function BlockPopover(
 			observer.disconnect();
 		};
 	}, [ selectedElement ] );
-
-	// Get the scrollable container that the block popover appears within.
-	const scrollContainer = useMemo( () => {
-		if ( ! __unstableContentRef?.current ) {
-			return;
-		}
-		return getScrollContainer( __unstableContentRef?.current );
-	}, [ __unstableContentRef?.current ] );
-
-	// Force the block popover to re-render whenever the content area is scrolled.
-	// This ensures that the position of the popover is accurate for fixed or sticky blocks.
-	useLayoutEffect( () => {
-		if ( ! scrollContainer ) {
-			return;
-		}
-
-		scrollContainer?.addEventListener?.(
-			'scroll',
-			forceRecomputePopoverDimensions
-		);
-
-		return () => {
-			scrollContainer?.removeEventHandler?.(
-				'scroll',
-				forceRecomputePopoverDimensions
-			);
-		};
-	}, [ scrollContainer ] );
 
 	const style = useMemo( () => {
 		if (

--- a/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
+++ b/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
@@ -3,7 +3,13 @@
  */
 import { useRefEffect } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
-import { useCallback, useLayoutEffect, useState } from '@wordpress/element';
+import { getScrollContainer } from '@wordpress/dom';
+import {
+	useCallback,
+	useLayoutEffect,
+	useMemo,
+	useState,
+} from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -40,24 +46,40 @@ const RESTRICTED_HEIGHT_PROPS = {
  *
  * @param {Element} contentElement       The DOM element that represents the editor content or canvas.
  * @param {Element} selectedBlockElement The outer DOM element of the first selected block.
+ * @param {Element} scrollContainer      The scrollable container for the contentElement.
  * @param {number}  toolbarHeight        The height of the toolbar in pixels.
  *
  * @return {Object} The popover props used to determine the position of the toolbar.
  */
-function getProps( contentElement, selectedBlockElement, toolbarHeight ) {
+function getProps(
+	contentElement,
+	selectedBlockElement,
+	scrollContainer,
+	toolbarHeight
+) {
 	if ( ! contentElement || ! selectedBlockElement ) {
 		return DEFAULT_PROPS;
 	}
 
+	// Get how far the content area has been scrolled.
+	const scrollTop = scrollContainer?.scrollTop || 0;
+
 	const blockRect = selectedBlockElement.getBoundingClientRect();
 	const contentRect = contentElement.getBoundingClientRect();
+
+	// Get the vertical position of top of the visible content area.
+	const topOfContentElementInViewport = scrollTop + contentRect.top;
 
 	// The document element's clientHeight represents the viewport height.
 	const viewportHeight =
 		contentElement.ownerDocument.documentElement.clientHeight;
 
-	const hasSpaceForToolbarAbove =
-		blockRect.top - contentRect.top > toolbarHeight;
+	// The restricted height area is calculated as the sum of the
+	// vertical position of the visible content area, plus the height
+	// of the block toolbar.
+	const restrictedTopArea = topOfContentElementInViewport + toolbarHeight;
+	const hasSpaceForToolbarAbove = blockRect.top > restrictedTopArea;
+
 	const isBlockTallerThanViewport =
 		blockRect.height > viewportHeight - toolbarHeight;
 
@@ -83,8 +105,19 @@ export default function useBlockToolbarPopoverProps( {
 } ) {
 	const selectedBlockElement = useBlockElement( clientId );
 	const [ toolbarHeight, setToolbarHeight ] = useState( 0 );
+	const scrollContainer = useMemo( () => {
+		if ( ! contentElement ) {
+			return;
+		}
+		return getScrollContainer( contentElement );
+	}, [ contentElement ] );
 	const [ props, setProps ] = useState( () =>
-		getProps( contentElement, selectedBlockElement, toolbarHeight )
+		getProps(
+			contentElement,
+			selectedBlockElement,
+			scrollContainer,
+			toolbarHeight
+		)
 	);
 	const blockIndex = useSelect(
 		( select ) => select( blockEditorStore ).getBlockIndex( clientId ),
@@ -98,7 +131,12 @@ export default function useBlockToolbarPopoverProps( {
 	const updateProps = useCallback(
 		() =>
 			setProps(
-				getProps( contentElement, selectedBlockElement, toolbarHeight )
+				getProps(
+					contentElement,
+					selectedBlockElement,
+					scrollContainer,
+					toolbarHeight
+				)
 			),
 		[ contentElement, selectedBlockElement, toolbarHeight ]
 	);

--- a/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
+++ b/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
@@ -138,7 +138,7 @@ export default function useBlockToolbarPopoverProps( {
 					toolbarHeight
 				)
 			),
-		[ contentElement, selectedBlockElement, toolbarHeight ]
+		[ contentElement, selectedBlockElement, scrollContainer, toolbarHeight ]
 	);
 
 	// Update props when the block is moved. This also ensures the props are


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of implementing: https://github.com/WordPress/gutenberg/issues/30121

An alternative to #46085.

This PR explores whether we can add support for fixed and sticky blocks to the block selection toolbar by flipping the position of the toolbar to be beneath the block when there is not enough space to display the toolbar above the block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

<!--
Over in #46085 some of the limitations of the approach that switched on the `fixed` strategy were:

* The content area for the editor canvas has a variable height depending on the context. For example, there is the top toolbar present normally, however if the editor is not run in full-screen mode, then there is also the logged in wp-admin header. Retaining the `absolute` position means that we don't need to determine the clipping area for the popover, and can let floating UI figure that out for us.
* There was a jittery issue when switching over to `fixed` that was difficult to debug. That issue doesn't appear to be present with this PR, although I did notice there was still a bit of jitter on sticky/fixed blocks that might need investigating. -->

Without this change, blocks that are included inside a sticky positioned block at the top of the screen are obscured by the block selection toolbar. By flipping to display beneath the block when there is not enough room, we can ensure that the block content is not obscured.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

<!--
* In the block popover component, force a re-render whenever the scroll container for the editor canvas is scrolled. This forces the position of the popover to update when scrolling, which fixes positioning issues for fixed/sticky blocks. -->
* In the block toolbar popover props, ensure the toolbar will flip position to be underneath the block if there is not enough space to display the toolbar above the block when it is initially selected. This implements the feedback on the other PR (https://github.com/WordPress/gutenberg/pull/46085#issuecomment-1338937500):

> I think that in most cases we should not be flipping the position of the toolbar if it's able to start out above the block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

To test the real world application for this PR, it might be easier to test #46142 instead, which includes the changes in this PR. However, you can still observe the changes in this PR with the following:

1. In the editor, select a block that begins well below the top of the visible area of the editor canvas. The block toolbar should be visible above the block. If you scroll the page so the block goes off the top of the viewport, then the toolbar should be "sticky" to the top of the editor canvas.
2. Select a block that is partially obscured at the top of the editor canvas. The block toolbar should be flipped and display beneath the block. As you scroll, the toolbar will flip between the top and bottom of the block. While this is a change from what's on `trunk`, it's this behaviour that ensures that for sticky and fixed position blocks, the toolbar will not obscure the content.

## Screenshots or screencast <!-- if applicable -->
| When a block is selected that does not have room for the toolbar initially (flips to bottom) | When a block is selected that does have enough room (does not flip) |
| --- | --- |
| <img width="867" alt="image" src="https://user-images.githubusercontent.com/14988353/207773538-3eba6718-e7ad-46eb-9a08-c1ba15f88a47.png"> | <img width="869" alt="image" src="https://user-images.githubusercontent.com/14988353/207773568-c3d0fe90-f107-45d4-b4c2-6792ee5013eb.png"> |