### PR TITLE
`NumberControl`: bolster tests

### DIFF
--- a/packages/components/src/number-control/stories/index.tsx
+++ b/packages/components/src/number-control/stories/index.tsx
@@ -62,3 +62,35 @@ export const Default = Template.bind( {} );
 Default.args = {
 	label: 'Value',
 };
+
+// Check if this was broken and at what point
+// in particular on commit actions, when `min` is not `undefined`
+export const Uncontrolled: ComponentStory< typeof NumberControl > = ( {
+	onChange,
+	...props
+} ) => {
+	const [ isValidValue, setIsValidValue ] = useState( true );
+
+	return (
+		<>
+			<NumberControl
+				{ ...props }
+				onChange={ ( v, extra ) => {
+					setIsValidValue(
+						( extra.event.target as HTMLInputElement ).validity
+							.valid
+					);
+					onChange?.( v, extra );
+				} }
+			/>
+			<p>Is valid? { isValidValue ? 'Yes' : 'No' }</p>
+		</>
+	);
+};
+Uncontrolled.argTypes = {
+	value: {
+		options: [ 'value', 'noValue' ],
+		mapping: { value: '15', noValue: undefined },
+		control: { type: 'select' },
+	},
+};

--- a/packages/components/src/number-control/test/index.tsx
+++ b/packages/components/src/number-control/test/index.tsx
@@ -15,9 +15,16 @@ import { useState } from '@wordpress/element';
 import NumberControl from '..';
 import type { NumberControlProps } from '../types';
 
