### PR TITLE
Limit start value on ordered lists

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -59,14 +59,6 @@ import EmbedHandlerPicker from './embed-handler-picker';
 
 const classes = 'block-editor-rich-text__editable';
 
-function limitIntegerValue( value ) {
-	const int32bit = Math.pow( 2, 31 );
-	return Math.min(
-		Math.max( parseInt( value, 10 ), -1 * ( int32bit - 1 ) ),
-		int32bit - 1
-	);
-}
-
 function RichTextWrapper(
 	{
 		children,
@@ -597,7 +589,7 @@ function RichTextWrapper(
 			selectionEnd={ selectionEnd }
 			onSelectionChange={ onSelectionChange }
 			tagName={ tagName }
-			start={ limitIntegerValue( start ) }
+			start={ start }
 			reversed={ reversed }
 			placeholder={ placeholder }
 			allowedFormats={ adjustedAllowedFormats }

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -59,6 +59,14 @@ import EmbedHandlerPicker from './embed-handler-picker';
 
 const classes = 'block-editor-rich-text__editable';
 
+function limitIntegerValue( value ) {
+	const int32bit = Math.pow( 2, 31 );
+	return Math.min(
+		Math.max( parseInt( value, 10 ), -1 * ( int32bit - 1 ) ),
+		int32bit - 1
+	);
+}
+
 function RichTextWrapper(
 	{
 		children,
@@ -589,7 +597,7 @@ function RichTextWrapper(
 			selectionEnd={ selectionEnd }
 			onSelectionChange={ onSelectionChange }
 			tagName={ tagName }
-			start={ start }
+			start={ limitIntegerValue( start ) }
 			reversed={ reversed }
 			placeholder={ placeholder }
 			allowedFormats={ adjustedAllowedFormats }

--- a/packages/block-library/src/list/ordered-list-settings.native.js
+++ b/packages/block-library/src/list/ordered-list-settings.native.js
@@ -5,16 +5,20 @@ import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 import { TextControl, PanelBody, ToggleControl } from '@wordpress/components';
 
+/**
+ * Limit the value to the range of a 32-bit signed integer.
+ *
+ * @param {string} value
+ * @returns Number or undefined
+ */
 function limitIntegerValue( value ) {
-	const int = parseInt( value, 10 );
-	if ( isNaN( int ) ) {
+	const intValue = parseInt( value, 10 );
+	if ( isNaN( intValue ) ) {
 		return undefined;
 	}
-	const int32bit = Math.pow( 2, 31 );
-	return Math.min(
-		Math.max( parseInt( value, 10 ), -1 * ( int32bit - 1 ) ),
-		int32bit - 1
-	);
+	// Get the maximum absolute value of a 32-bit signed integer.
+	const limit32bit = Math.pow( 2, 31 ) - 1;
+	return Math.min( Math.max( intValue, -1 * limit32bit ), limit32bit );
 }
 
 const OrderedListSettings = ( { setAttributes, reversed, start } ) => (

--- a/packages/block-library/src/list/ordered-list-settings.native.js
+++ b/packages/block-library/src/list/ordered-list-settings.native.js
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { InspectorControls } from '@wordpress/block-editor';
+import { TextControl, PanelBody, ToggleControl } from '@wordpress/components';
+
+function limitIntegerValue( value ) {
+	const int = parseInt( value, 10 );
+	if ( isNaN( int ) ) {
+		return undefined;
+	}
+	const int32bit = Math.pow( 2, 31 );
+	return Math.min(
+		Math.max( parseInt( value, 10 ), -1 * ( int32bit - 1 ) ),
+		int32bit - 1
+	);
+}
+
+const OrderedListSettings = ( { setAttributes, reversed, start } ) => (
+	<InspectorControls>
+		<PanelBody title={ __( 'Ordered list settings' ) }>
+			<TextControl
+				__nextHasNoMarginBottom
+				label={ __( 'Start value' ) }
+				type="number"
+				onChange={ ( value ) => {
+					const int = limitIntegerValue( value );
+
+					setAttributes( {
+						// It should be possible to unset the value,
+						// e.g. with an empty string.
+						start: isNaN( int ) ? undefined : int,
+					} );
+				} }
+				value={ Number.isInteger( start ) ? start.toString( 10 ) : '' }
+				step="1"
+			/>
+			<ToggleControl
+				label={ __( 'Reverse list numbering' ) }
+				checked={ reversed || false }
+				onChange={ ( value ) => {
+					setAttributes( {
+						// Unset the attribute if not reversed.
+						reversed: value || undefined,
+					} );
+				} }
+			/>
+		</PanelBody>
+	</InspectorControls>
+);
+
+export default OrderedListSettings;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Limits the start value for ordered lists to fit in a 32 bit integer: `2147483647`. 
This also limits the start value passed to the react native `<RichText>` component. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This fixes #39727
The mobile editor on Android is crashing when the start value is larger than an 32 bit integer. iOS can handle the larger values but the UI becomes unstable when the start value is over a 64 bit integer.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I've added two `Math.min(start, MAX_INT)` calls where the `ol` start value is handled in the `ol` list settings and in the props list that is passed to the native `<RichText>` component

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open the mobile editor on Android
2. Insert an list block configured as an ordered list
3. Open the list block settings and enter a start value of `2147483647`
4. Verify that the value is allowed
5. Enable 'Reverse list numbering' in the ordered list settings
6. Close the options and verify that the ordered list starts at `2147483647`
7. Open the block settings and enter a value *larger* than `2147483647`
8. Notice that the value resets back to `2147483647`
9. Close the block setting and verify that the editor does not crash 

## Screenshots or screencast <!-- if applicable -->


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
