### PR TITLE
Set custom color when applying initial background image.

### DIFF
--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { FastAverageColor } from 'fast-average-color';
 import { colord } from 'colord';
 
 /**
@@ -10,12 +9,10 @@ import { colord } from 'colord';
 import { useEffect, useState } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 
-function retrieveFastAverageColor() {
-	if ( ! retrieveFastAverageColor.fastAverageColor ) {
-		retrieveFastAverageColor.fastAverageColor = new FastAverageColor();
-	}
-	return retrieveFastAverageColor.fastAverageColor;
-}
+/**
+ * Internal dependencies
+ */
+import { retrieveFastAverageColor } from '../shared';
 
 /**
  * useCoverIsDark is a hook that returns a boolean variable specifying if the cover


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/44167

This PR adds a custom color to cover when an image is used as a background.

## Screenshots
![image](https://user-images.githubusercontent.com/11271197/210802054-21b75fa5-6022-4dbf-80b7-f4acda020be3.png)

