### PR TITLE
Lodash: Refactor blocks away from `_.map()`

### DIFF
--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, isEmpty, map, mapValues } from 'lodash';
+import { get, isEmpty, mapValues } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -269,7 +269,7 @@ export function categories( state = DEFAULT_CATEGORIES, action ) {
 				( { slug } ) => slug === action.slug
 			);
 			if ( categoryToChange ) {
-				return map( state, ( category ) => {
+				return state.map( ( category ) => {
 					if ( category.slug === action.slug ) {
 						return {
 							...category,

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -3,7 +3,7 @@
  */
 import createSelector from 'rememo';
 import removeAccents from 'remove-accents';
-import { get, map } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -553,12 +553,11 @@ export function getGroupingBlockName( state ) {
  */
 export const getChildBlockNames = createSelector(
 	( state, blockName ) => {
-		return map(
-			getBlockTypes( state ).filter( ( blockType ) => {
+		return getBlockTypes( state )
+			.filter( ( blockType ) => {
 				return blockType.parent?.includes( blockName );
-			} ),
-			( { name } ) => name
-		);
+			} )
+			.map( ( { name } ) => name );
 	},
 	( state ) => [ state.blockTypes ]
 );


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.map()` from the blocks package. There are just a couple of usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `Array.prototype.map()` instead. 

## Testing Instructions

* Verify tests still pass - all changes are covered by pre-existing tests.