### PR TITLE
Fix tab panel initial tab selection

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 -   `Placeholder`: set fixed right margin for label's icon ([46918](https://github.com/WordPress/gutenberg/pull/46918)).
 -   `TreeGrid`: Fix right-arrow keyboard navigation when a row contains more than two focusable elements ([46998](https://github.com/WordPress/gutenberg/pull/46998)).
+-   `TabPanel`: Fix initial tab selection when the tab declaration is lazily added to the `tabs` array ([47100](https://github.com/WordPress/gutenberg/pull/47100)).
 
 ## 23.1.0 (2023-01-02)
 

--- a/packages/components/src/tab-panel/index.tsx
+++ b/packages/components/src/tab-panel/index.tsx
@@ -103,25 +103,47 @@ export function TabPanel( {
 	const selectedTab = tabs.find( ( { name } ) => name === selected );
 	const selectedId = `${ instanceId }-${ selectedTab?.name ?? 'none' }`;
 
+	// Handle selecting the initial tab.
 	useEffect( () => {
-		const firstEnabledTab = tabs.find( ( tab ) => ! tab.disabled );
+		// If there's a selected tab, don't override it.
+		if ( selectedTab ) {
+			return;
+		}
+
 		const initialTab = tabs.find( ( tab ) => tab.name === initialTabName );
-		if ( ! selectedTab?.name && firstEnabledTab ) {
-			handleTabSelection(
-				initialTab && ! initialTab.disabled
-					? initialTab.name
-					: firstEnabledTab.name
-			);
-		} else if ( selectedTab?.disabled && firstEnabledTab ) {
+
+		// Wait for the denoted initial tab to be declared before making a
+		// selection. This ensures that if a tab is declared lazily it can
+		// still receive initial selection.
+		if ( initialTabName && ! initialTab ) {
+			return;
+		}
+
+		if ( initialTab && ! initialTab.disabled ) {
+			// Select the initial tab if it's not disabled.
+			handleTabSelection( initialTab.name );
+		} else {
+			// Fallback to the first enabled tab when the initial is disabled.
+			const firstEnabledTab = tabs.find( ( tab ) => ! tab.disabled );
+			if ( firstEnabledTab ) handleTabSelection( firstEnabledTab.name );
+		}
+	}, [ tabs, selectedTab, initialTabName, handleTabSelection ] );
+
+	// Handle the currently selected tab becoming disabled.
+	useEffect( () => {
+		// This effect only runs when the selected tab is defined and becomes disabled.
+		if ( ! selectedTab?.disabled ) {
+			return;
+		}
+
+		const firstEnabledTab = tabs.find( ( tab ) => ! tab.disabled );
+
+		// If the currently selected tab becomes disabled, select the first enabled tab.
+		// (if there is one).
+		if ( firstEnabledTab ) {
 			handleTabSelection( firstEnabledTab.name );
 		}
-	}, [
-		tabs,
-		selectedTab?.name,
-		selectedTab?.disabled,
-		initialTabName,
-		handleTabSelection,
-	] );
+	}, [ tabs, selectedTab?.disabled, handleTabSelection ] );
 
 	return (
 		<div className={ className }>

--- a/packages/components/src/tab-panel/test/index.tsx
+++ b/packages/components/src/tab-panel/test/index.tsx
@@ -147,7 +147,7 @@ describe( 'TabPanel', () => {
 		);
 	} );
 
-	it( 'should select `initialTabname` if defined', () => {
+	it( 'should select `initialTabName` if defined', () => {
 		const mockOnSelect = jest.fn();
 
 		render(
@@ -160,6 +160,39 @@ describe( 'TabPanel', () => {
 		);
 		expect( getSelectedTab() ).toHaveTextContent( 'Beta' );
 		expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+	} );
+
+	it( 'waits for the tab with the `initialTabName` to become present in the `tabs` array before selecting it', () => {
+		const mockOnSelect = jest.fn();
+
+		const { rerender } = render(
+			<TabPanel
+				tabs={ TABS }
+				initialTabName="delta"
+				children={ () => undefined }
+				onSelect={ mockOnSelect }
+			/>
+		);
+
+		// There should be no selected tab.
+		expect(
+			screen.queryByRole( 'tab', { selected: true } )
+		).not.toBeInTheDocument();
+
+		rerender(
+			<TabPanel
+				tabs={ [
+					{ name: 'delta', title: 'Delta', className: 'delta-class' },
+					...TABS,
+				] }
+				initialTabName="delta"
+				children={ () => undefined }
+				onSelect={ mockOnSelect }
+			/>
+		);
+
+		expect( getSelectedTab() ).toHaveTextContent( 'Delta' );
+		expect( mockOnSelect ).toHaveBeenLastCalledWith( 'delta' );
 	} );
 
 	it( 'should disable the tab when `disabled` is true', async () => {


### PR DESCRIPTION
## What?
Fixes https://github.com/WordPress/gutenberg/issues/47079

## Why?
From what I can tell there are two causes of the bug:
1. The Navigation block's List View tab isn't declared on first render, it only becomes present in the `tabs` array on later renders.
2. The TabPanel no longer supports lazily adding initial tabs after #46471, it now always falls back to the first enabled tab in the `tabs` array.

I did try looking to see if this could be fixed by always rendering the tab navigation block, but it's less than straightforward. The tab is added somewhat dynamically when there are fills in a slot. I struggled to see where the issue was coming from.

## How?
This fixes the issue. If `initalTabName` is declared, but there's no matching tab in the `tabs` array, the effect no longer makes a selection until it is in the tabs array.

This does leave a situation where `initalTabName` could be declared and the matching tab is never present, but I'd consider this implementor error (and the same issue could happen before #46471).

I have refactored the code a bit here too. I personally found the code a little hard to understand with the added logic, so it's now a little more verbose, but hopefully easier to follow. 

## Testing Instructions
1. Add a navigation block to a post and add some inner blocks to it
2. In the nav block's block inspector List View interface, select the 'Edit block' button of one of the inner blocks
3. Press the 'Go to parent'  button at the top of the inspector panel when that inner block is selected.

Expected - the List View tab should be selected again on the navigation block.
In trunk - the Appearance tab is selected.

## Screenshots or screencast <!-- if applicable -->
#### Before

https://user-images.githubusercontent.com/677833/211992292-174d6178-aa6d-410b-9ff4-562e29a930c9.mp4


#### After

https://user-images.githubusercontent.com/677833/211992314-910b3316-8e98-4d98-8cea-d19a1aad1666.mp4


