### PR TITLE
Tag cloud: Disable clicking on the tag links in the editor

### DIFF
--- a/packages/block-library/src/tag-cloud/edit.js
+++ b/packages/block-library/src/tag-cloud/edit.js
@@ -11,6 +11,7 @@ import {
 	__experimentalUnitControl as UnitControl,
 	__experimentalUseCustomUnits as useCustomUnits,
 	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
+	Disabled,
 } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -163,11 +164,13 @@ function TagCloudEdit( { attributes, setAttributes, taxonomies } ) {
 		<>
 			{ inspectorControls }
 			<div { ...useBlockProps() }>
-				<ServerSideRender
-					skipBlockSupportAttributes
-					block="core/tag-cloud"
-					attributes={ attributes }
-				/>
+				<Disabled>
+					<ServerSideRender
+						skipBlockSupportAttributes
+						block="core/tag-cloud"
+						attributes={ attributes }
+					/>
+				</Disabled>
 			</div>
 		</>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Wraps the tag cloud block in `<Disabled>` to prevent clicking the tag links while in the  editors.
Closes https://github.com/WordPress/gutenberg/issues/47295

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Clicking the links would try to load the link target inside the editors.
It was easy to click the links by mistake when trying to select the block.

## Testing Instructions
1. Activate a block theme
2. Make sure that your WordPress installation has a post with some tags.
3. Please test the block both in the site editor and the block editor. In the Site editor, you can place the block inside a query loop.
After placing the block, clicking anywhere in the block, including direct clicks on the tag links, should select the block, not the link.

### Testing Instructions for Screen reader users
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Before this PR, the screen reader would announce the individual links inside the tag cloud.
With this change, the screen reader will only announce the block name when selected, and will not read the inner content.

1. Activate a block theme
2. Make sure that your WordPress installation has a post with some tags.
3. Please test the block both in the site editor and the block editor. In the Site editor, you can place the block inside a query loop.
4. Navigate to and from the tag cloud block. Confirm that when the block is selected, you can no longer use arrow keys to navigate between the inner items.

Not receiving information about the tag links that are present is a regression, is there a better way to disable the clicking?
The block is server side rendered.
