### PR TITLE
ESLint: Enable `jest/recommended` for tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -372,6 +372,7 @@ module.exports = {
 			extends: [
 				'plugin:jest-dom/recommended',
 				'plugin:testing-library/react',
+				'plugin:jest/recommended',
 			],
 		},
 		{

--- a/package-lock.json
+++ b/package-lock.json
@@ -18688,6 +18688,7 @@
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-plugin-import": "^2.25.2",
+				"eslint-plugin-jest": "^27.2.1",
 				"eslint-plugin-jsdoc": "^37.0.3",
 				"eslint-plugin-jsx-a11y": "^6.5.1",
 				"eslint-plugin-prettier": "^3.3.0",
@@ -20635,6 +20636,7 @@
 					"version": "1.3.7",
 					"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
 					"integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+					"dev": true,
 					"requires": {
 						"mime-types": "~2.1.24",
 						"negotiator": "0.6.2"
@@ -22388,7 +22390,8 @@
 				"array-flatten": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-					"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+					"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+					"dev": true
 				},
 				"asn1": {
 					"version": "0.2.4",
@@ -22545,7 +22548,8 @@
 				"balanced-match": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-					"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+					"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+					"dev": true
 				},
 				"base64-js": {
 					"version": "1.5.1",
@@ -22663,6 +22667,7 @@
 					"version": "1.1.11",
 					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -22974,7 +22979,8 @@
 				"concat-map": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
@@ -22986,6 +22992,7 @@
 					"version": "0.5.3",
 					"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
 					"integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+					"dev": true,
 					"requires": {
 						"safe-buffer": "5.1.2"
 					}
@@ -23009,12 +23016,14 @@
 				"cookie": {
 					"version": "0.4.0",
 					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-					"integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+					"integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+					"dev": true
 				},
 				"cookie-signature": {
 					"version": "1.0.6",
 					"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-					"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+					"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+					"dev": true
 				},
 				"core-js": {
 					"version": "2.6.12",
@@ -23188,12 +23197,14 @@
 				"depd": {
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-					"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+					"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+					"dev": true
 				},
 				"destroy": {
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-					"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+					"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+					"dev": true
 				},
 				"devtools": {
 					"version": "6.12.1",
@@ -23253,7 +23264,8 @@
 				"ee-first": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-					"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+					"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+					"dev": true
 				},
 				"emitter-listener": {
 					"version": "1.1.2",
@@ -23279,7 +23291,8 @@
 				"encodeurl": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-					"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+					"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+					"dev": true
 				},
 				"end-of-stream": {
 					"version": "1.4.4",
@@ -23314,7 +23327,8 @@
 				"escape-html": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-					"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+					"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+					"dev": true
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
@@ -23325,7 +23339,8 @@
 				"etag": {
 					"version": "1.8.1",
 					"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-					"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+					"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+					"dev": true
 				},
 				"eventemitter3": {
 					"version": "3.1.2",
@@ -23370,6 +23385,61 @@
 					"resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
 					"integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
 					"dev": true
+				},
+				"express": {
+					"version": "4.17.1",
+					"resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+					"integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+					"dev": true,
+					"requires": {
+						"accepts": "~1.3.7",
+						"array-flatten": "1.1.1",
+						"body-parser": "1.19.0",
+						"content-disposition": "0.5.3",
+						"content-type": "~1.0.4",
+						"cookie": "0.4.0",
+						"cookie-signature": "1.0.6",
+						"debug": "2.6.9",
+						"depd": "~1.1.2",
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"etag": "~1.8.1",
+						"finalhandler": "~1.1.2",
+						"fresh": "0.5.2",
+						"merge-descriptors": "1.0.1",
+						"methods": "~1.1.2",
+						"on-finished": "~2.3.0",
+						"parseurl": "~1.3.3",
+						"path-to-regexp": "0.1.7",
+						"proxy-addr": "~2.0.5",
+						"qs": "6.7.0",
+						"range-parser": "~1.2.1",
+						"safe-buffer": "5.1.2",
+						"send": "0.17.1",
+						"serve-static": "1.14.1",
+						"setprototypeof": "1.1.1",
+						"statuses": "~1.5.0",
+						"type-is": "~1.6.18",
+						"utils-merge": "1.0.1",
+						"vary": "~1.1.2"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"dev": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"ms": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+							"dev": true
+						}
+					}
 				},
 				"extend": {
 					"version": "3.0.2",
@@ -23461,6 +23531,7 @@
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
 					"integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+					"dev": true,
 					"requires": {
 						"debug": "2.6.9",
 						"encodeurl": "~1.0.2",
@@ -23475,6 +23546,7 @@
 							"version": "2.6.9",
 							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"dev": true,
 							"requires": {
 								"ms": "2.0.0"
 							}
@@ -23482,7 +23554,8 @@
 						"ms": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+							"dev": true
 						}
 					}
 				},
@@ -23534,12 +23607,14 @@
 				"forwarded": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-					"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+					"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+					"dev": true
 				},
 				"fresh": {
 					"version": "0.5.2",
 					"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-					"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+					"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+					"dev": true
 				},
 				"fs-constants": {
 					"version": "1.0.0",
@@ -23767,6 +23842,7 @@
 					"version": "1.7.2",
 					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
 					"integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+					"dev": true,
 					"requires": {
 						"depd": "~1.1.2",
 						"inherits": "2.0.3",
@@ -23778,7 +23854,8 @@
 						"inherits": {
 							"version": "2.0.3",
 							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-							"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+							"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+							"dev": true
 						}
 					}
 				},
@@ -23889,7 +23966,8 @@
 				"ipaddr.js": {
 					"version": "1.9.1",
 					"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-					"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+					"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+					"dev": true
 				},
 				"is-arrayish": {
 					"version": "0.3.2",
@@ -24423,7 +24501,8 @@
 				"merge-descriptors": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-					"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+					"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+					"dev": true
 				},
 				"method-override": {
 					"version": "3.0.0",
@@ -24463,17 +24542,20 @@
 				"mime": {
 					"version": "1.6.0",
 					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+					"dev": true
 				},
 				"mime-db": {
 					"version": "1.48.0",
 					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
-					"integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ=="
+					"integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==",
+					"dev": true
 				},
 				"mime-types": {
 					"version": "2.1.31",
 					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
 					"integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
+					"dev": true,
 					"requires": {
 						"mime-db": "1.48.0"
 					}
@@ -24497,6 +24579,15 @@
 					"dev": true,
 					"requires": {
 						"dom-walk": "^0.1.0"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
@@ -24627,7 +24718,8 @@
 				"negotiator": {
 					"version": "0.6.2",
 					"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-					"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+					"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+					"dev": true
 				},
 				"nice-try": {
 					"version": "1.0.5",
@@ -24727,6 +24819,7 @@
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
 					"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+					"dev": true,
 					"requires": {
 						"ee-first": "1.1.1"
 					}
@@ -24869,7 +24962,8 @@
 				"parseurl": {
 					"version": "1.3.3",
 					"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-					"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+					"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+					"dev": true
 				},
 				"path-exists": {
 					"version": "4.0.0",
@@ -24898,7 +24992,8 @@
 				"path-to-regexp": {
 					"version": "0.1.7",
 					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-					"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+					"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+					"dev": true
 				},
 				"pem": {
 					"version": "1.14.4",
@@ -25076,6 +25171,7 @@
 					"version": "2.0.7",
 					"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
 					"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+					"dev": true,
 					"requires": {
 						"forwarded": "0.2.0",
 						"ipaddr.js": "1.9.1"
@@ -25144,7 +25240,8 @@
 				"range-parser": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-					"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+					"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+					"dev": true
 				},
 				"raw-body": {
 					"version": "2.4.0",
@@ -25369,7 +25466,8 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -25428,6 +25526,7 @@
 					"version": "0.17.1",
 					"resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
 					"integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+					"dev": true,
 					"requires": {
 						"debug": "2.6.9",
 						"depd": "~1.1.2",
@@ -25448,6 +25547,7 @@
 							"version": "2.6.9",
 							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"dev": true,
 							"requires": {
 								"ms": "2.0.0"
 							},
@@ -25455,14 +25555,16 @@
 								"ms": {
 									"version": "2.0.0",
 									"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-									"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+									"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+									"dev": true
 								}
 							}
 						},
 						"ms": {
 							"version": "2.1.1",
 							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-							"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+							"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+							"dev": true
 						}
 					}
 				},
@@ -25506,6 +25608,7 @@
 					"version": "1.14.1",
 					"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
 					"integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+					"dev": true,
 					"requires": {
 						"encodeurl": "~1.0.2",
 						"escape-html": "~1.0.3",
@@ -25528,7 +25631,8 @@
 				"setprototypeof": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-					"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+					"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+					"dev": true
 				},
 				"shared-preferences-builder": {
 					"version": "0.0.4",
@@ -25643,7 +25747,8 @@
 				"statuses": {
 					"version": "1.5.0",
 					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-					"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+					"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+					"dev": true
 				},
 				"stealthy-require": {
 					"version": "1.1.1",
@@ -25792,7 +25897,8 @@
 				"toidentifier": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-					"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+					"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+					"dev": true
 				},
 				"tough-cookie": {
 					"version": "2.5.0",
@@ -25887,7 +25993,8 @@
 				"unpipe": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-					"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+					"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+					"dev": true
 				},
 				"uri-js": {
 					"version": "4.4.1",
@@ -25939,7 +26046,8 @@
 				"utils-merge": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-					"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+					"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+					"dev": true
 				},
 				"uuid": {
 					"version": "8.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18688,7 +18688,6 @@
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-plugin-import": "^2.25.2",
-				"eslint-plugin-jest": "^25.2.3",
 				"eslint-plugin-jsdoc": "^37.0.3",
 				"eslint-plugin-jsx-a11y": "^6.5.1",
 				"eslint-plugin-prettier": "^3.3.0",
@@ -33824,12 +33823,12 @@
 			}
 		},
 		"eslint-plugin-jest": {
-			"version": "25.2.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.2.3.tgz",
-			"integrity": "sha512-Yoa0at3euTjERDvPGPWiItY1uuqKYQ5Ov2SmkSLmKRq9OFiVdEehw0rWuK4PA538k7CNqnvmkztjAB9l+HJ7kQ==",
+			"version": "27.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.1.tgz",
+			"integrity": "sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/experimental-utils": "^5.0.0"
+				"@typescript-eslint/utils": "^5.10.0"
 			}
 		},
 		"eslint-plugin-jest-dom": {

--- a/package.json
+++ b/package.json
@@ -185,6 +185,7 @@
 		"eslint-import-resolver-node": "0.3.4",
 		"eslint-plugin-eslint-comments": "3.1.2",
 		"eslint-plugin-import": "2.25.2",
+		"eslint-plugin-jest": "27.2.1",
 		"eslint-plugin-jest-dom": "4.0.2",
 		"eslint-plugin-playwright": "0.8.0",
 		"eslint-plugin-ssr-friendly": "1.0.6",

--- a/packages/block-editor/src/components/block-selection-clearer/test/index.js
+++ b/packages/block-editor/src/components/block-selection-clearer/test/index.js
@@ -50,7 +50,7 @@ describe( 'BlockSelectionClearer component', () => {
 
 		fireEvent.mouseDown( screen.getByTestId( 'selection-clearer' ) );
 
-		expect( mockClearSelectedBlock ).toBeCalled();
+		expect( mockClearSelectedBlock ).toHaveBeenCalled();
 	} );
 
 	it( 'should clear the selected block when multiple blocks are selected', () => {
@@ -71,7 +71,7 @@ describe( 'BlockSelectionClearer component', () => {
 
 		fireEvent.mouseDown( screen.getByTestId( 'selection-clearer' ) );
 
-		expect( mockClearSelectedBlock ).toBeCalled();
+		expect( mockClearSelectedBlock ).toHaveBeenCalled();
 	} );
 
 	it( 'should not clear the block selection when no blocks are selected', () => {
@@ -89,7 +89,7 @@ describe( 'BlockSelectionClearer component', () => {
 
 		fireEvent.mouseDown( screen.getByTestId( 'selection-clearer' ) );
 
-		expect( mockClearSelectedBlock ).not.toBeCalled();
+		expect( mockClearSelectedBlock ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should not clear the block selection when the feature is disabled', () => {
@@ -113,6 +113,6 @@ describe( 'BlockSelectionClearer component', () => {
 
 		fireEvent.mouseDown( screen.getByTestId( 'selection-clearer' ) );
 
-		expect( mockClearSelectedBlock ).not.toBeCalled();
+		expect( mockClearSelectedBlock ).not.toHaveBeenCalled();
 	} );
 } );

--- a/packages/block-editor/src/utils/test/parse-css-unit-to-px.js
+++ b/packages/block-editor/src/utils/test/parse-css-unit-to-px.js
@@ -22,20 +22,17 @@ describe( 'getPxFromCssUnit', () => {
 			[ '40Q', '38px' ], // 40 Q should be 1 cm.
 		];
 
+		test.each( testData )( 'getPxFromCssUnit( %s )', ( unit, expected ) => {
+			expect( getPxFromCssUnit( unit ) ).toBe( expected );
+		} );
 		test.each( testData )(
-			'test getPxFromCssUnit( %s )',
-			( unit, expected ) => {
-				expect( getPxFromCssUnit( unit ) ).toBe( expected );
-			}
-		);
-		test.each( testData )(
-			'test memoizedGetPxFromCssUnit( %s )',
+			'memoizedGetPxFromCssUnit( %s )',
 			( unit, expected ) => {
 				expect( memoizedGetPxFromCssUnit( unit ) ).toBe( expected );
 			}
 		);
 		test.each( testData )(
-			'test cached memoizedGetPxFromCssUnit( %s )',
+			'cached memoizedGetPxFromCssUnit( %s )',
 			( unit, expected ) => {
 				expect( memoizedGetPxFromCssUnit( unit ) ).toBe( expected );
 			}
@@ -63,14 +60,11 @@ describe( 'getPxFromCssUnit', () => {
 			[ '120%', '12px' ],
 		];
 
+		test.each( testData )( 'getPxFromCssUnit( %s )', ( unit, expected ) => {
+			expect( getPxFromCssUnit( unit, settings ) ).toBe( expected );
+		} );
 		test.each( testData )(
-			'test getPxFromCssUnit( %s )',
-			( unit, expected ) => {
-				expect( getPxFromCssUnit( unit, settings ) ).toBe( expected );
-			}
-		);
-		test.each( testData )(
-			'test memoizedGetPxFromCssUnit( %s )',
+			'memoizedGetPxFromCssUnit( %s )',
 			( unit, expected ) => {
 				expect( memoizedGetPxFromCssUnit( unit, settings ) ).toBe(
 					expected
@@ -78,7 +72,7 @@ describe( 'getPxFromCssUnit', () => {
 			}
 		);
 		test.each( testData )(
-			'test cached memoizedGetPxFromCssUnit( %s )',
+			'cached memoizedGetPxFromCssUnit( %s )',
 			( unit, expected ) => {
 				expect( memoizedGetPxFromCssUnit( unit, settings ) ).toBe(
 					expected
@@ -123,14 +117,11 @@ describe( 'getPxFromCssUnit', () => {
 			[ 'calc(12vw * 10px', null ], // Missing closing bracket.
 		];
 
+		test.each( testData )( 'getPxFromCssUnit( %s )', ( unit, expected ) => {
+			expect( getPxFromCssUnit( unit, settings ) ).toBe( expected );
+		} );
 		test.each( testData )(
-			'test getPxFromCssUnit( %s )',
-			( unit, expected ) => {
-				expect( getPxFromCssUnit( unit, settings ) ).toBe( expected );
-			}
-		);
-		test.each( testData )(
-			'test memoizedGetPxFromCssUnit( %s )',
+			'memoizedGetPxFromCssUnit( %s )',
 			( unit, expected ) => {
 				expect( memoizedGetPxFromCssUnit( unit, settings ) ).toBe(
 					expected
@@ -138,7 +129,7 @@ describe( 'getPxFromCssUnit', () => {
 			}
 		);
 		test.each( testData )(
-			'test cached memoizedGetPxFromCssUnit( %s )',
+			'cached memoizedGetPxFromCssUnit( %s )',
 			( unit, expected ) => {
 				expect( memoizedGetPxFromCssUnit( unit, settings ) ).toBe(
 					expected

--- a/packages/components/src/draggable/test/index.native.js
+++ b/packages/components/src/draggable/test/index.native.js
@@ -59,7 +59,7 @@ describe( 'Draggable', () => {
 			{ state: State.ACTIVE },
 		] );
 
-		expect( onLongPress ).toBeCalledTimes( 1 );
+		expect( onLongPress ).toHaveBeenCalledTimes( 1 );
 		expect( onLongPress ).toHaveBeenCalledWith( triggerId );
 	} );
 
@@ -111,16 +111,16 @@ describe( 'Draggable', () => {
 			{ state: State.END },
 		] );
 
-		expect( onDragStart ).toBeCalledTimes( 1 );
+		expect( onDragStart ).toHaveBeenCalledTimes( 1 );
 		expect( onDragStart ).toHaveBeenCalledWith( {
 			id: triggerId,
 			x: touchEvents[ 0 ].x,
 			y: touchEvents[ 0 ].y,
 		} );
-		expect( onDragOver ).toBeCalledTimes( 2 );
+		expect( onDragOver ).toHaveBeenCalledTimes( 2 );
 		expect( onDragOver ).toHaveBeenNthCalledWith( 1, touchEvents[ 1 ] );
 		expect( onDragOver ).toHaveBeenNthCalledWith( 2, touchEvents[ 2 ] );
-		expect( onDragEnd ).toBeCalledTimes( 1 );
+		expect( onDragEnd ).toHaveBeenCalledTimes( 1 );
 		expect( onDragEnd ).toHaveBeenCalledWith( {
 			id: triggerId,
 			x: touchEvents[ 2 ].x,

--- a/packages/components/src/theme/test/index.tsx
+++ b/packages/components/src/theme/test/index.tsx
@@ -26,7 +26,7 @@ const MyThemableComponent = ( props: MyThemableComponentProps ) => {
 
 describe( 'Theme', () => {
 	describe( 'accent color', () => {
-		it( 'it does not define the accent color (and its variations) as a CSS variable when the `accent` prop is undefined', () => {
+		it( 'does not define the accent color (and its variations) as a CSS variable when the `accent` prop is undefined', () => {
 			render(
 				<Theme data-testid="theme">
 					<MyThemableComponent>Inner</MyThemableComponent>
@@ -49,7 +49,7 @@ describe( 'Theme', () => {
 			} );
 		} );
 
-		it( 'it defines the accent color (and its variations) as a CSS variable', () => {
+		it( 'defines the accent color (and its variations) as a CSS variable', () => {
 			render(
 				<Theme accent="#123abc" data-testid="theme">
 					<MyThemableComponent>Inner</MyThemableComponent>
@@ -66,7 +66,7 @@ describe( 'Theme', () => {
 	} );
 
 	describe( 'background color', () => {
-		it( 'it does not define the background color (and its dependent colors) as a CSS variable when the `background` prop is undefined', () => {
+		it( 'does not define the background color (and its dependent colors) as a CSS variable when the `background` prop is undefined', () => {
 			render(
 				<Theme data-testid="theme">
 					<MyThemableComponent>Inner</MyThemableComponent>
@@ -91,7 +91,7 @@ describe( 'Theme', () => {
 			} );
 		} );
 
-		it( 'it defines the background color (and its dependent colors) as a CSS variable', () => {
+		it( 'defines the background color (and its dependent colors) as a CSS variable', () => {
 			render(
 				<Theme background="#ffffff" data-testid="theme">
 					<MyThemableComponent>Inner</MyThemableComponent>

--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -582,7 +582,7 @@ describe( 'ToolsPanel', () => {
 			// registerPanelItem has still only been called once.
 			expect( context.registerPanelItem ).toHaveBeenCalledTimes( 1 );
 			// deregisterPanelItem is called, given that we have switched panels.
-			expect( context.deregisterPanelItem ).toBeCalledWith(
+			expect( context.deregisterPanelItem ).toHaveBeenCalledWith(
 				altControlProps.label
 			);
 

--- a/packages/core-data/src/fetch/test/__experimental-fetch-url-data.js
+++ b/packages/core-data/src/fetch/test/__experimental-fetch-url-data.js
@@ -29,7 +29,7 @@ describe( 'fetchUrlData', () => {
 				fetchUrlData( 'https://www.wordpress.org' )
 			).resolves.toEqual( data );
 
-			expect( apiFetch ).toBeCalledTimes( 1 );
+			expect( apiFetch ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		it( 'rejects with error upon fetch failure', async () => {
@@ -49,7 +49,7 @@ describe( 'fetchUrlData', () => {
 				method: 'POST',
 			} );
 
-			expect( apiFetch ).toBeCalledTimes( 1 );
+			expect( apiFetch ).toHaveBeenCalledTimes( 1 );
 
 			const argsPassedToFetchApi = apiFetch.mock.calls[ 0 ][ 0 ];
 
@@ -74,7 +74,7 @@ describe( 'fetchUrlData', () => {
 			apiFetch.mockReturnValueOnce( Promise.resolve( data ) );
 
 			await expect( fetchUrlData( targetUrl ) ).resolves.toEqual( data );
-			expect( apiFetch ).toBeCalledTimes( 1 );
+			expect( apiFetch ).toHaveBeenCalledTimes( 1 );
 
 			// Allow us to reassert on calls without it being polluted by first fetch
 			// but retains the mock implementation from earlier.
@@ -84,7 +84,7 @@ describe( 'fetchUrlData', () => {
 			await expect( fetchUrlData( targetUrl ) ).resolves.toEqual( data );
 
 			// Should now be in cache so no need to refetch from API.
-			expect( apiFetch ).toBeCalledTimes( 0 );
+			expect( apiFetch ).toHaveBeenCalledTimes( 0 );
 		} );
 
 		it( 'does not cache failed requests', async () => {
@@ -109,7 +109,7 @@ describe( 'fetchUrlData', () => {
 			// with a new fetch.
 			await expect( fetchUrlData( targetUrl ) ).resolves.toEqual( data );
 
-			expect( apiFetch ).toBeCalledTimes( 2 );
+			expect( apiFetch ).toHaveBeenCalledTimes( 2 );
 		} );
 	} );
 
@@ -117,7 +117,7 @@ describe( 'fetchUrlData', () => {
 		it.each( [ '#internal-link' ] )(
 			'errors when an invalid URL is passed',
 			async ( targetUrl ) => {
-				expect( apiFetch ).toBeCalledTimes( 0 );
+				expect( apiFetch ).toHaveBeenCalledTimes( 0 );
 
 				await expect( fetchUrlData( targetUrl ) ).rejects.toEqual(
 					expect.stringContaining(
@@ -134,7 +134,7 @@ describe( 'fetchUrlData', () => {
 		] )(
 			'errors when a non-http protocol (%s) is passed as part of URL',
 			async ( targetUrl ) => {
-				expect( apiFetch ).toBeCalledTimes( 0 );
+				expect( apiFetch ).toHaveBeenCalledTimes( 0 );
 
 				await expect( fetchUrlData( targetUrl ) ).rejects.toEqual(
 					expect.stringContaining(

--- a/packages/data/src/components/with-dispatch/test/index.js
+++ b/packages/data/src/components/with-dispatch/test/index.js
@@ -78,7 +78,7 @@ describe( 'withDispatch', () => {
 
 		// Function value reference should not have changed in props update.
 		// The spy method is only called during inital render.
-		expect( ButtonSpy ).toBeCalledTimes( 1 );
+		expect( ButtonSpy ).toHaveBeenCalledTimes( 1 );
 
 		await user.click( screen.getByRole( 'button' ) );
 		expect( registry.select( 'counter' ).getCount() ).toBe( 2 );

--- a/packages/data/src/plugins/persistence/test/index.js
+++ b/packages/data/src/plugins/persistence/test/index.js
@@ -29,7 +29,7 @@ describe( 'persistence', () => {
 		expect( () => {
 			const options = Object.freeze( { persist: true, reducer() {} } );
 			registry.registerStore( 'test', options );
-		} ).not.toThrowError( /object is not extensible/ );
+		} ).not.toThrow( /object is not extensible/ );
 	} );
 
 	it( 'should load a persisted value as initialState', () => {

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -737,6 +737,7 @@ describe( 'createRegistry', () => {
 	describe( 'use', () => {
 		it( 'should pass through options object to plugin', () => {
 			const expectedOptions = {};
+			const anyObject = expect.any( Object );
 			let actualOptions;
 
 			function plugin( _registry, options ) {
@@ -748,7 +749,7 @@ describe( 'createRegistry', () => {
 					Object.fromEntries(
 						Object.entries( registry ).map( ( [ key ] ) => {
 							if ( key === 'stores' ) {
-								return [ key, expect.any( Object ) ];
+								return [ key, anyObject ];
 							}
 							// TODO: Remove this after namsespaces is removed.
 							if ( key === 'namespaces' ) {

--- a/packages/editor/src/components/autosave-monitor/test/index.js
+++ b/packages/editor/src/components/autosave-monitor/test/index.js
@@ -174,7 +174,10 @@ describe( 'AutosaveMonitor', () => {
 
 		jest.runOnlyPendingTimers();
 
-		expect( setTimeout ).lastCalledWith( expect.any( Function ), 5000 );
+		expect( setTimeout ).toHaveBeenLastCalledWith(
+			expect.any( Function ),
+			5000
+		);
 	} );
 
 	it( 'should schedule itself in 1000 ms if the post is not autosaveable at a time', () => {
@@ -186,6 +189,9 @@ describe( 'AutosaveMonitor', () => {
 
 		jest.runOnlyPendingTimers();
 
-		expect( setTimeout ).lastCalledWith( expect.any( Function ), 1000 );
+		expect( setTimeout ).toHaveBeenLastCalledWith(
+			expect.any( Function ),
+			1000
+		);
 	} );
 } );

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Bump `eslint-plugin-jest` version to 27.2.1.
+
 ## 13.8.0 (2023-01-02)
 
 ## 13.7.0 (2022-12-14)

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -39,7 +39,7 @@
 		"cosmiconfig": "^7.0.0",
 		"eslint-config-prettier": "^8.3.0",
 		"eslint-plugin-import": "^2.25.2",
-		"eslint-plugin-jest": "^25.2.3",
+		"eslint-plugin-jest": "^27.2.1",
 		"eslint-plugin-jsdoc": "^37.0.3",
 		"eslint-plugin-jsx-a11y": "^6.5.1",
 		"eslint-plugin-prettier": "^3.3.0",

--- a/packages/scripts/scripts/test-e2e.js
+++ b/packages/scripts/scripts/test-e2e.js
@@ -12,7 +12,6 @@ process.on( 'unhandledRejection', ( err ) => {
 /**
  * External dependencies
  */
-/* eslint-disable-next-line jest/no-jest-import */
 const jest = require( 'jest' );
 const { sync: spawn } = require( 'cross-spawn' );
 

--- a/packages/scripts/scripts/test-unit-jest.js
+++ b/packages/scripts/scripts/test-unit-jest.js
@@ -12,7 +12,6 @@ process.on( 'unhandledRejection', ( err ) => {
 /**
  * External dependencies
  */
-/* eslint-disable-next-line jest/no-jest-import */
 const jest = require( 'jest' );
 
 /**


### PR DESCRIPTION
## What?
This PR enables the `jest/recommended` rules for tests. We're updating to the latest `eslint-plugin-jest` version too. Finally, we're addressing all the present errors, most of which are pretty straightforward. 

## Why?
By enabling the ESLint plugins of our libraries and enabling their recommended configuration, we ensure to be following the best practices for writing our tests.

## How?
Most of what we're doing is straightforward, but I'll do a self-review to add context.

## Testing Instructions
* Verify all tests still pass.
* Verify there are no new linting errors: `npm run lint:js`

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None
