### PR TITLE
Apply icon color direct to path to prevent overrides by any custom css * usage

### DIFF
--- a/packages/block-editor/src/components/default-block-appender/content.scss
+++ b/packages/block-editor/src/components/default-block-appender/content.scss
@@ -95,6 +95,12 @@
 		}
 	}
 
+	.block-editor-inserter__toggle.components-button.has-icon {
+		path {
+			color: $white;
+		}
+	}
+
 	// This content only shows up inside the empty appender.
 	.block-editor-default-block-appender__content {
 		display: none;


### PR DESCRIPTION
## What?
Prevents the likes of `body * { color: red }` in custom styles making the block inserter icon red.

## Why?
Fixes: #46568

## How?
Applies the block inserter color direct to SVG path

## Testing Instructions
- Add `* { color: red; }` to custom CSS box in site editor global styles
- Make sure the insert icon is not red

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
