### PR TITLE
[Block Editor]: Stabilize __experimentalGetAllowedBlocks

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -159,6 +159,19 @@ _Returns_
 
 -   `?string`: Return the client ID of the block, or null if none exists.
 
+### getAllowedBlocks
+
+Returns the list of allowed inserter blocks for inner blocks children.
+
+_Parameters_
+
+-   _state_ `Object`: Editor state.
+-   _rootClientId_ `?string`: Optional root client ID of block list.
+
+_Returns_
+
+-   `Array?`: The list of allowed block types.
+
 ### getBlock
 
 Returns a block given its client ID. This is a parsed copy of the block,

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -225,7 +225,7 @@ export default compose( [
 			const {
 				getBlockRootClientId,
 				hasInserterItems,
-				__experimentalGetAllowedBlocks,
+				getAllowedBlocks,
 				__experimentalGetDirectInsertBlock,
 				getSettings,
 			} = select( blockEditorStore );
@@ -235,8 +235,7 @@ export default compose( [
 			rootClientId =
 				rootClientId || getBlockRootClientId( clientId ) || undefined;
 
-			const allowedBlocks =
-				__experimentalGetAllowedBlocks( rootClientId );
+			const allowedBlocks = getAllowedBlocks( rootClientId );
 
 			const directInsertBlock =
 				shouldDirectInsert &&

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2144,14 +2144,14 @@ export const hasInserterItems = createSelector(
 );
 
 /**
- * Returns the list of allowed inserter blocks for inner blocks children
+ * Returns the list of allowed inserter blocks for inner blocks children.
  *
  * @param {Object}  state        Editor state.
  * @param {?string} rootClientId Optional root client ID of block list.
  *
  * @return {Array?} The list of allowed block types.
  */
-export const __experimentalGetAllowedBlocks = createSelector(
+export const getAllowedBlocks = createSelector(
 	( state, rootClientId = null ) => {
 		if ( ! rootClientId ) {
 			return;
@@ -2160,6 +2160,28 @@ export const __experimentalGetAllowedBlocks = createSelector(
 		return getBlockTypes().filter( ( blockType ) =>
 			canIncludeBlockTypeInInserter( state, blockType, rootClientId )
 		);
+	},
+	( state, rootClientId ) => [
+		state.blockListSettings[ rootClientId ],
+		state.blocks.byClientId,
+		state.settings.allowedBlockTypes,
+		state.settings.templateLock,
+		getBlockTypes(),
+	]
+);
+
+export const __experimentalGetAllowedBlocks = createSelector(
+	( state, rootClientId = null ) => {
+		deprecated(
+			'wp.data.select( "core/block-editor" ).__experimentalGetAllowedBlocks',
+			{
+				alternative:
+					'wp.data.select( "core/block-editor" ).getAllowedBlocks',
+				since: '6.2',
+				version: '6.4',
+			}
+		);
+		return getAllowedBlocks( state, rootClientId );
 	},
 	( state, rootClientId ) => [
 		state.blockListSettings[ rootClientId ],

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2184,11 +2184,7 @@ export const __experimentalGetAllowedBlocks = createSelector(
 		return getAllowedBlocks( state, rootClientId );
 	},
 	( state, rootClientId ) => [
-		state.blockListSettings[ rootClientId ],
-		state.blocks.byClientId,
-		state.settings.allowedBlockTypes,
-		state.settings.templateLock,
-		getBlockTypes(),
+		...getAllowedBlocks.getDependants( state, rootClientId ),
 	]
 );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/47196

This PR stabilizes `__experimentalGetAllowedBlocks` to `getAllowedBlocks`.

WP Directory link: https://wpdirectory.net/search/01GPZCT769GRRJ7RHYW2N4E6B0

## Testing Instructions
1. Everything should work as before.
2. The change affects the inserter fetching the allowed blocks for the selected insertion point.


