### PR TITLE
REST API: Do not set sidebar status to 'active' when using classic theme

### DIFF
--- a/lib/compat/wordpress-6.2/rest-api.php
+++ b/lib/compat/wordpress-6.2/rest-api.php
@@ -111,8 +111,9 @@ add_action( 'rest_api_init', 'gutenberg_register_global_styles_endpoints' );
  * @return WP_REST_Response $response Updated response object.
  */
 function gutenberg_modify_rest_sidebars_response( $response ) {
-	$response->data['status'] = wp_is_block_theme() ? 'inactive' : 'active';
-
+	if ( wp_is_block_theme() ) {
+		$response->data['status'] = 'inactive';
+	}
 	return $response;
 }
 add_filter( 'rest_prepare_sidebar', 'gutenberg_modify_rest_sidebars_response' );


### PR DESCRIPTION
## What? Why? How?

Fixes an error in https://github.com/WordPress/gutenberg/pull/45509. See https://github.com/WordPress/gutenberg/pull/45509#discussion_r1061978541.

The previous code would set `status = 'inactive'` on the sidebar when using a block theme and `status = 'active'` when using a classic theme. It is correct to set `status = 'inactive'` when using a block theme but if using a classic theme then `status` should **not** be changed.

## Testing Instructions
Same as in https://github.com/WordPress/gutenberg/pull/45509.