### PR TITLE
[Block Library - Social Icon]: Fix React warning when adding `link label`

### DIFF
--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -106,7 +106,7 @@ const SocialLinkEdit = ( {
 							help={ __(
 								'Briefly describe the link to help screen reader users.'
 							) }
-							value={ label }
+							value={ label || '' }
 							onChange={ ( value ) =>
 								setAttributes( { label: value } )
 							}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
While investigating something different for `Social Icons` I noticed the React warning when adding a `link label`. This PR is simple fix for that.

## Testing Instructions
1. Insert `Social Icons` block and then insert one `Social Icon`.
2. In the inspector controls add a `link label`
3. Observe that there are no React warnings


## Error shown in trunk
<img width="1208" alt="Screenshot 2023-01-05 at 3 09 49 PM" src="https://user-images.githubusercontent.com/16275880/210787974-9adbbb7d-a007-4fbd-afaf-81d87281f7c2.png">

