### PR TITLE
Remove @storybook/addon-knobs from the repository

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1897,70 +1897,6 @@
 				}
 			}
 		},
-		"@emotion/core": {
-			"version": "10.1.1",
-			"resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.1.tgz",
-			"integrity": "sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.5.5",
-				"@emotion/cache": "^10.0.27",
-				"@emotion/css": "^10.0.27",
-				"@emotion/serialize": "^0.11.15",
-				"@emotion/sheet": "0.9.4",
-				"@emotion/utils": "0.11.3"
-			},
-			"dependencies": {
-				"@emotion/cache": {
-					"version": "10.0.29",
-					"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
-					"integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
-					"dev": true,
-					"requires": {
-						"@emotion/sheet": "0.9.4",
-						"@emotion/stylis": "0.8.5",
-						"@emotion/utils": "0.11.3",
-						"@emotion/weak-memoize": "0.2.5"
-					}
-				},
-				"@emotion/css": {
-					"version": "10.0.27",
-					"resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
-					"integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
-					"dev": true,
-					"requires": {
-						"@emotion/serialize": "^0.11.15",
-						"@emotion/utils": "0.11.3",
-						"babel-plugin-emotion": "^10.0.27"
-					}
-				},
-				"@emotion/serialize": {
-					"version": "0.11.16",
-					"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
-					"integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
-					"dev": true,
-					"requires": {
-						"@emotion/hash": "0.8.0",
-						"@emotion/memoize": "0.7.4",
-						"@emotion/unitless": "0.7.5",
-						"@emotion/utils": "0.11.3",
-						"csstype": "^2.5.7"
-					}
-				},
-				"@emotion/utils": {
-					"version": "0.11.3",
-					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-					"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==",
-					"dev": true
-				},
-				"csstype": {
-					"version": "2.6.19",
-					"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
-					"integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==",
-					"dev": true
-				}
-			}
-		},
 		"@emotion/css": {
 			"version": "11.7.1",
 			"resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.7.1.tgz",
@@ -2142,12 +2078,6 @@
 				"csstype": "^3.0.2"
 			}
 		},
-		"@emotion/sheet": {
-			"version": "0.9.4",
-			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
-			"integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==",
-			"dev": true
-		},
 		"@emotion/styled": {
 			"version": "11.6.0",
 			"resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.6.0.tgz",
@@ -2169,66 +2099,6 @@
 					}
 				}
 			}
-		},
-		"@emotion/styled-base": {
-			"version": "10.0.31",
-			"resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.0.31.tgz",
-			"integrity": "sha512-wTOE1NcXmqMWlyrtwdkqg87Mu6Rj1MaukEoEmEkHirO5IoHDJ8LgCQL4MjJODgxWxXibGR3opGp1p7YvkNEdXQ==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.5.5",
-				"@emotion/is-prop-valid": "0.8.8",
-				"@emotion/serialize": "^0.11.15",
-				"@emotion/utils": "0.11.3"
-			},
-			"dependencies": {
-				"@emotion/is-prop-valid": {
-					"version": "0.8.8",
-					"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-					"integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-					"dev": true,
-					"requires": {
-						"@emotion/memoize": "0.7.4"
-					}
-				},
-				"@emotion/memoize": {
-					"version": "0.7.4",
-					"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-					"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-					"dev": true
-				},
-				"@emotion/serialize": {
-					"version": "0.11.16",
-					"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
-					"integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
-					"dev": true,
-					"requires": {
-						"@emotion/hash": "0.8.0",
-						"@emotion/memoize": "0.7.4",
-						"@emotion/unitless": "0.7.5",
-						"@emotion/utils": "0.11.3",
-						"csstype": "^2.5.7"
-					}
-				},
-				"@emotion/utils": {
-					"version": "0.11.3",
-					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-					"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==",
-					"dev": true
-				},
-				"csstype": {
-					"version": "2.6.19",
-					"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
-					"integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==",
-					"dev": true
-				}
-			}
-		},
-		"@emotion/stylis": {
-			"version": "0.8.5",
-			"resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-			"integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
-			"dev": true
 		},
 		"@emotion/unitless": {
 			"version": "0.7.5",
@@ -8229,18 +8099,6 @@
 			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.6.0.tgz",
 			"integrity": "sha512-cPqjjzuFWNK3BSKLm0abspP0sp/IGOli4p5I5fKFAzdS8fvjdOwDCfZqAaIiXd9lPkOWi3SUUfZof3hEb7J/uw=="
 		},
-		"@reach/router": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/@reach/router/-/router-1.3.4.tgz",
-			"integrity": "sha512-+mtn9wjlB9NN2CNnnC/BRYtwdKBfSyyasPYraNAyvaV1occr/5NnB4CVzjEZipNHwYebQwcndGUmpFzxAUoqSA==",
-			"dev": true,
-			"requires": {
-				"create-react-context": "0.3.0",
-				"invariant": "^2.2.3",
-				"prop-types": "^15.6.1",
-				"react-lifecycles-compat": "^3.0.4"
-			}
-		},
 		"@react-native-clipboard/clipboard": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@react-native-clipboard/clipboard/-/clipboard-1.9.0.tgz",
