### PR TITLE
WP_HTML_Tag_Processor: Add `get_attribute_names_with_prefix()` method

### DIFF
--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1413,11 +1413,20 @@ class WP_HTML_Tag_Processor {
 	}
 
 	/**
-	 * Returns the names of all attributes matching a given prefix in the currently-opened tag.
+	 * Returns the (lowercase) names of all attributes matching a given prefix in the currently-opened tag.
+	 *
+	 * Note that matching is case-insensitive. This is in accordance with the spec:
+	 *
+	 * > There must never be two or more attributes on
+	 * > the same start tag whose names are an ASCII
+	 * > case-insensitive match for each other.
+	 *     - HTML 5 spec
+	 *
+	 * @see https://html.spec.whatwg.org/multipage/syntax.html#attributes-2:ascii-case-insensitive
 	 *
 	 * Example:
 	 * <code>
-	 *     $p = new WP_HTML_Tag_Processor( '<div data-enabled class="test" data-test-id="14">Test</div>' );
+	 *     $p = new WP_HTML_Tag_Processor( '<div data-ENABLED class="test" DATA-test-id="14">Test</div>' );
 	 *     $p->next_tag( [ 'class_name' => 'test' ] ) === true;
 	 *     $p->get_attribute_names_with_prefix( 'data-' ) === array( 'data-enabled', 'data-test-id' );
 	 *

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1427,7 +1427,6 @@ class WP_HTML_Tag_Processor {
 	 *
 	 * @since 6.2.0
 	 *
-	 * @param string $prefix Prefix of attributes whose value is requested.
 	 * @return array|null List of attribute names, or `null` if not at a tag.
 	 */
 	function get_attribute_names() {

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1446,14 +1446,13 @@ class WP_HTML_Tag_Processor {
 
 		$comparable = strtolower( $prefix );
 
-		$matches = array_filter(
-			$this->attributes,
-			function( $attr ) use ( $comparable ) {
-				return str_starts_with( $attr, $comparable );
-			},
-			ARRAY_FILTER_USE_KEY
-		);
-		return array_keys( $matches );
+		$matches = array();
+		foreach ( array_keys( $this->attributes ) as $attr_name ) {
+			if ( str_starts_with( $attr_name, $comparable ) ) {
+				$matches[] = $attr_name;
+			}
+		}
+		return $matches;
 	}
 
 	/**

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1413,28 +1413,36 @@ class WP_HTML_Tag_Processor {
 	}
 
 	/**
-	 * Returns the names of all attributes in the currently-opened tag.
+	 * Returns the names of all attributes matching a given prefix in the currently-opened tag.
 	 *
 	 * Example:
 	 * <code>
-	 *     $p = new WP_HTML_Tag_Processor( '<div enabled class="test" data-test-id="14">Test</div>' );
+	 *     $p = new WP_HTML_Tag_Processor( '<div data-enabled class="test" data-test-id="14">Test</div>' );
 	 *     $p->next_tag( [ 'class_name' => 'test' ] ) === true;
-	 *     $p->get_attribute_names() === array( 'enabled', 'class', 'data-test-id' );
+	 *     $p->get_attribute_names_with_prefix() === array( 'data-enabled', 'data-test-id' );
 	 *
 	 *     $p->next_tag( [] ) === false;
-	 *     $p->get_attribute_names() === null;
+	 *     $p->get_attribute_names_with_prefix() === null;
 	 * </code>
 	 *
 	 * @since 6.2.0
 	 *
 	 * @return array|null List of attribute names, or `null` if not at a tag.
 	 */
-	function get_attribute_names() {
+	function get_attribute_names_with_prefix( $prefix ) {
 		if ( $this->is_closing_tag || null === $this->tag_name_starts_at ) {
 			return null;
 		}
 
-		return array_keys( $this->attributes );
+		$comparable = strtolower( $prefix );
+
+		$matches = array_filter(
+			array_keys( $this->attributes ),
+			function( $attr ) use ( $comparable ) {
+				return str_starts_with( $attr, $comparable );
+			}
+		);
+		return array_values( $matches );
 	}
 
 	/**

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1419,10 +1419,10 @@ class WP_HTML_Tag_Processor {
 	 * <code>
 	 *     $p = new WP_HTML_Tag_Processor( '<div data-enabled class="test" data-test-id="14">Test</div>' );
 	 *     $p->next_tag( [ 'class_name' => 'test' ] ) === true;
-	 *     $p->get_attribute_names_with_prefix() === array( 'data-enabled', 'data-test-id' );
+	 *     $p->get_attribute_names_with_prefix( 'data-' ) === array( 'data-enabled', 'data-test-id' );
 	 *
 	 *     $p->next_tag( [] ) === false;
-	 *     $p->get_attribute_names_with_prefix() === null;
+	 *     $p->get_attribute_names_with_prefix( 'data-' ) === null;
 	 * </code>
 	 *
 	 * @since 6.2.0

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1413,7 +1413,7 @@ class WP_HTML_Tag_Processor {
 	}
 
 	/**
-	 * Returns the (lowercase) names of all attributes matching a given prefix in the currently-opened tag.
+	 * Returns the lowercase names of all attributes matching a given prefix in the currently-opened tag.
 	 *
 	 * Note that matching is case-insensitive. This is in accordance with the spec:
 	 *

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1427,6 +1427,7 @@ class WP_HTML_Tag_Processor {
 	 *
 	 * @since 6.2.0
 	 *
+	 * @param string $prefix Prefix of requested attribute names.
 	 * @return array|null List of attribute names, or `null` if not at a tag.
 	 */
 	function get_attribute_names_with_prefix( $prefix ) {

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1413,6 +1413,32 @@ class WP_HTML_Tag_Processor {
 	}
 
 	/**
+	 * Returns the names of all attributes in the currently-opened tag.
+	 *
+	 * Example:
+	 * <code>
+	 *     $p = new WP_HTML_Tag_Processor( '<div enabled class="test" data-test-id="14">Test</div>' );
+	 *     $p->next_tag( [ 'class_name' => 'test' ] ) === true;
+	 *     $p->get_attribute_names() === array( 'enabled', 'class', 'data-test-id' );
+	 *
+	 *     $p->next_tag( [] ) === false;
+	 *     $p->get_attribute_names() === null;
+	 * </code>
+	 *
+	 * @since 6.2.0
+	 *
+	 * @param string $prefix Prefix of attributes whose value is requested.
+	 * @return array|null List of attribute names, or `null` if not at a tag.
+	 */
+	function get_attribute_names() {
+		if ( null === $this->tag_name_starts_at ) {
+			return null;
+		}
+
+		return array_keys( $this->attributes );
+	}
+
+	/**
 	 * Returns the lowercase name of the currently-opened tag.
 	 *
 	 * Example:

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1430,7 +1430,7 @@ class WP_HTML_Tag_Processor {
 	 * @return array|null List of attribute names, or `null` if not at a tag.
 	 */
 	function get_attribute_names() {
-		if ( null === $this->tag_name_starts_at ) {
+		if ( $this->is_closing_tag || null === $this->tag_name_starts_at ) {
 			return null;
 		}
 

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1447,12 +1447,13 @@ class WP_HTML_Tag_Processor {
 		$comparable = strtolower( $prefix );
 
 		$matches = array_filter(
-			array_keys( $this->attributes ),
+			$this->attributes,
 			function( $attr ) use ( $comparable ) {
 				return str_starts_with( $attr, $comparable );
-			}
+			},
+			ARRAY_FILTER_USE_KEY
 		);
-		return array_values( $matches );
+		return array_keys( $matches );
 	}
 
 	/**

--- a/phpunit/html/wp-html-tag-processor-test.php
+++ b/phpunit/html/wp-html-tag-processor-test.php
@@ -152,18 +152,6 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers WP_HTML_Tag_Processor::get_attribute_names
-	 */
-	public function test_get_attribute_names() {
-		$p = new WP_HTML_Tag_Processor( '<div enabled class="test" data-test-id="14">Test</div>' );
-		$p->next_tag();
-		$this->assertSame(
-			array( 'enabled', 'class', 'data-test-id' ),
-			$p->get_attribute_names()
-		);
-	}
-
-	/**
 	 * @ticket 56299
 	 *
 	 * @covers next_tag
@@ -205,6 +193,18 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 		$p->next_tag();
 		$p->set_attribute( 'data-enabled', 'abc' );
 		$this->assertEquals( '<div data-enabled="abc">Test</div>', $p->get_updated_html(), 'A case-insensitive set_attribute call did not update the existing attribute.' );
+	}
+
+	/**
+	 * @covers WP_HTML_Tag_Processor::get_attribute_names
+	 */
+	public function test_get_attribute_names() {
+		$p = new WP_HTML_Tag_Processor( '<div enabled class="test" data-test-id="14">Test</div>' );
+		$p->next_tag();
+		$this->assertSame(
+			array( 'enabled', 'class', 'data-test-id' ),
+			$p->get_attribute_names()
+		);
 	}
 
 	/**

--- a/phpunit/html/wp-html-tag-processor-test.php
+++ b/phpunit/html/wp-html-tag-processor-test.php
@@ -257,8 +257,8 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 	 *
 	 * @covers get_attribute_names_with_prefix
 	 */
-	public function test_get_attribute_names_with_prefix_returns_attribute_names() {
-		$p = new WP_HTML_Tag_Processor( '<div data-enabled class="test" data-test-id="14">Test</div>' );
+	public function test_get_attribute_names_with_prefix_returns_matching_attribute_names_in_lowercase() {
+		$p = new WP_HTML_Tag_Processor( '<div DATA-enabled class="test" data-test-ID="14">Test</div>' );
 		$p->next_tag();
 		$this->assertSame(
 			array( 'data-enabled', 'data-test-id' ),

--- a/phpunit/html/wp-html-tag-processor-test.php
+++ b/phpunit/html/wp-html-tag-processor-test.php
@@ -152,6 +152,18 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers WP_HTML_Tag_Processor::get_attribute_names
+	 */
+	public function test_get_attribute_names() {
+		$p = new WP_HTML_Tag_Processor( '<div enabled class="test" data-test-id="14">Test</div>' );
+		$p->next_tag();
+		$this->assertSame(
+			array( 'enabled', 'class', 'data-test-id' ),
+			$p->get_attribute_names()
+		);
+	}
+
+	/**
 	 * @ticket 56299
 	 *
 	 * @covers next_tag

--- a/phpunit/html/wp-html-tag-processor-test.php
+++ b/phpunit/html/wp-html-tag-processor-test.php
@@ -211,58 +211,58 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers get_attribute_names
+	 * @covers get_attribute_names_with_prefix
 	 */
-	public function test_get_attribute_names_returns_null_before_finding_tags() {
-		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
-		$this->assertNull( $p->get_attribute_names() );
+	public function test_get_attribute_names_with_prefix_returns_null_before_finding_tags() {
+		$p = new WP_HTML_Tag_Processor( '<div data-foo="bar">Test</div>' );
+		$this->assertNull( $p->get_attribute_names_with_prefix( 'data-' ) );
 	}
 
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers get_attribute
+	 * @covers get_attribute_names_with_prefix
 	 */
-	public function test_get_attribute_names_returns_null_when_not_in_open_tag() {
-		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
+	public function test_get_attribute_names_with_prefix_returns_null_when_not_in_open_tag() {
+		$p = new WP_HTML_Tag_Processor( '<div data-foo="bar">Test</div>' );
 		$p->next_tag( 'p' );
-		$this->assertNull( $p->get_attribute_names(), 'Accessing attributes of a non-existing tag did not return null' );
+		$this->assertNull( $p->get_attribute_names_with_prefix( 'data-' ), 'Accessing attributes of a non-existing tag did not return null' );
 	}
 
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers get_attribute_names
+	 * @covers get_attribute_names_with_prefix
 	 */
-	public function test_get_attribute_names_returns_null_when_in_closing_tag() {
-		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
+	public function test_get_attribute_names_with_prefix_returns_null_when_in_closing_tag() {
+		$p = new WP_HTML_Tag_Processor( '<div data-foo="bar">Test</div>' );
 		$p->next_tag( 'div' );
 		$p->next_tag( array( 'tag_closers' => 'visit' ) );
-		$this->assertNull( $p->get_attribute_names(), 'Accessing attributes of a closing tag did not return null' );
+		$this->assertNull( $p->get_attribute_names_with_prefix( 'data-' ), 'Accessing attributes of a closing tag did not return null' );
 	}
 
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers get_attribute_names
+	 * @covers get_attribute_names_with_prefix
 	 */
-	public function test_get_attribute_names_returns_empty_array_when_no_attributes_present() {
+	public function test_get_attribute_names_with_prefix_returns_empty_array_when_no_attributes_present() {
 		$p = new WP_HTML_Tag_Processor( '<div>Test</div>' );
 		$p->next_tag( 'div' );
-		$this->assertSame( array(), $p->get_attribute_names(), 'Accessing the attributes on a tag without any did not return an empty array' );
+		$this->assertSame( array(), $p->get_attribute_names_with_prefix( 'data-' ), 'Accessing the attributes on a tag without any did not return an empty array' );
 	}
 
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers get_attribute_names
+	 * @covers get_attribute_names_with_prefix
 	 */
-	public function test_get_attribute_names_returns_attribute_names() {
-		$p = new WP_HTML_Tag_Processor( '<div enabled class="test" data-test-id="14">Test</div>' );
+	public function test_get_attribute_names_with_prefix_returns_attribute_names() {
+		$p = new WP_HTML_Tag_Processor( '<div data-enabled class="test" data-test-id="14">Test</div>' );
 		$p->next_tag();
 		$this->assertSame(
-			array( 'enabled', 'class', 'data-test-id' ),
-			$p->get_attribute_names()
+			array( 'data-enabled', 'data-test-id' ),
+			$p->get_attribute_names_with_prefix( 'data-' )
 		);
 	}
 
@@ -271,20 +271,20 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 	 *
 	 * @covers set_attribute
 	 * @covers get_updated_html
-	 * @covers get_attribute_names
+	 * @covers get_attribute_names_with_prefix
 	 */
-	public function test_get_attribute_names_returns_attribute_added_by_set_attribute() {
-		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
+	public function test_get_attribute_names_with_prefix_returns_attribute_added_by_set_attribute() {
+		$p = new WP_HTML_Tag_Processor( '<div data-foo="bar">Test</div>' );
 		$p->next_tag();
-		$p->set_attribute( 'test-attribute', 'test-value' );
+		$p->set_attribute( 'data-test-id', '14' );
 		$this->assertSame(
-			'<div test-attribute="test-value" class="test">Test</div>',
+			'<div data-test-id="14" data-foo="bar">Test</div>',
 			$p->get_updated_html(),
 			"Updated HTML doesn't include attribute added via set_attribute"
 		);
 		$this->assertSame(
-			array( 'test-attribute', 'class' ),
-			$p->get_attribute_names(),
+			array( 'data-test-id', 'data-foo' ),
+			$p->get_attribute_names_with_prefix( 'data-' ),
 			"Accessing attribute names doesn't find attribute added via set_attribute"
 		);
 	}

--- a/phpunit/html/wp-html-tag-processor-test.php
+++ b/phpunit/html/wp-html-tag-processor-test.php
@@ -80,6 +80,19 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 	 * @covers next_tag
 	 * @covers get_attribute
 	 */
+	public function test_get_attribute_returns_null_when_in_closing_tag() {
+		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
+		$this->assertTrue( $p->next_tag( 'div' ), 'Querying an existing tag did not return true' );
+		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), 'Querying an existing closing tag did not return true' );
+		$this->assertNull( $p->get_attribute( 'class' ), 'Accessing an attribute of a closing tag did not return null' );
+	}
+
+	/**
+	 * @ticket 56299
+	 *
+	 * @covers next_tag
+	 * @covers get_attribute
+	 */
 	public function test_get_attribute_returns_null_when_attribute_missing() {
 		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
 		$this->assertTrue( $p->next_tag( 'div' ), 'Querying an existing tag did not return true' );

--- a/phpunit/html/wp-html-tag-processor-test.php
+++ b/phpunit/html/wp-html-tag-processor-test.php
@@ -269,6 +269,29 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 	/**
 	 * @ticket 56299
 	 *
+	 * @covers set_attribute
+	 * @covers get_updated_html
+	 * @covers get_attribute_names
+	 */
+	public function test_get_attribute_names_returns_attribute_added_by_set_attribute() {
+		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
+		$p->next_tag();
+		$p->set_attribute( 'test-attribute', 'test-value' );
+		$this->assertSame(
+			'<div test-attribute="test-value" class="test">Test</div>',
+			$p->get_updated_html(),
+			"Updated HTML doesn't include attribute added via set_attribute"
+		);
+		$this->assertSame(
+			array( 'test-attribute', 'class' ),
+			$p->get_attribute_names(),
+			"Accessing attribute names doesn't find attribute added via set_attribute"
+		);
+	}
+
+	/**
+	 * @ticket 56299
+	 *
 	 * @covers __toString
 	 */
 	public function tostring_returns_updated_html() {

--- a/phpunit/html/wp-html-tag-processor-test.php
+++ b/phpunit/html/wp-html-tag-processor-test.php
@@ -209,9 +209,55 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers WP_HTML_Tag_Processor::get_attribute_names
+	 * @ticket 56299
+	 *
+	 * @covers get_attribute_names
 	 */
-	public function test_get_attribute_names() {
+	public function test_get_attribute_names_returns_null_before_finding_tags() {
+		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
+		$this->assertNull( $p->get_attribute_names() );
+	}
+
+	/**
+	 * @ticket 56299
+	 *
+	 * @covers get_attribute
+	 */
+	public function test_get_attribute_names_returns_null_when_not_in_open_tag() {
+		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
+		$p->next_tag( 'p' );
+		$this->assertNull( $p->get_attribute_names(), 'Accessing attributes of a non-existing tag did not return null' );
+	}
+
+	/**
+	 * @ticket 56299
+	 *
+	 * @covers get_attribute_names
+	 */
+	public function test_get_attribute_names_returns_null_when_in_closing_tag() {
+		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
+		$p->next_tag( 'div' );
+		$p->next_tag( array( 'tag_closers' => 'visit' ) );
+		$this->assertNull( $p->get_attribute_names(), 'Accessing attributes of a closing tag did not return null' );
+	}
+
+	/**
+	 * @ticket 56299
+	 *
+	 * @covers get_attribute_names
+	 */
+	public function test_get_attribute_names_returns_empty_array_when_no_attributes_present() {
+		$p = new WP_HTML_Tag_Processor( '<div>Test</div>' );
+		$p->next_tag( 'div' );
+		$this->assertSame( array(), $p->get_attribute_names(), 'Accessing the attributes on a tag without any did not return an empty array' );
+	}
+
+	/**
+	 * @ticket 56299
+	 *
+	 * @covers get_attribute_names
+	 */
+	public function test_get_attribute_names_returns_attribute_names() {
 		$p = new WP_HTML_Tag_Processor( '<div enabled class="test" data-test-id="14">Test</div>' );
 		$p->next_tag();
 		$this->assertSame(


### PR DESCRIPTION
## What?
Add a `get_attribute_names_with_prefix()` method to `WP_HTML_Tag_Processor`, which returns the set of attribute name/value pairs of all attributes whose name starts with a given prefix.

```php
$p = new WP_HTML_Tag_Processor( '<div data-enabled class="test" data-test-id="14">Test</div>' );
$p->next_tag();
$p->get_attributes_by_prefix( 'data-' ) === array( 'data-enabled', 'data-test-id' );
```

## Why?

Getting all attributes with a given prefix is handy for `data-` attributes, and custom namesepaces (e.g. `ng-` or `x-`).

Furthermore, it helps with syntax like `<img wp-bind:src="myblock.imageSource" />`, which is a requirement for the Block Interactivity API ([see](https://github.com/WordPress/block-hydration-experiments/pull/118#issuecomment-1353407526)).

OTOH, it can be costly to compute the _value_ of an attribute, which is why we're only returning the matching attribute _names_ here. Users can then call `get_attribute( $name )` for the attributes they're interested in.

This PR is the lovechild of #46672 and #46685 -- combining `get_attribute_names` and `get_attributes_by_prefix`.

More background: https://github.com/WordPress/block-hydration-experiments/pull/118#discussion_r1051132800.

## How?
It filters the current tag's `$attributes` for all attribute names that start with `$prefix`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
See included unit tests.
