### PR TITLE
Add clear Apply and Cancel buttons to Link Control

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -250,13 +250,14 @@ function LinkControl( {
 	const handleCancel = ( event ) => {
 		event.preventDefault();
 
-		// If there is an existing link then revert to the existing
-		// link and exit editing mode. Otherwise remove the link.
+		// Ensure that any unsubmitted input changes are reset.
+		resetInternalValues();
+
 		if ( hasLinkValue ) {
-			// Ensure that any unsubmitted input changes are reset.
-			resetInternalValues();
+			// If there is a link then exist editing mode and show preview.
 			stopEditing();
 		} else {
+			// If there is no link value, then remove the link entirely.
 			onRemove?.();
 		}
 	};

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -117,7 +117,7 @@ function LinkControl( {
 	value,
 	settings = DEFAULT_LINK_SETTINGS,
 	onChange = noop,
-	onRemove = noop,
+	onRemove,
 	noDirectEntry = false,
 	showSuggestions = true,
 	showInitialSuggestions,
@@ -257,7 +257,7 @@ function LinkControl( {
 			resetInternalValues();
 			stopEditing();
 		} else {
-			onRemove();
+			onRemove?.();
 		}
 	};
 

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -118,6 +118,7 @@ function LinkControl( {
 	settings = DEFAULT_LINK_SETTINGS,
 	onChange = noop,
 	onRemove,
+	onCancel,
 	noDirectEntry = false,
 	showSuggestions = true,
 	showInitialSuggestions,
@@ -260,6 +261,8 @@ function LinkControl( {
 			// If there is no link value, then remove the link entirely.
 			onRemove?.();
 		}
+
+		onCancel?.();
 	};
 
 	const currentUrlInputValue = propInputValue || internalUrlInputValue;

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -117,7 +117,7 @@ function LinkControl( {
 	value,
 	settings = DEFAULT_LINK_SETTINGS,
 	onChange = noop,
-	onRemove,
+	onRemove = noop,
 	noDirectEntry = false,
 	showSuggestions = true,
 	showInitialSuggestions,
@@ -195,6 +195,8 @@ function LinkControl( {
 		isEndingEditWithFocus.current = false;
 	}, [ isEditingLink, isCreatingPage ] );
 
+	const hasLinkValue = value?.url?.trim()?.length > 0;
+
 	/**
 	 * Cancels editing state and marks that focus may need to be restored after
 	 * the next render, if focus was within the wrapper when editing finished.
@@ -240,6 +242,25 @@ function LinkControl( {
 		}
 	};
 
+	const resetInternalValues = () => {
+		setInternalUrlInputValue( value?.url );
+		setInternalTextInputValue( value?.title );
+	};
+
+	const handleCancel = ( event ) => {
+		event.preventDefault();
+
+		// If there is an existing link then revert to the existing
+		// link and exit editing mode. Otherwise remove the link.
+		if ( hasLinkValue ) {
+			// Ensure that any unsubmitted input changes are reset.
+			resetInternalValues();
+			stopEditing();
+		} else {
+			onRemove();
+		}
+	};
+
 	const currentUrlInputValue = propInputValue || internalUrlInputValue;
 
 	const currentInputIsEmpty = ! currentUrlInputValue?.trim()?.length;
@@ -252,7 +273,7 @@ function LinkControl( {
 	// Only show text control once a URL value has been committed
 	// and it isn't just empty whitespace.
 	// See https://github.com/WordPress/gutenberg/pull/33849/#issuecomment-932194927.
-	const showTextControl = value?.url?.trim()?.length > 0 && hasTextControl;
+	const showTextControl = hasLinkValue && hasTextControl;
 
 	return (
 		<div
@@ -324,7 +345,7 @@ function LinkControl( {
 						>
 							{ __( 'Apply' ) }
 						</Button>
-						<Button variant="secondary" onClick={ stopEditing }>
+						<Button variant="secondary" onClick={ handleCancel }>
 							{ __( 'Cancel' ) }
 						</Button>
 					</ButtonGroup>

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -250,6 +250,7 @@ function LinkControl( {
 
 	const handleCancel = ( event ) => {
 		event.preventDefault();
+		event.stopPropagation();
 
 		// Ensure that any unsubmitted input changes are reset.
 		resetInternalValues();

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -6,8 +6,13 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Button, Spinner, Notice, TextControl } from '@wordpress/components';
-import { keyboardReturn } from '@wordpress/icons';
+import {
+	Button,
+	ButtonGroup,
+	Spinner,
+	Notice,
+	TextControl,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useRef, useState, useEffect } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
@@ -299,17 +304,7 @@ function LinkControl( {
 								createSuggestionButtonText
 							}
 							useLabel={ showTextControl }
-						>
-							<div className="block-editor-link-control__search-actions">
-								<Button
-									onClick={ handleSubmit }
-									label={ __( 'Submit' ) }
-									icon={ keyboardReturn }
-									className="block-editor-link-control__search-submit"
-									disabled={ currentInputIsEmpty } // Disallow submitting empty values.
-								/>
-							</div>
-						</LinkControlSearchInput>
+						/>
 					</div>
 					{ errorMessage && (
 						<Notice
@@ -320,6 +315,19 @@ function LinkControl( {
 							{ errorMessage }
 						</Notice>
 					) }
+					<ButtonGroup className="block-editor-link-control__search-actions">
+						<Button
+							variant="primary"
+							onClick={ handleSubmit }
+							className="xblock-editor-link-control__search-submit"
+							disabled={ currentInputIsEmpty } // Disallow submitting empty values.
+						>
+							{ __( 'Apply' ) }
+						</Button>
+						<Button variant="secondary" onClick={ stopEditing }>
+							{ __( 'Cancel' ) }
+						</Button>
+					</ButtonGroup>
 				</>
 			) }
 

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -77,20 +77,11 @@ $preview-image-height: 140px;
 }
 
 .block-editor-link-control__search-actions {
-	position: absolute;
-	/*
-	 * Actions must be positioned on top of URLInput, since the input will grow
-	 * when suggestions are rendered.
-	 *
-	 * Compensate for:
-	 *  - Border (1px)
-	 *  - Vertically, for the difference in height between the input (40px) and
-	 *    the icon buttons.
-	 *  - Horizontally, pad to the minimum of: default input padding, or the
-	 *    equivalent of the vertical padding.
-	 */
-	top: 1px + ( ( 40px - $button-size ) * 0.5 );
-	right: $grid-unit-20 + 1px + min($grid-unit-10, ( 40px - $button-size ) * 0.5);
+	display: flex;
+	flex-direction: row-reverse; // put "Cancel" on the left but retain DOM order.
+	justify-content: flex-start;
+	margin: $grid-unit-20; // allow margin collapse for vertical spacing.
+	gap: $grid-unit-10;
 }
 
 .components-button .block-editor-link-control__search-submit .has-icon {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -64,7 +64,6 @@ $preview-image-height: 140px;
 		width: calc(100% - #{$grid-unit-20 * 2});
 		display: block;
 		padding: 11px $grid-unit-20;
-		padding-right: ( $button-size * $block-editor-link-control-number-of-actions ); // width of reset and submit buttons
 		margin: 0;
 		position: relative;
 		border: 1px solid $gray-300;
@@ -470,14 +469,8 @@ $preview-image-height: 140px;
 		position: absolute;
 		left: auto;
 		bottom: auto;
-		/*
-		 * Position spinner to the left of the actions.
-		 *
-		 * Compensate for:
-		 *  - Input padding right ($button-size)
-		 */
 		top: calc(50% - #{$spinner-size} / 2);
-		right: $button-size;
+		right: $grid-unit-20;
 	}
 }
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -537,7 +537,7 @@ describe( 'Manual link entry', () => {
 				} );
 
 				let submitButton = screen.getByRole( 'button', {
-					name: 'Submit',
+					name: 'Apply',
 				} );
 
 				expect( submitButton ).toBeDisabled();
@@ -555,7 +555,7 @@ describe( 'Manual link entry', () => {
 				await user.keyboard( '[Enter]' );
 
 				submitButton = screen.getByRole( 'button', {
-					name: 'Submit',
+					name: 'Apply',
 				} );
 
 				// Verify the UI hasn't allowed submission.
@@ -578,7 +578,7 @@ describe( 'Manual link entry', () => {
 				} );
 
 				let submitButton = screen.queryByRole( 'button', {
-					name: 'Submit',
+					name: 'Apply',
 				} );
 
 				expect( submitButton ).toBeDisabled();
@@ -597,7 +597,7 @@ describe( 'Manual link entry', () => {
 				await user.click( submitButton );
 
 				submitButton = screen.queryByRole( 'button', {
-					name: 'Submit',
+					name: 'Apply',
 				} );
 
 				// Verify the UI hasn't allowed submission.
@@ -1859,7 +1859,7 @@ describe( 'Controlling link title text', () => {
 		expect( textInput ).toHaveValue( textValue );
 
 		const submitButton = screen.queryByRole( 'button', {
-			name: 'Submit',
+			name: 'Apply',
 		} );
 
 		await user.click( submitButton );

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -715,6 +715,22 @@ describe( 'Manual link entry', () => {
 			expect( searchInput ).toHaveValue( initialLink.url );
 			expect( textInput ).toHaveValue( initialLink.text );
 		} );
+
+		it( 'should call onCancel callback when cancelling if provided', async () => {
+			const user = userEvent.setup();
+			const mockOnCancel = jest.fn();
+
+			render( <LinkControl onCancel={ mockOnCancel } /> );
+
+			const cancelButton = screen.queryByRole( 'button', {
+				name: 'Cancel',
+			} );
+
+			await user.click( cancelButton );
+
+			// Verify the consumer can handle the cancellation.
+			expect( mockOnCancel ).toHaveBeenCalled();
+		} );
 	} );
 
 	describe( 'Alternative link protocols and formats', () => {

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -612,6 +612,7 @@ describe( 'Manual link entry', () => {
 		it( 'should allow cancellation of the link creation process and reset any entered values', async () => {
 			const user = userEvent.setup();
 			const mockOnRemove = jest.fn();
+			const mockOnCancel = jest.fn();
 
 			render( <LinkControl onRemove={ mockOnRemove } /> );
 
@@ -635,6 +636,9 @@ describe( 'Manual link entry', () => {
 
 			// Verify the consumer can handle the cancellation.
 			expect( mockOnRemove ).toHaveBeenCalled();
+
+			// Ensure optional callback is not called.
+			expect( mockOnCancel ).not.toHaveBeenCalled();
 
 			expect( searchInput ).toHaveValue( '' );
 		} );

--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -137,7 +137,7 @@ describe( 'General media replace flow', () => {
 
 		await user.click(
 			screen.getByRole( 'button', {
-				name: 'Submit',
+				name: 'Apply',
 			} )
 		);
 

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -313,7 +313,7 @@ export default function NavigationLinkEdit( {
 	function removeLink() {
 		// Reset all attributes that comprise the link.
 		setAttributes( {
-			url: '',
+			url: undefined,
 			label: '',
 			id: '',
 			kind: '',

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -312,12 +312,17 @@ export default function NavigationLinkEdit( {
 	 */
 	function removeLink() {
 		// Reset all attributes that comprise the link.
+		// It is critical that all attributes are reset
+		// to their default values otherwise this may
+		// in advertently trigger side effects because
+		// the values will have "changed".
 		setAttributes( {
 			url: undefined,
-			label: '',
-			id: '',
-			kind: '',
-			type: '',
+			label: undefined,
+			id: undefined,
+			kind: undefined,
+			type: undefined,
+			opensInNewTab: false,
 		} );
 
 		// Close the link editing UI.

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/links.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/links.test.js.snap
@@ -68,6 +68,6 @@ exports[`Links should contain a label when it should open in a new tab 1`] = `
 
 exports[`Links should contain a label when it should open in a new tab 2`] = `
 "<!-- wp:paragraph -->
-<p>This is <a href=\\"http://wordpress.org\\">WordPress</a></p>
+<p>This is <a href=\\"http://wordpress.org\\" target=\\"_blank\\" rel=\\"noreferrer noopener\\">WordPress</a></p>
 <!-- /wp:paragraph -->"
 `;

--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -122,6 +122,7 @@ describe( 'Links', () => {
 		// Navigate to and toggle the "Open in new tab" checkbox.
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Space' );
 
 		// Toggle should still have focus and be checked.
@@ -134,6 +135,7 @@ describe( 'Links', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 
 		// Tab back to the Submit and apply the link.
+		await pressKeyWithModifier( 'shift', 'Tab' );
 		await pressKeyWithModifier( 'shift', 'Tab' );
 		await page.keyboard.press( 'Enter' );
 

--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -769,6 +769,7 @@ describe( 'Links', () => {
 			await page.keyboard.press( 'Tab' );
 			await page.keyboard.press( 'Tab' );
 			await page.keyboard.press( 'Tab' );
+			await page.keyboard.press( 'Tab' );
 
 			// Make a selection within the RichText.
 			await pressKeyWithModifier( 'shift', 'ArrowRight' );

--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -528,6 +528,7 @@ describe( 'Links', () => {
 		// Navigate to and toggle the "Open in new tab" checkbox.
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Space' );
 
 		// Confirm that focus was not prematurely returned to the paragraph on

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -486,7 +486,7 @@ test.describe( 'Image', () => {
 			await page.click( 'role=button[name="Edit"i]' );
 			// Replace the url.
 			await page.fill( 'role=combobox[name="URL"i]', imageUrl );
-			await page.click( 'role=button[name="Submit"i]' );
+			await page.click( 'role=button[name="Apply"i]' );
 
 			const regex = new RegExp(
 				`<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds `Apply` and `Cancel` buttons to the `<LinkControl>` component.

Affords the ability to explicitly cancel the creation or editing of the link.

Closes https://github.com/WordPress/gutenberg/issues/46593

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

**TLDR** 
- it needs to be clearer how to commit and cancel creation/editing of links. Currently it's unclear and unintuitive. 
- Addition of clear unambiguous buttons greatly improves the experience. 
- Specific "Close" button is _required_ for a11y reasons (click away or cancel on blur is [_not_ sufficient](https://github.com/WordPress/gutenberg/pull/46933#issuecomment-1386433792)).

There are a number of small UX issues with not having clear buttons to apply or cancel a link. Specifically there have been quite a few issues reporting around inconsistencies and bugs when submitting changes and UX confusion about how/when changes should be committed.

Examples

- https://github.com/WordPress/gutenberg/issues/45741
- https://github.com/WordPress/gutenberg/issues/43144
- https://github.com/WordPress/gutenberg/issues/40892
- https://github.com/WordPress/gutenberg/issues/35795

This PR is a first step in addressing these issues. See `Next Steps` for followup ideas.


#### Editing an existing link

When you have an existing link and you make changes to the text or URL it's not immediately obvious how to submit those changes. In fact you have to click on the very small icon button which is inside the URL input. Questions that might arrise:

- Where on earth(!) is the submit button? 
- Does clicking submit on the URL input submit my changes to the Text value of the link?

By adding a clear `Apply` button it's 

- clear where the button is that "commits" the changes
- clear that one button will commit _all_ the changes.

#### Cancelling edits to an existing link

When you have an existing link and you make changes to the text or URL and then decide you don't want to commit those changes it's very unclear how to exit the editing process.

In fact you have to click outside of the component to close it. But that's not at all intuitive.

With a dedicated `Cancel` button it is immediately clear how to exit the editing process and all ambiguity is removed.

#### Cancelling the creation of a new link

When you are creating a new link and then decide that in fact you do not wish to do this it's not immediately clear how to exit the link creation process.

In fact you have to click outside of the component to close it. But that's not at all intuitive and can even lead to focus loss from the place where you were originally creating the link which is extremely frustrating.

With a dedicated `Cancel` button it is immediately clear how to exit the editing process and all ambiguity is removed. Moreover your focus is returned back to where you were originally editing which avoids UX issues related to that.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds x2 new buttons 

- `Apply` - this replaces the icon-base submit button but displays all of the same behaviours and allows for submitting any current changes to the link value.
- `Cancel` - this is new and provides a clear means for the user to cancel editing or creation of links.

Care has been taken to ensure that when cancelling an action any _un_committed edits to a link value are discarded.


## Next Steps

If this PR lands then the next step would be to make changes to the link settings (e.g. `Open in new tab`) to be explicitly committed by the user. 

Currently these controls require lots of custom code to handle when they should/shouldn't be committed and it's never resulted in a satisfactory UX. 

We can greatly improve the UX simply by having a rule than _any_ changes to the link value must be explicitly committed bu the user.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

#### Manual testing

- New Post
- Add some text
- Create a new link
- See new UI with `Apply` and `Cancel` buttons
- Click `Cancel` - see link creation is cancelled and focus returned to previous location.
- Create a new link and submit a value.
- Click the edit button on the link you created.
- Make some text changes and URL changes then click `Cancel`.
- See the changes you made have been discarded. 

Repeat the above with other locations where `LinkControl` is used such as

- Nav block
- Button block
- Image block

...etc

#### Automated testing

Review and then run the tests:
```
npm run test:unit packages/block-editor/src/components/link-control/test/index.js
```





### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

Repeat same tests as above but ensure that you can complete the tasks using the keyboard only.

Specifically check that the tab order of the Link Control allows for `Apply` as the first tab stop (and thus the primary option) but also allows access to `Cancel` as the secondary stop.

## Screenshots or screencast <!-- if applicable -->

<img width="431" alt="Screenshot 2023-01-06 at 13 35 07" src="https://user-images.githubusercontent.com/444434/211022860-6a3d5eec-77b9-4041-a2c1-a36ab9feccb6.png">


#### Before

https://user-images.githubusercontent.com/444434/210999164-8a24578e-9783-4916-86bc-915d12ec574c.mp4

#### After


https://user-images.githubusercontent.com/444434/211000861-61950caa-803c-443a-bcec-788cd6d5f43e.mp4





