### PR TITLE
Add `shortName` property to FontSize Preset to override t-shirt size label

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -125,7 +125,7 @@ Settings related to typography.
 | textDecoration | boolean | true |  |
 | textTransform | boolean | true |  |
 | dropCap | boolean | true |  |
-| fontSizes | array |  | fluid, name, size, slug |
+| fontSizes | array |  | fluid, name, shortName, size, slug |
 | fontFamilies | array |  | fontFace, fontFamily, name, slug |
 
 ---

--- a/packages/components/src/font-size-picker/constants.ts
+++ b/packages/components/src/font-size-picker/constants.ts
@@ -4,12 +4,12 @@
 import { __ } from '@wordpress/i18n';
 
 /**
- * List of T-shirt abbreviations.
+ * List of default short names.
  *
  * When there are 5 font sizes or fewer, we assume that the font sizes are
  * ordered by size and show T-shirt labels.
  */
-export const T_SHIRT_ABBREVIATIONS = [
+export const DEFAULT_SHORT_NAMES = [
 	/* translators: S stands for 'small' and is a size label. */
 	__( 'S' ),
 	/* translators: M stands for 'medium' and is a size label. */
@@ -23,12 +23,12 @@ export const T_SHIRT_ABBREVIATIONS = [
 ];
 
 /**
- * List of T-shirt names.
+ * List of default T-shirt names.
  *
  * When there are 5 font sizes or fewer, we assume that the font sizes are
  * ordered by size and show T-shirt labels.
  */
-export const T_SHIRT_NAMES = [
+export const DEFAULT_NAMES = [
 	__( 'Small' ),
 	__( 'Medium' ),
 	__( 'Large' ),

--- a/packages/components/src/font-size-picker/font-size-picker-toggle-group.tsx
+++ b/packages/components/src/font-size-picker/font-size-picker-toggle-group.tsx
@@ -47,8 +47,7 @@ const FontSizePickerToggleGroup = ( props: FontSizePickerToggleGroupProps ) => {
 					key={ fontSize.slug }
 					value={ fontSize.size }
 					label={
-						fontSize.shortName &&
-						hasValidShortName( fontSize.shortName )
+						hasValidShortName( fontSize?.shortName )
 							? fontSize.shortName
 							: T_SHIRT_ABBREVIATIONS[ index ]
 					}

--- a/packages/components/src/font-size-picker/font-size-picker-toggle-group.tsx
+++ b/packages/components/src/font-size-picker/font-size-picker-toggle-group.tsx
@@ -11,24 +11,8 @@ import {
 	ToggleGroupControlOption,
 } from '../toggle-group-control';
 import { T_SHIRT_ABBREVIATIONS, T_SHIRT_NAMES } from './constants';
+import { hasValidShortName } from './utils';
 import type { FontSizePickerToggleGroupProps } from './types';
-
-/**
- * hasValidShortName
- *
- * check that the font size short name is a string with at most
- * 3 characters length (e.g. "XXS", "XS", "S", "M", "L", "XL", "XXL")
- *
- * @param  shortName font size object
- * @return boolean
- */
-function hasValidShortName( shortName: string | undefined ): boolean {
-	return (
-		typeof shortName === 'string' &&
-		shortName.length >= 1 &&
-		shortName.length <= 3
-	);
-}
 
 const FontSizePickerToggleGroup = ( props: FontSizePickerToggleGroupProps ) => {
 	const { fontSizes, value, __nextHasNoMarginBottom, size, onChange } = props;

--- a/packages/components/src/font-size-picker/font-size-picker-toggle-group.tsx
+++ b/packages/components/src/font-size-picker/font-size-picker-toggle-group.tsx
@@ -10,7 +10,7 @@ import {
 	ToggleGroupControl,
 	ToggleGroupControlOption,
 } from '../toggle-group-control';
-import { T_SHIRT_ABBREVIATIONS, T_SHIRT_NAMES } from './constants';
+import { DEFAULT_SHORT_NAMES, DEFAULT_NAMES } from './constants';
 import { hasValidShortName } from './utils';
 import type { FontSizePickerToggleGroupProps } from './types';
 
@@ -34,9 +34,9 @@ const FontSizePickerToggleGroup = ( props: FontSizePickerToggleGroupProps ) => {
 						fontSize.shortName &&
 						hasValidShortName( fontSize.shortName )
 							? fontSize.shortName
-							: T_SHIRT_ABBREVIATIONS[ index ]
+							: DEFAULT_SHORT_NAMES[ index ]
 					}
-					aria-label={ fontSize.name || T_SHIRT_NAMES[ index ] }
+					aria-label={ fontSize.name || DEFAULT_NAMES[ index ] }
 					showTooltip
 				/>
 			) ) }

--- a/packages/components/src/font-size-picker/font-size-picker-toggle-group.tsx
+++ b/packages/components/src/font-size-picker/font-size-picker-toggle-group.tsx
@@ -13,6 +13,23 @@ import {
 import { T_SHIRT_ABBREVIATIONS, T_SHIRT_NAMES } from './constants';
 import type { FontSizePickerToggleGroupProps } from './types';
 
+/**
+ * hasValidShortName
+ *
+ * check that the font size short name is a string with at most
+ * 3 characters length (e.g. "XXS", "XS", "S", "M", "L", "XL", "XXL")
+ *
+ * @param  shortName font size object
+ * @return boolean
+ */
+function hasValidShortName( shortName: string | undefined ): boolean {
+	return (
+		typeof shortName === 'string' &&
+		shortName.length >= 1 &&
+		shortName.length <= 3
+	);
+}
+
 const FontSizePickerToggleGroup = ( props: FontSizePickerToggleGroupProps ) => {
 	const { fontSizes, value, __nextHasNoMarginBottom, size, onChange } = props;
 	return (
@@ -29,7 +46,12 @@ const FontSizePickerToggleGroup = ( props: FontSizePickerToggleGroupProps ) => {
 				<ToggleGroupControlOption
 					key={ fontSize.slug }
 					value={ fontSize.size }
-					label={ T_SHIRT_ABBREVIATIONS[ index ] }
+					label={
+						fontSize.shortName &&
+						hasValidShortName( fontSize.shortName )
+							? fontSize.shortName
+							: T_SHIRT_ABBREVIATIONS[ index ]
+					}
 					aria-label={ fontSize.name || T_SHIRT_NAMES[ index ] }
 					showTooltip
 				/>

--- a/packages/components/src/font-size-picker/font-size-picker-toggle-group.tsx
+++ b/packages/components/src/font-size-picker/font-size-picker-toggle-group.tsx
@@ -31,7 +31,8 @@ const FontSizePickerToggleGroup = ( props: FontSizePickerToggleGroupProps ) => {
 					key={ fontSize.slug }
 					value={ fontSize.size }
 					label={
-						hasValidShortName( fontSize?.shortName )
+						fontSize.shortName &&
+						hasValidShortName( fontSize.shortName )
 							? fontSize.shortName
 							: T_SHIRT_ABBREVIATIONS[ index ]
 					}

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -36,7 +36,7 @@ import {
 import { Spacer } from '../spacer';
 import FontSizePickerSelect from './font-size-picker-select';
 import FontSizePickerToggleGroup from './font-size-picker-toggle-group';
-import { T_SHIRT_NAMES } from './constants';
+import { DEFAULT_NAMES } from './constants';
 
 const UnforwardedFontSizePicker = (
 	props: FontSizePickerProps,
@@ -86,7 +86,7 @@ const UnforwardedFontSizePicker = (
 			if ( selectedFontSize ) {
 				return (
 					selectedFontSize.name ||
-					T_SHIRT_NAMES[ fontSizes.indexOf( selectedFontSize ) ]
+					DEFAULT_NAMES[ fontSizes.indexOf( selectedFontSize ) ]
 				);
 			}
 			return '';

--- a/packages/components/src/font-size-picker/types.ts
+++ b/packages/components/src/font-size-picker/types.ts
@@ -77,6 +77,11 @@ export type FontSize = {
 	 * size. Used for the class generation process.
 	 */
 	slug: string;
+	/**
+	 * The `shortName` property is a string with a short label for that font
+	 * size e.g.: `S`.
+	 */
+	shortName?: string;
 };
 
 export type FontSizePickerSelectProps = Pick<

--- a/packages/components/src/font-size-picker/utils.ts
+++ b/packages/components/src/font-size-picker/utils.ts
@@ -44,3 +44,20 @@ export function getCommonSizeUnit( fontSizes: FontSize[] ) {
 	} );
 	return areAllSizesSameUnit ? firstUnit : null;
 }
+
+/**
+ * hasValidShortName
+ *
+ * check that the font size short name is a string with at most
+ * 3 characters length (e.g. "XXS", "XS", "S", "M", "L", "XL", "XXL")
+ *
+ * @param  shortName font size object
+ * @return boolean
+ */
+export function hasValidShortName( shortName: string | undefined ): boolean {
+	return (
+		typeof shortName === 'string' &&
+		shortName.length >= 1 &&
+		shortName.length <= 3
+	);
+}

--- a/packages/components/src/font-size-picker/utils.ts
+++ b/packages/components/src/font-size-picker/utils.ts
@@ -49,10 +49,10 @@ export function getCommonSizeUnit( fontSizes: FontSize[] ) {
  * Validate that the font size short name is a string with at most
  * 3 characters length (e.g. "XXS", "XS", "S", "M", "L", "XL", "XXL").
  *
- * @param shortName The short name to validate.
+ * @param  shortName The short name to validate.
  * @return Whether the short name is valid.
  */
-export function hasValidShortName( shortName: string | undefined ): boolean {
+export function hasValidShortName( shortName: string ): boolean {
 	return (
 		typeof shortName === 'string' &&
 		shortName.length >= 1 &&

--- a/packages/components/src/font-size-picker/utils.ts
+++ b/packages/components/src/font-size-picker/utils.ts
@@ -46,13 +46,11 @@ export function getCommonSizeUnit( fontSizes: FontSize[] ) {
 }
 
 /**
- * hasValidShortName
+ * Validate that the font size short name is a string with at most
+ * 3 characters length (e.g. "XXS", "XS", "S", "M", "L", "XL", "XXL").
  *
- * check that the font size short name is a string with at most
- * 3 characters length (e.g. "XXS", "XS", "S", "M", "L", "XL", "XXL")
- *
- * @param  shortName font size object
- * @return boolean
+ * @param shortName The short name to validate.
+ * @return Whether the short name is valid.
  */
 export function hasValidShortName( shortName: string | undefined ): boolean {
 	return (

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -395,6 +395,10 @@
 										"description": "Kebab-case unique identifier for the font size preset.",
 										"type": "string"
 									},
+									"shortName": {
+										"description": "Short name of the font size preset. Gets used in the font size selector if fewer than 5 presets are defined.",
+										"type": "string"
+									},
 									"size": {
 										"description": "CSS font-size value, including units.",
 										"type": "string"

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -396,8 +396,10 @@
 										"type": "string"
 									},
 									"shortName": {
-										"description": "Short name of the font size preset. Gets used in the font size selector if fewer than 5 presets are defined.",
-										"type": "string"
+										"description": "Short name of the font size preset. Needs to be between 1 and 3 characters long.",
+										"type": "string",
+										"minLength": 1,
+										"maxLength": 3
 									},
 									"size": {
 										"description": "CSS font-size value, including units.",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add a new `shortName` property which can optionally be added to any FontSize Preset in `theme.json` which gets used instead of hardcoded t-shirt size in `FontSizePicker`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As outlined in #44245 there are several usecases where font sizes may not be following the t-shirt size scale. When you for example start with `XS` and make your way from there. Or have multiple small variants you want to be able to better control the labels that get used for the various custom font size options.

Closing: #44245

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding a new optional `shortName` property to font size presets.

```json
{
    "apiVersion": 2,
    "settings": {
        "typography": {
            "fontSizes": [
                {
                    "slug": "xs",
                    "name": "Extra Small",
                    "value": "10",
                    "shortName": "XS"
                }
            ]
        }
    }
}
```

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Define at least one font size preset that has a `shortName` defined in it's `theme.json`.
- Verify that the label renders correctly in the FontSizePicker

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