@@ -9761,348 +9619,6 @@
 					"dev": true,
 					"requires": {
 						"lodash": "^4.17.15"
-					}
-				}
-			}
-		},
-		"@storybook/addon-knobs": {
-			"version": "6.2.9",
-			"resolved": "https://registry.npmjs.org/@storybook/addon-knobs/-/addon-knobs-6.2.9.tgz",
-			"integrity": "sha512-ic3xXy9uWPfIGP4x3VuGnrUmg/Jn9rHKIqZMhRcC7mFDRVlgbekvQxaruC6VY9LW6o8jV/miReSZkJf7M8o0aQ==",
-			"dev": true,
-			"requires": {
-				"@storybook/addons": "6.2.9",
-				"@storybook/api": "6.2.9",
-				"@storybook/channels": "6.2.9",
-				"@storybook/client-api": "6.2.9",
-				"@storybook/components": "6.2.9",
-				"@storybook/core-events": "6.2.9",
-				"@storybook/theming": "6.2.9",
-				"copy-to-clipboard": "^3.3.1",
-				"core-js": "^3.8.2",
-				"escape-html": "^1.0.3",
-				"fast-deep-equal": "^3.1.3",
-				"global": "^4.4.0",
-				"lodash": "^4.17.20",
-				"prop-types": "^15.7.2",
-				"qs": "^6.10.0",
-				"react-colorful": "^5.0.1",
-				"react-lifecycles-compat": "^3.0.4",
-				"react-select": "^3.2.0",
-				"regenerator-runtime": "^0.13.7"
-			},
-			"dependencies": {
-				"@emotion/is-prop-valid": {
-					"version": "0.8.8",
-					"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-					"integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-					"dev": true,
-					"requires": {
-						"@emotion/memoize": "0.7.4"
-					}
-				},
-				"@emotion/memoize": {
-					"version": "0.7.4",
-					"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-					"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-					"dev": true
-				},
-				"@emotion/styled": {
-					"version": "10.0.27",
-					"resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-10.0.27.tgz",
-					"integrity": "sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==",
-					"dev": true,
-					"requires": {
-						"@emotion/styled-base": "^10.0.27",
-						"babel-plugin-emotion": "^10.0.27"
-					}
-				},
-				"@storybook/addons": {
-					"version": "6.2.9",
-					"resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.2.9.tgz",
-					"integrity": "sha512-GnmEKbJwiN1jncN9NSA8CuR1i2XAlasPcl/Zn0jkfV9WitQeczVcJCPw86SGH84AD+tTBCyF2i9UC0KaOV1YBQ==",
-					"dev": true,
-					"requires": {
-						"@storybook/api": "6.2.9",
-						"@storybook/channels": "6.2.9",
-						"@storybook/client-logger": "6.2.9",
-						"@storybook/core-events": "6.2.9",
-						"@storybook/router": "6.2.9",
-						"@storybook/theming": "6.2.9",
-						"core-js": "^3.8.2",
-						"global": "^4.4.0",
-						"regenerator-runtime": "^0.13.7"
-					}
-				},
-				"@storybook/api": {
-					"version": "6.2.9",
-					"resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.2.9.tgz",
-					"integrity": "sha512-okkA3HAScE9tGnYBrjTOcgzT+L1lRHNoEh3ZfGgh1u/XNEyHGNkj4grvkd6nX7BzRcYQ/l2VkcKCqmOjUnSkVQ==",
-					"dev": true,
-					"requires": {
-						"@reach/router": "^1.3.4",
-						"@storybook/channels": "6.2.9",
-						"@storybook/client-logger": "6.2.9",
-						"@storybook/core-events": "6.2.9",
-						"@storybook/csf": "0.0.1",
-						"@storybook/router": "6.2.9",
-						"@storybook/semver": "^7.3.2",
-						"@storybook/theming": "6.2.9",
-						"@types/reach__router": "^1.3.7",
-						"core-js": "^3.8.2",
-						"fast-deep-equal": "^3.1.3",
-						"global": "^4.4.0",
-						"lodash": "^4.17.20",
-						"memoizerific": "^1.11.3",
-						"qs": "^6.10.0",
-						"regenerator-runtime": "^0.13.7",
-						"store2": "^2.12.0",
-						"telejson": "^5.1.0",
-						"ts-dedent": "^2.0.0",
-						"util-deprecate": "^1.0.2"
-					}
-				},
-				"@storybook/channel-postmessage": {
-					"version": "6.2.9",
-					"resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.2.9.tgz",
-					"integrity": "sha512-OqV+gLeeCHR0KExsIz0B7gD17Cjd9D+I75qnBsLWM9inWO5kc/WZ5svw8Bvjlcm6snWpvxUaT8L+svuqcPSmww==",
-					"dev": true,
-					"requires": {
-						"@storybook/channels": "6.2.9",
-						"@storybook/client-logger": "6.2.9",
-						"@storybook/core-events": "6.2.9",
-						"core-js": "^3.8.2",
-						"global": "^4.4.0",
-						"qs": "^6.10.0",
-						"telejson": "^5.1.0"
-					}
-				},
-				"@storybook/channels": {
-					"version": "6.2.9",
-					"resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.2.9.tgz",
-					"integrity": "sha512-6dC8Fb2ipNyOQXnUZMDeEUaJGH5DMLzyHlGLhVyDtrO5WR6bO8mQdkzf4+5dSKXgCBNX0BSkssXth4pDjn18rg==",
-					"dev": true,
-					"requires": {
-						"core-js": "^3.8.2",
-						"ts-dedent": "^2.0.0",
-						"util-deprecate": "^1.0.2"
-					}
-				},
-				"@storybook/client-api": {
-					"version": "6.2.9",
-					"resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-6.2.9.tgz",
-					"integrity": "sha512-aLvEUVkbvv6Qo/2mF4rFCecdqi2CGOUDdsV1a6EFIVS/9gXFdpirsOwKHo9qNjacGdWPlBYGCUcbrw+DvNaSFA==",
-					"dev": true,
-					"requires": {
-						"@storybook/addons": "6.2.9",
-						"@storybook/channel-postmessage": "6.2.9",
-						"@storybook/channels": "6.2.9",
-						"@storybook/client-logger": "6.2.9",
-						"@storybook/core-events": "6.2.9",
-						"@storybook/csf": "0.0.1",
-						"@types/qs": "^6.9.5",
-						"@types/webpack-env": "^1.16.0",
-						"core-js": "^3.8.2",
-						"global": "^4.4.0",
-						"lodash": "^4.17.20",
-						"memoizerific": "^1.11.3",
-						"qs": "^6.10.0",
-						"regenerator-runtime": "^0.13.7",
-						"stable": "^0.1.8",
-						"store2": "^2.12.0",
-						"ts-dedent": "^2.0.0",
-						"util-deprecate": "^1.0.2"
-					}
-				},
-				"@storybook/client-logger": {
-					"version": "6.2.9",
-					"resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.2.9.tgz",
-					"integrity": "sha512-IfOQZuvpjh66qBInQCJOb9S0dTGpzZ/Cxlcvokp+PYt95KztaWN3mPm+HaDQCeRsrWNe0Bpm1zuickcJ6dBOXg==",
-					"dev": true,
-					"requires": {
-						"core-js": "^3.8.2",
-						"global": "^4.4.0"
-					}
-				},
-				"@storybook/components": {
-					"version": "6.2.9",
-					"resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.2.9.tgz",
-					"integrity": "sha512-hnV1MI2aB2g1sJ7NJphpxi7TwrMZQ/tpCJeHnkjmzyC6ez1MXqcBXGrEEdSXzRfAxjQTOEpu6H1mnns0xMP0Ag==",
-					"dev": true,
-					"requires": {
-						"@popperjs/core": "^2.6.0",
-						"@storybook/client-logger": "6.2.9",
-						"@storybook/csf": "0.0.1",
-						"@storybook/theming": "6.2.9",
-						"@types/color-convert": "^2.0.0",
-						"@types/overlayscrollbars": "^1.12.0",
-						"@types/react-syntax-highlighter": "11.0.5",
-						"color-convert": "^2.0.1",
-						"core-js": "^3.8.2",
-						"fast-deep-equal": "^3.1.3",
-						"global": "^4.4.0",
-						"lodash": "^4.17.20",
-						"markdown-to-jsx": "^7.1.0",
-						"memoizerific": "^1.11.3",
-						"overlayscrollbars": "^1.13.1",
-						"polished": "^4.0.5",
-						"prop-types": "^15.7.2",
-						"react-colorful": "^5.0.1",
-						"react-popper-tooltip": "^3.1.1",
-						"react-syntax-highlighter": "^13.5.3",
-						"react-textarea-autosize": "^8.3.0",
-						"regenerator-runtime": "^0.13.7",
-						"ts-dedent": "^2.0.0",
-						"util-deprecate": "^1.0.2"
-					}
-				},
-				"@storybook/core-events": {
-					"version": "6.2.9",
-					"resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.2.9.tgz",
-					"integrity": "sha512-xQmbX/oYQK1QsAGN8hriXX5SUKOoTUe3L4dVaVHxJqy7MReRWJpprJmCpbAPJzWS6WCbDFfCM5kVEexHLOzJlQ==",
-					"dev": true,
-					"requires": {
-						"core-js": "^3.8.2"
-					}
-				},
-				"@storybook/router": {
-					"version": "6.2.9",
-					"resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.2.9.tgz",
-					"integrity": "sha512-7Bn1OFoItCl8whXRT8N1qp1Lky7kzXJ3aslWp5E8HcM8rxh4OYXfbaeiyJEJxBTGC5zxgY+tAEXHFjsAviFROg==",
-					"dev": true,
-					"requires": {
-						"@reach/router": "^1.3.4",
-						"@storybook/client-logger": "6.2.9",
-						"@types/reach__router": "^1.3.7",
-						"core-js": "^3.8.2",
-						"fast-deep-equal": "^3.1.3",
-						"global": "^4.4.0",
-						"lodash": "^4.17.20",
-						"memoizerific": "^1.11.3",
-						"qs": "^6.10.0",
-						"ts-dedent": "^2.0.0"
-					}
-				},
-				"@storybook/semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/@storybook/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==",
-					"dev": true,
-					"requires": {
-						"core-js": "^3.6.5",
-						"find-up": "^4.1.0"
-					}
-				},
-				"@storybook/theming": {
-					"version": "6.2.9",
-					"resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.2.9.tgz",
-					"integrity": "sha512-183oJW7AD7Fhqg5NT4ct3GJntwteAb9jZnQ6yhf9JSdY+fk8OhxRbPf7ov0au2gYACcGrWDd9K5pYQsvWlP5gA==",
-					"dev": true,
-					"requires": {
-						"@emotion/core": "^10.1.1",
-						"@emotion/is-prop-valid": "^0.8.6",
-						"@emotion/styled": "^10.0.27",
-						"@storybook/client-logger": "6.2.9",
-						"core-js": "^3.8.2",
-						"deep-object-diff": "^1.1.0",
-						"emotion-theming": "^10.0.27",
-						"global": "^4.4.0",
-						"memoizerific": "^1.11.3",
-						"polished": "^4.0.5",
-						"resolve-from": "^5.0.0",
-						"ts-dedent": "^2.0.0"
-					}
-				},
-				"@types/qs": {
-					"version": "6.9.6",
-					"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.6.tgz",
-					"integrity": "sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA==",
-					"dev": true
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"fast-deep-equal": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-					"dev": true
-				},
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				},
-				"resolve-from": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-					"dev": true
-				},
-				"side-channel": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-					"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-					"requires": {
-						"call-bind": "^1.0.0",
-						"get-intrinsic": "^1.0.2",
-						"object-inspect": "^1.9.0"
 					}
 				}
 			}
