### PR TITLE
Block Inserter: Correctly apply style to the default inserter

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `BlockInspector`: Fix browser warning error when block is not selected ([#46875](https://github.com/WordPress/gutenberg/pull/46875)).
 -   Move component styles needed for iframes to content styles ([#47103](https://github.com/WordPress/gutenberg/pull/47103)).
+-   Block Inserter: Correctly apply style to the default inserter ([#47166](https://github.com/WordPress/gutenberg/pull/47166)).
 
 ## 11.1.0 (2023-01-02)
 

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -59,7 +59,6 @@
 
 // Sibling inserter / "inbetweenserter".
 .block-editor-block-list__empty-block-inserter,
-.block-editor-default-block-appender,
 .block-editor-block-list__insertion-point-inserter {
 	.block-editor-inserter__toggle.components-button.has-icon {
 		// Basic look

--- a/packages/block-editor/src/components/default-block-appender/content.scss
+++ b/packages/block-editor/src/components/default-block-appender/content.scss
@@ -30,6 +30,23 @@
 	.components-drop-zone__content-icon {
 		display: none;
 	}
+
+	.block-editor-inserter__toggle.components-button.has-icon {
+		// Basic look
+		background: $gray-900;
+		border-radius: $radius-block-ui;
+		color: $white;
+		padding: 0;
+
+		// Special dimensions for this button.
+		min-width: $button-size-small;
+		height: $button-size-small;
+
+		&:hover {
+			color: $white;
+			background: var(--wp-admin-theme-color);
+		}
+	}
 }
 
 // The black plus that shows up on the right side of an empty paragraph block, or the initial appender
@@ -78,6 +95,7 @@
 		box-shadow: none;
 		height: $button-size-small;
 		width: $button-size-small;
+		min-width: $button-size-small;
 
 		// Hide by default, then we unhide it when the selected block is a direct ancestor.
 		display: none;


### PR DESCRIPTION
Related:

- #44298
- #47103
- #47110

## What?
This PR fixes two problems with the default block inserter style not being applied in the block theme and site editor.

1.Nested block inserter is not square:

![nested-inserter-block-theme](https://user-images.githubusercontent.com/54422211/212522944-4d9e8664-ae66-4c0c-88ce-6b338f6ab9f3.png)

2. Style is not applied to the root inserter:

![root-inserter-block-theme](https://user-images.githubusercontent.com/54422211/212522949-8bd4bc72-569b-4a0b-ac80-a3f04e5d1f56.png)

## Why?
In #44298, the styles loaded into the iframe editor instance were separated. The default inserter (`.block-editor-default-block-appender`) is loaded in the iframe, so it must be defined in `content.css`, not `style.css`.

The Classic theme does not have this problem because the iframe editor is not used and both stylesheets are loaded:

![nested-inserter-classic-theme](https://user-images.githubusercontent.com/54422211/212522886-ef3771ee-6c94-49f7-999a-67363d35af41.png)

![root-inserter-classic-theme](https://user-images.githubusercontent.com/54422211/212522904-8b52820a-3b2e-4745-8c38-8d176c725d70.png)

## How?
Moved styles related to default inserters from `style.css` to `content.css`.

## Testing Instructions

I think we need to check all the inserters below, both block and classic themes, just to be sure.

- Nest inserter displayed when group blocks, etc. are selected
- Root inserter when no block is selected
- Inserter displayed on the right side of an empty paragraph block
- Inserter displayed when mouseover between blocks