### PR TITLE
Simplify the way we create a link UI control in the offcanvas editor

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/appender.js
+++ b/packages/block-editor/src/components/off-canvas-editor/appender.js
@@ -2,24 +2,14 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { forwardRef, useState } from '@wordpress/element';
+import { forwardRef } from '@wordpress/element';
 /**
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
 import Inserter from '../inserter';
-import { LinkUI } from './link-ui';
-import { updateAttributes } from './update-attributes';
-import { useInsertedBlock } from './use-inserted-block';
-
-const BLOCKS_WITH_LINK_UI_SUPPORT = [
-	'core/navigation-link',
-	'core/navigation-submenu',
-];
 
 export const Appender = forwardRef( ( props, ref ) => {
-	const [ insertedBlockClientId, setInsertedBlockClientId ] = useState();
-
 	const { hideInserter, clientId } = useSelect( ( select ) => {
 		const {
 			getTemplateLock,
@@ -37,59 +27,18 @@ export const Appender = forwardRef( ( props, ref ) => {
 		};
 	}, [] );
 
-	const {
-		insertedBlockAttributes,
-		insertedBlockName,
-		setInsertedBlockAttributes,
-	} = useInsertedBlock( insertedBlockClientId );
-
-	const maybeSetInsertedBlockOnInsertion = ( _insertedBlock ) => {
-		if ( ! _insertedBlock?.clientId ) {
-			return;
-		}
-
-		setInsertedBlockClientId( _insertedBlock?.clientId );
-	};
-
-	let maybeLinkUI;
-
-	if (
-		insertedBlockClientId &&
-		BLOCKS_WITH_LINK_UI_SUPPORT?.includes( insertedBlockName )
-	) {
-		maybeLinkUI = (
-			<LinkUI
-				clientId={ insertedBlockClientId }
-				link={ insertedBlockAttributes }
-				onClose={ () => setInsertedBlockClientId( null ) }
-				hasCreateSuggestion={ false }
-				onChange={ ( updatedValue ) => {
-					updateAttributes(
-						updatedValue,
-						setInsertedBlockAttributes,
-						insertedBlockAttributes
-					);
-					setInsertedBlockClientId( null );
-				} }
-			/>
-		);
-	}
-
 	if ( hideInserter ) {
 		return null;
 	}
 
 	return (
 		<div className="offcanvas-editor__appender">
-			{ maybeLinkUI }
-
 			<Inserter
 				ref={ ref }
 				rootClientId={ clientId }
 				position="bottom right"
 				isAppender={ true }
 				selectBlockOnInsert={ false }
-				onSelectOrClose={ maybeSetInsertedBlockOnInsertion }
 				__experimentalIsQuick
 				{ ...props }
 			/>

--- a/packages/block-editor/src/components/off-canvas-editor/block-contents.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-contents.js
@@ -92,29 +92,24 @@ const ListViewBlockContents = forwardRef(
 			? selectedClientIds
 			: [ clientId ];
 
-		let maybeLinkUI;
-		if ( isLinkUIOpen ) {
-			maybeLinkUI = (
-				<LinkUI
-					clientId={ lastInsertedBlockClientId }
-					link={ insertedBlockAttributes }
-					onClose={ () => setIsLinkUIOpen( false ) }
-					hasCreateSuggestion={ false }
-					onChange={ ( updatedValue ) => {
-						updateAttributes(
-							updatedValue,
-							setInsertedBlockAttributes,
-							insertedBlockAttributes
-						);
-						setIsLinkUIOpen( false );
-					} }
-				/>
-			);
-		}
-
 		return (
 			<>
-				{ maybeLinkUI }
+				{ isLinkUIOpen && (
+					<LinkUI
+						clientId={ lastInsertedBlockClientId }
+						link={ insertedBlockAttributes }
+						onClose={ () => setIsLinkUIOpen( false ) }
+						hasCreateSuggestion={ false }
+						onChange={ ( updatedValue ) => {
+							updateAttributes(
+								updatedValue,
+								setInsertedBlockAttributes,
+								insertedBlockAttributes
+							);
+							setIsLinkUIOpen( false );
+						} }
+					/>
+				) }
 				<BlockDraggable clientIds={ draggableClientIds }>
 					{ ( { draggable, onDragStart, onDragEnd } ) => (
 						<ListViewBlockSelectButton

--- a/packages/block-editor/src/components/off-canvas-editor/block-contents.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-contents.js
@@ -68,17 +68,22 @@ const ListViewBlockContents = forwardRef(
 			setInsertedBlockAttributes,
 		} = useInsertedBlock( lastInsertedBlockClientId );
 
-		const hasCommittedLinkValue = insertedBlockAttributes?.id;
+		const hasExistingLinkValue = insertedBlockAttributes?.id;
 
 		useEffect( () => {
 			if (
 				clientId === lastInsertedBlockClientId &&
 				BLOCKS_WITH_LINK_UI_SUPPORT?.includes( insertedBlockName ) &&
-				! hasCommittedLinkValue
+				! hasExistingLinkValue // don't re-show the Link UI if the block already has a link value.
 			) {
 				setIsLinkUIOpen( true );
 			}
-		}, [ lastInsertedBlockClientId, hasCommittedLinkValue ] );
+		}, [
+			lastInsertedBlockClientId,
+			clientId,
+			insertedBlockName,
+			hasExistingLinkValue,
+		] );
 
 		const isBlockMoveTarget =
 			blockMovingClientId && selectedBlockInBlockEditor === clientId;

--- a/packages/block-editor/src/components/off-canvas-editor/block-contents.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-contents.js
@@ -68,14 +68,17 @@ const ListViewBlockContents = forwardRef(
 			setInsertedBlockAttributes,
 		} = useInsertedBlock( lastInsertedBlockClientId );
 
+		const hasCommittedLinkValue = insertedBlockAttributes?.id;
+
 		useEffect( () => {
 			if (
 				clientId === lastInsertedBlockClientId &&
-				BLOCKS_WITH_LINK_UI_SUPPORT?.includes( insertedBlockName )
+				BLOCKS_WITH_LINK_UI_SUPPORT?.includes( insertedBlockName ) &&
+				! hasCommittedLinkValue
 			) {
 				setIsLinkUIOpen( true );
 			}
-		}, [ lastInsertedBlockClientId ] );
+		}, [ lastInsertedBlockClientId, hasCommittedLinkValue ] );
 
 		const isBlockMoveTarget =
 			blockMovingClientId && selectedBlockInBlockEditor === clientId;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is a small refactor as suggested in https://github.com/WordPress/gutenberg/pull/46503, which should simplify the code that creates the LinkUI.
## Why?
Simple code is easier to understand and maintain. This will also allow us to display the link UI alongside the relevant block when we are inserting a submenu at a different point in the tree (see https://github.com/WordPress/gutenberg/pull/46582).

## How?
- move the LinkUI component up to the ListViewBlockContents component
- conditionally trigger the Link UI based on the result of calling the new getLastInsertedBlock selector

## Testing Instructions
1. Add a navigation block
2. Open the offcanvas editor:
<img width="299" alt="Screenshot 2022-12-22 at 13 32 03" src="https://user-images.githubusercontent.com/275961/209145071-2921c8a3-fc03-4fd1-b4b7-d9826465f44a.png">
3. Attempt to add a block using the block inserter
4. Check that the block is added correctly and that the inserter closes when you have selected a link.

### Testing Instructions for Keyboard
As above

Co-authored-by: Dave Smith <getdavemail@gmail.com>
