### PR TITLE
Update copyright year to 2023 in `license.md`.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 ## Gutenberg
 
-    Copyright 2016-2022 by the contributors
+    Copyright 2016-2023 by the contributors
 
 **License for Contributions (on and after April 15, 2021)**
 


### PR DESCRIPTION
## Description
Updates the license copyright to 2023

Related: https://github.com/WordPress/wordpress-develop/commit/7978e05ec02ac35170727f4bb7f6b4b39c2dca39