### PR TITLE
Inline preview: center align block in global styles inline preview

### DIFF
--- a/packages/edit-site/src/components/global-styles/block-preview-panel.js
+++ b/packages/edit-site/src/components/global-styles/block-preview-panel.js
@@ -22,9 +22,19 @@ const BlockPreviewPanel = ( { name } ) => {
 				{ containerResizeListener }
 
 				<BlockPreview
+					blocks={ blocks }
 					viewportWidth={ viewportWidth }
 					__experimentalMinHeight={ minHeight }
-					blocks={ blocks }
+					__experimentalStyles={ [
+						{
+							css: `
+								body{
+									min-height:${ minHeight }px;
+									display:flex;align-items:center;justify-content:center;
+								}
+							`,
+						},
+					] }
 				/>
 			</div>
 		</Spacer>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Blocks such as Button, Heading are top left aligned in the inline preview. This PR will keep the blocks center aligned for the better user experience.

| Before | After |
| --- | --- |
| <img width="264" alt="image" src="https://user-images.githubusercontent.com/1935113/209077767-7caa3ba5-281f-4b1b-ac3f-a106f8c92972.png"> | <img width="264" alt="image" src="https://user-images.githubusercontent.com/1935113/209077001-3d34c685-2f1f-432b-a796-54c87d98dde6.png"> |
| <img width="264" alt="image" src="https://user-images.githubusercontent.com/1935113/209077798-323d4e0f-7b4d-4c15-ac78-5187aa835db5.png"> | <img width="264" alt="image" src="https://user-images.githubusercontent.com/1935113/209077117-a438fb81-6600-47eb-9b9f-53e104b28636.png"> |