@@ -13203,15 +12719,6 @@
 					"integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
 					"dev": true
 				}
-			}
-		},
-		"@storybook/csf": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.0.1.tgz",
-			"integrity": "sha512-USTLkZze5gkel8MYCujSRBVIrUQ3YPBrLOx7GNk/0wttvVtlzWXAq9eLbQ4p/NicGxP+3T7KPEMVV//g+yubpw==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.15"
 			}
 		},
 		"@storybook/csf-tools": {
@@ -16367,15 +15874,6 @@
 				"classnames": "*"
 			}
 		},
-		"@types/color-convert": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.0.tgz",
-			"integrity": "sha512-m7GG7IKKGuJUXvkZ1qqG3ChccdIM/qBBo913z+Xft0nKCX4hAU/IxKwZBU4cpRZ7GS5kV4vOblUkILtSShCPXQ==",
-			"dev": true,
-			"requires": {
-				"@types/color-name": "*"
-			}
-		},
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -16839,12 +16337,6 @@
 			"resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.0.tgz",
 			"integrity": "sha512-PGcyveRIpL1XIqK8eBsmRBt76eFgtzuPiSTyKHZxnGemp2yzGzWpjYKAfK3wIMiU7eH+851yEpiuP8JZerTmWg=="
 		},
-		"@types/overlayscrollbars": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/@types/overlayscrollbars/-/overlayscrollbars-1.12.0.tgz",
-			"integrity": "sha512-h/pScHNKi4mb+TrJGDon8Yb06ujFG0mSg12wIO0sWMUF3dQIe2ExRRdNRviaNt9IjxIiOfnRr7FsQAdHwK4sMg==",
-			"dev": true
-		},
 		"@types/parse-json": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -16878,15 +16370,6 @@
 			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
 			"integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
 			"dev": true
