### PR TITLE
E2E (cover.test.js): Wait for the height input element

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/cover.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/cover.test.js
@@ -126,7 +126,7 @@ describe( 'Cover', () => {
 			'.components-circular-option-picker__option-wrapper:first-child button'
 		);
 
-		// Select the cover block.By default the child paragraph gets selected.
+		// Select the cover block. By default the child paragraph gets selected.
 		await page.click(
 			'.edit-post-header-toolbar__document-overview-toggle'
 		);
@@ -134,16 +134,12 @@ describe( 'Cover', () => {
 			'.block-editor-list-view-block__contents-container a'
 		);
 
-		const heightInput = (
-			await page.$x(
-				'//div[./label[contains(text(),"Minimum height of cover")]]/following-sibling::div//input'
-			)
-		 )[ 0 ];
+		const heightInput = await page.waitForSelector(
+			'input[id*="block-cover-height-input"]'
+		);
 
 		// Verify the height of the cover is not defined.
-		expect(
-			await page.evaluate( ( { value } ) => value, heightInput )
-		).toBeFalsy();
+		expect( heightInput.value ).toBeFalsy();
 
 		const resizeButton = await page.$(
 			'.components-resizable-box__handle-bottom'

--- a/packages/e2e-tests/specs/editor/blocks/cover.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/cover.test.js
@@ -139,7 +139,7 @@ describe( 'Cover', () => {
 		);
 
 		// Verify the height of the cover is not defined.
-		expect( heightInput.value ).toBeFalsy();
+		expect( heightInput.value ).toBe( '' );
 
 		const resizeButton = await page.$(
 			'.components-resizable-box__handle-bottom'

--- a/packages/e2e-tests/specs/editor/blocks/cover.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/cover.test.js
@@ -134,12 +134,14 @@ describe( 'Cover', () => {
 			'.block-editor-list-view-block__contents-container a'
 		);
 
-		const heightInput = await page.waitForSelector(
+		const heightInputHandle = await page.waitForSelector(
 			'input[id*="block-cover-height-input"]'
 		);
 
 		// Verify the height of the cover is not defined.
-		expect( heightInput.value ).toBe( '' );
+		expect(
+			await page.evaluate( ( { value } ) => value, heightInputHandle )
+		).toBe( '' );
 
 		const resizeButton = await page.$(
 			'.components-resizable-box__handle-bottom'
@@ -184,7 +186,7 @@ describe( 'Cover', () => {
 		expect(
 			await page.evaluate(
 				( { value } ) => Number.parseInt( value ),
-				heightInput
+				heightInputHandle
 			)
 		).toBeGreaterThan( 100 );
 	} );


### PR DESCRIPTION
## What?

Fix failing spec when the concurrent mode is enabled (https://github.com/WordPress/gutenberg/pull/46467#issuecomment-1380408396):

```
> cover.test.js: Cover › can be resized using drag & drop:

Evaluation failed: TypeError: Cannot destructure property 'value' of 'undefined' as it is undefined.
```


## How?
Update the input element selector so we can wait until it's available.

---

✅ Tested against changes in #46467.