### PR TITLE
useSelect: add unit tests for static select mode

### DIFF
--- a/packages/data/src/components/use-select/test/index.js
+++ b/packages/data/src/components/use-select/test/index.js
@@ -1146,4 +1146,38 @@ describe( 'useSelect', () => {
 			expect( screen.getByRole( 'status' ) ).toHaveTextContent( '10' );
 		} );
 	} );
+
+	describe( 'static store selection mode', () => {
+		it( 'can read the current value from store', () => {
+			registry.registerStore( 'testStore', {
+				reducer: ( s = 0, a ) => ( a.type === 'INC' ? s + 1 : s ),
+				actions: { inc: () => ( { type: 'INC' } ) },
+				selectors: { get: ( s ) => s },
+			} );
+
+			const record = jest.fn();
+
+			function TestComponent() {
+				const { get } = useSelect( 'testStore' );
+				return (
+					<button onClick={ () => record( get() ) }>record</button>
+				);
+			}
+
+			render(
+				<RegistryProvider value={ registry }>
+					<TestComponent />
+				</RegistryProvider>
+			);
+
+			fireEvent.click( screen.getByRole( 'button' ) );
+			expect( record ).toHaveBeenLastCalledWith( 0 );
+
+			// no need to act() as the component doesn't react to the updates
+			registry.dispatch( 'testStore' ).inc();
+
+			fireEvent.click( screen.getByRole( 'button' ) );
+			expect( record ).toHaveBeenLastCalledWith( 1 );
+		} );
+	} );
 } );

--- a/packages/data/src/components/use-select/test/index.js
+++ b/packages/data/src/components/use-select/test/index.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { act, render, fireEvent, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * WordPress dependencies
@@ -435,7 +436,9 @@ describe( 'useSelect', () => {
 			);
 		} );
 
-		it( 'captures state changes scheduled between render and effect', () => {
+		it( 'captures state changes scheduled between render and effect', async () => {
+			const user = userEvent.setup();
+
 			registry.registerStore( 'store-1', counterStore );
 
 			class ChildComponent extends Component {
@@ -484,7 +487,7 @@ describe( 'useSelect', () => {
 				</RegistryProvider>
 			);
 
-			fireEvent.click( screen.getByText( 'triggerChildDispatch' ) );
+			await user.click( screen.getByText( 'triggerChildDispatch' ) );
 
 			expect( selectCount1AndDep ).toHaveBeenCalledTimes( 3 );
 			expect( screen.getByRole( 'status' ) ).toHaveTextContent(
@@ -1148,7 +1151,9 @@ describe( 'useSelect', () => {
 	} );
 
 	describe( 'static store selection mode', () => {
-		it( 'can read the current value from store', () => {
+		it( 'can read the current value from store', async () => {
+			const user = userEvent.setup();
+
 			registry.registerStore( 'testStore', {
 				reducer: ( s = 0, a ) => ( a.type === 'INC' ? s + 1 : s ),
 				actions: { inc: () => ( { type: 'INC' } ) },
@@ -1170,13 +1175,13 @@ describe( 'useSelect', () => {
 				</RegistryProvider>
 			);
 
-			fireEvent.click( screen.getByRole( 'button' ) );
+			await user.click( screen.getByRole( 'button' ) );
 			expect( record ).toHaveBeenLastCalledWith( 0 );
 
 			// no need to act() as the component doesn't react to the updates
 			registry.dispatch( 'testStore' ).inc();
 
-			fireEvent.click( screen.getByRole( 'button' ) );
+			await user.click( screen.getByRole( 'button' ) );
 			expect( record ).toHaveBeenLastCalledWith( 1 );
 		} );
 	} );

--- a/packages/data/src/components/use-select/test/index.js
+++ b/packages/data/src/components/use-select/test/index.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { act, render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { act, render, fireEvent, screen } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -436,9 +435,7 @@ describe( 'useSelect', () => {
 			);
 		} );
 
-		it( 'captures state changes scheduled between render and effect', async () => {
-			const user = userEvent.setup();
-
+		it( 'captures state changes scheduled between render and effect', () => {
 			registry.registerStore( 'store-1', counterStore );
 
 			class ChildComponent extends Component {
@@ -487,7 +484,7 @@ describe( 'useSelect', () => {
 				</RegistryProvider>
 			);
 
-			await user.click( screen.getByText( 'triggerChildDispatch' ) );
+			fireEvent.click( screen.getByText( 'triggerChildDispatch' ) );
 
 			expect( selectCount1AndDep ).toHaveBeenCalledTimes( 3 );
 			expect( screen.getByRole( 'status' ) ).toHaveTextContent(
@@ -1151,9 +1148,7 @@ describe( 'useSelect', () => {
 	} );
 
 	describe( 'static store selection mode', () => {
-		it( 'can read the current value from store', async () => {
-			const user = userEvent.setup();
-
+		it( 'can read the current value from store', () => {
 			registry.registerStore( 'testStore', {
 				reducer: ( s = 0, a ) => ( a.type === 'INC' ? s + 1 : s ),
 				actions: { inc: () => ( { type: 'INC' } ) },
@@ -1175,13 +1170,13 @@ describe( 'useSelect', () => {
 				</RegistryProvider>
 			);
 
-			await user.click( screen.getByRole( 'button' ) );
+			fireEvent.click( screen.getByRole( 'button' ) );
 			expect( record ).toHaveBeenLastCalledWith( 0 );
 
 			// no need to act() as the component doesn't react to the updates
 			registry.dispatch( 'testStore' ).inc();
 
-			await user.click( screen.getByRole( 'button' ) );
+			fireEvent.click( screen.getByRole( 'button' ) );
 			expect( record ).toHaveBeenLastCalledWith( 1 );
 		} );
 	} );


### PR DESCRIPTION
When working on new `useSelect` implementation in #46538 I discovered we don't have any unit tests for the "static select mode", i.e., using `useSelect` in a non-reactive way, typically to read the latest value in an event handler:
```js
const { getStuff } = useSelect( blockEditorStore );
const handleClick = () => {
  console.log( 'latest stuff is:', getStuff() );
}
```
This PR fixes that omission. There is a new test that passes with the old `useSelect`, and will also pass with the new `useSelect` in #46538. Test-driven development!