### PR TITLE
Fixed incorrect CHANGELOG link

### DIFF
--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -37,7 +37,7 @@
 
 ### Deprecations
 
--   `withBlockContentContext` is no longer used by the block editor and therefore got deprecated ([#41395](https://github.com/WordPress/gutenberg/pull/3204139530)).
+-   `withBlockContentContext` is no longer used by the block editor and therefore got deprecated ([#41395](https://github.com/WordPress/gutenberg/pull/41395)).
 
 ### New API
 


### PR DESCRIPTION
## What?
Fixed incorrect CHANGELOG link

## Why?
Because it was incorrect.

## How?
By pressing keys on my keyboard using my fingers. Mainly backspace.

## Testing Instructions
1. See link
2. Click link
3. ???
4. Profit

### Testing Instructions for Keyboard
1. Tab to select link
2. Press Enter
3. ???
4. Profit
