### PR TITLE
package-lock.json: dedupe the scheduler package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52602,16 +52602,6 @@
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.0"
-			},
-			"dependencies": {
-				"scheduler": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-					"integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-					"requires": {
-						"loose-envify": "^1.1.0"
-					}
-				}
 			}
 		},
 		"react-easy-crop": {
@@ -52997,6 +52987,14 @@
 					"version": "0.4.3",
 					"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",
 					"integrity": "sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA=="
+				},
+				"scheduler": {
+					"version": "0.21.0",
+					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+					"integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+					"requires": {
+						"loose-envify": "^1.1.0"
+					}
 				},
 				"semver": {
 					"version": "6.3.0",
@@ -53654,15 +53652,6 @@
 					"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
 					"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
 					"dev": true
-				},
-				"scheduler": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-					"integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-					"dev": true,
-					"requires": {
-						"loose-envify": "^1.1.0"
-					}
 				}
 			}
 		},
@@ -55511,9 +55500,9 @@
 			}
 		},
 		"scheduler": {
-			"version": "0.21.0",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
-			"integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+			"integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
 			"requires": {
 				"loose-envify": "^1.1.0"
 			}


### PR DESCRIPTION
The 18.2 versions of `react-dom` and `react-test-renderer` depend on `scheduler@0.23.0`, but currently this package is not in the top-level `node_modules/scheduler`, but both these packages have a private copy in _their_ `./node_modules` subdirectory. This is a bit suboptimal, so I'm moving this version of the package to the top level.

The `react-native` package still depends on an older version, `scheduler@0.21.0`, and we let `react-native` have this older version in its own private `./node_modules`.

Discovered this when debugging the `scheduler` package in #46538.