### PR TITLE
[Inserter]: Try fix media tab when upload of media types has been disabled

### DIFF
--- a/packages/block-editor/src/components/inserter/media-tab/hooks.js
+++ b/packages/block-editor/src/components/inserter/media-tab/hooks.js
@@ -66,14 +66,15 @@ export function useMediaCategories( rootClientId ) {
 				per_page: 1,
 				_fields: [ 'id' ],
 			};
-			const [ image, video, audio ] = await Promise.all( [
+			const [ image, video, audio ] = await Promise.allSettled( [
 				fetchMedia( { ...query, media_type: 'image' } ),
 				fetchMedia( { ...query, media_type: 'video' } ),
 				fetchMedia( { ...query, media_type: 'audio' } ),
 			] );
-			const showImage = canInsertImage && !! image.length;
-			const showVideo = canInsertVideo && !! video.length;
-			const showAudio = canInsertAudio && !! audio.length;
+			// The `value` property is only present if the promise's status is "fulfilled".
+			const showImage = canInsertImage && !! image.value?.length;
+			const showVideo = canInsertVideo && !! video.value?.length;
+			const showAudio = canInsertAudio && !! audio.value?.length;
 			setCategories(
 				MEDIA_CATEGORIES.filter(
 					( { mediaType } ) =>


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Temp fix for: https://github.com/WordPress/gutenberg/issues/46658

From the issue:
>The media tab added in https://github.com/WordPress/gutenberg/pull/44918 is not being displayed in case audio and video files uploads are disabled.

>The media types in WordPress can be limited (or extended) via upload_mimes filter. In case a plugin or a custom code is limiting the upload types to images only.

> In case such code is in effect, the Gutenberg is producing JS errors as displayed on the screenshot below upon clicking on the Block inserter toggle and no media tab is being displayed.
<!-- In a few words, what is the PR actually doing? -->
### Step-by-step reproduction instructions

1. Add the code for limiting the media types allowed to be uploaded to a mu-plugin on your test installation
2. Go to new post screen
3. Click on the Block inserter toggle
4. The media tab should be shown for the available media

```
add_filter( 'upload_mimes', function( $mimes ) {
	return array_filter( $mimes, function( $type ) {
		return ( false !== strpos( $type, 'image' ) );
	} );
} );
```

## Notes
I'm not sure if there are more nuances to this because `upload_mimes` restricts what media types are allowed to be uploaded. As it seems the REST API doesn't fetch the restricted media types, but if there are available media items in the Library, they can be still be inserted through the Library.. Either way though, media tab cannot work properly in this case even if media items exist, because the implementation relies on the REST API.

The requests are still made and fail, without breaking the editor and the media tab though.
Since I'm changing the implementation of media categories in this soon to land PR: https://github.com/WordPress/gutenberg/pull/46251, I'd prefer to handle this better there by taking into account the `allowedMimeTypes` setting. What do you think?

