### PR TITLE
Snackbar: Update snackbar position when list view or inserter opened

### DIFF
--- a/packages/components/src/snackbar/list.tsx
+++ b/packages/components/src/snackbar/list.tsx
@@ -73,7 +73,6 @@ export function SnackbarList( {
 
 					return (
 						<motion.div
-							layout={ ! isReducedMotion } // See https://www.framer.com/docs/animation/#layout-animations
 							initial={ 'init' }
 							animate={ 'open' }
 							exit={ 'exit' }

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -137,6 +137,7 @@ function Layout( { styles } ) {
 		'is-inserter-opened': isInserterOpened,
 		'is-list-view-opened': isListViewOpened,
 		'is-entity-save-view-open': !! entitiesSavedStatesCallback,
+		'has-secondary-sidebar': isListViewOpened || isInserterOpened,
 	} );
 
 	const openSidebarPanel = () =>

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -128,6 +128,17 @@ function Layout( { styles } ) {
 
 	const isDistractionFree = isDistractionFreeMode && isLargeViewport;
 
+	const className = classnames( 'edit-post-layout', 'is-mode-' + mode, {
+		'is-sidebar-opened': sidebarIsOpened,
+		'has-fixed-toolbar': hasFixedToolbar,
+		'has-metaboxes': hasActiveMetaboxes,
+		'show-icon-labels': showIconLabels,
+		'is-distraction-free': isDistractionFree,
+		'is-inserter-opened': isInserterOpened,
+		'is-list-view-opened': isListViewOpened,
+		'is-entity-save-view-open': !! entitiesSavedStatesCallback,
+	} );
+
 	const openSidebarPanel = () =>
 		openGeneralSidebar(
 			hasBlockSelected ? 'edit-post/block' : 'edit-post/document'
@@ -158,15 +169,6 @@ function Layout( { styles } ) {
 		},
 		[ entitiesSavedStatesCallback ]
 	);
-
-	const className = classnames( 'edit-post-layout', 'is-mode-' + mode, {
-		'is-sidebar-opened': sidebarIsOpened,
-		'has-fixed-toolbar': hasFixedToolbar,
-		'has-metaboxes': hasActiveMetaboxes,
-		'show-icon-labels': showIconLabels,
-		'is-distraction-free': isDistractionFree,
-		'is-entity-save-view-open': !! entitiesSavedStatesCallback,
-	} );
 
 	const secondarySidebarLabel = isListViewOpened
 		? __( 'Document Overview' )

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -18,6 +18,13 @@
 	}
 }
 
+.is-inserter-opened,
+.is-list-view-opened {
+	.components-editor-notices__snackbar {
+		padding-left: calc(16px + #{$nav-sidebar-width});
+	}
+}
+
 @include editor-left(".edit-post-layout .components-editor-notices__snackbar");
 
 .edit-post-layout .editor-post-publish-panel {

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -14,13 +14,13 @@
 
 .is-distraction-free {
 	.components-editor-notices__snackbar {
-		bottom: calc(#{$grid-unit-50} / 2);
+		bottom: math.div($grid-unit-50, 2);
 	}
 }
 
 .has-secondary-sidebar {
 	.components-editor-notices__snackbar {
-		padding-left: calc(#{$grid-unit-20} + #{$nav-sidebar-width});
+		padding-left: $grid-unit-20 + $nav-sidebar-width;
 	}
 }
 

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -7,21 +7,20 @@
 .edit-post-layout .components-editor-notices__snackbar {
 	position: fixed;
 	right: 0;
-	bottom: 40px;
-	padding-left: 16px;
-	padding-right: 16px;
+	bottom: $grid-unit-50;
+	padding-left: $grid-unit-20;
+	padding-right: $grid-unit-20;
 }
 
 .is-distraction-free {
 	.components-editor-notices__snackbar {
-		bottom: 20px;
+		bottom: calc(#{$grid-unit-50} / 2);
 	}
 }
 
-.is-inserter-opened,
-.is-list-view-opened {
+.has-secondary-sidebar {
 	.components-editor-notices__snackbar {
-		padding-left: calc(16px + #{$nav-sidebar-width});
+		padding-left: calc(#{$grid-unit-20} + #{$nav-sidebar-width});
 	}
 }
 

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -155,8 +155,8 @@ export default function Editor() {
 
 	const className = classnames( {
 		'show-icon-labels': showIconLabels,
-		'inserter-open': isInserterOpen,
-		'list-view-open': isListViewOpen,
+		'is-inserter-opened': isInserterOpen,
+		'is-list-view-opened': isListViewOpen,
 	} );
 
 	return (

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -155,8 +155,7 @@ export default function Editor() {
 
 	const className = classnames( {
 		'show-icon-labels': showIconLabels,
-		'is-inserter-opened': isInserterOpen,
-		'is-list-view-opened': isListViewOpen,
+		'has-secondary-sidebar': isListViewOpen || isInserterOpen,
 	} );
 
 	return (

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { useMemo } from '@wordpress/element';
@@ -148,6 +153,12 @@ export default function Editor() {
 		return <CanvasSpinner />;
 	}
 
+	const className = classnames( {
+		'show-icon-labels': showIconLabels,
+		'inserter-open': isInserterOpen,
+		'list-view-open': isListViewOpen,
+	} );
+
 	return (
 		<>
 			{ isEditMode && <WelcomeGuide /> }
@@ -163,9 +174,7 @@ export default function Editor() {
 							{ isEditMode && <StartTemplateOptions /> }
 							<InterfaceSkeleton
 								enableRegionNavigation={ false }
-								className={
-									showIconLabels && 'show-icon-labels'
-								}
+								className={ className }
 								notices={ isEditMode && <EditorSnackbars /> }
 								content={
 									<>

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -19,8 +19,8 @@
 	}
 
 	@media (min-width: $break-medium) {
-		.inserter-open .components-editor-notices__snackbar,
-		.list-view-open .components-editor-notices__snackbar {
+		.is-inserter-opened .components-editor-notices__snackbar,
+		.is-list-view-opened .components-editor-notices__snackbar {
 			padding-left: calc(16px + #{$nav-sidebar-width});
 		}
 	}

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -18,10 +18,12 @@
 		padding-right: 16px;
 	}
 
-	.inserter-open .components-editor-notices__snackbar,
-	.list-view-open .components-editor-notices__snackbar {
-		padding-left: calc(16px + #{$nav-sidebar-width});
-		transition: none;
+	@media (min-width: $break-medium) {
+		.inserter-open .components-editor-notices__snackbar,
+		.list-view-open .components-editor-notices__snackbar {
+			padding-left: calc(16px + #{$nav-sidebar-width});
+			transition: none;
+		}
 	}
 }
 @include editor-left(".edit-site .components-editor-notices__snackbar")

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -9,11 +9,19 @@
 }
 
 // Adjust the position of the notices
-.edit-site .components-editor-notices__snackbar {
-	position: fixed;
-	right: 0;
-	bottom: 40px;
-	padding-left: 16px;
-	padding-right: 16px;
+.edit-site {
+	.components-editor-notices__snackbar {
+		position: fixed;
+		right: 0;
+		bottom: 40px;
+		padding-left: 16px;
+		padding-right: 16px;
+	}
+
+	.inserter-open .components-editor-notices__snackbar,
+	.list-view-open .components-editor-notices__snackbar {
+		padding-left: calc(16px + #{$nav-sidebar-width});
+		transition: none;
+	}
 }
 @include editor-left(".edit-site .components-editor-notices__snackbar")

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -18,7 +18,7 @@
 		padding-right: $grid-unit-20;
 	}
 
-	@media (min-width: $break-medium) {
+	@include break-medium {
 		.is-inserter-opened .components-editor-notices__snackbar,
 		.is-list-view-opened .components-editor-notices__snackbar {
 			padding-left: calc(#{$grid-unit-20} + #{$nav-sidebar-width});

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -19,8 +19,7 @@
 	}
 
 	@include break-medium {
-		.is-inserter-opened .components-editor-notices__snackbar,
-		.is-list-view-opened .components-editor-notices__snackbar {
+		.has-secondary-sidebar .components-editor-notices__snackbar {
 			padding-left: calc(#{$grid-unit-20} + #{$nav-sidebar-width});
 		}
 	}

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -20,7 +20,7 @@
 
 	@include break-medium {
 		.has-secondary-sidebar .components-editor-notices__snackbar {
-			padding-left: calc(#{$grid-unit-20} + #{$nav-sidebar-width});
+			padding-left: $grid-unit-20 + $nav-sidebar-width;
 		}
 	}
 }

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -22,7 +22,6 @@
 		.inserter-open .components-editor-notices__snackbar,
 		.list-view-open .components-editor-notices__snackbar {
 			padding-left: calc(16px + #{$nav-sidebar-width});
-			transition: none;
 		}
 	}
 }

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -13,15 +13,15 @@
 	.components-editor-notices__snackbar {
 		position: fixed;
 		right: 0;
-		bottom: 40px;
-		padding-left: 16px;
-		padding-right: 16px;
+		bottom: $grid-unit-50;
+		padding-left: $grid-unit-20;
+		padding-right: $grid-unit-20;
 	}
 
 	@media (min-width: $break-medium) {
 		.is-inserter-opened .components-editor-notices__snackbar,
 		.is-list-view-opened .components-editor-notices__snackbar {
-			padding-left: calc(16px + #{$nav-sidebar-width});
+			padding-left: calc(#{$grid-unit-20} + #{$nav-sidebar-width});
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Spin off from https://github.com/WordPress/gutenberg/pull/47199 to address the original concern in https://github.com/WordPress/gutenberg/pull/45237#pullrequestreview-1244791223.

This change will move snackbars so that their left edge is always lined up with the left edge of the editor canvas (plus padding). This change affects both the post and site editors.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The snackbards interfere with the interface elements in the inserter and list view depending on state. This often disrupts the flow of pattern insertion as one example (see videos). 

By shifting the snackbars over to match the left edge of the canvas (that also moves), we can avoid this issue. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adding `is-inserter-open` and `is-list-view-open` classes to the editor containers on both the post and site editor. Then adjusting the left padding of the snackbar container based on the `$nav-sidebar-width`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open the site editor
2. Perform an action that will trigger a snackbar notice
3. Open the inserter or list view
4. Confirm that the snackbar moves with the left edge of the canvas and clear of the sidebar.
5. Close the sidebar and confirm the snackbar moves back to the left edge with the canvas.
6. Repeat the same in the post editor.
7. Confirm that you can still interact as expected with snackbars (dismiss, click an action link).

## Screenshots or screencast <!-- if applicable -->

**Before: snackbars get in the way of pattern insertion flows**

https://user-images.githubusercontent.com/1464705/213555843-d4834778-5292-4048-8a9c-56f5dc0c744f.mp4

**After: snackbars move out of the way and do not interfere with flows (update: there's no animation making them slide around in the latest version)**

https://user-images.githubusercontent.com/1464705/213555974-c67405e7-696c-4a9f-b80e-2569085b8aa5.mp4





