### PR TITLE
Remove Block Inspector Button

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -20,7 +20,6 @@ import {
 	__unstableUseTypewriter as useTypewriter,
 	__unstableUseClipboardHandler as useClipboardHandler,
 	__unstableUseTypingObserver as useTypingObserver,
-	__unstableBlockSettingsMenuFirstItem,
 	__experimentalUseResizeCanvas as useResizeCanvas,
 	__unstableEditorStyles as EditorStyles,
 	useSetting,
@@ -43,7 +42,6 @@ import { store as coreStore } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
-import BlockInspectorButton from './block-inspector-button';
 import { store as editPostStore } from '../../store';
 
 function MaybeIframe( {
@@ -419,11 +417,6 @@ export default function VisualEditor( { styles } ) {
 					</MaybeIframe>
 				</motion.div>
 			</motion.div>
-			<__unstableBlockSettingsMenuFirstItem>
-				{ ( { onClose } ) => (
-					<BlockInspectorButton onClick={ onClose } />
-				) }
-			</__unstableBlockSettingsMenuFirstItem>
 		</BlockTools>
 	);
 }

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -20,7 +20,6 @@ import {
 	BlockInspector,
 	BlockTools,
 	__unstableBlockToolbarLastItem,
-	__unstableBlockSettingsMenuFirstItem,
 	__unstableUseTypingObserver as useTypingObserver,
 	BlockEditorKeyboardShortcuts,
 	store as blockEditorStore,
@@ -43,7 +42,6 @@ import TemplatePartConverter from '../template-part-converter';
 import NavigateToLink from '../navigate-to-link';
 import { SidebarInspectorFill } from '../sidebar-edit-mode';
 import { store as editSiteStore } from '../../store';
-import BlockInspectorButton from './block-inspector-button';
 import BackButton from './back-button';
 import ResizableEditor from './resizable-editor';
 import EditorCanvas from './editor-canvas';
@@ -249,11 +247,6 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 									/>
 								</EditorCanvas>
 							</ResizableEditor>
-							<__unstableBlockSettingsMenuFirstItem>
-								{ ( { onClose } ) => (
-									<BlockInspectorButton onClick={ onClose } />
-								) }
-							</__unstableBlockSettingsMenuFirstItem>
 							<__unstableBlockToolbarLastItem>
 								<__unstableBlockNameContext.Consumer>
 									{ ( blockName ) =>


### PR DESCRIPTION
## What?
Removes the Show/Hide block settings button.

## Why?
As raised in https://github.com/WordPress/gutenberg/pull/46077#issuecomment-1361183918, this button doesn't seem to serve a useful function.

## How?
Removes all the code.

## Testing Instructions
1. Open the post editor.
2. Add a block
3. Open the ellipsis menu for the block
4. Check that the "Hide/Show block settings" button isn't there.

### Testing Instructions for Keyboard
As above.

## Screenshots or screencast <!-- if applicable -->
Before:
<img width="763" alt="Screenshot 2022-12-21 at 14 34 50" src="https://user-images.githubusercontent.com/275961/208929920-f3c5bf2d-2c12-4dc1-8d76-4aea6194f746.png">


After:
<img width="769" alt="Screenshot 2022-12-21 at 14 33 25" src="https://user-images.githubusercontent.com/275961/208929645-41a1cec3-4933-4723-b411-4dab38f5279b.png">
