### PR TITLE
Fix nav list alignment

### DIFF
--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -178,7 +178,7 @@
 	.block-editor-block-icon {
 		align-self: flex-start;
 		margin-right: $grid-unit-10;
-		width: $icon-size;
+		flex: 0 0 $icon-size;
 	}
 
 	.block-editor-list-view-block__menu-cell,

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -176,7 +176,6 @@
 	}
 
 	.block-editor-block-icon {
-		align-self: flex-start;
 		margin-right: $grid-unit-10;
 		flex: 0 0 $icon-size;
 	}
@@ -319,16 +318,6 @@
 
 	.block-editor-list-view-block-select-button__lock {
 		line-height: 0;
-		width: 16px;
-		min-width: 24px;
-		height: 16px;
-		margin-left: auto;
-		padding: 0;
-		vertical-align: middle;
-		display: inline-flex;
-		justify-content: center;
-		align-items: center;
-		overflow: hidden;
 	}
 }
 

--- a/packages/block-editor/src/components/off-canvas-editor/style.scss
+++ b/packages/block-editor/src/components/off-canvas-editor/style.scss
@@ -1,7 +1,7 @@
 .offcanvas-editor__appender .block-editor-inserter__toggle {
 	background-color: #1e1e1e;
 	color: #fff;
-	margin: $grid-unit-10 0 0 28px;
+	margin: $grid-unit-10 0 0 24px;
 	border-radius: 2px;
 	height: 24px;
 	min-width: 24px;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Aligns the block appender and cleans up some of the unused list view CSS.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Closes #46359 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Adjusts the left margin to 24px to match the width of the expander caret.
- Fixes the width CSS for the `synced-block` icon to use `flex` since it's inside a flex container.
- Removes some unused CSS for the lock icon.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Create a navigation menu with content
2. In the off-canvas editor in the block sidebar see that the [+] appender is aligned with the leftmost block icon.
3. See that the removed CSS doesn't affect the list view on the left either.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

![nav-alignment-compare](https://user-images.githubusercontent.com/5129775/208722698-98a2f8f4-dab5-4534-a934-2cc311c457db.gif)

### Before

![nav-alignment-before](https://user-images.githubusercontent.com/5129775/208722673-23e4af9f-81dd-4096-9e94-ddc68d1ab756.png)

### After

![nav-alignment-after](https://user-images.githubusercontent.com/5129775/208719357-b9a6173c-88d1-4d79-8fd0-37bb01b72ff2.png)
