### PR TITLE
[Inserter]: Don't show empty `reusable` tab if not allowed to insert reusable blocks

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -67,20 +67,24 @@ function InserterMenu(
 			insertionIndex: __experimentalInsertionIndex,
 			shouldFocusBlock,
 		} );
-	const { showPatterns, hasReusableBlocks } = useSelect(
+	const { showPatterns, inserterItems } = useSelect(
 		( select ) => {
-			const { __experimentalGetAllowedPatterns, getSettings } =
+			const { __experimentalGetAllowedPatterns, getInserterItems } =
 				select( blockEditorStore );
 			return {
 				showPatterns: !! __experimentalGetAllowedPatterns(
 					destinationRootClientId
 				).length,
-				hasReusableBlocks:
-					!! getSettings().__experimentalReusableBlocks?.length,
+				inserterItems: getInserterItems( destinationRootClientId ),
 			};
 		},
 		[ destinationRootClientId ]
 	);
+	const hasReusableBlocks = useMemo( () => {
+		return inserterItems.some(
+			( { category } ) => category === 'reusable'
+		);
+	}, [ inserterItems ] );
 
 	const mediaCategories = useMediaCategories( destinationRootClientId );
 	const showMedia = !! mediaCategories.length;


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
While investigating something different I noticed that we show the `reusable` tab in the Inserter even in cases we can't insert a reusable block. This PR fixes that.
<!-- In a few words, what is the PR actually doing? -->


## Testing Instructions
1. Observe that the `reusable` tab in inserter is shown in every case we can insert a reusable block
2. Observe that is not shown when we can't - example inside a `Buttons` block

### Before

https://user-images.githubusercontent.com/16275880/210842050-414214e2-efb2-44e8-90de-9c5f39e7547e.mov


### After


https://user-images.githubusercontent.com/16275880/210842065-6b719337-e6c3-45e5-88e5-d16ac577c7d8.mov


