### PR TITLE
[Webfonts] Use Core's `_deprecated_argument()` for deprecating data structures

### DIFF
--- a/lib/experimental/fonts-api/deprecations/class-wp-webfonts.php
+++ b/lib/experimental/fonts-api/deprecations/class-wp-webfonts.php
@@ -197,7 +197,7 @@ class WP_Webfonts extends WP_Dependencies {
 	 * @return string|null The font family slug if successfully registered. Else null.
 	 */
 	protected function extract_font_family_from_deprecated_webfonts_structure( array $webfont, $message ) {
-		trigger_error( $message, E_USER_DEPRECATED );
+		_deprecated_argument( __METHOD__, '14.9.1', $message );
 
 		$font_family = WP_Fonts_Utils::get_font_family_from_variation( $webfont );
 		if ( ! $font_family ) {

--- a/lib/experimental/fonts-api/deprecations/class-wp-webfonts.php
+++ b/lib/experimental/fonts-api/deprecations/class-wp-webfonts.php
@@ -157,7 +157,7 @@ class WP_Webfonts extends WP_Dependencies {
 	public function migrate_deprecated_structure( array $webfonts ) {
 		$message = 'A deprecated fonts array structure passed to wp_register_fonts(). ' .
 			'Variations must be grouped and keyed by their font family.';
-		trigger_error( $message, E_USER_DEPRECATED );
+		_deprecated_argument( __METHOD__, '14.9.1', $message );
 
 		$new_webfonts = array();
 		foreach ( $webfonts as $webfont ) {

--- a/phpunit/fonts-api/wp-fonts-testcase.php
+++ b/phpunit/fonts-api/wp-fonts-testcase.php
@@ -256,13 +256,4 @@ abstract class WP_Fonts_TestCase extends WP_UnitTestCase {
 
 		return $handles;
 	}
-
-	/**
-	 * Suppresses deprecation notices allowing a test to skip deprecations
-	 * to test notices or other specifics.
-	 */
-	protected function suppress_deprecations() {
-		$this->error_reporting_level = error_reporting();
-		error_reporting( $this->error_reporting_level & ~E_USER_DEPRECATED );
-	}
 }

--- a/phpunit/fonts-api/wpRegisterFonts-test.php
+++ b/phpunit/fonts-api/wpRegisterFonts-test.php
@@ -105,27 +105,23 @@ class Tests_Fonts_WpRegisterFonts extends WP_Fonts_TestCase {
 	/**
 	 * @dataProvider data_deprecated_structure
 	 *
+	 * @expectedDeprecated WP_Webfonts::migrate_deprecated_structure
+	 *
 	 * @param array $fonts Fonts to test.
 	 */
 	public function test_should_throw_deprecation_with_deprecated_structure( array $fonts ) {
-		$this->expectDeprecation();
-		$this->expectDeprecationMessage(
-			'A deprecated fonts array structure passed to wp_register_fonts(). ' .
-			'Variations must be grouped and keyed by their font family.'
-		);
-
 		wp_register_fonts( $fonts );
 	}
 
 	/**
 	 * @dataProvider data_deprecated_structure
 	 *
+	 * @expectedDeprecated WP_Webfonts::migrate_deprecated_structure
+	 *
 	 * @param array $fonts    Fonts to test.
 	 * @param array $expected Expected results.
 	 */
 	public function test_should_register_with_deprecated_structure( array $fonts, array $expected ) {
-		$this->suppress_deprecations();
-
 		$actual = wp_register_fonts( $fonts );
 		$this->assertSame( $expected['wp_register_fonts'], $actual, 'Font family handle(s) should be returned' );
 		$this->assertSame( $expected['get_registered'], $this->get_registered_handles(), 'Fonts should match registered queue' );
@@ -236,12 +232,12 @@ class Tests_Fonts_WpRegisterFonts extends WP_Fonts_TestCase {
 	/**
 	 * @dataProvider data_invalid_font_family
 	 *
+	 * @expectedDeprecated WP_Webfonts::migrate_deprecated_structure
+	 *
 	 * @param array  $fonts            Fonts to test.
 	 * @param string $expected_message Expected notice message.
 	 */
 	public function test_should_not_register_with_undefined_font_family( array $fonts, $expected_message ) {
-		$this->suppress_deprecations();
-
 		$this->expectNotice();
 		$this->expectNoticeMessage( $expected_message );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes #47123.

## What?
<!-- In a few words, what is the PR actually doing? -->
Use Core's `_deprecated_argument()` instead of `trigger_error()` for deprecating data structures. This is similar to how deprecated functions in the API's BC layer uses Core's `_deprecated_function()`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To avoid filling server logs on production sites. `_deprecated_argument()` is Core's standard and will only display the deprecation when `WP_Debug` is on.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
See above.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

With `WP_Debug` off:
1. Active TT3.
2. Active the Gutenberg plugin.
3. [Install this testing plugin](https://gist.github.com/hellofromtonya/1bbbc9a5354a905278080a9f022c2f60) which uses Jetpack's Google Font Provider and deprecated functionality and data structures.
4. Run the site.
5. Open the server logs. > Notice there no deprecations.

Now turn on `WP_Debug`:
Repeat steps 1-5. Notice there are deprecations.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
