### PR TITLE
E2E: Fix `confirmValidDropZonePosition()` when dropzone not ready

### DIFF
--- a/test/e2e/specs/editor/blocks/paragraph.spec.js
+++ b/test/e2e/specs/editor/blocks/paragraph.spec.js
@@ -569,6 +569,10 @@ class DraggingUtils {
 		// Check that both x and y axis of the dropzone
 		// have a less than 1 difference with a given target element
 		const box = await this.dropZone.boundingBox();
+		if ( ! box ) {
+			return false;
+		}
+
 		return (
 			Math.abs( element.x - box.x ) < 1 &&
 			Math.abs( element.y - box.y ) < 1


### PR DESCRIPTION
## What?
This PR attempts to improve `confirmValidDropZonePosition()` in order to fix the flaky test reported in #46463.

Fixes #46463.

## Why?
See #46463.

## How?
Since `confirmValidDropZonePosition()` is being polled for, we're making it return `false` if the drop zone bounding box is `null`. That way it won't throw an error and will just continue polling. This brings the test back closer to how it worked with regard to the polling behavior prior to #46187.

## Testing Instructions
Verify all tests are green.