### PR TITLE
Migrate from TextControl to InputControl to remove margin overrides

### DIFF
--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -12,9 +12,10 @@ import {
 	PanelBody,
 	Placeholder,
 	RangeControl,
-	TextControl,
 	ToggleControl,
 	ToolbarGroup,
+	__experimentalHStack as HStack,
+	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { grid, list, edit, rss } from '@wordpress/icons';
@@ -66,17 +67,20 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 						onSubmit={ onSubmitURL }
 						className="wp-block-rss__placeholder-form"
 					>
-						<TextControl
-							placeholder={ __( 'Enter URL here…' ) }
-							value={ feedURL }
-							onChange={ ( value ) =>
-								setAttributes( { feedURL: value } )
-							}
-							className="wp-block-rss__placeholder-input"
-						/>
-						<Button variant="primary" type="submit">
-							{ __( 'Use URL' ) }
-						</Button>
+						<HStack align="baseline">
+							<InputControl
+								__next36pxDefaultSize
+								placeholder={ __( 'Enter URL here…' ) }
+								value={ feedURL }
+								onChange={ ( value ) =>
+									setAttributes( { feedURL: value } )
+								}
+								className="wp-block-rss__placeholder-input"
+							/>
+							<Button variant="primary" type="submit">
+								{ __( 'Use URL' ) }
+							</Button>
+						</HStack>
 					</form>
 				</Placeholder>
 			</div>

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -67,7 +67,7 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 						onSubmit={ onSubmitURL }
 						className="wp-block-rss__placeholder-form"
 					>
-						<HStack align="baseline">
+						<HStack wrap>
 							<InputControl
 								__next36pxDefaultSize
 								placeholder={ __( 'Enter URL here…' ) }

--- a/packages/block-library/src/rss/editor.scss
+++ b/packages/block-library/src/rss/editor.scss
@@ -3,9 +3,6 @@
 }
 
 .wp-block-rss__placeholder-form {
-	display: flex;
-	align-items: stretch;
-
 	> * {
 		margin-bottom: $grid-unit-10;
 	}
@@ -18,15 +15,5 @@
 }
 
 .wp-block-rss__placeholder-input {
-	display: flex;
-	align-items: stretch;
-	flex-grow: 1;
-
-	.components-base-control__field {
-		margin: 0;
-		display: flex;
-		align-items: stretch;
-		flex-grow: 1;
-		margin-right: $grid-unit-10;
-	}
+	flex: 1;
 }

--- a/packages/block-library/src/rss/editor.scss
+++ b/packages/block-library/src/rss/editor.scss
@@ -12,8 +12,10 @@
 			margin-bottom: 0;
 		}
 	}
+
+	.wp-block-rss__placeholder-input {
+		flex: 1;
+		min-width: 80%;
+	}
 }
 
-.wp-block-rss__placeholder-input {
-	flex: 1;
-}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

Updated `TextControl` to `InputControl` component for RSS block. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While working on [this project](https://github.com/WordPress/gutenberg/issues/38730) to remove margin overrides, I found that moving this to InputControl required less CSS. It is also the plan to replace TextControl with InputControl per [the storybook docs](https://wordpress.github.io/gutenberg/?path=/docs/components-experimental-inputcontrol--default).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding InputControl and HStack to remove CSS overrides. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Add RSS block to the editor
2. Verify Spacing 
3. Ensure it works the same as before 

| Before | After |
| --- | --- |
| <img width="660" alt="Screenshot 2023-01-14 at 12 38 48 AM" src="https://user-images.githubusercontent.com/35543432/212464095-c14340bd-7d8b-4464-a1ee-392cbfd99141.png"> | <img width="662" alt="Screenshot 2023-01-14 at 12 39 36 AM" src="https://user-images.githubusercontent.com/35543432/212464097-3b41214e-f329-4ba6-a820-05136d42cee7.png"> |

## Additional Notes

Before the changes, if the screen size was smaller, the input wouldn't match the button size (fixed in this PR): 

<img width="652" alt="Screenshot 2023-01-14 at 12 38 57 AM" src="https://user-images.githubusercontent.com/35543432/212464102-3dddbc1f-99e8-4ed2-9ee4-9da34d24473c.png">

However, the button would also move below the input on smaller screen sizes. Should it be below like in trunk?

| Before | After |
| --- | --- |
| <img width="421" alt="Screenshot 2023-01-14 at 12 40 20 AM" src="https://user-images.githubusercontent.com/35543432/212464186-43d4cde4-6b49-41b6-85a6-5b8f82925e4f.png"> | <img width="418" alt="Screenshot 2023-01-14 at 12 40 26 AM" src="https://user-images.githubusercontent.com/35543432/212464189-9e079338-5e01-4ebb-b23a-773a1851dd16.png"> |

<br />