### PR TITLE
Gallery: Avoid creating new layout objects on every render

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -65,6 +65,7 @@ const linkOptions = [
 ];
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 const allowedBlocks = [ 'core/image' ];
+const LAYOUT = { type: 'default', alignments: [] };
 
 const PLACEHOLDER_TEXT = Platform.isNative
 	? __( 'ADD MEDIA' )
@@ -489,7 +490,7 @@ function GalleryEdit( props ) {
 		allowedBlocks,
 		orientation: 'horizontal',
 		renderAppender: false,
-		__experimentalLayout: { type: 'default', alignments: [] },
+		__experimentalLayout: LAYOUT,
 	} );
 
 	if ( ! hasImages ) {


### PR DESCRIPTION
## What?
Similar to #30374.

Updates Gallery block to use stable reference object for the layout settings.

## Why?
I noticed that the `ImageEdit` component was doing extra rerender due to context and `__unstableParentLayout` change. Also, it's a good practice if the setting isn't reactive value.

## Testing Instructions
The Gallery block should work as before.
