### PR TITLE
`MediaUtils`: move `window` access to function bodies

### DIFF
--- a/packages/blob/src/index.js
+++ b/packages/blob/src/index.js
@@ -1,9 +1,4 @@
 /**
- * Browser dependencies
- */
-const { createObjectURL, revokeObjectURL } = window.URL;
-
-/**
  * @type {Record<string, File|undefined>}
  */
 const cache = {};
@@ -16,7 +11,7 @@ const cache = {};
  * @return {string} The blob URL.
  */
 export function createBlobURL( file ) {
-	const url = createObjectURL( file );
+	const url = window.URL.createObjectURL( file );
 
 	cache[ url ] = file;
 
@@ -56,7 +51,7 @@ export function getBlobTypeByURL( url ) {
  */
 export function revokeBlobURL( url ) {
 	if ( cache[ url ] ) {
-		revokeObjectURL( url );
+		window.URL.revokeObjectURL( url );
 	}
 
 	delete cache[ url ];

--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -4,16 +4,16 @@
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-const { wp } = window;
-
 const DEFAULT_EMPTY_GALLERY = [];
 
 /**
  * Prepares the Featured Image toolbars and frames.
  *
- * @return {wp.media.view.MediaFrame.Select} The default media workflow.
+ * @return {window.wp.media.view.MediaFrame.Select} The default media workflow.
  */
 const getFeaturedImageMediaFrame = () => {
+	const { wp } = window;
+
 	return wp.media.view.MediaFrame.Select.extend( {
 		/**
 		 * Enables the Set Featured Image Button.
@@ -73,9 +73,10 @@ const getFeaturedImageMediaFrame = () => {
 /**
  * Prepares the Gallery toolbars and frames.
  *
- * @return {wp.media.view.MediaFrame.Post} The default media workflow.
+ * @return {window.wp.media.view.MediaFrame.Post} The default media workflow.
  */
 const getGalleryDetailsMediaFrame = () => {
+	const { wp } = window;
 	/**
 	 * Custom gallery details frame.
 	 *
@@ -210,6 +211,8 @@ const slimImageObject = ( img ) => {
 };
 
 const getAttachmentsCollection = ( ids ) => {
+	const { wp } = window;
+
 	return wp.media.query( {
 		order: 'ASC',
 		orderby: 'post__in',
@@ -235,6 +238,8 @@ class MediaUpload extends Component {
 		this.onSelect = this.onSelect.bind( this );
 		this.onUpdate = this.onUpdate.bind( this );
 		this.onClose = this.onClose.bind( this );
+
+		const { wp } = window;
 
 		if ( gallery ) {
 			this.buildAndSetGalleryFrame();
@@ -287,6 +292,8 @@ class MediaUpload extends Component {
 			return;
 		}
 
+		const { wp } = window;
+
 		this.lastGalleryValue = value;
 
 		// If a frame already existed remove it.
@@ -324,6 +331,7 @@ class MediaUpload extends Component {
 	 * @return {void}
 	 */
 	buildAndSetFeatureImageFrame() {
+		const { wp } = window;
 		const featuredImageFrame = getFeaturedImageMediaFrame();
 		const attachments = getAttachmentsCollection( this.props.value );
 		const selection = new wp.media.model.Selection( attachments.models, {
@@ -371,6 +379,7 @@ class MediaUpload extends Component {
 	}
 
 	onOpen() {
+		const { wp } = window;
 		const { value } = this.props;
 		this.updateCollection();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Move access to the global `window.wp` object to respective function bodies for the `@wordpress/media-utils` and `@wordpress/blob` packages.

This issue was brought up in the WordPress Slack core-js channel (https://wordpress.slack.com/archives/C5UNMSU4R/p1668693333126039).

## Why?

Currently, it's not possible to use those packages (or packages that depend on them) in a Node.js environment because the global `window` is not available there.

## How?

By moving access to `window.wp` to those functions a Node.js process won't fail during static initialization.

## Testing Instructions

To test whether the import of the `@wordpress/media-utils` package fails create a local project and add the `@wordpress/media-utils` package as a dependency. It's sufficient to just imort that package in a file. I used these steps:

```
$ mkdir arbitrary-project-name && cd arbitrary-project name
$ npm init -y
$ npm i --save @wordpress/media-utils
```

Create a file `index.mjs` which contains the corresponding import

```
import mediaUtils from '@wordpress/media-utils'
```

Then execute `node index.mjs` on the command line.

To test whether this patch fixes the process failure described above use that exact project and link the dependency by using `npm link`.

1. Checkout this branch && cd into `packages/media-utils`
2. run `npm link` (make sure to run `npm build:packages` before)
3. Go back to that local project and run `npm link @wordpress/media-utils` (it may be necessary to do that for `@wordpress/blob`, too).
4. Run `node index.mjs` again