### PR TITLE
core-data: Refactor tests to use real timers

### DIFF
--- a/packages/core-data/src/hooks/test/use-entity-record.js
+++ b/packages/core-data/src/hooks/test/use-entity-record.js
@@ -9,7 +9,7 @@ jest.mock( '@wordpress/api-fetch' );
 /**
  * External dependencies
  */
-import { act, render } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -21,15 +21,8 @@ describe( 'useEntityRecord', () => {
 	let registry;
 
 	beforeEach( () => {
-		jest.useFakeTimers();
-
 		registry = createRegistry();
 		registry.register( coreDataStore );
-	} );
-
-	afterEach( () => {
-		jest.runOnlyPendingTimers();
-		jest.useRealTimers();
 	} );
 
 	const TEST_RECORD = { id: 1, hello: 'world' };
@@ -60,14 +53,12 @@ describe( 'useEntityRecord', () => {
 			status: 'IDLE',
 		} );
 
-		await act( async () => {
-			jest.advanceTimersByTime( 1 );
-		} );
-
 		// Fetch request should have been issued
-		expect( triggerFetch ).toHaveBeenCalledWith( {
-			path: '/wp/v2/widgets/1?context=edit',
-		} );
+		await waitFor( () =>
+			expect( triggerFetch ).toHaveBeenCalledWith( {
+				path: '/wp/v2/widgets/1?context=edit',
+			} )
+		);
 
 		expect( data ).toEqual( {
 			edit: expect.any( Function ),
@@ -96,27 +87,25 @@ describe( 'useEntityRecord', () => {
 			</RegistryProvider>
 		);
 
-		await act( async () => {
-			jest.advanceTimersByTime( 1 );
-		} );
-
-		expect( widget ).toEqual( {
-			edit: expect.any( Function ),
-			editedRecord: { hello: 'world', id: 1 },
-			hasEdits: false,
-			record: { hello: 'world', id: 1 },
-			save: expect.any( Function ),
-			hasResolved: true,
-			isResolving: false,
-			status: 'SUCCESS',
-		} );
+		await waitFor( () =>
+			expect( widget ).toEqual( {
+				edit: expect.any( Function ),
+				editedRecord: { hello: 'world', id: 1 },
+				hasEdits: false,
+				record: { hello: 'world', id: 1 },
+				save: expect.any( Function ),
+				hasResolved: true,
+				isResolving: false,
+				status: 'SUCCESS',
+			} )
+		);
 
 		await act( async () => {
 			widget.edit( { hello: 'foo' } );
-			jest.advanceTimersByTime( 1 );
 		} );
 
-		expect( widget.hasEdits ).toEqual( true );
+		await waitFor( () => expect( widget.hasEdits ).toEqual( true ) );
+
 		expect( widget.record ).toEqual( { hello: 'world', id: 1 } );
 		expect( widget.editedRecord ).toEqual( { hello: 'foo', id: 1 } );
 	} );

--- a/packages/core-data/src/hooks/test/use-entity-records.js
+++ b/packages/core-data/src/hooks/test/use-entity-records.js
@@ -9,7 +9,7 @@ jest.mock( '@wordpress/api-fetch' );
 /**
  * External dependencies
  */
-import { act, render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -21,15 +21,8 @@ describe( 'useEntityRecords', () => {
 	let registry;
 
 	beforeEach( () => {
-		jest.useFakeTimers();
-
 		registry = createRegistry();
 		registry.register( coreDataStore );
-	} );
-
-	afterEach( () => {
-		jest.runOnlyPendingTimers();
-		jest.useRealTimers();
 	} );
 
 	const TEST_RECORDS = [
@@ -60,14 +53,12 @@ describe( 'useEntityRecords', () => {
 			status: 'IDLE',
 		} );
 
-		await act( async () => {
-			jest.advanceTimersByTime( 1 );
-		} );
-
 		// Fetch request should have been issued
-		expect( triggerFetch ).toHaveBeenCalledWith( {
-			path: '/wp/v2/widgets?context=edit&status=draft',
-		} );
+		await waitFor( () =>
+			expect( triggerFetch ).toHaveBeenCalledWith( {
+				path: '/wp/v2/widgets?context=edit&status=draft',
+			} )
+		);
 
 		expect( data ).toEqual( {
 			records: TEST_RECORDS,

--- a/packages/core-data/src/hooks/test/use-query-select.js
+++ b/packages/core-data/src/hooks/test/use-query-select.js
@@ -10,7 +10,7 @@ import {
 /**
  * External dependencies
  */
-import { act, render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -21,8 +21,6 @@ describe( 'useQuerySelect', () => {
 	let registry;
 
 	beforeEach( () => {
-		jest.useFakeTimers();
-
 		registry = createRegistry();
 		registry.registerStore( 'testStore', {
 			reducer: () => ( { foo: 'bar' } ),
@@ -31,11 +29,6 @@ describe( 'useQuerySelect', () => {
 				testSelector: ( state, key ) => state[ key ],
 			},
 		} );
-	} );
-
-	afterEach( () => {
-		jest.runOnlyPendingTimers();
-		jest.useRealTimers();
 	} );
 
 	const getTestComponent = ( mapSelectSpy, dependencyKey ) => ( props ) => {
@@ -177,21 +170,20 @@ describe( 'useQuerySelect', () => {
 			status: 'IDLE',
 		} );
 
-		await act( async () => {
-			jest.advanceTimersToNextTimer();
-		} );
-
 		// Re-render, expect resolved data
 		render(
 			<RegistryProvider value={ registry }>
 				<TestComponent />
 			</RegistryProvider>
 		);
-		expect( querySelectData ).toEqual( {
-			data: 15,
-			isResolving: false,
-			hasResolved: true,
-			status: 'SUCCESS',
-		} );
+
+		await waitFor( () =>
+			expect( querySelectData ).toEqual( {
+				data: 15,
+				isResolving: false,
+				hasResolved: true,
+				status: 'SUCCESS',
+			} )
+		);
 	} );
 } );

--- a/packages/core-data/src/hooks/test/use-resource-permissions.js
+++ b/packages/core-data/src/hooks/test/use-resource-permissions.js
@@ -9,7 +9,7 @@ jest.mock( '@wordpress/api-fetch' );
 /**
  * External dependencies
  */
-import { act, render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -20,8 +20,6 @@ import useResourcePermissions from '../use-resource-permissions';
 describe( 'useResourcePermissions', () => {
 	let registry;
 	beforeEach( () => {
-		jest.useFakeTimers();
-
 		registry = createRegistry();
 		registry.register( coreDataStore );
 
@@ -32,11 +30,6 @@ describe( 'useResourcePermissions', () => {
 				} ),
 			},
 		} ) );
-	} );
-
-	afterEach( () => {
-		jest.runOnlyPendingTimers();
-		jest.useRealTimers();
 	} );
 
 	it( 'retrieves the relevant permissions for a key-less resource', async () => {
@@ -58,18 +51,15 @@ describe( 'useResourcePermissions', () => {
 			canRead: false,
 		} );
 
-		// Required to make sure no updates happen outside of act()
-		await act( async () => {
-			jest.advanceTimersByTime( 1 );
-		} );
-
-		expect( data ).toEqual( {
-			status: 'SUCCESS',
-			isResolving: false,
-			hasResolved: true,
-			canCreate: true,
-			canRead: false,
-		} );
+		await waitFor( () =>
+			expect( data ).toEqual( {
+				status: 'SUCCESS',
+				isResolving: false,
+				hasResolved: true,
+				canCreate: true,
+				canRead: false,
+			} )
+		);
 	} );
 
 	it( 'retrieves the relevant permissions for a resource with a key', async () => {
@@ -93,19 +83,16 @@ describe( 'useResourcePermissions', () => {
 			canDelete: false,
 		} );
 
-		// Required to make sure no updates happen outside of act()
-		await act( async () => {
-			jest.advanceTimersByTime( 1 );
-		} );
-
-		expect( data ).toEqual( {
-			status: 'SUCCESS',
-			isResolving: false,
-			hasResolved: true,
-			canCreate: true,
-			canRead: false,
-			canUpdate: false,
-			canDelete: false,
-		} );
+		await waitFor( () =>
+			expect( data ).toEqual( {
+				status: 'SUCCESS',
+				isResolving: false,
+				hasResolved: true,
+				canCreate: true,
+				canRead: false,
+				canUpdate: false,
+				canDelete: false,
+			} )
+		);
 	} );
 } );


### PR DESCRIPTION
## What?
This PR updates more tests in the `@wordpress/core-data` package to use real timers. This is a follow-up to #46714, #47056, and #47144.

## Why?
We discovered that Jest real timers are preferable when their use is possible, see https://github.com/facebook/react/issues/25889 and the description in #46714.

This post is great writing that explains the rationale in more detail:
https://jsnajdr.wordpress.com/2023/01/11/prefer-jest-real-timers-when-testing-with-react-testing-library/

## How?
We're removing the specific `jest.useFakeTimers();` calls. We're also removing the now unnecessary `jest.advanceTimersByTime()` calls and post-test cleanup that we've been doing with `jest.runOnlyPendingTimers()` and `jest.useRealTimers()`.

## Testing Instructions
Verify all tests still pass.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None.