### PR TITLE
Navigation: Add a manage menus button to the menu selector dropdown

### DIFF
--- a/packages/block-library/src/navigation/edit/manage-menus-button.js
+++ b/packages/block-library/src/navigation/edit/manage-menus-button.js
@@ -2,20 +2,31 @@
  * WordPress dependencies
  */
 import { addQueryArgs } from '@wordpress/url';
-import { Button } from '@wordpress/components';
+import { Button, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-const ManageMenusButton = ( { className = '', disabled } ) => (
-	<Button
-		variant="link"
-		disabled={ disabled }
-		className={ className }
-		href={ addQueryArgs( 'edit.php', {
-			post_type: 'wp_navigation',
-		} ) }
-	>
-		{ __( 'Manage menus' ) }
-	</Button>
-);
+const ManageMenusButton = ( {
+	className = '',
+	disabled,
+	isMenuItem = false,
+} ) => {
+	let ComponentName = Button;
+	if ( isMenuItem ) {
+		ComponentName = MenuItem;
+	}
+
+	return (
+		<ComponentName
+			variant="link"
+			disabled={ disabled }
+			className={ className }
+			href={ addQueryArgs( 'edit.php', {
+				post_type: 'wp_navigation',
+			} ) }
+		>
+			{ __( 'Manage menus' ) }
+		</ComponentName>
+	);
+};
 
 export default ManageMenusButton;

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -67,6 +67,7 @@ const ExperimentControls = ( props ) => {
 		onCreateNew,
 		onSelectClassicMenu,
 		onSelectNavigationMenu,
+		isManageMenusButtonDisabled,
 	} = props;
 
 	return (
@@ -88,6 +89,7 @@ const ExperimentControls = ( props ) => {
 					}
 					createNavigationMenuIsError={ createNavigationMenuIsError }
 					actionLabel={ actionLabel }
+					isManageMenusButtonDisabled={ isManageMenusButtonDisabled }
 				/>
 			</HStack>
 			<ExperimentMainContent { ...props } />
@@ -116,6 +118,7 @@ const DefaultControls = ( props ) => {
 				createNavigationMenuIsSuccess={ createNavigationMenuIsSuccess }
 				createNavigationMenuIsError={ createNavigationMenuIsError }
 				actionLabel={ actionLabel }
+				isManageMenusButtonDisabled={ isManageMenusButtonDisabled }
 			/>
 			<ManageMenusButton disabled={ isManageMenusButtonDisabled } />
 		</>

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -20,6 +20,7 @@ import { useEffect, useMemo, useState } from '@wordpress/element';
  */
 import useNavigationMenu from '../use-navigation-menu';
 import useNavigationEntities from '../use-navigation-entities';
+import ManageMenusButton from './manage-menus-button';
 
 function NavigationMenuSelector( {
 	currentMenuId,
@@ -30,6 +31,7 @@ function NavigationMenuSelector( {
 	createNavigationMenuIsSuccess,
 	createNavigationMenuIsError,
 	toggleProps = {},
+	isManageMenusButtonDisabled,
 } ) {
 	const isOffCanvasNavigationEditorEnabled =
 		window?.__experimentalEnableOffCanvasNavigationEditor === true;
@@ -234,6 +236,14 @@ function NavigationMenuSelector( {
 							>
 								{ __( 'Create new menu' ) }
 							</MenuItem>
+							{ isOffCanvasNavigationEditorEnabled && (
+								<ManageMenusButton
+									isManageMenusButtonDisabled={
+										isManageMenusButtonDisabled
+									}
+									isMenuItem={ true }
+								/>
+							) }
 						</MenuGroup>
 					) }
 				</>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The adds the "manage menus" button to the navigation menu selector component when the offcanvas editor is enabled.

## Why?
We should give users a way to manage their menus.

## How?
This requires a slight change to the ManageMenusButton component, to switch it to use a MenuItem rather than a Button.

## Testing Instructions
1. Enable the offcanvaseditor experiment
2. Add a navigation block to a new post
3. Open the "Menu" section in the inspector controls
4. Open the "Select menu" drop down
5. Confirm that there is a "manage menus" option in the dropdown.

### Testing Instructions for Keyboard
As above.

## Screenshots or screencast <!-- if applicable -->
<img width="292" alt="Screenshot 2023-01-10 at 10 57 39" src="https://user-images.githubusercontent.com/275961/211533554-a11546fb-04e8-4a8d-b7df-5ee07de35242.png">
