### PR TITLE
Remove local() from generated webfonts styles

### DIFF
--- a/lib/experimental/class-wp-webfonts-provider-local.php
+++ b/lib/experimental/class-wp-webfonts-provider-local.php
@@ -244,7 +244,7 @@ class WP_Webfonts_Provider_Local extends WP_Webfonts_Provider {
 	 * @return string The CSS.
 	 */
 	private function compile_src( $font_family, array $value ) {
-		$src = "local($font_family)";
+		$src = '';
 
 		foreach ( $value as $item ) {
 

--- a/lib/experimental/class-wp-webfonts-provider-local.php
+++ b/lib/experimental/class-wp-webfonts-provider-local.php
@@ -85,14 +85,14 @@ class WP_Webfonts_Provider_Local extends WP_Webfonts_Provider {
 	 *      font-style:normal;
 	 *      font-weight:200 900;
 	 *      font-stretch:normal;
-	 *      src:local("Source Serif Pro"), url('/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');
+	 *      src:url('/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');
 	 * }
 	 * @font-face{
 	 *      font-family:"Source Serif Pro";
 	 *      font-style:italic;
 	 *      font-weight:200 900;
 	 *      font-stretch:normal;
-	 *      src:local("Source Serif Pro"), url('/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');
+	 *      src:url('/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');
 	 * }
 	 * </code>
 	 *
@@ -256,6 +256,8 @@ class WP_Webfonts_Provider_Local extends WP_Webfonts_Provider {
 				? ", url({$item['url']})"
 				: ", url('{$item['url']}') format('{$item['format']}')";
 		}
+
+		$src = ltrim( $src, ',' );
 		return $src;
 	}
 

--- a/lib/experimental/class-wp-webfonts-provider-local.php
+++ b/lib/experimental/class-wp-webfonts-provider-local.php
@@ -257,7 +257,7 @@ class WP_Webfonts_Provider_Local extends WP_Webfonts_Provider {
 				: ", url('{$item['url']}') format('{$item['format']}')";
 		}
 
-		$src = ltrim( $src, ',' );
+		$src = ltrim( $src, ', ' );
 		return $src;
 	}
 

--- a/phpunit/webfonts/wp-webfonts-tests-dataset.php
+++ b/phpunit/webfonts/wp-webfonts-tests-dataset.php
@@ -1026,15 +1026,15 @@ trait WP_Webfonts_Tests_Datasets {
 	protected function get_registered_fonts_css() {
 		return array(
 			'merriweather-200-900-normal' => <<<CSS
-@font-face{font-family:Merriweather;font-style:normal;font-weight:200 900;font-display:fallback;font-stretch:normal;src:local(Merriweather), url('https://example.com/assets/fonts/merriweather.ttf.woff2') format('woff2');}
+@font-face{font-family:Merriweather;font-style:normal;font-weight:200 900;font-display:fallback;font-stretch:normal;src:url('https://example.com/assets/fonts/merriweather.ttf.woff2') format('woff2');}
 CSS
 		,
 			'Source Serif Pro-300-normal' => <<<CSS
-@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:300;font-display:fallback;font-stretch:normal;src:local("Source Serif Pro"), url('https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');}
+@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:300;font-display:fallback;font-stretch:normal;src:url('https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');}
 CSS
 		,
 			'Source Serif Pro-900-italic' => <<<CSS
-@font-face{font-family:"Source Serif Pro";font-style:italic;font-weight:900;font-display:fallback;font-stretch:normal;src:local("Source Serif Pro"), url('https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');}
+@font-face{font-family:"Source Serif Pro";font-style:italic;font-weight:900;font-display:fallback;font-stretch:normal;src:url('https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');}
 CSS
 		,
 			'font1-300-normal'            => 'font1-300-normal',

--- a/phpunit/webfonts/wpWebfontsProviderLocal-test.php
+++ b/phpunit/webfonts/wpWebfontsProviderLocal-test.php
@@ -112,7 +112,7 @@ class Tests_Webfonts_WpWebfontsProviderLocal extends WP_UnitTestCase {
 				'expected' => array(
 					'style-element' => "<style id='wp-webfonts-local' type='text/css'>\n%s\n</style>\n",
 					'font-face-css' => <<<CSS
-@font-face{font-family:"Open Sans";font-style:italic;font-weight:bold;src:local("Open Sans"), url('http://example.org/assets/fonts/OpenSans-Italic-VariableFont_wdth,wght.ttf') format('truetype');}
+@font-face{font-family:"Open Sans";font-style:italic;font-weight:bold;src:url('http://example.org/assets/fonts/OpenSans-Italic-VariableFont_wdth,wght.ttf') format('truetype');}
 CSS
 					,
 				),
@@ -139,7 +139,7 @@ CSS
 				'expected' => array(
 					'style-element' => "<style id='wp-webfonts-local' type='text/css'>\n%s\n</style>\n",
 					'font-face-css' => <<<CSS
-@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-stretch:normal;src:local("Source Serif Pro"), url('http://example.org/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');}@font-face{font-family:"Source Serif Pro";font-style:italic;font-weight:200 900;font-stretch:normal;src:local("Source Serif Pro"), url('http://example.org/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');}
+@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-stretch:normal;src:url('http://example.org/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');}@font-face{font-family:"Source Serif Pro";font-style:italic;font-weight:200 900;font-stretch:normal;src:url('http://example.org/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');}
 CSS
 
 					,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR removes the `local()` generated styles from the webfonts API.

## Why?
Apparently, using `local()` in `@font-face` styles generated from the Webfonts API is causing some issues for users: https://github.com/WordPress/gutenberg/issues/42190
