### PR TITLE
Replace block settings menu with a custom menu in off canvas editor

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/block.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block.js
@@ -236,7 +236,7 @@ function ListViewBlock( {
 		? selectedClientIds
 		: [ clientId ];
 
-	const BlockSettingsDropdownComponent = LeafMoreMenu
+	const MoreMenuComponent = LeafMoreMenu
 		? LeafMoreMenu
 		: BlockSettingsDropdown;
 
@@ -356,7 +356,7 @@ function ListViewBlock( {
 					>
 						{ ( { ref, tabIndex, onFocus } ) => (
 							<>
-								<BlockSettingsDropdownComponent
+								<MoreMenuComponent
 									clientIds={ dropdownClientIds }
 									block={ block }
 									clientId={ clientId }

--- a/packages/block-editor/src/components/off-canvas-editor/block.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block.js
@@ -6,11 +6,10 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { createBlock, hasBlockSupport } from '@wordpress/blocks';
+import { hasBlockSupport } from '@wordpress/blocks';
 import {
 	__experimentalTreeGridCell as TreeGridCell,
 	__experimentalTreeGridItem as TreeGridItem,
-	MenuItem,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { moreVertical } from '@wordpress/icons';
@@ -86,8 +85,7 @@ function ListViewBlock( {
 		( isSelected &&
 			selectedClientIds[ selectedClientIds.length - 1 ] === clientId );
 
-	const { insertBlock, replaceBlock, toggleBlockHighlight } =
-		useDispatch( blockEditorStore );
+	const { toggleBlockHighlight } = useDispatch( blockEditorStore );
 
 	const blockInformation = useBlockDisplayInformation( clientId );
 	const block = useSelect(
@@ -128,7 +126,8 @@ function ListViewBlock( {
 		[ selectBlock ]
 	);
 
-	const { isTreeGridMounted, expand, collapse } = useListViewContext();
+	const { isTreeGridMounted, expand, collapse, LeafMoreMenu } =
+		useListViewContext();
 
 	const toggleExpanded = useCallback(
 		( event ) => {
@@ -236,6 +235,10 @@ function ListViewBlock( {
 	const dropdownClientIds = selectedClientIds.includes( clientId )
 		? selectedClientIds
 		: [ clientId ];
+
+	const BlockSettingsDropdownComponent = LeafMoreMenu
+		? LeafMoreMenu
+		: BlockSettingsDropdown;
 
 	return (
 		<ListViewLeaf
@@ -352,61 +355,26 @@ function ListViewBlock( {
 						colSpan={ isEditable ? 1 : 2 } // When an item is not editable then we don't output the cell for the edit button, so we need to adjust the colspan so that the HTML is valid.
 					>
 						{ ( { ref, tabIndex, onFocus } ) => (
-							<BlockSettingsDropdown
-								clientIds={ dropdownClientIds }
-								icon={ moreVertical }
-								label={ settingsAriaLabel }
-								toggleProps={ {
-									ref,
-									className:
-										'block-editor-list-view-block__menu',
-									tabIndex,
-									onFocus,
-								} }
-								disableOpenOnArrowDown
-								__experimentalSelectBlock={ updateSelection }
-							>
-								{ ( { onClose } ) => (
-									<MenuItem
-										onClick={ () => {
-											const newLink = createBlock(
-												'core/navigation-link'
-											);
-											if (
-												block.name ===
-												'core/navigation-submenu'
-											) {
-												const updateSelectionOnInsert = false;
-												insertBlock(
-													newLink,
-													block.innerBlocks.length,
-													clientId,
-													updateSelectionOnInsert
-												);
-											} else {
-												// Convert to a submenu if the block currently isn't one.
-												const newSubmenu = createBlock(
-													'core/navigation-submenu',
-													block.attributes,
-													block.innerBlocks
-														? [
-																...block.innerBlocks,
-																newLink,
-														  ]
-														: [ newLink ]
-												);
-												replaceBlock(
-													clientId,
-													newSubmenu
-												);
-											}
-											onClose();
-										} }
-									>
-										{ __( 'Add submenu item' ) }
-									</MenuItem>
-								) }
-							</BlockSettingsDropdown>
+							<>
+								<BlockSettingsDropdownComponent
+									clientIds={ dropdownClientIds }
+									block={ block }
+									clientId={ clientId }
+									icon={ moreVertical }
+									label={ settingsAriaLabel }
+									toggleProps={ {
+										ref,
+										className:
+											'block-editor-list-view-block__menu',
+										tabIndex,
+										onFocus,
+									} }
+									disableOpenOnArrowDown
+									__experimentalSelectBlock={
+										updateSelection
+									}
+								/>
+							</>
 						) }
 					</TreeGridCell>
 				</>

--- a/packages/block-editor/src/components/off-canvas-editor/index.js
+++ b/packages/block-editor/src/components/off-canvas-editor/index.js
@@ -60,7 +60,8 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
  * @param {Array}   props.blocks              Custom subset of block client IDs to be used instead of the default hierarchy.
  * @param {boolean} props.showBlockMovers     Flag to enable block movers
  * @param {boolean} props.isExpanded          Flag to determine whether nested levels are expanded by default.
- * @param {boolean} props.selectBlockInCanvas Flag to determine whether the list view should be a block selection mechanism,.
+ * @param {boolean} props.selectBlockInCanvas Flag to determine whether the list view should be a block selection mechanism.
+ * @param {Object}  props.LeafMoreMenu        Optional more menu substitution.
  * @param {Object}  ref                       Forwarded ref
  */
 function __ExperimentalOffCanvasEditor(
@@ -70,6 +71,7 @@ function __ExperimentalOffCanvasEditor(
 		showBlockMovers = false,
 		isExpanded = false,
 		selectBlockInCanvas = true,
+		LeafMoreMenu,
 	},
 	ref
 ) {
@@ -188,8 +190,16 @@ function __ExperimentalOffCanvasEditor(
 			expandedState,
 			expand,
 			collapse,
+			LeafMoreMenu,
 		} ),
-		[ isMounted.current, draggedClientIds, expandedState, expand, collapse ]
+		[
+			isMounted.current,
+			draggedClientIds,
+			expandedState,
+			expand,
+			collapse,
+			LeafMoreMenu,
+		]
 	);
 
 	return (

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { createBlock } from '@wordpress/blocks';
 import {
 	__experimentalOffCanvasEditor as OffCanvasEditor,
 	InspectorControls,
@@ -11,85 +10,16 @@ import {
 	PanelBody,
 	__experimentalHStack as HStack,
 	__experimentalHeading as Heading,
-	DropdownMenu,
-	MenuItem,
-	MenuGroup,
 } from '@wordpress/components';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { moreVertical } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import ManageMenusButton from './manage-menus-button';
 import NavigationMenuSelector from './navigation-menu-selector';
-
-const POPOVER_PROPS = {
-	className: 'block-editor-block-settings-menu__popover',
-	position: 'bottom right',
-	variant: 'toolbar',
-};
-
-const LeafMoreMenu = ( props ) => {
-	const { clientId, block } = props;
-
-	const { insertBlock, replaceBlock, removeBlocks } =
-		useDispatch( blockEditorStore );
-
-	return (
-		<DropdownMenu
-			icon={ moreVertical }
-			label={ __( 'Options' ) }
-			className="block-editor-block-settings-menu"
-			popoverProps={ POPOVER_PROPS }
-			noIcons
-			{ ...props }
-		>
-			{ ( { onClose } ) => (
-				<MenuGroup>
-					<MenuItem
-						onClick={ () => {
-							const newLink = createBlock(
-								'core/navigation-link'
-							);
-							if ( block.name === 'core/navigation-submenu' ) {
-								const updateSelectionOnInsert = false;
-								insertBlock(
-									newLink,
-									block.innerBlocks.length,
-									clientId,
-									updateSelectionOnInsert
-								);
-							} else {
-								// Convert to a submenu if the block currently isn't one.
-								const newSubmenu = createBlock(
-									'core/navigation-submenu',
-									block.attributes,
-									block.innerBlocks
-										? [ ...block.innerBlocks, newLink ]
-										: [ newLink ]
-								);
-								replaceBlock( clientId, newSubmenu );
-							}
-							onClose();
-						} }
-					>
-						{ __( 'Add submenu item' ) }
-					</MenuItem>
-					<MenuItem
-						onClick={ () => {
-							removeBlocks( [ clientId ], false );
-							onClose();
-						} }
-					>
-						{ __( 'Remove item' ) }
-					</MenuItem>
-				</MenuGroup>
-			) }
-		</DropdownMenu>
-	);
-};
+import { LeafMoreMenu } from '../leaf-more-menu';
 
 const MenuInspectorControls = ( {
 	clientId,

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { createBlock } from '@wordpress/blocks';
 import {
 	__experimentalOffCanvasEditor as OffCanvasEditor,
 	InspectorControls,
@@ -10,15 +11,85 @@ import {
 	PanelBody,
 	__experimentalHStack as HStack,
 	__experimentalHeading as Heading,
+	DropdownMenu,
+	MenuItem,
+	MenuGroup,
 } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { moreVertical } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import ManageMenusButton from './manage-menus-button';
 import NavigationMenuSelector from './navigation-menu-selector';
+
+const POPOVER_PROPS = {
+	className: 'block-editor-block-settings-menu__popover',
+	position: 'bottom right',
+	variant: 'toolbar',
+};
+
+const LeafMoreMenu = ( props ) => {
+	const { clientId, block } = props;
+
+	const { insertBlock, replaceBlock, removeBlocks } =
+		useDispatch( blockEditorStore );
+
+	return (
+		<DropdownMenu
+			icon={ moreVertical }
+			label={ __( 'Options' ) }
+			className="block-editor-block-settings-menu"
+			popoverProps={ POPOVER_PROPS }
+			noIcons
+			{ ...props }
+		>
+			{ ( { onClose } ) => (
+				<MenuGroup>
+					<MenuItem
+						onClick={ () => {
+							const newLink = createBlock(
+								'core/navigation-link'
+							);
+							if ( block.name === 'core/navigation-submenu' ) {
+								const updateSelectionOnInsert = false;
+								insertBlock(
+									newLink,
+									block.innerBlocks.length,
+									clientId,
+									updateSelectionOnInsert
+								);
+							} else {
+								// Convert to a submenu if the block currently isn't one.
+								const newSubmenu = createBlock(
+									'core/navigation-submenu',
+									block.attributes,
+									block.innerBlocks
+										? [ ...block.innerBlocks, newLink ]
+										: [ newLink ]
+								);
+								replaceBlock( clientId, newSubmenu );
+							}
+							onClose();
+						} }
+					>
+						{ __( 'Add submenu item' ) }
+					</MenuItem>
+					<MenuItem
+						onClick={ () => {
+							removeBlocks( [ clientId ], false );
+							onClose();
+						} }
+					>
+						{ __( 'Remove item' ) }
+					</MenuItem>
+				</MenuGroup>
+			) }
+		</DropdownMenu>
+	);
+};
 
 const MenuInspectorControls = ( {
 	clientId,
@@ -88,6 +159,7 @@ const MenuInspectorControls = ( {
 								blocks={ clientIdsTree }
 								isExpanded={ true }
 								selectBlockInCanvas={ false }
+								LeafMoreMenu={ LeafMoreMenu }
 							/>
 						) }
 					</>

--- a/packages/block-library/src/navigation/leaf-more-menu.js
+++ b/packages/block-library/src/navigation/leaf-more-menu.js
@@ -1,0 +1,75 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+import { moreVertical } from '@wordpress/icons';
+import { DropdownMenu, MenuItem, MenuGroup } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+const POPOVER_PROPS = {
+	className: 'block-editor-block-settings-menu__popover',
+	position: 'bottom right',
+	variant: 'toolbar',
+};
+
+export const LeafMoreMenu = ( props ) => {
+	const { clientId, block } = props;
+
+	const { insertBlock, replaceBlock, removeBlocks } =
+		useDispatch( blockEditorStore );
+
+	return (
+		<DropdownMenu
+			icon={ moreVertical }
+			label={ __( 'Options' ) }
+			className="block-editor-block-settings-menu"
+			popoverProps={ POPOVER_PROPS }
+			noIcons
+			{ ...props }
+		>
+			{ ( { onClose } ) => (
+				<MenuGroup>
+					<MenuItem
+						onClick={ () => {
+							const newLink = createBlock(
+								'core/navigation-link'
+							);
+							if ( block.name === 'core/navigation-submenu' ) {
+								const updateSelectionOnInsert = false;
+								insertBlock(
+									newLink,
+									block.innerBlocks.length,
+									clientId,
+									updateSelectionOnInsert
+								);
+							} else {
+								// Convert to a submenu if the block currently isn't one.
+								const newSubmenu = createBlock(
+									'core/navigation-submenu',
+									block.attributes,
+									block.innerBlocks
+										? [ ...block.innerBlocks, newLink ]
+										: [ newLink ]
+								);
+								replaceBlock( clientId, newSubmenu );
+							}
+							onClose();
+						} }
+					>
+						{ __( 'Add submenu item' ) }
+					</MenuItem>
+					<MenuItem
+						onClick={ () => {
+							removeBlocks( [ clientId ], false );
+							onClose();
+						} }
+					>
+						{ __( 'Remove item' ) }
+					</MenuItem>
+				</MenuGroup>
+			) }
+		</DropdownMenu>
+	);
+};

--- a/packages/block-library/src/navigation/leaf-more-menu.js
+++ b/packages/block-library/src/navigation/leaf-more-menu.js
@@ -5,8 +5,8 @@ import { createBlock } from '@wordpress/blocks';
 import { moreVertical } from '@wordpress/icons';
 import { DropdownMenu, MenuItem, MenuGroup } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { store as blockEditorStore } from '@wordpress/block-editor';
-import { __ } from '@wordpress/i18n';
+import { store as blockEditorStore, BlockTitle } from '@wordpress/block-editor';
+import { __, sprintf } from '@wordpress/i18n';
 
 const POPOVER_PROPS = {
 	className: 'block-editor-block-settings-menu__popover',
@@ -19,6 +19,12 @@ export const LeafMoreMenu = ( props ) => {
 
 	const { insertBlock, replaceBlock, removeBlocks } =
 		useDispatch( blockEditorStore );
+
+	const label = sprintf(
+		/* translators: %s: block name */
+		__( 'Remove %s' ),
+		BlockTitle( { clientId, maximumLength: 25 } )
+	);
 
 	return (
 		<DropdownMenu
@@ -66,7 +72,7 @@ export const LeafMoreMenu = ( props ) => {
 							onClose();
 						} }
 					>
-						{ __( 'Remove item' ) }
+						{ label }
 					</MenuItem>
 				</MenuGroup>
 			) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

The tree view displayed by the navigation block (which is temporarily called the "off canvas editor") is a modified List View. Like the list view by default this tree shows a dot "more" menu with the typical block actions (make template part, duplicate, copy etc.).

This PR implements a way to replace the default block menu in this tree view of blocks with a custom one decided where the list view is instanced.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In the particular case of the navigation block:

- items are needed that don't make sense for other situations (e.g. add submenu)
- a  different order of the items makes more sense (e.g. add submenu should be the 1st item)
- some items in the default menu make no sense (e.g. create template part or group for navigation links)

The standard way to register items via plugins for the block settings menu is not flexible enough to allow modifications like the ones above.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Luckily the List view implements a context that is consumed for it's many children, so adding a new more menu is only:

- a prop in the main component
- adding that prop to context
- consuming context and replacing the menu component with the provided one

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

0. Make sure to have the "Off canvas navigation editor" ON
1. In a post
2. Add a navigation block
3. Add some items
4. Select the navigation block
5. In the block inspector observe the tree view of the navigation block
6. Hover over an item and click the three vertical dots
7. Observe the small menu of two items this PR adds

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

0. Make sure to have the "Off canvas navigation editor" ON
1. In a post
2. Add a navigation block
3. Add some items
4. Select the navigation block
5. Use Control Option  N to move focus to the inspector
6. Tab all the way to selecting a navigation item in the tree
7. Using Arrow right focus the more menu
8. Open the menu
9. Observe the small menu of two items this PR adds


## Screenshots or screencast <!-- if applicable -->

<img width="1589" alt="Screenshot 2022-12-20 at 15 07 43" src="https://user-images.githubusercontent.com/107534/208674689-7da5ac3e-0307-46e5-900e-6408b39493ba.png">

