### PR TITLE
Update last inserted block state to track multiple blocks

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -556,20 +556,6 @@ _Properties_
 -   _isDisabled_ `boolean`: Whether or not the user should be prevented from inserting this item.
 -   _frecency_ `number`: Heuristic that combines frequency and recency.
 
-### getLastInsertedBlockClientId
-
-> **Deprecated**
-
-Gets the client id of the last inserted block.
-
-_Parameters_
-
--   _state_ `Object`: Global application state.
-
-_Returns_
-
--   `string|undefined`: Client Id of the last inserted block.
-
 ### getLastInsertedBlocksClientIds
 
 Gets the client ids of the last inserted blocks.

--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -556,6 +556,20 @@ _Properties_
 -   _isDisabled_ `boolean`: Whether or not the user should be prevented from inserting this item.
 -   _frecency_ `number`: Heuristic that combines frequency and recency.
 
+### getLastInsertedBlockClientId
+
+> **Deprecated**
+
+Gets the client id of the last inserted block.
+
+_Parameters_
+
+-   _state_ `Object`: Global application state.
+
+_Returns_
+
+-   `string|undefined`: Client Id of the last inserted block.
+
 ### getLastMultiSelectedBlockClientId
 
 Returns the client ID of the last block in the multi-selection set, or null

--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -556,18 +556,6 @@ _Properties_
 -   _isDisabled_ `boolean`: Whether or not the user should be prevented from inserting this item.
 -   _frecency_ `number`: Heuristic that combines frequency and recency.
 
-### getLastInsertedBlockClientId
-
-Gets the client id of the last inserted block.
-
-_Parameters_
-
--   _state_ `Object`: Global application state.
-
-_Returns_
-
--   `string|undefined`: Client Id of the last inserted block.
-
 ### getLastMultiSelectedBlockClientId
 
 Returns the client ID of the last block in the multi-selection set, or null

--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -570,6 +570,18 @@ _Returns_
 
 -   `string|undefined`: Client Id of the last inserted block.
 
+### getLastInsertedBlocksClientIds
+
+Gets the client ids of the last inserted blocks.
+
+_Parameters_
+
+-   _state_ `Object`: Global application state.
+
+_Returns_
+
+-   `Array|undefined`: Client Ids of the last inserted block(s).
+
 ### getLastMultiSelectedBlockClientId
 
 Returns the client ID of the last block in the multi-selection set, or null

--- a/packages/block-editor/src/components/off-canvas-editor/block-contents.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-contents.js
@@ -51,13 +51,13 @@ const ListViewBlockContents = forwardRef(
 				const {
 					hasBlockMovingClientId,
 					getSelectedBlockClientId,
-					getLastInsertedBlockClientIds,
+					getLastInsertedBlocksClientIds,
 				} = select( blockEditorStore );
 				return {
 					blockMovingClientId: hasBlockMovingClientId(),
 					selectedBlockInBlockEditor: getSelectedBlockClientId(),
 					lastInsertedBlockClientId:
-						getLastInsertedBlockClientIds()[ 0 ],
+						getLastInsertedBlocksClientIds()[ 0 ],
 				};
 			},
 			[ clientId ]

--- a/packages/block-editor/src/components/off-canvas-editor/block-contents.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-contents.js
@@ -51,12 +51,13 @@ const ListViewBlockContents = forwardRef(
 				const {
 					hasBlockMovingClientId,
 					getSelectedBlockClientId,
-					getLastInsertedBlockClientId,
+					__experimentalGetLastInsertedBlockClientId,
 				} = select( blockEditorStore );
 				return {
 					blockMovingClientId: hasBlockMovingClientId(),
 					selectedBlockInBlockEditor: getSelectedBlockClientId(),
-					lastInsertedBlockClientId: getLastInsertedBlockClientId(),
+					lastInsertedBlockClientId:
+						__experimentalGetLastInsertedBlockClientId(),
 				};
 			},
 			[ clientId ]

