### PR TITLE
TabPanel: add tabName prop (controlled component)

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   `TabPanel`: add tabName prop for tab panel ([#46704](https://github.com/WordPress/gutenberg/pull/46704)).
+
 ### Enhancements
 
 -   `SearchControl`: polish metrics for `compact` size variant ([#54663](https://github.com/WordPress/gutenberg/pull/54663)).

--- a/packages/components/src/tab-panel/README.md
+++ b/packages/components/src/tab-panel/README.md
@@ -144,6 +144,14 @@ The name of the tab to be selected upon mounting of component. If this prop is n
 -   Required: No
 -   Default: none
 
+#### tabName
+
+The name of the tab to be selected.
+
+-   Type: `String`
+-   Required: No
+-   Default: none
+
 #### selectOnMove
 
 When `true`, the tab will be selected when receiving focus (automatic tab activation). When `false`, the tab will be selected only when clicked (manual tab activation). See the [official W3C docs](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/) for more info.

--- a/packages/components/src/tab-panel/index.tsx
+++ b/packages/components/src/tab-panel/index.tsx
@@ -78,6 +78,7 @@ const UnforwardedTabPanel = (
 		tabs,
 		selectOnMove = true,
 		initialTabName,
+		tabName,
 		orientation = 'horizontal',
 		activeClass = 'is-active',
 		onSelect,
@@ -87,11 +88,11 @@ const UnforwardedTabPanel = (
 	const instanceId = useInstanceId( TabPanel, 'tab-panel' );
 
 	const prependInstanceId = useCallback(
-		( tabName: string | undefined ) => {
-			if ( typeof tabName === 'undefined' ) {
+		( tab: string | undefined ) => {
+			if ( typeof tab === 'undefined' ) {
 				return;
 			}
-			return `${ instanceId }-${ tabName }`;
+			return `${ instanceId }-${ tab }`;
 		},
 		[ instanceId ]
 	);
@@ -118,14 +119,14 @@ const UnforwardedTabPanel = (
 		},
 		orientation,
 		selectOnMove,
-		defaultSelectedId: prependInstanceId( initialTabName ),
+		defaultSelectedId: prependInstanceId( tabName || initialTabName ),
 	} );
 
 	const selectedTabName = extractTabName( tabStore.useState( 'selectedId' ) );
 
 	const setTabStoreSelectedId = useCallback(
-		( tabName: string ) => {
-			tabStore.setState( 'selectedId', prependInstanceId( tabName ) );
+		( tab: string ) => {
+			tabStore.setState( 'selectedId', prependInstanceId( tab ) );
 		},
 		[ prependInstanceId, tabStore ]
 	);
@@ -144,6 +145,13 @@ const UnforwardedTabPanel = (
 			onSelect?.( selectedTabName );
 		}
 	}, [ selectedTabName, initialTabName, onSelect, previousSelectedTabName ] );
+
+	// handle selection of tabName
+	useEffect( () => {
+		if ( tabName ) {
+			setTabStoreSelectedId( tabName );
+		}
+	}, [ tabName, setTabStoreSelectedId ] );
 
 	// Handle selecting the initial tab.
 	useLayoutEffect( () => {
@@ -190,6 +198,7 @@ const UnforwardedTabPanel = (
 			setTabStoreSelectedId( firstEnabledTab.name );
 		}
 	}, [ tabs, selectedTab?.disabled, setTabStoreSelectedId, instanceId ] );
+
 	return (
 		<div className={ className } ref={ ref }>
 			<Ariakit.TabList

--- a/packages/components/src/tab-panel/stories/index.story.tsx
+++ b/packages/components/src/tab-panel/stories/index.story.tsx
@@ -43,6 +43,26 @@ Default.args = {
 	],
 };
 
+export const SelectedTab = Template.bind( {} );
+SelectedTab.args = {
+	children: ( tab ) => <p>Selected tab: { tab.title }</p>,
+	tabs: [
+		{
+			name: 'tab1',
+			title: 'Tab 1',
+		},
+		{
+			name: 'tab2',
+			title: 'Tab 2',
+		},
+		{
+			name: 'tab3',
+			title: 'Tab 3',
+		},
+	],
+	tabName: 'tab2',
+};
+
 export const DisabledTab = Template.bind( {} );
 DisabledTab.args = {
 	children: ( tab ) => <p>Selected tab: { tab.title }</p>,

--- a/packages/components/src/tab-panel/types.ts
+++ b/packages/components/src/tab-panel/types.ts
@@ -53,6 +53,10 @@ export type TabPanelProps = {
 	 */
 	initialTabName?: string;
 	/**
+	 * The name of the tab to be selected.
+	 */
+	tabName?: string;
+	/**
 	 * The function called when a tab has been selected.
 	 * It is passed the `tabName` as an argument.
 	 */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add new prop `selectedTabName` to control the component tab selection programatically.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently it is not possible to activate a tab using component props. This allows to activate a tab programatically.
The first usecase for this is to auto select the tab in `style book` based on the selected block in global styles.

![tab-selection](https://user-images.githubusercontent.com/1935113/209305187-60e235b4-c052-4d68-9996-dcdb984e7af2.gif)


