### PR TITLE
Navigation Link: Fix PHP notices in unit tests

### DIFF
--- a/phpunit/class-block-library-navigation-link-test.php
+++ b/phpunit/class-block-library-navigation-link-test.php
@@ -87,7 +87,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 
 	public static function wpTearDownAfterClass() {
 		foreach ( self::$pages as $page_to_delete ) {
-			wp_delete_post( $page_to_delete );
+			wp_delete_post( $page_to_delete->ID );
 		}
 		foreach ( self::$terms as $term_to_delete ) {
 			wp_delete_term( $term_to_delete->term_id, $term_to_delete->taxonomy );


### PR DESCRIPTION
## What?
PR fixes PHP notices generate by the Navigation Link unit tests.

Notice

```
PHP Notice:  Function wpdb::prepare was called <strong>incorrectly</strong>. Unsupported value type (object). Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 4.8.2.) in /var/www/html/wp-includes/functions.php on line 5838
```

## Why?
We passed the post object to the `wp_delete_post` in the teardown method when it expects the post ID.

## Testing Instructions
Running this command shouldn't generate the notice (see above).

```
npm run test:unit:php -- --filter Block_Library_Navigation_Link_Test
```
