### PR TITLE
Disable the ability select text in the `useBlockPreview` hook

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -10,6 +10,7 @@
 -   Move component styles needed for iframes to content styles ([#47103](https://github.com/WordPress/gutenberg/pull/47103)).
 -   Block Inserter: Correctly apply style to the default inserter ([#47166](https://github.com/WordPress/gutenberg/pull/47166)).
 -   List View: Fix crash when the first template-parts is deleted width del key ([#47227](https://github.com/WordPress/gutenberg/pull/47227)).
+-   Block Preview: Try to fix multiple rendering of controls ([#47331](https://github.com/WordPress/gutenberg/pull/47331)).
 
 ## 11.1.0 (2023-01-02)
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -10,7 +10,7 @@
 -   Move component styles needed for iframes to content styles ([#47103](https://github.com/WordPress/gutenberg/pull/47103)).
 -   Block Inserter: Correctly apply style to the default inserter ([#47166](https://github.com/WordPress/gutenberg/pull/47166)).
 -   List View: Fix crash when the first template-parts is deleted width del key ([#47227](https://github.com/WordPress/gutenberg/pull/47227)).
--   Block Preview: Try to fix multiple rendering of controls ([#47331](https://github.com/WordPress/gutenberg/pull/47331)).
+-   Disable the ability select text in the `useBlockPreview` hook ([#47331](https://github.com/WordPress/gutenberg/pull/47331)).
 
 ## 11.1.0 (2023-01-02)
 

--- a/packages/block-editor/src/components/block-preview/content.scss
+++ b/packages/block-editor/src/components/block-preview/content.scss
@@ -4,6 +4,8 @@
 }
 
 .block-editor-block-preview__live-content {
+	user-select: none;
+
 	* {
 		pointer-events: none;
 	}


### PR DESCRIPTION
Fixes: #47293

## What?
This PR fixes a bug that caused multiple rendering of controls when a block was selected in the site editor. This problem, as reported in #47293, seems to occur sometimes when selecting a block in a post template.

## Why?
I have confirmed that this problem doesn't occur when the Gutenberg plugin is disabled. I can't explain the root cause, but I noticed the following different style attributes in the rendering of the post template.

```html
<!-- Gutenberg Plugin Activated -->
<ul class="wp-block-post-template">
  </li>
  <li class="wp-block-post block-editor-block-preview__live-content components-disabled" style="display: none;">
  </li>
  <li class="wp-block-post block-editor-block-preview__live-content components-disabled">
  </li>
  <li class="wp-block-post block-editor-block-preview__live-content components-disabled">
  </li>
</ul>

<!-- Gutenberg Plugin Deactivated -->
<ul class="wp-block-post-template">
  <li class="wp-block-post block-editor-block-list__layout">
  </li>
  <li class="wp-block-post block-editor-block-preview__live-content components-disabled" style="user-select: none; display: none;">
  </li>
  <li class="wp-block-post block-editor-block-preview__live-content components-disabled" style="user-select: none;">
  </li>
  <li class="wp-block-post block-editor-block-preview__live-content components-disabled" style="user-select: none;">
  </li>
</ul>
```

In other words, I thought that the `user-select:none;` style should always be applied to the `li.wp-block-post block-editor-block-preview__live-content` element in order to achieve the expected behavior.

## How?
Added `user-select: none;` in the `.block-editor-block-preview__live-content ` selector.

As an alternative approach, I have confirmed that the following changes will also solve the problem.

```diff
--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -52,6 +52,7 @@ function PostTemplateBlockPreview( {
 
        const style = {
                display: isHidden ? 'none' : undefined,
+               userSelect: 'none',
        };
 
        return (
```

## Testing Instructions
- Open the site editor.
- In edit mode, repeat the click in the post template block.
- Make sure no duplicate controls appear.
