### PR TITLE
Fix TreeGrid keyboard nav skipping Edit Block button in off canvas editor

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Bug Fix
 
 -   `Placeholder`: set fixed right margin for label's icon ([46918](https://github.com/WordPress/gutenberg/pull/46918)).
+-   `TreeGrid`: Fix right-arrow keyboard navigation when a row contains more than two focusable elements ([46998](https://github.com/WordPress/gutenberg/pull/46998)).
 
 ## 23.1.0 (2023-01-02)
 

--- a/packages/components/src/tree-grid/index.js
+++ b/packages/components/src/tree-grid/index.js
@@ -150,12 +150,10 @@ function TreeGrid(
 							event.preventDefault();
 							return;
 						}
-						// If a row is focused, and it is expanded, focuses the rightmost cell in the row.
+						// If a row is focused, and it is expanded, focuses the next cell in the row.
 						const focusableItems = getRowFocusables( activeRow );
 						if ( focusableItems.length > 0 ) {
-							focusableItems[
-								focusableItems.length - 1
-							]?.focus();
+							focusableItems[ nextIndex ]?.focus();
 						}
 					}
 					// Prevent key use for anything else. For example, Voiceover


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/issues/46939#issuecomment-1376732975 (second item)

## What?
In the off-canvas editor, pressing the right arrow key when the block is focused should move focus to the Edit Block button. Instead it skips that and moves focus to the block options menu button.

## Why?
I think this came about because List View only has two columns, so the keyboard nav was updated with that in mind, and it didn't cause any issues.

The off-canvas editor generally has three columns, so this problem has become evident.

This fix shouldn't change anything in the main List View, it should just fix the issue in the off-canvas editor.

## How?
Fixes the issue by using the already calculated `nextIndex` instead of always focusing the last item in the row (`focusableItems.length - 1`).

## Testing Instructions for Keyboard
1. Create a new post
2. Tab to the 'Settings' button in the Editor top bar and ensure this is toggled on
3. Tab to the post content and insert a navigation block by typing '/navigation' and pressing enter
4. Tab to the block settings region (or navigate to the region) and tab until you reach the 'Block navigation structure'
5. Hopefully there's at least one block in the navigation structure! Pressing the right-arrow key should first focus the 'Edit x block' button. Pressing right again should focus the 'Options for x block button'

Note that some blocks have don't have an 'Edit x block' button, specifically the inner blocks of a Page List currently don't.

## Screenshots or screencast <!-- if applicable -->

#### Before

https://user-images.githubusercontent.com/677833/211473023-26f48734-654b-440f-a286-14f684f82732.mp4

#### After

https://user-images.githubusercontent.com/677833/211472752-d4b0edb0-2123-4cfd-b3e7-92950f6b0d03.mp4
