### PR TITLE
Add support in `check-license` for conjunctive (AND) licenses.

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Updated dependencies to require React 18 ([45235](https://github.com/WordPress/gutenberg/pull/45235))
 
+### Enhancements
+
+-   License check script supports conjunctive (AND) licenses. ([46801](https://github.com/WordPress/gutenberg/pull/46801))
+
 ## 24.6.0 (2022-11-16)
 
 ## 24.5.0 (2022-11-02)

--- a/packages/scripts/scripts/check-licenses.js
+++ b/packages/scripts/scripts/check-licenses.js
@@ -358,8 +358,9 @@ function checkDepLicense( path ) {
  * In that case, the software is only compatible if all of the licenses in the list are
  * compatible.
  *
- * @param {Array} packageLicenses the licenses that a package is licensed under.
- * @param {Array} compatibleLicenses the list of compatible licenses.
+ * @param {Array} packageLicenses    The licenses that a package is licensed under.
+ * @param {Array} compatibleLicenses The list of compatible licenses.
+ *
  * @return {boolean} true if all of the packageLicenses appear in compatibleLicenses.
  */
 function checkAllCompatible( packageLicenses, compatibleLicenses ) {

--- a/packages/scripts/scripts/check-licenses.js
+++ b/packages/scripts/scripts/check-licenses.js
@@ -88,6 +88,9 @@ const licenses = [
 /*
  * Some packages don't included a license string in their package.json file, but they
  * do have a license listed elsewhere. These files are checked for matching license strings.
+ * Only the first matching license file with a matching license string is considered.
+ *
+ * See: licenseFileStrings.
  */
 const licenseFiles = [
 	'LICENCE',
@@ -227,6 +230,7 @@ function traverseDepTree( deps ) {
 
 function detectTypeFromLicenseFiles( path ) {
 	return licenseFiles.reduce( ( detectedType, licenseFile ) => {
+		// If another LICENSE file already had licenses in it, use those.
 		if ( detectedType ) {
 			return detectedType;
 		}
@@ -235,28 +239,37 @@ function detectTypeFromLicenseFiles( path ) {
 
 		if ( existsSync( licensePath ) ) {
 			const licenseText = readFileSync( licensePath ).toString();
-
-			// Check if the file contains any of the strings in licenseFileStrings.
-			return Object.keys( licenseFileStrings ).reduce(
-				( stringDetectedType, licenseStringType ) => {
-					const licenseFileString =
-						licenseFileStrings[ licenseStringType ];
-
-					return licenseFileString.reduce(
-						( currentDetectedType, fileString ) => {
-							if ( licenseText.includes( fileString ) ) {
-								return licenseStringType;
-							}
-							return currentDetectedType;
-						},
-						stringDetectedType
-					);
-				},
-				detectedType
-			);
+			return detectTypeFromLicenseText( licenseText );
 		}
+
 		return detectedType;
 	}, false );
+}
+
+function detectTypeFromLicenseText( licenseText ) {
+	// Check if the file contains any of the strings in licenseFileStrings.
+	return Object.keys( licenseFileStrings ).reduce(
+		( stringDetectedType, licenseStringType ) => {
+			const licenseFileString = licenseFileStrings[ licenseStringType ];
+
+			return licenseFileString.reduce(
+				( currentDetectedType, fileString ) => {
+					if ( licenseText.includes( fileString ) ) {
+						if ( currentDetectedType ) {
+							return currentDetectedType.concat(
+								' AND ',
+								licenseStringType
+							);
+						}
+						return licenseStringType;
+					}
+					return currentDetectedType;
+				},
+				stringDetectedType
+			);
+		},
+		false
+	);
 }
 
 function checkDepLicense( path ) {
@@ -294,11 +307,17 @@ function checkDepLicense( path ) {
 		licenseType = undefined;
 	}
 
-	if ( licenseType ) {
-		const allowed = licenses.find( ( allowedLicense ) =>
-			checkLicense( allowedLicense, licenseType )
-		);
-		if ( allowed ) {
+	if ( licenseType !== undefined ) {
+		let licenseTypes = [ licenseType ];
+		if ( licenseType.includes( ' AND ' ) ) {
+			licenseTypes = licenseType
+				.replace( /^\(*/g, '' )
+				.replace( /\)*$/, '' )
+				.split( ' AND ' )
+				.map( ( e ) => e.trim() );
+		}
+
+		if ( checkAllAllowed( licenseTypes, licenses ) ) {
 			return;
 		}
 	}
@@ -313,17 +332,40 @@ function checkDepLicense( path ) {
 		return;
 	}
 
-	// Now that we have a license to check, see if any of the allowed licenses match.
-	const allowed = licenses.find( ( allowedLicense ) =>
-		checkLicense( allowedLicense, detectedLicenseType )
-	);
-
-	if ( ! allowed ) {
-		process.exitCode = 1;
-		process.stdout.write(
-			`${ ERROR } Module ${ packageInfo.name } has an incompatible license '${ licenseType }'.\n`
-		);
+	let detectedLicenseTypes = [ detectedLicenseType ];
+	if ( detectedLicenseType.includes( ' AND ' ) ) {
+		detectedLicenseTypes = detectedLicenseType
+			.replace( /^\(*/g, '' )
+			.replace( /\)*$/, '' )
+			.split( ' AND ' )
+			.map( ( e ) => e.trim() );
 	}
+
+	if ( checkAllAllowed( detectedLicenseTypes, licenses ) ) {
+		return;
+	}
+
+	process.exitCode = 1;
+	process.stdout.write(
+		`${ ERROR } Module ${ packageInfo.name } has an incompatible license '${ licenseType }'.\n`
+	);
+}
+
+function checkAllAllowed( packageLicenses, allowedLicenses ) {
+	return packageLicenses.reduce( ( allowed, license ) => {
+		return (
+			allowed &&
+			allowedLicenses.find( ( allowedLicense ) =>
+				checkLicense( allowedLicense, license )
+			)
+		);
+	}, true );
 }
 
 traverseDepTree( topLevelDeps );
+
+// Required for unit testing
+module.exports = {
+	detectTypeFromLicenseText,
+	checkAllAllowed,
+};

--- a/packages/scripts/scripts/check-licenses.js
+++ b/packages/scripts/scripts/check-licenses.js
@@ -317,7 +317,7 @@ function checkDepLicense( path ) {
 				.map( ( e ) => e.trim() );
 		}
 
-		if ( checkAllAllowed( licenseTypes, licenses ) ) {
+		if ( checkAllCompatible( licenseTypes, licenses ) ) {
 			return;
 		}
 	}
@@ -341,7 +341,7 @@ function checkDepLicense( path ) {
 			.map( ( e ) => e.trim() );
 	}
 
-	if ( checkAllAllowed( detectedLicenseTypes, licenses ) ) {
+	if ( checkAllCompatible( detectedLicenseTypes, licenses ) ) {
 		return;
 	}
 
@@ -351,12 +351,25 @@ function checkDepLicense( path ) {
 	);
 }
 
-function checkAllAllowed( packageLicenses, allowedLicenses ) {
-	return packageLicenses.reduce( ( allowed, license ) => {
+/**
+ * Check that all of the licenses for a package are compatible.
+ *
+ * This function is invoked when the licenses are a conjunctive ("AND") list of licenses.
+ * In that case, the software is only compatible if all of the licenses in the list are
+ * compatible.
+ *
+ * @param {Array} packageLicenses the licenses that a package is licensed under.
+ * @param {Array} compatibleLicenses the list of compatible licenses.
+ * @return {boolean} true if all of the packageLicenses appear in compatibleLicenses.
+ */
+function checkAllCompatible( packageLicenses, compatibleLicenses ) {
+	return packageLicenses.reduce( ( compatible, packageLicense ) => {
 		return (
-			allowed &&
-			allowedLicenses.find( ( allowedLicense ) =>
-				checkLicense( allowedLicense, license )
+			compatible &&
+			compatibleLicenses.reduce(
+				( found, allowedLicense ) =>
+					found || checkLicense( allowedLicense, packageLicense ),
+				false
 			)
 		);
 	}, true );
@@ -367,5 +380,5 @@ traverseDepTree( topLevelDeps );
 // Required for unit testing
 module.exports = {
 	detectTypeFromLicenseText,
-	checkAllAllowed,
+	checkAllCompatible,
 };

--- a/packages/scripts/scripts/test/check-licenses.js
+++ b/packages/scripts/scripts/test/check-licenses.js
@@ -7,7 +7,10 @@ const path = require( 'path' );
 /**
  * Internal dependencies
  */
-import { detectTypeFromLicenseText } from '../check-licenses';
+import {
+	detectTypeFromLicenseText,
+	checkAllCompatible,
+} from '../check-licenses';
 
 describe( 'detectTypeFromLicenseText', () => {
 	let licenseText;
@@ -57,6 +60,30 @@ describe( 'detectTypeFromLicenseText', () => {
 
 		expect( detectTypeFromLicenseText( licenseText ) ).toBe(
 			'Apache-2.0 AND MIT'
+		);
+	} );
+} );
+
+describe( 'checkAllCompatible', () => {
+	it( "should return 'true' when single license is in the allowed list", () => {
+		expect( checkAllCompatible( [ 'B' ], [ 'A', 'B', 'C' ] ) ).toBe( true );
+	} );
+
+	it( "should return 'false' when single license is not in the allowed list", () => {
+		expect( checkAllCompatible( [ 'D' ], [ 'A', 'B', 'C' ] ) ).toBe(
+			false
+		);
+	} );
+
+	it( "should return 'true' when all licenses are in the allowed list", () => {
+		expect( checkAllCompatible( [ 'A', 'C' ], [ 'A', 'B', 'C' ] ) ).toBe(
+			true
+		);
+	} );
+
+	it( "should return 'false' when any license is not in the allowed list", () => {
+		expect( checkAllCompatible( [ 'A', 'D' ], [ 'A', 'B', 'C' ] ) ).toBe(
+			false
 		);
 	} );
 } );

--- a/packages/scripts/scripts/test/check-licenses.js
+++ b/packages/scripts/scripts/test/check-licenses.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+/**
+ * Internal dependencies
+ */
+import { detectTypeFromLicenseText } from '../check-licenses';
+
+describe( 'detectTypeFromLicenseText', () => {
+	let licenseText;
+
+	it( "should return 'Apache 2.0' when the license text is the Apache 2.0 license", () => {
+		licenseText = fs
+			.readFileSync( path.resolve( __dirname, 'licenses/apache2.txt' ) )
+			.toString();
+
+		expect( detectTypeFromLicenseText( licenseText ) ).toBe( 'Apache-2.0' );
+	} );
+
+	it( "should return 'BSD' when the license text is the BSD 3-clause license", () => {
+		licenseText = fs
+			.readFileSync(
+				path.resolve( __dirname, 'licenses/bsd3clause.txt' )
+			)
+			.toString();
+
+		expect( detectTypeFromLicenseText( licenseText ) ).toBe( 'BSD' );
+	} );
+
+	it( "should return 'BSD-3-Clause-W3C' when the license text is the W3C variation of the BSD 3-clause license", () => {
+		licenseText = fs
+			.readFileSync( path.resolve( __dirname, 'licenses/w3cbsd.txt' ) )
+			.toString();
+
+		expect( detectTypeFromLicenseText( licenseText ) ).toBe(
+			'BSD-3-Clause-W3C'
+		);
+	} );
+
+	it( "should return 'MIT' when the license text is the MIT license", () => {
+		licenseText = fs
+			.readFileSync( path.resolve( __dirname, 'licenses/mit.txt' ) )
+			.toString();
+
+		expect( detectTypeFromLicenseText( licenseText ) ).toBe( 'MIT' );
+	} );
+
+	it( "should return 'Apache2 AND MIT' when the license text is Apache2 followed by MIT license", () => {
+		licenseText = fs
+			.readFileSync(
+				path.resolve( __dirname, 'licenses/apache2-mit.txt' )
+			)
+			.toString();
+
+		expect( detectTypeFromLicenseText( licenseText ) ).toBe(
+			'Apache-2.0 AND MIT'
+		);
+	} );
+} );

--- a/packages/scripts/scripts/test/licenses/apache2-mit.txt
+++ b/packages/scripts/scripts/test/licenses/apache2-mit.txt
@@ -1,0 +1,227 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-----
+
+Contains code from https://github.com/mozilla/language-mapping-list
+
+The MIT License (MIT)
+
+Copyright (c) 2013 fullname
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/scripts/scripts/test/licenses/apache2.txt
+++ b/packages/scripts/scripts/test/licenses/apache2.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/scripts/scripts/test/licenses/bsd3clause.txt
+++ b/packages/scripts/scripts/test/licenses/bsd3clause.txt
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) [year], [fullname]
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/scripts/scripts/test/licenses/mit.txt
+++ b/packages/scripts/scripts/test/licenses/mit.txt
@@ -1,0 +1,7 @@
+Copyright <YEAR> <COPYRIGHT HOLDER>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/scripts/scripts/test/licenses/w3cbsd.txt
+++ b/packages/scripts/scripts/test/licenses/w3cbsd.txt
@@ -1,0 +1,9 @@
+# W3C 3-clause BSD License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+*    Redistributions of works must retain the original copyright notice, this list of conditions and the following disclaimer.
+*    Redistributions in binary form must reproduce the original copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+*    Neither the name of the W3C nor the names of its contributors may be used to endorse or promote products derived from this work without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
## What?
Conjuctive licenses were being ignored in both the `package.json` and within various LICENSE files. In the first case, this could lead to false negatives $(e.g., 'MIT AND BSD' being treated as non-compatible). In the second case, the implementation was such that only one license was returned (whichever detected license occurred later in `licenseFileStrings`). Based on the ordering of that list, this was likely to cause a false positive, because the non-compatible 'Apache-2.0' license occurs before any of the compatible licenses.

Progress on #38461.

## Why?
Conjunctive licenses for dependencies could either result in false negative (license-compatible dependencies being deemed incompatible) or false positive (license-incompatible dependencies being deemed compatible), depending on how they were detected.

## How?
 * Add tests for basic license file detection.
 * Treat license files with multiple detected licenses as conjunctive. Include test for conjunctive license.
 * Add (primitive) support for conjunctive ("AND") licenses. This support does not include handling of more complex compound licenses which include multiple levels of AND and OR clauses.

## Testing Instructions
 * New unit tests for license file variations.
 * You may follow the reproduction steps in #38461 involving adding the `shaka-player` dependency. I did so.

The following output is observed on `trunk`:

```
brandon.durette@brandon-durette gutenberg % npm run other:check-licenses | grep ERROR
[0]  ERROR  Module eme-encryption-scheme-polyfill has an incompatible license 'Apache-2.0'.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! gutenberg@14.8.0-rc.2 other:check-licenses: `concurrently "wp-scripts check-licenses --prod --gpl2 --ignore=@react-native-community/cli,@react-native-community/cli-platform-ios" "wp-scripts check-licenses --dev"`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the gutenberg@14.8.0-rc.2 other:check-licenses script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/brandon.durette/.npm/_logs/2022-12-27T19_44_00_508Z-debug.log
```

On my `check-license` branch, the following output is observed: 

```
brandon.durette@brandon-durette gutenberg % npm run other:check-licenses | grep ERROR
[0]  ERROR  Module shaka-player has an incompatible license 'Apache-2.0'.
[0]  ERROR  Module eme-encryption-scheme-polyfill has an incompatible license 'Apache-2.0'.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! gutenberg@14.8.0-rc.2 other:check-licenses: `concurrently "wp-scripts check-licenses --prod --gpl2 --ignore=@react-native-community/cli,@react-native-community/cli-platform-ios" "wp-scripts check-licenses --dev"`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the gutenberg@14.8.0-rc.2 other:check-licenses script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/brandon.durette/.npm/_logs/2022-12-27T19_46_36_413Z-debug.log
```

Note the addition of `shaka-player` as directly incompatible.
