### PR TITLE
RSS: Correctly output 'datetime' string

### DIFF
--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -48,7 +48,7 @@ function render_block_core_rss( $attributes ) {
 			if ( $date ) {
 				$date = sprintf(
 					'<time datetime="%1$s" class="wp-block-rss__item-publish-date">%2$s</time> ',
-					esc_attr( date_i18n( get_option( 'c' ), $date ) ),
+					esc_attr( date_i18n( 'c', $date ) ),
 					esc_attr( date_i18n( get_option( 'date_format' ), $date ) )
 				);
 			}


### PR DESCRIPTION
## What?
Fixes #47000.

PR fixes the `datetime` output for the RSS block.

## Why?
The `date_i18n` requires the correct format string, but the `get_option( 'c' )` doesn't exist and returns false, preventing the date output.

## How?

I've updated to code, and now the format is passed directly.

## Testing Instructions
1. Open a Post or Page.
2. Insert an RSS Block.
3. Set feed URL. Example - `https://make.wordpress.org/core`
4. Toggle "Display date" from the settings.
5. Confirm that the `datetime` attribute is correctly set. It's easier to check this by DevTools Inspector.

## Screenshots or screencast <!-- if applicable -->
**Before**
![CleanShot 2023-01-10 at 16 55 41](https://user-images.githubusercontent.com/240569/211558074-51c1cd91-12fb-43fe-bc96-3d5298d69036.png)

**After**
![CleanShot 2023-01-10 at 16 56 07](https://user-images.githubusercontent.com/240569/211558089-cf86df85-20fa-4d66-9944-bf8147cca761.png)
