### PR TITLE
Stabilise BlockPreview props

### DIFF
--- a/packages/block-editor/src/components/block-pattern-setup/index.js
+++ b/packages/block-editor/src/components/block-pattern-setup/index.js
@@ -127,10 +127,7 @@ function BlockPatternSlide( { className, pattern, minHeight } ) {
 			aria-label={ title }
 			aria-describedby={ description ? descriptionId : undefined }
 		>
-			<BlockPreview
-				blocks={ blocks }
-				__experimentalMinHeight={ minHeight }
-			/>
+			<BlockPreview blocks={ blocks } minHeight={ minHeight } />
 			{ !! description && (
 				<VisuallyHidden id={ descriptionId }>
 					{ description }

--- a/packages/block-editor/src/components/block-preview/README.md
+++ b/packages/block-editor/src/components/block-preview/README.md
@@ -30,26 +30,26 @@ Width of the preview container in pixels. Controls at what size the blocks will 
 
 Set `viewportWidth` to `0` to make the viewport the same width as the container.
 
-### `__experimentalPadding`
+### minHeight
 
--   **Type** `Int`
--   **Default** `undefined`
+Minimum height of the preview iframe in pixels.
 
-Padding for the preview container body.
+-   **Type:** `Int`
+-   **Default:** `undefined`
 
-### `__experimentalStyles`
+### `additionalStyles`
 
 List of additional editor styles to load into the preview iframe. Each object
 should contain a `css` attribute. See `EditorStyles` for more info.
 
 ```jsx
 <BlockPreview
-    blocks={ blocks }
-	__experimentalStyles={ [
-		{ css: '.wp-block { margin: 16px; }' },
+	blocks={ blocks }
+	additionalStyles={ [
+		{ css: 'body { padding: 16px; }' },
 	] }
 />
 ```
 
--   **Type** `Int`
+-   **Type** `Array`
 -   **Default** `[]`

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -45,11 +45,11 @@ function ScaledBlockPreview( {
 		if ( styles ) {
 			return [
 				...styles,
-				...additionalStyles,
 				{
-					css: 'body{height:auto;overflow:hidden;border:none;}',
+					css: 'body{height:auto;overflow:hidden;border:none;padding:0;}',
 					__unstableType: 'presets',
 				},
+				...additionalStyles,
 			];
 		}
 

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -23,9 +23,8 @@ const MAX_HEIGHT = 2000;
 function ScaledBlockPreview( {
 	viewportWidth,
 	containerWidth,
-	__experimentalPadding,
-	__experimentalMinHeight,
-	__experimentalStyles,
+	minHeight,
+	additionalStyles = [],
 } ) {
 	if ( ! viewportWidth ) {
 		viewportWidth = containerWidth;
@@ -46,7 +45,7 @@ function ScaledBlockPreview( {
 		if ( styles ) {
 			return [
 				...styles,
-				...__experimentalStyles,
+				...additionalStyles,
 				{
 					css: 'body{height:auto;overflow:hidden;border:none;}',
 					__unstableType: 'presets',
@@ -55,7 +54,7 @@ function ScaledBlockPreview( {
 		}
 
 		return styles;
-	}, [ styles, __experimentalStyles ] );
+	}, [ styles, additionalStyles ] );
 
 	const svgFilters = useMemo( () => {
 		return [ ...( duotone?.default ?? [] ), ...( duotone?.theme ?? [] ) ];
@@ -73,7 +72,7 @@ function ScaledBlockPreview( {
 				height: contentHeight * scale,
 				maxHeight:
 					contentHeight > MAX_HEIGHT ? MAX_HEIGHT * scale : undefined,
-				minHeight: __experimentalMinHeight,
+				minHeight,
 			} }
 		>
 			<Iframe
@@ -87,7 +86,6 @@ function ScaledBlockPreview( {
 					);
 					documentElement.style.position = 'absolute';
 					documentElement.style.width = '100%';
-					bodyElement.style.padding = __experimentalPadding + 'px';
 
 					// Necessary for contentResizeListener to work.
 					bodyElement.style.boxSizing = 'border-box';
@@ -105,9 +103,9 @@ function ScaledBlockPreview( {
 					// See: https://github.com/WordPress/gutenberg/pull/38175.
 					maxHeight: MAX_HEIGHT,
 					minHeight:
-						scale !== 0 && scale < 1 && __experimentalMinHeight
-							? __experimentalMinHeight / scale
-							: __experimentalMinHeight,
+						scale !== 0 && scale < 1 && minHeight
+							? minHeight / scale
+							: minHeight,
 				} }
 			>
 				{ contentResizeListener }

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -26,7 +26,6 @@ export function BlockPreview( {
 	additionalStyles = [],
 	// Deprecated props:
 	__experimentalMinHeight,
-	__experimentalStyles,
 	__experimentalPadding,
 } ) {
 	if ( __experimentalMinHeight ) {
@@ -34,15 +33,6 @@ export function BlockPreview( {
 		deprecated( 'The __experimentalMinHeight prop', {
 			since: '6.2',
 			alternative: 'minHeight',
-		} );
-	}
-	if ( __experimentalStyles ) {
-		additionalStyles = __experimentalStyles;
-		deprecated( 'The __experimentalStyles prop of BlockPreview', {
-			plugin: 'Gutenberg',
-			since: '15.0',
-			version: '15.2',
-			alternative: 'additionalStyles',
 		} );
 	}
 	if ( __experimentalPadding ) {

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -32,6 +32,7 @@ export function BlockPreview( {
 		minHeight = __experimentalMinHeight;
 		deprecated( 'The __experimentalMinHeight prop', {
 			since: '6.2',
+			version: '6.4',
 			alternative: 'minHeight',
 		} );
 	}
@@ -42,6 +43,7 @@ export function BlockPreview( {
 		];
 		deprecated( 'The __experimentalPadding prop of BlockPreview', {
 			since: '6.2',
+			version: '6.4',
 			alternative: 'additionalStyles',
 		} );
 	}

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
 import { useDisabled, useMergeRefs } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { memo, useMemo } from '@wordpress/element';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -20,11 +21,41 @@ import { BlockListItems } from '../block-list';
 
 export function BlockPreview( {
 	blocks,
-	__experimentalPadding = 0,
 	viewportWidth = 1200,
+	minHeight,
+	additionalStyles = [],
+	// Deprecated props:
 	__experimentalMinHeight,
-	__experimentalStyles = [],
+	__experimentalStyles,
+	__experimentalPadding,
 } ) {
+	if ( __experimentalMinHeight ) {
+		minHeight = __experimentalMinHeight;
+		deprecated( 'The __experimentalMinHeight prop', {
+			since: '6.2',
+			alternative: 'minHeight',
+		} );
+	}
+	if ( __experimentalStyles ) {
+		additionalStyles = __experimentalStyles;
+		deprecated( 'The __experimentalStyles prop of BlockPreview', {
+			plugin: 'Gutenberg',
+			since: '15.0',
+			version: '15.2',
+			alternative: 'additionalStyles',
+		} );
+	}
+	if ( __experimentalPadding ) {
+		additionalStyles = [
+			...additionalStyles,
+			{ css: `body { padding: ${ __experimentalPadding }px; }` },
+		];
+		deprecated( 'The __experimentalPadding prop of BlockPreview', {
+			since: '6.2',
+			alternative: 'additionalStyles',
+		} );
+	}
+
 	const originalSettings = useSelect(
 		( select ) => select( blockEditorStore ).getSettings(),
 		[]
@@ -37,16 +68,17 @@ export function BlockPreview( {
 		() => ( Array.isArray( blocks ) ? blocks : [ blocks ] ),
 		[ blocks ]
 	);
+
 	if ( ! blocks || blocks.length === 0 ) {
 		return null;
 	}
+
 	return (
 		<BlockEditorProvider value={ renderedBlocks } settings={ settings }>
 			<AutoHeightBlockPreview
 				viewportWidth={ viewportWidth }
-				__experimentalPadding={ __experimentalPadding }
-				__experimentalMinHeight={ __experimentalMinHeight }
-				__experimentalStyles={ __experimentalStyles }
+				minHeight={ minHeight }
+				additionalStyles={ additionalStyles }
 			/>
 		</BlockEditorProvider>
 	);

--- a/packages/block-editor/src/components/inserter/preview-panel.js
+++ b/packages/block-editor/src/components/inserter/preview-panel.js
@@ -23,8 +23,6 @@ function InserterPreviewPanel( { item } ) {
 				{ isReusable || example ? (
 					<div className="block-editor-inserter__preview-content">
 						<BlockPreview
-							__experimentalPadding={ 16 }
-							viewportWidth={ example?.viewportWidth ?? 500 }
 							blocks={
 								example
 									? getBlockFromExample( name, {
@@ -36,6 +34,10 @@ function InserterPreviewPanel( { item } ) {
 									  } )
 									: createBlock( name, initialAttributes )
 							}
+							viewportWidth={ example?.viewportWidth ?? 500 }
+							additionalStyles={ [
+								{ css: 'body { padding: 16px; }' },
+							] }
 						/>
 					</div>
 				) : (

--- a/packages/edit-site/src/components/global-styles/block-preview-panel.js
+++ b/packages/edit-site/src/components/global-styles/block-preview-panel.js
@@ -36,8 +36,8 @@ const BlockPreviewPanel = ( { name, variation = '' } ) => {
 				<BlockPreview
 					blocks={ blocks }
 					viewportWidth={ viewportWidth }
-					__experimentalMinHeight={ minHeight }
-					__experimentalStyles={ [
+					minHeight={ minHeight }
+					additionalStyles={ [
 						{
 							css: `
 								body{

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -171,7 +171,7 @@ const Example = memo( ( { title, blocks, isSelected, onClick } ) => (
 			<BlockPreview
 				blocks={ blocks }
 				viewportWidth={ 0 }
-				__experimentalStyles={ [
+				additionalStyles={ [
 					{
 						css:
 							'.wp-block:first-child { margin-top: 0; }' +


### PR DESCRIPTION
## What?
Removes/stabilises the `__experimental` props from `BlockPreview` in `@wordpress/block-editor`.

- Remove `__experimentalMinHeight` in favour of `minHeight`.

  This has been around for a while (https://github.com/WordPress/gutenberg/pull/38997) and seems stable, so mark it as such.

- Remove `__experimentalStyles` in favour of `additionalStyles`.

  This was added recently (https://github.com/WordPress/gutenberg/pull/45960) but I think it's quite flexible. I decided to use the word "additional" for clarity.

- Remove `__experimentalPadding` in favour of passing a `body { padding: ...; }` style to `additionalStyles`.

  Given `additionalStyles` lets us add arbitrary styles to the iframe body, we don't need props for every CSS property including padding.

## Why?
https://github.com/WordPress/gutenberg/issues/47196

## Testing Instructions

- Check that there is still 16px of padding around the block preview when hovering over an item in the inserter.
- Check that pattern previews look correct when choosing a block pattern.
- Check that the Style Book still looks correct.
- Check that the block preview in Styles → Blocks still looks correct.