### PR TITLE
Optimize keydown event handlers

### DIFF
--- a/packages/block-editor/src/components/rich-text/use-enter.js
+++ b/packages/block-editor/src/components/rich-text/use-enter.js
@@ -28,6 +28,10 @@ export function useEnter( props ) {
 				return;
 			}
 
+			if ( event.keyCode !== ENTER ) {
+				return;
+			}
+
 			const {
 				removeEditorOnlyFormats,
 				value,
@@ -39,10 +43,6 @@ export function useEnter( props ) {
 				disableLineBreaks,
 				onSplitAtEnd,
 			} = propsRef.current;
-
-			if ( event.keyCode !== ENTER ) {
-				return;
-			}
 
 			event.preventDefault();
 

--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -167,6 +167,12 @@ export default function useArrowNav() {
 		}
 
 		function onKeyDown( event ) {
+			// Abort if navigation has already been handled (e.g. RichText
+			// inline boundaries).
+			if ( event.defaultPrevented ) {
+				return;
+			}
+
 			const { keyCode, target, shiftKey, ctrlKey, altKey, metaKey } =
 				event;
 			const isUp = keyCode === UP;
@@ -182,24 +188,20 @@ export default function useArrowNav() {
 			const { ownerDocument } = node;
 			const { defaultView } = ownerDocument;
 
+			if ( ! isNav ) {
+				return;
+			}
+
 			// If there is a multi-selection, the arrow keys should collapse the
 			// selection to the start or end of the selection.
 			if ( hasMultiSelection() ) {
+				if ( shiftKey ) {
+					return;
+				}
+
 				// Only handle if we have a full selection (not a native partial
 				// selection).
 				if ( ! __unstableIsFullySelected() ) {
-					return;
-				}
-
-				if ( event.defaultPrevented ) {
-					return;
-				}
-
-				if ( ! isNav ) {
-					return;
-				}
-
-				if ( shiftKey ) {
 					return;
 				}
 
@@ -214,6 +216,12 @@ export default function useArrowNav() {
 				return;
 			}
 
+			// Abort if our current target is not a candidate for navigation
+			// (e.g. preserve native input behaviors).
+			if ( ! isNavigationCandidate( target, keyCode, hasModifier ) ) {
+				return;
+			}
+
 			// When presing any key other than up or down, the initial vertical
 			// position must ALWAYS be reset. The vertical position is saved so
 			// it can be restored as well as possible on sebsequent vertical
@@ -225,22 +233,6 @@ export default function useArrowNav() {
 				verticalRect = null;
 			} else if ( ! verticalRect ) {
 				verticalRect = computeCaretRect( defaultView );
-			}
-
-			// Abort if navigation has already been handled (e.g. RichText
-			// inline boundaries).
-			if ( event.defaultPrevented ) {
-				return;
-			}
-
-			if ( ! isNav ) {
-				return;
-			}
-
-			// Abort if our current target is not a candidate for navigation
-			// (e.g. preserve native input behaviors).
-			if ( ! isNavigationCandidate( target, keyCode, hasModifier ) ) {
-				return;
 			}
 
 			// In the case of RTL scripts, right means previous and left means


### PR DESCRIPTION
## What and Why

In my measurements, keydown events represent 10% of the "typing" metric approximatively so that's 5ms out of 50ms. I noticed that we have a dozen of keydown event handlers in our code base, This PR micro-optimizes a couple of them to bail early when possible.

To be honest I don't expect any impact on the numbers maybe 1ms (which is within the margin of error) but it's also a harmless PR.