### PR TITLE
Add box shadow support to blocks (using code editor for now).

### DIFF
--- a/lib/block-supports/shadow.php
+++ b/lib/block-supports/shadow.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Shadow block support flag.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Registers the style and shadow block attributes for block types that support it.
+ *
+ * @param WP_Block_Type $block_type Block Type.
+ */
+function gutenberg_register_shadow_support( $block_type ) {
+	if ( ! property_exists( $block_type, 'supports' ) ) {
+		return;
+	}
+
+	$has_shadow_support = true; // _wp_array_get( $block_type->supports, array( 'shadow' ), false );
+	if ( ! $has_shadow_support ) {
+		return;
+	}
+
+	if ( ! $block_type->attributes ) {
+		$block_type->attributes = array();
+	}
+
+	if ( $has_shadow_support && ! array_key_exists( 'style', $block_type->attributes ) ) {
+		$block_type->attributes['style'] = array(
+			'type' => 'object',
+		);
+	}
+
+	if ( $has_shadow_support && ! array_key_exists( 'shadow', $block_type->attributes ) ) {
+		$block_type->attributes['shadow'] = array(
+			'type' => 'string',
+		);
+	}
+}
+
+/**
+ * Add CSS classes and inline styles for typography features such as font sizes
+ * to the incoming attributes array. This will be applied to the block markup in
+ * the front-end.
+ *
+ * @param  WP_Block_Type $block_type       Block type.
+ * @param  array         $block_attributes Block attributes.
+ *
+ * @return array Typography CSS classes and inline styles.
+ */
+function gutenberg_apply_shadow_support( $block_type, $block_attributes ) {
+	if ( ! property_exists( $block_type, 'supports' ) ) {
+		return array();
+	}
+
+	$has_shadow_support = true; // _wp_array_get( $block_type->supports, array( 'shadow' ), false );
+	if ( ! $has_shadow_support ) {
+		return array();
+	}
+
+	$shadow_block_styles = array();
+
+	$preset_shadow = array_key_exists( 'shadow', $block_attributes ) ? "var:preset|shadow|{$block_attributes['shadow']}" : null;
+    $custom_shadow                    = isset( $block_attributes['style']['shadow'] ) ? $block_attributes['style']['shadow'] : null;
+    $shadow_block_styles['shadow'] = $preset_shadow ? $preset_shadow : $custom_shadow;
+
+	$attributes = array();
+	$styles     = gutenberg_style_engine_get_styles( $shadow_block_styles );
+
+	if ( ! empty( $styles['css'] ) ) {
+		$attributes['style'] = $styles['css'];
+	}
+
+	return $attributes;
+}
+
+// Register the block support.
+WP_Block_Supports::get_instance()->register(
+	'shadow',
+	array(
+		'register_attribute' => 'gutenberg_register_shadow_support',
+		'apply'              => 'gutenberg_apply_shadow_support',
+	)
+);

