### PR TITLE
List View: Fix crash when the first template-parts is deleted width del key

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   `BlockInspector`: Fix browser warning error when block is not selected ([#46875](https://github.com/WordPress/gutenberg/pull/46875)).
 -   Move component styles needed for iframes to content styles ([#47103](https://github.com/WordPress/gutenberg/pull/47103)).
 -   Block Inserter: Correctly apply style to the default inserter ([#47166](https://github.com/WordPress/gutenberg/pull/47166)).
+-   List View: Fix crash when the first template-parts is deleted width del key ([#47227](https://github.com/WordPress/gutenberg/pull/47227)).
 
 ## 11.1.0 (2023-01-02)
 

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -209,7 +209,7 @@ function ListViewBlock( {
 		'is-synced-branch': isSyncedBranch,
 		'is-dragging': isDragged,
 		'has-single-cell': ! showBlockActions,
-		'is-synced': blockInformation.isSynced,
+		'is-synced': blockInformation?.isSynced,
 	} );
 
 	// Only include all selected blocks if the currently clicked on block


### PR DESCRIPTION
Fixes: #47226

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR fixes the site editor crash when deleting the first template part block with the `del` key while the list view is open. This problem occurs when the template part block you are trying to delete is at the top of the block list.

## Why?

I have confirmed that the `useBlockDisplayInformation` hook returns `null` when the first template part is deleted with the del key.
I don't know why this does not occur when deleting from the dropdown, but I expect it is because the order of events and processing changes.

I also believe that the null check is necessary because [`useBlockDisplayInformation` may return `null`](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/README.md#useblockdisplayinformation).

## How?

Added optional chaining.

### Testing Instructions

- Access the site editor
- Open "Page" template
- Open the list view (Opening the list view is a must.)
- Select "Header" template
- Press the DEL key

### Before

https://user-images.githubusercontent.com/54422211/213079438-d61394f4-c9ce-49b4-8b3b-f478cd3cb187.mp4

### After

https://user-images.githubusercontent.com/54422211/213079451-5d39754b-42a5-4e78-9b09-ab9bf60bdd44.mp4

