### PR TITLE
Block Inspector: fix browser warning error when block is not selected

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   `BlockInspector`: Fix browser warning error when block is not selected ([#46875](https://github.com/WordPress/gutenberg/pull/46875)).
+
 ## 11.1.0 (2023-01-02)
 
 ## 11.0.0 (2022-12-14)

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -177,7 +177,7 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 
 	const blockInspectorAnimationSettings = useSelect(
 		( select ) => {
-			if ( isOffCanvasNavigationEditorEnabled ) {
+			if ( isOffCanvasNavigationEditorEnabled && blockType ) {
 				const globalBlockInspectorAnimationSettings =
 					select( blockEditorStore ).getSettings()
 						.__experimentalBlockInspectorAnimation;


### PR DESCRIPTION
## What?
This PR fixes that `BlockInspector` outputs a warning error in the action when no block is selected.

https://user-images.githubusercontent.com/54422211/210481651-5bc8e12c-3faa-4bd9-881f-b53fa6f002a9.mp4

## Why?
This is because `blockType` is null and refers to the property `name` if no block is selected.

## How?
Added null check.

## Testing Instructions

- Set `SCRIPT_DEBUG` to true.
- In the site editor, move templates and template parts, click on screens, click on sidebar tabs, etc.
- Confirm that no browser warning errors are displayed.