### PR TITLE
DropdownMenu: convert Storybook examples from knobs to controls

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,8 @@
 -   `SandBox`: Convert to TypeScript ([#46478](https://github.com/WordPress/gutenberg/pull/46478)).
 -   `ResponsiveWrapper`: Convert to TypeScript ([#46480](https://github.com/WordPress/gutenberg/pull/46480)).
 -   `ItemGroup`: migrate Storybook to controls, refactor to TypeScript ([46945](https://github.com/WordPress/gutenberg/pull/46945)).
+-   `Toolbar`: unify Storybook examples under one file, migrate from knobs to controls ([47117](https://github.com/WordPress/gutenberg/pull/47117)).
+-   `DropdownMenu`: migrate Storybook to controls ([47149](https://github.com/WordPress/gutenberg/pull/47149)).
 
 ### Bug Fix
 

--- a/packages/components/src/dropdown-menu/README.md
+++ b/packages/components/src/dropdown-menu/README.md
@@ -205,6 +205,6 @@ Use this object to modify props available for the `NavigableMenu` component that
 
 In some contexts, the arrow down key used to open the dropdown menu might need to be disabled—for example when that key is used to perform another action.
 
--   Type: `Object`
+-   Type: `boolean`
 -   Required: No
 -   Default: `false`

--- a/packages/components/src/dropdown-menu/stories/index.js
+++ b/packages/components/src/dropdown-menu/stories/index.js
@@ -2,21 +2,30 @@
  * Internal dependencies
  */
 import DropdownMenu from '../';
+import { MenuGroup, MenuItem } from '../../';
 
 /**
  * WordPress dependencies
  */
-import { menu, arrowUp, arrowDown, chevronDown } from '@wordpress/icons';
+import {
+	menu,
+	arrowUp,
+	arrowDown,
+	chevronDown,
+	more,
+	trash,
+} from '@wordpress/icons';
 
 export default {
 	title: 'Components/DropdownMenu',
 	component: DropdownMenu,
 	argTypes: {
 		className: { control: { type: 'text' } },
+		children: { control: { type: null } },
 		disableOpenOnArrowDown: { control: { type: 'boolean' } },
 		icon: {
-			options: [ 'menu', 'chevronDown' ],
-			mapping: { menu, chevronDown },
+			options: [ 'menu', 'chevronDown', 'more' ],
+			mapping: { menu, chevronDown, more },
 			control: { type: 'select' },
 		},
 		menuProps: {
@@ -57,4 +66,27 @@ Default.args = {
 	toggleProps: {
 		showTooltip: true,
 	},
+};
+
+export const WithChildren = Template.bind( {} );
+WithChildren.args = {
+	label: 'Select a direction.',
+	icon: more,
+	children: ( { onClose } ) => (
+		<>
+			<MenuGroup>
+				<MenuItem icon={ arrowUp } onClick={ onClose }>
+					Move Up
+				</MenuItem>
+				<MenuItem icon={ arrowDown } onClick={ onClose }>
+					Move Down
+				</MenuItem>
+			</MenuGroup>
+			<MenuGroup>
+				<MenuItem icon={ trash } onClick={ onClose }>
+					Remove
+				</MenuItem>
+			</MenuGroup>
+		</>
+	),
 };

--- a/packages/components/src/dropdown-menu/stories/index.js
+++ b/packages/components/src/dropdown-menu/stories/index.js
@@ -46,7 +46,11 @@ export default {
 	},
 };
 
-const Template = ( props ) => <DropdownMenu { ...props } />;
+const Template = ( props ) => (
+	<div style={ { height: 150 } }>
+		<DropdownMenu { ...props } />
+	</div>
+);
 
 export const Default = Template.bind( {} );
 Default.args = {

--- a/packages/components/src/dropdown-menu/stories/index.js
+++ b/packages/components/src/dropdown-menu/stories/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { text, boolean } from '@storybook/addon-knobs';
-
-/**
  * Internal dependencies
  */
 import DropdownMenu from '../';
@@ -11,42 +6,55 @@ import DropdownMenu from '../';
 /**
  * WordPress dependencies
  */
-import { menu, arrowUp, arrowDown } from '@wordpress/icons';
+import { menu, arrowUp, arrowDown, chevronDown } from '@wordpress/icons';
 
 export default {
 	title: 'Components/DropdownMenu',
 	component: DropdownMenu,
+	argTypes: {
+		className: { control: { type: 'text' } },
+		disableOpenOnArrowDown: { control: { type: 'boolean' } },
+		icon: {
+			options: [ 'menu', 'chevronDown' ],
+			mapping: { menu, chevronDown },
+			control: { type: 'select' },
+		},
+		menuProps: {
+			control: { type: 'object' },
+		},
+		noIcons: { control: { type: 'boolean' } },
+		popoverProps: {
+			control: { type: 'object' },
+		},
+		text: { control: { type: 'text' } },
+	},
 	parameters: {
-		knobs: { disable: false },
+		controls: { expanded: true },
+		docs: { source: { state: 'open' } },
 	},
 };
 
-export const _default = () => {
-	const label = text( 'Label', 'Select a direction.' );
-	const firstMenuItemLabel = text( 'First Menu Item Label', 'Up' );
-	const secondMenuItemLabel = text( 'First Menu Item Label', 'Down' );
-	const toggleButtonTootip = boolean(
-		'Show tooltip on a toggle button',
-		true
-	);
+const Template = ( props ) => <DropdownMenu { ...props } />;
 
-	const controls = [
+export const Default = Template.bind( {} );
+Default.args = {
+	label: 'Select a direction.',
+	icon: menu,
+	controls: [
 		{
-			title: firstMenuItemLabel,
+			title: 'First Menu Item Label',
 			icon: arrowUp,
+			// eslint-disable-next-line no-console
+			onClick: () => console.log( 'up!' ),
 		},
 		{
-			title: secondMenuItemLabel,
+			title: 'Second Menu Item Label',
 			icon: arrowDown,
+			// eslint-disable-next-line no-console
+			onClick: () => console.log( 'down!' ),
 		},
-	];
-
-	return (
-		<DropdownMenu
-			icon={ menu }
-			label={ label }
-			controls={ controls }
-			toggleProps={ { showTooltip: toggleButtonTootip } }
-		/>
-	);
+	],
+	toggleProps: {
+		showTooltip: true,
+	},
 };

--- a/packages/components/src/dropdown-menu/stories/index.js
+++ b/packages/components/src/dropdown-menu/stories/index.js
@@ -36,6 +36,9 @@ export default {
 			control: { type: 'object' },
 		},
 		text: { control: { type: 'text' } },
+		toggleProps: {
+			control: { type: 'object' },
+		},
 	},
 	parameters: {
 		controls: { expanded: true },
@@ -63,9 +66,6 @@ Default.args = {
 			onClick: () => console.log( 'down!' ),
 		},
 	],
-	toggleProps: {
-		showTooltip: true,
-	},
 };
 
 export const WithChildren = Template.bind( {} );

--- a/packages/components/src/dropdown-menu/stories/index.js
+++ b/packages/components/src/dropdown-menu/stories/index.js
@@ -73,6 +73,31 @@ Default.args = {
 };
 
 export const WithChildren = Template.bind( {} );
+// Adding custom source because Storybook is not able to show the contents of
+// the `children` prop correctly in the code snippet.
+WithChildren.parameters = {
+	docs: {
+		source: {
+			code: `<DropdownMenu label="Select a direction." icon={ more }>
+  <MenuGroup>
+    <MenuItem icon={ arrowUp } onClick={ onClose }>
+      Move Up
+    </MenuItem>
+    <MenuItem icon={ arrowDown } onClick={ onClose }>
+      Move Down
+    </MenuItem>
+  </MenuGroup>
+  <MenuGroup>
+    <MenuItem icon={ trash } onClick={ onClose }>
+      Remove
+    </MenuItem>
+  </MenuGroup>
+</DropdownMenu>`,
+			language: 'jsx',
+			type: 'auto',
+		},
+	},
+};
 WithChildren.args = {
 	label: 'Select a direction.',
 	icon: more,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Convert `DropdownMenu` Storybook examples from using knobs (deprecated) to controls

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The knobs addon is currently blocking using npm 8 (see https://github.com/WordPress/gutenberg/issues/46443)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I rewrote the Storybook example, keeping the previous default example intact and adding one more example ("With Children"). I also added more info for the control args, so that all relevant props show in the controls panel.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Checkout this PR on your local machine, install dependencies and run local Storybook.
- Make sure that the DropdownMenu default example works as the current one on `trunk`
- Make sure that all controls work as expected
- Make sure that the new `WithChildren` Storybook example works as expected