### PR TITLE
Toolbar: fix duplicate focus style on anchor link button

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,6 +17,7 @@
 -   `InputControl`: Fix internal `Flex` wrapper usage that could add an unintended `height: 100%` ([#46213](https://github.com/WordPress/gutenberg/pull/46213)).
 -   `Navigator`: Allow calling `goTo` and `goBack` twice in one render cycle ([#46391](https://github.com/WordPress/gutenberg/pull/46391)).
 -   `Modal`: Fix unexpected modal closing in IME Composition ([#46453](https://github.com/WordPress/gutenberg/pull/46453)).
+-   `Toolbar`: Fix duplicate focus style on anchor link button ([#46759](https://github.com/WordPress/gutenberg/pull/46759)).
 
 ### Enhancements
 

--- a/packages/components/src/toolbar/style.scss
+++ b/packages/components/src/toolbar/style.scss
@@ -21,7 +21,7 @@
 		padding-right: $grid-unit-20;
 
 		// Don't show the focus inherited by the Button component.
-		&:focus:enabled {
+		&:focus:not(:disabled) {
 			box-shadow: none;
 			outline: none;
 		}


### PR DESCRIPTION
Fixes #46757

## What?
This PR fixes a problem in which two focus outlines are displayed when the anchor link button is used in the `Toolbar` component. As seen in this image, the Edit button in the template part is the anchor link button.

![capture](https://user-images.githubusercontent.com/54422211/209278878-75831a04-b672-43d5-b939-fd8debaf4c7b.png)

## Why?
In the `Toolbar` component, the following code overrides the focus style inherited from the `Button` component:

https://github.com/WordPress/gutenberg/blob/f30366307d23ae190a5d0e03119dfa82e7616b19/packages/components/src/toolbar/style.scss#L23-L27

I think that the `a` element doesn't support the `:disabled` pseudo-element, and as a result, the `:enabled` pseudo-element does not work. Also, if you look at [the HTML standard](https://html.spec.whatwg.org/multipage/semantics-other.html#selector-enabled), you will see that the `:enabled` pseudo-element does not support the `a` element.

> The :enabled pseudo-class must match any button, input, select, textarea, optgroup, option, fieldset element, or form-associated custom element that is not actually disabled.

## How?
I used `:not(:disabled)` instead of `:enabled`. This also matches the `a` element, which does not support `:disabled`/`:enabled`.

## Testing Instructions
- Select a template-part on the block toolbar.
- Focus on that button with the keyboard controls or click on it with the mouse cursor (Hold the cursor click.).
- See how the focus outline appears

## Screenshots or screencast 

I also tested in Windows high contrast mode.

### Before

https://user-images.githubusercontent.com/54422211/209279701-896c09d0-07bb-452a-b49b-bcaa47d1f71c.mp4

https://user-images.githubusercontent.com/54422211/209279710-aef9e251-2224-42dc-ba8e-187611a79a1a.mp4

### After

https://user-images.githubusercontent.com/54422211/209279766-d5e2d7cf-f0f7-4812-b2e8-11b3ccb4b05b.mp4

https://user-images.githubusercontent.com/54422211/209279775-cefb4177-2140-4164-9545-a463de8c780e.mp4

