### PR TITLE
Performances: Avoid UI shifting when selecting blocks

### DIFF
--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -101,6 +101,8 @@ body.block-editor-page {
 
 .interface-interface-skeleton__header {
 	@supports (scrollbar-gutter: stable) {
+		// The scrollbar-gutter property ensures space is reserved for the scrollbar to appear,
+		// when scrollbars are set to be always visible. This ensure icons stay visually aligned.
 		scrollbar-gutter: stable;
 		overflow: hidden;
 	}

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -99,6 +99,13 @@ body.block-editor-page {
 
 @include wordpress-admin-schemes();
 
+.interface-interface-skeleton__header {
+	@supports (scrollbar-gutter: stable) {
+		scrollbar-gutter: stable;
+		overflow: hidden;
+	}
+}
+
 // The edit-site package adds or removes the sidebar when it's opened or closed.
 // The edit-post package, however, always has the sidebar in the canvas.
 // These edit-post specific rules ensures there isn't a border on the right of
@@ -109,6 +116,7 @@ body.block-editor-page {
 	.is-sidebar-opened & {
 		@include break-medium() {
 			border-left: $border-width solid $gray-200;
+			overflow: hidden scroll;
 		}
 	}
 }


### PR DESCRIPTION
## What?
Force the use of overflow scroll on scrollable areas to avoid UI shifting/resizing when getting a scrollbar

## Why?
When the content of a scrollable area changes and overflow, the whole page resizes triggering massive repaint of the page

## How
Force overflow: scroll on both .interface-interface-skeleton__content and .interface-interface-skeleton__sidebar

Fixes: #45386
Fixes: #23427

## Testing Instructions
1. Open a page
2. collapse/expand panels in the sidebar to create overflow
3. the blocks container should not change its size because of the sidebar scrollbar appearing

## Before

https://user-images.githubusercontent.com/4660731/212645869-50ad328a-c48c-4e4f-b837-0c7b3031f317.mov

## After

https://user-images.githubusercontent.com/4660731/212645910-8a857d85-1e20-4e0a-bfee-5aca57a55e6c.mov