### PR TITLE
Fix offsite navigation editor component loading issue.

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/block-contents.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-contents.js
@@ -53,11 +53,14 @@ const ListViewBlockContents = forwardRef(
 					getSelectedBlockClientId,
 					getLastInsertedBlocksClientIds,
 				} = select( blockEditorStore );
+				const lastInsertedBlocksClientIds =
+					getLastInsertedBlocksClientIds();
 				return {
 					blockMovingClientId: hasBlockMovingClientId(),
 					selectedBlockInBlockEditor: getSelectedBlockClientId(),
 					lastInsertedBlockClientId:
-						getLastInsertedBlocksClientIds()[ 0 ],
+						lastInsertedBlocksClientIds &&
+						lastInsertedBlocksClientIds[ 0 ],
 				};
 			},
 			[ clientId ]


### PR DESCRIPTION
The offsite navigation editor component is crashing on https://github.com/WordPress/gutenberg/pull/46248. This change fixes the issue.