### PR TITLE
WP_HTML_Processor: Add `set_content_inside_balanced_tags`

### DIFF
--- a/lib/experimental/html/class-wp-html-processor.php
+++ b/lib/experimental/html/class-wp-html-processor.php
@@ -157,6 +157,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	}
 
 	public function set_content_inside_balanced_tags( $content ) {
+		$this->get_updated_html();
 		list( $start_name, $end_name ) = $this->get_balanced_tags();
 		$this->set_content_inside_bookmarks( $start_name, $end_name, $content );
 		$this->seek( $start_name );
@@ -171,8 +172,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		if ( ! isset( $this->bookmarks[ $start_bookmark ], $this->bookmarks[ $end_bookmark ] ) ) {
 			return null;
 		}
-
-		$this->get_updated_html();
 
 		$start = $this->bookmarks[ $start_bookmark ];
 		$end   = $this->bookmarks[ $end_bookmark ];

--- a/lib/experimental/html/class-wp-html-processor.php
+++ b/lib/experimental/html/class-wp-html-processor.php
@@ -157,6 +157,10 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	}
 
 	public function set_content_inside_balanced_tags( $content ) {
+		if ( self::is_html_void_element( $this->get_tag() ) ) {
+			return false;
+		}
+
 		$this->get_updated_html();
 		list( $start_name, $end_name ) = $this->get_balanced_tags();
 		$this->set_content_inside_bookmarks( $start_name, $end_name, $content );

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1314,20 +1314,20 @@ class WP_HTML_Tag_Processor {
 			$tail_delta = 0;
 
 			foreach ( $this->lexical_updates as $diff ) {
-				$update_head = $bookmark->start >= $diff->start;
-				$update_tail = $bookmark->end >= $diff->start;
+				$bookmark_start_is_after_diff_start = $bookmark->start >= $diff->start;
+				$bookmark_end_is_after_diff_end     = $bookmark->end >= $diff->start;
 
-				if ( ! $update_head && ! $update_tail ) {
+				if ( ! $bookmark_start_is_after_diff_start && ! $bookmark_end_is_after_diff_end ) {
 					break;
 				}
 
 				$delta = strlen( $diff->text ) - ( $diff->end - $diff->start );
 
-				if ( $update_head ) {
+				if ( $bookmark_start_is_after_diff_start ) {
 					$head_delta += $delta;
 				}
 
-				if ( $update_tail ) {
+				if ( $bookmark_end_is_after_diff_end ) {
 					$tail_delta += $delta;
 				}
 			}

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1342,7 +1342,7 @@ class WP_HTML_Tag_Processor {
 
 			// Did we end up invalidating the bookmark?
 			if ( ! isset( $this->bookmarks[ $bookmark_name ] ) ) {
-				break;
+				continue;
 			}
 
 			$bookmark->start += $head_delta;

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1303,7 +1303,7 @@ class WP_HTML_Tag_Processor {
 			$this->updated_bytes = $diff->end;
 		}
 
-		foreach ( $this->bookmarks as $bookmark ) {
+		foreach ( $this->bookmarks as $bookmark_name => $bookmark ) {
 			/**
 			 * As we loop through $this->lexical_updates, we keep comparing
 			 * $bookmark->start and $bookmark->end to $diff->start. We can't
@@ -1316,6 +1316,14 @@ class WP_HTML_Tag_Processor {
 			foreach ( $this->lexical_updates as $diff ) {
 				$bookmark_start_is_after_diff_start = $bookmark->start >= $diff->start;
 				$bookmark_end_is_after_diff_end     = $bookmark->end >= $diff->start;
+
+				if ( $bookmark_start_is_after_diff_start ) {
+					$bookmark_end_is_before_diff_end = $bookmark->end < $diff->end;
+					if ( $bookmark_end_is_before_diff_end ) {
+						// The bookmark is fully contained within the diff. We need to invalidate it.
+						$this->release_bookmark( $bookmark_name );
+					}
+				}
 
 				if ( ! $bookmark_start_is_after_diff_start && ! $bookmark_end_is_after_diff_end ) {
 					break;
@@ -1330,6 +1338,11 @@ class WP_HTML_Tag_Processor {
 				if ( $bookmark_end_is_after_diff_end ) {
 					$tail_delta += $delta;
 				}
+			}
+
+			// Did we end up invalidating the bookmark?
+			if ( ! isset( $this->bookmarks[ $bookmark_name ] ) ) {
+				break;
 			}
 
 			$bookmark->start += $head_delta;

--- a/phpunit/html/wp-html-processor-test.php
+++ b/phpunit/html/wp-html-processor-test.php
@@ -225,6 +225,15 @@ HTML
 		$this->assertEquals( 1, $p2_count );
 	}
 
+	public function test_set_content_inside_balanced_tags_on_void_element_has_no_effect() {
+		$tags = new WP_HTML_Processor( self::HTML );
+
+		$tags->next_tag( 'img' );
+		$content = $tags->set_content_inside_balanced_tags( 'This is the new img content' );
+		$this->assertFalse( $content );
+		$this->assertSame( self::HTML, $tags->get_updated_html() );
+	}
+
 	public function test_set_content_inside_balanced_tags_sets_content_correctly() {
 		$tags = new WP_HTML_Processor( self::HTML );
 

--- a/phpunit/html/wp-html-processor-test.php
+++ b/phpunit/html/wp-html-processor-test.php
@@ -257,4 +257,13 @@ HTML
 		$tags->set_content_inside_balanced_tags( 'This is the even newer section content.' );
 		$this->assertSame( '<div>outside</div><section>This is the even newer section content.</section>', $tags->get_updated_html() );
 	}
+
+	public function test_set_content_inside_balanced_tags_followed_by_set_attribute_works() {
+		$tags = new WP_HTML_Processor( self::HTML );
+
+		$tags->next_tag( 'section' );
+		$tags->set_content_inside_balanced_tags( 'This is the new section content.' );
+		$tags->set_attribute( 'id', 'thesection' );
+		$this->assertSame( '<div>outside</div><section id="thesection">This is the new section content.</section>', $tags->get_updated_html() );
+	}
 }

--- a/phpunit/html/wp-html-processor-test.php
+++ b/phpunit/html/wp-html-processor-test.php
@@ -23,8 +23,10 @@ if ( ! class_exists( 'WP_UnitTestCase' ) ) {
  * @coversDefaultClass WP_HTML_Processor
  */
 class WP_HTML_Processor_Test extends WP_UnitTestCase {
+	const HTML = '<div>outside</div><section><div><img>inside</div></section>';
+
 	public function test_find_descendant_tag() {
-		$tags = new WP_HTML_Processor( '<div>outside</div><section><div><img>inside</div></section>' );
+		$tags = new WP_HTML_Processor( self::HTML );
 
 		$tags->next_tag( 'div' );
 		$state = $tags->new_state();
@@ -224,7 +226,7 @@ HTML
 	}
 
 	public function test_set_content_inside_balanced_tags_sets_content_correctly() {
-		$tags = new WP_HTML_Processor( '<div>outside</div><section><div><img>inside</div></section>' );
+		$tags = new WP_HTML_Processor( self::HTML );
 
 		$tags->next_tag( 'section' );
 		$tags->set_content_inside_balanced_tags( 'This is the new section content.' );
@@ -232,7 +234,7 @@ HTML
 	}
 
 	public function test_set_content_inside_balanced_tags_updates_bookmarks_correctly() {
-		$tags = new WP_HTML_Processor( '<div>outside</div><section><div><img>inside</div></section>' );
+		$tags = new WP_HTML_Processor( self::HTML );
 
 		$tags->next_tag( 'div' );
 		$tags->set_bookmark( 'start' );

--- a/phpunit/html/wp-html-processor-test.php
+++ b/phpunit/html/wp-html-processor-test.php
@@ -230,4 +230,20 @@ HTML
 		$tags->set_content_inside_balanced_tags( 'This is the new section content.' );
 		$this->assertSame( '<div>outside</div><section>This is the new section content.</section>', $tags->get_updated_html() );
 	}
+
+	public function test_set_content_inside_balanced_tags_updates_bookmarks_correctly() {
+		$tags = new WP_HTML_Processor( '<div>outside</div><section><div><img>inside</div></section>' );
+
+		$tags->next_tag( 'div' );
+		$tags->set_bookmark( 'start' );
+		$tags->next_tag( 'img' );
+		$this->assertSame( 'IMG', $tags->get_tag() );
+		$tags->set_bookmark( 'after' );
+		$tags->seek( 'start' );
+
+		$tags->set_content_inside_balanced_tags( 'This is the new div content.' );
+		$this->assertSame( '<div>This is the new div content.</div><section><div><img>inside</div></section>', $tags->get_updated_html() );
+		$tags->seek( 'after' );
+		$this->assertSame( 'IMG', $tags->get_tag() );
+	}
 }

--- a/phpunit/html/wp-html-processor-test.php
+++ b/phpunit/html/wp-html-processor-test.php
@@ -266,4 +266,13 @@ HTML
 		$tags->set_attribute( 'id', 'thesection' );
 		$this->assertSame( '<div>outside</div><section id="thesection">This is the new section content.</section>', $tags->get_updated_html() );
 	}
+
+	public function test_set_content_inside_balanced_tags_preceded_by_set_attribute_works() {
+		$tags = new WP_HTML_Processor( self::HTML );
+
+		$tags->next_tag( 'section' );
+		$tags->set_attribute( 'id', 'thesection' );
+		$tags->set_content_inside_balanced_tags( 'This is the new section content.' );
+		$this->assertSame( '<div>outside</div><section id="thesection">This is the new section content.</section>', $tags->get_updated_html() );
+	}
 }

--- a/phpunit/html/wp-html-processor-test.php
+++ b/phpunit/html/wp-html-processor-test.php
@@ -284,4 +284,21 @@ HTML
 		$tags->set_content_inside_balanced_tags( 'This is the new section content.' );
 		$this->assertSame( '<div>outside</div><section id="thesection">This is the new section content.</section>', $tags->get_updated_html() );
 	}
+
+	public function test_set_content_inside_balanced_tags_invalidates_bookmarks_that_point_to_replaced_content() {
+		$tags = new WP_HTML_Processor( self::HTML );
+
+		$tags->next_tag( 'section' );
+		$tags->set_bookmark( 'start' );
+		$tags->next_tag( 'img' );
+		$tags->set_bookmark( 'replaced' );
+		$tags->seek( 'start' );
+
+		$tags->set_content_inside_balanced_tags( 'This is the new section content.' );
+		$this->assertSame( '<div>outside</div><section>This is the new section content.</section>', $tags->get_updated_html() );
+
+		$this->expectExceptionMessage( 'Invalid bookmark name' );
+		$successful_seek = $tags->seek( 'replaced' );
+		$this->assertFalse( $successful_seek );
+	}
 }

--- a/phpunit/html/wp-html-processor-test.php
+++ b/phpunit/html/wp-html-processor-test.php
@@ -222,4 +222,12 @@ HTML
 		// Did we only visit the tags inside section > * > p?
 		$this->assertEquals( 1, $p2_count );
 	}
+
+	public function test_set_content_inside_balanced_tags_sets_content_correctly() {
+		$tags = new WP_HTML_Processor( '<div>outside</div><section><div><img>inside</div></section>' );
+
+		$tags->next_tag( 'section' );
+		$tags->set_content_inside_balanced_tags( 'This is the new section content.' );
+		$this->assertSame( '<div>outside</div><section>This is the new section content.</section>', $tags->get_updated_html() );
+	}
 }

--- a/phpunit/html/wp-html-processor-test.php
+++ b/phpunit/html/wp-html-processor-test.php
@@ -248,4 +248,13 @@ HTML
 		$tags->seek( 'after' );
 		$this->assertSame( 'IMG', $tags->get_tag() );
 	}
+
+	public function test_set_content_inside_balanced_tags_subsequent_updates_on_the_same_tag_work() {
+		$tags = new WP_HTML_Processor( self::HTML );
+
+		$tags->next_tag( 'section' );
+		$tags->set_content_inside_balanced_tags( 'This is the new section content.' );
+		$tags->set_content_inside_balanced_tags( 'This is the even newer section content.' );
+		$this->assertSame( '<div>outside</div><section>This is the even newer section content.</section>', $tags->get_updated_html() );
+	}
 }


