### PR TITLE
Sticky Position: Make help text aware of whether or not there is a parent block

### DIFF
--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -46,9 +46,7 @@ const STICKY_OPTION = {
 	value: 'sticky',
 	name: __( 'Sticky' ),
 	className: OPTION_CLASSNAME,
-	__experimentalHint: __(
-		'The block will stick to the top of the window instead of scrolling.'
-	),
+	__experimentalHint: __( 'Sticks to the top of the window.' ),
 };
 
 const FIXED_OPTION = {
@@ -242,9 +240,7 @@ export function PositionEdit( props ) {
 							__( 'Sticks to the top of the parent %s block.' ),
 							parentBlockTitle
 					  )
-					: __(
-							'Sticks to the top of the window instead of scrolling.'
-					  ),
+					: __( 'Sticks to the top of the window.' ),
 			} );
 		}
 		if ( allowFixed || value === FIXED_OPTION.value ) {

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -46,7 +46,7 @@ const STICKY_OPTION = {
 	value: 'sticky',
 	name: __( 'Sticky' ),
 	className: OPTION_CLASSNAME,
-	__experimentalHint: __( 'Sticks to the top of the window.' ),
+	__experimentalHint: __( 'Sticks to the top of the window when scrolling.' ),
 };
 
 const FIXED_OPTION = {
@@ -237,10 +237,12 @@ export function PositionEdit( props ) {
 				__experimentalHint: parentBlockTitle
 					? sprintf(
 							/* translators: %s: Name of the block's parent. */
-							__( 'Sticks to the top of the parent %s block.' ),
+							__(
+								'Sticks to the top of the parent %s block when scrolling.'
+							),
 							parentBlockTitle
 					  )
-					: __( 'Sticks to the top of the window.' ),
+					: __( 'Sticks to the top of the window when scrolling.' ),
 			} );
 		}
 		if ( allowFixed || value === FIXED_OPTION.value ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of https://github.com/WordPress/gutenberg/issues/47043

Make help text for Sticky Position controls aware of whether or not there is a parent block, and conditionally change the help text to refer to sticking to the top of the window, or the top of the parent block (including that block's name).

The proposed text so far:

* If there is a block parent: `'Sticks to the top of the parent %s block.'`
* If there is no block parent: `'Sticks to the top of the window instead of scrolling.'`

Happy to change this text to whatever works the best here.

Kudos @richtabor for the idea!

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This PR is an alternative to #47207, but has a similar objective of trying to improve the UX surrounding Sticky Position support by making it clearer to the user where and how the sticky position will be applied. This PR is a fairly subtle change, but makes the help text more explicit based on the context of where the block is located.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In the `PositionEdit` component, check to see whether or not there is a block parent. If so, use its display title in the help text message for the sticky option. If not, default to the help text indicating the block will stick to the top of the window.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In a post (or the site editor), add a Group block at the root of the document, and set it to Sticky in the block's settings — note that the hint text in the list of options should refer to sticking to the top of the window.
2. Create a Group block that is nested (e.g. within a template part, or within another Group block). Go to set the block to Sticky, and you should see the help text indicate the it will stick to the top of the parent block rather than the window.

## Screenshots or screencast <!-- if applicable -->

| The dropdown list when the block is at the root level | The dropdown list when the block has at least one parent |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/213087476-2da40d73-f19d-464b-abc4-4faee8be5df0.png) | ![image](https://user-images.githubusercontent.com/14988353/213087491-d62028da-6fbe-4105-8400-f51ab72d1492.png) |