### PR TITLE
Template Parts: Add unit tests for template part creation functions

### DIFF
--- a/packages/edit-site/src/utils/test/template-part-create.js
+++ b/packages/edit-site/src/utils/test/template-part-create.js
@@ -1,0 +1,63 @@
+/**
+ * Internal dependencies
+ */
+import {
+	getUniqueTemplatePartTitle,
+	getCleanTemplatePartSlug,
+} from '../template-part-create';
+
+describe( 'getUniqueTemplatePartTitle', () => {
+	it( 'should return the title if it is unique', () => {
+		const title = 'My Template Part';
+		const templateParts = [
+			{
+				title: {
+					rendered: 'Template Part With Another Title',
+				},
+			},
+		];
+
+		expect( getUniqueTemplatePartTitle( title, templateParts ) ).toBe(
+			title
+		);
+	} );
+
+	it( 'should return the title with a suffix if it is not unique', () => {
+		const title = 'My Template Part';
+		const templateParts = [
+			{
+				title: {
+					rendered: 'My Template Part',
+				},
+			},
+			{
+				title: {
+					rendered: 'My Template Part 2',
+				},
+			},
+		];
+
+		expect( getUniqueTemplatePartTitle( title, templateParts ) ).toBe(
+			'My Template Part 3'
+		);
+	} );
+} );
+
+describe( 'getCleanTemplatePartSlug', () => {
+	it( 'should return a slug with only latin chars', () => {
+		const title = 'Myɶ Template Partɮ';
+		expect( getCleanTemplatePartSlug( title ) ).toBe( 'my-template-part' );
+	} );
+
+	it( 'should return a slug with only latin chars and numbers', () => {
+		const title = 'My Template Part 2';
+		expect( getCleanTemplatePartSlug( title ) ).toBe(
+			'my-template-part-2'
+		);
+	} );
+
+	it( 'should return a slug of wp-custom-part', () => {
+		const title = '';
+		expect( getCleanTemplatePartSlug( title ) ).toBe( 'wp-custom-part' );
+	} );
+} );

--- a/packages/edit-site/src/utils/test/template-part-create.js
+++ b/packages/edit-site/src/utils/test/template-part-create.js
@@ -56,7 +56,7 @@ describe( 'getCleanTemplatePartSlug', () => {
 		);
 	} );
 
-	it( 'should return a slug of wp-custom-part', () => {
+	it( 'should default the slug to wp-custom-part', () => {
 		const title = '';
 		expect( getCleanTemplatePartSlug( title ) ).toBe( 'wp-custom-part' );
 	} );


### PR DESCRIPTION
## What?
Follow up to https://github.com/WordPress/gutenberg/pull/47082 that adds unit tests for `getUniqueTemplatePartTitle` and `getCleanTemplatePartSlug`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To make sure these are working correctly. :)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Some pretty basic Jest unit tests in `packages/edit-site/src/utils/test/`.

## Testing Instructions
Run `npm run test:unit packages/edit-site/src/utils/test/template-part-create.js` and you should see these tests pass:

<img width="960" alt="Screenshot 2023-01-17 at 11 31 25 AM" src="https://user-images.githubusercontent.com/1464705/212995219-b078e03e-9c77-4fd6-8957-6e3d293cae57.png">

