### PR TITLE
Nav offcanvas disable direct insertion

### DIFF
--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -220,48 +220,53 @@ class Inserter extends Component {
 }
 
 export default compose( [
-	withSelect( ( select, { clientId, rootClientId } ) => {
-		const {
-			getBlockRootClientId,
-			hasInserterItems,
-			__experimentalGetAllowedBlocks,
-			__experimentalGetDirectInsertBlock,
-			getSettings,
-		} = select( blockEditorStore );
+	withSelect(
+		( select, { clientId, rootClientId, shouldDirectInsert = true } ) => {
+			const {
+				getBlockRootClientId,
+				hasInserterItems,
+				__experimentalGetAllowedBlocks,
+				__experimentalGetDirectInsertBlock,
+				getSettings,
+			} = select( blockEditorStore );
 
-		const { getBlockVariations } = select( blocksStore );
+			const { getBlockVariations } = select( blocksStore );
 
-		rootClientId =
-			rootClientId || getBlockRootClientId( clientId ) || undefined;
+			rootClientId =
+				rootClientId || getBlockRootClientId( clientId ) || undefined;
 
-		const allowedBlocks = __experimentalGetAllowedBlocks( rootClientId );
+			const allowedBlocks =
+				__experimentalGetAllowedBlocks( rootClientId );
 
-		const directInsertBlock =
-			__experimentalGetDirectInsertBlock( rootClientId );
+			const directInsertBlock =
+				shouldDirectInsert &&
+				__experimentalGetDirectInsertBlock( rootClientId );
 
-		const settings = getSettings();
+			const settings = getSettings();
 
-		const hasSingleBlockType =
-			allowedBlocks?.length === 1 &&
-			getBlockVariations( allowedBlocks[ 0 ].name, 'inserter' )
-				?.length === 0;
+			const hasSingleBlockType =
+				allowedBlocks?.length === 1 &&
+				getBlockVariations( allowedBlocks[ 0 ].name, 'inserter' )
+					?.length === 0;
 
-		let allowedBlockType = false;
-		if ( hasSingleBlockType ) {
-			allowedBlockType = allowedBlocks[ 0 ];
+			let allowedBlockType = false;
+			if ( hasSingleBlockType ) {
+				allowedBlockType = allowedBlocks[ 0 ];
+			}
+
+			return {
+				hasItems: hasInserterItems( rootClientId ),
+				hasSingleBlockType,
+				blockTitle: allowedBlockType ? allowedBlockType.title : '',
+				allowedBlockType,
+				directInsertBlock,
+				rootClientId,
+				prioritizePatterns:
+					settings.__experimentalPreferPatternsOnRoot &&
+					! rootClientId,
+			};
 		}
-
-		return {
-			hasItems: hasInserterItems( rootClientId ),
-			hasSingleBlockType,
-			blockTitle: allowedBlockType ? allowedBlockType.title : '',
-			allowedBlockType,
-			directInsertBlock,
-			rootClientId,
-			prioritizePatterns:
-				settings.__experimentalPreferPatternsOnRoot && ! rootClientId,
-		};
-	} ),
+	),
 	withDispatch( ( dispatch, ownProps, { select } ) => {
 		return {
 			insertOnlyAllowedBlock() {

--- a/packages/block-editor/src/components/off-canvas-editor/appender.js
+++ b/packages/block-editor/src/components/off-canvas-editor/appender.js
@@ -39,6 +39,7 @@ export const Appender = forwardRef( ( props, ref ) => {
 				position="bottom right"
 				isAppender={ true }
 				selectBlockOnInsert={ false }
+				shouldDirectInsert={ false }
 				__experimentalIsQuick
 				{ ...props }
 			/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Allows consumers of the `<Inserter>` component to manually disable [the direct block insertion functionality](https://github.com/WordPress/gutenberg/issues/45996#issuecomment-1325118608).

Disables for the Nav Offcanvas experiment.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Contributors have disucssed that in the offcanvas the insertion of a Nav link should be 2 step:

- select a block
- configure the block (if necessary)

Most commonly this manifests as 

- pick "Custom Link"
- see block inserted and Link UI appears
- choose link

This PR enables that functionality whilst also preserving the direct insertion for the editor canvas (as per `trunk`).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

[The process by which direct block insertion is achieved has been previously detailed.
](https://github.com/WordPress/gutenberg/issues/45996#issuecomment-1325118608)

The configuration happens in the Nav block `inner-blocks.js` component.

https://github.com/WordPress/gutenberg/blob/8e93b93ce4756ebd4b9b3d13fa53f1969c685efb/packages/block-library/src/navigation/edit/inner-blocks.js#L116-L117

Therefore there is no way to make this configuration conditional in relation to usage within the offcanvas.

As a result this PR adds a new prop which provides a means to hard overide the direct insertion config which is provided by a `withSelect` HOC.

This prop defaults to `true` to ensure that the existing functionality is preserved by default. This makes this PR backwards compatible.

However when the new prop is set to true...

```jsx
<Inserter
	shouldDirectInsert={ false }
	{ ...props }
/>
```

....then it short circuits all the direct insert lookup and simply provides the standard block picker UI.




## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Enable offcanvas experiment
- New Post
- Add Nav block and toggle offcanvas open.
- Try adding a block. You should see the two step block picker. It should _not_ auto insert a Custom Link.
- Now try the same within the block editor canvas. It should continue to auto insert (unless you have inserted a block that is _not_ a link or submenu).
- 
#### Backwards Compat.

- In `packages/block-editor/src/components/off-canvas-editor/appender.js` try removing the `shouldDirectInsert` prop.
- Repeat the above and you should see that the direct insert is restored in the offcanvas. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/444434/210754762-9f93cd88-f4ef-4b7d-97b5-7439181f14cb.mp4

