### PR TITLE
Mobile - Block Actions Menu - Fix block title regression and adds integration tests

### DIFF
--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -329,13 +329,12 @@ export default compose(
 		const blockName = getBlockName( clientId );
 		const blockType = getBlockType( blockName );
 		const blockTitle = blockType?.title;
-		const firstClientId = clientId;
-		const rootClientId = getBlockRootClientId( firstClientId );
+		const rootClientId = getBlockRootClientId( clientId );
 		const blockOrder = getBlockOrder( rootClientId );
 
-		const firstIndex = getBlockIndex( firstClientId );
-		const isFirst = firstIndex === 0;
-		const isLast = clientId === blockOrder.length - 1;
+		const currentBlockIndex = getBlockIndex( clientId );
+		const isFirst = currentBlockIndex === 0;
+		const isLast = currentBlockIndex === blockOrder.length - 1;
 
 		const innerBlocks = getBlocksByClientId( clientId );
 
@@ -374,7 +373,7 @@ export default compose(
 		return {
 			blockTitle,
 			canInsertBlockType,
-			currentIndex: firstIndex,
+			currentIndex: currentBlockIndex,
 			getBlocksByClientId,
 			isEmptyDefaultBlock,
 			isLocked,
@@ -425,9 +424,9 @@ export default compose(
 					return duplicateBlocks( [ clientId ] );
 				},
 				onMoveDown: ( ...args ) =>
-					moveBlocksDown( clientId, rootClientId, ...args ),
+					moveBlocksDown( [ clientId ], rootClientId, ...args ),
 				onMoveUp: ( ...args ) =>
-					moveBlocksUp( clientId, rootClientId, ...args ),
+					moveBlocksUp( [ clientId ], rootClientId, ...args ),
 				openGeneralSidebar: () =>
 					openGeneralSidebar( 'edit-post/block' ),
 				pasteBlock: ( clipboardBlock ) => {

--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -312,7 +312,7 @@ const BlockActionsMenu = ( {
 const EMPTY_BLOCK_LIST = [];
 
 export default compose(
-	withSelect( ( select, { clientIds } ) => {
+	withSelect( ( select, { clientId } ) => {
 		const {
 			getBlockIndex,
 			getBlockRootClientId,
@@ -325,23 +325,19 @@ export default compose(
 			canInsertBlockType,
 			getTemplateLock,
 		} = select( blockEditorStore );
-		const normalizedClientIds = Array.isArray( clientIds )
-			? clientIds
-			: [ clientIds ];
-		const block = getBlock( normalizedClientIds );
-		const blockName = getBlockName( normalizedClientIds );
+		const block = getBlock( clientId );
+		const blockName = getBlockName( clientId );
 		const blockType = getBlockType( blockName );
 		const blockTitle = blockType?.title;
-		const firstClientId = normalizedClientIds[ 0 ];
+		const firstClientId = clientId;
 		const rootClientId = getBlockRootClientId( firstClientId );
 		const blockOrder = getBlockOrder( rootClientId );
 
 		const firstIndex = getBlockIndex( firstClientId );
-		const lastIndex = getBlockIndex(
-			normalizedClientIds[ normalizedClientIds.length - 1 ]
-		);
+		const isFirst = firstIndex === 0;
+		const isLast = clientId === blockOrder.length - 1;
 
-		const innerBlocks = getBlocksByClientId( clientIds );
+		const innerBlocks = getBlocksByClientId( clientId );
 
 		const canDuplicate = innerBlocks.every( ( innerBlock ) => {
 			return (
@@ -383,8 +379,8 @@ export default compose(
 			isEmptyDefaultBlock,
 			isLocked,
 			canDuplicate,
-			isFirst: firstIndex === 0,
-			isLast: lastIndex === blockOrder.length - 1,
+			isFirst,
+			isLast,
 			isReusableBlockType,
 			reusableBlock,
 			rootClientId,
@@ -395,7 +391,7 @@ export default compose(
 	withDispatch(
 		(
 			dispatch,
-			{ clientIds, rootClientId, currentIndex, selectedBlockClientId },
+			{ clientId, rootClientId, currentIndex, selectedBlockClientId },
 			{ select }
 		) => {
 			const {
@@ -426,12 +422,12 @@ export default compose(
 					);
 				},
 				duplicateBlock() {
-					return duplicateBlocks( clientIds );
+					return duplicateBlocks( [ clientId ] );
 				},
 				onMoveDown: ( ...args ) =>
-					moveBlocksDown( clientIds, rootClientId, ...args ),
+					moveBlocksDown( clientId, rootClientId, ...args ),
 				onMoveUp: ( ...args ) =>
-					moveBlocksUp( clientIds, rootClientId, ...args ),
+					moveBlocksUp( clientId, rootClientId, ...args ),
 				openGeneralSidebar: () =>
 					openGeneralSidebar( 'edit-post/block' ),
 				pasteBlock: ( clipboardBlock ) => {
@@ -452,7 +448,7 @@ export default compose(
 							rootClientId
 						);
 					} else {
-						replaceBlocks( clientIds, clipboardBlock );
+						replaceBlocks( clientId, clipboardBlock );
 					}
 				},
 				removeBlocks,

--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -286,6 +286,7 @@ const BlockActionsMenu = ( {
 				} }
 			/>
 			<Picker
+				testID="block-actions-menu"
 				ref={ blockActionsMenuPickerRef }
 				options={ options }
 				onChange={ onPickerSelect }

--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -399,7 +399,7 @@ export default compose(
 				duplicateBlocks,
 				removeBlocks,
 				insertBlock,
-				replaceBlocks,
+				replaceBlock,
 				clearSelectedBlock,
 			} = dispatch( blockEditorStore );
 			const { openGeneralSidebar } = dispatch( 'core/edit-post' );
@@ -447,7 +447,7 @@ export default compose(
 							rootClientId
 						);
 					} else {
-						replaceBlocks( clientId, clipboardBlock );
+						replaceBlock( clientId, clipboardBlock );
 					}
 				},
 				removeBlocks,

--- a/packages/block-editor/src/components/block-mobile-toolbar/index.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/index.native.js
@@ -98,7 +98,7 @@ const BlockMobileToolbar = ( {
 			</BlockSettingsButton.Slot>
 
 			<BlockActionsMenu
-				clientIds={ [ clientId ] }
+				clientId={ clientId }
 				wrapBlockMover={ wrapBlockMover }
 				wrapBlockSettings={ wrapBlockSettings && fillsLength }
 				isStackedHorizontally={ isStackedHorizontally }

--- a/packages/block-editor/src/components/block-mobile-toolbar/test/__snapshots__/block-actions-menu.native.js.snap
+++ b/packages/block-editor/src/components/block-mobile-toolbar/test/__snapshots__/block-actions-menu.native.js.snap
@@ -1,0 +1,121 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Block Actions Menu block options copies and pastes a block 1`] = `
+"<!-- wp:heading -->
+<h2 class=\\"wp-block-heading\\"></h2>
+<!-- /wp:heading -->
+
+<!-- wp:spacer -->
+<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading -->
+<h2 class=\\"wp-block-heading\\"></h2>
+<!-- /wp:heading -->"
+`;
+
+exports[`Block Actions Menu block options cuts and pastes a block 1`] = `
+"<!-- wp:spacer -->
+<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading -->
+<h2 class=\\"wp-block-heading\\"></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Block Actions Menu block options does not replace a non empty Paragraph block when pasting another block 1`] = `
+"<!-- wp:paragraph -->
+<p>Hello!</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class=\\"wp-block-heading\\"></h2>
+<!-- /wp:heading -->
+
+<!-- wp:spacer -->
+<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading -->
+<h2 class=\\"wp-block-heading\\"></h2>
+<!-- /wp:heading -->"
+`;
+
+exports[`Block Actions Menu block options duplicates a block 1`] = `
+"<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:spacer -->
+<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:spacer -->
+<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading -->
+<h2 class=\\"wp-block-heading\\"></h2>
+<!-- /wp:heading -->"
+`;
+
+exports[`Block Actions Menu block options transforms a Paragraph block into a Pullquote block 1`] = `
+"<!-- wp:pullquote -->
+<figure class=\\"wp-block-pullquote\\"><blockquote><p>Hello!</p></blockquote></figure>
+<!-- /wp:pullquote -->
+
+<!-- wp:spacer -->
+<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading -->
+<h2 class=\\"wp-block-heading\\"></h2>
+<!-- /wp:heading -->"
+`;
+
+exports[`Block Actions Menu moving blocks disables the Move Down button for the last block 1`] = `
+"<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:spacer -->
+<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading -->
+<h2 class=\\"wp-block-heading\\"></h2>
+<!-- /wp:heading -->"
+`;
+
+exports[`Block Actions Menu moving blocks disables the Move Up button for the first block 1`] = `
+"<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:spacer -->
+<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading -->
+<h2 class=\\"wp-block-heading\\"></h2>
+<!-- /wp:heading -->"
+`;
+
+exports[`Block Actions Menu moving blocks moves blocks up and down 1`] = `
+"<!-- wp:heading -->
+<h2 class=\\"wp-block-heading\\"></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:spacer -->
+<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->"
+`;

--- a/packages/block-editor/src/components/block-mobile-toolbar/test/__snapshots__/block-actions-menu.native.js.snap
+++ b/packages/block-editor/src/components/block-mobile-toolbar/test/__snapshots__/block-actions-menu.native.js.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Block Actions Menu block options copies and pastes a block 1`] = `
-"<!-- wp:heading -->
+"<!-- wp:paragraph -->
+<p>Hello!</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
 <h2 class=\\"wp-block-heading\\"></h2>
 <!-- /wp:heading -->
 
@@ -24,7 +28,7 @@ exports[`Block Actions Menu block options cuts and pastes a block 1`] = `
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p></p>
+<p>Hello!</p>
 <!-- /wp:paragraph -->"
 `;
 
@@ -48,7 +52,7 @@ exports[`Block Actions Menu block options does not replace a non empty Paragraph
 
 exports[`Block Actions Menu block options duplicates a block 1`] = `
 "<!-- wp:paragraph -->
-<p></p>
+<p>Hello!</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:spacer -->
@@ -80,7 +84,7 @@ exports[`Block Actions Menu block options transforms a Paragraph block into a Pu
 
 exports[`Block Actions Menu moving blocks disables the Move Down button for the last block 1`] = `
 "<!-- wp:paragraph -->
-<p></p>
+<p>Hello!</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:spacer -->
@@ -94,7 +98,7 @@ exports[`Block Actions Menu moving blocks disables the Move Down button for the 
 
 exports[`Block Actions Menu moving blocks disables the Move Up button for the first block 1`] = `
 "<!-- wp:paragraph -->
-<p></p>
+<p>Hello!</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:spacer -->
@@ -112,7 +116,7 @@ exports[`Block Actions Menu moving blocks moves blocks up and down 1`] = `
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p></p>
+<p>Hello!</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:spacer -->

--- a/packages/block-editor/src/components/block-mobile-toolbar/test/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/test/block-actions-menu.native.js
@@ -1,0 +1,304 @@
+/**
+ * External dependencies
+ */
+import {
+	fireEvent,
+	initializeEditor,
+	getBlock,
+	within,
+	getEditorHtml,
+	changeTextOfRichText,
+} from 'test/helpers';
+
+/**
+ * WordPress dependencies
+ */
+import { getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
+import { registerCoreBlocks } from '@wordpress/block-library';
+
+const INITIAL_HTML = `<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+<!-- wp:spacer -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+<!-- wp:heading -->
+<h2 class="wp-block-heading"></h2>
+<!-- /wp:heading -->`;
+
+beforeAll( () => {
+	// Register all core blocks
+	registerCoreBlocks();
+} );
+
+afterAll( () => {
+	// Clean up registered blocks
+	getBlockTypes().forEach( ( block ) => {
+		unregisterBlockType( block.name );
+	} );
+} );
+
+describe( 'Block Actions Menu', () => {
+	it( "renders the block name in the Picker's header", async () => {
+		const screen = await initializeEditor( {
+			initialHtml: `<!-- wp:paragraph -->
+            <p></p>
+            <!-- /wp:paragraph -->`,
+		} );
+		const { getByLabelText, getByRole } = screen;
+
+		// Get block
+		const paragraphBlock = await getBlock( screen, 'Paragraph' );
+		fireEvent.press( paragraphBlock );
+
+		// Open block actions menu
+		const blockActionsButton = getByLabelText( /Open Block Actions Menu/ );
+		fireEvent.press( blockActionsButton );
+
+		// Get Picker title
+		const pickerHeader = getByRole( 'header' );
+		const headerTitle = within( pickerHeader ).getByText(
+			/Paragraph block options/
+		);
+		expect( headerTitle ).toBeVisible();
+	} );
+
+	describe( 'moving blocks', () => {
+		it( 'moves blocks up and down', async () => {
+			const screen = await initializeEditor( {
+				initialHtml: INITIAL_HTML,
+			} );
+			const { getByLabelText } = screen;
+
+			// Get Spacer block
+			const spacerBlock = await getBlock( screen, 'Spacer', {
+				rowIndex: 2,
+			} );
+			fireEvent.press( spacerBlock );
+
+			// Tap on the Move Down button
+			const downButton = getByLabelText(
+				/Move block down from row 2 to row 3/
+			);
+			fireEvent.press( downButton );
+
+			// Get Heading block
+			const headingBlock = await getBlock( screen, 'Heading', {
+				rowIndex: 2,
+			} );
+			fireEvent.press( headingBlock );
+
+			// Tap on the Move Up button
+			const upButton = getByLabelText(
+				/Move block up from row 2 to row 1/
+			);
+			fireEvent.press( upButton );
+
+			expect( getEditorHtml() ).toMatchSnapshot();
+		} );
+
+		it( 'disables the Move Up button for the first block', async () => {
+			const screen = await initializeEditor( {
+				initialHtml: INITIAL_HTML,
+			} );
+			const { getByLabelText } = screen;
+
+			// Get Paragraph block
+			const paragraphBlock = await getBlock( screen, 'Paragraph' );
+			fireEvent.press( paragraphBlock );
+
+			// Get the Move Up button
+			const upButton = getByLabelText( /Move block up/ );
+			const isUpButtonDisabled =
+				upButton.props.accessibilityState?.disabled;
+			expect( isUpButtonDisabled ).toBe( true );
+
+			// Press the button to make sure the move doesn't block
+			fireEvent.press( upButton );
+
+			expect( getEditorHtml() ).toMatchSnapshot();
+		} );
+
+		it( 'disables the Move Down button for the last block', async () => {
+			const screen = await initializeEditor( {
+				initialHtml: INITIAL_HTML,
+			} );
+			const { getByLabelText } = screen;
+
+			// Get Heading block
+			const headingBlock = await getBlock( screen, 'Heading', {
+				rowIndex: 3,
+			} );
+			fireEvent.press( headingBlock );
+
+			// Get the Move Down button
+			const downButton = getByLabelText( /Move block down/ );
+			const isDownButtonDisabled =
+				downButton.props.accessibilityState?.disabled;
+			expect( isDownButtonDisabled ).toBe( true );
+
+			// Press the button to make sure the move doesn't block
+			fireEvent.press( downButton );
+
+			expect( getEditorHtml() ).toMatchSnapshot();
+		} );
+	} );
+
+	describe( 'block options', () => {
+		it( 'copies and pastes a block', async () => {
+			const screen = await initializeEditor( {
+				initialHtml: INITIAL_HTML,
+			} );
+			const { getByLabelText } = screen;
+
+			// Get Heading block
+			const headingBlock = await getBlock( screen, 'Heading', {
+				rowIndex: 3,
+			} );
+			fireEvent.press( headingBlock );
+
+			// Open block actions menu
+			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
+
+			// Tap on the Copy button
+			fireEvent.press( getByLabelText( /Copy block/ ) );
+
+			// Get Paragraph block
+			const paragraphBlock = await getBlock( screen, 'Paragraph' );
+			fireEvent.press( paragraphBlock );
+
+			// Open block actions menu
+			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
+
+			// Tap on the Paste block after button
+			fireEvent.press( getByLabelText( /Paste block after/ ) );
+
+			expect( getEditorHtml() ).toMatchSnapshot();
+		} );
+
+		it( 'does not replace a non empty Paragraph block when pasting another block', async () => {
+			const screen = await initializeEditor( {
+				initialHtml: INITIAL_HTML,
+			} );
+			const { getByLabelText } = screen;
+
+			// Get Heading block
+			const headingBlock = await getBlock( screen, 'Heading', {
+				rowIndex: 3,
+			} );
+			fireEvent.press( headingBlock );
+
+			// Open block actions menu
+			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
+
+			// Tap on the Copy button
+			fireEvent.press( getByLabelText( /Copy block/ ) );
+
+			// Get Paragraph block
+			const paragraphBlock = await getBlock( screen, 'Paragraph' );
+			fireEvent.press( paragraphBlock );
+
+			// Set some text to the Paragraph block
+			const paragraphField =
+				within( paragraphBlock ).getByPlaceholderText(
+					'Start writing…'
+				);
+			changeTextOfRichText( paragraphField, 'Hello!' );
+
+			// Open block actions menu
+			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
+
+			// Tap on the Past block after button
+			fireEvent.press( getByLabelText( /Paste block after/ ) );
+
+			expect( getEditorHtml() ).toMatchSnapshot();
+		} );
+
+		it( 'cuts and pastes a block', async () => {
+			const screen = await initializeEditor( {
+				initialHtml: INITIAL_HTML,
+			} );
+			const { getByLabelText } = screen;
+
+			// Get Paragraph block
+			const paragraphBlock = await getBlock( screen, 'Paragraph' );
+			fireEvent.press( paragraphBlock );
+
+			// Open block actions menu
+			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
+
+			// Tap on the Cut button
+			fireEvent.press( getByLabelText( /Cut block/ ) );
+
+			const headingBlock = await getBlock( screen, 'Heading', {
+				rowIndex: 2,
+			} );
+			fireEvent.press( headingBlock );
+
+			// Open block actions menu
+			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
+
+			// Tap on the Cut button
+			fireEvent.press( getByLabelText( /Paste block after/ ) );
+
+			expect( getEditorHtml() ).toMatchSnapshot();
+		} );
+
+		it( 'duplicates a block', async () => {
+			const screen = await initializeEditor( {
+				initialHtml: INITIAL_HTML,
+			} );
+			const { getByLabelText } = screen;
+
+			// Get Spacer block
+			const spacerBlock = await getBlock( screen, 'Spacer', {
+				rowIndex: 2,
+			} );
+			fireEvent.press( spacerBlock );
+
+			// Open block actions menu
+			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
+
+			// Tap on the Duplicate button
+			fireEvent.press( getByLabelText( /Duplicate block/ ) );
+
+			expect( getEditorHtml() ).toMatchSnapshot();
+		} );
+
+		it( 'transforms a Paragraph block into a Pullquote block', async () => {
+			const screen = await initializeEditor( {
+				initialHtml: INITIAL_HTML,
+			} );
+			const { getByLabelText, getByRole } = screen;
+
+			// Get Paragraph block
+			const paragraphBlock = await getBlock( screen, 'Paragraph' );
+			fireEvent.press( paragraphBlock );
+
+			// Set some text to the Paragraph block
+			const paragraphField =
+				within( paragraphBlock ).getByPlaceholderText(
+					'Start writing…'
+				);
+			changeTextOfRichText( paragraphField, 'Hello!' );
+
+			// Open block actions menu
+			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
+
+			// Tap on the Transform block button
+			fireEvent.press( getByLabelText( /Transform block…/ ) );
+
+			// Get Picker title
+			const pickerHeader = getByRole( 'header' );
+			const headerTitle = within( pickerHeader ).getByText(
+				/Transform Paragraph to/
+			);
+			expect( headerTitle ).toBeVisible();
+
+			// Tap on the Transform block button
+			fireEvent.press( getByLabelText( /Pullquote/ ) );
+
+			expect( getEditorHtml() ).toMatchSnapshot();
+		} );
+	} );
+} );

--- a/packages/block-editor/src/components/block-mobile-toolbar/test/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/test/block-actions-menu.native.js
@@ -117,7 +117,7 @@ describe( 'Block Actions Menu', () => {
 				upButton.props.accessibilityState?.disabled;
 			expect( isUpButtonDisabled ).toBe( true );
 
-			// Press the button to make sure the move doesn't block
+			// Press the button to make sure the block doesn't move
 			fireEvent.press( upButton );
 
 			expect( getEditorHtml() ).toMatchSnapshot();
@@ -144,7 +144,7 @@ describe( 'Block Actions Menu', () => {
 				downButton.props.accessibilityState?.disabled;
 			expect( isDownButtonDisabled ).toBe( true );
 
-			// Press the button to make sure the move doesn't block
+			// Press the button to make sure the block doesn't move
 			fireEvent.press( downButton );
 
 			expect( getEditorHtml() ).toMatchSnapshot();

--- a/packages/block-editor/src/components/block-mobile-toolbar/test/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/test/block-actions-menu.native.js
@@ -67,6 +67,7 @@ describe( 'Block Actions Menu', () => {
 		it( 'moves blocks up and down', async () => {
 			const screen = await initializeEditor( {
 				initialHtml: INITIAL_HTML,
+				screenWidth: 100,
 			} );
 			const { getByLabelText } = screen;
 
@@ -76,11 +77,11 @@ describe( 'Block Actions Menu', () => {
 			} );
 			fireEvent.press( spacerBlock );
 
+			// Open block actions menu
+			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
+
 			// Tap on the Move Down button
-			const downButton = getByLabelText(
-				/Move block down from row 2 to row 3/
-			);
-			fireEvent.press( downButton );
+			fireEvent.press( getByLabelText( /Move block down/ ) );
 
 			// Get Heading block
 			const headingBlock = await getBlock( screen, 'Heading', {
@@ -88,11 +89,11 @@ describe( 'Block Actions Menu', () => {
 			} );
 			fireEvent.press( headingBlock );
 
+			// Open block actions menu
+			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
+
 			// Tap on the Move Up button
-			const upButton = getByLabelText(
-				/Move block up from row 2 to row 1/
-			);
-			fireEvent.press( upButton );
+			fireEvent.press( getByLabelText( /Move block up/ ) );
 
 			expect( getEditorHtml() ).toMatchSnapshot();
 		} );
@@ -106,6 +107,9 @@ describe( 'Block Actions Menu', () => {
 			// Get Paragraph block
 			const paragraphBlock = await getBlock( screen, 'Paragraph' );
 			fireEvent.press( paragraphBlock );
+
+			// Open block actions menu
+			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
 
 			// Get the Move Up button
 			const upButton = getByLabelText( /Move block up/ );
@@ -130,6 +134,9 @@ describe( 'Block Actions Menu', () => {
 				rowIndex: 3,
 			} );
 			fireEvent.press( headingBlock );
+
+			// Open block actions menu
+			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
 
 			// Get the Move Down button
 			const downButton = getByLabelText( /Move block down/ );

--- a/packages/block-editor/src/components/block-mover/test/__snapshots__/index.native.js.snap
+++ b/packages/block-editor/src/components/block-mover/test/__snapshots__/index.native.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Block Mover Picker moving blocks disables the Move Down button for the last block 1`] = `
 "<!-- wp:paragraph -->
-<p></p>
+<p>Hello!</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:spacer -->
@@ -16,7 +16,7 @@ exports[`Block Mover Picker moving blocks disables the Move Down button for the 
 
 exports[`Block Mover Picker moving blocks disables the Move Up button for the first block 1`] = `
 "<!-- wp:paragraph -->
-<p></p>
+<p>Hello!</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:spacer -->
@@ -34,7 +34,7 @@ exports[`Block Mover Picker moving blocks moves blocks up and down 1`] = `
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p></p>
+<p>Hello!</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:spacer -->

--- a/packages/block-editor/src/components/block-mover/test/__snapshots__/index.native.js.snap
+++ b/packages/block-editor/src/components/block-mover/test/__snapshots__/index.native.js.snap
@@ -1,5 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Block Mover Picker moving blocks disables the Move Down button for the last block 1`] = `
+"<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:spacer -->
+<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading -->
+<h2 class=\\"wp-block-heading\\"></h2>
+<!-- /wp:heading -->"
+`;
+
+exports[`Block Mover Picker moving blocks disables the Move Up button for the first block 1`] = `
+"<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:spacer -->
+<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading -->
+<h2 class=\\"wp-block-heading\\"></h2>
+<!-- /wp:heading -->"
+`;
+
+exports[`Block Mover Picker moving blocks moves blocks up and down 1`] = `
+"<!-- wp:heading -->
+<h2 class=\\"wp-block-heading\\"></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:spacer -->
+<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->"
+`;
+
 exports[`Block Mover Picker should match snapshot 1`] = `
 Array [
   <View>

--- a/packages/block-editor/src/components/block-mover/test/index.native.js
+++ b/packages/block-editor/src/components/block-mover/test/index.native.js
@@ -131,7 +131,7 @@ describe( 'Block Mover Picker', () => {
 				upButton.props.accessibilityState?.disabled;
 			expect( isUpButtonDisabled ).toBe( true );
 
-			// Press the button to make sure the move doesn't block
+			// Press the button to make sure the block doesn't move
 			fireEvent.press( upButton );
 
 			expect( getEditorHtml() ).toMatchSnapshot();
@@ -155,7 +155,7 @@ describe( 'Block Mover Picker', () => {
 				downButton.props.accessibilityState?.disabled;
 			expect( isDownButtonDisabled ).toBe( true );
 
-			// Press the button to make sure the move doesn't block
+			// Press the button to make sure the block doesn't move
 			fireEvent.press( downButton );
 
 			expect( getEditorHtml() ).toMatchSnapshot();

--- a/packages/block-editor/src/components/block-mover/test/index.native.js
+++ b/packages/block-editor/src/components/block-mover/test/index.native.js
@@ -1,12 +1,34 @@
 /**
  * External dependencies
  */
-import { render } from 'test/helpers';
+import {
+	fireEvent,
+	initializeEditor,
+	getBlock,
+	getEditorHtml,
+	render,
+} from 'test/helpers';
+
+/**
+ * WordPress dependencies
+ */
+import { getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
+import { registerCoreBlocks } from '@wordpress/block-library';
 
 /**
  * Internal dependencies
  */
 import { BlockMover } from '../index';
+
+const INITIAL_HTML = `<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+<!-- wp:spacer -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+<!-- wp:heading -->
+<h2 class="wp-block-heading"></h2>
+<!-- /wp:heading -->`;
 
 describe( 'Block Mover Picker', () => {
 	it( 'renders without crashing', () => {
@@ -45,5 +67,98 @@ describe( 'Block Mover Picker', () => {
 		};
 		const screen = render( <BlockMover { ...props } /> );
 		expect( screen.toJSON() ).toMatchSnapshot();
+	} );
+
+	describe( 'moving blocks', () => {
+		beforeAll( () => {
+			// Register all core blocks
+			registerCoreBlocks();
+		} );
+
+		afterAll( () => {
+			// Clean up registered blocks
+			getBlockTypes().forEach( ( block ) => {
+				unregisterBlockType( block.name );
+			} );
+		} );
+
+		it( 'moves blocks up and down', async () => {
+			const screen = await initializeEditor( {
+				initialHtml: INITIAL_HTML,
+			} );
+			const { getByLabelText } = screen;
+
+			// Get Spacer block
+			const spacerBlock = await getBlock( screen, 'Spacer', {
+				rowIndex: 2,
+			} );
+			fireEvent.press( spacerBlock );
+
+			// Tap on the Move Down button
+			const downButton = getByLabelText(
+				/Move block down from row 2 to row 3/
+			);
+			fireEvent.press( downButton );
+
+			// Get Heading block
+			const headingBlock = await getBlock( screen, 'Heading', {
+				rowIndex: 2,
+			} );
+			fireEvent.press( headingBlock );
+
+			// Tap on the Move Up button
+			const upButton = getByLabelText(
+				/Move block up from row 2 to row 1/
+			);
+			fireEvent.press( upButton );
+
+			expect( getEditorHtml() ).toMatchSnapshot();
+		} );
+
+		it( 'disables the Move Up button for the first block', async () => {
+			const screen = await initializeEditor( {
+				initialHtml: INITIAL_HTML,
+			} );
+			const { getByLabelText } = screen;
+
+			// Get Paragraph block
+			const paragraphBlock = await getBlock( screen, 'Paragraph' );
+			fireEvent.press( paragraphBlock );
+
+			// Get the Move Up button
+			const upButton = getByLabelText( /Move block up/ );
+			const isUpButtonDisabled =
+				upButton.props.accessibilityState?.disabled;
+			expect( isUpButtonDisabled ).toBe( true );
+
+			// Press the button to make sure the move doesn't block
+			fireEvent.press( upButton );
+
+			expect( getEditorHtml() ).toMatchSnapshot();
+		} );
+
+		it( 'disables the Move Down button for the last block', async () => {
+			const screen = await initializeEditor( {
+				initialHtml: INITIAL_HTML,
+			} );
+			const { getByLabelText } = screen;
+
+			// Get Heading block
+			const headingBlock = await getBlock( screen, 'Heading', {
+				rowIndex: 3,
+			} );
+			fireEvent.press( headingBlock );
+
+			// Get the Move Down button
+			const downButton = getByLabelText( /Move block down/ );
+			const isDownButtonDisabled =
+				downButton.props.accessibilityState?.disabled;
+			expect( isDownButtonDisabled ).toBe( true );
+
+			// Press the button to make sure the move doesn't block
+			fireEvent.press( downButton );
+
+			expect( getEditorHtml() ).toMatchSnapshot();
+		} );
 	} );
 } );

--- a/packages/block-editor/src/components/block-mover/test/index.native.js
+++ b/packages/block-editor/src/components/block-mover/test/index.native.js
@@ -2,11 +2,14 @@
  * External dependencies
  */
 import {
+	addBlock,
 	fireEvent,
 	initializeEditor,
 	getBlock,
+	within,
 	getEditorHtml,
 	render,
+	changeTextOfRichText,
 } from 'test/helpers';
 
 /**
@@ -19,16 +22,6 @@ import { registerCoreBlocks } from '@wordpress/block-library';
  * Internal dependencies
  */
 import { BlockMover } from '../index';
-
-const INITIAL_HTML = `<!-- wp:paragraph -->
-<p></p>
-<!-- /wp:paragraph -->
-<!-- wp:spacer -->
-<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-<!-- wp:heading -->
-<h2 class="wp-block-heading"></h2>
-<!-- /wp:heading -->`;
 
 describe( 'Block Mover Picker', () => {
 	it( 'renders without crashing', () => {
@@ -83,10 +76,26 @@ describe( 'Block Mover Picker', () => {
 		} );
 
 		it( 'moves blocks up and down', async () => {
-			const screen = await initializeEditor( {
-				initialHtml: INITIAL_HTML,
-			} );
+			const screen = await initializeEditor();
 			const { getByLabelText } = screen;
+
+			// Add Paragraph block
+			await addBlock( screen, 'Paragraph' );
+
+			// Get Paragraph block
+			const paragraphBlock = await getBlock( screen, 'Paragraph' );
+			fireEvent.press( paragraphBlock );
+			const paragraphField =
+				within( paragraphBlock ).getByPlaceholderText(
+					'Start writing…'
+				);
+			changeTextOfRichText( paragraphField, 'Hello!' );
+
+			// Add Spacer block
+			await addBlock( screen, 'Spacer' );
+
+			// Add Heading block
+			await addBlock( screen, 'Heading' );
 
 			// Get Spacer block
 			const spacerBlock = await getBlock( screen, 'Spacer', {
@@ -116,13 +125,29 @@ describe( 'Block Mover Picker', () => {
 		} );
 
 		it( 'disables the Move Up button for the first block', async () => {
-			const screen = await initializeEditor( {
-				initialHtml: INITIAL_HTML,
-			} );
+			const screen = await initializeEditor();
 			const { getByLabelText } = screen;
 
+			// Add Paragraph block
+			await addBlock( screen, 'Paragraph' );
+
 			// Get Paragraph block
-			const paragraphBlock = await getBlock( screen, 'Paragraph' );
+			let paragraphBlock = await getBlock( screen, 'Paragraph' );
+			fireEvent.press( paragraphBlock );
+			const paragraphField =
+				within( paragraphBlock ).getByPlaceholderText(
+					'Start writing…'
+				);
+			changeTextOfRichText( paragraphField, 'Hello!' );
+
+			// Add Spacer block
+			await addBlock( screen, 'Spacer' );
+
+			// Add Heading block
+			await addBlock( screen, 'Heading' );
+
+			// Get Paragraph block
+			paragraphBlock = await getBlock( screen, 'Paragraph' );
 			fireEvent.press( paragraphBlock );
 
 			// Get the Move Up button
@@ -138,10 +163,26 @@ describe( 'Block Mover Picker', () => {
 		} );
 
 		it( 'disables the Move Down button for the last block', async () => {
-			const screen = await initializeEditor( {
-				initialHtml: INITIAL_HTML,
-			} );
+			const screen = await initializeEditor();
 			const { getByLabelText } = screen;
+
+			// Add Paragraph block
+			await addBlock( screen, 'Paragraph' );
+
+			// Get Paragraph block
+			const paragraphBlock = await getBlock( screen, 'Paragraph' );
+			fireEvent.press( paragraphBlock );
+			const paragraphField =
+				within( paragraphBlock ).getByPlaceholderText(
+					'Start writing…'
+				);
+			changeTextOfRichText( paragraphField, 'Hello!' );
+
+			// Add Spacer block
+			await addBlock( screen, 'Spacer' );
+
+			// Add Heading block
+			await addBlock( screen, 'Heading' );
 
 			// Get Heading block
 			const headingBlock = await getBlock( screen, 'Heading', {

--- a/test/native/__mocks__/styleMock.js
+++ b/test/native/__mocks__/styleMock.js
@@ -92,6 +92,7 @@ module.exports = {
 	},
 	defaultBlock: {
 		marginTop: 16,
+		marginLeft: 16,
 	},
 	scrollableContent: {
 		paddingBottom: 20,

--- a/test/native/integration-test-helpers/initialize-editor.js
+++ b/test/native/integration-test-helpers/initialize-editor.js
@@ -31,6 +31,7 @@ export async function initializeEditor( props, { component } = {} ) {
 	const postType = 'post';
 
 	return waitForStoreResolvers( () => {
+		const { screenWidth = 320, ...rest } = props || {};
 		const editorElement = component
 			? createElement( component, { postType, postId } )
 			: internalInitializeEditor( uniqueId, postType, postId );
@@ -38,7 +39,7 @@ export async function initializeEditor( props, { component } = {} ) {
 		const screen = render(
 			cloneElement( editorElement, {
 				initialTitle: 'test',
-				...props,
+				...rest,
 			} )
 		);
 
@@ -47,7 +48,7 @@ export async function initializeEditor( props, { component } = {} ) {
 		fireEvent( screen.getByTestId( 'block-list-wrapper' ), 'layout', {
 			nativeEvent: {
 				layout: {
-					width: 100,
+					width: screenWidth,
 				},
 			},
 		} );


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/46673
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/5337

**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/5340

## What?
After some changes were introduced in https://github.com/WordPress/gutenberg/pull/43849 related to the refactor of the `lodash` library effort, the block title within the block actions menu picker was showing as `undefined`.

## Why?
To fix a regression in the mobile editor related to the block actions menu.

## How?
By simplifying the code by passing just the current `cliendId` as a string instead of an array with just one `clientId`, by updating this and adapting the code, it now gets the right block title in the block actions menu.

It also adds several integration tests:

  **Block Actions Menu**
    ✓ renders the block name in the Picker's header
    **moving blocks** (from the block actions menu, these show up when the canvas is smaller so we hide the up/down arrows below blocks and show them in the actions menu instead)
      ✓ moves blocks up and down
      ✓ disables the Move Up button for the first block
      ✓ disables the Move Down button for the last block
    **block options**
      ✓ copies and pastes a block
      ✓ does not replace a non empty Paragraph block when pasting another block
      ✓ cuts and pastes a block
      ✓ duplicates a block
      ✓ transforms a Paragraph block into a Pullquote block

  **Block Mover Picker**
    **moving blocks** (The up/down arrows that show up below a block)
      ✓ moves blocks up and down
      ✓ disables the Move Up button for the first block
      ✓ disables the Move Down button for the last block

## Testing Instructions

Even though there are new integration tests that should cover quite a few cases, let's smoke-test using the demo app as well.

- Open the app
- Add a block
- Tap on the `...` three dots button to open the block actions menu
- **Expect** to see the block title's in the header of the picker
- Add several blocks and test: Copy, Cut, Paste after, Duplicate and transform features.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
Before | After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/208882495-81d8770e-565c-4045-a5de-42cc96e51dea.png" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/208880378-1ce6531e-7584-4539-9a32-c08ea6d1078e.png" width="200" /></kbd>