### PR TITLE
Added a note to register_block_pattern_category()

### DIFF
--- a/docs/reference-guides/block-api/block-patterns.md
+++ b/docs/reference-guides/block-api/block-patterns.md
@@ -113,6 +113,8 @@ _Note:_
 
 `register_block_pattern_category()` should be called from a handler attached to the init hook.
 
+The category will not show under Patterns unless a pattern has been assigned to that category.
+
 ```php
 function my_plugin_register_my_pattern_categories() {
   register_block_pattern_category( ... );


### PR DESCRIPTION
Added a note to the `register_block_pattern_category()` stating that the category will not show unless a pattern has been assigned to that category.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adding a note to help new users adding a custom category that their code is most likely working but if they don't have a pattern assigned to that category it is not showing.
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It is confusing when you add your custom category and no category shows up, questions arise too if you did it correctly.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adding a note to help troubleshooting.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
There is no testing needed. It's helping troubleshooting.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a
## Screenshots or screencast <!-- if applicable -->
n/a