### PR TITLE
Storybook: Fix crash when `parameters` is undefined

### DIFF
--- a/storybook/webpack/source-link-loader.js
+++ b/storybook/webpack/source-link-loader.js
@@ -46,7 +46,8 @@ function alterParameters( properties, componentPath ) {
 
 	if ( ! parameters ) {
 		parameters = babel.types.objectProperty(
-			babel.types.identifier( 'parameters' )
+			babel.types.identifier( 'parameters' ),
+			babel.types.objectExpression( [] )
 		);
 		properties.push( parameters );
 	}


### PR DESCRIPTION
## What?

Fixes a bug where the Storybook does not build properly when one of the exported metadata objects do not contain a `parameters` property.

Reported in https://github.com/WordPress/gutenberg/pull/45787#discussion_r1042861328

## How?

In one of our custom Babel plugins, the expression to create a `parameters: {}` was incorrect.

## Testing Instructions

1. In one of the story files, for example [Divider](https://github.com/WordPress/gutenberg/blob/9ac117bfb94fdb3908c82a251adcee996f1bc3cc/packages/components/src/divider/stories/index.tsx#L27-L30), remove the `parameters` property from the default export.
2. `npm run storybook:dev` should start and load the Storybook as expected.
