### PR TITLE
Keycodes: fix tilde (~) character isn't displayed correctly

### DIFF
--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -233,11 +233,11 @@ export const displayShortcutList = mapValues( modifiers, ( modifier ) => {
 			/** @type {string[]} */ ( [] )
 		);
 
-		// Symbols (`,.) are removed by the default regular expression,
+		// Symbols (~`,.) are removed by the default regular expression,
 		// so override the rule to allow symbols used for shortcuts.
 		// see: https://github.com/blakeembrey/change-case#options
 		const capitalizedCharacter = capitalCase( character, {
-			stripRegexp: /[^A-Z0-9`,\.\\\-]/gi,
+			stripRegexp: /[^A-Z0-9~`,\.\\\-]/gi,
 		} );
 
 		return [ ...modifierKeys, capitalizedCharacter ];
@@ -298,6 +298,8 @@ export const shortcutAriaLabel = mapValues( modifiers, ( modifier ) => {
 			'.': __( 'Period' ),
 			/* translators: backtick as in the character '`' */
 			'`': __( 'Backtick' ),
+			/* translators: tilde as in the character '~' */
+			'~': __( 'Tilde' ),
 		};
 
 		return [ ...modifier( _isApple ), character ]


### PR DESCRIPTION
Related to #45019

## What?
This PR fixes the following two problems with the keyboard shortcut modal:

- Tilde character not displayed
- `aria-abel` containing tilde character is not displayed correctly

![before](https://user-images.githubusercontent.com/54422211/210038325-c44f297e-e08c-4562-abea-f4b689bf8287.png)

## Why?
`capitalCase()` is used in the display of shortcut characters and aria-label.
This library [removes symbols by default](https://github.com/blakeembrey/change-case#options) and needs to explicitly add to the regular expression.

## Testing Instructions
- Open the Site Editor or Post Editor or Block Widget Editor.
- Open the keyboard shortcut modal.
- Confirm that the tilde appears in the third shortcut indicated by "Navigate to the previous part of the editor.".
- Check that "Control + Shift + Tilde" is correctly output as the `aria-label` in the browser developer tools.

![after](https://user-images.githubusercontent.com/54422211/210039058-19bae28d-633f-42f0-9958-7d78d18874c9.png)
