### PR TITLE
Navigation block: Fix some off canvas appender accessibility issues

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/appender.js
+++ b/packages/block-editor/src/components/off-canvas-editor/appender.js
@@ -1,48 +1,69 @@
 /**
  * WordPress dependencies
  */
+import { useInstanceId } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { forwardRef } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+
 /**
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
 import Inserter from '../inserter';
 
-export const Appender = forwardRef( ( props, ref ) => {
-	const { hideInserter, clientId } = useSelect( ( select ) => {
-		const {
-			getTemplateLock,
-			__unstableGetEditorMode,
-			getSelectedBlockClientId,
-		} = select( blockEditorStore );
+export const Appender = forwardRef(
+	( { nestingLevel, blockCount, ...props }, ref ) => {
+		const instanceId = useInstanceId( Appender );
+		const { hideInserter, clientId } = useSelect( ( select ) => {
+			const {
+				getTemplateLock,
+				__unstableGetEditorMode,
+				getSelectedBlockClientId,
+			} = select( blockEditorStore );
 
-		const _clientId = getSelectedBlockClientId();
+			const _clientId = getSelectedBlockClientId();
 
-		return {
-			clientId: getSelectedBlockClientId(),
-			hideInserter:
-				!! getTemplateLock( _clientId ) ||
-				__unstableGetEditorMode() === 'zoom-out',
-		};
-	}, [] );
+			return {
+				clientId: getSelectedBlockClientId(),
+				hideInserter:
+					!! getTemplateLock( _clientId ) ||
+					__unstableGetEditorMode() === 'zoom-out',
+			};
+		}, [] );
 
-	if ( hideInserter ) {
-		return null;
+		if ( hideInserter ) {
+			return null;
+		}
+
+		const descriptionId = `off-canvas-editor-appender__${ instanceId }`;
+		const description = sprintf(
+			/* translators: 1: The numerical position of the block. 2: The level of nesting for the block. */
+			__( 'Append at position %1$d, Level %2$d' ),
+			blockCount + 1,
+			nestingLevel
+		);
+
+		return (
+			<div className="offcanvas-editor-appender">
+				<Inserter
+					ref={ ref }
+					rootClientId={ clientId }
+					position="bottom right"
+					isAppender={ true }
+					selectBlockOnInsert={ false }
+					shouldDirectInsert={ false }
+					__experimentalIsQuick
+					{ ...props }
+					toggleProps={ { 'aria-describedby': descriptionId } }
+				/>
+				<div
+					className="offcanvas-editor-appender__description"
+					id={ descriptionId }
+				>
+					{ description }
+				</div>
+			</div>
+		);
 	}
-
-	return (
-		<div className="offcanvas-editor__appender">
-			<Inserter
-				ref={ ref }
-				rootClientId={ clientId }
-				position="bottom right"
-				isAppender={ true }
-				selectBlockOnInsert={ false }
-				shouldDirectInsert={ false }
-				__experimentalIsQuick
-				{ ...props }
-			/>
-		</div>
-	);
-} );
+);

--- a/packages/block-editor/src/components/off-canvas-editor/branch.js
+++ b/packages/block-editor/src/components/off-canvas-editor/branch.js
@@ -222,7 +222,11 @@ function ListViewBranch( props ) {
 				>
 					<TreeGridCell>
 						{ ( treeGridCellProps ) => (
-							<Appender { ...treeGridCellProps } />
+							<Appender
+								nestingLevel={ level }
+								blockCount={ blockCount }
+								{ ...treeGridCellProps }
+							/>
 						) }
 					</TreeGridCell>
 				</TreeGridRow>

--- a/packages/block-editor/src/components/off-canvas-editor/branch.js
+++ b/packages/block-editor/src/components/off-canvas-editor/branch.js
@@ -1,12 +1,18 @@
 /**
  * WordPress dependencies
  */
-import { memo } from '@wordpress/element';
+import {
+	__experimentalTreeGridRow as TreeGridRow,
+	__experimentalTreeGridCell as TreeGridCell,
+} from '@wordpress/components';
 import { AsyncModeProvider, useSelect } from '@wordpress/data';
+import { memo } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
+
+import { Appender } from './appender';
 import ListViewBlock from './block';
 import { useListViewContext } from './context';
 import { isClientIdSelected } from './utils';
@@ -111,8 +117,14 @@ function ListViewBranch( props ) {
 		return null;
 	}
 
+	// Only show the appender at the first level.
+	const showAppender = level === 1;
+
 	const filteredBlocks = blocks.filter( Boolean );
 	const blockCount = filteredBlocks.length;
+
+	// The appender means an extra row in List View, so add 1 to the row count.
+	const rowCount = showAppender ? blockCount + 1 : blockCount;
 	let nextPosition = listPosition;
 
 	return (
@@ -167,7 +179,7 @@ function ListViewBranch( props ) {
 								isDragged={ isDragged }
 								level={ level }
 								position={ position }
-								rowCount={ blockCount }
+								rowCount={ rowCount }
 								siblingBlockCount={ blockCount }
 								showBlockMovers={ showBlockMovers }
 								path={ updatedPath }
@@ -201,6 +213,20 @@ function ListViewBranch( props ) {
 					</AsyncModeProvider>
 				);
 			} ) }
