### PR TITLE
Cover block: add HTML element selection

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -231,7 +231,7 @@ Add an image or video with a text overlay — great for headers. ([Source](https
 -	**Name:** core/cover
 -	**Category:** media
 -	**Supports:** align, anchor, color (~~background~~, ~~text~~), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** allowedBlocks, alt, backgroundType, contentPosition, customGradient, customOverlayColor, dimRatio, focalPoint, gradient, hasParallax, id, isDark, isRepeated, minHeight, minHeightUnit, overlayColor, templateLock, url, useFeaturedImage
+-	**Attributes:** allowedBlocks, alt, backgroundType, contentPosition, customGradient, customOverlayColor, dimRatio, focalPoint, gradient, hasParallax, id, isDark, isRepeated, minHeight, minHeightUnit, overlayColor, tagName, templateLock, url, useFeaturedImage
 
 ## Embed
 

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -74,6 +74,10 @@
 		"templateLock": {
 			"type": [ "string", "boolean" ],
 			"enum": [ "all", "insert", "contentOnly", false ]
+		},
+		"tagName": {
+			"type": "string",
+			"default": "div"
 		}
 	},
 	"usesContext": [ "postId", "postType" ],

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -94,6 +94,7 @@ function CoverEdit( {
 		alt,
 		allowedBlocks,
 		templateLock,
+		tagName: TagName = 'div',
 	} = attributes;
 
 	const [ featuredImage ] = useEntityProp(
@@ -247,7 +248,7 @@ function CoverEdit( {
 			<>
 				{ blockControls }
 				{ inspectorControls }
-				<div
+				<TagName
 					{ ...blockProps }
 					className={ classnames(
 						'is-placeholder',
@@ -286,7 +287,7 @@ function CoverEdit( {
 						} }
 						showHandle={ isSelected }
 					/>
-				</div>
+				</TagName>
 			</>
 		);
 	}
@@ -308,7 +309,7 @@ function CoverEdit( {
 		<>
 			{ blockControls }
 			{ inspectorControls }
-			<div
+			<TagName
 				{ ...blockProps }
 				className={ classnames( classes, blockProps.className ) }
 				style={ { ...style, ...blockProps.style } }
@@ -399,7 +400,7 @@ function CoverEdit( {
 					toggleUseFeaturedImage={ toggleUseFeaturedImage }
 				/>
 				<div { ...innerBlocksProps } />
-			</div>
+			</TagName>
 		</>
 	);
 }

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -11,6 +11,7 @@ import {
 	RangeControl,
 	TextareaControl,
 	ToggleControl,
+	SelectControl,
 	__experimentalUseCustomUnits as useCustomUnits,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalUnitControl as UnitControl,
@@ -102,6 +103,7 @@ export default function CoverInspectorControls( {
 		minHeight,
 		minHeightUnit,
 		alt,
+		tagName,
 	} = attributes;
 	const {
 		isVideoBackground,
@@ -139,6 +141,27 @@ export default function CoverInspectorControls( {
 	};
 
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();
+
+	const htmlElementMessages = {
+		header: __(
+			'The <header> element should represent introductory content, typically a group of introductory or navigational aids.'
+		),
+		main: __(
+			'The <main> element should be used for the primary content of your document only. '
+		),
+		section: __(
+			"The <section> element should represent a standalone portion of the document that can't be better represented by another element."
+		),
+		article: __(
+			'The <article> element should represent a self-contained, syndicatable portion of the document.'
+		),
+		aside: __(
+			"The <aside> element should represent a portion of a document whose content is only indirectly related to the document's main content."
+		),
+		footer: __(
+			'The <footer> element should represent a footer for its nearest sectioning element (e.g.: <section>, <article>, <main> etc.).'
+		),
+	};
 
 	return (
 		<>
@@ -311,6 +334,26 @@ export default function CoverInspectorControls( {
 						}
 					/>
 				</ToolsPanelItem>
+			</InspectorControls>
+			<InspectorControls __experimentalGroup="advanced">
+				<SelectControl
+					__nextHasNoMarginBottom
+					label={ __( 'HTML element' ) }
+					options={ [
+						{ label: __( 'Default (<div>)' ), value: 'div' },
+						{ label: '<header>', value: 'header' },
+						{ label: '<main>', value: 'main' },
+						{ label: '<section>', value: 'section' },
+						{ label: '<article>', value: 'article' },
+						{ label: '<aside>', value: 'aside' },
+						{ label: '<footer>', value: 'footer' },
+					] }
+					value={ tagName }
+					onChange={ ( value ) =>
+						setAttributes( { tagName: value } )
+					}
+					help={ htmlElementMessages[ tagName ] }
+				/>
 			</InspectorControls>
 		</>
 	);

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -44,6 +44,7 @@ export default function save( { attributes } ) {
 		id,
 		minHeight: minHeightProp,
 		minHeightUnit,
+		tagName: Tag,
 	} = attributes;
 	const overlayColorClass = getColorClassName(
 		'background-color',
@@ -102,7 +103,7 @@ export default function save( { attributes } ) {
 	const gradientValue = gradient || customGradient;
 
 	return (
-		<div { ...useBlockProps.save( { className: classes, style } ) }>
+		<Tag { ...useBlockProps.save( { className: classes, style } ) }>
 			<span
 				aria-hidden="true"
 				className={ classnames(
@@ -163,6 +164,6 @@ export default function save( { attributes } ) {
 					className: 'wp-block-cover__inner-container',
 				} ) }
 			/>
-		</div>
+		</Tag>
 	);
 }

--- a/test/integration/fixtures/blocks/core__cover.json
+++ b/test/integration/fixtures/blocks/core__cover.json
@@ -10,7 +10,8 @@
 			"isRepeated": false,
 			"dimRatio": 40,
 			"backgroundType": "image",
-			"isDark": true
+			"isDark": true,
+			"tagName": "div"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__cover__deprecated-1.json
+++ b/test/integration/fixtures/blocks/core__cover__deprecated-1.json
@@ -7,7 +7,8 @@
 			"id": 34,
 			"hasParallax": false,
 			"dimRatio": 50,
-			"backgroundType": "image"
+			"backgroundType": "image",
+			"tagName": "div"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__cover__deprecated-10.json
+++ b/test/integration/fixtures/blocks/core__cover__deprecated-10.json
@@ -11,7 +11,8 @@
 			"isRepeated": false,
 			"dimRatio": 50,
 			"backgroundType": "image",
-			"isDark": true
+			"isDark": true,
+			"tagName": "div"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__cover__deprecated-2.json
+++ b/test/integration/fixtures/blocks/core__cover__deprecated-2.json
@@ -7,7 +7,8 @@
 			"id": 34,
 			"hasParallax": false,
 			"dimRatio": 50,
-			"backgroundType": "image"
+			"backgroundType": "image",
+			"tagName": "div"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__cover__deprecated-3.json
+++ b/test/integration/fixtures/blocks/core__cover__deprecated-3.json
@@ -7,7 +7,8 @@
 			"id": 35,
 			"hasParallax": false,
 			"dimRatio": 50,
-			"backgroundType": "image"
+			"backgroundType": "image",
+			"tagName": "div"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__cover__deprecated-4.json
+++ b/test/integration/fixtures/blocks/core__cover__deprecated-4.json
@@ -11,7 +11,8 @@
 			"focalPoint": {
 				"x": "0.07",
 				"y": "0.07"
-			}
+			},
+			"tagName": "div"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__cover__deprecated-5.json
+++ b/test/integration/fixtures/blocks/core__cover__deprecated-5.json
@@ -7,7 +7,8 @@
 			"hasParallax": false,
 			"dimRatio": 50,
 			"backgroundType": "image",
-			"gradient": "midnight"
+			"gradient": "midnight",
+			"tagName": "div"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__cover__deprecated-6.json
+++ b/test/integration/fixtures/blocks/core__cover__deprecated-6.json
@@ -7,7 +7,8 @@
 			"hasParallax": false,
 			"dimRatio": 40,
 			"backgroundType": "image",
-			"isRepeated": false
+			"isRepeated": false,
+			"tagName": "div"
 		},
 		"innerBlocks": [
 			{
@@ -40,7 +41,8 @@
 			"isRepeated": false,
 			"minHeight": 48,
 			"minHeightUnit": "vw",
-			"align": "full"
+			"align": "full",
+			"tagName": "div"
 		},
 		"innerBlocks": [
 			{
@@ -65,7 +67,8 @@
 			"backgroundType": "image",
 			"isRepeated": false,
 			"contentPosition": "bottom right",
-			"alt": ""
+			"alt": "",
+			"tagName": "div"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__cover__deprecated-7.json
+++ b/test/integration/fixtures/blocks/core__cover__deprecated-7.json
@@ -8,7 +8,8 @@
 			"dimRatio": 40,
 			"backgroundType": "image",
 			"isRepeated": false,
-			"alt": ""
+			"alt": "",
+			"tagName": "div"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__cover__deprecated-8.json
+++ b/test/integration/fixtures/blocks/core__cover__deprecated-8.json
@@ -9,7 +9,8 @@
 			"isRepeated": false,
 			"dimRatio": 40,
 			"backgroundType": "image",
-			"isDark": true
+			"isDark": true,
+			"tagName": "div"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__cover__deprecated-9.json
+++ b/test/integration/fixtures/blocks/core__cover__deprecated-9.json
@@ -10,7 +10,8 @@
 			"overlayColor": "primary",
 			"backgroundType": "image",
 			"minHeightUnit": "%",
-			"isDark": true
+			"isDark": true,
+			"tagName": "div"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__cover__duotone-fixed-background.json
+++ b/test/integration/fixtures/blocks/core__cover__duotone-fixed-background.json
@@ -12,6 +12,7 @@
 			"dimRatio": 10,
 			"backgroundType": "image",
 			"isDark": false,
+			"tagName": "div",
 			"style": {
 				"color": {
 					"duotone": [ "#8c00b7", "#fcff41" ]

--- a/test/integration/fixtures/blocks/core__cover__gradient-custom.json
+++ b/test/integration/fixtures/blocks/core__cover__gradient-custom.json
@@ -10,7 +10,8 @@
 			"dimRatio": 100,
 			"backgroundType": "image",
 			"customGradient": "linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)",
-			"isDark": true
+			"isDark": true,
+			"tagName": "div"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__cover__gradient-image.json
+++ b/test/integration/fixtures/blocks/core__cover__gradient-image.json
@@ -11,7 +11,8 @@
 			"dimRatio": 30,
 			"backgroundType": "image",
 			"customGradient": "linear-gradient(135deg,rgba(0,208,132,1) 0%,rgba(6,147,227,1) 100%)",
-			"isDark": true
+			"isDark": true,
+			"tagName": "div"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__cover__gradient-video.json
+++ b/test/integration/fixtures/blocks/core__cover__gradient-video.json
@@ -11,7 +11,8 @@
 			"dimRatio": 70,
 			"backgroundType": "video",
 			"customGradient": "linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)",
-			"isDark": true
+			"isDark": true,
+			"tagName": "div"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__cover__gradient.json
+++ b/test/integration/fixtures/blocks/core__cover__gradient.json
@@ -10,7 +10,8 @@
 			"dimRatio": 100,
 			"backgroundType": "image",
 			"gradient": "luminous-dusk",
-			"isDark": false
+			"isDark": false,
+			"tagName": "div"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__cover__gradient__deprecated-8.json
+++ b/test/integration/fixtures/blocks/core__cover__gradient__deprecated-8.json
@@ -9,7 +9,8 @@
 			"dimRatio": 100,
 			"backgroundType": "image",
 			"gradient": "electric-grass",
-			"isDark": false
+			"isDark": false,
+			"tagName": "div"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__cover__solid-color.json
+++ b/test/integration/fixtures/blocks/core__cover__solid-color.json
@@ -10,7 +10,8 @@
 			"dimRatio": 100,
 			"overlayColor": "primary",
 			"backgroundType": "image",
-			"isDark": true
+			"isDark": true,
+			"tagName": "div"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__cover__video-overlay.json
+++ b/test/integration/fixtures/blocks/core__cover__video-overlay.json
@@ -11,7 +11,8 @@
 			"dimRatio": 10,
 			"customOverlayColor": "#3615d9",
 			"backgroundType": "video",
-			"isDark": true
+			"isDark": true,
+			"tagName": "div"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__cover__video.json
+++ b/test/integration/fixtures/blocks/core__cover__video.json
@@ -10,7 +10,8 @@
 			"isRepeated": false,
 			"dimRatio": 40,
 			"backgroundType": "video",
-			"isDark": true
+			"isDark": true,
+			"tagName": "div"
 		},
 		"innerBlocks": [
 			{


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds an option to change the default `<div>` of the cover block to main, header, footer, section, aside, or article.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The cover block is a container, but is missing this option that other container blocks already have.
Fixes https://github.com/WordPress/gutenberg/issues/46926

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Adds a new block attribute that holds a string with the tag name.
- Adds a new select list option under the Advanced panel of the block setting sidebar.

## Testing Instructions
1. Add a cover block in the site editor or block editor.
2. Open the advanced panel in the block settings sidebar.
3. Confirm that there is an HTML element select option.
4. Change the option and confirm that the chosen HTML element is used for the block: both in the editors and on the front.
