### PR TITLE
rich-text: Fix bug where bare tag name format types could not be registered

### DIFF
--- a/packages/rich-text/src/register-format-type.js
+++ b/packages/rich-text/src/register-format-type.js
@@ -82,7 +82,10 @@ export function registerFormatType( name, settings ) {
 			richTextStore
 		).getFormatTypeForBareElement( settings.tagName );
 
-		if ( formatTypeForBareElement ) {
+		if (
+			formatTypeForBareElement &&
+			formatTypeForBareElement.name !== 'core/unknown'
+		) {
 			window.console.error(
 				`Format "${ formatTypeForBareElement.name }" is already registered to handle bare tag name "${ settings.tagName }".`
 			);

--- a/packages/rich-text/src/test/register-format-type.js
+++ b/packages/rich-text/src/test/register-format-type.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { select } from '@wordpress/data';
+import { dispatch, select } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -11,10 +11,21 @@ import { unregisterFormatType } from '../unregister-format-type';
 import { getFormatType } from '../get-format-type';
 import { store as richTextStore } from '../store';
 
+const UNKNOWN_FORMAT = {
+	name: 'core/unknown',
+	title: 'Clear Unknown Formatting',
+	tagName: '*',
+	className: null,
+	edit: () => null,
+};
+
 describe( 'registerFormatType', () => {
 	beforeAll( () => {
 		// Initialize the rich-text store.
 		require( '../store' );
+
+		// Register "core/unknown" format
+		dispatch( richTextStore ).addFormatTypes( UNKNOWN_FORMAT );
 	} );
 
 	afterEach( () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR fixes #46795. It also tweaks the test suite to account for the reported bug.

## Why?
Users should be able to register format types to handle bare tag names. Unfortunately, this is currently not possible as described in #46795.

## How?
When registering a new format type _name/format_, the code now checks if the existing format type that handles a bare tag name _xxx_ is `core/unknown`. If it is, it means nobody registered a specific format type for tag name _xxx_ and, therefore, _name/format_ should be allowed.

## Testing Instructions
1. Go to the post editor
2. Open your browser's developer tools
3. In the JavaScript console, type the following:

```js
wp.richText.registerFormatType( 'name/format', {
  title: 'Test bare tag format',
  tagName: 'xxx',
  className: null,
  edit: () => null,
} );
```

It should work.

4. Then type the following:

```js
wp.richText.registerFormatType( 'name/another-format', {
  title: 'Test bare tag format',
  tagName: 'xxx',
  className: null,
  edit: () => null,
} );
```

It should fail because tag name `xxx` is already handled by `name/format` (registered in step 3).