### PR TITLE
ESLint: Disable jest rules for storybook playwright

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -368,6 +368,7 @@ module.exports = {
 				'packages/react-native-*/**/*.[tj]s?(x)',
 				'test/native/**/*.[tj]s?(x)',
 				'test/e2e/**/*.[tj]s?(x)',
+				'test/storybook-playwright/**/*.[tj]s?(x)',
 			],
 			extends: [
 				'plugin:jest-dom/recommended',


### PR DESCRIPTION
## What?
In #47065 we enabled `jest` recommended ESLint rules for our tests. 

However, I just noticed that there are a couple of false positives in the storybook playwright specs. They're false positives since they reference the [playwright test runner](https://playwright.dev/docs/intro), not the jest one. 

This PR disables that directory from being linted with the ESLint rules for tests.

## Why?
To fix the related ESLint errors, see the screenshot below.

## How?
We're just altering our ESLint config to disable `jest`, `@testing-library` and `jest-dom` rules for the storywright playwright directory.

## Testing Instructions
Run `npm run lint:js` and verify there are no errors.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
![](https://cldup.com/N2_uRVAPv1.png)