### PR TITLE
Navigation Block: Avoid showing the contrast checker warning twice

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -472,17 +472,19 @@ function Navigation( {
 			'[data-type="core/navigation-submenu"] [data-type="core/navigation-link"]'
 		);
 
-		if ( subMenuElement ) {
-			// Only detect submenu overlay colors if they have previously been explicitly set.
-			// This avoids the contrast checker from reporting on inherited submenu colors and
-			// showing the contrast warning twice.
-			if ( overlayTextColor.color || overlayBackgroundColor.color ) {
-				detectColors(
-					subMenuElement,
-					setDetectedOverlayColor,
-					setDetectedOverlayBackgroundColor
-				);
-			}
+		if ( ! subMenuElement ) {
+			return;
+		}
+
+		// Only detect submenu overlay colors if they have previously been explicitly set.
+		// This avoids the contrast checker from reporting on inherited submenu colors and
+		// showing the contrast warning twice.
+		if ( overlayTextColor.color || overlayBackgroundColor.color ) {
+			detectColors(
+				subMenuElement,
+				setDetectedOverlayColor,
+				setDetectedOverlayBackgroundColor
+			);
 		}
 	} );
 

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -467,15 +467,22 @@ function Navigation( {
 			setDetectedColor,
 			setDetectedBackgroundColor
 		);
+
 		const subMenuElement = navRef.current?.querySelector(
-			'[data-type="core/navigation-link"] [data-type="core/navigation-link"]'
+			'[data-type="core/navigation-submenu"] [data-type="core/navigation-link"]'
 		);
+
 		if ( subMenuElement ) {
-			detectColors(
-				subMenuElement,
-				setDetectedOverlayColor,
-				setDetectedOverlayBackgroundColor
-			);
+			// Only detect submenu overlay colors if they have previously been explicitly set.
+			// This avoids the contrast checker from reporting on inherited submenu colors and
+			// showing the contrast warning twice.
+			if ( overlayTextColor.color || overlayBackgroundColor.color ) {
+				detectColors(
+					subMenuElement,
+					setDetectedOverlayColor,
+					setDetectedOverlayBackgroundColor
+				);
+			}
 		}
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/46637. 

* Avoid showing the contrast checker warning twice when submenus inherit poor contrast colors from the top level. 
* Fix the query of submenus from `navRef.current` so it doesn't mistakenly select top level items as sub menu items.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The contrast checker was incorrectly showing contrast warnings for submenu colors, even though they weren't set. This was confusing and seemed like the same warning was just being repeated.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Two things have changed:

* Use `[data-type="core/navigation-submenu"] [data-type="core/navigation-link"]` as the query selector on `navRef.current` so that it's always looking for a submenu and links within that submenu. As far as I can see this will ensure that it's not confusing other top level links for sub menu links.
* Check that a user has first set either a text or background color on the submenu. If both are transparent and unset, then the top level colors will be inherited/detected, and in this scenario you'll already have a contrast warning for the top level.

## Testing Instructions
1. Using at least Gutenberg 14.8 RC1, head to Appearance > Editor (beta)
2. Select the navigation block.
3. Using the color settings, set the text and background color to hard to read colors.
4. Confirm you only see one contrast warning.
5. Add a submenu item.
6. Confirm you only see one contrast warning.
7. Using the color settings, set the overlay text and overlay background to hard to read colors. 
8. Confirm you see two contrast warnings.
9. Using the color settings, set the text and background color to *easy* to read colors.
10. Confirm you only see one contrast warning.
 
## Screenshots or screencast <!-- if applicable -->

**Before**
<img width="143" alt="208336626-2b1cdac3-6a85-411e-b5ea-6bcd14e8ab95" src="https://user-images.githubusercontent.com/1464705/212778021-8117b9f8-4233-407c-9024-cafec45e26fe.png">

**After**
<img width="279" alt="Screenshot 2023-01-16 at 3 06 11 PM" src="https://user-images.githubusercontent.com/1464705/212778039-1fb42350-5f8d-4ae4-a4b6-1965493b899b.png">



