### PR TITLE
Fix padding and margin visualizer styles

### DIFF
--- a/packages/block-editor/src/content.scss
+++ b/packages/block-editor/src/content.scss
@@ -12,3 +12,4 @@
 @import "./components/plain-text/content.scss";
 @import "./components/rich-text/content.scss";
 @import "./components/warning/content.scss";
+@import "./hooks/padding.scss";

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -51,7 +51,6 @@
 @import "./hooks/position.scss";
 @import "./hooks/typography.scss";
 @import "./hooks/color.scss";
-@import "./hooks/padding.scss";
 
 @import "./components/block-toolbar/style.scss";
 @import "./components/inserter/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I noticed in passing that the padding and margin visualizer styles are really broken

## How?
This seems to be a result of the introduction of iframed content in the post editor. I think the styles should be in the content.scss file, but this is the first time I've seen it so I may be wrong.

## Testing Instructions
1. Add a group block
2. Change padding or margin
3. The visualizer should show in the canvas correctly with a blue border.

### Testing Instructions for Keyboard
This isn't really a keyboard friendly feature

## Screenshots or screencast <!-- if applicable -->
#### Before

https://user-images.githubusercontent.com/677833/212285469-0ce99b12-3bb9-456b-9854-c73704165f27.mp4

#### After

https://user-images.githubusercontent.com/677833/212285153-6ff696cb-fdb5-4c44-98b9-c1a6f9af3e23.mp4

