### PR TITLE
Template Parts: Avoid duplicate titles on creation

### DIFF
--- a/packages/edit-site/src/components/add-new-template/new-template-part.js
+++ b/packages/edit-site/src/components/add-new-template/new-template-part.js
@@ -20,6 +20,7 @@ import { plus } from '@wordpress/icons';
 import { useHistory } from '../routes';
 import { store as editSiteStore } from '../../store';
 import CreateTemplatePartModal from '../create-template-part-modal';
+import { useExistingTemplateParts } from './utils';
 
 export default function NewTemplatePart( {
 	postType,
@@ -31,6 +32,7 @@ export default function NewTemplatePart( {
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { __unstableSetCanvasMode } = useDispatch( editSiteStore );
+	const existingTemplateParts = useExistingTemplateParts();
 
 	async function createTemplatePart( { title, area } ) {
 		if ( ! title ) {
@@ -39,6 +41,26 @@ export default function NewTemplatePart( {
 			} );
 			return;
 		}
+
+		const uniqueTitle = () => {
+			const lowercaseTitle = title.toLowerCase();
+			const existingTitles = existingTemplateParts.map(
+				( templatePart ) => templatePart.title.rendered.toLowerCase()
+			);
+
+			if ( ! existingTitles.includes( lowercaseTitle ) ) {
+				return title;
+			}
+
+			let suffix = 2;
+			while (
+				existingTitles.includes( `${ lowercaseTitle } ${ suffix }` )
+			) {
+				suffix++;
+			}
+
+			return `${ title } ${ suffix }`;
+		};
 
 		try {
 			// Currently template parts only allow latin chars.
@@ -52,7 +74,7 @@ export default function NewTemplatePart( {
 				'wp_template_part',
 				{
 					slug: cleanSlug,
-					title,
+					title: uniqueTitle(),
 					content: '',
 					area,
 				},

--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -52,6 +52,20 @@ export const useExistingTemplates = () => {
 	);
 };
 
+export const useExistingTemplateParts = () => {
+	return useSelect(
+		( select ) =>
+			select( coreStore ).getEntityRecords(
+				'postType',
+				'wp_template_part',
+				{
+					per_page: -1,
+				}
+			),
+		[]
+	);
+};
+
 export const useDefaultTemplateTypes = () => {
 	return useSelect(
 		( select ) =>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #42473. Do not allow duplicate titles for template parts when creating a new template part in the UI. Instead add an iterator suffix as is done with slugs.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See #42473 for images. Essentially we don't want users to have a huge list of template parts all with the same name in the UI. It becomes impossible to pick the correct one.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I perform this on the client side at creation time, **although I'm wondering if a filter on the PHP side would be a better approach**? Interested in thoughts.

The same thing needs to happen on conversion of a group of blocks to a template part, this is not yet handled. This would mean needing to separate out the client side code to be used in two separate components. If this is switched to a PHP filter it would just happen automatically, everywhere.

## Testing Instructions
* Open the site editor
* Select template parts in the sidebar and hit the + button.
* Add two or more template parts that have the same name
* Confirm that there is a numerical suffix added to the name of the template part.

![2023-01-09 16 32 07](https://user-images.githubusercontent.com/1464705/211435271-6920a898-c54d-4fae-91da-7661c52b5060.gif)

