### PR TITLE
Fix the 'test_remove_invalid_element_pseudo_selectors' test case

### DIFF
--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -894,6 +894,11 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 									'background' => 'blue',
 								),
 							),
+							':seen' => array(
+								'color' => array(
+									'background' => 'ivory',
+								),
+							),
 						),
 					),
 				),

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -894,7 +894,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 									'background' => 'blue',
 								),
 							),
-							':seen' => array(
+							':seen'  => array(
 								'color' => array(
 									'background' => 'ivory',
 								),


### PR DESCRIPTION
## What?
This a follow-up to #41786.

PR updates the 'test_remove_invalid_element_pseudo_selectors' test case's input value to match the test's intent.

## Why?
The input and expected output were the same, so the test case wasn't testing invalid pseudo selector removal.

## How?
I added an invalid pseudo selector to the input value.

## Testing Instructions
PHP Unit tests are passing on CI.

```
npm run test:unit:php -- --filter WP_Theme_JSON_Gutenberg_Test
```
