### PR TITLE
Sidebar Tabs: Stabilize the block inspector tabs experiment

### DIFF
--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -198,7 +198,7 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 				),
 
-				'blockInspectorTabs'       => array(
+				'blockInspectorTabs'                     => array(
 					'description' => __( 'Block inspector tab display overrides.', 'gutenberg' ),
 					'type'        => 'object',
 					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),

--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -168,12 +168,6 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 					'context'     => array( 'mobile' ),
 				),
 
-				'__experimentalBlockInspectorTabs'       => array(
-					'description' => __( 'Block inspector tab display overrides.', 'gutenberg' ),
-					'type'        => 'object',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
 				'__experimentalBlockInspectorAnimation'  => array(
 					'description' => __( 'Whether to enable animation when showing and hiding the block inspector.', 'gutenberg' ),
 					'type'        => 'object',
@@ -201,6 +195,12 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 				'blockCategories'                        => array(
 					'description' => __( 'Returns all the categories for block types that will be shown in the block editor.', 'gutenberg' ),
 					'type'        => 'array',
+					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+				),
+
+				'blockInspectorTabs'       => array(
+					'description' => __( 'Block inspector tab display overrides.', 'gutenberg' ),
+					'type'        => 'object',
 					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 				),
 

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -86,9 +86,6 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-off-canvas-navigation-editor', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableOffCanvasNavigationEditor = true', 'before' );
 	}
