### PR TITLE
[WIP] Add Link Control UI to the Nav item block sidebar

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -27,6 +27,7 @@ import {
 	store as blockEditorStore,
 	getColorClassName,
 	useInnerBlocksProps,
+	__experimentalLinkControl as LinkControl,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP } from '@wordpress/url';
 import { useState, useEffect, useRef } from '@wordpress/element';
@@ -46,7 +47,7 @@ import { useMergeRefs } from '@wordpress/compose';
  * Internal dependencies
  */
 import { name } from './block.json';
-import { LinkUI } from './link-ui';
+import { LinkUI, getSuggestionsQuery } from './link-ui';
 import { updateAttributes } from './update-attributes';
 import { getColors } from '../navigation/edit/utils';
 
@@ -406,6 +407,12 @@ export default function NavigationLinkEdit( {
 			? __( 'This item has been deleted, or is a draft' )
 			: __( 'This item is missing a link' );
 
+	const testLink = {
+		url,
+		opensInNewTab: attributes?.opensInNewTab,
+		title: label && stripHTML( label ),
+	};
+
 	return (
 		<>
 			<BlockControls>
@@ -429,7 +436,37 @@ export default function NavigationLinkEdit( {
 			</BlockControls>
 			{ /* Warning, this duplicated in packages/block-library/src/navigation-submenu/edit.js */ }
 			<InspectorControls>
+				{ /* className="wp-block-navigation-link__inline-link-input"
+				clientId={ clientId }
+				link={ attributes }
+				onClose={ () => setIsLinkOpen( false ) }
+				anchor={ popoverAnchor }
+				hasCreateSuggestion={ userCanCreate }
+				onRemove={ removeLink }
+				onChange=
+				{ ( updatedValue ) => {
+					updateAttributes( updatedValue, setAttributes, attributes );
+				} } */ }
+
 				<PanelBody title={ __( 'Link settings' ) }>
+					<LinkControl
+						hasTextControl
+						hasRichPreviews
+						className="wp-block-navigation-link__inline-link-input"
+						value={ testLink }
+						showInitialSuggestions={ true }
+						noDirectEntry={ !! type }
+						noURLSuggestion={ !! type }
+						suggestionsQuery={ getSuggestionsQuery( type, kind ) }
+						onChange={ ( updatedValue ) => {
+							updateAttributes(
+								updatedValue,
+								setAttributes,
+								attributes
+							);
+						} }
+						onRemove={ removeLink }
+					/>
 					<TextControl
 						__nextHasNoMarginBottom
 						value={ label ? stripHTML( label ) : '' }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds the `<LinkControl>` component to the inspector controls sidebar of the Nav Link block.

Closes https://github.com/WordPress/gutenberg/issues/46217

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently (and this is especially problematic when utilising the new offcanvas experiment for the Nav block) it's difficult to edit the link settings once it's been created because you don't have access to the link creation UI.

By adding it to the sidebar we provide this powerful feature.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
