### PR TITLE
Template parts and Reusable block: Fix multiple selection overlay styles

### DIFF
--- a/packages/block-editor/src/components/block-content-overlay/content.scss
+++ b/packages/block-editor/src/components/block-content-overlay/content.scss
@@ -14,17 +14,17 @@
 		z-index: z-index(".block-editor-block-list__block.has-block-overlay");
 	}
 
-	&::after {
+	&:not(.is-multi-selected)::after {
 		content: none !important;
 	}
 
-	&:hover:not(.is-dragging-blocks)::before {
+	&:hover:not(.is-dragging-blocks):not(.is-multi-selected)::before {
 		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color) inset;
 	}
 
-	&.is-reusable:hover:not(.is-dragging-blocks)::before,
-	&.wp-block-template-part:hover:not(.is-dragging-blocks)::before {
+	&.is-reusable:hover:not(.is-dragging-blocks):not(.is-multi-selected)::before,
+	&.wp-block-template-part:hover:not(.is-dragging-blocks):not(.is-multi-selected)::before {
 		background: rgba(var(--wp-block-synced-color--rgb), 0.04);
 		box-shadow: 0 0 0 $border-width var(--wp-block-synced-color) inset;
 	}


### PR DESCRIPTION
Fixes: #47341

## What?
This PR fixes a problem where styles were not applied correctly to the template part and reusable block when multiple blocks are selected.

![multi-select](https://user-images.githubusercontent.com/54422211/213976031-4da3bfb8-5ff4-4e66-be08-8cc622b797b4.png)

## Why?
I think that these blocks have the following problems when multi blocks are selected:

- The overlay don't appear on the block
- Purple border and background color on mouseover (Other blocks don't change style on mouseover).

## How?
Added `.is-multi-selected` selector to achieve the same style as other blocks.

## Testing Instructions
- Open the site editor.
- Insert some blocks, template parts, and reusable blocks.
- Select all blocks using the keyboard or mouse.
- Confirm that the overlay indicating that the block is selected is applied to all blocks.
- Confirm that the style doesn't change when the template part and reusable blocks are moused over.

## Screenshots or screencast 

### Before

https://user-images.githubusercontent.com/54422211/213975924-699231bd-8f03-4a80-a3e0-0eba9fd41efc.mp4

### After

https://user-images.githubusercontent.com/54422211/213975888-a170b3db-4607-45d3-b3ea-76a63d78905f.mp4