### PR TITLE
Increase the width of the site editor sidebar

### DIFF
--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -49,7 +49,7 @@ $button-size: 36px;
 $button-size-small: 24px;
 $header-height: 60px;
 $panel-header-height: $grid-unit-60;
-$nav-sidebar-width: 320px;
+$nav-sidebar-width: 360px;
 $admin-bar-height: 32px;
 $admin-bar-height-big: 46px;
 $admin-sidebar-width: 160px;


### PR DESCRIPTION
Related #36667 

This is just a tiny PR that increases the size of the site editor sidebar per feedback from our designers. Check how it feels.

<img width="1440" alt="Screenshot 2022-12-23 at 4 05 11 PM" src="https://user-images.githubusercontent.com/272444/209357166-6a283e33-c0db-409b-8e11-edc5b591f7e8.png">
