### PR TITLE
Lodash: Remove dependency from `customize-widgets`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18313,8 +18313,7 @@
 				"@wordpress/preferences": "file:packages/preferences",
 				"@wordpress/widgets": "file:packages/widgets",
 				"classnames": "^2.3.1",
-				"fast-deep-equal": "^3.1.3",
-				"lodash": "^4.17.21"
+				"fast-deep-equal": "^3.1.3"
 			}
 		},
 		"@wordpress/data": {

--- a/packages/customize-widgets/package.json
+++ b/packages/customize-widgets/package.json
@@ -44,8 +44,7 @@
 		"@wordpress/preferences": "file:../preferences",
 		"@wordpress/widgets": "file:../widgets",
 		"classnames": "^2.3.1",
-		"fast-deep-equal": "^3.1.3",
-		"lodash": "^4.17.21"
+		"fast-deep-equal": "^3.1.3"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",


### PR DESCRIPTION
## What?
This PR removes the `lodash` dependency from the `customize-widgets` package.

## Why?
It's no longer necessary there.

## How?
Just removing the dependency.

## Testing Instructions
Verify all checks are green.
