### PR TITLE
Image Editor: merge context provider into editor component

### DIFF
--- a/packages/block-editor/src/components/image-editor/context.js
+++ b/packages/block-editor/src/components/image-editor/context.js
@@ -18,19 +18,15 @@ export default function ImageEditingProvider( {
 	url,
 	naturalWidth,
 	naturalHeight,
-	isEditing,
 	onFinishEditing,
 	onSaveImage,
 	children,
 } ) {
-	const transformImage = useTransformImage(
-		{
-			url,
-			naturalWidth,
-			naturalHeight,
-		},
-		isEditing
-	);
+	const transformImage = useTransformImage( {
+		url,
+		naturalWidth,
+		naturalHeight,
+	} );
 
 	const saveImage = useSaveImage( {
 		id,

--- a/packages/block-editor/src/components/image-editor/cropper.js
+++ b/packages/block-editor/src/components/image-editor/cropper.js
@@ -66,7 +66,9 @@ export default function ImageCropper( {
 				crop={ position }
 				zoom={ zoom / 100 }
 				aspect={ aspect }
-				onCropChange={ setPosition }
+				onCropChange={ ( pos ) => {
+					setPosition( pos );
+				} }
 				onCropComplete={ ( newCropPercent ) => {
 					setCrop( newCropPercent );
 				} }

--- a/packages/block-editor/src/components/image-editor/index.js
+++ b/packages/block-editor/src/components/image-editor/index.js
@@ -7,6 +7,7 @@ import { ToolbarGroup, ToolbarItem } from '@wordpress/components';
  * Internal dependencies
  */
 import BlockControls from '../block-controls';
+import ImageEditingProvider from './context';
 import Cropper from './cropper';
 import ZoomDropdown from './zoom-dropdown';
 import AspectRatioDropdown from './aspect-ratio-dropdown';
@@ -14,16 +15,26 @@ import RotationButton from './rotation-button';
 import FormControls from './form-controls';
 
 export default function ImageEditor( {
+	id,
 	url,
 	width,
 	height,
 	clientWidth,
 	naturalHeight,
 	naturalWidth,
+	onSaveImage,
+	onFinishEditing,
 	borderProps,
 } ) {
 	return (
-		<>
+		<ImageEditingProvider
+			id={ id }
+			url={ url }
+			naturalWidth={ naturalWidth }
+			naturalHeight={ naturalHeight }
+			onSaveImage={ onSaveImage }
+			onFinishEditing={ onFinishEditing }
+		>
 			<Cropper
 				borderProps={ borderProps }
 				url={ url }
@@ -47,8 +58,6 @@ export default function ImageEditor( {
 					<FormControls />
 				</ToolbarGroup>
 			</BlockControls>
-		</>
+		</ImageEditingProvider>
 	);
 }
-
-export { default as ImageEditingProvider } from './context';

--- a/packages/block-editor/src/components/image-editor/use-transform-image.js
+++ b/packages/block-editor/src/components/image-editor/use-transform-image.js
@@ -1,47 +1,35 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { useCallback, useMemo, useState } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 
-function useTransformState( { url, naturalWidth, naturalHeight } ) {
+export default function useTransformImage( {
+	url,
+	naturalWidth,
+	naturalHeight,
+} ) {
 	const [ editedUrl, setEditedUrl ] = useState();
 	const [ crop, setCrop ] = useState();
 	const [ position, setPosition ] = useState( { x: 0, y: 0 } );
-	const [ zoom, setZoom ] = useState();
-	const [ rotation, setRotation ] = useState();
-	const [ aspect, setAspect ] = useState();
-	const [ defaultAspect, setDefaultAspect ] = useState();
-
-	const initializeTransformValues = useCallback( () => {
-		setPosition( { x: 0, y: 0 } );
-		setZoom( 100 );
-		setRotation( 0 );
-		setAspect( naturalWidth / naturalHeight );
-		setDefaultAspect( naturalWidth / naturalHeight );
-	}, [
-		naturalWidth,
-		naturalHeight,
-		setPosition,
-		setZoom,
-		setRotation,
-		setAspect,
-		setDefaultAspect,
-	] );
+	const [ zoom, setZoom ] = useState( 100 );
+	const [ rotation, setRotation ] = useState( 0 );
+	const defaultAspect = naturalWidth / naturalHeight;
+	const [ aspect, setAspect ] = useState( defaultAspect );
 
 	const rotateClockwise = useCallback( () => {
 		const angle = ( rotation + 90 ) % 360;
 
-		let naturalAspectRatio = naturalWidth / naturalHeight;
+		let naturalAspectRatio = defaultAspect;
 
 		if ( rotation % 180 === 90 ) {
-			naturalAspectRatio = naturalHeight / naturalWidth;
+			naturalAspectRatio = 1 / defaultAspect;
 		}
 
 		if ( angle === 0 ) {
 			setEditedUrl();
 			setRotation( angle );
-			setAspect( naturalWidth / naturalHeight );
+			setAspect( defaultAspect );
 			setPosition( {
 				x: -( position.y * naturalAspectRatio ),
 				y: position.x * naturalAspectRatio,
@@ -100,15 +88,7 @@ function useTransformState( { url, naturalWidth, naturalHeight } ) {
 		if ( typeof imgCrossOrigin === 'string' ) {
 			el.crossOrigin = imgCrossOrigin;
 		}
-	}, [
-		rotation,
-		naturalWidth,
-		naturalHeight,
-		setEditedUrl,
-		setRotation,
-		setAspect,
-		setPosition,
-	] );
+	}, [ rotation, defaultAspect ] );
 
 	return useMemo(
 		() => ( {
@@ -126,37 +106,16 @@ function useTransformState( { url, naturalWidth, naturalHeight } ) {
 			aspect,
 			setAspect,
 			defaultAspect,
-			initializeTransformValues,
 		} ),
 		[
 			editedUrl,
-			setEditedUrl,
 			crop,
-			setCrop,
 			position,
-			setPosition,
 			zoom,
-			setZoom,
 			rotation,
-			setRotation,
 			rotateClockwise,
 			aspect,
-			setAspect,
 			defaultAspect,
-			initializeTransformValues,
 		]
 	);
-}
-
-export default function useTransformImage( imageProperties, isEditing ) {
-	const transformState = useTransformState( imageProperties );
-	const { initializeTransformValues } = transformState;
-
-	useEffect( () => {
-		if ( isEditing ) {
-			initializeTransformValues();
-		}
-	}, [ isEditing, initializeTransformValues ] );
-
-	return transformState;
 }

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -54,10 +54,7 @@ export { default as __experimentalColorGradientSettingsDropdown } from './colors
 export { default as __experimentalPanelColorGradientSettings } from './colors-gradients/panel-color-gradient-settings';
 export { default as __experimentalUseMultipleOriginColorsAndGradients } from './colors-gradients/use-multiple-origin-colors-and-gradients';
 export { default as __experimentalHeightControl } from './height-control';
-export {
-	default as __experimentalImageEditor,
-	ImageEditingProvider as __experimentalImageEditingProvider,
-} from './image-editor';
+export { default as __experimentalImageEditor } from './image-editor';
 export { default as __experimentalImageSizeControl } from './image-size-control';
 export { default as InnerBlocks, useInnerBlocksProps } from './inner-blocks';
 export {

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -28,7 +28,6 @@ import {
 	store as blockEditorStore,
 	BlockAlignmentControl,
 	__experimentalImageEditor as ImageEditor,
-	__experimentalImageEditingProvider as ImageEditingProvider,
 	__experimentalGetElementClassName,
 	__experimentalUseBorderProps as useBorderProps,
 } from '@wordpress/block-editor';
@@ -518,13 +517,20 @@ export default function Image( {
 	if ( canEditImage && isEditingImage ) {
 		img = (
 			<ImageEditor
-				borderProps={ isRounded ? undefined : borderProps }
+				id={ id }
 				url={ url }
 				width={ width }
 				height={ height }
 				clientWidth={ clientWidth }
 				naturalHeight={ naturalHeight }
 				naturalWidth={ naturalWidth }
+				onSaveImage={ ( imageAttributes ) =>
+					setAttributes( imageAttributes )
+				}
+				onFinishEditing={ () => {
+					setIsEditingImage( false );
+				} }
+				borderProps={ isRounded ? undefined : borderProps }
 			/>
 		);
 	} else if ( ! isResizable || ! imageWidthWithinContainer ) {
@@ -609,18 +615,7 @@ export default function Image( {
 	}
 
 	return (
-		<ImageEditingProvider
-			id={ id }
-			url={ url }
-			naturalWidth={ naturalWidth }
-			naturalHeight={ naturalHeight }
-			clientWidth={ clientWidth }
-			onSaveImage={ ( imageAttributes ) =>
-				setAttributes( imageAttributes )
-			}
-			isEditing={ isEditingImage }
-			onFinishEditing={ () => setIsEditingImage( false ) }
-		>
+		<>
 			{ /* Hide controls during upload to avoid component remount,
 				which causes duplicated image upload. */ }
 			{ ! temporaryURL && controls }
@@ -648,6 +643,6 @@ export default function Image( {
 						}
 					/>
 				) }
-		</ImageEditingProvider>
+		</>
 	);
 }

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -34,7 +34,6 @@ import {
 	useBlockProps,
 	store as blockEditorStore,
 	__experimentalImageEditor as ImageEditor,
-	__experimentalImageEditingProvider as ImageEditingProvider,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -219,27 +218,21 @@ const SiteLogo = ( {
 
 	const imgEdit =
 		canEditImage && isEditingImage ? (
-			<ImageEditingProvider
+			<ImageEditor
 				id={ logoId }
 				url={ logoUrl }
-				naturalWidth={ naturalWidth }
-				naturalHeight={ naturalHeight }
+				width={ currentWidth }
+				height={ currentHeight }
 				clientWidth={ clientWidth }
+				naturalHeight={ naturalHeight }
+				naturalWidth={ naturalWidth }
 				onSaveImage={ ( imageAttributes ) => {
 					setLogo( imageAttributes.id );
 				} }
-				isEditing={ isEditingImage }
-				onFinishEditing={ () => setIsEditingImage( false ) }
-			>
-				<ImageEditor
-					url={ logoUrl }
-					width={ currentWidth }
-					height={ currentHeight }
-					clientWidth={ clientWidth }
-					naturalHeight={ naturalHeight }
-					naturalWidth={ naturalWidth }
-				/>
-			</ImageEditingProvider>
+				onFinishEditing={ () => {
+					setIsEditingImage( false );
+				} }
+			/>
 		) : (
 			<ResizableBox
 				size={ {


### PR DESCRIPTION
After enabling React 18 concurrent mode, e2e tests for image editing start failing. There is an infinite loop of state updates, triggering a "[maximum update depth exceeded](https://reactjs.org/docs/error-decoder.html/?invariant=185)" error, and crashing the Image block.

Apparently @youknowriad already encountered this in his first React 18 upgrade attempt. I can tell from the [`isNaN` checks](https://github.com/WordPress/gutenberg/pull/32765/files#diff-fc0460f83afff83a8777683d56f96e1a1f28d8cee9d18e645556861a7650607e) he added to `Cropper` back then.

What's wrong? There is an `ImageEditingProvider` component, which holds the state for `zoom` and `aspect` values for the image editor. This provider is always rendered in the Image block, even if the image editor is not active. And the initial values for these states are `undefined`.

When the image editor is activated, there is an effect that initializes the `zoom` and `aspect` values. But because it's an effect, it runs with a slight delay. By the time the initializing state update is done, the image editor with `Cropper` component from `react-easy-crop` has already rendered with `undefined` props for zoom and aspect, and does its own internal calculations. With `undefined` values, the results are `NaN`. And because `NaN !== NaN`, code like:
```js
componentDidUpdate( prevProps ) {
  if ( prevProps.zoom !== props.zoom ) {
    this.recomputeCropPosition();
  }
}
```
will always think that `zoom` has changed and will loop.

What if we initialized the `zoom` and `aspect` state correctly from the very beginning? That turns out to be impossible, because we know the `aspect` value only after the image has loaded and the `naturalWidth` and `naturalHeight` values are known. On the very initial render, the values are not yet known.

I solved this by realizing that we can move the `ImageEditingProvider` component into the `ImageEditor` component. It's an internal component that provides context to image editor's subcomponents. It doesn't need to be part of public API.

Now the `ImageEditingProvider` is initialized only when image editor is being activated, which is possible only after the image is fully loaded and all the values are known.

**How to test:** The Image block case is very well covered by e2e tests. Additionally, verify that the Site Logo image editor also works as expected.