### PR TITLE
Enable image size for featured images in templates

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -43,7 +43,7 @@ function getMediaSourceUrlBySizeSlug( media, slug ) {
 	);
 }
 
-function PostFeaturedImageDisplay( {
+export default function PostFeaturedImageEdit( {
 	clientId,
 	attributes,
 	setAttributes,
@@ -167,10 +167,41 @@ function PostFeaturedImageDisplay( {
 		</>
 	);
 	let image;
+
+	/**
+	 * A post featured image block placed in a query loop
+	 * does not have image replacement or upload options.
+	 */
 	if ( ! featuredImage && isDescendentOfQueryLoop ) {
 		return (
 			<>
 				{ controls }
+				<div { ...blockProps }>
+					{ placeholder() }
+					<Overlay
+						attributes={ attributes }
+						setAttributes={ setAttributes }
+						clientId={ clientId }
+					/>
+				</div>
+			</>
+		);
+	}
+
+	/**
+	 * A post featured image placed in a block template, outside a query loop,
+	 * does not have a postId and will always be a placeholder image.
+	 * It does not have image replacement, upload, or link options.
+	 */
+	if ( ! featuredImage && ! postId ) {
+		return (
+			<>
+				<DimensionControls
+					clientId={ clientId }
+					attributes={ attributes }
+					setAttributes={ setAttributes }
+					imageSizeOptions={ imageSizeOptions }
+				/>
 				<div { ...blockProps }>
 					{ placeholder() }
 					<Overlay
@@ -190,6 +221,13 @@ function PostFeaturedImageDisplay( {
 		objectFit: height && scale,
 	};
 
+	/**
+	 * When the post featured image block is placed in a context where:
+	 * - It has a postId (for example in a single post)
+	 * - It is not inside a query loop
+	 * - It has no image assigned yet
+	 * Then display the placeholder with the image upload option.
+	 */
 	if ( ! featuredImage ) {
 		image = (
 			<MediaPlaceholder
@@ -236,6 +274,12 @@ function PostFeaturedImageDisplay( {
 		);
 	}
 
+	/**
+	 * When the post featured image block:
+	 * - Has an image assigned
+	 * - Is not inside a query loop
+	 * Then display the image and the image replacement option.
+	 */
 	return (
 		<>
 			{ controls }
@@ -265,30 +309,4 @@ function PostFeaturedImageDisplay( {
 			</figure>
 		</>
 	);
-}
-
-export default function PostFeaturedImageEdit( props ) {
-	const blockProps = useBlockProps();
-	const borderProps = useBorderProps( props.attributes );
-
-	if ( ! props.context?.postId ) {
-		return (
-			<div { ...blockProps }>
-				<Placeholder
-					className={ classnames(
-						'block-editor-media-placeholder',
-						borderProps.className
-					) }
-					withIllustration={ true }
-					style={ borderProps.style }
-				/>
-				<Overlay
-					attributes={ props.attributes }
-					setAttributes={ props.setAttributes }
-					clientId={ props.clientId }
-				/>
-			</div>
-		);
-	}
-	return <PostFeaturedImageDisplay { ...props } />;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR enables the image size controls when the featured image placeholder is added to a block template that has no postId, for example the single post and single page templates.

Closes https://github.com/WordPress/gutenberg/issues/45842

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It was not possible to adjust the size of the featured image in the single post and page templates via the UI (unless you placed it in a query loop).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The block had a conditional check for the post id, after which it rendered the placeholder without any extra block settings.
This condition was moved, and now renders the placeholder and the size settings.

## Testing Instructions

1. Activate a theme with support for the site editor
2. In the site editor, open or create a single post template.
3. In the single post template, add a post featured image block if there isn't one.
4. The post featured image should show a placeholder:
- The placeholder should not have an upload button.
- The block toolbar should have the duotone option, If the theme supports duotone. If the image is placed in a group, it should also have alignment options, depending on the settings. The toolbar should not have a "replace" option.
- The block settings sidebar should have the color overlay, the padding, margin, and border settings.
- Confirm that the settings sidebar has the height, width and scale settings that are enabled in this PR.
- It should not have the link settings.
- It should not have the image size select list option where the user can choose between thumbnail / full etc.

5. Adjust the image's height and width setting. Confirm that the image size changes correctly.
6. After adjusting the height, confirm that the scale settings are displayed. Test the 3 scale settings and confirm that they work correctly.
7. Next please view the single template on the front, using a post that has a featured image, and confirm that the image size is applied correctly.

Please test for possible regressions with featured images placed in the block editor and site editor, in and outside of query loops.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
A recording of the single template in Twenty Twenty Three, with the image height, width and scale settings.

https://user-images.githubusercontent.com/7422055/210315048-c34827ed-8789-4f2b-8dc1-258be62585ad.mov

