### PR TITLE
NumberControl: Clarify deprecation message about `hideHTMLArrows` prop

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Deprecations
+
+-   `NumberControl`: Clarify deprecation message about `hideHTMLArrows` prop ([#47370](https://github.com/WordPress/gutenberg/pull/47370)).
+
 ### Enhancements
 
 -   `Dropdown`: deprecate `position`  prop, use `popoverProps` instead ([46865](https://github.com/WordPress/gutenberg/pull/46865)).

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -52,7 +52,7 @@ function UnforwardedNumberControl(
 	forwardedRef: ForwardedRef< any >
 ) {
 	if ( hideHTMLArrows ) {
-		deprecated( 'NumberControl hideHTMLArrows prop ', {
+		deprecated( 'wp.components.NumberControl hideHTMLArrows prop ', {
 			alternative: 'spinControls="none"',
 			since: '6.2',
 			version: '6.3',

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -52,7 +52,7 @@ function UnforwardedNumberControl(
 	forwardedRef: ForwardedRef< any >
 ) {
 	if ( hideHTMLArrows ) {
-		deprecated( 'hideHTMLArrows', {
+		deprecated( 'NumberControl hideHTMLArrows prop ', {
 			alternative: 'spinControls="none"',
 			since: '6.2',
 			version: '6.3',


### PR DESCRIPTION
## What?
This PR clarifies the message about the `hideHTMLArrows` prop of the `NumberControl` component, which is marked as deprecated.

### Before

![before](https://user-images.githubusercontent.com/54422211/214211681-cde65de5-7cc8-4205-9611-3739ff821e1d.png)

### After

![after](https://user-images.githubusercontent.com/54422211/214211694-b1f8914c-0be4-4f9f-b9f2-515595734c7a.png)

## Why?
Developers will see this message in the next major WordPress release, as this property is marked as deprecated in WordPress 6.2. However, it is difficult to tell at a glance which component the property relates to. Maybe some developers can predict components from the word `UnforwardedNumberControl`, though.

## How?
I included the component name in the message, as we did with deprecated messages such as [UnitControl](https://github.com/WordPress/gutenberg/blob/ea08f55ad5906882170776baf339309f42dc25ac/packages/components/src/unit-control/index.tsx#L68) and [Button](https://github.com/WordPress/gutenberg/blob/ea08f55ad5906882170776baf339309f42dc25ac/packages/components/src/button/index.js#L47) components.