### PR TITLE
Update push changes to global styles label text to "apply globally"

### DIFF
--- a/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
@@ -97,7 +97,7 @@ function PushChangesToGlobalStylesControl( {
 		createSuccessNotice(
 			sprintf(
 				// translators: %s: Title of the block e.g. 'Heading'.
-				__( 'Pushed styles to all %s blocks.' ),
+				__( 'Applied styles to all %s blocks.' ),
 				getBlockType( name ).title
 			),
 			{

--- a/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
@@ -137,7 +137,7 @@ function PushChangesToGlobalStylesControl( {
 				disabled={ changes.length === 0 }
 				onClick={ pushChanges }
 			>
-				{ __( 'Push changes globally' ) }
+				{ __( 'Apply globally' ) }
 			</Button>
 		</BaseControl>
 	);

--- a/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
@@ -137,7 +137,7 @@ function PushChangesToGlobalStylesControl( {
 				disabled={ changes.length === 0 }
 				onClick={ pushChanges }
 			>
-				{ __( 'Push changes to Global Styles' ) }
+				{ __( 'Push changes globally' ) }
 			</Button>
 		</BaseControl>
 	);

--- a/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
@@ -97,7 +97,7 @@ function PushChangesToGlobalStylesControl( {
 		createSuccessNotice(
 			sprintf(
 				// translators: %s: Title of the block e.g. 'Heading'.
-				__( 'Applied styles to all %s blocks.' ),
+				__( '%s styles updated.' ),
 				getBlockType( name ).title
 			),
 			{
@@ -124,7 +124,7 @@ function PushChangesToGlobalStylesControl( {
 			help={ sprintf(
 				// translators: %s: Title of the block e.g. 'Heading'.
 				__(
-					'Move this block’s typography, spacing, dimensions, and color styles to all %s blocks.'
+					'Apply this block’s typography, spacing, dimensions, and color styles to all %s blocks.'
 				),
 				getBlockType( name ).title
 			) }

--- a/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
@@ -97,7 +97,7 @@ function PushChangesToGlobalStylesControl( {
 		createSuccessNotice(
 			sprintf(
 				// translators: %s: Title of the block e.g. 'Heading'.
-				__( '%s styles updated.' ),
+				__( '%s styles applied.' ),
 				getBlockType( name ).title
 			),
 			{

--- a/test/e2e/specs/site-editor/push-to-global-styles.spec.js
+++ b/test/e2e/specs/site-editor/push-to-global-styles.spec.js
@@ -59,7 +59,7 @@ test.describe( 'Push to Global Styles button', () => {
 		// Push button should be disabled
 		await expect(
 			page.getByRole( 'button', {
-				name: 'Push changes to Global Styles',
+				name: 'Apply globally',
 			} )
 		).toBeDisabled();
 
@@ -69,27 +69,25 @@ test.describe( 'Push to Global Styles button', () => {
 		// Push button should now be enabled
 		await expect(
 			page.getByRole( 'button', {
-				name: 'Push changes to Global Styles',
+				name: 'Apply globally',
 			} )
 		).toBeEnabled();
 
 		// Press the Push button
-		await page
-			.getByRole( 'button', { name: 'Push changes to Global Styles' } )
-			.click();
+		await page.getByRole( 'button', { name: 'Apply globally' } ).click();
 
 		// Snackbar notification should appear
 		await expect(
 			page.getByRole( 'button', {
 				name: 'Dismiss this notice',
-				text: 'Pushed styles to all Heading blocks.',
+				text: 'Applied styles to all Heading blocks.',
 			} )
 		).toBeVisible();
 
 		// Push button should be disabled again
 		await expect(
 			page.getByRole( 'button', {
-				name: 'Push changes to Global Styles',
+				name: 'Apply globally',
 			} )
 		).toBeDisabled();
 

--- a/test/e2e/specs/site-editor/push-to-global-styles.spec.js
+++ b/test/e2e/specs/site-editor/push-to-global-styles.spec.js
@@ -80,7 +80,7 @@ test.describe( 'Push to Global Styles button', () => {
 		await expect(
 			page.getByRole( 'button', {
 				name: 'Dismiss this notice',
-				text: 'Applied styles to all Heading blocks.',
+				text: 'Heading styles updated.',
 			} )
 		).toBeVisible();
 

--- a/test/e2e/specs/site-editor/push-to-global-styles.spec.js
+++ b/test/e2e/specs/site-editor/push-to-global-styles.spec.js
@@ -80,7 +80,7 @@ test.describe( 'Push to Global Styles button', () => {
 		await expect(
 			page.getByRole( 'button', {
 				name: 'Dismiss this notice',
-				text: 'Heading styles updated.',
+				text: 'Heading styles applied.',
 			} )
 		).toBeVisible();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #46928

Renames "Push changes to global styles" to "Apply globally" at the block level in the site editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As raised in #46928, this avoids referring to Global Styles as a proper noun, and instead the label text describes the action.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Update the button label and help text.
* Update the snackbar notification text to say "styles updated".

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open up the site editor, and add a block that can be styled by global styles (e.g. Button block)
2. At the block level, select the button and expand the Advanced area
3. See that the label of the button under Styles now says "Apply globally"
4. Once styles are applied the snackbar notification text should also read "styles updated" instead of "pushed"

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="300" src="https://user-images.githubusercontent.com/26996883/210913526-77cc2bf3-1482-477b-a7da-8e7af09b2867.png" /> | <img width="300" src="https://user-images.githubusercontent.com/14988353/211428568-5fb45e8b-1618-49cf-a3cb-eae3186b78f7.png" /> |

The snackbar notification text is also updated:

<img width="350" src="https://user-images.githubusercontent.com/14988353/211428540-a10de0a0-70e8-4a1e-9d71-3adc8952574a.png" />

