### PR TITLE
Global Styles: Don't remove Custom CSS for users with the correct caps

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2818,7 +2818,12 @@ class WP_Theme_JSON_Gutenberg {
 				continue;
 			}
 
-			$output = static::remove_insecure_styles( $input );
+			// The global styles custom CSS is not sanitized, but can only be edited by users with 'edit_css' capability.
+			if ( isset( $input['css'] ) && current_user_can( 'edit_css' ) ) {
+				$output = $input;
+			} else {
+				$output = static::remove_insecure_styles( $input );
+			}
 
 			/*
 			 * Get a reference to element name from path.

--- a/lib/experimental/kses.php
+++ b/lib/experimental/kses.php
@@ -62,5 +62,6 @@ function gutenberg_override_core_kses_init_filters() {
 	}
 
 }
+// The 'kses_init_filters' is usually initialized with default priority. Use higher priority to override.
 add_action( 'init', 'gutenberg_override_core_kses_init_filters', 20 );
 add_action( 'set_current_user', 'gutenberg_override_core_kses_init_filters' );

--- a/lib/experimental/kses.php
+++ b/lib/experimental/kses.php
@@ -62,5 +62,5 @@ function gutenberg_override_core_kses_init_filters() {
 	}
 
 }
-add_action( 'init', 'gutenberg_override_core_kses_init_filters' );
+add_action( 'init', 'gutenberg_override_core_kses_init_filters', 20 );
 add_action( 'set_current_user', 'gutenberg_override_core_kses_init_filters' );

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1619,6 +1619,15 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	public function test_allows_custom_css_for_users_with_caps() {
 		wp_set_current_user( self::$administrator_id );
 
+		// Explicitly grant 'edit_css' capabilities.
+		$grant_edit_css_cap = function( $caps, $cap ) {
+			if ( 'edit_css' === $cap ) {
+				$caps = array( 'edit_theme_options' );
+			}
+			return $caps;
+		};
+		add_filter( 'map_meta_cap', $grant_edit_css_cap, 10, 2 );
+
 		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
 			array(
 				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
@@ -1650,6 +1659,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertEqualSetsWithIndex( $expected, $actual );
+		remove_filter( 'map_meta_cap', $grant_edit_css_cap );
 	}
 
 	public function test_removes_custom_css_for_users_without_caps() {

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1654,7 +1654,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertEqualSetsWithIndex( $expected, $actual );
+		$this->assertSameSetsWithIndex( $expected, $actual );
 	}
 
 	/**

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -22,6 +22,10 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'role' => 'administrator',
 			)
 		);
+
+		if ( is_multisite() ) {
+			grant_super_admin( self::$administrator_id );
+		}
 	}
 
 	/**
@@ -1618,15 +1622,6 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 	public function test_allows_custom_css_for_users_with_caps() {
 		wp_set_current_user( self::$administrator_id );
-
-		// Explicitly grant 'edit_css' capabilities.
-		$grant_edit_css_cap = function( $caps, $cap ) {
-			if ( 'edit_css' === $cap ) {
-				$caps = array( 'edit_theme_options' );
-			}
-			return $caps;
-		};
-		add_filter( 'map_meta_cap', $grant_edit_css_cap, 10, 2 );
 
 		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
 			array(


### PR DESCRIPTION
## What?
Related #46815.

PR updates `WP_Theme_JSON::remove_insecure_properties` to skip custom CSS sanitization when a  user has `edit_css` capabilities.

## Why?
When KSES filters are registered, the `remove_insecure_properties` remove the custom CSS values without checking the right capabilities.

## Testing Instructions

1. Enable the KSES filters with `add_action( 'init', 'kses_init_filters' );`
2. Enable Custom CSS via Gutenberg > Experiments
3. Go to Appearance > Editor
4. Open the Styles sidebar
5. Select "Custom CSS"
6. Add some CSS code
7. Confirm CSS code is saved
