### PR TITLE
Introduce function to control whether to use persistent cache for certain theme file-based logic

### DIFF
--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -5,7 +5,7 @@
  * @package gutenberg
  */
 
-if ( ! function_exists( 'wp_theme_use_cache' ) ) {
+if ( ! function_exists( 'wp_theme_use_persistent_cache' ) ) {
 	/**
 	 * Returns whether theme file-based logic should use caching where applicable.
 	 *
@@ -13,7 +13,7 @@ if ( ! function_exists( 'wp_theme_use_cache' ) ) {
 	 * production environments. However, when developing a theme, using a cache can be detrimental as changes to the
 	 * theme files may not immediately be reflected.
 	 *
-	 * The {@see 'wp_theme_use_cache'} filter can be used to control this behavior, decoupled from the overall
+	 * The {@see 'wp_theme_use_persistent_cache'} filter can be used to control this behavior, decoupled from the overall
 	 * environment's configuration, as neither `WP_DEBUG` nor `WP_ENVIRONMENT_TYPE` are a reliable indicator for
 	 * whether a theme is being developed or not.
 	 *
@@ -21,7 +21,7 @@ if ( ! function_exists( 'wp_theme_use_cache' ) ) {
 	 *
 	 * @return bool True when a cache should be used for theme file-based logic, false otherwise.
 	 */
-	function wp_theme_use_cache() {
+	function wp_theme_use_persistent_cache() {
 		// By default, use a cache unless in a local or development environment.
 		// This is not reliable though, so a filter is available for more granular handling.
 		$use_cache = ! in_array( wp_get_environment_type(), array( 'local', 'development' ), true );
@@ -44,7 +44,7 @@ if ( ! function_exists( 'wp_theme_use_cache' ) ) {
 		 * @param bool $use_cache Whether to use a cache for theme file-based logic. By default this is true unless in
 		 *                        a local or development environment.
 		 */
-		return apply_filters( 'wp_theme_use_cache', $use_cache );
+		return apply_filters( 'wp_theme_use_persistent_cache', $use_cache );
 	}
 }
 
@@ -69,7 +69,7 @@ if ( ! function_exists( 'wp_theme_has_theme_json' ) ) {
 		 * with the $found parameter which apparently had some issues in some implementations
 		 * https://developer.wordpress.org/reference/functions/wp_cache_get/
 		 */
-		if ( wp_theme_use_cache() && is_int( $theme_has_support ) ) {
+		if ( wp_theme_use_persistent_cache() && is_int( $theme_has_support ) ) {
 			return (bool) $theme_has_support;
 		}
 
@@ -111,7 +111,7 @@ if ( ! function_exists( 'wp_theme_has_theme_json_clean_cache' ) ) {
  * @return string Stylesheet.
  */
 function gutenberg_get_global_stylesheet( $types = array() ) {
-	$can_use_cached = empty( $types ) && wp_theme_use_cache();
+	$can_use_cached = empty( $types ) && wp_theme_use_persistent_cache();
 	$cache_key      = 'gutenberg_get_global_stylesheet';
 	$cache_group    = 'theme_json';
 	if ( $can_use_cached ) {
@@ -215,7 +215,7 @@ function gutenberg_get_global_settings( $path = array(), $context = array() ) {
 	$cache_key   = 'gutenberg_get_global_settings_' . $origin;
 	$settings    = wp_cache_get( $cache_key, $cache_group );
 
-	if ( false === $settings || ! wp_theme_use_cache() ) {
+	if ( false === $settings || ! wp_theme_use_persistent_cache() ) {
 		$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_settings();
 		wp_cache_set( $cache_key, $settings, $cache_group );
 	}

--- a/phpunit/get-global-styles-and-settings-test.php
+++ b/phpunit/get-global-styles-and-settings-test.php
@@ -7,6 +7,21 @@
 
 class WP_Get_Global_Styles_And_Settings_Test extends WP_UnitTestCase {
 
+	/**
+	 * Administrator ID.
+	 *
+	 * @var int
+	 */
+	private static $administrator_id;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$administrator_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$administrator_id );
+	}
+
 	public function test_wp_theme_use_persistent_cache() {
 		$expected_default = ! in_array( wp_get_environment_type(), array( 'local', 'development' ), true );
 
@@ -17,5 +32,34 @@ class WP_Get_Global_Styles_And_Settings_Test extends WP_UnitTestCase {
 
 		add_filter( 'wp_theme_use_persistent_cache', '__return_false' );
 		$this->assertFalse( wp_theme_use_persistent_cache() );
+	}
+
+	public function test_global_styles_user_cpt_change_invalidates_cached_stylesheet() {
+		$this->override_theme_root( realpath( DIR_TESTDATA . '/themedir1' ) );
+		add_filter( 'wp_theme_use_persistent_cache', '__return_true' );
+		switch_theme( 'block-theme' );
+		wp_set_current_user( self::$administrator_id );
+
+		$styles = gutenberg_get_global_stylesheet();
+		$this->assertStringNotContainsString( 'background-color: hotpink;', $styles );
+
+		$user_cpt                                = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( wp_get_theme(), true );
+		$config                                  = json_decode( $user_cpt['post_content'], true );
+		$config['styles']['color']['background'] = 'hotpink';
+		$user_cpt['post_content']                = wp_json_encode( $config );
+
+		wp_update_post( $user_cpt, true, false );
+
+		$styles = gutenberg_get_global_stylesheet();
+		$this->assertStringContainsString( 'background-color: hotpink;', $styles );
+	}
+
+	public function override_theme_root( $theme_root ) {
+		$override = function() use ( $theme_root ) {
+			return $theme_root;
+		};
+		add_filter( 'theme_root', $override );
+		add_filter( 'stylesheet_root', $override );
+		add_filter( 'template_root', $override );
 	}
 }

--- a/phpunit/get-global-styles-and-settings-test.php
+++ b/phpunit/get-global-styles-and-settings-test.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Tests functions in get-global-styles-and-settings-test.php.
+ *
+ * @package Gutenberg
+ */
+
+class WP_Get_Global_Styles_And_Settings_Test extends WP_UnitTestCase {
+
+	public function test_wp_theme_use_cache() {
+		$expected_default = ! in_array( wp_get_environment_type(), array( 'local', 'development' ), true );
+
+		$this->assertSame( $expected_default, wp_theme_use_cache() );
+
+		add_filter( 'wp_theme_use_cache', '__return_true' );
+		$this->assertTrue( wp_theme_use_cache() );
+
+		add_filter( 'wp_theme_use_cache', '__return_false' );
+		$this->assertFalse( wp_theme_use_cache() );
+	}
+}

--- a/phpunit/get-global-styles-and-settings-test.php
+++ b/phpunit/get-global-styles-and-settings-test.php
@@ -7,59 +7,13 @@
 
 class WP_Get_Global_Styles_And_Settings_Test extends WP_UnitTestCase {
 
-	/**
-	 * Administrator ID.
-	 *
-	 * @var int
-	 */
-	private static $administrator_id;
-
-	public static function wpSetUpBeforeClass( $factory ) {
-		self::$administrator_id = $factory->user->create( array( 'role' => 'administrator' ) );
-	}
-
-	public static function wpTearDownAfterClass() {
-		self::delete_user( self::$administrator_id );
-	}
-
 	public function test_wp_theme_use_persistent_cache() {
-		$expected_default = ! in_array( wp_get_environment_type(), array( 'local', 'development' ), true );
-
-		$this->assertSame( $expected_default, wp_theme_use_persistent_cache() );
+		$this->assertFalse( wp_theme_use_persistent_cache() );
 
 		add_filter( 'wp_theme_use_persistent_cache', '__return_true' );
 		$this->assertTrue( wp_theme_use_persistent_cache() );
 
 		add_filter( 'wp_theme_use_persistent_cache', '__return_false' );
 		$this->assertFalse( wp_theme_use_persistent_cache() );
-	}
-
-	public function test_global_styles_user_cpt_change_invalidates_cached_stylesheet() {
-		$this->override_theme_root( realpath( DIR_TESTDATA . '/themedir1' ) );
-		add_filter( 'wp_theme_use_persistent_cache', '__return_true' );
-		switch_theme( 'block-theme' );
-		wp_set_current_user( self::$administrator_id );
-
-		$styles = gutenberg_get_global_stylesheet();
-		$this->assertStringNotContainsString( 'background-color: hotpink;', $styles );
-
-		$user_cpt                                = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( wp_get_theme(), true );
-		$config                                  = json_decode( $user_cpt['post_content'], true );
-		$config['styles']['color']['background'] = 'hotpink';
-		$user_cpt['post_content']                = wp_json_encode( $config );
-
-		wp_update_post( $user_cpt, true, false );
-
-		$styles = gutenberg_get_global_stylesheet();
-		$this->assertStringContainsString( 'background-color: hotpink;', $styles );
-	}
-
-	public function override_theme_root( $theme_root ) {
-		$override = function() use ( $theme_root ) {
-			return $theme_root;
-		};
-		add_filter( 'theme_root', $override );
-		add_filter( 'stylesheet_root', $override );
-		add_filter( 'template_root', $override );
 	}
 }

--- a/phpunit/get-global-styles-and-settings-test.php
+++ b/phpunit/get-global-styles-and-settings-test.php
@@ -7,15 +7,15 @@
 
 class WP_Get_Global_Styles_And_Settings_Test extends WP_UnitTestCase {
 
-	public function test_wp_theme_use_cache() {
+	public function test_wp_theme_use_persistent_cache() {
 		$expected_default = ! in_array( wp_get_environment_type(), array( 'local', 'development' ), true );
 
-		$this->assertSame( $expected_default, wp_theme_use_cache() );
+		$this->assertSame( $expected_default, wp_theme_use_persistent_cache() );
 
-		add_filter( 'wp_theme_use_cache', '__return_true' );
-		$this->assertTrue( wp_theme_use_cache() );
+		add_filter( 'wp_theme_use_persistent_cache', '__return_true' );
+		$this->assertTrue( wp_theme_use_persistent_cache() );
 
-		add_filter( 'wp_theme_use_cache', '__return_false' );
-		$this->assertFalse( wp_theme_use_cache() );
+		add_filter( 'wp_theme_use_persistent_cache', '__return_false' );
+		$this->assertFalse( wp_theme_use_persistent_cache() );
 	}
 }


### PR DESCRIPTION
## What?
Addresses #45912

## Why?
See #45912.

## How?
* Introduces new function to control whether a persistent cache should be used for certain theme file-based logic.
* This is necessary because those caches cannot be reliably invalidated when direct file changes to the theme are made, which is typically the case during development of the theme. WordPress can cater for file changes made through WP Admin (e.g. through a theme update, or via the theme file editor), but not through other ways.
* Since #46150, no persistent caching is used for these functions entirely, however reintroducing persistent caching in a reliable way should still be worked on in the near future.
* In order to maintain the current behavior, at this point the default is simply `false`. As noted in the code documentation, neither `WP_DEBUG` nor the environment type are reliable ways to know whether a theme is currently being developed, so those aren't reliable defaults anyway. The filter introduced by this function is the main benefit here; however as of #46150 for now enabling persistent cache is discouraged except for experimental nature, as we keep working towards reliable cache invalidation and decoupling hooks from the cached data.
