### PR TITLE
Adds an identifier prop to the RichText component for captions, allowing annotation

### DIFF
--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -251,6 +251,7 @@ function AudioEdit( {
 				{ showCaption &&
 					( ! RichText.isEmpty( caption ) || isSelected ) && (
 						<RichText
+							identifier="caption"
 							tagName="figcaption"
 							className={ __experimentalGetElementClassName(
 								'caption'

--- a/packages/block-library/src/embed/embed-preview.js
+++ b/packages/block-library/src/embed/embed-preview.js
@@ -143,6 +143,7 @@ class EmbedPreview extends Component {
 				) }
 				{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
 					<RichText
+						identifier="caption"
 						tagName="figcaption"
 						className={ __experimentalGetElementClassName(
 							'caption'

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -51,6 +51,7 @@ export const Gallery = ( props ) => {
 			) }
 			<RichTextVisibilityHelper
 				isHidden={ ! isSelected && RichText.isEmpty( caption ) }
+				identifier="caption"
 				tagName="figcaption"
 				className={ classnames(
 					'blocks-gallery-caption',

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -639,6 +639,7 @@ export default function Image( {
 			{ showCaption &&
 				( ! RichText.isEmpty( caption ) || isSelected ) && (
 					<RichText
+						identifier="caption"
 						className={ __experimentalGetElementClassName(
 							'caption'
 						) }

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -510,6 +510,7 @@ function TableEdit( {
 			) }
 			{ ! isEmpty && (
 				<RichText
+					identifier="caption"
 					tagName="figcaption"
 					className={ __experimentalGetElementClassName( 'caption' ) }
 					aria-label={ __( 'Table caption text' ) }

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -327,6 +327,7 @@ function VideoEdit( {
 				{ showCaption &&
 					( ! RichText.isEmpty( caption ) || isSelected ) && (
 						<RichText
+							identifier="caption"
 							tagName="figcaption"
 							className={ __experimentalGetElementClassName(
 								'caption'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR adds an `identifier` prop to the `RichText` component for audio, embed, gallery, image, table, and video captions.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This PR is a follow-up to [this older PR](https://github.com/WordPress/gutenberg/pull/11595). With this PR, we allow to annotate textual content in audio, embed, gallery, image, table, and video captions using the `core/annotations` store. In Yoast SEO, we use this annotation functionality for our highlighting functionality, e.g., in our [keyphrase distribution assessment](https://yoast.com/keyphrase-distribution-what-it-is-and-how-to-balance-it/).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR opens up captions to annotation by adding an `identifier` prop to the `RichText` component for audio, embed, gallery, image, table, and video captions.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open a new Post.
2. Insert a paragraph block and an image block.
3. Add a caption to the image.
4. Add the text "This is a test for Gutenberg." to the paragraph block, as well as to the image caption.
5. Add the following code to your console. Replace the `blockClientId` with the id of the paragraph block (you can find that in the `data-block` attribute when you inspect the underlying HTML):
```javascript
wp.data.dispatch( "core/annotations" ).__experimentalAddAnnotation({
  type: 'ANNOTATION_ADD',
  id: 'test',
  blockClientId: 'd10cd677-8236-4e0a-8062-f96e9f17ca2c', // change this!
  richTextIdentifier: 'content',
  source: 'test',
  selector: 'range',
  range: {
    start: 19,
    end: 28
  }
})
```
6. Confirm the word "Gutenberg" is marked with yellow in the paragraph block.
7. Add the following code to your console. Replace the `blockClientId` with the id of the image caption block:
```javascript
wp.data.dispatch( "core/annotations" ).__experimentalAddAnnotation({
  type: 'ANNOTATION_ADD',
  id: 'test',
  blockClientId: 'd10cd677-8236-4e0a-8062-f96e9f17ca2c', // change this!
  richTextIdentifier: 'caption',
  source: 'test',
  selector: 'range',
  range: {
    start: 19,
    end: 28
  }
})
```
8. Confirm the word "Gutenberg" is marked with yellow in the image caption.
9. Without this PR, the word "Gutenberg" would be highlighted in the paragraph content, but **not** in the image caption content. 
10. Repeat the above steps for audio, embed, gallery, table, and video blocks.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

NA

## Screenshots or screencast <!-- if applicable -->

NA
