### PR TITLE
Improve empty menu state in nav off-canvas editor

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/index.js
+++ b/packages/block-editor/src/components/off-canvas-editor/index.js
@@ -210,24 +210,16 @@ function __ExperimentalOffCanvasEditor(
 					applicationAriaLabel={ __( 'Block navigation structure' ) }
 				>
 					<ListViewContext.Provider value={ contextValue }>
-						{ clientIdsTree.length ? (
-							<ListViewBranch
-								blocks={ clientIdsTree }
-								selectBlock={ selectEditorBlock }
-								showBlockMovers={ showBlockMovers }
-								fixedListWindow={ fixedListWindow }
-								selectedClientIds={ selectedClientIds }
-								isExpanded={ isExpanded }
-								shouldShowInnerBlocks={ shouldShowInnerBlocks }
-								selectBlockInCanvas={ selectBlockInCanvas }
-							/>
-						) : (
-							<tr className="offcanvas-editor-list-view-is-empty">
-								{ __(
-									'Your menu is currently empty. Add your first menu item to get started.'
-								) }
-							</tr>
-						) }
+						<ListViewBranch
+							blocks={ clientIdsTree }
+							selectBlock={ selectEditorBlock }
+							showBlockMovers={ showBlockMovers }
+							fixedListWindow={ fixedListWindow }
+							selectedClientIds={ selectedClientIds }
+							isExpanded={ isExpanded }
+							shouldShowInnerBlocks={ shouldShowInnerBlocks }
+							selectBlockInCanvas={ selectBlockInCanvas }
+						/>
 						<TreeGridRow
 							level={ 1 }
 							setSize={ 1 }
@@ -239,6 +231,15 @@ function __ExperimentalOffCanvasEditor(
 									<Appender { ...treeGridCellProps } />
 								) }
 							</TreeGridCell>
+							{ ! clientIdsTree.length && (
+								<TreeGridCell withoutGridItem>
+									<div className="offcanvas-editor-list-view-is-empty">
+										{ __(
+											'Your menu is currently empty. Add your first menu item to get started.'
+										) }
+									</div>
+								</TreeGridCell>
+							) }
 						</TreeGridRow>
 					</ListViewContext.Provider>
 				</TreeGrid>

--- a/packages/block-editor/src/components/off-canvas-editor/index.js
+++ b/packages/block-editor/src/components/off-canvas-editor/index.js
@@ -210,16 +210,24 @@ function __ExperimentalOffCanvasEditor(
 					applicationAriaLabel={ __( 'Block navigation structure' ) }
 				>
 					<ListViewContext.Provider value={ contextValue }>
-						<ListViewBranch
-							blocks={ clientIdsTree }
-							selectBlock={ selectEditorBlock }
-							showBlockMovers={ showBlockMovers }
-							fixedListWindow={ fixedListWindow }
-							selectedClientIds={ selectedClientIds }
-							isExpanded={ isExpanded }
-							shouldShowInnerBlocks={ shouldShowInnerBlocks }
-							selectBlockInCanvas={ selectBlockInCanvas }
-						/>
+						{ clientIdsTree.length ? (
+							<ListViewBranch
+								blocks={ clientIdsTree }
+								selectBlock={ selectEditorBlock }
+								showBlockMovers={ showBlockMovers }
+								fixedListWindow={ fixedListWindow }
+								selectedClientIds={ selectedClientIds }
+								isExpanded={ isExpanded }
+								shouldShowInnerBlocks={ shouldShowInnerBlocks }
+								selectBlockInCanvas={ selectBlockInCanvas }
+							/>
+						) : (
+							<tr className="offcanvas-editor-list-view-is-empty">
+								{ __(
+									'Your menu is currently empty. Add your first menu item to get started.'
+								) }
+							</tr>
+						) }
 						<TreeGridRow
 							level={ 1 }
 							setSize={ 1 }

--- a/packages/block-editor/src/components/off-canvas-editor/style.scss
+++ b/packages/block-editor/src/components/off-canvas-editor/style.scss
@@ -26,6 +26,5 @@
 }
 
 .offcanvas-editor-list-view-is-empty {
-	display: block;
-	margin-left: 28px;
+	margin-left: $grid-unit-20;
 }

--- a/packages/block-editor/src/components/off-canvas-editor/style.scss
+++ b/packages/block-editor/src/components/off-canvas-editor/style.scss
@@ -24,3 +24,8 @@
 	// sidebar width - tab panel padding
 	max-width: $sidebar-width - (2 * $grid-unit-20);
 }
+
+.offcanvas-editor-list-view-is-empty {
+	display: block;
+	margin-left: 28px;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds a note to the empty nav list to provide some direction.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #46202

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds a note when there are no children for the nav block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Create an empty nav menu
2. See the note
3. Add an item
4. Note is no longer shown

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

![image](https://user-images.githubusercontent.com/5129775/208032408-88241b5e-01a6-48da-a4da-7b83073084b8.png)

