### PR TITLE
Make `Button` component types specific to `<a>` and `<button>`

### DIFF
--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -103,14 +103,18 @@ export function UnforwardedButton(
 ) {
 	const withDeprecatedProps = useDeprecatedProps( props );
 	const {
+		href,
 		isSmall,
 		isBusy,
 		isDestructive,
 		className,
+		disabled,
 		icon,
 		iconPosition = 'left',
 		iconSize,
+		isPressed,
 		showTooltip,
+		target,
 		tooltipPosition,
 		shortcut,
 		label,
@@ -126,12 +130,10 @@ export function UnforwardedButton(
 		Button,
 		'components-button__description'
 	);
-
 	const isAnchorElement =
 		hasAnchorProps( withDeprecatedProps ) &&
 		! hasButtonProps( withDeprecatedProps );
 	const isButtonElement = ! isAnchorElement;
-
 	const hasChildren =
 		( 'string' === typeof children && !! children ) ||
 		( Array.isArray( children ) &&
@@ -161,9 +163,9 @@ export function UnforwardedButton(
 		? { href: withDeprecatedProps.href, target: withDeprecatedProps.target }
 		: {
 				type: 'button',
-				disabled: trulyDisabled,
+				disabled: withDeprecatedProps.disabled && ! isFocusable,
 				'aria-pressed': withDeprecatedProps.isPressed,
-		  };
+			};
 
 	if ( isButtonElement && withDeprecatedProps.disabled && isFocusable ) {
 		// In this case, the button will be disabled, but still focusable and

--- a/packages/components/src/button/test/index.tsx
+++ b/packages/components/src/button/test/index.tsx
@@ -126,7 +126,7 @@ describe( 'Button', () => {
 		} );
 
 		it( 'should not pass the prop target into the element', () => {
-			render( <Button target="_blank" /> );
+			render( <Button href="https://wordpress.org/" target="_blank" /> );
 
 			expect( screen.getByRole( 'button' ) ).not.toHaveAttribute(
 				'target'

--- a/packages/components/src/button/types.ts
+++ b/packages/components/src/button/types.ts
@@ -9,7 +9,7 @@ import type { ReactNode } from 'react';
 import type { Props as IconProps } from '../icon';
 import type { PopoverProps } from '../popover/types';
 
-export type ButtonProps = {
+export type BaseButtonProps = {
 	/**
 	 * The button's children.
 	 */
@@ -19,18 +19,9 @@ export type ButtonProps = {
 	 */
 	describedBy?: string;
 	/**
-	 * Whether the button is disabled.
-	 * If `true`, this will force a `button` element to be rendered.
-	 */
-	disabled?: boolean;
-	/**
 	 * Whether the button is focused.
 	 */
 	focus?: boolean;
-	/**
-	 * If provided, renders `a` instead of `button`.
-	 */
-	href?: string;
 	/**
 	 * If provided, renders an Icon component inside the button.
 	 */
@@ -56,10 +47,6 @@ export type ButtonProps = {
 	 */
 	isDestructive?: boolean;
 	/**
-	 * Renders a pressed button style.
-	 */
-	isPressed?: boolean;
-	/**
 	 * Decreases the size of the button.
 	 */
 	isSmall?: boolean;
@@ -77,10 +64,6 @@ export type ButtonProps = {
 	 * If provided, renders a Tooltip component for the button.
 	 */
 	showTooltip?: boolean;
-	/**
-	 * If provided with `href`, sets the `target` attribute to the `a`.
-	 */
-	target?: string;
 	/**
 	 * If provided, displays the given text inside the button. If the button contains children elements, the text is displayed before them.
 	 */
@@ -104,6 +87,31 @@ export type ButtonProps = {
 	 */
 	__experimentalIsFocusable?: boolean;
 };
+
+export type ButtonPropsAnchorElement = BaseButtonProps & {
+	/**
+	 * If provided, renders `a` instead of `button`.
+	 */
+	href: string;
+	/**
+	 * If provided with `href`, sets the `target` attribute to the `a`.
+	 */
+	target?: string;
+}
+
+export type ButtonPropsButtonElement = BaseButtonProps & {
+	/**
+	 * Whether the button is disabled.
+	 * If `true`, this will force a `button` element to be rendered.
+	 */
+	disabled?: boolean;
+	/**
+	 * Renders a pressed button style.
+	 */
+	isPressed?: boolean;
+}
+
+export type ButtonProps = ButtonPropsAnchorElement | ButtonPropsButtonElement;
 
 export type DeprecatedButtonProps = {
 	isDefault?: boolean;


### PR DESCRIPTION
Not ready for review

* A follow up to https://github.com/WordPress/gutenberg/pull/46997
* Makes the `<Button>` types specific to whether the button is a `<a>` or `<button>`