### PR TITLE
Check if locale properties exist before using them

### DIFF
--- a/lib/compat/wordpress-6.1/date-settings.php
+++ b/lib/compat/wordpress-6.1/date-settings.php
@@ -45,10 +45,10 @@ function gutenberg_update_date_settings( $scripts ) {
 				array(
 					'l10n'     => array(
 						'locale'        => get_user_locale(),
-						'months'        => array_values( $wp_locale->month ),
-						'monthsShort'   => array_values( $wp_locale->month_abbrev ),
-						'weekdays'      => array_values( $wp_locale->weekday ),
-						'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
+						'months'        => is_array( $wp_locale->month ) ? array_values( $wp_locale->month ) : null,
+						'monthsShort'   => is_array( $wp_locale->month_abbrev ) ? array_values( $wp_locale->month_abbrev ) : null,
+						'weekdays'      => is_array( $wp_locale->weekday ) ? array_values( $wp_locale->weekday ) : null,
+						'weekdaysShort' => is_array( $wp_locale->weekday_abbrev ) ? array_values( $wp_locale->weekday_abbrev ) : null,
 						'meridiem'      => (object) $wp_locale->meridiem,
 						'relative'      => array(
 							/* translators: %s: Duration. */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
We are observing warnings in a deployment of Gutenberg plugin v14.8.4. Somehow, these locale properties are null. To avoid warnings, we'll just check if they are defined. If they aren't, we'll pass null. This *should* trigger locale inheritance in momentjs on the client.

When can this happen? Well, it could theoretically happen if `WP_Scripts->init()` was called outside of a normal WP request -- when `WP_Locale` hasn't been set up.

Another very confusing thing is that this only started happening after 14.8.4 was deployed. It was fine in 14.7.3. But I cannot find any code related to this feature which was changed for 14.8!

## Why?
To stop warnings

## How?
`is_array`

## Testing Instructions
Check that the syntax is correct