### PR TITLE
Media & Text: set the default width to none

### DIFF
--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -10,7 +10,7 @@
 	"attributes": {
 		"align": {
 			"type": "string",
-			"default": "wide"
+			"default": "none"
 		},
 		"mediaAlt": {
 			"type": "string",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
WIP, testing fixtures/deprecation

Changes the default `align` of the Media & Text block from wide to none.
Fixes https://github.com/WordPress/gutenberg/issues/20941

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Users and developers have reported that the wide alignment is unexpected and that they would prefer it to be set to none by default (see the discussions in the issue)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Updates the default value of the `align` block attribute in block.json

## Testing Instructions
1. Place a Media & text block in the Site Editor or block editor.
2. Confirm that the width is the default content width, not wide.
