### PR TITLE
Fix misaligned layout control icons

### DIFF
--- a/packages/block-editor/src/hooks/layout.scss
+++ b/packages/block-editor/src/hooks/layout.scss
@@ -7,7 +7,7 @@
 		margin-right: $grid-unit-30;
 
 		svg {
-			margin: auto 0 $grid-unit-05 $grid-unit-10;
+			margin: auto 0 auto $grid-unit-10;
 		}
 	}
 }

--- a/packages/block-editor/src/hooks/layout.scss
+++ b/packages/block-editor/src/hooks/layout.scss
@@ -7,8 +7,12 @@
 		margin-right: $grid-unit-30;
 
 		svg {
-			margin: auto 0 auto $grid-unit-10;
+			margin: auto 0 $grid-unit-05 $grid-unit-10;
 		}
+	}
+
+	.components-input-control {
+		margin-bottom: 0;
 	}
 }
 

--- a/packages/block-editor/src/hooks/layout.scss
+++ b/packages/block-editor/src/hooks/layout.scss
@@ -10,10 +10,10 @@
 			margin: auto 0 $grid-unit-05 $grid-unit-10;
 		}
 	}
+}
 
-	.components-input-control {
-		margin-bottom: 0;
-	}
+.block-editor-block-inspector .block-editor-hooks__layout-controls-unit-input {
+	margin-bottom: 0;
 }
 
 .block-editor-hooks__layout-controls-reset {

--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -71,6 +71,7 @@ export default {
 				<div className="block-editor-hooks__layout-controls">
 					<div className="block-editor-hooks__layout-controls-unit">
 						<UnitControl
+							className="block-editor-hooks__layout-controls-unit-input"
 							label={ __( 'Content' ) }
 							labelPosition="top"
 							__unstableInputWidth="80px"
@@ -91,6 +92,7 @@ export default {
 					</div>
 					<div className="block-editor-hooks__layout-controls-unit">
 						<UnitControl
+							className="block-editor-hooks__layout-controls-unit-input"
 							label={ __( 'Wide' ) }
 							labelPosition="top"
 							__unstableInputWidth="80px"


### PR DESCRIPTION
## What?
Apply `auto` margin-bottom to vertically center the layout controls again. Closes #47088.

## Why?
The icons are no longer where they should be. Look fine in WordPress core, but not in Gutenberg. 

## How?
Minor style change. 

## Testing Instructions
1. Add a group block
2. Open Inspector Sidebar
3. See icons properly aligned in the Layout panel

## Screenshots or screencast <!-- if applicable -->

Before: 
<img width="493" alt="211924238-6740381f-5346-4764-a3a1-c7ff2601ea36" src="https://user-images.githubusercontent.com/1813435/211925524-66edf7d4-395b-4279-b4de-7d5f23e7a5b3.png">

After: 

<img width="577" alt="CleanShot 2023-01-11 at 16 51 26@2x" src="https://user-images.githubusercontent.com/1813435/211925498-832189b4-be11-4999-abda-ba8cd6caf03f.png">
