### PR TITLE
Update/block support settings use tag processor

### DIFF
--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -49,29 +49,14 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$class_name = gutenberg_get_elements_class_name( $block );
-
 	// Like the layout hook this assumes the hook only applies to blocks with a single wrapper.
-	// Retrieve the opening tag of the first HTML element.
-	$html_element_matches = array();
-	preg_match( '/<[^>]+>/', $block_content, $html_element_matches, PREG_OFFSET_CAPTURE );
-	$first_element = $html_element_matches[0][0];
-	// If the first HTML element has a class attribute just add the new class
-	// as we do on layout and duotone.
-	if ( str_contains( $first_element, 'class="' ) ) {
-		$content = preg_replace(
-			'/' . preg_quote( 'class="', '/' ) . '/',
-			'class="' . $class_name . ' ',
-			$block_content,
-			1
-		);
-	} else {
-		// If the first HTML element has no class attribute we should inject the attribute before the attribute at the end.
-		$first_element_offset = $html_element_matches[0][1];
-		$content              = substr_replace( $block_content, ' class="' . $class_name . '"', $first_element_offset + strlen( $first_element ) - 1, 0 );
+	// Add the class name to the first element, presuming it's the wrapper, if it exists.
+	$tags = new WP_HTML_Tag_Processor( $block_content );
+	if ( $tags->next_tag() ) {
+		$tags->add_class( gutenberg_get_elements_class_name( $block ) );
 	}
 
-	return $content;
+	return $tags->get_updated_html();
 }
 
 /**

--- a/lib/block-supports/settings.php
+++ b/lib/block-supports/settings.php
@@ -43,29 +43,14 @@ function _gutenberg_add_block_level_presets_class( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$class_name = _gutenberg_get_presets_class_name( $block );
-
 	// Like the layout hook this assumes the hook only applies to blocks with a single wrapper.
-	// Retrieve the opening tag of the first HTML element.
-	$html_element_matches = array();
-	preg_match( '/<[^>]+>/', $block_content, $html_element_matches, PREG_OFFSET_CAPTURE );
-	$first_element = $html_element_matches[0][0];
-	// If the first HTML element has a class attribute just add the new class
-	// as we do on layout and duotone.
-	if ( strpos( $first_element, 'class="' ) !== false ) {
-		$content = preg_replace(
-			'/' . preg_quote( 'class="', '/' ) . '/',
-			'class="' . $class_name . ' ',
-			$block_content,
-			1
-		);
-	} else {
-		// If the first HTML element has no class attribute we should inject the attribute before the attribute at the end.
-		$first_element_offset = $html_element_matches[0][1];
-		$content              = substr_replace( $block_content, ' class="' . $class_name . '"', $first_element_offset + strlen( $first_element ) - 1, 0 );
+	// Add the class name to the first element, presuming it's the wrapper, if it exists.
+	$tags = new WP_HTML_Tag_Processor( $block_content );
+	if ( $tags->next_tag() ) {
+		$tags->add_class( _gutenberg_get_presets_class_name( $block ) );
 	}
 
-	return $content;
+	return $tags->get_updated_html();
 }
 
 /**


### PR DESCRIPTION
## What?

Use `WP_HTML_Tag_Processor` to add new class name to wrapping elements when rendering block supports.

## Why?

This class was built to quickly and reliably modify HTML tag attributes. It circumvents specific problems, such as matching on the wrong attributes (such as `data-custom-class="some value"`), overlooking matches (such as `class=blue` or `class='wp-block-group'`), writing updates in a way that get overlooked by the browser (by writing to the end of the tag instead of before any potential duplicate attributes), and by writing invalid content to the HTML (such as through a bug in a PCRE pattern greedily matching more than it should).

A side perk here is that application code becomes more focused on the semantic operations it's performing rather than the mechanisms through which it does it.

## How?

Utilizes the API provided by the Tag Processor to do the heavy lifting for us.

## Testing

Hopefully the unit tests cover this.
Otherwise try to use block supports and make sure that the expected classes appear where they are and not where they shouldn't be.
I'm not that familiar with how this system works so I hope you can help figure out what needs to be tested.