### PR TITLE
Now that WP_Query is cached, just load all templates.

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -29,7 +29,6 @@ function render_block_core_template_part( $attributes ) {
 			array(
 				'post_type'      => 'wp_template_part',
 				'post_status'    => 'publish',
-				'post_name__in'  => array( $attributes['slug'] ),
 				'tax_query'      => array(
 					array(
 						'taxonomy' => 'wp_theme',
@@ -37,11 +36,18 @@ function render_block_core_template_part( $attributes ) {
 						'terms'    => $attributes['theme'],
 					),
 				),
-				'posts_per_page' => 1,
+				'posts_per_page' => -1,
 				'no_found_rows'  => true,
 			)
 		);
-		$template_part_post  = $template_part_query->have_posts() ? $template_part_query->next_post() : null;
+		$template_part_post = null;
+		if ( $template_part_query->have_posts() ) {
+			foreach ( $template_part_query->posts as $template_post ) {
+				if ( $template_post->post_name === $attributes['slug'] ) {
+					$template_part_post = $template_post;
+				}
+			}
+		}
 		if ( $template_part_post ) {
 			// A published post might already exist if this template part was customized elsewhere
 			// or if it's part of a customized template.

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -40,7 +40,7 @@ function render_block_core_template_part( $attributes ) {
 				'no_found_rows'  => true,
 			)
 		);
-		$template_part_post = null;
+		$template_part_post  = null;
 		if ( $template_part_query->have_posts() ) {
 			foreach ( $template_part_query->posts as $template_post ) {
 				if ( $template_post->post_name === $attributes['slug'] ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
See #45309

Now that `WP_Query` is cached https://github.com/WordPress/wordpress-develop/commit/7f7d616d822b79c952cbd6a3046a6f6a8aa5a35e, we should just load all template parts and use php to filter. 

### Before
<img width="176" alt="Screenshot 2023-01-18 at 16 53 04" src="https://user-images.githubusercontent.com/237508/213244788-5caa109a-6791-4792-b35a-7c41c3b2b889.png">

### After
<img width="164" alt="Screenshot 2023-01-18 at 16 53 30" src="https://user-images.githubusercontent.com/237508/213244779-327e1017-fc8d-49c4-8e16-0347fe611c0a.png">




## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
