### PR TITLE
Lodash: Refactor components away from `_.map()`

### DIFF
--- a/packages/components/src/autocomplete/autocompleter-ui.js
+++ b/packages/components/src/autocomplete/autocompleter-ui.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { map } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -70,7 +69,7 @@ export function getAutoCompleterUI( autocompleter ) {
 					role="listbox"
 					className="components-autocomplete__results"
 				>
-					{ map( items, ( option, index ) => (
+					{ items.map( ( option, index ) => (
 						<Button
 							key={ option.key }
 							id={ `components-autocomplete-item-${ instanceId }-${ option.key }` }

--- a/packages/components/src/color-palette/index.native.js
+++ b/packages/components/src/color-palette/index.native.js
@@ -11,7 +11,6 @@ import {
 	Platform,
 	Text,
 } from 'react-native';
-import { map } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -64,13 +63,21 @@ function ColorPalette( {
 	const opacity = useRef( new Animated.Value( 1 ) ).current;
 
 	const defaultColors = [
-		...new Set( map( defaultSettings.colors, 'color' ) ),
+		...new Set(
+			( defaultSettings.colors ?? [] ).map( ( { color } ) => color )
+		),
 	];
 	const mergedColors = [
-		...new Set( map( defaultSettings.allColors, 'color' ) ),
+		...new Set(
+			( defaultSettings.allColors ?? [] ).map( ( { color } ) => color )
+		),
 	];
 	const defaultGradientColors = [
-		...new Set( map( defaultSettings.gradients, 'gradient' ) ),
+		...new Set(
+			( defaultSettings.gradients ?? [] ).map(
+				( { gradient } ) => gradient
+			)
+		),
 	];
 	const colors = isGradientSegment ? defaultGradientColors : defaultColors;
 

--- a/packages/components/src/keyboard-shortcuts/index.js
+++ b/packages/components/src/keyboard-shortcuts/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { map } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useRef, Children } from '@wordpress/element';
@@ -28,16 +23,18 @@ function KeyboardShortcut( {
 function KeyboardShortcuts( { children, shortcuts, bindGlobal, eventName } ) {
 	const target = useRef();
 
-	const element = map( shortcuts, ( callback, shortcut ) => (
-		<KeyboardShortcut
-			key={ shortcut }
-			shortcut={ shortcut }
-			callback={ callback }
-			bindGlobal={ bindGlobal }
-			eventName={ eventName }
-			target={ target }
-		/>
-	) );
+	const element = Object.entries( shortcuts ?? {} ).map(
+		( [ shortcut, callback ] ) => (
+			<KeyboardShortcut
+				key={ shortcut }
+				shortcut={ shortcut }
+				callback={ callback }
+				bindGlobal={ bindGlobal }
+				eventName={ eventName }
+				target={ target }
+			/>
+		)
+	);
 
 	// Render as non-visual if there are no children pressed. Keyboard
 	// events will be bound to the document instead.


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.map()` from the components package. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `Array.prototype.map()` instead, with nullish coalescing where necessary. 

## Testing Instructions

* Verify the slash inserter autocomplete still works well on mobile (#29772 for testing instructions).
* Verify ColorPalette component still works properly on mobile.
* Verify the keyboard shortcuts still work.
* Verify all checks are still green.