### PR TITLE
Remove ESLint ignore directive docs

### DIFF
--- a/packages/element/src/raw-html.js
+++ b/packages/element/src/raw-html.js
@@ -3,7 +3,6 @@
  */
 import { Children, createElement } from './react';
 
-// Disable reason: JSDoc linter doesn't seem to parse the union (`&`) correctly.
 /** @typedef {{children: string} & import('react').ComponentPropsWithoutRef<'div'>} RawHTMLProps */
 
 /**

--- a/packages/prettier-config/lib/index.js
+++ b/packages/prettier-config/lib/index.js
@@ -15,8 +15,6 @@ const isWPPrettier = prettierPackage.name === 'wp-prettier';
 const customOptions = isWPPrettier ? { parenSpacing: true } : {};
 const customStyleOptions = isWPPrettier ? { parenSpacing: false } : {};
 
-// Disable reason: The current JSDoc tooling does not yet understand TypeScript
-// union types.
 /** @type {PrettierConfig & WPPrettierOptions} */
 const config = {
 	useTabs: true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR is a follow up to #24586 where ESLint ignore directives were removed after an update to the ESLint JSDoc package added support for type declarations, whilst the ignore directives were removed not all the comments explaining the ignore directives were removed, this PR removes those.

References:

- [packages/element/src/raw-html.js](https://github.com/WordPress/gutenberg/pull/24586/files#diff-567fd351104c401b15a8466bf2b2b623ea37b425f177fc4907e442706229f7bcR6)
- [packages/prettier-config/lib/index.js](https://github.com/WordPress/gutenberg/pull/24586/files#diff-dd5bcef0bab45794d4f4122ee12bde08a3899471e6d4a7edef715fbeb453e69bR9)


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To remove redundant documentation

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
n/a

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