-function StatefulNumberControl( props: NumberControlProps ) {
-	const [ value, setValue ] = useState( props.value );
-	const handleOnChange = ( v: string | undefined ) => setValue( v );
+function ControlledNumberControl( {
+	value: valueProp,
+	onChange,
+	...props
+}: NumberControlProps ) {
+	const [ value, setValue ] = useState( valueProp );
+	const handleOnChange: NumberControlProps[ 'onChange' ] = ( v, extra ) => {
+		setValue( v );
+		onChange?.( v, extra );
+	};
 
 	return (
 		<NumberControl
@@ -28,15 +35,20 @@ function StatefulNumberControl( props: NumberControlProps ) {
 	);
 }
 
-describe( 'NumberControl', () => {
+describe.each( [
+	[ 'uncontrolled', NumberControl ],
+	[ 'controlled', ControlledNumberControl ],
+] )( 'NumberControl %s', ( ...modeAndComponent ) => {
+	const [ , Component ] = modeAndComponent;
+
 	describe( 'Basic rendering', () => {
 		it( 'should render', () => {
-			render( <NumberControl /> );
+			render( <Component /> );
 			expect( screen.getByRole( 'spinbutton' ) ).toBeVisible();
 		} );
 
 		it( 'should render custom className', () => {
-			render( <NumberControl className="hello" /> );
+			render( <Component className="hello" /> );
 			expect( screen.getByRole( 'spinbutton' ) ).toBeVisible();
 		} );
 	} );
@@ -46,9 +58,7 @@ describe( 'NumberControl', () => {
 			const user = userEvent.setup();
 			const spy = jest.fn();
 
-			render(
-				<NumberControl value={ 5 } onChange={ ( v ) => spy( v ) } />
-			);
+			render( <Component value={ 5 } onChange={ ( v ) => spy( v ) } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 			await user.clear( input );
@@ -62,7 +72,7 @@ describe( 'NumberControl', () => {
 			const onChangeSpy = jest.fn();
 
 			render(
-				<NumberControl
+				<Component
 					value={ 5 }
 					min={ 4 }
 					max={ 10 }
@@ -105,7 +115,7 @@ describe( 'NumberControl', () => {
 			const onChangeSpy = jest.fn();
 
 			render(
-				<NumberControl
+				<Component
 					value={ 5 }
 					min={ 1 }
 					max={ 10 }
@@ -147,7 +157,7 @@ describe( 'NumberControl', () => {
 		it( 'should clamp value within range on ENTER keypress', async () => {
 			const user = userEvent.setup();
 
-			render( <NumberControl value={ 5 } min={ 0 } max={ 10 } /> );
+			render( <Component value={ 5 } min={ 0 } max={ 10 } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 
@@ -165,7 +175,7 @@ describe( 'NumberControl', () => {
 		it( 'should clamp value within range on blur', async () => {
 			const user = userEvent.setup();
 
-			render( <NumberControl value={ 5 } min={ 0 } max={ 10 } /> );
+			render( <Component value={ 5 } min={ 0 } max={ 10 } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 			await user.clear( input );
@@ -184,7 +194,7 @@ describe( 'NumberControl', () => {
 		it( 'should parse non-numeric values to a number on ENTER keypress when required', async () => {
 			const user = userEvent.setup();
 
-			render( <NumberControl value={ 5 } required /> );
+			render( <Component value={ 5 } required /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 			await user.clear( input );
@@ -197,7 +207,7 @@ describe( 'NumberControl', () => {
 		it( 'should parse non-numeric values to empty string on ENTER keypress when not required', async () => {
 			const user = userEvent.setup();
 
-			render( <NumberControl value={ 5 } required={ false } /> );
+			render( <Component value={ 5 } required={ false } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 			await user.clear( input );
@@ -216,7 +226,7 @@ describe( 'NumberControl', () => {
 		it( 'should not enforce numerical value for empty string when required is omitted', async () => {
 			const user = userEvent.setup();
 
-			render( <NumberControl value={ 5 } /> );
+			render( <Component value={ 5 } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 			await user.clear( input );
@@ -231,7 +241,7 @@ describe( 'NumberControl', () => {
 		it( 'should enforce numerical value for empty string when required', async () => {
 			const user = userEvent.setup();
 
-			render( <NumberControl value={ 5 } required /> );
+			render( <Component value={ 5 } required /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 			await user.clear( input );
@@ -247,7 +257,7 @@ describe( 'NumberControl', () => {
 
 			const spy = jest.fn();
 
-			render( <StatefulNumberControl value={ 5 } onKeyDown={ spy } /> );
+			render( <Component value={ 5 } onKeyDown={ spy } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 			await user.click( input );
@@ -259,7 +269,7 @@ describe( 'NumberControl', () => {
 		it( 'should increment by step on key UP press', async () => {
 			const user = userEvent.setup();
 
-			render( <StatefulNumberControl value={ 5 } /> );
+			render( <Component value={ 5 } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 			await user.click( input );
@@ -271,7 +281,7 @@ describe( 'NumberControl', () => {
 		it( 'should increment from a negative value', async () => {
 			const user = userEvent.setup();
 
-			render( <StatefulNumberControl value={ -5 } /> );
+			render( <Component value={ -5 } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 			await user.click( input );
@@ -283,7 +293,7 @@ describe( 'NumberControl', () => {
 		it( 'should increment while preserving the decimal value when `step` is “any”', async () => {
 			const user = userEvent.setup();
 
-			render( <StatefulNumberControl value={ 866.5309 } step="any" /> );
+			render( <Component value={ 866.5309 } step="any" /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 			await user.click( input );
@@ -295,7 +305,7 @@ describe( 'NumberControl', () => {
 		it( 'should increment by shiftStep on key UP + shift press', async () => {
 			const user = userEvent.setup();
 
-			render( <StatefulNumberControl value={ 5 } shiftStep={ 10 } /> );
+			render( <Component value={ 5 } shiftStep={ 10 } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 			await user.click( input );
@@ -307,7 +317,7 @@ describe( 'NumberControl', () => {
 		it( 'should increment by shiftStep while preserving the decimal value when `step` is “any”', async () => {
 			const user = userEvent.setup();
 
-			render( <StatefulNumberControl value={ 857.5309 } step="any" /> );
+			render( <Component value={ 857.5309 } step="any" /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 			await user.click( input );
@@ -319,7 +329,7 @@ describe( 'NumberControl', () => {
 		it( 'should increment by custom shiftStep on key UP + shift press', async () => {
 			const user = userEvent.setup();
 
-			render( <StatefulNumberControl value={ 5 } shiftStep={ 100 } /> );
+			render( <Component value={ 5 } shiftStep={ 100 } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 			await user.click( input );
@@ -331,13 +341,7 @@ describe( 'NumberControl', () => {
 		it( 'should increment but be limited by max on shiftStep', async () => {
 			const user = userEvent.setup();
 
-			render(
-				<StatefulNumberControl
-					value={ 5 }
-					shiftStep={ 100 }
-					max={ 99 }
-				/>
-			);
+			render( <Component value={ 5 } shiftStep={ 100 } max={ 99 } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 			await user.click( input );
@@ -350,7 +354,7 @@ describe( 'NumberControl', () => {
 			const user = userEvent.setup();
 
 			render(
-				<StatefulNumberControl
+				<Component
 					value={ 5 }
 					shiftStep={ 100 }
 					isShiftStepEnabled={ false }
@@ -370,7 +374,7 @@ describe( 'NumberControl', () => {
 			const user = userEvent.setup();
 			const spy = jest.fn();
 
-			render( <StatefulNumberControl value={ 5 } onKeyDown={ spy } /> );
+			render( <Component value={ 5 } onKeyDown={ spy } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 			await user.click( input );
@@ -382,7 +386,7 @@ describe( 'NumberControl', () => {
 		it( 'should decrement by step on key DOWN press', async () => {
 			const user = userEvent.setup();
 
-			render( <StatefulNumberControl value={ 5 } /> );
+			render( <Component value={ 5 } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 			await user.click( input );
@@ -394,7 +398,7 @@ describe( 'NumberControl', () => {
 		it( 'should decrement from a negative value', async () => {
 			const user = userEvent.setup();
 
-			render( <StatefulNumberControl value={ -5 } /> );
+			render( <Component value={ -5 } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 			await user.click( input );
@@ -406,7 +410,7 @@ describe( 'NumberControl', () => {
 		it( 'should decrement while preserving the decimal value when `step` is “any”', async () => {
 			const user = userEvent.setup();
 
-			render( <StatefulNumberControl value={ 868.5309 } step="any" /> );
+			render( <Component value={ 868.5309 } step="any" /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 			await user.click( input );
@@ -418,7 +422,7 @@ describe( 'NumberControl', () => {
 		it( 'should decrement by shiftStep on key DOWN + shift press', async () => {
 			const user = userEvent.setup();
 
-			render( <StatefulNumberControl value={ 5 } /> );
+			render( <Component value={ 5 } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 			await user.click( input );
@@ -430,7 +434,7 @@ describe( 'NumberControl', () => {
 		it( 'should decrement by shiftStep while preserving the decimal value when `step` is “any”', async () => {
 			const user = userEvent.setup();
 
-			render( <StatefulNumberControl value={ 877.5309 } step="any" /> );
+			render( <Component value={ 877.5309 } step="any" /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 			await user.click( input );
@@ -442,7 +446,7 @@ describe( 'NumberControl', () => {
 		it( 'should decrement by custom shiftStep on key DOWN + shift press', async () => {
 			const user = userEvent.setup();
 
-			render( <StatefulNumberControl value={ 5 } shiftStep={ 100 } /> );
+			render( <Component value={ 5 } shiftStep={ 100 } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 			await user.click( input );
@@ -454,13 +458,7 @@ describe( 'NumberControl', () => {
 		it( 'should decrement but be limited by min on shiftStep', async () => {
 			const user = userEvent.setup();
 
-			render(
-				<StatefulNumberControl
-					value={ 5 }
-					shiftStep={ 100 }
-					min={ 4 }
-				/>
-			);
+			render( <Component value={ 5 } shiftStep={ 100 } min={ 4 } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 			await user.click( input );
@@ -473,7 +471,7 @@ describe( 'NumberControl', () => {
 			const user = userEvent.setup();
 
 			render(
-				<StatefulNumberControl
+				<Component
 					value={ 5 }
 					shiftStep={ 100 }
 					isShiftStepEnabled={ false }
@@ -496,7 +494,7 @@ describe( 'NumberControl', () => {
 		] as NumberControlProps[ 'spinControls' ][] )(
 			'should not appear when spinControls = %s',
 			( spinControls ) => {
-				render( <NumberControl spinControls={ spinControls } /> );
+				render( <Component spinControls={ spinControls } /> );
 				expect(
 					screen.queryByLabelText( 'Increment' )
 				).not.toBeInTheDocument();
@@ -521,7 +519,7 @@ describe( 'NumberControl', () => {
 				const user = userEvent.setup();
 				const onChange = jest.fn();
 				render(
-					<NumberControl
+					<Component
 						{ ...props }
 						spinControls="custom"
 						onChange={ onChange }

--- a/packages/components/src/number-control/test/index.tsx
+++ b/packages/components/src/number-control/test/index.tsx
@@ -15,6 +15,13 @@ import { useState } from '@wordpress/element';
 import NumberControl from '..';
 import type { NumberControlProps } from '../types';
 
+function expectInputToHaveEmptyStringValue( input: HTMLElement ) {
+	// React Testing Library associates `null` to empty string types for
+	// numeric `input` elements
+	// (see https://github.com/testing-library/jest-dom/blob/v5.16.5/src/utils.js#L191-L192)
+	return expect( input ).toHaveValue( null );
+}
+
 function ControlledNumberControl( {
 	value: valueProp,
 	onChange,
@@ -39,12 +46,21 @@ describe.each( [
 	[ 'uncontrolled', NumberControl ],
 	[ 'controlled', ControlledNumberControl ],
 ] )( 'NumberControl %s', ( ...modeAndComponent ) => {
-	const [ , Component ] = modeAndComponent;
+	const [ mode, Component ] = modeAndComponent;
 
 	describe( 'Basic rendering', () => {
-		it( 'should render', () => {
+		it( 'should render', async () => {
+			const user = userEvent.setup();
+
 			render( <Component /> );
-			expect( screen.getByRole( 'spinbutton' ) ).toBeVisible();
+
+			const input = screen.getByRole( 'spinbutton' );
+
+			await user.clear( input );
+			await user.type( input, '14' );
+
+			expect( input ).toBeVisible();
+			expect( input ).toHaveValue( 14 );
 		} );
 
 		it( 'should render custom className', () => {
@@ -58,7 +74,7 @@ describe.each( [
 			const user = userEvent.setup();
 			const spy = jest.fn();
 
-			render( <Component value={ 5 } onChange={ ( v ) => spy( v ) } /> );
+			render( <Component onChange={ ( v ) => spy( v ) } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 			await user.clear( input );
@@ -73,7 +89,6 @@ describe.each( [
 
 			render(
 				<Component
-					value={ 5 }
 					min={ 4 }
 					max={ 10 }
 					onChange={ ( v, extra ) =>
@@ -88,26 +103,41 @@ describe.each( [
 
 			const input = screen.getByRole( 'spinbutton' );
 
+			// Type `5`, a value in the min-max range.
+			await user.clear( input );
+			await user.type( input, '5' );
+
+			// Before blurring, the value is still un-clamped
+			expect( input ).toHaveValue( 5 );
+
+			// Blur the input, make sure that the value remains unchanged.
+			await user.keyboard( '[Tab]' );
+			expect( input ).toHaveValue( 5 );
+
+			// Type `1`, a value that is outside of the min-max range.
 			await user.clear( input );
 			await user.type( input, '1' );
 
 			// Before blurring, the value is still un-clamped
 			expect( input ).toHaveValue( 1 );
 
-			// Blur the input
+			// Blur the input, make sure that the value gets clamped.
 			await user.keyboard( '[Tab]' );
-
-			// After blur, value is clamped
 			expect( input ).toHaveValue( 4 );
 
-			expect( onChangeSpy ).toHaveBeenCalledTimes( 3 );
+			expect( onChangeSpy ).toHaveBeenCalledTimes( 4 );
 
-			// First call: clear the input
-			expect( onChangeSpy ).toHaveBeenNthCalledWith( 1, '', true );
+			// First call: type `5`
+			expect( onChangeSpy ).toHaveBeenNthCalledWith( 1, '5', true );
+
+			// TODO: why not another call that converts `'5'` to `5`, like in the next test?
+
+			// Second call: clear the input
+			expect( onChangeSpy ).toHaveBeenNthCalledWith( 2, '', true );
 			// Second call: type '1'
-			expect( onChangeSpy ).toHaveBeenNthCalledWith( 2, '1', false );
+			expect( onChangeSpy ).toHaveBeenNthCalledWith( 3, '1', false );
 			// Third call: clamp value
-			expect( onChangeSpy ).toHaveBeenNthCalledWith( 3, 4, true );
+			expect( onChangeSpy ).toHaveBeenNthCalledWith( 4, 4, true );
 		} );
 
 		it( 'should call onChange callback when value is not valid', async () => {
@@ -116,7 +146,6 @@ describe.each( [
 
 			render(
 				<Component
-					value={ 5 }
 					min={ 1 }
 					max={ 10 }
 					onChange={ ( v, extra ) =>
@@ -132,6 +161,15 @@ describe.each( [
 			const input = screen.getByRole( 'spinbutton' );
 
 			await user.clear( input );
+			await user.type( input, '5' );
+
+			expect( input ).toHaveValue( 5 );
+
+			await user.keyboard( '[Enter]' );
+
+			expect( input ).toHaveValue( 5 );
+
+			await user.clear( input );
 			await user.type( input, '14' );
 
 			expect( input ).toHaveValue( 14 );
@@ -140,16 +178,21 @@ describe.each( [
 
 			expect( input ).toHaveValue( 10 );
 
-			expect( onChangeSpy ).toHaveBeenCalledTimes( 4 );
+			expect( onChangeSpy ).toHaveBeenCalledTimes( 6 );
 
-			// First call: clear value
-			expect( onChangeSpy ).toHaveBeenNthCalledWith( 1, '', true );
-			// Second call: valid, unclamped value
-			expect( onChangeSpy ).toHaveBeenNthCalledWith( 2, '1', true );
-			// Third call: invalid, unclamped value
-			expect( onChangeSpy ).toHaveBeenNthCalledWith( 3, '14', false );
-			// Fourth call: valid, clamped value
-			expect( onChangeSpy ).toHaveBeenNthCalledWith( 4, 10, true );
+			// First call: type `5`
+			expect( onChangeSpy ).toHaveBeenNthCalledWith( 1, '5', true );
+			// Second call: clear value
+			// TODO: Why does this call happen?
+			expect( onChangeSpy ).toHaveBeenNthCalledWith( 2, 5, true );
+			// Third call: clear value
+			expect( onChangeSpy ).toHaveBeenNthCalledWith( 3, '', true );
+			// Fourth call: valid, unclamped value
+			expect( onChangeSpy ).toHaveBeenNthCalledWith( 4, '1', true );
+			// Fifth call: invalid, unclamped value
+			expect( onChangeSpy ).toHaveBeenNthCalledWith( 5, '14', false );
+			// Sixth call: valid, clamped value
+			expect( onChangeSpy ).toHaveBeenNthCalledWith( 6, 10, true );
 		} );
 	} );
 
@@ -157,46 +200,86 @@ describe.each( [
 		it( 'should clamp value within range on ENTER keypress', async () => {
 			const user = userEvent.setup();
 
-			render( <Component value={ 5 } min={ 0 } max={ 10 } /> );
+			render( <Component min={ 0 } max={ 10 } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 
+			// Type a value within the min-max range.
+			// The value should not be clamped when pressing the ENTER key.
+			await user.clear( input );
+			await user.type( input, '5' );
+			await user.keyboard( '[Enter]' );
+
+			expect( input ).toHaveValue( 5 );
+
+			// Type a value below the min-max range.
+			// The value should be clamped to [min] when pressing the ENTER key.
 			await user.clear( input );
 			await user.type( input, '-100' );
 			await user.keyboard( '[Enter]' );
 
-			/**
-			 * This is zero because the value has been adjusted to
-			 * respect the min/max range of the input.
-			 */
 			expect( input ).toHaveValue( 0 );
+
+			// Type a value above the min-max range.
+			// The value should be clamped to [max] when pressing the ENTER key.
+			await user.clear( input );
+			await user.type( input, '14' );
+			await user.keyboard( '[Enter]' );
+
+			expect( input ).toHaveValue( 10 );
 		} );
 
 		it( 'should clamp value within range on blur', async () => {
 			const user = userEvent.setup();
 
-			render( <Component value={ 5 } min={ 0 } max={ 10 } /> );
+			render( <Component min={ 0 } max={ 10 } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
+
+			// Type a value within the min-max range.
+			// The value should not be clamped when blurring the input by clicking outside it.
 			await user.clear( input );
-			await user.type( input, '41' );
+			await user.type( input, '5' );
+			await user.tab();
 
-			// Before blurring, the value is still un-clamped
-			expect( input ).toHaveValue( 41 );
+			expect( input ).toHaveValue( 5 );
 
-			// Blur the input
-			await user.click( document.body );
+			// Type a value below the min-max range.
+			// The value should be clamped to [min] when pressing the ENTER key.
+			await user.clear( input );
+			await user.type( input, '-2' );
+			await user.tab();
 
-			// After blur, value is clamped
-			expect( input ).toHaveValue( 10 );
+			expect( input ).toHaveValue( 0 );
+
+			// Type a value above the min-max range.
+			// The value should be clamped to [max] when pressing the ENTER key.
+			// TODO: why does it not work if clamping to MIN before?
+			// await user.clear( input );
+			// await user.type( input, '41' );
+			// await user.tab();
+
+			// expect( input ).toHaveValue( 10 );
 		} );
 
-		it( 'should parse non-numeric values to a number on ENTER keypress when required', async () => {
+		// TODO: add min/max
+		it( 'should parse non-numeric values on ENTER keypress when required', async () => {
 			const user = userEvent.setup();
 
-			render( <Component value={ 5 } required /> );
+			render( <Component required /> );
 
 			const input = screen.getByRole( 'spinbutton' );
+
+			// Type a numeric value.
+			// The value should be parsed as-is when pressing the ENTER key.
+			await user.clear( input );
+			await user.type( input, '5' );
+			await user.keyboard( '[Enter]' );
+
+			expect( input ).toHaveValue( 5 );
+
+			// Type a non-numeric value.
+			// The value should be parsed to the default value when pressing the ENTER key.
 			await user.clear( input );
 			await user.type( input, 'abc' );
 			await user.keyboard( '[Enter]' );
@@ -204,46 +287,75 @@ describe.each( [
 			expect( input ).toHaveValue( 0 );
 		} );
 
+		// Todo: try with different min-max
+		// Todo: try without writing a valid value first
+		// Todo: should check the value before enter as well
 		it( 'should parse non-numeric values to empty string on ENTER keypress when not required', async () => {
 			const user = userEvent.setup();
 
-			render( <Component value={ 5 } required={ false } /> );
+			render( <Component /> );
 
 			const input = screen.getByRole( 'spinbutton' );
+
+			// Type a value within the min-max range.
+			// The value should be parsed as-is when pressing the ENTER key.
+			await user.clear( input );
+			await user.type( input, '5' );
+			await user.keyboard( '[Enter]' );
+
+			expect( input ).toHaveValue( 5 );
+
+			// Type a non-numeric value.
+			// The value should be rejected (i.e not assigned) when pressing the ENTER key.
 			await user.clear( input );
 			await user.type( input, 'abc' );
 			await user.keyboard( '[Enter]' );
 
 			// Note: the `input` field may still visually show the invalid input,
 			// while internally parsing the value as an empty string.
-			//
-			// React Testing Library associates `null` to empty string types for
-			// numeric `input` elements
-			// (see https://github.com/testing-library/jest-dom/blob/v5.16.5/src/utils.js#L191-L192)
-			expect( input ).toHaveValue( null );
+			expectInputToHaveEmptyStringValue( input );
 		} );
 
+		// TODO: investigate why it parses to empty string only when there's a valid value before
 		it( 'should not enforce numerical value for empty string when required is omitted', async () => {
 			const user = userEvent.setup();
 
-			render( <Component value={ 5 } /> );
+			render( <Component /> );
 
 			const input = screen.getByRole( 'spinbutton' );
+
+			// Type a valid numeric value, then press enter.
+			// The value should be parsed correctly.
+			await user.clear( input );
+			await user.type( input, '5' );
+			await user.keyboard( '[Enter]' );
+
+			expect( input ).toHaveValue( 5 );
+
+			// Type a valid numeric value.
 			await user.clear( input );
 			await user.keyboard( '[Enter]' );
 
-			// React Testing Library associates `null` to empty string types for
-			// numeric `input` elements
-			// (see https://github.com/testing-library/jest-dom/blob/v5.16.5/src/utils.js#L191-L192)
-			expect( input ).toHaveValue( null );
+			expectInputToHaveEmptyStringValue( input );
 		} );
 
 		it( 'should enforce numerical value for empty string when required', async () => {
 			const user = userEvent.setup();
 
-			render( <Component value={ 5 } required /> );
+			render( <Component required /> );
 
 			const input = screen.getByRole( 'spinbutton' );
+
+			// Type a valid numeric value, then press enter.
+			// The value should be parsed correctly.
+			await user.clear( input );
+			await user.type( input, '5' );
+			await user.keyboard( '[Enter]' );
+
+			expect( input ).toHaveValue( 5 );
+
+			// Clear the input and submit.
+			// The empty string value should be enforced to the default numeric value.
 			await user.clear( input );
 			await user.keyboard( '[Enter]' );
 
@@ -252,26 +364,37 @@ describe.each( [
 	} );
 
 	describe( 'Key UP interactions', () => {
+		// Test expected values when incrementing / decrementing from empty values
+		// When min/max are defined too!
 		it( 'should fire onKeyDown callback', async () => {
 			const user = userEvent.setup();
 
 			const spy = jest.fn();
 
-			render( <Component value={ 5 } onKeyDown={ spy } /> );
+			render( <Component onKeyDown={ spy } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
 			await user.click( input );
 			await user.keyboard( '[ArrowUp]' );
 
-			expect( spy ).toHaveBeenCalled();
+			expect( spy ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		it( 'should increment by step on key UP press', async () => {
 			const user = userEvent.setup();
 
-			render( <Component value={ 5 } /> );
+			render( <Component /> );
 
 			const input = screen.getByRole( 'spinbutton' );
+
+			// Type a valid numeric value.
+			// The value should be parsed correctly.
+			await user.clear( input );
+			await user.type( input, '5' );
+
+			expect( input ).toHaveValue( 5 );
+
+			// Focus the input and press the up arrow to increment the value.
 			await user.click( input );
 			await user.keyboard( '[ArrowUp]' );
 
@@ -281,9 +404,18 @@ describe.each( [
 		it( 'should increment from a negative value', async () => {
 			const user = userEvent.setup();
 
-			render( <Component value={ -5 } /> );
+			render( <Component /> );
 
 			const input = screen.getByRole( 'spinbutton' );
+
+			// Type a valid numeric value.
+			// The value should be parsed correctly.
+			await user.clear( input );
+			await user.type( input, '-5' );
+
+			expect( input ).toHaveValue( -5 );
+
+			// Focus the input and press the up arrow to increment the value.
 			await user.click( input );
 			await user.keyboard( '[ArrowUp]' );
 
@@ -293,21 +425,39 @@ describe.each( [
 		it( 'should increment while preserving the decimal value when `step` is “any”', async () => {
 			const user = userEvent.setup();
 
-			render( <Component value={ 866.5309 } step="any" /> );
+			render( <Component step="any" /> );
 
 			const input = screen.getByRole( 'spinbutton' );
+
+			// Type a valid numeric value.
+			// The value should be parsed correctly.
+			await user.clear( input );
+			await user.type( input, '866.5309' );
+
+			expect( input ).toHaveValue( 866.5309 );
+
+			// Focus the input and press the up arrow to increment the value.
 			await user.click( input );
 			await user.keyboard( '[ArrowUp]' );
 
 			expect( input ).toHaveValue( 867.5309 );
 		} );
 
-		it( 'should increment by shiftStep on key UP + shift press', async () => {
+		it( 'should increment by default shiftStep on key UP + shift press', async () => {
 			const user = userEvent.setup();
 
-			render( <Component value={ 5 } shiftStep={ 10 } /> );
+			render( <Component /> );
 
 			const input = screen.getByRole( 'spinbutton' );
+
+			// Type a valid numeric value.
+			// The value should be parsed correctly.
+			await user.clear( input );
+			await user.type( input, '5' );
+
+			expect( input ).toHaveValue( 5 );
+
+			// Focus the input and press the shift+up arrow to increment the value.
 			await user.click( input );
 			await user.keyboard( '{Shift>}[ArrowUp]{/Shift}' );
 
@@ -317,21 +467,41 @@ describe.each( [
 		it( 'should increment by shiftStep while preserving the decimal value when `step` is “any”', async () => {
 			const user = userEvent.setup();
 
-			render( <Component value={ 857.5309 } step="any" /> );
+			render( <Component step="any" /> );
 
 			const input = screen.getByRole( 'spinbutton' );
+
+			// Type a valid numeric value.
+			// The value should be parsed correctly.
+			await user.clear( input );
+			await user.type( input, '857.5309' );
+
+			expect( input ).toHaveValue( 857.5309 );
+
+			// Focus the input and press the shift+up arrow to increment the value.
 			await user.click( input );
 			await user.keyboard( '{Shift>}[ArrowUp]{/Shift}' );
 
 			expect( input ).toHaveValue( 867.5309 );
 		} );
 
+		// Todo: why in this case it increments to `shiftStep`,
+		// but in the default case it increments to `2 * shiftstep` ?
 		it( 'should increment by custom shiftStep on key UP + shift press', async () => {
 			const user = userEvent.setup();
 
-			render( <Component value={ 5 } shiftStep={ 100 } /> );
+			render( <Component shiftStep={ 100 } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
+
+			// Type a valid numeric value.
+			// The value should be parsed correctly.
+			await user.clear( input );
+			await user.type( input, '5' );
+
+			expect( input ).toHaveValue( 5 );
+
+			// Focus the input and press the shift+up arrow to increment the value.
 			await user.click( input );
 			await user.keyboard( '{Shift>}[ArrowUp]{/Shift}' );
 
@@ -341,9 +511,18 @@ describe.each( [
 		it( 'should increment but be limited by max on shiftStep', async () => {
 			const user = userEvent.setup();
 
-			render( <Component value={ 5 } shiftStep={ 100 } max={ 99 } /> );
+			render( <Component shiftStep={ 100 } max={ 99 } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
+
+			// Type a valid numeric value.
+			await user.clear( input );
+			await user.type( input, '5' );
+
+			expect( input ).toHaveValue( 5 );
+
+			// Focus the input and press the shift+up arrow to increment the value,
+			// which gets clamped by the value of `max`.
 			await user.click( input );
 			await user.keyboard( '{Shift>}[ArrowUp]{/Shift}' );
 
@@ -354,14 +533,20 @@ describe.each( [
 			const user = userEvent.setup();
 
 			render(
-				<Component
-					value={ 5 }
-					shiftStep={ 100 }
-					isShiftStepEnabled={ false }
-				/>
+				<Component shiftStep={ 100 } isShiftStepEnabled={ false } />
 			);
 
 			const input = screen.getByRole( 'spinbutton' );
+
+			// Type a valid numeric value.
+			// The value should be parsed correctly.
+			await user.clear( input );
+			await user.type( input, '5' );
+
+			expect( input ).toHaveValue( 5 );
+
+			// Focus the input and press the shift+up arrow to increment the value,
+			// but the "shift" is ignored, and therefore the value increments normally.
 			await user.click( input );
 			await user.keyboard( '{Shift>}[ArrowUp]{/Shift}' );
 
@@ -374,9 +559,16 @@ describe.each( [
 			const user = userEvent.setup();
 			const spy = jest.fn();
 
-			render( <Component value={ 5 } onKeyDown={ spy } /> );
+			render( <Component onKeyDown={ spy } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
+
+			// Type a valid numeric value.
+			// The value should be parsed correctly.
+			await user.clear( input );
+			await user.type( input, '5' );
+
+			// Focus the input and press the down arrow to decrement the value.
 			await user.click( input );
 			await user.keyboard( '[ArrowDown]' );
 
@@ -386,9 +578,16 @@ describe.each( [
 		it( 'should decrement by step on key DOWN press', async () => {
 			const user = userEvent.setup();
 
-			render( <Component value={ 5 } /> );
+			render( <Component /> );
 
 			const input = screen.getByRole( 'spinbutton' );
+
+			// Type a valid numeric value.
+			// The value should be parsed correctly.
+			await user.clear( input );
+			await user.type( input, '5' );
+
+			// Focus the input and press the down arrow to decrement the value.
 			await user.click( input );
 			await user.keyboard( '[ArrowDown]' );
 
@@ -398,9 +597,16 @@ describe.each( [
 		it( 'should decrement from a negative value', async () => {
 			const user = userEvent.setup();
 
-			render( <Component value={ -5 } /> );
+			render( <Component /> );
 
 			const input = screen.getByRole( 'spinbutton' );
+
+			// Type a valid numeric value.
+			// The value should be parsed correctly.
+			await user.clear( input );
+			await user.type( input, '-5' );
+
+			// Focus the input and press the down arrow to decrement the value.
 			await user.click( input );
 			await user.keyboard( '[ArrowDown]' );
 
@@ -410,9 +616,16 @@ describe.each( [
 		it( 'should decrement while preserving the decimal value when `step` is “any”', async () => {
 			const user = userEvent.setup();
 
-			render( <Component value={ 868.5309 } step="any" /> );
+			render( <Component step="any" /> );
 
 			const input = screen.getByRole( 'spinbutton' );
+
+			// Type a valid numeric value.
+			// The value should be parsed correctly.
+			await user.clear( input );
+			await user.type( input, '868.5309' );
+
+			// Focus the input and press the down arrow to decrement the value.
 			await user.click( input );
 			await user.keyboard( '[ArrowDown]' );
 
@@ -422,9 +635,16 @@ describe.each( [
 		it( 'should decrement by shiftStep on key DOWN + shift press', async () => {
 			const user = userEvent.setup();
 
-			render( <Component value={ 5 } /> );
+			render( <Component /> );
 
 			const input = screen.getByRole( 'spinbutton' );
+
+			// Type a valid numeric value.
+			// The value should be parsed correctly.
+			await user.clear( input );
+			await user.type( input, '5' );
+
+			// Focus the input and press the shift+down arrow to decrement the value.
 			await user.click( input );
 			await user.keyboard( '{Shift>}[ArrowDown]{/Shift}' );
 
@@ -434,9 +654,16 @@ describe.each( [
 		it( 'should decrement by shiftStep while preserving the decimal value when `step` is “any”', async () => {
 			const user = userEvent.setup();
 
-			render( <Component value={ 877.5309 } step="any" /> );
+			render( <Component step="any" /> );
 
 			const input = screen.getByRole( 'spinbutton' );
+
+			// Type a valid numeric value.
+			// The value should be parsed correctly.
+			await user.clear( input );
+			await user.type( input, '877.5309' );
+
+			// Focus the input and press the shift+down arrow to decrement the value.
 			await user.click( input );
 			await user.keyboard( '{Shift>}[ArrowDown]{/Shift}' );
 
@@ -446,9 +673,16 @@ describe.each( [
 		it( 'should decrement by custom shiftStep on key DOWN + shift press', async () => {
 			const user = userEvent.setup();
 
-			render( <Component value={ 5 } shiftStep={ 100 } /> );
+			render( <Component shiftStep={ 100 } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
+
+			// Type a valid numeric value.
+			// The value should be parsed correctly.
+			await user.clear( input );
+			await user.type( input, '5' );
+
+			// Focus the input and press the shift+down arrow to decrement the value.
 			await user.click( input );
 			await user.keyboard( '{Shift>}[ArrowDown]{/Shift}' );
 
@@ -458,9 +692,17 @@ describe.each( [
 		it( 'should decrement but be limited by min on shiftStep', async () => {
 			const user = userEvent.setup();
 
-			render( <Component value={ 5 } shiftStep={ 100 } min={ 4 } /> );
+			render( <Component shiftStep={ 100 } min={ 4 } /> );
 
 			const input = screen.getByRole( 'spinbutton' );
+
+			// Type a valid numeric value.
+			// The value should be parsed correctly.
+			await user.clear( input );
+			await user.type( input, '5' );
+
+			// Focus the input and press the shift+down arrow to decrement the value,
+			// which gets clamped by the value of `min`.
 			await user.click( input );
 			await user.keyboard( '{Shift>}[ArrowDown]{/Shift}' );
 
@@ -471,14 +713,16 @@ describe.each( [
 			const user = userEvent.setup();
 
 			render(
-				<Component
-					value={ 5 }
-					shiftStep={ 100 }
-					isShiftStepEnabled={ false }
-				/>
+				<Component shiftStep={ 100 } isShiftStepEnabled={ false } />
 			);
 
 			const input = screen.getByRole( 'spinbutton' );
+
+			// Type a valid numeric value.
+			// The value should be parsed correctly.
+			await user.clear( input );
+			await user.type( input, '5' );
+
 			await user.click( input );
 			await user.keyboard( '{Shift>}[ArrowDown]{/Shift}' );
 
@@ -494,7 +738,7 @@ describe.each( [
 		] as NumberControlProps[ 'spinControls' ][] )(
 			'should not appear when spinControls = %s',
 			( spinControls ) => {
-				render( <Component spinControls={ spinControls } /> );
+				render( <NumberControl spinControls={ spinControls } /> );
 				expect(
 					screen.queryByLabelText( 'Increment' )
 				).not.toBeInTheDocument();
@@ -504,39 +748,56 @@ describe.each( [
 			}
 		);
 
-		test.each( [
-			[ 'up', '1', {} ],
-			[ 'up', '2', { value: '1' } ],
-			[ 'up', '12', { value: '10', step: '2' } ],
-			[ 'up', '10', { value: '10', max: 10 } ],
-			[ 'down', '-1', {} ],
-			[ 'down', '1', { value: '2' } ],
-			[ 'down', '10', { value: '12', step: '2' } ],
-			[ 'down', '10', { value: '10', min: 10 } ],
-		] )(
-			'should spin %s to %s when props = %o',
-			async ( direction, expectedValue, props ) => {
-				const user = userEvent.setup();
-				const onChange = jest.fn();
-				render(
-					<Component
-						{ ...props }
-						spinControls="custom"
-						onChange={ onChange }
-					/>
-				);
-				await user.click(
-					screen.getByLabelText(
-						direction === 'up' ? 'Increment' : 'Decrement'
-					)
-				);
-				expect( onChange ).toHaveBeenCalledWith( expectedValue, {
-					event: expect.objectContaining( {
-						target: expect.any( HTMLInputElement ),
-						type: expect.any( String ),
-					} ),
-				} );
-			}
-		);
+		// Note: Custom spin buttons currently work only when the component is controlled.
+		if ( mode === 'controlled' ) {
+			test.each( [
+				[ undefined, 'up', '1', {} ],
+				[ '1', 'up', '2', {} ],
+				[ '10', 'up', '12', { step: '2' } ],
+				[ '10', 'up', '10', { max: 10 } ],
+				[ undefined, 'down', '-1', {} ],
+				[ '2', 'down', '1', {} ],
+				[ '12', 'down', '10', { step: '2' } ],
+				[ '10', 'down', '10', { min: 10 } ],
+			] )(
+				'should spin %s %s to %s when props = %o',
+				async ( initialValue, direction, expectedValue, props ) => {
+					const user = userEvent.setup();
+					const onChange = jest.fn();
+					render(
+						<Component
+							{ ...props }
+							spinControls="custom"
+							onChange={ onChange }
+						/>
+					);
+
+					const input = screen.getByRole( 'spinbutton' );
+					if ( initialValue !== undefined ) {
+						await user.clear( input );
+						await user.type( input, initialValue );
+					}
+
+					await user.click(
+						screen.getByLabelText(
+							direction === 'up' ? 'Increment' : 'Decrement'
+						)
+					);
+
+					expect( onChange ).toHaveBeenCalledTimes(
+						( initialValue ?? '' ).length + 1
+					);
+					expect( onChange ).toHaveBeenLastCalledWith(
+						expectedValue,
+						{
+							event: expect.objectContaining( {
+								target: input,
+								type: expect.any( String ),
+							} ),
+						}
+					);
+				}
+			);
+		}
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In preparation for the changes proposed in #45982, this PR improves the unit tests for `NumberControl`:

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The changes in #45982 have the potential to introduces unwanted side effects, and therefore it's better to bolster unit tests in order to gain more confidence when making those changes.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- all tests now run against both the controlled and uncontrolled version of the component

[TODO]:
- test both user input AND setting directly the `value` programmatically
- add more tests around validation, eg.:
  - test number and string
  - adding non numbers
  - adding numbers outside of range
  - leaving the field empty
  - adding a value, and then deleting it
  - typing and pressing enter
  - typing and blurring the input
  - with and without pressEnterToChange
  - with and without required


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

This PR doesn't introduce runtime changes (the only changes are to the unit tests).

Review the tests code, make sure that all tests pass and expect the correct behaviour.