### PR TITLE
Change "Custom" CSS navigation label to "Additional CSS"

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-root.js
+++ b/packages/edit-site/src/components/global-styles/screen-root.js
@@ -122,7 +122,9 @@ function ScreenRoot() {
 								aria-label={ __( 'Additional CSS' ) }
 							>
 								<HStack justify="space-between">
-									<FlexItem>{ __( 'Custom' ) }</FlexItem>
+									<FlexItem>
+										{ __( 'Additional CSS' ) }
+									</FlexItem>
 									<IconWithCurrentColor
 										icon={
 											isRTL() ? chevronLeft : chevronRight


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #47092 by changing the more ambiguous `Custom` label, to the more familiar `Additional CSS` label.

## Why?
In its current form, you have to read the descriptive text to understand that this navigation button will get you to where you add additional CSS. With the change, it's immediately clear — and familiar (as it is the same language as the Customizer has used for years). 

## How?
Small copy change. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Ensure the custom css experiment is on. 
2. Head to the Site Editor, Global Styles sidebar.
3. See change.

## Screenshots or screencast <!-- if applicable -->

Current: 

<img width="430" alt="211938359-ffd6aebf-63c0-4798-b37c-6dcd1d2a69bd" src="https://user-images.githubusercontent.com/1813435/211939032-efb9fbaf-9e0f-4167-a257-48cfbac09e1f.png">


This PR:

<img width="408" alt="211938198-445df2b4-3896-45d5-9078-ae4b521e1b48" src="https://user-images.githubusercontent.com/1813435/211939008-9422563b-eddf-444a-ad34-9fe97184187e.png">
