### PR TITLE
Block Editor: Make `URLPopover` tests more precise

### DIFF
--- a/packages/block-editor/src/components/url-popover/test/index.js
+++ b/packages/block-editor/src/components/url-popover/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { act, render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -10,6 +10,16 @@ import userEvent from '@testing-library/user-event';
 import URLPopover from '../';
 
 jest.useRealTimers();
+
+/**
+ * Returns the first found popover element up the DOM tree.
+ *
+ * @param {HTMLElement} element Element to start with.
+ * @return {HTMLElement|null} Popover element, or `null` if not found.
+ */
+function getWrappingPopoverElement( element ) {
+	return element.closest( '.components-popover' );
+}
 
 describe( 'URLPopover', () => {
 	it( 'matches the snapshot in its default state', async () => {
@@ -22,8 +32,11 @@ describe( 'URLPopover', () => {
 			</URLPopover>
 		);
 
-		// wait for `Popover` effects to finish
-		await act( () => Promise.resolve() );
+		await waitFor( () =>
+			expect(
+				getWrappingPopoverElement( screen.getByText( 'Editor' ) )
+			).toBePositionedPopover()
+		);
 
 		expect( container ).toMatchSnapshot();
 	} );
@@ -53,8 +66,11 @@ describe( 'URLPopover', () => {
 			</URLPopover>
 		);
 
-		// wait for `Popover` effects to finish
-		await act( () => Promise.resolve() );
+		await waitFor( () =>
+			expect(
+				getWrappingPopoverElement( screen.getByText( 'Editor' ) )
+			).toBePositionedPopover()
+		);
 
 		expect( container ).toMatchSnapshot();
 	} );


### PR DESCRIPTION

## What?
This PR updates the `URLPopover` tests to actually wait for the popover to be positioned, instead of waiting for the next event loop tick.

## Why?
This makes the test more comprehensible as it clearly expresses the intention of waiting until the popover has already been positioned.

## How?
We're using the `toBePositionedPopover` matcher that we've been using for other tests.

## Testing Instructions
Verify tests pass: `npm run test:unit packages/block-editor/src/components/url-popover/test/index.js`