### PR TITLE
WP_HTML_Tag_Processor: Make `get_attribute` reflect attribute set via `set_attribute`, even without updating

### DIFF
--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1059,7 +1059,7 @@ class WP_HTML_Tag_Processor {
 			return true;
 		}
 
-		/**
+		/*
 		 * > There must never be two or more attributes on
 		 * > the same start tag whose names are an ASCII
 		 * > case-insensitive match for each other.
@@ -1127,18 +1127,20 @@ class WP_HTML_Tag_Processor {
 			return;
 		}
 
-		if ( isset( $this->lexical_updates['class'] ) ) {
-			$existing_class = $this->extract_attribute_value_from_lexical_update( 'class' );
-			if ( true === $existing_class ) {
-				$existing_class = '';
-			}
-		} elseif ( isset( $this->attributes['class'] ) ) {
+		$existing_class = $this->get_enqueued_attribute_value( 'class' );
+		if ( null === $existing_class || true === $existing_class ) {
+			$existing_class = '';
+		}
+
+		if ( false === $existing_class && isset( $this->attributes['class'] ) ) {
 			$existing_class = substr(
 				$this->html,
 				$this->attributes['class']->value_starts_at,
 				$this->attributes['class']->value_length
 			);
-		} else {
+		}
+
+		if ( false === $existing_class ) {
 			$existing_class = '';
 		}
 
@@ -1258,7 +1260,7 @@ class WP_HTML_Tag_Processor {
 			return;
 		}
 
-		/**
+		/*
 		 * Attribute updates can be enqueued in any order but as we
 		 * progress through the document to replace them we have to
 		 * make our replacements in the order in which they are found
@@ -1277,7 +1279,7 @@ class WP_HTML_Tag_Processor {
 		}
 
 		foreach ( $this->bookmarks as $bookmark ) {
-			/**
+			/*
 			 * As we loop through $this->lexical_updates, we keep comparing
 			 * $bookmark->start and $bookmark->end to $diff->start. We can't
 			 * change it and still expect the correct result, so let's accumulate
@@ -1378,50 +1380,66 @@ class WP_HTML_Tag_Processor {
 	}
 
 	/**
-	 * Given an attribute name, return its value as set in $lexical_updates.
+	 * Return the enqueued value for a given attribute, if one exists.
+	 *
+	 * Enqueued updates can take different data types:
+	 *  - If an update is enqueued and is boolean, the return will be `true`
+	 *  - If an update is otherwise enqueued, the return will be the string value of that update.
+	 *  - If an attribute is enqueued to be removed, the return will be `null` to indicate that.
+	 *  - If no updates are enqueued, the return will be `false` to differentiate from "removed."
 	 *
 	 * @since 6.2.0
 	 *
-	 * @param string $name The attribute name.
-	 * @return string|true|null Value of attribute or `null` if not available.
-	 *                          Boolean attributes return `true`.
+	 * @param string $comparable_name The attribute name in its comparable form.
+	 * @return string|boolean|null Value of enqueued update if present, otherwise false.
 	 */
