### PR TITLE
BorderControl: improve popover waiting

### DIFF
--- a/packages/components/src/border-control/test/index.js
+++ b/packages/components/src/border-control/test/index.js
@@ -14,6 +14,8 @@ import {
  */
 import { BorderControl } from '../';
 
+jest.useRealTimers();
+
 const colors = [
 	{ name: 'Gray', color: '#f6f7f7' },
 	{ name: 'Blue', color: '#72aee6' },

--- a/packages/components/src/border-control/test/index.js
+++ b/packages/components/src/border-control/test/index.js
@@ -1,7 +1,13 @@
 /**
  * External dependencies
  */
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -37,29 +43,24 @@ function createProps( customProps ) {
 
 const toggleLabelRegex = /Border color( and style)* picker/;
 
-const renderBorderControl = async ( props ) => {
-	const view = render( <BorderControl { ...props } /> );
-	// When the `Popover` component is rendered or updated, the `useFloating`
-	// hook from the `floating-ui` package will schedule a state update in a
-	// promise handler. We need to wait for this promise handler to execute
-	// before checking results. That's what this async `act()` call achieves.
-	// See also: https://floating-ui.com/docs/react-dom#testing
-	await act( () => Promise.resolve() );
-	return view;
-};
-
-const rerenderBorderControl = async ( rerender, props ) => {
-	const view = rerender( <BorderControl { ...props } /> );
-	// Same reason to `act()` as in `renderBorderControl` above.
-	await act( () => Promise.resolve() );
-	return view;
-};
+function getWrappingPopoverElement( element ) {
+	return element.closest( '.components-popover' );
+}
 
 const openPopover = async () => {
 	const toggleButton = screen.getByLabelText( toggleLabelRegex );
 	fireEvent.click( toggleButton );
-	// Same reason to `act()` as in `renderBorderControl` above.
-	await act( () => Promise.resolve() );
+
+	// Wait for color picker popover to fully appear
+	const pickerButton = screen.getByRole( 'button', {
+		name: /^Custom color picker/,
+	} );
+
+	await waitFor( () =>
+		expect(
+			getWrappingPopoverElement( pickerButton )
+		).toBePositionedPopover()
+	);
 };
 
 const getButton = ( name ) => {
@@ -95,7 +96,7 @@ describe( 'BorderControl', () => {
 	describe( 'basic rendering', () => {
 		it( 'should render standard border control', async () => {
 			const props = createProps();
-			await renderBorderControl( props );
+			render( <BorderControl { ...props } /> );
 
 			const label = screen.getByText( props.label );
 			const colorButton = screen.getByLabelText( toggleLabelRegex );
@@ -116,7 +117,7 @@ describe( 'BorderControl', () => {
 
 		it( 'should hide label', async () => {
 			const props = createProps( { hideLabelFromVision: true } );
-			await renderBorderControl( props );
+			render( <BorderControl { ...props } /> );
 			const label = screen.getByText( props.label );
 
 			// As visually hidden labels are still included in the document
@@ -130,7 +131,7 @@ describe( 'BorderControl', () => {
 
 		it( 'should render with slider', async () => {
 			const props = createProps( { withSlider: true } );
-			await renderBorderControl( props );
+			render( <BorderControl { ...props } /> );
 
 			const slider = getSliderInput();
 			expect( slider ).toBeInTheDocument();
@@ -138,7 +139,7 @@ describe( 'BorderControl', () => {
 
 		it( 'should render placeholder in UnitControl', async () => {
 			const props = createProps( { placeholder: 'Mixed' } );
-			await renderBorderControl( props );
+			render( <BorderControl { ...props } /> );
 
 			const widthInput = getWidthInput();
 			expect( widthInput ).toHaveAttribute( 'placeholder', 'Mixed' );
@@ -146,7 +147,7 @@ describe( 'BorderControl', () => {
 
 		it( 'should render color and style popover', async () => {
 			const props = createProps();
-			await renderBorderControl( props );
+			render( <BorderControl { ...props } /> );
 			await openPopover();
 
 			const customColorPicker = getButton( /Custom color picker/ );
@@ -170,7 +171,7 @@ describe( 'BorderControl', () => {
 
 		it( 'should render color and style popover header', async () => {
 			const props = createProps( { showDropdownHeader: true } );
-			await renderBorderControl( props );
+			render( <BorderControl { ...props } /> );
 			await openPopover();
 
 			const headerLabel = screen.getByText( 'Border color' );
@@ -182,7 +183,7 @@ describe( 'BorderControl', () => {
 
 		it( 'should not render style options when opted out of', async () => {
 			const props = createProps( { enableStyle: false } );
-			await renderBorderControl( props );
+			render( <BorderControl { ...props } /> );
 			await openPopover();
 
 			const styleLabel = screen.queryByText( 'Style' );
@@ -201,7 +202,7 @@ describe( 'BorderControl', () => {
 		describe( 'with style selection enabled', () => {
 			it( 'should include both color and style in label', async () => {
 				const props = createProps( { value: undefined } );
-				await renderBorderControl( props );
+				render( <BorderControl { ...props } /> );
 
 				expect(
 					screen.getByLabelText( 'Border color and style picker.' )
@@ -210,7 +211,7 @@ describe( 'BorderControl', () => {
 
 			it( 'should correctly describe named color selection', async () => {
 				const props = createProps( { value: { color: '#72aee6' } } );
-				await renderBorderControl( props );
+				render( <BorderControl { ...props } /> );
 
 				expect(
 					screen.getByLabelText(
@@ -221,7 +222,7 @@ describe( 'BorderControl', () => {
 
 			it( 'should correctly describe custom color selection', async () => {
 				const props = createProps( { value: { color: '#4b1d80' } } );
-				await renderBorderControl( props );
+				render( <BorderControl { ...props } /> );
 
 				expect(
 					screen.getByLabelText(
@@ -234,7 +235,7 @@ describe( 'BorderControl', () => {
 				const props = createProps( {
 					value: { color: '#72aee6', style: 'dotted' },
 				} );
-				await renderBorderControl( props );
+				render( <BorderControl { ...props } /> );
 
 				expect(
 					screen.getByLabelText(
@@ -247,7 +248,7 @@ describe( 'BorderControl', () => {
 				const props = createProps( {
 					value: { color: '#4b1d80', style: 'dashed' },
 				} );
-				await renderBorderControl( props );
+				render( <BorderControl { ...props } /> );
 
 				expect(
 					screen.getByLabelText(
@@ -263,7 +264,7 @@ describe( 'BorderControl', () => {
 					value: undefined,
 					enableStyle: false,
 				} );
-				await renderBorderControl( props );
+				render( <BorderControl { ...props } /> );
 
 				expect(
 					screen.getByLabelText( 'Border color picker.' )
@@ -275,7 +276,7 @@ describe( 'BorderControl', () => {
 					value: { color: '#72aee6' },
 					enableStyle: false,
 				} );
-				await renderBorderControl( props );
+				render( <BorderControl { ...props } /> );
 
 				expect(
 					screen.getByLabelText(
@@ -289,7 +290,7 @@ describe( 'BorderControl', () => {
 					value: { color: '#4b1d80' },
 					enableStyle: false,
 				} );
-				await renderBorderControl( props );
+				render( <BorderControl { ...props } /> );
 
 				expect(
 					screen.getByLabelText(
@@ -303,7 +304,7 @@ describe( 'BorderControl', () => {
 	describe( 'onChange handling', () => {
 		it( 'should update width with slider value', async () => {
 			const props = createProps( { withSlider: true } );
-			const { rerender } = await renderBorderControl( props );
+			const { rerender } = render( <BorderControl { ...props } /> );
 
 			const slider = getSliderInput();
 			fireEvent.change( slider, { target: { value: '5' } } );
@@ -313,7 +314,7 @@ describe( 'BorderControl', () => {
 				width: '5px',
 			} );
 
-			await rerenderBorderControl( rerender, props );
+			rerender( <BorderControl { ...props } /> );
 			const widthInput = getWidthInput();
 
 			expect( widthInput.value ).toEqual( '5' );
@@ -321,7 +322,7 @@ describe( 'BorderControl', () => {
 
 		it( 'should update color selection', async () => {
 			const props = createProps();
-			await renderBorderControl( props );
+			render( <BorderControl { ...props } /> );
 			await openPopover();
 			clickButton( 'Color: Green' );
 
@@ -333,7 +334,7 @@ describe( 'BorderControl', () => {
 
 		it( 'should clear color selection when toggling swatch off', async () => {
 			const props = createProps();
-			await renderBorderControl( props );
+			render( <BorderControl { ...props } /> );
 			await openPopover();
 			clickButton( 'Color: Blue' );
 
@@ -345,7 +346,7 @@ describe( 'BorderControl', () => {
 
 		it( 'should update style selection', async () => {
 			const props = createProps();
-			await renderBorderControl( props );
+			render( <BorderControl { ...props } /> );
 			await openPopover();
 			clickButton( 'Dashed' );
 
@@ -357,7 +358,7 @@ describe( 'BorderControl', () => {
 
 		it( 'should take no action when color and style popover is closed', async () => {
 			const props = createProps( { showDropdownHeader: true } );
-			await renderBorderControl( props );
+			render( <BorderControl { ...props } /> );
 			await openPopover();
 			clickButton( 'Close border color' );
 
@@ -366,7 +367,7 @@ describe( 'BorderControl', () => {
 
 		it( 'should reset color and style only when popover reset button clicked', async () => {
 			const props = createProps();
-			await renderBorderControl( props );
+			render( <BorderControl { ...props } /> );
 			await openPopover();
 			clickButton( 'Reset to default' );
 
@@ -379,9 +380,9 @@ describe( 'BorderControl', () => {
 
 		it( 'should sanitize border when width and color are undefined', async () => {
 			const props = createProps();
-			const { rerender } = await renderBorderControl( props );
+			const { rerender } = render( <BorderControl { ...props } /> );
 			clearWidthInput();
-			await rerenderBorderControl( rerender, props );
+			rerender( <BorderControl { ...props } /> );
 			await openPopover();
 			clickButton( 'Color: Blue' );
 
@@ -392,9 +393,9 @@ describe( 'BorderControl', () => {
 			const props = createProps( {
 				shouldSanitizeBorder: false,
 			} );
-			const { rerender } = await renderBorderControl( props );
+			const { rerender } = render( <BorderControl { ...props } /> );
 			clearWidthInput();
-			await rerenderBorderControl( rerender, props );
+			rerender( <BorderControl { ...props } /> );
 			await openPopover();
 			clickButton( 'Color: Blue' );
 
@@ -407,7 +408,7 @@ describe( 'BorderControl', () => {
 
 		it( 'should clear color and set style to `none` when setting zero width', async () => {
 			const props = createProps();
-			await renderBorderControl( props );
+			render( <BorderControl { ...props } /> );
 			await openPopover();
 			clickButton( 'Color: Green' );
 			clickButton( 'Dotted' );
@@ -422,12 +423,12 @@ describe( 'BorderControl', () => {
 
 		it( 'should reselect color and style selections when changing to non-zero width', async () => {
 			const props = createProps();
-			const { rerender } = await renderBorderControl( props );
+			const { rerender } = render( <BorderControl { ...props } /> );
 			await openPopover();
 			clickButton( 'Color: Green' );
-			await rerenderBorderControl( rerender, props );
+			rerender( <BorderControl { ...props } /> );
 			clickButton( 'Dotted' );
-			await rerenderBorderControl( rerender, props );
+			rerender( <BorderControl { ...props } /> );
 			setWidthInput( '0' );
 			setWidthInput( '5' );
 
@@ -440,7 +441,7 @@ describe( 'BorderControl', () => {
 
 		it( 'should set a non-zero width when applying color to zero width border', async () => {
 			const props = createProps( { value: undefined } );
-			const { rerender } = await renderBorderControl( props );
+			const { rerender } = render( <BorderControl { ...props } /> );
 			await openPopover();
 			clickButton( 'Color: Yellow' );
 
@@ -451,7 +452,7 @@ describe( 'BorderControl', () => {
 			} );
 
 			setWidthInput( '0' );
-			await rerenderBorderControl( rerender, props );
+			rerender( <BorderControl { ...props } /> );
 			clickButton( 'Color: Green' );
 
 			expect( props.onChange ).toHaveBeenCalledWith( {
@@ -466,7 +467,7 @@ describe( 'BorderControl', () => {
 				value: undefined,
 				shouldSanitizeBorder: false,
 			} );
-			const { rerender } = await renderBorderControl( props );
+			const { rerender } = render( <BorderControl { ...props } /> );
 			await openPopover();
 			clickButton( 'Dashed' );
 
@@ -477,7 +478,7 @@ describe( 'BorderControl', () => {
 			} );
 
 			setWidthInput( '0' );
-			await rerenderBorderControl( rerender, props );
+			rerender( <BorderControl { ...props } /> );
 			clickButton( 'Dotted' );
 
 			expect( props.onChange ).toHaveBeenCalledWith( {

--- a/packages/components/src/border-control/test/index.js
+++ b/packages/components/src/border-control/test/index.js
@@ -94,7 +94,7 @@ const clearWidthInput = () => setWidthInput( '' );
 
 describe( 'BorderControl', () => {
 	describe( 'basic rendering', () => {
-		it( 'should render standard border control', async () => {
+		it( 'should render standard border control', () => {
 			const props = createProps();
 			render( <BorderControl { ...props } /> );
 
@@ -115,7 +115,7 @@ describe( 'BorderControl', () => {
 			expect( slider ).not.toBeInTheDocument();
 		} );
 
-		it( 'should hide label', async () => {
+		it( 'should hide label', () => {
 			const props = createProps( { hideLabelFromVision: true } );
 			render( <BorderControl { ...props } /> );
 			const label = screen.getByText( props.label );
@@ -129,7 +129,7 @@ describe( 'BorderControl', () => {
 			);
 		} );
 
-		it( 'should render with slider', async () => {
+		it( 'should render with slider', () => {
 			const props = createProps( { withSlider: true } );
 			render( <BorderControl { ...props } /> );
 
@@ -137,7 +137,7 @@ describe( 'BorderControl', () => {
 			expect( slider ).toBeInTheDocument();
 		} );
 
-		it( 'should render placeholder in UnitControl', async () => {
+		it( 'should render placeholder in UnitControl', () => {
 			const props = createProps( { placeholder: 'Mixed' } );
 			render( <BorderControl { ...props } /> );
 
@@ -200,7 +200,7 @@ describe( 'BorderControl', () => {
 
 	describe( 'color and style picker aria labels', () => {
 		describe( 'with style selection enabled', () => {
-			it( 'should include both color and style in label', async () => {
+			it( 'should include both color and style in label', () => {
 				const props = createProps( { value: undefined } );
 				render( <BorderControl { ...props } /> );
 
@@ -209,7 +209,7 @@ describe( 'BorderControl', () => {
 				).toBeInTheDocument();
 			} );
 
-			it( 'should correctly describe named color selection', async () => {
+			it( 'should correctly describe named color selection', () => {
 				const props = createProps( { value: { color: '#72aee6' } } );
 				render( <BorderControl { ...props } /> );
 
@@ -220,7 +220,7 @@ describe( 'BorderControl', () => {
 				).toBeInTheDocument();
 			} );
 
-			it( 'should correctly describe custom color selection', async () => {
+			it( 'should correctly describe custom color selection', () => {
 				const props = createProps( { value: { color: '#4b1d80' } } );
 				render( <BorderControl { ...props } /> );
 
@@ -231,7 +231,7 @@ describe( 'BorderControl', () => {
 				).toBeInTheDocument();
 			} );
 
-			it( 'should correctly describe named color and style selections', async () => {
+			it( 'should correctly describe named color and style selections', () => {
 				const props = createProps( {
 					value: { color: '#72aee6', style: 'dotted' },
 				} );
@@ -244,7 +244,7 @@ describe( 'BorderControl', () => {
 				).toBeInTheDocument();
 			} );
 
-			it( 'should correctly describe custom color and style selections', async () => {
+			it( 'should correctly describe custom color and style selections', () => {
 				const props = createProps( {
 					value: { color: '#4b1d80', style: 'dashed' },
 				} );
@@ -259,7 +259,7 @@ describe( 'BorderControl', () => {
 		} );
 
 		describe( 'with style selection disabled', () => {
-			it( 'should only include color in the label', async () => {
+			it( 'should only include color in the label', () => {
 				const props = createProps( {
 					value: undefined,
 					enableStyle: false,
@@ -271,7 +271,7 @@ describe( 'BorderControl', () => {
 				).toBeInTheDocument();
 			} );
 
-			it( 'should correctly describe named color selection', async () => {
+			it( 'should correctly describe named color selection', () => {
 				const props = createProps( {
 					value: { color: '#72aee6' },
 					enableStyle: false,
@@ -285,7 +285,7 @@ describe( 'BorderControl', () => {
 				).toBeInTheDocument();
 			} );
 
-			it( 'should correctly describe custom color selection', async () => {
+			it( 'should correctly describe custom color selection', () => {
 				const props = createProps( {
 					value: { color: '#4b1d80' },
 					enableStyle: false,
@@ -302,7 +302,7 @@ describe( 'BorderControl', () => {
 	} );
 
 	describe( 'onChange handling', () => {
-		it( 'should update width with slider value', async () => {
+		it( 'should update width with slider value', () => {
 			const props = createProps( { withSlider: true } );
 			const { rerender } = render( <BorderControl { ...props } /> );
 


### PR DESCRIPTION
Improves the `BorderControl` unit tests by:
- removing the low-value `renderBorderControl` and `rerenderBorderControl` helpers and replace them with direct `render` and `rerender` calls. Also they don't need to be async, as they don't need to do any `await act()` call. Only opening a popover requires something like that.
- when opening a popover (the color picker), waits for it using the standard method we've developed lately.