### PR TITLE
Iframe: restore typewriter effect in post editor

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -310,7 +310,11 @@ export default function VisualEditor( { styles } ) {
 			...styles,
 			{
 				// We should move this in to future to the body.
-				css: `.edit-post-visual-editor__post-title-wrapper{margin-top:4rem}`,
+				css:
+					`.edit-post-visual-editor__post-title-wrapper{margin-top:4rem}` +
+					( paddingBottom
+						? `body{padding-bottom:${ paddingBottom }}`
+						: '' ),
 			},
 		],
 		[ styles ]
@@ -358,7 +362,6 @@ export default function VisualEditor( { styles } ) {
 						contentRef={ contentRef }
 						styles={ styles }
 						assets={ assets }
-						style={ { paddingBottom } }
 					>
 						{ themeSupportsLayout &&
 							! themeHasDisabledLayoutStyles &&


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Currently the typewriter hook is incompatible with the iframe.

## Why?

Typewriter effect is broken for block based themes.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

Open the demo content, type a bit and press Enter, Backspace, Shift+Enter etc. the caret should remain at the same vertical position.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
