### PR TITLE
Remove the editor notices from the site editor frame

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -174,7 +174,7 @@ export default function Editor() {
 								content={
 									<>
 										<GlobalStylesRenderer />
-										<EditorNotices />
+										{ isEditMode && <EditorNotices /> }
 										{ showVisualEditor && editedPost && (
 											<BlockEditor />
 										) }


### PR DESCRIPTION
closes #46274

## What?

As discussed on the related issue, this PR just removes the notices from the site editor frame, the notices are only shown in edit mode.

## Testing Instructions

You call this in the browser console to add notices:

```
wp.data.dispatch('core/notices').createNotice( 'warning', 'Hello World', {} );
```

Check that they don't appear in browse mode but they appear on edit mode.