--- a/lib/block-supports/shadow.php
+++ b/lib/block-supports/shadow.php
@@ -45,11 +45,8 @@ function gutenberg_register_shadow_support( $block_type ) {
  * @return array Shadow CSS classes and inline styles.
  */
 function gutenberg_apply_shadow_support( $block_type, $block_attributes ) {
-	if ( ! property_exists( $block_type, 'supports' ) ) {
-		return array();
-	}
+	$has_shadow_support = block_has_support( $block_type, array( 'shadow' ), false );
 
-	$has_shadow_support = _wp_array_get( $block_type->supports, array( 'shadow' ), false );
 	if ( ! $has_shadow_support ) {
 		return array();
 	}

--- a/lib/block-supports/shadow.php
+++ b/lib/block-supports/shadow.php
@@ -38,14 +38,14 @@ function gutenberg_register_shadow_support( $block_type ) {
 }
 
 /**
- * Add CSS classes and inline styles for typography features such as font sizes
- * to the incoming attributes array. This will be applied to the block markup in
+ * Add CSS classes and inline styles for shadow features to the incoming attributes array.
+ * This will be applied to the block markup in
  * the front-end.
  *
  * @param  WP_Block_Type $block_type       Block type.
  * @param  array         $block_attributes Block attributes.
  *
- * @return array Typography CSS classes and inline styles.
+ * @return array Shadow CSS classes and inline styles.
  */
 function gutenberg_apply_shadow_support( $block_type, $block_attributes ) {
 	if ( ! property_exists( $block_type, 'supports' ) ) {
@@ -59,9 +59,9 @@ function gutenberg_apply_shadow_support( $block_type, $block_attributes ) {
 
 	$shadow_block_styles = array();
 
-	$preset_shadow = array_key_exists( 'shadow', $block_attributes ) ? "var:preset|shadow|{$block_attributes['shadow']}" : null;
-    $custom_shadow                    = isset( $block_attributes['style']['shadow'] ) ? $block_attributes['style']['shadow'] : null;
-    $shadow_block_styles['shadow'] = $preset_shadow ? $preset_shadow : $custom_shadow;
+	$preset_shadow                 = array_key_exists( 'shadow', $block_attributes ) ? "var:preset|shadow|{$block_attributes['shadow']}" : null;
+	$custom_shadow                 = isset( $block_attributes['style']['shadow'] ) ? $block_attributes['style']['shadow'] : null;
+	$shadow_block_styles['shadow'] = $preset_shadow ? $preset_shadow : $custom_shadow;
 
 	$attributes = array();
 	$styles     = gutenberg_style_engine_get_styles( $shadow_block_styles );

--- a/lib/block-supports/shadow.php
+++ b/lib/block-supports/shadow.php
@@ -11,11 +11,8 @@
  * @param WP_Block_Type $block_type Block Type.
  */
 function gutenberg_register_shadow_support( $block_type ) {
-	if ( ! property_exists( $block_type, 'supports' ) ) {
-		return;
-	}
+	$has_shadow_support = block_has_support( $block_type, array( 'shadow' ), false );
 
-	$has_shadow_support = true; // _wp_array_get( $block_type->supports, array( 'shadow' ), false );
 	if ( ! $has_shadow_support ) {
 		return;
 	}
@@ -52,7 +49,7 @@ function gutenberg_apply_shadow_support( $block_type, $block_attributes ) {
 		return array();
 	}
 
-	$has_shadow_support = true; // _wp_array_get( $block_type->supports, array( 'shadow' ), false );
+	$has_shadow_support = _wp_array_get( $block_type->supports, array( 'shadow' ), false );
 	if ( ! $has_shadow_support ) {
 		return array();
 	}

--- a/lib/compat/wordpress-6.2/blocks.php
+++ b/lib/compat/wordpress-6.2/blocks.php
@@ -20,6 +20,7 @@ function gutenberg_safe_style_attrs_6_2( $attrs ) {
 	$attrs[] = 'bottom';
 	$attrs[] = 'left';
 	$attrs[] = 'z-index';
+	$attrs[] = 'box-shadow';
 
 	return $attrs;
 }

--- a/lib/load.php
+++ b/lib/load.php
@@ -137,3 +137,4 @@ require __DIR__ . '/block-supports/position.php';
 require __DIR__ . '/block-supports/spacing.php';
 require __DIR__ . '/block-supports/dimensions.php';
 require __DIR__ . '/block-supports/duotone.php';
+require __DIR__ . '/block-supports/shadow.php';

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -136,6 +136,17 @@ final class WP_Style_Engine {
 				),
 			),
 		),
+		'shadow' => array(
+			'shadow' => array(
+				'property_keys' => array(
+					'default'    => 'box-shadow',
+				),
+				'path'          => array( 'shadow' ),
+				'css_vars'      => array(
+					'shadow' => '--wp--preset--shadow--$slug',
+				),
+			)
+		),
 		'dimensions' => array(
 			'minHeight' => array(
 				'property_keys' => array(

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -136,16 +136,16 @@ final class WP_Style_Engine {
 				),
 			),
 		),
-		'shadow' => array(
+		'shadow'     => array(
 			'shadow' => array(
 				'property_keys' => array(
-					'default'    => 'box-shadow',
+					'default' => 'box-shadow',
 				),
 				'path'          => array( 'shadow' ),
 				'css_vars'      => array(
 					'shadow' => '--wp--preset--shadow--$slug',
 				),
-			)
+			),
 		),
 		'dimensions' => array(
 			'minHeight' => array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds support for shadow via templates.
* Allows to set a preset shadow using the `shadow` block prop. 
```
<!-- wp:post-title {"shadow":"natural"} /-->
```
* Allows to set a custom shadow using the style prop.
```
<!-- wp:post-title {"style":{"shadow": "10px 10px 10px 10px #000"}} /-->
```

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Active a block theme.
2. Give shadow definitions to blocks such as `page-title` using `shadow` or `style` props in the templates.
3. Validate that shadow is applied to the block in editor and frontend.

## Screenshots or screencast <!-- if applicable -->

<img width="477" alt="image" src="https://user-images.githubusercontent.com/1935113/210720295-da9bad27-ef32-417f-88ca-64acf21eb952.png">
