### PR TITLE
Global Styles: Hide Custom CSS setting for users without 'edit_css' cap

### DIFF
--- a/lib/compat/wordpress-6.2/class-gutenberg-rest-global-styles-controller-6-2.php
+++ b/lib/compat/wordpress-6.2/class-gutenberg-rest-global-styles-controller-6-2.php
@@ -104,8 +104,8 @@ class Gutenberg_REST_Global_Styles_Controller_6_2 extends WP_REST_Global_Styles_
 			$rels[] = 'https://api.w.org/action-publish';
 		}
 
-		if ( current_user_can( 'unfiltered_html' ) ) {
-			$rels[] = 'https://api.w.org/action-unfiltered-html';
+		if ( current_user_can( 'edit_css' ) ) {
+			$rels[] = 'https://api.w.org/action-edit-css';
 		}
 
 		return $rels;

--- a/lib/compat/wordpress-6.2/class-gutenberg-rest-global-styles-controller-6-2.php
+++ b/lib/compat/wordpress-6.2/class-gutenberg-rest-global-styles-controller-6-2.php
@@ -90,6 +90,28 @@ class Gutenberg_REST_Global_Styles_Controller_6_2 extends WP_REST_Global_Styles_
 	}
 
 	/**
+	 * Get the link relations available for the post and current user.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @return array List of link relations.
+	 */
+	protected function get_available_actions() {
+		$rels = array();
+
+		$post_type = get_post_type_object( $this->post_type );
+		if ( current_user_can( $post_type->cap->publish_posts ) ) {
+			$rels[] = 'https://api.w.org/action-publish';
+		}
+
+		if ( current_user_can( 'unfiltered_html' ) ) {
+			$rels[] = 'https://api.w.org/action-unfiltered-html';
+		}
+
+		return $rels;
+	}
+
+	/**
 	 * Updates a single global style config.
 	 *
 	 * @since 5.9.0

--- a/lib/compat/wordpress-6.2/class-gutenberg-rest-global-styles-controller-6-2.php
+++ b/lib/compat/wordpress-6.2/class-gutenberg-rest-global-styles-controller-6-2.php
@@ -93,6 +93,7 @@ class Gutenberg_REST_Global_Styles_Controller_6_2 extends WP_REST_Global_Styles_
 	 * Get the link relations available for the post and current user.
 	 *
 	 * @since 5.9.0
+	 * @since 6.2.0 Added 'edit-css' action.
 	 *
 	 * @return array List of link relations.
 	 */

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -86,9 +86,6 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-off-canvas-navigation-editor', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableOffCanvasNavigationEditor = true', 'before' );
 	}
-	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-global-styles-custom-css', $gutenberg_experiments ) ) {
-		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableGlobalStylesCustomCSS = true', 'before' );
-	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -77,22 +77,6 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
-	add_settings_field(
-		'gutenberg-global-styles-custom-css',
-		__( 'Global styles custom css ', 'gutenberg' ),
-		'gutenberg_display_experiment_field',
-		'gutenberg-experiments',
-		'gutenberg_experiments_section',
-		array(
-			'label' => sprintf(
-				/* translators: %s: WordPress documentation for roles and capabilities. */
-				__( 'Test the Global Styles custom CSS field in the site editor. This requires a user to have <a href="%s">unfiltered html capabilities</a>.', 'gutenberg' ),
-				'https://wordpress.org/support/article/roles-and-capabilities/#unfiltered_html'
-			),
-			'id'    => 'gutenberg-global-styles-custom-css',
-		)
-	);
-
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/packages/edit-site/src/components/global-styles/screen-root.js
+++ b/packages/edit-site/src/components/global-styles/screen-root.js
@@ -40,8 +40,7 @@ function ScreenRoot() {
 
 		return {
 			variations: __experimentalGetCurrentThemeGlobalStylesVariations(),
-			canEditCSS:
-				globalStyles?._links?.[ 'wp:action-unfiltered-html' ] ?? false,
+			canEditCSS: globalStyles?._links?.[ 'wp:action-edit-css' ] ?? false,
 		};
 	}, [] );
 

--- a/packages/edit-site/src/components/global-styles/screen-root.js
+++ b/packages/edit-site/src/components/global-styles/screen-root.js
@@ -40,7 +40,8 @@ function ScreenRoot() {
 
 		return {
 			variations: __experimentalGetCurrentThemeGlobalStylesVariations(),
-			canEditCSS: globalStyles?._links?.[ 'wp:action-edit-css' ] ?? false,
+			canEditCSS:
+				!! globalStyles?._links?.[ 'wp:action-edit-css' ] ?? false,
 		};
 	}, [] );
 

--- a/packages/edit-site/src/components/global-styles/screen-root.js
+++ b/packages/edit-site/src/components/global-styles/screen-root.js
@@ -26,17 +26,25 @@ import ContextMenu from './context-menu';
 import StylesPreview from './preview';
 
 function ScreenRoot() {
-	const { variations } = useSelect( ( select ) => {
+	const { variations, canEditCSS } = useSelect( ( select ) => {
+		const {
+			getEntityRecord,
+			__experimentalGetCurrentGlobalStylesId,
+			__experimentalGetCurrentThemeGlobalStylesVariations,
+		} = select( coreStore );
+
+		const globalStylesId = __experimentalGetCurrentGlobalStylesId();
+		const globalStyles = globalStylesId
+			? getEntityRecord( 'root', 'globalStyles', globalStylesId )
+			: undefined;
+
 		return {
-			variations:
-				select(
-					coreStore
-				).__experimentalGetCurrentThemeGlobalStylesVariations(),
+			variations: __experimentalGetCurrentThemeGlobalStylesVariations(),
+			canEditCSS:
+				globalStyles?._links?.[ 'wp:action-unfiltered-html' ] ?? false,
 		};
 	}, [] );
 
-	const __experimentalGlobalStylesCustomCSS =
-		window?.__experimentalEnableGlobalStylesCustomCSS;
 	return (
 		<Card size="small">
 			<CardBody>
@@ -102,7 +110,7 @@ function ScreenRoot() {
 				</ItemGroup>
 			</CardBody>
 
-			{ __experimentalGlobalStylesCustomCSS && (
+			{ canEditCSS && (
 				<>
 					<CardDivider />
 					<CardBody>


### PR DESCRIPTION
## What?
See #46651.

PR adds a capability check before displaying the Custom CSS setting and removes this feature behind the experimental flag.

## Why?

The changes from users without `unfiltered_html` capabilities aren't persistent, and the feature looks broken. It also matches the behavior of the "Additional CSS" setting in Customizer.

## How?

The Global Styles endpoint now has a new action listed in link relations for users with `edit_css` caps. The client uses this action to check the required permissions.

The `edit_css` is a mapped capability, which in Core defaults to `unfiltered_html`. See the permission section of this make post for more details - https://make.wordpress.org/core/2016/11/26/extending-the-custom-css-editor/.

## Testing Instructions
1. Open the Site Editor.
2. Open the global styles sidebar.
3. Confirm that the Custom CSS setting is displayed.
4. Disable unfiltered HTML by adding the following constant to `wp-config.php` - `define( 'DISALLOW_UNFILTERED_HTML', true );`
5. Reload the site editor.
6. Open the global styles sidebar.
7. Confirm that the Custom CSS setting isn't displayed.

## Screenshot

![CleanShot 2022-12-29 at 15 30 30](https://user-images.githubusercontent.com/240569/209945131-ee28998c-240f-4dfe-9567-5aa07a8a6d03.png)