+			{ showAppender && (
+				<TreeGridRow
+					level={ level }
+					setSize={ rowCount }
+					positionInSet={ rowCount }
+					isExpanded={ true }
+				>
+					<TreeGridCell>
+						{ ( treeGridCellProps ) => (
+							<Appender { ...treeGridCellProps } />
+						) }
+					</TreeGridCell>
+				</TreeGridRow>
+			) }
 		</>
 	);
 }

--- a/packages/block-editor/src/components/off-canvas-editor/index.js
+++ b/packages/block-editor/src/components/off-canvas-editor/index.js
@@ -32,7 +32,6 @@ import useListViewClientIds from './use-list-view-client-ids';
 import useListViewDropZone from './use-list-view-drop-zone';
 import useListViewExpandSelectedItem from './use-list-view-expand-selected-item';
 import { store as blockEditorStore } from '../../store';
-import { Appender } from './appender';
 
 const expanded = ( state, action ) => {
 	if ( Array.isArray( action.clientIds ) ) {
@@ -236,11 +235,6 @@ function __ExperimentalOffCanvasEditor(
 							positionInSet={ 1 }
 							isExpanded={ true }
 						>
-							<TreeGridCell>
-								{ ( treeGridCellProps ) => (
-									<Appender { ...treeGridCellProps } />
-								) }
-							</TreeGridCell>
 							{ ! clientIdsTree.length && (
 								<TreeGridCell withoutGridItem>
 									<div className="offcanvas-editor-list-view-is-empty">

--- a/packages/block-editor/src/components/off-canvas-editor/style.scss
+++ b/packages/block-editor/src/components/off-canvas-editor/style.scss
@@ -1,4 +1,4 @@
-.offcanvas-editor__appender .block-editor-inserter__toggle {
+.offcanvas-editor-appender .block-editor-inserter__toggle {
 	background-color: #1e1e1e;
 	color: #fff;
 	margin: $grid-unit-10 0 0 24px;
@@ -12,6 +12,10 @@
 		background: var(--wp-admin-theme-color);
 		color: #fff;
 	}
+}
+
+.offcanvas-editor-appender__description {
+	display: none;
 }
 
 .offcanvas-editor-list-view-tree-wrapper {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #47024
See also #47011

Sets the correct `aria-posinset` and `aria-setsize` html attributes for the off-canvas editor's appender.

Also adds an aria description ('Append at position 3, Level 1') to give some context about where the block will be added.

## Why?
The `aria-posinset` and `aria-setsize` issue is very minor as screen readers don't announce them. But it's good to set it correctly just in case screenreaders do start announcing them after an update.

The aria description is used to replace the fact that screen readers don't announce that information These descriptions could be improved to mention the parent block name (especially in the case of the appender). The trouble is there's no safe way to access the `rootClientId` at the moment. For now this is roughly inline with the other aria descriptions in List View.

## How?
- Moves the `Appender` implementation to the `ListViewBranch` component (where it has access to the block count and nesting level).
- Passes in the correct values for `aria-posinset` and `aria-setsize`. The `aria-setsize` for blocks also needs to be incremented when there's an appender to account for the extra row.
- Adds an aria description to the appender.

### Testing Instructions for Keyboard
1. Create a new post
2. Tab to the 'Settings' button in the Editor top bar and ensure this is toggled on
3. Tab to the post content and insert a navigation block by typing '/navigation' and pressing enter
4. Tab to the block settings region (or navigate to the region) and tab until you reach the 'Block navigation structure'
5. If there are no blocks in the menu, you should land straight on the 'Add block' appender. If there are blocks, press the down arrow until you reach the 'Add block' button.
6. You should hear an additional description like 'Append at position 2, level 1'.

## Screenshots or screencast 
![Screen Shot 2023-01-11 at 1 40 00 pm](https://user-images.githubusercontent.com/677833/211726412-b523c201-1e61-4d9c-b886-b33121a1394e.png)

