### PR TITLE
Only use a single comment for the flakiness report on PRs

### DIFF
--- a/packages/report-flaky-tests/src/__tests__/markdown.test.ts
+++ b/packages/report-flaky-tests/src/__tests__/markdown.test.ts
@@ -246,15 +246,17 @@ describe( 'renderCommitComment', () => {
 				issueUrl: 'url2',
 			},
 		];
+		const commitSHA = 'commitSHA';
 
 		const commentBody = renderCommitComment( {
 			reportedIssues,
 			runURL,
+			commitSHA,
 		} );
 
 		expect( commentBody ).toMatchInlineSnapshot( `
 		"<!-- flaky-tests-report-comment -->
-		**Flaky tests detected.**
+		**Flaky tests detected in commitSHA.**
 		Some tests passed with failed attempts. The failures may not be related to this commit but are still reported for visibility. See [the documentation](https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/testing-overview.md#flaky-tests) for more information.
 
 		🔍  Workflow run URL: runURL
@@ -270,6 +272,7 @@ describe( 'isReportComment', () => {
 		const commentBody = renderCommitComment( {
 			reportedIssues: [],
 			runURL: '',
+			commitSHA: 'commitSHA',
 		} );
 
 		expect( isReportComment( commentBody ) ).toBe( true );

--- a/packages/report-flaky-tests/src/__tests__/run.test.ts
+++ b/packages/report-flaky-tests/src/__tests__/run.test.ts
@@ -31,6 +31,7 @@ const mockPullRequestEventContext = {
 	sha: 'mergeSHA',
 	eventName: 'pull_request',
 	payload: {
+		number: 10,
 		pull_request: {
 			head: {
 				ref: 'headBranch',
@@ -60,7 +61,8 @@ const mockAPI = {
 	findMergeBaseCommit: jest.fn(),
 	updateIssue: jest.fn(),
 	createIssue: jest.fn(),
-	createComment: jest.fn(),
+	createCommentOnPR: jest.fn(),
+	createCommentOnCommit: jest.fn(),
 };
 jest.mock( '../github-api', () => ( {
 	GitHubAPI: jest.fn( () => mockAPI ),
@@ -130,7 +132,7 @@ describe( 'Report flaky tests', () => {
 			html_url: 'html_url',
 		} ) );
 
-		mockAPI.createComment.mockImplementationOnce( () => ( {
+		mockAPI.createCommentOnPR.mockImplementationOnce( () => ( {
 			html_url: 'comment_html_url',
 		} ) );
 
@@ -159,12 +161,12 @@ describe( 'Report flaky tests', () => {
 			'Created new flaky issue'
 		);
 
-		expect( mockAPI.createComment ).toHaveBeenCalledTimes( 1 );
-		expect( mockAPI.createComment.mock.calls[ 0 ][ 0 ] ).toBe( 'headSHA' );
-		expect( mockAPI.createComment.mock.calls[ 0 ][ 1 ] )
+		expect( mockAPI.createCommentOnPR ).toHaveBeenCalledTimes( 1 );
+		expect( mockAPI.createCommentOnPR.mock.calls[ 0 ][ 0 ] ).toBe( 10 );
+		expect( mockAPI.createCommentOnPR.mock.calls[ 0 ][ 1 ] )
 			.toMatchInlineSnapshot( `
 		"<!-- flaky-tests-report-comment -->
-		**Flaky tests detected.**
+		**Flaky tests detected in headSHA.**
 		Some tests passed with failed attempts. The failures may not be related to this commit but are still reported for visibility. See [the documentation](https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/testing-overview.md#flaky-tests) for more information.
 
 		🔍  Workflow run URL: https://github.com/WordPress/gutenberg/actions/runs/100
@@ -230,7 +232,7 @@ describe( 'Report flaky tests', () => {
 			html_url: 'html_url',
 		} ) );
 
-		mockAPI.createComment.mockImplementationOnce( () => ( {
+		mockAPI.createCommentOnCommit.mockImplementationOnce( () => ( {
 			html_url: 'comment_html_url',
 		} ) );
 
@@ -259,14 +261,14 @@ describe( 'Report flaky tests', () => {
 			'Created new flaky issue'
 		);
 
-		expect( mockAPI.createComment ).toHaveBeenCalledTimes( 1 );
-		expect( mockAPI.createComment.mock.calls[ 0 ][ 0 ] ).toBe(
+		expect( mockAPI.createCommentOnCommit ).toHaveBeenCalledTimes( 1 );
+		expect( mockAPI.createCommentOnCommit.mock.calls[ 0 ][ 0 ] ).toBe(
 			'commitSHA'
 		);
-		expect( mockAPI.createComment.mock.calls[ 0 ][ 1 ] )
+		expect( mockAPI.createCommentOnCommit.mock.calls[ 0 ][ 1 ] )
 			.toMatchInlineSnapshot( `
 		"<!-- flaky-tests-report-comment -->
-		**Flaky tests detected.**
+		**Flaky tests detected in commitSHA.**
 		Some tests passed with failed attempts. The failures may not be related to this commit but are still reported for visibility. See [the documentation](https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/testing-overview.md#flaky-tests) for more information.
 
 		🔍  Workflow run URL: https://github.com/WordPress/gutenberg/actions/runs/100
@@ -331,6 +333,7 @@ describe( 'Report flaky tests', () => {
 
 		expect( mockAPI.updateIssue ).not.toHaveBeenCalled();
 
-		expect( mockAPI.createComment ).not.toHaveBeenCalled();
+		expect( mockAPI.createCommentOnPR ).not.toHaveBeenCalled();
+		expect( mockAPI.createCommentOnCommit ).not.toHaveBeenCalled();
 	} );
 } );

--- a/packages/report-flaky-tests/src/markdown.ts
+++ b/packages/report-flaky-tests/src/markdown.ts
@@ -208,12 +208,14 @@ const FLAKY_TESTS_REPORT_COMMENT_TOKEN = `flaky-tests-report-comment`;
 function renderCommitComment( {
 	reportedIssues,
 	runURL,
+	commitSHA,
 }: {
 	reportedIssues: ReportedIssue[];
 	runURL: string;
+	commitSHA: string;
 } ) {
 	return `<!-- ${ FLAKY_TESTS_REPORT_COMMENT_TOKEN } -->
-**Flaky tests detected.**
+**Flaky tests detected in ${ commitSHA }.**
 Some tests passed with failed attempts. The failures may not be related to this commit but are still reported for visibility. See [the documentation](https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/testing-overview.md#flaky-tests) for more information.
 
 🔍  Workflow run URL: ${ runURL }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Continued from https://github.com/WordPress/gutenberg/pull/45798, instead of posting a comment on each commit, we only post a single comment on PRs.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
1. We currently have too many flaky tests and some of them are way too flaky than expected. This is causing the job to post comments on nearly every commit, which is super noisy.
2. Comments on commits will send notifications separately, this is also annoying and too verbose.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR updates the system so that it will stop posting comments on commits if it's triggered by PRs. Instead, it will post a single comment on the PR and update it.

One downside of this is that only the latest commit on the PR will be shown in the comment, and other commits will be hidden in the edit history. I think this is acceptable as oftentimes only the latest run is all we care about.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
This can be tested with a [fork](https://github.com/WordPress/gutenberg/pull/45798#issuecomment-1319601801) on your own repo.

Or you can view an example PR here: https://github.com/kevin940726/gutenberg/pull/43#issuecomment-1362704099

## Screenshots or screencast <!-- if applicable -->
![image](https://user-images.githubusercontent.com/7753001/209527959-6336a13e-6e1e-4642-b94b-79e73c59ee16.png)
