### PR TITLE
Add custom label to nav block list view appender

### DIFF
--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -30,18 +30,25 @@ const defaultRenderToggle = ( {
 	hasSingleBlockType,
 	toggleProps = {},
 	prioritizePatterns,
+	label,
 } ) => {
-	let label;
-	if ( hasSingleBlockType ) {
-		label = sprintf(
+	let buttonLabel;
+
+	if ( label ) {
+		buttonLabel = label;
+	} else if ( hasSingleBlockType ) {
+		buttonLabel = sprintf(
 			// translators: %s: the name of the block when there is only one
 			_x( 'Add %s', 'directly add the only allowed block' ),
 			blockTitle
 		);
 	} else if ( prioritizePatterns ) {
-		label = __( 'Add pattern' );
+		buttonLabel = __( 'Add pattern' );
 	} else {
-		label = _x( 'Add block', 'Generic label for block inserter button' );
+		buttonLabel = _x(
+			'Add block',
+			'Generic label for block inserter button'
+		);
 	}
 
 	const { onClick, ...rest } = toggleProps;
@@ -59,7 +66,7 @@ const defaultRenderToggle = ( {
 	return (
 		<Button
 			icon={ plus }
-			label={ label }
+			label={ buttonLabel }
 			tooltipPosition="bottom"
 			onClick={ handleClick }
 			className="block-editor-inserter__toggle"
@@ -109,6 +116,7 @@ class Inserter extends Component {
 			hasItems,
 			renderToggle = defaultRenderToggle,
 			prioritizePatterns,
+			toggleLabel,
 		} = this.props;
 
 		return renderToggle( {
@@ -120,6 +128,7 @@ class Inserter extends Component {
 			directInsertBlock,
 			toggleProps,
 			prioritizePatterns,
+			label: toggleLabel,
 		} );
 	}
 

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -10,9 +10,14 @@ import { speak } from '@wordpress/a11y';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { Dropdown, Button } from '@wordpress/components';
 import { Component } from '@wordpress/element';
-import { withDispatch, withSelect } from '@wordpress/data';
+import { useSelect, withDispatch, withSelect } from '@wordpress/data';
 import { compose, ifCondition } from '@wordpress/compose';
-import { createBlock, store as blocksStore } from '@wordpress/blocks';
+import {
+	createBlock,
+	store as blocksStore,
+	__experimentalGetBlockLabel as getBlockLabel,
+	getBlockType,
+} from '@wordpress/blocks';
 import { plus } from '@wordpress/icons';
 
 /**
@@ -21,6 +26,15 @@ import { plus } from '@wordpress/icons';
 import InserterMenu from './menu';
 import QuickInserter from './quick-inserter';
 import { store as blockEditorStore } from '../../store';
+
+// Duplicated from elsewhere.
+function getBlockDisplayText( block ) {
+	if ( block ) {
+		const blockType = getBlockType( block.name );
+		return blockType ? getBlockLabel( blockType, block.attributes ) : null;
+	}
+	return null;
+}
 
 const defaultRenderToggle = ( {
 	onToggle,
@@ -31,10 +45,19 @@ const defaultRenderToggle = ( {
 	toggleProps = {},
 	prioritizePatterns,
 	label,
+	rootClientId,
 } ) => {
-	let buttonLabel;
+	const {
+		getBlock,
+	} = useSelect( blockEditorStore );
+	const rootBlock = getBlock( rootClientId );
+	const rootBlockTitle = getBlockDisplayText( rootBlock );
 
-	if ( label ) {
+	let buttonLabel;
+	if ( rootBlockTitle ) {
+		/* translators: %s is a block name, e.g. Navigation */
+		buttonLabel = sprintf( __('Add block to %s' ), rootBlockTitle );
+	} else if ( label ) {
 		buttonLabel = label;
 	} else if ( hasSingleBlockType ) {
 		buttonLabel = sprintf(
@@ -117,6 +140,8 @@ class Inserter extends Component {
 			renderToggle = defaultRenderToggle,
 			prioritizePatterns,
 			toggleLabel,
+			clientId,
+			rootClientId,
 		} = this.props;
 
 		return renderToggle( {
@@ -129,6 +154,8 @@ class Inserter extends Component {
 			toggleProps,
 			prioritizePatterns,
 			label: toggleLabel,
+			clientId,
+			rootClientId,
 		} );
 	}
 

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -10,14 +10,9 @@ import { speak } from '@wordpress/a11y';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { Dropdown, Button } from '@wordpress/components';
 import { Component } from '@wordpress/element';
-import { useSelect, withDispatch, withSelect } from '@wordpress/data';
+import { withDispatch, withSelect } from '@wordpress/data';
 import { compose, ifCondition } from '@wordpress/compose';
-import {
-	createBlock,
-	store as blocksStore,
-	__experimentalGetBlockLabel as getBlockLabel,
-	getBlockType,
-} from '@wordpress/blocks';
+import { createBlock, store as blocksStore } from '@wordpress/blocks';
 import { plus } from '@wordpress/icons';
 
 /**
@@ -27,15 +22,6 @@ import InserterMenu from './menu';
 import QuickInserter from './quick-inserter';
 import { store as blockEditorStore } from '../../store';
 
-// Duplicated from elsewhere.
-function getBlockDisplayText( block ) {
-	if ( block ) {
-		const blockType = getBlockType( block.name );
-		return blockType ? getBlockLabel( blockType, block.attributes ) : null;
-	}
-	return null;
-}
-
 const defaultRenderToggle = ( {
 	onToggle,
 	disabled,
@@ -44,34 +30,18 @@ const defaultRenderToggle = ( {
 	hasSingleBlockType,
 	toggleProps = {},
 	prioritizePatterns,
-	label,
-	rootClientId,
 } ) => {
-	const {
-		getBlock,
-	} = useSelect( blockEditorStore );
-	const rootBlock = getBlock( rootClientId );
-	const rootBlockTitle = getBlockDisplayText( rootBlock );
-
-	let buttonLabel;
-	if ( rootBlockTitle ) {
-		/* translators: %s is a block name, e.g. Navigation */
-		buttonLabel = sprintf( __('Add block to %s' ), rootBlockTitle );
-	} else if ( label ) {
-		buttonLabel = label;
-	} else if ( hasSingleBlockType ) {
-		buttonLabel = sprintf(
+	let label;
+	if ( hasSingleBlockType ) {
+		label = sprintf(
 			// translators: %s: the name of the block when there is only one
 			_x( 'Add %s', 'directly add the only allowed block' ),
 			blockTitle
 		);
 	} else if ( prioritizePatterns ) {
-		buttonLabel = __( 'Add pattern' );
+		label = __( 'Add pattern' );
 	} else {
-		buttonLabel = _x(
-			'Add block',
-			'Generic label for block inserter button'
-		);
+		label = _x( 'Add block', 'Generic label for block inserter button' );
 	}
 
 	const { onClick, ...rest } = toggleProps;
@@ -89,7 +59,7 @@ const defaultRenderToggle = ( {
 	return (
 		<Button
 			icon={ plus }
-			label={ buttonLabel }
+			label={ label }
 			tooltipPosition="bottom"
 			onClick={ handleClick }
 			className="block-editor-inserter__toggle"
@@ -139,9 +109,6 @@ class Inserter extends Component {
 			hasItems,
 			renderToggle = defaultRenderToggle,
 			prioritizePatterns,
-			toggleLabel,
-			clientId,
-			rootClientId,
 		} = this.props;
 
 		return renderToggle( {
@@ -153,9 +120,6 @@ class Inserter extends Component {
 			directInsertBlock,
 			toggleProps,
 			prioritizePatterns,
-			label: toggleLabel,
-			clientId,
-			rootClientId,
 		} );
 	}
 

--- a/packages/block-editor/src/components/off-canvas-editor/appender.js
+++ b/packages/block-editor/src/components/off-canvas-editor/appender.js
@@ -10,6 +10,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import useBlockDisplayTitle from '../block-title/use-block-display-title';
 import Inserter from '../inserter';
 
 export const Appender = forwardRef(
@@ -32,14 +33,20 @@ export const Appender = forwardRef(
 			};
 		}, [] );
 
+		const blockTitle = useBlockDisplayTitle( {
+			clientId,
+			context: 'list-view',
+		} );
+
 		if ( hideInserter ) {
 			return null;
 		}
 
 		const descriptionId = `off-canvas-editor-appender__${ instanceId }`;
 		const description = sprintf(
-			/* translators: 1: The numerical position of the block. 2: The level of nesting for the block. */
-			__( 'Append at position %1$d, Level %2$d' ),
+			/* translators: 1: The name of the block. 2: The numerical position of the block. 3: The level of nesting for the block. */
+			__( 'Append to %1$s block at position %2$d, Level %3$d' ),
+			blockTitle,
 			blockCount + 1,
 			nestingLevel
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

~Renames the accessible name for the appender in the Navigation block list view to be `Add block to Navigation menu`. As requested in https://github.com/WordPress/gutenberg/issues/47011/.~

Update to add the name of the block to the `aria-describedBy` attribute so that it reads in the form: 

> Append to Navigation block at position 1, Level 1

The `Add block` button remains "as is" but the additional context is provided by the area description.

Closes https://github.com/WordPress/gutenberg/issues/47011

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently just `Add block` (the default) has been reported as overly generic and lacking context for users of assistive tech.

This PR adds additional context to the button.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Augment the existing `aria-describedby` with information about the block to which the new block will be appended,.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Check when you focus the appender with a screen reader you hear `Append to Navigation block at position 1, Level 1` shortly after focusing the block appender in the Nav list view.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

Ensure appender continues to be keyboard focusable.

## Screenshots or screencast <!-- if applicable -->
