### PR TITLE
Add "Learn more about CSS" help text to Custom CSS control

### DIFF
--- a/packages/edit-site/src/components/global-styles/custom-css.js
+++ b/packages/edit-site/src/components/global-styles/custom-css.js
@@ -1,7 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { TextareaControl, Panel, PanelBody } from '@wordpress/components';
+import {
+	ExternalLink,
+	TextareaControl,
+	Panel,
+	PanelBody,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -51,9 +56,13 @@ function CustomCSSControl() {
 				rows={ 15 }
 				className="edit-site-global-styles__custom-css-input"
 				spellCheck={ false }
-				help={ __(
-					"Enter your custom CSS in the textarea and preview in the editor. Changes won't take effect until you've saved the template."
-				) }
+				help={
+					<>
+						<ExternalLink href="https://wordpress.org/support/article/css/">
+							{ __( 'Learn more about CSS' ) }
+						</ExternalLink>
+					</>
+				}
 			/>
 			{ originalThemeCustomCSS && (
 				<Panel>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #46669 by replacing the redundant help text with the same "Learn more about CSS" link that currently exists in the Customizer. 

## Why?
- Remove duplicative/confusing help text (current help text suggests CSS is applied to a "template", but it is applied throughout the site). 
- Present a teachable moment for those users who want to deploy additional CSS on their site.

## How?
Leverages the ExternalLink component, using the same link that is currently employed in the Customizer. 

## Testing Instructions
1. Enable the Global styles custom CSS experiment
1. Open the Site Editor.
2. View the Global Styles sidebar.
3. Click on "Custom" 
4. View the control with new help text

## Screenshot

Current: 
<img width="468" alt="CleanShot 2023-01-11 at 17 38 11@2x" src="https://user-images.githubusercontent.com/1813435/211933002-61ecc7be-8d4b-46d2-b55e-7748106fdf71.png">


Suggested: 
<img width="461" alt="211931900-008da51e-0ee2-43a0-895a-5dc5c48ba414" src="https://user-images.githubusercontent.com/1813435/211932826-6c9ca316-637f-4d05-b430-ae98295d6fed.png">
