### PR TITLE
Move wordcount to the top of the outline

### DIFF
--- a/packages/edit-post/src/components/secondary-sidebar/list-view-outline.js
+++ b/packages/edit-post/src/components/secondary-sidebar/list-view-outline.js
@@ -65,18 +65,6 @@ export default function ListViewOutline() {
 	}, [] );
 	return (
 		<>
-			{ headingCount > 0 ? (
-				<DocumentOutline />
-			) : (
-				<div className="edit-post-editor__list-view-empty-headings">
-					<EmptyOutlineIllustration />
-					<p>
-						{ __(
-							'Navigate the structure of your document and address issues like empty or incorrect heading levels.'
-						) }
-					</p>
-				</div>
-			) }
 			<div className="edit-post-editor__list-view-overview">
 				<div>
 					<Text>{ __( 'Characters:' ) }</Text>
@@ -93,6 +81,18 @@ export default function ListViewOutline() {
 					<TimeToRead />
 				</div>
 			</div>
+			{ headingCount > 0 ? (
+				<DocumentOutline />
+			) : (
+				<div className="edit-post-editor__list-view-empty-headings">
+					<EmptyOutlineIllustration />
+					<p>
+						{ __(
+							'Navigate the structure of your document and address issues like empty or incorrect heading levels.'
+						) }
+					</p>
+				</div>
+			) }
 		</>
 	);
 }

--- a/packages/edit-post/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-post/src/components/secondary-sidebar/style.scss
@@ -76,24 +76,23 @@
 }
 
 .edit-post-editor__list-view-overview {
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-10;
+	border-bottom: $border-width solid $gray-300;
+	padding: $grid-unit-20;
+
 	& > div > span:first-child {
 		// Width of the text information fields.
 		width: 90px;
 		display: inline-block;
 	}
-	border-bottom: $border-width solid $gray-300;
-	width: calc(100% - #{ $grid-unit-40 });
-	padding: $grid-unit-20;
-	& > div {
-		padding: 0 0 $grid-unit-10;
-		& > span {
-			font-size: $helptext-font-size;
-			line-height: $default-line-height;
-			color: $gray-700;
-		}
+
+	& > div > span {
+		font-size: $helptext-font-size;
+		line-height: $default-line-height;
+		color: $gray-700;
 	}
-	// Height of the overview container.
-	height: 72px;
 }
 
 .edit-post-editor__list-view-container {

--- a/packages/edit-post/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-post/src/components/secondary-sidebar/style.scss
@@ -81,7 +81,7 @@
 		width: 90px;
 		display: inline-block;
 	}
-	border-top: $border-width solid $gray-300;
+	border-bottom: $border-width solid $gray-300;
 	width: calc(100% - #{ $grid-unit-40 });
 	padding: $grid-unit-20;
 	& > div {


### PR DESCRIPTION
## What?

The list view has merged with the outline, and moved the doc meta information to the bottom:

<img width="1392" alt="before" src="https://user-images.githubusercontent.com/1204802/208412190-2cc45837-7f54-4218-ad3a-1d9b638cd855.png">

This PR moves the meta information back to the top:

<img width="1392" alt="after 1" src="https://user-images.githubusercontent.com/1204802/208412213-f3372314-e52b-4d52-8b56-49897b6d5886.png">

<img width="1392" alt="after 2" src="https://user-images.githubusercontent.com/1204802/208412217-4d872146-95c0-4042-9e9e-53b740eef6ca.png">

## Why?

This is in response to some feedback that it can be hard to find: https://github.com/Automattic/wp-calypso/issues/70094

## Testing Instructions

Test the list view > outline, and observe the meta information (word count, etc.) is now at the top of the container.