### PR TITLE
Chore: Remove Inexistent parameter from function call in categories block.

### DIFF
--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -63,7 +63,7 @@ export default function CategoriesEdit( {
 		const parentId = showHierarchy ? 0 : null;
 		const categoriesList = getCategoriesList( parentId );
 		return categoriesList.map( ( category ) =>
-			renderCategoryListItem( category, 0 )
+			renderCategoryListItem( category )
 		);
 	};
 


### PR DESCRIPTION
renderCategoryListItem has just one parameter, not two. The "0" being passed is useless.
