### PR TITLE
Apply namespace and inherit it at RichText

### DIFF
--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -63,7 +63,7 @@ function append( element, child ) {
 	const { type, attributes } = child;
 
 	if ( type ) {
-		child = element.ownerDocument.createElement( type );
+		child = element.ownerDocument.createElementNS( attributes?.xmlns || element.namespaceURI, type );
 
 		for ( const key in attributes ) {
 			child.setAttribute( key, attributes[ key ] );


### PR DESCRIPTION
I want to use SVG in RichText, but it was not show on editor because it does not have correct namespace. The simple solution is to apply namespace at generating DOM.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Enable to apply namespace at RichText.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In RichText, element that requires correct namespace like SVG fail to render. Need to apply correct namespace.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Apply namespace to child at append function in richtext to-dom.js if xmlns was in attribete, otherwise namespace of parent element.