-		},
-		"@types/reach__router": {
-			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.3.8.tgz",
-			"integrity": "sha512-cjjT0FPdwuvhLWpCDt2WCh4sdBqNzJe3XhxXmRQGsY3IvT58M8sE4E7A0QaFYuJs3ar+McSJTiJxdYKWAXbBhw==",
-			"dev": true,
-			"requires": {
-				"@types/react": "*"
-			}
 		},
 		"@types/react": {
 			"version": "18.0.21",
@@ -28291,51 +27774,6 @@
 				"object.assign": "^4.1.0"
 			}
 		},
-		"babel-plugin-emotion": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.2.2.tgz",
-			"integrity": "sha512-SMSkGoqTbTyUTDeuVuPIWifPdUGkTk1Kf9BWRiXIOIcuyMfsdp2EjeiiFvOzX8NOBvEh/ypKYvUh2rkgAJMCLA==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
-				"@emotion/hash": "0.8.0",
-				"@emotion/memoize": "0.7.4",
-				"@emotion/serialize": "^0.11.16",
-				"babel-plugin-macros": "^2.0.0",
-				"babel-plugin-syntax-jsx": "^6.18.0",
-				"convert-source-map": "^1.5.0",
-				"escape-string-regexp": "^1.0.5",
-				"find-root": "^1.1.0",
-				"source-map": "^0.5.7"
-			},
-			"dependencies": {
-				"@emotion/serialize": {
-					"version": "0.11.16",
-					"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
-					"integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
-					"dev": true,
-					"requires": {
-						"@emotion/hash": "0.8.0",
-						"@emotion/memoize": "0.7.4",
-						"@emotion/unitless": "0.7.5",
-						"@emotion/utils": "0.11.3",
-						"csstype": "^2.5.7"
-					}
-				},
-				"@emotion/utils": {
-					"version": "0.11.3",
-					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-					"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==",
-					"dev": true
-				},
-				"csstype": {
-					"version": "2.6.19",
-					"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
-					"integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==",
-					"dev": true
-				}
-			}
-		},
 		"babel-plugin-extract-import-names": {
 			"version": "1.6.22",
 			"resolved": "https://registry.npmjs.org/babel-plugin-extract-import-names/-/babel-plugin-extract-import-names-1.6.22.tgz",
@@ -28528,12 +27966,6 @@
 			"requires": {
 				"@babel/template": "^7.0.0-beta.49"
 			}
-		},
-		"babel-plugin-syntax-jsx": {
-			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
-			"dev": true
 		},
 		"babel-plugin-syntax-trailing-function-commas": {
 			"version": "7.0.0-beta.0",
@@ -29469,6 +28901,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
 			"integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1",
 				"get-intrinsic": "^1.0.0"
@@ -31115,15 +30548,6 @@
 			"integrity": "sha512-Q4+qBFnN4bwGwvtXXzbp4P/4iNk0MaiGAzvQ8OiMtlLjkIKjmNN689uVzShSM0908q7GoFHXIPx4zi75ocoaHw==",
 			"dev": true
 		},
