### PR TITLE
Perf: Avoid cloning listeners in data event emitter

### DIFF
--- a/packages/data/src/utils/emitter.js
+++ b/packages/data/src/utils/emitter.js
@@ -7,11 +7,43 @@ export function createEmitter() {
 	let isPaused = false;
 	let isPending = false;
 	const listeners = new Set();
-	const notifyListeners = () =>
-		// We use Array.from to clone the listeners Set
-		// This ensures that we don't run a listener
-		// that was added as a response to another listener.
-		Array.from( listeners ).forEach( ( listener ) => listener() );
+	const deletedListeners = new Set();
+	const existingEndToken = () => {};
+
+	const notifyListeners = () => {
+		// Drop everything that's already been removed from the queue.
+		for ( const deletedListener of deletedListeners ) {
+			listeners.delete( deletedListener );
+		}
+		deletedListeners.clear();
+
+		// Some listeners might add new listeners while we're
+		// iterating; we want to avoid calling them now though.
+		// Since Set iteration occurs in insertion order we can
+		// add a unique symbol to indicate the last existing
+		// listener and stop iterating once we find it. All
+		// listeners added after the symbol _must_ have been
+		// added while iterating, and we can skip them until
+		// the next time this is called.
+		// Add this, but make sure it's the last item in the set.
+		listeners.delete( existingEndToken );
+		listeners.add( existingEndToken );
+		for ( const listener of listeners ) {
+			if ( existingEndToken === listener ) {
+				break;
+			}
+
+			listener();
+
+			// Listeners deleted on this go-around are run one
+			// final time and then removed from future queues.
+			if ( deletedListeners.has( listener ) ) {
+				deletedListeners.delete( listener );
+				listeners.delete( listener );
+			}
+		}
+		listeners.delete( existingEndToken );
+	};
 
 	return {
 		get isPaused() {
@@ -20,7 +52,11 @@ export function createEmitter() {
 
 		subscribe( listener ) {
 			listeners.add( listener );
-			return () => listeners.delete( listener );
+
+			// Because we call listeners that have been removed during
+			// the process of notifying existing listeners, we enqueue
+			// them for removal instead of directly removing them.
+			return () => deletedListeners.add( listener );
 		},
 
 		pause() {


### PR DESCRIPTION
## Notes

I'm not sure whether to expect the impact of this change to be measurable. Initially it appeared as though it was cutting off 100ms of typing lag on a local build of Gutenberg, but after reverting the change the lag was gone, so I think something within my session was slow and this could be a red-herring. Still, as I hunt for unnecessary allocations it seems wise to consider this change anyway. GC pressure is extremely difficult to measure and connect back to source code but it has a significant impact on runtime performance.

## What?

Introduces a subtle performance refactor in the data module's base event emitter.

## Why?

This code is in almost every critical hot path for editor updates and interactivity. Every little improvement is important for guarding the editor responsiveness while typing, and reducing GC pressure might be a significant hidden component to this work.

## How?

In the core event emitter class for the `@data` module we have a note explaining that we clone the set of listeners to avoid calling newly created listeners during the `notifyListeners` loop.

In this patch we use a special token inserted at the end of the listeners set that indicates when we've reached the last previously-existing listener while iterating. This is a result of `Set` iteration following insertion order.

By adding, watching for, and removing this token we can safely iterate the set without cloning on every call, which can reduce pressure on the garbage collector and lead to lower memory use and reduced GC overhead.

The results of this change may or may not be easily measurable, but if it's found to be a positive change regardless it might still be worth introducing since this code is in the critical path of all state updates, and it runs following every key press.

## Testing

Since this code is run in so many places the test suite should start failing if it's breaking something. The risk involved in this change is that we re-run a listener that was added during a call to `notifyListeners`, as the comment in the existing code warns about. While that should be impossible with this patch, it's worth trying to find a way to verify this aspect of its behavior. I'm not sure when or how that might arise, so help would be welcome in identifying it.

#reduce-allocations