### PR TITLE
Search Block: Apply border color correctly when button is outside or absent

### DIFF
--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -66,14 +66,14 @@ function render_block_core_search( $attributes ) {
 
 	if ( $show_input ) {
 		$input_classes = array( 'wp-block-search__input' );
-		if ( $is_button_inside ) {
+		if ( ! $is_button_inside && ! empty( $border_color_classes ) ) {
 			$input_classes[] = $border_color_classes;
 		}
 		if ( ! empty( $typography_classes ) ) {
 			$input_classes[] = $typography_classes;
 		}
 		$input_markup = sprintf(
-			'<input type="search" id="%s" class="wp-block-search__input %s" name="s" value="%s" placeholder="%s" %s required />',
+			'<input type="search" id="%s" class="%s" name="s" value="%s" placeholder="%s" %s required />',
 			$input_id,
 			esc_attr( implode( ' ', $input_classes ) ),
 			get_search_query(),


### PR DESCRIPTION
## What?
This PR fixes an issue where the border color is not applied correctly on the front end when there is a button outside or no button in the search block.

| Editor | Frontend |
| --- | --- |
| ![editor](https://user-images.githubusercontent.com/54422211/211822455-a830ba19-172f-43ea-b57d-73ac8ab9f52c.png) |![frontend](https://user-images.githubusercontent.com/54422211/211822494-9fc292ad-d724-4966-9d80-f27d2b1b8720.png) |

## Why?
I think the condition for applying the border color class is reversed.

## How?
I have correctly changed the condition statement. At the same time, I added an empty check for the `$border_color_classes`, [as is done on the button element](https://github.com/WordPress/gutenberg/blob/2d4949606169ca88010ebcd23da720c5f9d015b8/packages/block-library/src/search/index.php#L106).

## Testing Instructions

- Use the following markup to add blocks.

<details>
<summary>Test Data</summary>

```html
<!-- wp:search {"label":"The border color is applied to the input and button elements when the button is outside","placeholder":"Placeholder","buttonText":"Search","style":{"border":{"width":"10px"}},"borderColor":"pale-pink"} /-->

<!-- wp:search {"label":"Only the wrapper gets the color when the button is inside","placeholder":"Placeholder","buttonText":"Search","buttonPosition":"button-inside","style":{"border":{"width":"10px"}},"borderColor":"pale-pink"} /-->

<!-- wp:search {"label":"Only the input element gets the color when the block has no button","placeholder":"Placeholder","buttonText":"Search","buttonPosition":"no-button","style":{"border":{"width":"10px"}},"borderColor":"pale-pink"} /-->
```
</details>


- As with the editor, verify that the border color is applied correctly on the front end.