### PR TITLE
Add https option to prependUrl util

### DIFF
--- a/packages/url/README.md
+++ b/packages/url/README.md
@@ -476,6 +476,7 @@ const actualURL = prependHTTP( 'wordpress.org' ); // http://wordpress.org
 _Parameters_
 
 -   _url_ `string`: The URL to test.
+-   _https_ `boolean`: whether or not to use secure https protocol.
 
 _Returns_
 

--- a/packages/url/src/prepend-http.js
+++ b/packages/url/src/prepend-http.js
@@ -8,8 +8,9 @@ const USABLE_HREF_REGEXP = /^(?:[a-z]+:|#|\?|\.|\/)/i;
 /**
  * Prepends "http://" to a url, if it looks like something that is meant to be a TLD.
  *
- * @param {string} url The URL to test.
+ * @param {string}  url   The URL to test.
  *
+ * @param {boolean} https whether or not to use secure https protocol.
  * @example
  * ```js
  * const actualURL = prependHTTP( 'wordpress.org' ); // http://wordpress.org
@@ -17,14 +18,15 @@ const USABLE_HREF_REGEXP = /^(?:[a-z]+:|#|\?|\.|\/)/i;
  *
  * @return {string} The updated URL.
  */
-export function prependHTTP( url ) {
+export function prependHTTP( url, https = false ) {
 	if ( ! url ) {
 		return url;
 	}
 
 	url = url.trim();
 	if ( ! USABLE_HREF_REGEXP.test( url ) && ! isEmail( url ) ) {
-		return 'http://' + url;
+		const protocol = https ? 'https://' : 'http://';
+		return `${ protocol }${ url }`;
 	}
 
 	return url;

--- a/packages/url/src/test/index.js
+++ b/packages/url/src/test/index.js
@@ -888,6 +888,16 @@ describe( 'prependHTTP', () => {
 
 		expect( prependHTTP( url ) ).toBe( 'http://wordpress.org' );
 	} );
+
+	it( 'should use secure protocol when useHttps option is provided', () => {
+		const url = 'wordpress.org ';
+
+		expect(
+			prependHTTP( url, {
+				https: true,
+			} )
+		).toBe( 'https://wordpress.org' );
+	} );
 } );
 
 describe( 'safeDecodeURI', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add ability to use the `https` protocol when consuming the `prependHttp` util.

Part of https://github.com/WordPress/gutenberg/issues/46244

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Needed for https://github.com/WordPress/gutenberg/issues/46244

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add option. Add tests.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Run `npm run test:unit packages/url/src/test/index.js`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
