### PR TITLE
[Fonts API] Remove local() from @font-face styles.

### DIFF
--- a/lib/experimental/fonts-api/class-wp-fonts-provider-local.php
+++ b/lib/experimental/fonts-api/class-wp-fonts-provider-local.php
@@ -205,7 +205,7 @@ class WP_Fonts_Provider_Local extends WP_Fonts_Provider {
 	 * @return string The CSS.
 	 */
 	private function compile_src( $font_family, array $value ) {
-		$src = "local($font_family)";
+		$src = '';
 
 		foreach ( $value as $item ) {
 
@@ -217,6 +217,8 @@ class WP_Fonts_Provider_Local extends WP_Fonts_Provider {
 				? ", url({$item['url']})"
 				: ", url('{$item['url']}') format('{$item['format']}')";
 		}
+
+		$src = ltrim( $src, ', ' );
 		return $src;
 	}
 

--- a/phpunit/fonts-api/wp-fonts-tests-dataset.php
+++ b/phpunit/fonts-api/wp-fonts-tests-dataset.php
@@ -1035,15 +1035,15 @@ trait WP_Fonts_Tests_Datasets {
 	protected function get_registered_fonts_css() {
 		return array(
 			'merriweather-200-900-normal' => <<<CSS
-@font-face{font-family:Merriweather;font-style:normal;font-weight:200 900;font-display:fallback;font-stretch:normal;src:local(Merriweather), url('https://example.com/assets/fonts/merriweather.ttf.woff2') format('woff2');}
+@font-face{font-family:Merriweather;font-style:normal;font-weight:200 900;font-display:fallback;font-stretch:normal;src:url('https://example.com/assets/fonts/merriweather.ttf.woff2') format('woff2');}
 CSS
 		,
 			'Source Serif Pro-300-normal' => <<<CSS
-@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:300;font-display:fallback;font-stretch:normal;src:local("Source Serif Pro"), url('https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');}
+@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:300;font-display:fallback;font-stretch:normal;src:url('https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');}
 CSS
 		,
 			'Source Serif Pro-900-italic' => <<<CSS
-@font-face{font-family:"Source Serif Pro";font-style:italic;font-weight:900;font-display:fallback;font-stretch:normal;src:local("Source Serif Pro"), url('https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');}
+@font-face{font-family:"Source Serif Pro";font-style:italic;font-weight:900;font-display:fallback;font-stretch:normal;src:url('https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');}
 CSS
 		,
 			'font1-300-normal'            => 'font1-300-normal',

--- a/phpunit/fonts-api/wpFontsProviderLocal-test.php
+++ b/phpunit/fonts-api/wpFontsProviderLocal-test.php
@@ -114,7 +114,7 @@ class Tests_Fonts_WpFontsProviderLocal extends WP_UnitTestCase {
 				'expected' => array(
 					'style-element' => "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n",
 					'font-face-css' => <<<CSS
-@font-face{font-family:"Open Sans";font-style:italic;font-weight:bold;src:local("Open Sans"), url('http://example.org/assets/fonts/OpenSans-Italic-VariableFont_wdth,wght.ttf') format('truetype');}
+@font-face{font-family:"Open Sans";font-style:italic;font-weight:bold;src:url('http://example.org/assets/fonts/OpenSans-Italic-VariableFont_wdth,wght.ttf') format('truetype');}
 CSS
 					,
 				),
@@ -141,7 +141,7 @@ CSS
 				'expected' => array(
 					'style-element' => "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n",
 					'font-face-css' => <<<CSS
-@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-stretch:normal;src:local("Source Serif Pro"), url('http://example.org/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');}@font-face{font-family:"Source Serif Pro";font-style:italic;font-weight:200 900;font-stretch:normal;src:local("Source Serif Pro"), url('http://example.org/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');}
+@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-stretch:normal;src:url('http://example.org/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');}@font-face{font-family:"Source Serif Pro";font-style:italic;font-weight:200 900;font-stretch:normal;src:url('http://example.org/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');}
 CSS
 
 					,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes #42190

Core Trac https://core.trac.wordpress.org/ticket/57430

## What?
<!-- In a few words, what is the PR actually doing? -->

Removes adding `local()` as a `@font-face` `src`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

From the issue:
>The problem is that by taking the `$font_familiy` name here, we don't consider that the user may have installed the font from separate files to bold, medium, light, etc. And those files should be listed as different local files.

From the Trac ticket:
>loading the local font file can lean to unexpected compatibility issues due to version or locale mismatches of the font.

## Testing Instructions
Testing instructions are in the issue's description. The expected results:

Before the PR:
```css
@font-face {
  font-family: "El Messiri";
  font-style: normal;
  font-weight: 400;
  font-display: fallback;
  src: local("El Messiri"),
    url("https://your-host.com/wp-content/themes/your-theme/assets/fonts/static/ElMessiri-Regular.ttf")
      format("truetype");
}
@font-face {
  font-family: "El Messiri";
  font-style: normal;
  font-weight: 700;
  font-display: fallback;
  src: local("El Messiri"),
    url("https://your-host.com/wp-content/themes/your-theme/assets/fonts/static/ElMessiri-Bold.ttf")
      format("truetype");
}
```

after the PR:
```css
@font-face {
  font-family: "El Messiri";
  font-style: normal;
  font-weight: 400;
  font-display: fallback;
  src: url("https://your-host.com/wp-content/themes/your-theme/assets/fonts/static/ElMessiri-Regular.ttf")
      format("truetype");
}
@font-face {
  font-family: "El Messiri";
  font-style: normal;
  font-weight: 700;
  font-display: fallback;
  src: url("https://your-host.com/wp-content/themes/your-theme/assets/fonts/static/ElMessiri-Bold.ttf")
      format("truetype");
}
```