### PR TITLE
Components: Improve `PanelBody` tests

### DIFF
--- a/packages/components/src/panel/test/__snapshots__/body.js.snap
+++ b/packages/components/src/panel/test/__snapshots__/body.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PanelBody basic rendering should render an empty div with the matching className 1`] = `
+<div>
+  <div
+    class="components-panel__body is-opened"
+  />
+</div>
+`;

--- a/packages/components/src/panel/test/body.js
+++ b/packages/components/src/panel/test/body.js
@@ -8,20 +8,12 @@ import { render, fireEvent, screen } from '@testing-library/react';
  */
 import { PanelBody } from '../body';
 
-const getPanelBody = ( container ) =>
-	// There currently isn't an accessible way to retrieve the panel body wrapper.
-	// eslint-disable-next-line testing-library/no-node-access
-	container.querySelector( '.components-panel__body' );
-
 describe( 'PanelBody', () => {
 	describe( 'basic rendering', () => {
 		it( 'should render an empty div with the matching className', () => {
 			const { container } = render( <PanelBody /> );
 
-			const panelBody = getPanelBody( container );
-
-			expect( panelBody ).toBeVisible();
-			expect( panelBody.tagName ).toBe( 'DIV' );
+			expect( container ).toMatchSnapshot();
 		} );
 
 		it( 'should render inner content, if opened', () => {

--- a/packages/components/src/panel/test/body.js
+++ b/packages/components/src/panel/test/body.js
@@ -17,6 +17,7 @@ describe( 'PanelBody', () => {
 	describe( 'basic rendering', () => {
 		it( 'should render an empty div with the matching className', () => {
 			const { container } = render( <PanelBody /> );
+
 			const panelBody = getPanelBody( container );
 
 			expect( panelBody ).toBeVisible();
@@ -29,9 +30,8 @@ describe( 'PanelBody', () => {
 					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
-			const panelContent = screen.getByTestId( 'inner-content' );
 
-			expect( panelContent ).toBeVisible();
+			expect( screen.getByTestId( 'inner-content' ) ).toBeVisible();
 		} );
 
 		it( 'should be opened by default', () => {
@@ -40,9 +40,8 @@ describe( 'PanelBody', () => {
 					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
-			const panelContent = screen.getByTestId( 'inner-content' );
 
-			expect( panelContent ).toBeVisible();
+			expect( screen.getByTestId( 'inner-content' ) ).toBeVisible();
 		} );
 
 		it( 'should render as initially opened, if specified', () => {
@@ -51,9 +50,8 @@ describe( 'PanelBody', () => {
 					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
-			const panelContent = screen.getByTestId( 'inner-content' );
 
-			expect( panelContent ).toBeVisible();
+			expect( screen.getByTestId( 'inner-content' ) ).toBeVisible();
 		} );
 
 		it( 'should call the children function, if specified', () => {
@@ -153,9 +151,7 @@ describe( 'PanelBody', () => {
 				</PanelBody>
 			);
 
-			const panelToggle = screen.getByRole( 'button', { name: 'Panel' } );
-
-			fireEvent.click( panelToggle );
+			fireEvent.click( screen.getByRole( 'button', { name: 'Panel' } ) );
 
 			expect( mock ).toHaveBeenCalled();
 		} );

--- a/packages/components/src/panel/test/body.js
+++ b/packages/components/src/panel/test/body.js
@@ -56,6 +56,7 @@ describe( 'PanelBody', () => {
 					) }
 				</PanelBody>
 			);
+
 			let panelContent = screen.getByTestId( 'inner-content' );
 
 			expect( panelContent ).toBeInTheDocument();
@@ -71,6 +72,7 @@ describe( 'PanelBody', () => {
 					) }
 				</PanelBody>
 			);
+
 			panelContent = screen.getByTestId( 'inner-content' );
 
 			expect( panelContent ).toBeVisible();
@@ -85,6 +87,7 @@ describe( 'PanelBody', () => {
 					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
+
 			let panelContent = screen.getByTestId( 'inner-content' );
 
 			expect( panelContent ).toBeVisible();
@@ -116,6 +119,7 @@ describe( 'PanelBody', () => {
 					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
+
 			let panelContent = screen.queryByTestId( 'inner-content' );
 			const panelToggle = screen.getByRole( 'button', { name: 'Panel' } );
 

--- a/packages/components/src/panel/test/body.js
+++ b/packages/components/src/panel/test/body.js
@@ -12,8 +12,6 @@ const getPanelBody = ( container ) =>
 	// There currently isn't an accessible way to retrieve the panel body wrapper.
 	// eslint-disable-next-line testing-library/no-node-access
 	container.querySelector( '.components-panel__body' );
-const getPanelBodyContent = () => screen.queryByTestId( 'inner-content' );
-const getPanelToggle = () => screen.getByRole( 'button', { name: 'Panel' } );
 
 describe( 'PanelBody', () => {
 	describe( 'basic rendering', () => {
@@ -21,45 +19,45 @@ describe( 'PanelBody', () => {
 			const { container } = render( <PanelBody /> );
 			const panelBody = getPanelBody( container );
 
-			expect( panelBody ).toBeTruthy();
+			expect( panelBody ).toBeVisible();
 			expect( panelBody.tagName ).toBe( 'DIV' );
 		} );
 
 		it( 'should render inner content, if opened', () => {
-			const { container } = render(
+			render(
 				<PanelBody opened={ true }>
 					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
-			const panelContent = getPanelBodyContent( container );
+			const panelContent = screen.queryByTestId( 'inner-content' );
 
-			expect( panelContent ).toBeTruthy();
+			expect( panelContent ).toBeVisible();
 		} );
 
 		it( 'should be opened by default', () => {
-			const { container } = render(
+			render(
 				<PanelBody>
 					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
-			const panelContent = getPanelBodyContent( container );
+			const panelContent = screen.queryByTestId( 'inner-content' );
 
-			expect( panelContent ).toBeTruthy();
+			expect( panelContent ).toBeVisible();
 		} );
 
 		it( 'should render as initially opened, if specified', () => {
-			const { container } = render(
+			render(
 				<PanelBody initialOpen={ true }>
 					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
-			const panelContent = getPanelBodyContent( container );
+			const panelContent = screen.queryByTestId( 'inner-content' );
 
-			expect( panelContent ).toBeTruthy();
+			expect( panelContent ).toBeVisible();
 		} );
 
 		it( 'should call the children function, if specified', () => {
-			const { container, rerender } = render(
+			const { rerender } = render(
 				<PanelBody opened={ true }>
 					{ ( { opened } ) => (
 						<div hidden={ opened } data-testid="inner-content">
@@ -68,9 +66,10 @@ describe( 'PanelBody', () => {
 					) }
 				</PanelBody>
 			);
-			let panelContent = getPanelBodyContent( container );
+			let panelContent = screen.queryByTestId( 'inner-content' );
 
-			expect( panelContent ).toBeTruthy();
+			expect( panelContent ).toBeInTheDocument();
+			expect( panelContent ).not.toBeVisible();
 			expect( panelContent ).toHaveAttribute( 'hidden', '' );
 
 			rerender(
@@ -82,23 +81,23 @@ describe( 'PanelBody', () => {
 					) }
 				</PanelBody>
 			);
-			panelContent = getPanelBodyContent( container );
+			panelContent = screen.queryByTestId( 'inner-content' );
 
-			expect( panelContent ).toBeTruthy();
+			expect( panelContent ).toBeVisible();
 			expect( panelContent ).not.toHaveAttribute( 'hidden' );
 		} );
 	} );
 
 	describe( 'toggling', () => {
 		it( 'should toggle collapse with opened prop', () => {
-			const { container, rerender } = render(
+			const { rerender } = render(
 				<PanelBody opened={ true }>
 					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
-			let panelContent = getPanelBodyContent( container );
+			let panelContent = screen.queryByTestId( 'inner-content' );
 
-			expect( panelContent ).toBeTruthy();
+			expect( panelContent ).toBeVisible();
 
 			rerender(
 				<PanelBody opened={ false }>
@@ -106,9 +105,9 @@ describe( 'PanelBody', () => {
 				</PanelBody>
 			);
 
-			panelContent = getPanelBodyContent( container );
+			panelContent = screen.queryByTestId( 'inner-content' );
 
-			expect( panelContent ).toBeFalsy();
+			expect( panelContent ).not.toBeInTheDocument();
 
 			rerender(
 				<PanelBody opened={ true }>
@@ -116,45 +115,45 @@ describe( 'PanelBody', () => {
 				</PanelBody>
 			);
 
-			panelContent = getPanelBodyContent( container );
+			panelContent = screen.queryByTestId( 'inner-content' );
 
-			expect( panelContent ).toBeTruthy();
+			expect( panelContent ).toBeVisible();
 		} );
 
 		it( 'should toggle when clicking header', () => {
-			const { container } = render(
+			render(
 				<PanelBody title="Panel" initialOpen={ false }>
 					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
-			let panelContent = getPanelBodyContent( container );
-			const panelToggle = getPanelToggle( container );
+			let panelContent = screen.queryByTestId( 'inner-content' );
+			const panelToggle = screen.getByRole( 'button', { name: 'Panel' } );
 
-			expect( panelContent ).toBeFalsy();
-
-			fireEvent.click( panelToggle );
-
-			panelContent = getPanelBodyContent( container );
-
-			expect( panelContent ).toBeTruthy();
+			expect( panelContent ).not.toBeInTheDocument();
 
 			fireEvent.click( panelToggle );
 
-			panelContent = getPanelBodyContent( container );
+			panelContent = screen.queryByTestId( 'inner-content' );
 
-			expect( panelContent ).toBeFalsy();
+			expect( panelContent ).toBeVisible();
+
+			fireEvent.click( panelToggle );
+
+			panelContent = screen.queryByTestId( 'inner-content' );
+
+			expect( panelContent ).not.toBeInTheDocument();
 		} );
 
 		it( 'should pass button props to panel title', () => {
 			const mock = jest.fn();
 
-			const { container } = render(
+			render(
 				<PanelBody title="Panel" buttonProps={ { onClick: mock } }>
 					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
 
-			const panelToggle = getPanelToggle( container );
+			const panelToggle = screen.getByRole( 'button', { name: 'Panel' } );
 
 			fireEvent.click( panelToggle );
 

--- a/packages/components/src/panel/test/body.js
+++ b/packages/components/src/panel/test/body.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -113,7 +114,11 @@ describe( 'PanelBody', () => {
 			expect( panelContent ).toBeVisible();
 		} );
 
-		it( 'should toggle when clicking header', () => {
+		it( 'should toggle when clicking header', async () => {
+			const user = userEvent.setup( {
+				advanceTimers: jest.advanceTimersByTime,
+			} );
+
 			render(
 				<PanelBody title="Panel" initialOpen={ false }>
 					<div data-testid="inner-content">Content</div>
@@ -125,20 +130,23 @@ describe( 'PanelBody', () => {
 
 			expect( panelContent ).not.toBeInTheDocument();
 
-			fireEvent.click( panelToggle );
+			await user.click( panelToggle );
 
 			panelContent = screen.getByTestId( 'inner-content' );
 
 			expect( panelContent ).toBeVisible();
 
-			fireEvent.click( panelToggle );
+			await user.click( panelToggle );
 
 			panelContent = screen.queryByTestId( 'inner-content' );
 
 			expect( panelContent ).not.toBeInTheDocument();
 		} );
 
-		it( 'should pass button props to panel title', () => {
+		it( 'should pass button props to panel title', async () => {
+			const user = userEvent.setup( {
+				advanceTimers: jest.advanceTimersByTime,
+			} );
 			const mock = jest.fn();
 
 			render(
@@ -147,7 +155,7 @@ describe( 'PanelBody', () => {
 				</PanelBody>
 			);
 
-			fireEvent.click( screen.getByRole( 'button', { name: 'Panel' } ) );
+			await user.click( screen.getByRole( 'button', { name: 'Panel' } ) );
 
 			expect( mock ).toHaveBeenCalled();
 		} );

--- a/packages/components/src/panel/test/body.js
+++ b/packages/components/src/panel/test/body.js
@@ -29,7 +29,7 @@ describe( 'PanelBody', () => {
 					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
-			const panelContent = screen.queryByTestId( 'inner-content' );
+			const panelContent = screen.getByTestId( 'inner-content' );
 
 			expect( panelContent ).toBeVisible();
 		} );
@@ -40,7 +40,7 @@ describe( 'PanelBody', () => {
 					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
-			const panelContent = screen.queryByTestId( 'inner-content' );
+			const panelContent = screen.getByTestId( 'inner-content' );
 
 			expect( panelContent ).toBeVisible();
 		} );
@@ -51,7 +51,7 @@ describe( 'PanelBody', () => {
 					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
-			const panelContent = screen.queryByTestId( 'inner-content' );
+			const panelContent = screen.getByTestId( 'inner-content' );
 
 			expect( panelContent ).toBeVisible();
 		} );
@@ -66,7 +66,7 @@ describe( 'PanelBody', () => {
 					) }
 				</PanelBody>
 			);
-			let panelContent = screen.queryByTestId( 'inner-content' );
+			let panelContent = screen.getByTestId( 'inner-content' );
 
 			expect( panelContent ).toBeInTheDocument();
 			expect( panelContent ).not.toBeVisible();
@@ -81,7 +81,7 @@ describe( 'PanelBody', () => {
 					) }
 				</PanelBody>
 			);
-			panelContent = screen.queryByTestId( 'inner-content' );
+			panelContent = screen.getByTestId( 'inner-content' );
 
 			expect( panelContent ).toBeVisible();
 			expect( panelContent ).not.toHaveAttribute( 'hidden' );
@@ -95,7 +95,7 @@ describe( 'PanelBody', () => {
 					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
-			let panelContent = screen.queryByTestId( 'inner-content' );
+			let panelContent = screen.getByTestId( 'inner-content' );
 
 			expect( panelContent ).toBeVisible();
 
@@ -115,7 +115,7 @@ describe( 'PanelBody', () => {
 				</PanelBody>
 			);
 
-			panelContent = screen.queryByTestId( 'inner-content' );
+			panelContent = screen.getByTestId( 'inner-content' );
 
 			expect( panelContent ).toBeVisible();
 		} );
@@ -133,7 +133,7 @@ describe( 'PanelBody', () => {
 
 			fireEvent.click( panelToggle );
 
-			panelContent = screen.queryByTestId( 'inner-content' );
+			panelContent = screen.getByTestId( 'inner-content' );
 
 			expect( panelContent ).toBeVisible();
 

--- a/packages/components/src/panel/test/body.js
+++ b/packages/components/src/panel/test/body.js
@@ -25,7 +25,7 @@ describe( 'PanelBody', () => {
 
 		it( 'should render inner content, if opened', () => {
 			render(
-				<PanelBody opened={ true }>
+				<PanelBody opened>
 					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
@@ -47,7 +47,7 @@ describe( 'PanelBody', () => {
 
 		it( 'should render as initially opened, if specified', () => {
 			render(
-				<PanelBody initialOpen={ true }>
+				<PanelBody initialOpen>
 					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
@@ -58,7 +58,7 @@ describe( 'PanelBody', () => {
 
 		it( 'should call the children function, if specified', () => {
 			const { rerender } = render(
-				<PanelBody opened={ true }>
+				<PanelBody opened>
 					{ ( { opened } ) => (
 						<div hidden={ opened } data-testid="inner-content">
 							Content
@@ -91,7 +91,7 @@ describe( 'PanelBody', () => {
 	describe( 'toggling', () => {
 		it( 'should toggle collapse with opened prop', () => {
 			const { rerender } = render(
-				<PanelBody opened={ true }>
+				<PanelBody opened>
 					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
@@ -110,7 +110,7 @@ describe( 'PanelBody', () => {
 			expect( panelContent ).not.toBeInTheDocument();
 
 			rerender(
-				<PanelBody opened={ true }>
+				<PanelBody opened>
 					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);

--- a/packages/components/src/panel/test/body.js
+++ b/packages/components/src/panel/test/body.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -10,10 +10,8 @@ import { PanelBody } from '../body';
 
 const getPanelBody = ( container ) =>
 	container.querySelector( '.components-panel__body' );
-const getPanelBodyContent = ( container ) =>
-	container.querySelector( '.components-panel__body > div' );
-const getPanelToggle = ( container ) =>
-	container.querySelector( '.components-panel__body-toggle' );
+const getPanelBodyContent = () => screen.queryByTestId( 'inner-content' );
+const getPanelToggle = () => screen.getByRole( 'button', { name: 'Panel' } );
 
 describe( 'PanelBody', () => {
 	describe( 'basic rendering', () => {
@@ -28,7 +26,7 @@ describe( 'PanelBody', () => {
 		it( 'should render inner content, if opened', () => {
 			const { container } = render(
 				<PanelBody opened={ true }>
-					<div className="inner-content">Content</div>
+					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
 			const panelContent = getPanelBodyContent( container );
@@ -39,7 +37,7 @@ describe( 'PanelBody', () => {
 		it( 'should be opened by default', () => {
 			const { container } = render(
 				<PanelBody>
-					<div>Content</div>
+					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
 			const panelContent = getPanelBodyContent( container );
@@ -50,7 +48,7 @@ describe( 'PanelBody', () => {
 		it( 'should render as initially opened, if specified', () => {
 			const { container } = render(
 				<PanelBody initialOpen={ true }>
-					<div>Content</div>
+					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
 			const panelContent = getPanelBodyContent( container );
@@ -61,7 +59,11 @@ describe( 'PanelBody', () => {
 		it( 'should call the children function, if specified', () => {
 			const { container, rerender } = render(
 				<PanelBody opened={ true }>
-					{ ( { opened } ) => <div hidden={ opened }>Content</div> }
+					{ ( { opened } ) => (
+						<div hidden={ opened } data-testid="inner-content">
+							Content
+						</div>
+					) }
 				</PanelBody>
 			);
 			let panelContent = getPanelBodyContent( container );
@@ -71,7 +73,11 @@ describe( 'PanelBody', () => {
 
 			rerender(
 				<PanelBody opened={ false }>
-					{ ( { opened } ) => <div hidden={ opened }>Content</div> }
+					{ ( { opened } ) => (
+						<div hidden={ opened } data-testid="inner-content">
+							Content
+						</div>
+					) }
 				</PanelBody>
 			);
 			panelContent = getPanelBodyContent( container );
@@ -85,7 +91,7 @@ describe( 'PanelBody', () => {
 		it( 'should toggle collapse with opened prop', () => {
 			const { container, rerender } = render(
 				<PanelBody opened={ true }>
-					<div>Content</div>
+					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
 			let panelContent = getPanelBodyContent( container );
@@ -94,7 +100,7 @@ describe( 'PanelBody', () => {
 
 			rerender(
 				<PanelBody opened={ false }>
-					<div>Content</div>
+					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
 
@@ -104,7 +110,7 @@ describe( 'PanelBody', () => {
 
 			rerender(
 				<PanelBody opened={ true }>
-					<div>Content</div>
+					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
 
@@ -116,7 +122,7 @@ describe( 'PanelBody', () => {
 		it( 'should toggle when clicking header', () => {
 			const { container } = render(
 				<PanelBody title="Panel" initialOpen={ false }>
-					<div>Content</div>
+					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
 			let panelContent = getPanelBodyContent( container );
@@ -142,7 +148,7 @@ describe( 'PanelBody', () => {
 
 			const { container } = render(
 				<PanelBody title="Panel" buttonProps={ { onClick: mock } }>
-					<div>Content</div>
+					<div data-testid="inner-content">Content</div>
 				</PanelBody>
 			);
 

--- a/packages/components/src/panel/test/body.js
+++ b/packages/components/src/panel/test/body.js
@@ -9,6 +9,8 @@ import { render, fireEvent, screen } from '@testing-library/react';
 import { PanelBody } from '../body';
 
 const getPanelBody = ( container ) =>
+	// There currently isn't an accessible way to retrieve the panel body wrapper.
+	// eslint-disable-next-line testing-library/no-node-access
 	container.querySelector( '.components-panel__body' );
 const getPanelBodyContent = () => screen.queryByTestId( 'inner-content' );
 const getPanelToggle = () => screen.getByRole( 'button', { name: 'Panel' } );


### PR DESCRIPTION
## What?
This PR fixes a few `no-node-access` ESLint violations in the `PanelBody` tests. It also uses the opportunity to improve the existing tests. 

## Why?
We're fixing some ESLint rule violations that will allow us to enable `no-node-access` rule for the repo, but we're also improving the quality of the tests.

## How?
The improvements are as follows:

* Using `screen` queries instead of `querySelector`.
* Improve the matchers usage - use `.toBeVisible()` and `.toBeInTheDocument()` instead of `toBeTruthy()` or `toBeFalsy()`.
* Remove redundant `={ true }` prop values.
* Inlining elements instead of declaring constants when they're used just once.
* Using `user-event` instead of `fireEvent`.

## Testing Instructions
Verify all tests are green.
