### PR TITLE
Fixed incorrect type annotations in @wordpress/data

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -500,6 +500,10 @@ import { store as myCustomStore } from 'my-custom-store';
 dispatch( myCustomStore ).setPrice( 'hammer', 9.75 );
 ```
 
+_Type_
+
+-   `(storeNameOrDescriptor: StoreDescriptor|string) => Object`
+
 _Parameters_
 
 -   _storeNameOrDescriptor_ `StoreDescriptor|string`: The store descriptor. The legacy calling convention of passing the store name is also supported.
@@ -646,6 +650,10 @@ import { store as myCustomStore } from 'my-custom-store';
 
 select( myCustomStore ).getPrice( 'hammer' );
 ```
+
+_Type_
+
+-   `(storeNameOrDescriptor: StoreDescriptor|string) => Object`
 
 _Parameters_
 

--- a/packages/data/src/components/use-dispatch/use-dispatch.js
+++ b/packages/data/src/components/use-dispatch/use-dispatch.js
@@ -5,7 +5,7 @@ import useRegistry from '../registry-provider/use-registry';
 
 /**
  * @typedef {import('../../types').StoreDescriptor<StoreConfig>} StoreDescriptor
- * @template StoreConfig
+ * @template {import('../../types').AnyConfig} StoreConfig
  */
 /**
  * @typedef {import('../../types').UseDispatchReturn<StoreNameOrDescriptor>} UseDispatchReturn

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -28,17 +28,18 @@ const renderQueue = createQueue();
 
 /**
  * @typedef {import('../../types').StoreDescriptor<C>} StoreDescriptor
- * @template C
+ * @template {import('../../types').AnyConfig} C
  */
 /**
  * @typedef {import('../../types').ReduxStoreConfig<State,Actions,Selectors>} ReduxStoreConfig
- * @template State,Actions,Selectors
- */
-/**
- * @typedef {import('../../types').UseSelectReturn<T>} UseSelectReturn
- * @template T
+ * @template State,Selectors
+ * @template {Record<string,import('../../types').ActionCreator>} Actions
  */
 /** @typedef {import('../../types').MapSelect} MapSelect */
+/**
+ * @typedef {import('../../types').UseSelectReturn<T>} UseSelectReturn
+ * @template {MapSelect|StoreDescriptor<any>} T
+ */
 
 /**
  * Custom react hook for retrieving props from registered selectors.

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -98,8 +98,10 @@ export const combineReducers = turboCombineReducers;
  * ```
  *
  * @return {Object} Object containing the store's selectors.
+ *
+ * @type {(storeNameOrDescriptor: StoreDescriptor|string) => Object}
  */
-export const select = defaultRegistry.select;
+export const select  = defaultRegistry.select;
 
 /**
  * Given a store descriptor, returns an object containing the store's selectors pre-bound to state
@@ -154,6 +156,8 @@ export const suspendSelect = defaultRegistry.suspendSelect;
  * dispatch( myCustomStore ).setPrice( 'hammer', 9.75 );
  * ```
  * @return {Object} Object containing the action creators.
+ *
+ * @type {(storeNameOrDescriptor: StoreDescriptor|string) => Object}
  */
 export const dispatch = defaultRegistry.dispatch;
 

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -101,7 +101,7 @@ export const combineReducers = turboCombineReducers;
  *
  * @type {(storeNameOrDescriptor: StoreDescriptor|string) => Object}
  */
-export const select  = defaultRegistry.select;
+export const select = defaultRegistry.select;
 
 /**
  * Given a store descriptor, returns an object containing the store's selectors pre-bound to state

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -26,11 +26,12 @@ import * as metadataActions from './metadata/actions';
 /** @typedef {import('../types').DataRegistry} DataRegistry */
 /**
  * @typedef {import('../types').StoreDescriptor<C>} StoreDescriptor
- * @template C
+ * @template {import('../types').AnyConfig} C
  */
 /**
  * @typedef {import('../types').ReduxStoreConfig<State,Actions,Selectors>} ReduxStoreConfig
- * @template State,Actions,Selectors
+ * @template State,Selectors
+ * @template {Record<string,import('../../types').ActionCreator>} Actions
  */
 
 const trimUndefinedValues = ( array ) => {
@@ -99,7 +100,8 @@ function createResolversCache() {
  * } );
  * ```
  *
- * @template State,Actions,Selectors
+ * @template State,Selectors
+ * @template {Record<string,import('../../types').ActionCreator>} Actions
  * @param {string}                                    key     Unique namespace identifier.
  * @param {ReduxStoreConfig<State,Actions,Selectors>} options Registered store options, with properties
  *                                                            describing reducer, actions, selectors,


### PR DESCRIPTION
## What?
This PR modifies several type annotations in the `data` package so that they don't throw errors when used in a TS codebase. The errors are mainly due to type constraints not being satisfied in templated types.

This PR fixes #46626.

## How?
Mostly I just added the needed type constraints to the affected type annotations. In the case of the `select()` and `dispatch()` functions, I added a new `@type` annotation, but I am not sure whether to remove the (now redundant) `@param` and `@return` annotations.

## Testing Instructions

1. Check out https://github.com/marekdedic/DefinitelyTyped/tree/wordpress__rich-text-upstream-data
2. Delete the types/wordpress__data directory to force use of types in @wordpress/data
3. Run npm test wordpress__rich-text
4. You should see no error with this PR, as opposed to trunk

# Important notice
I have not been able to test this PR directly due to #46652. I have manually modified the built types to fix the issue and then applied the fixes from the build artifacts to the source code. Could you please test this before merging?