### PR TITLE
Fix HStack docs to show code sample

### DIFF
--- a/packages/components/src/h-stack/component.tsx
+++ b/packages/components/src/h-stack/component.tsx
@@ -20,7 +20,6 @@ function UnconnectedHStack(
  *
  * `HStack` can render anything inside.
  *
- * @example
  * ```jsx
  * import {
  * 	__experimentalHStack as HStack,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
The docs for HStack are inconsistent between VStack and ZStack as the sample code isn't showing. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To make it consistent with other docs. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By removing `@example` as discussed with @mirka 

## Testing Instructions

1. `npm run storybook:dev`
2. Go to HStack docs
3. Ensure sample code shows

**Before:** 

<img width="1052" alt="Screenshot 2023-01-11 at 3 34 04 PM" src="https://user-images.githubusercontent.com/35543432/212464428-997ab220-a554-4eb9-8033-82d9b2069a55.png">

**After:** 

<img width="1051" alt="Screenshot 2023-01-11 at 3 33 40 PM" src="https://user-images.githubusercontent.com/35543432/212464427-f3323111-60dd-4374-999a-6badec95044d.png">


