### PR TITLE
Block inserter search e2e test: scope list item lookup to the inserter panel

### DIFF
--- a/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js
@@ -318,7 +318,7 @@ describe( 'Inserting blocks', () => {
 		);
 		await browseAll.click();
 		const availableBlocks = await page.$$(
-			'.block-editor-block-types-list__list-item'
+			'.edit-post-editor__inserter-panel .block-editor-block-types-list__list-item'
 		);
 		expect( availableBlocks ).toHaveLength( 1 );
 	} );


### PR DESCRIPTION
Fixes #45332. There is a flaky e2e test, "passes the search value in the main inserter when clicking `Browse all`":

<img width="844" alt="Screenshot 2023-01-11 at 14 03 11" src="https://user-images.githubusercontent.com/664258/211819134-354be30a-c442-4721-a300-132e4a3c4ee7.png">

Most recently seen in @tyxla's https://github.com/WordPress/gutenberg/pull/47056#issuecomment-1378666882 and also in #46467 (enabling concurrent mode) where I originally fixed it.

There's a situation that looks like this:

<img width="1134" alt="Screenshot 2023-01-06 at 8 47 22" src="https://user-images.githubusercontent.com/664258/211819390-56665c71-dcc6-4700-be98-9f3c7a3f74d7.png">

We enter a search term into a popover block inserter ("Verse"), then click "Browse all" and expect the search term to be transferred to the sidebar inserter panel.

But there is a brief moment in time where _both_ inserters are shown. The panel is displayed synchronously after clicking on "Browse all", but the popover is hidden only a bit later, after a `setTimeout( fn, 0 )` inside [`useFocusOutside`](https://github.com/WordPress/gutenberg/blob/trunk/packages/compose/src/hooks/use-focus-outside/index.ts#L171-L184).

Sometimes the test catches just that moment and then finds two block list items instead of just one. I'm fixing the test by scoping the list item lookup only to the sidebar panel.