### PR TITLE
Page List Block: fix warning error when the parent page has no child pages

### DIFF
--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -308,6 +308,11 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	$nested_pages = block_core_page_list_nest_pages( $top_level_pages, $pages_with_children );
 
 	if ( 0 !== $parent_page_id ) {
+		// If the parent page has no child pages, there is nothing to show.
+		if ( ! array_key_exists( $parent_page_id, $pages_with_children ) ) {
+			return;
+		}
+
 		$nested_pages = block_core_page_list_nest_pages(
 			$pages_with_children[ $parent_page_id ],
 			$pages_with_children


### PR DESCRIPTION
## What?
This PR fixes warning error when the parent page has no child pages in te page list block.

## Why?

If the parent page that has no child pages is specified, the editor will display a normal alert message in the editor.

![warning](https://user-images.githubusercontent.com/54422211/210064478-3e6cc4b1-2c95-470a-9bed-8b080d3f4e5c.png)

However, dynamic rendering treats it as having child pages, resulting in an error that the key does not exist.

```
Warning: Undefined array key XX in /path/to/wp-content/plugins/gutenberg/build/block-library/blocks/page-list.php on line 312
```

## How?
If the parent page has no child pages, it stops further processing and renders nothing.

## Testing Instructions

- Creates a page that has no child pages.
- Inset a page list block.
- Select that page from the block sidebar and save it.
- Reload the browser and confirm that no PHP errors appear in both the editor and the front end.
- If a parent page with child pages is selected, confirm that it renders correctly as before.
- Confirm that it works correctly even when inserted within a navigation block.
