### PR TITLE
Iframe: compat styles: check for ownerNode === null

### DIFF
--- a/packages/block-editor/src/components/iframe/use-compatibility-styles.js
+++ b/packages/block-editor/src/components/iframe/use-compatibility-styles.js
@@ -28,6 +28,12 @@ export function useCompatibilityStyles() {
 
 				const { ownerNode, cssRules } = styleSheet;
 
+				// Stylesheet is added by another stylesheet. See
+				// https://developer.mozilla.org/en-US/docs/Web/API/StyleSheet/ownerNode#notes.
+				if ( ownerNode === null ) {
+					return accumulator;
+				}
+
 				if ( ! cssRules ) {
 					return accumulator;
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

When checking the ownerNode of a stylesheet, it may be null if the stylesheet was imported by another stylesheet. In that case we should return early.

See https://developer.mozilla.org/en-US/docs/Web/API/StyleSheet/ownerNode#notes.

## Why?

Prevents an error.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
