### PR TITLE
Multi-block selection and rich text test: wait for expected UI to appear

### DIFF
--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -395,7 +395,7 @@ describe( 'Multi-block selection', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '/group' );
 		await page.waitForXPath(
-			`//*[contains(@class, "components-autocomplete__result") and contains(@class, "is-selected") and contains(text(), 'Group')]`
+			'//button[@aria-selected="true"][text()="Group"]'
 		);
 		await page.keyboard.press( 'Enter' );
 
@@ -658,6 +658,9 @@ describe( 'Multi-block selection', () => {
 	it( 'should gradually multi-select', async () => {
 		await clickBlockAppender();
 		await page.keyboard.type( '/columns' );
+		await page.waitForXPath(
+			'//button[@aria-selected="true"][text()="Columns"]'
+		);
 		await page.keyboard.press( 'Enter' );
 		// Select two columns.
 		await page.keyboard.press( 'ArrowRight' );
@@ -665,9 +668,13 @@ describe( 'Multi-block selection', () => {
 		// Navigate to appender.
 		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.press( 'Enter' );
-		// Select a paragraph.
+		// Wait for inserter results to appear and then select a paragraph.
+		await page.waitForSelector(
+			'.block-editor-inserter__quick-inserter-results .block-editor-block-types-list__item'
+		);
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Enter' );
+		// Type two paragraphs
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '2' );
@@ -705,6 +712,9 @@ describe( 'Multi-block selection', () => {
 		await page.keyboard.press( 'Enter' );
 		// Add a list.
 		await page.keyboard.type( '/list' );
+		await page.waitForXPath(
+			'//button[@aria-selected="true"][text()="List"]'
+		);
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '1' );
 
@@ -924,6 +934,9 @@ describe( 'Multi-block selection', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '/hr' );
+		await page.waitForXPath(
+			'//button[@aria-selected="true"][text()="Separator"]'
+		);
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'ArrowUp' );

--- a/packages/e2e-tests/specs/editor/various/rich-text.test.js
+++ b/packages/e2e-tests/specs/editor/various/rich-text.test.js
@@ -408,6 +408,10 @@ describe( 'RichText', () => {
 		await button.evaluate( ( element ) => element.scrollIntoView() );
 		await button.click();
 
+		// Wait for the popover with "Text" tab to appear.
+		await page.waitForXPath(
+			'//button[@role="tab"][@aria-selected="true"][text()="Text"]'
+		);
 		// Tab to the "Text" tab.
 		await page.keyboard.press( 'Tab' );
 		// Tab to black.


### PR DESCRIPTION
Fixes some flaky e2e tests when testing multi-block selection and rich-text formatting. What all these tests have in common is that they do a lot of keyboard events in quick succession, like: type `/columns` into block inserter, then tab, tab, arrow right, enter...

But the expected UI elements we're navigating to and focusing don't always appear so fast. There is for example `useAsyncList` in block inserter search results, which initially renders and empty list and starts populating it only after `requestIdleCallback`. Popovers also take some time to appear and focus. Etc.

Some examples of actual failures. Here the test did Tab and Enter, expecting to select a paragraph block in block inserter popover:

![should gradually multi-select 2023-01-12T13-31-01](https://user-images.githubusercontent.com/664258/212636475-0ccc25df-5238-407a-b524-fb4c3a486a20.jpg)

But what really happened is that the paragraph block item was not there yet, and the Tab tabbed to the "Browse all" button, clicked on it, and then, instead of entering paragraph content, typed into sidebar inserter search field.

Another test was supposed to tab (four times) into the color popover and select a specific color there:

![should preserve internal formatting 2023-01-12T13-33-13](https://user-images.githubusercontent.com/664258/212636928-77581513-a58a-4b46-99b9-465ff06c0213.jpg)

But when the tabbing was being done, the popover wasn't there yet, so instead the editor keyboard-navigated to the right sidebar and selected the "Styles" button there (notice the focus ring around it).

I'm fixing this by adding some `waitFor` calls that wait for expected elements to appear.

These flaky tests fail much more often when concurrent mode is enabled, so I was forced to fix them while working on #46467.