### PR TITLE
Zoom out mode: scale iframe instead of contents

### DIFF
--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -237,9 +237,8 @@ function BlockPopoverInbetween( {
 				props.className
 			) }
 			resize={ false }
-			overlay={ true }
 			flip={ false }
-			placement="bottom-start"
+			placement="overlay"
 			variant="unstyled"
 		>
 			<div className="block-editor-block-popover__inbetween-container">

--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -68,53 +68,6 @@ function BlockPopoverInbetween( {
 	const previousElement = useBlockElement( previousClientId );
 	const nextElement = useBlockElement( nextClientId );
 	const isVertical = orientation === 'vertical';
-	const style = useMemo( () => {
-		if (
-			// popoverRecomputeCounter is by definition always equal or greater than 0.
-			// This check is only there to satisfy the correctness of the
-			// exhaustive-deps rule for the `useMemo` hook.
-			popoverRecomputeCounter < 0 ||
-			( ! previousElement && ! nextElement ) ||
-			! isVisible
-		) {
-			return {};
-		}
-
-		const previousRect = previousElement
-			? previousElement.getBoundingClientRect()
-			: null;
-		const nextRect = nextElement
-			? nextElement.getBoundingClientRect()
-			: null;
-
-		if ( isVertical ) {
-			return {
-				width: previousRect ? previousRect.width : nextRect.width,
-				height:
-					nextRect && previousRect
-						? nextRect.top - previousRect.bottom
-						: 0,
-			};
-		}
-
-		let width = 0;
-		if ( previousRect && nextRect ) {
-			width = isRTL()
-				? previousRect.left - nextRect.right
-				: nextRect.left - previousRect.right;
-		}
-
-		return {
-			width,
-			height: previousRect ? previousRect.height : nextRect.height,
-		};
-	}, [
-		previousElement,
-		nextElement,
-		isVertical,
-		popoverRecomputeCounter,
-		isVisible,
-	] );
 
 	const popoverAnchor = useMemo( () => {
 		if (
@@ -142,10 +95,17 @@ function BlockPopoverInbetween( {
 
 				let left = 0;
 				let top = 0;
+				let width = 0;
+				let height = 0;
 
 				if ( isVertical ) {
 					// vertical
 					top = previousRect ? previousRect.bottom : nextRect.top;
+					width = previousRect ? previousRect.width : nextRect.width;
+					height =
+						nextRect && previousRect
+							? nextRect.top - previousRect.bottom
+							: 0;
 
 					if ( isRTL() ) {
 						// vertical, rtl
@@ -158,21 +118,32 @@ function BlockPopoverInbetween( {
 					}
 				} else {
 					top = previousRect ? previousRect.top : nextRect.top;
+					height = previousRect
+						? previousRect.height
+						: nextRect.height;
 
 					if ( isRTL() ) {
 						// non vertical, rtl
 						left = previousRect
 							? previousRect.left
 							: nextRect.right;
+						width =
+							previousRect && nextRect
+								? previousRect.left - nextRect.right
+								: 0;
 					} else {
 						// non vertical, ltr
 						left = previousRect
 							? previousRect.right
 							: nextRect.left;
+						width =
+							previousRect && nextRect
+								? nextRect.left - previousRect.right
+								: 0;
 					}
 				}
 
-				return new window.DOMRect( left, top, 0, 0 );
+				return new window.DOMRect( left, top, width, height );
 			},
 		};
 	}, [
@@ -266,14 +237,12 @@ function BlockPopoverInbetween( {
 				props.className
 			) }
 			resize={ false }
+			overlay={ true }
 			flip={ false }
 			placement="bottom-start"
 			variant="unstyled"
 		>
-			<div
-				className="block-editor-block-popover__inbetween-container"
-				style={ style }
-			>
+			<div className="block-editor-block-popover__inbetween-container">
 				{ children }
 			</div>
 		</Popover>

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -247,6 +247,11 @@ function Iframe( {
 		return '<!doctype html>' + renderToString( styleAssets );
 	}, [] );
 
+	// We need to counter the margin created by scaling the iframe. If the scale
+	// is e.g. 0.45, then the top + bottom margin is 0.55 (1 - scale). Just the
+	// top or bottom margin is 0.55 / 2 ((1 - scale) / 2).
+	const marginFromScaling = ( contentHeight * ( 1 - scale ) ) / 2;
+
 	return (
 		<>
 			{ tabIndex >= 0 && before }
@@ -256,10 +261,10 @@ function Iframe( {
 					...props.style,
 					height: expand ? contentHeight : props.style?.height,
 					marginTop: scale
-						? -( ( contentHeight * ( 1 - scale ) ) / 2 ) + frameSize
+						? -marginFromScaling + frameSize
 						: props.style?.marginTop,
 					marginBottom: scale
-						? -( ( contentHeight * ( 1 - scale ) ) / 2 ) + frameSize
+						? -marginFromScaling + frameSize
 						: props.style?.marginBottom,
 					transform: scale
 						? `scale( ${ scale } )`

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -108,6 +108,7 @@ function Iframe( {
 	tabIndex = 0,
 	scale = 1,
 	frameSize = 0,
+	expand = false,
 	readonly,
 	forwardedRef: ref,
 	...props
@@ -251,6 +252,20 @@ function Iframe( {
 			{ tabIndex >= 0 && before }
 			<iframe
 				{ ...props }
+				style={ {
+					...props.style,
+					height: expand ? contentHeight : props.style?.height,
+					marginTop: scale
+						? -( ( contentHeight * ( 1 - scale ) ) / 2 ) + frameSize
+						: props.style?.marginTop,
+					marginBottom: scale
+						? -( ( contentHeight * ( 1 - scale ) ) / 2 ) + frameSize
+						: props.style?.marginBottom,
+					transform: scale
+						? `scale( ${ scale } )`
+						: props.style?.transform,
+					transition: 'all .3s',
+				} }
 				ref={ useMergeRefs( [ ref, setRef ] ) }
 				tabIndex={ tabIndex }
 				// Correct doctype is required to enable rendering in standards
@@ -265,13 +280,6 @@ function Iframe( {
 							<head ref={ headRef }>
 								{ styleAssets }
 								{ head }
-								<style>
-									{ `html { transition: background 5s; ${
-										frameSize
-											? 'background: #2f2f2f; transition: background 0s;'
-											: ''
-									} }` }
-								</style>
 							</head>
 							<body
 								ref={ bodyRef }
@@ -280,17 +288,6 @@ function Iframe( {
 									'editor-styles-wrapper',
 									...bodyClasses
 								) }
-								style={ {
-									// This is the remaining percentage from the scaling down
-									// of the iframe body(`scale(0.45)`). We also need to subtract
-									// the body's bottom margin.
-									marginBottom: `-${
-										contentHeight * ( 1 - scale ) -
-										frameSize
-									}px`,
-									marginTop: frameSize,
-									transform: `scale( ${ scale } )`,
-								} }
 							>
 								{ contentResizeListener }
 								<StyleProvider document={ iframeDocument }>

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,7 +13,7 @@
 -   `Dropdown`: deprecate `position`  prop, use `popoverProps` instead ([46865](https://github.com/WordPress/gutenberg/pull/46865)).
 -   `Button`: improve padding for buttons with icon and text. ([46764](https://github.com/WordPress/gutenberg/pull/46764)).
 -   `ColorPalette`: Use computed color when css variable is passed to `ColorPicker` ([47181](https://github.com/WordPress/gutenberg/pull/47181)).
--   `Popover`: add `overlay` option to the `placement` prop.
+-   `Popover`: add `overlay` option to the `placement` prop ([47004](https://github.com/WordPress/gutenberg/pull/47004)).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 -   `Dropdown`: deprecate `position`  prop, use `popoverProps` instead ([46865](https://github.com/WordPress/gutenberg/pull/46865)).
 -   `Button`: improve padding for buttons with icon and text. ([46764](https://github.com/WordPress/gutenberg/pull/46764)).
 -   `ColorPalette`: Use computed color when css variable is passed to `ColorPicker` ([47181](https://github.com/WordPress/gutenberg/pull/47181)).
+-   `Popover`: add `overlay` option to the `placement` prop.
 
 ### Internal
 
@@ -29,6 +30,7 @@
 -   `QueryControls`: Convert to TypeScript ([#46721](https://github.com/WordPress/gutenberg/pull/46721)).
 -   `TreeGrid`: Convert to TypeScript ([#47516](https://github.com/WordPress/gutenberg/pull/47516)).
 -   `Notice`: refactor to TypeScript ([47118](https://github.com/WordPress/gutenberg/pull/47118)).
+-   `Popover`: Take iframe element scaling into account.
 
 ### Bug Fix
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -30,7 +30,7 @@
 -   `QueryControls`: Convert to TypeScript ([#46721](https://github.com/WordPress/gutenberg/pull/46721)).
 -   `TreeGrid`: Convert to TypeScript ([#47516](https://github.com/WordPress/gutenberg/pull/47516)).
 -   `Notice`: refactor to TypeScript ([47118](https://github.com/WordPress/gutenberg/pull/47118)).
--   `Popover`: Take iframe element scaling into account.
+-   `Popover`: Take iframe element scaling into account ([47004](https://github.com/WordPress/gutenberg/pull/47004)).
 
 ### Bug Fix
 

--- a/packages/components/src/popover/README.md
+++ b/packages/components/src/popover/README.md
@@ -196,9 +196,12 @@ A callback invoked when the popover should be closed.
 
 -   Required: No
 
-### `placement`: `'top' | 'top-start' | 'top-end' | 'right' | 'right-start' | 'right-end' | 'bottom' | 'bottom-start' | 'bottom-end' | 'left' | 'left-start' | 'left-end'`
+### `placement`: `'top' | 'top-start' | 'top-end' | 'right' | 'right-start' | 'right-end' | 'bottom' | 'bottom-start' | 'bottom-end' | 'left' | 'left-start' | 'left-end' | 'overlay'`
 
 Used to specify the popover's position with respect to its anchor.
+
+`overlay` is a special case that places the popover over the reference element.
+Please note that other placement related props may not behave as excepted.
 
 -   Required: No
 -   Default: `"bottom-start"`

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -183,6 +183,7 @@ const UnforwardedPopover = (
 		resize = true,
 		shift = false,
 		variant,
+		overlay = false,
 
 		// Deprecated props
 		__unstableForcePosition,
@@ -272,6 +273,14 @@ const UnforwardedPopover = (
 	const middleware = [
 		// Custom middleware which adjusts the popover's position by taking into
 		// account the offset of the anchor's iframe (if any) compared to the page.
+		overlay
+			? {
+					name: 'overlay',
+					fn( { rects }: MiddlewareArguments ) {
+						return rects.reference;
+					},
+			  }
+			: undefined,
 		{
 			name: 'frameOffset',
 			fn( { x, y }: MiddlewareArguments ) {
@@ -308,6 +317,24 @@ const UnforwardedPopover = (
 						Object.assign( firstElementChild.style, {
 							maxHeight: `${ sizeProps.availableHeight }px`,
 							overflow: 'auto',
+						} );
+					},
+			  } )
+			: undefined,
+		overlay
+			? size( {
+					apply( { rects } ) {
+						const { firstElementChild } =
+							refs.floating.current ?? {};
+
+						// Only HTMLElement instances have the `style` property.
+						if ( ! ( firstElementChild instanceof HTMLElement ) )
+							return;
+
+						// Reduce the height of the popover to the available space.
+						Object.assign( firstElementChild.style, {
+							width: `${ rects.reference.width }px`,
+							height: `${ rects.reference.height }px`,
 						} );
 					},
 			  } )

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -366,9 +366,9 @@ const UnforwardedPopover = (
 		middlewareData: { arrow: arrowData },
 	} = useFloating( {
 		placement:
-			( normalizedPlacementFromProps === 'overlay'
+			normalizedPlacementFromProps === 'overlay'
 				? undefined
-				: normalizedPlacementFromProps ) || 'bottom',
+				: normalizedPlacementFromProps,
 		middleware,
 		whileElementsMounted: ( referenceParam, floatingParam, updateParam ) =>
 			autoUpdate( referenceParam, floatingParam, updateParam, {

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -392,15 +392,10 @@ const UnforwardedPopover = (
 	} = useFloating( {
 		placement: normalizedPlacementFromProps,
 		middleware,
-		whileElementsMounted: (
-			referenceParam,
-			floatingParam,
-			updateParam
-		) => {
-			return autoUpdate( referenceParam, floatingParam, updateParam, {
+		whileElementsMounted: ( referenceParam, floatingParam, updateParam ) =>
+			autoUpdate( referenceParam, floatingParam, updateParam, {
 				animationFrame: true,
-			} );
-		},
+			} ),
 	} );
 
 	const arrowCallbackRef = useCallback(

--- a/packages/components/src/popover/overlay-middlewares.tsx
+++ b/packages/components/src/popover/overlay-middlewares.tsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { size, MiddlewareArguments } from '@floating-ui/react-dom';
+
+export function overlayMiddlewares() {
+	return [
+		{
+			name: 'overlay',
+			fn( { rects }: MiddlewareArguments ) {
+				return rects.reference;
+			},
+		},
+		size( {
+			apply( { rects, elements } ) {
+				const { firstElementChild } = elements.floating ?? {};
+
+				// Only HTMLElement instances have the `style` property.
+				if ( ! ( firstElementChild instanceof HTMLElement ) ) return;
+
+				// Reduce the height of the popover to the available space.
+				Object.assign( firstElementChild.style, {
+					width: `${ rects.reference.width }px`,
+					height: `${ rects.reference.height }px`,
+				} );
+			},
+		} ),
+	];
+}

--- a/packages/components/src/popover/stories/index.tsx
+++ b/packages/components/src/popover/stories/index.tsx
@@ -31,6 +31,7 @@ const AVAILABLE_PLACEMENTS: PopoverProps[ 'placement' ][] = [
 	'left',
 	'left-start',
 	'left-end',
+	'overlay',
 ];
 
 const meta: ComponentMeta< typeof Popover > = {
@@ -170,7 +171,12 @@ export const AllPlacements: ComponentStory< typeof Popover > = ( {
 		</h2>
 		<div>
 			{ AVAILABLE_PLACEMENTS.map( ( p ) => (
-				<PopoverWithAnchor key={ p } placement={ p } { ...args }>
+				<PopoverWithAnchor
+					key={ p }
+					placement={ p }
+					{ ...args }
+					resize={ p === 'overlay' ? true : args.resize }
+				>
 					{ children }
 					<div>
 						<small>(placement: { p })</small>

--- a/packages/components/src/popover/types.ts
+++ b/packages/components/src/popover/types.ts
@@ -12,8 +12,10 @@ type DomRectWithOwnerDocument = DOMRect & {
 	ownerDocument?: Document;
 };
 
+type PopoverPlacement = Placement | 'overlay';
+
 export type AnimatedWrapperProps = {
-	placement: Placement;
+	placement: PopoverPlacement;
 	shouldAnimate?: boolean;
 };
 
@@ -111,7 +113,7 @@ export type PopoverProps = {
 	 *
 	 * @default 'bottom-start'
 	 */
-	placement?: Placement;
+	placement?: PopoverPlacement;
 	/**
 	 * Legacy way to specify the popover's position with respect to its anchor.
 	 * _Note: this prop is deprecated. Use the `placement` prop instead._

--- a/packages/components/src/popover/types.ts
+++ b/packages/components/src/popover/types.ts
@@ -148,6 +148,13 @@ export type PopoverProps = {
 	 * @default undefined
 	 */
 	variant?: 'unstyled' | 'toolbar';
+	/**
+	 * Places the popover over the reference rectangle and adjusts its size to
+	 * fit it exactly.
+	 *
+	 * @default false
+	 */
+	overlay?: boolean;
 	// Deprecated props
 	/**
 	 * Prevent the popover from flipping and resizing when meeting the viewport

--- a/packages/components/src/popover/types.ts
+++ b/packages/components/src/popover/types.ts
@@ -150,13 +150,6 @@ export type PopoverProps = {
 	 * @default undefined
 	 */
 	variant?: 'unstyled' | 'toolbar';
-	/**
-	 * Places the popover over the reference rectangle and adjusts its size to
-	 * fit it exactly.
-	 *
-	 * @default false
-	 */
-	overlay?: boolean;
 	// Deprecated props
 	/**
 	 * Prevent the popover from flipping and resizing when meeting the viewport

--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -33,6 +33,7 @@ function EditorCanvas( { enableResizing, settings, children, ...props } ) {
 	const mouseMoveTypingRef = useMouseMoveTypingReset();
 	return (
 		<Iframe
+			expand={ isZoomOutMode }
 			scale={ ( isZoomOutMode && 0.45 ) || undefined }
 			frameSize={ isZoomOutMode ? 100 : undefined }
 			style={ enableResizing ? {} : deviceStyles }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR moves the scaling from zoom out mode from the iframe body to the frame element.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We should avoid adding styles such as margin, height and positioning _inside_ the iframe as it might interfere with theme styles.

See also #46929.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

One important detail: I refactored the in between inserter by moving the width/height calculation inside the popover ref and adding a new popover prop "overlay" to tell it to overlay this reference.

The problem with the current approach is that when the width is calculated in the in between inserted, it isn't scaled.

In any case, I find this new approach a bit clearer, it clears up some in between inserter logic.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Enable the zoomed out mode experiment. Go to the site editor and toggle it. Ensure popovers are positioned correctly and scrolling works as expected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
