### PR TITLE
Announce when block inserted in Navigation list view

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/block-contents.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-contents.js
@@ -8,8 +8,6 @@ import classnames from 'classnames';
  */
 import { useSelect } from '@wordpress/data';
 import { forwardRef, useEffect, useState } from '@wordpress/element';
-import { speak } from '@wordpress/a11y';
-import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -20,7 +18,6 @@ import { store as blockEditorStore } from '../../store';
 import { updateAttributes } from './update-attributes';
 import { LinkUI } from './link-ui';
 import { useInsertedBlock } from './use-inserted-block';
-import useBlockDisplayTitle from '../block-title/use-block-display-title';
 
 const BLOCKS_WITH_LINK_UI_SUPPORT = [
 	'core/navigation-link',
@@ -45,12 +42,6 @@ const ListViewBlockContents = forwardRef(
 	) => {
 		const { clientId } = block;
 		const [ isLinkUIOpen, setIsLinkUIOpen ] = useState();
-
-		const blockTitle = useBlockDisplayTitle( {
-			clientId,
-			context: 'list-view',
-		} );
-
 		const {
 			blockMovingClientId,
 			selectedBlockInBlockEditor,
@@ -97,16 +88,6 @@ const ListViewBlockContents = forwardRef(
 			insertedBlockName,
 			hasExistingLinkValue,
 		] );
-
-		useEffect( () => {
-			if ( clientId === lastInsertedBlockClientId && blockTitle ) {
-				speak(
-					// translators: %s: name of block being inserted (i.e. Paragraph, Image, Group etc)
-					sprintf( __( '%s block inserted' ), blockTitle ),
-					'assertive'
-				);
-			}
-		}, [ lastInsertedBlockClientId, clientId, blockTitle ] );
 
 		const isBlockMoveTarget =
 			blockMovingClientId && selectedBlockInBlockEditor === clientId;

--- a/packages/block-editor/src/components/off-canvas-editor/block-contents.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-contents.js
@@ -8,6 +8,8 @@ import classnames from 'classnames';
  */
 import { useSelect } from '@wordpress/data';
 import { forwardRef, useEffect, useState } from '@wordpress/element';
+import { speak } from '@wordpress/a11y';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -18,6 +20,7 @@ import { store as blockEditorStore } from '../../store';
 import { updateAttributes } from './update-attributes';
 import { LinkUI } from './link-ui';
 import { useInsertedBlock } from './use-inserted-block';
+import useBlockDisplayTitle from '../block-title/use-block-display-title';
 
 const BLOCKS_WITH_LINK_UI_SUPPORT = [
 	'core/navigation-link',
@@ -42,6 +45,12 @@ const ListViewBlockContents = forwardRef(
 	) => {
 		const { clientId } = block;
 		const [ isLinkUIOpen, setIsLinkUIOpen ] = useState();
+
+		const blockTitle = useBlockDisplayTitle( {
+			clientId,
+			context: 'list-view',
+		} );
+
 		const {
 			blockMovingClientId,
 			selectedBlockInBlockEditor,
@@ -88,6 +97,16 @@ const ListViewBlockContents = forwardRef(
 			insertedBlockName,
 			hasExistingLinkValue,
 		] );
+
+		useEffect( () => {
+			if ( clientId === lastInsertedBlockClientId && blockTitle ) {
+				speak(
+					// translators: %s: name of block being inserted (i.e. Paragraph, Image, Group etc)
+					sprintf( __( '%s block inserted' ), blockTitle ),
+					'assertive'
+				);
+			}
+		}, [ lastInsertedBlockClientId, clientId, blockTitle ] );
 
 		const isBlockMoveTarget =
 			blockMovingClientId && selectedBlockInBlockEditor === clientId;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Announces via `speak()` when a block is inserted into the Navigation block's list view in the form:

> %%BLOCK NAME%% inserted

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently once you insert a block in the list view there is no notice that the block is inserted. This is because the block's selection is disabled to avoid moving focus away from the Navigation block's inspector controls sidebar.

By adding this announcement it is clearer to users of assistive technology that a block has been inserted.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Announces name of last selected block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
