### PR TITLE
Doc: Fix missing link to Block Styles page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ The Editor offers rich new value to users with visual, drag-and-drop creation to
 Whether you want to extend the functionality of the block editor, or create a plugin based on it, [see the developer documentation](/docs/how-to-guides/README.md) to find all the information about the basic concepts you need to get started, the block editor APIs and its architecture.
 
 -   [Gutenberg Architecture](/docs/explanations/architecture/README.md)
--   [Block Styles](/docs/reference-guides/filters/block-filters.md#block-styles)
+-   [Block Styles](/docs/reference-guides/block-api/block-styles.md)
 -   [Creating Block Patterns](/docs/reference-guides/block-api/block-patterns.md)
 -   [Theming for the Block Editor](/docs/how-to-guides/themes/README.md)
 -   [Block API Reference](/docs/reference-guides/block-api/README.md)

--- a/docs/how-to-guides/javascript/extending-the-block-editor.md
+++ b/docs/how-to-guides/javascript/extending-the-block-editor.md
@@ -1,6 +1,6 @@
 # Extending the Block Editor
 
-Let's look at using the [Block Style example](/docs/reference-guides/filters/block-filters.md#block-styles) to extend the editor. This example allows you to add your own custom CSS class name to any core block type.
+Let's look at using the [Block Style example](/docs/reference-guides/block-api/block-styles.md) to extend the editor. This example allows you to add your own custom CSS class name to any core block type.
 
 Replace the existing `console.log()` code in your `myguten.js` file with:
 

--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -408,7 +408,7 @@ It contains as set of options to control features used in the editor. See the [t
 
 Block styles can be used to provide alternative styles to block. It works by adding a class name to the block's wrapper. Using CSS, a theme developer can target the class name for the block style if it is selected.
 
-Plugins and Themes can also register [custom block style](/docs/reference-guides/filters/block-filters.md#block-styles) for existing blocks.
+Plugins and Themes can also register [custom block style](/docs/reference-guides/block-api/block-styles.md) for existing blocks.
 
 ### Example
 

--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -145,7 +145,7 @@ styles: [
 ],
 ```
 
-Plugins and Themes can also register [custom block style](/docs/reference-guides/filters/block-filters.md#block-styles) for existing blocks.
+Plugins and Themes can also register [custom block style](/docs/reference-guides/block-api/block-styles.md) for existing blocks.
 
 #### attributes (optional)
 


### PR DESCRIPTION
## What?
This PR fixes the missing link to Block Styles page in the Block Editor Handbook.

## Why?

Block style page were moved to the Block API directory in https://github.com/WordPress/gutenberg/pull/31055.

## Testing Instructions

Access the following four pages, which have been changed in this PR:

- https://github.com/WordPress/gutenberg/blob/doc/fix-block-styles-link/docs/README.md
- https://github.com/WordPress/gutenberg/blob/doc/fix-block-styles-link/docs/how-to-guides/javascript/extending-the-block-editor.md
- https://github.com/WordPress/gutenberg/blob/doc/fix-block-styles-link/docs/reference-guides/block-api/block-metadata.md
- https://github.com/WordPress/gutenberg/blob/doc/fix-block-styles-link/docs/reference-guides/block-api/block-registration.md

Search the page for the word "block styles" and click on the link found. Then, confirm that you are correctly navigated to the Block Styles page.