### PR TITLE
fixed table block footer section issue

### DIFF
--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -11,6 +11,11 @@
 		width: 100%;
 	}
 
+	tfoot {
+		font-weight: 700;
+    	text-align: inherit;
+	}
+
 	// Match default border style to default style in editor
 	td,
 	th {

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -11,9 +11,12 @@
 		width: 100%;
 	}
 
+	thead {
+		border-bottom: 3px solid;
+	}
+
 	tfoot {
-		font-weight: 700;
-    	text-align: inherit;
+		border-top: 3px solid;
 	}
 
 	// Match default border style to default style in editor

--- a/packages/block-library/src/table/theme.scss
+++ b/packages/block-library/src/table/theme.scss
@@ -1,10 +1,6 @@
 .wp-block-table {
 	margin: 0 0 1em 0;
 
-	thead {
-		border-bottom: 3px solid;
-	}
-
 	td,
 	th {
 		word-break: normal;

--- a/packages/block-library/src/table/theme.scss
+++ b/packages/block-library/src/table/theme.scss
@@ -5,12 +5,6 @@
 		border-bottom: 3px solid;
 	}
 
-	tfoot {
-		border-top: 3px solid;
-		font-weight: 700;
-    	text-align: inherit;
-	}
-
 	td,
 	th {
 		word-break: normal;

--- a/packages/block-library/src/table/theme.scss
+++ b/packages/block-library/src/table/theme.scss
@@ -7,6 +7,8 @@
 
 	tfoot {
 		border-top: 3px solid;
+		font-weight: 700;
+    	text-align: inherit;
 	}
 
 	td,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The PR is added to resolved table block tfoot issue for both front-end and back-end.

## Why?
I have checked Gutenberg table block and I have added its header section, test data, and footer section. But, in admin and at front-end user can't identify that which is footer section. Because footer section is react like row & columns data.

## How?
First I have checked its CSS and found that tfoot was not working like header. So, I have added its CSS.

## Testing Instructions

1. Open a Post or Page.
2. Insert a Table Block.
3. Enable Header section from block setting.
4. Enable Footer section from block setting.
5. Insert data into the table and check that table header & tfoot is not looks like same.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast
![table_block_back_end](https://user-images.githubusercontent.com/53076293/207776038-7d5109e7-1467-426d-a6d3-b00689099127.png)
![table_block_front_end](https://user-images.githubusercontent.com/53076293/207776045-83d06be2-d221-4d6b-a931-5cb8670ed1b3.png)