-		"copy-to-clipboard": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
-			"integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
-			"dev": true,
-			"requires": {
-				"toggle-selection": "^1.0.6"
-			}
-		},
 		"copy-webpack-plugin": {
 			"version": "10.2.0",
 			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-10.2.0.tgz",
@@ -31597,16 +31021,6 @@
 				"ripemd160": "^2.0.0",
 				"safe-buffer": "^5.0.1",
 				"sha.js": "^2.4.8"
-			}
-		},
-		"create-react-context": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
-			"integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
-			"dev": true,
-			"requires": {
-				"gud": "^1.0.0",
-				"warning": "^4.0.3"
 			}
 		},
 		"cross-env": {
@@ -32127,12 +31541,6 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-			"dev": true
-		},
-		"deep-object-diff": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.0.tgz",
-			"integrity": "sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==",
 			"dev": true
 		},
 		"deepmerge": {
@@ -32760,24 +32168,6 @@
 				"utila": "~0.4"
 			}
 		},
-		"dom-helpers": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-			"integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.8.7",
-				"csstype": "^3.0.2"
-			},
-			"dependencies": {
-				"csstype": {
-					"version": "3.0.8",
-					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
-					"integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==",
-					"dev": true
-				}
-			}
-		},
 		"dom-scroll-into-view": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/dom-scroll-into-view/-/dom-scroll-into-view-1.2.1.tgz",
@@ -33004,17 +32394,6 @@
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
 			"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
 			"dev": true
-		},
-		"emotion-theming": {
-			"version": "10.0.27",
-			"resolved": "https://registry.npmjs.org/emotion-theming/-/emotion-theming-10.0.27.tgz",
-			"integrity": "sha512-MlF1yu/gYh8u+sLUqA0YuA9JX0P4Hb69WlKc/9OLo+WCXuX6sy/KoIa+qJimgmr2dWqnypYKYPX37esjDBbhdw==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.5.5",
-				"@emotion/weak-memoize": "0.2.5",
-				"hoist-non-react-statics": "^3.3.0"
-			}
 		},
 		"encodeurl": {
 			"version": "1.0.2",
@@ -36766,6 +36145,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
 			"integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
+			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
@@ -36775,7 +36155,8 @@
 				"has-symbols": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+					"dev": true
 				}
 			}
 		},
@@ -37249,12 +36630,6 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-0.1.5.tgz",
 			"integrity": "sha1-DH4heVWeXOfY1x9EI6+TcQCyJIw="
-		},
-		"gud": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-			"integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
-			"dev": true
 		},
 		"handle-thing": {
 			"version": "2.0.1",
@@ -44941,12 +44316,6 @@
 			"integrity": "sha512-NcWuJFHDA8V3wkDgR/j4+gZx+YQwstPgfQDV8ndUeWWzta3dnDTBxpVzqS9lkmJAuV5YX35lmyojl6HO5JXAgw==",
 			"dev": true
 		},
-		"markdown-to-jsx": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.3.tgz",
-			"integrity": "sha512-jtQ6VyT7rMT5tPV0g2EJakEnXLiPksnvlYtwQsVVZ611JsWGN8bQ1tVSDX4s6JllfEH6wmsYxNjTUAMrPmNA8w==",
-			"dev": true
-		},
 		"markdownlint": {
 			"version": "0.25.1",
 			"resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.25.1.tgz",
@@ -48612,7 +47981,8 @@
 		"object-inspect": {
 			"version": "1.10.3",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
-			"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw=="
+			"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+			"dev": true
 		},
 		"object-is": {
 			"version": "1.1.5",
@@ -49590,12 +48960,6 @@
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 		},
-		"overlayscrollbars": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/overlayscrollbars/-/overlayscrollbars-1.13.1.tgz",
-			"integrity": "sha512-gIQfzgGgu1wy80EB4/6DaJGHMEGmizq27xHIESrzXq0Y/J0Ay1P3DWk6tuVmEPIZH15zaBlxeEJOqdJKmowHCQ==",
-			"dev": true
-		},
 		"p-all": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/p-all/-/p-all-2.1.0.tgz",
