### PR TITLE
Video Block: Fix browser warning error when settings are toggled

### DIFF
--- a/packages/block-library/src/video/edit-common-settings.js
+++ b/packages/block-library/src/video/edit-common-settings.js
@@ -50,28 +50,28 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 			<ToggleControl
 				label={ __( 'Autoplay' ) }
 				onChange={ toggleFactory.autoplay }
-				checked={ autoplay }
+				checked={ !! autoplay }
 				help={ getAutoplayHelp }
 			/>
 			<ToggleControl
 				label={ __( 'Loop' ) }
 				onChange={ toggleFactory.loop }
-				checked={ loop }
+				checked={ !! loop }
 			/>
 			<ToggleControl
 				label={ __( 'Muted' ) }
 				onChange={ toggleFactory.muted }
-				checked={ muted }
+				checked={ !! muted }
 			/>
 			<ToggleControl
 				label={ __( 'Playback controls' ) }
 				onChange={ toggleFactory.controls }
-				checked={ controls }
+				checked={ !! controls }
 			/>
 			<ToggleControl
 				label={ __( 'Play inline' ) }
 				onChange={ toggleFactory.playsInline }
-				checked={ playsInline }
+				checked={ !! playsInline }
 			/>
 			<SelectControl
 				label={ __( 'Preload' ) }


### PR DESCRIPTION
## What?
This PR fixes the browser warning error that occurs when the toggle control value is changed in the block sidebar.

https://user-images.githubusercontent.com/54422211/210175993-a33c47cf-91a0-421f-b4e1-ebc2925fe0e8.mp4

## Why?
This is because the variables given as the initial value are `undefined`.

## How?
I used `!!` to convert them to boolean values.

## Testing Instructions

- Insert a video block and set the media.
- Toggle one of the settings fron the block sidebar setting.
- Confirm that no browser warning errors occur.