### PR TITLE
Fix UrlInput combobox to use the ARIA 1.0 pattern.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -78,6 +78,8 @@
 #### Block Library
 - Lodash: Remove `_.pickBy()` from latest posts block. ([46974](https://github.com/WordPress/gutenberg/pull/46974))
 
+### Accessibility
+- Block Editor: Revert `aria-controls` to `aria-owns` in `URLInput` to use the more broadly supported ARIA 1.0 combobox pattern. ([47148](https://github.com/WordPress/gutenberg/pull/47148))
 
 ### Experiments
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -140,6 +140,17 @@ describe( 'Basic rendering', () => {
 		expect( searchInput ).toBeInTheDocument();
 	} );
 
+	it( 'should have aria-owns attribute to follow the ARIA 1.0 pattern', () => {
+		render( <LinkControl /> );
+
+		// Search Input UI.
+		const searchInput = screen.getByRole( 'combobox', { name: 'URL' } );
+
+		expect( searchInput ).toBeInTheDocument();
+		expect( searchInput ).not.toHaveAttribute( 'aria-controls' );
+		expect( searchInput ).toHaveAttribute( 'aria-owns' );
+	} );
+
 	it( 'should not render protocol in links', async () => {
 		const user = userEvent.setup();
 		mockFetchSearchSuggestions.mockImplementation( () =>
@@ -1375,6 +1386,15 @@ describe( 'Selecting links', () => {
 				firstSearchSuggestion
 			);
 
+			// Check aria-selected attribute is omitted on non-highlighted items.
+			expect( firstSearchSuggestion ).toHaveAttribute(
+				'aria-selected',
+				'true'
+			);
+			expect( secondSearchSuggestion ).not.toHaveAttribute(
+				'aria-selected'
+			);
+
 			// Check we can go down again using the down arrow.
 			triggerArrowDown( searchInput );
 
@@ -1387,6 +1407,15 @@ describe( 'Selecting links', () => {
 				secondSearchSuggestion
 			);
 
+			// Check aria-selected attribute is omitted on non-highlighted items.
+			expect( firstSearchSuggestion ).not.toHaveAttribute(
+				'aria-selected'
+			);
+			expect( secondSearchSuggestion ).toHaveAttribute(
+				'aria-selected',
+				'true'
+			);
+
 			// Check we can go back up via up arrow.
 			triggerArrowUp( searchInput );
 
@@ -1397,6 +1426,15 @@ describe( 'Selecting links', () => {
 			// We should be back to highlighting the first search result again.
 			expect( selectedSearchResultElement ).toEqual(
 				firstSearchSuggestion
+			);
+
+			// Check aria-selected attribute is omitted on non-highlighted items.
+			expect( firstSearchSuggestion ).toHaveAttribute(
+				'aria-selected',
+				'true'
+			);
+			expect( secondSearchSuggestion ).not.toHaveAttribute(
+				'aria-selected'
 			);
 
 			expect( mockFetchSearchSuggestions ).toHaveBeenCalledTimes( 1 );

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -137,7 +137,7 @@ describe( 'Basic rendering', () => {
 		// Search Input UI.
 		const searchInput = screen.getByRole( 'combobox', { name: 'URL' } );
 
-		expect( searchInput ).toBeInTheDocument();
+		expect( searchInput ).toBeVisible();
 	} );
 
 	it( 'should have aria-owns attribute to follow the ARIA 1.0 pattern', () => {
@@ -146,9 +146,111 @@ describe( 'Basic rendering', () => {
 		// Search Input UI.
 		const searchInput = screen.getByRole( 'combobox', { name: 'URL' } );
 
-		expect( searchInput ).toBeInTheDocument();
+		expect( searchInput ).toBeVisible();
 		expect( searchInput ).not.toHaveAttribute( 'aria-controls' );
 		expect( searchInput ).toHaveAttribute( 'aria-owns' );
+	} );
+
+	it( 'should have aria-selected attribute only on the highlighted item', async () => {
+		const user = userEvent.setup();
+
+		let resolver;
+		mockFetchSearchSuggestions.mockImplementation(
+			() =>
+				new Promise( ( resolve ) => {
+					resolver = resolve;
+				} )
+		);
+
+		render( <LinkControl /> );
+
+		// Search Input UI.
+		const searchInput = screen.getByRole( 'combobox', { name: 'URL' } );
+
+		// Simulate searching for a term.
+		await user.type( searchInput, 'Hello' );
+
+		// Wait for the spinner SVG icon to be rendered.
+		expect( await screen.findByRole( 'presentation' ) ).toBeVisible();
+		// Check the suggestions list is not rendered yet.
+		expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
+
+		// Make the search suggestions fetch return a response.
+		resolver( fauxEntitySuggestions );
+
+		const resultsList = await screen.findByRole( 'listbox', {
+			name: 'Search results for "Hello"',
+		} );
+
+		// Check the suggestions list is rendered.
+		expect( resultsList ).toBeVisible();
+		// Check the spinner SVG icon is not rendered any longer.
+		expect( screen.queryByRole( 'presentation' ) ).not.toBeInTheDocument();
+
+		const searchResultElements =
+			within( resultsList ).getAllByRole( 'option' );
+
+		expect( searchResultElements ).toHaveLength(
+			// The fauxEntitySuggestions length plus the 'Press ENTER to add this link' button.
+			fauxEntitySuggestions.length + 1
+		);
+
+		// Step down into the search results, highlighting the first result item.
+		triggerArrowDown( searchInput );
+
+		const firstSearchSuggestion = searchResultElements[ 0 ];
+		const secondSearchSuggestion = searchResultElements[ 1 ];
+
+		let selectedSearchResultElement = screen.getByRole( 'option', {
+			selected: true,
+		} );
+
+		// We should have highlighted the first item using the keyboard.
+		expect( selectedSearchResultElement ).toEqual( firstSearchSuggestion );
+
+		// Check the aria-selected attribute is set on the highlighted item.
+		expect( firstSearchSuggestion ).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
+		// Check the aria-selected attribute is omitted on the non-highlighted items.
+		expect( secondSearchSuggestion ).not.toHaveAttribute( 'aria-selected' );
+
+		// Step down into the search results, highlighting the second result item.
+		triggerArrowDown( searchInput );
+
+		selectedSearchResultElement = screen.getByRole( 'option', {
+			selected: true,
+		} );
+
+		// We should have highlighted the first item using the keyboard.
+		expect( selectedSearchResultElement ).toEqual( secondSearchSuggestion );
+
+		// Check the aria-selected attribute is omitted on non-highlighted items.
+		expect( firstSearchSuggestion ).not.toHaveAttribute( 'aria-selected' );
+		// Check the aria-selected attribute is set on the highlighted item.
+		expect( secondSearchSuggestion ).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
+
+		// Step up into the search results, highlighting the first result item.
+		triggerArrowUp( searchInput );
+
+		selectedSearchResultElement = screen.getByRole( 'option', {
+			selected: true,
+		} );
+
+		// We should be back to highlighting the first search result again.
+		expect( selectedSearchResultElement ).toEqual( firstSearchSuggestion );
+
+		// Check the aria-selected attribute is set on the highlighted item.
+		expect( firstSearchSuggestion ).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
+		// Check the aria-selected attribute is omitted on non-highlighted items.
+		expect( secondSearchSuggestion ).not.toHaveAttribute( 'aria-selected' );
 	} );
 
 	it( 'should not render protocol in links', async () => {
@@ -570,7 +672,7 @@ describe( 'Manual link entry', () => {
 				} );
 
 				// Verify the UI hasn't allowed submission.
-				expect( searchInput ).toBeInTheDocument();
+				expect( searchInput ).toBeVisible();
 				expect( submitButton ).toBeDisabled();
 				expect( submitButton ).toBeVisible();
 			}
@@ -612,7 +714,7 @@ describe( 'Manual link entry', () => {
 				} );
 
 				// Verify the UI hasn't allowed submission.
-				expect( searchInput ).toBeInTheDocument();
+				expect( searchInput ).toBeVisible();
 				expect( submitButton ).toBeDisabled();
 				expect( submitButton ).toBeVisible();
 			}
@@ -1386,15 +1488,6 @@ describe( 'Selecting links', () => {
 				firstSearchSuggestion
 			);
 
-			// Check aria-selected attribute is omitted on non-highlighted items.
-			expect( firstSearchSuggestion ).toHaveAttribute(
-				'aria-selected',
-				'true'
-			);
-			expect( secondSearchSuggestion ).not.toHaveAttribute(
-				'aria-selected'
-			);
-
 			// Check we can go down again using the down arrow.
 			triggerArrowDown( searchInput );
 
@@ -1407,15 +1500,6 @@ describe( 'Selecting links', () => {
 				secondSearchSuggestion
 			);
 
-			// Check aria-selected attribute is omitted on non-highlighted items.
-			expect( firstSearchSuggestion ).not.toHaveAttribute(
-				'aria-selected'
-			);
-			expect( secondSearchSuggestion ).toHaveAttribute(
-				'aria-selected',
-				'true'
-			);
-
 			// Check we can go back up via up arrow.
 			triggerArrowUp( searchInput );
 
@@ -1426,15 +1510,6 @@ describe( 'Selecting links', () => {
 			// We should be back to highlighting the first search result again.
 			expect( selectedSearchResultElement ).toEqual(
 				firstSearchSuggestion
-			);
-
-			// Check aria-selected attribute is omitted on non-highlighted items.
-			expect( firstSearchSuggestion ).toHaveAttribute(
-				'aria-selected',
-				'true'
-			);
-			expect( secondSearchSuggestion ).not.toHaveAttribute(
-				'aria-selected'
 			);
 
 			expect( mockFetchSearchSuggestions ).toHaveBeenCalledTimes( 1 );

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -147,6 +147,8 @@ describe( 'Basic rendering', () => {
 		const searchInput = screen.getByRole( 'combobox', { name: 'URL' } );
 
 		expect( searchInput ).toBeVisible();
+		// Make sure we use the ARIA 1.0 pattern with aria-owns.
+		// See https://github.com/WordPress/gutenberg/issues/47147
 		expect( searchInput ).not.toHaveAttribute( 'aria-controls' );
 		expect( searchInput ).toHaveAttribute( 'aria-owns' );
 	} );
@@ -208,7 +210,7 @@ describe( 'Basic rendering', () => {
 		// We should have highlighted the first item using the keyboard.
 		expect( selectedSearchResultElement ).toEqual( firstSearchSuggestion );
 
-		// Check the aria-selected attribute is set on the highlighted item.
+		// Check the aria-selected attribute is set only on the highlighted item.
 		expect( firstSearchSuggestion ).toHaveAttribute(
 			'aria-selected',
 			'true'
@@ -228,7 +230,7 @@ describe( 'Basic rendering', () => {
 
 		// Check the aria-selected attribute is omitted on non-highlighted items.
 		expect( firstSearchSuggestion ).not.toHaveAttribute( 'aria-selected' );
-		// Check the aria-selected attribute is set on the highlighted item.
+		// Check the aria-selected attribute is set only on the highlighted item.
 		expect( secondSearchSuggestion ).toHaveAttribute(
 			'aria-selected',
 			'true'
@@ -244,7 +246,7 @@ describe( 'Basic rendering', () => {
 		// We should be back to highlighting the first search result again.
 		expect( selectedSearchResultElement ).toEqual( firstSearchSuggestion );
 
-		// Check the aria-selected attribute is set on the highlighted item.
+		// Check the aria-selected attribute is set only on the highlighted item.
 		expect( firstSearchSuggestion ).toHaveAttribute(
 			'aria-selected',
 			'true'

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -468,7 +468,7 @@ class URLInput extends Component {
 			'aria-label': label ? undefined : __( 'URL' ), // Ensure input always has an accessible label
 			'aria-expanded': showSuggestions,
 			'aria-autocomplete': 'list',
-			'aria-controls': suggestionsListboxId,
+			'aria-owns': suggestionsListboxId,
 			'aria-activedescendant':
 				selectedSuggestion !== null
 					? `${ suggestionOptionIdPrefix }-${ selectedSuggestion }`
@@ -531,7 +531,8 @@ class URLInput extends Component {
 				tabIndex: '-1',
 				id: `${ suggestionOptionIdPrefix }-${ index }`,
 				ref: this.bindSuggestionNode( index ),
-				'aria-selected': index === selectedSuggestion,
+				'aria-selected':
+					index === selectedSuggestion ? true : undefined,
 			};
 		};
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes #47147
Safari and VoiceOver don't read the UrlInput combobox suggestions. To make the combobox implementation be broadly supported, there's the need to stick to the 'old' ARIA 1.0 pattern. 

/Cc @tyxla @mirka

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The combobox implementation needs to be consistent across all the codebase and use the most broadly supported ARIA pattern.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- reverts the change from https://github.com/WordPress/gutenberg/pull/43278 changing `aria-controls` back to `aria-owns`
- additionally, improves the usage of `aria-selected`, as it needs to be set only on the highlighted item
- enforces correct usage of these attributes in the tests, to prevent new regressions

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- edit a post
- use Safari and VoiceOver
- add a link to a word in a paragraph
- type 'hello' in the URL input search to get some link suggestions
- use the Down and Up keys to navigate through the suggestion options
- observe VoiceOver does announce the options

Optionally test with the most common browser / screen reader combinations. I tested with:
- macOS: Safari + VoiceOver
- Windows: Firefox + NVDA
- Windows: Chrome + NVDA
- Windows: JAWS 2019 + Chrome
- Windows: JAWS 2019 + Firefox

Update: note to clarify that Safari and VoiceOver are buggy anyways. When testing, you may notice some weirdness in the way the options are announced e.g.:

- sometimes they are announced as `{option name}, clickable`
- sometimes they are announced as `{option name}, selected, (1 of n), completion selected` (this is the expected behavior)
- sometimes you may need to delete one of the typed characters and re-type it again to make VoiceOver announce the options

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
See above.

## Screenshots or screencast <!-- if applicable -->

<img width="823" alt="Screenshot 2023-01-13 at 17 09 33" src="https://user-images.githubusercontent.com/1682452/212366817-061febbd-fc98-4dd3-a4c3-eab673523f1d.png">
