### PR TITLE
Updates some spacing + dimensions in the Site Hub

### DIFF
--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -100,6 +100,7 @@ const SiteHub = forwardRef(
 				<HStack
 					justify="flex-start"
 					className="edit-site-site-hub__text-content"
+					spacing="0"
 				>
 					<motion.div
 						className="edit-site-site-hub__view-mode-toggle-container"

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -15,8 +15,14 @@
 
 .edit-site-site-hub__view-mode-toggle-container {
 	height: $header-height;
-	width: $header-height;
+	width: $header-height + 4px;
 	flex-shrink: 0;
+}
+
+.edit-site-layout.is-edit-mode {
+	.edit-site-site-hub__view-mode-toggle-container {
+		width: $header-height;
+	}
 }
 
 .edit-site-site-hub__text-content {

--- a/packages/edit-site/src/components/site-icon/index.js
+++ b/packages/edit-site/src/components/site-icon/index.js
@@ -41,7 +41,7 @@ function SiteIcon( { className } ) {
 	) : (
 		<Icon
 			className="edit-site-site-icon__icon"
-			size="36px"
+			size="32px"
 			icon={ wordpress }
 		/>
 	);

--- a/packages/edit-site/src/components/site-icon/style.scss
+++ b/packages/edit-site/src/components/site-icon/style.scss
@@ -3,8 +3,8 @@
 }
 
 .edit-site-site-icon__image {
-	width: $button-size;
-	height: $button-size;
+	width: $grid-unit-40;
+	height: $grid-unit-40;
 	border-radius: $radius-block-ui;
 	object-fit: cover;
 }


### PR DESCRIPTION
* Reduces spacing between icon button and title
* Reduces site icon to 32px to match Edit button
* Ensures left and right padding matches

<img width="917" alt="Screenshot 2023-01-12 at 17 05 34" src="https://user-images.githubusercontent.com/846565/212132804-f55c8272-adbb-4b2d-9ffb-6f42c1b6d7d3.png">

This change did involve increasing the W button footprint to 64px in view mode, but that was essential unless we want to reduce the footprint of the whole button down to 32px which seemed like a usability trade-off. It resizes back to 60px in edit mode, and seems to work fine.