### PR TITLE
Determine initial inspector tab from block editor state

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -477,6 +477,10 @@ _Returns_
 
 -   `Array`: ids of top-level and descendant blocks.
 
+### getDefaultInspectorControlsTab
+
+Undocumented declaration.
+
 ### getDraggedBlockClientIds
 
 Returns the client ids of any blocks being directly dragged.
@@ -1484,6 +1488,10 @@ Action that sets whether given blocks are visible on the canvas.
 _Parameters_
 
 -   _updates_ `Record<string,boolean>`: For each block's clientId, its new visibility setting.
+
+### setDefaultInspectorControlsTab
+
+Undocumented declaration.
 
 ### setHasControlledInnerBlocks
 

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -45,13 +45,17 @@ function BlockCard( { title, icon, description, blockType, className } ) {
 		};
 	}, [] );
 
-	const { selectBlock } = useDispatch( blockEditorStore );
+	const { selectBlock, setDefaultInspectorControlsTab } =
+		useDispatch( blockEditorStore );
 
 	return (
 		<div className={ classnames( 'block-editor-block-card', className ) }>
 			{ isOffCanvasNavigationEditorEnabled && parentNavBlockClientId && (
 				<Button
-					onClick={ () => selectBlock( parentNavBlockClientId ) }
+					onClick={ () => {
+						setDefaultInspectorControlsTab( 'list' );
+						selectBlock( parentNavBlockClientId );
+					} }
 					label={ __( 'Go to parent Navigation block' ) }
 					style={
 						// TODO: This style override is also used in ToolsPanelHeader.

--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { useSelect } from '@wordpress/data';
 import { TabPanel } from '@wordpress/components';
 
 /**
@@ -10,7 +11,7 @@ import { TAB_SETTINGS, TAB_STYLES, TAB_LIST_VIEW } from './utils';
 import SettingsTab from './settings-tab';
 import StylesTab from './styles-tab';
 import InspectorControls from '../inspector-controls';
-import useIsListViewTabDisabled from './use-is-list-view-tab-disabled';
+import { store as blockEditorStore } from '../../store';
 
 export default function InspectorControlsTabs( {
 	blockName,
@@ -18,14 +19,10 @@ export default function InspectorControlsTabs( {
 	hasBlockStyles,
 	tabs,
 } ) {
-	// The tabs panel will mount before fills are rendered to the list view
-	// slot. This means the list view tab isn't initially included in the
-	// available tabs so the panel defaults selection to the styles tab
-	// which at the time is the first tab. This check allows blocks known to
-	// include the list view tab to set it as the tab selected by default.
-	const initialTabName = ! useIsListViewTabDisabled( blockName )
-		? TAB_LIST_VIEW.name
-		: undefined;
+	const initialTabName = useSelect( ( select ) => {
+		const { getDefaultInspectorControlsTab } = select( blockEditorStore );
+		return getDefaultInspectorControlsTab() ?? TAB_STYLES.name;
+	}, [] );
 
 	return (
 		<TabPanel
@@ -53,7 +50,9 @@ export default function InspectorControlsTabs( {
 
 				if ( tab.name === TAB_LIST_VIEW.name ) {
 					return (
-						<InspectorControls.Slot __experimentalGroup="list" />
+						<div>
+							<InspectorControls.Slot __experimentalGroup="list" />
+						</div>
 					);
 				}
 			} }

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -42,15 +42,13 @@ export default function useInspectorControlsTabs( blockName ) {
 		color: colorGroup,
 		default: defaultGroup,
 		dimensions: dimensionsGroup,
-		list: listGroup,
 		typography: typographyGroup,
 	} = InspectorControlsGroups;
 
 	// List View Tab: If there are any fills for the list group add that tab.
 	const listViewDisabled = useIsListViewTabDisabled( blockName );
-	const listFills = useSlotFills( listGroup.Slot.__unstableName );
 
-	if ( ! listViewDisabled && !! listFills && listFills.length ) {
+	if ( ! listViewDisabled ) {
 		tabs.push( TAB_LIST_VIEW );
 	}
 

--- a/packages/block-editor/src/components/off-canvas-editor/block-edit-button.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-edit-button.js
@@ -15,10 +15,12 @@ export default forwardRef( function BlockEditButton(
 	{ clientId, ...props },
 	ref
 ) {
-	const { selectBlock } = useDispatch( blockEditorStore );
+	const { selectBlock, setDefaultInspectorControlsTab } =
+		useDispatch( blockEditorStore );
 
 	const onClick = () => {
 		selectBlock( clientId );
+		setDefaultInspectorControlsTab( 'settings' );
 	};
 
 	return (

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1501,6 +1501,12 @@ export const __unstableMarkAutomaticChange =
 		} );
 	};
 
+export const setDefaultInspectorControlsTab =
+	( tab ) =>
+	( { dispatch } ) => {
+		dispatch( { type: 'SET_DEFAULT_INSPECTOR_CONTROLS_TAB', tab } );
+	};
+
 /**
  * Action that enables or disables the navigation mode.
  *

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1673,6 +1673,15 @@ export const blockListSettings = ( state = {}, action ) => {
 	return state;
 };
 
+export function defaultInspectorControlsTab( state = null, action ) {
+	switch ( action.type ) {
+		case 'SET_DEFAULT_INSPECTOR_CONTROLS_TAB':
+			return action.tab;
+	}
+
+	return state;
+}
+
 /**
  * Reducer returning which mode is enabled.
  *
@@ -1879,6 +1888,7 @@ export default combineReducers( {
 	settings,
 	preferences,
 	lastBlockAttributesChange,
+	defaultInspectorControlsTab,
 	editorMode,
 	hasBlockMovingClientId,
 	automaticChangeStatus,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2534,6 +2534,10 @@ export function isNavigationMode( state ) {
 	return state.editorMode === 'navigation';
 }
 
+export function getDefaultInspectorControlsTab( state ) {
+	return state.defaultInspectorControlsTab;
+}
+
 /**
  * Returns the current editor mode.
  *


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #45951

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Having style as the default works for most cases but for navigation editing the inspector tabs that we expect to be most used are list and settings. So this PR aims to fix defaulting to styles when the off canvas editor is used.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds a new state `defaultInspectorControlsTab`, selector, action and reducer to the block editor store.
Uses this state to decide what is the initial tab when the tab panel is mounted.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In the site editor
2. Have a navigation block
3. Add social icons and some icons in it
4. Add some links
5. In the off canvas editor click the pencil icon on the social links block
6. Observe the tab selected is settings
7. From the top of the inspector click the back arrow
8. Observe the tab selected is list

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/107534/210794919-e22f0996-f56d-4091-9740-31fe304b6fcc.mp4



