### PR TITLE
Quick update to versions in WordPress doc for 6.1.1

### DIFF
--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -6,6 +6,7 @@ If anything looks incorrect here, please bring it up in #core-editor in [WordPre
 
 | Gutenberg Versions | WordPress Version |
 | ------------------ | ----------------- |
+| 13.1-14.1          | 6.1.1             |
 | 13.1-14.1          | 6.1               |
 | 12.0-13.0          | 6.0.3             |
 | 12.0-13.0          | 6.0.2             |


### PR DESCRIPTION
This is just a brief update to the versions in WordPress doc to update it for the 6.1.1 release. 