### PR TITLE
Edit-post site logo: Fix focus style.

### DIFF
--- a/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
@@ -35,7 +35,7 @@
 			position: absolute;
 			top: 9px;
 			right: 9px;
-			bottom: 9px;
+			bottom: 9px + $border-width; // Height of toolbar in edit-post (not edit-site) is 61px tall.
 			left: 9px;
 			border-radius: $radius-block-ui + $border-width + $border-width;
 			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $gray-900;


### PR DESCRIPTION
## What?

The site logo (the W button in the top left corner) has an incorrect focus style in the post editor, being 1px off below:

<img width="201" alt="before" src="https://user-images.githubusercontent.com/1204802/209111734-c97e6565-ab3a-414b-a006-14af16cc2a68.png">

That's because the height of the toolbar is 60px tall, plus 1px border. This PR fixes it by adding that extra 1px border to the bottom positioning of the focus style:

<img width="230" alt="after" src="https://user-images.githubusercontent.com/1204802/209111854-e40eb75c-16f7-4053-8228-5db7e29bd8cc.png">

This issue is different in the site editor, and not a place to fix it at this point, as the site logo there is currently a little bit in flux. See also #46700

## Testing Instructions

Set focus on the W back button in the post editor, and observe a focus style that is square.