### PR TITLE
Chore: Fix incorrect usage of map instead of forEach.

### DIFF
--- a/packages/e2e-tests/specs/editor/various/block-switcher.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-switcher.test.js
@@ -76,7 +76,7 @@ describe( 'Block Switcher', () => {
 				'core/group',
 				'core/heading',
 				'core/columns',
-			].map( ( block ) => wp.blocks.unregisterBlockType( block ) );
+			].forEach( ( block ) => wp.blocks.unregisterBlockType( block ) );
 		} );
 
 		await page.keyboard.press( 'ArrowUp' );


### PR DESCRIPTION
In this case, we should use forEach instead of a map. We are applying an operation to every element of an array. We are not mapping an array into another array.