### PR TITLE
Global Styles: Allow content/wide widths when unfiltered_html is not allowed

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -279,9 +279,19 @@ class WP_Theme_JSON_Gutenberg {
 	 * @var array
 	 */
 	const INDIRECT_PROPERTIES_METADATA = array(
-		'gap'        => array( 'spacing', 'blockGap' ),
-		'column-gap' => array( 'spacing', 'blockGap', 'left' ),
-		'row-gap'    => array( 'spacing', 'blockGap', 'top' ),
+		'gap'        => array(
+			array( 'spacing', 'blockGap' )
+		),
+		'column-gap' => array(
+			array( 'spacing', 'blockGap', 'left' )
+		),
+		'row-gap'    => array(
+			array( 'spacing', 'blockGap', 'top' )
+		),
+		'max-width'  => array(
+			array( 'layout', 'contentSize' ),
+			array( 'layout', 'wideSize' ),
+		),
 	);
 
 	/**
@@ -2821,6 +2831,19 @@ class WP_Theme_JSON_Gutenberg {
 				}
 			}
 		}
+
+		foreach ( static::INDIRECT_PROPERTIES_METADATA as $property => $paths ) {
+			foreach ( $paths as $path ) {
+				$value = _wp_array_get( $input, $path, array() );
+				if (
+					isset( $value ) &&
+					! is_array( $value ) &&
+					static::is_safe_css_declaration( $property, $value )
+				) {
+					_wp_array_set( $output, $path, $value );
+				}
+			}
+		}
 		return $output;
 	}
 
@@ -2852,14 +2875,16 @@ class WP_Theme_JSON_Gutenberg {
 		}
 
 		// Ensure indirect properties not handled by `compute_style_properties` are allowed.
-		foreach ( static::INDIRECT_PROPERTIES_METADATA as $property => $path ) {
-			$value = _wp_array_get( $input, $path, array() );
-			if (
-				isset( $value ) &&
-				! is_array( $value ) &&
-				static::is_safe_css_declaration( $property, $value )
-			) {
-				_wp_array_set( $output, $path, $value );
+		foreach ( static::INDIRECT_PROPERTIES_METADATA as $property => $paths ) {
+			foreach ( $paths as $path ) {
+				$value = _wp_array_get( $input, $path, array() );
+				if (
+					isset( $value ) &&
+					! is_array( $value ) &&
+					static::is_safe_css_declaration( $property, $value )
+				) {
+					_wp_array_set( $output, $path, $value );
+				}
 			}
 		}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -280,13 +280,13 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	const INDIRECT_PROPERTIES_METADATA = array(
 		'gap'        => array(
-			array( 'spacing', 'blockGap' )
+			array( 'spacing', 'blockGap' ),
 		),
 		'column-gap' => array(
-			array( 'spacing', 'blockGap', 'left' )
+			array( 'spacing', 'blockGap', 'left' ),
 		),
 		'row-gap'    => array(
-			array( 'spacing', 'blockGap', 'top' )
+			array( 'spacing', 'blockGap', 'top' ),
 		),
 		'max-width'  => array(
 			array( 'layout', 'contentSize' ),

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -754,8 +754,8 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	public function test_allow_indirect_properties() {
 		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
 			array(
-				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-				'styles'  => array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'   => array(
 					'blocks'  => array(
 						'core/social-links' => array(
 							'spacing' => array(
@@ -770,12 +770,18 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						'blockGap' => '3em',
 					),
 				),
+				'settings' => array(
+					'layout' => array(
+						'contentSize' => '800px',
+						'wideSize'    => '1000px',
+					),
+				),
 			)
 		);
 
 		$expected = array(
-			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-			'styles'  => array(
+			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'styles'   => array(
 				'blocks'  => array(
 					'core/social-links' => array(
 						'spacing' => array(
@@ -788,6 +794,12 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				),
 				'spacing' => array(
 					'blockGap' => '3em',
+				),
+			),
+			'settings' => array(
+				'layout' => array(
+					'contentSize' => '800px',
+					'wideSize'    => '1000px',
 				),
 			),
 		);


### PR DESCRIPTION
## What?
Follow-up of https://github.com/WordPress/gutenberg/pull/46388.

This PR ensures that the content and wide width settings set via Global Styles are considered safe and thus output as custom properties on the body element.

## Why?
Because secure `layout.contentSize` and `layout.wideSize` settings are being stripped out for users without the `unfiltered_html` capability as part of `remove_insecure_settings`.

## How?
- Updates the `INDIRECT_PROPERTIES_METADATA` array introduced in https://github.com/WordPress/gutenberg/pull/46388 to allow the `layout.contentSize` and `layout.wideSize` settings.
- Modifies the `remove_insecure_settings` to check the `INDIRECT_PROPERTIES_METADATA` array for settings that are not included in `PRESETS_METADATA`.

## Testing Instructions
Note: a quick way to test this PR is to place the following in `lib/init.php` in the Gutenberg plugin, rather than worrying about changing user capabilities:

```
add_action( 'init', 'kses_init_filters' );
```

1. With this PR applied and with a user with `unfiltered_html` capability (e.g. a regular admin), you should be able to save content and wide widths in Appearance > Editor > Styles > Layout.
2. Repeating the above with a user _without_ `unfiltered_html` capability (or enable the KSES filters with `add_action( 'init', 'kses_init_filters' );`) you should now still be able to save content and wide widths in Appearance > Editor > Styles > Layout.

Ensure tests pass:

```
npm run test:unit:php -- --filter WP_Theme_JSON_Gutenberg_Test
```

## Screenshots or screencast 

Before | After
--- | ---
![before](https://user-images.githubusercontent.com/1233880/208944052-6123a650-9237-4706-b317-b59405b2165f.gif) | ![after](https://user-images.githubusercontent.com/1233880/208944073-45fd28a3-640b-43c2-9bd5-e4be66717f71.gif)

