### PR TITLE
Site Hub: Remove the aria-label from the Edit button

### DIFF
--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -136,7 +136,6 @@ const SiteHub = forwardRef(
 				{ showEditButton && (
 					<Button
 						className="edit-site-site-hub__edit-button"
-						label={ __( 'Open the editor' ) }
 						onClick={ () => {
 							__unstableSetCanvasMode( 'edit' );
 						} }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Removes the aria-label from the Edit button that is located in the top part of the screen in browse mode (When you first open the Site Editor).

Closes https://github.com/WordPress/gutenberg/issues/47335.
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The aria-label (Open the editor) and button text (Edit) did not match. [For details please see the issue](https://github.com/WordPress/gutenberg/issues/47335).

## Testing Instructions
1. Open the Site Editor.
2. View the source of the Edit button at the top part of the page and confirm that it does not have an aria-label.

### Testing Instructions for screen reader users
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

1. Open the Site Editor.
2. Navigate past the "Go back to the dashboard" link, past the plain texts "Home" and "Templates" to the next focusable item which is a button with the accessible name "Edit".  (As opposed to the previous label "Open the editor").

## Screenshots or screencast <!-- if applicable -->
Before:

![Button with aria-label](https://user-images.githubusercontent.com/7422055/213978882-66172a2e-6588-426b-aa49-b98da30c910f.png)

After:
![Button without aria-label](https://user-images.githubusercontent.com/7422055/213979226-baf9ebdc-4b1e-41b2-841d-048063af8e17.png)
