### PR TITLE
Block Editor Iframe: Support displaying fixed elements by only applying scale when it is not 1

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -268,7 +268,10 @@ function Iframe(
 										frameSize
 									}px`,
 									marginTop: frameSize,
-									transform: `scale( ${ scale } )`,
+									transform:
+										scale !== 1
+											? `scale( ${ scale } )`
+											: undefined,
 								} }
 								inert={ readonly ? 'true' : undefined }
 							>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of implementing https://github.com/WordPress/gutenberg/issues/30121

This PR updates the block editor iframe so that the CSS transform (scale) is only applied when it is a non-1 value — this ensures that the block editor iframe can support fixed position elements, which will be part of implementing position block support (see #30121).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It turns out that fixed position CSS isn't displayed by the browser when a CSS transform is applied to one of its ancestors (here's a helpful blog post I found on the topic: https://achrafkassioui.com/blog/position-fixed-and-CSS-transforms/).

It appears that the `transform: scale` rule applied to the body element of the block editor iframe is only needed for browse mode, when it has a value that is not `1`, so the approach in this PR is to conditionally output the transform instead of always outputting it.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In the block editor iframe, only output the `transform: scale` rule when the scale value is not `1`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

For the purposes of this PR, test that browse mode is still working as expected.

1. Switch on browse mode under: `/wp-admin/admin.php?page=gutenberg-experiments`
2. Open up the site editor, and check that clicking the Zoomed out view button still works as expected

If you want to try testing fixed positioning and that this PR fixes the issue, then you can apply this PR on top of https://github.com/WordPress/gutenberg/pull/46142. With this applied on top of that PR, open up the Group block's `block.json` file, and add `"fixed": true` to the `supports.position` object. Then, in the site editor, set a Group block to Fixed Position under the position dropdown in the inspector controls. The block should lose its width, and then be fixed to the top of the viewport.

For the purposes of this PR, there's likely no need to go through all the steps of the above to test out the fixed position PR — for now, let's verify whether or not we can safely update this transform rule.

## Screenshots or screencast <!-- if applicable -->

In the below screengrab (where this PR is applied on top of the fixed/sticky position support PR #46142), a block is set to Fixed Position, and when _not_ in the zoomed out view, it remains fixed to the viewport. When clicking on the zoomed out view, the block becomes no longer fixed (which is to be expected) while the user views the page in the browse mode. Switching off from zoomed out view, the fixed positioning is restored.

https://user-images.githubusercontent.com/14988353/210940867-e5278988-33e2-4fd2-b101-022de14a72cd.mp4


