### PR TITLE
Adds a global save button to the site editor

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -141,6 +141,7 @@ $z-layers: (
 
 	".skip-to-selected-block": 100000,
 	".interface-interface-skeleton__actions": 100000,
+	".edit-site-layout__actions": 100000,
 
 	// The focus styles of the region navigation containers should be above their content.
 	".is-focusing-regions {region} :focus::after": 1000000,

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -94,10 +94,8 @@ $z-layers: (
 	// the Publish Post sidebar.
 	".edit-post-layout .edit-post-post-publish-panel {greater than small}": 99998,
 
-	".entities-saved-states__panel": 100001,
 	// For larger views, the wp-admin navbar dropdown should be on top of
 	// the multi-entity saving sidebar.
-	".entities-saved-states__panel {greater than small}": 99998,
 	".edit-site-editor__toggle-save-panel": 100000,
 
 	// Show sidebar in greater than small viewports above editor related elements

--- a/packages/e2e-test-utils-playwright/src/editor/site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/site-editor.ts
@@ -14,7 +14,7 @@ export async function saveSiteEditorEntities( this: Editor ) {
 	);
 	// Second Save button in the entities panel.
 	await this.page.click(
-		'role=region[name="Editor publish"i] >> role=button[name="Save"i]'
+		'role=region[name="Save sidebar"i] >> role=button[name="Save"i]'
 	);
 	await this.page.waitForSelector(
 		'role=region[name="Editor top bar"i] >> role=button[name="Save"i][disabled]'

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -3,7 +3,7 @@
  */
 import { useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { Button, Notice } from '@wordpress/components';
+import { Notice } from '@wordpress/components';
 import { EntityProvider, store as coreStore } from '@wordpress/core-data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import {
@@ -16,11 +16,7 @@ import {
 	ComplementaryArea,
 	store as interfaceStore,
 } from '@wordpress/interface';
-import {
-	EditorNotices,
-	EditorSnackbars,
-	EntitiesSavedStates,
-} from '@wordpress/editor';
+import { EditorNotices, EditorSnackbars } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -64,7 +60,6 @@ export default function Editor() {
 		isRightSidebarOpen,
 		isInserterOpen,
 		isListViewOpen,
-		isSaveViewOpen,
 		showIconLabels,
 	} = useSelect( ( select ) => {
 		const {
@@ -75,7 +70,6 @@ export default function Editor() {
 			getCanvasMode,
 			isInserterOpened,
 			isListViewOpened,
-			isSaveViewOpened,
 		} = unlock( select( editSiteStore ) );
 		const { hasFinishedResolution, getEntityRecord } = select( coreStore );
 		const { __unstableGetEditorMode } = select( blockEditorStore );
@@ -104,7 +98,6 @@ export default function Editor() {
 			blockEditorMode: __unstableGetEditorMode(),
 			isInserterOpen: isInserterOpened(),
 			isListViewOpen: isListViewOpened(),
-			isSaveViewOpen: isSaveViewOpened(),
 			isRightSidebarOpen: getActiveComplementaryArea(
 				editSiteStore.name
 			),
@@ -114,8 +107,7 @@ export default function Editor() {
 			),
 		};
 	}, [] );
-	const { setIsSaveViewOpened, setEditedPostContext } =
-		useDispatch( editSiteStore );
+	const { setEditedPostContext } = useDispatch( editSiteStore );
 
 	const isViewMode = canvasMode === 'view';
 	const isEditMode = canvasMode === 'edit';
@@ -209,38 +201,6 @@ export default function Editor() {
 									isEditMode &&
 									isRightSidebarOpen && (
 										<ComplementaryArea.Slot scope="core/edit-site" />
-									)
-								}
-								actions={
-									isEditMode && (
-										<>
-											{ isSaveViewOpen ? (
-												<EntitiesSavedStates
-													close={ () =>
-														setIsSaveViewOpened(
-															false
-														)
-													}
-												/>
-											) : (
-												<div className="edit-site-editor__toggle-save-panel">
-													<Button
-														variant="secondary"
-														className="edit-site-editor__toggle-save-panel-button"
-														onClick={ () =>
-															setIsSaveViewOpened(
-																true
-															)
-														}
-														aria-expanded={ false }
-													>
-														{ __(
-															'Open save panel'
-														) }
-													</Button>
-												</div>
-											) }
-										</>
 									)
 								}
 								footer={

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -7,8 +7,8 @@
 	display: flex;
 	justify-content: center;
 
-	.interface-interface-skeleton__actions:focus &,
-	.interface-interface-skeleton__actions:focus-within & {
+	.edit-site-layout__actions:focus &,
+	.edit-site-layout__actions:focus-within & {
 		top: auto;
 		bottom: 0;
 	}

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -268,12 +268,7 @@ export default function Layout() {
 						) }
 					</AnimatePresence>
 
-					<NavigableRegion
-						className="edit-site-layout__actions"
-						ariaLabel={ __( 'Save sidebar' ) }
-					>
-						<SavePanel />
-					</NavigableRegion>
+					<SavePanel />
 
 					{ showCanvas && (
 						<div

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -39,6 +39,7 @@ import SiteHub from '../site-hub';
 import ResizeHandle from '../block-editor/resize-handle';
 import useSyncCanvasModeWithURL from '../sync-state-with-url/use-sync-canvas-mode-with-url';
 import { unlock } from '../../experiments';
+import SavePanel from '../save-panel';
 
 const ANIMATION_DURATION = 0.5;
 const emptyResizeHandleStyles = {
@@ -266,6 +267,13 @@ export default function Layout() {
 							</ResizableBox>
 						) }
 					</AnimatePresence>
+
+					<NavigableRegion
+						className="edit-site-layout__actions"
+						ariaLabel={ __( 'Save sidebar' ) }
+					>
+						<SavePanel />
+					</NavigableRegion>
 
 					{ showCanvas && (
 						<div

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -85,9 +85,9 @@ $hub-height: $grid-unit-20 * 2 + $button-size;
 	}
 
 	> div {
-		overflow-y: auto;
-		min-height: 100%;
-		@include custom-scrollbars-on-hover;
+		display: flex;
+		flex-direction: column;
+		height: 100%;
 	}
 
 	.resizable-editor__drag-handle {

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -215,10 +215,15 @@ $hub-height: $grid-unit-20 * 2 + $button-size;
 	right: 0;
 	width: $sidebar-width;
 	color: $gray-900;
+	background: $white;
 
 	&:focus,
 	&:focus-within {
-		top: auto;
+		top: 0;
 		bottom: 0;
+	}
+
+	@include break-medium {
+		border-left: $border-width solid $gray-300;
 	}
 }

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -205,3 +205,20 @@ $hub-height: $grid-unit-20 * 2 + $button-size;
 		border-radius: $radius-block-ui;
 	}
 }
+
+.edit-site-layout__actions {
+	z-index: z-index(".edit-site-layout__actions");
+	position: fixed !important; // Need to override the default relative positioning
+	top: -9999em;
+	bottom: auto;
+	left: auto;
+	right: 0;
+	width: $sidebar-width;
+	color: $gray-900;
+
+	&:focus,
+	&:focus-within {
+		top: auto;
+		bottom: 0;
+	}
+}

--- a/packages/edit-site/src/components/save-panel/index.js
+++ b/packages/edit-site/src/components/save-panel/index.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { EntitiesSavedStates } from '@wordpress/editor';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../../store';
+
+export default function SavePanel() {
+	const { isSaveViewOpen } = useSelect( ( select ) => {
+		const { isSaveViewOpened } = select( editSiteStore );
+
+		// The currently selected entity to display.
+		// Typically template or template part in the site editor.
+		return {
+			isSaveViewOpen: isSaveViewOpened(),
+		};
+	}, [] );
+	const { setIsSaveViewOpened } = useDispatch( editSiteStore );
+
+	return isSaveViewOpen ? (
+		<EntitiesSavedStates close={ () => setIsSaveViewOpened( false ) } />
+	) : (
+		<div className="edit-site-editor__toggle-save-panel">
+			<Button
+				variant="secondary"
+				className="edit-site-editor__toggle-save-panel-button"
+				onClick={ () => setIsSaveViewOpened( true ) }
+				aria-expanded={ false }
+			>
+				{ __( 'Open save panel' ) }
+			</Button>
+		</div>
+	);
+}

--- a/packages/edit-site/src/components/save-panel/index.js
+++ b/packages/edit-site/src/components/save-panel/index.js
@@ -1,40 +1,65 @@
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
+import { Button, Modal } from '@wordpress/components';
 import { EntitiesSavedStates } from '@wordpress/editor';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { NavigableRegion } from '@wordpress/interface';
 
 /**
  * Internal dependencies
  */
 import { store as editSiteStore } from '../../store';
+import { unlock } from '../../experiments';
 
 export default function SavePanel() {
-	const { isSaveViewOpen } = useSelect( ( select ) => {
-		const { isSaveViewOpened } = select( editSiteStore );
+	const { isSaveViewOpen, canvasMode } = useSelect( ( select ) => {
+		const { isSaveViewOpened, getCanvasMode } = unlock(
+			select( editSiteStore )
+		);
 
 		// The currently selected entity to display.
 		// Typically template or template part in the site editor.
 		return {
 			isSaveViewOpen: isSaveViewOpened(),
+			canvasMode: getCanvasMode(),
 		};
 	}, [] );
 	const { setIsSaveViewOpened } = useDispatch( editSiteStore );
+	const onClose = () => setIsSaveViewOpened( false );
 
-	return isSaveViewOpen ? (
-		<EntitiesSavedStates close={ () => setIsSaveViewOpened( false ) } />
-	) : (
-		<div className="edit-site-editor__toggle-save-panel">
-			<Button
-				variant="secondary"
-				className="edit-site-editor__toggle-save-panel-button"
-				onClick={ () => setIsSaveViewOpened( true ) }
-				aria-expanded={ false }
+	if ( canvasMode === 'view' ) {
+		return isSaveViewOpen ? (
+			<Modal
+				className="edit-site-save-panel__modal"
+				onRequestClose={ onClose }
+				__experimentalHideHeader
 			>
-				{ __( 'Open save panel' ) }
-			</Button>
-		</div>
+				<EntitiesSavedStates close={ onClose } />
+			</Modal>
+		) : null;
+	}
+
+	return (
+		<NavigableRegion
+			className="edit-site-layout__actions"
+			ariaLabel={ __( 'Save sidebar' ) }
+		>
+			{ isSaveViewOpen ? (
+				<EntitiesSavedStates close={ onClose } />
+			) : (
+				<div className="edit-site-editor__toggle-save-panel">
+					<Button
+						variant="secondary"
+						className="edit-site-editor__toggle-save-panel-button"
+						onClick={ () => setIsSaveViewOpened( true ) }
+						aria-expanded={ false }
+					>
+						{ __( 'Open save panel' ) }
+					</Button>
+				</div>
+			) }
+		</NavigableRegion>
 	);
 }

--- a/packages/edit-site/src/components/save-panel/style.scss
+++ b/packages/edit-site/src/components/save-panel/style.scss
@@ -1,0 +1,5 @@
+.edit-site-save-panel__modal {
+	@include break-small() {
+		width: 600px;
+	}
+}

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -11,6 +11,7 @@ import SidebarNavigationScreenMain from '../sidebar-navigation-screen-main';
 import SidebarNavigationScreenTemplates from '../sidebar-navigation-screen-templates';
 import useSyncSidebarPathWithURL from '../sync-state-with-url/use-sync-sidebar-path-with-url';
 import SidebarNavigationScreenNavigationMenus from '../sidebar-navigation-screen-navigation-menus';
+import SaveButton from '../save-button';
 
 function SidebarScreens() {
 	useSyncSidebarPathWithURL();
@@ -27,12 +28,17 @@ function SidebarScreens() {
 
 function Sidebar() {
 	return (
-		<NavigatorProvider
-			className="edit-site-sidebar__content"
-			initialPath="/"
-		>
-			<SidebarScreens />
-		</NavigatorProvider>
+		<>
+			<NavigatorProvider
+				className="edit-site-sidebar__content"
+				initialPath="/"
+			>
+				<SidebarScreens />
+			</NavigatorProvider>
+			<div className="edit-site-sidebar__footer">
+				<SaveButton />
+			</div>
+		</>
 	);
 }
 

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -2,7 +2,9 @@
  * WordPress dependencies
  */
 import { memo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import { __experimentalNavigatorProvider as NavigatorProvider } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -27,6 +29,16 @@ function SidebarScreens() {
 }
 
 function Sidebar() {
+	const { isDirty } = useSelect( ( select ) => {
+		const { __experimentalGetDirtyEntityRecords } = select( coreStore );
+		const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
+		// The currently selected entity to display.
+		// Typically template or template part in the site editor.
+		return {
+			isDirty: dirtyEntityRecords.length > 0,
+		};
+	}, [] );
+
 	return (
 		<>
 			<NavigatorProvider
@@ -35,9 +47,11 @@ function Sidebar() {
 			>
 				<SidebarScreens />
 			</NavigatorProvider>
-			<div className="edit-site-sidebar__footer">
-				<SaveButton />
-			</div>
+			{ isDirty && (
+				<div className="edit-site-sidebar__footer">
+					<SaveButton />
+				</div>
+			) }
 		</>
 	);
 }

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -1,3 +1,18 @@
+.edit-site-sidebar__content {
+	flex-grow: 1;
+	overflow-y: auto;
+	@include custom-scrollbars-on-hover;
+}
+
+.edit-site-sidebar__footer {
+	border-top: 1px solid $gray-800;
+	flex-shrink: 0;
+	margin: 0 $canvas-padding;
+	padding: $canvas-padding 0;
+	display: flex;
+	justify-content: flex-end;
+}
+
 .edit-site-sidebar__content.edit-site-sidebar__content {
 	overflow-x: unset;
 }

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -18,6 +18,7 @@ import { __ } from '@wordpress/i18n';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { forwardRef } from '@wordpress/element';
+import { pencil } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -28,6 +29,7 @@ import getIsListPage from '../../utils/get-is-list-page';
 import SiteIcon from '../site-icon';
 import useEditedEntityRecord from '../use-edited-entity-record';
 import { unlock } from '../../experiments';
+import SaveButton from '../save-button';
 
 const HUB_ANIMATION_DURATION = 0.3;
 
@@ -132,15 +134,17 @@ const SiteHub = forwardRef(
 				</HStack>
 
 				{ showEditButton && (
-					<Button
-						className="edit-site-site-hub__edit-button"
-						onClick={ () => {
-							setCanvasMode( 'edit' );
-						} }
-						variant="primary"
-					>
-						{ __( 'Edit' ) }
-					</Button>
+					<>
+						<Button
+							className="edit-site-site-hub__edit-button"
+							label={ __( 'Edit' ) }
+							onClick={ () => {
+								setCanvasMode( 'edit' );
+							} }
+							icon={ pencil }
+						/>
+						<SaveButton />
+					</>
 				) }
 
 				{ isMobileViewport && ! isMobileCanvasVisible && (

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -18,7 +18,6 @@ import { __ } from '@wordpress/i18n';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { forwardRef } from '@wordpress/element';
-import { pencil } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -29,7 +28,6 @@ import getIsListPage from '../../utils/get-is-list-page';
 import SiteIcon from '../site-icon';
 import useEditedEntityRecord from '../use-edited-entity-record';
 import { unlock } from '../../experiments';
-import SaveButton from '../save-button';
 
 const HUB_ANIMATION_DURATION = 0.3;
 
@@ -134,17 +132,15 @@ const SiteHub = forwardRef(
 				</HStack>
 
 				{ showEditButton && (
-					<>
-						<Button
-							className="edit-site-site-hub__edit-button"
-							label={ __( 'Edit' ) }
-							onClick={ () => {
-								setCanvasMode( 'edit' );
-							} }
-							icon={ pencil }
-						/>
-						<SaveButton />
-					</>
+					<Button
+						className="edit-site-site-hub__edit-button"
+						onClick={ () => {
+							setCanvasMode( 'edit' );
+						} }
+						variant="primary"
+					>
+						{ __( 'Edit' ) }
+					</Button>
 				) }
 
 				{ isMobileViewport && ! isMobileCanvasVisible && (

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -7,6 +7,7 @@
 
 .edit-site-site-hub__edit-button {
 	height: $grid-unit-40;
+	color: $white;
 }
 
 .edit-site-site-hub__post-type {

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -19,6 +19,7 @@
 @import "./components/welcome-guide/style.scss";
 @import "./components/keyboard-shortcut-help-modal/style.scss";
 @import "./components/layout/style.scss";
+@import "./components/save-panel/style.scss";
 @import "./components/sidebar/style.scss";
 @import "./components/sidebar-navigation-item/style.scss";
 @import "./components/sidebar-navigation-screen/style.scss";

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -1,50 +1,27 @@
-.entities-saved-states__panel {
-	@include reset;
-	background: $white;
-	position: fixed;
-	z-index: z-index(".entities-saved-states__panel");
-	top: $admin-bar-height-big;
-	bottom: 0;
-	right: 0;
-	left: 0;
-	overflow: auto;
-	box-sizing: border-box;
-
-	.entities-saved-states__find-entity {
-		display: none;
-	}
-	.entities-saved-states__find-entity-small {
-		display: block;
-	}
+.entities-saved-states__find-entity {
+	display: none;
 
 	@include break-medium() {
-		top: $admin-bar-height;
-		left: auto;
-		width: $sidebar-width;
-		border-left: $border-width solid $gray-300;
-
-		body.is-fullscreen-mode & {
-			top: 0;
-		}
-
-		.entities-saved-states__find-entity {
-			display: block;
-		}
-		.entities-saved-states__find-entity-small {
-			display: none;
-		}
+		display: block;
 	}
+}
+.entities-saved-states__find-entity-small {
+	display: block;
 
-	.entities-saved-states__panel-header {
-		background: $white;
-		padding-left: $grid-unit-10;
-		padding-right: $grid-unit-10;
-		height: $header-height + $border-width;
-		border-bottom: $border-width solid $gray-300;
+	@include break-medium() {
+		display: none;
 	}
+}
 
-	.entities-saved-states__text-prompt {
-		padding: $grid-unit-20;
-		padding-bottom: $grid-unit-05;
-	}
+.entities-saved-states__panel-header {
+	background: $white;
+	padding-left: $grid-unit-10;
+	padding-right: $grid-unit-10;
+	height: $header-height;
+	border-bottom: $border-width solid $gray-300;
+}
+
+.entities-saved-states__text-prompt {
+	padding: $grid-unit-20;
+	padding-bottom: $grid-unit-05;
 }


### PR DESCRIPTION
Related #36667 closes #46985

## What and why?

This PR tries to add a global save button to the site editor. Check #46985 for the reasoning. The TLDR is that we're able to make edits to the templates and navigation... from within the edit mode but also outside it, meaning there's a need to save changes globally. 

## How?

 - This just adds the existing save button to the bottom of the sidebar
 - I've also extracted the "save" aria region from the editor to the layout, so it's shared between view and edit mode.
 - In view mode, the save panel is wrapped in a modal
 - I've removed some specific styles from the EntitiesSavedStates component and checked that it's good enough in all of our editors.

## Testing Instructions

 1- Open the site editor
 2- Enter edit mode and make changes to any part of the site
 3- Leave the edit mode without saving
 4- You should be able to save using the "save" button inside the site editor sidebar.
