### PR TITLE
Try removing default align-items styles from flex layout

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -267,11 +267,6 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 					'selector'     => $selector,
 					'declarations' => array( 'align-items' => $justify_content_options[ $layout['justifyContent'] ] ),
 				);
-			} else {
-				$layout_styles[] = array(
-					'selector'     => $selector,
-					'declarations' => array( 'align-items' => 'flex-start' ),
-				);
 			}
 			if ( ! empty( $layout['verticalAlignment'] ) && array_key_exists( $layout['verticalAlignment'], $vertical_alignment_options ) ) {
 				$layout_styles[] = array(

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -346,8 +346,7 @@
 						{
 							"selector": "",
 							"rules": {
-								"flex-wrap": "wrap",
-								"align-items": "center"
+								"flex-wrap": "wrap"
 							}
 						},
 						{

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -138,8 +138,7 @@ export default {
 			: 'wrap';
 		const verticalAlignment =
 			verticalAlignmentMap[ layout.verticalAlignment ];
-		const alignItems =
-			alignItemsMap[ layout.justifyContent ] || alignItemsMap.left;
+		const alignItems = alignItemsMap[ layout.justifyContent ];
 
 		let output = '';
 		const rules = [];
@@ -160,7 +159,9 @@ export default {
 				rules.push( `justify-content: ${ verticalAlignment }` );
 			}
 			rules.push( 'flex-direction: column' );
-			rules.push( `align-items: ${ alignItems }` );
+			if ( alignItems ) {
+				rules.push( `align-items: ${ alignItems }` );
+			}
 		}
 
 		if ( rules.length ) {

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -197,12 +197,7 @@ function FlexLayoutVerticalAlignmentControl( {
 } ) {
 	const { orientation = 'horizontal' } = layout;
 
-	const defaultVerticalAlignment =
-		orientation === 'horizontal'
-			? verticalAlignmentMap.center
-			: verticalAlignmentMap.top;
-
-	const { verticalAlignment = defaultVerticalAlignment } = layout;
+	const { verticalAlignment = 'top' } = layout;
 
 	const onVerticalAlignmentChange = ( value ) => {
 		onChange( {
@@ -264,7 +259,10 @@ function FlexLayoutJustifyContentControl( {
 	onChange,
 	isToolbar = false,
 } ) {
-	const { justifyContent = 'left', orientation = 'horizontal' } = layout;
+	const { orientation = 'horizontal' } = layout;
+	const defaultJustification =
+		orientation === 'horizontal' ? 'left' : 'stretch';
+	const { justifyContent = defaultJustification } = layout;
 	const onJustificationChange = ( value ) => {
 		onChange( {
 			...layout,

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -1,11 +1,6 @@
 // Import styles for rendering the static content of deprecated gallery versions.
 @import "./deprecated.scss";
 
-// The following is a temporary override until flex layout supports
-// an align items setting of normal.
-figure.wp-block-gallery.has-nested-images {
-	align-items: normal;
-}
 // Styles for current version of gallery block.
 .wp-block-gallery.has-nested-images {
 	// Need bogus :not(#individual-image) to override long :not()

--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -53,7 +53,8 @@
 			"allowInheriting": false,
 			"allowVerticalAlignment": false,
 			"default": {
-				"type": "flex"
+				"type": "flex",
+				"justifyContent": "left"
 			}
 		},
 		"color": {

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -12,6 +12,11 @@
 	// Unset background colors that can be inherited from Global Styles.
 	background: none;
 
+	// Alignment style needed for vertical orientation so buttons don't stretch full width.
+	&.is-vertical {
+		align-items: flex-start;
+	}
+
 	// Some themes add underlines, false underlines (via shadows), and borders to <a>.
 	.wp-social-link a,
 	.wp-social-link a:hover {

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -12,11 +12,6 @@
 	// Unset background colors that can be inherited from Global Styles.
 	background: none;
 
-	// Alignment style needed for vertical orientation so buttons don't stretch full width.
-	&.is-vertical {
-		align-items: flex-start;
-	}
-
 	// Some themes add underlines, false underlines (via shadows), and borders to <a>.
 	.wp-social-link a,
 	.wp-social-link a:hover {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We're increasingly running into issues caused by the `align-items` property that gets added by default to flex layouts. In horizontal layouts, we're adding `align-items: center` and in vertical ones `align-items: flex-start`. For most blocks, it's not useful to set these properties to these particular values, and in some cases it's actively working against their layout potential. 

I've only found one case where setting this value by default is needed: the Social Icons block in its vertical orientation, as described in #38069.

#46133 and #45117 describe layout scenarios that should be fairly straightforward to build and become difficult or impossible with the current `align-items` defaults.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* This PR tries removing `align-items` from the default flex layout. 
* Given the special case of Social Icons, it adds the property back in this block's styles.
* It also removes a fallback style from the Gallery block which should no longer be needed.

It's still possible to manipulate the value to some extent in horizontal orientations (such as Row block) with the block alignment settings, and the justification controls for vertical orientations (such as Stack block).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add the following blocks to a page: Social Icons, Buttons, Gallery, Navigation, Row, Stack.
2. Add some contents to each and check that they render as expected in the editor and the front end.
3. Check that the layouts described in #46133 and #45117 are now possible to build with no custom CSS additions.

 
### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

A Stack inside a Row should now by default take up the full height of the tallest block inside the Row:

<img width="753" alt="Screenshot 2023-01-12 at 3 42 05 pm" src="https://user-images.githubusercontent.com/8096000/211977945-5964152f-471a-4952-95ba-f357e5c64f3c.png">
