### PR TITLE
Navigation Block List View: Improve the accessible Name of the Tree Grid inside the component.

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/index.js
+++ b/packages/block-editor/src/components/off-canvas-editor/index.js
@@ -216,6 +216,7 @@ function OffCanvasEditor(
 					onCollapseRow={ collapseRow }
 					onExpandRow={ expandRow }
 					onFocusRow={ focusRow }
+					// eslint-disable-next-line jsx-a11y/aria-props
 					aria-description={ description }
 				>
 					<ListViewContext.Provider value={ contextValue }>

--- a/packages/block-editor/src/components/off-canvas-editor/index.js
+++ b/packages/block-editor/src/components/off-canvas-editor/index.js
@@ -60,10 +60,18 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
  * @param {boolean} props.showBlockMovers Flag to enable block movers
  * @param {boolean} props.isExpanded      Flag to determine whether nested levels are expanded by default.
  * @param {Object}  props.LeafMoreMenu    Optional more menu substitution.
+ * @param {string}  props.description         Optional accessible description for the tree grid component.
  * @param {Object}  ref                   Forwarded ref
  */
 function OffCanvasEditor(
-	{ id, blocks, showBlockMovers = false, isExpanded = false, LeafMoreMenu },
+	{
+		id,
+		blocks,
+		showBlockMovers = false,
+		isExpanded = false,
+		LeafMoreMenu,
+		description = __( 'Block navigation structure' ),
+	},
 	ref
 ) {
 	const { clientIdsTree, draggedClientIds, selectedClientIds } =
@@ -208,7 +216,7 @@ function OffCanvasEditor(
 					onCollapseRow={ collapseRow }
 					onExpandRow={ expandRow }
 					onFocusRow={ focusRow }
-					applicationAriaLabel={ __( 'Block navigation structure' ) }
+					aria-description={ description }
 				>
 					<ListViewContext.Provider value={ contextValue }>
 						<ListViewBranch

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -13,7 +13,7 @@ import {
 	Spinner,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -22,6 +22,7 @@ import NavigationMenuSelector from './navigation-menu-selector';
 import { LeafMoreMenu } from '../leaf-more-menu';
 import { unlock } from '../../experiments';
 import DeletedNavigationWarning from './deleted-navigation-warning';
+import useNavigationMenu from '../use-navigation-menu';
 
 /* translators: %s: The name of a menu. */
 const actionLabel = __( "Switch to '%s'" );
@@ -43,6 +44,7 @@ const MainContent = ( {
 		},
 		[ clientId ]
 	);
+	const { navigationMenu } = useNavigationMenu( currentMenuId );
 
 	if ( currentMenuId && isNavigationMenuMissing ) {
 		return <p>{ __( 'Select or create a menu' ) }</p>;
@@ -56,11 +58,19 @@ const MainContent = ( {
 		return <Spinner />;
 	}
 
+	const description = navigationMenu
+		? sprintf(
+				/* translators: %s: The name of a menu. */
+				__( 'Structure for navigation menu: %s' ),
+				navigationMenu?.title || __('Untitled menu')
+		  )
+		: __( 'You have not yet created any menus. Displaying a list of your Pages' );
 	return (
 		<OffCanvasEditor
 			blocks={ clientIdsTree }
 			isExpanded={ true }
 			LeafMoreMenu={ LeafMoreMenu }
+			description={ description }
 		/>
 	);
 };

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -62,7 +62,7 @@ const MainContent = ( {
 		? sprintf(
 				/* translators: %s: The name of a menu. */
 				__( 'Structure for navigation menu: %s' ),
-				navigationMenu?.title || __('Untitled menu')
+				navigationMenu?.title || __( 'Untitled menu' )
 		  )
 		: __( 'You have not yet created any menus. Displaying a list of your Pages' );
 	return (

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -64,7 +64,9 @@ const MainContent = ( {
 				__( 'Structure for navigation menu: %s' ),
 				navigationMenu?.title || __( 'Untitled menu' )
 		  )
-		: __( 'You have not yet created any menus. Displaying a list of your Pages' );
+		: __(
+				'You have not yet created any menus. Displaying a list of your Pages'
+		  );
 	return (
 		<OffCanvasEditor
 			blocks={ clientIdsTree }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This makes it possible to modify the name of the OffCanvasEditor component, so that it can be customized to the context it's being used in.

## Why?
The previous label doesn't make sense in the Navigation List View context.

## How?
Adds a prop to the OffCanvasEditor component. The List View component should also get this prop if this is the right way to achieve this.

### Testing Instructions for Keyboard
1. Enable the OffCanvasEditor experiment
2. Create a new post
3. Add a navigation block
4. Open the inspector controls
5. Select the "List View" panel - "role"="application", "label"="No navigation menu selected, displaying Page List"
6. Check that the label changes when you change the selected navigation menu, using the "Select menu" dropdown.

Fixes https://github.com/WordPress/gutenberg/issues/47022