### PR TITLE
Data: recreate listeningStores set for every markListeningStores call

### DIFF
--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -60,7 +60,7 @@ function getStoreName( storeNameOrDescriptor ) {
 export function createRegistry( storeConfigs = {}, parent = null ) {
 	const stores = {};
 	const emitter = createEmitter();
-	const listeningStores = new Set();
+	let listeningStores = null;
 
 	/**
 	 * Global listener called for each store's update.
@@ -112,7 +112,7 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 	 */
 	function select( storeNameOrDescriptor ) {
 		const storeName = getStoreName( storeNameOrDescriptor );
-		listeningStores.add( storeName );
+		listeningStores?.add( storeName );
 		const store = stores[ storeName ];
 		if ( store ) {
 			return store.getSelectors();
@@ -122,11 +122,12 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 	}
 
 	function __unstableMarkListeningStores( callback, ref ) {
-		listeningStores.clear();
+		listeningStores = new Set();
 		try {
 			return callback.call( this );
 		} finally {
 			ref.current = Array.from( listeningStores );
+			listeningStores = null;
 		}
 	}
 
@@ -143,7 +144,7 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 	 */
 	function resolveSelect( storeNameOrDescriptor ) {
 		const storeName = getStoreName( storeNameOrDescriptor );
-		listeningStores.add( storeName );
+		listeningStores?.add( storeName );
 		const store = stores[ storeName ];
 		if ( store ) {
 			return store.getResolveSelectors();
@@ -165,7 +166,7 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 	 */
 	function suspendSelect( storeNameOrDescriptor ) {
 		const storeName = getStoreName( storeNameOrDescriptor );
-		listeningStores.add( storeName );
+		listeningStores?.add( storeName );
 		const store = stores[ storeName ];
 		if ( store ) {
 			return store.getSuspendSelectors();


### PR DESCRIPTION
There is an `__unstableMarkListeningStores` API in a data registry that allow "marking" every store that was accessed in a `select` callback:
```js
const storesRef = { current: null };
registry.__unstableMarkListeningStores( () => {
  return registry.select( 'a' ).get() + registry.select( 'b' ).get();
}, storesRef );
expect( storesRef.current ).toEqual( [ 'a', 'b' ] );
```
We can use the stores array to, e.g., choose which stores we need to subscribe to to get updates.

This PR changes the implementation so that:
- we're creating a new `Set()` for each `__unstableMarkListeningStores` call, instead of reusing one global one, and merely `.clear()`-ing it on every call
- we avoid adding stores to the set when we're running outside `__unstableMarkListeningStores`. In that case the `.add()` operations are redundant.

This is a spinoff from #46538, where there will be optimization opportunities: we will be able to call `__unstableMarkListeningStores` only in very specific cases, where the set of selected stores can actually change, instead calling it for every select. 