### PR TITLE
Snackbar: Reduce the time messages display by half

### DIFF
--- a/packages/components/src/snackbar/index.tsx
+++ b/packages/components/src/snackbar/index.tsx
@@ -19,7 +19,7 @@ import Button from '../button';
 import type { NoticeAction, SnackbarProps } from './types';
 import type { WordPressComponentProps } from '../ui/context';
 
-const NOTICE_TIMEOUT = 10000;
+const NOTICE_TIMEOUT = 5000;
 
 /**
  * Custom hook which announces the message with the given politeness, if a

--- a/packages/components/src/snackbar/index.tsx
+++ b/packages/components/src/snackbar/index.tsx
@@ -19,7 +19,7 @@ import Button from '../button';
 import type { NoticeAction, SnackbarProps } from './types';
 import type { WordPressComponentProps } from '../ui/context';
 
-const NOTICE_TIMEOUT = 5000;
+const NOTICE_TIMEOUT = 6000;
 
 /**
  * Custom hook which announces the message with the given politeness, if a


### PR DESCRIPTION
## What?
The snackbar messages currently stay on the screen for 10 seconds. This PR reduces that time to 5 seconds.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This can often result in messages stacking up, even on flows where there's a lot of time between actions. [See inserting patterns as an example](https://github.com/WordPress/gutenberg/pull/45237#pullrequestreview-1244791223) of where the UI can be obscured because the snackbar messages stick around for so long.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Reduce the `NOTICE_TIMEOUT` from 1000ms to 500ms.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Perform any action that initiates a snackbar display. Inserting a pattern or block is a good one.

## Screenshots or screencast <!-- if applicable -->
This is 5 seconds -- notice how the snackbar message covers the button to show the pattern directory:

![2023-01-16 10 58 49](https://user-images.githubusercontent.com/1464705/212749360-aa850cd5-60fb-4565-a268-af49034ee8c6.gif)
