### PR TITLE
Lodash: Refactor away from `_.clone()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,6 +50,7 @@ const restrictedImports = [
 			'castArray',
 			'chunk',
 			'clamp',
+			'clone',
 			'cloneDeep',
 			'compact',
 			'concat',

--- a/packages/block-editor/src/components/autocomplete/index.js
+++ b/packages/block-editor/src/components/autocomplete/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { clone } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { applyFilters, hasFilter } from '@wordpress/hooks';
@@ -44,7 +39,9 @@ function useCompleters( { completers = EMPTY_ARRAY } ) {
 		if ( hasFilter( 'editor.Autocomplete.completers' ) ) {
 			// Provide copies so filters may directly modify them.
 			if ( filteredCompleters === completers ) {
-				filteredCompleters = filteredCompleters.map( clone );
+				filteredCompleters = filteredCompleters.map(
+					( completer ) => ( { ...completer } )
+				);
 			}
 
 			filteredCompleters = applyFilters(

--- a/packages/editor/src/hooks/default-autocompleters.js
+++ b/packages/editor/src/hooks/default-autocompleters.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { clone } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
@@ -15,7 +10,7 @@ import { userAutocompleter } from '../components';
 
 function setDefaultCompleters( completers = [] ) {
 	// Provide copies so filters may directly modify them.
-	completers.push( clone( userAutocompleter ) );
+	completers.push( { ...userAutocompleter } );
 
 	return completers;
 }


### PR DESCRIPTION
## What?
This PR refactors and removes Lodash's `_.clone()`. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

Since the sole usages of `.clone()` are simple objects, it's easy enough to just create new objects by spreading the original objects. 

## Testing Instructions

* Verify the user autocompleter still works (typing `@` in a paragraph block yields a dropdown with the users).
* Verify all checks are still green.