### PR TITLE
Navigation list view: use smaller lock icon

### DIFF
--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -12,7 +12,7 @@ import {
 	__experimentalTruncate as Truncate,
 } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
-import { Icon, lock } from '@wordpress/icons';
+import { Icon, lockSmall as lock } from '@wordpress/icons';
 import { SPACE, ENTER } from '@wordpress/keycodes';
 
 /**

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -319,11 +319,16 @@
 
 	.block-editor-list-view-block-select-button__lock {
 		line-height: 0;
-		width: 24px;
+		width: 16px;
 		min-width: 24px;
+		height: 16px;
 		margin-left: auto;
 		padding: 0;
 		vertical-align: middle;
+		display: inline-flex;
+		justify-content: center;
+		align-items: center;
+		overflow: hidden;
 	}
 }
 

--- a/packages/block-editor/src/components/off-canvas-editor/block-select-button.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-select-button.js
@@ -12,7 +12,7 @@ import {
 	__experimentalTruncate as Truncate,
 } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
-import { Icon, lock } from '@wordpress/icons';
+import { Icon, lockSmall as lock } from '@wordpress/icons';
 import { SPACE, ENTER } from '@wordpress/keycodes';
 
 /**
@@ -104,7 +104,7 @@ function ListViewBlockSelectButton(
 						</span>
 					) }
 					{ isLocked && (
-						<span className="block-editor-list-view-block-select-button__lock">
+						<span className="block-editor-list-view-block-select-button__lock offcanvas-editor-list-view-block-select-button__lock">
 							<Icon icon={ lock } />
 						</span>
 					) }

--- a/packages/block-editor/src/components/off-canvas-editor/block-select-button.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-select-button.js
@@ -104,7 +104,7 @@ function ListViewBlockSelectButton(
 						</span>
 					) }
 					{ isLocked && (
-						<span className="block-editor-list-view-block-select-button__lock offcanvas-editor-list-view-block-select-button__lock">
+						<span className="block-editor-list-view-block-select-button__lock">
 							<Icon icon={ lock } />
 						</span>
 					) }

--- a/packages/block-editor/src/components/off-canvas-editor/style.scss
+++ b/packages/block-editor/src/components/off-canvas-editor/style.scss
@@ -23,12 +23,4 @@
 	display: block;
 	// sidebar width - tab panel padding
 	max-width: $sidebar-width - (2 * $grid-unit-20);
-	.offcanvas-editor-list-view-block-select-button__lock {
-		display: inline-flex;
-		justify-content: center;
-		align-items: center;
-		overflow: hidden;
-		width: 16px;
-		height: 16px;
-	}
 }

--- a/packages/block-editor/src/components/off-canvas-editor/style.scss
+++ b/packages/block-editor/src/components/off-canvas-editor/style.scss
@@ -23,4 +23,12 @@
 	display: block;
 	// sidebar width - tab panel padding
 	max-width: $sidebar-width - (2 * $grid-unit-20);
+	.offcanvas-editor-list-view-block-select-button__lock {
+		display: inline-flex;
+		justify-content: center;
+		align-items: center;
+		overflow: hidden;
+		width: 16px;
+		height: 16px;
+	}
 }

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -129,6 +129,7 @@ export { default as listItem } from './library/list-item';
 export { default as listView } from './library/list-view';
 export { default as lock } from './library/lock';
 export { default as lockOutline } from './library/lock-outline';
+export { default as lockSmall } from './library/lock-small';
 export { default as login } from './library/login';
 export { default as loop } from './library/loop';
 export { default as mapMarker } from './library/map-marker';

--- a/packages/icons/src/library/lock-small.js
+++ b/packages/icons/src/library/lock-small.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const lockSmall = (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M15 11h-.2V9c0-1.5-1.2-2.8-2.8-2.8S9.2 7.5 9.2 9v2H9c-.6 0-1 .4-1 1v4c0 .6.4 1 1 1h6c.6 0 1-.4 1-1v-4c0-.6-.4-1-1-1zm-1.8 0h-2.5V9c0-.7.6-1.2 1.2-1.2s1.2.6 1.2 1.2v2z"
+		/>
+	</SVG>
+);
+
+export default lockSmall;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR reduces the size of the lock icon on the off canvas list view

I believe this closes https://github.com/WordPress/gutenberg/issues/46191

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The right sidebar has less space and everything was looking very cramped when we have a menu with multiple nesting levels. This helps alleviate that while we keep improving the styles for the menu on the off canvas list view.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Insert a navigation block
Add a page list to it in case it doesn't already have it
Check the icons of the page list items on the list view and the right sidebar. They should be small on the later, and bigger on the former.

## Screenshots or screencast <!-- if applicable -->

Before | After 
--- | ---
<img width="1460" alt="Screenshot 2022-12-15 at 12 29 55" src="https://user-images.githubusercontent.com/3593343/207848676-c31ca6bd-5b87-4b5e-ada0-e5b49cffbcd7.png"> | <img width="1460" alt="Screenshot 2022-12-15 at 12 29 07" src="https://user-images.githubusercontent.com/3593343/207848693-5d618723-1089-4583-9b22-0bfc8bdbfd4c.png">

