### PR TITLE
Iframe: preload style assets to avoid flash of unstyled content

### DIFF
--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -33,11 +33,10 @@ function ScaledBlockPreview( {
 
 	const [ contentResizeListener, { height: contentHeight } ] =
 		useResizeObserver();
-	const { styles, assets, duotone } = useSelect( ( select ) => {
+	const { styles, duotone } = useSelect( ( select ) => {
 		const settings = select( store ).getSettings();
 		return {
 			styles: settings.styles,
-			assets: settings.__unstableResolvedAssets,
 			duotone: settings.__experimentalFeatures?.color?.duotone,
 		};
 	}, [] );
@@ -79,7 +78,6 @@ function ScaledBlockPreview( {
 		>
 			<Iframe
 				head={ <EditorStyles styles={ editorStyles } /> }
-				assets={ assets }
 				contentRef={ useRefEffect( ( bodyElement ) => {
 					const {
 						ownerDocument: { documentElement },

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -316,7 +316,7 @@ function IframeIfReady( props, ref ) {
 		return null;
 	}
 
-	return <Iframe { ...props } forwardRef={ ref } />;
+	return <Iframe { ...props } forwardedRef={ ref } />;
 }
 
 export default forwardRef( IframeIfReady );

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -12,6 +12,7 @@ import {
 	forwardRef,
 	useMemo,
 	useReducer,
+	renderToString,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
@@ -204,7 +205,7 @@ function Iframe(
 	}, [] );
 	const bodyRef = useMergeRefs( [ contentRef, clearerRef, writingFlowRef ] );
 
-	head = (
+	const styleAssets = (
 		<>
 			<style>{ 'html{height:auto!important;}body{margin:0}' }</style>
 			{ [ ...styles, ...neededCompatStyles ].map(
@@ -224,9 +225,15 @@ function Iframe(
 					);
 				}
 			) }
-			{ head }
 		</>
 	);
+
+	// Correct doctype is required to enable rendering in standards
+	// mode. Also preload the styles to avoid a flash of unstyled
+	// content.
+	const srcDoc = useMemo( () => {
+		return '<!doctype html>' + renderToString( styleAssets );
+	}, [] );
 
 	return (
 		<>
@@ -235,14 +242,17 @@ function Iframe(
 				{ ...props }
 				ref={ useMergeRefs( [ ref, setRef ] ) }
 				tabIndex={ tabIndex }
-				// Correct doctype is required to enable rendering in standards mode
-				srcDoc="<!doctype html>"
+				// Correct doctype is required to enable rendering in standards
+				// mode. Also preload the styles to avoid a flash of unstyled
+				// content.
+				srcDoc={ srcDoc }
 				title={ __( 'Editor canvas' ) }
 			>
 				{ iframeDocument &&
 					createPortal(
 						<>
 							<head ref={ headRef }>
+								{ styleAssets }
 								{ head }
 								<style>
 									{ `html { transition: background 5s; ${

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -19,7 +19,10 @@ function BlockEditorProvider( props ) {
 
 	const { updateSettings } = useDispatch( blockEditorStore );
 	useEffect( () => {
-		updateSettings( settings );
+		updateSettings( {
+			...settings,
+			__internalIsInitialized: true,
+		} );
 	}, [ settings ] );
 
 	// Syncs the entity provider with changes in the block-editor store.

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -121,6 +121,9 @@ export default function VisualEditor( { styles } ) {
 		wrapperUniqueId,
 		isBlockBasedTheme,
 		assets,
+		themeHasDisabledLayoutStyles,
+		themeSupportsLayout,
+		isFocusMode,
 	} = useSelect( ( select ) => {
 		const {
 			isFeatureActive,
@@ -161,8 +164,12 @@ export default function VisualEditor( { styles } ) {
 			isBlockBasedTheme: editorSettings.__unstableIsBlockBasedTheme,
 			// WARNING: use getEditorSettings from the editor store, not the
 			// block editor store. The settings on the block editor store set
-			// with a delay.
+			// with a delay and we need the assets on the first render for the
+			// iframe srcDoc.
 			assets: editorSettings.__unstableResolvedAssets,
+			themeHasDisabledLayoutStyles: editorSettings.disableLayoutStyles,
+			themeSupportsLayout: editorSettings.supportsLayout,
+			isFocusMode: editorSettings.focusMode,
 		};
 	}, [] );
 	const { isCleanNewPost } = useSelect( editorStore );
@@ -170,15 +177,6 @@ export default function VisualEditor( { styles } ) {
 		( select ) => select( editPostStore ).hasMetaBoxes(),
 		[]
 	);
-	const { themeHasDisabledLayoutStyles, themeSupportsLayout, isFocusMode } =
-		useSelect( ( select ) => {
-			const _settings = select( blockEditorStore ).getSettings();
-			return {
-				themeHasDisabledLayoutStyles: _settings.disableLayoutStyles,
-				themeSupportsLayout: _settings.supportsLayout,
-				isFocusMode: _settings.focusMode,
-			};
-		}, [] );
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 	const { setIsEditingTemplate } = useDispatch( editPostStore );
 	const desktopCanvasStyles = {

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -46,14 +46,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import BlockInspectorButton from './block-inspector-button';
 import { store as editPostStore } from '../../store';
 
-function MaybeIframe( {
-	children,
-	contentRef,
-	shouldIframe,
-	styles,
-	assets,
-	style,
-} ) {
+function MaybeIframe( { children, contentRef, shouldIframe, styles, style } ) {
 	const ref = useMouseMoveTypingReset();
 
 	if ( ! shouldIframe ) {
@@ -75,7 +68,6 @@ function MaybeIframe( {
 	return (
 		<Iframe
 			head={ <EditorStyles styles={ styles } /> }
-			assets={ assets }
 			ref={ ref }
 			contentRef={ contentRef }
 			style={ { width: '100%', height: '100%', display: 'block' } }
@@ -120,10 +112,6 @@ export default function VisualEditor( { styles } ) {
 		wrapperBlockName,
 		wrapperUniqueId,
 		isBlockBasedTheme,
-		assets,
-		themeHasDisabledLayoutStyles,
-		themeSupportsLayout,
-		isFocusMode,
 	} = useSelect( ( select ) => {
 		const {
 			isFeatureActive,
@@ -162,16 +150,17 @@ export default function VisualEditor( { styles } ) {
 			wrapperBlockName: _wrapperBlockName,
 			wrapperUniqueId: getCurrentPostId(),
 			isBlockBasedTheme: editorSettings.__unstableIsBlockBasedTheme,
-			// WARNING: use getEditorSettings from the editor store, not the
-			// block editor store. The settings on the block editor store set
-			// with a delay and we need the assets on the first render for the
-			// iframe srcDoc.
-			assets: editorSettings.__unstableResolvedAssets,
-			themeHasDisabledLayoutStyles: editorSettings.disableLayoutStyles,
-			themeSupportsLayout: editorSettings.supportsLayout,
-			isFocusMode: editorSettings.focusMode,
 		};
 	}, [] );
+	const { themeHasDisabledLayoutStyles, themeSupportsLayout, isFocusMode } =
+		useSelect( ( select ) => {
+			const _settings = select( blockEditorStore ).getSettings();
+			return {
+				themeHasDisabledLayoutStyles: _settings.disableLayoutStyles,
+				themeSupportsLayout: _settings.supportsLayout,
+				isFocusMode: _settings.focusMode,
+			};
+		}, [] );
 	const { isCleanNewPost } = useSelect( editorStore );
 	const hasMetaBoxes = useSelect(
 		( select ) => select( editPostStore ).hasMetaBoxes(),
@@ -359,7 +348,6 @@ export default function VisualEditor( { styles } ) {
 						}
 						contentRef={ contentRef }
 						styles={ styles }
-						assets={ assets }
 					>
 						{ themeSupportsLayout &&
 							! themeHasDisabledLayoutStyles &&

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -120,6 +120,7 @@ export default function VisualEditor( { styles } ) {
 		wrapperBlockName,
 		wrapperUniqueId,
 		isBlockBasedTheme,
+		assets,
 	} = useSelect( ( select ) => {
 		const {
 			isFeatureActive,
@@ -158,6 +159,10 @@ export default function VisualEditor( { styles } ) {
 			wrapperBlockName: _wrapperBlockName,
 			wrapperUniqueId: getCurrentPostId(),
 			isBlockBasedTheme: editorSettings.__unstableIsBlockBasedTheme,
+			// WARNING: use getEditorSettings from the editor store, not the
+			// block editor store. The settings on the block editor store set
+			// with a delay.
+			assets: editorSettings.__unstableResolvedAssets,
 		};
 	}, [] );
 	const { isCleanNewPost } = useSelect( editorStore );
@@ -165,20 +170,15 @@ export default function VisualEditor( { styles } ) {
 		( select ) => select( editPostStore ).hasMetaBoxes(),
 		[]
 	);
-	const {
-		themeHasDisabledLayoutStyles,
-		themeSupportsLayout,
-		assets,
-		isFocusMode,
-	} = useSelect( ( select ) => {
-		const _settings = select( blockEditorStore ).getSettings();
-		return {
-			themeHasDisabledLayoutStyles: _settings.disableLayoutStyles,
-			themeSupportsLayout: _settings.supportsLayout,
-			assets: _settings.__unstableResolvedAssets,
-			isFocusMode: _settings.focusMode,
-		};
-	}, [] );
+	const { themeHasDisabledLayoutStyles, themeSupportsLayout, isFocusMode } =
+		useSelect( ( select ) => {
+			const _settings = select( blockEditorStore ).getSettings();
+			return {
+				themeHasDisabledLayoutStyles: _settings.disableLayoutStyles,
+				themeSupportsLayout: _settings.supportsLayout,
+				isFocusMode: _settings.focusMode,
+			};
+		}, [] );
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 	const { setIsEditingTemplate } = useDispatch( editPostStore );
 	const desktopCanvasStyles = {

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -152,6 +152,11 @@ export default function VisualEditor( { styles } ) {
 			isBlockBasedTheme: editorSettings.__unstableIsBlockBasedTheme,
 		};
 	}, [] );
+	const { isCleanNewPost } = useSelect( editorStore );
+	const hasMetaBoxes = useSelect(
+		( select ) => select( editPostStore ).hasMetaBoxes(),
+		[]
+	);
 	const { themeHasDisabledLayoutStyles, themeSupportsLayout, isFocusMode } =
 		useSelect( ( select ) => {
 			const _settings = select( blockEditorStore ).getSettings();
@@ -161,11 +166,6 @@ export default function VisualEditor( { styles } ) {
 				isFocusMode: _settings.focusMode,
 			};
 		}, [] );
-	const { isCleanNewPost } = useSelect( editorStore );
-	const hasMetaBoxes = useSelect(
-		( select ) => select( editPostStore ).hasMetaBoxes(),
-		[]
-	);
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 	const { setIsEditingTemplate } = useDispatch( editPostStore );
 	const desktopCanvasStyles = {

--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -53,7 +53,6 @@ function EditorCanvas( { enableResizing, settings, children, ...props } ) {
 					) }
 				</>
 			}
-			assets={ settings.__unstableResolvedAssets }
 			ref={ mouseMoveTypingRef }
 			name="editor-canvas"
 			className="edit-site-visual-editor__editor-canvas"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Preloads the iframe stylesheets by adding them to the srcDoc. I also had to get assets through editor settings from the editor store because the assets were not in the block editor store on initial render.

|Before|After|
|-|-|
|![flash-before](https://user-images.githubusercontent.com/4710635/208936005-bf11f544-60b8-415d-8250-2db7359f8612.gif)|![flash-after](https://user-images.githubusercontent.com/4710635/208935985-f698290e-105c-4b03-be34-dfe7a0e451e5.gif)|

## Why?

To avoid a flash of unstyled content.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

Create a new post with a block based theme. When reloading the page, you briefly see the default browser focus outline on the title. Also the appender button is unstyled. This should be gone.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
