### PR TITLE
Dashicon: remove unnecessary type for `className` prop

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Internal
 
--   `Dashicon`: remove unnecessary type for `classname` prop ([46849](https://github.com/WordPress/gutenberg/pull/46849)).
+-   `Dashicon`: remove unnecessary type for `className` prop ([46849](https://github.com/WordPress/gutenberg/pull/46849)).
 
 ## 23.1.0 (2023-01-02)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   `Dashicon`: remove unnecessary type for `classname` prop ([46849](https://github.com/WordPress/gutenberg/pull/46849)).
+
 ## 23.1.0 (2023-01-02)
 
 ## 23.0.0 (2022-12-14)

--- a/packages/components/src/dashicon/types.ts
+++ b/packages/components/src/dashicon/types.ts
@@ -3,12 +3,6 @@ export type DashiconProps = {
 	 * The icon name
 	 */
 	icon: IconKey;
-
-	/**
-	 * Class name
-	 */
-	className?: string;
-
 	/**
 	 * Size of the icon
 	 */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up to #45924

Remove unnecessary prop for `classname`, which is already included in the component props when using the `WordrpressComponentProps` utility type.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Code cleanup

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Deleted prop type declaration.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Project builds without TS errors