### PR TITLE
Add missing controls to flex layouts.

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -200,7 +200,11 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		);
 
 		if ( 'horizontal' === $layout_orientation ) {
-			$justify_content_options += array( 'space-between' => 'space-between' );
+			$justify_content_options    += array( 'space-between' => 'space-between' );
+			$vertical_alignment_options += array( 'stretch' => 'stretch' );
+		} else {
+			$justify_content_options    += array( 'stretch' => 'stretch' );
+			$vertical_alignment_options += array( 'spaceBetween' => 'space-between' );
 		}
 
 		if ( ! empty( $layout['flexWrap'] ) && 'nowrap' === $layout['flexWrap'] ) {
@@ -267,6 +271,12 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				$layout_styles[] = array(
 					'selector'     => $selector,
 					'declarations' => array( 'align-items' => 'flex-start' ),
+				);
+			}
+			if ( ! empty( $layout['verticalAlignment'] ) && array_key_exists( $layout['verticalAlignment'], $vertical_alignment_options ) ) {
+				$layout_styles[] = array(
+					'selector'     => $selector,
+					'declarations' => array( 'justify-content' => $vertical_alignment_options[ $layout['verticalAlignment'] ] ),
 				);
 			}
 		}

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -204,7 +204,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			$vertical_alignment_options += array( 'stretch' => 'stretch' );
 		} else {
 			$justify_content_options    += array( 'stretch' => 'stretch' );
-			$vertical_alignment_options += array( 'spaceBetween' => 'space-between' );
+			$vertical_alignment_options += array( 'space-between' => 'space-between' );
 		}
 
 		if ( ! empty( $layout['flexWrap'] ) && 'nowrap' === $layout['flexWrap'] ) {

--- a/packages/block-editor/src/components/block-vertical-alignment-control/icons.js
+++ b/packages/block-editor/src/components/block-vertical-alignment-control/icons.js
@@ -20,3 +20,16 @@ export const alignTop = (
 		<Path d="M9 20h6V9H9v11zM4 4v1.5h16V4H4z" />
 	</SVG>
 );
+
+// Todo: Replace with the real icons.
+export const alignStretch = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M20 11h-5V4H9v7H4v1.5h5V20h6v-7.5h5z" />
+	</SVG>
+);
+
+export const spaceBetween = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M20 11h-5V4H9v7H4v1.5h5V20h6v-7.5h5z" />
+	</SVG>
+);

--- a/packages/block-editor/src/components/block-vertical-alignment-control/icons.js
+++ b/packages/block-editor/src/components/block-vertical-alignment-control/icons.js
@@ -24,12 +24,12 @@ export const alignTop = (
 // Todo: Replace with the real icons.
 export const alignStretch = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M20 11h-5V4H9v7H4v1.5h5V20h6v-7.5h5z" />
+		<Path d="M4 4L20 4L20 5.5L4 5.5L4 4ZM10 7L14 7L14 17L10 17L10 7ZM20 18.5L4 18.5L4 20L20 20L20 18.5Z" />
 	</SVG>
 );
 
 export const spaceBetween = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M20 11h-5V4H9v7H4v1.5h5V20h6v-7.5h5z" />
+		<Path d="M7 4H17V8L7 8V4ZM7 16L17 16V20L7 20V16ZM20 11.25H4V12.75H20V11.25Z" />
 	</SVG>
 );

--- a/packages/block-editor/src/components/block-vertical-alignment-control/icons.js
+++ b/packages/block-editor/src/components/block-vertical-alignment-control/icons.js
@@ -21,7 +21,6 @@ export const alignTop = (
 	</SVG>
 );
 
-// Todo: Replace with the real icons.
 export const alignStretch = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path d="M4 4L20 4L20 5.5L4 5.5L4 4ZM10 7L14 7L14 17L10 17L10 7ZM20 18.5L4 18.5L4 20L20 20L20 18.5Z" />

