### PR TITLE
Do not override rich text role attribute

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -360,6 +360,7 @@ function RichTextWrapper(
 	}
 
 	const TagName = tagName;
+
 	return (
 		<>
 			{ isSelected && (
@@ -389,11 +390,11 @@ function RichTextWrapper(
 			) }
 			<TagName
 				// Overridable props.
-				role="textbox"
 				aria-multiline={ ! disableLineBreaks }
 				aria-label={ placeholder }
 				{ ...props }
 				{ ...autocompleteProps }
+				role="textbox"
 				ref={ useMergeRefs( [
 					forwardedRef,
 					autocompleteProps.ref,


### PR DESCRIPTION
## What?
Make sure the role of the Rich Text component is always set to `textbox` and avoid setting it to `document` on certain blocks, [listed here](https://github.com/WordPress/gutenberg/issues/42158).

## Why?
Allowing for the possibility of the role of the Rich Text component to be anything other than `textbox` opens up the possibility for an inconsistent experience for folks using Assistive Technologies.

Thoughts that motivate this:
- It shouldn't be possible to have an `aria-multiline=true` element be anything other than `role="textbox"`.
- It doesn't seem like there's a reason for the role of this editable text field to be anything other than `textbox`; especially not `document` which is defined as

> the top container containing content that assistive technology users may want to browse in a **reading mode**.
