### PR TITLE
ComboboxControl: Fix unexpected behaviour in IME Composition

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -19,6 +19,7 @@
 -   `Modal`: Fix unexpected modal closing in IME Composition ([#46453](https://github.com/WordPress/gutenberg/pull/46453)).
 -   `Toolbar`: Fix duplicate focus style on anchor link button ([#46759](https://github.com/WordPress/gutenberg/pull/46759)).
 -   `useNavigateRegions`: Ensure region navigation picks the next region based on where the current user focus is located instead of starting at the beginning ([#44883](https://github.com/WordPress/gutenberg/pull/44883)).
+-   `ComboboxControl`: Fix unexpected behaviour in IME Composition ([#46827](https://github.com/WordPress/gutenberg/pull/46827)).
 
 ### Enhancements
 

--- a/packages/components/src/combobox-control/index.js
+++ b/packages/components/src/combobox-control/index.js
@@ -121,7 +121,15 @@ function ComboboxControl( {
 	const onKeyDown = ( event ) => {
 		let preventDefault = false;
 
-		if ( event.defaultPrevented ) {
+		if (
+			event.defaultPrevented ||
+			// Ignore keydowns from IMEs
+			event.nativeEvent.isComposing ||
+			// Workaround for Mac Safari where the final Enter/Backspace of an IME composition
+			// is `isComposing=false`, even though it's technically still part of the composition.
+			// These can only be detected by keyCode.
+			event.keyCode === 229
+		) {
 			return;
 		}
 


### PR DESCRIPTION
Part of #45605

## What?
This PR fixes the following two problems with IME compositions in the `ComboboxControl` component:

1. Outputs both the suggested word and committed characters when the `enter` key is pressed
2. The typed characters disappear when the `escape` key is pressed

https://user-images.githubusercontent.com/54422211/210077611-076b68eb-3b89-497c-b814-7bee711907b9.mp4

## Why?

This component handles keydown events, but the IME mode has the following roles during input:

- `Enter`: to confirm your input.
- `Escape` to hide input candidates or cancel what you are typing.

During these operations, key events should be ignored because character input is not finalized.

## How?

Added determination of whether or not the compose is in progress, as was done with https://github.com/WordPress/gutenberg/pull/45607 and https://github.com/WordPress/gutenberg/pull/45626.

## Testing Instructions for Keyboard

In the storybook, confirm the following actions.
<details>
<summary>example of data for the options prop</summary>

```
[
  {
    "value": "[ああああああ]",
    "label": "[ああああああ]"
  },
  {
    "value": "[ああああいい]",
    "label": "[ああああいい]"
  },
  {
    "value": "[ああああうう]",
    "label": "[ああああうう]"
  },
  {
    "value": "[ああいいああ]",
    "label": "[ああいいああ]"
  },
  {
    "value": "[ああいいいい]",
    "label": "[ああいいいい]"
  },
  {
    "value": "[ああいいうう]",
    "label": "[ああいいうう]"
  },
  {
    "value": "[ああううああ]",
    "label": "[ああううああ]"
  },
  {
    "value": "[ああうういい]",
    "label": "[ああうういい]"
  },
  {
    "value": "[ああうううう]",
    "label": "[ああうううう]"
  },
  {
    "value": "[いいああああ]",
    "label": "[いいああああ]"
  },
  {
    "value": "[いいああいい]",
    "label": "[いいああいい]"
  },
  {
    "value": "[いいああうう]",
    "label": "[いいああうう]"
  },
  {
    "value": "[いいいいああ]",
    "label": "[いいいいああ]"
  },
  {
    "value": "[いいいいいい]",
    "label": "[いいいいいい]"
  },
  {
    "value": "[いいいいうう]",
    "label": "[いいいいうう]"
  },
  {
    "value": "[いいううああ]",
    "label": "[いいううああ]"
  },
  {
    "value": "[いいうういい]",
    "label": "[いいうういい]"
  },
  {
    "value": "[いいうううう]",
    "label": "[いいうううう]"
  },
  {
    "value": "[ううああああ]",
    "label": "[ううああああ]"
  },
  {
    "value": "[ううああいい]",
    "label": "[ううああいい]"
  },
  {
    "value": "[ううああうう]",
    "label": "[ううああうう]"
  },
  {
    "value": "[うういいああ]",
    "label": "[うういいああ]"
  },
  {
    "value": "[うういいいい]",
    "label": "[うういいいい]"
  },
  {
    "value": "[うういいうう]",
    "label": "[うういいうう]"
  },
  {
    "value": "[ううううああ]",
    "label": "[ううううああ]"
  },
  {
    "value": "[うううういい]",
    "label": "[うううういい]"
  },
  {
    "value": "[うううううう]",
    "label": "[うううううう]"
  }
]
```
</details>

1. The first time you press the `enter` key, the characters should be comitted. The second time you press the `enter` key, the selected suggestion should be entered.
2. The first time you press the `escape` key, the IME candidate should disappear. The second time you press the `escape` key, the characters you entered should disappear.

https://user-images.githubusercontent.com/54422211/210078240-10af390a-0592-4e67-9090-552027b813cd.mp4

In addition, I have confirmed that the following browsers work as expected in Windows 11:

✅ Google Chrome Version 108.0.5359.125
✅ Microsoft Edge Version 108.0.1462.54
✅ FireFox Version 107.0.1

## Next Step

This component still has the following two issues that this PR does not resolve:

- Suggestions list is filtered during composition
- Re-filtering of the suggestion list when IME conversion candidates are selected with the `arrow-up` / `arrow-down` keys.

I believe this problem is due to TokenInput triggering events even while composing:

https://github.com/WordPress/gutenberg/blob/0b8030d1c6f3cd598c77ffbc4542ca2f9df4c0c5/packages/components/src/form-token-field/token-input.tsx#L38-L44

Since this component is used by both `ComboboxControl` and `FormTokenField`, I would like to address this issue as a follow-up.