### PR TITLE
Allow resizing the sidebar and frame of the site editor

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -183,6 +183,7 @@ $z-layers: (
 	".edit-site-layout__header": 2,
 	".edit-site-layout__canvas-container": 2,
 	".edit-site-layout__sidebar": 1,
+	".edit-site-layout__canvas-container.is-resizing::after": 100,
 );
 
 @function z-index( $key ) {

--- a/packages/edit-site/src/components/block-editor/resize-handle.js
+++ b/packages/edit-site/src/components/block-editor/resize-handle.js
@@ -7,7 +7,11 @@ import { VisuallyHidden } from '@wordpress/components';
 
 const DELTA_DISTANCE = 20; // The distance to resize per keydown in pixels.
 
-export default function ResizeHandle( { direction, resizeWidthBy } ) {
+export default function ResizeHandle( {
+	variation = 'default',
+	direction,
+	resizeWidthBy,
+} ) {
 	function handleKeyDown( event ) {
 		const { keyCode } = event;
 
@@ -27,7 +31,7 @@ export default function ResizeHandle( { direction, resizeWidthBy } ) {
 	return (
 		<>
 			<button
-				className={ `resizable-editor__drag-handle is-${ direction }` }
+				className={ `resizable-editor__drag-handle is-${ direction } is-variation-${ variation }` }
 				aria-label={ __( 'Drag to resize' ) }
 				aria-describedby={ `resizable-editor__resize-help-${ direction }` }
 				onKeyDown={ handleKeyDown }

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -88,7 +88,7 @@
 	cursor: ew-resize;
 	outline: none;
 	background: none;
-	border-radius: 2px;
+	border-radius: $radius-block-ui;
 	border: 0;
 
 	&.is-variation-default {
@@ -119,7 +119,7 @@
 		content: "";
 		width: $grid-unit-05;
 		background: $gray-600;
-		border-radius: 2px;
+		border-radius: $radius-block-ui;
 	}
 
 	&.is-left {

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -103,7 +103,7 @@
 			border-radius: 0;
 			background: $gray-800;
 			left: auto;
-			right: 0;
+			right: 50%;
 			transition: all ease 0.2s;
 			transition-delay: 0.1s;
 			@include reduce-motion;

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -97,7 +97,17 @@
 
 	&.is-variation-separator {
 		height: 100%;
-		opacity: 0;
+
+		&::after {
+			width: 1px;
+			border-radius: 0;
+			background: $gray-800;
+			left: auto;
+			right: 0;
+			transition: all ease .2s;
+			transition-delay: .1s;
+			@include reduce-motion;
+		}
 	}
 
 	&::after {
@@ -127,6 +137,7 @@
 			background: $gray-400;
 		}
 		&.is-variation-separator::after {
+			width: 2px;
 			background: var(--wp-admin-theme-color);
 		}
 	}

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -84,14 +84,26 @@
 	bottom: 0;
 	padding: 0;
 	margin: auto 0;
-	width: $grid-unit-05;
+	width: $grid-unit-15;
 	height: $height;
 	appearance: none;
 	cursor: ew-resize;
 	outline: none;
-	background: $gray-600;
+	background: none;
 	border-radius: 2px;
 	border: 0;
+
+	&::after {
+		position: absolute;
+		top: 0;
+		left: $grid-unit-05;
+		right: 0;
+		bottom: 0;
+		content: "";
+		width: $grid-unit-05;
+		background: $gray-600;
+		border-radius: 2px;
+	}
 
 	&.is-left {
 		left: -$grid-unit-20;
@@ -101,12 +113,12 @@
 		right: -$grid-unit-20;
 	}
 
-	&:hover,
-	&:active {
+	&:hover::after,
+	&:active::after {
 		background: $gray-400;
 	}
 
-	&:focus {
+	&:focus::after {
 		box-shadow: 0 0 0 1px $gray-800, 0 0 0 calc(var(--wp-admin-border-width-focus) + 1px) var(--wp-admin-theme-color);
 	}
 }

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -78,20 +78,27 @@
 }
 
 .resizable-editor__drag-handle {
-	$height: 100px;
 	position: absolute;
 	top: 0;
 	bottom: 0;
 	padding: 0;
 	margin: auto 0;
 	width: $grid-unit-15;
-	height: $height;
 	appearance: none;
 	cursor: ew-resize;
 	outline: none;
 	background: none;
 	border-radius: 2px;
 	border: 0;
+
+	&.is-variation-default {
+		height: 100px;
+	}
+
+	&.is-variation-separator {
+		height: 100%;
+		opacity: 0;
+	}
 
 	&::after {
 		position: absolute;
@@ -113,9 +120,15 @@
 		right: -$grid-unit-20;
 	}
 
-	&:hover::after,
-	&:active::after {
-		background: $gray-400;
+	&:hover,
+	&:active {
+		opacity: 1;
+		&.is-variation-default::after {
+			background: $gray-400;
+		}
+		&.is-variation-separator::after {
+			background: var(--wp-admin-theme-color);
+		}
 	}
 
 	&:focus::after {

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -104,8 +104,8 @@
 			background: $gray-800;
 			left: auto;
 			right: 0;
-			transition: all ease .2s;
-			transition-delay: .1s;
+			transition: all ease 0.2s;
+			transition-delay: 0.1s;
 			@include reduce-motion;
 		}
 	}

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -103,6 +103,10 @@ export default function Layout( { onError } ) {
 	const [ isResizing, setIsResizing ] = useState( false );
 	const isResizingEnabled = ! isMobileViewport && canvasMode === 'view';
 	const defaultSidebarWidth = isMobileViewport ? '100vw' : 360;
+	let canvasWidth = isResizing ? '100%' : fullSize.width;
+	if ( showFrame && ! isResizing ) {
+		canvasWidth = canvasSize.width - canvasPadding;
+	}
 	useEffect( () => {
 		if ( canvasMode === 'view' && isMobileViewport ) {
 			setIsMobileCanvasVisible( false );
@@ -185,9 +189,10 @@ export default function Layout( { onError } ) {
 								} }
 								transition={ {
 									type: 'tween',
-									duration: disableMotion
-										? 0
-										: ANIMATION_DURATION,
+									duration:
+										disableMotion || isResizing
+											? 0
+											: ANIMATION_DURATION,
 									ease: 'easeOut',
 								} }
 								size={ {
@@ -273,10 +278,7 @@ export default function Layout( { onError } ) {
 										} }
 										initial={ false }
 										animate={ {
-											width: showFrame
-												? canvasSize.width -
-												  canvasPadding
-												: fullSize.width,
+											width: canvasWidth,
 										} }
 										transition={ {
 											type: 'tween',

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -209,7 +209,12 @@ export default function Layout( { onError } ) {
 									setIsResizing( true );
 								} }
 								handleComponent={ {
-									right: <ResizeHandle direction="right" />,
+									right: (
+										<ResizeHandle
+											direction="right"
+											variation="separator"
+										/>
+									),
 								} }
 								handleClasses={ undefined }
 								handleStyles={ {

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -19,7 +19,7 @@ import {
 	useResizeObserver,
 } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
 import { NavigableRegion } from '@wordpress/interface';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 
@@ -54,7 +54,7 @@ const emptyResizeHandleStyles = {
 export default function Layout( { onError } ) {
 	// This ensures the edited entity id and type are initialized properly.
 	useInitEditedEntityFromURL();
-
+	const hubRef = useRef();
 	const { params } = useLocation();
 	const isListPage = getIsListPage( params );
 	const isEditorPage = ! isListPage;
@@ -133,6 +133,7 @@ export default function Layout( { onError } ) {
 				) }
 			>
 				<SiteHub
+					ref={ hubRef }
 					className="edit-site-layout__hub"
 					style={ {
 						width:
@@ -212,6 +213,13 @@ export default function Layout( { onError } ) {
 								} }
 								onResizeStart={ () => {
 									setIsResizing( true );
+								} }
+								onResize={ ( event, direction, elt ) => {
+									// This is a performance optimization
+									// We set the width imperatively to avoid re-rendering
+									// the whole component while resizing.
+									hubRef.current.style.width =
+										elt.clientWidth - 48 + 'px';
 								} }
 								handleComponent={ {
 									right: (

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -101,6 +101,8 @@ export default function Layout( { onError } ) {
 	const [ fullResizer, fullSize ] = useResizeObserver();
 	const [ forcedWidth, setForcedWidth ] = useState( null );
 	const [ isResizing, setIsResizing ] = useState( false );
+	const isResizingEnabled = ! isMobileViewport && canvasMode === 'view';
+	const defaultSidebarWidth = isMobileViewport ? '100vw' : 360;
 	useEffect( () => {
 		if ( canvasMode === 'view' && isMobileViewport ) {
 			setIsMobileCanvasVisible( false );
@@ -129,7 +131,10 @@ export default function Layout( { onError } ) {
 				<SiteHub
 					className="edit-site-layout__hub"
 					style={ {
-						width: forcedWidth ? forcedWidth - 48 : undefined,
+						width:
+							isResizingEnabled && forcedWidth
+								? forcedWidth - 48
+								: undefined,
 					} }
 					isMobileCanvasVisible={ isMobileCanvasVisible }
 					setIsMobileCanvasVisible={ setIsMobileCanvasVisible }
@@ -188,18 +193,13 @@ export default function Layout( { onError } ) {
 								size={ {
 									height: '100%',
 									width:
-										! isMobileViewport &&
-										isEditorPage &&
-										canvasMode === 'view'
-											? forcedWidth ?? 360
-											: undefined,
+										isResizingEnabled && forcedWidth
+											? forcedWidth
+											: defaultSidebarWidth,
 								} }
 								className="edit-site-layout__sidebar"
 								enable={ {
-									right:
-										! isMobileViewport &&
-										isEditorPage &&
-										canvasMode === 'view',
+									right: isResizingEnabled,
 								} }
 								onResizeStop={ ( event, direction, elt ) => {
 									setForcedWidth( elt.clientWidth );
@@ -215,9 +215,11 @@ export default function Layout( { onError } ) {
 								handleStyles={ {
 									right: emptyResizeHandleStyles,
 								} }
-								minWidth={ 320 }
+								minWidth={ isResizingEnabled ? 320 : undefined }
 								maxWidth={
-									fullSize ? fullSize.width - 360 : undefined
+									isResizingEnabled && fullSize
+										? fullSize.width - 360
+										: undefined
 								}
 							>
 								<NavigableRegion

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -109,6 +109,7 @@ $hub-height: $grid-unit-20 * 2 + $button-size;
 		right: 0;
 		bottom: 0;
 		content: "";
+		z-index: z-index(".edit-site-layout__canvas-container.is-resizing::after");
 	}
 }
 
@@ -122,9 +123,9 @@ $hub-height: $grid-unit-20 * 2 + $button-size;
 	& > div {
 		color: $gray-900;
 		background: $white;
-		z-index: -1;
 		box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.8), 0 8px 10px -6px rgba(0, 0, 0, 0.8);
 	}
+
 	@include break-medium {
 		top: $canvas-padding;
 		bottom: $canvas-padding;

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -63,6 +63,7 @@ $hub-height: $grid-unit-20 * 2 + $button-size;
 .edit-site-layout__content {
 	flex-grow: 1;
 	display: flex;
+	gap: $canvas-padding;
 
 	// Hide scrollbars during the edit/view animation.
 	overflow: hidden;
@@ -85,7 +86,7 @@ $hub-height: $grid-unit-20 * 2 + $button-size;
 	}
 
 	.resizable-editor__drag-handle.is-right {
-		right: -$grid-unit-20 + $canvas-padding;
+		right: 0;
 	}
 
 	> div {

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -78,7 +78,7 @@ $hub-height: $grid-unit-20 * 2 + $button-size;
 
 	// This is only necessary for the exit animation
 	.edit-site-layout.is-full-canvas & {
-		position: fixed;
+		position: fixed !important;
 		height: 100vh;
 		left: 0;
 		top: 0;

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -70,9 +70,7 @@ $hub-height: $grid-unit-20 * 2 + $button-size;
 
 .edit-site-layout__sidebar {
 	z-index: z-index(".edit-site-layout__sidebar");
-	overflow-y: auto;
 	width: 100vw;
-	@include custom-scrollbars-on-hover;
 
 	@include break-medium {
 		width: $nav-sidebar-width;
@@ -85,12 +83,37 @@ $hub-height: $grid-unit-20 * 2 + $button-size;
 		left: 0;
 		top: 0;
 	}
+
+	.resizable-editor__drag-handle {
+		opacity: 1;
+		animation: drag-handle__fade-in-animation 1s ease;
+		&.is-right {
+			right: -$grid-unit-20 + $canvas-padding;
+		}
+	}
+
+	> div {
+		overflow-y: auto;
+		min-height: 100%;
+		@include custom-scrollbars-on-hover;
+	}
 }
 
 .edit-site-layout__canvas-container {
 	position: relative;
 	flex-grow: 1;
 	z-index: z-index(".edit-site-layout__canvas-container");
+
+	&.is-resizing::after {
+		// This covers the whole content which ensures mouse up triggers
+		// even if the content is "inert".
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		content: "";
+	}
 }
 
 .edit-site-layout__canvas {
@@ -99,11 +122,12 @@ $hub-height: $grid-unit-20 * 2 + $button-size;
 	left: 0;
 	bottom: 0;
 	width: 100%;
-	box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.8), 0 8px 10px -6px rgba(0, 0, 0, 0.8);
 
 	& > div {
 		color: $gray-900;
 		background: $white;
+		z-index: -1;
+		box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.8), 0 8px 10px -6px rgba(0, 0, 0, 0.8);
 	}
 	@include break-medium {
 		top: $canvas-padding;
@@ -179,5 +203,18 @@ $hub-height: $grid-unit-20 * 2 + $button-size;
 	.edit-site-layout__view-mode-toggle-icon {
 		display: flex;
 		border-radius: $radius-block-ui;
+	}
+}
+
+@keyframes drag-handle__fade-in-animation {
+	0% {
+		opacity: 0;
+	}
+	// Delay showing the drag handles after the layout animation finishes.
+	50% {
+		opacity: 0;
+	}
+	100% {
+		opacity: 1;
 	}
 }

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -84,12 +84,8 @@ $hub-height: $grid-unit-20 * 2 + $button-size;
 		top: 0;
 	}
 
-	.resizable-editor__drag-handle {
-		opacity: 1;
-		animation: drag-handle__fade-in-animation 1s ease;
-		&.is-right {
-			right: -$grid-unit-20 + $canvas-padding;
-		}
+	.resizable-editor__drag-handle.is-right {
+		right: -$grid-unit-20 + $canvas-padding;
 	}
 
 	> div {
@@ -203,18 +199,5 @@ $hub-height: $grid-unit-20 * 2 + $button-size;
 	.edit-site-layout__view-mode-toggle-icon {
 		display: flex;
 		border-radius: $radius-block-ui;
-	}
-}
-
-@keyframes drag-handle__fade-in-animation {
-	0% {
-		opacity: 0;
-	}
-	// Delay showing the drag handles after the layout animation finishes.
-	50% {
-		opacity: 0;
-	}
-	100% {
-		opacity: 1;
 	}
 }

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -86,7 +86,7 @@ $hub-height: $grid-unit-20 * 2 + $button-size;
 	}
 
 	.resizable-editor__drag-handle.is-right {
-		right: 0;
+		right: math.div(-$grid-unit-15, 2);
 	}
 
 	> div {

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -17,6 +17,7 @@ import { useReducedMotion, useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -29,123 +30,132 @@ import useEditedEntityRecord from '../use-edited-entity-record';
 
 const HUB_ANIMATION_DURATION = 0.3;
 
-function SiteHub( {
-	isMobileCanvasVisible,
-	setIsMobileCanvasVisible,
-	...props
-} ) {
-	const { params } = useLocation();
-	const isListPage = getIsListPage( params );
-	const isEditorPage = ! isListPage;
-	const { canvasMode, dashboardLink, entityConfig } = useSelect(
-		( select ) => {
-			select( editSiteStore ).getEditedPostType();
-			const { __unstableGetCanvasMode, getSettings, getEditedPostType } =
-				select( editSiteStore );
-			return {
-				canvasMode: __unstableGetCanvasMode(),
-				dashboardLink: getSettings().__experimentalDashboardLink,
-				entityConfig: select( coreStore ).getEntityConfig(
-					'postType',
-					getEditedPostType()
-				),
-			};
-		},
-		[]
-	);
-	const disableMotion = useReducedMotion();
-	const isMobileViewport = useViewportMatch( 'medium', '<' );
-	const { __unstableSetCanvasMode } = useDispatch( editSiteStore );
-	const { clearSelectedBlock } = useDispatch( blockEditorStore );
-	const showEditButton =
-		( isEditorPage && canvasMode === 'view' && ! isMobileViewport ) ||
-		( isMobileViewport && canvasMode === 'view' && isMobileCanvasVisible );
-	const isBackToDashboardButton =
-		( ! isMobileViewport && canvasMode === 'view' ) ||
-		( isMobileViewport && ! isMobileCanvasVisible );
-	const showLabels = canvasMode !== 'edit';
-	const siteIconButtonProps = isBackToDashboardButton
-		? {
-				href: dashboardLink || 'index.php',
-				'aria-label': __( 'Go back to the dashboard' ),
-		  }
-		: {
-				label: __( 'Open Navigation Sidebar' ),
-				onClick: () => {
-					clearSelectedBlock();
-					setIsMobileCanvasVisible( false );
-					__unstableSetCanvasMode( 'view' );
-				},
-		  };
-	const { getTitle } = useEditedEntityRecord();
+const SiteHub = forwardRef(
+	( { isMobileCanvasVisible, setIsMobileCanvasVisible, ...props }, ref ) => {
+		const { params } = useLocation();
+		const isListPage = getIsListPage( params );
+		const isEditorPage = ! isListPage;
+		const { canvasMode, dashboardLink, entityConfig } = useSelect(
+			( select ) => {
+				select( editSiteStore ).getEditedPostType();
+				const {
+					__unstableGetCanvasMode,
+					getSettings,
+					getEditedPostType,
+				} = select( editSiteStore );
+				return {
+					canvasMode: __unstableGetCanvasMode(),
+					dashboardLink: getSettings().__experimentalDashboardLink,
+					entityConfig: select( coreStore ).getEntityConfig(
+						'postType',
+						getEditedPostType()
+					),
+				};
+			},
+			[]
+		);
+		const disableMotion = useReducedMotion();
+		const isMobileViewport = useViewportMatch( 'medium', '<' );
+		const { __unstableSetCanvasMode } = useDispatch( editSiteStore );
+		const { clearSelectedBlock } = useDispatch( blockEditorStore );
+		const showEditButton =
+			( isEditorPage && canvasMode === 'view' && ! isMobileViewport ) ||
+			( isMobileViewport &&
+				canvasMode === 'view' &&
+				isMobileCanvasVisible );
+		const isBackToDashboardButton =
+			( ! isMobileViewport && canvasMode === 'view' ) ||
+			( isMobileViewport && ! isMobileCanvasVisible );
+		const showLabels = canvasMode !== 'edit';
+		const siteIconButtonProps = isBackToDashboardButton
+			? {
+					href: dashboardLink || 'index.php',
+					'aria-label': __( 'Go back to the dashboard' ),
+			  }
+			: {
+					label: __( 'Open Navigation Sidebar' ),
+					onClick: () => {
+						clearSelectedBlock();
+						setIsMobileCanvasVisible( false );
+						__unstableSetCanvasMode( 'view' );
+					},
+			  };
+		const { getTitle } = useEditedEntityRecord();
 
-	return (
-		<motion.div
-			{ ...props }
-			className={ classnames( 'edit-site-site-hub', props.className ) }
-			layout
-			transition={ {
-				type: 'tween',
-				duration: disableMotion ? 0 : HUB_ANIMATION_DURATION,
-				ease: 'easeOut',
-			} }
-		>
-			<HStack
-				justify="flex-start"
-				className="edit-site-site-hub__text-content"
-			>
-				<motion.div
-					className="edit-site-site-hub__view-mode-toggle-container"
-					layout
-					transition={ {
-						type: 'tween',
-						duration: disableMotion ? 0 : HUB_ANIMATION_DURATION,
-						ease: 'easeOut',
-					} }
-				>
-					<Button
-						{ ...siteIconButtonProps }
-						className="edit-site-layout__view-mode-toggle"
-					>
-						<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
-					</Button>
-				</motion.div>
-
-				{ showLabels && (
-					<VStack spacing={ 0 }>
-						<div className="edit-site-site-hub__title">
-							{ getTitle() }
-						</div>
-						<div className="edit-site-site-hub__post-type">
-							{ entityConfig?.label }
-						</div>
-					</VStack>
+		return (
+			<motion.div
+				ref={ ref }
+				{ ...props }
+				className={ classnames(
+					'edit-site-site-hub',
+					props.className
 				) }
-			</HStack>
-
-			{ showEditButton && (
-				<Button
-					className="edit-site-site-hub__edit-button"
-					label={ __( 'Open the editor' ) }
-					onClick={ () => {
-						__unstableSetCanvasMode( 'edit' );
-					} }
-					variant="primary"
+				layout
+				transition={ {
+					type: 'tween',
+					duration: disableMotion ? 0 : HUB_ANIMATION_DURATION,
+					ease: 'easeOut',
+				} }
+			>
+				<HStack
+					justify="flex-start"
+					className="edit-site-site-hub__text-content"
 				>
-					{ __( 'Edit' ) }
-				</Button>
-			) }
+					<motion.div
+						className="edit-site-site-hub__view-mode-toggle-container"
+						layout
+						transition={ {
+							type: 'tween',
+							duration: disableMotion
+								? 0
+								: HUB_ANIMATION_DURATION,
+							ease: 'easeOut',
+						} }
+					>
+						<Button
+							{ ...siteIconButtonProps }
+							className="edit-site-layout__view-mode-toggle"
+						>
+							<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
+						</Button>
+					</motion.div>
 
-			{ isMobileViewport && ! isMobileCanvasVisible && (
-				<Button
-					onClick={ () => setIsMobileCanvasVisible( true ) }
-					variant="primary"
-				>
-					{ __( 'View Editor' ) }
-				</Button>
-			) }
-		</motion.div>
-	);
-}
+					{ showLabels && (
+						<VStack spacing={ 0 }>
+							<div className="edit-site-site-hub__title">
+								{ getTitle() }
+							</div>
+							<div className="edit-site-site-hub__post-type">
+								{ entityConfig?.label }
+							</div>
+						</VStack>
+					) }
+				</HStack>
+
+				{ showEditButton && (
+					<Button
+						className="edit-site-site-hub__edit-button"
+						label={ __( 'Open the editor' ) }
+						onClick={ () => {
+							__unstableSetCanvasMode( 'edit' );
+						} }
+						variant="primary"
+					>
+						{ __( 'Edit' ) }
+					</Button>
+				) }
+
+				{ isMobileViewport && ! isMobileCanvasVisible && (
+					<Button
+						onClick={ () => setIsMobileCanvasVisible( true ) }
+						variant="primary"
+					>
+						{ __( 'View Editor' ) }
+					</Button>
+				) }
+			</motion.div>
+		);
+	}
+);
 
 export default SiteHub;

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -30,9 +30,9 @@ import useEditedEntityRecord from '../use-edited-entity-record';
 const HUB_ANIMATION_DURATION = 0.3;
 
 function SiteHub( {
-	className,
 	isMobileCanvasVisible,
 	setIsMobileCanvasVisible,
+	...props
 } ) {
 	const { params } = useLocation();
 	const isListPage = getIsListPage( params );
@@ -81,7 +81,8 @@ function SiteHub( {
 
 	return (
 		<motion.div
-			className={ classnames( 'edit-site-site-hub', className ) }
+			{ ...props }
+			className={ classnames( 'edit-site-site-hub', props.className ) }
 			layout
 			transition={ {
 				type: 'tween',


### PR DESCRIPTION
Related #36667 

## What?

This PR adds the ability to resize the canvas size. It also removes the resizing that was specific to the template parts as it's a bit redundant.

Here's what it looks like so far


https://user-images.githubusercontent.com/272444/210776289-d439eac0-9d84-46ed-9766-46e5f56576e4.mov



**Notes**:

 - I've reused the ResizeableBox component and the resize handles we had previously. The only change there is that I made the resize handlers touch area larger.
 - Resizing impacts both the sidebar and the frame, it's like we're moving a separator between them.

**Testing instructions**

 - Open the site editor and play with the resizers.