### PR TITLE
Lodash: Remove `_.pickBy()` from template deletion

### DIFF
--- a/packages/edit-post/src/components/header/template-title/delete-template.js
+++ b/packages/edit-post/src/components/header/template-title/delete-template.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { pickBy } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
@@ -58,11 +53,10 @@ export default function DeleteTemplate() {
 			template: '',
 		} );
 		const settings = getEditorSettings();
-		const newAvailableTemplates = pickBy(
-			settings.availableTemplates,
-			( _title, id ) => {
-				return id !== template.slug;
-			}
+		const newAvailableTemplates = Object.fromEntries(
+			Object.entries( settings.availableTemplates ?? {} ).filter(
+				( [ id ] ) => id !== template.slug
+			)
 		);
 		updateEditorSettings( {
 			...settings,


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.pickBy()` from the post editor template deletion component. There is just a single usage in that component and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `Object.fromEntries( Object.entries() )` with `Array.prototype.filter()` instead of `_.pickBy()`. 

## Testing Instructions

* Edit a post that uses a custom template.
* Try deleting that template and verify the deletion still works well, and that the list of available templates still appears properly.