### PR TITLE
Revert "[Site Editor]: Add default white background for themes with no `background color` set"

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -430,8 +430,8 @@
 	}
 }
 
+/** Zoom Out mode styles **/
 .block-editor-iframe__body {
-	background-color: $white;
 	transition: all 0.3s;
 	transform-origin: top center;
 }


### PR DESCRIPTION
Reverts WordPress/gutenberg#46314

We're running a very large deployment of Gutenberg (v14.8.4 at this point), and unfortunately this has been causing issues! I know this is on the radar already, but I think this ended up breaking more things than it fixed.

Reasoning: most themes _do_ provide styles which set the background color correctly in the editor -- at least, all of the themes we have been testing with do. In this scenario, the change _overwrites_ those styles **even for block-based themes,** meaning the editor background color doesn't work at all for many themes. (Partly because of specificity and style loading order.) I think this would also break things if the styles were applied at a different level. 

At the same time, I'm not sure how many themes people use wouldn't have editor styles set up correctly. At any rate, it seems like there would be higher usage of themes which are broken with this change rather than the other way around, assuming that the most popular themes set the background color correctly.

IMO, the fix needs to be applied much higher in the DOM -- why is "a dark color... applied to the background" in the first place?