### PR TITLE
Fix number of arguments passed to hasBlockMetadataSupport.

### DIFF
--- a/packages/block-editor/src/hooks/metadata.js
+++ b/packages/block-editor/src/hooks/metadata.js
@@ -27,8 +27,7 @@ export function addMetaAttribute( blockTypeSettings ) {
 
 	const supportsBlockNaming = hasBlockMetadataSupport(
 		blockTypeSettings,
-		'name',
-		false
+		'name'
 	);
 
 	if ( supportsBlockNaming ) {


### PR DESCRIPTION
hasBlockMetadataSupport only has 2 arguments not three as we were passing.
