### PR TITLE
Navigation: Remove ghost inserter

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -375,12 +375,19 @@ export default function NavigationLinkEdit( {
 	const DEFAULT_BLOCK = {
 		name: 'core/navigation-link',
 	};
-	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		allowedBlocks: ALLOWED_BLOCKS,
-		__experimentalDefaultBlock: DEFAULT_BLOCK,
-		__experimentalDirectInsert: true,
-		renderAppender: false,
-	} );
+
+	const innerBlocksProps = useInnerBlocksProps(
+		{
+			...blockProps,
+			className: 'remove-outline', // Remove the outline from the inner blocks container.
+		},
+		{
+			allowedBlocks: ALLOWED_BLOCKS,
+			__experimentalDefaultBlock: DEFAULT_BLOCK,
+			__experimentalDirectInsert: true,
+			renderAppender: false,
+		}
+	);
 
 	if ( ! url || isInvalid || isDraft ) {
 		blockProps.onClick = () => setIsLinkOpen( true );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This removes the "ghost" inserter that appears around the innerBlocks for the navigation link block. This was introduced in https://github.com/WordPress/gutenberg/pull/45906.

Fixes https://github.com/WordPress/gutenberg/issues/46574

## Why?
Cleans up the UI.

## How?
By adding a `remove-outline` class to innerBlocksProps, and removing all other classes. I'm not sure if this is the best way, but every other approach I took didn't work.

## Testing Instructions
1. Add a navigation block to a post
2. Select a navigation link block in the canvas
3. Confirm that the "ghost" inserter is gone
4. Open the inspector controls for the block
5. Open the offcanvas editor (you need to have the experiment enabled)
6. Check that you can still drag and drop navigation link blocks into others to create submenus
7. Check that you can still drag and drop navigation submenu blocks into other submenus 

### Testing Instructions for Keyboard
Check that items within a navigation block can still be reordered using the keyboard.

## Screenshots or screencast <!-- if applicable -->
Before:
<img width="494" alt="Screenshot 2023-01-05 at 16 11 08" src="https://user-images.githubusercontent.com/275961/210829193-7b8aa74a-be10-47f3-b5c9-c16d5e8601e0.png">

After:
<img width="539" alt="Screenshot 2023-01-05 at 16 09 19" src="https://user-images.githubusercontent.com/275961/210829198-c8cb84a3-aa28-4446-aa92-272279740856.png">



