### PR TITLE
Update performance tests to work with themes that load editor into an iframe

### DIFF
--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -101,8 +101,10 @@ describe( 'Post Editor Performance', () => {
 		let i = 5;
 		while ( i-- ) {
 			await page.reload();
-			await page.waitForSelector( 'iframe[name="editor-canvas"]' );
-			await canvas().waitForSelector( '.wp-block' );
+			await page.waitForSelector( '.edit-post-layout', {
+				timeout: 120000,
+			} );
+			await canvas().waitForSelector( '.wp-block', { timeout: 120000 } );
 			const {
 				serverResponse,
 				firstPaint,

--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -15,6 +15,7 @@ import {
 	closeGlobalBlockInserter,
 	openListView,
 	closeListView,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 /**
@@ -100,7 +101,8 @@ describe( 'Post Editor Performance', () => {
 		let i = 5;
 		while ( i-- ) {
 			await page.reload();
-			await page.waitForSelector( '.wp-block' );
+			await page.waitForSelector( 'iframe[name="editor-canvas"]' );
+			await canvas().waitForSelector( '.wp-block' );
 			const {
 				serverResponse,
 				firstPaint,
@@ -166,8 +168,8 @@ describe( 'Post Editor Performance', () => {
 			)
 		);
 		// Select the block where we type in
-		await page.waitForSelector( 'p[aria-label="Paragraph block"]' );
-		await page.click( 'p[aria-label="Paragraph block"]' );
+		await canvas().waitForSelector( 'p[aria-label="Paragraph block"]' );
+		await canvas().click( 'p[aria-label="Paragraph block"]' );
 		// Ignore firsted typed character because it's different
 		// It probably deserves a dedicated metric.
 		// (isTyping triggers so it's slower)
@@ -217,7 +219,7 @@ describe( 'Post Editor Performance', () => {
 			);
 			dispatch( 'core/block-editor' ).resetBlocks( blocks );
 		} );
-		const paragraphs = await page.$$( '.wp-block' );
+		const paragraphs = await canvas().$$( '.wp-block' );
 		await page.tracing.start( {
 			path: traceFile,
 			screenshots: false,


### PR DESCRIPTION
Hopefully fixes the _Run performance tests_ GitHub action which is currently failing on every PR.

Working out why the actions is failing by looking at the logs is a bit confusing because the performance tests run differently depending on the branch, what's in `trunk` a the time of run, etc. 

Instead I ignored all of that and ran `npm run test:performance` locally which output a few errors to do with using selectors that will no longer work as of https://github.com/WordPress/gutenberg/pull/46212 because the block editor is now loaded into an iframe.

The two big mysteries in my mind are:

- why didn't the action fail in https://github.com/WordPress/gutenberg/pull/46212 and block merge? 
- why does the action pass when run on a `trunk` commit?

Anyway with these changes `npm run test:performance` and `./bin/plugin/cli.js perf` work for me on my local machine. Let's see what GitHub thinks.