### PR TITLE
Template Sidebar: Fix list of current template part areas to show nested template parts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17908,6 +17908,7 @@
 				"fast-deep-equal": "^3.1.3",
 				"history": "^5.1.0",
 				"lodash": "^4.17.21",
+				"memize": "^1.1.0",
 				"react-autosize-textarea": "^7.1.0",
 				"rememo": "^4.0.0"
 			},

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -61,6 +61,7 @@
 		"fast-deep-equal": "^3.1.3",
 		"history": "^5.1.0",
 		"lodash": "^4.17.21",
+		"memize": "^1.1.0",
 		"react-autosize-textarea": "^7.1.0",
 		"rememo": "^4.0.0"
 	},

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -248,6 +248,31 @@ export function isSaveViewOpened( state ) {
 }
 
 /**
+ * Turns a recursive list of blocks into a flat list of blocks annotated with
+ * their child index and parent block.
+ *
+ * @param {Object} parentBlock A parent block to flatten
+ * @return {Object} A flat list of blocks, annotated by their index and parent ID, consisting
+ * 							    of all the input blocks and all the inner blocks in the tree.
+ */
+function blocksTreeToAnnotatedList( parentBlock ) {
+	return ( parentBlock.innerBlocks || [] ).flatMap( ( innerBlock, index ) =>
+		[ { block: innerBlock, parentBlock, childIndex: index } ].concat(
+			blocksTreeToAnnotatedList( innerBlock )
+		)
+	);
+}
+
+function getFlattenedBlockList( blockList = [] ) {
+	const list = blockList.flatMap( ( rootBlock ) =>
+		[ rootBlock ].concat(
+			blocksTreeToAnnotatedList( rootBlock ).map( ( { block } ) => block )
+		)
+	);
+	return list;
+}
+
+/**
  * Returns the template parts and their blocks for the current edited template.
  *
  * @param {Object} state Global application state.
@@ -279,7 +304,7 @@ export const getCurrentTemplateTemplateParts = createRegistrySelector(
 			  )
 			: {};
 
-		return ( template.blocks ?? [] )
+		return getFlattenedBlockList( template.blocks ?? [] )
 			.filter( ( block ) => isTemplatePart( block ) )
 			.map( ( block ) => {
 				const {

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -16,7 +16,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
 /**
  * Internal dependencies
  */
-import { memoizedGetFilteredTemplatePartBlocks } from './utils';
+import { getFilteredTemplatePartBlocks } from './utils';
 
 /**
  * @typedef {'template'|'template_type'} TemplateType Template type.
@@ -273,10 +273,7 @@ export const getCurrentTemplateTemplateParts = createRegistrySelector(
 			{ per_page: -1 }
 		);
 
-		return memoizedGetFilteredTemplatePartBlocks(
-			template.blocks,
-			templateParts
-		);
+		return getFilteredTemplatePartBlocks( template.blocks, templateParts );
 	}
 );
 

--- a/packages/edit-site/src/store/test/utils.js
+++ b/packages/edit-site/src/store/test/utils.js
@@ -1,0 +1,125 @@
+/**
+ * Internal dependencies
+ */
+import { getFilteredTemplatePartBlocks } from '../utils';
+
+const NESTED_BLOCKS = [
+	{
+		clientId: '1',
+		name: 'core/group',
+		innerBlocks: [
+			{
+				clientId: '2',
+				name: 'core/template-part',
+				attributes: {
+					slug: 'header',
+					theme: 'my-theme',
+				},
+				innerBlocks: [
+					{
+						clientId: '3',
+						name: 'core/group',
+						innerBlocks: [],
+					},
+				],
+			},
+			{
+				clientId: '4',
+				name: 'core/template-part',
+				attributes: {
+					slug: 'aside',
+					theme: 'my-theme',
+				},
+				innerBlocks: [],
+			},
+		],
+	},
+	{
+		clientId: '5',
+		name: 'core/paragraph',
+		innerBlocks: [],
+	},
+	{
+		clientId: '6',
+		name: 'core/template-part',
+		attributes: {
+			slug: 'footer',
+			theme: 'my-theme',
+		},
+		innerBlocks: [],
+	},
+];
+
+const TEMPLATE_PARTS = [
+	{
+		id: 'my-theme//header',
+		slug: 'header',
+		theme: 'my-theme',
+	},
+	{
+		id: 'my-theme//aside',
+		slug: 'aside',
+		theme: 'my-theme',
+	},
+	{
+		id: 'my-theme//footer',
+		slug: 'footer',
+		theme: 'my-theme',
+	},
+];
+
+describe( 'utils', () => {
+	describe( 'getFilteredTemplatePartBlocks', () => {
+		it( 'returns a flattened list of filtered template parts preserving a depth-first order', () => {
+			const flattenedFilteredTemplateParts =
+				getFilteredTemplatePartBlocks( NESTED_BLOCKS, TEMPLATE_PARTS );
+			expect( flattenedFilteredTemplateParts ).toEqual( [
+				{
+					block: {
+						clientId: '2',
+						name: 'core/template-part',
+						attributes: {
+							slug: 'header',
+							theme: 'my-theme',
+						},
+					},
+					templatePart: {
+						id: 'my-theme//header',
+						slug: 'header',
+						theme: 'my-theme',
+					},
+				},
+				{
+					block: {
+						clientId: '4',
+						name: 'core/template-part',
+						attributes: {
+							slug: 'aside',
+							theme: 'my-theme',
+						},
+					},
+					templatePart: {
+						id: 'my-theme//aside',
+						slug: 'aside',
+						theme: 'my-theme',
+					},
+				},
+				{
+					block: {
+						clientId: '6',
+						name: 'core/template-part',
+						attributes: {
+							slug: 'footer',
+							theme: 'my-theme',
+						},
+					},
+					templatePart: {
+						id: 'my-theme//footer',
+						slug: 'footer',
+						theme: 'my-theme',
+					},
+				},
+			] );
+		} );
+	} );
+} );

