### PR TITLE
Lodash: Remove `omit` usage from RN test mocks

### DIFF
--- a/test/native/__mocks__/@wordpress/react-native-aztec/index.js
+++ b/test/native/__mocks__/@wordpress/react-native-aztec/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { TextInput } from 'react-native';
-import { omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -15,9 +14,8 @@ const AztecInputState = jest.requireActual( '@wordpress/react-native-aztec' )
 const AztecKeyCodes = jest.requireActual( '@wordpress/react-native-aztec' )
 	.default.KeyCodes;
 
-const UNSUPPORTED_PROPS = [ 'style' ];
-
 const RCTAztecView = ( { accessibilityLabel, text, ...rest }, ref ) => {
+	const { style, ...supportedProps } = rest;
 	const inputRef = useRef();
 
 	useImperativeHandle( ref, () => ( {
@@ -40,7 +38,7 @@ const RCTAztecView = ( { accessibilityLabel, text, ...rest }, ref ) => {
 
 	return (
 		<TextInput
-			{ ...omit( rest, UNSUPPORTED_PROPS ) }
+			{ ...supportedProps }
 			accessibilityLabel={
 				accessibilityLabel || `Text input. ${ text.text || 'Empty' }`
 			}


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.omit()` usage from the native test mocks. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using destructuring with rest props. The changes are only in the RN test mocks.

## Testing Instructions

Verify React native tests are still green.