### PR TITLE
Site Editor: Don't show block inserter when the canvas is view mode

### DIFF
--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 -   Fluid typography: add configurable fluid typography settings for minimum font size to theme.json ([#42489](https://github.com/WordPress/gutenberg/pull/42489)).
 
+### Bug Fix
+
+-   Don't show block inserter when the canvas is view mode ([#46763](https://github.com/WordPress/gutenberg/pull/46763)).
+
+
 ## 4.19.0 (2022-11-16)
 
 ## 4.18.0 (2022-11-02)

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -153,7 +153,8 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 		// Disable resizing in mobile viewport.
 		! isMobileViewport;
 	const isViewMode = canvasMode === 'view';
-
+	const showBlockAppender =
+		( isTemplatePart && hasBlocks ) || isViewMode ? false : undefined;
 	// eslint-disable-next-line @wordpress/data-no-store-string-literals
 	const { enableComplementaryArea } = useDispatch( 'core/interface' );
 
@@ -243,11 +244,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 									<BlockList
 										className="edit-site-block-editor__block-list wp-site-blocks"
 										__experimentalLayout={ LAYOUT }
-										renderAppender={
-											isTemplatePart && hasBlocks
-												? false
-												: undefined
-										}
+										renderAppender={ showBlockAppender }
 									/>
 								</EditorCanvas>
 							</ResizableEditor>

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -155,6 +155,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 	const isViewMode = canvasMode === 'view';
 	const showBlockAppender =
 		( isTemplatePart && hasBlocks ) || isViewMode ? false : undefined;
+
 	// eslint-disable-next-line @wordpress/data-no-store-string-literals
 	const { enableComplementaryArea } = useDispatch( 'core/interface' );
 


### PR DESCRIPTION
Fixes: #46720

## What?
This PR hides the block inserter when the site editor canvas is in _view mode_.

![inserter](https://user-images.githubusercontent.com/54422211/209337092-8f9b7330-1b4c-4362-9fc9-9efa86459e5f.png)

## Why?
When the canvas is in view mode, there is no operation on the block editor, so pressing the + button does not respond. This button should be expected not to be displayed when in view mode.

## How?
Added a display condition for the `renderAppender` prop of `<BlockList />`, whether it is in view mode or not.

## Testing Instructions

In both the Template Editor and the Template Parts Editor, check the following:

- Block inserter is NOT displayed when in **view mode**
- Block inserter is displayed in **edit mode**

## Screenshots or screencast

### Before

https://user-images.githubusercontent.com/54422211/209336378-f4f72d72-5847-4f12-802f-4f7cb5a3d307.mp4

### After

https://user-images.githubusercontent.com/54422211/209336392-6ae4f776-b433-43b8-a6e4-d955e9cd7280.mp4