### PR TITLE
Fix: Bug on withSafeTimeouts.

### DIFF
--- a/packages/compose/src/higher-order/with-safe-timeout/index.tsx
+++ b/packages/compose/src/higher-order/with-safe-timeout/index.tsx
@@ -59,7 +59,9 @@ const withSafeTimeout = createHigherOrderComponent(
 
 			clearTimeout( id: number ) {
 				clearTimeout( id );
-				this.timeouts.filter( ( timeoutId ) => timeoutId !== id );
+				this.timeouts = this.timeouts.filter(
+					( timeoutId ) => timeoutId !== id
+				);
 			}
 
 			render() {


### PR DESCRIPTION
This call `this.timeouts.filter( ( timeoutId ) => timeoutId !== id );` did nothing it just returned the filtered array but we need to assign it to this.timeouts otherwise the timeoutId is not removed from the array.