### PR TITLE
Lodash: Refactor post editor away from `_.map()`

### DIFF
--- a/packages/edit-post/src/components/block-manager/category.js
+++ b/packages/edit-post/src/components/block-manager/category.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { map } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useMemo, useCallback } from '@wordpress/element';
@@ -50,7 +45,7 @@ function BlockManagerCategory( { title, blockTypes } ) {
 	}, [] );
 	const toggleAllVisible = useCallback(
 		( nextIsChecked ) => {
-			const blockNames = map( blockTypes, 'name' );
+			const blockNames = blockTypes.map( ( { name } ) => name );
 			if ( nextIsChecked ) {
 				showBlockTypes( blockNames );
 			} else {
@@ -64,9 +59,9 @@ function BlockManagerCategory( { title, blockTypes } ) {
 		return null;
 	}
 
-	const checkedBlockNames = map( filteredBlockTypes, 'name' ).filter(
-		( type ) => ! hiddenBlockTypes.includes( type )
-	);
+	const checkedBlockNames = filteredBlockTypes
+		.map( ( { name } ) => name )
+		.filter( ( type ) => ! hiddenBlockTypes.includes( type ) );
 
 	const titleId = 'edit-post-block-manager__category-title-' + instanceId;
 

--- a/packages/edit-post/src/components/meta-boxes/index.js
+++ b/packages/edit-post/src/components/meta-boxes/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { map } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useSelect, useRegistry } from '@wordpress/data';
@@ -50,7 +45,7 @@ export default function MetaBoxes( { location } ) {
 
 	return (
 		<>
-			{ map( metaBoxes, ( { id } ) => (
+			{ ( metaBoxes ?? [] ).map( ( { id } ) => (
 				<MetaBoxVisibility key={ id } id={ id } />
 			) ) }
 			<MetaBoxesArea location={ location } />

--- a/packages/edit-post/src/components/preferences-modal/meta-boxes-section.js
+++ b/packages/edit-post/src/components/preferences-modal/meta-boxes-section.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { map } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -36,7 +31,7 @@ export function MetaBoxesSection( {
 			{ areCustomFieldsRegistered && (
 				<EnableCustomFieldsOption label={ __( 'Custom fields' ) } />
 			) }
-			{ map( thirdPartyMetaBoxes, ( { id, title } ) => (
+			{ thirdPartyMetaBoxes.map( ( { id, title } ) => (
 				<EnablePanelOption
 					key={ id }
 					label={ title }

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { map } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { store as blocksStore } from '@wordpress/blocks';
@@ -136,7 +131,7 @@ function Editor( {
 			// all block types).
 			const defaultAllowedBlockTypes =
 				true === settings.allowedBlockTypes
-					? map( blockTypes, 'name' )
+					? blockTypes.map( ( { name } ) => name )
 					: settings.allowedBlockTypes || [];
 
 			result.allowedBlockTypes = defaultAllowedBlockTypes.filter(

--- a/packages/edit-post/src/editor.native.js
+++ b/packages/edit-post/src/editor.native.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import memize from 'memize';
-import { map } from 'lodash';
 import { I18nManager } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
@@ -74,7 +73,7 @@ class Editor extends Component {
 			// all block types).
 			const defaultAllowedBlockTypes =
 				true === settings.allowedBlockTypes
-					? map( blockTypes, 'name' )
+					? blockTypes.map( ( { name } ) => name )
 					: settings.allowedBlockTypes || [];
 
 			settings.allowedBlockTypes = defaultAllowedBlockTypes.filter(


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.map()` from the post editor package. There are just a couple of usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `Array.prototype.map()` instead. We're also adding nullish coalescing where necessary.

## Testing Instructions

* Verify you're still seeing all block types and filtered block types in the block manager in your preferences in the post editor.
* Verify the meta boxes section still appears properly at the bottom of the post editor when there are no custom meta boxes registered.
* Verify the 3rd party meta boxes section still lists them all in your preferences in the post editor.
* Verify you can still insert all the same blocks as before in the editor - on the web, and on mobile.
* Verify all checks are still green.