@@ -50419,26 +49783,6 @@
 				"ts-pnp": "^1.1.6"
 			}
 		},
-		"polished": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/polished/-/polished-4.1.3.tgz",
-			"integrity": "sha512-ocPAcVBUOryJEKe0z2KLd1l9EBa1r5mSwlKpExmrLzsnIzJo4axsoU9O2BjOTkDGDT4mZ0WFE5XKTlR3nLnZOA==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.14.0"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.14.6",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
-					"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				}
-			}
-		},
 		"popmotion": {
 			"version": "11.0.5",
 			"resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.5.tgz",
@@ -51199,12 +50543,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
 			"integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==",
-			"dev": true
-		},
-		"prismjs": {
-			"version": "1.24.1",
-			"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.1.tgz",
-			"integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==",
 			"dev": true
 		},
 		"private": {
@@ -52335,21 +51673,6 @@
 				}
 			}
 		},
-		"react-fast-compare": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-			"integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==",
-			"dev": true
-		},
-		"react-input-autosize": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-3.0.0.tgz",
-			"integrity": "sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==",
-			"dev": true,
-			"requires": {
-				"prop-types": "^15.5.8"
-			}
-		},
 		"react-inspector": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-5.1.1.tgz",
@@ -52365,12 +51688,6 @@
 			"version": "16.8.4",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.4.tgz",
 			"integrity": "sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA=="
-		},
-		"react-lifecycles-compat": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-			"dev": true
 		},
 		"react-native": {
 			"version": "0.69.4",
@@ -53190,100 +52507,11 @@
 				}
 			}
 		},
-		"react-popper": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
-			"integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
-			"dev": true,
-			"requires": {
-				"react-fast-compare": "^3.0.1",
-				"warning": "^4.0.2"
-			}
-		},
-		"react-popper-tooltip": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/react-popper-tooltip/-/react-popper-tooltip-3.1.1.tgz",
-			"integrity": "sha512-EnERAnnKRptQBJyaee5GJScWNUKQPDD2ywvzZyUjst/wj5U64C8/CnSYLNEmP2hG0IJ3ZhtDxE8oDN+KOyavXQ==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.12.5",
-				"@popperjs/core": "^2.5.4",
-				"react-popper": "^2.2.4"
-			}
-		},
 		"react-refresh": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.10.0.tgz",
 			"integrity": "sha512-PgidR3wST3dDYKr6b4pJoqQFpPGNKDSCDx4cZoshjXipw3LzO7mG1My2pwEzz2JVkF+inx3xRpDeQLFQGH/hsQ==",
 			"dev": true
-		},
-		"react-select": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/react-select/-/react-select-3.2.0.tgz",
-			"integrity": "sha512-B/q3TnCZXEKItO0fFN/I0tWOX3WJvi/X2wtdffmwSQVRwg5BpValScTO1vdic9AxlUgmeSzib2hAZAwIUQUZGQ==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.4.4",
-				"@emotion/cache": "^10.0.9",
-				"@emotion/core": "^10.0.9",
-				"@emotion/css": "^10.0.9",
-				"memoize-one": "^5.0.0",
-				"prop-types": "^15.6.0",
-				"react-input-autosize": "^3.0.0",
-				"react-transition-group": "^4.3.0"
-			},
-			"dependencies": {
-				"@emotion/cache": {
-					"version": "10.0.29",
-					"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
-					"integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
-					"dev": true,
-					"requires": {
-						"@emotion/sheet": "0.9.4",
-						"@emotion/stylis": "0.8.5",
-						"@emotion/utils": "0.11.3",
-						"@emotion/weak-memoize": "0.2.5"
-					}
-				},
-				"@emotion/css": {
-					"version": "10.0.27",
-					"resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
-					"integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
-					"dev": true,
-					"requires": {
-						"@emotion/serialize": "^0.11.15",
-						"@emotion/utils": "0.11.3",
-						"babel-plugin-emotion": "^10.0.27"
-					},
-					"dependencies": {
-						"@emotion/serialize": {
-							"version": "0.11.16",
-							"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
-							"integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
-							"dev": true,
-							"requires": {
-								"@emotion/hash": "0.8.0",
-								"@emotion/memoize": "0.7.4",
-								"@emotion/unitless": "0.7.5",
-								"@emotion/utils": "0.11.3",
-								"csstype": "^2.5.7"
-							}
-						}
-					}
-				},
-				"@emotion/utils": {
-					"version": "0.11.3",
-					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-					"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==",
-					"dev": true
-				},
-				"csstype": {
-					"version": "2.6.19",
-					"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
-					"integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==",
-					"dev": true
-				}
-			}
 		},
 		"react-shallow-renderer": {
 			"version": "16.15.0",
@@ -53313,19 +52541,6 @@
 				"throttle-debounce": "^3.0.1"
 			}
 		},
