### PR TITLE
Fix accessing potentially undefined block editor setting __experimentalBlockInspectorAnimation

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -181,7 +181,9 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 				const globalBlockInspectorAnimationSettings =
 					select( blockEditorStore ).getSettings()
 						.__experimentalBlockInspectorAnimation;
-				return globalBlockInspectorAnimationSettings[ blockType.name ];
+				return globalBlockInspectorAnimationSettings?.[
+					blockType.name
+				];
 			}
 			return null;
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes JS error when attempting to access property of potentially undefined `__experimentalBlockInspectorAnimation` added in https://github.com/WordPress/gutenberg/pull/46342/.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The following error was thrown upon selecting the block:

<img width="966" alt="Screenshot 2022-12-15 at 06 56 44" src="https://user-images.githubusercontent.com/444434/207796391-56f02ac7-51f1-4a16-af2b-d78e7b096b49.png">

This only happened when the Nav block offcanvas experiment was on.

This was due to accessing a property of a object which is potentially undefined. Block settings are not guaranteed to be available.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Use conditional chaining to guard accessing the prop returning `undefined` if not available.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Enable experiment
- Add Nav block
- Select block and toggle open inspector controls
- Check no errors in console

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
