### PR TITLE
Theme: Exclude readme from public docs

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1230,12 +1230,6 @@
 		"parent": "components"
 	},
 	{
-		"title": "Theme",
-		"slug": "theme",
-		"markdown_source": "../packages/components/src/theme/README.md",
-		"parent": "components"
-	},
-	{
 		"title": "ToggleControl",
 		"slug": "toggle-control",
 		"markdown_source": "../packages/components/src/toggle-control/README.md",

--- a/docs/tool/manifest.js
+++ b/docs/tool/manifest.js
@@ -12,6 +12,7 @@ const componentPaths = glob( 'packages/components/src/*/**/README.md', {
 	ignore: [
 		'**/src/mobile/**/README.md',
 		'**/src/ui/**/README.md',
+		'packages/components/src/theme/README.md',
 		'packages/components/src/view/README.md',
 	],
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Excludes the `Theme` component readme from the public docs.

## Why?

The component isn't exported from the public package.

## How?

Add it as an exclude in the build script.

## Testing Instructions

✅  CI checks pass