### PR TITLE
TextareaControl: Forward refs

### DIFF
--- a/packages/components/src/textarea-control/index.tsx
+++ b/packages/components/src/textarea-control/index.tsx
@@ -82,6 +82,6 @@ export function UnforwardedTextareaControl(
 	);
 }
 
-export const TextTextareaControl = forwardRef( UnforwardedTextareaControl );
+export const TextareaControl = forwardRef( UnforwardedTextareaControl );
 
-export default TextTextareaControl;
+export default TextareaControl;

--- a/packages/components/src/textarea-control/index.tsx
+++ b/packages/components/src/textarea-control/index.tsx
@@ -7,6 +7,7 @@ import type { ChangeEvent } from 'react';
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
+import { forwardRef, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -39,7 +40,7 @@ import type { WordPressComponentProps } from '../ui/context';
  * };
  * ```
  */
-export function TextareaControl(
+export function UnforwardedTextareaControl(
 	props: WordPressComponentProps< TextareaControlProps, 'textarea', false >
 ) {
 	const {
@@ -57,7 +58,7 @@ export function TextareaControl(
 	const id = `inspector-textarea-control-${ instanceId }`;
 	const onChangeValue = ( event: ChangeEvent< HTMLTextAreaElement > ) =>
 		onChange( event.target.value );
-
+	const textareaRef = useRef( null );
 	return (
 		<BaseControl
 			__nextHasNoMarginBottom={ __nextHasNoMarginBottom }
@@ -71,6 +72,7 @@ export function TextareaControl(
 				className="components-textarea-control__input"
 				id={ id }
 				rows={ rows }
+				ref={ textareaRef }
 				onChange={ onChangeValue }
 				aria-describedby={ !! help ? id + '__help' : undefined }
 				value={ value }
@@ -80,4 +82,6 @@ export function TextareaControl(
 	);
 }
 
-export default TextareaControl;
+export const TextTextareaControl = forwardRef( UnforwardedTextareaControl );
+
+export default TextTextareaControl;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Expose a reference from TextareaControl.

## Why?

So one can work with textarea scrollheight property...

## How?

I used `forwardRef()`