--- a/packages/block-editor/src/components/block-vertical-alignment-control/ui.js
+++ b/packages/block-editor/src/components/block-vertical-alignment-control/ui.js
@@ -7,7 +7,13 @@ import { ToolbarGroup, ToolbarDropdownMenu } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { alignTop, alignCenter, alignBottom } from './icons';
+import {
+	alignTop,
+	alignCenter,
+	alignBottom,
+	alignStretch,
+	spaceBetween,
+} from './icons';
 
 const BLOCK_ALIGNMENTS_CONTROLS = {
 	top: {
@@ -21,6 +27,14 @@ const BLOCK_ALIGNMENTS_CONTROLS = {
 	bottom: {
 		icon: alignBottom,
 		title: _x( 'Align bottom', 'Block vertical alignment setting' ),
+	},
+	stretch: {
+		icon: alignStretch,
+		title: _x( 'Stretch to fill', 'Block vertical alignment setting' ),
+	},
+	spaceBetween: {
+		icon: spaceBetween,
+		title: _x( 'Space between', 'Block vertical alignment setting' ),
 	},
 };
 

--- a/packages/block-editor/src/components/block-vertical-alignment-control/ui.js
+++ b/packages/block-editor/src/components/block-vertical-alignment-control/ui.js
@@ -32,7 +32,7 @@ const BLOCK_ALIGNMENTS_CONTROLS = {
 		icon: alignStretch,
 		title: _x( 'Stretch to fill', 'Block vertical alignment setting' ),
 	},
-	spaceBetween: {
+	'space-between': {
 		icon: spaceBetween,
 		title: _x( 'Space between', 'Block vertical alignment setting' ),
 	},
@@ -40,10 +40,6 @@ const BLOCK_ALIGNMENTS_CONTROLS = {
 
 const DEFAULT_CONTROLS = [ 'top', 'center', 'bottom' ];
 const DEFAULT_CONTROL = 'top';
-
-const POPOVER_PROPS = {
-	variant: 'toolbar',
-};
 
 function BlockVerticalAlignmentUI( {
 	value,
@@ -63,7 +59,7 @@ function BlockVerticalAlignmentUI( {
 	const UIComponent = isToolbar ? ToolbarGroup : ToolbarDropdownMenu;
 	const extraProps = isToolbar
 		? { isCollapsed }
-		: { popoverProps: { POPOVER_PROPS } };
+		: { popoverProps: { variant: 'toolbar' } };
 
 	return (
 		<UIComponent

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -44,12 +44,15 @@ const alignItemsMap = {
 	left: 'flex-start',
 	right: 'flex-end',
 	center: 'center',
+	stretch: 'stretch',
 };
 
 const verticalAlignmentMap = {
 	top: 'flex-start',
 	center: 'center',
 	bottom: 'flex-end',
+	stretch: 'stretch',
+	spaceBetween: 'space-between',
 };
 
 const flexWrapOptions = [ 'wrap', 'nowrap' ];
@@ -101,14 +104,13 @@ export default {
 					onChange={ onChange }
 					isToolbar
 				/>
-				{ allowVerticalAlignment &&
-					layout?.orientation !== 'vertical' && (
-						<FlexLayoutVerticalAlignmentControl
-							layout={ layout }
-							onChange={ onChange }
-							isToolbar
-						/>
-					) }
+				{ allowVerticalAlignment && (
+					<FlexLayoutVerticalAlignmentControl
+						layout={ layout }
+						onChange={ onChange }
+						isToolbar
+					/>
+				) }
 			</BlockControls>
 		);
 	},
@@ -153,6 +155,9 @@ export default {
 				rules.push( `justify-content: ${ justifyContent }` );
 			}
 		} else {
+			if ( verticalAlignment ) {
+				rules.push( `justify-content: ${ verticalAlignment }` );
+			}
 			rules.push( 'flex-direction: column' );
 			rules.push( `align-items: ${ alignItems }` );
 		}
@@ -188,7 +193,14 @@ function FlexLayoutVerticalAlignmentControl( {
 	onChange,
 	isToolbar = false,
 } ) {
-	const { verticalAlignment = verticalAlignmentMap.center } = layout;
+	const { orientation = 'horizontal' } = layout;
+
+	const defaultVerticalAlignment =
+		orientation === 'horizontal'
+			? verticalAlignmentMap.center
+			: verticalAlignmentMap.top;
+
+	const { verticalAlignment = defaultVerticalAlignment } = layout;
 
 	const onVerticalAlignmentChange = ( value ) => {
 		onChange( {
@@ -201,6 +213,11 @@ function FlexLayoutVerticalAlignmentControl( {
 			<BlockVerticalAlignmentControl
 				onChange={ onVerticalAlignmentChange }
 				value={ verticalAlignment }
+				controls={
+					orientation === 'horizontal'
+						? [ 'top', 'center', 'bottom', 'stretch' ]
+						: [ 'top', 'center', 'bottom', 'spaceBetween' ]
+				}
 			/>
 		);
 	}
@@ -255,6 +272,8 @@ function FlexLayoutJustifyContentControl( {
 	const allowedControls = [ 'left', 'center', 'right' ];
 	if ( orientation === 'horizontal' ) {
 		allowedControls.push( 'space-between' );
+	} else {
+		allowedControls.push( 'stretch' );
 	}
 	if ( isToolbar ) {
 		return (
@@ -292,6 +311,13 @@ function FlexLayoutJustifyContentControl( {
 			value: 'space-between',
 			icon: justifySpaceBetween,
 			label: __( 'Space between items' ),
+		} );
+	} else {
+		// Todo: we also need an icon here.
+		justificationOptions.push( {
+			value: 'stretch',
+			icon: justifySpaceBetween,
+			label: __( 'Stretch items' ),
 		} );
 	}
 

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -7,6 +7,7 @@ import {
 	justifyCenter,
 	justifyRight,
 	justifySpaceBetween,
+	justifyStretch,
 	arrowRight,
 	arrowDown,
 } from '@wordpress/icons';
@@ -316,7 +317,7 @@ function FlexLayoutJustifyContentControl( {
 		// Todo: we also need an icon here.
 		justificationOptions.push( {
 			value: 'stretch',
-			icon: justifySpaceBetween,
+			icon: justifyStretch,
 			label: __( 'Stretch items' ),
 		} );
 	}

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -52,7 +52,7 @@ const verticalAlignmentMap = {
 	center: 'center',
 	bottom: 'flex-end',
 	stretch: 'stretch',
-	spaceBetween: 'space-between',
+	'space-between': 'space-between',
 };
 
 const flexWrapOptions = [ 'wrap', 'nowrap' ];
@@ -216,7 +216,7 @@ function FlexLayoutVerticalAlignmentControl( {
 				controls={
 					orientation === 'horizontal'
 						? [ 'top', 'center', 'bottom', 'stretch' ]
-						: [ 'top', 'center', 'bottom', 'spaceBetween' ]
+						: [ 'top', 'center', 'bottom', 'space-between' ]
 				}
 			/>
 		);

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -114,6 +114,7 @@ export { default as justifyLeft } from './library/justify-left';
 export { default as justifyCenter } from './library/justify-center';
 export { default as justifyRight } from './library/justify-right';
 export { default as justifySpaceBetween } from './library/justify-space-between';
+export { default as justifyStretch } from './library/justify-stretch';
 export { default as key } from './library/key';
 export { default as keyboardClose } from './library/keyboard-close';
 export { default as keyboardReturn } from './library/keyboard-return';

--- a/packages/icons/src/library/justify-stretch.js
+++ b/packages/icons/src/library/justify-stretch.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const justifyStretch = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M4 4H5.5V20H4V4ZM7 10L17 10V14L7 14V10ZM20 4H18.5V20H20V4Z" />
+	</SVG>
+);
+
+export default justifyStretch;

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -362,7 +362,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'verticalAlignment' => 'bottom',
 					),
 				),
-				'expected_output' => '.wp-layout{flex-wrap:nowrap;flex-direction:column;align-items:flex-start;}',
+				'expected_output' => '.wp-layout{flex-wrap:nowrap;flex-direction:column;align-items:flex-start;justify-content:flex-end;}',
 			),
 			'default layout with blockGap to verify converting gap value into valid CSS' => array(
 				'args'            => array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #45868 and #46133 as well as making #45117 possible. Complementary to #47099 - technically this PR provides the controls to solve all the layout problems in those issues, which #47099 addresses the problem of which is the most sensible default aligmnent value for flex containers.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Adds a "stretch" option to the vertical alignment controls for the Row block:
<img width="380" alt="Screenshot 2023-01-13 at 3 36 19 pm" src="https://user-images.githubusercontent.com/8096000/212238569-792923a1-d115-4a7f-830b-5d3ef46e551e.png">

* Adds vertical alignment controls to the Stack block, with "top", "center", "bottom" and "space-between" options (these essentially implement `justify-content` for Stack):
<img width="270" alt="Screenshot 2023-01-13 at 3 36 41 pm" src="https://user-images.githubusercontent.com/8096000/212238521-d5609e69-2116-4a50-80bd-a83ba1d401fd.png">

* Adds a "stretch" option to the justification controls for the Stack block:
<img width="283" alt="Screenshot 2023-01-13 at 3 35 34 pm" src="https://user-images.githubusercontent.com/8096000/212238537-c479f44c-4921-49ed-bad9-71b6ef9f7e9e.png">

## Todo:

We need some icons for "stretch" and also for "space-between" in a vertical context, cc @WordPress/gutenberg-design 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add Row and Stack blocks with content to a post;
2. Verify that it's possible to justify and align contents in both orientations equally.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
