### PR TITLE
[WIP] dynamic titles and URLs for Nav block items

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -387,6 +387,7 @@ function LinkControl( {
 								createSuggestionButtonText
 							}
 							hideLabelFromVision={ ! showTextControl }
+							isDisabled={ value?.id }
 						/>
 					</div>
 					{ errorMessage && (

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -47,6 +47,7 @@ const LinkControlSearchInput = forwardRef(
 			withURLSuggestion = true,
 			createSuggestionButtonText,
 			hideLabelFromVision = false,
+			isDisabled = false,
 		},
 		ref
 	) => {
@@ -156,6 +157,7 @@ const LinkControlSearchInput = forwardRef(
 						}
 					} }
 					ref={ ref }
+					isDisabled={ isDisabled }
 				/>
 				{ children }
 			</div>

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -435,6 +435,7 @@ class URLInput extends Component {
 			__experimentalRenderControl: renderControl,
 			value = '',
 			hideLabelFromVision = false,
+			isDisabled,
 		} = this.props;
 
 		const {
@@ -476,6 +477,7 @@ class URLInput extends Component {
 					? `${ suggestionOptionIdPrefix }-${ selectedSuggestion }`
 					: undefined,
 			ref: this.inputRef,
+			disabled: isDisabled,
 		};
 
 		if ( renderControl ) {

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -35,7 +35,7 @@ import {
 } from '@wordpress/dom';
 import { decodeEntities } from '@wordpress/html-entities';
 import { link as linkIcon, addSubmenu } from '@wordpress/icons';
-import { store as coreStore } from '@wordpress/core-data';
+import { store as coreStore, useEntityRecord } from '@wordpress/core-data';
 import { useMergeRefs } from '@wordpress/compose';
 
 /**
@@ -180,6 +180,8 @@ export default function NavigationLinkEdit( {
 	const itemLabelPlaceholder = __( 'Add label…' );
 	const ref = useRef();
 
+	const { record: navPostRecord } = useEntityRecord( 'postType', type, id );
+
 	// Change the label using inspector causes rich text to change focus on firefox.
 	// This is a workaround to keep the focus on the label field when label filed is focused we don't render the rich text.
 	const [ isLabelFieldFocused, setIsLabelFieldFocused ] = useState( false );
@@ -281,6 +283,24 @@ export default function NavigationLinkEdit( {
 			}
 		}
 	}, [ url ] );
+
+	useEffect( () => {
+		// Only updates attributes if:
+		// - there is an ID (and it has changed).
+		// - there is a navPostRecord.
+		if ( id && navPostRecord ) {
+			// Conditionall update attributes to avoid
+			// unnecessary re-renders.
+			setAttributes( {
+				...( label !== navPostRecord?.title.rendered && {
+					label: navPostRecord?.title.rendered,
+				} ),
+				...( url !== navPostRecord?.link && {
+					url: navPostRecord?.link,
+				} ),
+			} );
+		}
+	}, [ id, navPostRecord ] );
 
 	/**
 	 * Focus the Link label text and select it.

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -160,16 +160,18 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	$is_post_type           = isset( $attributes['kind'] ) && 'post-type' === $attributes['kind'];
 	$is_post_type           = $is_post_type || isset( $attributes['type'] ) && ( 'post' === $attributes['type'] || 'page' === $attributes['type'] );
 
+	$post = $is_post_type && $navigation_link_has_id ? get_post( $attributes['id'] ) : null;
+
 	// Don't render the block's subtree if it is a draft or if the ID does not exist.
-	if ( $is_post_type && $navigation_link_has_id ) {
-		$post = get_post( $attributes['id'] );
-		if ( ! $post || 'publish' !== $post->post_status ) {
-			return '';
-		}
+	if ( ! $post || 'publish' !== $post->post_status ) {
+		return '';
 	}
 
+	$dynamic_url   = $post ? get_permalink( $post ) : $attributes['url'];
+	$dynamic_label = $post ? $post->post_title : $attributes['label'];
+
 	// Don't render the block's subtree if it has no label.
-	if ( empty( $attributes['label'] ) ) {
+	if ( empty( $dynamic_label ) ) {
 		return '';
 	}
 
@@ -195,8 +197,8 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		'<a class="wp-block-navigation-item__content" ';
 
 	// Start appending HTML attributes to anchor tag.
-	if ( isset( $attributes['url'] ) ) {
-		$html .= ' href="' . esc_url( block_core_navigation_link_maybe_urldecode( $attributes['url'] ) ) . '"';
+	if ( isset( $dynamic_url ) ) {
+		$html .= ' href="' . esc_url( block_core_navigation_link_maybe_urldecode( $dynamic_url ) ) . '"';
 	}
 
 	if ( $is_active ) {
@@ -224,8 +226,8 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		// Wrap title with span to isolate it from submenu icon.
 		'<span class="wp-block-navigation-item__label">';
 
-	if ( isset( $attributes['label'] ) ) {
-		$html .= wp_kses_post( $attributes['label'] );
+	if ( isset( $dynamic_label ) ) {
+		$html .= wp_kses_post( $dynamic_label );
 	}
 
 	$html .= '</span>';

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -158,7 +158,7 @@ export function LinkUI( props ) {
 		};
 	}
 
-	const { label, url, opensInNewTab, type, kind } = props.link;
+	const { label, url, opensInNewTab, type, kind, id } = props.link;
 
 	let userCanCreate = false;
 	if ( ! type || type === 'page' ) {
@@ -174,8 +174,9 @@ export function LinkUI( props ) {
 			url,
 			opensInNewTab,
 			title: label && stripHTML( label ),
+			id,
 		} ),
-		[ label, opensInNewTab, url ]
+		[ label, opensInNewTab, url, id ]
 	);
 
 	return (

--- a/packages/block-library/src/navigation-link/update-attributes.js
+++ b/packages/block-library/src/navigation-link/update-attributes.js
@@ -86,12 +86,13 @@ export const updateAttributes = (
 		( ! newKind && ! isBuiltInType ) || newKind === 'custom';
 	const kind = isCustomLink ? 'custom' : newKind;
 
+	const hasId = id && Number.isInteger( id );
+
 	setAttributes( {
-		// Passed `url` may already be encoded. To prevent double encoding, decodeURI is executed to revert to the original string.
 		...( newUrl && { url: encodeURI( safeDecodeURI( newUrl ) ) } ),
 		...( label && { label } ),
 		...( undefined !== opensInNewTab && { opensInNewTab } ),
-		...( id && Number.isInteger( id ) && { id } ),
+		...( hasId && { id } ),
 		...( kind && { kind } ),
 		...( type && type !== 'URL' && { type } ),
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Currently a WIP

Closes https://github.com/WordPress/gutenberg/issues/18345



<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Menus in classic themes will automatically sync entity (post/pages...etc) based links with the underlying entity.

For example if I create a link to the Page "Dave's Page" then no URL is stored an the information about the Page is dynamically populated.

If I then go to the "Pages" area in WP Admin, update "Dave's Page" to "Bobs Page", and then return to the Menus page, my menu item will have updated to reflect that change. That is its Label and URL will now be the same as the updated page.

Currently the Nav block does not exhibit this behaviour.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/444434/210649234-e553e62a-4723-4599-9224-e6979b9867dd.mp4

