### PR TITLE
Update PHPDoc for `gutenberg_get_global_stylesheet`

### DIFF
--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -65,8 +65,8 @@ if ( ! function_exists( 'wp_theme_has_theme_json_clean_cache' ) ) {
  * @param array $types Types of styles to load. Optional.
  *                     It accepts as values: 'variables', 'presets', 'styles', 'base-layout-styles, and 'custom-css'.
  *                     If empty, it'll load the following:
- *                     - for themes with theme.json: 'variables', 'presets', 'base-layout-styles'
- *                     - for temes without theme.json: 'variables', 'presets', 'styles', 'custom-css'
+ *                     - for themes without theme.json: 'variables', 'presets', 'base-layout-styles'
+ *                     - for temes with theme.json: 'variables', 'presets', 'styles', 'custom-css'
  *
  * @return string Stylesheet.
  */

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -63,9 +63,10 @@ if ( ! function_exists( 'wp_theme_has_theme_json_clean_cache' ) ) {
  * Returns the stylesheet resulting of merging core, theme, and user data.
  *
  * @param array $types Types of styles to load. Optional.
- *                     It accepts 'variables', 'styles', 'presets', 'custom-css' as values.
- *                     If empty, it'll load all for themes with theme.json support
- *                     and only [ 'variables', 'presets' ] for themes without theme.json support.
+ *                     It accepts as values: 'variables', 'presets', 'styles', 'base-layout-styles, and 'custom-css'.
+ *                     If empty, it'll load the following:
+ *                     - for themes with theme.json: 'variables', 'presets', 'base-layout-styles'
+ *                     - for temes without theme.json: 'variables', 'presets', 'styles', 'custom-css'
  *
  * @return string Stylesheet.
  */
@@ -85,7 +86,7 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 	if ( empty( $types ) && ! $supports_theme_json ) {
 		$types = array( 'variables', 'presets', 'base-layout-styles' );
 	} elseif ( empty( $types ) ) {
-		$types = array( 'variables', 'styles', 'presets', 'custom-css' );
+		$types = array( 'variables', 'presets', 'styles', 'custom-css' );
 	}
 
 	/*

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -65,8 +65,8 @@ if ( ! function_exists( 'wp_theme_has_theme_json_clean_cache' ) ) {
  * @param array $types Types of styles to load. Optional.
  *                     It accepts as values: 'variables', 'presets', 'styles', 'base-layout-styles, and 'custom-css'.
  *                     If empty, it'll load the following:
- *                     - for themes without theme.json: 'variables', 'presets', 'base-layout-styles'
- *                     - for temes with theme.json: 'variables', 'presets', 'styles', 'custom-css'
+ *                     - for themes without theme.json: 'variables', 'presets', 'base-layout-styles'.
+ *                     - for temes with theme.json: 'variables', 'presets', 'styles', 'custom-css'.
  *
  * @return string Stylesheet.
  */


### PR DESCRIPTION
This PR updates the PHPDoc of the `gutenberg_get_global_stylesheet` function to reflect the actual code. It also sorts the values passed to an array differently, so they are easier to compare. It has no effects in actual behavior.
