### PR TITLE
Inner Blocks: Fix provides context condition

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -87,8 +87,10 @@ function UncontrolledInnerBlocks( props ) {
 
 			const blockType = getBlockType( block.name );
 
-			if ( ! blockType || ! blockType.providesContext ) {
-				return {};
+			if (
+				Object.keys( blockType?.providesContext ?? {} ).length === 0
+			) {
+				return { name: block.name };
 			}
 
 			return {


### PR DESCRIPTION
## What?
PR fixes early return condition check when block type doesn't provide context.

## Why?
The default `providesContext` value is an empty object. Since its [truthy value](https://developer.mozilla.org/en-US/docs/Glossary/Truthy), the early return condition was never met.

The `getBlockContext` will return a new object on every attribute change and cause extra re-render. This is another issue I'm trying to solve.

## How?
Use `Object.keys` to check if the block type defines the context to provide.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Quote Block.
3. Using DevTools, place log point [after early return condition](https://github.com/WordPress/gutenberg/blob/99bc9c7393b20375ffd1e5f879e79410f4c9f06b/packages/block-editor/src/components/inner-blocks/index.js#L94-L97).
4. Confirm that noting is logged when tying in the citation field.
5. Try the same on the trunk and see logs on each attribute update.

### Testing Instructions for Keyboard
Doesn't affect UI.
