### PR TITLE
Fix compatibility with WP 6.0.x

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1806,7 +1806,7 @@ class WP_Theme_JSON_Gutenberg {
 				 * Values that already have a clamp() function will not pass the test,
 				 * and therefore the original $value will be returned.
 				 */
-				$value = wp_get_typography_font_size_value( array( 'size' => $value ) );
+				$value = gutenberg_get_typography_font_size_value( array( 'size' => $value ) );
 			}
 
 			$declarations[] = array(


### PR DESCRIPTION
## What?
Fixes #46802.

PR fixes compatibility with WP 6.0.x.

## Why?
The `WP_Theme_JSON` was using the `wp_get_typography_font_size_value` method only available in WP 6.1.

## How?
Replaced the `wp_get_typography_font_size_value` with `gutenberg_get_typography_font_size_value`

The same method when used in blocks is automatically renamed during the build. So no need to rename them manually.

## Testing Instructions
1. Test using WP 6.0 - `wp core update --version=6.0.3 --force`
2. Confirm there are no PHP fatal errors when accessing the site.
3. Add a Search block to the post and change font size.
4. Confirm block doesn't trigger PHP fatal errors

**An example error**
```
PHP Fatal error:  Uncaught Error: Call to undefined function wp_get_typography_font_size_value() in ~/wp-content/plugins/gutenberg/lib/class-wp-theme-json-gutenberg.php:1809
```