### PR TITLE
Spacing visualizer: Fixed problem with style not being applied

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `BlockInspector`: Fix browser warning error when block is not selected ([#46875](https://github.com/WordPress/gutenberg/pull/46875)).
 -   Move component styles needed for iframes to content styles ([#47103](https://github.com/WordPress/gutenberg/pull/47103)).
+-   Spacing visualizer: Fixed problem with style not being applied ([#47167](https://github.com/WordPress/gutenberg/pull/47167)).
 
 ## 11.1.0 (2023-01-02)
 

--- a/packages/block-editor/src/content.scss
+++ b/packages/block-editor/src/content.scss
@@ -12,3 +12,4 @@
 @import "./components/plain-text/content.scss";
 @import "./components/rich-text/content.scss";
 @import "./components/warning/content.scss";
+@import "./hooks/padding.scss";

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -51,7 +51,6 @@
 @import "./hooks/position.scss";
 @import "./hooks/typography.scss";
 @import "./hooks/color.scss";
-@import "./hooks/padding.scss";
 
 @import "./components/block-toolbar/style.scss";
 @import "./components/inserter/style.scss";


### PR DESCRIPTION
Related: ##44298

## What?
This PR fixes a problem with styles not being applied to the  `{Margin|Padding}Visualizer` when the Dimensions setting is changed.

https://user-images.githubusercontent.com/54422211/212525099-33507fb8-f119-48a8-9de9-17c223dd6195.mp4

## Why?
[This style is part of style.css](https://github.com/WordPress/gutenberg/blob/3d2a6d7eaa4509c4d89bde674e9b73743868db2c/packages/block-editor/src/style.scss#L54), but this stylesheet is not applied inside the iframe. Since this visualizer is rendered inside the iframe editor, the styles must be loaded in `content.css`, not `style.css`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
Confirm that the visualizer displays correctly when you mouse over the slider pointer or change slides.
