### PR TITLE
Fix duplicate template parts logic overriding existing template part

### DIFF
--- a/packages/edit-site/src/components/add-new-template/new-template-part.js
+++ b/packages/edit-site/src/components/add-new-template/new-template-part.js
@@ -42,11 +42,11 @@ export default function NewTemplatePart( {
 		}
 
 		try {
-			const cleanSlug = getCleanTemplatePartSlug( title );
 			const uniqueTitle = getUniqueTemplatePartTitle(
 				title,
 				existingTemplateParts
 			);
+			const cleanSlug = getCleanTemplatePartSlug( uniqueTitle );
 
 			const templatePart = await saveEntityRecord(
 				'postType',

--- a/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
@@ -45,11 +45,11 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 	}
 
 	const onConvert = async ( { title, area } ) => {
-		const cleanSlug = getCleanTemplatePartSlug( title );
 		const uniqueTitle = getUniqueTemplatePartTitle(
 			title,
 			existingTemplateParts
 		);
+		const cleanSlug = getCleanTemplatePartSlug( uniqueTitle );
 
 		const templatePart = await saveEntityRecord(
 			'postType',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow up to #47082

Ensure slugs created via the logic to avoid duplicate names for template parts are based on the unique title, and not the originally passed in title.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is a subtle issue — it only appears when the duplicate template part is overriding a template part that is provided as part of the theme. If there is already an update to that template part, then an entry exists for it in the database, so the duplicate template part is created correctly. However, if the user has never altered the template part, then nothing exists in the database, so the generated slug might match the existing template part, causing the template part creation to override the existing template part.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Swap the order so that `getCleanTemplatePartSlug` comes after `getUniqueTemplatePartTitle` and pass in the `uniqueTitle`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Following the same instructions as #47082, however first ensure that you're working from a clean slate and any adjustments to template parts in your theme have been cleared:

1. Open a template for editing in the site editor
2. Select a group block, or more than one block together.
3. Select "Create Template part" from the more menu in the block toolbar.
4. Give the template part a name that already exists for another template part.
5. Confirm that the template part name receives a numerical suffix to make it unique.
6. Confirm that the creation flow of a new template part still works correctly, and duplicates are given suffixes.
7. Ensure that the original template part still exists in the list of template parts.

## Screenshots or screencast <!-- if applicable -->

| Before (in a theme with an unaltered Header template part, that template part was overridden but renamed) | After (in a theme with an unaltered Header template part, a new template part is created) |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/212218379-9f29ca8f-2acb-48b0-a5ed-f9fdbec4eed2.png) | ![image](https://user-images.githubusercontent.com/14988353/212218393-2deef2c3-c7c6-49d3-a2b9-f345afce6fdf.png) |