### PR TITLE
WIP: RSS Block: Improve handling of feed items with empty titles.

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -699,7 +699,7 @@ Display entries from any RSS or Atom feed. ([Source](https://github.com/WordPres
 -	**Name:** core/rss
 -	**Category:** widgets
 -	**Supports:** align, ~~html~~
--	**Attributes:** blockLayout, columns, displayAuthor, displayDate, displayExcerpt, excerptLength, feedURL, itemsToShow
+-	**Attributes:** blockLayout, columns, displayAuthor, displayDate, displayExcerpt, excerptLength, feedURL, itemsToShow, titleLength
 
 ## Search
 

--- a/packages/block-library/src/rss/block.json
+++ b/packages/block-library/src/rss/block.json
@@ -42,7 +42,7 @@
 		},
 		"titleLength": {
 			"type": "number",
-			"default": 30
+			"default": 75
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/rss/block.json
+++ b/packages/block-library/src/rss/block.json
@@ -39,6 +39,10 @@
 		"excerptLength": {
 			"type": "number",
 			"default": 55
+		},
+		"titleLength": {
+			"type": "number",
+			"default": 30
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -158,7 +158,7 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 							setAttributes( { titleLength: value } )
 						}
 						min={ 20 }
-						max={ 150 }
+						max={ 130 }
 						required
 					/>
 					{ blockLayout === 'grid' && (

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -157,8 +157,8 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 						onChange={ ( value ) =>
 							setAttributes( { titleLength: value } )
 						}
-						min={ 10 }
-						max={ 100 }
+						min={ 20 }
+						max={ 150 }
 						required
 					/>
 					{ blockLayout === 'grid' && (

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -35,6 +35,7 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 		displayDate,
 		displayExcerpt,
 		excerptLength,
+		titleLength,
 		feedURL,
 		itemsToShow,
 	} = attributes;
@@ -149,6 +150,17 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 							required
 						/>
 					) }
+					<RangeControl
+						__nextHasNoMarginBottom
+						label={ __( 'Max number of words in title' ) }
+						value={ titleLength }
+						onChange={ ( value ) =>
+							setAttributes( { titleLength: value } )
+						}
+						min={ 10 }
+						max={ 100 }
+						required
+					/>
 					{ blockLayout === 'grid' && (
 						<RangeControl
 							__nextHasNoMarginBottom

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -152,7 +152,7 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 					) }
 					<RangeControl
 						__nextHasNoMarginBottom
-						label={ __( 'Max number of words in title' ) }
+						label={ __( 'Max number of characters in title' ) }
 						value={ titleLength }
 						onChange={ ( value ) =>
 							setAttributes( { titleLength: value } )

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -41,7 +41,9 @@ function render_block_core_rss( $attributes ) {
 			preg_match( '/^(.{0,' . $attributes['titleLength'] . '})\s/', $excerpt, $parts );
 			$title = __( $parts[1] );
 			// Excerpt will be sanitized later on
-			$excerpt = trim(substr($excerpt, strlen($title)));
+			if ( $attributes['displayExcerpt'] ) {
+				$excerpt = trim(substr($excerpt, strlen($title)));
+			}
 		}
 		$link = $item->get_link();
 		$link = esc_url( $link );

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -20,8 +20,30 @@ function trim_to_word_boundary( $to_trim, $character_count, $more = ' [&hellip;]
 		return $to_trim;
 	}
 
-	preg_match( '/^(.{0,' . $character_count . '})\s/', $to_trim, $parts );
-	return $parts[1] . $more;
+	preg_match( '/^.{0,' . $character_count . '}\s/', $to_trim, $parts );
+	return $parts[0] . $more;
+}
+
+/**
+ * Helper funtion to trim text up to the first period (.) followed by a space.
+ * If no period is found, the text is trimmed to the nearest word boundary.
+ * If multiple periods are found, the last one within $title_length is used.
+ * 
+ * @param string $to_trim The text to trim.
+ * @param int    $title_length The maximum number of characters to return.
+ * @param string $more The string to append to the trimmed text.
+ */
+function trim_title_from_excerpt( $to_trim, $title_length, $more = ' [&hellip;]' ) {
+	$to_trim = trim_to_word_boundary($to_trim, $title_length, $more );
+
+	// Match to the first period followed by a space.
+	preg_match( '/^.{0,' . $title_length . '}\.\s/', $to_trim, $parts );
+
+	if ( empty( $parts[0] ) ) {
+		return $to_trim;
+	}
+
+	return $parts[0] . $more;
 }
 
 /**
@@ -57,7 +79,7 @@ function render_block_core_rss( $attributes ) {
 
 		if ( empty( $title ) ) {
 			// If the title is empty, use the begining of the excerpt instead.
-			$title = trim_to_word_boundary( $excerpt_trimmed, $attributes['titleLength'], '' );
+			$title = trim_title_from_excerpt( $excerpt_trimmed, $attributes['titleLength'], '' );
 			if ( $attributes['displayExcerpt'] ) {
 				// Trim out the words that were used for the title.
 				$excerpt_trimmed = trim( substr( $excerpt_trimmed, strlen( $title ) ) );

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -41,6 +41,8 @@ function render_block_core_rss( $attributes ) {
 			if ( $attributes['displayExcerpt'] ) {
 				$excerpt_trimmed = trim(substr($excerpt_trimmed, strlen($title)));
 			}
+		} else {
+			$title = substr($title, 0, $attributes['titleLength']);
 		}
 		$link = $item->get_link();
 		$link = esc_url( $link );

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -38,7 +38,10 @@ function render_block_core_rss( $attributes ) {
 
 		$title = esc_html( trim( strip_tags( $item->get_title() ) ) );
 		if ( empty( $title ) ) {
-			$title = __( '(no title)' );
+			preg_match( '/^(.{0,' . $attributes['titleLength'] . '})\s/', $excerpt, $parts );
+			$title = __( $parts[1] );
+			// Excerpt will be sanitized later on
+			$excerpt = trim(substr($excerpt, strlen($title)));
 		}
 		$link = $item->get_link();
 		$link = esc_url( $link );

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -30,6 +30,12 @@ function render_block_core_rss( $attributes ) {
 	$rss_items  = $rss->get_items( 0, $attributes['itemsToShow'] );
 	$list_items = '';
 	foreach ( $rss_items as $item ) {
+		$excerpt = '';
+		if ( $attributes['displayExcerpt'] ) {
+			$excerpt = html_entity_decode( $item->get_description(), ENT_QUOTES, get_option( 'blog_charset' ) );
+			$excerpt = esc_attr( wp_trim_words( $excerpt, $attributes['excerptLength'], ' [&hellip;]' ) );
+		}
+
 		$title = esc_html( trim( strip_tags( $item->get_title() ) ) );
 		if ( empty( $title ) ) {
 			$title = __( '(no title)' );
@@ -67,11 +73,7 @@ function render_block_core_rss( $attributes ) {
 			}
 		}
 
-		$excerpt = '';
 		if ( $attributes['displayExcerpt'] ) {
-			$excerpt = html_entity_decode( $item->get_description(), ENT_QUOTES, get_option( 'blog_charset' ) );
-			$excerpt = esc_attr( wp_trim_words( $excerpt, $attributes['excerptLength'], ' [&hellip;]' ) );
-
 			// Change existing [...] to [&hellip;].
 			if ( '[...]' === substr( $excerpt, -5 ) ) {
 				$excerpt = substr( $excerpt, 0, -5 ) . '[&hellip;]';

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -28,13 +28,12 @@ function trim_to_word_boundary( $to_trim, $character_count, $more = ' [&hellip;]
  * Helper funtion to trim text up to the first period (.) followed by a space.
  * If no period is found, the text is trimmed to the nearest word boundary.
  * If multiple periods are found, the last one within $title_length is used.
- * 
+ *
  * @param string $to_trim The text to trim.
  * @param int    $title_length The maximum number of characters to return.
- * @param string $more The string to append to the trimmed text.
  */
-function trim_title_from_excerpt( $to_trim, $title_length, $more = ' [&hellip;]' ) {
-	$to_trim = trim_to_word_boundary($to_trim, $title_length, $more );
+function trim_title_from_excerpt( $to_trim, $title_length ) {
+	$to_trim = trim_to_word_boundary( $to_trim, $title_length, '' );
 
 	// Match to the first period followed by a space.
 	preg_match( '/^.{0,' . $title_length . '}\.\s/', $to_trim, $parts );
@@ -43,7 +42,7 @@ function trim_title_from_excerpt( $to_trim, $title_length, $more = ' [&hellip;]'
 		return $to_trim;
 	}
 
-	return $parts[0] . $more;
+	return $parts[0];
 }
 
 /**
@@ -79,7 +78,7 @@ function render_block_core_rss( $attributes ) {
 
 		if ( empty( $title ) ) {
 			// If the title is empty, use the begining of the excerpt instead.
-			$title = trim_title_from_excerpt( $excerpt_trimmed, $attributes['titleLength'], '' );
+			$title = trim_title_from_excerpt( $excerpt_trimmed, $attributes['titleLength'] );
 			if ( $attributes['displayExcerpt'] ) {
 				// Trim out the words that were used for the title.
 				$excerpt_trimmed = trim( substr( $excerpt_trimmed, strlen( $title ) ) );

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -30,19 +30,16 @@ function render_block_core_rss( $attributes ) {
 	$rss_items  = $rss->get_items( 0, $attributes['itemsToShow'] );
 	$list_items = '';
 	foreach ( $rss_items as $item ) {
-		$excerpt = '';
-		if ( $attributes['displayExcerpt'] ) {
-			$excerpt = html_entity_decode( $item->get_description(), ENT_QUOTES, get_option( 'blog_charset' ) );
-			$excerpt = esc_attr( wp_trim_words( $excerpt, $attributes['excerptLength'], ' [&hellip;]' ) );
-		}
+		$excerpt_decoded = html_entity_decode( $item->get_description(), ENT_QUOTES, get_option( 'blog_charset' ) );
+		$excerpt_trimmed = esc_attr( wp_trim_words( $excerpt_decoded, $attributes['excerptLength'], ' [&hellip;]' ) );
 
 		$title = esc_html( trim( strip_tags( $item->get_title() ) ) );
 		if ( empty( $title ) ) {
-			preg_match( '/^(.{0,' . $attributes['titleLength'] . '})\s/', $excerpt, $parts );
+			preg_match( '/^(.{0,' . $attributes['titleLength'] . '})\s/', $excerpt_trimmed, $parts );
 			$title = __( $parts[1] );
 			// Excerpt will be sanitized later on
 			if ( $attributes['displayExcerpt'] ) {
-				$excerpt = trim(substr($excerpt, strlen($title)));
+				$excerpt_trimmed = trim(substr($excerpt_trimmed, strlen($title)));
 			}
 		}
 		$link = $item->get_link();
@@ -78,7 +75,9 @@ function render_block_core_rss( $attributes ) {
 			}
 		}
 
+		$excerpt = '';
 		if ( $attributes['displayExcerpt'] ) {
+			$excerpt = $excerpt_trimmed;
 			// Change existing [...] to [&hellip;].
 			if ( '[...]' === substr( $excerpt, -5 ) ) {
 				$excerpt = substr( $excerpt, 0, -5 ) . '[&hellip;]';

--- a/test/integration/fixtures/blocks/core__rss.json
+++ b/test/integration/fixtures/blocks/core__rss.json
@@ -10,7 +10,8 @@
 			"displayExcerpt": true,
 			"displayAuthor": true,
 			"displayDate": true,
-			"excerptLength": 20
+			"excerptLength": 20,
+			"titleLength": 75
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
## What?
This PR handles RSS feed items with empty titles by taking the first 𝒙 characters from the post excerpt and "moving them across" to become the feed item's title. The effect is inspired by https://github.com/scripting/titlelessFeedsHowto

## Why?
It was highlighted by Dave Winer's post about how RSS feed readers can display a consistent view of items that may or may not have titles without resorting to adding "(No Title)" placeholder text. 

http://scripting.com/2022/12/08.html#a152840

He also created this example implementation https://github.com/scripting/titlelessFeedsHowto

Matt then reached out to the team about seeing whether we could implement this idea in wordpress

## How?
using a new `titleLength` property and a regex based filter in the render method. I used characters rather than words because I think it's good for titles to have a somewhat consistent length, which is better measured with characters.

## Testing Instructions
* Insert an RSS feed block
* Configure it to subscribe to a feed where some items are missing titles. e.g. `http://scripting.com/rss.xml`
* It should have a settings slider to select the maximum title length
* If a feed item has no title, it should use the first `titleLength` characters followed by an ellipsis. The characters/words used for the title should be removed from the post excerpt so that no words are duplicated or repeated between the title and excerpt.
* The title should be trimmed to the nearest word boundary, if a period character is present, it should be used as the end of the title.
* The effect should be achieved in both the editor and the live site.

Note that this will also truncate author's titles to `titleLength` characters which I've set to default to `75`.

## Screenshots or screencast <!-- if applicable -->

### Before

![before](https://user-images.githubusercontent.com/5634774/208106485-6b4e1271-ce44-429a-89d3-c161174b0b83.png)

### After


The title "_Mastodon and RSS, as precedents_" is author specified, the others are taken from the excerpt.

https://user-images.githubusercontent.com/22446385/208328437-c0a5b034-3c10-45da-ba8c-f470fc6774fa.mov


Code was written by @davemart-in originally, who's is going on holiday leave. I will handle feedback etc.