### PR TITLE
Try: Filter Pattern Categories by Editor Type

### DIFF
--- a/lib/compat/wordpress-6.2/block-patterns.php
+++ b/lib/compat/wordpress-6.2/block-patterns.php
@@ -134,6 +134,7 @@ function gutenberg_register_core_block_patterns_categories() {
 		array(
 			'label'       => _x( 'Footers', 'Block pattern category', 'gutenberg' ),
 			'description' => __( 'A variety of footer designs displaying information and site navigation.', 'gutenberg' ),
+			'editors'     => array( 'core/site' ),
 		)
 	);
 	register_block_pattern_category(

--- a/lib/compat/wordpress-6.2/block-patterns.php
+++ b/lib/compat/wordpress-6.2/block-patterns.php
@@ -14,7 +14,7 @@ function gutenberg_register_core_block_patterns_categories() {
 	register_block_pattern_category(
 		'banner',
 		array(
-			'label' => _x( 'Banners', 'Block pattern category', 'gutenberg' ),
+			'label'       => _x( 'Banners', 'Block pattern category', 'gutenberg' ),
 			'description' => __( 'An element that helps structure or contrast the contents of a page.', 'gutenberg' ),
 		)
 	);

--- a/lib/compat/wordpress-6.2/block-patterns.php
+++ b/lib/compat/wordpress-6.2/block-patterns.php
@@ -15,6 +15,7 @@ function gutenberg_register_core_block_patterns_categories() {
 		'banner',
 		array(
 			'label' => _x( 'Banners', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'An element that helps structure or contrast the contents of a page.', 'gutenberg' ),
 		)
 	);
 	register_block_pattern_category(

--- a/lib/compat/wordpress-6.2/block-patterns.php
+++ b/lib/compat/wordpress-6.2/block-patterns.php
@@ -135,6 +135,7 @@ function gutenberg_register_core_block_patterns_categories() {
 		array(
 			'label'       => _x( 'Headers', 'Block pattern category', 'gutenberg' ),
 			'description' => __( 'A variety of header designs displaying your site title and navigation.', 'gutenberg' ),
+			'editors'    => array( 'core/site' ),
 		)
 	);
 }

--- a/lib/compat/wordpress-6.2/block-patterns.php
+++ b/lib/compat/wordpress-6.2/block-patterns.php
@@ -141,7 +141,7 @@ function gutenberg_register_core_block_patterns_categories() {
 		array(
 			'label'       => _x( 'Headers', 'Block pattern category', 'gutenberg' ),
 			'description' => __( 'A variety of header designs displaying your site title and navigation.', 'gutenberg' ),
-			'editors'    => array( 'core/site' ),
+			'editors'     => array( 'core/site' ),
 		)
 	);
 }

--- a/lib/compat/wordpress-6.2/block-patterns.php
+++ b/lib/compat/wordpress-6.2/block-patterns.php
@@ -9,6 +9,8 @@
  * Registers the block pattern categories.
  */
 function gutenberg_register_core_block_patterns_categories() {
+	// Register universal block pattern categories
+	// Available in post and site editor.
 	register_block_pattern_category(
 		'banner',
 		array(
@@ -51,7 +53,8 @@ function gutenberg_register_core_block_patterns_categories() {
 		)
 	);
 
-	// Register new core block pattern categories.
+	// Register new universal core block pattern categories.
+	// Available in post and site editor.
 	register_block_pattern_category(
 		'call-to-action',
 		array(
@@ -122,7 +125,9 @@ function gutenberg_register_core_block_patterns_categories() {
 			'description' => __( 'Display your latest posts in lists, grids or other layouts.', 'gutenberg' ),
 		)
 	);
-	// Site building pattern categories.
+
+	// Register site building pattern categories.
+	// Available in site editor.
 	register_block_pattern_category(
 		'footer',
 		array(

--- a/lib/compat/wordpress-6.2/class-gutenberg-rest-block-pattern-categories-controller.php
+++ b/lib/compat/wordpress-6.2/class-gutenberg-rest-block-pattern-categories-controller.php
@@ -25,7 +25,7 @@ class Gutenberg_REST_Block_Pattern_Categories_Controller extends WP_REST_Block_P
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		$fields = $this->get_fields_for_response( $request );
-		$keys   = array( 'name', 'label', 'description' );
+		$keys   = array( 'name', 'label', 'description', 'editors' );
 		$data   = array();
 		foreach ( $keys as $key ) {
 			if ( isset( $item[ $key ] ) && rest_is_field_included( $key, $fields ) ) {
@@ -67,6 +67,12 @@ class Gutenberg_REST_Block_Pattern_Categories_Controller extends WP_REST_Block_P
 				'description' => array(
 					'description' => __( 'The category description, in human readable format.', 'gutenberg' ),
 					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'editors' => array(
+					'description' => __( 'The editors this category is allowed to be shown on.', 'gutenberg' ),
+					'type'        => 'array',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),

--- a/lib/compat/wordpress-6.2/class-gutenberg-rest-block-pattern-categories-controller.php
+++ b/lib/compat/wordpress-6.2/class-gutenberg-rest-block-pattern-categories-controller.php
@@ -70,7 +70,7 @@ class Gutenberg_REST_Block_Pattern_Categories_Controller extends WP_REST_Block_P
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),
-				'editors' => array(
+				'editors'     => array(
 					'description' => __( 'The editors this category is allowed to be shown on.', 'gutenberg' ),
 					'type'        => 'array',
 					'readonly'    => true,

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -102,10 +102,17 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			[
 				...( settingsBlockPatternCategories || [] ),
 				...( restBlockPatternCategories || [] ),
-			].filter(
-				( x, index, arr ) =>
-					index === arr.findIndex( ( y ) => x.name === y.name )
-			),
+			]
+				.filter(
+					( x, index, arr ) =>
+						index === arr.findIndex( ( y ) => x.name === y.name )
+				)
+				.filter( ( cat ) => {
+					if ( ! cat?.editors?.length ) {
+						return true;
+					}
+					return cat.editors.includes( 'core/post' );
+				} ),
 		[ settingsBlockPatternCategories, restBlockPatternCategories ]
 	);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This adds the ability to filter Pattern Categories by editor type (post or site editor), as a small step to improving the pattern inserter experience.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Part of https://github.com/WordPress/gutenberg/issues/44501

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds an `editors` key to the block patterns category controller, which accepts an array of allowed editors (core/post and/or core/site). Also adds an additional filter to `blockPatternCategories`, which filters by editor type based on the `editors` key. 

Currently, the 'Headers' and 'Footers' categories have been restricted to only showing in the Site editor.

This PR also adds a description to the 'Banners' category, as it was previously missing.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Go to the Site editor
2. Ensure all pattern categories are listed in the pattern inserter
3. Go to the Post editor
4. Ensure all pattern categories are listed in the pattern inserter, excluding 'Headers' and 'Footers'

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

| Post Editor | Site Editor |
| ---------- | --------- |
| <img width="340" alt="image" src="https://user-images.githubusercontent.com/1645628/214338520-b63e9a2c-70de-4c17-bf49-8a67445fda60.png"> | <img width="343" alt="image" src="https://user-images.githubusercontent.com/1645628/214338646-e252ca70-ae56-443a-9c2a-4613f7121826.png"> |