### PR TITLE
Try adding sticky position support to the template part block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -815,7 +815,7 @@ Edit the different global regions of your site, like the header, footer, sidebar
 
 -	**Name:** core/template-part
 -	**Category:** theme
--	**Supports:** align, ~~html~~, ~~reusable~~
+-	**Supports:** align, position (sticky), ~~html~~, ~~reusable~~
 -	**Attributes:** area, slug, tagName, theme
 
 ## Term Description

--- a/packages/block-library/src/template-part/block.json
+++ b/packages/block-library/src/template-part/block.json
@@ -23,6 +23,9 @@
 	"supports": {
 		"align": true,
 		"html": false,
+		"position": {
+			"sticky": true
+		},
 		"reusable": false
 	},
 	"editorStyle": "wp-block-template-part-editor"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of https://github.com/WordPress/gutenberg/issues/47043

🚧 🚧 🚧 🚧 🚧 This PR explores an idea, but it may not be suitable to land 🚧 🚧 🚧 🚧 🚧 

This PR explores opting the Template Part block into sticky position support. This is a potentially contentious issue! Some of the trade-offs are described in Why. The intention of this PR is to have a PR we can play with to then discuss the pros and cons, and hopefully learn a little more about what the desired end goal might be... I am very happy to close out this PR if the consensus is to not add more styling controls to the template part block at this time 🙂

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The sticky position block support sets a block to sticky in relation to its immediate parent. In order to create a sticky header, without enabling sticky positioning on the template part block itself, this means that we need to wrap a template header part in a sticky Group block in order for it to work.

In this PR, we experiment with enabling position support directly on the template part block. There are some pros and cons with this approach:

Pros:

* You can set the position directly on the template part block, without having to wrap the template part in a Group block
* Improved discoverability of positioning for the template part block

Cons:

* The sticky positioning is applied to the block attributes _where the template part is inserted_. This means that it does not apply to all instances of that template part across multiple templates. A user would need to go through each template and set it to the desired position type, which is likely not obvious. This is a similar issue that led to styling controls being removed from the template part block back in https://github.com/WordPress/gutenberg/pull/36571 — in short, if a user thinks they've made a change to the template part, but they've only made changes to the local instance of the template part within a particular template, it could be frustrating.
* If we land on this approach and then later decide to remove it (as in #36571) dealing with the backwards compatibility problem of sites that have already started using it could be a challenge.

⚠️ As pointed out in https://github.com/WordPress/gutenberg/issues/47043#issuecomment-1380575277 by @jameskoster, one of the issues with exposing controls at the template part level is that users might likely think that the setting they've made will apply across all instances of that template part across other templates, however it does not. One idea might be to allow setting things like positioning at the document level (so, globally within the context of a template part) — however doing that might not be simple to implement, and could also be tricky to make intuitive for the user.

In looking at this PR, part of the goal is to determine what we think might be the best course of action. My hope is that we can come up with a solid direction for next steps whether or not this particular PR lands!

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Opt the template part block in to using the sticky position block support

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

* In the site editor, select a template part block at the root of the document.
* You should see the Position panel in the inspector controls in the sidebar.
* Selecting "sticky" should stick it to the top of the screen when scrolling the site. Note: if your theme has site-wide padding, you might need to set the Top value of the site padding to `0` for the header to sit flush at the top of the page.

## Screenshots or screencast <!-- if applicable -->

| Within the site editor | On the site frontend |
| --- | --- |
| <img width="1427" alt="image" src="https://user-images.githubusercontent.com/14988353/212222955-a33382f5-ba5d-4237-8bf5-db8da21f8711.png"> | <img width="1299" alt="image" src="https://user-images.githubusercontent.com/14988353/212223003-b137a7d0-edb9-4915-b53c-01ae56d515b4.png"> |