### PR TITLE
Page List Item: Disable block toolbar

### DIFF
--- a/packages/block-library/src/page-list-item/block.json
+++ b/packages/block-library/src/page-list-item/block.json
@@ -44,7 +44,8 @@
 		"reusable": false,
 		"html": false,
 		"lock": false,
-		"inserter": false
+		"inserter": false,
+		"__experimentalToolbar": false
 	},
 	"editorStyle": "wp-block-page-list-editor",
 	"style": "wp-block-page-list"


### PR DESCRIPTION
## What?
This removes the "more" menu for page list item blocks:
Fixes #46751

## Why?
These actions don't make sense on this block as you can't manipulate it directly.

## How?
Adds the `__experimentalToolbar` support to the block.json

## Testing Instructions
1. Add a navigation block to a post
2. Add a page list block to the navigation block
3. Open the list view so that you can see the contents of the page list block
4. Check that you can't see/access the "more" menu (under the three dots)
5. Open the block inspector for the navigation block
6. Expand the off canvas editor so that you can see the items inside the page list block
7. Check that the page list items don't have a "more" menu (three dots)

### Testing Instructions for Keyboard
As above

## Screenshots or screencast <!-- if applicable -->
<img width="294" alt="Screenshot 2023-01-06 at 16 13 53" src="https://user-images.githubusercontent.com/275961/211052986-fd4a8037-d43d-4919-b019-04d65be2e44b.png">
<img width="281" alt="Screenshot 2023-01-06 at 16 13 40" src="https://user-images.githubusercontent.com/275961/211052989-c1fe982d-624d-4dc9-8816-fbaf17fc22fe.png">