-		"react-syntax-highlighter": {
-			"version": "13.5.3",
-			"resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-13.5.3.tgz",
-			"integrity": "sha512-crPaF+QGPeHNIblxxCdf2Lg936NAHKhNhuMzRL3F9ct6aYXL3NcZtCL0Rms9+qVo6Y1EQLdXGypBNSbPL/r+qg==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.3.1",
-				"highlight.js": "^10.1.1",
-				"lowlight": "^1.14.0",
-				"prismjs": "^1.21.0",
-				"refractor": "^3.1.0"
-			}
-		},
 		"react-test-renderer": {
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
@@ -53343,29 +52558,6 @@
 					"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
 					"dev": true
 				}
-			}
-		},
-		"react-textarea-autosize": {
-			"version": "8.3.3",
-			"resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.3.tgz",
-			"integrity": "sha512-2XlHXK2TDxS6vbQaoPbMOfQ8GK7+irc2fVK6QFIcC8GOnH3zI/v481n+j1L0WaPVvKxwesnY93fEfH++sus2rQ==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.10.2",
-				"use-composed-ref": "^1.0.0",
-				"use-latest": "^1.0.0"
-			}
-		},
-		"react-transition-group": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
-			"integrity": "sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.5.5",
-				"dom-helpers": "^5.0.1",
-				"loose-envify": "^1.4.0",
-				"prop-types": "^15.6.2"
 			}
 		},
 		"read": {
@@ -53734,33 +52926,6 @@
 			"integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
 			"requires": {
 				"@babel/runtime": "^7.9.2"
-			}
-		},
-		"refractor": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/refractor/-/refractor-3.4.0.tgz",
-			"integrity": "sha512-dBeD02lC5eytm9Gld2Mx0cMcnR+zhSnsTfPpWqFaMgUMJfC9A6bcN3Br/NaXrnBJcuxnLFR90k1jrkaSyV8umg==",
-			"dev": true,
-			"requires": {
-				"hastscript": "^6.0.0",
-				"parse-entities": "^2.0.0",
-				"prismjs": "~1.24.0"
-			},
-			"dependencies": {
-				"parse-entities": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
-					"integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
-					"dev": true,
-					"requires": {
-						"character-entities": "^1.0.0",
-						"character-entities-legacy": "^1.0.0",
-						"character-reference-invalid": "^1.0.0",
-						"is-alphanumerical": "^1.0.0",
-						"is-decimal": "^1.0.0",
-						"is-hexadecimal": "^1.0.0"
-					}
-				}
 			}
 		},
 		"regenerate": {
@@ -58997,65 +58162,6 @@
 				}
 			}
 		},
-		"telejson": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/telejson/-/telejson-5.3.3.tgz",
-			"integrity": "sha512-PjqkJZpzEggA9TBpVtJi1LVptP7tYtXB6rEubwlHap76AMjzvOdKX41CxyaW7ahhzDU1aftXnMCx5kAPDZTQBA==",
-			"dev": true,
-			"requires": {
-				"@types/is-function": "^1.0.0",
-				"global": "^4.4.0",
-				"is-function": "^1.0.2",
-				"is-regex": "^1.1.2",
-				"is-symbol": "^1.0.3",
-				"isobject": "^4.0.0",
-				"lodash": "^4.17.21",
-				"memoizerific": "^1.11.3"
-			},
-			"dependencies": {
-				"call-bind": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-					"dev": true,
-					"requires": {
-						"function-bind": "^1.1.1",
-						"get-intrinsic": "^1.0.2"
-					}
-				},
-				"has-symbols": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-					"dev": true
-				},
-				"is-regex": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
-					"integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"has-symbols": "^1.0.2"
-					}
-				},
-				"is-symbol": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-					"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-					"dev": true,
-					"requires": {
-						"has-symbols": "^1.0.2"
-					}
-				},
-				"isobject": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
-					"dev": true
-				}
-			}
-		},
 		"temp": {
 			"version": "0.8.3",
 			"resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
@@ -59440,12 +58546,6 @@
 				"repeat-string": "^1.6.1"
 			}
 		},
-		"toggle-selection": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-			"integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI=",
-			"dev": true
-		},
 		"totalist": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
@@ -59531,12 +58631,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.1.1.tgz",
 			"integrity": "sha512-riHuwnzAUCfdIeTBNUq7+Yj+ANnrMXo/7+Z74dIdudS7ys2k8aSGMzpJRMFDF7CLwUTbtvi1ZZff/Wl+XxmqIA==",
-			"dev": true
-		},
-		"ts-essentials": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-2.0.12.tgz",
-			"integrity": "sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==",
 			"dev": true
 		},
 		"ts-pnp": {
@@ -60183,30 +59277,6 @@
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
 		},
-		"use-composed-ref": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.1.0.tgz",
-			"integrity": "sha512-my1lNHGWsSDAhhVAT4MKs6IjBUtG6ZG11uUqexPH9PptiIZDQOzaF4f5tEbJ2+7qvNbtXNBbU3SfmN+fXlWDhg==",
-			"dev": true,
-			"requires": {
-				"ts-essentials": "^2.0.3"
-			}
-		},
-		"use-isomorphic-layout-effect": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz",
-			"integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==",
-			"dev": true
-		},
-		"use-latest": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.0.tgz",
-			"integrity": "sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==",
-			"dev": true,
-			"requires": {
-				"use-isomorphic-layout-effect": "^1.0.0"
-			}
-		},
 		"use-lilius": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/use-lilius/-/use-lilius-2.0.1.tgz",
