### PR TITLE
In-between inserter: Fix console error when moving mouse in Firefox

### DIFF
--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -43,6 +43,11 @@ export function useInBetweenInserter() {
 					return;
 				}
 
+				// Ignore text nodes sometimes detected in FireFox.
+				if ( event.target.nodeType === event.target.TEXT_NODE ) {
+					return;
+				}
+
 				if ( isMultiSelecting() ) {
 					return;
 				}


### PR DESCRIPTION
Fixes: #47165

## What?
This PR fixes console errors output when moving the mouse in FireFox.

## Why?
I was unable to find the root cause, but as [this video shows](https://github.com/WordPress/gutenberg/issues/47165#issuecomment-1383097678), I discovered that the mouse move event also detects text nodes. The text node does not have a `classList`, resulting in a console error.

## How?
Checking if the node type is a text node.

## Testing Instructions
- Open the site editor in FireFox.
- Enter edit mode for any of the templates.
- Move the mouse cursor to confirm that the browser console error does not appear.