### PR TITLE
BorderBoxControl test: wait for color picker popover to appear

### DIFF
--- a/packages/components/src/border-box-control/test/index.js
+++ b/packages/components/src/border-box-control/test/index.js
@@ -201,20 +201,12 @@ describe( 'BorderBoxControl', () => {
 			);
 
 			const styleLabel = screen.queryByText( 'Style' );
-			const solidButton = screen.queryByRole( 'button', {
-				name: 'Solid',
-			} );
-			const dashedButton = screen.queryByRole( 'button', {
-				name: 'Dashed',
-			} );
-			const dottedButton = screen.queryByRole( 'button', {
-				name: 'Dotted',
+			const styleButtons = screen.queryAllByRole( 'button', {
+				name: /(Solid)|(Dashed)|(Dotted)/,
 			} );
 
 			expect( styleLabel ).not.toBeInTheDocument();
-			expect( solidButton ).not.toBeInTheDocument();
-			expect( dashedButton ).not.toBeInTheDocument();
-			expect( dottedButton ).not.toBeInTheDocument();
+			expect( styleButtons.length ).toBe( 0 );
 		} );
 	} );
 
@@ -292,7 +284,7 @@ describe( 'BorderBoxControl', () => {
 
 			for ( let i = 0; i < colorButtons.length; i++ ) {
 				// Click on the color button to show the color picker popover.
-				await user.click( colorButtons[ 0 ] );
+				await user.click( colorButtons[ i ] );
 
 				// Wait for color picker popover to fully appear
 				const colorPickerButton = screen.getByRole( 'button', {
@@ -305,23 +297,15 @@ describe( 'BorderBoxControl', () => {
 				);
 
 				const styleLabel = screen.queryByText( 'Style' );
-				const solidButton = screen.queryByRole( 'button', {
-					name: 'Solid',
-				} );
-				const dashedButton = screen.queryByRole( 'button', {
-					name: 'Dashed',
-				} );
-				const dottedButton = screen.queryByRole( 'button', {
-					name: 'Dotted',
+				const styleButtons = screen.queryAllByRole( 'button', {
+					name: /(Solid)|(Dashed)|(Dotted)/,
 				} );
 
 				expect( styleLabel ).not.toBeInTheDocument();
-				expect( solidButton ).not.toBeInTheDocument();
-				expect( dashedButton ).not.toBeInTheDocument();
-				expect( dottedButton ).not.toBeInTheDocument();
+				expect( styleButtons.length ).toBe( 0 );
 
 				// Click again to hide the popover.
-				await user.click( colorButtons[ 0 ] );
+				await user.click( colorButtons[ i ] );
 			}
 		} );
 	} );


### PR DESCRIPTION
Cleans up the `BorderBoxControl` unit tests where we're testing the "Style" section of the color picker popover:

<img width="571" alt="Screenshot 2022-12-18 at 9 54 39" src="https://user-images.githubusercontent.com/664258/208290035-f0ed97c4-cca3-4c6d-8c9f-9136a4222c49.png">

Namely, that it doesn't appear when disabled with the `enableStyle={ false }` prop. This test needs to wait for popover positioning in order to avoid `act()` warnings.

I'm also refactoring the "split view" test to use a `for` loop.