### PR TITLE
Navigation Sidebar: Hide behind the experiment flag

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/index.js
@@ -69,7 +69,7 @@ export function SidebarComplementaryAreaFills() {
 	// See https://github.com/WordPress/gutenberg/blob/trunk/docs/how-to-guides/feature-flags.md#dead-code-elimination.
 	let MaybeNavigationMenuSidebar = Fragment;
 
-	if ( process.env.IS_GUTENBERG_PLUGIN ) {
+	if ( window?.__experimentalEnableOffCanvasNavigationEditor === true ) {
 		MaybeNavigationMenuSidebar = NavigationMenuSidebar;
 	}
 


### PR DESCRIPTION
## What?
This changes the conditions under which we make the navigation sidebar visible.

## Why?
As raised in https://github.com/Automattic/wp-calypso/issues/71278, this sidebar is quite broken and not a great experience. We hope that the Navigation List View experiment will improve this experience, so lets make this sidebar dependent on that flag being enabled.

## How?
Just changing the conditional

## Testing Instructions
- Turn off the "Off canvas navigation editor" in the experiments page
- Open the Site Editor
- Check that you can't see the Navigation Sidebar
- Turn on the "Off canvas navigation editor" in the experiments page
- Open the Site Editor
- Check that you can see the Navigation Sidebar


### Testing Instructions for Keyboard
As above

## Screenshots or screencast <!-- if applicable -->
With the experiment flag disabled:
<img width="344" alt="Screenshot 2022-12-21 at 15 03 03" src="https://user-images.githubusercontent.com/275961/208936342-cfeb1099-c4f5-4c62-a22d-55deccdb2e87.png">

With the experiment flag enabled:
<img width="351" alt="Screenshot 2022-12-21 at 15 03 40" src="https://user-images.githubusercontent.com/275961/208936322-33e4347b-618a-4a9c-a1d5-9c9d3d67f8a7.png">

