### PR TITLE
ToggleGroupControl: add new opt-in prop

### DIFF
--- a/packages/block-editor/src/hooks/child-layout.js
+++ b/packages/block-editor/src/hooks/child-layout.js
@@ -65,6 +65,7 @@ export function ChildLayoutEdit( {
 	return (
 		<>
 			<ToggleGroupControl
+				__nextHasNoMarginBottom
 				size={ '__unstable-large' }
 				label={ childLayoutOrientation( parentLayout ) }
 				value={ selfStretch || 'fit' }

--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -118,6 +118,7 @@ export default {
 					) }
 				</p>
 				<ToggleGroupControl
+					__nextHasNoMarginBottom
 					label={ __( 'Justification' ) }
 					value={ justifyContent }
 					onChange={ onJustificationChange }

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -323,6 +323,7 @@ function FlexLayoutJustifyContentControl( {
 
 	return (
 		<ToggleGroupControl
+			__nextHasNoMarginBottom
 			label={ __( 'Justification' ) }
 			value={ justifyContent }
 			onChange={ onJustificationChange }
@@ -366,6 +367,7 @@ function OrientationControl( { layout, onChange } ) {
 	} = layout;
 	return (
 		<ToggleGroupControl
+			__nextHasNoMarginBottom
 			className="block-editor-hooks__flex-layout-orientation-controls"
 			label={ __( 'Orientation' ) }
 			value={ orientation }

--- a/packages/block-library/src/comments-pagination/comments-pagination-arrow-controls.js
+++ b/packages/block-library/src/comments-pagination/comments-pagination-arrow-controls.js
@@ -10,6 +10,7 @@ import {
 export function CommentsPaginationArrowControls( { value, onChange } ) {
 	return (
 		<ToggleGroupControl
+			__nextHasNoMarginBottom
 			label={ __( 'Arrow' ) }
 			value={ value }
 			onChange={ onChange }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -595,6 +595,7 @@ function Navigation( {
 						) }
 						<h3>{ __( 'Overlay Menu' ) }</h3>
 						<ToggleGroupControl
+							__nextHasNoMarginBottom
 							label={ __( 'Configure overlay menu' ) }
 							value={ overlayMenu }
 							help={ __(

--- a/packages/block-library/src/navigation/edit/overlay-menu-preview.js
+++ b/packages/block-library/src/navigation/edit/overlay-menu-preview.js
@@ -26,6 +26,7 @@ export default function OverlayMenuPreview( { setAttributes, hasIcon, icon } ) {
 			/>
 
 			<ToggleGroupControl
+				__nextHasNoMarginBottom
 				label={ __( 'Icon' ) }
 				value={ icon }
 				onChange={ ( value ) => setAttributes( { icon: value } ) }

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -132,6 +132,7 @@ const DimensionControls = ( {
 					panelId={ clientId }
 				>
 					<ToggleGroupControl
+						__nextHasNoMarginBottom
 						label={ scaleLabel }
 						value={ scale }
 						help={ scaleHelp[ scale ] }

--- a/packages/block-library/src/post-navigation-link/edit.js
+++ b/packages/block-library/src/post-navigation-link/edit.js
@@ -77,6 +77,7 @@ export default function PostNavigationLinkEdit( {
 						/>
 					) }
 					<ToggleGroupControl
+						__nextHasNoMarginBottom
 						label={ __( 'Arrow' ) }
 						value={ arrow }
 						onChange={ ( value ) => {

--- a/packages/block-library/src/query-pagination/query-pagination-arrow-controls.js
+++ b/packages/block-library/src/query-pagination/query-pagination-arrow-controls.js
@@ -10,6 +10,7 @@ import {
 export function QueryPaginationArrowControls( { value, onChange } ) {
 	return (
 		<ToggleGroupControl
+			__nextHasNoMarginBottom
 			label={ __( 'Arrow' ) }
 			value={ value }
 			onChange={ onChange }

--- a/packages/components/src/toggle-group-control/stories/index.tsx
+++ b/packages/components/src/toggle-group-control/stories/index.tsx
@@ -48,6 +48,7 @@ const Template: ComponentStory< typeof ToggleGroupControl > = ( {
 
 	return (
 		<ToggleGroupControl
+			__nextHasNoMarginBottom
 			{ ...props }
 			onChange={ ( ...changeArgs ) => {
 				setValue( ...changeArgs );

--- a/packages/components/src/tools-panel/stories/index.js
+++ b/packages/components/src/tools-panel/stories/index.js
@@ -87,6 +87,7 @@ export const _default = () => {
 						onDeselect={ () => setScale( undefined ) }
 					>
 						<ToggleGroupControl
+							__nextHasNoMarginBottom
 							label="Scale"
 							value={ scale }
 							onChange={ ( next ) => setScale( next ) }
@@ -367,6 +368,7 @@ export const WithConditionalDefaultControl = () => {
 					isShownByDefault={ !! height }
 				>
 					<ToggleGroupControl
+						__nextHasNoMarginBottom
 						label="Scale"
 						value={ scale }
 						onChange={ ( next ) =>
@@ -456,6 +458,7 @@ export const WithConditionallyRenderedControl = () => {
 						isShownByDefault={ true }
 					>
 						<ToggleGroupControl
+							__nextHasNoMarginBottom
 							label="Scale"
 							value={ scale }
 							onChange={ ( next ) =>

--- a/packages/edit-site/src/components/global-styles/screen-heading-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-heading-color.js
@@ -128,6 +128,7 @@ function ScreenHeadingColor( { name, variation = '' } ) {
 				<h4>{ __( 'Select heading level' ) }</h4>
 
 				<ToggleGroupControl
+					__nextHasNoMarginBottom
 					label={ __( 'Select heading level' ) }
 					hideLabelFromVision={ true }
 					value={ selectedLevel }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

Adding new opt-in prop `__nextHasNoMarginBottom` to usages of `ToggleGroupControl` in the Gutenberg codebase. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Part of this project: https://github.com/WordPress/gutenberg/issues/38730
The tl;dr is `BaseControl` has a `margin-bottom` which makes it difficult to reuse and results in inconsistent use. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding the prop `__nextHasNoMarginBottom`.

## Additional Notes

- There is slightly less bottom margin for [the three components/blocks with arrow toggle options](/#user-content-arrow), but I think it looks good.
- For ToolsPanel stories, there is a margin override added from ToolsPanels styles, so there is no visual change. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

### Test in Block Editor: 

- #### SCALE_OPTIONS (dimension controls)

	1. Add Featured Post block
	2. Change the height
	3. Ensure the space below the 'Scale' options is the same as before
	<br><img width="287" alt="Screenshot 2023-01-17 at 8 22 51 PM" src="https://user-images.githubusercontent.com/35543432/213363011-765d6471-257e-4610-8dce-6e95359f9ef6.png">

---

### Test in Block Editor or Site Editor:

- #### ChildLayoutEdit

	1. Add a Row block 
	2. Add any child block within Row
	3. Click on three dots menu for 'Dimensions' in the block inspector and select 'Width'
	5. Toggle to 'Fixed'
	6. Ensure the space below the toggle group is the same as before 
	<br><img width="286" alt="Screenshot 2023-01-18 at 9 26 17 PM" src="https://user-images.githubusercontent.com/35543432/213362468-a86304d0-9d6c-48a6-a624-33afa251cbb2.png">

- #### DefaultLayoutInspectorControls

	1.  Add Post Content block (usually in a query loop but not needed for this test)
	2. Click on the settings icon in the block inspector
	3. Toggle on the switch 'Inner blocks use content width'
	7. Ensure spacing below options for 'Justification 'is the same as before
	<br><img width="278" alt="Screenshot 2023-01-17 at 8 20 00 PM" src="https://user-images.githubusercontent.com/35543432/213362761-b17306eb-7800-4bf2-879f-a69aeb7b4f8d.png">

- #### FlexLayoutJustifyContentControl & OverlayMenuPreview & stylingInspectorControls 

	1. Add Navigation block
	2. Click on the settings icon in the block inspector 
	3. Ensure the space below options for 'Justification' and 'Orientation' are the same as before
	4. Click on the icon under 'Display'
	5. Ensure the space below the 'Icon' and 'Overlay Menu' toggle group are the same as before 
	<br><img width="270" alt="Screenshot 2023-01-17 at 8 19 30 PM" src="https://user-images.githubusercontent.com/35543432/213362549-a61ad266-d62a-461f-a514-a846f3298184.png">
 
<h3 id="arrow"> --- <em>Begin - Arrow changes</em> --- </h3>

The following three components/blocks have the same change in spacing as described above: 

| Before  | After |
| ------------- | ------------- |
| <img width="281" alt="Screenshot 2023-01-18 at 9 32 15 PM" src="https://user-images.githubusercontent.com/35543432/213363500-61b03aa4-ff92-4e33-a61b-bbaf1f104a52.png">  | <img width="283" alt="Screenshot 2023-01-18 at 9 33 33 PM" src="https://user-images.githubusercontent.com/35543432/213363475-2a88f53f-df44-45ca-b9b4-9ab0061526b4.png">l  |

- #### PostNavigationLinkEdit 

	1. Add the Next post and/or Previous post block
	2. Click on the settings icon
	3. Check the spacing below the 'Arrow' toggle group

- #### QueryPaginationArrowControls 

	1. Add Query Loop block
	2. Start blank and choose any template
	3. Click on Pagination block 
	4. Check the spacing below the 'Arrow' toggle group
---

### Test in Site Editor:

- #### CommentsPaginationArrowControls 

	1.  Edit the Single Post template
	2. Add a Comments block if you don't have one 
	3.  Click on the Comments Pagination block
	4. Check the spacing below the 'Arrow' toggle group

### --- _End Arrow changes_ ---

- #### ScreenHeadingColor

	1. Click on Global Styles icon > Colors > Headings while in the site editor 
	2. Ensure the space below 'Select heading level' is the same as before
	<br><img width="278" alt="Screenshot 2023-01-17 at 8 44 14 PM" src="https://user-images.githubusercontent.com/35543432/213363082-6f88cc59-2f01-4a86-91a1-72761ffafe1c.png">

---

### Test in Storybook:

- #### ToggleGroupControl 
	
	1. Go to ToggleGroupControl in Storybook
	2. Click on the icon in the toolbar with mirrored arrows and select 'Show' to enable the margin checker
	3. See that margin below the toggle group has been removed
	<br><img width="613" alt="Screenshot 2023-01-18 at 9 54 58 PM" src="https://user-images.githubusercontent.com/35543432/213366400-5cb298ff-4e1b-4f7c-bbeb-1c5c61829f9e.png">

- #### ToolsPanel

	ToolsPanel won't look visually different, but the changes are for `default`, `With Conditional Default Control`, and `With Conditionally Rendered Control`.

