### PR TITLE
Lodash: Remove dependency from server-side-render

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19560,8 +19560,7 @@
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/url": "file:packages/url",
-				"fast-deep-equal": "^3.1.3",
-				"lodash": "^4.17.21"
+				"fast-deep-equal": "^3.1.3"
 			}
 		},
 		"@wordpress/shortcode": {

--- a/packages/server-side-render/package.json
+++ b/packages/server-side-render/package.json
@@ -36,8 +36,7 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/url": "file:../url",
-		"fast-deep-equal": "^3.1.3",
-		"lodash": "^4.17.21"
+		"fast-deep-equal": "^3.1.3"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",


### PR DESCRIPTION
## What?
This PR removes the `lodash` dependency from the `server-side-render` package.

## Why?
It's no longer necessary there.

## How?
Just removing the dependency.

## Testing Instructions
Verify all checks are green.
