### PR TITLE
Site Editor: Force visual editor in browse mode

### DIFF
--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Force visual editor in browse mode ([#47329](https://github.com/WordPress/gutenberg/pull/47329)).
+
 ## 5.2.0 (2023-01-11)
 
 ## 5.1.0 (2023-01-02)

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -180,7 +180,8 @@ export default function Editor() {
 											<BlockEditor />
 										) }
 										{ editorMode === 'text' &&
-											editedPost && <CodeEditor /> }
+											editedPost &&
+											isEditMode && <CodeEditor /> }
 										{ hasLoadedPost && ! editedPost && (
 											<Notice
 												status="warning"


### PR DESCRIPTION
Fixes: #47194

## What?
This PR forces the visual editor to appear when the site editor is in browse mode.

## Why?

As reported in #47194, if you switch to the code editor and then return to browse mode, the code editor is retained and you can edit the code. My understanding is that the browse mode is to check the appearance of the template, not the code, and should not be able to edit the content.

## How?
In browse mode, the visual editor is displayed regardless of the editor mode setting. This PR doesn't change the mode stored in the store. This is because I believe that switching between editor modes should be done explicitly by the user.

## Testing Instructions

Switch the editor mode to code editor and check the following points:

- Visual editor should appear when returning to browse mode
- If you go back to edit mode again, the chord editor should be restored.
- In browse mode, the shortcut to switch to the code editor should not work
  - Windows Shortcut: `Ctrl`+ `Shift` + `Alt` + `M`
  - Mac Shortcut: `⇧` + `⌥` + `⌘` + `M`

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/54422211/213861209-68bc1137-b6a9-4310-97eb-ffda78a3bcf5.mp4


