### PR TITLE
Button: Try improving padding for icon + text buttons.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   `Dropdown`: deprecate `position`  prop, use `popoverProps` instead ([46865](https://github.com/WordPress/gutenberg/pull/46865)).
+-   `Button`: improve padding for buttons with icon and text. ([46764](https://github.com/WordPress/gutenberg/pull/46764)).
 
 ### Internal
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -282,14 +282,15 @@
 
 		&.has-text {
 			justify-content: start;
+			padding-right: 12px;
 		}
 
 		&.has-text svg {
-			margin-right: 8px;
+			margin-right: $grid-unit-10;
 		}
 
 		&.has-text .dashicon {
-			margin-right: 10px;
+			margin-right: $grid-unit-10 + 2px;
 		}
 	}
 


### PR DESCRIPTION
## What?

Primary and secondary Buttons have an awkward padding when both an icon and text is provided. You can see this in [Storybook](https://wordpress.github.io/gutenberg/?path=/story/components-button--default&args=icon:more;iconPosition:right;variant:primary), or in this PR: #46014:

<img width="264" alt="before" src="https://user-images.githubusercontent.com/1204802/209338959-a60003ce-b910-4d87-beac-3620f0f2d6e8.png">

By default, the button has 6px top/bottom padding, 12px left/right padding. But when a button `has-icon`, that padding becomes a blanket 6px:

<img width="378" alt="padding" src="https://user-images.githubusercontent.com/1204802/209339023-3d31fb39-b038-40af-88a7-3af31fbec681.png">

This PR fixes it, by providing a 12px _right_ padding, baked in:

<img width="267" alt="after" src="https://user-images.githubusercontent.com/1204802/209339047-91cd7fec-2f12-4992-9b73-08b2cb4497f7.png">

Adding this padding, at a glance, seems safe enough since the code a few lines down applies the following:

```
		&.has-text svg {
			margin-right: $grid-unit-10;
		}

		&.has-text .dashicon {
			margin-right: $grid-unit-10 + 2px;
		}
```

That is, the component already assumes a left to right reading direction, with the icon on the left. 

I haven't been able to test, however it seems like this would break in RTL contexts. Furthermore, the button component appears to have an `iconPosition` prop, which at the moment seems to do nothing — even if set to right, the icon still shows up on the left: https://wordpress.github.io/gutenberg/?path=/story/components-button--default&args=icon:more;iconPosition:right;variant:primary

As is, this PR will improve things for primary and secondary buttons, and does not tackle the problem of RTL or iconPosition being broken. However it would be good to follow up on those.

## Testing Instructions

Perhaps easiest to test in storybook.
https://wordpress.github.io/gutenberg/?path=/story/components-button--default&args=icon:more;iconPosition:right;variant:primary
