### PR TITLE
Update template part hover style in list view

### DIFF
--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -24,8 +24,15 @@
 	}
 	&.is-synced:not(.is-selected) .block-editor-list-view-block-contents {
 		&:hover,
+		&:focus,
 		.block-editor-block-icon {
 			color: var(--wp-block-synced-color);
+		}
+
+		&:focus::after {
+			box-shadow:
+				inset 0 0 0 1px $white,
+				0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-synced-color);
 		}
 	}
 	&.is-selected .block-editor-list-view-block-contents,

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -22,8 +22,11 @@
 	&.is-selected.is-synced td {
 		background: var(--wp-block-synced-color);
 	}
-	&.is-synced:not(.is-selected) .block-editor-list-view-block-contents .block-editor-block-icon {
-		color: var(--wp-block-synced-color);
+	&.is-synced:not(.is-selected) .block-editor-list-view-block-contents {
+		&:hover,
+		.block-editor-block-icon {
+			color: var(--wp-block-synced-color);
+		}
 	}
 	&.is-selected .block-editor-list-view-block-contents,
 	&.is-selected .components-button.has-icon {


### PR DESCRIPTION
In list view, hovering/focussing an item has blue accents. This clashed when applied to template parts which already have purple accents. This PR updates those styles so that all template part accents are purple.

### Before

https://user-images.githubusercontent.com/846565/208925712-da49687e-2e8d-402d-9cf3-f3b89cb1d844.mp4



### After

https://user-images.githubusercontent.com/846565/208925993-0e52c8b6-39a8-461b-ad80-e12ec6f94d2a.mp4

