### PR TITLE
Lodash: Deprecate `_.map()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -101,6 +101,7 @@ const restrictedImports = [
 			'keys',
 			'last',
 			'lowerCase',
+			'map',
 			'mapKeys',
 			'maxBy',
 			'memoize',


### PR DESCRIPTION
## What?
This PR deprecates Lodash's `_.map()` in our ESLint config, since it's no longer in use.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're adding a rule to forbid the usage of `_.map()` through ESLint. 

## Testing Instructions

No testing is necessary.