### PR TITLE
Performance: Avoid string-allocation on keypress with inputRule

### DIFF
--- a/packages/format-library/src/code/index.js
+++ b/packages/format-library/src/code/index.js
@@ -20,16 +20,18 @@ export const code = {
 	__unstableInputRule( value ) {
 		const BACKTICK = '`';
 		const { start, text } = value;
-		const characterBefore = text.slice( start - 1, start );
+		const characterBefore = text[ start - 1 ];
 
 		// Quick check the text for the necessary character.
 		if ( characterBefore !== BACKTICK ) {
 			return value;
 		}
 
-		const textBefore = text.slice( 0, start - 1 );
-		const indexBefore = textBefore.lastIndexOf( BACKTICK );
+		if ( start - 2 < 0 ) {
+			return value;
+		}
 
+		const indexBefore = text.lastIndexOf( BACKTICK, start - 2 );
 		if ( indexBefore === -1 ) {
 			return value;
 		}


### PR DESCRIPTION
## What?

Introduce subtle performance refactor.

## Why?

Every bit of code that runs on every keypress is in the critical hot path. If we can avoid GC pressure, memory allocations, or CPU cycles, we should examine that to guard the responsiveness of the editor for someone while typing.

## How?

While checking for inline code snippets surrounded by the backtick we have been allocating new substrings from input strings when looking for those characters, but we don't need to do this.

In this patch we're directly checking for the character on the input string using string indexing and then passing the `position` parameter to the `lastIndexOf` function so that it is able to scan the original input string without copying it.

The performance impact of this change should be small and hard to measure, but it should reduce pressure on the garbage collector and be worthwhile even without clear measured results.

## Testing Instructions

Verify that inline code snippets are still functioning the way we expect them to. Check at the beginning of a line, or at the end of one.

Try by adding backticks around existing text.

Note that some peculiarities of the inline code behavior is already in `trunk`, for example, when entering a new backtick when others exist already in a paragraph. The following video was recorded from `trunk` to show that _this isn't a new issue in this PR_.

https://user-images.githubusercontent.com/5431237/211943330-71fff9d5-bce3-41bf-8551-a04d39fdfabe.mov

