### PR TITLE
Revert "[`customize-widgets/utils/widgetToBlock`] Initialize a widget's `raw_content.content` to an empty string if it's `undefined`"

### DIFF
--- a/packages/customize-widgets/src/utils.js
+++ b/packages/customize-widgets/src/utils.js
@@ -103,7 +103,7 @@ export function widgetToBlock( { id, idBase, number, instance } ) {
 	} = instance;
 
 	if ( idBase === 'block' ) {
-		const parsedBlocks = parse( raw.content, {
+		const parsedBlocks = parse( raw.content ?? '', {
 			__unstableSkipAutop: true,
 		} );
 		block = parsedBlocks.length

--- a/packages/customize-widgets/src/utils.js
+++ b/packages/customize-widgets/src/utils.js
@@ -98,13 +98,9 @@ export function widgetToBlock( { id, idBase, number, instance } ) {
 	const {
 		encoded_serialized_instance: encoded,
 		instance_hash_key: hash,
-		raw_instance: rawInstance,
+		raw_instance: raw,
 		...rest
 	} = instance;
-
-	// It's unclear why `content` is sometimes `undefined`, but it shouldn't be.
-	const rawContent = rawInstance.content || '';
-	const raw = { ...rawInstance, content: rawContent };
 
 	if ( idBase === 'block' ) {
 		const parsedBlocks = parse( raw.content, {


### PR DESCRIPTION
Reverts WordPress/gutenberg#46487

See https://github.com/WordPress/gutenberg/pull/46487#issuecomment-1354060260.

Guarding against an unexpectedly `undefined` `instance.raw.content` before sending it to `parse()` is okay but #46487 sets `instance.raw.content = ''` on all widget types, not just block widgets.

Does this simpler fix that only affects block widgets fix the issue for you @fullofcaffeine?