### PR TITLE
[Block Editor]: Update text align toolbar control label

### DIFF
--- a/packages/block-editor/src/components/alignment-control/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/alignment-control/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`AlignmentUI should allow custom alignment controls to be specified 1`] 
   <div
     class="components-toolbar"
     icon="[object Object]"
-    label="Align"
+    label="Align text"
   >
     <div>
       <button
@@ -66,7 +66,7 @@ exports[`AlignmentUI should match snapshot when controls are hidden 1`] = `
     <button
       aria-expanded="false"
       aria-haspopup="true"
-      aria-label="Align"
+      aria-label="Align text"
       class="components-button components-dropdown-menu__toggle has-icon"
       data-toolbar-item="true"
       type="button"
@@ -93,7 +93,7 @@ exports[`AlignmentUI should match snapshot when controls are visible 1`] = `
   <div
     class="components-toolbar"
     icon="[object Object]"
-    label="Align"
+    label="Align text"
   >
     <div>
       <button

--- a/packages/block-editor/src/components/alignment-control/test/index.js
+++ b/packages/block-editor/src/components/alignment-control/test/index.js
@@ -70,7 +70,7 @@ describe( 'AlignmentUI', () => {
 
 		await user.click(
 			screen.getByRole( 'button', {
-				name: 'Align',
+				name: 'Align text',
 			} )
 		);
 

--- a/packages/block-editor/src/components/alignment-control/ui.js
+++ b/packages/block-editor/src/components/alignment-control/ui.js
@@ -32,7 +32,7 @@ function AlignmentUI( {
 	value,
 	onChange,
 	alignmentControls = DEFAULT_ALIGNMENT_CONTROLS,
-	label = __( 'Align' ),
+	label = __( 'Align text' ),
 	describedBy = __( 'Change text alignment' ),
 	isCollapsed = true,
 	isToolbar,

--- a/packages/block-editor/src/hooks/test/align.native.js
+++ b/packages/block-editor/src/hooks/test/align.native.js
@@ -83,7 +83,7 @@ describe( 'Align options', () => {
 					expect( paragraphBlock ).toBeVisible();
 
 					// Open alignments menu
-					const alignmentButtons = getByLabelText( 'Align' );
+					const alignmentButtons = getByLabelText( 'Align text' );
 					fireEvent.press( alignmentButtons );
 
 					// Select alignment option.

--- a/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
@@ -56,7 +56,7 @@ const tabThroughBlockToolbar = async () => {
 	await expect( await getActiveLabel() ).toBe( 'Move down' );
 
 	await page.keyboard.press( 'ArrowRight' );
-	await expect( await getActiveLabel() ).toBe( 'Align' );
+	await expect( await getActiveLabel() ).toBe( 'Align text' );
 
 	await page.keyboard.press( 'ArrowRight' );
 	await expect( await getActiveLabel() ).toBe( 'Bold' );

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -624,7 +624,7 @@ describe( 'Multi-block selection', () => {
 		await page.keyboard.type( '2' );
 		await pressKeyWithModifier( 'primary', 'a' );
 		await pressKeyWithModifier( 'primary', 'a' );
-		await clickBlockToolbarButton( 'Align' );
+		await clickBlockToolbarButton( 'Align text' );
 		await clickButton( 'Align text center' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/46683

`AlignmentControl` toolbar control is used from blocks to change the `align text` setting. If a block support both `align` and `align text`, the label is the same for both(`Align`) which creates a11y problems.

This PR updates the label of the align text control to `Align text`.
## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/16275880/212129945-d7e36739-825b-47be-a56c-5ba00289db9c.mov



