### PR TITLE
[Mobile] - E2E Tests - Fix block insertion flakiness

### DIFF
--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-2.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-2.test.js
@@ -10,6 +10,7 @@ import {
 	paragraphBlockEmpty,
 	separatorBlockEmpty,
 } from './helpers/test-data';
+import { waitForMediaLibrary } from './helpers/utils';
 
 describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 	it( 'adds new block at the end of post', async () => {
@@ -65,13 +66,14 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 
 		await editorPage.addNewBlock( blockNames.image, 'before' );
 
+		await waitForMediaLibrary( editorPage.driver );
+		await editorPage.closePicker();
+
 		const imageBlock = await editorPage.getBlockAtPosition(
 			blockNames.image,
 			2
 		);
 		expect( imageBlock ).toBeTruthy();
-
-		await editorPage.closePicker();
 
 		const expectedHtml = [
 			headerBlockEmpty,

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-2.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-2.test.js
@@ -14,7 +14,18 @@ import {
 describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 	it( 'adds new block at the end of post', async () => {
 		await editorPage.addNewBlock( blockNames.heading );
+
+		const headingBlock = await editorPage.getBlockAtPosition(
+			blockNames.heading
+		);
+		expect( headingBlock ).toBeTruthy();
+
 		await editorPage.addNewBlock( blockNames.list );
+
+		const listItemBlock = await editorPage.getBlockAtPosition(
+			blockNames.listItem
+		);
+		expect( listItemBlock ).toBeTruthy();
 
 		const expectedHtml = [ headerBlockEmpty, listBlockEmpty ].join(
 			'\n\n'
@@ -28,6 +39,12 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 		await firstBlock.click();
 
 		await editorPage.addNewBlock( blockNames.separator );
+
+		const separatorBlock = await editorPage.getBlockAtPosition(
+			blockNames.separator,
+			2
+		);
+		expect( separatorBlock ).toBeTruthy();
 
 		const expectedHtml = [
 			headerBlockEmpty,
@@ -47,6 +64,13 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 		await separatorBlockElement.click();
 
 		await editorPage.addNewBlock( blockNames.image, 'before' );
+
+		const imageBlock = await editorPage.getBlockAtPosition(
+			blockNames.image,
+			2
+		);
+		expect( imageBlock ).toBeTruthy();
+
 		await editorPage.closePicker();
 
 		const expectedHtml = [
@@ -63,6 +87,12 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 	it( 'inserts block at the end of post when no block is selected', async () => {
 		await editorPage.addNewBlock( blockNames.more );
 
+		const moreBlock = await editorPage.getBlockAtPosition(
+			blockNames.more,
+			5
+		);
+		expect( moreBlock ).toBeTruthy();
+
 		const expectedHtml = [
 			headerBlockEmpty,
 			imageBlockEmpty,
@@ -77,6 +107,12 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 
 	it( 'creates a new Paragraph block tapping on the empty area below the last block', async () => {
 		await editorPage.addParagraphBlockByTappingEmptyAreaBelowLastBlock();
+
+		const paragraphBlock = await editorPage.getBlockAtPosition(
+			blockNames.paragraph,
+			6
+		);
+		expect( paragraphBlock ).toBeTruthy();
 
 		const expectedHtml = [
 			headerBlockEmpty,

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion.test.js
@@ -81,7 +81,7 @@ describe( 'Gutenberg Editor tests for Block insertion', () => {
 
 	it( 'should be able to insert block at the beginning of post from the title', async () => {
 		await editorPage.addNewBlock( blockNames.paragraph );
-		let paragraphBlockElement = await editorPage.getTextBlockAtPosition(
+		const paragraphBlockElement = await editorPage.getTextBlockAtPosition(
 			blockNames.paragraph
 		);
 		if ( isAndroid() ) {
@@ -98,15 +98,19 @@ describe( 'Gutenberg Editor tests for Block insertion', () => {
 		const titleElement = await editorPage.getTitleElement( {
 			autoscroll: true,
 		} );
+		expect( titleElement ).toBeTruthy();
 		await titleElement.click();
 
 		await editorPage.addNewBlock( blockNames.paragraph );
-		paragraphBlockElement = await editorPage.getTextBlockAtPosition(
+		const emptyParagraphBlock = await editorPage.getBlockAtPosition(
 			blockNames.paragraph
 		);
-		await clickMiddleOfElement( editorPage.driver, paragraphBlockElement );
+		expect( emptyParagraphBlock ).toBeTruthy();
+		const emptyParagraphBlockElement =
+			await editorPage.getTextBlockAtPosition( blockNames.paragraph );
+		expect( emptyParagraphBlockElement ).toBeTruthy();
+
 		await editorPage.sendTextToParagraphBlock( 1, testData.mediumText );
-		await paragraphBlockElement.click();
 		const html = await editorPage.getHtmlContent();
 		expect( html.toLowerCase() ).toBe(
 			testData.blockInsertionHtmlFromTitle.toLowerCase()

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -313,12 +313,17 @@ const clickElementOutsideOfTextInput = async ( driver, element ) => {
 };
 
 // Long press to activate context menu.
-const longPressMiddleOfElement = async ( driver, element ) => {
+const longPressMiddleOfElement = async (
+	driver,
+	element,
+	customElementSize
+) => {
 	const location = await element.getLocation();
-	const size = await element.getSize();
+	const size = customElementSize || ( await element.getSize() );
 
 	const x = location.x + size.width / 2;
 	const y = location.y + size.height / 2;
+
 	const action = new wd.TouchAction( driver )
 		.longPress( { x, y } )
 		.wait( 5000 ) // Setting to wait a bit longer because this is failing more frequently on the CI

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -316,6 +316,7 @@ const clickElementOutsideOfTextInput = async ( driver, element ) => {
 const longPressMiddleOfElement = async (
 	driver,
 	element,
+	waitTime = 5000, // Setting to wait a bit longer because this is failing more frequently on the CI
 	customElementSize
 ) => {
 	const location = await element.getLocation();
@@ -326,7 +327,7 @@ const longPressMiddleOfElement = async (
 
 	const action = new wd.TouchAction( driver )
 		.longPress( { x, y } )
-		.wait( 5000 ) // Setting to wait a bit longer because this is failing more frequently on the CI
+		.wait( waitTime )
 		.release();
 	await action.perform();
 };

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -314,6 +314,7 @@ class EditorPage {
 			await longPressMiddleOfElement(
 				this.driver,
 				addButton,
+				8000,
 				customElementSize
 			);
 			const addBlockBeforeButtonLocator = isAndroid()

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -305,7 +305,17 @@ class EditorPage {
 		);
 
 		if ( relativePosition === 'before' ) {
-			await longPressMiddleOfElement( this.driver, addButton );
+			// On Android it doesn't get the right size of the button
+			const customElementSize = {
+				width: 43,
+				height: 43,
+			};
+
+			await longPressMiddleOfElement(
+				this.driver,
+				addButton,
+				customElementSize
+			);
 			const addBlockBeforeButtonLocator = isAndroid()
 				? '//android.widget.Button[@content-desc="Add Block Before"]'
 				: '//XCUIElementTypeButton[@name="Add Block Before"]';

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -801,6 +801,7 @@ const blockNames = {
 	image: 'Image',
 	latestPosts: 'Latest Posts',
 	list: 'List',
+	listItem: 'List item',
 	more: 'More',
 	paragraph: 'Paragraph',
 	search: 'Search',


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/5332

## What?
This PR addresses an issue with two E2E tests that fail constantly, related to Block insertion.

## Why?
To avoid constant failures of these flaky tests, we are updating them so they're more stable.

## How?
These tests check that block insertion works correctly by adding different blocks and then checking the output HTML to have the right content added, this is a problem if there are no other checks along the way while blocks are being added and just go directly to check the HTML content, due to delays or content taking more time to be added.

To avoid unstable test results, we are asserting that each block that is added exists before continuing to add the rest.

This PR updates the following E2E tests:

### Block Insertion 

For this test we check some elements exist after being created, we also added a check for the Paragraph's TextInput to be there before typing content.

### Block Insertion 2

We are also checking each block exists after they're added before adding more blocks.

It now waits for the media library picker to be opened `waitForMediaLibrary` after adding the `Image` block.

The `longPressMiddleOfElement` helper, now supports passing the element's size, since I saw on Android for the `Add block` button, it was not returning the right `width` size of the element, causing the test to break on Android.

## Testing Instructions
CI check on Gutenberg Mobile should pass from the [latest commit](https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/19110).

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A