### PR TITLE
`DimensionControl(Experimental)`: refactor to TypeScript

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -33,6 +33,7 @@
 -   `Higher Order` -- `with-constrained-tabbing`: Convert to TypeScript ([#48162](https://github.com/WordPress/gutenberg/pull/48162)).
 -   `Autocomplete`: Convert to TypeScript ([#47751](https://github.com/WordPress/gutenberg/pull/47751)).
 -   `Autocomplete`: avoid calling setState on input ([#48565](https://github.com/WordPress/gutenberg/pull/48565)).
+-   `DimensionControl(Experimental)`: Convert to TypeScript ([#47351](https://github.com/WordPress/gutenberg/pull/47351)).
 
 ## 23.4.0 (2023-02-15)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -18,6 +18,7 @@
 -   `withFallbackStyles` HOC: Convert to TypeScript ([#48720](https://github.com/WordPress/gutenberg/pull/48720)).
 -   `navigateRegions` HOC: Convert to TypeScript ([#48632](https://github.com/WordPress/gutenberg/pull/48632)).
 -   `withSpokenMessages`: HOC: Convert to TypeScript ([#48163](https://github.com/WordPress/gutenberg/pull/48163)).
+-   `DimensionControl(Experimental)`: Convert to TypeScript ([#47351](https://github.com/WordPress/gutenberg/pull/47351)).
 
 ## 23.5.0 (2023-03-01)
 
@@ -33,7 +34,6 @@
 -   `Higher Order` -- `with-constrained-tabbing`: Convert to TypeScript ([#48162](https://github.com/WordPress/gutenberg/pull/48162)).
 -   `Autocomplete`: Convert to TypeScript ([#47751](https://github.com/WordPress/gutenberg/pull/47751)).
 -   `Autocomplete`: avoid calling setState on input ([#48565](https://github.com/WordPress/gutenberg/pull/48565)).
--   `DimensionControl(Experimental)`: Convert to TypeScript ([#47351](https://github.com/WordPress/gutenberg/pull/47351)).
 
 ## 23.4.0 (2023-02-15)
 

--- a/packages/components/src/dimension-control/README.md
+++ b/packages/components/src/dimension-control/README.md
@@ -61,21 +61,21 @@ _Note:_ by default, if you do not provide an initial `value` prop for the curren
 
 ### `label`
 
--   **Type:** `String`
+-   **Type:** `string`
 -   **Required:** Yes
 
 The human readable label for the control.
 
 ### `value`
 
--   **Type:** `String`
+-   **Type:** `string`
 -   **Required:** No
 
 The current value of the dimension UI control. If provided the UI with automatically select the value.
 
 ### `sizes`
 
--   **Type:** `Array`
+-   **Type:** `{ name: string; slug: string }[]`
 -   **Default:** See `packages/block-editor/src/components/dimension-control/sizes.ts`
 -   **Required:** No
 
@@ -99,14 +99,14 @@ By default a set of relative sizes (`small`, `medium`...etc) are provided. See `
 
 ### `icon`
 
--   **Type:** `String`
+-   **Type:** `string`
 -   **Required:** No
 
 An optional dashicon to display before to the control label.
 
 ### `onChange`
 
--   **Type:** `Function`
+-   **Type:** `( value?: string ) => void;`
 -   **Required:** No
 -   **Arguments:**:
     -   `size` - a string representing the selected size (eg: `medium`)
@@ -115,7 +115,7 @@ A callback which is triggered when a spacing size value changes (is selected/cli
 
 ### `className`
 
--   **Type:** `String`
+-   **Type:** `string`
 -   **Default:** `''`
 -   **Required:** No
 

--- a/packages/components/src/dimension-control/README.md
+++ b/packages/components/src/dimension-control/README.md
@@ -62,7 +62,6 @@ _Note:_ by default, if you do not provide an initial `value` prop for the curren
 ### `label`
 
 -   **Type:** `String`
--   **Default:** `undefined`
 -   **Required:** Yes
 
 The human readable label for the control.
@@ -70,7 +69,6 @@ The human readable label for the control.
 ### `value`
 
 -   **Type:** `String`
--   **Default:** `''`
 -   **Required:** No
 
 The current value of the dimension UI control. If provided the UI with automatically select the value.
@@ -78,7 +76,7 @@ The current value of the dimension UI control. If provided the UI with automatic
 ### `sizes`
 
 -   **Type:** `Array`
--   **Default:** See `packages/block-editor/src/components/dimension-control/sizes.js`
+-   **Default:** See `packages/block-editor/src/components/dimension-control/sizes.ts`
 -   **Required:** No
 
 An optional array of size objects in the following shape:
@@ -102,7 +100,6 @@ By default a set of relative sizes (`small`, `medium`...etc) are provided. See `
 ### `icon`
 
 -   **Type:** `String`
--   **Default:** `undefined`
 -   **Required:** No
 
 An optional dashicon to display before to the control label.
@@ -110,7 +107,6 @@ An optional dashicon to display before to the control label.
 ### `onChange`
 
 -   **Type:** `Function`
--   **Default:** `undefined`
 -   **Required:** No
 -   **Arguments:**:
     -   `size` - a string representing the selected size (eg: `medium`)

--- a/packages/components/src/dimension-control/README.md
+++ b/packages/components/src/dimension-control/README.md
@@ -8,52 +8,23 @@ This feature is still experimental. “Experimental” means this is an early im
 
 ## Usage
 
-In a block's `edit` implementation, render a `<DimensionControl />` component.
-
 ```jsx
-import { registerBlockType } from '@wordpress/blocks';
-import { __ } from '@wordpress/i18n';
-import { DimensionControl } from '@wordpress/components';
+import { useState } from 'react';
+import { __experimentalDimensionControl as DimensionControl } from '@wordpress/components';
 
-const partialRight =
-	( fn, ...partialArgs ) =>
-	( ...args ) =>
-		fn( ...args, ...partialArgs );
+export default function MyCustomDimensionControl() {
+	const [ paddingSize, setPaddingSize ] = useState( '' );
 
-registerBlockType( 'my-plugin/my-block', {
-	// ...
-
-	attributes: {
-		// other attributes here
-		// ...
-
-		paddingSize: {
-			type: 'string',
-		},
-	},
-
-	edit( { attributes, setAttributes, clientId } ) {
-		const { paddingSize } = attributes;
-
-		const updateSpacing = ( dimension, size, device = '' ) => {
-			setAttributes( {
-				[ `${ dimension }${ device }` ]: size,
-			} );
-		};
-
-		return (
-			<DimensionControl
-				label={ __( 'Padding' ) }
-				icon={ 'desktop' }
-				onChange={ partialRight( updateSpacing, 'paddingSize' ) }
-				value={ paddingSize }
-			/>
-		);
-	},
-} );
+	return (
+		<DimensionControl
+			label={ 'Padding' }
+			icon={ 'desktop' }
+			onChange={ ( value ) => setPaddingSize( value ) }
+			value={ paddingSize }
+		/>
+	);
+}
 ```
-
-_Note:_ it is recommended to partially apply the value of the Block attribute to be updated (eg: `paddingSize`, `marginSize`...etc) to your callback functions. This avoids the need to unnecessarily couple the component to the Block attribute schema.
 
 _Note:_ by default, if you do not provide an initial `value` prop for the current dimension value, then no value will be selected (ie: there is no default dimension set).
 

--- a/packages/components/src/dimension-control/index.tsx
+++ b/packages/components/src/dimension-control/index.tsx
@@ -17,6 +17,29 @@ import sizesTable, { findSizeBySlug } from './sizes';
 import type { DimensionControlProps, Size } from './types';
 import type { SelectControlProps } from '../select-control/types';
 
+/**
+ * `DimensionControl` is a component designed to provide a UI to control spacing and/or dimensions.
+ *
+ * This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
+ *
+ * ```jsx
+ * import { useState } from 'react';
+ * import { __experimentalDimensionControl as DimensionControl } from '@wordpress/components';
+ *
+ * export default function MyCustomDimensionControl() {
+ * 	const [ paddingSize, setPaddingSize ] = useState( '' );
+ *
+ * 	return (
+ * 		<DimensionControl
+ * 			label={ 'Padding' }
+ * 			icon={ 'desktop' }
+ * 			onChange={ ( value ) => setPaddingSize( value ) }
+ * 			value={ paddingSize }
+ * 		/>
+ * 	);
+ * }
+ * ```
+ */
 export function DimensionControl( props: DimensionControlProps ) {
 	const {
 		label,
@@ -77,24 +100,4 @@ export function DimensionControl( props: DimensionControlProps ) {
 	);
 }
 
-/**
- * `DimensionControl` is a component designed to provide a UI to control spacing and/or dimensions.
- *
- * This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
- *
- *  * ```jsx
- * import {
- *	__experimentalDimensionControl as DimensionControl
- * } from '@wordpress/components';
- *
- * const MyDimensionControl = () => {
- * 	return (
- *		<DimensionConrol
- *			label="Please select a size"
- *			onChange={ (size) => console.log(size) }
- *		/>
- * 	);
- * };
- * ```
- */
 export default DimensionControl;

--- a/packages/components/src/dimension-control/index.tsx
+++ b/packages/components/src/dimension-control/index.tsx
@@ -74,4 +74,24 @@ export function DimensionControl( props: DimensionControlProps ) {
 	);
 }
 
+/**
+ * `DimensionControl` is a component designed to provide a UI to control spacing and/or dimensions.
+ *
+ * This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
+ *
+ *  * ```jsx
+ * import {
+ *	__experimentalDimensionControl as DimensionControl
+ * } from '@wordpress/components';
+ *
+ * const MyDimensionControl = () => {
+ * 	return (
+ *		<DimensionConrol
+ *			label="Please select a size"
+ *			onChange={ (size) => console.log(size) }
+ *		/>
+ * 	);
+ * };
+ * ```
+ */
 export default DimensionControl;

--- a/packages/components/src/dimension-control/index.tsx
+++ b/packages/components/src/dimension-control/index.tsx
@@ -28,6 +28,9 @@ export function DimensionControl( props: DimensionControlProps ) {
 	} = props;
 
 	const onChangeSpacingSize: SelectControlProps[ 'onChange' ] = ( val ) => {
+		/* TODO: We know `val` is going to be a string (and not an array of strings) because
+		we don't pass `multiple` to `SelectControl`. Reevaluate if we can get rid of the type cast
+		after https://github.com/WordPress/gutenberg/pull/47390 is finished. */
 		const theSize = findSizeBySlug( sizes, val as string );
 
 		if ( ! theSize || value === theSize.slug ) {

--- a/packages/components/src/dimension-control/index.tsx
+++ b/packages/components/src/dimension-control/index.tsx
@@ -11,10 +11,13 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { Icon, SelectControl } from '../';
+import Icon from '../icon';
+import SelectControl from '../select-control';
 import sizesTable, { findSizeBySlug } from './sizes';
+import type { DimensionControlProps, Size } from './types';
+import type { SelectControlProps } from '../select-control/types';
 
-export function DimensionControl( props ) {
+export function DimensionControl( props: DimensionControlProps ) {
 	const {
 		label,
 		value,
@@ -24,17 +27,17 @@ export function DimensionControl( props ) {
 		className = '',
 	} = props;
 
-	const onChangeSpacingSize = ( val ) => {
-		const theSize = findSizeBySlug( sizes, val );
+	const onChangeSpacingSize: SelectControlProps[ 'onChange' ] = ( val ) => {
+		const theSize = findSizeBySlug( sizes, val as string );
 
 		if ( ! theSize || value === theSize.slug ) {
-			onChange( undefined );
+			onChange?.( undefined );
 		} else if ( typeof onChange === 'function' ) {
 			onChange( theSize.slug );
 		}
 	};
 
-	const formatSizesAsOptions = ( theSizes ) => {
+	const formatSizesAsOptions = ( theSizes: Size[] ) => {
 		const options = theSizes.map( ( { name, slug } ) => ( {
 			label: name,
 			value: slug,
@@ -45,7 +48,8 @@ export function DimensionControl( props ) {
 				label: __( 'Default' ),
 				value: '',
 			},
-		].concat( options );
+			...options,
+		];
 	};
 
 	const selectLabel = (

--- a/packages/components/src/dimension-control/index.tsx
+++ b/packages/components/src/dimension-control/index.tsx
@@ -15,7 +15,7 @@ import Icon from '../icon';
 import SelectControl from '../select-control';
 import sizesTable, { findSizeBySlug } from './sizes';
 import type { DimensionControlProps, Size } from './types';
-import type { SelectControlProps } from '../select-control/types';
+import type { SelectControlSingleSelectionProps } from '../select-control/types';
 
 /**
  * `DimensionControl` is a component designed to provide a UI to control spacing and/or dimensions.
@@ -50,18 +50,16 @@ export function DimensionControl( props: DimensionControlProps ) {
 		className = '',
 	} = props;
 
-	const onChangeSpacingSize: SelectControlProps[ 'onChange' ] = ( val ) => {
-		/* TODO: We know `val` is going to be a string (and not an array of strings) because
-		we don't pass `multiple` to `SelectControl`. Reevaluate if we can get rid of the type cast
-		after https://github.com/WordPress/gutenberg/pull/47390 is finished. */
-		const theSize = findSizeBySlug( sizes, val as string );
+	const onChangeSpacingSize: SelectControlSingleSelectionProps[ 'onChange' ] =
+		( val ) => {
+			const theSize = findSizeBySlug( sizes, val );
 
-		if ( ! theSize || value === theSize.slug ) {
-			onChange?.( undefined );
-		} else if ( typeof onChange === 'function' ) {
-			onChange( theSize.slug );
-		}
-	};
+			if ( ! theSize || value === theSize.slug ) {
+				onChange?.( undefined );
+			} else if ( typeof onChange === 'function' ) {
+				onChange( theSize.slug );
+			}
+		};
 
 	const formatSizesAsOptions = ( theSizes: Size[] ) => {
 		const options = theSizes.map( ( { name, slug } ) => ( {

--- a/packages/components/src/dimension-control/sizes.ts
+++ b/packages/components/src/dimension-control/sizes.ts
@@ -16,12 +16,13 @@ import { _x } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { Size } from './types';
+
 /**
  * Finds the correct size object from the provided sizes
  * table by size slug (eg: `medium`)
  *
- * @param  sizes
- * @param  slug
+ * @param {Array}  sizes containing objects for each size definition.
+ * @param {string} slug  a string representation of the size (eg: `medium`).
  */
 export const findSizeBySlug = ( sizes: Size[], slug: string ) =>
 	sizes.find( ( size ) => slug === size.slug );

--- a/packages/components/src/dimension-control/sizes.ts
+++ b/packages/components/src/dimension-control/sizes.ts
@@ -21,8 +21,8 @@ import type { Size } from './types';
  * Finds the correct size object from the provided sizes
  * table by size slug (eg: `medium`)
  *
- * @param  sizes containing objects for each size definition.
- * @param  slug  a string representation of the size (eg: `medium`).
+ * @param sizes containing objects for each size definition.
+ * @param slug  a string representation of the size (eg: `medium`).
  */
 export const findSizeBySlug = ( sizes: Size[], slug: string ) =>
 	sizes.find( ( size ) => slug === size.slug );

--- a/packages/components/src/dimension-control/sizes.ts
+++ b/packages/components/src/dimension-control/sizes.ts
@@ -21,8 +21,8 @@ import type { Size } from './types';
  * Finds the correct size object from the provided sizes
  * table by size slug (eg: `medium`)
  *
- * @param {Array}  sizes containing objects for each size definition.
- * @param {string} slug  a string representation of the size (eg: `medium`).
+ * @param  sizes containing objects for each size definition.
+ * @param  slug  a string representation of the size (eg: `medium`).
  */
 export const findSizeBySlug = ( sizes: Size[], slug: string ) =>
 	sizes.find( ( size ) => slug === size.slug );

--- a/packages/components/src/dimension-control/sizes.ts
+++ b/packages/components/src/dimension-control/sizes.ts
@@ -13,15 +13,17 @@
 import { _x } from '@wordpress/i18n';
 
 /**
+ * Internal dependencies
+ */
+import type { Size } from './types';
+/**
  * Finds the correct size object from the provided sizes
  * table by size slug (eg: `medium`)
  *
- * @param {Array}  sizes containing objects for each size definition.
- * @param {string} slug  a string representation of the size (eg: `medium`).
- *
- * @return {Object} the matching size definition.
+ * @param  sizes
+ * @param  slug
  */
-export const findSizeBySlug = ( sizes, slug ) =>
+export const findSizeBySlug = ( sizes: Size[], slug: string ) =>
 	sizes.find( ( size ) => slug === size.slug );
 
 export default [

--- a/packages/components/src/dimension-control/stories/index.tsx
+++ b/packages/components/src/dimension-control/stories/index.tsx
@@ -1,7 +1,4 @@
 /**
- * WordPress dependencies
- */
-/**
  * External dependencies
  */
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
@@ -29,24 +26,4 @@ export const Default = Template.bind( {} );
 Default.args = {
 	label: 'Please select a size',
 	sizes,
-};
-
-export const CustomSizes = Template.bind( {} );
-
-CustomSizes.args = {
-	label: 'How tall are you?',
-	sizes: [
-		{
-			name: 'Tall',
-			slug: 'tall',
-		},
-		{
-			name: 'Very Tall',
-			slug: 'very-tall',
-		},
-		{
-			name: 'Very Very Tall',
-			slug: 'very-very-tall',
-		},
-	],
 };

--- a/packages/components/src/dimension-control/stories/index.tsx
+++ b/packages/components/src/dimension-control/stories/index.tsx
@@ -8,12 +8,27 @@ import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import { DimensionControl } from '..';
 import sizes from '../sizes';
 
+/**
+ * WordPress dependencies
+ */
+import { desktop, tablet, mobile } from '@wordpress/icons';
+
 export default {
 	component: DimensionControl,
 	title: 'Components (Experimental)/DimensionControl',
 	argTypes: {
 		onChange: { action: 'onChange' },
 		value: { control: { type: null } },
+		icon: {
+			control: { type: 'select' },
+			options: [ '-', 'desktop', 'tablet', 'mobile' ],
+			mapping: {
+				undefined,
+				desktop,
+				tablet,
+				mobile,
+			},
+		},
 	},
 } as ComponentMeta< typeof DimensionControl >;
 

--- a/packages/components/src/dimension-control/stories/index.tsx
+++ b/packages/components/src/dimension-control/stories/index.tsx
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import { DimensionControl } from '..';
+import sizes from '../sizes';
+
+export default {
+	component: DimensionControl,
+	title: 'Components (Experimental)/DimensionControl',
+};
+
+export const _default = () => {
+	const [ size, setSize ] = useState< string | undefined >();
+	return (
+		<>
+			<DimensionControl
+				label="Please select a size"
+				sizes={ sizes }
+				onChange={ ( v ) => setSize( v ) }
+			/>
+			<div>Selected size: { size ?? '-' }</div>
+		</>
+	);
+};
+
+export const _withSizesProp = () => {
+	const [ size, setSize ] = useState< string | undefined >();
+	const customSizes = [
+		{
+			name: 'Tall',
+			slug: 'tall',
+		},
+		{
+			name: 'Very Tall',
+			slug: 'very-tall',
+		},
+		{
+			name: 'Very Very Tall',
+			slug: 'very-very-tall',
+		},
+	];
+	return (
+		<>
+			<DimensionControl
+				label="Please select a size"
+				sizes={ customSizes }
+				onChange={ ( v ) => setSize( v ) }
+			/>
+			<div>Selected size: { size ?? '-' }</div>
+		</>
+	);
+};

--- a/packages/components/src/dimension-control/stories/index.tsx
+++ b/packages/components/src/dimension-control/stories/index.tsx
@@ -23,7 +23,7 @@ export default {
 			control: { type: 'select' },
 			options: [ '-', 'desktop', 'tablet', 'mobile' ],
 			mapping: {
-				undefined,
+				'-': undefined,
 				desktop,
 				tablet,
 				mobile,

--- a/packages/components/src/dimension-control/stories/index.tsx
+++ b/packages/components/src/dimension-control/stories/index.tsx
@@ -1,7 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+/**
+ * External dependencies
+ */
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
 /**
  * Internal dependencies
  */
@@ -11,25 +14,28 @@ import sizes from '../sizes';
 export default {
 	component: DimensionControl,
 	title: 'Components (Experimental)/DimensionControl',
+	argTypes: {
+		onChange: { action: 'onChange' },
+		value: { control: { type: null } },
+	},
+} as ComponentMeta< typeof DimensionControl >;
+
+const Template: ComponentStory< typeof DimensionControl > = ( args ) => (
+	<DimensionControl { ...args } />
+);
+
+export const Default = Template.bind( {} );
+
+Default.args = {
+	label: 'Please select a size',
+	sizes,
 };
 
-export const _default = () => {
-	const [ size, setSize ] = useState< string | undefined >();
-	return (
-		<>
-			<DimensionControl
-				label="Please select a size"
-				sizes={ sizes }
-				onChange={ ( v ) => setSize( v ) }
-			/>
-			<div>Selected size: { size ?? '-' }</div>
-		</>
-	);
-};
+export const CustomSizes = Template.bind( {} );
 
-export const _withSizesProp = () => {
-	const [ size, setSize ] = useState< string | undefined >();
-	const customSizes = [
+CustomSizes.args = {
+	label: 'How tall are you?',
+	sizes: [
 		{
 			name: 'Tall',
 			slug: 'tall',
@@ -42,15 +48,5 @@ export const _withSizesProp = () => {
 			name: 'Very Very Tall',
 			slug: 'very-very-tall',
 		},
-	];
-	return (
-		<>
-			<DimensionControl
-				label="Please select a size"
-				sizes={ customSizes }
-				onChange={ ( v ) => setSize( v ) }
-			/>
-			<div>Selected size: { size ?? '-' }</div>
-		</>
-	);
+	],
 };

--- a/packages/components/src/dimension-control/stories/index.tsx
+++ b/packages/components/src/dimension-control/stories/index.tsx
@@ -29,6 +29,10 @@ export default {
 				mobile,
 			},
 		},
+		parameters: {
+			controls: { expanded: true },
+			docs: { source: { state: 'open' } },
+		},
 	},
 } as ComponentMeta< typeof DimensionControl >;
 

--- a/packages/components/src/dimension-control/types.ts
+++ b/packages/components/src/dimension-control/types.ts
@@ -5,38 +5,38 @@ import type { IconType } from '../icon';
 
 export type Size = {
 	/**
-	 * Human-readable name of the size
+	 * Human-readable name of the size.
 	 */
 	name: string;
 	/**
-	 * Short unique identifying name of the size
+	 * Short unique identifying name of the size.
 	 */
 	slug: string;
 };
 
 export type DimensionControlProps< IconProps = unknown > = {
 	/**
-	 * Label for the control
+	 * Label for the control.
 	 */
 	label: string;
 	/**
-	 * An array of sizes to choose from
+	 * An array of sizes to choose from.
 	 */
 	sizes: Size[];
 	/**
-	 * Optional icon rendered in front on the label
+	 * Optional icon rendered in front on the label.
 	 */
 	icon?: IconType< IconProps >;
 	/**
-	 * Used to externally control the current value of the control
+	 * Used to externally control the current value of the control.
 	 */
 	value?: string;
 	/**
-	 *		Function called with the control's internal state changes. The `value` property is equal to a given size slug
+	 * Function called with the control's internal state changes. The `value` property is equal to a given size slug.
 	 */
 	onChange?: ( value?: string ) => void;
 	/**
-	 * CSS class applied to `SelectControl`
+	 * CSS class applied to `SelectControl`.
 	 */
 	className?: string;
 };

--- a/packages/components/src/dimension-control/types.ts
+++ b/packages/components/src/dimension-control/types.ts
@@ -14,7 +14,7 @@ export type Size = {
 	slug: string;
 };
 
-export type DimensionControlProps< IconProps = unknown > = {
+export type DimensionControlProps = {
 	/**
 	 * Label for the control.
 	 */
@@ -26,7 +26,7 @@ export type DimensionControlProps< IconProps = unknown > = {
 	/**
 	 * Optional icon rendered in front on the label.
 	 */
-	icon?: IconType< IconProps >;
+	icon?: IconType;
 	/**
 	 * Used to externally control the current value of the control.
 	 */

--- a/packages/components/src/dimension-control/types.ts
+++ b/packages/components/src/dimension-control/types.ts
@@ -22,7 +22,7 @@ export type DimensionControlProps< IconProps = unknown > = {
 	/**
 	 * An array of sizes to choose from.
 	 */
-	sizes: Size[];
+	sizes?: Size[];
 	/**
 	 * Optional icon rendered in front on the label.
 	 */

--- a/packages/components/src/dimension-control/types.ts
+++ b/packages/components/src/dimension-control/types.ts
@@ -37,6 +37,8 @@ export type DimensionControlProps< IconProps = unknown > = {
 	onChange?: ( value?: string ) => void;
 	/**
 	 * CSS class applied to `SelectControl`.
+	 *
+	 * @default ''
 	 */
 	className?: string;
 };

--- a/packages/components/src/dimension-control/types.ts
+++ b/packages/components/src/dimension-control/types.ts
@@ -21,6 +21,10 @@ export type DimensionControlProps = {
 	label: string;
 	/**
 	 * An array of sizes to choose from.
+	 *
+	 * @default DEFAULT_SIZES
+	 *
+	 * @see packages/components/src/dimension-control/sizes.ts
 	 */
 	sizes?: Size[];
 	/**

--- a/packages/components/src/dimension-control/types.ts
+++ b/packages/components/src/dimension-control/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Internal dependencies
+ */
+import type { IconType } from '../icon';
+
+export type Size = {
+	/**
+	 * Human-readable name of the size
+	 */
+	name: string;
+	/**
+	 * Short unique identifying name of the size
+	 */
+	slug: string;
+};
+
+export type DimensionControlProps< IconProps = unknown > = {
+	/**
+	 * Label for the control
+	 */
+	label: string;
+	/**
+	 * An array of sizes to choose from
+	 */
+	sizes: Size[];
+	/**
+	 * Optional icon rendered in front on the label
+	 */
+	icon?: IconType< IconProps >;
+	/**
+	 * Used to externally control the current value of the control
+	 */
+	value?: string;
+	/**
+	 *		Function called with the control's internal state changes. The `value` property is equal to a given size slug
+	 */
+	onChange?: ( value?: string ) => void;
+	/**
+	 * CSS class applied to `SelectControl`
+	 */
+	className?: string;
+};

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -46,7 +46,6 @@
 		"src/**/test/**/*.js", // only exclude js files, ts{x} files should be checked
 		"src/index.js",
 		"src/custom-gradient-picker",
-		"src/dimension-control",
 		"src/duotone-picker",
 		"src/gradient-picker",
 		"src/higher-order/with-filters",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Refactor `DimensionControl` component to TypeScript

## Why?

Part of https://github.com/WordPress/gutenberg/issues/35744

## How?

- Followed general recommendations from the [TypeScript Migration guide](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/CONTRIBUTING.md#refactoring-a-component-to-typescript). 
- Renamed file to `.tsx` and created a `types.ts` file with relevant types

## Testing Instructions

1. Ensure there are no type errors

Wit this PR we introduce a story for this component. Please verify it behaves as expected.
