### PR TITLE
[List View]: Improve icon alignments and added scroll when blocks are deeply nested.

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -517,4 +517,12 @@
 	& > * {
 		visibility: visible;
 	}
+
+	// Always enable scrollbar on Mobile devices.
+	@media (hover: none) {
+		.scrollable {
+			visibility: visible;
+		}
+	}
+
 }

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -489,11 +489,8 @@
 	/* stylelint-enable function-comma-space-after */
 }
 
-@mixin custom-scrollbars-on-hover() {
+@mixin custom-scrollbars-on-hover($track-color: #1e1e1e, $handle-color: #757575) {
 	visibility: hidden;
-
-	$handle-color: #757575;
-	$track-color: #1e1e1e;
 
 	// WebKit
 	&::-webkit-scrollbar {

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -1,5 +1,9 @@
 .block-editor-list-view-tree {
 	width: 100%;
+	max-width: 100%;
+	overflow-x: auto;
+	@include custom-scrollbars-on-hover(#ffffff);
+	display: block;
 	border-collapse: collapse;
 	padding: 0;
 	margin: 0;
@@ -9,11 +13,18 @@
 		margin: (-$grid-unit-15) (-$grid-unit-15 * 0.5) 0;
 		width: calc(100% + #{ $grid-unit-15 });
 	}
+
+	tbody {
+		display: flex;
+		flex-direction: column;
+	}
 }
 
 .block-editor-list-view-leaf {
 	// Use position relative for row animation.
 	position: relative;
+	display: flex;
+	max-width: $sidebar-width - (2 * $grid-unit-20);
 
 	// The background has to be applied to the td, not tr, or border-radius won't work.
 	&.is-selected td {
@@ -190,6 +201,10 @@
 		flex: 0 0 $icon-size;
 	}
 
+	.block-editor-list-view-block__contents-cell {
+		flex-basis: 100%;
+	}
+
 	.block-editor-list-view-block__menu-cell,
 	.block-editor-list-view-block__mover-cell,
 	.block-editor-list-view-block__contents-cell {
@@ -291,17 +306,24 @@
 	}
 
 	.block-editor-list-view-block-select-button__label-wrapper {
-		min-width: 120px;
+		//min-width: 120px;
 	}
 
 	.block-editor-list-view-block-select-button__title {
-		flex: 1;
-		position: relative;
+		//flex: 1;
+		//position: relative;
+		margin-right: auto;
+		display: inline-flex;
+		align-items: center;
 
 		.components-truncate {
-			position: absolute;
+			//position: absolute;
 			width: 100%;
-			transform: translateY(-50%);
+			//transform: translateY(-50%);
+			display: inline-block;
+			max-width: 120px;
+			text-overflow: ellipsis;
+			overflow: hidden;
 		}
 	}
 

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -25,7 +25,6 @@
 	// Use position relative for row animation.
 	position: relative;
 	display: flex;
-	align-items: center;
 
 	// The background has to be applied to the td, not tr, or border-radius won't work.
 	&.is-selected td {
@@ -244,6 +243,8 @@
 
 	.block-editor-list-view-block__menu-cell {
 		padding-right: $grid-unit-05;
+		display: flex;
+		align-items: center;
 
 		.components-button.has-icon {
 			height: 24px;

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -24,7 +24,6 @@
 	// Use position relative for row animation.
 	position: relative;
 	display: flex;
-	max-width: $sidebar-width - (2 * $grid-unit-20);
 
 	// The background has to be applied to the td, not tr, or border-radius won't work.
 	&.is-selected td {
@@ -305,21 +304,13 @@
 		}
 	}
 
-	.block-editor-list-view-block-select-button__label-wrapper {
-		//min-width: 120px;
-	}
-
 	.block-editor-list-view-block-select-button__title {
-		//flex: 1;
-		//position: relative;
 		margin-right: auto;
 		display: inline-flex;
 		align-items: center;
 
 		.components-truncate {
-			//position: absolute;
 			width: 100%;
-			//transform: translateY(-50%);
 			display: inline-block;
 			max-width: 120px;
 			text-overflow: ellipsis;

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -25,6 +25,7 @@
 	// Use position relative for row animation.
 	position: relative;
 	display: flex;
+	align-items: center;
 
 	// The background has to be applied to the td, not tr, or border-radius won't work.
 	&.is-selected td {

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -292,6 +292,12 @@
 		}
 	}
 
+	.block-editor-block-settings-menu {
+		height: 100%;
+		display: flex;
+		align-items: center;
+	}
+
 	.block-editor-inserter__toggle {
 		background: $gray-900;
 		color: $white;

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -1,12 +1,13 @@
 .block-editor-list-view-tree {
-	width: 100%;
-	max-width: 100%;
+	//extending over the padding of the sidebar so that we don't get the icons cut off
+	width: calc(100% + #{ $grid-unit-20 });
+	max-width: calc(100% + #{ $grid-unit-20 });
+	margin: 0 ($grid-unit-20 * -1) 0 0;
+	padding: 0;
 	overflow-x: auto;
 	@include custom-scrollbars-on-hover(#ffffff);
 	display: block;
 	border-collapse: collapse;
-	padding: 0;
-	margin: 0;
 
 	// Move upwards when in modal.
 	.components-modal__content & {

--- a/packages/block-editor/src/components/off-canvas-editor/index.js
+++ b/packages/block-editor/src/components/off-canvas-editor/index.js
@@ -208,52 +208,50 @@ function __ExperimentalOffCanvasEditor(
 				listViewRef={ elementRef }
 				blockDropTarget={ blockDropTarget }
 			/>
-			<div className="offcanvas-editor-list-view-tree-wrapper">
-				<TreeGrid
-					id={ id }
-					className="block-editor-list-view-tree"
-					aria-label={ __( 'Block navigation structure' ) }
-					ref={ treeGridRef }
-					onCollapseRow={ collapseRow }
-					onExpandRow={ expandRow }
-					onFocusRow={ focusRow }
-					applicationAriaLabel={ __( 'Block navigation structure' ) }
-				>
-					<ListViewContext.Provider value={ contextValue }>
-						<ListViewBranch
-							blocks={ clientIdsTree }
-							selectBlock={ selectEditorBlock }
-							showBlockMovers={ showBlockMovers }
-							fixedListWindow={ fixedListWindow }
-							selectedClientIds={ selectedClientIds }
-							isExpanded={ isExpanded }
-							shouldShowInnerBlocks={ shouldShowInnerBlocks }
-							selectBlockInCanvas={ selectBlockInCanvas }
-						/>
-						<TreeGridRow
-							level={ 1 }
-							setSize={ 1 }
-							positionInSet={ 1 }
-							isExpanded={ true }
-						>
-							<TreeGridCell>
-								{ ( treeGridCellProps ) => (
-									<Appender { ...treeGridCellProps } />
-								) }
-							</TreeGridCell>
-							{ ! clientIdsTree.length && (
-								<TreeGridCell withoutGridItem>
-									<div className="offcanvas-editor-list-view-is-empty">
-										{ __(
-											'Your menu is currently empty. Add your first menu item to get started.'
-										) }
-									</div>
-								</TreeGridCell>
+			<TreeGrid
+				id={ id }
+				className="block-editor-list-view-tree"
+				aria-label={ __( 'Block navigation structure' ) }
+				ref={ treeGridRef }
+				onCollapseRow={ collapseRow }
+				onExpandRow={ expandRow }
+				onFocusRow={ focusRow }
+				applicationAriaLabel={ __( 'Block navigation structure' ) }
+			>
+				<ListViewContext.Provider value={ contextValue }>
+					<ListViewBranch
+						blocks={ clientIdsTree }
+						selectBlock={ selectEditorBlock }
+						showBlockMovers={ showBlockMovers }
+						fixedListWindow={ fixedListWindow }
+						selectedClientIds={ selectedClientIds }
+						isExpanded={ isExpanded }
+						shouldShowInnerBlocks={ shouldShowInnerBlocks }
+						selectBlockInCanvas={ selectBlockInCanvas }
+					/>
+					<TreeGridRow
+						level={ 1 }
+						setSize={ 1 }
+						positionInSet={ 1 }
+						isExpanded={ true }
+					>
+						<TreeGridCell>
+							{ ( treeGridCellProps ) => (
+								<Appender { ...treeGridCellProps } />
 							) }
-						</TreeGridRow>
-					</ListViewContext.Provider>
-				</TreeGrid>
-			</div>
+						</TreeGridCell>
+						{ ! clientIdsTree.length && (
+							<TreeGridCell withoutGridItem>
+								<div className="offcanvas-editor-list-view-is-empty">
+									{ __(
+										'Your menu is currently empty. Add your first menu item to get started.'
+									) }
+								</div>
+							</TreeGridCell>
+						) }
+					</TreeGridRow>
+				</ListViewContext.Provider>
+			</TreeGrid>
 		</AsyncModeProvider>
 	);
 }

--- a/packages/block-editor/src/components/off-canvas-editor/style.scss
+++ b/packages/block-editor/src/components/off-canvas-editor/style.scss
@@ -14,6 +14,11 @@
 	}
 }
 
+.offcanvas-editor-list-view-leaf {
+	// sidebar width - tab panel padding
+	max-width: $sidebar-width - (2 * $grid-unit-20);
+}
+
 .offcanvas-editor-list-view-is-empty {
 	margin-left: $grid-unit-20;
 }

--- a/packages/block-editor/src/components/off-canvas-editor/style.scss
+++ b/packages/block-editor/src/components/off-canvas-editor/style.scss
@@ -17,6 +17,7 @@
 .offcanvas-editor-list-view-tree-wrapper {
 	max-width: 100%;
 	overflow-x: auto;
+	@include custom-scrollbars-on-hover(#ffffff);
 }
 
 .offcanvas-editor-list-view-leaf {

--- a/packages/block-editor/src/components/off-canvas-editor/style.scss
+++ b/packages/block-editor/src/components/off-canvas-editor/style.scss
@@ -14,18 +14,6 @@
 	}
 }
 
-.offcanvas-editor-list-view-tree-wrapper {
-	max-width: 100%;
-	overflow-x: auto;
-	@include custom-scrollbars-on-hover(#ffffff);
-}
-
-.offcanvas-editor-list-view-leaf {
-	display: block;
-	// sidebar width - tab panel padding
-	max-width: $sidebar-width - (2 * $grid-unit-20);
-}
-
 .offcanvas-editor-list-view-is-empty {
 	margin-left: $grid-unit-20;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR makes some changes on how the List View is styled to accommodate better when items are deeply nested. It also includes the CSS scrollbar already implemented in https://github.com/WordPress/gutenberg/pull/45100 that only appears on hover when a scrollbar is needed.
Closes https://github.com/WordPress/gutenberg/issues/46474

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Having the list view show on the right sidebar (which is narrower than the list view) has uncovered some uncomfortable user experience with scrollbars showing very early and icons not being visible or aligned. 


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR implements: 
- a scrollbar that is only visible on hover when the nesting pushes the content
- a refactor of the list view styles so that content is only pushed if absolutely necessary, making it a bit more compact and triggering the scroll only on cases that have deeper nesting

I'm implementing [this codepen](https://codepen.io/joen/pen/RwBPWVX) that @jasmussen worked on for this particular solution and that was discussed  in https://github.com/WordPress/gutenberg/issues/46474

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

We should test both the regular List View and the List View on the right sidebar for the navigation block inspector. There shouldn't be any visual regressions on the list view.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Everything should still be accessible via keyboard on the list view.

## Screenshots or screencast <!-- if applicable -->

Before | After
--- | ---
![Screen Capture on 2023-01-09 at 17-47-06](https://user-images.githubusercontent.com/3593343/211362545-4928e06a-c2f1-4afb-9541-d200b731c379.gif) | ![Screen Capture on 2023-01-09 at 17-40-34](https://user-images.githubusercontent.com/3593343/211362569-2249fc3d-ac91-423f-967d-dd69a3e451cc.gif)


EDIT: This one is blocked for now because it needs further design direction. This approach is heavy-handed and touches on the list view too, and the results are not that much of a visual improvement, in my opinion.