### PR TITLE
Add filter to query loop post template

### DIFF
--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -94,6 +94,8 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 			)
 		)->render( array( 'dynamic' => false ) );
 
+		$block_content = apply_filters( 'post_template_block_content', $block_content, $query, $block->context['queryId'] );
+
 		// Wrap the render inner blocks in a `li` element with the appropriate post classes.
 		$post_classes = implode( ' ', get_post_class( 'wp-block-post' ) );
 		$content     .= '<li class="' . esc_attr( $post_classes ) . '">' . $block_content . '</li>';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adding a filter to query loop post template block content.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Having a way to make exceptional changes. This gives developers more options to do things that are not (yet) possible with the Block Editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By adding this or a similar filter (and maybe even others, e.g. to add classes/attributes dynamically or to change the ul > li to something)

## Testing Instructions
Add to functions.php and change the queryId (or remove the IF statement)
```
add_filter('post_template_block_content', function($content, $query, $queryId) {
    if($queryId === 123){
        return '<p>Post #'. $query->current_post . '</p>'. $content;
    }

    return $content;
}, 10, 3);
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
-

## Screenshots or screencast <!-- if applicable -->
-