### PR TITLE
Add settings "drawer" to Link Control

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -11,6 +11,7 @@ import { __ } from '@wordpress/i18n';
 import { useRef, useState, useEffect } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
 import { ENTER } from '@wordpress/keycodes';
+import { settings as settingsIcon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -135,6 +136,8 @@ function LinkControl( {
 	const wrapperNode = useRef();
 	const textInputRef = useRef();
 	const isEndingEditWithFocus = useRef( false );
+
+	const [ settingsOpen, setSettingsOpen ] = useState( false );
 
 	const [ internalUrlInputValue, setInternalUrlInputValue ] =
 		useInternalInputValue( value?.url || '' );
@@ -267,7 +270,7 @@ function LinkControl( {
 	const shownUnlinkControl =
 		onRemove && value && ! isEditingLink && ! isCreatingPage;
 
-	const showSettingsDrawer = !! settings?.length;
+	const showSettings = !! settings?.length;
 
 	// Only show text control once a URL value has been committed
 	// and it isn't just empty whitespace.
@@ -295,18 +298,6 @@ function LinkControl( {
 							'has-text-control': showTextControl,
 						} ) }
 					>
-						{ showTextControl && (
-							<TextControl
-								__nextHasNoMarginBottom
-								ref={ textInputRef }
-								className="block-editor-link-control__field block-editor-link-control__text-content"
-								label="Text"
-								value={ internalTextInputValue }
-								onChange={ setInternalTextInputValue }
-								onKeyDown={ handleSubmitWithEnter }
-							/>
-						) }
-
 						<LinkControlSearchInput
 							currentLink={ value }
 							className="block-editor-link-control__field block-editor-link-control__search-input"
@@ -351,12 +342,42 @@ function LinkControl( {
 			) }
 
 			<div className="block-editor-link-control__tools">
-				{ showSettingsDrawer && (
-					<LinkControlSettingsDrawer
-						value={ value }
-						settings={ settings }
-						onChange={ onChange }
-					/>
+				{ ( showSettings || showTextControl ) && (
+					<>
+						{ settingsOpen && (
+							<div
+								className="block-editor-link-control__drawer"
+								hidden={ ! settingsOpen }
+								id={ 'link-1' }
+							>
+								{ showTextControl && (
+									<TextControl
+										__nextHasNoMarginBottom
+										ref={ textInputRef }
+										className="block-editor-link-control__setting block-editor-link-control__text-content"
+										label="Text"
+										value={ internalTextInputValue }
+										onChange={ setInternalTextInputValue }
+										onKeyDown={ handleSubmitWithEnter }
+									/>
+								) }
+								{ showSettings && (
+									<LinkControlSettingsDrawer
+										value={ value }
+										settings={ settings }
+										onChange={ onChange }
+									/>
+								) }
+							</div>
+						) }
+						<Button
+							aria-expanded={ settingsOpen }
+							onClick={ () => setSettingsOpen( ! settingsOpen ) }
+							icon={ settingsIcon }
+							label={ __( 'Toggle link settings' ) }
+							aria-controls="link-1"
+						/>
+					</>
 				) }
 
 				{ isEditing && (

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -351,12 +351,19 @@ function LinkControl( {
 			<div className="block-editor-link-control__tools">
 				{ ( showSettings || showTextControl ) && (
 					<>
+						<Button
+							aria-expanded={ settingsOpen }
+							onClick={ () => setSettingsOpen( ! settingsOpen ) }
+							icon={ settingsIcon }
+							label={ __( 'Toggle link settings' ) }
+							aria-controls="link-1" // todo - this should be dynamic
+						/>
 						<AnimatePresence>
 							{ settingsOpen && (
 								<motion.div
 									className="block-editor-link-control__drawer"
 									hidden={ ! settingsOpen }
-									id={ 'link-1' }
+									id={ 'link-1' } // todo - this should be dynamic
 									initial="collapsed"
 									animate="open"
 									exit="collapsed"
@@ -388,13 +395,6 @@ function LinkControl( {
 								</motion.div>
 							) }
 						</AnimatePresence>
-						<Button
-							aria-expanded={ settingsOpen }
-							onClick={ () => setSettingsOpen( ! settingsOpen ) }
-							icon={ settingsIcon }
-							label={ __( 'Toggle link settings' ) }
-							aria-controls="link-1"
-						/>
 					</>
 				) }
 

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -342,24 +342,26 @@ function LinkControl( {
 				/>
 			) }
 
-			<div className="block-editor-link-control__tools">
-				{ ( showSettings || showTextControl ) && (
-					<LinkControlSettingsDrawer
-						settingsOpen={ settingsOpen }
-						setSettingsOpen={ setSettingsOpen }
-						showTextControl={ showTextControl }
-						showSettings={ showSettings }
-						textInputRef={ textInputRef }
-						internalTextInputValue={ internalTextInputValue }
-						setInternalTextInputValue={ setInternalTextInputValue }
-						handleSubmitWithEnter={ handleSubmitWithEnter }
-						value={ value }
-						settings={ settings }
-						onChange={ onChange }
-					/>
-				) }
+			{ isEditing && (
+				<div className="block-editor-link-control__tools">
+					{ ( showSettings || showTextControl ) && (
+						<LinkControlSettingsDrawer
+							settingsOpen={ settingsOpen }
+							setSettingsOpen={ setSettingsOpen }
+							showTextControl={ showTextControl }
+							showSettings={ showSettings }
+							textInputRef={ textInputRef }
+							internalTextInputValue={ internalTextInputValue }
+							setInternalTextInputValue={
+								setInternalTextInputValue
+							}
+							handleSubmitWithEnter={ handleSubmitWithEnter }
+							value={ value }
+							settings={ settings }
+							onChange={ onChange }
+						/>
+					) }
 
-				{ isEditing && (
 					<div className="block-editor-link-control__search-actions">
 						<Button
 							variant="primary"
@@ -373,8 +375,8 @@ function LinkControl( {
 							{ __( 'Cancel' ) }
 						</Button>
 					</div>
-				) }
-			</div>
+				</div>
+			) }
 
 			{ renderControlBottom && renderControlBottom() }
 		</div>

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -211,6 +211,7 @@ function LinkControl( {
 			wrapperNode.current.ownerDocument.activeElement
 		);
 
+		setSettingsOpen( false );
 		setIsEditingLink( false );
 	};
 

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -14,6 +14,7 @@ import {
 	__unstableMotion as motion,
 	__unstableAnimatePresence as AnimatePresence,
 } from '@wordpress/components';
+import { useReducedMotion } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { useRef, useState, useEffect } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
@@ -143,6 +144,10 @@ function LinkControl( {
 	const wrapperNode = useRef();
 	const textInputRef = useRef();
 	const isEndingEditWithFocus = useRef( false );
+
+	const prefersReducedMotion = useReducedMotion();
+	const MaybeAnimatePresence = prefersReducedMotion ? 'div' : AnimatePresence;
+	const MaybeMotionDiv = prefersReducedMotion ? 'div' : motion.div;
 
 	const [ settingsOpen, setSettingsOpen ] = useState( false );
 
@@ -360,9 +365,9 @@ function LinkControl( {
 							label={ __( 'Toggle link settings' ) }
 							aria-controls="link-1" // todo - this should be dynamic
 						/>
-						<AnimatePresence>
+						<MaybeAnimatePresence>
 							{ settingsOpen && (
-								<motion.div
+								<MaybeMotionDiv
 									className="block-editor-link-control__drawer"
 									hidden={ ! settingsOpen }
 									id={ 'link-1' } // todo - this should be dynamic
@@ -401,9 +406,9 @@ function LinkControl( {
 											/>
 										) }
 									</div>
-								</motion.div>
+								</MaybeMotionDiv>
 							) }
-						</AnimatePresence>
+						</MaybeAnimatePresence>
 					</>
 				) }
 

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -371,6 +371,9 @@ function LinkControl( {
 										open: { opacity: 1, height: 'auto' },
 										collapsed: { opacity: 0, height: 0 },
 									} }
+									transition={ {
+										duration: 0.2,
+									} }
 								>
 									{ showTextControl && (
 										<TextControl

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -6,20 +6,11 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	Button,
-	Spinner,
-	Notice,
-	TextControl,
-	__unstableMotion as motion,
-	__unstableAnimatePresence as AnimatePresence,
-} from '@wordpress/components';
-import { useReducedMotion } from '@wordpress/compose';
+import { Button, Spinner, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useRef, useState, useEffect } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
 import { ENTER } from '@wordpress/keycodes';
-import { settings as settingsIcon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -144,10 +135,6 @@ function LinkControl( {
 	const wrapperNode = useRef();
 	const textInputRef = useRef();
 	const isEndingEditWithFocus = useRef( false );
-
-	const prefersReducedMotion = useReducedMotion();
-	const MaybeAnimatePresence = prefersReducedMotion ? 'div' : AnimatePresence;
-	const MaybeMotionDiv = prefersReducedMotion ? 'div' : motion.div;
 
 	const [ settingsOpen, setSettingsOpen ] = useState( false );
 
@@ -291,6 +278,7 @@ function LinkControl( {
 	const showTextControl = hasLinkValue && hasTextControl;
 
 	const isEditing = ( isEditingLink || ! value ) && ! isCreatingPage;
+
 	return (
 		<div
 			tabIndex={ -1 }
@@ -356,60 +344,19 @@ function LinkControl( {
 
 			<div className="block-editor-link-control__tools">
 				{ ( showSettings || showTextControl ) && (
-					<>
-						<Button
-							className="block-editor-link-control__drawer-toggle"
-							aria-expanded={ settingsOpen }
-							onClick={ () => setSettingsOpen( ! settingsOpen ) }
-							icon={ settingsIcon }
-							label={ __( 'Toggle link settings' ) }
-							aria-controls="link-1" // todo - this should be dynamic
-						/>
-						<MaybeAnimatePresence>
-							{ settingsOpen && (
-								<MaybeMotionDiv
-									className="block-editor-link-control__drawer"
-									hidden={ ! settingsOpen }
-									id={ 'link-1' } // todo - this should be dynamic
-									initial="collapsed"
-									animate="open"
-									exit="collapsed"
-									variants={ {
-										open: { opacity: 1, height: 'auto' },
-										collapsed: { opacity: 0, height: 0 },
-									} }
-									transition={ {
-										duration: 0.1,
-									} }
-								>
-									<div className="block-editor-link-control__drawer-inner">
-										{ showTextControl && (
-											<TextControl
-												__nextHasNoMarginBottom
-												ref={ textInputRef }
-												className="block-editor-link-control__setting block-editor-link-control__text-content"
-												label="Text"
-												value={ internalTextInputValue }
-												onChange={
-													setInternalTextInputValue
-												}
-												onKeyDown={
-													handleSubmitWithEnter
-												}
-											/>
-										) }
-										{ showSettings && (
-											<LinkControlSettingsDrawer
-												value={ value }
-												settings={ settings }
-												onChange={ onChange }
-											/>
-										) }
-									</div>
-								</MaybeMotionDiv>
-							) }
-						</MaybeAnimatePresence>
-					</>
+					<LinkControlSettingsDrawer
+						settingsOpen={ settingsOpen }
+						setSettingsOpen={ setSettingsOpen }
+						showTextControl={ showTextControl }
+						showSettings={ showSettings }
+						textInputRef={ textInputRef }
+						internalTextInputValue={ internalTextInputValue }
+						setInternalTextInputValue={ setInternalTextInputValue }
+						handleSubmitWithEnter={ handleSubmitWithEnter }
+						value={ value }
+						settings={ settings }
+						onChange={ onChange }
+					/>
 				) }
 
 				{ isEditing && (

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -379,7 +379,7 @@ function LinkControl( {
 										collapsed: { opacity: 0, height: 0 },
 									} }
 									transition={ {
-										duration: 0.2,
+										duration: 0.1,
 									} }
 								>
 									<div className="block-editor-link-control__drawer-inner">

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -352,6 +352,7 @@ function LinkControl( {
 				{ ( showSettings || showTextControl ) && (
 					<>
 						<Button
+							className="block-editor-link-control__drawer-toggle"
 							aria-expanded={ settingsOpen }
 							onClick={ () => setSettingsOpen( ! settingsOpen ) }
 							icon={ settingsIcon }
@@ -375,26 +376,30 @@ function LinkControl( {
 										duration: 0.2,
 									} }
 								>
-									{ showTextControl && (
-										<TextControl
-											__nextHasNoMarginBottom
-											ref={ textInputRef }
-											className="block-editor-link-control__setting block-editor-link-control__text-content"
-											label="Text"
-											value={ internalTextInputValue }
-											onChange={
-												setInternalTextInputValue
-											}
-											onKeyDown={ handleSubmitWithEnter }
-										/>
-									) }
-									{ showSettings && (
-										<LinkControlSettingsDrawer
-											value={ value }
-											settings={ settings }
-											onChange={ onChange }
-										/>
-									) }
+									<div className="block-editor-link-control__drawer-inner">
+										{ showTextControl && (
+											<TextControl
+												__nextHasNoMarginBottom
+												ref={ textInputRef }
+												className="block-editor-link-control__setting block-editor-link-control__text-content"
+												label="Text"
+												value={ internalTextInputValue }
+												onChange={
+													setInternalTextInputValue
+												}
+												onKeyDown={
+													handleSubmitWithEnter
+												}
+											/>
+										) }
+										{ showSettings && (
+											<LinkControlSettingsDrawer
+												value={ value }
+												settings={ settings }
+												onChange={ onChange }
+											/>
+										) }
+									</div>
 								</motion.div>
 							) }
 						</AnimatePresence>

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -350,15 +350,13 @@ function LinkControl( {
 				/>
 			) }
 
-			<div className="block-editor-link-control__drawer">
+			<div className="block-editor-link-control__tools">
 				{ showSettingsDrawer && (
-					<div className="block-editor-link-control__tools">
-						<LinkControlSettingsDrawer
-							value={ value }
-							settings={ settings }
-							onChange={ onChange }
-						/>
-					</div>
+					<LinkControlSettingsDrawer
+						value={ value }
+						settings={ settings }
+						onChange={ onChange }
+					/>
 				) }
 
 				{ isEditing && (

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -6,7 +6,14 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Button, Spinner, Notice, TextControl } from '@wordpress/components';
+import {
+	Button,
+	Spinner,
+	Notice,
+	TextControl,
+	__unstableMotion as motion,
+	__unstableAnimatePresence as AnimatePresence,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useRef, useState, useEffect } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
@@ -344,32 +351,43 @@ function LinkControl( {
 			<div className="block-editor-link-control__tools">
 				{ ( showSettings || showTextControl ) && (
 					<>
-						{ settingsOpen && (
-							<div
-								className="block-editor-link-control__drawer"
-								hidden={ ! settingsOpen }
-								id={ 'link-1' }
-							>
-								{ showTextControl && (
-									<TextControl
-										__nextHasNoMarginBottom
-										ref={ textInputRef }
-										className="block-editor-link-control__setting block-editor-link-control__text-content"
-										label="Text"
-										value={ internalTextInputValue }
-										onChange={ setInternalTextInputValue }
-										onKeyDown={ handleSubmitWithEnter }
-									/>
-								) }
-								{ showSettings && (
-									<LinkControlSettingsDrawer
-										value={ value }
-										settings={ settings }
-										onChange={ onChange }
-									/>
-								) }
-							</div>
-						) }
+						<AnimatePresence>
+							{ settingsOpen && (
+								<motion.div
+									className="block-editor-link-control__drawer"
+									hidden={ ! settingsOpen }
+									id={ 'link-1' }
+									initial="collapsed"
+									animate="open"
+									exit="collapsed"
+									variants={ {
+										open: { opacity: 1, height: 'auto' },
+										collapsed: { opacity: 0, height: 0 },
+									} }
+								>
+									{ showTextControl && (
+										<TextControl
+											__nextHasNoMarginBottom
+											ref={ textInputRef }
+											className="block-editor-link-control__setting block-editor-link-control__text-content"
+											label="Text"
+											value={ internalTextInputValue }
+											onChange={
+												setInternalTextInputValue
+											}
+											onKeyDown={ handleSubmitWithEnter }
+										/>
+									) }
+									{ showSettings && (
+										<LinkControlSettingsDrawer
+											value={ value }
+											settings={ settings }
+											onChange={ onChange }
+										/>
+									) }
+								</motion.div>
+							) }
+						</AnimatePresence>
 						<Button
 							aria-expanded={ settingsOpen }
 							onClick={ () => setSettingsOpen( ! settingsOpen ) }

--- a/packages/block-editor/src/components/link-control/settings-drawer.js
+++ b/packages/block-editor/src/components/link-control/settings-drawer.js
@@ -10,7 +10,7 @@ import {
 import { settings as settingsIcon } from '@wordpress/icons';
 import { useReducedMotion, useInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-
+import { Fragment } from '@wordpress/element';
 /**
  * Internal dependencies
  */
@@ -30,7 +30,9 @@ function LinkSettingsDrawer( {
 	onChange,
 } ) {
 	const prefersReducedMotion = useReducedMotion();
-	const MaybeAnimatePresence = prefersReducedMotion ? 'div' : AnimatePresence;
+	const MaybeAnimatePresence = prefersReducedMotion
+		? Fragment
+		: AnimatePresence;
 	const MaybeMotionDiv = prefersReducedMotion ? 'div' : motion.div;
 
 	const id = useInstanceId( LinkSettingsDrawer );

--- a/packages/block-editor/src/components/link-control/settings-drawer.js
+++ b/packages/block-editor/src/components/link-control/settings-drawer.js
@@ -33,7 +33,9 @@ function LinkSettingsDrawer( {
 	const MaybeAnimatePresence = prefersReducedMotion ? 'div' : AnimatePresence;
 	const MaybeMotionDiv = prefersReducedMotion ? 'div' : motion.div;
 
-	const settingsDrawerId = useInstanceId( LinkSettingsDrawer );
+	const id = useInstanceId( LinkSettingsDrawer );
+
+	const settingsDrawerId = `link-control-settings-drawer-${ id }`;
 
 	return (
 		<>

--- a/packages/block-editor/src/components/link-control/settings-drawer.js
+++ b/packages/block-editor/src/components/link-control/settings-drawer.js
@@ -2,15 +2,11 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, ToggleControl, VisuallyHidden } from '@wordpress/components';
-import { settings as settingsIcon } from '@wordpress/icons';
-import { useState } from '@wordpress/element';
+import { ToggleControl, VisuallyHidden } from '@wordpress/components';
 
 const noop = () => {};
 
 const LinkControlSettingsDrawer = ( { value, onChange = noop, settings } ) => {
-	const [ isOpen, setIsOpen ] = useState( false );
-
 	if ( ! settings || ! settings.length ) {
 		return null;
 	}
@@ -33,28 +29,12 @@ const LinkControlSettingsDrawer = ( { value, onChange = noop, settings } ) => {
 	) );
 
 	return (
-		<>
-			<Button
-				aria-expanded={ isOpen }
-				onClick={ () => setIsOpen( ! isOpen ) }
-				icon={ settingsIcon }
-				label={ __( 'Toggle link settings' ) }
-				aria-controls="link-1"
-			/>
-
-			{ isOpen && (
-				<fieldset
-					hidden={ ! isOpen }
-					id={ 'link-1' }
-					className="block-editor-link-control__settings"
-				>
-					<VisuallyHidden as="legend">
-						{ __( 'Currently selected link settings' ) }
-					</VisuallyHidden>
-					{ theSettings }
-				</fieldset>
-			) }
-		</>
+		<fieldset className="block-editor-link-control__settings">
+			<VisuallyHidden as="legend">
+				{ __( 'Currently selected link settings' ) }
+			</VisuallyHidden>
+			{ theSettings }
+		</fieldset>
 	);
 };
 

--- a/packages/block-editor/src/components/link-control/settings-drawer.js
+++ b/packages/block-editor/src/components/link-control/settings-drawer.js
@@ -1,41 +1,92 @@
 /**
  * WordPress dependencies
  */
+import {
+	Button,
+	TextControl,
+	__unstableMotion as motion,
+	__unstableAnimatePresence as AnimatePresence,
+} from '@wordpress/components';
+import { settings as settingsIcon } from '@wordpress/icons';
+import { useReducedMotion, useInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { ToggleControl, VisuallyHidden } from '@wordpress/components';
 
-const noop = () => {};
+/**
+ * Internal dependencies
+ */
+import Settings from './settings';
 
-const LinkControlSettingsDrawer = ( { value, onChange = noop, settings } ) => {
-	if ( ! settings || ! settings.length ) {
-		return null;
-	}
+function LinkSettingsDrawer( {
+	settingsOpen,
+	setSettingsOpen,
+	showTextControl,
+	showSettings,
+	textInputRef,
+	internalTextInputValue,
+	setInternalTextInputValue,
+	handleSubmitWithEnter,
+	value,
+	settings,
+	onChange,
+} ) {
+	const prefersReducedMotion = useReducedMotion();
+	const MaybeAnimatePresence = prefersReducedMotion ? 'div' : AnimatePresence;
+	const MaybeMotionDiv = prefersReducedMotion ? 'div' : motion.div;
 
-	const handleSettingChange = ( setting ) => ( newValue ) => {
-		onChange( {
-			...value,
-			[ setting.id ]: newValue,
-		} );
-	};
-
-	const theSettings = settings.map( ( setting ) => (
-		<ToggleControl
-			className="block-editor-link-control__setting"
-			key={ setting.id }
-			label={ setting.title }
-			onChange={ handleSettingChange( setting ) }
-			checked={ value ? !! value[ setting.id ] : false }
-		/>
-	) );
+	const settingsDrawerId = useInstanceId( LinkSettingsDrawer );
 
 	return (
-		<fieldset className="block-editor-link-control__settings">
-			<VisuallyHidden as="legend">
-				{ __( 'Currently selected link settings' ) }
-			</VisuallyHidden>
-			{ theSettings }
-		</fieldset>
+		<>
+			<Button
+				className="block-editor-link-control__drawer-toggle"
+				aria-expanded={ settingsOpen }
+				onClick={ () => setSettingsOpen( ! settingsOpen ) }
+				icon={ settingsIcon }
+				label={ __( 'Toggle link settings' ) }
+				aria-controls={ settingsDrawerId }
+			/>
+			<MaybeAnimatePresence>
+				{ settingsOpen && (
+					<MaybeMotionDiv
+						className="block-editor-link-control__drawer"
+						hidden={ ! settingsOpen }
+						id={ settingsDrawerId }
+						initial="collapsed"
+						animate="open"
+						exit="collapsed"
+						variants={ {
+							open: { opacity: 1, height: 'auto' },
+							collapsed: { opacity: 0, height: 0 },
+						} }
+						transition={ {
+							duration: 0.1,
+						} }
+					>
+						<div className="block-editor-link-control__drawer-inner">
+							{ showTextControl && (
+								<TextControl
+									__nextHasNoMarginBottom
+									ref={ textInputRef }
+									className="block-editor-link-control__setting block-editor-link-control__text-content"
+									label="Text"
+									value={ internalTextInputValue }
+									onChange={ setInternalTextInputValue }
+									onKeyDown={ handleSubmitWithEnter }
+								/>
+							) }
+							{ showSettings && (
+								<Settings
+									value={ value }
+									settings={ settings }
+									onChange={ onChange }
+								/>
+							) }
+						</div>
+					</MaybeMotionDiv>
+				) }
+			</MaybeAnimatePresence>
+		</>
 	);
-};
+}
 
-export default LinkControlSettingsDrawer;
+export default LinkSettingsDrawer;

--- a/packages/block-editor/src/components/link-control/settings-drawer.js
+++ b/packages/block-editor/src/components/link-control/settings-drawer.js
@@ -2,11 +2,15 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { ToggleControl, VisuallyHidden } from '@wordpress/components';
+import { Button, ToggleControl, VisuallyHidden } from '@wordpress/components';
+import { settings as settingsIcon } from '@wordpress/icons';
+import { useState } from '@wordpress/element';
 
 const noop = () => {};
 
 const LinkControlSettingsDrawer = ( { value, onChange = noop, settings } ) => {
+	const [ isOpen, setIsOpen ] = useState( false );
+
 	if ( ! settings || ! settings.length ) {
 		return null;
 	}
@@ -29,12 +33,28 @@ const LinkControlSettingsDrawer = ( { value, onChange = noop, settings } ) => {
 	) );
 
 	return (
-		<fieldset className="block-editor-link-control__settings">
-			<VisuallyHidden as="legend">
-				{ __( 'Currently selected link settings' ) }
-			</VisuallyHidden>
-			{ theSettings }
-		</fieldset>
+		<>
+			<Button
+				aria-expanded={ isOpen }
+				onClick={ () => setIsOpen( ! isOpen ) }
+				icon={ settingsIcon }
+				label={ __( 'Toggle link settings' ) }
+				aria-controls="link-1"
+			/>
+
+			{ isOpen && (
+				<fieldset
+					hidden={ ! isOpen }
+					id={ 'link-1' }
+					className="block-editor-link-control__settings"
+				>
+					<VisuallyHidden as="legend">
+						{ __( 'Currently selected link settings' ) }
+					</VisuallyHidden>
+					{ theSettings }
+				</fieldset>
+			) }
+		</>
 	);
 };
 

--- a/packages/block-editor/src/components/link-control/settings.js
+++ b/packages/block-editor/src/components/link-control/settings.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { ToggleControl, VisuallyHidden } from '@wordpress/components';
+
+const noop = () => {};
+
+const LinkControlSettings = ( { value, onChange = noop, settings } ) => {
+	if ( ! settings || ! settings.length ) {
+		return null;
+	}
+
+	const handleSettingChange = ( setting ) => ( newValue ) => {
+		onChange( {
+			...value,
+			[ setting.id ]: newValue,
+		} );
+	};
+
+	const theSettings = settings.map( ( setting ) => (
+		<ToggleControl
+			className="block-editor-link-control__setting"
+			key={ setting.id }
+			label={ setting.title }
+			onChange={ handleSettingChange( setting ) }
+			checked={ value ? !! value[ setting.id ] : false }
+		/>
+	) );
+
+	return (
+		<fieldset className="block-editor-link-control__settings">
+			<VisuallyHidden as="legend">
+				{ __( 'Currently selected link settings' ) }
+			</VisuallyHidden>
+			{ theSettings }
+		</fieldset>
+	);
+};
+
+export default LinkControlSettings;

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -426,8 +426,13 @@ $preview-image-height: 140px;
 	padding: 10px;
 }
 
+.block-editor-link-control__drawer {
+	flex-basis: 100%; // occupy full width.
+}
+
 .block-editor-link-control__tools {
 	display: flex;
+	flex-wrap: wrap;
 	align-items: center;
 	justify-content: space-between;
 	border-top: $border-width solid $gray-300;
@@ -443,11 +448,6 @@ $preview-image-height: 140px;
 .block-editor-link-control__settings {
 	flex: 1;
 	margin: 0;
-
-
-	:last-child {
-		margin-bottom: 0;
-	}
 
 	.is-alternate & {
 		border-top: $border-width solid $gray-900;

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -432,7 +432,6 @@ $preview-image-height: 140px;
 	order: 30;
 	flex-direction: column;
 	flex-basis: 100%; // occupy full width.
-	overflow: hidden;
 }
 
 // Inner div required to avoid padding/margin

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -80,6 +80,7 @@ $preview-image-height: 140px;
 	flex-direction: row-reverse; // put "Cancel" on the left but retain DOM order.
 	justify-content: flex-start;
 	gap: $grid-unit-10;
+	order: 20;
 }
 
 .components-button .block-editor-link-control__search-submit .has-icon {
@@ -427,7 +428,24 @@ $preview-image-height: 140px;
 }
 
 .block-editor-link-control__drawer {
+	display: flex; // allow for ordering.
+	order: 30;
+	flex-direction: column;
 	flex-basis: 100%; // occupy full width.
+	margin-top: $grid-unit-20;
+	padding-top: $grid-unit-20;
+	position: relative;
+
+	&::after {
+		content: "";
+		display: block;
+		height: 1px;
+		background-color: $gray-300;
+		position: absolute;
+		left: -$grid-unit-20;
+		right: -$grid-unit-20;
+		top: 0;
+	}
 }
 
 .block-editor-link-control__tools {
@@ -435,9 +453,9 @@ $preview-image-height: 140px;
 	flex-wrap: wrap;
 	align-items: center;
 	justify-content: space-between;
-	border-top: $border-width solid $gray-300;
 	margin: 0;
 	padding: $grid-unit-20;
+	padding-top: 0;
 }
 
 .block-editor-link-control__unlink {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -432,6 +432,15 @@ $preview-image-height: 140px;
 	order: 30;
 	flex-direction: column;
 	flex-basis: 100%; // occupy full width.
+	overflow: hidden;
+}
+
+// Inner div required to avoid padding/margin
+// causing janky animation.
+.block-editor-link-control__drawer-inner {
+	display: flex; // allow for ordering.
+	flex-direction: column;
+	flex-basis: 100%; // occupy full width.
 	margin-top: $grid-unit-20;
 	padding-top: $grid-unit-20;
 	position: relative;
@@ -475,7 +484,7 @@ $preview-image-height: 140px;
 .block-editor-link-control__setting {
 	margin-bottom: $grid-unit-20;
 
-	:last-child {
+	&.block-editor-link-control__setting:last-child {
 		margin-bottom: 0;
 	}
 }

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -426,7 +426,7 @@ $preview-image-height: 140px;
 	padding: 10px;
 }
 
-.block-editor-link-control__drawer {
+.block-editor-link-control__tools {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -1670,6 +1670,10 @@ describe( 'Addition Settings UI', () => {
 
 		render( <LinkControlConsumer /> );
 
+		const user = userEvent.setup();
+
+		await toggleSettingsDrawer( user );
+
 		const newTabSettingLabel = screen.getByText( expectedSettingText );
 		expect( newTabSettingLabel ).toBeVisible();
 
@@ -1707,6 +1711,10 @@ describe( 'Addition Settings UI', () => {
 		};
 
 		render( <LinkControlConsumer /> );
+
+		const user = userEvent.setup();
+
+		await toggleSettingsDrawer( user );
 
 		expect( screen.queryAllByRole( 'checkbox' ) ).toHaveLength( 2 );
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -1658,13 +1658,31 @@ describe( 'Selecting links', () => {
 } );
 
 describe( 'Addition Settings UI', () => {
-	it( 'should provides a means to toggle the link settings', async () => {
+	it( 'should not show a means to toggle the link settings when not editing a link', async () => {
 		const selectedLink = fauxEntitySuggestions[ 0 ];
 
 		const LinkControlConsumer = () => {
 			const [ link ] = useState( selectedLink );
 
 			return <LinkControl value={ link } />;
+		};
+
+		render( <LinkControlConsumer /> );
+
+		const settingsToggle = screen.queryByRole( 'button', {
+			name: 'Toggle link settings',
+			ariaControls: 'link-settings-1',
+		} );
+
+		expect( settingsToggle ).not.toBeInTheDocument();
+	} );
+	it( 'should provides a means to toggle the link settings', async () => {
+		const selectedLink = fauxEntitySuggestions[ 0 ];
+
+		const LinkControlConsumer = () => {
+			const [ link ] = useState( selectedLink );
+
+			return <LinkControl value={ link } forceIsEditingLink />;
 		};
 
 		render( <LinkControlConsumer /> );
@@ -1703,7 +1721,7 @@ describe( 'Addition Settings UI', () => {
 		const LinkControlConsumer = () => {
 			const [ link ] = useState( selectedLink );
 
-			return <LinkControl value={ link } />;
+			return <LinkControl value={ link } forceIsEditingLink />;
 		};
 
 		render( <LinkControlConsumer /> );
@@ -1744,6 +1762,7 @@ describe( 'Addition Settings UI', () => {
 				<LinkControl
 					value={ { ...link, newTab: false, noFollow: true } }
 					settings={ customSettings }
+					forceIsEditingLink
 				/>
 			);
 		};

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -2056,6 +2056,10 @@ describe( 'Controlling link title text', () => {
 			/>
 		);
 
+		const user = userEvent.setup();
+
+		await toggleSettingsDrawer( user );
+
 		expect(
 			screen.queryByRole( 'textbox', { name: 'Text' } )
 		).toBeVisible();
@@ -2082,6 +2086,10 @@ describe( 'Controlling link title text', () => {
 				/>
 			);
 
+			const user = userEvent.setup();
+
+			await toggleSettingsDrawer( user );
+
 			const textInput = screen.queryByRole( 'textbox', {
 				name: 'Text',
 			} );
@@ -2103,6 +2111,8 @@ describe( 'Controlling link title text', () => {
 				onChange={ mockOnChange }
 			/>
 		);
+
+		await toggleSettingsDrawer( user );
 
 		const textInput = screen.queryByRole( 'textbox', { name: 'Text' } );
 
@@ -2137,6 +2147,8 @@ describe( 'Controlling link title text', () => {
 				onChange={ mockOnChange }
 			/>
 		);
+
+		await toggleSettingsDrawer( user );
 
 		const textInput = screen.queryByRole( 'textbox', { name: 'Text' } );
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -1658,6 +1658,39 @@ describe( 'Selecting links', () => {
 } );
 
 describe( 'Addition Settings UI', () => {
+	it( 'should provides a means to toggle the link settings', async () => {
+		const selectedLink = fauxEntitySuggestions[ 0 ];
+
+		const LinkControlConsumer = () => {
+			const [ link ] = useState( selectedLink );
+
+			return <LinkControl value={ link } />;
+		};
+
+		render( <LinkControlConsumer /> );
+
+		const user = userEvent.setup();
+
+		const settingsToggle = screen.queryByRole( 'button', {
+			name: 'Toggle link settings',
+			ariaControls: 'link-settings-1',
+		} );
+
+		expect( settingsToggle ).toBeVisible();
+
+		await user.click( settingsToggle );
+
+		const newTabSettingInput = screen.getByRole( 'checkbox', {
+			name: 'Open in new tab',
+		} );
+
+		expect( newTabSettingInput ).toBeVisible();
+
+		await user.click( settingsToggle );
+
+		expect( newTabSettingInput ).not.toBeVisible();
+	} );
+
 	it( 'should display "New Tab" setting (in "off" mode) by default when a link is selected', async () => {
 		const selectedLink = fauxEntitySuggestions[ 0 ];
 		const expectedSettingText = 'Open in new tab';

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -1676,9 +1676,13 @@ describe( 'Addition Settings UI', () => {
 			ariaControls: 'link-settings-1',
 		} );
 
+		expect( settingsToggle ).toHaveAttribute( 'aria-expanded', 'false' );
+
 		expect( settingsToggle ).toBeVisible();
 
 		await user.click( settingsToggle );
+
+		expect( settingsToggle ).toHaveAttribute( 'aria-expanded', 'true' );
 
 		const newTabSettingInput = screen.getByRole( 'checkbox', {
 			name: 'Open in new tab',
@@ -1688,6 +1692,7 @@ describe( 'Addition Settings UI', () => {
 
 		await user.click( settingsToggle );
 
+		expect( settingsToggle ).toHaveAttribute( 'aria-expanded', 'false' );
 		expect( newTabSettingInput ).not.toBeVisible();
 	} );
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -53,6 +53,11 @@ jest.mock( '@wordpress/data/src/components/use-dispatch', () => ( {
 
 jest.useRealTimers();
 
+jest.mock( '@wordpress/compose', () => ( {
+	...jest.requireActual( '@wordpress/compose' ),
+	useReducedMotion: jest.fn( () => true ),
+} ) );
+
 beforeEach( () => {
 	// Setup a DOM element as a render target.
 	mockFetchSearchSuggestions.mockImplementation( fetchFauxEntitySuggestions );
@@ -789,6 +794,8 @@ describe( 'Manual link entry', () => {
 
 			await user.click( editButton );
 
+			await toggleSettingsDrawer( user );
+
 			let searchInput = screen.getByRole( 'combobox', {
 				name: 'URL',
 			} );
@@ -820,6 +827,8 @@ describe( 'Manual link entry', () => {
 			} );
 
 			await user.click( editButton );
+
+			await toggleSettingsDrawer( user );
 
 			// Re-query the inputs as they have been replaced.
 			searchInput = screen.getByRole( 'combobox', {
@@ -2152,3 +2161,11 @@ describe( 'Controlling link title text', () => {
 		).not.toBeInTheDocument();
 	} );
 } );
+
+async function toggleSettingsDrawer( user ) {
+	const settingsToggle = screen.queryByRole( 'button', {
+		name: 'Toggle link settings',
+	} );
+
+	await user.click( settingsToggle );
+}

--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -8,6 +8,7 @@ import {
 	createNewPost,
 	pressKeyWithModifier,
 	showBlockToolbar,
+	pressKeyTimes,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Links', () => {
@@ -596,8 +597,10 @@ describe( 'Links', () => {
 			// Press Cmd+K to insert a link.
 			await pressKeyWithModifier( 'primary', 'K' );
 
-			// Wait for the URL field to auto-focus.
-			await waitForURLFieldAutoFocus();
+			const [ settingsToggle ] = await page.$x(
+				'//button[contains(@aria-label, "Toggle link settings")]'
+			);
+			await settingsToggle.click();
 
 			const textInput = await page
 				.waitForXPath(
@@ -624,11 +627,17 @@ describe( 'Links', () => {
 				'//button[contains(@aria-label, "Edit")]'
 			);
 			await editButton.click();
+
 			await waitForURLFieldAutoFocus();
 
-			await pressKeyWithModifier( 'shift', 'Tab' );
+			const [ settingsToggle ] = await page.$x(
+				'//button[contains(@aria-label, "Toggle link settings")]'
+			);
+			await settingsToggle.click();
 
-			// Tabbing back should land us in the text input.
+			await page.keyboard.press( 'Tab' );
+
+			// Tabbing should land us in the text input.
 			const { isTextInput, textValue } = await page.evaluate( () => {
 				const el = document.activeElement;
 
@@ -685,7 +694,12 @@ describe( 'Links', () => {
 
 			await waitForURLFieldAutoFocus();
 
-			await pressKeyWithModifier( 'shift', 'Tab' );
+			const [ settingsToggle ] = await page.$x(
+				'//button[contains(@aria-label, "Toggle link settings")]'
+			);
+			await settingsToggle.click();
+
+			await page.keyboard.press( 'Tab' );
 
 			// Tabbing back should land us in the text input.
 			const textInputValue = await page.evaluate(
@@ -715,9 +729,14 @@ describe( 'Links', () => {
 			await editButton.click();
 			await waitForURLFieldAutoFocus();
 
-			await pressKeyWithModifier( 'shift', 'Tab' );
+			const [ settingsToggle ] = await page.$x(
+				'//button[contains(@aria-label, "Toggle link settings")]'
+			);
+			await settingsToggle.click();
 
-			// Tabbing back should land us in the text input.
+			await page.keyboard.press( 'Tab' );
+
+			// Tabbing should land us in the text input.
 			const textInputValue = await page.evaluate(
 				() => document.activeElement.value
 			);
@@ -761,11 +780,13 @@ describe( 'Links', () => {
 			await editButton.click();
 			await waitForURLFieldAutoFocus();
 
+			const [ settingsToggle ] = await page.$x(
+				'//button[contains(@aria-label, "Toggle link settings")]'
+			);
+			await settingsToggle.click();
+
 			// Move focus back to RichText for the underlying link.
-			await page.keyboard.press( 'Tab' );
-			await page.keyboard.press( 'Tab' );
-			await page.keyboard.press( 'Tab' );
-			await page.keyboard.press( 'Tab' );
+			await pressKeyTimes( 'Tab', 5 );
 
 			// Make a selection within the RichText.
 			await pressKeyWithModifier( 'shift', 'ArrowRight' );
@@ -773,7 +794,7 @@ describe( 'Links', () => {
 			await pressKeyWithModifier( 'shift', 'ArrowRight' );
 
 			// Move back to the text input.
-			await page.keyboard.press( 'Tab' );
+			await pressKeyTimes( 'Tab', 3 );
 
 			// Tabbing back should land us in the text input.
 			const textInputValue = await page.evaluate(

--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -120,13 +120,12 @@ describe( 'Links', () => {
 		// Type a URL.
 		await page.keyboard.type( 'https://wordpress.org/gutenberg' );
 
-		const [ settingsToggle ] = await page.$x(
-			'//button[contains(@aria-label, "Toggle link settings")]'
-		);
-		await settingsToggle.click();
+		// Open settings.
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Space' );
 
 		// Navigate to and toggle the "Open in new tab" checkbox.
-		await pressKeyTimes( 'Tab', 2 );
+		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Space' );
 
 		// Toggle should still have focus and be checked.

--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -999,8 +999,14 @@ describe( 'Links', () => {
 			await page.keyboard.press( 'Tab' );
 			await page.keyboard.press( 'Enter' );
 
+			await waitForURLFieldAutoFocus();
+
+			// Toggle link settings open
+			await page.keyboard.press( 'Tab' );
+			await page.keyboard.press( 'Space' );
+
 			// Move to Link Text field.
-			await pressKeyWithModifier( 'shift', 'Tab' );
+			await page.keyboard.press( 'Tab' );
 
 			// Change text to "z"
 			await page.keyboard.type( 'z' );

--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -120,8 +120,13 @@ describe( 'Links', () => {
 		// Type a URL.
 		await page.keyboard.type( 'https://wordpress.org/gutenberg' );
 
+		const [ settingsToggle ] = await page.$x(
+			'//button[contains(@aria-label, "Toggle link settings")]'
+		);
+		await settingsToggle.click();
+
 		// Navigate to and toggle the "Open in new tab" checkbox.
-		await page.keyboard.press( 'Tab' );
+		await pressKeyTimes( 'Tab', 2 );
 		await page.keyboard.press( 'Space' );
 
 		// Toggle should still have focus and be checked.
@@ -525,6 +530,10 @@ describe( 'Links', () => {
 		await waitForURLFieldAutoFocus();
 		await page.keyboard.type( 'w.org' );
 
+		// Toggle link settings open
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Space' );
+
 		// Navigate to and toggle the "Open in new tab" checkbox.
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Space' );
@@ -533,10 +542,9 @@ describe( 'Links', () => {
 		// a changing value of the setting.
 		await page.waitForSelector( ':focus.components-form-toggle__input' );
 
-		// Close dialog. Expect that "Open in new tab" would have been applied
+		// Submit link. Expect that "Open in new tab" would have been applied
 		// immediately.
-
-		await pressKeyWithModifier( 'shift', 'Tab' );
+		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Enter' );
 
 		// Wait for Gutenberg to finish the job.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Implements a accordion-like panel and toggle for link settings.

All settings + the link text control are now hidden in the panel by default which must be expanded to reveal the settings.

Part of https://github.com/WordPress/gutenberg/issues/47310

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As shown in the revised design in https://github.com/WordPress/gutenberg/issues/47310 this is important in order to accommodate future settings and also to reduce visual noise and clutter.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Refactor component structure and implement accordion drawer.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/444434/214929120-333838c9-eb38-4c06-a74a-b8e8ed892409.mp4

