### PR TITLE
Shadow: rename shadow palette to presets

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -58,7 +58,7 @@ Settings related to shadows.
 
 | Property  | Type   | Default | Props  |
 | ---       | ---    | ---    |---   |
-| palette | array |  | name, shadow, slug |
+| presets | array |  | name, shadow, slug |
 
 ---
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -118,8 +118,8 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	const PRESETS_METADATA = array(
 		array(
-			'path'              => array( 'shadow', 'palette' ),
-			'prevent_override'  => array( 'shadow', 'defaultPalette' ),
+			'path'              => array( 'shadow', 'presets' ),
+			'prevent_override'  => array( 'shadow', 'defaultPresets' ),
 			'use_default_names' => false,
 			'value_key'         => 'shadow',
 			'css_vars'          => '--wp--preset--shadow--$slug',
@@ -343,8 +343,8 @@ class WP_Theme_JSON_Gutenberg {
 			'width'  => null,
 		),
 		'shadow'                        => array(
-			'palette'        => null,
-			'defaultPalette' => null,
+			'presets'        => null,
+			'defaultPresets' => null,
 		),
 		'color'                         => array(
 			'background'       => null,

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -187,7 +187,7 @@
 			"text": true
 		},
 		"shadow": {
-			"palette": [
+			"presets": [
 				{
 					"name": "Natural",
 					"slug": "natural",

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -476,7 +476,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'settings' => array(
 					'shadow' => array(
-						'palette' => array(
+						'presets' => array(
 							array(
 								'slug'   => 'natural',
 								'shadow' => '5px 5px 5px 0 black',
@@ -502,7 +502,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'settings' => array(
 					'shadow' => array(
-						'palette' => array(
+						'presets' => array(
 							array(
 								'slug'   => 'natural',
 								'shadow' => '5px 5px 0 0 black',

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -74,7 +74,7 @@
 					"description": "Settings related to shadows.",
 					"type": "object",
 					"properties": {
-						"palette": {
+						"presets": {
 							"description": "Shadow presets for the shadow picker.\nGenerates a single custom property (`--wp--preset--shadow--{slug}`) per preset value.",
 							"type": "array",
 							"items": {


### PR DESCRIPTION
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Rename `shadow => palette` to `shadow => presets` to give more meaning.
It has no effect from previous behavior.

The new definition of the shadow presets changes to

```
"shadow": {
	"defaultPresets": true,
	"presets": [{
		"name": "Demo shadow",
		"slug": "demo-shadow",
		"shadow": "5px 5px 0 0 black"
	}]
},
```