### PR TITLE
Allow not updating selection when dispatching replaceBlock(s)

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1311,11 +1311,16 @@ function selectionHelper( state = {}, action ) {
 				return state;
 			}
 
+			const shouldNotUpdateSelection = false;
+
 			const blockToSelect =
 				action.blocks[ action.indexToSelect ] ||
 				action.blocks[ action.blocks.length - 1 ];
 
-			if ( ! blockToSelect ) {
+			if (
+				! blockToSelect ||
+				action.indexToSelect === shouldNotUpdateSelection
+			) {
 				return {};
 			}
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1313,14 +1313,15 @@ function selectionHelper( state = {}, action ) {
 
 			const shouldNotUpdateSelection = false;
 
+			if ( action.indexToSelect === shouldNotUpdateSelection ) {
+				return state;
+			}
+
 			const blockToSelect =
 				action.blocks[ action.indexToSelect ] ||
 				action.blocks[ action.blocks.length - 1 ];
 
-			if (
-				! blockToSelect ||
-				action.indexToSelect === shouldNotUpdateSelection
-			) {
+			if ( ! blockToSelect ) {
 				return {};
 			}
 

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -2719,7 +2719,7 @@ describe( 'state', () => {
 			);
 		} );
 
-		it( 'should replace the selected block but not apply a selection  when `indexToSelect` is explicitly set to `false`', () => {
+		it( 'should replace the selected block but not updated selection  when `indexToSelect` is explicitly set to `false`', () => {
 			const original = deepFreeze( {
 				selectionStart: { clientId: 'chicken' },
 				selectionEnd: { clientId: 'chicken' },
@@ -2737,8 +2737,8 @@ describe( 'state', () => {
 			const state = selection( original, action );
 			expect( state ).toEqual(
 				expect.objectContaining( {
-					selectionStart: {},
-					selectionEnd: {},
+					selectionStart: { clientId: 'chicken' },
+					selectionEnd: { clientId: 'chicken' },
 				} )
 			);
 		} );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -2719,6 +2719,30 @@ describe( 'state', () => {
 			);
 		} );
 
+		it( 'should replace the selected block but not apply a selection  when `indexToSelect` is explicitly set to `false`', () => {
+			const original = deepFreeze( {
+				selectionStart: { clientId: 'chicken' },
+				selectionEnd: { clientId: 'chicken' },
+			} );
+			const action = {
+				type: 'REPLACE_BLOCKS',
+				clientIds: [ 'chicken' ],
+				blocks: [
+					{ clientId: 'rigas' },
+					{ clientId: 'chicken' },
+					{ clientId: 'wings' },
+				],
+				indexToSelect: false,
+			};
+			const state = selection( original, action );
+			expect( state ).toEqual(
+				expect.objectContaining( {
+					selectionStart: {},
+					selectionEnd: {},
+				} )
+			);
+		} );
+
 		it( 'should reset if replacing with empty set', () => {
 			const original = deepFreeze( {
 				selectionStart: { clientId: 'chicken' },


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Allow for the `replaceBlock`/`replaceBlocks` action to _not_ update the selection. This marries with the approach in `insertBlocks` and `replaceInnerBlocks`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The action already allows for defining an index to be selected following the replacement of the blocks via the `indexToSelect` argument. However if this isn't provided then the reducer will automatically default to selecting the last block in the replaced set.

However, with the advent of offcanvas editing ([relevant PR](https://github.com/WordPress/gutenberg/pull/46582/)) there are occasions where when inserting / replacing blocks we do not want to update the selection in the canvas. 

For example, in https://github.com/WordPress/gutenberg/pull/46582/ we want to replace a `core/navigation-link` block with a `core/navigation-submenu` block but _not_ select the block once it's been inserted. With the current action that is not possible.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR enables the functionality by repurposing the `indexToSelect` argument. If it is explicitly set to `false` then the reducer will return an empty object which causes the selection _not_ to be updated.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
