### PR TITLE
Browse mode: Add an H2 inside the sidebar navigation screen title

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -18,7 +18,7 @@ export default function SidebarNavigationScreenMain() {
 	return (
 		<SidebarNavigationScreen
 			path="/"
-			heading={ __( 'Design' ) }
+			title={ __( 'Design' ) }
 			content={
 				<ItemGroup>
 					<NavigatorButton

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -18,7 +18,7 @@ export default function SidebarNavigationScreenMain() {
 	return (
 		<SidebarNavigationScreen
 			path="/"
-			title={ __( 'Design' ) }
+			heading={ __( 'Design' ) }
 			content={
 				<ItemGroup>
 					<NavigatorButton

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -122,7 +122,7 @@ export default function SidebarNavigationScreenTemplates( {
 			title={
 				<HStack justify="space-between">
 					<div style={ { flexShrink: 0 } }>
-						{ config[ postType ].labels.title }
+						<h2>{ config[ postType ].labels.title }</h2>
 					</div>
 					{ ! isMobileViewport && (
 						<AddNewTemplate

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -1,10 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalItemGroup as ItemGroup,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { useEntityRecords } from '@wordpress/core-data';
@@ -119,21 +116,17 @@ export default function SidebarNavigationScreenTemplates( {
 		<SidebarNavigationScreen
 			path={ config[ postType ].path }
 			parentTitle={ __( 'Design' ) }
-			title={
-				<HStack justify="space-between">
-					<div style={ { flexShrink: 0 } }>
-						<h2>{ config[ postType ].labels.title }</h2>
-					</div>
-					{ ! isMobileViewport && (
-						<AddNewTemplate
-							templateType={ postType }
-							toggleProps={ {
-								className:
-									'edit-site-sidebar-navigation-screen-templates__add-button',
-							} }
-						/>
-					) }
-				</HStack>
+			title={ config[ postType ].labels.title }
+			action={
+				! isMobileViewport && (
+					<AddNewTemplate
+						templateType={ postType }
+						toggleProps={ {
+							className:
+								'edit-site-sidebar-navigation-screen-templates__add-button',
+						} }
+					/>
+				)
 			}
 			content={
 				<>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -117,7 +117,7 @@ export default function SidebarNavigationScreenTemplates( {
 			path={ config[ postType ].path }
 			parentTitle={ __( 'Design' ) }
 			title={ config[ postType ].labels.title }
-			action={
+			actions={
 				! isMobileViewport && (
 					<AddNewTemplate
 						templateType={ postType }

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -15,7 +15,6 @@ export default function SidebarNavigationScreen( {
 	parentTitle,
 	title,
 	content,
-	heading,
 } ) {
 	return (
 		<NavigatorScreen
@@ -41,10 +40,9 @@ export default function SidebarNavigationScreen( {
 					) : (
 						<div className="edit-site-sidebar-navigation-screen__icon-placeholder" />
 					) }
-
-					{ ! parentTitle && heading ? (
+					{ ! parentTitle ? (
 						<div className="edit-site-sidebar-navigation-screen__title">
-							<h2>{ heading } </h2>
+							<h2>{ title }</h2>
 						</div>
 					) : (
 						<div className="edit-site-sidebar-navigation-screen__title">

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -15,6 +15,7 @@ export default function SidebarNavigationScreen( {
 	parentTitle,
 	title,
 	content,
+	heading,
 } ) {
 	return (
 		<NavigatorScreen
@@ -41,9 +42,15 @@ export default function SidebarNavigationScreen( {
 						<div className="edit-site-sidebar-navigation-screen__icon-placeholder" />
 					) }
 
-					<div className="edit-site-sidebar-navigation-screen__title">
-						{ title }
-					</div>
+					{ ! parentTitle && heading ? (
+						<div className="edit-site-sidebar-navigation-screen__title">
+							<h2>{ heading } </h2>
+						</div>
+					) : (
+						<div className="edit-site-sidebar-navigation-screen__title">
+							{ title }
+						</div>
+					) }
 				</HStack>
 
 				<nav className="edit-site-sidebar-navigation-screen__content">

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -14,10 +14,9 @@ export default function SidebarNavigationScreen( {
 	path,
 	parentTitle,
 	title,
+	action,
 	content,
 } ) {
-	const TagName = parentTitle ? 'div' : 'h2';
-
 	return (
 		<NavigatorScreen
 			className="edit-site-sidebar-navigation-screen"
@@ -42,9 +41,10 @@ export default function SidebarNavigationScreen( {
 					) : (
 						<div className="edit-site-sidebar-navigation-screen__icon-placeholder" />
 					) }
-					<TagName className="edit-site-sidebar-navigation-screen__title">
+					<h2 className="edit-site-sidebar-navigation-screen__title">
 						{ title }
-					</TagName>
+					</h2>
+					{ action }
 				</HStack>
 
 				<nav className="edit-site-sidebar-navigation-screen__content">

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -14,7 +14,7 @@ export default function SidebarNavigationScreen( {
 	path,
 	parentTitle,
 	title,
-	action,
+	actions,
 	content,
 } ) {
 	return (
@@ -44,7 +44,7 @@ export default function SidebarNavigationScreen( {
 					<h2 className="edit-site-sidebar-navigation-screen__title">
 						{ title }
 					</h2>
-					{ action }
+					{ actions }
 				</HStack>
 
 				<nav className="edit-site-sidebar-navigation-screen__content">

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -16,6 +16,8 @@ export default function SidebarNavigationScreen( {
 	title,
 	content,
 } ) {
+	const TagName = parentTitle ? 'div' : 'h2';
+
 	return (
 		<NavigatorScreen
 			className="edit-site-sidebar-navigation-screen"
@@ -40,15 +42,9 @@ export default function SidebarNavigationScreen( {
 					) : (
 						<div className="edit-site-sidebar-navigation-screen__icon-placeholder" />
 					) }
-					{ ! parentTitle ? (
-						<div className="edit-site-sidebar-navigation-screen__title">
-							<h2>{ title }</h2>
-						</div>
-					) : (
-						<div className="edit-site-sidebar-navigation-screen__title">
-							{ title }
-						</div>
-					) }
+					<TagName className="edit-site-sidebar-navigation-screen__title">
+						{ title }
+					</TagName>
 				</HStack>
 
 				<nav className="edit-site-sidebar-navigation-screen__content">

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -26,6 +26,13 @@
 	flex-grow: 1;
 }
 
+.edit-site-sidebar-navigation-screen__title h2 {
+	font-size: calc(1.56 * 13px);
+	font-weight: 500;
+	color: $white;
+	margin: 0;
+}
+
 .edit-site-sidebar-navigation-screen__back {
 	color: $gray-200;
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -24,6 +24,8 @@
 	font-size: calc(1.56 * 13px);
 	font-weight: 500;
 	flex-grow: 1;
+	color: $white;
+	margin: 0;
 }
 
 .edit-site-sidebar-navigation-screen__title h2 {

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -28,13 +28,6 @@
 	margin: 0;
 }
 
-.edit-site-sidebar-navigation-screen__title h2 {
-	font-size: calc(1.56 * 13px);
-	font-weight: 500;
-	color: $white;
-	margin: 0;
-}
-
 .edit-site-sidebar-navigation-screen__back {
 	color: $gray-200;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Places the words design, templates and template parts inside `h2` elements in the navigation sidebar in the Site Editor.
Closes https://github.com/WordPress/gutenberg/issues/47217

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Text that visually looks like headings should use HTML heading elements.

By using heading elements for the visual heading texts instead of divs, users can use the headings to navigate to the content; the list of buttons that represents the templates and template parts.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Updates the sidebar navigation screen title div:
Adds a new condition for displaying either the heading text or the inner elements that include the
the back button, the template/template parts heading and the add new button.

## Testing Instructions
1.  Open the Site Editor.
2. Confirm that there is no visual change to the sidebar.
3. View the source and confirm that the word Design is placed inside an `H2`.
4. Select either templates or template parts.
5. On the navigation screen that you just opened, confirm that there is no visual change and that the text templates or template parts are inside an `H2`.

### Testing Instructions for Screen reader
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Open the Site Editor
2. Use the relevant command for your screen reader to navigate to the next heading.
3. This should find a H2 heading with the text Design. 
4. Next navigate forwards to the button with the text Templates. Activate the button.
5. Use the relevant command for your screen reader to navigate to the next heading.
6. This should find a H2 heading with the text Templates. With this, the test is completed.

Note that this document does not have an H1. This will be implemented in a separate PR.

## Screenshots or screencast <!-- if applicable -->
