### PR TITLE
Chore: Remove unreachable line from phpunit/fixtures/mock-provider.php

### DIFF
--- a/phpunit/fixtures/mock-provider.php
+++ b/phpunit/fixtures/mock-provider.php
@@ -11,7 +11,6 @@ class Mock_Provider extends WP_Webfonts_Provider {
 	public function get_css() {
 		$handles = array_keys( $this->webfonts );
 		return implode( '; ', $handles );
-		return sprintf( $this->css, implode( '; ', $handles ) );
 	}
 
 	/**


### PR DESCRIPTION
Line return sprintf( $this->css, implode( '; ', $handles ) ); is never executed because we have a return statement before.