### PR TITLE
Navigation: Add more explicit labels to the Navigation Menu Selector

### DIFF
--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -69,7 +69,10 @@ function NavigationMenuSelector( {
 			navigationMenus?.map( ( { id, title } ) => {
 				const label = decodeEntities( title.rendered );
 				if ( id === currentMenuId && ! isCreatingMenu ) {
-					setSelectorLabel( currentTitle );
+					setSelectorLabel(
+						/* translators: %s is the name of a navigation menu. */
+						sprintf( __( 'You are currently editing %s' ), label )
+					);
 					setEnableOptions( shouldEnableMenuSelector );
 				}
 				return {
@@ -102,7 +105,7 @@ function NavigationMenuSelector( {
 		if ( ! hasResolvedNavigationMenus ) {
 			setSelectorLabel( __( 'Loading …' ) );
 		} else if ( noMenuSelected || noBlockMenus || menuUnavailable ) {
-			setSelectorLabel( __( 'Select menu' ) );
+			setSelectorLabel( __( 'Choose a Navigation menu' ) );
 			setEnableOptions( shouldEnableMenuSelector );
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The labels for the Navigation Menu Selector are very opaque. This improves them to help explain what they do.

## Why?
This will particularly help keyboard users, although it will be useful for all.

## How?
Updating the labels with more context.

## Testing Instructions
1. Enable the offcanvaseditor experiment
2. Remove all your navigation menus (from /wp-admin/edit.php?post_type=wp_navigation)
3. Add a navigation block to a new post
4. Open the "Menu" section in the inspector controls
5. Hover the "three dots"
6. Check that the title text says "Choose a Navigation menu"
7. Create a new menu
8. Check that you now have a navigation menu selected and the title text says "You are currently editing %NAVIGATION_NAME%

### Testing Instructions for Keyboard
As above.

## Screenshots or screencast <!-- if applicable -->
<img width="306" alt="Screenshot 2023-01-10 at 11 35 51" src="https://user-images.githubusercontent.com/275961/211541851-438bd70c-a45a-430f-8413-8651d9c8c02e.png">

<img width="367" alt="Screenshot 2023-01-10 at 11 35 29" src="https://user-images.githubusercontent.com/275961/211541879-93e6ca4c-c7be-4f4c-add0-ba0960218de9.png">


