### PR TITLE
Tabs in preferences: Fix regression from horizontal tabs.

### DIFF
--- a/packages/interface/src/components/preferences-modal-tabs/style.scss
+++ b/packages/interface/src/components/preferences-modal-tabs/style.scss
@@ -7,19 +7,27 @@ $vertical-tabs-width: 160px;
 		// Aligns button text instead of button box.
 		left: $grid-unit-20;
 		width: $vertical-tabs-width;
+
 		.components-tab-panel__tabs-item {
 			border-radius: $radius-block-ui;
 			font-weight: 400;
+
 			&.is-active {
 				background: $gray-100;
 				box-shadow: none;
 				font-weight: 500;
 			}
+
+			&.is-active::after {
+				content: none;
+			}
+
 			&:focus:not(:disabled) {
 				box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 			}
 		}
 	}
+
 	.components-tab-panel__tab-content {
 		padding-left: $grid-unit-30;
 		margin-left: $vertical-tabs-width;


### PR DESCRIPTION
## What?

Followup to #46276, related to #46681. 46276 refactored the tab component a bit, to put the tab indicator in a pseudo element. This caused it to show up in the preferences dialog, which has an entirely different tab style:

<img width="181" alt="before" src="https://user-images.githubusercontent.com/1204802/209652803-dc1ead95-d28b-4f35-b23c-d6a72e77538d.png">

This PR fixes it by removing the pseudo element for the preferences tabs:

<img width="207" alt="after" src="https://user-images.githubusercontent.com/1204802/209652819-d94b2604-314c-4bbe-9c7f-31038d177b08.png">

#46681 is still worth looking into, in terms of unifying vertical tab sets across.

## Testing Instructions

Test the preferences modal (Top toolbar > Options > Preferences) and observe no stripe below each active tab.