### PR TITLE
Fix react key error with position controls

### DIFF
--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -274,10 +274,7 @@ export function PositionPanel( props ) {
 	return Platform.select( {
 		web:
 			options.length > 1 ? (
-				<InspectorControls
-					key="position"
-					__experimentalGroup="position"
-				>
+				<InspectorControls __experimentalGroup="position">
 					<BaseControl className="block-editor-hooks__position-selection">
 						<CustomSelectControl
 							__nextUnconstrainedWidth
@@ -323,7 +320,9 @@ export const withInspectorControls = createHigherOrderComponent(
 			positionSupport && ! useIsPositionDisabled( props );
 
 		return [
-			showPositionControls && <PositionPanel { ...props } />,
+			showPositionControls && (
+				<PositionPanel key="position" { ...props } />
+			),
 			<BlockEdit key="edit" { ...props } />,
 		];
 	},


### PR DESCRIPTION
## What?
Fixes a react `key` warning that occurs in `trunk`:
![Screen Shot 2023-01-24 at 10 36 59 am](https://user-images.githubusercontent.com/677833/214201253-724413c9-caa4-45ea-9c7f-5460787a4a6a.png)

## How?
The key should be defined on an element within an array. It looks like it was accidentally refactored out of the array in #47334

## Testing Instructions
1. Open the site editor
2. Check the dev tools console, ensure the above warning doesn't appear.
