### PR TITLE
Add registered fonts to theme JSON AFTER the child and parent data has been merged.

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -245,9 +245,6 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			} else {
 				$theme_json_data = array();
 			}
-			// BEGIN OF EXPERIMENTAL CODE. Not to backport to core.
-			$theme_json_data = gutenberg_add_registered_fonts_to_theme_json( $theme_json_data );
-			// END OF EXPERIMENTAL CODE.
 
 			/**
 			 * Filters the data provided by the theme for global styles and settings.
@@ -266,9 +263,6 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 				if ( '' !== $parent_theme_json_file ) {
 					$parent_theme_json_data = static::read_json_file( $parent_theme_json_file );
 					$parent_theme_json_data = static::translate( $parent_theme_json_data, $wp_theme->parent()->get( 'TextDomain' ) );
-					// BEGIN OF EXPERIMENTAL CODE. Not to backport to core.
-					$parent_theme_json_data = gutenberg_add_registered_fonts_to_theme_json( $parent_theme_json_data );
-					// END OF EXPERIMENTAL CODE.
 					$parent_theme = new WP_Theme_JSON_Gutenberg( $parent_theme_json_data );
 
 					/*
@@ -279,6 +273,11 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 					static::$theme = $parent_theme;
 				}
 			}
+
+			// BEGIN OF EXPERIMENTAL CODE. Not to backport to core.
+			static::$theme = gutenberg_add_registered_fonts_to_theme_json( static::$theme );
+			// END OF EXPERIMENTAL CODE.
+
 		}
 
 		if ( ! $options['with_supports'] ) {

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -263,7 +263,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 				if ( '' !== $parent_theme_json_file ) {
 					$parent_theme_json_data = static::read_json_file( $parent_theme_json_file );
 					$parent_theme_json_data = static::translate( $parent_theme_json_data, $wp_theme->parent()->get( 'TextDomain' ) );
-					$parent_theme = new WP_Theme_JSON_Gutenberg( $parent_theme_json_data );
+					$parent_theme           = new WP_Theme_JSON_Gutenberg( $parent_theme_json_data );
 
 					/*
 					 * Merge the child theme.json into the parent theme.json.

--- a/lib/experimental/fonts-api/register-fonts-from-theme-json.php
+++ b/lib/experimental/fonts-api/register-fonts-from-theme-json.php
@@ -121,8 +121,11 @@ if ( ! function_exists( 'gutenberg_add_registered_fonts_to_theme_json' ) ) {
 	 */
 	function gutenberg_add_registered_fonts_to_theme_json( $data ) {
 		$font_families_registered = wp_fonts()->get_registered_font_families();
-		$font_families_from_theme = ! empty( $data['settings']['typography']['fontFamilies'] )
-			? $data['settings']['typography']['fontFamilies']
+
+		$raw_data = $data->get_raw_data();
+
+		$font_families_from_theme = ! empty( $raw_data['settings']['typography']['fontFamilies']['theme'] )
+			? $raw_data['settings']['typography']['fontFamilies']['theme']
 			: array();
 
 		/**
@@ -157,21 +160,24 @@ if ( ! function_exists( 'gutenberg_add_registered_fonts_to_theme_json' ) ) {
 
 		// Make sure the path to settings.typography.fontFamilies.theme exists
 		// before adding missing fonts.
-		if ( empty( $data['settings'] ) ) {
-			$data['settings'] = array();
+		if ( empty( $raw_data['settings'] ) ) {
+			$raw_data['settings'] = array();
 		}
-		if ( empty( $data['settings']['typography'] ) ) {
-			$data['settings']['typography'] = array();
+		if ( empty( $raw_data['settings']['typography'] ) ) {
+			$raw_data['settings']['typography'] = array();
 		}
-		if ( empty( $data['settings']['typography']['fontFamilies'] ) ) {
-			$data['settings']['typography']['fontFamilies'] = array();
+		if ( empty( $raw_data['settings']['typography']['fontFamilies'] ) ) {
+			$raw_data['settings']['typography']['fontFamilies'] = array();
+		}
+		if ( empty( $raw_data['settings']['typography']['fontFamilies'] ) ) {
+			$raw_data['settings']['typography']['fontFamilies']['theme'] = array();
 		}
 
 		foreach ( $to_add as $font_family_handle ) {
-			$data['settings']['typography']['fontFamilies'][] = wp_fonts()->to_theme_json( $font_family_handle );
+			$raw_data['settings']['typography']['fontFamilies']['theme'][] = wp_fonts()->to_theme_json( $font_family_handle );
 		}
 
-		return $data;
+		return new WP_Theme_JSON_Gutenberg( $raw_data );
 	}
 }
 


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This fixes a problem noted here: https://github.com/Automattic/themes/issues/6827

In short because fonts registered via Font Provider are appended to a CHILD theme's data any fonts provided by the PARENT are no longer provided.

This change appends the fonts to the theme data AFTER the parent and child data have been merged.

## Testing Instructions
You will need to test with a rather specific theme scenario at the moment.

In an environment with Gutenberg plugin activated
Jetpack activated and the Google Font Provider activated
(wpcom simple sites fit this scenario)

Using [this branch of Blockbase](https://github.com/Automattic/themes/pull/6777) (which permist SOME but not ALL Jetpack fonts to be registered) 
activate a Blockbase CHILD theme (such as Geologist).

Navigate to the Site Editor and observe the collection of fonts provided.  Note that ALL of the fonts offered by Blockbase as well as ALL of the fonts provided by Jetpack are available.

This fixes the problem [noted here](https://github.com/Automattic/themes/pull/6788) where the original change (#6777) was rolled back.

## Screenshots or screencast <!-- if applicable -->

<img width="305" alt="image" src="https://user-images.githubusercontent.com/146530/213496994-7c990a0d-44a5-4fe0-a069-4a9dabbc6479.png">

<img width="287" alt="image" src="https://user-images.githubusercontent.com/146530/213497079-1c3159b1-ba59-4bda-b8f0-1029c510a854.png">
