### PR TITLE
[Mobile] - Block Editor Settings Endpoint - Use `wp_get_global_styles` instead of `gutenberg_get_global_styles`

### DIFF
--- a/lib/experimental/block-editor-settings-mobile.php
+++ b/lib/experimental/block-editor-settings-mobile.php
@@ -23,7 +23,7 @@ function gutenberg_get_block_editor_settings_mobile( $settings ) {
 		'mobile' === $_GET['context']
 	) {
 		if ( wp_theme_has_theme_json() ) {
-			$settings['__experimentalStyles'] = gutenberg_get_global_styles();
+			$settings['__experimentalStyles'] = wp_get_global_styles();
 		}
 
 		// To tell mobile that the site uses quote v2 (inner blocks).


### PR DESCRIPTION
## What?
Fix a regression on the mobile block editor settings used from the apps.

## Why?
From a [recent update](https://github.com/WordPress/gutenberg/pull/46102) removing some code in favor of requiring at least WordPress `6.0` a file used for the mobile endpoint for the editor's settings was missed to update.

## How?
By updating the usage to get the global styles from `gutenberg_get_global_styles` to `wp_get_global_styles`

## Testing Instructions

- Using a local instance of WordPress with these changes.
- Using Postman make a request like `http://localhost:8888/wp-json/wp-block-editor/v1/settings?context=mobile`
- Expect the endpoint to return the data, check for the following attributes: `__experimentalFeatures`, and `__experimentalStyles`

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A