### PR TITLE
Site Editor: fix unnatural rounded corners in view mode

### DIFF
--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Bug Fix
 
 -   Don't show block inserter when the canvas is view mode ([#46763](https://github.com/WordPress/gutenberg/pull/46763)).
+-   Fix unnatural rounded corners in view mode ([#46792](https://github.com/WordPress/gutenberg/pull/46792)).
 
 
 ## 4.19.0 (2022-11-16)

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -113,7 +113,6 @@ $hub-height: $grid-unit-20 * 2 + $button-size;
 		& > div {
 			border-radius: $radius-block-ui * 4;
 			// Not sure why this is necessary.
-			.edit-site-layout:not(.is-full-canvas) & .edit-site-visual-editor__editor-canvas,
 			.edit-site-layout:not(.is-full-canvas) & .interface-interface-skeleton__content {
 				border-radius: $radius-block-ui * 4;
 			}


### PR DESCRIPTION
Fixes #46783

## What?
This PR fixes unnatural rounded corners when the notice data is present in the view mode of the site editor.

![before](https://user-images.githubusercontent.com/54422211/209612547-b70ed75c-9b42-4b6d-a4d0-f38878ed79f2.png)

## Why?
The rounded corners are caused by the fact that `border-radius` is added to the iframe canvas itself.
I don't know why this style is applied, but removing this doesn't seem to affect the rest of the canvas.

## How?
Style removed.

## Testing Instructions
To display the notification bar, execute the following code in the console:

```javascript
wp.data.dispatch('core/notices').createNotice( 'warning', 'Hello World', {} );
```

Alternatively, you can clear template customization to display the notification "Template reverted."

## Screenshots or screencast

I have checked various layouts in this PR and the clearing of rounded corners doesn't appear to affect other areas.

<details>
<summary>Screenshots</summary>

![default](https://user-images.githubusercontent.com/54422211/209612571-771f4a24-b93a-4191-b8d2-3d640e378a6b.png)

![gradient-background](https://user-images.githubusercontent.com/54422211/209612579-05a7e7e8-6976-4fd7-808d-2509f56bd4df.png)

![edit](https://user-images.githubusercontent.com/54422211/209612586-3f929e64-e952-4b0b-9794-531b1bba936e.png)

![zoom-out](https://user-images.githubusercontent.com/54422211/209612591-6c810ecb-2552-42d4-8614-084b8b2f7696.png)

![template-parts](https://user-images.githubusercontent.com/54422211/209612596-6999b166-a325-4c21-aa1f-152b85d2c459.png)

</details>
