### PR TITLE
Restore `gutenberg_` prefix to function calls in PHPUnit tests

### DIFF
--- a/phpunit/class-block-library-navigation-link-test.php
+++ b/phpunit/class-block-library-navigation-link-test.php
@@ -121,7 +121,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		$this->assertEquals(
 			true,
 			strpos(
-				render_block_core_navigation_link(
+				gutenberg_render_block_core_navigation_link(
 					$navigation_link_block->attributes,
 					array(),
 					$navigation_link_block
@@ -142,7 +142,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
 		$this->assertEquals(
 			'',
-			render_block_core_navigation_link(
+			gutenberg_render_block_core_navigation_link(
 				$navigation_link_block->attributes,
 				array(),
 				$navigation_link_block
@@ -162,7 +162,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			'',
-			render_block_core_navigation_link(
+			gutenberg_render_block_core_navigation_link(
 				$navigation_link_block->attributes,
 				array(),
 				$navigation_link_block
@@ -182,7 +182,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		$this->assertEquals(
 			true,
 			strpos(
-				render_block_core_navigation_link(
+				gutenberg_render_block_core_navigation_link(
 					$navigation_link_block->attributes,
 					array(),
 					$navigation_link_block
@@ -202,7 +202,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		$this->assertEquals(
 			true,
 			strpos(
-				render_block_core_navigation_link(
+				gutenberg_render_block_core_navigation_link(
 					$navigation_link_block->attributes,
 					array(),
 					$navigation_link_block
@@ -224,7 +224,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			'',
-			render_block_core_navigation_link(
+			gutenberg_render_block_core_navigation_link(
 				$navigation_link_block->attributes,
 				array(),
 				$navigation_link_block
@@ -244,7 +244,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		$this->assertEquals(
 			true,
 			strpos(
-				render_block_core_navigation_link(
+				gutenberg_render_block_core_navigation_link(
 					$navigation_link_block->attributes,
 					array(),
 					$navigation_link_block


### PR DESCRIPTION
Discovered in https://github.com/WordPress/gutenberg/pull/46435
See some conversation in Slack https://wordpress.slack.com/archives/C02QB2JS7/p1671470350718839

## What?

Restores the `gutenberg_` prefix to function calls in the Navigation Link PHPUnit tests.

## Why?

The prefixes were erroneously removed in #40657. Without the prefix, the tests run against the WordPress core version of the functions, instead of the version in Gutenberg the plugin.

## Testing Instructions

All tests should pass.

