### PR TITLE
Shadow: add shadow presets support via theme.json

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -52,6 +52,16 @@ Settings related to borders.
 
 ---
 
+### shadow
+
+Settings related to shadows.
+
+| Property  | Type   | Default | Props  |
+| ---       | ---    | ---    |---   |
+| palette | array |  | name, shadow, slug |
+
+---
+
 ### color
 
 Settings related to colors.

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -118,6 +118,15 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	const PRESETS_METADATA = array(
 		array(
+			'path'              => array( 'shadow', 'palette' ),
+			'prevent_override'  => array( 'shadow', 'defaultPalette' ),
+			'use_default_names' => false,
+			'value_key'         => 'shadow',
+			'css_vars'          => '--wp--preset--shadow--$slug',
+			'classes'           => array(),
+			'properties'        => array( 'box-shadow' ),
+		),
+		array(
 			'path'              => array( 'color', 'palette' ),
 			'prevent_override'  => array( 'color', 'defaultPalette' ),
 			'use_default_names' => false,
@@ -332,6 +341,10 @@ class WP_Theme_JSON_Gutenberg {
 			'radius' => null,
 			'style'  => null,
 			'width'  => null,
+		),
+		'shadow'                        => array(
+			'palette'        => null,
+			'defaultPalette' => null,
 		),
 		'color'                         => array(
 			'background'       => null,

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -186,6 +186,20 @@
 			],
 			"text": true
 		},
+		"shadow": {
+			"palette": [
+				{
+					"name": "Natural",
+					"slug": "natural",
+					"shadow": "0 .2rem .3rem 0 rgba(0,0,0, 0.3), 0 .5rem .6rem 0 rgba(0,0,0, 0.4)"
+				},
+				{
+					"name": "Sharp",
+					"slug": "sharp",
+					"shadow": ".5rem .5rem 0 0 rgba(0,0,0, 0.4)"
+				}
+			]
+		},
 		"layout": {
 			"definitions": {
 				"default": {

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -435,6 +435,76 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEquals( $variables, $theme_json->get_stylesheet( array( 'variables' ) ) );
 	}
 
+	/**
+	 * Tests generating the spacing presets array based on the spacing scale provided.
+	 *
+	 * @dataProvider data_set_spacing_sizes_when_invalid
+	 */
+	public function test_shadow_preset_styles() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'shadow' => array(
+						'palette' => array(
+							array(
+								'slug'   => 'natural',
+								'shadow' => '5px 5px 5px 0 black',
+							),
+							array(
+								'slug'   => 'sharp',
+								'shadow' => '5px 5px black',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$styles = 'body{--wp--preset--shadow--natural: 5px 5px 5px 0 black;--wp--preset--shadow--sharp: 5px 5px black;}';
+		$this->assertEquals( $styles, $theme_json->get_stylesheet() );
+		$this->assertEquals( $styles, $theme_json->get_stylesheet( array( 'variables' ) ) );
+	}
+
+	public function test_get_shadow_styles_for_blocks() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'shadow' => array(
+						'palette' => array(
+							array(
+								'slug'   => 'natural',
+								'shadow' => '5px 5px 0 0 black',
+							),
+						),
+					),
+				),
+				'styles'   => array(
+					'blocks'   => array(
+						'core/paragraph' => array(
+							'shadow' => 'var(--wp--preset--shadow--natural)',
+						),
+					),
+					'elements' => array(
+						'button' => array(
+							'shadow' => 'var:preset|shadow|natural',
+						),
+						'link'   => array(
+							'shadow' => array( 'ref' => 'styles.elements.button.shadow' ),
+						),
+					),
+				),
+			)
+		);
+
+		$global_styles  = 'body{--wp--preset--shadow--natural: 5px 5px 0 0 black;}body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
+		$element_styles = 'a:where(:not(.wp-element-button)){box-shadow: var(--wp--preset--shadow--natural);}.wp-element-button, .wp-block-button__link{box-shadow: var(--wp--preset--shadow--natural);}p{box-shadow: var(--wp--preset--shadow--natural);}';
+		$styles         = $global_styles . $element_styles;
+
+		$this->assertEquals( $styles, $theme_json->get_stylesheet() );
+	}
+
 	public function test_get_stylesheet_handles_whitelisted_element_pseudo_selectors() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -67,6 +67,40 @@
 				}
 			}
 		},
+		"settingsPropertiesShadow": {
+			"type": "object",
+			"properties": {
+				"shadow": {
+					"description": "Settings related to shadows.",
+					"type": "object",
+					"properties": {
+						"palette": {
+							"description": "Shadow presets for the shadow picker.\nGenerates a single custom property (`--wp--preset--shadow--{slug}`) per preset value.",
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"name": {
+										"description": "Name of the shadow preset, translatable.",
+										"type": "string"
+									},
+									"slug": {
+										"description": "Kebab-case unique identifier for the shadow preset.",
+										"type": "string"
+									},
+									"shadow": {
+										"description": "CSS box-shadow value",
+										"type": "string"
+									}
+								},
+								"required": [ "name", "slug", "shadow" ],
+								"additionalProperties": false
+							}
+						}
+					}
+				}
+			}
+		},
 		"settingsPropertiesColor": {
 			"type": "object",
 			"properties": {
@@ -586,6 +620,7 @@
 				{ "$ref": "#/definitions/settingsPropertiesAppearanceTools" },
 				{ "$ref": "#/definitions/settingsPropertiesBorder" },
 				{ "$ref": "#/definitions/settingsPropertiesColor" },
+				{ "$ref": "#/definitions/settingsPropertiesShadow" },
 				{ "$ref": "#/definitions/settingsPropertiesLayout" },
 				{ "$ref": "#/definitions/settingsPropertiesSpacing" },
 				{ "$ref": "#/definitions/settingsPropertiesTypography" },
@@ -602,6 +637,7 @@
 					"properties": {
 						"appearanceTools": {},
 						"border": {},
+						"shadow": {},
 						"color": {},
 						"layout": {},
 						"spacing": {},
@@ -1952,6 +1988,7 @@
 						"spacing": {},
 						"typography": {},
 						"border": {},
+						"shadow": {},
 						"custom": {},
 						"blocks": {
 							"description": "Settings defined on a per-block basis.",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This adds support for default and theme shadow presets via theme.json

It ads following default presets to Gutenberg bundled theme.json
* Natural
* Sharp

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. This change should create two default preset variables `--wp--preset--shadow--natural` and `--wp--preset--shadow--sharp` in global style sheet.
2. Add the following styles in the current active theme.
```
"settings": {
		"shadow": {
			"palette": [
				{
					"name": "Natural",
					"slug": "theme-natural",
					"shadow": "5px 5px 0px -2px #FFFFFF, 5px 5px #000000"
				},
				{
					"name": "Crisp",
					"slug": "theme-crisp",
					"shadow": "5px 5px #000000"
				},
				{
					"name": "Sharp",
					"slug": "theme-sharp",
					"shadow": "5px 5px 0 0 #999999"
				},
				{
					"name": "Soft",
					"slug": "theme-soft",
					"shadow": "5px 5px 10px 0 #999999"
				}
			]
		}
}
```
3. Verify that it creates the respective preset variables in global style sheet.
4. Apply shadow to any block such as button in the current active theme.
```
{
    "styles": {
         "elements": {
              "button": {
                  "shadow": "var(--wp--preset--shadow--natural)"
              }
         }
    }
}
```
5. Verify the button shadow.

This is a PR to add support via theme.json. 
Verify end to end feature including UI in global styles from here #46502

## Related issues

Partial Fix for #44651