### PR TITLE
Tests: Use real timers where fake timers are unnecessary

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-list-item/test/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/test/index.js
@@ -15,8 +15,6 @@ import { useSelect } from '@wordpress/data';
 import DownloadableBlockListItem from '../';
 import { plugin } from '../../test/fixtures';
 
-jest.useFakeTimers();
-
 jest.mock( '@wordpress/data/src/components/use-select', () => {
 	// This allows us to tweak the returned value on each test.
 	const mock = jest.fn();
@@ -68,9 +66,7 @@ describe( 'DownloadableBlockListItem', () => {
 	} );
 
 	it( 'should try to install the block plugin', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		useSelect.mockImplementation( () => ( {
 			isInstalling: false,

--- a/packages/block-editor/src/components/alignment-control/test/index.js
+++ b/packages/block-editor/src/components/alignment-control/test/index.js
@@ -14,8 +14,6 @@ import { alignLeft, alignCenter } from '@wordpress/icons';
  */
 import AlignmentUI from '../ui';
 
-jest.useFakeTimers();
-
 describe( 'AlignmentUI', () => {
 	const alignment = 'left';
 	const onChangeSpy = jest.fn();
@@ -50,9 +48,7 @@ describe( 'AlignmentUI', () => {
 	} );
 
 	test( 'should expand controls when toggled', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		const { unmount } = render(
 			<AlignmentUI
@@ -85,9 +81,7 @@ describe( 'AlignmentUI', () => {
 	} );
 
 	test( 'should call on change with undefined when a control is already active', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		render(
 			<AlignmentUI
@@ -111,9 +105,7 @@ describe( 'AlignmentUI', () => {
 	} );
 
 	test( 'should call on change a new value when the control is not active', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		render(
 			<AlignmentUI
@@ -136,9 +128,7 @@ describe( 'AlignmentUI', () => {
 	} );
 
 	test( 'should allow custom alignment controls to be specified', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		const { container } = render(
 			<AlignmentUI

--- a/packages/block-editor/src/components/block-alignment-control/test/index.js
+++ b/packages/block-editor/src/components/block-alignment-control/test/index.js
@@ -9,8 +9,6 @@ import userEvent from '@testing-library/user-event';
  */
 import BlockAlignmentUI from '../ui';
 
-jest.useFakeTimers();
-
 describe( 'BlockAlignmentUI', () => {
 	const alignment = 'left';
 	const onChange = jest.fn();
@@ -45,9 +43,7 @@ describe( 'BlockAlignmentUI', () => {
 	} );
 
 	test( 'should expand controls when toggled', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		const { unmount } = render(
 			<BlockAlignmentUI
@@ -80,9 +76,7 @@ describe( 'BlockAlignmentUI', () => {
 	} );
 
 	test( 'should call onChange with undefined, when the control is already active', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		render(
 			<BlockAlignmentUI
@@ -105,9 +99,7 @@ describe( 'BlockAlignmentUI', () => {
 	} );
 
 	test( 'should call onChange with alignment value when the control is inactive', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		render(
 			<BlockAlignmentUI

--- a/packages/block-editor/src/components/block-vertical-alignment-control/test/index.js
+++ b/packages/block-editor/src/components/block-vertical-alignment-control/test/index.js
@@ -9,8 +9,6 @@ import userEvent from '@testing-library/user-event';
  */
 import BlockVerticalAlignmentUI from '../ui';
 
-jest.useFakeTimers();
-
 describe( 'BlockVerticalAlignmentUI', () => {
 	const alignment = 'top';
 	const onChange = jest.fn();
@@ -43,9 +41,7 @@ describe( 'BlockVerticalAlignmentUI', () => {
 	} );
 
 	test( 'should expand controls when toggled', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		const { unmount } = render(
 			<BlockVerticalAlignmentUI
@@ -78,9 +74,7 @@ describe( 'BlockVerticalAlignmentUI', () => {
 	} );
 
 	it( 'should call onChange with undefined, when the control is already active', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		render(
 			<BlockVerticalAlignmentUI
@@ -104,9 +98,7 @@ describe( 'BlockVerticalAlignmentUI', () => {
 
 	it( 'should call onChange with alignment value when the control is inactive', async () => {
 		// note "middle" alias for "center"
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		render(
 			<BlockVerticalAlignmentUI

--- a/packages/block-editor/src/components/colors/test/with-colors.js
+++ b/packages/block-editor/src/components/colors/test/with-colors.js
@@ -9,8 +9,6 @@ import userEvent from '@testing-library/user-event';
  */
 import { createCustomColorsHOC } from '../with-colors';
 
-jest.useFakeTimers();
-
 describe( 'createCustomColorsHOC', () => {
 	it( 'provides the wrapped component with color values and setter functions as props', () => {
 		const withCustomColors = createCustomColorsHOC( [
@@ -44,9 +42,7 @@ describe( 'createCustomColorsHOC', () => {
 	} );
 
 	it( 'setting the color to a value in the provided custom color array updated the backgroundColor attribute', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 		const withCustomColors = createCustomColorsHOC( [
 			{ name: 'Red', slug: 'red', color: 'ff0000' },
 		] );
@@ -76,9 +72,7 @@ describe( 'createCustomColorsHOC', () => {
 	} );
 
 	it( 'setting the color to a value not in the provided custom color array updates customBackgroundColor attribute', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 		const withCustomColors = createCustomColorsHOC( [
 			{ name: 'Red', slug: 'red', color: 'ff0000' },
 		] );

--- a/packages/block-editor/src/components/default-block-appender/test/index.js
+++ b/packages/block-editor/src/components/default-block-appender/test/index.js
@@ -9,8 +9,6 @@ import userEvent from '@testing-library/user-event';
  */
 import { DefaultBlockAppender, ZWNBSP } from '../';
 
-jest.useFakeTimers();
-
 describe( 'DefaultBlockAppender', () => {
 	it( 'should match snapshot', () => {
 		const onAppend = jest.fn();
@@ -23,9 +21,7 @@ describe( 'DefaultBlockAppender', () => {
 	} );
 
 	it( 'should append a default block when input focused', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 		const onAppend = jest.fn();
 
 		const { container } = render(
@@ -44,9 +40,7 @@ describe( 'DefaultBlockAppender', () => {
 	} );
 
 	it( 'should optionally show without prompt', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 		const onAppend = jest.fn();
 
 		const { container } = render(

--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -14,8 +14,6 @@ import { useState } from '@wordpress/element';
  */
 import MediaReplaceFlow from '../';
 
-jest.useFakeTimers();
-
 const noop = () => {};
 
 function TestWrapper() {
@@ -57,9 +55,7 @@ describe( 'General media replace flow', () => {
 	} );
 
 	it( 'renders replace menu', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		render( <TestWrapper /> );
 
@@ -81,9 +77,7 @@ describe( 'General media replace flow', () => {
 	} );
 
 	it( 'displays media URL', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		render( <TestWrapper /> );
 
@@ -106,9 +100,7 @@ describe( 'General media replace flow', () => {
 	} );
 
 	it( 'edits media URL', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		render( <TestWrapper /> );
 

--- a/packages/block-editor/src/components/responsive-block-control/test/index.js
+++ b/packages/block-editor/src/components/responsive-block-control/test/index.js
@@ -15,8 +15,6 @@ import { SelectControl } from '@wordpress/components';
  */
 import ResponsiveBlockControl from '../index';
 
-jest.useFakeTimers();
-
 const inputId = 'input-12345678';
 
 const sizeOptions = [
@@ -246,9 +244,7 @@ describe( 'Default and Responsive modes', () => {
 	} );
 
 	it( 'should switch between default and responsive modes when interacting with toggle control', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 		const ResponsiveBlockControlConsumer = () => {
 			const [ isResponsive, setIsResponsive ] = useState( false );
 

--- a/packages/block-editor/src/components/url-input/test/button.js
+++ b/packages/block-editor/src/components/url-input/test/button.js
@@ -9,8 +9,6 @@ import userEvent from '@testing-library/user-event';
  */
 import URLInputButton from '../button';
 
-jest.useFakeTimers();
-
 describe( 'URLInputButton', () => {
 	it( 'should render a `Insert link` button and not be pressed when `url` is not provided', () => {
 		render( <URLInputButton /> );
@@ -57,9 +55,7 @@ describe( 'URLInputButton', () => {
 	} );
 
 	it( 'should render a form when `Insert link` button is clicked', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 		render( <URLInputButton /> );
 
 		// Click the button to insert a link.
@@ -76,9 +72,7 @@ describe( 'URLInputButton', () => {
 	} );
 
 	it( 'should call `onChange` function once per each value change', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 		const onChangeMock = jest.fn();
 
 		render( <URLInputButton onChange={ onChangeMock } /> );
@@ -104,9 +98,7 @@ describe( 'URLInputButton', () => {
 	} );
 
 	it( 'should close the form when the user clicks the `Close` button', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		render( <URLInputButton /> );
 
@@ -135,9 +127,7 @@ describe( 'URLInputButton', () => {
 	} );
 
 	it( 'should close the form when user submits it', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 		const onChangeMock = jest.fn();
 
 		render( <URLInputButton onChange={ onChangeMock } /> );

--- a/packages/block-editor/src/components/warning/test/index.js
+++ b/packages/block-editor/src/components/warning/test/index.js
@@ -9,8 +9,6 @@ import userEvent from '@testing-library/user-event';
  */
 import Warning from '../index';
 
-jest.useFakeTimers();
-
 describe( 'Warning', () => {
 	it( 'should match snapshot', () => {
 		const { container } = render( <Warning>error</Warning> );
@@ -33,9 +31,7 @@ describe( 'Warning', () => {
 	} );
 
 	it( 'should show hidden secondary actions', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		render(
 			<Warning secondaryActions={ [ { title: 'test', onClick: null } ] }>

--- a/packages/compose/src/higher-order/pure/test/index.js
+++ b/packages/compose/src/higher-order/pure/test/index.js
@@ -14,8 +14,6 @@ import { Component } from '@wordpress/element';
  */
 import pure from '../';
 
-jest.useFakeTimers();
-
 describe( 'pure', () => {
 	it( 'functional component should rerender only when props change', () => {
 		let i = 0;
@@ -42,9 +40,7 @@ describe( 'pure', () => {
 	} );
 
 	it( 'class component should rerender if the props or state change', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 		let i = 0;
 		const MyComp = pure(
 			class extends Component {

--- a/packages/compose/src/higher-order/with-state/test/index.js
+++ b/packages/compose/src/higher-order/with-state/test/index.js
@@ -9,13 +9,9 @@ import userEvent from '@testing-library/user-event';
  */
 import withState from '../';
 
-jest.useFakeTimers();
-
 describe( 'withState', () => {
 	it( 'should pass initial state and allow updates', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 		const EnhancedComponent = withState( {
 			count: 0,
 		} )( ( { count, setState } ) => (

--- a/packages/compose/src/hooks/use-focus-outside/test/index.js
+++ b/packages/compose/src/hooks/use-focus-outside/test/index.js
@@ -9,8 +9,6 @@ import userEvent from '@testing-library/user-event';
  */
 import useFocusOutside from '../';
 
-jest.useFakeTimers();
-
 const FocusOutsideComponent = ( { onFocusOutside: callback } ) => (
 	<div>
 		{ /* Wrapper */ }
@@ -29,9 +27,7 @@ const FocusOutsideComponent = ( { onFocusOutside: callback } ) => (
 describe( 'useFocusOutside', () => {
 	it( 'should not call handler if focus shifts to element within component', async () => {
 		const mockOnFocusOutside = jest.fn();
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		render(
 			<FocusOutsideComponent onFocusOutside={ mockOnFocusOutside } />
@@ -52,9 +48,7 @@ describe( 'useFocusOutside', () => {
 
 	it( 'should not call handler if focus transitions via click to button', async () => {
 		const mockOnFocusOutside = jest.fn();
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		render(
 			<FocusOutsideComponent onFocusOutside={ mockOnFocusOutside } />
@@ -71,9 +65,7 @@ describe( 'useFocusOutside', () => {
 
 	it( 'should call handler if focus shifts to element outside component', async () => {
 		const mockOnFocusOutside = jest.fn();
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		render(
 			<FocusOutsideComponent onFocusOutside={ mockOnFocusOutside } />
@@ -101,9 +93,7 @@ describe( 'useFocusOutside', () => {
 			.spyOn( document, 'hasFocus' )
 			.mockImplementation( () => false );
 		const mockOnFocusOutside = jest.fn();
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		render(
 			<FocusOutsideComponent onFocusOutside={ mockOnFocusOutside } />
@@ -128,9 +118,7 @@ describe( 'useFocusOutside', () => {
 
 	it( 'should cancel check when unmounting while queued', async () => {
 		const mockOnFocusOutside = jest.fn();
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		const { unmount } = render(
 			<FocusOutsideComponent onFocusOutside={ mockOnFocusOutside } />
@@ -146,8 +134,6 @@ describe( 'useFocusOutside', () => {
 		// handler is queued
 		button.blur();
 		unmount();
-
-		jest.runAllTimers();
 
 		expect( mockOnFocusOutside ).not.toHaveBeenCalled();
 	} );

--- a/packages/compose/src/utils/debounce/test/index.ts
+++ b/packages/compose/src/utils/debounce/test/index.ts
@@ -5,14 +5,6 @@ import { debounce } from '../index';
 
 const identity = ( value ) => value;
 
-beforeAll( () => {
-	jest.useRealTimers();
-} );
-
-afterAll( () => {
-	jest.useFakeTimers();
-} );
-
 describe( 'debounce', () => {
 	it( 'should debounce a function', () => {
 		return new Promise( ( done ) => {

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -55,12 +55,6 @@ describe( 'editEntityRecord', () => {
 describe( 'deleteEntityRecord', () => {
 	beforeEach( async () => {
 		apiFetch.mockReset();
-		jest.useFakeTimers();
-	} );
-
-	afterEach( () => {
-		jest.runOnlyPendingTimers();
-		jest.useRealTimers();
 	} );
 
 	it( 'triggers a DELETE request for an existing record', async () => {
@@ -182,12 +176,6 @@ describe( 'deleteEntityRecord', () => {
 describe( 'saveEditedEntityRecord', () => {
 	beforeEach( async () => {
 		apiFetch.mockReset();
-		jest.useFakeTimers();
-	} );
-
-	afterEach( () => {
-		jest.runOnlyPendingTimers();
-		jest.useRealTimers();
 	} );
 
 	it( 'Uses "id" as a key when no entity key is provided', async () => {
@@ -277,17 +265,11 @@ describe( 'saveEntityRecord', () => {
 
 	beforeEach( async () => {
 		apiFetch.mockReset();
-		jest.useFakeTimers();
 		dispatch = Object.assign( jest.fn(), {
 			receiveEntityRecords: jest.fn(),
 			__unstableAcquireStoreLock: jest.fn(),
 			__unstableReleaseStoreLock: jest.fn(),
 		} );
-	} );
-
-	afterEach( () => {
-		jest.runOnlyPendingTimers();
-		jest.useRealTimers();
 	} );
 
 	it( 'triggers a POST request for a new record', async () => {

--- a/packages/core-data/src/test/entities.js
+++ b/packages/core-data/src/test/entities.js
@@ -52,12 +52,6 @@ describe( 'getMethodName', () => {
 describe( 'getKindEntities', () => {
 	beforeEach( async () => {
 		triggerFetch.mockReset();
-		jest.useFakeTimers();
-	} );
-
-	afterEach( () => {
-		jest.runOnlyPendingTimers();
-		jest.useRealTimers();
 	} );
 
 	it( 'shouldn’t do anything if the entities have already been resolved', async () => {

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -30,12 +30,6 @@ describe( 'getEntityRecord', () => {
 
 	beforeEach( async () => {
 		triggerFetch.mockReset();
-		jest.useFakeTimers();
-	} );
-
-	afterEach( () => {
-		jest.runOnlyPendingTimers();
-		jest.useRealTimers();
 	} );
 
 	it( 'yields with requested post type', async () => {
@@ -152,12 +146,6 @@ describe( 'getEntityRecords', () => {
 
 	beforeEach( async () => {
 		triggerFetch.mockReset();
-		jest.useFakeTimers();
-	} );
-
-	afterEach( () => {
-		jest.runOnlyPendingTimers();
-		jest.useRealTimers();
 	} );
 
 	it( 'dispatches the requested post type', async () => {

--- a/packages/edit-post/src/components/preferences-modal/options/test/enable-custom-fields.js
+++ b/packages/edit-post/src/components/preferences-modal/options/test/enable-custom-fields.js
@@ -12,8 +12,6 @@ import {
 	CustomFieldsConfirmation,
 } from '../enable-custom-fields';
 
-jest.useFakeTimers();
-
 describe( 'EnableCustomFieldsOption', () => {
 	it( 'renders a checked checkbox when custom fields are enabled', () => {
 		const { container } = render(
@@ -32,9 +30,7 @@ describe( 'EnableCustomFieldsOption', () => {
 	} );
 
 	it( 'renders an unchecked checkbox and a confirmation message when toggled off', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		const { container } = render(
 			<EnableCustomFieldsOption areCustomFieldsEnabled />
@@ -46,9 +42,7 @@ describe( 'EnableCustomFieldsOption', () => {
 	} );
 
 	it( 'renders a checked checkbox and a confirmation message when toggled on', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		const { container } = render(
 			<EnableCustomFieldsOption areCustomFieldsEnabled={ false } />
@@ -62,9 +56,7 @@ describe( 'EnableCustomFieldsOption', () => {
 
 describe( 'CustomFieldsConfirmation', () => {
 	it( 'submits the toggle-custom-fields-form', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 		const submit = jest.fn();
 		const getElementById = jest
 			.spyOn( document, 'getElementById' )

--- a/packages/editor/src/components/page-attributes/test/order.js
+++ b/packages/editor/src/components/page-attributes/test/order.js
@@ -9,8 +9,6 @@ import userEvent from '@testing-library/user-event';
  */
 import { PageAttributesOrder } from '../order';
 
-jest.useFakeTimers();
-
 describe( 'PageAttributesOrder', () => {
 	/**
 	 * When starting to type inside the spinbutton, select the current value
@@ -22,9 +20,7 @@ describe( 'PageAttributesOrder', () => {
 	};
 
 	it( 'should reject invalid input', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		const onUpdateOrder = jest.fn();
 
@@ -41,9 +37,7 @@ describe( 'PageAttributesOrder', () => {
 	} );
 
 	it( 'should update with zero input', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		const onUpdateOrder = jest.fn();
 
@@ -59,9 +53,7 @@ describe( 'PageAttributesOrder', () => {
 	} );
 
 	it( 'should update with valid positive input', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		const onUpdateOrder = jest.fn();
 
@@ -77,9 +69,7 @@ describe( 'PageAttributesOrder', () => {
 	} );
 
 	it( 'should update with valid negative input', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		const onUpdateOrder = jest.fn();
 

--- a/packages/editor/src/components/post-preview-button/test/index.js
+++ b/packages/editor/src/components/post-preview-button/test/index.js
@@ -9,8 +9,6 @@ import userEvent from '@testing-library/user-event';
  */
 import { PostPreviewButton } from '../';
 
-jest.useFakeTimers();
-
 describe( 'PostPreviewButton', () => {
 	const documentWrite = jest.fn();
 	const documentTitle = jest.fn();
@@ -175,9 +173,7 @@ describe( 'PostPreviewButton', () => {
 	} );
 
 	it( 'should save post if `isDraft` is `true`', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 		const url = 'https://wordpress.org';
 		const savePost = jest.fn();
 		const autosave = jest.fn();
@@ -203,9 +199,7 @@ describe( 'PostPreviewButton', () => {
 	} );
 
 	it( 'should autosave post if `isDraft` is `false`', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 		const url = 'https://wordpress.org';
 		const savePost = jest.fn();
 		const autosave = jest.fn();
@@ -231,9 +225,7 @@ describe( 'PostPreviewButton', () => {
 	} );
 
 	it( 'should open a window with the specified target', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 		const postId = 123;
 		const url = 'https://wordpress.org';
 
@@ -257,9 +249,7 @@ describe( 'PostPreviewButton', () => {
 	} );
 
 	it( 'should set the location in the window properly', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 		const postId = 123;
 		const url = 'https://wordpress.org';
 
@@ -290,9 +280,7 @@ describe( 'PostPreviewButton', () => {
 	} );
 
 	it( 'should display a `Generating preview` message while waiting for autosaving', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 		const previewText = 'Generating preview…';
 		const url = 'https://wordpress.org';
 		const savePost = jest.fn();

--- a/packages/editor/src/components/post-publish-button/test/index.js
+++ b/packages/editor/src/components/post-publish-button/test/index.js
@@ -9,8 +9,6 @@ import userEvent from '@testing-library/user-event';
  */
 import { PostPublishButton } from '../';
 
-jest.useFakeTimers();
-
 describe( 'PostPublishButton', () => {
 	describe( 'aria-disabled', () => {
 		it( 'should be true if post is currently saving', () => {
@@ -92,9 +90,7 @@ describe( 'PostPublishButton', () => {
 
 	describe( 'publish status', () => {
 		it( 'should be pending for contributor', async () => {
-			const user = userEvent.setup( {
-				advanceTimers: jest.advanceTimersByTime,
-			} );
+			const user = userEvent.setup();
 			const onStatusChange = jest.fn();
 			const onSave = jest.fn();
 			render(
@@ -115,9 +111,7 @@ describe( 'PostPublishButton', () => {
 		} );
 
 		it( 'should be future for scheduled post', async () => {
-			const user = userEvent.setup( {
-				advanceTimers: jest.advanceTimersByTime,
-			} );
+			const user = userEvent.setup();
 			const onStatusChange = jest.fn();
 			const onSave = jest.fn();
 			render(
@@ -139,9 +133,7 @@ describe( 'PostPublishButton', () => {
 		} );
 
 		it( 'should be private for private visibility', async () => {
-			const user = userEvent.setup( {
-				advanceTimers: jest.advanceTimersByTime,
-			} );
+			const user = userEvent.setup();
 			const onStatusChange = jest.fn();
 			const onSave = jest.fn();
 			render(
@@ -163,9 +155,7 @@ describe( 'PostPublishButton', () => {
 		} );
 
 		it( 'should be publish otherwise', async () => {
-			const user = userEvent.setup( {
-				advanceTimers: jest.advanceTimersByTime,
-			} );
+			const user = userEvent.setup();
 			const onStatusChange = jest.fn();
 			const onSave = jest.fn();
 			render(
@@ -188,9 +178,7 @@ describe( 'PostPublishButton', () => {
 
 	describe( 'click', () => {
 		it( 'should save with status', async () => {
-			const user = userEvent.setup( {
-				advanceTimers: jest.advanceTimersByTime,
-			} );
+			const user = userEvent.setup();
 			const onStatusChange = jest.fn();
 			const onSave = jest.fn();
 			render(

--- a/packages/editor/src/components/post-saved-state/test/index.js
+++ b/packages/editor/src/components/post-saved-state/test/index.js
@@ -15,8 +15,6 @@ import { useSelect } from '@wordpress/data';
  */
 import PostSavedState from '../';
 
-jest.useFakeTimers();
-
 const mockSavePost = jest.fn();
 
 jest.mock( '@wordpress/data/src/components/use-dispatch', () => {
@@ -96,9 +94,7 @@ describe( 'PostSavedState', () => {
 	} );
 
 	it( 'should return Save button if edits to be saved', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 
 		useSelect.mockImplementation( () => ( {
 			isDirty: true,


### PR DESCRIPTION
## What?
This PR updates more tests across the various packages to use real timers where possible. This is a follow-up to #46714 and #47056.

There are more tests that use fake timers, but this PR doesn't attempt to attack them all. Many of them actually make sense to use fake timers anyway.

## Why?
We discovered that Jest real timers are preferable when their use is possible, see https://github.com/facebook/react/issues/25889 and the description in #46714.

## How?
We're removing the specific `jest.useFakeTimers();` calls, and the unnecessary `advanceTimers: jest.advanceTimersByTime`  in the user-event setup. We're also removing the now unnecessary `jest.advanceTimersByTime()` calls and post-test cleanup that we've been doing with `jest.runOnlyPendingTimers()` and `jest.useRealTimers()`.

## Testing Instructions
Verify all tests still pass.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None.