### PR TITLE
Parse the attributes in a case-insensitive way to comply with the HTML parsing spec.

### DIFF
--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1009,8 +1009,8 @@ class WP_HTML_Tag_Processor {
 			return false;
 		}
 
-		$attribute_start = $this->parsed_bytes;
-		$attribute_name = substr( $this->html, $attribute_start, $name_length );
+		$attribute_start     = $this->parsed_bytes;
+		$attribute_name      = substr( $this->html, $attribute_start, $name_length );
 		$this->parsed_bytes += $name_length;
 		if ( $this->parsed_bytes >= strlen( $this->html ) ) {
 			return false;
@@ -1067,7 +1067,7 @@ class WP_HTML_Tag_Processor {
 		 *
 		 * @see https://html.spec.whatwg.org/multipage/syntax.html#attributes-2:ascii-case-insensitive
 		 */
-		$comparable_name = strtolower( $attribute_name);
+		$comparable_name = strtolower( $attribute_name );
 
 		// If an attribute is listed many times, only use the first declaration and ignore the rest.
 		if ( ! array_key_exists( $comparable_name, $this->attributes ) ) {

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1474,6 +1474,14 @@ class WP_HTML_Tag_Processor {
 			return false;
 		}
 
+		/**
+		 * Uppercase characters in the attributes names are converted into lowercase characters
+		 * according to the HTML parsing spec:
+		 *
+		 * @see https://html.spec.whatwg.org/multipage/parsing.html#attribute-name-state
+		 */
+		$name = strtolower( $name );
+
 		/*
 		 * Verify that the attribute name is allowable. In WP_DEBUG
 		 * environments we want to crash quickly to alert developers

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1581,6 +1581,13 @@ class WP_HTML_Tag_Processor {
 	 * @param string $name The attribute name to remove.
 	 */
 	public function remove_attribute( $name ) {
+		/**
+		 * Uppercase characters in the attributes names are converted into lowercase characters
+		 * according to the HTML parsing spec:
+		 *
+		 * @see https://html.spec.whatwg.org/multipage/parsing.html#attribute-name-state
+		 */
+		$name = strtolower( $name );
 		if ( $this->is_closing_tag || ! isset( $this->attributes[ $name ] ) ) {
 			return false;
 		}

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1009,8 +1009,14 @@ class WP_HTML_Tag_Processor {
 			return false;
 		}
 
-		$attribute_start     = $this->parsed_bytes;
-		$attribute_name      = substr( $this->html, $attribute_start, $name_length );
+		$attribute_start = $this->parsed_bytes;
+		/**
+		 * Uppercase characters in the attributes names are converted into lowercase characters
+		 * according to the HTML parsing spec:
+		 *
+		 * @see https://html.spec.whatwg.org/multipage/parsing.html#attribute-name-state
+		 */
+		$attribute_name      = strtolower( substr( $this->html, $attribute_start, $name_length ) );
 		$this->parsed_bytes += $name_length;
 		if ( $this->parsed_bytes >= strlen( $this->html ) ) {
 			return false;

--- a/phpunit/html/wp-html-tag-processor-test.php
+++ b/phpunit/html/wp-html-tag-processor-test.php
@@ -179,7 +179,7 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 		$p = new WP_HTML_Tag_Processor( '<div DATA-enabled="true">Test</div>' );
 		$p->next_tag();
 		$p->remove_attribute( 'data-enabled' );
-		$this->assertEquals( '<div>Test</div>', $p->get_updated_html(), 'A case-insensitive remove_attribute call did not remove the attribute.' );
+		$this->assertEquals( '<div >Test</div>', $p->get_updated_html(), 'A case-insensitive remove_attribute call did not remove the attribute.' );
 	}
 
 	/**

--- a/phpunit/html/wp-html-tag-processor-test.php
+++ b/phpunit/html/wp-html-tag-processor-test.php
@@ -192,7 +192,7 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 		$p = new WP_HTML_Tag_Processor( '<div DATA-enabled="true">Test</div>' );
 		$p->next_tag();
 		$p->set_attribute( 'data-enabled', 'abc' );
-		$this->assertEquals( '<div data-enabled="abc">Test</div>', $p->get_updated_html(), 'A case-insensitive set_attribute call did not remove the attribute.' );
+		$this->assertEquals( '<div data-enabled="abc">Test</div>', $p->get_updated_html(), 'A case-insensitive set_attribute call did not update the existing attribute.' );
 	}
 
 	/**

--- a/phpunit/html/wp-html-tag-processor-test.php
+++ b/phpunit/html/wp-html-tag-processor-test.php
@@ -154,6 +154,24 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 	/**
 	 * @ticket 56299
 	 *
+	 * @covers next_tag
+	 * @covers get_attribute
+	 */
+	public function test_attributes_parser_is_case_insensitive() {
+		$p = new WP_HTML_Tag_Processor( '<div DATA-enabled="true" data-VISIBLE>Test</div>' );
+		$p->next_tag();
+		$p->get_attribute( 'data-enabled' );
+		$this->assertEquals( 'true', $p->get_attribute( 'DATA-enabled' ), 'A case-insensitive get_attribute call did not return "true".' );
+		$this->assertEquals( 'true', $p->get_attribute( 'data-enabled' ), 'A case-insensitive get_attribute call did not return "true".' );
+		$this->assertEquals( 'true', $p->get_attribute( 'DATA-ENABLED' ), 'A case-insensitive get_attribute call did not return "true".' );
+		$this->assertEquals( true, $p->get_attribute( 'data-VISIBLE' ), 'A case-insensitive get_attribute call did not return true.' );
+		$this->assertEquals( true, $p->get_attribute( 'DATA-visible' ), 'A case-insensitive get_attribute call did not return true.' );
+		$this->assertEquals( true, $p->get_attribute( 'dAtA-ViSiBlE' ), 'A case-insensitive get_attribute call did not return true.' );
+	}
+
+	/**
+	 * @ticket 56299
+	 *
 	 * @covers __toString
 	 */
 	public function tostring_returns_updated_html() {

--- a/phpunit/html/wp-html-tag-processor-test.php
+++ b/phpunit/html/wp-html-tag-processor-test.php
@@ -172,6 +172,32 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 	/**
 	 * @ticket 56299
 	 *
+	 * @covers next_tag
+	 * @covers remove_attribute
+	 */
+	public function test_remove_attribute_is_case_insensitive() {
+		$p = new WP_HTML_Tag_Processor( '<div DATA-enabled="true">Test</div>' );
+		$p->next_tag();
+		$p->remove_attribute( 'data-enabled' );
+		$this->assertEquals( '<div>Test</div>', $p->get_updated_html(), 'A case-insensitive remove_attribute call did not remove the attribute.' );
+	}
+
+	/**
+	 * @ticket 56299
+	 *
+	 * @covers next_tag
+	 * @covers set_attribute
+	 */
+	public function test_set_attribute_is_case_insensitive() {
+		$p = new WP_HTML_Tag_Processor( '<div DATA-enabled="true">Test</div>' );
+		$p->next_tag();
+		$p->set_attribute( 'data-enabled', 'abc' );
+		$this->assertEquals( '<div data-enabled="abc">Test</div>', $p->get_updated_html(), 'A case-insensitive set_attribute call did not remove the attribute.' );
+	}
+
+	/**
+	 * @ticket 56299
+	 *
 	 * @covers __toString
 	 */
 	public function tostring_returns_updated_html() {


### PR DESCRIPTION
Accordingly to
https://html.spec.whatwg.org/multipage/parsing.html#attribute-name-state, the uppercase letters in the attribute names should be consumed as lowercase letters, e.g. `<a HREF="#">` should be parsed as `a` with an attribute `href` (not `HREF`).

In particular, the following test case should pass:

```php
$p = new WP_HTML_Tag_Processor( '<div DATA-enabled="true">Test</div>' );
$p->next_tag();
$p->get_attribute( 'data-enabled' );
$this->assertEquals( 'true', $p->get_attribute( 'DATA-enabled' ) );
$this->assertEquals( 'true', $p->get_attribute( 'data-enabled' ) );
$this->assertEquals( 'true', $p->get_attribute( 'DATA-ENABLED' ) );
```

cc @dmsnell @ockham 