### PR TITLE
Allow resizing the sidebar in the site editor using keyboard

### DIFF
--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -233,7 +233,17 @@ export default function Layout( { onError } ) {
 								} }
 								handleComponent={ {
 									right: (
-										<ResizeHandle variation="separator" />
+										<ResizeHandle
+											direction="right"
+											variation="separator"
+											resizeWidthBy={ ( delta ) => {
+												setForcedWidth(
+													( forcedWidth ??
+														defaultSidebarWidth ) +
+														delta
+												);
+											} }
+										/>
 									),
 								} }
 								handleClasses={ undefined }

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -89,6 +89,10 @@ $hub-height: $grid-unit-20 * 2 + $button-size;
 		min-height: 100%;
 		@include custom-scrollbars-on-hover;
 	}
+
+	.resizable-editor__drag-handle {
+		right: 0;
+	}
 }
 
 .edit-site-layout__canvas-container {


### PR DESCRIPTION
## What?

This PR adds a callback to the resize handle in the site editor to allow resizing the sidebar using keyboard (arrow keys).

## Testing Instructions

 - Tab into the resize handle 
 - Once the resize handle is focused, use arrow keys to resize the sidebar.
