### PR TITLE
Guide: Remove knobs in stories

### DIFF
--- a/packages/components/src/guide/stories/index.js
+++ b/packages/components/src/guide/stories/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { text, number } from '@storybook/addon-knobs';
-
-/**
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
@@ -17,19 +12,18 @@ import Guide from '../';
 export default {
 	title: 'Components/Guide',
 	component: Guide,
-	parameters: {
-		knobs: { disable: false },
+	argTypes: {
+		contentLabel: { control: 'text' },
+		finishButtonText: { control: 'text' },
+		onFinish: { action: 'onFinish' },
 	},
 };
 
-const ModalExample = ( { numberOfPages, ...props } ) => {
+const Template = ( { onFinish, ...props } ) => {
 	const [ isOpen, setOpen ] = useState( false );
 
 	const openGuide = () => setOpen( true );
 	const closeGuide = () => setOpen( false );
-
-	const loremIpsum =
-		'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
 
 	return (
 		<>
@@ -39,40 +33,19 @@ const ModalExample = ( { numberOfPages, ...props } ) => {
 			{ isOpen && (
 				<Guide
 					{ ...props }
-					onFinish={ closeGuide }
-					pages={ Array.from( { length: numberOfPages } ).map(
-						( _, page ) => ( {
-							content: (
-								<>
-									<h1>
-										Page { page + 1 } of { numberOfPages }
-									</h1>
-									<p>{ loremIpsum }</p>
-								</>
-							),
-						} )
-					) }
+					onFinish={ ( ...finishArgs ) => {
+						closeGuide( ...finishArgs );
+						onFinish( ...finishArgs );
+					} }
 				/>
 			) }
 		</>
 	);
 };
 
-export const _default = () => {
-	const finishButtonText = text( 'finishButtonText', 'Finish' );
-	const contentLabel = text( 'title', 'Guide title' );
-	const numberOfPages = number( 'numberOfPages', 3, {
-		range: true,
-		min: 1,
-		max: 10,
-		step: 1,
-	} );
-
-	const modalProps = {
-		finishButtonText,
-		contentLabel,
-		numberOfPages,
-	};
-
-	return <ModalExample { ...modalProps } />;
+export const Default = Template.bind( {} );
+Default.args = {
+	pages: Array.from( { length: 3 } ).map( ( _, page ) => ( {
+		content: <p>{ `Page ${ page + 1 }` }</p>,
+	} ) ),
 };


### PR DESCRIPTION
Part of #35665

## What?

Remove the Knobs add-on from `Guide` stories.

## Why?

This is now a blocker for supporting npm 8 (#46443).

## How?

Just a quick, minimal refactor.

## Testing Instructions

1. `npm run storybook:dev`
2. Go to the `Guide` component.
3. The stories and controls should be covering the cases covered by the previous knobs. See inline code comments for intentional alterations.
