### PR TITLE
[Block Editor - Post Template]: Fix layout styles

### DIFF
--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -28,7 +28,7 @@ const TEMPLATE = [
 function PostTemplateInnerBlocks() {
 	const innerBlocksProps = useInnerBlocksProps(
 		{ className: 'wp-block-post' },
-		{ template: TEMPLATE }
+		{ template: TEMPLATE, __unstableDisableLayoutClassNames: true }
 	);
 	return <li { ...innerBlocksProps } />;
 }
@@ -98,6 +98,7 @@ export default function PostTemplateEdit( {
 		displayLayout: { type: layoutType = 'flex', columns = 1 } = {},
 		previewPostType,
 	},
+	__unstableLayoutClassNames,
 } ) {
 	const [ { page } ] = queryContext;
 	const [ activeBlockContextId, setActiveBlockContextId ] = useState();
@@ -216,7 +217,7 @@ export default function PostTemplateEdit( {
 	);
 	const hasLayoutFlex = layoutType === 'flex' && columns > 1;
 	const blockProps = useBlockProps( {
-		className: classnames( {
+		className: classnames( __unstableLayoutClassNames, {
 			'is-flex-container': hasLayoutFlex,
 			[ `columns-${ columns }` ]: hasLayoutFlex,
 		} ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/47129

Layout classes(`is-layout-flow`) should be applied only to the wrapper element(`ul`) and not on the selected inner blocks wrapper through `useInnerBlocksProps`. This is already [handled server side].(https://github.com/WordPress/gutenberg/pull/41827)

Related: https://github.com/WordPress/gutenberg/pull/44600
<!-- In a few words, what is the PR actually doing? -->


## Testing Instructions
1. Insert Query Loop block and ensure the 'spacing' between the selected `post` and the others is the same and remains the same when we select another's post inner block.
2. Ensure the proper layout classes are added in the wrapper(`ul`)
3. Query Loop instances should work as before with no style regressions



### Before

<img width="828" alt="Markup 2022-12-27 at 15 06 06" src="https://user-images.githubusercontent.com/26996883/212223014-18e8718a-c749-4392-b1eb-250ba13a21ce.png">

### After

https://user-images.githubusercontent.com/16275880/212966995-46d15690-5e52-42bd-8cc6-f3253f7a1e13.mov



