### PR TITLE
WP_HTML_Tag_Processor: Implement `get_attribute_names()` method

### DIFF
--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1427,7 +1427,6 @@ class WP_HTML_Tag_Processor {
 	 *
 	 * @since 6.2.0
 	 *
-	 * @param string $prefix Prefix of attributes whose value is requested.
 	 * @return array|null List of attribute names, or `null` if not at a tag.
 	 */
 	function get_attribute_names() {

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1413,6 +1413,32 @@ class WP_HTML_Tag_Processor {
 	}
 
 	/**
+	 * Returns the names of all attributes in the currently-opened tag.
+	 *
+	 * Example:
+	 * <code>
+	 *     $p = new WP_HTML_Tag_Processor( '<div enabled class="test" data-test-id="14">Test</div>' );
+	 *     $p->next_tag( [ 'class_name' => 'test' ] ) === true;
+	 *     $p->get_attribute_names() === array( 'enabled', 'class', 'data-test-id' );
+	 *
+	 *     $p->next_tag( [] ) === false;
+	 *     $p->get_attribute_names() === null;
+	 * </code>
+	 *
+	 * @since 6.2.0
+	 *
+	 * @param string $prefix Prefix of attributes whose value is requested.
+	 * @return array|null List of attribute names, or `null` if not at a tag.
+	 */
+	function get_attribute_names() {
+		if ( null === $this->tag_name_starts_at ) {
+			return null;
+		}
+
+		return array_keys( $this->attributes );
+	}
+
+	/**
 	 * Returns the lowercase name of the currently-opened tag.
 	 *
 	 * Example:

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1430,7 +1430,7 @@ class WP_HTML_Tag_Processor {
 	 * @return array|null List of attribute names, or `null` if not at a tag.
 	 */
 	function get_attribute_names() {
-		if ( null === $this->tag_name_starts_at ) {
+		if ( $this->is_closing_tag || null === $this->tag_name_starts_at ) {
 			return null;
 		}
 

--- a/phpunit/html/wp-html-tag-processor-test.php
+++ b/phpunit/html/wp-html-tag-processor-test.php
@@ -152,18 +152,6 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers WP_HTML_Tag_Processor::get_attribute_names
-	 */
-	public function test_get_attribute_names() {
-		$p = new WP_HTML_Tag_Processor( '<div enabled class="test" data-test-id="14">Test</div>' );
-		$p->next_tag();
-		$this->assertSame(
-			array( 'enabled', 'class', 'data-test-id' ),
-			$p->get_attribute_names()
-		);
-	}
-
-	/**
 	 * @ticket 56299
 	 *
 	 * @covers next_tag
@@ -205,6 +193,18 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 		$p->next_tag();
 		$p->set_attribute( 'data-enabled', 'abc' );
 		$this->assertEquals( '<div data-enabled="abc">Test</div>', $p->get_updated_html(), 'A case-insensitive set_attribute call did not update the existing attribute.' );
+	}
+
+	/**
+	 * @covers WP_HTML_Tag_Processor::get_attribute_names
+	 */
+	public function test_get_attribute_names() {
+		$p = new WP_HTML_Tag_Processor( '<div enabled class="test" data-test-id="14">Test</div>' );
+		$p->next_tag();
+		$this->assertSame(
+			array( 'enabled', 'class', 'data-test-id' ),
+			$p->get_attribute_names()
+		);
 	}
 
 	/**

--- a/phpunit/html/wp-html-tag-processor-test.php
+++ b/phpunit/html/wp-html-tag-processor-test.php
@@ -152,6 +152,18 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers WP_HTML_Tag_Processor::get_attribute_names
+	 */
+	public function test_get_attribute_names() {
+		$p = new WP_HTML_Tag_Processor( '<div enabled class="test" data-test-id="14">Test</div>' );
+		$p->next_tag();
+		$this->assertSame(
+			array( 'enabled', 'class', 'data-test-id' ),
+			$p->get_attribute_names()
+		);
+	}
+
+	/**
 	 * @ticket 56299
 	 *
 	 * @covers next_tag

--- a/phpunit/html/wp-html-tag-processor-test.php
+++ b/phpunit/html/wp-html-tag-processor-test.php
@@ -221,7 +221,7 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers get_attribute
+	 * @covers get_attribute_names
 	 */
 	public function test_get_attribute_names_returns_null_when_not_in_open_tag() {
 		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );

--- a/phpunit/html/wp-html-tag-processor-test.php
+++ b/phpunit/html/wp-html-tag-processor-test.php
@@ -80,6 +80,19 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 	 * @covers next_tag
 	 * @covers get_attribute
 	 */
+	public function test_get_attribute_returns_null_when_in_closing_tag() {
+		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
+		$this->assertTrue( $p->next_tag( 'div' ), 'Querying an existing tag did not return true' );
+		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), 'Querying an existing closing tag did not return true' );
+		$this->assertNull( $p->get_attribute( 'class' ), 'Accessing an attribute of a closing tag did not return null' );
+	}
+
+	/**
+	 * @ticket 56299
+	 *
+	 * @covers next_tag
+	 * @covers get_attribute
+	 */
 	public function test_get_attribute_returns_null_when_attribute_missing() {
 		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
 		$this->assertTrue( $p->next_tag( 'div' ), 'Querying an existing tag did not return true' );

--- a/phpunit/html/wp-html-tag-processor-test.php
+++ b/phpunit/html/wp-html-tag-processor-test.php
@@ -269,6 +269,29 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 	/**
 	 * @ticket 56299
 	 *
+	 * @covers set_attribute
+	 * @covers get_updated_html
+	 * @covers get_attribute_names
+	 */
+	public function test_get_attribute_names_returns_attribute_added_by_set_attribute() {
+		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
+		$p->next_tag();
+		$p->set_attribute( 'test-attribute', 'test-value' );
+		$this->assertSame(
+			'<div test-attribute="test-value" class="test">Test</div>',
+			$p->get_updated_html(),
+			"Updated HTML doesn't include attribute added via set_attribute"
+		);
+		$this->assertSame(
+			array( 'test-attribute', 'class' ),
+			$p->get_attribute_names(),
+			"Accessing attribute names doesn't find attribute added via set_attribute"
+		);
+	}
+
+	/**
+	 * @ticket 56299
+	 *
 	 * @covers __toString
 	 */
 	public function tostring_returns_updated_html() {

--- a/phpunit/html/wp-html-tag-processor-test.php
+++ b/phpunit/html/wp-html-tag-processor-test.php
@@ -209,9 +209,55 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers WP_HTML_Tag_Processor::get_attribute_names
+	 * @ticket 56299
+	 *
+	 * @covers get_attribute_names
 	 */
-	public function test_get_attribute_names() {
+	public function test_get_attribute_names_returns_null_before_finding_tags() {
+		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
+		$this->assertNull( $p->get_attribute_names() );
+	}
+
+	/**
+	 * @ticket 56299
+	 *
+	 * @covers get_attribute
+	 */
+	public function test_get_attribute_names_returns_null_when_not_in_open_tag() {
+		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
+		$p->next_tag( 'p' );
+		$this->assertNull( $p->get_attribute_names(), 'Accessing attributes of a non-existing tag did not return null' );
+	}
+
+	/**
+	 * @ticket 56299
+	 *
+	 * @covers get_attribute_names
+	 */
+	public function test_get_attribute_names_returns_null_when_in_closing_tag() {
+		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
+		$p->next_tag( 'div' );
+		$p->next_tag( array( 'tag_closers' => 'visit' ) );
+		$this->assertNull( $p->get_attribute_names(), 'Accessing attributes of a closing tag did not return null' );
+	}
+
+	/**
+	 * @ticket 56299
+	 *
+	 * @covers get_attribute_names
+	 */
+	public function test_get_attribute_names_returns_empty_array_when_no_attributes_present() {
+		$p = new WP_HTML_Tag_Processor( '<div>Test</div>' );
+		$p->next_tag( 'div' );
+		$this->assertSame( array(), $p->get_attribute_names(), 'Accessing the attributes on a tag without any did not return an empty array' );
+	}
+
+	/**
+	 * @ticket 56299
+	 *
+	 * @covers get_attribute_names
+	 */
+	public function test_get_attribute_names_returns_attribute_names() {
 		$p = new WP_HTML_Tag_Processor( '<div enabled class="test" data-test-id="14">Test</div>' );
 		$p->next_tag();
 		$this->assertSame(


### PR DESCRIPTION
## What?
Add a `get_attribute_names()` method to `WP_HTML_Tag_Processor`, which returns the names of all attributes in a given tag.

```php
$p = new WP_HTML_Tag_Processor( '<div enabled class="test" data-test-id="14">Test</div>' );
$p->next_tag();
$p->get_attribute_names() === array( 'enabled', 'class', 'data-test-id' );
```

Alternative to adding a `get_attribute_by_prefix` method (https://github.com/WordPress/gutenberg/pull/46672).

## Why?
Getting all attributes comes in handy for larger classes of attributes without knowing _exactly_ which ones to expect. Examples include prefixed attributes for datasets (`data-`) and custom namespaces (e.g. `ng-` or `x-`).

Furthermore, it helps with syntax like `<img wp-bind:src="myblock.imageSource" />`, which is a requirement for the Block Interactivity API ([see](https://github.com/WordPress/block-hydration-experiments/pull/118#issuecomment-1353407526)).

More background: https://github.com/WordPress/block-hydration-experiments/pull/118#discussion_r1051132800.

## How?
Basically returns `array_keys( $this->attributes )` 🤷‍♂️ 

## Testing Instructions
See included unit test.