### PR TITLE
TextControl: remove margin overrides and add new opt-in prop (pt 2/2)

### DIFF
--- a/packages/block-editor/src/components/date-format-picker/index.js
+++ b/packages/block-editor/src/components/date-format-picker/index.js
@@ -9,8 +9,8 @@ import {
 	ExternalLink,
 	VisuallyHidden,
 	CustomSelectControl,
-	BaseControl,
 	ToggleControl,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 
 // So that we can illustrate the different formats in the dropdown properly,
@@ -110,29 +110,27 @@ function NonDefaultControls( { format, onChange } ) {
 	);
 
 	return (
-		<>
-			<BaseControl className="block-editor-date-format-picker__custom-format-select-control">
-				<CustomSelectControl
-					__nextUnconstrainedWidth
-					label={ __( 'Choose a format' ) }
-					options={ [ ...suggestedOptions, customOption ] }
-					value={
-						isCustom
-							? customOption
-							: suggestedOptions.find(
-									( option ) => option.format === format
-							  ) ?? customOption
+		<VStack>
+			<CustomSelectControl
+				__nextUnconstrainedWidth
+				label={ __( 'Choose a format' ) }
+				options={ [ ...suggestedOptions, customOption ] }
+				value={
+					isCustom
+						? customOption
+						: suggestedOptions.find(
+								( option ) => option.format === format
+						  ) ?? customOption
+				}
+				onChange={ ( { selectedItem } ) => {
+					if ( selectedItem === customOption ) {
+						setIsCustom( true );
+					} else {
+						setIsCustom( false );
+						onChange( selectedItem.format );
 					}
-					onChange={ ( { selectedItem } ) => {
-						if ( selectedItem === customOption ) {
-							setIsCustom( true );
-						} else {
-							setIsCustom( false );
-							onChange( selectedItem.format );
-						}
-					} }
-				/>
-			</BaseControl>
+				} }
+			/>
 			{ isCustom && (
 				<TextControl
 					__nextHasNoMarginBottom
@@ -156,6 +154,6 @@ function NonDefaultControls( { format, onChange } ) {
 					onChange={ ( value ) => onChange( value ) }
 				/>
 			) }
-		</>
+		</VStack>
 	);
 }

--- a/packages/block-editor/src/components/date-format-picker/index.js
+++ b/packages/block-editor/src/components/date-format-picker/index.js
@@ -135,6 +135,7 @@ function NonDefaultControls( { format, onChange } ) {
 			</BaseControl>
 			{ isCustom && (
 				<TextControl
+					__nextHasNoMarginBottom
 					label={ __( 'Custom format' ) }
 					hideLabelFromVision
 					help={ createInterpolateElement(

--- a/packages/block-editor/src/components/date-format-picker/style.scss
+++ b/packages/block-editor/src/components/date-format-picker/style.scss
@@ -1,16 +1,14 @@
 .block-editor-date-format-picker {
 	margin-bottom: $grid-unit-20;
+
+	.block-editor-date-format-picker__custom-format-select-control {
+		margin-bottom: 0;
+	}
 }
 
 .block-editor-date-format-picker__default-format-toggle-control__hint {
 	color: $gray-700;
 	display: block;
-}
-
-.block-editor-date-format-picker__custom-format-select-control {
-	&.components-base-control {
-		margin-bottom: 0;
-	}
 }
 
 .block-editor-date-format-picker__custom-format-select-control__custom-option {

--- a/packages/block-editor/src/components/date-format-picker/style.scss
+++ b/packages/block-editor/src/components/date-format-picker/style.scss
@@ -1,9 +1,5 @@
 .block-editor-date-format-picker {
 	margin-bottom: $grid-unit-20;
-
-	.block-editor-date-format-picker__custom-format-select-control {
-		margin-bottom: 0;
-	}
 }
 
 .block-editor-date-format-picker__default-format-toggle-control__hint {

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -12,6 +12,7 @@ import {
 	TextControl,
 	SVG,
 	Path,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { link as linkIcon, close } from '@wordpress/icons';
 
@@ -209,23 +210,26 @@ const ImageURLInputUI = ( {
 	};
 
 	const advancedOptions = (
-		<>
+		<VStack spacing="3">
 			<ToggleControl
+				__nextHasNoMarginBottom
 				label={ __( 'Open in new tab' ) }
 				onChange={ onSetNewTab }
 				checked={ linkTarget === '_blank' }
 			/>
 			<TextControl
+				__nextHasNoMarginBottom
 				label={ __( 'Link rel' ) }
 				value={ rel ?? '' }
 				onChange={ onSetLinkRel }
 			/>
 			<TextControl
+				__nextHasNoMarginBottom
 				label={ __( 'Link CSS Class' ) }
 				value={ linkClass || '' }
 				onChange={ onSetLinkClass }
 			/>
-		</>
+		</VStack>
 	);
 
 	const linkEditorValue = urlInput !== null ? urlInput : url;

--- a/packages/block-editor/src/components/url-popover/style.scss
+++ b/packages/block-editor/src/components/url-popover/style.scss
@@ -2,11 +2,13 @@
 	border-top: $border-width solid $gray-300;
 }
 
-.block-editor-url-popover__additional-controls > div[role="menu"] .components-button:not(:disabled):not([aria-disabled="true"]):not(.is-secondary) > svg {
+.block-editor-url-popover__additional-controls > div[role="menu"]
+.components-button:not(:disabled):not([aria-disabled="true"]):not(.is-secondary) > svg {
 	box-shadow: none;
 }
 
-.block-editor-url-popover__additional-controls div[role="menu"] > .components-button {
+.block-editor-url-popover__additional-controls
+div[role="menu"] > .components-button {
 	padding-left: $grid-unit-15;
 }
 
@@ -52,12 +54,6 @@
 		transform: rotate(180deg);
 	}
 }
-.block-editor-url-popover__input-container {
-	.components-base-control:last-child,
-	.components-base-control:last-child .components-base-control__field {
-		margin-bottom: 0;
-	}
-}
 
 .block-editor-url-popover__settings {
 	display: block;
@@ -68,10 +64,6 @@
 .block-editor-url-popover__link-editor,
 .block-editor-url-popover__link-viewer {
 	display: flex;
-
-	.block-editor-url-input .components-base-control__field {
-		margin-bottom: 0;
-	}
 }
 
 .block-editor-url-popover__link-viewer-url {

--- a/packages/block-editor/src/components/url-popover/style.scss
+++ b/packages/block-editor/src/components/url-popover/style.scss
@@ -2,13 +2,11 @@
 	border-top: $border-width solid $gray-300;
 }
 
-.block-editor-url-popover__additional-controls > div[role="menu"]
-.components-button:not(:disabled):not([aria-disabled="true"]):not(.is-secondary) > svg {
+.block-editor-url-popover__additional-controls > div[role="menu"] .components-button:not(:disabled):not([aria-disabled="true"]):not(.is-secondary) > svg {
 	box-shadow: none;
 }
 
-.block-editor-url-popover__additional-controls
-div[role="menu"] > .components-button {
+.block-editor-url-popover__additional-controls div[role="menu"] > .components-button {
 	padding-left: $grid-unit-15;
 }
 

--- a/packages/block-library/src/post-comment/edit.js
+++ b/packages/block-library/src/post-comment/edit.js
@@ -43,6 +43,7 @@ export default function Edit( { attributes: { commentId }, setAttributes } ) {
 					) }
 				>
 					<TextControl
+						__nextHasNoMarginBottom
 						value={ commentId }
 						onChange={ ( val ) =>
 							setCommentIdInput( parseInt( val ) )

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -102,6 +102,7 @@ const SocialLinkEdit = ( {
 				>
 					<PanelRow>
 						<TextControl
+							__nextHasNoMarginBottom
 							label={ __( 'Link label' ) }
 							help={ __(
 								'Briefly describe the link to help screen reader users.'
@@ -116,6 +117,7 @@ const SocialLinkEdit = ( {
 			</InspectorControls>
 			<InspectorControls __experimentalGroup="advanced">
 				<TextControl
+					__nextHasNoMarginBottom
 					label={ __( 'Link rel' ) }
 					value={ rel || '' }
 					onChange={ ( value ) => setAttributes( { rel: value } ) }

--- a/packages/block-library/src/template-part/edit/title-modal.js
+++ b/packages/block-library/src/template-part/edit/title-modal.js
@@ -5,10 +5,10 @@ import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	TextControl,
-	Flex,
-	FlexItem,
 	Button,
 	Modal,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 
 export default function TitleModal( { areaLabel, onClose, onSubmit } ) {
@@ -33,16 +33,14 @@ export default function TitleModal( { areaLabel, onClose, onSubmit } ) {
 			onRequestClose={ onClose }
 		>
 			<form onSubmit={ submitForCreation }>
-				<TextControl
-					label={ __( 'Name' ) }
-					value={ title }
-					onChange={ setTitle }
-				/>
-				<Flex
-					className="wp-block-template-part__placeholder-create-new__title-form-actions"
-					justify="flex-end"
-				>
-					<FlexItem>
+				<VStack spacing="5">
+					<TextControl
+						__nextHasNoMarginBottom
+						label={ __( 'Name' ) }
+						value={ title }
+						onChange={ setTitle }
+					/>
+					<HStack justify="right">
 						<Button
 							variant="primary"
 							type="submit"
@@ -51,8 +49,8 @@ export default function TitleModal( { areaLabel, onClose, onSubmit } ) {
 						>
 							{ __( 'Create' ) }
 						</Button>
-					</FlexItem>
-				</Flex>
+					</HStack>
+				</VStack>
 			</form>
 		</Modal>
 	);

--- a/packages/block-library/src/video/editor.scss
+++ b/packages/block-library/src/video/editor.scss
@@ -71,21 +71,7 @@
 }
 
 .block-library-video-tracks-editor__track-list-track {
-	display: flex;
-	place-content: space-between;
-	align-items: baseline;
 	padding-left: $grid-unit-15;
-}
-
-.block-library-video-tracks-editor__single-track-editor-label-language {
-	display: flex;
-	margin-top: $grid-unit-15;
-	& > .components-base-control {
-		width: 50%;
-	}
-	& > .components-base-control:first-child {
-		margin-right: $grid-unit-20;
-	}
 }
 
 .block-library-video-tracks-editor__single-track-editor-kind-select {
@@ -93,14 +79,11 @@
 }
 
 .block-library-video-tracks-editor__single-track-editor-buttons-container {
-	display: flex;
-	place-content: space-between;
-	margin-top: $grid-unit-40;
+	margin-top: $grid-unit-20;
 }
 
 .block-library-video-tracks-editor__single-track-editor-edit-track-label {
 	margin-top: $grid-unit-05;
-	margin-bottom: $grid-unit-15;
 	color: $gray-700;
 	text-transform: uppercase;
 	font-size: 11px;
@@ -126,17 +109,7 @@
 	padding: $grid-unit-15;
 }
 
-.block-library-video-tracks-editor__single-track-editor .components-base-control {
-	.components-base-control__label {
-		margin-bottom: $grid-unit-05;
-	}
-	.components-base-control__field {
-		margin-bottom: $grid-unit-15;
-	}
-	.components-text-control__input {
-		margin-left: 0;
-	}
-	.components-input-control__label {
-		margin-bottom: $grid-unit-05;
-	}
+.block-library-video-tracks-editor__single-track-editor-track-title,
+.block-library-video-tracks-editor__single-track-editor-source-language {
+	flex: 1;
 }

--- a/packages/block-library/src/video/editor.scss
+++ b/packages/block-library/src/video/editor.scss
@@ -78,10 +78,6 @@
 	max-width: 240px;
 }
 
-.block-library-video-tracks-editor__single-track-editor-buttons-container {
-	margin-top: $grid-unit-20;
-}
-
 .block-library-video-tracks-editor__single-track-editor-edit-track-label {
 	margin-top: $grid-unit-05;
 	color: $gray-700;
@@ -109,7 +105,3 @@
 	padding: $grid-unit-15;
 }
 
-.block-library-video-tracks-editor__single-track-editor-track-title,
-.block-library-video-tracks-editor__single-track-editor-source-language {
-	flex: 1;
-}

--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -13,6 +13,7 @@ import {
 	Button,
 	TextControl,
 	SelectControl,
+	__experimentalGrid as Grid,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
@@ -88,7 +89,7 @@ function SingleTrackEditor( { track, onChange, onClose, onRemove } ) {
 		<NavigableMenu>
 			<VStack
 				className="block-library-video-tracks-editor__single-track-editor"
-				spacing="3"
+				spacing="4"
 			>
 				<span className="block-library-video-tracks-editor__single-track-editor-edit-track-label">
 					{ __( 'Edit track' ) }
@@ -96,10 +97,9 @@ function SingleTrackEditor( { track, onChange, onClose, onRemove } ) {
 				<span>
 					{ __( 'File' ) }: <b>{ fileName }</b>
 				</span>
-				<HStack spacing="4">
+				<Grid columns={ 2 } gap={ 4 }>
 					<TextControl
 						__nextHasNoMarginBottom
-						className="block-library-video-tracks-editor__single-track-editor-track-title"
 						/* eslint-disable jsx-a11y/no-autofocus */
 						autoFocus
 						/* eslint-enable jsx-a11y/no-autofocus */
@@ -115,7 +115,6 @@ function SingleTrackEditor( { track, onChange, onClose, onRemove } ) {
 					/>
 					<TextControl
 						__nextHasNoMarginBottom
-						className="block-library-video-tracks-editor__single-track-editor-source-language"
 						onChange={ ( newSrcLang ) =>
 							onChange( {
 								...track,
@@ -126,7 +125,7 @@ function SingleTrackEditor( { track, onChange, onClose, onRemove } ) {
 						value={ srcLang }
 						help={ __( 'Language tag (en, fr, etc.)' ) }
 					/>
-				</HStack>
+				</Grid>
 				<SelectControl
 					__nextHasNoMarginBottom
 					className="block-library-video-tracks-editor__single-track-editor-kind-select"

--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -13,6 +13,8 @@ import {
 	Button,
 	TextControl,
 	SelectControl,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import {
 	MediaUpload,
@@ -49,7 +51,7 @@ function TrackList( { tracks, onEditPress } ) {
 	} else {
 		content = tracks.map( ( track, index ) => {
 			return (
-				<div
+				<HStack
 					key={ index }
 					className="block-library-video-tracks-editor__track-list-track"
 				>
@@ -65,7 +67,7 @@ function TrackList( { tracks, onEditPress } ) {
 					>
 						{ __( 'Edit' ) }
 					</Button>
-				</div>
+				</HStack>
 			);
 		} );
 	}
@@ -84,15 +86,20 @@ function SingleTrackEditor( { track, onChange, onClose, onRemove } ) {
 	const fileName = src.startsWith( 'blob:' ) ? '' : getFilename( src ) || '';
 	return (
 		<NavigableMenu>
-			<div className="block-library-video-tracks-editor__single-track-editor">
+			<VStack
+				className="block-library-video-tracks-editor__single-track-editor"
+				spacing="3"
+			>
 				<span className="block-library-video-tracks-editor__single-track-editor-edit-track-label">
 					{ __( 'Edit track' ) }
 				</span>
 				<span>
 					{ __( 'File' ) }: <b>{ fileName }</b>
 				</span>
-				<div className="block-library-video-tracks-editor__single-track-editor-label-language">
+				<HStack spacing="4">
 					<TextControl
+						__nextHasNoMarginBottom
+						className="block-library-video-tracks-editor__single-track-editor-track-title"
 						/* eslint-disable jsx-a11y/no-autofocus */
 						autoFocus
 						/* eslint-enable jsx-a11y/no-autofocus */
@@ -107,6 +114,8 @@ function SingleTrackEditor( { track, onChange, onClose, onRemove } ) {
 						help={ __( 'Title of track' ) }
 					/>
 					<TextControl
+						__nextHasNoMarginBottom
+						className="block-library-video-tracks-editor__single-track-editor-source-language"
 						onChange={ ( newSrcLang ) =>
 							onChange( {
 								...track,
@@ -117,7 +126,7 @@ function SingleTrackEditor( { track, onChange, onClose, onRemove } ) {
 						value={ srcLang }
 						help={ __( 'Language tag (en, fr, etc.)' ) }
 					/>
-				</div>
+				</HStack>
 				<SelectControl
 					__nextHasNoMarginBottom
 					className="block-library-video-tracks-editor__single-track-editor-kind-select"
@@ -131,7 +140,7 @@ function SingleTrackEditor( { track, onChange, onClose, onRemove } ) {
 						} );
 					} }
 				/>
-				<div className="block-library-video-tracks-editor__single-track-editor-buttons-container">
+				<HStack className="block-library-video-tracks-editor__single-track-editor-buttons-container">
 					<Button
 						variant="secondary"
 						onClick={ () => {
@@ -163,8 +172,8 @@ function SingleTrackEditor( { track, onChange, onClose, onRemove } ) {
 					<Button isDestructive variant="link" onClick={ onRemove }>
 						{ __( 'Remove track' ) }
 					</Button>
-				</div>
-			</div>
+				</HStack>
+			</VStack>
 		</NavigableMenu>
 	);
 }

--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -126,52 +126,58 @@ function SingleTrackEditor( { track, onChange, onClose, onRemove } ) {
 						help={ __( 'Language tag (en, fr, etc.)' ) }
 					/>
 				</Grid>
-				<SelectControl
-					__nextHasNoMarginBottom
-					className="block-library-video-tracks-editor__single-track-editor-kind-select"
-					options={ KIND_OPTIONS }
-					value={ kind }
-					label={ __( 'Kind' ) }
-					onChange={ ( newKind ) => {
-						onChange( {
-							...track,
-							kind: newKind,
-						} );
-					} }
-				/>
-				<HStack className="block-library-video-tracks-editor__single-track-editor-buttons-container">
-					<Button
-						variant="secondary"
-						onClick={ () => {
-							const changes = {};
-							let hasChanges = false;
-							if ( label === '' ) {
-								changes.label = __( 'English' );
-								hasChanges = true;
-							}
-							if ( srcLang === '' ) {
-								changes.srcLang = 'en';
-								hasChanges = true;
-							}
-							if ( track.kind === undefined ) {
-								changes.kind = DEFAULT_KIND;
-								hasChanges = true;
-							}
-							if ( hasChanges ) {
-								onChange( {
-									...track,
-									...changes,
-								} );
-							}
-							onClose();
+				<VStack spacing="8">
+					<SelectControl
+						__nextHasNoMarginBottom
+						className="block-library-video-tracks-editor__single-track-editor-kind-select"
+						options={ KIND_OPTIONS }
+						value={ kind }
+						label={ __( 'Kind' ) }
+						onChange={ ( newKind ) => {
+							onChange( {
+								...track,
+								kind: newKind,
+							} );
 						} }
-					>
-						{ __( 'Close' ) }
-					</Button>
-					<Button isDestructive variant="link" onClick={ onRemove }>
-						{ __( 'Remove track' ) }
-					</Button>
-				</HStack>
+					/>
+					<HStack className="block-library-video-tracks-editor__single-track-editor-buttons-container">
+						<Button
+							variant="secondary"
+							onClick={ () => {
+								const changes = {};
+								let hasChanges = false;
+								if ( label === '' ) {
+									changes.label = __( 'English' );
+									hasChanges = true;
+								}
+								if ( srcLang === '' ) {
+									changes.srcLang = 'en';
+									hasChanges = true;
+								}
+								if ( track.kind === undefined ) {
+									changes.kind = DEFAULT_KIND;
+									hasChanges = true;
+								}
+								if ( hasChanges ) {
+									onChange( {
+										...track,
+										...changes,
+									} );
+								}
+								onClose();
+							} }
+						>
+							{ __( 'Close' ) }
+						</Button>
+						<Button
+							isDestructive
+							variant="link"
+							onClick={ onRemove }
+						>
+							{ __( 'Remove track' ) }
+						</Button>
+					</HStack>
+				</VStack>
 			</VStack>
 		</NavigableMenu>
 	);

--- a/packages/components/src/placeholder/stories/index.tsx
+++ b/packages/components/src/placeholder/stories/index.tsx
@@ -44,6 +44,7 @@ const Template: ComponentStory< typeof Placeholder > = ( args ) => {
 		<Placeholder { ...args }>
 			<div>
 				<TextControl
+					__nextHasNoMarginBottom
 					label="Sample Field"
 					placeholder="Enter something here"
 					value={ value }

--- a/packages/edit-site/src/components/create-template-part-modal/index.js
+++ b/packages/edit-site/src/components/create-template-part-modal/index.js
@@ -13,6 +13,7 @@ import {
 	Modal,
 	__experimentalRadioGroup as RadioGroup,
 	__experimentalRadio as Radio,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
@@ -54,76 +55,84 @@ export default function CreateTemplatePartModal( { closeModal, onCreate } ) {
 					await onCreate( { title, area } );
 				} }
 			>
-				<TextControl
-					label={ __( 'Name' ) }
-					value={ title }
-					onChange={ setTitle }
-					required
-				/>
-				<BaseControl
-					label={ __( 'Area' ) }
-					id={ `edit-site-create-template-part-modal__area-selection-${ instanceId }` }
-					className="edit-site-create-template-part-modal__area-base-control"
-				>
-					<RadioGroup
+				<VStack spacing="4">
+					<TextControl
+						__nextHasNoMarginBottom
+						label={ __( 'Name' ) }
+						value={ title }
+						onChange={ setTitle }
+						required
+					/>
+					<BaseControl
 						label={ __( 'Area' ) }
-						className="edit-site-create-template-part-modal__area-radio-group"
 						id={ `edit-site-create-template-part-modal__area-selection-${ instanceId }` }
-						onChange={ setArea }
-						checked={ area }
+						className="edit-site-create-template-part-modal__area-base-control"
 					>
-						{ templatePartAreas.map(
-							( { icon, label, area: value, description } ) => (
-								<Radio
-									key={ label }
-									value={ value }
-									className="edit-site-create-template-part-modal__area-radio"
-								>
-									<Flex align="start" justify="start">
-										<FlexItem>
-											<Icon icon={ icon } />
-										</FlexItem>
-										<FlexBlock className="edit-site-create-template-part-modal__option-label">
-											{ label }
-											<div>{ description }</div>
-										</FlexBlock>
+						<RadioGroup
+							label={ __( 'Area' ) }
+							className="edit-site-create-template-part-modal__area-radio-group"
+							id={ `edit-site-create-template-part-modal__area-selection-${ instanceId }` }
+							onChange={ setArea }
+							checked={ area }
+						>
+							{ templatePartAreas.map(
+								( {
+									icon,
+									label,
+									area: value,
+									description,
+								} ) => (
+									<Radio
+										key={ label }
+										value={ value }
+										className="edit-site-create-template-part-modal__area-radio"
+									>
+										<Flex align="start" justify="start">
+											<FlexItem>
+												<Icon icon={ icon } />
+											</FlexItem>
+											<FlexBlock className="edit-site-create-template-part-modal__option-label">
+												{ label }
+												<div>{ description }</div>
+											</FlexBlock>
 
-										<FlexItem className="edit-site-create-template-part-modal__checkbox">
-											{ area === value && (
-												<Icon icon={ check } />
-											) }
-										</FlexItem>
-									</Flex>
-								</Radio>
-							)
-						) }
-					</RadioGroup>
-				</BaseControl>
-				<Flex
-					className="edit-site-create-template-part-modal__modal-actions"
-					justify="flex-end"
-				>
-					<FlexItem>
-						<Button
-							variant="secondary"
-							onClick={ () => {
-								closeModal();
-							} }
-						>
-							{ __( 'Cancel' ) }
-						</Button>
-					</FlexItem>
-					<FlexItem>
-						<Button
-							variant="primary"
-							type="submit"
-							disabled={ ! title }
-							isBusy={ isSubmitting }
-						>
-							{ __( 'Create' ) }
-						</Button>
-					</FlexItem>
-				</Flex>
+											<FlexItem className="edit-site-create-template-part-modal__checkbox">
+												{ area === value && (
+													<Icon icon={ check } />
+												) }
+											</FlexItem>
+										</Flex>
+									</Radio>
+								)
+							) }
+						</RadioGroup>
+					</BaseControl>
+					<Flex
+						className="edit-site-create-template-part-modal__modal-actions"
+						justify="flex-end"
+					>
+						<FlexItem>
+							<Button
+								variant="secondary"
+								onClick={ () => {
+									closeModal();
+								} }
+							>
+								{ __( 'Cancel' ) }
+							</Button>
+						</FlexItem>
+						<FlexItem>
+							<Button
+								variant="primary"
+								type="submit"
+								disabled={ ! title }
+								isBusy={ isSubmitting }
+							>
+								{ __( 'Create' ) }
+							</Button>
+						</FlexItem>
+					</Flex>
+				</VStack>
 			</form>
 		</Modal>
 	);

--- a/packages/edit-site/src/components/create-template-part-modal/style.scss
+++ b/packages/edit-site/src/components/create-template-part-modal/style.scss
@@ -8,16 +8,6 @@
 	}
 }
 
-
-.edit-site-create-template-part-modal__modal-actions {
-	padding-top: $grid-unit-15;
-}
-
-.edit-site-create-template-part-modal__area-base-control .components-base-control__label {
-	margin: $grid-unit-20 0 $grid-unit-10;
-	cursor: auto;
-}
-
 .edit-site-create-template-part-modal__area-radio-group {
 	width: 100%;
 	border: $border-width solid $gray-700;

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -14,6 +14,7 @@ import {
 	TextControl,
 	TreeSelect,
 	withFilters,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useDebounce } from '@wordpress/compose';
@@ -415,6 +416,7 @@ export function HierarchicalTermSelector( { slug } ) {
 		<>
 			{ showFilter && (
 				<TextControl
+					__nextHasNoMarginBottom
 					className="editor-post-taxonomies__hierarchical-terms-filter"
 					label={ filterLabel }
 					value={ filterValue }
@@ -443,22 +445,25 @@ export function HierarchicalTermSelector( { slug } ) {
 			) }
 			{ showForm && (
 				<form onSubmit={ onAddTerm }>
-					<TextControl
-						className="editor-post-taxonomies__hierarchical-terms-input"
-						label={ newTermLabel }
-						value={ formName }
-						onChange={ onChangeFormName }
-						required
-					/>
-					{ !! availableTerms.length && (
-						<TreeSelect
-							label={ parentSelectLabel }
-							noOptionLabel={ noParentOption }
-							onChange={ onChangeFormParent }
-							selectedId={ formParent }
-							tree={ availableTermsTree }
+					<VStack>
+						<TextControl
+							__nextHasNoMarginBottom
+							className="editor-post-taxonomies__hierarchical-terms-input"
+							label={ newTermLabel }
+							value={ formName }
+							onChange={ onChangeFormName }
+							required
 						/>
-					) }
+						{ !! availableTerms.length && (
+							<TreeSelect
+								label={ parentSelectLabel }
+								noOptionLabel={ noParentOption }
+								onChange={ onChangeFormParent }
+								selectedId={ formParent }
+								tree={ availableTermsTree }
+							/>
+						) }
+					</VStack>
 					<Button
 						variant="secondary"
 						type="submit"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Part 2/2

## What?

<!-- In a few words, what is the PR actually doing? -->

Added new opt-in prop `__nextHasNoMarginBottom` for usages of `TextControl` in the Gutenberg codebase and removed margin overrides. 

This is part of https://github.com/WordPress/gutenberg/pull/47157 but was separated due to small visual changes to each of the blocks/components in this PR. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

These changes will result in less CSS used in favour of components. 

Part of this project: https://github.com/WordPress/gutenberg/issues/38730
The tl;dr is `BaseControl` has a `margin-bottom` which makes it difficult to reuse and results in inconsistent use. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By removing margin overrides in the CSS and adding the prop `__nextHasNoMarginBottom`. As well as adding `VStack` and `HStack` (and sometimes replacing `Flex` with those) to remove additional CSS.

## Additional Notes 

`packages/block-library/src/post-comment/edit.js` has been deprecated. I looked at it in the editor, and it looks a bit broken as it is: 

<img width="356" alt="Screenshot 2023-01-11 at 12 16 16 PM" src="https://user-images.githubusercontent.com/35543432/212459378-fe6753e0-f4c6-4b63-8256-7a1dd7286b64.png">

Adding the prop won't affect it by much, it shifts slightly down a pixel (similar to the legacy widget in t[he SelectControl PR](https://github.com/WordPress/gutenberg/pull/46448/files), which we updated without adding additional overrides), so I added it here to be consistent. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

**Rather than verifying if the changes look the same as trunk, we'll need to make sure that these minor visual changes are okay or if we need to add CSS overrides to match perfectly to trunk.** 

#### Block Editor testing steps:

- <h3 id="HierarchicalTermSelector">HierarchicalTermSelector</h2>

	1. Edit post
	2. Look for 'Categories' in block inspector
	3. Change line 40 to a lower number if you don't have more than 8 categories on your test site: https://github.com/WordPress/gutenberg/blob/f7052d3e1e3e69f3b09b412c071c6c1eac69836f/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js#L40
	4. Ensure the space below the text input for 'Search categories' looks the same as before 
	5. Click on 'Add New Category' 
	6. Ensure space below the text input for 'New category name' looks the same as before 
	<br /><img width="287" alt="Screenshot 2023-01-10 at 7 21 11 PM" src="https://user-images.githubusercontent.com/35543432/212442560-db07890b-7be4-42ce-b1e9-7cbbc2de79e5.png">

- ### NonDefaultControls (DateFormatPicker)

	1. Add a Post Date block
	2. Toggle off 'default format' in the block inspector
	3. Choose 'Custom' format from the dropdown
	5. Verify spacing 

	| <br /> Before  | <br />After |
	| --- | --- |
	| <img width="281" alt="Screenshot 2023-01-13 at 10 54 57 PM" src="https://user-images.githubusercontent.com/35543432/212460050-1373200d-ee6f-458b-b271-09fcb05786a1.png"> | <img width="288" alt="Screenshot 2023-01-13 at 10 55 02 PM" src="https://user-images.githubusercontent.com/35543432/212460051-f5cc7dbf-bcbd-45d4-bff5-34bc1428e96f.png"> |

- ### ImageURLInputUI

	1. Add an Image block and upload/add an image 
	2. Click on the Image block toolbar to add a URL
	3. Click on the downward-facing arrow to view additional options
	4. Verify spacing 

	| <br /> Before  | <br />After |
	| --- | --- |
	| <img width="480" alt="Screenshot 2023-01-13 at 11 03 57 PM" src="https://user-images.githubusercontent.com/35543432/212460420-05adc84e-b078-4d30-b315-ebc977585dd9.png"> | <img width="476" alt="Screenshot 2023-01-13 at 11 04 07 PM" src="https://user-images.githubusercontent.com/35543432/212460422-b57d5cf4-4d93-432f-813e-2722af991de9.png"> |

- ### SingleTrackEditor

	1. Add a Video block and upload/add video
	2. Click on 'Text tracks' in the toolbar
	3. Add or upload a .vtt text file (I used [a sample I found here](https://gist.github.com/samdutton/ca37f3adaf4e23679957b8083e061177))
	4. Verify spacing 
	
	| <br /> Before  | <br />After |
	| --- | --- |
	| <img width="378" alt="Screenshot 2023-01-13 at 11 26 12 PM" src="https://user-images.githubusercontent.com/35543432/212461855-278101c4-9dac-49cd-98c0-f59d6005e901.png"> | <img width="377" alt="Screenshot 2023-01-13 at 11 26 18 PM" src="https://user-images.githubusercontent.com/35543432/212461848-a216199a-be93-4aa8-90b3-4fa6997e1cf0.png"> |

- ### SocialLinkEdit

	1. Add a Social Icons block to the editor
	2. Add any icon
	3. Look for 'Link label' in block inspector and see that there is a bit less space below, but it's more even
	4. Look for 'Link Rel' under 'Advanced'
	6. Ensure space below 'Link Rel' looks the same as trunk

	| <br /> Before  | <br />After |
	| --- | --- |
	| <img width="287" alt="Screenshot 2023-01-11 at 10 37 06 PM" src="https://user-images.githubusercontent.com/35543432/212459885-1144fba2-2ae1-4e41-b449-803e2c8cc5ce.png"> | <img width="285" alt="Screenshot 2023-01-11 at 10 37 11 PM" src="https://user-images.githubusercontent.com/35543432/212459887-ef18ce9e-3e78-4dc4-a478-6e9a92b8c953.png"> |

<hr />

#### Site Editor testing steps:

- ### CreateTemplatePartModal

	1. Open site editor
	2. Click on template parts
	3. Click plus icon to create a new template part
	4. Verify spacing 

	| <br /> Before  | <br />After |
	| --- | --- |
	| <img width="510" alt="Screenshot 2023-01-13 at 11 06 48 PM" src="https://user-images.githubusercontent.com/35543432/212460531-7efe7195-8824-4a2c-bebf-20e7be05988e.png"> | <img width="514" alt="Screenshot 2023-01-13 at 11 08 10 PM" src="https://user-images.githubusercontent.com/35543432/212460532-b9752f9d-f6a8-41a9-9b55-63225723803e.png"> |

- ### TitleModal

	1. Edit a template in the site editor
	2. Add a Template Part block 
	3. Choose start blank
	4. Verify spacing 

	| <br /> Before  | <br />After |
	| --- | --- |
	| <img width="373" alt="Screenshot 2023-01-13 at 11 10 46 PM" src="https://user-images.githubusercontent.com/35543432/212460621-4cdba801-8bcc-4787-9d95-96d30566b029.png"> | <img width="370" alt="Screenshot 2023-01-13 at 11 09 40 PM" src="https://user-images.githubusercontent.com/35543432/212460579-08962752-25db-47cb-8b85-0c0d82562868.png"> |

<hr />

#### Storybook testing steps: 

- ### Placeholder

	1. `npm run storybook:dev`
	2. Open Placeholder component 
	3. Verify spacing 

	| <br /> Before  | <br />After |
	| --- | --- |
	| <img width="400" alt="Screenshot 2023-01-13 at 11 13 51 PM" src="https://user-images.githubusercontent.com/35543432/212460917-399e80dc-66b6-4178-966f-4dec5fb7a9c0.png"> | <img width="400" alt="Screenshot 2023-01-13 at 11 14 12 PM" src="https://user-images.githubusercontent.com/35543432/212460913-bd244133-4ad4-40c1-b992-fb948e8eb30c.png"> |

<br />