### PR TITLE
`ColorPalette`: Use computed color when css variable is passed to `ColorPicker`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `Dropdown`: deprecate `position`  prop, use `popoverProps` instead ([46865](https://github.com/WordPress/gutenberg/pull/46865)).
 -   `Button`: improve padding for buttons with icon and text. ([46764](https://github.com/WordPress/gutenberg/pull/46764)).
+-   `ColorPalette`: Use computed color when css variable is passed to `ColorPicker` ([47181](https://github.com/WordPress/gutenberg/pull/47181)).
 
 ### Internal
 

--- a/packages/components/src/color-palette/index.tsx
+++ b/packages/components/src/color-palette/index.tsx
@@ -214,25 +214,25 @@ const areColorsMultiplePalette = (
 	);
 };
 
-const getComputedBackgroundColorValueFromRef = (
+const normalizeColorValue = (
 	value: string | undefined,
 	ref: RefObject< HTMLElement > | null
 ) => {
-	let computedValue = value;
 	const currentValueIsCssVariable = /^var\(/.test( value ?? '' );
 
-	if ( currentValueIsCssVariable && ref?.current ) {
-		const { ownerDocument } = ref.current;
-		const { defaultView } = ownerDocument;
-		const computedBackgroundColor = defaultView?.getComputedStyle(
-			ref.current
-		).backgroundColor;
-
-		if ( computedBackgroundColor ) {
-			computedValue = colord( computedBackgroundColor ).toHex();
-		}
+	if ( ! currentValueIsCssVariable || ! ref?.current ) {
+		return value;
 	}
-	return computedValue;
+
+	const { ownerDocument } = ref.current;
+	const { defaultView } = ownerDocument;
+	const computedBackgroundColor = defaultView?.getComputedStyle(
+		ref.current
+	).backgroundColor;
+
+	return computedBackgroundColor
+		? colord( computedBackgroundColor ).toHex()
+		: value;
 };
 
 function UnforwardedColorPalette(
@@ -280,10 +280,7 @@ function UnforwardedColorPalette(
 	const renderCustomColorPicker = () => (
 		<DropdownContentWrapper paddingSize="none">
 			<ColorPicker
-				color={ getComputedBackgroundColorValueFromRef(
-					value,
-					customColorPaletteRef
-				) }
+				color={ normalizeColorValue( value, customColorPaletteRef ) }
 				onChange={ ( color ) => onChange( color ) }
 				enableAlpha={ enableAlpha }
 			/>


### PR DESCRIPTION
Closes #46492

## What?
This PR passes the computed color to the `ColorPicker` component if the value of the `ColorPalette` component is a CSS variable. This will ensure that the correct color value is set in the input field when the custom color picker is opened.

## Why?
The `ColorPicker` component doesn't know what actual color the CSS variable points to. Therefore, the color input field of the `ColorPicker` component displays `#000000` as a fallback.

## How?
I used the following approach to pass the computed value to the `ColorPicker` component:

- Set a `ref` in the custom color picker area and reference its DOM node.
- Use the new `getComputedBackgroundColorValueFromRef()` function to read the background-color from that DOM node. Therefore, `ColorPalette` itself doesn't directly reference CSS variables; it expects CSS variables to be correctly defined by the consumer or theme. I also created this function because it may help resolve the following issue:
  - #41459
  - #44904 

## Testing Instructions

### In the block editor

Enable Empty Theme and update theme.json as follows:

<details>
<summary>/test/emptytheme/theme.json</summary>

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		},
		"color": {
			"palette": [
				{
					"name": "Normal Color",
					"slug": "normal",
					"color": "#378C60"
				},
				{
					"name": "Variable Color (Hex)",
					"slug": "hex",
					"color": "var(--wp--custom--hex)"
				},
				{
					"name": "Variable Color (RGB)",
					"slug": "rgb",
					"color": "var(--wp--custom--rgb)"
				},
				{
					"name": "Variable Color (RGBA)",
					"slug": "rgba",
					"color": "var(--wp--custom--rgba)"
				}
			]
		},
		"custom": {
			"hex": "#e42c64",
			"rgb": "rgb(45,36,138)",
			"rgba": "rgba(45,36,138, 0.5)"
		}
	}
}
```
</details>

The definition of the `settings.custom` property creates the following CSS variable, which is referenced as the value of the `settings.color.palette`:

```
--wp--custom--hex: #e42c64;
--wp--custom--rgb: rgb(45,36,138);
--wp--custom--rgba: rgba(45,36,138, 0.5);
```

- Inserts a block that supports the color.
- Open the Text Color or Background Color menu and click on one of the palettes in the THEME area.
- When you open the custom color palette, confirm that the input field is set to the value calculated from the CSS variable.

### In the storybook

- Build Storybook and access "ColorPalette" > "CSS Variables".
- Select one of the palettes, open the color picker, and verify that the input field is set to the calculated value.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/54422211/212678589-cbfb74da-dc29-433f-924f-c524b784929b.mp4