### PR TITLE
Site Editor: Memoize sidebar component

### DIFF
--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -28,7 +28,7 @@ import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 /**
  * Internal dependencies
  */
-import { Sidebar } from '../sidebar';
+import Sidebar from '../sidebar';
 import Editor from '../editor';
 import ListPage from '../list';
 import ErrorBoundary from '../error-boundary';

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { memo } from '@wordpress/element';
 import { __experimentalNavigatorProvider as NavigatorProvider } from '@wordpress/components';
 
 /**
@@ -22,7 +23,7 @@ function SidebarScreens() {
 	);
 }
 
-export function Sidebar() {
+function Sidebar() {
 	return (
 		<NavigatorProvider
 			className="edit-site-sidebar__content"
@@ -32,3 +33,5 @@ export function Sidebar() {
 		</NavigatorProvider>
 	);
 }
+
+export default memo( Sidebar );


### PR DESCRIPTION
## What?
Small performance optimization for the Sidebar component to avoid rerendering when resizing the editor canvas.

## Why?
I don't think we need to re-render the Sidebar every time the parent component re-renders. This can be expensive when a site has many templates.

The component is self-contained, I don't see any downsides with memoizing it.

## Testing Instructions
1. Open the Site Editor.
2. Enable component re-render highlights in React DevTools.
3. Confirm that the sidebar doesn't re-render when resizing the canvas.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://user-images.githubusercontent.com/240569/208046466-b9fd8ead-5af8-4a65-a2c6-57ac8e583951.mp4

**After**

https://user-images.githubusercontent.com/240569/208046510-8390a50e-39c9-4a50-8434-c59b17bc3f03.mp4



