### PR TITLE
Navigation: Add an icon to the add submenu item option

### DIFF
--- a/packages/block-library/src/navigation/leaf-more-menu.js
+++ b/packages/block-library/src/navigation/leaf-more-menu.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { createBlock } from '@wordpress/blocks';
-import { moreVertical } from '@wordpress/icons';
+import { addSubmenu, moreVertical } from '@wordpress/icons';
 import { DropdownMenu, MenuItem, MenuGroup } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { store as blockEditorStore, BlockTitle } from '@wordpress/block-editor';
@@ -38,6 +38,7 @@ export const LeafMoreMenu = ( props ) => {
 			{ ( { onClose } ) => (
 				<MenuGroup>
 					<MenuItem
+						icon={ addSubmenu }
 						onClick={ () => {
 							const newLink = createBlock(
 								'core/navigation-link'


### PR DESCRIPTION

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds a "submenu" icon to the "Add submenu item" option in the more menu for navigation links.

Fixes #46072.

## Why?
This helps create an association between this action and the item that gets created.

## How?
Just add the icon to the MenuItem

## Testing Instructions
1. Add a navigation block
1. Open the inspector controls
2. Click on the more menu (three dots) by a navigation item
3. Check that the "add submenu item" option has a submenu item by it.

### Testing Instructions for Keyboard
This isn't visible for keyboard users

## Screenshot
<img width="289" alt="Screenshot 2023-01-04 at 14 23 37" src="https://user-images.githubusercontent.com/275961/210576424-6f97f296-3bac-438d-a99e-116c911d33e2.png">
s or screencast <!-- if applicable -->
