### PR TITLE
ESLint: Fix `jest/expect-expect` violations

### DIFF
--- a/packages/components/src/ui/context/test/context-connect.tsx
+++ b/packages/components/src/ui/context/test/context-connect.tsx
@@ -10,6 +10,7 @@ import { contextConnect, contextConnectWithoutRef } from '../context-connect';
 import type { WordPressComponentProps } from '../wordpress-component';
 
 // Static TypeScript tests
+/* eslint-disable jest/expect-expect */
 describe( 'ref forwarding', () => {
 	const ComponentWithRef = (
 		props: WordPressComponentProps< {}, 'div' >,
@@ -53,3 +54,4 @@ describe( 'ref forwarding', () => {
 		<NoRef foo={ null } />;
 	} );
 } );
+/* eslint-enable jest/expect-expect */

--- a/packages/components/src/ui/context/test/wordpress-component.tsx
+++ b/packages/components/src/ui/context/test/wordpress-component.tsx
@@ -14,6 +14,7 @@ import { forwardRef } from '@wordpress/element';
 import type { WordPressComponentProps } from '../wordpress-component';
 
 // Static TypeScript checks
+/* eslint-disable jest/expect-expect */
 describe( 'WordPressComponentProps', () => {
 	it( 'should not accept a ref', () => {
 		const Foo = ( props: WordPressComponentProps< {}, 'div' > ) => (
@@ -34,3 +35,4 @@ describe( 'WordPressComponentProps', () => {
 		<ForwardedFoo ref={ null } />;
 	} );
 } );
+/* eslint-enable jest/expect-expect */

--- a/packages/custom-templated-path-webpack-plugin/test/index.js
+++ b/packages/custom-templated-path-webpack-plugin/test/index.js
@@ -32,7 +32,9 @@ describe( 'CustomTemplatedPathPlugin', () => {
 	} );
 
 	it( 'should resolve with basename output', async () => {
-		await webpackAsync( config );
-		await accessAsync( outputFile );
+		expect( async () => {
+			await webpackAsync( config );
+			await accessAsync( outputFile );
+		} ).not.toThrow();
 	} );
 } );

--- a/packages/editor/src/components/editor-help/test/index.native.js
+++ b/packages/editor/src/components/editor-help/test/index.native.js
@@ -36,11 +36,11 @@ it( 'navigates back from help topic detail screen', async () => {
 	fireEvent.press( backButton[ backButton.length - 1 ] );
 
 	// Currently logs `act` warning due to https://github.com/callstack/react-native-testing-library/issues/379
-	await waitForElementToBeRemoved( () =>
-		screen.getByText(
-			'Each block has its own settings. To find them, tap on a block. Its settings will appear on the toolbar at the bottom of the screen.'
-		)
-	);
+	const text =
+		'Each block has its own settings. To find them, tap on a block. Its settings will appear on the toolbar at the bottom of the screen.';
+	await waitForElementToBeRemoved( () => screen.getByText( text ) );
+
+	expect( screen.queryByText( text ) ).toBeNull();
 } );
 
 it( 'dismisses when close button is pressed', async () => {

--- a/test/integration/full-content/full-content.test.js
+++ b/test/integration/full-content/full-content.test.js
@@ -221,76 +221,80 @@ describe( 'full post content fixture', () => {
 	} );
 
 	it( 'should be present for each block', () => {
-		const errors = [];
+		expect( () => {
+			const errors = [];
 
-		getBlockTypes()
-			.map( ( block ) => block.name )
-			// We don't want tests for each oembed provider, which all have the same
-			// `save` functions and attributes.
-			// The `core/template` is not worth testing here because it's never saved, it's covered better in e2e tests.
-			.filter(
-				( name ) => ! [ 'core/embed', 'core/template' ].includes( name )
-			)
-			.forEach( ( name ) => {
-				const nameToFilename = blockNameToFixtureBasename( name );
-				const foundFixtures = blockBasenames
-					.filter(
-						( basename ) =>
-							basename === nameToFilename ||
-							basename.startsWith( nameToFilename + '__' )
-					)
-					.map( ( basename ) => {
-						const { filename: htmlFixtureFileName } =
-							getBlockFixtureHTML( basename );
-						const { file: jsonFixtureContent } =
-							getBlockFixtureJSON( basename );
-						// The parser output for this test.  For missing files,
-						// JSON.parse( null ) === null.
-						const parserOutput = JSON.parse( jsonFixtureContent );
-						// The name of the first block that this fixture file
-						// contains (if any).
-						const firstBlock = get(
-							parserOutput,
-							[ '0', 'name' ],
-							null
-						);
-						return {
-							filename: htmlFixtureFileName,
-							parserOutput,
-							firstBlock,
-						};
-					} )
-					.filter( ( fixture ) => fixture.parserOutput !== null );
-
-				if ( ! foundFixtures.length ) {
-					errors.push(
-						format(
-							"Expected a fixture file called '%s.html' or '%s__*.html' in `test/integration/fixtures/blocks/` " +
-								'\n\n' +
-								'For more information on how to create test fixtures see https://github.com/WordPress/gutenberg/blob/1f75f8f6f500a20df5b9d6e317b4d72dd5af4ede/test/integration/fixtures/blocks/README.md\n\n',
-							nameToFilename,
-							nameToFilename
+			getBlockTypes()
+				.map( ( block ) => block.name )
+				// We don't want tests for each oembed provider, which all have the same
+				// `save` functions and attributes.
+				// The `core/template` is not worth testing here because it's never saved, it's covered better in e2e tests.
+				.filter(
+					( name ) =>
+						! [ 'core/embed', 'core/template' ].includes( name )
+				)
+				.forEach( ( name ) => {
+					const nameToFilename = blockNameToFixtureBasename( name );
+					const foundFixtures = blockBasenames
+						.filter(
+							( basename ) =>
+								basename === nameToFilename ||
+								basename.startsWith( nameToFilename + '__' )
 						)
-					);
-				}
+						.map( ( basename ) => {
+							const { filename: htmlFixtureFileName } =
+								getBlockFixtureHTML( basename );
+							const { file: jsonFixtureContent } =
+								getBlockFixtureJSON( basename );
+							// The parser output for this test.  For missing files,
+							// JSON.parse( null ) === null.
+							const parserOutput =
+								JSON.parse( jsonFixtureContent );
+							// The name of the first block that this fixture file
+							// contains (if any).
+							const firstBlock = get(
+								parserOutput,
+								[ '0', 'name' ],
+								null
+							);
+							return {
+								filename: htmlFixtureFileName,
+								parserOutput,
+								firstBlock,
+							};
+						} )
+						.filter( ( fixture ) => fixture.parserOutput !== null );
 
-				foundFixtures.forEach( ( fixture ) => {
-					if ( name !== fixture.firstBlock ) {
+					if ( ! foundFixtures.length ) {
 						errors.push(
 							format(
-								"Expected fixture file '%s' to test the '%s' block.",
-								fixture.filename,
-								name
+								"Expected a fixture file called '%s.html' or '%s__*.html' in `test/integration/fixtures/blocks/` " +
+									'\n\n' +
+									'For more information on how to create test fixtures see https://github.com/WordPress/gutenberg/blob/1f75f8f6f500a20df5b9d6e317b4d72dd5af4ede/test/integration/fixtures/blocks/README.md\n\n',
+								nameToFilename,
+								nameToFilename
 							)
 						);
 					}
-				} );
-			} );
 
-		if ( errors.length ) {
-			throw new Error(
-				'Problem(s) with fixture files:\n\n' + errors.join( '\n' )
-			);
-		}
+					foundFixtures.forEach( ( fixture ) => {
+						if ( name !== fixture.firstBlock ) {
+							errors.push(
+								format(
+									"Expected fixture file '%s' to test the '%s' block.",
+									fixture.filename,
+									name
+								)
+							);
+						}
+					} );
+				} );
+
+			if ( errors.length ) {
+				throw new Error(
+					'Problem(s) with fixture files:\n\n' + errors.join( '\n' )
+				);
+			}
+		} ).not.toThrow();
 	} );
 } );


### PR DESCRIPTION
## What?
This PR fixes all of the [`jest/expect-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/b9faa0f27773465c4cad0116acf36c471ae2d6c1/docs/rules/expect-expect.md) violations that should not exist.

## Why?
Ideally, the project should not have any ESLint errors and warnings. We already removed all errors, and this PR cuts many of the existing warnings.

## How?
We're extending the rule when needed. We're also finishing up a few tests that were not quite finished. We're ignoring the rule where that's the intended way to move forward.

We're leaving three violations of the rule intact - those are expected, since these tests are empty and still have to be written. The rest of the warnings are violating the `jest/no-disabled-tests`, so this PR isn't touching them intentionally. 

## Testing Instructions
* Run `npm run lint:js` and verify that the only `jest/expect-expect` violations are the ones in the screenshot below. 
* Verify all tests still pass.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2023-01-17 at 16 05 06](https://user-images.githubusercontent.com/8436925/212919669-f6c15a6f-345e-4698-8fe1-3e8557adb606.png)
