### PR TITLE
`MenuItemsChoice`: Refactor to TypeScript

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,6 +17,7 @@
 -   `ResizableBox`: refactor styles to TypeScript ([47756](https://github.com/WordPress/gutenberg/pull/47756)).
 -   `BorderBoxControl`: migrate tests to TypeScript, remove act() call ([47755](https://github.com/WordPress/gutenberg/pull/47755)).
 -   `Toolbar`: Convert to TypeScript ([#47087](https://github.com/WordPress/gutenberg/pull/47087)).
+-   `MenuItemsChoice`: Convert to TypeScript ([#47180](https://github.com/WordPress/gutenberg/pull/47180)).
 
 ## 23.3.0 (2023-02-01)
 
@@ -43,7 +44,6 @@
 -   `QueryControls`: Convert to TypeScript ([#46721](https://github.com/WordPress/gutenberg/pull/46721)).
 -   `TreeGrid`: Convert to TypeScript ([#47516](https://github.com/WordPress/gutenberg/pull/47516)).
 -   `Notice`: refactor to TypeScript ([47118](https://github.com/WordPress/gutenberg/pull/47118)).
--   `MenuItemsChoice`: Convert to TypeScript ([#47180](https://github.com/WordPress/gutenberg/pull/47180)).
 
 ### Bug Fix
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -43,6 +43,7 @@
 -   `QueryControls`: Convert to TypeScript ([#46721](https://github.com/WordPress/gutenberg/pull/46721)).
 -   `TreeGrid`: Convert to TypeScript ([#47516](https://github.com/WordPress/gutenberg/pull/47516)).
 -   `Notice`: refactor to TypeScript ([47118](https://github.com/WordPress/gutenberg/pull/47118)).
+-   `MenuItemsChoice`: Convert to TypeScript ([#47180](https://github.com/WordPress/gutenberg/pull/47180)).
 
 ### Bug Fix
 

--- a/packages/components/src/menu-items-choice/index.tsx
+++ b/packages/components/src/menu-items-choice/index.tsx
@@ -17,30 +17,34 @@ function MenuItemsChoice( {
 	onSelect,
 	value,
 }: MenuItemsChoiceProps ) {
-	return choices.map( ( item ) => {
-		const isSelected = value === item.value;
-		return (
-			<MenuItem
-				key={ item.value }
-				role="menuitemradio"
-				icon={ isSelected && check }
-				info={ item.info }
-				isSelected={ isSelected }
-				shortcut={ item.shortcut }
-				className="components-menu-items-choice"
-				onClick={ () => {
-					if ( ! isSelected ) {
-						onSelect( item.value );
-					}
-				} }
-				onMouseEnter={ () => onHover( item.value ) }
-				onMouseLeave={ () => onHover() }
-				aria-label={ item[ 'aria-label' ] }
-			>
-				{ item.label }
-			</MenuItem>
-		);
-	} );
+	return (
+		<>
+			{ choices.map( ( item ) => {
+				const isSelected = value === item.value;
+				return (
+					<MenuItem
+						key={ item.value }
+						role="menuitemradio"
+						icon={ isSelected && check }
+						info={ item.info }
+						isSelected={ isSelected }
+						shortcut={ item.shortcut }
+						className="components-menu-items-choice"
+						onClick={ () => {
+							if ( ! isSelected ) {
+								onSelect( item.value );
+							}
+						} }
+						onMouseEnter={ () => onHover( item.value ) }
+						onMouseLeave={ () => onHover() }
+						aria-label={ item[ 'aria-label' ] }
+					>
+						{ item.label }
+					</MenuItem>
+				);
+			} ) }
+		</>
+	);
 }
 
 export default MenuItemsChoice;

--- a/packages/components/src/menu-items-choice/index.tsx
+++ b/packages/components/src/menu-items-choice/index.tsx
@@ -11,6 +11,39 @@ import type { MenuItemsChoiceProps } from './types';
 
 const noop = () => {};
 
+/**
+ * `MenuItemsChoice` functions similarly to a set of `MenuItem`s, but allows the user to select one option from a set of multiple choices.
+ *
+ *
+ * ```jsx
+ * import { MenuGroup, MenuItemsChoice } from '@wordpress/components';
+ * import { useState } from '@wordpress/element';
+ *
+ * const MyMenuItemsChoice = () => {
+ * 	const [ mode, setMode ] = useState( 'visual' );
+ * 	const choices = [
+ * 		{
+ * 			value: 'visual',
+ * 			label: 'Visual editor',
+ * 		},
+ * 		{
+ * 			value: 'text',
+ * 			label: 'Code editor',
+ * 		},
+ * 	];
+ *
+ * 	return (
+ * 		<MenuGroup label="Editor">
+ * 			<MenuItemsChoice
+ * 				choices={ choices }
+ * 				value={ mode }
+ * 				onSelect={ ( newMode ) => setMode( newMode ) }
+ * 			/>
+ * 		</MenuGroup>
+ * 	);
+ * };
+ * ```
+ */
 function MenuItemsChoice( {
 	choices = [],
 	onHover = noop,
@@ -47,37 +80,4 @@ function MenuItemsChoice( {
 	);
 }
 
-/**
- * `MenuItemsChoice` functions similarly to a set of `MenuItem`s, but allows the user to select one option from a set of multiple choices.
- *
- *
- * ```jsx
- * import { MenuGroup, MenuItemsChoice } from '@wordpress/components';
- * import { useState } from '@wordpress/element';
- *
- * const MyMenuItemsChoice = () => {
- * 	const [ mode, setMode ] = useState( 'visual' );
- * 	const choices = [
- * 		{
- * 			value: 'visual',
- * 			label: 'Visual editor',
- * 		},
- * 		{
- * 			value: 'text',
- * 			label: 'Code editor',
- * 		},
- * 	];
- *
- * 	return (
- * 		<MenuGroup label="Editor">
- * 			<MenuItemsChoice
- * 				choices={ choices }
- * 				value={ mode }
- * 				onSelect={ ( newMode ) => setMode( newMode ) }
- * 			/>
- * 		</MenuGroup>
- * 	);
- * };
- * ```
- */
 export default MenuItemsChoice;

--- a/packages/components/src/menu-items-choice/index.tsx
+++ b/packages/components/src/menu-items-choice/index.tsx
@@ -47,4 +47,37 @@ function MenuItemsChoice( {
 	);
 }
 
+/**
+ * `MenuItemsChoice` functions similarly to a set of `MenuItem`s, but allows the user to select one option from a set of multiple choices.
+ *
+ *
+ * ```jsx
+ * import { MenuGroup, MenuItemsChoice } from '@wordpress/components';
+ * import { useState } from '@wordpress/element';
+ *
+ * const MyMenuItemsChoice = () => {
+ * 	const [ mode, setMode ] = useState( 'visual' );
+ * 	const choices = [
+ * 		{
+ * 			value: 'visual',
+ * 			label: 'Visual editor',
+ * 		},
+ * 		{
+ * 			value: 'text',
+ * 			label: 'Code editor',
+ * 		},
+ * 	];
+ *
+ * 	return (
+ * 		<MenuGroup label="Editor">
+ * 			<MenuItemsChoice
+ * 				choices={ choices }
+ * 				value={ mode }
+ * 				onSelect={ ( newMode ) => setMode( newMode ) }
+ * 			/>
+ * 		</MenuGroup>
+ * 	);
+ * };
+ * ```
+ */
 export default MenuItemsChoice;

--- a/packages/components/src/menu-items-choice/index.tsx
+++ b/packages/components/src/menu-items-choice/index.tsx
@@ -36,7 +36,7 @@ function MenuItemsChoice( {
 							}
 						} }
 						onMouseEnter={ () => onHover( item.value ) }
-						onMouseLeave={ () => onHover() }
+						onMouseLeave={ () => onHover( null ) }
 						aria-label={ item[ 'aria-label' ] }
 					>
 						{ item.label }

--- a/packages/components/src/menu-items-choice/index.tsx
+++ b/packages/components/src/menu-items-choice/index.tsx
@@ -7,15 +7,16 @@ import { check } from '@wordpress/icons';
  * Internal dependencies
  */
 import MenuItem from '../menu-item';
+import type { MenuItemsChoiceProps } from './types';
 
 const noop = () => {};
 
-export default function MenuItemsChoice( {
+function MenuItemsChoice( {
 	choices = [],
 	onHover = noop,
 	onSelect,
 	value,
-} ) {
+}: MenuItemsChoiceProps ) {
 	return choices.map( ( item ) => {
 		const isSelected = value === item.value;
 		return (
@@ -33,7 +34,7 @@ export default function MenuItemsChoice( {
 					}
 				} }
 				onMouseEnter={ () => onHover( item.value ) }
-				onMouseLeave={ () => onHover( null ) }
+				onMouseLeave={ () => onHover() }
 				aria-label={ item[ 'aria-label' ] }
 			>
 				{ item.label }
@@ -41,3 +42,5 @@ export default function MenuItemsChoice( {
 		);
 	} );
 }
+
+export default MenuItemsChoice;

--- a/packages/components/src/menu-items-choice/stories/index.tsx
+++ b/packages/components/src/menu-items-choice/stories/index.tsx
@@ -4,6 +4,11 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 /**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import MenuItemsChoice from '..';
@@ -23,9 +28,18 @@ const meta: ComponentMeta< typeof MenuItemsChoice > = {
 export default meta;
 
 const Template: ComponentStory< typeof MenuItemsChoice > = ( args ) => {
+	const [ choice, setChoice ] = useState( args.value ?? '' );
+	const [ hovered, setHovered ] = useState< string | undefined >();
+
 	return (
 		<MenuGroup label="Editor">
-			<MenuItemsChoice { ...args } />
+			<MenuItemsChoice
+				{ ...args }
+				value={ choice }
+				onSelect={ ( value ) => setChoice( value ) }
+				onHover={ ( value ) => setHovered( value ) }
+			/>
+			<div>Currently hovered value: { hovered ? hovered : '-' }</div>
 		</MenuGroup>
 	);
 };
@@ -33,6 +47,7 @@ const Template: ComponentStory< typeof MenuItemsChoice > = ( args ) => {
 export const Default: ComponentStory< typeof MenuItemsChoice > = Template.bind(
 	{}
 );
+
 Default.args = {
 	choices: [
 		{

--- a/packages/components/src/menu-items-choice/stories/index.tsx
+++ b/packages/components/src/menu-items-choice/stories/index.tsx
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+
+/**
+ * Internal dependencies
+ */
+import MenuItemsChoice from '..';
+import MenuGroup from '../../menu-group';
+
+const meta: ComponentMeta< typeof MenuItemsChoice > = {
+	component: MenuItemsChoice,
+	title: 'Components/MenuItemsChoice',
+	argTypes: {},
+	parameters: {
+		controls: {
+			expanded: true,
+		},
+		docs: { source: { state: 'open' } },
+	},
+};
+export default meta;
+
+const Template: ComponentStory< typeof MenuItemsChoice > = ( args ) => {
+	return (
+		<MenuGroup label="Editor">
+			<MenuItemsChoice { ...args } />
+		</MenuGroup>
+	);
+};
+
+export const Default: ComponentStory< typeof MenuItemsChoice > = Template.bind(
+	{}
+);
+Default.args = {
+	choices: [
+		{
+			value: 'arbitrary-choice-1',
+			label: 'Arbitrary Label #1',
+			info: 'Arbitrary Explanatory 1',
+		},
+		{
+			value: 'arbitrary-choice-2',
+			label: 'Arbitrary Label #2',
+			info: 'Arbitrary Explanatory 2',
+		},
+		{
+			value: 'arbitrary-choice-3',
+			label: 'Arbitrary Label #3',
+			info: 'Arbitrary Explanatory 3',
+		},
+	],
+	value: 'arbitrary-choice-1',
+};

--- a/packages/components/src/menu-items-choice/stories/index.tsx
+++ b/packages/components/src/menu-items-choice/stories/index.tsx
@@ -17,7 +17,11 @@ import MenuGroup from '../../menu-group';
 const meta: ComponentMeta< typeof MenuItemsChoice > = {
 	component: MenuItemsChoice,
 	title: 'Components/MenuItemsChoice',
-	argTypes: {},
+	argTypes: {
+		onHover: { action: 'onHover' },
+		onSelect: { action: 'onSelect' },
+		value: { control: { type: null } },
+	},
 	parameters: {
 		controls: {
 			expanded: true,
@@ -27,19 +31,24 @@ const meta: ComponentMeta< typeof MenuItemsChoice > = {
 };
 export default meta;
 
-const Template: ComponentStory< typeof MenuItemsChoice > = ( args ) => {
-	const [ choice, setChoice ] = useState( args.value ?? '' );
-	const [ hovered, setHovered ] = useState< string | undefined >();
+const Template: ComponentStory< typeof MenuItemsChoice > = ( {
+	onHover,
+	onSelect,
+	choices,
+} ) => {
+	const [ choice, setChoice ] = useState( choices[ 0 ]?.value ?? '' );
 
 	return (
 		<MenuGroup label="Editor">
 			<MenuItemsChoice
-				{ ...args }
+				choices={ choices }
 				value={ choice }
-				onSelect={ ( value ) => setChoice( value ) }
-				onHover={ ( value ) => setHovered( value ) }
+				onSelect={ ( ...selectArgs ) => {
+					onSelect( ...selectArgs );
+					setChoice( ...selectArgs );
+				} }
+				onHover={ onHover }
 			/>
-			<div>Currently hovered value: { hovered ? hovered : '-' }</div>
 		</MenuGroup>
 	);
 };

--- a/packages/components/src/menu-items-choice/types.ts
+++ b/packages/components/src/menu-items-choice/types.ts
@@ -6,6 +6,8 @@ import type { ShortcutProps } from '../shortcut/types';
 export type MenuItemsChoiceProps = {
 	/**
 	 * Array of choices.
+	 *
+	 * @default []
 	 */
 	choices: readonly MenuItemChoice[];
 	/**
@@ -21,6 +23,8 @@ export type MenuItemsChoiceProps = {
 	/**
 	 * Callback function to be called with a choice when user
 	 * hovers over a new choice (will be empty on mouse leave).
+	 *
+	 * @default noop
 	 */
 	onHover: ( value: string | null ) => void;
 };

--- a/packages/components/src/menu-items-choice/types.ts
+++ b/packages/components/src/menu-items-choice/types.ts
@@ -22,7 +22,7 @@ export type MenuItemsChoiceProps = {
 	 * Callback function to be called with a choice when user
 	 * hovers over a new choice (will be empty on mouse leave).
 	 */
-	onHover: ( value?: string ) => void;
+	onHover: ( value: string | null ) => void;
 };
 
 export type MenuItemChoice = {

--- a/packages/components/src/menu-items-choice/types.ts
+++ b/packages/components/src/menu-items-choice/types.ts
@@ -5,7 +5,7 @@ import type { ShortcutProps } from '../shortcut/types';
 
 export type MenuItemsChoiceProps = {
 	/**
-	 * Array of choices
+	 * Array of choices.
 	 */
 	choices: readonly MenuItemChoice[];
 	/**
@@ -35,7 +35,7 @@ export type MenuItemChoice = {
 	 */
 	value: string;
 	/**
-	 * Additional information which will be rendered below the given label
+	 * Additional information which will be rendered below the given label.
 	 */
 	info?: string;
 	/**
@@ -44,7 +44,7 @@ export type MenuItemChoice = {
 	 */
 	shortcut?: ShortcutProps[ 'shortcut' ];
 	/**
-	 * Aria compliant label
+	 * Aria compliant label.
 	 */
 	[ 'aria-label' ]?: string;
 };

--- a/packages/components/src/menu-items-choice/types.ts
+++ b/packages/components/src/menu-items-choice/types.ts
@@ -1,0 +1,50 @@
+/**
+ * Internal dependencies
+ */
+import type { ShortcutProps } from '../shortcut/types';
+
+export type MenuItemsChoiceProps = {
+	/**
+	 * Array of choices
+	 */
+	choices: readonly MenuItemChoice[];
+	/**
+	 * Value of currently selected choice (should match a `value` property
+	 * from a choice in `choices`).
+	 */
+	value: string;
+	/**
+	 * Callback function to be called with the selected choice when user
+	 * selects a new choice.
+	 */
+	onSelect( value: string ): void;
+	/**
+	 * Callback function to be called with a choice when user
+	 * hovers over a new choice (will be empty on mouse leave).
+	 */
+	onHover: ( value?: string ) => void;
+};
+
+export type MenuItemChoice = {
+	/**
+	 * Human-readable label for choice.
+	 */
+	label: string;
+	/**
+	 * Unique value for choice.
+	 */
+	value: string;
+	/**
+	 * Additional information which will be rendered below the given label
+	 */
+	info?: string;
+	/**
+	 * Optional keyboard sequence to trigger choice with keyboard shortcut
+	 * (e.g. `ctrl+s`).
+	 */
+	shortcut?: ShortcutProps[ 'shortcut' ];
+	/**
+	 * Aria compliant label
+	 */
+	[ 'aria-label' ]?: string;
+};

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -56,7 +56,6 @@
 		"src/higher-order/with-filters",
 		"src/higher-order/with-focus-return",
 		"src/higher-order/with-notices",
-		"src/menu-items-choice",
 		"src/navigation",
 		"src/palette-edit",
 		"src/panel/body.js"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Refactor `MenuItemsChoice` component to TypeScript

## Why?

Part of https://github.com/WordPress/gutenberg/issues/35744

## How?

- Followed general recommendations from the [TypeScript Migration guide](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/CONTRIBUTING.md#refactoring-a-component-to-typescript). 
- Renamed file to `.tsx` and created a `types.ts` file with relevant types

## Testing Instructions

1. Ensure there are no type errors
2. Component should behave as expected

Wit this PR we introduce a story for this component. Please verify it behaves as expected.