--- a/packages/edit-site/src/store/test/utils.js
+++ b/packages/edit-site/src/store/test/utils.js
@@ -50,6 +50,64 @@ const NESTED_BLOCKS = [
 	},
 ];
 
+const FLATTENED_BLOCKS = [
+	{
+		block: {
+			clientId: '2',
+			name: 'core/template-part',
+			attributes: {
+				slug: 'header',
+				theme: 'my-theme',
+			},
+		},
+		templatePart: {
+			id: 'my-theme//header',
+			slug: 'header',
+			theme: 'my-theme',
+		},
+	},
+	{
+		block: {
+			clientId: '4',
+			name: 'core/template-part',
+			attributes: {
+				slug: 'aside',
+				theme: 'my-theme',
+			},
+		},
+		templatePart: {
+			id: 'my-theme//aside',
+			slug: 'aside',
+			theme: 'my-theme',
+		},
+	},
+	{
+		block: {
+			clientId: '6',
+			name: 'core/template-part',
+			attributes: {
+				slug: 'footer',
+				theme: 'my-theme',
+			},
+		},
+		templatePart: {
+			id: 'my-theme//footer',
+			slug: 'footer',
+			theme: 'my-theme',
+		},
+	},
+];
+
+const SINGLE_TEMPLATE_PART_BLOCK = {
+	clientId: '1',
+	name: 'core/template-part',
+	innerBlocks: [],
+	attributes: {
+		slug: 'aside',
+		theme: 'my-theme',
+	},
+};
+
 const TEMPLATE_PARTS = [
 	{
 		id: 'my-theme//header',
@@ -73,25 +131,34 @@ describe( 'utils', () => {
 		it( 'returns a flattened list of filtered template parts preserving a depth-first order', () => {
 			const flattenedFilteredTemplateParts =
 				getFilteredTemplatePartBlocks( NESTED_BLOCKS, TEMPLATE_PARTS );
-			expect( flattenedFilteredTemplateParts ).toEqual( [
+			expect( flattenedFilteredTemplateParts ).toEqual(
+				FLATTENED_BLOCKS
+			);
+		} );
+
+		it( 'returns a cached result when passed the same params', () => {
+			// Clear the cache and call the function twice.
+			getFilteredTemplatePartBlocks.clear();
+			getFilteredTemplatePartBlocks( NESTED_BLOCKS, TEMPLATE_PARTS );
+			expect(
+				getFilteredTemplatePartBlocks( NESTED_BLOCKS, TEMPLATE_PARTS )
+			).toEqual( FLATTENED_BLOCKS );
+
+			// The function has been called twice with the same params, so the cache size should be 1.
+			const [ , , originalSize ] =
+				getFilteredTemplatePartBlocks.getCache();
+			expect( originalSize ).toBe( 1 );
+
+			// Call the function again, with different params.
+			expect(
+				getFilteredTemplatePartBlocks(
+					[ SINGLE_TEMPLATE_PART_BLOCK ],
+					TEMPLATE_PARTS
+				)
+			).toEqual( [
 				{
 					block: {
-						clientId: '2',
-						name: 'core/template-part',
-						attributes: {
-							slug: 'header',
-							theme: 'my-theme',
-						},
-					},
-					templatePart: {
-						id: 'my-theme//header',
-						slug: 'header',
-						theme: 'my-theme',
-					},
-				},
-				{
-					block: {
-						clientId: '4',
+						clientId: '1',
 						name: 'core/template-part',
 						attributes: {
 							slug: 'aside',
@@ -104,22 +171,11 @@ describe( 'utils', () => {
 						theme: 'my-theme',
 					},
 				},
-				{
-					block: {
-						clientId: '6',
-						name: 'core/template-part',
-						attributes: {
-							slug: 'footer',
-							theme: 'my-theme',
-						},
-					},
-					templatePart: {
-						id: 'my-theme//footer',
-						slug: 'footer',
-						theme: 'my-theme',
-					},
-				},
 			] );
+
+			// The function has been called with different params, so the cache size should now be 2.
+			const [ , , finalSize ] = getFilteredTemplatePartBlocks.getCache();
+			expect( finalSize ).toBe( 2 );
 		} );
 	} );
 } );

--- a/packages/edit-site/src/store/utils.js
+++ b/packages/edit-site/src/store/utils.js
@@ -20,10 +20,7 @@ const EMPTY_ARRAY = [];
  * @param {?Array} templateParts Available template parts.
  * @return {Array} An array of template parts and their blocks.
  */
-export function getFilteredTemplatePartBlocks(
-	blocks = EMPTY_ARRAY,
-	templateParts
-) {
+function getFilteredTemplatePartBlocks( blocks = EMPTY_ARRAY, templateParts ) {
 	const templatePartsById = templateParts
 		? // Key template parts by their ID.
 		  templateParts.reduce(
@@ -65,6 +62,8 @@ export function getFilteredTemplatePartBlocks(
 	return result;
 }
 
-export const memoizedGetFilteredTemplatePartBlocks = memoize(
+const memoizedGetFilteredTemplatePartBlocks = memoize(
 	getFilteredTemplatePartBlocks
 );
+
+export { memoizedGetFilteredTemplatePartBlocks as getFilteredTemplatePartBlocks };

--- a/packages/edit-site/src/store/utils.js
+++ b/packages/edit-site/src/store/utils.js
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import memoize from 'memize';
+
+/**
+ * WordPress dependencies
+ */
+import { isTemplatePart } from '@wordpress/blocks';
+
+const EMPTY_ARRAY = [];
+
+/**
+ * Get a flattened and filtered list of template parts and the matching block for that template part.
+ *
+ * Takes a list of blocks defined within a template, and a list of template parts, and returns a
+ * flattened list of template parts and the matching block for that template part.
+ *
+ * @param {Array}  blocks        Blocks to flatten.
+ * @param {?Array} templateParts Available template parts.
+ * @return {Array} An array of template parts and their blocks.
+ */
+export function getFilteredTemplatePartBlocks(
+	blocks = EMPTY_ARRAY,
+	templateParts
+) {
+	const templatePartsById = templateParts
+		? // Key template parts by their ID.
+		  templateParts.reduce(
+				( newTemplateParts, part ) => ( {
+					...newTemplateParts,
+					[ part.id ]: part,
+				} ),
+				{}
+		  )
+		: {};
+
+	const result = [];
+
+	// Iterate over all blocks, recursing into inner blocks.
+	// Output will be based on a depth-first traversal.
+	const stack = [ ...blocks ];
+	while ( stack.length ) {
+		const { innerBlocks, ...block } = stack.shift();
+		// Place inner blocks at the beginning of the stack to preserve order.
+		stack.unshift( ...innerBlocks );
+
+		if ( isTemplatePart( block ) ) {
+			const {
+				attributes: { theme, slug },
+			} = block;
+			const templatePartId = `${ theme }//${ slug }`;
+			const templatePart = templatePartsById[ templatePartId ];
+
+			// Only add to output if the found template part block is in the list of available template parts.
+			if ( templatePart ) {
+				result.push( {
+					templatePart,
+					block,
+				} );
+			}
+		}
+	}
+
+	return result;
+}
+
+export const memoizedGetFilteredTemplatePartBlocks = memoize(
+	getFilteredTemplatePartBlocks
+);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #47213 

Ensure that the Template tab in the sidebar reflects all template parts in the template, irrespective of their level of nesting. This resolves a bug where nested header or footer template parts were not visible in the list.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Nesting template parts is useful to do, particularly for sticky headers, so we need to make sure nested template parts are still accessible via the Template navigation in the sidebar.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The approach in this PR does two things:

* Iterate over all nested blocks in the template to locate the template parts.
* Optimise the selector so that it uses memoized calculation.

Overall this reduces the number of times that the processing of the template's blocks occurs. In my local environment, this reduces the processing from around 126 times with the list view open, to 3.

Detailed changes:

* Borrow `flattenBlocks` logic from the block editor reducer [here](https://github.com/WordPress/gutenberg/blob/7e7e78cb1ea1585811650416176779259f94430b/packages/block-editor/src/store/reducer.js#L80), but simplify the logic slightly.
* Introduce `memize` into the `edit-site` package (it is also used in many other packages).
* Move filtering of template blocks logic out of `getCurrentTemplateTemplateParts` and into a separate utility `getFilteredTemplatePartBlocks` function.
* Use a memoized version of that function `memoizedGetFilteredTemplatePartBlocks` in `getCurrentTemplateTemplateParts` selector.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. See if you can reproduce #47213 by wrapping a header block in a group block, and see that it's no longer visible in the Template tab in the site editor, without this PR
2. With this PR applied, if you nest a Group block, it should still be available in the template tab in the right hand sidebar

## Screenshots or screencast <!-- if applicable -->

| Before (header not visible in sidebar) | After (header visible in sidebar) |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/213096329-2470a1ec-610b-4092-b1ad-ec78763e2d5f.png) | ![image](https://user-images.githubusercontent.com/14988353/213096346-8a39be9a-610d-4eb7-8951-77d150cbc3d1.png) |