@@ -60504,15 +59574,6 @@
 			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
 			"requires": {
 				"makeerror": "1.0.x"
-			}
-		},
-		"warning": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-			"integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-			"dev": true,
-			"requires": {
-				"loose-envify": "^1.0.0"
 			}
 		},
 		"watchpack": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
 		"@storybook/addon-actions": "6.5.7",
 		"@storybook/addon-controls": "6.5.7",
 		"@storybook/addon-docs": "6.5.7",
-		"@storybook/addon-knobs": "6.2.9",
 		"@storybook/addon-toolbars": "6.5.7",
 		"@storybook/addon-viewport": "6.5.7",
 		"@storybook/builder-webpack5": "6.5.7",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,6 +17,7 @@
 -   `ItemGroup`: migrate Storybook to controls, refactor to TypeScript ([46945](https://github.com/WordPress/gutenberg/pull/46945)).
 -   `Toolbar`: unify Storybook examples under one file, migrate from knobs to controls ([47117](https://github.com/WordPress/gutenberg/pull/47117)).
 -   `DropdownMenu`: migrate Storybook to controls ([47149](https://github.com/WordPress/gutenberg/pull/47149)).
+-   Removed deprecated `@storybook/addon-knobs` dependency from the package ([47152](https://github.com/WordPress/gutenberg/pull/47152)).
 
 ### Bug Fix
 

--- a/packages/components/CONTRIBUTING.md
+++ b/packages/components/CONTRIBUTING.md
@@ -361,7 +361,7 @@ Primary.args = {
 };
 ```
 
-A great tool to use when writing stories is the [Storybook Controls addon](https://storybook.js.org/addons/@storybook/addon-controls). Ideally props should be exposed by using this addon, which provides a graphical UI to interact dynamically with the component without needing to write code.
+A great tool to use when writing stories is the [Storybook Controls addon](https://storybook.js.org/addons/@storybook/addon-controls). Ideally props should be exposed by using this addon, which provides a graphical UI to interact dynamically with the component without needing to write code. Historically, we used [Knobs](https://storybook.js.org/addons/@storybook/addon-knobs), but it was deprecated and later removed in [#47152](https://github.com/WordPress/gutenberg/pull/47152).
 
 The default value of each control should coincide with the default value of the props (i.e. it should be `undefined` if a prop is not required). A story should, therefore, also explicitly show how values from the Context System are applied to (sub)components. A good example of how this may look like is the [`Card` story](https://wordpress.github.io/gutenberg/?path=/story/components-card--default) (code [here](/packages/components/src/card/stories/index.tsx)).
 

--- a/packages/components/CONTRIBUTING.md
+++ b/packages/components/CONTRIBUTING.md
@@ -361,7 +361,7 @@ Primary.args = {
 };
 ```
 
-A great tool to use when writing stories is the [Storybook Controls addon](https://storybook.js.org/addons/@storybook/addon-controls). Ideally props should be exposed by using this addon, which provides a graphical UI to interact dynamically with the component without needing to write code. Avoid using [Knobs](https://storybook.js.org/addons/@storybook/addon-knobs) for new stories, as this addon is deprecated.
+A great tool to use when writing stories is the [Storybook Controls addon](https://storybook.js.org/addons/@storybook/addon-controls). Ideally props should be exposed by using this addon, which provides a graphical UI to interact dynamically with the component without needing to write code.
 
 The default value of each control should coincide with the default value of the props (i.e. it should be `undefined` if a prop is not required). A story should, therefore, also explicitly show how values from the Context System are applied to (sub)components. A good example of how this may look like is the [`Card` story](https://wordpress.github.io/gutenberg/?path=/story/components-card--default) (code [here](/packages/components/src/card/stories/index.tsx)).
 

--- a/storybook/main.js
+++ b/storybook/main.js
@@ -18,7 +18,6 @@ module.exports = {
 			options: { configureJSX: true },
 		},
 		'@storybook/addon-controls',
-		'@storybook/addon-knobs', // Deprecated, new stories should use addon-controls.
 		'@storybook/addon-viewport',
 		'@storybook/addon-a11y',
 		'@storybook/addon-toolbars',

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -91,11 +91,6 @@ export const parameters = {
 	controls: {
 		sort: 'requiredFirst',
 	},
-	knobs: {
-		// Knobs are deprecated, and new stories should use addon-controls.
-		// Will be enabled on a per-story basis until migration is complete.
-		disable: true,
-	},
 	options: {
 		storySort: {
 			order: [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Remove the `@storybook/addon-knobs` dependency from the repository

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The dependency has been deprecated for a long time, and we recently removed all usages from all Storybook examples.

This dependency is currently blocking using npm 8 (see https://github.com/WordPress/gutenberg/issues/46443)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removed from:
- npm dependency
- docs
- Storybook settings

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Make sure that the project builds correctly
- Make sure that Storybook examples load and function as on `trunk`
- Do a smoke test on the editor, make sure that everything works as on `trunk`