### PR TITLE
Lodash: Refactor editor away from `_.map()`

### DIFF
--- a/packages/editor/src/components/post-template/index.js
+++ b/packages/editor/src/components/post-template/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, map } from 'lodash';
+import { isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -52,9 +52,8 @@ export function PostTemplate() {
 					template: templateSlug || '',
 				} );
 			} }
-			options={ map(
-				availableTemplates,
-				( templateName, templateSlug ) => ( {
+			options={ Object.entries( availableTemplates ?? {} ).map(
+				( [ templateSlug, templateName ] ) => ( {
 					value: templateSlug,
 					label: templateName,
 				} )

--- a/packages/editor/src/utils/terms.js
+++ b/packages/editor/src/utils/terms.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { groupBy, map, unescape as lodashUnescapeString } from 'lodash';
+import { groupBy, unescape as lodashUnescapeString } from 'lodash';
 
 /**
  * Returns terms in a tree form.
@@ -68,5 +68,5 @@ export const unescapeTerm = ( term ) => {
  * @return {Object[]} Array of term objects unescaped.
  */
 export const unescapeTerms = ( terms ) => {
-	return map( terms, unescapeTerm );
+	return ( terms ?? [] ).map( unescapeTerm );
 };


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.map()` from the editor package. There are just a couple of usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `Array.prototype.map()` instead. We're adding nullish coalescing where necessary.

## Testing Instructions

* Verify you're still able to change the template of a post, and that the existing templates are listed properly.
* Verify that the most listed tags are still displayed below the tag field in post settings in the sidebar.
* Verify all checks are still green.