### PR TITLE
Site editor: Update resize handle.

### DIFF
--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -105,7 +105,7 @@
 			border-radius: 0;
 			background: transparent;
 			left: 50%;
-			transform: translateX( -1px );
+			transform: translateX(-1px);
 			right: 0;
 			transition: all ease 0.2s;
 			transition-delay: 0.1s;

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -97,12 +97,15 @@
 
 	&.is-variation-separator {
 		height: 100%;
+		width: $grid-unit-30;
+		right: 0;
 
 		&::after {
 			width: 2px;
 			border-radius: 0;
-			background: $gray-800;
-			left: 0;
+			background: transparent;
+			left: 50%;
+			transform: translateX( -1px );
 			right: 0;
 			transition: all ease 0.2s;
 			transition-delay: 0.1s;

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -99,11 +99,11 @@
 		height: 100%;
 
 		&::after {
-			width: 4px;
+			width: 2px;
 			border-radius: 0;
 			background: $gray-800;
-			left: auto;
-			right: 50%;
+			left: 0;
+			right: 0;
 			transition: all ease 0.2s;
 			transition-delay: 0.1s;
 			@include reduce-motion;
@@ -112,10 +112,10 @@
 
 	&::after {
 		position: absolute;
-		top: $grid-unit-40;
+		top: $grid-unit-30;
 		left: $grid-unit-05;
 		right: 0;
-		bottom: $grid-unit-40;
+		bottom: $grid-unit-30;
 		content: "";
 		width: $grid-unit-05;
 		background: $gray-600;

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -99,7 +99,7 @@
 		height: 100%;
 
 		&::after {
-			width: 1px;
+			width: 4px;
 			border-radius: 0;
 			background: $gray-800;
 			left: auto;
@@ -112,10 +112,10 @@
 
 	&::after {
 		position: absolute;
-		top: 0;
+		top: $grid-unit-40;
 		left: $grid-unit-05;
 		right: 0;
-		bottom: 0;
+		bottom: $grid-unit-40;
 		content: "";
 		width: $grid-unit-05;
 		background: $gray-600;
@@ -137,12 +137,16 @@
 			background: $gray-400;
 		}
 		&.is-variation-separator::after {
-			width: 2px;
 			background: var(--wp-admin-theme-color);
 		}
 	}
 
 	&:focus::after {
 		box-shadow: 0 0 0 1px $gray-800, 0 0 0 calc(var(--wp-admin-border-width-focus) + 1px) var(--wp-admin-theme-color);
+	}
+
+	&.is-variation-separator:focus::after {
+		border-radius: $radius-block-ui;
+		box-shadow: inset 0 0 0 2px var(--wp-admin-theme-color);
 	}
 }

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -233,9 +233,7 @@ export default function Layout( { onError } ) {
 								} }
 								handleComponent={ {
 									right: (
-										<ResizeHandle
-											variation="separator"
-										/>
+										<ResizeHandle variation="separator" />
 									),
 								} }
 								handleClasses={ undefined }

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -234,7 +234,6 @@ export default function Layout( { onError } ) {
 								handleComponent={ {
 									right: (
 										<ResizeHandle
-											direction="right"
 											variation="separator"
 										/>
 									),

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -84,10 +84,6 @@ $hub-height: $grid-unit-20 * 2 + $button-size;
 		top: 0;
 	}
 
-	.resizable-editor__drag-handle.is-right {
-		right: math.div(-$grid-unit-15, 2);
-	}
-
 	> div {
 		overflow-y: auto;
 		min-height: 100%;

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -63,7 +63,6 @@ $hub-height: $grid-unit-20 * 2 + $button-size;
 .edit-site-layout__content {
 	flex-grow: 1;
 	display: flex;
-	gap: $canvas-padding;
 
 	// Hide scrollbars during the edit/view animation.
 	overflow: hidden;


### PR DESCRIPTION
## What?

Followup to #46903. Changes the resize handle to not act as a visual separator, and eliminates the double gutter.

Before:

![before](https://user-images.githubusercontent.com/1204802/212272985-14b53b89-eb32-41ac-b083-56d53da18a80.gif)

After:

![after](https://user-images.githubusercontent.com/1204802/212272696-82f6dfaf-e816-410f-bca8-67d4128678d0.gif)

This is a draft because this solution isn't quite ideal either. The border is still there acting as a separator all the time, it gets partially covered by the viewport drop shadow, and it isn't centered in the gutter between the two elements. Ideally we could keep the gap value, that part was correct. But the double gutter needs a separate solution then. Would love input and ideas 🙏

## Testing Instructions

Please test the resize handle between the left and right sides in the site editor (tab stop after the item in the menu) and it should work, without adding a double gutter.