### PR TITLE
Update HTML Custom block to use isSelected for raw HTML view and by d…

### DIFF
--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -2,13 +2,9 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useContext, useState } from '@wordpress/element';
-import {
-	BlockControls,
-	PlainText,
-	useBlockProps,
-} from '@wordpress/block-editor';
-import { ToolbarButton, Disabled, ToolbarGroup } from '@wordpress/components';
+import { useContext } from '@wordpress/element';
+import { PlainText, useBlockProps } from '@wordpress/block-editor';
+import { Disabled } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -16,38 +12,12 @@ import { ToolbarButton, Disabled, ToolbarGroup } from '@wordpress/components';
 import Preview from './preview';
 
 export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
-	const [ isPreview, setIsPreview ] = useState();
 	const isDisabled = useContext( Disabled.Context );
-
-	function switchToPreview() {
-		setIsPreview( true );
-	}
-
-	function switchToHTML() {
-		setIsPreview( false );
-	}
 
 	return (
 		<div { ...useBlockProps( { className: 'block-library-html__edit' } ) }>
-			<BlockControls>
-				<ToolbarGroup>
-					<ToolbarButton
-						className="components-tab-button"
-						isPressed={ ! isPreview }
-						onClick={ switchToHTML }
-					>
-						HTML
-					</ToolbarButton>
-					<ToolbarButton
-						className="components-tab-button"
-						isPressed={ isPreview }
-						onClick={ switchToPreview }
-					>
-						{ __( 'Preview' ) }
-					</ToolbarButton>
-				</ToolbarGroup>
-			</BlockControls>
-			{ isPreview || isDisabled ? (
+			{ ( ! isSelected && '' !== attributes.content.trim() ) ||
+			isDisabled ? (
 				<Preview
 					content={ attributes.content }
 					isSelected={ isSelected }

--- a/packages/block-library/src/html/preview.js
+++ b/packages/block-library/src/html/preview.js
@@ -20,7 +20,7 @@ const DEFAULT_STYLES = `
 	}
 `;
 
-export default function HTMLEditPreview( { content, isSelected } ) {
+export default function HTMLEditPreview( { content } ) {
 	const settingStyles = useSelect( ( select ) => {
 		return select( blockEditorStore ).getSettings()?.styles;
 	}, [] );
@@ -34,13 +34,11 @@ export default function HTMLEditPreview( { content, isSelected } ) {
 		<>
 			<SandBox html={ content } styles={ styles } />
 			{ /*
-				An overlay is added when the block is not selected in order to register click events.
+				An overlay is added when the block is in preview in order to register click events.
 				Some browsers do not bubble up the clicks from the sandboxed iframe, which makes it
 				difficult to reselect the block.
 			*/ }
-			{ ! isSelected && (
-				<div className="block-library-html__preview-overlay"></div>
-			) }
+			<div className="block-library-html__preview-overlay"></div>
 		</>
 	);
 }


### PR DESCRIPTION
## What?
This PR is to put the Custom HTML block in preview mode, and on select show raw HTML.

## Why?
Raw HTML is sometimes unavoidable and can be scary or jarring to the enduser. In order to maintain a what-you-see-is-what-you-get feel in the block editor, it is important to have the Custom HTML block look more at home with the rest of the blocks/content in the editor.

## How?
This is just a small change to the block so it always displays in preview mode unless selected or empty.

## Testing Instructions
1.) Create a new post or open an existing one.
2.) Add a new or edit an existing Custom HTML Block.
3.) Once content is added Custom HTML block should be in preview mode (if Custom HTML block is there already, that should be in preview mode too).
4.) On select the block should display raw HTML and be able to be edited.
5.) If all content is removed (or only whitespace), Custom HTML block should not be in preview mode no matter what.

### Testing Instructions for Keyboard
N/A. No significant changes were made to the general UI of the block. Prevew | HTML buttons have been removed as they are no longer needed.
