### PR TITLE
Post Template: Add default value for `offset`

### DIFF
--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -74,7 +74,7 @@ export default function PostTemplateEdit( {
 	context: {
 		query: {
 			perPage,
-			offset,
+			offset = 0,
 			postType,
 			order,
 			orderBy,
@@ -121,6 +121,7 @@ export default function PostTemplateEdit( {
 					slug: templateSlug.replace( 'category-', '' ),
 				} );
 			const query = {
+				offset: perPage ? perPage * ( page - 1 ) + offset : 0,
 				order,
 				orderby: orderBy,
 			};
@@ -144,14 +145,8 @@ export default function PostTemplateEdit( {
 					Object.assign( query, builtTaxQuery );
 				}
 			}
-			if ( perPage && parseInt( perPage, 10 ) ) {
-				const normalizedPerPage = Math.abs( parseInt( offset, 10 ) );
-				const normalizedOffset = parseInt( offset, 10 )
-					? Math.abs( parseInt( offset, 10 ) )
-					: 0;
-				query.offset =
-					normalizedPerPage * ( page - 1 ) + normalizedOffset;
-				query.perPage = normalizedPerPage;
+			if ( perPage ) {
+				query.per_page = perPage;
 			}
 			if ( author ) {
 				query.author = author;

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -121,7 +121,6 @@ export default function PostTemplateEdit( {
 					slug: templateSlug.replace( 'category-', '' ),
 				} );
 			const query = {
-				offset: perPage ? perPage * ( page - 1 ) + offset : 0,
 				order,
 				orderby: orderBy,
 			};
@@ -145,8 +144,14 @@ export default function PostTemplateEdit( {
 					Object.assign( query, builtTaxQuery );
 				}
 			}
-			if ( perPage ) {
-				query.per_page = perPage;
+			if ( perPage && parseInt( perPage, 10 ) ) {
+				const normalizedPerPage = Math.abs( parseInt( offset, 10 ) );
+				const normalizedOffset = parseInt( offset, 10 )
+					? Math.abs( parseInt( offset, 10 ) )
+					: 0;
+				query.offset =
+					normalizedPerPage * ( page - 1 ) + normalizedOffset;
+				query.perPage = normalizedPerPage;
 			}
 			if ( author ) {
 				query.author = author;


### PR DESCRIPTION
Closes: #45867

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR ~normalizes the values of `offset` and `perPage` query parameters~ adds default value for `offset` of the Post Template block in the editor.

## Why?
Query parameters in the Post Template block are inherited from the Query block. Then, within the query to be built, the `offset` property is calculated in the following part:

https://github.com/WordPress/gutenberg/blob/2499646e1dff9a82520749eb17d96cf85c8a0a1a/packages/block-library/src/post-template/edit.js#L123-L124

This formula works correctly when the block is generated from a variation placeholder since all variations of the query block have an `offset` value.

However, if a query block with the innerBlock is created as a variation, [the placeholder is skipped and the content is rendered directly](https://github.com/WordPress/gutenberg/blob/2499646e1dff9a82520749eb17d96cf85c8a0a1a/packages/block-library/src/query/edit/index.js#L33). As a result, if no offset is defined, `NaN` is generated by the following formula:

```javascript
perPage ? perPage * ( page - 1 ) + undefined : 0, 
```

This will generate an incorrect request URL, as reported in #45867.

## How?
~I have rewritten the logic that generates these two values to be nearly identical to what PHP renders on the front end:~

Just adds default value for offset.

https://github.com/WordPress/gutenberg/blob/2499646e1dff9a82520749eb17d96cf85c8a0a1a/lib/compat/wordpress-6.1/blocks.php#L190-L206

As a result, if incorrect values are injected, these values are normalized and the incorrect request URL will not generated.

## Testing Instructions

- Use the following code to generate query variations with invalid parameters.
- Insert this variation.

- Before: An invalid request URL will be generated and the content will not be rendered.

```
http://localhost:8888/index.php?rest_route=%2Fwp%2Fv2%2Fposts&context=edit&offset=NaN&per_page=incorrect&_locale=user
```
- After: The content should render correctly. And the result should match that of the front end.