### PR TITLE
Fix bullet hierarchy

### DIFF
--- a/packages/components/src/theme/README.md
+++ b/packages/components/src/theme/README.md
@@ -57,8 +57,8 @@ If you would like your custom component to be themeable as a child of the `Theme
 -  Grayscale:
    -  `--wp-components-color-gray-100`: Used for light gray backgrounds.
    -  `--wp-components-color-gray-200`: Used sparingly for light borders.
-	 -	`--wp-components-color-gray-300`: Used for most borders.
-	 -	`--wp-components-color-gray-400`
-	 -	`--wp-components-color-gray-600`: Meets 3:1 UI or large text contrast against white.
-	 -	`--wp-components-color-gray-700`: Meets 4.6:1 text contrast against white.
-	 -	`--wp-components-color-gray-800`
+   -	`--wp-components-color-gray-300`: Used for most borders.
+   -	`--wp-components-color-gray-400`
+   -	`--wp-components-color-gray-600`: Meets 3:1 UI or large text contrast against white.
+   -	`--wp-components-color-gray-700`: Meets 4.6:1 text contrast against white.
+   -	`--wp-components-color-gray-800`


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Re-align all bullet points to first level rather than sub-points for `--wp-components-color-gray-200`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Each bullet point is not a parent or child of any bullet points but `--wp-components-color-gray-300` to `--wp-components-color-gray-800` are sub-points of `--wp-components-color-gray-200` (parent bullet point)

## Screenshots or screencast <!-- if applicable -->
![Screenshot from 2023-01-16 15-33-12](https://user-images.githubusercontent.com/4319097/212651715-8afc4731-f957-4ffe-a0d9-583884aa6377.png)


