### PR TITLE
Data: Fix `no-node-access` violation in suspense tests

### DIFF
--- a/packages/data/src/components/use-select/test/suspense.js
+++ b/packages/data/src/components/use-select/test/suspense.js
@@ -139,10 +139,11 @@ describe( 'useSuspenseSelect', () => {
 			}
 
 			render() {
+				const { children } = this.props;
 				if ( this.state.error ) {
 					return <div aria-label="error">{ this.state.error }</div>;
 				}
-				return this.props.children;
+				return children;
 			}
 		}
 


### PR DESCRIPTION
## What?
This PR fixes a `no-node-access` violation in the suspense tests.

## Why?
This is a preparatory PR in order tobe able to enable the [`no-node-access` ESLint rule](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-node-access.md) for all tests.

## How?
We're just changing the way we access the `children` prop to avoid the false positive.

## Testing Instructions
Verify tests still pass: `npm run test:unit packages/data/src/components/use-select/test/suspense.js`