### PR TITLE
Align labels on Link Control

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -55,7 +55,7 @@ $preview-image-height: 140px;
 	.components-base-control__label {
 		margin-right: $grid-unit-20;
 		margin-bottom: 0;
-		width: 29px; // align with search results.
+		min-width: 29px; // align with search results.
 	}
 
 	input[type="text"],

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -55,6 +55,7 @@ $preview-image-height: 140px;
 	.components-base-control__label {
 		margin-right: $grid-unit-20;
 		margin-bottom: 0;
+		width: 29px; // align with search results.
 	}
 
 	input[type="text"],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Corrects misaligned labels for URL and Text when displayed in Link Control.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Misalignment is bad.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Uses CSS to force a set with on the labels. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- New Post
- Add text and add link
- Edit the link
- Check labels align correctly

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="519" alt="Screen Shot 2023-01-06 at 11 25 43" src="https://user-images.githubusercontent.com/444434/211003837-4fd556e0-8e1f-4c1f-8127-313815cc62db.png">


