### PR TITLE
Add close button to the Inserter to improve keyboard a11y

### DIFF
--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -149,40 +149,58 @@ class Inserter extends Component {
 
 		if ( isQuick ) {
 			return (
-				<QuickInserter
-					onSelect={ ( blocks ) => {
-						const firstBlock =
-							Array.isArray( blocks ) && blocks?.length
-								? blocks[ 0 ]
-								: blocks;
-						if (
-							onSelectOrClose &&
-							typeof onSelectOrClose === 'function'
-						) {
-							onSelectOrClose( firstBlock );
-						}
+				<>
+					<QuickInserter
+						onSelect={ ( blocks ) => {
+							const firstBlock =
+								Array.isArray( blocks ) && blocks?.length
+									? blocks[ 0 ]
+									: blocks;
+							if (
+								onSelectOrClose &&
+								typeof onSelectOrClose === 'function'
+							) {
+								onSelectOrClose( firstBlock );
+							}
+							onClose();
+						} }
+						rootClientId={ rootClientId }
+						clientId={ clientId }
+						isAppender={ isAppender }
+						prioritizePatterns={ prioritizePatterns }
+						selectBlockOnInsert={ selectBlockOnInsert }
+					/>
+					<Button
+						variant="secondary"
+						className="block-editor-inserter__close"
+						onClick={ onClose }
+					>
+						{ __( 'Close' ) }
+					</Button>
+				</>
+			);
+		}
+
+		return (
+			<>
+				<InserterMenu
+					onSelect={ () => {
 						onClose();
 					} }
 					rootClientId={ rootClientId }
 					clientId={ clientId }
 					isAppender={ isAppender }
+					showInserterHelpPanel={ showInserterHelpPanel }
 					prioritizePatterns={ prioritizePatterns }
-					selectBlockOnInsert={ selectBlockOnInsert }
 				/>
-			);
-		}
-
-		return (
-			<InserterMenu
-				onSelect={ () => {
-					onClose();
-				} }
-				rootClientId={ rootClientId }
-				clientId={ clientId }
-				isAppender={ isAppender }
-				showInserterHelpPanel={ showInserterHelpPanel }
-				prioritizePatterns={ prioritizePatterns }
-			/>
+				<Button
+					variant="secondary"
+					className="block-editor-inserter__close"
+					onClick={ onClose }
+				>
+					{ __( 'Close' ) }
+				</Button>
+			</>
 		);
 	}
 

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -639,3 +639,21 @@ $block-inserter-tabs-height: 44px;
 		height: 100%;
 	}
 }
+
+.block-editor-inserter__close.block-editor-inserter__close {
+	position: absolute;
+	top: -999em;
+	display: block;
+	background: $white;
+	width: 100%;
+	height: ($button-size + $grid-unit-10);
+	border-radius: 0;
+
+	&:focus,
+	&:focus-within {
+		top: auto;
+		bottom: 0;
+	}
+
+}
+


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds a focusable (only) `Close` button to the inserter.

This is a PoC and can be refined or changed as required based on feedback.

Closes https://github.com/WordPress/gutenberg/issues/47016#issuecomment-1398106680

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To ensure there is a clear exit route for keyboard users and users of assistive tech in general.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds a button which is only visible once focused.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

See below.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

- Toggle inserter within the canvas 
- Use keyboard to tab through tab stops until the final one.
- See the final tab stop reveals a "Close" button
- Activate that button
- See Inserter is closed 

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/444434/213848233-c906aa5f-e477-4fa5-8fcc-2fbb34b24d5e.mp4


