### PR TITLE
WP_HTML_Tag_Processor: Add `get_attributes_by_prefix()` method

### DIFF
--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1428,7 +1428,7 @@ class WP_HTML_Tag_Processor {
 	 * @since 6.2.0
 	 *
 	 * @param string $prefix Prefix of attributes whose value is requested.
-	 * @return array|null Associative array of attribute names and values, or `null` if not at a tag.
+	 * @return array|null Associative array of matching attribute names and values, or `null` if not at a tag.
 	 *                    Boolean attributes map to `true`.
 	 */
 	function get_attributes_by_prefix( $prefix ) {

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1413,6 +1413,45 @@ class WP_HTML_Tag_Processor {
 	}
 
 	/**
+	 * Returns parsed attributes matching a given prefix in the currently-opened tag.
+	 *
+	 * Example:
+	 * <code>
+	 *     $p = new WP_HTML_Tag_Processor( '<div data-enabled class="test" data-test-id="14">Test</div>' );
+	 *     $p->next_tag( [ 'class_name' => 'test' ] ) === true;
+	 *     $p->get_attributes_by_prefix( 'data-' ) === array( 'data-enabled' => true, 'data-test-id' => '14' );
+	 *
+	 *     $p->next_tag( [] ) === false;
+	 *     $p->get_attributes_by_prefix( 'data' ) === null;
+	 * </code>
+	 *
+	 * @since 6.2.0
+	 *
+	 * @param string $prefix Prefix of attributes whose value is requested.
+	 * @return array|null Associative array of attribute names and values, or `null` if not at a tag.
+	 *                    Boolean attributes map to `true`.
+	 */
+	function get_attributes_by_prefix( $prefix ) {
+		if ( null === $this->tag_name_starts_at ) {
+			return null;
+		}
+
+		$comparable = strtolower( $prefix );
+		$matches    = array_filter(
+			array_keys( $this->attributes ),
+			function( $attr ) use ( $comparable ) {
+				return str_starts_with( $attr, $comparable );
+			}
+		);
+
+		$results = array();
+		foreach ( $matches as $attr ) {
+			$results[ $attr ] = $this->get_attribute( $attr );
+		}
+		return $results;
+	}
+
+	/**
 	 * Returns the lowercase name of the currently-opened tag.
 	 *
 	 * Example:

--- a/phpunit/html/wp-html-tag-processor-test.php
+++ b/phpunit/html/wp-html-tag-processor-test.php
@@ -152,6 +152,21 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers WP_HTML_Tag_Processor::get_attributes_by_prefix
+	 */
+	public function test_get_attributes_by_prefix_returns_set_of_prefixed_attributes() {
+		$p = new WP_HTML_Tag_Processor( '<div data-enabled class="test" data-test-id="14">Test</div>' );
+		$p->next_tag();
+		$this->assertSame(
+			array(
+				'data-enabled' => true,
+				'data-test-id' => '14',
+			),
+			$p->get_attributes_by_prefix( 'data-' )
+		);
+	}
+
+	/**
 	 * @ticket 56299
 	 *
 	 * @covers next_tag

--- a/phpunit/html/wp-html-tag-processor-test.php
+++ b/phpunit/html/wp-html-tag-processor-test.php
@@ -154,8 +154,8 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 	/**
 	 * @covers WP_HTML_Tag_Processor::get_attributes_by_prefix
 	 */
-	public function test_get_attributes_by_prefix_returns_set_of_prefixed_attributes() {
-		$p = new WP_HTML_Tag_Processor( '<div data-enabled class="test" data-test-id="14">Test</div>' );
+	public function test_get_attributes_by_prefix_returns_set_of_matching_attributes_in_lowercase() {
+		$p = new WP_HTML_Tag_Processor( '<div DATA-enabled class="test" data-test-ID="14">Test</div>' );
 		$p->next_tag();
 		$this->assertSame(
 			array(


### PR DESCRIPTION
## What?
Add a `get_attributes_by_prefix()` method to `WP_HTML_Tag_Processor`, which returns the set of attribute name/value pairs of all attributes whose name starts with a given prefix.

```php
$p = new WP_HTML_Tag_Processor( '<div data-enabled class="test" data-test-id="14">Test</div>' );
$p->next_tag();
$p->get_attributes_by_prefix( 'data-' ) === array( 'data-enabled' => true, 'data-test-id' => '14' );
```

## Why?
Getting all attributes with a given prefix is handy for `data-` attributes, and custom namesepaces (e.g. `ng-` or `x-`).

Furthermore, it helps with syntax like `<img wp-bind:src="myblock.imageSource" />`, which is a requirement for the Block Interactivity API ([see](https://github.com/WordPress/block-hydration-experiments/pull/118#issuecomment-1353407526)).

More background: https://github.com/WordPress/block-hydration-experiments/pull/118#discussion_r1051132800.

## How?
It filters the current tag's `$attributes` for all attribute names that start with `$prefix`, and then calls `get_attribute` for each of them.

## Testing Instructions
See included unit test.