### PR TITLE
Include Add menu item text on off canvas editor inserter.

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/appender.js
+++ b/packages/block-editor/src/components/off-canvas-editor/appender.js
@@ -6,6 +6,8 @@ import { speak } from '@wordpress/a11y';
 import { useSelect } from '@wordpress/data';
 import { forwardRef, useState, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { plus } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -84,6 +86,41 @@ export const Appender = forwardRef(
 					selectBlockOnInsert={ false }
 					shouldDirectInsert={ false }
 					__experimentalIsQuick
+					renderToggle={ ( {
+						onToggle,
+						disabled,
+						isOpen,
+						hasSingleBlockType,
+						toggleProps = {},
+					} ) => {
+						const { onClick, ...rest } = toggleProps;
+						// Handle both onClick functions from the toggle and the parent component.
+						function handleClick( event ) {
+							if ( onToggle ) {
+								onToggle( event );
+							}
+							if ( onClick ) {
+								onClick( event );
+							}
+						}
+						return (
+							<Button
+								icon={ plus }
+								onClick={ handleClick }
+								className="block-editor-inserter__toggle"
+								aria-haspopup={
+									! hasSingleBlockType ? 'true' : false
+								}
+								aria-expanded={
+									! hasSingleBlockType ? isOpen : false
+								}
+								disabled={ disabled }
+								{ ...rest }
+							>
+								{ __( 'Add menu item' ) }
+							</Button>
+						);
+					} }
 					{ ...props }
 					toggleProps={ { 'aria-describedby': descriptionId } }
 					onSelectOrClose={ ( maybeInsertedBlock ) => {

--- a/packages/block-editor/src/components/off-canvas-editor/style.scss
+++ b/packages/block-editor/src/components/off-canvas-editor/style.scss
@@ -1,17 +1,6 @@
 .offcanvas-editor-appender .block-editor-inserter__toggle {
-	background-color: #1e1e1e;
-	color: #fff;
-	margin: $grid-unit-10 0 0 24px;
-	border-radius: 2px;
-	height: 24px;
+	margin: 0 0 0 $grid-unit-40;
 	min-width: 24px;
-	padding: 0;
-
-	&:hover,
-	&:focus {
-		background: var(--wp-admin-theme-color);
-		color: #fff;
-	}
 }
 
 .offcanvas-editor-appender__description {


### PR DESCRIPTION
Follows a suggestion by @jameskoster and includes "Add menu item" test on the off-canvas menu editor inserter.

## Screenshot
![image](https://user-images.githubusercontent.com/11271197/211052407-506df153-8499-431c-9dea-aa46d817a88b.png)
![image](https://user-images.githubusercontent.com/11271197/211052471-0fb32745-4a7e-4362-a2c9-985516068ada.png)
