### PR TITLE
List View: Update template part children background color

### DIFF
--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -74,7 +74,7 @@
 	&.is-branch-selected:not(.is-selected):not(.is-synced-branch) {
 		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 	}
-	&.is-synced-branch:not(.is-selected) {
+	&.is-synced-branch.is-branch-selected {
 		background: rgba(var(--wp-block-synced-color--rgb), 0.04);
 	}
 	&.is-branch-selected.is-first-selected td:first-child {


### PR DESCRIPTION
Currently template part children have a light purple background in List View, regardless of whether the parent is selected. This is inconsistent with other containers:

<img width="350" alt="Screenshot 2022-12-21 at 14 23 48" src="https://user-images.githubusercontent.com/846565/208928540-fa4c4919-fa88-4d40-9e03-66a49ddf6fec.png">

This PR fixes that:

<img width="350" alt="Screenshot 2022-12-21 at 14 27 11" src="https://user-images.githubusercontent.com/846565/208928580-caa5e276-8fe4-4e46-a8db-a493314a1fbf.png">
