### PR TITLE
Update the site hub to show the page title and the template title

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -31,7 +31,9 @@ import { store as preferencesStore } from '@wordpress/preferences';
  * Internal dependencies
  */
 import TemplateDetails from '../../template-details';
-import useEditedEntityRecord from '../../use-edited-entity-record';
+import useEditedEntityRecord, {
+	useEntityRecordTitle,
+} from '../../use-edited-entity-record';
 
 function getBlockDisplayText( block ) {
 	if ( block ) {
@@ -66,6 +68,10 @@ function useSecondaryText() {
 	return {};
 }
 
+function PostTitle( { postType, postId } ) {
+	return useEntityRecordTitle( 'postType', postType, postId );
+}
+
 export default function DocumentActions() {
 	const showIconLabels = useSelect(
 		( select ) =>
@@ -75,7 +81,7 @@ export default function DocumentActions() {
 			),
 		[]
 	);
-	const { isLoaded, record, getTitle } = useEditedEntityRecord();
+	const { isLoaded, record } = useEditedEntityRecord();
 	const { label, icon } = useSecondaryText();
 
 	// Use internal state instead of a ref to make sure that the component
@@ -138,7 +144,7 @@ export default function DocumentActions() {
 							entityLabel
 						) }
 					</VisuallyHidden>
-					{ getTitle() }
+					<PostTitle postType={ record.type } postId={ record.id } />
 				</Text>
 				<div className="edit-site-document-actions__secondary-item">
 					<BlockIcon icon={ icon } showColors />

--- a/packages/edit-site/src/components/use-edited-entity-record/index.js
+++ b/packages/edit-site/src/components/use-edited-entity-record/index.js
@@ -3,7 +3,6 @@
  */
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { store as editorStore } from '@wordpress/editor';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
@@ -12,11 +11,9 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { store as editSiteStore } from '../../store';
 
 export default function useEditedEntityRecord() {
-	const { record, title, isLoaded } = useSelect( ( select ) => {
+	const { record, isLoaded } = useSelect( ( select ) => {
 		const { getEditedPostType, getEditedPostId } = select( editSiteStore );
 		const { getEditedEntityRecord } = select( coreStore );
-		const { __experimentalGetTemplateInfo: getTemplateInfo } =
-			select( editorStore );
 		const postType = getEditedPostType();
 		const postId = getEditedPostId();
 		const _record = getEditedEntityRecord( 'postType', postType, postId );
@@ -24,7 +21,6 @@ export default function useEditedEntityRecord() {
 
 		return {
 			record: _record,
-			title: getTemplateInfo( _record ).title,
 			isLoaded: _isLoaded,
 		};
 	}, [] );
@@ -32,6 +28,24 @@ export default function useEditedEntityRecord() {
 	return {
 		isLoaded,
 		record,
-		getTitle: () => ( title ? decodeEntities( title ) : null ),
 	};
+}
+
+export function useEntityRecordTitle( kind, type, id ) {
+	const { title } = useSelect(
+		( select ) => {
+			const { getEntityRecord, getEntityConfig } = select( coreStore );
+			const record = getEntityRecord( kind, type, id );
+			const entityConfig = getEntityConfig( kind, type );
+			return {
+				title:
+					record && entityConfig
+						? decodeEntities( entityConfig.getTitle( record ) )
+						: null,
+			};
+		},
+		[ kind, type, id ]
+	);
+
+	return title ? decodeEntities( title ) : null;
 }


### PR DESCRIPTION
Related #36667

## What?

This PR updates the site hub to show the "page title" and "template title" instead of the "template title" and "template type" per suggestion from @jameskoster 

## Testing Instructions

1- Open the site editor
2- Navigate it and check how the content of the site hub changes.

