### PR TITLE
[Mobile] - Inserter - Add block insertion integration tests

### DIFF
--- a/packages/block-editor/src/components/inserter/test/__snapshots__/index.native.js.snap
+++ b/packages/block-editor/src/components/inserter/test/__snapshots__/index.native.js.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Inserter can add blocks after another block 1`] = `
+"<!-- wp:spacer -->
+<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading -->
+<h2 class=\\"wp-block-heading\\"></h2>
+<!-- /wp:heading -->
+
+<!-- wp:more -->
+<!--more-->
+<!-- /wp:more -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Inserter can add blocks before another block 1`] = `
+"<!-- wp:heading -->
+<h2 class=\\"wp-block-heading\\"></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Inserter can add blocks to the beginning 1`] = `
+"<!-- wp:more -->
+<!--more-->
+<!-- /wp:more -->
+
+<!-- wp:spacer -->
+<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading -->
+<h2 class=\\"wp-block-heading\\"></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Inserter can add blocks to the end 1`] = `
+"<!-- wp:spacer -->
+<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading -->
+<h2 class=\\"wp-block-heading\\"></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:more -->
+<!--more-->
+<!-- /wp:more -->"
+`;

--- a/packages/block-editor/src/components/inserter/test/index.native.js
+++ b/packages/block-editor/src/components/inserter/test/index.native.js
@@ -70,7 +70,7 @@ describe( 'Inserter', () => {
 			const addBlockToBeginningButton = await getByLabelText(
 				'Add To Beginning'
 			);
-			expect( addBlockToBeginningButton ).toBeTruthy();
+			expect( addBlockToBeginningButton ).toBeVisible();
 			fireEvent.press( addBlockToBeginningButton );
 
 			// Add another block at the beginning
@@ -100,7 +100,7 @@ describe( 'Inserter', () => {
 			const addBlockBeforeButton = await getByLabelText(
 				'Add Block Before'
 			);
-			expect( addBlockBeforeButton ).toBeTruthy();
+			expect( addBlockBeforeButton ).toBeVisible();
 			fireEvent.press( addBlockBeforeButton );
 
 			// Add another block before the first one
@@ -138,7 +138,7 @@ describe( 'Inserter', () => {
 			const addBlockAfterButton = await getByLabelText(
 				'Add Block After'
 			);
-			expect( addBlockAfterButton ).toBeTruthy();
+			expect( addBlockAfterButton ).toBeVisible();
 			fireEvent.press( addBlockAfterButton );
 
 			// Add another block after the Heading block
@@ -172,7 +172,7 @@ describe( 'Inserter', () => {
 
 			// Get Add To End option
 			const addBlockToEndButton = await getByLabelText( 'Add To End' );
-			expect( addBlockToEndButton ).toBeTruthy();
+			expect( addBlockToEndButton ).toBeVisible();
 			fireEvent.press( addBlockToEndButton );
 
 			// Add another block to the end after the Paragraph Block

--- a/packages/block-editor/src/components/inserter/test/index.native.js
+++ b/packages/block-editor/src/components/inserter/test/index.native.js
@@ -1,7 +1,20 @@
 /**
  * External dependencies
  */
-import { render } from 'test/helpers';
+import {
+	addBlock,
+	fireEvent,
+	initializeEditor,
+	getBlock,
+	getEditorHtml,
+	render,
+} from 'test/helpers';
+
+/**
+ * WordPress dependencies
+ */
+import { getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
+import { registerCoreBlocks } from '@wordpress/block-library';
 
 /**
  * Internal dependencies
@@ -19,5 +32,153 @@ describe( 'Inserter', () => {
 		);
 
 		expect( screen.getByTestId( 'add-block-button' ) ).toBeTruthy();
+	} );
+
+	describe( 'can add blocks', () => {
+		beforeAll( () => {
+			// Register all core blocks
+			registerCoreBlocks();
+		} );
+
+		afterAll( () => {
+			// Clean up registered blocks
+			getBlockTypes().forEach( ( block ) => {
+				unregisterBlockType( block.name );
+			} );
+		} );
+
+		it( 'to the beginning', async () => {
+			const screen = await initializeEditor();
+			const { getByLabelText, getByTestId } = screen;
+
+			// Add Spacer block
+			await addBlock( screen, 'Spacer' );
+
+			// Add Heading block
+			await addBlock( screen, 'Heading' );
+
+			// Add Paragraph block
+			await addBlock( screen, 'Paragraph' );
+
+			// Get Inserter button
+			const addBlockButton = await getByTestId( 'add-block-button' );
+
+			// Long press the inserter button
+			fireEvent( addBlockButton, 'onLongPress' );
+
+			// Get Add To Beginning option
+			const addBlockToBeginningButton = await getByLabelText(
+				'Add To Beginning'
+			);
+			expect( addBlockToBeginningButton ).toBeTruthy();
+			fireEvent.press( addBlockToBeginningButton );
+
+			// Add another block at the beginning
+			await addBlock( screen, 'More', true );
+
+			expect( getEditorHtml() ).toMatchSnapshot();
+		} );
+
+		it( 'before another block', async () => {
+			const screen = await initializeEditor();
+			const { getByLabelText, getByTestId } = screen;
+
+			// Add Paragraph block
+			await addBlock( screen, 'Paragraph' );
+
+			// Get Paragraph block
+			const paragraphBlock = await getBlock( screen, 'Paragraph' );
+			fireEvent.press( paragraphBlock );
+
+			// Get Inserter button
+			const addBlockButton = await getByTestId( 'add-block-button' );
+
+			// Long press the inserter button
+			fireEvent( addBlockButton, 'onLongPress' );
+
+			// Get Add Block Before option
+			const addBlockBeforeButton = await getByLabelText(
+				'Add Block Before'
+			);
+			expect( addBlockBeforeButton ).toBeTruthy();
+			fireEvent.press( addBlockBeforeButton );
+
+			// Add another block before the first one
+			await addBlock( screen, 'Heading', true );
+
+			expect( getEditorHtml() ).toMatchSnapshot();
+		} );
+
+		it( 'after another block', async () => {
+			const screen = await initializeEditor();
+			const { getByLabelText, getByTestId } = screen;
+
+			// Add Spacer block
+			await addBlock( screen, 'Spacer' );
+
+			// Add Heading block
+			await addBlock( screen, 'Heading' );
+
+			// Add Paragraph block
+			await addBlock( screen, 'Paragraph' );
+
+			// Get Heading block
+			const headingBlock = await getBlock( screen, 'Heading', {
+				rowIndex: 2,
+			} );
+			fireEvent.press( headingBlock );
+
+			// Get Inserter button
+			const addBlockButton = await getByTestId( 'add-block-button' );
+
+			// Long press the inserter button
+			fireEvent( addBlockButton, 'onLongPress' );
+
+			// Get Add Block After option
+			const addBlockAfterButton = await getByLabelText(
+				'Add Block After'
+			);
+			expect( addBlockAfterButton ).toBeTruthy();
+			fireEvent.press( addBlockAfterButton );
+
+			// Add another block after the Heading block
+			await addBlock( screen, 'More', true );
+
+			expect( getEditorHtml() ).toMatchSnapshot();
+		} );
+
+		it( 'to the end', async () => {
+			const screen = await initializeEditor();
+			const { getByLabelText, getByTestId } = screen;
+
+			// Add Spacer block
+			await addBlock( screen, 'Spacer' );
+
+			// Add Heading block
+			await addBlock( screen, 'Heading' );
+
+			// Add Paragraph block
+			await addBlock( screen, 'Paragraph' );
+
+			// Get Spacer block
+			const spacerBlock = await getBlock( screen, 'Spacer' );
+			fireEvent.press( spacerBlock );
+
+			// Get Inserter button
+			const addBlockButton = await getByTestId( 'add-block-button' );
+
+			// Long press the inserter button
+			fireEvent( addBlockButton, 'onLongPress' );
+
+			// Get Add To End option
+			const addBlockToEndButton = await getByLabelText( 'Add To End' );
+			expect( addBlockToEndButton ).toBeTruthy();
+			fireEvent.press( addBlockToEndButton );
+
+			// Add another block to the end after the Paragraph Block
+			await addBlock( screen, 'More', true );
+
+			expect( getEditorHtml() ).toMatchSnapshot();
+		} );
 	} );
 } );

--- a/packages/block-editor/src/components/inserter/test/index.native.js
+++ b/packages/block-editor/src/components/inserter/test/index.native.js
@@ -74,7 +74,7 @@ describe( 'Inserter', () => {
 			fireEvent.press( addBlockToBeginningButton );
 
 			// Add another block at the beginning
-			await addBlock( screen, 'More', true );
+			await addBlock( screen, 'More', { isPickerOpened: true } );
 
 			expect( getEditorHtml() ).toMatchSnapshot();
 		} );
@@ -104,7 +104,7 @@ describe( 'Inserter', () => {
 			fireEvent.press( addBlockBeforeButton );
 
 			// Add another block before the first one
-			await addBlock( screen, 'Heading', true );
+			await addBlock( screen, 'Heading', { isPickerOpened: true } );
 
 			expect( getEditorHtml() ).toMatchSnapshot();
 		} );
@@ -142,7 +142,7 @@ describe( 'Inserter', () => {
 			fireEvent.press( addBlockAfterButton );
 
 			// Add another block after the Heading block
-			await addBlock( screen, 'More', true );
+			await addBlock( screen, 'More', { isPickerOpened: true } );
 
 			expect( getEditorHtml() ).toMatchSnapshot();
 		} );
@@ -176,7 +176,7 @@ describe( 'Inserter', () => {
 			fireEvent.press( addBlockToEndButton );
 
 			// Add another block to the end after the Paragraph Block
-			await addBlock( screen, 'More', true );
+			await addBlock( screen, 'More', { isPickerOpened: true } );
 
 			expect( getEditorHtml() ).toMatchSnapshot();
 		} );

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-2.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-2.test.js
@@ -4,13 +4,11 @@
 import { blockNames } from './pages/editor-page';
 import {
 	headerBlockEmpty,
-	imageBlockEmpty,
 	listBlockEmpty,
 	moreBlockEmpty,
 	paragraphBlockEmpty,
 	separatorBlockEmpty,
 } from './helpers/test-data';
-import { waitForMediaLibrary } from './helpers/utils';
 
 describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 	it( 'adds new block at the end of post', async () => {
@@ -57,47 +55,17 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 		expect( html.toLowerCase() ).toBe( expectedHtml );
 	} );
 
-	it( 'inserts block before selected block', async () => {
-		const separatorBlockElement = await editorPage.getBlockAtPosition(
-			blockNames.separator,
-			2
-		);
-		await separatorBlockElement.click();
-
-		await editorPage.addNewBlock( blockNames.image, 'before' );
-
-		await waitForMediaLibrary( editorPage.driver );
-		await editorPage.closePicker();
-
-		const imageBlock = await editorPage.getBlockAtPosition(
-			blockNames.image,
-			2
-		);
-		expect( imageBlock ).toBeTruthy();
-
-		const expectedHtml = [
-			headerBlockEmpty,
-			imageBlockEmpty,
-			separatorBlockEmpty,
-			listBlockEmpty,
-		].join( '\n\n' );
-
-		const html = await editorPage.getHtmlContent();
-		expect( html.toLowerCase() ).toBe( expectedHtml );
-	} );
-
 	it( 'inserts block at the end of post when no block is selected', async () => {
 		await editorPage.addNewBlock( blockNames.more );
 
 		const moreBlock = await editorPage.getBlockAtPosition(
 			blockNames.more,
-			5
+			4
 		);
 		expect( moreBlock ).toBeTruthy();
 
 		const expectedHtml = [
 			headerBlockEmpty,
-			imageBlockEmpty,
 			separatorBlockEmpty,
 			listBlockEmpty,
 			moreBlockEmpty,
@@ -112,13 +80,12 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 
 		const paragraphBlock = await editorPage.getBlockAtPosition(
 			blockNames.paragraph,
-			6
+			5
 		);
 		expect( paragraphBlock ).toBeTruthy();
 
 		const expectedHtml = [
 			headerBlockEmpty,
-			imageBlockEmpty,
 			separatorBlockEmpty,
 			listBlockEmpty,
 			moreBlockEmpty,

--- a/test/native/integration-test-helpers/add-block.js
+++ b/test/native/integration-test-helpers/add-block.js
@@ -14,7 +14,7 @@ import { waitFor } from './wait-for';
  * @param {import('@testing-library/react-native').RenderAPI} screen                   A Testing Library screen.
  * @param {string}                                            blockName                Name of the block to be inserted as shown in the block picker.
  * @param {Object}                                            options                  Configuration options for adding a block.
- * @param {boolean}                                           [options.isPickerOpened] Option to skip openning the inserter picker.
+ * @param {boolean}                                           [options.isPickerOpened] Option to skip opening the inserter picker.
  */
 export const addBlock = async (
 	screen,

--- a/test/native/integration-test-helpers/add-block.js
+++ b/test/native/integration-test-helpers/add-block.js
@@ -11,11 +11,16 @@ import { waitFor } from './wait-for';
 /**
  * Adds a block via the block picker.
  *
- * @param {import('@testing-library/react-native').RenderAPI} screen                 A Testing Library screen.
- * @param {string}                                            blockName              Name of the block to be inserted as shown in the block picker.
- * @param {boolean}                                           [isPickerOpened=false] isPickerOpened Option to skip opening the inserter picker.
+ * @param {import('@testing-library/react-native').RenderAPI} screen                   A Testing Library screen.
+ * @param {string}                                            blockName                Name of the block to be inserted as shown in the block picker.
+ * @param {Object}                                            options                  Configuration options for adding a block.
+ * @param {boolean}                                           [options.isPickerOpened] Option to skip openning the inserter picker.
  */
-export const addBlock = async ( screen, blockName, isPickerOpened = false ) => {
+export const addBlock = async (
+	screen,
+	blockName,
+	{ isPickerOpened } = {}
+) => {
 	const { getByLabelText, getByTestId, getByText } = screen;
 
 	if ( ! isPickerOpened ) {

--- a/test/native/integration-test-helpers/add-block.js
+++ b/test/native/integration-test-helpers/add-block.js
@@ -11,13 +11,16 @@ import { waitFor } from './wait-for';
 /**
  * Adds a block via the block picker.
  *
- * @param {import('@testing-library/react-native').RenderAPI} screen    A Testing Library screen.
- * @param {string}                                            blockName Name of the block to be inserted as shown in the block picker.
+ * @param {import('@testing-library/react-native').RenderAPI} screen                 A Testing Library screen.
+ * @param {string}                                            blockName              Name of the block to be inserted as shown in the block picker.
+ * @param {boolean}                                           [isPickerOpened=false] isPickerOpened Option to skip opening the inserter picker.
  */
-export const addBlock = async ( screen, blockName ) => {
+export const addBlock = async ( screen, blockName, isPickerOpened = false ) => {
 	const { getByLabelText, getByTestId, getByText } = screen;
 
-	fireEvent.press( getByLabelText( 'Add block' ) );
+	if ( ! isPickerOpened ) {
+		fireEvent.press( getByLabelText( 'Add block' ) );
+	}
 
 	const blockList = getByTestId( 'InserterUI-Blocks' );
 	// onScroll event used to force the FlatList to render all items


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/5358

Closes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4915

## What?
This PR adds new integration tests for block insertion: Add a block to the beginning, after a block, before a block, and to the end of the content.

## Why?
We previously had an E2E test that covered the `Add block before` but it was very flaky due to the long-press functionality being unstable.

## How?
By adding the following tests:

- **Inserter**
  - **can add blocks**
      - to the beginning
      - before another block
      - after another block 
      - to the end

It also removes the E2E test that covered the `Add block before` functionality, this will now be covered by an integration test.

## Testing Instructions
- CI unit tests check should pass.
- Gutenberg Mobile CI checks should pass.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A