-	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-block-inspector-tabs', $gutenberg_experiments ) ) {
-		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableBlockInspectorTabs = true', 'before' );
-	}
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-global-styles-custom-css', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableGlobalStylesCustomCSS = true', 'before' );
 	}

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -78,18 +78,6 @@ function gutenberg_initialize_experiments_settings() {
 	);
 
 	add_settings_field(
-		'gutenberg-block-inspector-tabs',
-		__( 'Block inspector tabs ', 'gutenberg' ),
-		'gutenberg_display_experiment_field',
-		'gutenberg-experiments',
-		'gutenberg_experiments_section',
-		array(
-			'label' => __( 'Test a new block inspector view splitting settings and appearance controls into tabs', 'gutenberg' ),
-			'id'    => 'gutenberg-block-inspector-tabs',
-		)
-	);
-
-	add_settings_field(
 		'gutenberg-global-styles-custom-css',
 		__( 'Global styles custom css ', 'gutenberg' ),
 		'gutenberg_display_experiment_field',

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -16,12 +16,6 @@ import { store as blockEditorStore } from '../../store';
 const EMPTY_ARRAY = [];
 
 function getShowTabs( blockName, tabSettings = {} ) {
-	// Don't allow settings to force the display of tabs if the block inspector
-	// tabs experiment hasn't been opted into.
-	if ( ! window?.__experimentalEnableBlockInspectorTabs ) {
-		return false;
-	}
-
 	// Block specific setting takes precedence over generic default.
 	if ( tabSettings[ blockName ] !== undefined ) {
 		return tabSettings[ blockName ];

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -36,16 +36,14 @@ export default function useInspectorControlsTabs( blockName ) {
 		color: colorGroup,
 		default: defaultGroup,
 		dimensions: dimensionsGroup,
-		list: listGroup,
 		position: positionGroup,
 		typography: typographyGroup,
 	} = InspectorControlsGroups;
 
 	// List View Tab: If there are any fills for the list group add that tab.
 	const listViewDisabled = useIsListViewTabDisabled( blockName );
-	const listFills = useSlotFills( listGroup.Slot.__unstableName );
 
-	if ( ! listViewDisabled && !! listFills && listFills.length ) {
+	if ( ! listViewDisabled ) {
 		tabs.push( TAB_LIST_VIEW );
 	}
 

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -36,14 +36,16 @@ export default function useInspectorControlsTabs( blockName ) {
 		color: colorGroup,
 		default: defaultGroup,
 		dimensions: dimensionsGroup,
+		list: listGroup,
 		position: positionGroup,
 		typography: typographyGroup,
 	} = InspectorControlsGroups;
 
 	// List View Tab: If there are any fills for the list group add that tab.
 	const listViewDisabled = useIsListViewTabDisabled( blockName );
+	const listFills = useSlotFills( listGroup.Slot.__unstableName );
 
-	if ( ! listViewDisabled ) {
+	if ( ! listViewDisabled && !! listFills && listFills.length ) {
 		tabs.push( TAB_LIST_VIEW );
 	}
 

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -75,8 +75,7 @@ export default function useInspectorControlsTabs( blockName ) {
 	}
 
 	const tabSettings = useSelect( ( select ) => {
-		return select( blockEditorStore ).getSettings()
-			.__experimentalBlockInspectorTabs;
+		return select( blockEditorStore ).getSettings().blockInspectorTabs;
 	}, [] );
 
 	const showTabs = getShowTabs( blockName, tabSettings );

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -390,11 +390,11 @@ add_action( 'init', 'register_block_core_navigation_link' );
 function gutenberg_disable_tabs_for_navigation_link_block( $settings ) {
 	$current_tab_settings = _wp_array_get(
 		$settings,
-		array( '__experimentalBlockInspectorTabs' ),
+		array( 'blockInspectorTabs' ),
 		array()
 	);
 
-	$settings['__experimentalBlockInspectorTabs'] = array_merge(
+	$settings['blockInspectorTabs'] = array_merge(
 		$current_tab_settings,
 		array( 'core/navigation-link' => false )
 	);

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -308,11 +308,11 @@ add_action( 'init', 'register_block_core_navigation_submenu' );
 function gutenberg_disable_tabs_for_navigation_submenu_block( $settings ) {
 	$current_tab_settings = _wp_array_get(
 		$settings,
-		array( '__experimentalBlockInspectorTabs' ),
+		array( 'blockInspectorTabs' ),
 		array()
 	);
 
-	$settings['__experimentalBlockInspectorTabs'] = array_merge(
+	$settings['blockInspectorTabs'] = array_merge(
 		$current_tab_settings,
 		array( 'core/navigation-submenu' => false )
 	);

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -125,9 +125,12 @@ const DefaultControls = ( props ) => {
 const MenuInspectorControls = ( props ) => {
 	const isOffCanvasNavigationEditorEnabled =
 		window?.__experimentalEnableOffCanvasNavigationEditor === true;
+	const menuControlsSlot = isOffCanvasNavigationEditorEnabled
+		? 'list'
+		: undefined;
 
 	return (
-		<InspectorControls __experimentalGroup="list">
+		<InspectorControls __experimentalGroup={ menuControlsSlot }>
 			<PanelBody
 				title={
 					isOffCanvasNavigationEditorEnabled ? null : __( 'Menu' )

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -125,12 +125,9 @@ const DefaultControls = ( props ) => {
 const MenuInspectorControls = ( props ) => {
 	const isOffCanvasNavigationEditorEnabled =
 		window?.__experimentalEnableOffCanvasNavigationEditor === true;
-	const menuControlsSlot = window?.__experimentalEnableBlockInspectorTabs
-		? 'list'
-		: undefined;
 
 	return (
-		<InspectorControls __experimentalGroup={ menuControlsSlot }>
+		<InspectorControls __experimentalGroup="list">
 			<PanelBody
 				title={
 					isOffCanvasNavigationEditorEnabled ? null : __( 'Menu' )

--- a/packages/e2e-test-utils-playwright/src/editor/index.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/index.ts
@@ -18,6 +18,7 @@ import { selectBlocks } from './select-blocks';
 import { setContent } from './set-content';
 import { showBlockToolbar } from './show-block-toolbar';
 import { saveSiteEditorEntities } from './site-editor';
+import { switchBlockInspectorTab } from './switch-block-inspector-tab';
 import { transformBlockTo } from './transform-block-to';
 
 type EditorConstructorProps = {
@@ -67,5 +68,6 @@ export class Editor {
 	selectBlocks = selectBlocks.bind( this );
 	setContent = setContent.bind( this );
 	showBlockToolbar = showBlockToolbar.bind( this );
+	switchBlockInspectorTab = switchBlockInspectorTab.bind( this );
 	transformBlockTo = transformBlockTo.bind( this );
 }

--- a/packages/e2e-test-utils-playwright/src/editor/switch-block-inspector-tab.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/switch-block-inspector-tab.ts
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies
+ */
+import type { Editor } from './index';
+import { expect } from '../test';
+
+/**
+ * Clicks on the block inspector tab button with the supplied label and waits
+ * for the tab switch.
+ *
+ * @param {Editor} this
+ * @param {string} label
+ */
+export async function switchBlockInspectorTab( this: Editor, label: string ) {
+	const inspectorTabButton = this.page.locator(
+		`role=region[name="Editor settings"i] >> role=tab[name="${ label }"i]`
+	);
+
+	if ( inspectorTabButton ) {
+		const id = await inspectorTabButton.getAttribute( 'id' );
+		await inspectorTabButton.click();
+
+		await expect(
+			this.page.locator(
+				`role=region[name="Editor settings"i] >> div[role="tabpanel"][aria-labelledby="${ id }"]`
+			)
+		).toBeVisible();
+	}
+}

--- a/packages/e2e-test-utils-playwright/src/editor/switch-block-inspector-tab.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/switch-block-inspector-tab.ts
@@ -15,15 +15,12 @@ export async function switchBlockInspectorTab( this: Editor, label: string ) {
 	const inspectorTabButton = this.page.locator(
 		`role=region[name="Editor settings"i] >> role=tab[name="${ label }"i]`
 	);
+	const id = await inspectorTabButton.getAttribute( 'id' );
 
-	if ( inspectorTabButton ) {
-		const id = await inspectorTabButton.getAttribute( 'id' );
-		await inspectorTabButton.click();
-
-		await expect(
-			this.page.locator(
-				`role=region[name="Editor settings"i] >> div[role="tabpanel"][aria-labelledby="${ id }"]`
-			)
-		).toBeVisible();
-	}
+	await inspectorTabButton.click();
+	await expect(
+		this.page.locator(
+			`role=region[name="Editor settings"i] >> div[role="tabpanel"][aria-labelledby="${ id }"]`
+		)
+	).toBeVisible();
 }

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -797,6 +797,15 @@ _Parameters_
 The block toolbar is not always visible while typing.
 Call this function to reveal it.
 
+### switchBlockInspectorTab
+
+Clicks on the block inspector tab button with the supplied label and waits
+for the tab switch.
+
+_Parameters_
+
+-   _label_ `string`: Aria label to find tab button by.
+
 ### switchEditorModeTo
 
 Switches editor mode.

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -81,6 +81,7 @@ export { selectBlockByClientId } from './select-block-by-client-id';
 export { setBrowserViewport } from './set-browser-viewport';
 export { setOption } from './set-option';
 export { setPostContent } from './set-post-content';
+export { switchBlockInspectorTab } from './switch-block-inspector-tab.js';
 export { switchEditorModeTo } from './switch-editor-mode-to';
 export { switchUserToAdmin } from './switch-user-to-admin';
 export { switchUserToTest } from './switch-user-to-test';

--- a/packages/e2e-test-utils/src/switch-block-inspector-tab.js
+++ b/packages/e2e-test-utils/src/switch-block-inspector-tab.js
@@ -1,0 +1,19 @@
+/**
+ * Clicks on the block inspector tab button with the supplied label and waits
+ * for the tab switch.
+ *
+ * @param { string } label Aria label to find tab button by.
+ */
+export async function switchBlockInspectorTab( label ) {
+	const tabButton = await page.$(
+		`.block-editor-block-inspector__tabs button[aria-label="${ label }"]`
+	);
+
+	if ( tabButton ) {
+		const id = await page.evaluate( ( tab ) => tab.id, tabButton );
+		await tabButton.click();
+		await page.waitForSelector(
+			`div[role="tabpanel"][aria-labelledby="${ id }"]`
+		);
+	}
+}

--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -9,6 +9,7 @@ import {
 	pressKeyWithModifier,
 	openDocumentSettingsSidebar,
 	getListViewBlocks,
+	switchBlockInspectorTab,
 } from '@wordpress/e2e-test-utils';
 
 async function openListViewSidebar() {
@@ -20,6 +21,20 @@ async function tabToColumnsControl() {
 	let isColumnsControl = false;
 	do {
 		await page.keyboard.press( 'Tab' );
+
+		const isBlockInspectorTab = await page.evaluate( () => {
+			const activeElement = document.activeElement;
+			return (
+				activeElement.getAttribute( 'role' ) === 'tab' &&
+				activeElement.attributes.getNamedItem( 'aria-label' ).value ===
+					'Styles'
+			);
+		} );
+
+		if ( isBlockInspectorTab ) {
+			await page.keyboard.press( 'ArrowRight' );
+		}
+
 		isColumnsControl = await page.evaluate( () => {
 			const activeElement = document.activeElement;
 			return (
@@ -60,6 +75,7 @@ describe( 'Navigating the block hierarchy', () => {
 
 		// Tweak the columns count.
 		await openDocumentSettingsSidebar();
+		await switchBlockInspectorTab( 'Settings' );
 		await page.focus(
 			'.block-editor-block-inspector [aria-label="Columns"][type="number"]'
 		);

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -135,7 +135,6 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 				Object.entries( settings ).filter( ( [ key ] ) =>
 					[
 						'__experimentalBlockDirectory',
-						'__experimentalBlockInspectorTabs',
 						'__experimentalDiscussionSettings',
 						'__experimentalFeatures',
 						'__experimentalPreferredStyleVariations',
@@ -143,6 +142,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 						'__unstableGalleryWithImageBlocks',
 						'alignWide',
 						'allowedBlockTypes',
+						'blockInspectorTabs',
 						'bodyPlaceholder',
 						'canLockBlocks',
 						'codeEditingEnabled',

--- a/test/e2e/specs/editor/blocks/avatar.spec.js
+++ b/test/e2e/specs/editor/blocks/avatar.spec.js
@@ -52,6 +52,7 @@ test.describe( 'Avatar', () => {
 		);
 
 		await expect( blockInspectorControls ).toBeVisible();
+		await editor.switchBlockInspectorTab( 'Settings' );
 
 		const userInput = page.locator(
 			'role=region[name="Editor settings"i] >> role=combobox[name="User"i]'

--- a/test/e2e/specs/editor/blocks/avatar.spec.js
+++ b/test/e2e/specs/editor/blocks/avatar.spec.js
@@ -65,7 +65,8 @@ test.describe( 'Avatar', () => {
 
 		await newUser.click();
 
-		const newSrc = await avatarImage.getAttribute( 'src' );
+		const updatedAvatarImage = avatarBlock.locator( 'img' );
+		const newSrc = await updatedAvatarImage.getAttribute( 'src' );
 
 		expect( newSrc ).not.toBe( originalSrc );
 	} );

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -131,6 +131,7 @@ test.describe( 'Buttons', () => {
 		await editor.insertBlock( { name: 'core/buttons' } );
 		await page.keyboard.type( 'Content' );
 		await editor.openDocumentSettingsSidebar();
+		await editor.switchBlockInspectorTab( 'Settings' );
 		await page.click(
 			'role=group[name="Button width"i] >> role=button[name="25%"i]'
 		);

--- a/test/e2e/specs/editor/blocks/table.spec.js
+++ b/test/e2e/specs/editor/blocks/table.spec.js
@@ -77,6 +77,7 @@ test.describe( 'Table', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/table' } );
 		await editor.openDocumentSettingsSidebar();
+		await editor.switchBlockInspectorTab( 'Settings' );
 
 		const headerSwitch = page.locator(
 			'role=checkbox[name="Header section"i]'
@@ -132,11 +133,13 @@ test.describe( 'Table', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/table' } );
 		await editor.openDocumentSettingsSidebar();
+		await editor.switchBlockInspectorTab( 'Settings' );
 
 		// Create the table.
 		await page.click( 'role=button[name="Create Table"i]' );
 
 		// Toggle on the switches and add some content.
+		await editor.switchBlockInspectorTab( 'Settings' );
 		await page.locator( 'role=checkbox[name="Header section"i]' ).check();
 		await page.locator( 'role=checkbox[name="Footer section"i]' ).check();
 		await page.click( 'role=textbox[name="Body cell text"i] >> nth=0' );
@@ -202,11 +205,12 @@ test.describe( 'Table', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/table' } );
 		await editor.openDocumentSettingsSidebar();
+		await editor.switchBlockInspectorTab( 'Settings' );
 
 		// Create the table.
 		await page.click( 'role=button[name="Create Table"i]' );
 
-		// Enable fixed width as it exascerbates the amount of empty space around the RichText.
+		// Enable fixed width as it exacerbates the amount of empty space around the RichText.
 		await page
 			.locator( 'role=checkbox[name="Fixed width table cells"i]' )
 			.check();

--- a/test/e2e/specs/editor/plugins/hooks-api.spec.js
+++ b/test/e2e/specs/editor/plugins/hooks-api.spec.js
@@ -18,10 +18,12 @@ test.describe( 'Using Hooks API', () => {
 	} );
 
 	test( 'Should contain a reset block button on the sidebar', async ( {
+		editor,
 		page,
 	} ) => {
 		await page.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'First paragraph' );
+		await editor.switchBlockInspectorTab( 'Settings' );
 		await expect(
 			page.locator( 'role=button[name="Reset Block"i]' )
 		).toBeVisible();
@@ -38,6 +40,7 @@ test.describe( 'Using Hooks API', () => {
 			'role=document[name="Paragraph block"i]'
 		);
 		await expect( paragraphBlock ).toHaveText( 'First paragraph' );
+		await editor.switchBlockInspectorTab( 'Settings' );
 		await page.click( 'role=button[name="Reset Block"i]' );
 		expect( await editor.getEditedPostContent() ).toEqual( '' );
 	} );

--- a/test/e2e/specs/site-editor/push-to-global-styles.spec.js
+++ b/test/e2e/specs/site-editor/push-to-global-styles.spec.js
@@ -52,8 +52,9 @@ test.describe( 'Push to Global Styles button', () => {
 			page.getByRole( 'button', { name: 'Uppercase' } )
 		).toHaveAttribute( 'aria-pressed', 'false' );
 
-		// Go to block settings and open the Advanced panel
+		// Go to block settings, select inner tab, and open the Advanced panel
 		await page.getByRole( 'button', { name: 'Settings' } ).click();
+		await page.getByRole( 'tab', { name: 'Settings' } ).click();
 		await page.getByRole( 'button', { name: 'Advanced' } ).click();
 
 		// Push button should be disabled
@@ -63,8 +64,15 @@ test.describe( 'Push to Global Styles button', () => {
 			} )
 		).toBeDisabled();
 
+		// Switch back to the Styles inspector tab to check typography style
+		await page.getByRole( 'tab', { name: 'Styles' } ).click();
+
 		// Make the Heading block uppercase
 		await page.getByRole( 'button', { name: 'Uppercase' } ).click();
+
+		// Switch back to the Settings inspector tab to check for enabled button
+		await page.getByRole( 'tab', { name: 'Settings' } ).click();
+		await page.getByRole( 'button', { name: 'Advanced' } ).click();
 
 		// Push button should now be enabled
 		await expect(


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/45005
- https://github.com/WordPress/gutenberg/issues/46938

## What?

- Stabilizes the Block Inspector Tabs experiment and block editor setting.
- Tweaks inclusion of list view tab so that it relies on the block allow list meaning it can be set as the default regardless of current fills

## Why?

We're pretty confident the tabs are here to stay, given generally positive feedback in recent calls for testing. These tabs must also be stabilized for the Navigation block's off-canvas editor to be the default experience.

## How?

- Removes the Gutenberg experiment for Block Inspector Tabs
- Removes setting of `window.__experimentalEnableBlockInspectorTabs` based on experiment
- Removes uses of `window.__experimentalEnableBlockInspectorTabs`
- Removes the `__experimental` prefix from the block inspector tabs block editor setting
- Removes the list view tab's check for fills so it relies only on the block allow list

## Testing Instructions
1. Confirm the Block Inspector Tabs experiment is no longer available on the Gutenberg Experiments page
2. Open the post editor, add a block, select it, and confirm that the block displays tabs within the block inspector
3. Add a Navigation block with submenu and links, select it, and confirm that it’s list view tab contains items
4. Within the Nav block’s list view, click the edit button for a submenu, and confirm the submenu block has no tabs
5. Navigate back to the Nav block, click the edit button for a navigation link, and confirm the navigation link block has no tabs
6. Add/update a filter to set the `blockInspectorTabs.default` editor setting to `false` to check complete disabling of tabs
7. Select various types of blocks and ensure tabs aren’t displayed
  <details>
  <summary>Click for quick and dirty patch to update block editor setting to test disabling tab display across blocks</summary>
  
  ```diff
    diff --git a/packages/block-library/src/navigation-link/index.php b/packages/block-library/src/navigation-link/index.php
    index f214a6b9b5..db113f7289 100644
    --- a/packages/block-library/src/navigation-link/index.php
    +++ b/packages/block-library/src/navigation-link/index.php
    @@ -396,7 +396,7 @@ function gutenberg_disable_tabs_for_navigation_link_block( $settings ) {
     
      $settings['blockInspectorTabs'] = array_merge(
       $current_tab_settings,
    -		array( 'core/navigation-link' => false )
    +		array( 'core/navigation-link' => false, 'default' => false )
      );
     
      return $settings;
    
  ```
  </details>


## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/211699895-52687c3d-65c1-4003-bbd0-b41380799ed0.mp4