### PR DESCRIPTION
## What?

Part of #44410.

Work in progress. Branch based on @dmsnell's #46345, which introduces the `get_content_inside_balanced_tags` counterpart.

## Why?
This is going to be a handy multi-purpose method for HTML manipulation. Needed for the Block Interactivity API, see https://github.com/WordPress/block-hydration-experiments/pull/125.

## How?
By hijacking `WP_HTML_Tag_Processor`'s established `$attribute_updates` mechanism. This seems to work well enough at a basic level but will of course require some changes.

What's interesting here is that while `$attribute_updates` is keyed by ("comparable", i.e. lowercase) attribute name, those keys are only relevant for [`set_attribute()`](https://github.com/WordPress/gutenberg/blob/169dc1b3dab28db05ad7629b2a1243ed0f6953c9/lib/experimental/html/class-wp-html-tag-processor.php#L1504-L1631) (to check if an attribute of the same name already exists). They are however entirely ignored by [`apply_attributes_updates`](https://github.com/WordPress/gutenberg/blob/169dc1b3dab28db05ad7629b2a1243ed0f6953c9/lib/experimental/html/class-wp-html-tag-processor.php#L1244-L1306) -- which is why we can use that mechanism for `set_content_inside_balanced_tags` without much modification 🎉 

## TODO

- [ ] https://github.com/WordPress/gutenberg/pull/47053
- [ ] https://github.com/WordPress/gutenberg/pull/47068

## Testing Instructions
Locally:

```
npm run test:unit:php -- --group=html-processor
```
