### PR TITLE
[Components - Placeholder]: Set fixed right margin for label's icon

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fix
 
--   `Placeholder`: fix label icon right margin when using dashicons ([46918](https://github.com/WordPress/gutenberg/pull/46918)).
+-   `Placeholder`: set fixed right margin for label's icon ([46918](https://github.com/WordPress/gutenberg/pull/46918)).
 
 ## 23.1.0 (2023-01-02)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `Dashicon`: remove unnecessary type for `className` prop ([46849](https://github.com/WordPress/gutenberg/pull/46849)).
 
+### Bug Fix
+
+-   `Placeholder`: fix label icon right margin when using dashicons ([46918](https://github.com/WordPress/gutenberg/pull/46918)).
+
 ## 23.1.0 (2023-01-02)
 
 ## 23.0.0 (2022-12-14)
@@ -76,6 +80,7 @@
 -   `TabPanel`: Add ability to set icon only tab buttons ([#45005](https://github.com/WordPress/gutenberg/pull/45005)).
 
 ### Internal
+
 -   `AnglePickerControl`: remove `:focus-visible' outline on `CircleOutlineWrapper` ([#45758](https://github.com/WordPress/gutenberg/pull/45758))
 
 ### Bug Fix

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -54,6 +54,10 @@
 		}
 	}
 
+	.dashicon {
+		margin-right: 0.7em;
+	}
+
 	// Don't take up space if the label is empty.
 	&:empty {
 		display: none;

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -45,17 +45,13 @@
 	> svg,
 	.dashicon,
 	.block-editor-block-icon {
-		margin-right: 1ch;
+		margin-right: $grid-unit-15;
 		fill: currentColor;
 		// Optimizate for high contrast modes.
 		// See also https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/.
 		@media (forced-colors: active) {
 			fill: CanvasText;
 		}
-	}
-
-	.dashicon {
-		margin-right: 0.7em;
 	}
 
 	// Don't take up space if the label is empty.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/45360
Fixes: https://github.com/WordPress/gutenberg/issues/36836
<!-- In a few words, what is the PR actually doing? -->

The Placeholder component adds margin-right to its icon but uses `ch` unit, which is defined as the width of the character 0 which in `dashicons` is `0`. This PR changes the margin to be the same for all cases(`12px` value) .


## Testing Instructions
1. Use a Placeholder component with a dashicon or you could update [this line](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/query/edit/query-placeholder.js#L75) to have `chart-bar` and insert a Query Loop block
2. Observe that the new margin is applied.


