### PR TITLE
Try a block editor setting to limit use of custom css to unfiltered html capability

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2710,6 +2710,10 @@ class WP_Theme_JSON_Gutenberg {
 			if ( empty( $input ) ) {
 				continue;
 			}
+			if ( is_array( $input ) && 'css' === key( $input ) ) {
+				$output = safecss_filter_attr( $input['css'] ); // need to work out what filter to use as safecss_filter_attr doesn't work.
+				continue;
+			}
 
 			$output = static::remove_insecure_styles( $input );
 

--- a/lib/compat/wordpress-6.2/block-editor-settings.php
+++ b/lib/compat/wordpress-6.2/block-editor-settings.php
@@ -13,6 +13,8 @@
  * @return array New block editor settings.
  */
 function gutenberg_get_block_editor_settings_6_2( $settings ) {
+	$can_user_edit_global_custom_css = apply_filters( 'enable_global_styles_custom_css', current_user_can( 'unfiltered_html' ) );
+
 	if ( wp_theme_has_theme_json() ) {
 		// Add the custom CSS as separate style sheet so any invalid CSS entered by users does not break other global styles.
 		$settings['styles'][] = array(
@@ -21,7 +23,7 @@ function gutenberg_get_block_editor_settings_6_2( $settings ) {
 			'isGlobalStyles' => true,
 		);
 	}
-	$settings['__experimentalCanUserEditGlobalCustomCSS'] = ! current_user_can( 'unfiltered_html' ) ? false : true;
+	$settings['__experimentalCanUserEditGlobalCustomCSS'] = ! $can_user_edit_global_custom_css ? false : true;
 	return $settings;
 }
 

--- a/lib/compat/wordpress-6.2/block-editor-settings.php
+++ b/lib/compat/wordpress-6.2/block-editor-settings.php
@@ -21,7 +21,7 @@ function gutenberg_get_block_editor_settings_6_2( $settings ) {
 			'isGlobalStyles' => true,
 		);
 	}
-
+	$settings['__experimentalCanUserEditGlobalCustomCSS'] = ! current_user_can( 'unfiltered_html' ) ? false : true;
 	return $settings;
 }
 

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -89,9 +89,6 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-block-inspector-tabs', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableBlockInspectorTabs = true', 'before' );
 	}
-	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-global-styles-custom-css', $gutenberg_experiments ) ) {
-		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableGlobalStylesCustomCSS = true', 'before' );
-	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -89,22 +89,6 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
-	add_settings_field(
-		'gutenberg-global-styles-custom-css',
-		__( 'Global styles custom css ', 'gutenberg' ),
-		'gutenberg_display_experiment_field',
-		'gutenberg-experiments',
-		'gutenberg_experiments_section',
-		array(
-			'label' => sprintf(
-				/* translators: %s: WordPress documentation for roles and capabilities. */
-				__( 'Test the Global Styles custom CSS field in the site editor. This requires a user to have <a href="%s">unfiltered html capabilities</a>.', 'gutenberg' ),
-				'https://wordpress.org/support/article/roles-and-capabilities/#unfiltered_html'
-			),
-			'id'    => 'gutenberg-global-styles-custom-css',
-		)
-	);
-
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/packages/edit-site/src/components/global-styles/screen-root.js
+++ b/packages/edit-site/src/components/global-styles/screen-root.js
@@ -16,6 +16,7 @@ import { isRTL, __ } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -26,6 +27,11 @@ import ContextMenu from './context-menu';
 import StylesPreview from './preview';
 
 function ScreenRoot() {
+	const canUserEditGlobalCustomCSS = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		return getSettings().__experimentalCanUserEditGlobalCustomCSS;
+	} );
+
 	const { variations } = useSelect( ( select ) => {
 		return {
 			variations:
@@ -35,8 +41,6 @@ function ScreenRoot() {
 		};
 	}, [] );
 
-	const __experimentalGlobalStylesCustomCSS =
-		window?.__experimentalEnableGlobalStylesCustomCSS;
 	return (
 		<Card size="small">
 			<CardBody>
@@ -102,7 +106,7 @@ function ScreenRoot() {
 				</ItemGroup>
 			</CardBody>
 
-			{ __experimentalGlobalStylesCustomCSS && (
+			{ canUserEditGlobalCustomCSS && (
 				<>
 					<CardDivider />
 					<CardBody>


### PR DESCRIPTION
## What?
Removes the [experimental flag](https://github.com/WordPress/gutenberg/pull/46663) for Global Styles custom CSS and use the `unfiltered_html` capability to check if a user should see it in the UI

## Why?
If the UI shows in the site editor for users without `unfiltered_html` then any content entered fails to save.

## How?
Adds a `__experimentalCanUserEditGlobalCustomCSS` block editor setting which is calculated with `apply_filters( 'enable_global_styles_custom_css', current_user_can( 'unfiltered_html' ) )`. The use of a filter allows plugins/themes to extend the use of global custom CSS to other capabilities, eg. `edit_css` could be used in the likes of multisite installs where admins don't have `unfiltered_html` by default.

## Testing Instructions

- Check that a standard admin on a standard site can add/edit global custom CSS in global styles
- Enable kses filters with add_action( 'init', 'kses_init_filters' ); and make sure it still works
- Check that  user with no `unfiltered_html` does not see the custom CSS option in global styles (you can remove `unfiltered_html` for all users with `define( 'DISALLOW_UNFILTERED_HTML', true );`
- Check that adding a filter like `add_filter( 'enable_global_styles_custom_css', current_user_can( 'edit_css' ) )` allows a user with this capability but without `unfiltered_html` to add/edit global styls

## Screenshots or screencast <!-- if applicable -->

Coming next year ....