### PR TITLE
Lodash: Refactor core data away from `_.map()`

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { capitalCase, pascalCase } from 'change-case';
-import { map, get } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -213,7 +213,7 @@ async function loadPostTypeEntities() {
 	const postTypes = await apiFetch( {
 		path: '/wp/v2/types?context=view',
 	} );
-	return map( postTypes, ( postType, name ) => {
+	return Object.entries( postTypes ?? {} ).map( ( [ name, postType ] ) => {
 		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
 			name
 		);
@@ -251,7 +251,7 @@ async function loadTaxonomyEntities() {
 	const taxonomies = await apiFetch( {
 		path: '/wp/v2/taxonomies?context=view',
 	} );
-	return map( taxonomies, ( taxonomy, name ) => {
+	return Object.entries( taxonomies ?? {} ).map( ( [ name, taxonomy ] ) => {
 		const namespace = taxonomy?.rest_namespace ?? 'wp/v2';
 		return {
 			kind: 'taxonomy',

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map, mapValues } from 'lodash';
+import { mapValues } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -230,7 +230,7 @@ const receiveQueries = compose( [
 
 	return getMergedItemIds(
 		state || [],
-		map( action.items, key ),
+		action.items.map( ( item ) => item[ key ] ),
 		page,
 		perPage
 	);

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import fastDeepEqual from 'fast-deep-equal/es6';
-import { map, groupBy, get } from 'lodash';
+import { groupBy, get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -68,10 +68,7 @@ export function users( state = { byId: {}, queries: {} }, action ) {
 				},
 				queries: {
 					...state.queries,
-					[ action.queryID ]: map(
-						action.users,
-						( user ) => user.id
-					),
+					[ action.queryID ]: action.users.map( ( user ) => user.id ),
 				},
 			};
 	}

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { set, map, get } from 'lodash';
+import { set, get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -147,9 +147,9 @@ export function getCurrentUser( state: State ): ET.User< 'edit' > {
  */
 export const getUserQueryResults = createSelector(
 	( state: State, queryID: string ): ET.User< 'edit' >[] => {
-		const queryResults = state.users.queries[ queryID ];
+		const queryResults = state.users.queries[ queryID ] ?? [];
 
-		return map( queryResults, ( id ) => state.users.byId[ id ] );
+		return queryResults.map( ( id ) => state.users.byId[ id ] );
 	},
 	( state: State, queryID: string ) => [
 		state.users.queries[ queryID ],


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.map()` from the core data package. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `Array.prototype.map()` instead, with nullish coalescing when necessary, and with `Object.entries()` to convert from an object when necessary. 

## Testing Instructions

* Verify you're still able to fetch posts when rendering the Latest Posts block in the post editor.
* Verify you're still able to fetch categories when rendering the Categories List block in the post editor.
* Verify all checks are green.