### PR TITLE
Fixes typo in class PHPDoc comment

### DIFF
--- a/lib/experimental/fonts-api/class-wp-fonts-provider.php
+++ b/lib/experimental/fonts-api/class-wp-fonts-provider.php
@@ -25,7 +25,7 @@ if ( class_exists( 'WP_Fonts_Provider' ) ) {
  * and how to generate the `@font-face` styles for its service.
  *
  * It receives a collection of fonts from the Controller
- * {@see WP_Fonts_Provider::set_setfonts()}, and when requested
+ * {@see WP_Fonts_Provider::set_fonts()}, and when requested
  * {@see WP_Fonts_Provider::get_css()}, it transforms them
  * into styles (in a performant way for the provider service
  * it manages).


### PR DESCRIPTION
## What?
In the process of looking into the new webfonts functionality I noticed a typo in the PHPDoc comment for the class `WP_Webfonts_Provider`

## Why?
This PR would update the method in the comment from "set_setfonts" to "set_fonts" to match the function name within the class.

## How?
This PR addresses the issue by updating the doc comment with the correct method name. This was not a code change/will not change any functionality.

## Testing Instructions
To test this verify that the updated method name matches the method in the class that is being discussed. The method `set_setfonts` does not exist and the method is named `set_fonts`. 

### Testing Instructions for Keyboard
This is a comment level change and not a visual change on the front end/gutenberg plugin functionality. This keyboard testing instruction may not apply for this small comment change.
