### PR TITLE
InputControl: avoid uncontrolled to controlled warning

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Bug Fix
 
 -   `TabPanel`: Fix initial tab selection when the tab declaration is lazily added to the `tabs` array ([47100](https://github.com/WordPress/gutenberg/pull/47100)).
+-   `InputControl`: Avoid the "controlled to uncontrolled" warning by forcing the internal `<input />` element to be always in controlled mode ([47250](https://github.com/WordPress/gutenberg/pull/47250)).
 
 ## 23.2.0 (2023-01-11)
 

--- a/packages/components/src/input-control/input-field.tsx
+++ b/packages/components/src/input-control/input-field.tsx
@@ -226,7 +226,9 @@ function InputField(
 			onMouseDown={ handleOnMouseDown }
 			ref={ ref }
 			inputSize={ size }
-			value={ value }
+			// Fallback to `''` to avoid "uncontrolled to controlled" warning.
+			// See https://github.com/WordPress/gutenberg/pull/47250 for details.
+			value={ value ?? '' }
 			type={ type }
 		/>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Make sure that the underlying `<input />` in `InputControl` doesn't switch inadvertently from uncontrolled to controlled mode.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While working on #45982 and on #47246, I noticed that the "uncontrolled to controlled" warning was being logged even when it shouldn't have.

After some investigation with @mirka, we realized that `InputControl` [always passes an explicit `value` prop](https://github.com/WordPress/gutenberg/blob/9d7bbe4e288a1ad21dc7fe49edbfca30ec721a67/packages/components/src/input-control/input-field.tsx#L229) to the underlying `<input />` element, because of [the component's internal state reducer](https://github.com/WordPress/gutenberg/blob/9d7bbe4e288a1ad21dc7fe49edbfca30ec721a67/packages/components/src/input-control/input-field.tsx#L80).

This causes the "uncontrolled to controlled" warning to be logged when value of the `input` goes from empty to any value.

_I will also note that this error doesn't probably get logged when using the editor because in most cases a fallback to an empty string is already provided by the component using `InputControl` (or any related component)._

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Since React interprets an `undefined` value as a sign of an uncontrolled component, the fix here is to pass an empty string to `<input />` instead of `undefined` (this is achieved via the `?? ''` code).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

About the error message:

- Checkout this PR.
- Remove the fix that this PR applies to the `packages/components/src/input-control/input-field.tsx` file
- Load the temporary "Uncontrolled" Storybook example. Input a value in the input field.
- Observe how the "uncontrolled to controlled" error message gets logged to console
- Apply the fix from this PR to the `packages/components/src/input-control/input-field.tsx` file
- Try again interacting with the "Uncontrolled" Storybook example, make sure that the error is not logged to console

Check that the component behaves as expected:

- In Storybook for `InputControl` and its derivatives (`NumberControl`, `UnitControl`, `RangeControl`, ....)
- In the editor, especially in the sidebar
- 
## Screenshots or screencast <!-- if applicable -->

Screencast of the error message logged to console that happens without the fix from this PR:

https://user-images.githubusercontent.com/1083581/213227823-f7341da6-2ce8-47fb-9779-f8d28a49a823.mp4


