### PR TITLE
Update the script registration of the react scripts with a cache version

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -549,13 +549,15 @@ function gutenberg_register_vendor_scripts( $scripts ) {
 		'react',
 		gutenberg_url( 'build/vendors/react' . $extension ),
 		// See https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/main/docs/TROUBLESHOOTING.md#externalising-react.
-		SCRIPT_DEBUG ? array( 'wp-react-refresh-entry', 'wp-polyfill' ) : array( 'wp-polyfill' )
+		SCRIPT_DEBUG ? array( 'wp-react-refresh-entry', 'wp-polyfill' ) : array( 'wp-polyfill' ),
+		'18'
 	);
 	gutenberg_override_script(
 		$scripts,
 		'react-dom',
 		gutenberg_url( 'build/vendors/react-dom' . $extension ),
-		array( 'react' )
+		array( 'react' ),
+		'18'
 	);
 }
 add_action( 'wp_default_scripts', 'gutenberg_register_vendor_scripts' );


### PR DESCRIPTION
closes #46737 

## What?

We did an update to React in the previous Gutenberg release 14.8 but it seems the script url didn't change, the version that is used for the script is the WP version which remains stable between two gutenberg versions. This PR forces the use of the React version for this script as a short term fix.

Long term, we should try to use the version from the package.json file somehow.

## Testing Instructions

1- Clear browse cache
2- Use a Gutenberg version prior to 14.7 (or 14.7)
3- Load the editor
4- Update the Gutenberg version to 14.8 (or this PR)
5- If you try to save the post, you'll have an error in 14.8 but it should work with this PR.
