### PR TITLE
Remove the border property from the body element on previews.

### DIFF
--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -49,7 +49,7 @@ function ScaledBlockPreview( {
 				...styles,
 				...__experimentalStyles,
 				{
-					css: 'body{height:auto;overflow:hidden;}',
+					css: 'body{height:auto;overflow:hidden;border:none;}',
 					__unstableType: 'presets',
 				},
 			];
@@ -90,9 +90,6 @@ function ScaledBlockPreview( {
 					documentElement.style.position = 'absolute';
 					documentElement.style.width = '100%';
 					bodyElement.style.padding = __experimentalPadding + 'px';
-
-					// Necessary for proper previews of styles with border styles assigned to the body.
-					bodyElement.style.border = 'none';
 
 					// Necessary for contentResizeListener to work.
 					bodyElement.style.boxSizing = 'border-box';

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -91,6 +91,9 @@ function ScaledBlockPreview( {
 					documentElement.style.width = '100%';
 					bodyElement.style.padding = __experimentalPadding + 'px';
 
+					// Necessary for proper previews of styles with border styles assigned to the body.
+					bodyElement.style.border = 'none';
+
 					// Necessary for contentResizeListener to work.
 					bodyElement.style.boxSizing = 'border-box';
 					bodyElement.style.position = 'absolute';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixing https://github.com/WordPress/gutenberg/issues/46874. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Because the style book and the different previews don’t show examples properly on variants where there's a body border defined.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Removing the body border from the preview so that the styles preview doesn't look borked.

## Testing Instructions
1. Activate TT3 and select Whisper style variant
2. Open Style book
3. Notice the bottom border of every example is not cut
4. Open Styles again > Blocks and notice the previews are no longer cut off.

## Screenshots or screencast <!-- if applicable -->
https://user-images.githubusercontent.com/252415/211051537-c08f48f8-3614-45d2-a93c-a2f4a546a8b6.mov