### PR TITLE
[Inserter]: Hide empty pattern categories

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -28,8 +28,11 @@ import BlockPatternList from '../block-patterns-list';
 import PatternsExplorerModal from './block-patterns-explorer/explorer';
 import MobileTabNavigation from './mobile-tab-navigation';
 
-function usePatternsCategories() {
-	const [ allPatterns, allCategories ] = usePatternsState();
+function usePatternsCategories( rootClientId ) {
+	const [ allPatterns, allCategories ] = usePatternsState(
+		undefined,
+		rootClientId
+	);
 
 	const hasRegisteredCategory = useCallback(
 		( pattern ) => {
@@ -184,7 +187,7 @@ function BlockPatternsTabs( {
 	rootClientId,
 } ) {
 	const [ showPatternsExplorer, setShowPatternsExplorer ] = useState( false );
-	const categories = usePatternsCategories();
+	const categories = usePatternsCategories( rootClientId );
 	const isMobile = useViewportMatch( 'medium', '<' );
 	return (
 		<>

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -131,7 +131,7 @@ export function BlockPatternsCategoryPanel( {
 		rootClientId
 	);
 
-	const availableCategories = usePatternsCategories();
+	const availableCategories = usePatternsCategories( rootClientId );
 	const currentCategoryPatterns = useMemo(
 		() =>
 			allPatterns.filter( ( pattern ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Right now we show all the available pattern categories without checking if there are available allowed patterns for the specific `rootClientId` we want to insert them. 

This PR shows only the pattern categories we have pattern to suggest.
<!-- In a few words, what is the PR actually doing? -->


## Testing Instructions
1.  Insert a Navigation block and try to add an `innerBlock` through the Inserter
2. Observe that from the available patterns, only one is allowed(with `social icons` block) and only that pattern category is shown.
3. Ensure that everything works as before based on the insertion clientId.

### Before

https://user-images.githubusercontent.com/16275880/210866627-95b52739-5c04-4bae-a880-54edfcf265d9.mov



### After

https://user-images.githubusercontent.com/16275880/210866636-b960965e-f72a-485b-959c-2cd69c9d94c9.mov

