### PR TITLE
[Pattern Setup]: Fix full heights during transition.

### DIFF
--- a/packages/block-editor/src/components/block-pattern-setup/style.scss
+++ b/packages/block-editor/src/components/block-pattern-setup/style.scss
@@ -6,7 +6,6 @@
 	width: 100%;
 	border-radius: $radius-block-ui;
 
-	// TODO change to check parent.
 	&.view-mode-grid {
 		.block-editor-block-pattern-setup__toolbar {
 			justify-content: center;
@@ -84,6 +83,7 @@
 		display: flex;
 		flex-direction: column;
 		width: 100%;
+		height: 100%;
 		box-sizing: border-box;
 
 		.carousel-container {
@@ -91,6 +91,7 @@
 			position: relative;
 			padding: 0;
 			margin: 0;
+			height: 100%;
 			list-style: none;
 			transform-style: preserve-3d;
 			* {
@@ -100,6 +101,8 @@
 				position: absolute;
 				top: 0;
 				width: 100%;
+				height: 100%;
+				background-color: $white;
 				margin: auto;
 				padding: 0;
 				transition: transform 0.5s, z-index 0.5s;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/46381

[This comment](https://github.com/WordPress/gutenberg/issues/46381#issuecomment-1344285696) shows at least a couple of issues to be handled. One is handled in this PR and is visible when we have different heights of patterns next to each other in `carousel` mode, some content overlaps during the transition. The second one is that we use css transition of `0.5s` and if we click the pagination buttons too quickly can feel shaky and bad. For the second problem I'll explore even changing the implementation to use css like [scroll-snap](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-type).

## Testing Instructions
1. Insert Query Loop and click `Choose`
2. In pattern setup with `carousel` mode go to a pattern with big height that is next to a smaller height one and click next and previous
3. Observe that there is no overlapping of content during the transition.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

### Before

https://user-images.githubusercontent.com/16275880/208101192-31e9cf59-1d62-4cf7-803e-d1904c3249ed.mov


### After

https://user-images.githubusercontent.com/16275880/208101294-841449d9-feab-47c5-b5d1-1414565b4c65.mov



