### PR TITLE
Lodash: Remove `_.pickBy()` from editor hooks

### DIFF
--- a/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
+++ b/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { pickBy, mapValues, isEmpty } from 'lodash';
+import { mapValues, isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -70,18 +70,17 @@ const createWithMetaAttributeSource = ( metaAttributes ) =>
 						attributes={ mergedAttributes }
 						setAttributes={ ( nextAttributes ) => {
 							const nextMeta = Object.fromEntries(
-								Object.entries(
-									// Filter to intersection of keys between the updated
-									// attributes and those with an associated meta key.
-									pickBy(
-										nextAttributes,
-										( value, key ) => metaAttributes[ key ]
+								Object.entries( nextAttributes ?? {} )
+									.filter(
+										// Filter to intersection of keys between the updated
+										// attributes and those with an associated meta key.
+										( [ key ] ) => key in metaAttributes
 									)
-								).map( ( [ attributeKey, value ] ) => [
-									// Rename the keys to the expected meta key name.
-									metaAttributes[ attributeKey ],
-									value,
-								] )
+									.map( ( [ attributeKey, value ] ) => [
+										// Rename the keys to the expected meta key name.
+										metaAttributes[ attributeKey ],
+										value,
+									] )
 							);
 
 							if ( ! isEmpty( nextMeta ) ) {
@@ -108,7 +107,11 @@ const createWithMetaAttributeSource = ( metaAttributes ) =>
 function shimAttributeSource( settings ) {
 	/** @type {WPMetaAttributeMapping} */
 	const metaAttributes = mapValues(
-		pickBy( settings.attributes, { source: 'meta' } ),
+		Object.fromEntries(
+			Object.entries( settings.attributes ?? {} ).filter(
+				( [ , { source } ] ) => source === 'meta'
+			)
+		),
 		'meta'
 	);
 	if ( ! isEmpty( metaAttributes ) ) {


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.pickBy()` from the editor hooks. There are just a couple of usages in that block and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `Object.fromEntries( Object.entries() )` with `Array.prototype.filter()` instead of `_.pickBy()`. 

## Testing Instructions

* Navigate to your local Gutenberg's `/packages/e2e-tests/plugins` directory.
* Archive `meta-attributes-block.php` and the `meta-attributes-block` directory.
* Upload the archive as a WP plugin and activate it. Disregard the plugin update prompt.
* Create a new post.
* Insert a "Test Meta Attribute Block (Early Registration)" block.
* Insert a "Test Meta Attribute Block (Late Registration)" block.
* Verify that as you change the content inside the blocks, the custom `my_meta` meta updates on save.
* Verify that as you change the custom meta `my_meta` on save, the content inside the blocks changes.
* Keep an eye out for errors and verify all checks are still green.