### PR TITLE
Add validation message to custom CSS input

### DIFF
--- a/packages/edit-site/src/components/global-styles/custom-css.js
+++ b/packages/edit-site/src/components/global-styles/custom-css.js
@@ -50,8 +50,18 @@ function CustomCSSControl( { blockName } ) {
 			return;
 		}
 		setCustomCSS( value );
-		// TODO: transform it to find syntax error. Note that it will be transformed again
-		// after applied to the preview frame. We should refactor this to prevent double-transform.
+		if ( cssError ) {
+			const [ transformed ] = transformStyles(
+				[ { css: value } ],
+				'.editor-styles-wrapper'
+			);
+			if ( transformed ) {
+				setCSSError( null );
+			}
+		}
+	}
+
+	function handleOnBlur( value ) {
 		const [ transformed ] = transformStyles(
 			[ { css: value } ],
 			'.editor-styles-wrapper'
@@ -89,9 +99,19 @@ function CustomCSSControl( { blockName } ) {
 						themeCustomCSS
 					}
 					onChange={ ( value ) => handleOnChange( value ) }
+					onBlur={ handleOnBlur }
 					className="edit-site-global-styles__custom-css-input"
 					spellCheck={ false }
 				/>
+				{ cssError && (
+					<Notice
+						status="warning"
+						onRemove={ () => setCSSError( null ) }
+						politeness="polite"
+					>
+						{ cssError }
+					</Notice>
+				) }
 				{ cssError && (
 					<Notice
 						status="warning"

--- a/packages/edit-site/src/components/global-styles/custom-css.js
+++ b/packages/edit-site/src/components/global-styles/custom-css.js
@@ -117,15 +117,6 @@ function CustomCSSControl( { blockName } ) {
 						{ cssError }
 					</Notice>
 				) }
-				{ cssError && (
-					<Notice
-						status="warning"
-						onRemove={ () => setCSSError( null ) }
-						politeness="polite"
-					>
-						{ cssError }
-					</Notice>
-				) }
 			</VStack>
 		</>
 	);

--- a/packages/edit-site/src/components/global-styles/custom-css.js
+++ b/packages/edit-site/src/components/global-styles/custom-css.js
@@ -72,7 +72,7 @@ function CustomCSSControl( { blockName } ) {
 
 			setCSSError(
 				transformed === null
-					? __( 'Error while parsing the CSS.' )
+					? __( 'There is an error with your CSS structure.' )
 					: null
 			);
 		}

--- a/packages/edit-site/src/components/global-styles/custom-css.js
+++ b/packages/edit-site/src/components/global-styles/custom-css.js
@@ -1,14 +1,19 @@
 /**
  * WordPress dependencies
  */
+import { useState } from '@wordpress/element';
 import {
 	TextareaControl,
 	Panel,
 	PanelBody,
 	__experimentalVStack as VStack,
+	Notice,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
+import {
+	experiments as blockEditorExperiments,
+	transformStyles,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -24,6 +29,7 @@ function CustomCSSControl( { blockName } ) {
 
 	const [ customCSS, setCustomCSS ] = useGlobalStyle( 'css', block );
 	const [ themeCSS ] = useGlobalStyle( 'css', block, 'base' );
+	const [ cssError, setCSSError ] = useState( null );
 	const ignoreThemeCustomCSS = '/* IgnoreThemeCustomCSS */';
 
 	// If there is custom css from theme.json show it in the edit box
@@ -44,6 +50,15 @@ function CustomCSSControl( { blockName } ) {
 			return;
 		}
 		setCustomCSS( value );
+		// TODO: transform it to find syntax error. Note that it will be transformed again
+		// after applied to the preview frame. We should refactor this to prevent double-transform.
+		const [ transformed ] = transformStyles(
+			[ { css: value } ],
+			'.editor-styles-wrapper'
+		);
+		setCSSError(
+			transformed === null ? __( 'Error while parsing the CSS.' ) : null
+		);
 	}
 
 	const originalThemeCustomCSS =
@@ -77,6 +92,15 @@ function CustomCSSControl( { blockName } ) {
 					className="edit-site-global-styles__custom-css-input"
 					spellCheck={ false }
 				/>
+				{ cssError && (
+					<Notice
+						status="warning"
+						onRemove={ () => setCSSError( null ) }
+						politeness="polite"
+					>
+						{ cssError }
+					</Notice>
+				) }
 			</VStack>
 		</>
 	);

--- a/packages/edit-site/src/components/global-styles/custom-css.js
+++ b/packages/edit-site/src/components/global-styles/custom-css.js
@@ -64,18 +64,21 @@ function CustomCSSControl( { blockName } ) {
 	}
 
 	function handleOnBlur( event ) {
-		if ( event?.target?.value ) {
-			const [ transformed ] = transformStyles(
-				[ { css: event.target.value } ],
-				'.editor-styles-wrapper'
-			);
-
-			setCSSError(
-				transformed === null
-					? __( 'There is an error with your CSS structure.' )
-					: null
-			);
+		if ( ! event?.target?.value ) {
+			setCSSError( null );
+			return;
 		}
+
+		const [ transformed ] = transformStyles(
+			[ { css: event.target.value } ],
+			'.editor-styles-wrapper'
+		);
+
+		setCSSError(
+			transformed === null
+				? __( 'There is an error with your CSS structure.' )
+				: null
+		);
 	}
 
 	const originalThemeCustomCSS =

--- a/packages/edit-site/src/components/global-styles/custom-css.js
+++ b/packages/edit-site/src/components/global-styles/custom-css.js
@@ -61,14 +61,19 @@ function CustomCSSControl( { blockName } ) {
 		}
 	}
 
-	function handleOnBlur( value ) {
-		const [ transformed ] = transformStyles(
-			[ { css: value } ],
-			'.editor-styles-wrapper'
-		);
-		setCSSError(
-			transformed === null ? __( 'Error while parsing the CSS.' ) : null
-		);
+	function handleOnBlur( event ) {
+		if ( event?.target?.value ) {
+			const [ transformed ] = transformStyles(
+				[ { css: event.target.value } ],
+				'.editor-styles-wrapper'
+			);
+
+			setCSSError(
+				transformed === null
+					? __( 'Error while parsing the CSS.' )
+					: null
+			);
+		}
 	}
 
 	const originalThemeCustomCSS =

--- a/packages/edit-site/src/components/global-styles/custom-css.js
+++ b/packages/edit-site/src/components/global-styles/custom-css.js
@@ -7,13 +7,15 @@ import {
 	Panel,
 	PanelBody,
 	__experimentalVStack as VStack,
-	Notice,
+	Tooltip,
+	Icon,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import {
 	experiments as blockEditorExperiments,
 	transformStyles,
 } from '@wordpress/block-editor';
+import { info } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -109,13 +111,14 @@ function CustomCSSControl( { blockName } ) {
 					spellCheck={ false }
 				/>
 				{ cssError && (
-					<Notice
-						status="warning"
-						onRemove={ () => setCSSError( null ) }
-						politeness="polite"
-					>
-						{ cssError }
-					</Notice>
+					<Tooltip text={ cssError }>
+						<div className="edit-site-global-styles__custom-css-validation-wrapper">
+							<Icon
+								icon={ info }
+								className="edit-site-global-styles__custom-css-validation-icon"
+							/>
+						</div>
+					</Tooltip>
 				) }
 			</VStack>
 		</>

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -166,6 +166,16 @@ $block-preview-height: 150px;
 	font-family: $editor_html_font;
 }
 
+.edit-site-global-styles__custom-css-validation-wrapper {
+	position: absolute;
+	bottom: $grid-unit-20;
+	right: $grid-unit * 3;
+}
+
+.edit-site-global-styles__custom-css-validation-icon {
+	fill: $alert-red;
+}
+
 .edit-site-global-styles__custom-css-theme-css {
 	width: 100%;
 	line-break: anywhere;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Part of https://github.com/WordPress/gutenberg/issues/30142. Add CSS validation message to custom CSS input. Currently only an error message `Error while parsing the CSS.` will be shown, there's no debug info.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
For users to know why their CSS isn't being applied to the preview.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR isn't ideal but it does the job for now. The challenge is how to move the validation/transformation to the input. Currently, all the transformation is done in `<EditorStyles>`, which is in a different package, and it will be too late to display error messages there. This PR currently does double-transform, and we should fix that in the future.

While testing this PR, I found out that the transformation library we use (`reworkcss`) is at least 4 years ago and has many bugs. For instance, `body{background:red` will throw an error while it should be valid syntax. On the other hand, `body{backgroundd:red;}` doesn't throw an error while it should be invalid. We should work on replacing/updating it in the future.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Enable custom CSS in gutenberg experiments
2. Go to Site Editor
3. Open Styles -> Custom CSS
4. Start writing some CSS and leave it in an invalid state
5. Blur the edit box and Notice the validation message appears when the CSS is invalid
6. Edit the CSS to make it valid and check that the error disappears

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Enable custom CSS in gutenberg experiments
2. Go to Site Editor, tab through to the "Edit" button and hit Enter.
3. Tab through to the "Styles" button in the editor toolbar and hit Enter. Use <kbd>Ctrl</kbd> + <kbd>`</kbd> to navigate to the "Styles" panel. Tab through to the "Additional CSS" button. 
5. Tab through to the textbox and start writing some CSS and leave it in an invalid state.
7. Tab away from the box and screen readers should announce the validation message if the CSS is invalid.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/7753001/212232514-2805a993-be0d-495c-b14e-a458f0ff7832.mp4

