### PR TITLE
E2E (multi-entity-saving.test.js): Wait for the font size picker controls to appear 

### DIFF
--- a/packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
@@ -314,7 +314,12 @@ describe( 'Multi-entity save flow', () => {
 			// Open the block settings.
 			await page.click( 'button[aria-label="Settings"]' );
 
-			// Change the font size
+			// Wait for the font size picker controls.
+			await page.waitForSelector(
+				'.components-font-size-picker__controls'
+			);
+
+			// Change the font size.
 			await page.click(
 				'.components-font-size-picker__controls button[aria-label="Small"]'
 			);
@@ -322,7 +327,7 @@ describe( 'Multi-entity save flow', () => {
 			// Save all changes.
 			await saveAllChanges();
 
-			// Change the font size
+			// Change the font size.
 			await page.click(
 				'.components-font-size-picker__controls button[aria-label="Medium"]'
 			);


### PR DESCRIPTION
## What?

Fix failing spec when the concurrent mode is enabled (https://github.com/WordPress/gutenberg/pull/46467#issuecomment-1380408396):
- `multi-entity-saving.test.js: Site Editor > Save flow should allow re-saving after changing the same block attribute`

## How?
Wait for the font size picker controls to appear before interacting with them.

---

✅ Tested against changes in #46467.