### PR TITLE
Lodash: Refactor away from `_.omit()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -107,6 +107,7 @@ const restrictedImports = [
 			'negate',
 			'noop',
 			'nth',
+			'omit',
 			'omitBy',
 			'once',
 			'orderby',

--- a/docs/reference-guides/block-api/block-deprecation.md
+++ b/docs/reference-guides/block-api/block-deprecation.md
@@ -234,7 +234,6 @@ E.g: a block wants to migrate a title attribute to a paragraph innerBlock.
 
 ```js
 const { registerBlockType } = wp.blocks;
-const { omit } = lodash;
 
 registerBlockType( 'gutenberg/block-with-deprecated-version', {
 	// ... block properties go here
@@ -254,8 +253,10 @@ registerBlockType( 'gutenberg/block-with-deprecated-version', {
 			},
 
 			migrate( attributes, innerBlocks ) {
+				const { title, ...restAttributes } = attributes;
+
 				return [
-					omit( attributes, 'title' ),
+					restAttributes,
 					[
 						createBlock( 'core/paragraph', {
 							content: attributes.title,
@@ -278,8 +279,7 @@ registerBlockType( 'gutenberg/block-with-deprecated-version', {
 
 ```js
 var el = wp.element.createElement,
-	registerBlockType = wp.blocks.registerBlockType,
-	omit = lodash.omit;
+	registerBlockType = wp.blocks.registerBlockType;
 
 registerBlockType( 'gutenberg/block-with-deprecated-version', {
 	// ... block properties go here
@@ -295,8 +295,10 @@ registerBlockType( 'gutenberg/block-with-deprecated-version', {
 			},
 
 			migrate: function ( attributes, innerBlocks ) {
+				const { title, ...restAttributes } = attributes;
+
 				return [
-					omit( attributes, 'title' ),
+					restAttributes,
 					[
 						createBlock( 'core/paragraph', {
 							content: attributes.title,

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -85,7 +85,13 @@ export function getMergedItemIds( itemIds, nextItemIds, page, perPage ) {
 function removeEntitiesById( entities, ids ) {
 	return Object.fromEntries(
 		Object.entries( entities ).filter(
-			( [ id ] ) => ! ids.some( ( itemId ) => +itemId === +id )
+			( [ id ] ) =>
+				! ids.some( ( itemId ) => {
+					if ( Number.isInteger( itemId ) ) {
+						return itemId === +id;
+					}
+					return itemId === id;
+				} )
 		)
 	);
 }

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map, omit, mapValues } from 'lodash';
+import { map, mapValues } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -74,6 +74,23 @@ export function getMergedItemIds( itemIds, nextItemIds, page, perPage ) {
 }
 
 /**
+ * Helper function to filter out entities with certain IDs.
+ * Entities are keyed by their ID.
+ *
+ * @param {Object} entities Entity objects, keyed by entity ID.
+ * @param {Array}  ids      Entity IDs to filter out.
+ *
+ * @return {Object} Next state.
+ */
+function removeEntitiesById( entities, ids ) {
+	return Object.fromEntries(
+		Object.entries( entities ).filter(
+			( [ id ] ) => ! ids.some( ( itemId ) => +itemId === +id )
+		)
+	);
+}
+
+/**
  * Reducer tracking items state, keyed by ID. Items are assumed to be normal,
  * where identifiers are common across all queries.
  *
@@ -104,7 +121,7 @@ export function items( state = {}, action ) {
 		}
 		case 'REMOVE_ITEMS':
 			return mapValues( state, ( contextState ) =>
-				omit( contextState, action.itemIds )
+				removeEntitiesById( contextState, action.itemIds )
 			);
 	}
 	return state;
@@ -157,7 +174,7 @@ export function itemIsComplete( state = {}, action ) {
 		}
 		case 'REMOVE_ITEMS':
 			return mapValues( state, ( contextState ) =>
-				omit( contextState, action.itemIds )
+				removeEntitiesById( contextState, action.itemIds )
 			);
 	}
 

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -80,7 +80,7 @@ export function getMergedItemIds( itemIds, nextItemIds, page, perPage ) {
  * @param {Object} entities Entity objects, keyed by entity ID.
  * @param {Array}  ids      Entity IDs to filter out.
  *
- * @return {Object} Next state.
+ * @return {Object} Filtered entities.
  */
 function removeEntitiesById( entities, ids ) {
 	return Object.fromEntries(

--- a/packages/core-data/src/queried-data/test/reducer.js
+++ b/packages/core-data/src/queried-data/test/reducer.js
@@ -224,4 +224,44 @@ describe( 'reducer', () => {
 			},
 		} );
 	} );
+
+	it( 'deletes an item with string ID', () => {
+		const kind = 'postType';
+		const name = 'wp_template';
+		const original = deepFreeze( {
+			items: {
+				default: {
+					'foo//bar1': { id: 'foo//bar1', name: 'Foo Bar 1' },
+					'foo//bar2': { id: 'foo//bar2', name: 'Foo Bar 2' },
+					'foo//bar3': { id: 'foo//bar3', name: 'Foo Bar 3' },
+				},
+			},
+			queries: {
+				default: {
+					'': [ 'foo//bar1', 'foo//bar2', 'foo//bar3' ],
+					's=2': [ 'foo//bar2' ],
+				},
+			},
+		} );
+		const state = reducer(
+			original,
+			removeItems( kind, name, 'foo//bar2' )
+		);
+
+		expect( state ).toEqual( {
+			itemIsComplete: {},
+			items: {
+				default: {
+					'foo//bar1': { id: 'foo//bar1', name: 'Foo Bar 1' },
+					'foo//bar3': { id: 'foo//bar3', name: 'Foo Bar 3' },
+				},
+			},
+			queries: {
+				default: {
+					'': [ 'foo//bar1', 'foo//bar3' ],
+					's=2': [],
+				},
+			},
+		} );
+	} );
 } );


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.omit()` completely and deprecates the import of that function. There are a few remaining usages in that package and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're creating an inline helper function to reduce repetition. It will omit the unnecessary IDs that are passed as an array, converting the IDs specifically to numbers to ensure that they're compared properly (like Lodash did under the hood when calling `_.omit`).

I'm also updating docs that used `_.omit()` in a couple of examples and deprecating the import of `_.omit()` in our ESLint config.

## Testing Instructions

Verify all checks are still green. The changes are covered by unit tests:

```
npm run test:unit packages/core-data
```