-	private function extract_attribute_value_from_lexical_update( $name ) {
-		$comparable = strtolower( trim( $name ) );
+	private function get_enqueued_attribute_value( $comparable_name ) {
+		if ( ! isset( $this->lexical_updates[ $comparable_name ] ) ) {
+			return false;
+		}
 
-		if ( ! isset( $this->lexical_updates[ $comparable ] ) ) {
+		$enqueued_text = $this->lexical_updates[ $comparable_name ]->text;
+
+		// Removed attributes erase the entire span.
+		if ( '' === $enqueued_text ) {
 			return null;
 		}
 
-		$attribute = trim( $this->lexical_updates[ $comparable ]->text );
-		// Has the attribute been removed?
-		if ( '' === $attribute ) {
-			return null;
-		}
-
-		/**
-		 * When the lexical update contains just the attribute name,
-		 * the value becomes a boolean true. For example:
+		/*
+		 * Boolean attribute updates are just the attribute name without a corresponding value.
 		 *
-		 * ```php
-		 * $p = new WP_HTML_Tag_Processor('<input type="checkbox" />');
-		 * $p->set_attribute('checked', true);
-		 * // The lexical update contains just the string "checked"
+		 * This value might differ from the given comparable name in that there could be leading
+		 * or trailing whitespace, and that the casing follows the name given in `set_attribute`.
 		 *
-		 * $p->get_attribute('checked');
-		 * // returns true thanks to the condition below
-		 *
-		 * echo $p->get_updated_html();
-		 * // <input type="checkbox" checked />
+		 * Example:
 		 * ```
+		 *     $p->set_attribute( 'data-TEST-id', 'update' );
+		 *     'update' === $p->get_enqueued_attribute_value( 'data-test-id' );
+		 * ```
+		 *
+		 * Here we detect this based on the absence of the `=`, which _must_ exist in any
+		 * attribute containing a value, e.g. `<input type="text" enabled />`.
+		 *                                            ¹           ²
+		 *                                       1. Attribute with a string value.
+		 *                                       2. Boolean attribute whose value is `true`.
 		 */
-		if ( $attribute === $comparable ) {
+		$equals_at = strpos( $enqueued_text, '=' );
+		if ( false === $equals_at ) {
 			return true;
 		}
 
-		// $attribute is a 'name="value"' string, so we extract the value.
-		$value = substr( $attribute, strlen( $comparable ) + 2, -1 );
-		return html_entity_decode( $value );
+		/*
+		 * Finally, a normal update's value will appear after the `=` and
+		 * be double-quoted, as performed incidentally by `set_attribute`.
+		 *
+		 * e.g. `type="text"`
+		 *           ¹²    ³
+		 *        1. Equals is here.
+		 *        2. Double-quoting starts one after the equals sign.
+		 *        3. Double-quoting ends at the last character in the update.
+		 */
+		$enqueued_value = substr( $enqueued_text, $equals_at + 2, -1 );
+		return html_entity_decode( $enqueued_value );
 	}
 
 	/**
@@ -1452,21 +1470,23 @@ class WP_HTML_Tag_Processor {
 
 		$comparable = strtolower( $name );
 
-		/**
-		 * For $this->lexical_updates (below), it makes sense (and is easy enough) to only
-		 * evaluate the updates for the attribute we're interested in (if any) and to ignore
-		 * updates for all other attributes. For class name updates OTOH, we would need to
-		 * replicate most of the logic from `class_name_updates_to_attributes_updates` here,
-		 * so we might as well just call that function and have classname updates "promoted"
-		 * to attribute updates.
+		/*
+		 * For every attribute other than `class` we can perform a quick check if there's an
+		 * enqueued lexical update whose value we should prefer over what's in the input HTML.
+		 *
+		 * The `class` attribute is special though because we expose the helpers `add_class`
+		 * and `remove_class` which form a builder for the `class` attribute, so we have to
+		 * additionally check if there are any enqueued class changes. If there are, we need
+		 * to first flush them out so can report the full string value of the attribute.
 		 */
 		if ( 'class' === $name ) {
 			$this->class_name_updates_to_attributes_updates();
 		}
 
 		// If we have an update for this attribute, return the updated value.
-		if ( isset( $this->lexical_updates[ $comparable ] ) ) {
-			return $this->extract_attribute_value_from_lexical_update( $comparable );
+		$enqueued_value = $this->get_enqueued_attribute_value( $comparable );
+		if ( false !== $enqueued_value ) {
+			return $enqueued_value;
 		}
 
 		if ( ! isset( $this->attributes[ $comparable ] ) ) {
@@ -1475,6 +1495,17 @@ class WP_HTML_Tag_Processor {
 
 		$attribute = $this->attributes[ $comparable ];
 
+		/*
+		 * This flag distinguishes an attribute with no value
+		 * from an attribute with an empty string value. For
+		 * unquoted attributes this could look very similar.
+		 * It refers to whether an `=` follows the name.
+		 *
+		 * e.g. <div boolean-attribute empty-attribute=></div>
+		 *           ¹                 ²
+		 *        1. Attribute `boolean-attribute` is `true`.
+		 *        2. Attribute `empty-attribute` is `""`.
+		 */
 		if ( true === $attribute->is_true ) {
 			return true;
 		}
@@ -1654,7 +1685,7 @@ class WP_HTML_Tag_Processor {
 			$updated_attribute = "{$name}=\"{$escaped_new_value}\"";
 		}
 
-		/**
+		/*
 		 * > There must never be two or more attributes on
 		 * > the same start tag whose names are an ASCII
 		 * > case-insensitive match for each other.
@@ -1700,6 +1731,14 @@ class WP_HTML_Tag_Processor {
 				' ' . $updated_attribute
 			);
 		}
+
+		/*
+		 * Any calls to update the `class` attribute directly should wipe out any
+		 * enqueued class changes from `add_class` and `remove_class`.
+		 */
+		if ( 'class' === $comparable_name && ! empty( $this->classname_updates ) ) {
+			$this->classname_updates = array();
+		}
 	}
 
 	/**
@@ -1714,7 +1753,7 @@ class WP_HTML_Tag_Processor {
 			return false;
 		}
 
-		/**
+		/*
 		 * > There must never be two or more attributes on
 		 * > the same start tag whose names are an ASCII
 		 * > case-insensitive match for each other.
@@ -1724,14 +1763,19 @@ class WP_HTML_Tag_Processor {
 		 */
 		$name = strtolower( $name );
 
+		/*
+		 * Any calls to update the `class` attribute directly should wipe out any
+		 * enqueued class changes from `add_class` and `remove_class`.
+		 */
+		if ( 'class' === $name && count( $this->classname_updates ) !== 0 ) {
+			$this->classname_updates = array();
+		}
+
+		// If we updated an attribute we didn't originally have, remove the enqueued update and move on.
 		if ( ! isset( $this->attributes[ $name ] ) ) {
-			if ( 'class' === $name && count( $this->classname_updates ) !== 0 ) {
-				$this->classname_updates = array();
-			}
 			if ( isset( $this->lexical_updates[ $name ] ) ) {
 				unset( $this->lexical_updates[ $name ] );
 			}
-
 			return false;
 		}
 

--- a/phpunit/html/wp-html-tag-processor-test.php
+++ b/phpunit/html/wp-html-tag-processor-test.php
@@ -871,8 +871,16 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
 		$p->next_tag();
 		$p->add_class( 'foo-class' );
-		$this->assertSame( '<div class="foo-class" id="first"><span id="second">Text</span></div>', $p->get_updated_html() );
-		$this->assertSame( 'foo-class', $p->get_attribute( 'class' ) );
+		$this->assertSame(
+			'<div class="foo-class" id="first"><span id="second">Text</span></div>',
+			$p->get_updated_html(),
+			'Updated HTML does not include class name added via add_class()'
+		);
+		$this->assertSame(
+			'foo-class',
+			$p->get_attribute( 'class' ),
+			"get_attribute( 'class' ) did not return class name added via add_class()"
+		);
 	}
 
 	/**
@@ -887,8 +895,16 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 		$p->next_tag();
 		$p->add_class( 'foo-class' );
 		$p->add_class( 'bar-class' );
-		$this->assertSame( '<div class="foo-class bar-class" id="first"><span id="second">Text</span></div>', $p->get_updated_html() );
-		$this->assertSame( 'foo-class bar-class', $p->get_attribute( 'class' ) );
+		$this->assertSame(
+			'<div class="foo-class bar-class" id="first"><span id="second">Text</span></div>',
+			$p->get_updated_html(),
+			'Updated HTML does not include class names added via subsequent add_class() calls'
+		);
+		$this->assertSame(
+			'foo-class bar-class',
+			$p->get_attribute( 'class' ),
+			"get_attribute( 'class' ) did not return class names added via subsequent add_class() calls"
+		);
 	}
 
 	/**
@@ -902,8 +918,15 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
 		$p->next_tag();
 		$p->remove_class( 'foo-class' );
-		$this->assertSame( self::HTML_SIMPLE, $p->get_updated_html() );
-		$this->assertNull( $p->get_attribute( 'class' ) );
+		$this->assertSame(
+			self::HTML_SIMPLE,
+			$p->get_updated_html(),
+			'Updated HTML includes class name that was removed by remove_class()'
+		);
+		$this->assertNull(
+			$p->get_attribute( 'class' ),
+			"get_attribute( 'class' ) did not return null for class name that was removed by remove_class()"
+		);
 	}
 
 	/**
@@ -920,9 +943,14 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 		$p->add_class( 'bar-class' );
 		$this->assertSame(
 			'<div class="main with-border foo-class bar-class" id="first"><span class="not-main bold with-border" id="second">Text</span></div>',
-			$p->get_updated_html()
+			$p->get_updated_html(),
+			'Updated HTML does not reflect class names added to existing class attribute via subsequent add_class() calls'
 		);
-		$this->assertSame( 'main with-border foo-class bar-class', $p->get_attribute( 'class' ) );
+		$this->assertSame(
+			'main with-border foo-class bar-class',
+			$p->get_attribute( 'class' ),
+			"get_attribute( 'class' ) does not reflect class names added to existing class attribute via subsequent add_class() calls"
+		);
 	}
 
 	/**
@@ -938,9 +966,14 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 		$p->remove_class( 'main' );
 		$this->assertSame(
 			'<div class=" with-border" id="first"><span class="not-main bold with-border" id="second">Text</span></div>',
-			$p->get_updated_html()
+			$p->get_updated_html(),
+			'Updated HTML does not reflect class name removed from existing class attribute via remove_class()'
 		);
-		$this->assertSame( ' with-border', $p->get_attribute( 'class' ) );
+		$this->assertSame(
+			' with-border',
+			$p->get_attribute( 'class' ),
+			"get_attribute( 'class' ) does not reflect class name removed from existing class attribute via remove_class()"
+		);
 	}
 
 	/**
@@ -957,9 +990,13 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 		$p->remove_class( 'with-border' );
 		$this->assertSame(
 			'<div  id="first"><span class="not-main bold with-border" id="second">Text</span></div>',
-			$p->get_updated_html()
+			$p->get_updated_html(),
+			'Updated HTML does not reflect class attribute removed via subesequent remove_class() calls'
 		);
-		$this->assertNull( $p->get_attribute( 'class' ) );
+		$this->assertNull(
+			$p->get_attribute( 'class' ),
+			"get_attribute( 'class' ) did not return null for class attribute removed via subesequent remove_class() calls"
+		);
 	}
 
 	/**
@@ -975,9 +1012,14 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 		$p->add_class( 'with-border' );
 		$this->assertSame(
 			'<div class="main with-border" id="first"><span class="not-main bold with-border" id="second">Text</span></div>',
-			$p->get_updated_html()
+			$p->get_updated_html(),
+			'Updated HTML does not reflect deduplicated class name added via add_class()'
 		);
-		$this->assertSame( 'main with-border', $p->get_attribute( 'class' ) );
+		$this->assertSame(
+			'main with-border',
+			$p->get_attribute( 'class' ),
+			"get_attribute( 'class' ) does not reflect deduplicated class name added via add_class()"
+		);
 	}
 
 	/**
@@ -993,9 +1035,14 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 		$p->add_class( 'main' );
 		$this->assertSame(
 			'<div class="main with-border" id="first"><span class="not-main bold with-border" id="second">Text</span></div>',
-			$p->get_updated_html()
+			$p->get_updated_html(),
+			'Updated HTML does not reflect class name order after adding duplicated class name via add_class()'
 		);
-		$this->assertSame( 'main with-border', $p->get_attribute( 'class' ) );
+		$this->assertSame(
+			'main with-border',
+			$p->get_attribute( 'class' ),
+			"get_attribute( 'class' ) does not reflect class name order after adding duplicated class name added via add_class()"
+		);
 	}
 
 	/**
@@ -1013,9 +1060,14 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 		$p->add_class( 'foo-class' );
 		$this->assertSame(
 			'<div class="   main   with-border foo-class" id="first"><span class="not-main bold with-border" id="second">Text</span></div>',
-			$p->get_updated_html()
+			$p->get_updated_html(),
+			'Updated HTML does not reflect existing excessive whitespace after adding class name via add_class()'
 		);
-		$this->assertSame( '   main   with-border foo-class', $p->get_attribute( 'class' ) );
+		$this->assertSame(
+			'   main   with-border foo-class',
+			$p->get_attribute( 'class' ),
+			"get_attribute( 'class' ) does not reflect existing excessive whitespace after adding class name via add_class()"
+		);
 	}
 
 	/**
@@ -1033,9 +1085,14 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 		$p->remove_class( 'with-border' );
 		$this->assertSame(
 			'<div class="   main" id="first"><span class="not-main bold with-border" id="second">Text</span></div>',
-			$p->get_updated_html()
+			$p->get_updated_html(),
+			'Updated HTML does not reflect existing excessive whitespace after removing class name via remove_class()'
 		);
-		$this->assertSame( '   main', $p->get_attribute( 'class' ) );
+		$this->assertSame(
+			'   main',
+			$p->get_attribute( 'class' ),
+			"get_attribute( 'class' ) does not reflect existing excessive whitespace after removing class name via removing_class()"
+		);
 	}
 
 	/**
@@ -1054,9 +1111,13 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 		$p->remove_class( 'with-border' );
 		$this->assertSame(
 			'<div  id="first"><span class="not-main bold with-border" id="second">Text</span></div>',
-			$p->get_updated_html()
+			$p->get_updated_html(),
+			'Updated HTML does not reflect removed class attribute after removing all class names via remove_class()'
 		);
-		$this->assertNull( $p->get_attribute( 'class' ) );
+		$this->assertNull(
+			$p->get_attribute( 'class' ),
+			"get_attribute( 'class' ) did not return null after removing all class names via remove_class()"
+		);
 	}
 
 	/**


### PR DESCRIPTION
## What?
This adds a unit test to make sure `get_attribute()` picks up an attribute added by `set_attribute()`.

## Why?
This seems like a contract we might want to enforce via a unit test.

It didn't work until recently, when https://github.com/WordPress/gutenberg/pull/46598 was merged.

## How?
See code.

We might want to consider adding an assertion like that to other `set_attribute()` tests as well; or adding a separate test case just for the `set_attribut`/`get_attribute` pair.

## Testing Instructions
See unit test.