### PR TITLE
Ensure appropriate fallback menu title in Nav block menu selector

### DIFF
--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -66,8 +66,12 @@ function NavigationMenuSelector( {
 
 	const menuChoices = useMemo( () => {
 		return (
-			navigationMenus?.map( ( { id, title } ) => {
-				const label = decodeEntities( title.rendered );
+			navigationMenus?.map( ( { id, title }, index ) => {
+				const label =
+					decodeEntities( title.rendered ) ||
+					/* translators: %s is the index of the menu in the list of menus. */
+					sprintf( __( 'Untitled menu %s' ), index + 1 );
+
 				if ( id === currentMenuId && ! isCreatingMenu ) {
 					setSelectorLabel(
 						/* translators: %s is the name of a navigation menu. */

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -70,7 +70,7 @@ function NavigationMenuSelector( {
 				const label =
 					decodeEntities( title.rendered ) ||
 					/* translators: %s is the index of the menu in the list of menus. */
-					sprintf( __( 'Untitled menu %s' ), index + 1 );
+					sprintf( __( '(no title %s)' ), index + 1 );
 
 				if ( id === currentMenuId && ! isCreatingMenu ) {
 					setSelectorLabel(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Ensures all menus in the Nav block menu selector have a name.

Closes https://github.com/WordPress/gutenberg/issues/47060

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's possible for a given menu(s) to not have a `title` property (i.e. one which is an empty string). In this case we currently display nothing in the dropdown (see Issue).

This needs to be fixed to allow the user to switch between menus.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Checks for title and if missing provides a suitable fallback with an appropriate index to distinguish between them if there are mutliple untitled menus.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Create x2 menus.
- Go to http://localhost:8888/wp-admin/edit.php?post_type=wp_navigation&paged=1
- Quick Edit both menus and delete their post titles.
- Return to editor and reload.
- Toggle open list view sidebar.
- In the dropdown you should see `Untitled menu %%index%%` for each of the untitled menus.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="454" alt="Screen Shot 2023-01-11 at 14 41 14" src="https://user-images.githubusercontent.com/444434/211834818-25a2984e-6efa-40ce-ac87-746e7b6e572b.png">
