### PR TITLE
TextControl: remove margin overrides and add new opt-in prop (pt 1/2)

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -271,6 +271,7 @@ function LinkControl( {
 					>
 						{ showTextControl && (
 							<TextControl
+								__nextHasNoMarginBottom
 								ref={ textInputRef }
 								className="block-editor-link-control__field block-editor-link-control__text-content"
 								label="Text"

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -49,7 +49,6 @@ $preview-image-height: 140px;
 	> .components-base-control__field {
 		display: flex;
 		align-items: center;
-		margin: 0;
 	}
 
 	.components-base-control__label {

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -68,6 +68,7 @@ export const withInspectorControl = createHigherOrderComponent(
 				const isWeb = Platform.OS === 'web';
 				const textControl = (
 					<TextControl
+						__nextHasNoMarginBottom
 						className="html-anchor-control"
 						label={ __( 'HTML anchor' ) }
 						help={

--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -61,6 +61,7 @@ export const withInspectorControl = createHigherOrderComponent(
 						<BlockEdit { ...props } />
 						<InspectorControls __experimentalGroup="advanced">
 							<TextControl
+								__nextHasNoMarginBottom
 								autoComplete="off"
 								label={ __( 'Additional CSS class(es)' ) }
 								value={ props.attributes.className || '' }

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -130,6 +130,7 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 			<InspectorControls>
 				<PanelBody>
 					<TextControl
+						__nextHasNoMarginBottom
 						label={ __( 'Name' ) }
 						value={ title }
 						onChange={ setTitle }

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -262,6 +262,7 @@ function ButtonEdit( props ) {
 			</InspectorControls>
 			<InspectorControls __experimentalGroup="advanced">
 				<TextControl
+					__nextHasNoMarginBottom
 					label={ __( 'Link rel' ) }
 					value={ rel || '' }
 					onChange={ ( newRel ) => setAttributes( { rel: newRel } ) }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -438,6 +438,7 @@ export default function Image( {
 			</InspectorControls>
 			<InspectorControls __experimentalGroup="advanced">
 				<TextControl
+					__nextHasNoMarginBottom
 					label={ __( 'Title attribute' ) }
 					value={ title || '' }
 					onChange={ onSetTitle }

--- a/packages/block-library/src/list/ordered-list-settings.js
+++ b/packages/block-library/src/list/ordered-list-settings.js
@@ -9,6 +9,7 @@ const OrderedListSettings = ( { setAttributes, reversed, start } ) => (
 	<InspectorControls>
 		<PanelBody title={ __( 'Ordered list settings' ) }>
 			<TextControl
+				__nextHasNoMarginBottom
 				label={ __( 'Start value' ) }
 				type="number"
 				onChange={ ( value ) => {

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -432,6 +432,7 @@ export default function NavigationLinkEdit( {
 			<InspectorControls>
 				<PanelBody title={ __( 'Link settings' ) }>
 					<TextControl
+						__nextHasNoMarginBottom
 						value={ label ? stripHTML( label ) : '' }
 						onChange={ ( labelValue ) => {
 							setAttributes( { label: labelValue } );
@@ -440,6 +441,7 @@ export default function NavigationLinkEdit( {
 						autoComplete="off"
 					/>
 					<TextControl
+						__nextHasNoMarginBottom
 						value={ url || '' }
 						onChange={ ( urlValue ) => {
 							updateAttributes(
@@ -463,6 +465,7 @@ export default function NavigationLinkEdit( {
 						) }
 					/>
 					<TextControl
+						__nextHasNoMarginBottom
 						value={ title || '' }
 						onChange={ ( titleValue ) => {
 							setAttributes( { title: titleValue } );
@@ -471,6 +474,7 @@ export default function NavigationLinkEdit( {
 						autoComplete="off"
 					/>
 					<TextControl
+						__nextHasNoMarginBottom
 						value={ rel || '' }
 						onChange={ ( relValue ) => {
 							setAttributes( { rel: relValue } );

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -393,6 +393,7 @@ export default function NavigationSubmenuEdit( {
 			<InspectorControls>
 				<PanelBody title={ __( 'Link settings' ) }>
 					<TextControl
+						__nextHasNoMarginBottom
 						value={ label || '' }
 						onChange={ ( labelValue ) => {
 							setAttributes( { label: labelValue } );
@@ -401,6 +402,7 @@ export default function NavigationSubmenuEdit( {
 						autoComplete="off"
 					/>
 					<TextControl
+						__nextHasNoMarginBottom
 						value={ url || '' }
 						onChange={ ( urlValue ) => {
 							setAttributes( { url: urlValue } );
@@ -422,6 +424,7 @@ export default function NavigationSubmenuEdit( {
 						) }
 					/>
 					<TextControl
+						__nextHasNoMarginBottom
 						value={ title || '' }
 						onChange={ ( titleValue ) => {
 							setAttributes( { title: titleValue } );
@@ -430,6 +433,7 @@ export default function NavigationSubmenuEdit( {
 						autoComplete="off"
 					/>
 					<TextControl
+						__nextHasNoMarginBottom
 						value={ rel || '' }
 						onChange={ ( relValue ) => {
 							setAttributes( { rel: relValue } );

--- a/packages/block-library/src/navigation/edit/navigation-menu-name-control.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-name-control.js
@@ -14,6 +14,7 @@ export default function NavigationMenuNameControl() {
 
 	return (
 		<TextControl
+			__nextHasNoMarginBottom
 			label={ __( 'Menu name' ) }
 			value={ title }
 			onChange={ updateTitle }

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -154,6 +154,7 @@ function PostFeaturedImageDisplay( {
 								checked={ linkTarget === '_blank' }
 							/>
 							<TextControl
+								__nextHasNoMarginBottom
 								label={ __( 'Link rel' ) }
 								value={ rel }
 								onChange={ ( newRel ) =>

--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -85,6 +85,7 @@ export default function PostTermsEdit( {
 			</BlockControls>
 			<InspectorControls __experimentalGroup="advanced">
 				<TextControl
+					__nextHasNoMarginBottom
 					autoComplete="off"
 					label={ __( 'Separator' ) }
 					value={ separator || '' }

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -134,6 +134,7 @@ export default function PostTitleEdit( {
 								checked={ linkTarget === '_blank' }
 							/>
 							<TextControl
+								__nextHasNoMarginBottom
 								label={ __( 'Link rel' ) }
 								value={ rel }
 								onChange={ ( newRel ) =>

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -247,6 +247,7 @@ export default function QueryInspectorControls( {
 								onDeselect={ () => setQuerySearch( '' ) }
 							>
 								<TextControl
+									__nextHasNoMarginBottom
 									label={ __( 'Keyword' ) }
 									value={ querySearch }
 									onChange={ setQuerySearch }

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -539,6 +539,7 @@ function TableEdit( {
 						onSubmit={ onCreateTable }
 					>
 						<TextControl
+							__nextHasNoMarginBottom
 							type="number"
 							label={ __( 'Column count' ) }
 							value={ initialColumnCount }
@@ -547,6 +548,7 @@ function TableEdit( {
 							className="blocks-table__placeholder-input"
 						/>
 						<TextControl
+							__nextHasNoMarginBottom
 							type="number"
 							label={ __( 'Row count' ) }
 							value={ initialRowCount }

--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -1,5 +1,4 @@
 .wp-block-table {
-
 	// Remove default <figure> style.
 	margin: 0;
 
@@ -81,10 +80,5 @@
 
 	input {
 		height: $button-size;
-	}
-
-
-	.components-base-control__field {
-		margin-bottom: 0;
 	}
 }

--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -75,6 +75,7 @@ export function TemplatePartAdvancedControls( {
 			{ isEntityAvailable && (
 				<>
 					<TextControl
+						__nextHasNoMarginBottom
 						label={ __( 'Title' ) }
 						value={ title }
 						onChange={ ( value ) => {

--- a/packages/edit-post/src/components/header/template-title/edit-template-title.js
+++ b/packages/edit-post/src/components/header/template-title/edit-template-title.js
@@ -46,6 +46,7 @@ export default function EditTemplateTitle() {
 	return (
 		<div className="edit-site-template-details__group">
 			<TextControl
+				__nextHasNoMarginBottom
 				label={ __( 'Title' ) }
 				value={ forceEmpty ? '' : templateTitle }
 				help={ __(

--- a/packages/edit-post/src/components/header/template-title/style.scss
+++ b/packages/edit-post/src/components/header/template-title/style.scss
@@ -49,10 +49,7 @@
 .edit-post-template-top-area__popover {
 	.components-popover__content {
 		min-width: 280px;
-
-		> div {
-			padding: 0;
-		}
+		padding: 0;
 	}
 
 	.edit-site-template-details__group {

--- a/packages/edit-post/src/components/sidebar/post-template/create-modal.js
+++ b/packages/edit-post/src/components/sidebar/post-template/create-modal.js
@@ -7,10 +7,10 @@ import { useState } from '@wordpress/element';
 import { serialize, createBlock } from '@wordpress/blocks';
 import {
 	Modal,
-	Flex,
-	FlexItem,
 	TextControl,
 	Button,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { cleanForSlug } from '@wordpress/url';
@@ -108,28 +108,23 @@ export default function PostTemplateCreateModal( { onClose } ) {
 				className="edit-post-post-template__create-form"
 				onSubmit={ submit }
 			>
-				<Flex align="flex-start" gap={ 8 }>
-					<FlexItem>
-						<TextControl
-							label={ __( 'Name' ) }
-							value={ title }
-							onChange={ setTitle }
-							placeholder={ DEFAULT_TITLE }
-							disabled={ isBusy }
-							help={ __(
-								'Describe the template, e.g. "Post with sidebar". Custom templates can be applied to any post or page.'
-							) }
-						/>
-					</FlexItem>
-				</Flex>
-
-				<Flex justify="flex-end" expanded={ false }>
-					<FlexItem>
+				<VStack spacing="3">
+					<TextControl
+						__nextHasNoMarginBottom
+						label={ __( 'Name' ) }
+						value={ title }
+						onChange={ setTitle }
+						placeholder={ DEFAULT_TITLE }
+						disabled={ isBusy }
+						help={ __(
+							'Describe the template, e.g. "Post with sidebar". Custom templates can be applied to any post or page.'
+						) }
+					/>
+					<HStack justify="right">
 						<Button variant="tertiary" onClick={ cancel }>
 							{ __( 'Cancel' ) }
 						</Button>
-					</FlexItem>
-					<FlexItem>
+
 						<Button
 							variant="primary"
 							type="submit"
@@ -138,8 +133,8 @@ export default function PostTemplateCreateModal( { onClose } ) {
 						>
 							{ __( 'Create' ) }
 						</Button>
-					</FlexItem>
-				</Flex>
+					</HStack>
+				</VStack>
 			</form>
 		</Modal>
 	);

--- a/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal.js
@@ -10,10 +10,10 @@ import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
 	Button,
-	Flex,
-	FlexItem,
 	Modal,
 	TextControl,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 
 /**
@@ -60,27 +60,22 @@ function AddCustomGenericTemplateModal( {
 		>
 			{ isCreatingTemplate && <TemplateActionsLoadingScreen /> }
 			<form onSubmit={ onCreateTemplate }>
-				<Flex align="flex-start" gap={ 8 }>
-					<FlexItem>
-						<TextControl
-							label={ __( 'Name' ) }
-							value={ title }
-							onChange={ setTitle }
-							placeholder={ defaultTitle }
-							disabled={ isBusy }
-							help={ __(
-								'Describe the template, e.g. "Post with sidebar".'
-							) }
-						/>
-					</FlexItem>
-				</Flex>
-
-				<Flex
-					className="edit-site-custom-generic-template__modal-actions"
-					justify="flex-end"
-					expanded={ false }
-				>
-					<FlexItem>
+				<VStack spacing={ 3 }>
+					<TextControl
+						__nextHasNoMarginBottom
+						label={ __( 'Name' ) }
+						value={ title }
+						onChange={ setTitle }
+						placeholder={ defaultTitle }
+						disabled={ isBusy }
+						help={ __(
+							'Describe the template, e.g. "Post with sidebar".'
+						) }
+					/>
+					<HStack
+						className="edit-site-custom-generic-template__modal-actions"
+						justify="right"
+					>
 						<Button
 							variant="tertiary"
 							onClick={ () => {
@@ -89,8 +84,6 @@ function AddCustomGenericTemplateModal( {
 						>
 							{ __( 'Cancel' ) }
 						</Button>
-					</FlexItem>
-					<FlexItem>
 						<Button
 							variant="primary"
 							type="submit"
@@ -99,8 +92,8 @@ function AddCustomGenericTemplateModal( {
 						>
 							{ __( 'Create' ) }
 						</Button>
-					</FlexItem>
-				</Flex>
+					</HStack>
+				</VStack>
 			</form>
 		</Modal>
 	);

--- a/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal.js
@@ -60,7 +60,7 @@ function AddCustomGenericTemplateModal( {
 		>
 			{ isCreatingTemplate && <TemplateActionsLoadingScreen /> }
 			<form onSubmit={ onCreateTemplate }>
-				<VStack spacing={ 3 }>
+				<VStack spacing={ 6 }>
 					<TextControl
 						__nextHasNoMarginBottom
 						label={ __( 'Name' ) }

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -151,10 +151,6 @@
 	}
 }
 
-.edit-site-custom-generic-template__modal-actions {
-	margin-top: $grid-unit-15;
-}
-
 .edit-site-template-actions-loading-screen-modal {
 	backdrop-filter: none;
 	background-color: transparent;

--- a/packages/edit-site/src/components/list/actions/rename-menu-item.js
+++ b/packages/edit-site/src/components/list/actions/rename-menu-item.js
@@ -6,11 +6,11 @@ import { useState } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import {
 	Button,
-	Flex,
-	FlexItem,
 	MenuItem,
 	Modal,
 	TextControl,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
@@ -82,23 +82,16 @@ export default function RenameMenuItem( { template, onClose } ) {
 					overlayClassName="edit-site-list__rename-modal"
 				>
 					<form onSubmit={ onTemplateRename }>
-						<Flex align="flex-start" gap={ 8 }>
-							<FlexItem>
-								<TextControl
-									label={ __( 'Name' ) }
-									value={ title }
-									onChange={ setTitle }
-									required
-								/>
-							</FlexItem>
-						</Flex>
+						<VStack spacing="5">
+							<TextControl
+								__nextHasNoMarginBottom
+								label={ __( 'Name' ) }
+								value={ title }
+								onChange={ setTitle }
+								required
+							/>
 
-						<Flex
-							className="edit-site-list__rename-modal-actions"
-							justify="flex-end"
-							expanded={ false }
-						>
-							<FlexItem>
+							<HStack justify="right">
 								<Button
 									variant="tertiary"
 									onClick={ () => {
@@ -107,13 +100,12 @@ export default function RenameMenuItem( { template, onClose } ) {
 								>
 									{ __( 'Cancel' ) }
 								</Button>
-							</FlexItem>
-							<FlexItem>
+
 								<Button variant="primary" type="submit">
 									{ __( 'Save' ) }
 								</Button>
-							</FlexItem>
-						</Flex>
+							</HStack>
+						</VStack>
 					</form>
 				</Modal>
 			) }

--- a/packages/edit-site/src/components/list/style.scss
+++ b/packages/edit-site/src/components/list/style.scss
@@ -132,10 +132,6 @@
 	}
 }
 
-.edit-site-list__rename-modal-actions {
-	margin-top: $grid-unit-15;
-}
-
 .edit-site-template__actions {
 	button:not(:last-child) {
 		margin-right: $grid-unit-10;

--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -122,6 +122,7 @@ class PostPublishPanelPostpublish extends Component {
 					</p>
 					<div className="post-publish-panel__postpublish-post-address-container">
 						<TextControl
+							__nextHasNoMarginBottom
 							className="post-publish-panel__postpublish-post-address"
 							readOnly
 							label={ sprintf(

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -4,7 +4,7 @@
 
 .editor-post-publish-panel__content {
 	// Ensure the post-publish panel accounts for the header and footer height.
-	min-height: calc(100% - #{ $header-height + 84px });
+	min-height: calc(100% - #{$header-height + 84px});
 
 	.components-spinner {
 		display: block;
@@ -156,10 +156,6 @@
 	display: flex;
 	align-items: flex-end;
 	margin-bottom: $grid-unit-20;
-
-	.components-base-control__field {
-		margin-bottom: 0;
-	}
 
 	.post-publish-panel__postpublish-post-address {
 		flex: 1;

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -13,10 +13,6 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
   box-sizing: inherit;
 }
 
-.emotion-2 {
-  margin-bottom: calc(4px * 2);
-}
-
 .components-panel__row .emotion-2 {
   margin-bottom: inherit;
 }
@@ -29,10 +25,6 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
   display: inline-block;
   margin-bottom: calc(4px * 2);
   padding: 0;
-}
-
-.components-panel__row .emotion-8 {
-  margin-bottom: inherit;
 }
 
 <div>
@@ -145,7 +137,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
         class="components-base-control components-checkbox-control emotion-0 emotion-1"
       >
         <div
-          class="components-base-control__field emotion-8 emotion-3"
+          class="components-base-control__field emotion-2 emotion-3"
         >
           <span
             class="components-checkbox-control__input-container"
@@ -183,10 +175,6 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
   box-sizing: inherit;
 }
 
-.emotion-2 {
-  margin-bottom: calc(4px * 2);
-}
-
 .components-panel__row .emotion-2 {
   margin-bottom: inherit;
 }
@@ -199,10 +187,6 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
   display: inline-block;
   margin-bottom: calc(4px * 2);
   padding: 0;
-}
-
-.components-panel__row .emotion-8 {
-  margin-bottom: inherit;
 }
 
 <div>
@@ -315,7 +299,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
         class="components-base-control components-checkbox-control emotion-0 emotion-1"
       >
         <div
-          class="components-base-control__field emotion-8 emotion-3"
+          class="components-base-control__field emotion-2 emotion-3"
         >
           <span
             class="components-checkbox-control__input-container"

--- a/packages/editor/src/components/post-slug/index.js
+++ b/packages/editor/src/components/post-slug/index.js
@@ -46,6 +46,7 @@ export class PostSlug extends Component {
 		return (
 			<PostSlugCheck>
 				<TextControl
+					__nextHasNoMarginBottom
 					label={ __( 'Slug' ) }
 					autoComplete="off"
 					spellCheck="false"

--- a/packages/editor/src/components/post-url/index.js
+++ b/packages/editor/src/components/post-url/index.js
@@ -51,6 +51,7 @@ export default function PostURL( { onClose } ) {
 			<InspectorPopoverHeader title={ __( 'URL' ) } onClose={ onClose } />
 			{ isEditable && (
 				<TextControl
+					__nextHasNoMarginBottom
 					label={ __( 'Permalink' ) }
 					value={ forceEmptyField ? '' : postSlug }
 					autoComplete="off"

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -12,8 +12,8 @@ import {
 	Modal,
 	Button,
 	TextControl,
-	Flex,
-	FlexItem,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { symbol } from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -136,16 +136,14 @@ export default function ReusableBlockConvertButton( {
 									onClose();
 								} }
 							>
-								<TextControl
-									label={ __( 'Name' ) }
-									value={ title }
-									onChange={ setTitle }
-								/>
-								<Flex
-									className="reusable-blocks-menu-items__convert-modal-actions"
-									justify="flex-end"
-								>
-									<FlexItem>
+								<VStack spacing="5">
+									<TextControl
+										__nextHasNoMarginBottom
+										label={ __( 'Name' ) }
+										value={ title }
+										onChange={ setTitle }
+									/>
+									<HStack justify="right">
 										<Button
 											variant="tertiary"
 											onClick={ () => {
@@ -155,13 +153,12 @@ export default function ReusableBlockConvertButton( {
 										>
 											{ __( 'Cancel' ) }
 										</Button>
-									</FlexItem>
-									<FlexItem>
+
 										<Button variant="primary" type="submit">
 											{ __( 'Save' ) }
 										</Button>
-									</FlexItem>
-								</Flex>
+									</HStack>
+								</VStack>
 							</form>
 						</Modal>
 					) }

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/style.scss
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/style.scss
@@ -1,7 +1,3 @@
 .reusable-blocks-menu-items__convert-modal {
 	z-index: z-index(".reusable-blocks-menu-items__convert-modal");
 }
-
-.reusable-blocks-menu-items__convert-modal-actions {
-	padding-top: $grid-unit-15;
-}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Part 1/2

## What?

<!-- In a few words, what is the PR actually doing? -->

Added new opt-in prop `__nextHasNoMarginBottom` for usages of `TextControl` in the Gutenberg codebase and removed margin overrides. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Part of this project: https://github.com/WordPress/gutenberg/issues/38730
The tl;dr is `BaseControl` has a `margin-bottom` which makes it difficult to reuse and results in inconsistent use. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By removing margin overrides in the CSS and adding the prop `__nextHasNoMarginBottom`. As well as adding `VStack` and `HStack` (and sometimes replacing `Flex` with those) to remove additional CSS and get the changes visually identical to trunk. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

<details>
<summary><h3>Block Editor testing steps:</h3></summary>

### Create a new **post** and follow testing steps below: 

- ### PostSlug

	1. Add `add_post_type_support( 'post', 'slug' );` to `gutenberg.php`
	2. Edit a post and look for 'Slug' under 'Summary' in the Post sidebar
	3. Ensure the space below the text input looks the same as before 
	<br /><img width="270" alt="Screenshot 2023-01-11 at 11 24 55 PM" src="https://user-images.githubusercontent.com/35543432/212442644-56e5f7e3-8350-4d5e-a9e0-d357988a08c3.png">

- ### PostURL

	1. If you don't have the option to edit the Permalink, edit line 50 to `! isEditable` to view it: https://github.com/WordPress/gutenberg/blob/fb38e7dbe99669cfc0c569903b34809974f68fc3/packages/editor/src/components/post-url/index.js#L52
	2. Click on the link next to the URL in the Post summary
	3. Ensure the space below the text input for 'Permalink' looks the same as before 
	<br /><img width="301" alt="Screenshot 2023-01-11 at 11 26 58 PM" src="https://user-images.githubusercontent.com/35543432/212442733-6cf0f6a2-9c5d-47e2-8bf1-5a5d035e688d.png">

- ### Link Control 

	1. Add a paragraph block
	2. Add a link to the text
	3. Click on the link to edit 
	4. Ensure the space below the text input 'Text' looks the same as before 

	<br /><img width="372" alt="Screenshot 2023-01-13 at 3 28 21 PM" src="https://user-images.githubusercontent.com/35543432/212436973-e3e48af8-85ed-41ef-b00f-eb661a28c19d.png">

- ### ButtonEdit & withInspectorControl (HTML/CSS fields)

	1. Add a button
	2. Go to the settings icon and then to 'Advanced' in the block inspector
	3. Look for the 'Link Rel' label (need to have single child Button selected)
	4. Ensure the space below the text inputs for 'Link Rel', 'HTML Anchor, and 'Additional CSS Class(es)' looks the same as before
<br /><img width="293" alt="Screenshot 2023-01-11 at 10 27 13 PM" src="https://user-images.githubusercontent.com/35543432/212438668-e34e80e6-03af-4f16-b299-14bf8efe7b6b.png">

- ### Image 

	1. Add an Image block
	2. Add/upload an image
	3. Click on the settings icon and then on 'Advanced'
	4. Ensure the space below the text input for 'Title Attribute' looks the same as before 
	<br /><img width="286" alt="Screenshot 2023-01-11 at 10 27 31 PM" src="https://user-images.githubusercontent.com/35543432/212444769-167c8a09-5d8b-466e-8c2c-2b2a8128b3ee.png">

- ### ReusableBlockEdit & ReusableBlockConvertButton

	1. Click three dots in toolbar of any block and choose 'Create reusable block'
	2. Enter a name and click 'Save'
	3. In block inspector, ensure the text input below 'Name' label looks the same as before

	| <br /> Step 1  | <br />Step 3 |
	| --- | --- |
	|  <img width="372" alt="Screenshot 2023-01-13 at 3 31 48 PM" src="https://user-images.githubusercontent.com/35543432/212437220-d22c95f8-ffee-4005-a3df-8250db4fadaa.png"> | <img width="290" alt="Screenshot 2023-01-11 at 10 57 33 PM" src="https://user-images.githubusercontent.com/35543432/212437244-78acb081-3bfc-453a-a205-1201a782b244.png"> |

- ### OrderedListSettings

	1. Add a list block 
	2. Change to an ordered list
	3. Click the settings icon in the block inspector and look for the 'Start Value' label (need to select List parent, not list item)
	4. Ensure the space below the text input looks the same as before
<br /><img width="287" alt="Screenshot 2023-01-11 at 10 26 23 PM" src="https://user-images.githubusercontent.com/35543432/212438873-653b620c-c506-48d5-ac6c-24b5afea2adf.png">

- ### NavigationLinkEdit & NavigationSubmenuEdit & NavigationMenuNameControl

	1. Add a Navigation block
	2. Click the settings icon and then on 'Advanced' in the block inspector 
	3. Ensure the space below the text input for 'Menu Name' looks the same as before 
	4. Add a new navigation item
	9. Look for the 'Link Settings' title in the block inspector
	10. Ensure the space below text input for 'Label', 'URL, 'Link Title', and 'Link Rel' looks the same as before
	11. Add a Submenu item to the Navigation block
	12. Repeat Step 4

	| <br /> Step 3  | <br />Step 6 and 8 |
	| ------------- | ------------- |
	| <img width="290" alt="Screenshot 2023-01-11 at 10 29 03 PM" src="https://user-images.githubusercontent.com/35543432/212439237-54710d21-8bf7-4bed-8cbd-7aabd2ab66db.png"> | <img width="289" alt="Screenshot 2023-01-11 at 10 29 40 PM" src="https://user-images.githubusercontent.com/35543432/212439264-b72f939a-77f4-4245-b3ec-860d038b6a8a.png"> |

- ### PostFeaturedImageDisplay

	1. Add a Post Featured Image block 
	2. Toggle switch 'Link to page' in the block inspector
	3.  Ensure the space below the text input for 'Link Rel' looks the same as before
	<br /><img width="280" alt="Screenshot 2023-01-11 at 10 32 09 PM" src="https://user-images.githubusercontent.com/35543432/212439310-f4498dec-420b-400e-ae7a-292a5ce44e23.png">

- ### PostTermsEdit

	1. Add Categories block
	2. Click the settings icon and then on 'Advanced' in the block inspector 
	3. Look for the 'Separator' label and ensure the space below the text input looks the same as before 
	<br /><img width="291" alt="Screenshot 2023-01-11 at 10 33 27 PM" src="https://user-images.githubusercontent.com/35543432/212439401-492cb573-3bd8-4a5e-9b40-bec6f8a78a38.png">

- ### QueryInspectorControls

	1. Add Query Loop block to the editor
	2. Start from blank and select any template option
	3. Click on three dots to access the menu for 'Filters' in the block inspector
	7. Select 'Keyword and ensure the space below the text input looks the same as before 

- ### TableEdit

	1. Add a Table block to the editor
	2. Ensure the space below the rows and columns text inputs look the same as before
	<br /><img width="678" alt="Screenshot 2023-01-11 at 10 38 12 PM" src="https://user-images.githubusercontent.com/35543432/212439453-3ed5073b-92cf-4aa8-a788-dfaf58b7b200.png">

- ### PostTemplateCreateModal & EditTemplateTitle

	1. Click on the template link in the sidebar
	2. Click on the icon to create a custom template 
	3. Ensure the space below the text input for 'Name' looks the same as before 
	4. Enter a name and create the template for the following steps below the image
	<br /><img width="402" alt="Screenshot 2023-01-13 at 4 48 54 PM" src="https://user-images.githubusercontent.com/35543432/212442329-8d992bc6-4cfb-4444-9d8c-ab58310e1b3c.png"><br />
	8. Click 'Edit template' for the template you just created
	9. Click on the title and ensure the space below the text input looks the same as before
	10. Go back and edit the Default Template and click on the title to check it as well

	| <br /> Before | <br />After |
	| ------------- | ------------- |
	| <img width="297" alt="Screenshot 2023-01-10 at 10 55 37 PM" src="https://user-images.githubusercontent.com/35543432/212439560-8a303fcc-b0a4-44f0-95ed-6c133a819232.png"> | <img width="293" alt="Screenshot 2023-01-13 at 4 08 08 PM" src="https://user-images.githubusercontent.com/35543432/212439933-d81b69b9-d3f6-4300-b746-44dc04a08cef.png"> |
	| <img width="300" alt="Screenshot 2023-01-10 at 6 57 16 PM" src="https://user-images.githubusercontent.com/35543432/212439651-67a9ac0a-6498-4698-af62-02e164510238.png"> | <img width="292" alt="Screenshot 2023-01-13 at 4 08 48 PM" src="https://user-images.githubusercontent.com/35543432/212439943-53398dfd-3c60-4285-8062-d1c8a89e4f28.png"> |

- ### PostPublishPanelPostpublish

	1. Publish the page or post (or make it a draft first if needed and then re-publish)
	2. Ensure the space below the text input for 'Page address' looks the same as before 
	<br /><img width="278" alt="Screenshot 2023-01-13 at 4 51 23 PM" src="https://user-images.githubusercontent.com/35543432/212442467-55e6bb80-c078-4684-b124-9c256ab2ac90.png">

</details>

#### Block Editor checklist:

- [ ] PostSlug
- [ ] PostURL
- [ ] Link Control 
- [ ] ButtonEdit & withInspectorControl (HTML/CSS fields)
- [ ] Image 
- [ ] ReusableBlockEdit & ReusableBlockConvertButton
- [ ] OrderedListSettings
- [ ] NavigationMenuNameControl & NavigationLinkEdit & NavigationSubmenuEdit
- [ ] PostFeaturedImageDisplay
- [ ] PostTermsEdit
- [ ] QueryInspectorControls
- [ ] SocialLinkEdit
- [ ] TableEdit
- [ ] PostTemplateCreateModal & EditTemplateTitle
- [ ] PostPublishPanelPostpublish

<hr />

<details>
<summary><h3>Site Editor testing steps:</h3></summary>

- ### AddCustomGenericTemplateModal & RenameMenuItem

	1. Open the site editor
	2. Click on 'Templates'
	3. Click on the plus icon to add a new template
	4. Select 'Custom template'
	5. Ensure the space below the text input looks the same as before 
	6. Click 'Create' and then navigate back to 'Templates' and go to 'Manage all templates'
	7. Click on the three dots next to your custom template and choose 'Rename'
	8. Ensure the space below the text input for 'Name' is the same as before 

	| <br /> Step 5  | <br />Step 8 |
	| --- | --- |
	| <img width="396" alt="Screenshot 2023-01-13 at 5 13 39 PM" src="https://user-images.githubusercontent.com/35543432/212443693-67cf6360-a669-4b31-a11b-25f8fde8c66f.png"> | <img width="397" alt="Screenshot 2023-01-13 at 5 13 52 PM" src="https://user-images.githubusercontent.com/35543432/212443694-357baa2e-856f-4318-a793-9462b045f15f.png"> |

- ### PostTitleEdit

	1.  Edit the Single template or add a Post Title block to any template in the site editor
	2. Toggle on the switch for 'Make title a link' in the block inspector
	3. Ensure the space below the 'Link Rel' text input looks the same as before 
	<br /><img width="299" alt="Screenshot 2023-01-12 at 12 08 13 AM" src="https://user-images.githubusercontent.com/35543432/212443764-98472a20-b8b1-4b33-8e26-2c1447db92e3.png">

- ### TemplatePartAdvancedControls

	1. Edit a template in the site editor (it can be the same one from above)
	2. Add a Template Part **block** 
	3. Choose start blank
	4. Create a new template part 
	5. Under Advanced in the sidebar, ensure the space below the text input for 'Name' in the modal looks the same as before 
	<img width="286" alt="Screenshot 2023-01-11 at 11 34 07 PM" src="https://user-images.githubusercontent.com/35543432/212443859-6a6a83ad-0fda-4b97-8fcb-aa7cd9c4570d.png">

</details>

#### Site Editor checklist:

- [ ] AddCustomGenericTemplateModal & RenameMenuItem
- [ ] PostTitleEdit
- [ ] TemplatePartAdvancedControls

<br />