### PR TITLE
Update icons for off-canvas navigation

### DIFF
--- a/packages/block-library/src/navigation-submenu/index.js
+++ b/packages/block-library/src/navigation-submenu/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { addSubmenu } from '@wordpress/icons';
+import { page } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -17,7 +17,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	icon: addSubmenu,
+	icon: page,
 
 	__experimentalLabel: ( { label } ) => label,
 

--- a/packages/block-library/src/navigation-submenu/index.js
+++ b/packages/block-library/src/navigation-submenu/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { page } from '@wordpress/icons';
+import { page, addSubmenu } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -17,7 +17,13 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	icon: page,
+	icon: ( { context } ) => {
+		if ( context === 'list-view' ) {
+			return page;
+		}
+
+		return addSubmenu;
+	},
 
 	__experimentalLabel: ( { label } ) => label,
 

--- a/packages/block-library/src/page-list-item/index.js
+++ b/packages/block-library/src/page-list-item/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { pages as icon } from '@wordpress/icons';
+import { page as icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies

--- a/packages/block-library/src/page-list/index.js
+++ b/packages/block-library/src/page-list/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { pages, update } from '@wordpress/icons';
+import { pages } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -15,13 +15,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	icon: ( { context } ) => {
-		if ( context === 'list-view' ) {
-			return update;
-		}
-
-		return pages;
-	},
+	icon: pages,
 	example: {},
 	edit,
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Polishes the Page List, Page List Item, and Navigation Submenu blocks icons for off-canvas navigation. The Navigation Submenu icon is only changed within the list-view context. 

Closes https://github.com/WordPress/gutenberg/issues/47283
Closes https://github.com/WordPress/gutenberg/issues/47267

## Why?
Cleaning up the off-canvas navigation icons.

## Testing Instructions
1. Open the Site Editor
2. Click on a Navigation block
3. Open Inspector, to see the off-canvas view
4. See new iconography

## Screenshot <!-- if applicable -->

Before: 

<img width="280" alt="before" src="https://user-images.githubusercontent.com/1813435/213956086-d3a2d579-3e47-4167-aa24-af53617f9989.png">

After: 

<img width="283" alt="after" src="https://user-images.githubusercontent.com/1813435/213956195-459741ff-a465-40ff-bad0-ebae9ed6ad5e.png">

Standalone submenu block still uses its existing icon: 

<img width="280" alt="sub" src="https://user-images.githubusercontent.com/1813435/213956327-c433e8d1-3856-4b82-99da-3cbf61fd114b.png">


