### PR TITLE
Button: Prepend HTTP to Buttons block links when missing protocol

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -32,6 +32,7 @@ import { displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
 import { link, linkOff } from '@wordpress/icons';
 import { createBlock } from '@wordpress/blocks';
 import { useMergeRefs } from '@wordpress/compose';
+import { prependHTTP } from '@wordpress/url';
 
 const NEW_TAB_REL = 'noreferrer noopener';
 
@@ -240,7 +241,7 @@ function ButtonEdit( props ) {
 							url: newURL = '',
 							opensInNewTab: newOpensInNewTab,
 						} ) => {
-							setAttributes( { url: newURL } );
+							setAttributes( { url: prependHTTP( newURL ) } );
 
 							if ( opensInNewTab !== newOpensInNewTab ) {
 								onToggleOpenInNewTab( newOpensInNewTab );

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -100,7 +100,7 @@ test.describe( 'Buttons', () => {
 		).toBeVisible();
 	} );
 
-	test.only( 'appends http protocol to links added which are missing a protocol', async ( {
+	test( 'appends http protocol to links added which are missing a protocol', async ( {
 		editor,
 		page,
 		pageUtils,

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -100,7 +100,7 @@ test.describe( 'Buttons', () => {
 		).toBeVisible();
 	} );
 
-	test( 'appends http protocol to links added which are missing a protocol', async ( {
+	test.only( 'appends http protocol to links added which are missing a protocol', async ( {
 		editor,
 		page,
 		pageUtils,
@@ -108,19 +108,18 @@ test.describe( 'Buttons', () => {
 		// Regression: https://github.com/WordPress/gutenberg/issues/34307
 		await editor.insertBlock( { name: 'core/buttons' } );
 		await pageUtils.pressKeyWithModifier( 'primary', 'k' );
-		await expect(
-			page.locator( 'role=combobox[name="URL"i]' )
-		).toBeFocused();
+
+		const urlInput = page.locator( 'role=combobox[name="URL"i]' );
+
+		await expect( urlInput ).toBeFocused();
 		await page.keyboard.type( 'example.com' );
 		await page.keyboard.press( 'Enter' );
 
-		// Move to "Edit" and switch back to edit
+		// Move to "Edit" and switch UI back to edit mode
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Enter' );
 
 		// Check the value of the URL input has had http:// prepended.
-		const urlInput = await page.locator( 'role=combobox[name="URL"i]' );
-
 		await expect( urlInput ).toHaveValue( 'http://example.com' );
 	} );
 

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -100,6 +100,30 @@ test.describe( 'Buttons', () => {
 		).toBeVisible();
 	} );
 
+	test( 'appends http protocol to links added which are missing a protocol', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		// Regression: https://github.com/WordPress/gutenberg/issues/34307
+		await editor.insertBlock( { name: 'core/buttons' } );
+		await pageUtils.pressKeyWithModifier( 'primary', 'k' );
+		await expect(
+			page.locator( 'role=combobox[name="URL"i]' )
+		).toBeFocused();
+		await page.keyboard.type( 'example.com' );
+		await page.keyboard.press( 'Enter' );
+
+		// Move to "Edit" and switch back to edit
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Enter' );
+
+		// Check the value of the URL input has had http:// prepended.
+		const urlInput = await page.locator( 'role=combobox[name="URL"i]' );
+
+		await expect( urlInput ).toHaveValue( 'http://example.com' );
+	} );
+
 	test( 'can jump to the link editor using the keyboard shortcut', async ( {
 		editor,
 		page,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Prepends `http://` to links created using the button block which don't provide a protocol.

Closes https://github.com/WordPress/gutenberg/issues/46385

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it provides a better UX.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

`prependUrl()` from `@wordpress/url`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Create a Page
- Add a Buttons Block
- Type a link without http:// or https://
- Publish the Page
- Click the button on the published Page

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
