### PR TITLE
Fix return type of getSpacingPresetSlug function.

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/utils.js
@@ -96,7 +96,7 @@ export function getSpacingPresetCssVar( value ) {
  *
  * @param {string} value Value to extract slug from.
  *
- * @return {number} The int value of the slug from given spacing preset.
+ * @return {string|undefined} The int value of the slug from given spacing preset.
  */
 export function getSpacingPresetSlug( value ) {
 	if ( ! value ) {


### PR DESCRIPTION
getSpacingPresetSlug returns a string or undefined ( '0', 'default', the result of a regex or undefined if regex did not match) and not a number as was documented.