### PR TITLE
Add E2E tests for 'Import widget area' button

### DIFF
--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -309,4 +309,70 @@ test.describe( 'Template Part', () => {
 
 		await expect( paragraph ).toBeVisible();
 	} );
+
+	test( 'can import a widget area into an empty template part', async ( {
+		admin,
+		siteEditor,
+		editor,
+		page,
+	} ) => {
+		await admin.visitSiteEditor();
+		await siteEditor.enterEditMode();
+
+		// Add a block and select it.
+		await editor.insertBlock( {
+			name: 'core/template-part',
+		} );
+
+		// Open Block Inspector -> Advanced.
+		await editor.openDocumentSettingsSidebar();
+		await page.getByRole( 'button', { name: 'Advanced' } ).click();
+
+		// Import the widget area.
+		await page
+			.getByRole( 'combobox', { name: 'Import widget area' } )
+			.selectOption( 'sidebar-1' );
+		await page.getByRole( 'button', { name: 'Import' } ).click();
+
+		// Verify that the widget area was imported.
+		await expect(
+			editor.canvas.locator( '[data-type="core/search"]' )
+		).toBeVisible();
+		await expect(
+			editor.canvas.locator( '[data-type="core/latest-posts"]' )
+		).toBeVisible();
+		await expect(
+			editor.canvas.locator( '[data-type="core/latest-comments"]' )
+		).toBeVisible();
+		await expect(
+			editor.canvas.locator( '[data-type="core/archives"]' )
+		).toBeVisible();
+		await expect(
+			editor.canvas.locator( '[data-type="core/categories"]' )
+		).toBeVisible();
+	} );
+
+	test( 'can not import a widget area into a non-empty template part', async ( {
+		admin,
+		siteEditor,
+		editor,
+		page,
+	} ) => {
+		await admin.visitSiteEditor();
+		await siteEditor.enterEditMode();
+
+		// Select existing header template part.
+		await editor.selectBlocks(
+			editor.canvas.locator( '[data-type="core/template-part"]' )
+		);
+
+		// Go to Block Inspector -> Advanced.
+		await editor.openDocumentSettingsSidebar();
+		await page.getByRole( 'button', { name: 'Advanced' } ).click();
+
+		// Verify that the widget area import button is not there.
+		await expect(
+			page.getByRole( 'combobox', { name: 'Import widget area' } )
+		).not.toBeVisible();
+	} );
 } );


### PR DESCRIPTION
## What?
Adds some basic E2E tests for the 'Import widget area' button added in https://github.com/WordPress/gutenberg/pull/45509.

## Why?
Anything to do with widgets tends to get forgotten about and break 😀. E2E tests, even simple ones, help catch regressions.

## Testing Instructions
`npm run test:e2e:playwright`