--- a/packages/block-editor/src/components/off-canvas-editor/block-contents.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-contents.js
@@ -51,13 +51,13 @@ const ListViewBlockContents = forwardRef(
 				const {
 					hasBlockMovingClientId,
 					getSelectedBlockClientId,
-					__experimentalGetLastInsertedBlockClientId,
+					getLastInsertedBlockClientIds,
 				} = select( blockEditorStore );
 				return {
 					blockMovingClientId: hasBlockMovingClientId(),
 					selectedBlockInBlockEditor: getSelectedBlockClientId(),
 					lastInsertedBlockClientId:
-						__experimentalGetLastInsertedBlockClientId(),
+						getLastInsertedBlockClientIds()[ 0 ],
 				};
 			},
 			[ clientId ]

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1829,6 +1829,8 @@ export function highlightedBlock( state, action ) {
 export function lastBlockInserted( state = {}, action ) {
 	switch ( action.type ) {
 		case 'INSERT_BLOCKS':
+		case 'REPLACE_BLOCKS':
+		case 'REPLACE_INNER_BLOCKS':
 			if ( ! action.blocks.length ) {
 				return state;
 			}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1835,10 +1835,13 @@ export function lastBlockInserted( state = {}, action ) {
 				return state;
 			}
 
-			const clientId = action.blocks[ 0 ].clientId;
+			const clientIds = action.blocks.map( ( block ) => {
+				return block.clientId;
+			} );
+
 			const source = action.meta?.source;
 
-			return { clientId, source };
+			return { clientIds, source };
 		case 'RESET_BLOCKS':
 			return {};
 	}

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2647,7 +2647,7 @@ export const __experimentalGetActiveBlockIdByBlockNames = createSelector(
 export function wasBlockJustInserted( state, clientId, source ) {
 	const { lastBlockInserted } = state;
 	return (
-		lastBlockInserted.clientId === clientId &&
+		lastBlockInserted.clientIds?.includes( clientId ) &&
 		lastBlockInserted.source === source
 	);
 }
@@ -2659,7 +2659,10 @@ export function wasBlockJustInserted( state, clientId, source ) {
  * @return {string|undefined} Client Id of the last inserted block.
  */
 export function __experimentalGetLastInsertedBlockClientId( state ) {
-	return state?.lastBlockInserted?.clientId;
+	return (
+		state?.lastBlockInserted?.clientIds?.length &&
+		state?.lastBlockInserted?.clientIds[ 0 ]
+	);
 }
 
 /**

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2677,6 +2677,16 @@ export function getLastInsertedBlockClientId( state ) {
 }
 
 /**
+ * Gets the client ids of the last inserted blocks.
+ *
+ * @param {Object} state Global application state.
+ * @return {Array|undefined} Client Ids of the last inserted block(s).
+ */
+export function getLastInsertedBlocksClientIds( state ) {
+	return state?.lastBlockInserted?.clientIds;
+}
+
+/**
  * Tells if the block is visible on the canvas or not.
  *
  * @param {Object} state    Global application state.

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2655,10 +2655,21 @@ export function wasBlockJustInserted( state, clientId, source ) {
 /**
  * Gets the client id of the last inserted block.
  *
+ * @deprecated
  * @param {Object} state Global application state.
  * @return {string|undefined} Client Id of the last inserted block.
  */
-export function __experimentalGetLastInsertedBlockClientId( state ) {
+export function getLastInsertedBlockClientId( state ) {
+	deprecated(
+		'wp.data.select( "core/block-editor" ).getLastInsertedBlockClientId',
+		{
+			since: '15.0',
+			plugin: 'Gutenberg',
+			alternative:
+				'wp.data.select( "core/block-editor" ).getLastInsertedBlocksClientIds',
+		}
+	);
+
 	return (
 		state?.lastBlockInserted?.clientIds?.length &&
 		state?.lastBlockInserted?.clientIds[ 0 ]

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2658,7 +2658,7 @@ export function wasBlockJustInserted( state, clientId, source ) {
  * @param {Object} state Global application state.
  * @return {string|undefined} Client Id of the last inserted block.
  */
-export function getLastInsertedBlockClientId( state ) {
+export function __experimentalGetLastInsertedBlockClientId( state ) {
 	return state?.lastBlockInserted?.clientId;
 }
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2653,30 +2653,6 @@ export function wasBlockJustInserted( state, clientId, source ) {
 }
 
 /**
- * Gets the client id of the last inserted block.
- *
- * @deprecated
- * @param {Object} state Global application state.
- * @return {string|undefined} Client Id of the last inserted block.
- */
-export function getLastInsertedBlockClientId( state ) {
-	deprecated(
-		'wp.data.select( "core/block-editor" ).getLastInsertedBlockClientId',
-		{
-			since: '15.0',
-			plugin: 'Gutenberg',
-			alternative:
-				'wp.data.select( "core/block-editor" ).getLastInsertedBlocksClientIds',
-		}
-	);
-
-	return (
-		state?.lastBlockInserted?.clientIds?.length &&
-		state?.lastBlockInserted?.clientIds[ 0 ]
-	);
-}
-
-/**
  * Gets the client ids of the last inserted blocks.
  *
  * @param {Object} state Global application state.

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -3313,6 +3313,48 @@ describe( 'state', () => {
 			expect( state ).toEqual( expectedState );
 		} );
 
+		it( 'should return client id of first block when blocks are replaced with REPLACE_BLOCKS', () => {
+			const clientIdOne = '62bfef6e-d5e9-43ba-b7f9-c77cf354141f';
+			const clientIdTwo = '9db792c6-a25a-495d-adbd-97d56a4c4189';
+
+			const action = {
+				blocks: [
+					{
+						clientId: clientIdOne,
+					},
+					{
+						clientId: clientIdTwo,
+					},
+				],
+				type: 'REPLACE_BLOCKS',
+			};
+
+			const state = lastBlockInserted( {}, action );
+
+			expect( state.clientId ).toBe( clientIdOne );
+		} );
+
+		it( 'should return client id of first block when inner blocks are replaced with REPLACE_INNER_BLOCKS', () => {
+			const clientIdOne = '62bfef6e-d5e9-43ba-b7f9-c77cf354141f';
+			const clientIdTwo = '9db792c6-a25a-495d-adbd-97d56a4c4189';
+
+			const action = {
+				blocks: [
+					{
+						clientId: clientIdOne,
+					},
+					{
+						clientId: clientIdTwo,
+					},
+				],
+				type: 'REPLACE_INNER_BLOCKS',
+			};
+
+			const state = lastBlockInserted( {}, action );
+
+			expect( state.clientId ).toBe( clientIdOne );
+		} );
+
 		it( 'should return empty state if last block inserted is called with action RESET_BLOCKS', () => {
 			const expectedState = {};
 

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -3255,7 +3255,7 @@ describe( 'state', () => {
 	} );
 
 	describe( 'lastBlockInserted', () => {
-		it( 'should return client id if last block inserted is called with action INSERT_BLOCKS', () => {
+		it( 'should contain client id if last block inserted is called with action INSERT_BLOCKS', () => {
 			const expectedClientId = '62bfef6e-d5e9-43ba-b7f9-c77cf354141f';
 
 			const action = {
@@ -3272,7 +3272,7 @@ describe( 'state', () => {
 
 			const state = lastBlockInserted( {}, action );
 
-			expect( state.clientId ).toBe( expectedClientId );
+			expect( state.clientIds ).toContain( expectedClientId );
 		} );
 
 		it( 'should return inserter_menu source if last block inserted is called with action INSERT_BLOCKS', () => {
@@ -3297,7 +3297,7 @@ describe( 'state', () => {
 
 		it( 'should return state if last block inserted is called with action INSERT_BLOCKS and block list is empty', () => {
 			const expectedState = {
-				clientId: '9db792c6-a25a-495d-adbd-97d56a4c4189',
+				clientIds: [ '9db792c6-a25a-495d-adbd-97d56a4c4189' ],
 			};
 
 			const action = {
@@ -3313,7 +3313,7 @@ describe( 'state', () => {
 			expect( state ).toEqual( expectedState );
 		} );
 
-		it( 'should return client id of first block when blocks are replaced with REPLACE_BLOCKS', () => {
+		it( 'should return client ids of blocks when called with REPLACE_BLOCKS', () => {
 			const clientIdOne = '62bfef6e-d5e9-43ba-b7f9-c77cf354141f';
 			const clientIdTwo = '9db792c6-a25a-495d-adbd-97d56a4c4189';
 
@@ -3331,10 +3331,10 @@ describe( 'state', () => {
 
 			const state = lastBlockInserted( {}, action );
 
-			expect( state.clientId ).toBe( clientIdOne );
+			expect( state.clientIds ).toEqual( [ clientIdOne, clientIdTwo ] );
 		} );
 
-		it( 'should return client id of first block when inner blocks are replaced with REPLACE_INNER_BLOCKS', () => {
+		it( 'should return client ids of all blocks when inner blocks are replaced with REPLACE_INNER_BLOCKS', () => {
 			const clientIdOne = '62bfef6e-d5e9-43ba-b7f9-c77cf354141f';
 			const clientIdTwo = '9db792c6-a25a-495d-adbd-97d56a4c4189';
 
@@ -3352,7 +3352,7 @@ describe( 'state', () => {
 
 			const state = lastBlockInserted( {}, action );
 
-			expect( state.clientId ).toBe( clientIdOne );
+			expect( state.clientIds ).toEqual( [ clientIdOne, clientIdTwo ] );
 		} );
 
 		it( 'should return empty state if last block inserted is called with action RESET_BLOCKS', () => {

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -73,7 +73,7 @@ const {
 	__experimentalGetPatternTransformItems,
 	wasBlockJustInserted,
 	__experimentalGetGlobalBlocksByName,
-	getLastInsertedBlockClientId,
+	getLastInsertedBlocksClientIds,
 } = selectors;
 
 describe( 'selectors', () => {
@@ -4667,22 +4667,25 @@ describe( '__unstableGetClientIdsTree', () => {
 	} );
 } );
 
-describe( 'getLastInsertedBlockClientId', () => {
+describe( 'getLastInsertedBlocksClientIds', () => {
 	it( 'should return undefined if no blocks have been inserted', () => {
 		const state = {
 			lastBlockInserted: {},
 		};
 
-		expect( getLastInsertedBlockClientId( state ) ).toEqual( undefined );
+		expect( getLastInsertedBlocksClientIds( state ) ).toEqual( undefined );
 	} );
 
-	it( 'should return clientId if blocks have been inserted', () => {
+	it( 'should return clientIds if blocks have been inserted', () => {
 		const state = {
 			lastBlockInserted: {
-				clientIds: [ '123456' ],
+				clientIds: [ '123456', '78910' ],
 			},
 		};
 
-		expect( getLastInsertedBlockClientId( state ) ).toEqual( '123456' );
+		expect( getLastInsertedBlocksClientIds( state ) ).toEqual( [
+			'123456',
+			'78910',
+		] );
 	} );
 } );

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -73,7 +73,7 @@ const {
 	__experimentalGetPatternTransformItems,
 	wasBlockJustInserted,
 	__experimentalGetGlobalBlocksByName,
-	__experimentalGetLastInsertedBlockClientId: getLastInsertedBlockClientId,
+	getLastInsertedBlockClientId,
 } = selectors;
 
 describe( 'selectors', () => {

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -4457,7 +4457,7 @@ describe( 'selectors', () => {
 
 			const state = {
 				lastBlockInserted: {
-					clientId: expectedClientId,
+					clientIds: [ expectedClientId ],
 					source,
 				},
 			};
@@ -4474,7 +4474,7 @@ describe( 'selectors', () => {
 
 			const state = {
 				lastBlockInserted: {
-					clientId: unexpectedClientId,
+					clientIds: [ unexpectedClientId ],
 					source,
 				},
 			};
@@ -4490,7 +4490,7 @@ describe( 'selectors', () => {
 
 			const state = {
 				lastBlockInserted: {
-					clientId,
+					clientIds: [ clientId ],
 				},
 			};
 
@@ -4679,7 +4679,7 @@ describe( 'getLastInsertedBlockClientId', () => {
 	it( 'should return clientId if blocks have been inserted', () => {
 		const state = {
 			lastBlockInserted: {
-				clientId: '123456',
+				clientIds: [ '123456' ],
 			},
 		};
 

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -73,7 +73,7 @@ const {
 	__experimentalGetPatternTransformItems,
 	wasBlockJustInserted,
 	__experimentalGetGlobalBlocksByName,
-	getLastInsertedBlockClientId,
+	__experimentalGetLastInsertedBlockClientId: getLastInsertedBlockClientId,
 } = selectors;
 
 describe( 'selectors', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Companion/sub PR to https://github.com/WordPress/gutenberg/pull/46857.

Currently the last inserted block is tracked in state as a _single_ clientId. However this only accounts for the scenario where a _single_ block has been inserted.

This PR updates and addresses this concern by changing the state to track all inserted blocks and also providing new selectors to access this new state shape (whilst deprecating existing ones).


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently the state only handle single blocks. It does not account for situations such as:

- `REPLACE_` type actions which may still "insert" new blocks but may provide multiple blocks.
- `INSERT_BLOCKS` action which may also provide multiple blocks

This is important as [sometimes](https://github.com/WordPress/gutenberg/pull/46857) it's important to know when `REPLACE_` type actions have caused new blocks to be inserted.

By altering the reducer state we can track this whilst still preserving the behaviour of the original selectors.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR:

- updates state reducer to handle tracking of _multiple_ inserted blocks.
- deprecates existing `getLastInsertedBlockClientId` selector which returned a single block only and is thus no longer suitable for accessing the state in an non-arbitrary way.
- adds a new selector `getLastInsertedBlocksClientIds` which returns an array of block clientIds.
- adds tests.
- include `REPLACE_` actions in the reducer to ensure these are also tracked as potential "insertions" of blocks

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Tests:
- `npm run test:unit packages/block-editor/src/store/test/selectors.js`
- `npm run test:unit packages/block-editor/src/store/test/reducer.js`

You can also add some blocks in a new Post and then run:

```js
wp.data.select('core/block-editor').getBlocksByClientId( wp.data.select('core/block-editor').getLastInsertedBlocksClientIds() )
```

...and check that you see an array of blocks.

Also try adding some blocks, transforming into a quote and then unwrapping the quote back to individual blocks. Then run the selector above. You should see multiple blocks returned.

#### Check Depreciation Notice

Run 

```
wp.data.select('core/block-editor').getLastInsertedBlockClientId()
```

Check that the deprecation notice in console is correct.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
