### PR TITLE
Revert "Block Settings/Support: Use Tag Processor to inject class name on wrapper."

### DIFF
--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -49,14 +49,29 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 		return $block_content;
 	}
 
+	$class_name = gutenberg_get_elements_class_name( $block );
+
 	// Like the layout hook this assumes the hook only applies to blocks with a single wrapper.
-	// Add the class name to the first element, presuming it's the wrapper, if it exists.
-	$tags = new WP_HTML_Tag_Processor( $block_content );
-	if ( $tags->next_tag() ) {
-		$tags->add_class( gutenberg_get_elements_class_name( $block ) );
+	// Retrieve the opening tag of the first HTML element.
+	$html_element_matches = array();
+	preg_match( '/<[^>]+>/', $block_content, $html_element_matches, PREG_OFFSET_CAPTURE );
+	$first_element = $html_element_matches[0][0];
+	// If the first HTML element has a class attribute just add the new class
+	// as we do on layout and duotone.
+	if ( str_contains( $first_element, 'class="' ) ) {
+		$content = preg_replace(
+			'/' . preg_quote( 'class="', '/' ) . '/',
+			'class="' . $class_name . ' ',
+			$block_content,
+			1
+		);
+	} else {
+		// If the first HTML element has no class attribute we should inject the attribute before the attribute at the end.
+		$first_element_offset = $html_element_matches[0][1];
+		$content              = substr_replace( $block_content, ' class="' . $class_name . '"', $first_element_offset + strlen( $first_element ) - 1, 0 );
 	}
 
-	return $tags->get_updated_html();
+	return $content;
 }
 
 /**

--- a/lib/block-supports/settings.php
+++ b/lib/block-supports/settings.php
@@ -43,14 +43,29 @@ function _gutenberg_add_block_level_presets_class( $block_content, $block ) {
 		return $block_content;
 	}
 
+	$class_name = _gutenberg_get_presets_class_name( $block );
+
 	// Like the layout hook this assumes the hook only applies to blocks with a single wrapper.
-	// Add the class name to the first element, presuming it's the wrapper, if it exists.
-	$tags = new WP_HTML_Tag_Processor( $block_content );
-	if ( $tags->next_tag() ) {
-		$tags->add_class( _gutenberg_get_presets_class_name( $block ) );
+	// Retrieve the opening tag of the first HTML element.
+	$html_element_matches = array();
+	preg_match( '/<[^>]+>/', $block_content, $html_element_matches, PREG_OFFSET_CAPTURE );
+	$first_element = $html_element_matches[0][0];
+	// If the first HTML element has a class attribute just add the new class
+	// as we do on layout and duotone.
+	if ( strpos( $first_element, 'class="' ) !== false ) {
+		$content = preg_replace(
+			'/' . preg_quote( 'class="', '/' ) . '/',
+			'class="' . $class_name . ' ',
+			$block_content,
+			1
+		);
+	} else {
+		// If the first HTML element has no class attribute we should inject the attribute before the attribute at the end.
+		$first_element_offset = $html_element_matches[0][1];
+		$content              = substr_replace( $block_content, ' class="' . $class_name . '"', $first_element_offset + strlen( $first_element ) - 1, 0 );
 	}
 
-	return $tags->get_updated_html();
+	return $content;
 }
 
 /**


### PR DESCRIPTION
## What?
Reverts #46625.

## Why?
See #47349.

## How?
It's a simple revert.

## Testing Instructions
Quoting #46625:

> Hopefully the unit tests cover this.
> Otherwise try to use block supports and make sure that the expected classes appear where they are and not where they shouldn't be.

#46625 was a refactor to replace a hand-crafted RegEx with use of the `WP_HTML_Tag_Processor`. Thus, it shouldn't have introduced any semantic changes; it might've fixed some edge cases (see its PR desc). However, since its main goal wasn't to be a bugfix, reverting it should be okay, since we're simply returning to the previous behavior, which should also be fine.
