### PR TITLE
Pattern Inserter: show insertion indicator when hovering on patterns

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { useState } from '@wordpress/element';
 import {
 	VisuallyHidden,
 	__unstableComposite as Composite,
@@ -28,9 +29,11 @@ function BlockPattern( {
 	isDraggable,
 	pattern,
 	onClick,
+	onHover,
 	composite,
 	showTooltip,
 } ) {
+	const [ isDragging, setIsDragging ] = useState( false );
 	const { blocks, viewportWidth } = pattern;
 	const instanceId = useInstanceId( BlockPattern );
 	const descriptionId = `block-editor-block-patterns-list__item-description-${ instanceId }`;
@@ -45,8 +48,19 @@ function BlockPattern( {
 				<div
 					className="block-editor-block-patterns-list__list-item"
 					draggable={ draggable }
-					onDragStart={ onDragStart }
-					onDragEnd={ onDragEnd }
+					onDragStart={ ( event ) => {
+						setIsDragging( true );
+						if ( onDragStart ) {
+							onHover( null );
+							onDragStart( event );
+						}
+					} }
+					onDragEnd={ ( event ) => {
+						setIsDragging( false );
+						if ( onDragEnd ) {
+							onDragEnd( event );
+						}
+					} }
 				>
 					<WithToolTip
 						showTooltip={ showTooltip }
@@ -57,7 +71,24 @@ function BlockPattern( {
 							as="div"
 							{ ...composite }
 							className="block-editor-block-patterns-list__item"
-							onClick={ () => onClick( pattern, blocks ) }
+							onClick={ () => {
+								onClick( pattern, blocks );
+								onHover( null );
+							} }
+							onFocus={ () => {
+								if ( isDragging ) {
+									return;
+								}
+								onHover( pattern );
+							} }
+							onMouseEnter={ () => {
+								if ( isDragging ) {
+									return;
+								}
+								onHover( pattern );
+							} }
+							onMouseLeave={ () => onHover( null ) }
+							onBlur={ () => onHover( null ) }
 							aria-label={ pattern.title }
 							aria-describedby={
 								pattern.description ? descriptionId : undefined
@@ -95,6 +126,7 @@ function BlockPatternList( {
 	isDraggable,
 	blockPatterns,
 	shownPatterns,
+	onHover,
 	onClickPattern,
 	orientation,
 	label = __( 'Block Patterns' ),
@@ -115,6 +147,7 @@ function BlockPatternList( {
 						key={ pattern.name }
 						pattern={ pattern }
 						onClick={ onClickPattern }
+						onHover={ onHover }
 						isDraggable={ isDraggable }
 						composite={ composite }
 						showTooltip={ showTitlesAsTooltip }

--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -75,12 +75,6 @@ function BlockPattern( {
 								onClick( pattern, blocks );
 								onHover( null );
 							} }
-							onFocus={ () => {
-								if ( isDragging ) {
-									return;
-								}
-								onHover( pattern );
-							} }
 							onMouseEnter={ () => {
 								if ( isDragging ) {
 									return;
@@ -88,7 +82,6 @@ function BlockPattern( {
 								onHover( pattern );
 							} }
 							onMouseLeave={ () => onHover( null ) }
-							onBlur={ () => onHover( null ) }
 							aria-label={ pattern.title }
 							aria-describedby={
 								pattern.description ? descriptionId : undefined

--- a/packages/block-editor/src/components/inserter-list-item/index.js
+++ b/packages/block-editor/src/components/inserter-list-item/index.js
@@ -107,12 +107,6 @@ function InserterListItem( {
 								onHover( null );
 							}
 						} }
-						onFocus={ () => {
-							if ( isDragging.current ) {
-								return;
-							}
-							onHover( item );
-						} }
 						onMouseEnter={ () => {
 							if ( isDragging.current ) {
 								return;
@@ -120,7 +114,6 @@ function InserterListItem( {
 							onHover( item );
 						} }
 						onMouseLeave={ () => onHover( null ) }
-						onBlur={ () => onHover( null ) }
 						{ ...props }
 					>
 						<span

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -92,6 +92,7 @@ function usePatternsCategories( rootClientId ) {
 export function BlockPatternsCategoryDialog( {
 	rootClientId,
 	onInsert,
+	onHover,
 	category,
 	showTitlesAsTooltip,
 } ) {
@@ -113,6 +114,7 @@ export function BlockPatternsCategoryDialog( {
 			<BlockPatternsCategoryPanel
 				rootClientId={ rootClientId }
 				onInsert={ onInsert }
+				onHover={ onHover }
 				category={ category }
 				showTitlesAsTooltip={ showTitlesAsTooltip }
 			/>
@@ -123,6 +125,7 @@ export function BlockPatternsCategoryDialog( {
 export function BlockPatternsCategoryPanel( {
 	rootClientId,
 	onInsert,
+	onHover,
 	category,
 	showTitlesAsTooltip,
 } ) {
@@ -156,6 +159,9 @@ export function BlockPatternsCategoryPanel( {
 
 	const currentShownPatterns = useAsyncList( currentCategoryPatterns );
 
+	// Hide block pattern preview on unmount.
+	useEffect( () => () => onHover( null ), [] );
+
 	if ( ! currentCategoryPatterns.length ) {
 		return null;
 	}
@@ -170,6 +176,7 @@ export function BlockPatternsCategoryPanel( {
 				shownPatterns={ currentShownPatterns }
 				blockPatterns={ currentCategoryPatterns }
 				onClickPattern={ onClick }
+				onHover={ onHover }
 				label={ category.label }
 				orientation="vertical"
 				category={ category.label }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -296,6 +296,7 @@ function InserterMenu(
 				<BlockPatternsCategoryDialog
 					rootClientId={ destinationRootClientId }
 					onInsert={ onInsertPattern }
+					onHover={ onHover }
 					category={ selectedPatternCategory }
 					showTitlesAsTooltip
 				/>

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -162,6 +162,7 @@ function InserterSearchResults( {
 					shownPatterns={ currentShownPatterns }
 					blockPatterns={ filteredBlockPatterns }
 					onClickPattern={ onSelectBlockPattern }
+					onHover={ onHover }
 					isDraggable={ isDraggable }
 				/>
 			</div>

--- a/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js
@@ -347,8 +347,10 @@ describe( 'Inserting blocks', () => {
 
 	it( 'shows block preview when hovering over block in inserter', async () => {
 		await openGlobalBlockInserter();
-		await page.waitForSelector( '.editor-block-list-item-paragraph' );
-		await page.focus( '.editor-block-list-item-paragraph' );
+		const paragraphButton = (
+			await page.$x( `//button//span[contains(text(), 'Paragraph')]` )
+		 )[ 0 ];
+		await paragraphButton.hover();
 		const preview = await page.waitForSelector(
 			'.block-editor-inserter__preview',
 			{


### PR DESCRIPTION
Closes: #45183

## What?
This PR shows the insertion indicator when hovering over a pattern in the main pattern inserter dialog.

## Why?
The main inserter currently has four tabs: Blocks, Patterms, Media, Reusable Block. Of these, for Patterns and Media, the indicator doesn't appear when hovering over an item. I believe it is necessary from a usability standpoint to indicate where an item will be inserted, no matter what kind of item it is.

## How?
The specific implementation was based on [what was already implemented in the block](https://github.com/WordPress/gutenberg/blob/c302e250fdbab8952a1bdf136c48c56c93b04267/packages/block-editor/src/components/inserter-list-item/index.js#L70-L123). One difference is that I used _state_ instead of _ref_ to manage whether or not we are dragging.

## Testing Instructions

In the main pattern inserter, check the following:

- The indicator should appear when mouseover or focus on a pattern
- The indicator should disappear when mouse out of pattern or out of focus
- The indicator should disappear when mouse drag is initiated

## Screenshots or screencast

https://user-images.githubusercontent.com/54422211/213712718-6af552ae-5a48-41bf-bb35-78196f083971.mp4

## Next Step

If this PR makes sense, I would like to add a similar implementation in the media dialog in another PR.
