### PR TITLE
Global styles: move custom CSS to ellipsis menu if no custom CSS present yet

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-root.js
+++ b/packages/edit-site/src/components/global-styles/screen-root.js
@@ -16,6 +16,7 @@ import { isRTL, __ } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -24,8 +25,12 @@ import { IconWithCurrentColor } from './icon-with-current-color';
 import { NavigationButtonAsItem } from './navigation-button';
 import ContextMenu from './context-menu';
 import StylesPreview from './preview';
+import { unlock } from '../../experiments';
 
 function ScreenRoot() {
+	const { useGlobalStyle } = unlock( blockEditorExperiments );
+	const [ customCSS ] = useGlobalStyle( 'css' );
+
 	const { variations, canEditCSS } = useSelect( ( select ) => {
 		const {
 			getEntityRecord,
@@ -110,7 +115,7 @@ function ScreenRoot() {
 				</ItemGroup>
 			</CardBody>
 
-			{ canEditCSS && (
+			{ canEditCSS && customCSS && (
 				<>
 					<CardDivider />
 					<CardBody>

--- a/packages/edit-site/src/components/global-styles/screen-root.js
+++ b/packages/edit-site/src/components/global-styles/screen-root.js
@@ -115,7 +115,7 @@ function ScreenRoot() {
 				</ItemGroup>
 			</CardBody>
 
-			{ canEditCSS && customCSS && (
+			{ canEditCSS && !! customCSS && (
 				<>
 					<CardDivider />
 					<CardBody>

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -42,7 +42,7 @@ const SLOT_FILL_NAME = 'GlobalStylesMenu';
 const { Slot: GlobalStylesMenuSlot, Fill: GlobalStylesMenuFill } =
 	createSlotFill( SLOT_FILL_NAME );
 
-function GlobalStylesMenu() {
+function GlobalStylesActionMenu() {
 	const { toggle } = useDispatch( preferencesStore );
 	const { useGlobalStylesReset } = unlock( blockEditorExperiments );
 	const [ canReset, onReset ] = useGlobalStylesReset();
@@ -332,7 +332,7 @@ function GlobalStylesUI( { isStyleBookOpened, onCloseStyleBook } ) {
 				<GlobalStylesStyleBook onClose={ onCloseStyleBook } />
 			) }
 
-			<GlobalStylesMenu />
+			<GlobalStylesActionMenu />
 		</NavigatorProvider>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -7,7 +7,7 @@ import {
 	__experimentalUseNavigator as useNavigator,
 } from '@wordpress/components';
 import { getBlockTypes, store as blocksStore } from '@wordpress/blocks';
-
+import { usePrevious } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -239,7 +239,26 @@ function GlobalStylesStyleBook( { onClose } ) {
 	);
 }
 
-function GlobalStylesUI( { isStyleBookOpened, onCloseStyleBook } ) {
+function NavigatorControl( { navigatorPath, setNavigatorPath } ) {
+	const { goTo, location } = useNavigator();
+	const previousNavigatorPath = usePrevious( navigatorPath );
+
+	if (
+		navigatorPath !== previousNavigatorPath &&
+		previousNavigatorPath !== '/css' &&
+		location.isBack !== true
+	) {
+		goTo( navigatorPath );
+		setNavigatorPath( '/' );
+	}
+}
+
+function GlobalStylesUI( {
+	isStyleBookOpened,
+	onCloseStyleBook,
+	navigatorPath,
+	setNavigatorPath,
+} ) {
 	const blocks = getBlockTypes();
 
 	return (
@@ -267,7 +286,10 @@ function GlobalStylesUI( { isStyleBookOpened, onCloseStyleBook } ) {
 					<ScreenBlock name={ block.name } />
 				</GlobalStylesNavigationScreen>
 			) ) }
-
+			<NavigatorControl
+				navigatorPath={ navigatorPath }
+				setNavigatorPath={ setNavigatorPath }
+			/>
 			<ContextScreens />
 
 			{ blocks.map( ( block ) => (

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -44,8 +44,11 @@ const { Slot: GlobalStylesMenuSlot, Fill: GlobalStylesMenuFill } =
 
 function GlobalStylesMenu() {
 	const { toggle } = useDispatch( preferencesStore );
-	const { useGlobalStylesReset } = unlock( blockEditorExperiments );
+	const { useGlobalStylesReset, useGlobalStyle } = unlock(
+		blockEditorExperiments
+	);
 	const [ canReset, onReset ] = useGlobalStylesReset();
+	const [ customCSS ] = useGlobalStyle( 'css' );
 	const { goTo } = useNavigator();
 	const loadCustomCSS = () => goTo( '/css' );
 	return (
@@ -59,10 +62,14 @@ function GlobalStylesMenu() {
 						onClick: onReset,
 						isDisabled: ! canReset,
 					},
-					{
-						title: __( 'Additional CSS' ),
-						onClick: loadCustomCSS,
-					},
+					...( ! customCSS
+						? [
+								{
+									title: __( 'Additional CSS' ),
+									onClick: loadCustomCSS,
+								},
+						  ]
+						: [] ),
 					{
 						title: __( 'Welcome Guide' ),
 						onClick: () =>
@@ -331,9 +338,11 @@ function GlobalStylesUI( { isStyleBookOpened, onCloseStyleBook } ) {
 			{ isStyleBookOpened && (
 				<GlobalStylesStyleBook onClose={ onCloseStyleBook } />
 			) }
+
 			<GlobalStylesNavigationScreen path="/css">
 				<ScreenCSS />
 			</GlobalStylesNavigationScreen>
+
 			<GlobalStylesMenu />
 		</NavigatorProvider>
 	);

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -44,11 +44,8 @@ const { Slot: GlobalStylesMenuSlot, Fill: GlobalStylesMenuFill } =
 
 function GlobalStylesMenu() {
 	const { toggle } = useDispatch( preferencesStore );
-	const { useGlobalStylesReset, useGlobalStyle } = unlock(
-		blockEditorExperiments
-	);
+	const { useGlobalStylesReset } = unlock( blockEditorExperiments );
 	const [ canReset, onReset ] = useGlobalStylesReset();
-	const [ customCSS ] = useGlobalStyle( 'css' );
 	const { goTo } = useNavigator();
 	const loadCustomCSS = () => goTo( '/css' );
 	return (
@@ -62,14 +59,10 @@ function GlobalStylesMenu() {
 						onClick: onReset,
 						isDisabled: ! canReset,
 					},
-					...( ! customCSS
-						? [
-								{
-									title: __( 'Additional CSS' ),
-									onClick: loadCustomCSS,
-								},
-						  ]
-						: [] ),
+					{
+						title: __( 'Additional CSS' ),
+						onClick: loadCustomCSS,
+					},
 					{
 						title: __( 'Welcome Guide' ),
 						onClick: () =>
@@ -338,10 +331,6 @@ function GlobalStylesUI( { isStyleBookOpened, onCloseStyleBook } ) {
 			{ isStyleBookOpened && (
 				<GlobalStylesStyleBook onClose={ onCloseStyleBook } />
 			) }
-
-			<GlobalStylesNavigationScreen path="/css">
-				<ScreenCSS />
-			</GlobalStylesNavigationScreen>
 
 			<GlobalStylesMenu />
 		</NavigatorProvider>

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -60,13 +60,13 @@ function GlobalStylesMenu() {
 						isDisabled: ! canReset,
 					},
 					{
-						title: __( 'Additional CSS' ),
-						onClick: loadCustomCSS,
-					},
-					{
 						title: __( 'Welcome Guide' ),
 						onClick: () =>
 							toggle( 'core/edit-site', 'welcomeGuideStyles' ),
+					},
+					{
+						title: __( 'Additional CSS' ),
+						onClick: loadCustomCSS,
 					},
 				] }
 			/>

--- a/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
@@ -26,6 +26,7 @@ import { unlock } from '../../experiments';
 const { useGlobalStylesReset } = unlock( blockEditorExperiments );
 
 export default function GlobalStylesSidebar() {
+	const [ navigatorPath, setNavigatorPath ] = useState( '/' );
 	const [ canReset, onReset ] = useGlobalStylesReset();
 	const { toggle } = useDispatch( preferencesStore );
 	const [ isStyleBookOpened, setIsStyleBookOpened ] = useState( false );
@@ -33,6 +34,9 @@ export default function GlobalStylesSidebar() {
 		( select ) => select( editSiteStore ).getEditorMode(),
 		[]
 	);
+
+	const loadCustomCSS = () => setNavigatorPath( '/css' );
+
 	useEffect( () => {
 		if ( editorMode !== 'visual' ) {
 			setIsStyleBookOpened( false );
@@ -77,6 +81,10 @@ export default function GlobalStylesSidebar() {
 									isDisabled: ! canReset,
 								},
 								{
+									title: __( 'Additional CSS' ),
+									onClick: loadCustomCSS,
+								},
+								{
 									title: __( 'Welcome Guide' ),
 									onClick: () =>
 										toggle(
@@ -93,6 +101,8 @@ export default function GlobalStylesSidebar() {
 			<GlobalStylesUI
 				isStyleBookOpened={ isStyleBookOpened }
 				onCloseStyleBook={ () => setIsStyleBookOpened( false ) }
+				navigatorPath={ navigatorPath }
+				setNavigatorPath={ setNavigatorPath }
 			/>
 		</DefaultSidebar>
 	);

--- a/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
@@ -1,19 +1,12 @@
 /**
  * WordPress dependencies
  */
-import {
-	DropdownMenu,
-	FlexItem,
-	FlexBlock,
-	Flex,
-	Button,
-} from '@wordpress/components';
+import { FlexItem, FlexBlock, Flex, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { styles, moreVertical, seen } from '@wordpress/icons';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { store as preferencesStore } from '@wordpress/preferences';
+import { styles, seen } from '@wordpress/icons';
+import { useSelect } from '@wordpress/data';
+
 import { useState, useEffect } from '@wordpress/element';
-import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -21,21 +14,14 @@ import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
 import DefaultSidebar from './default-sidebar';
 import { GlobalStylesUI } from '../global-styles';
 import { store as editSiteStore } from '../../store';
-import { unlock } from '../../experiments';
-
-const { useGlobalStylesReset } = unlock( blockEditorExperiments );
+import { GlobalStylesMenuSlot } from '../global-styles/ui';
 
 export default function GlobalStylesSidebar() {
-	const [ navigatorPath, setNavigatorPath ] = useState( '/' );
-	const [ canReset, onReset ] = useGlobalStylesReset();
-	const { toggle } = useDispatch( preferencesStore );
 	const [ isStyleBookOpened, setIsStyleBookOpened ] = useState( false );
 	const editorMode = useSelect(
 		( select ) => select( editSiteStore ).getEditorMode(),
 		[]
 	);
-
-	const loadCustomCSS = () => setNavigatorPath( '/css' );
 
 	useEffect( () => {
 		if ( editorMode !== 'visual' ) {
@@ -71,29 +57,7 @@ export default function GlobalStylesSidebar() {
 						/>
 					</FlexItem>
 					<FlexItem>
-						<DropdownMenu
-							icon={ moreVertical }
-							label={ __( 'More Styles actions' ) }
-							controls={ [
-								{
-									title: __( 'Reset to defaults' ),
-									onClick: onReset,
-									isDisabled: ! canReset,
-								},
-								{
-									title: __( 'Additional CSS' ),
-									onClick: loadCustomCSS,
-								},
-								{
-									title: __( 'Welcome Guide' ),
-									onClick: () =>
-										toggle(
-											'core/edit-site',
-											'welcomeGuideStyles'
-										),
-								},
-							] }
-						/>
+						<GlobalStylesMenuSlot />
 					</FlexItem>
 				</Flex>
 			}
@@ -101,8 +65,6 @@ export default function GlobalStylesSidebar() {
 			<GlobalStylesUI
 				isStyleBookOpened={ isStyleBookOpened }
 				onCloseStyleBook={ () => setIsStyleBookOpened( false ) }
-				navigatorPath={ navigatorPath }
-				setNavigatorPath={ setNavigatorPath }
 			/>
 		</DefaultSidebar>
 	);


### PR DESCRIPTION
## What?
Moves the custom CSS to the Global Styles ellipsis menu by default. Once Custom CSS has been added the option appears permanently in the sidebar.

## Why?
Fixes: #47266

## How?
Checks to see if `styles.css` is undefined and if so only shows Custom CSS in the global styles ellipsis menu.

## Testing Instructions

- On a site with no global styles custom CSS added check that the Custom CSS option only appears in the ellipsis menu and not in the sidebar
- Select the Custom CSS option from the menu and make sure you are taken to the CSS input form
- Add some custom CSS and save
- Make sure the option the option now permanently appears in the sidebar
- Choose menu option to reset global styles to defaults and check that CSS option disappears from sidebar

### Testing Instructions for Keyboard

- Tab to the ellipsis menu
- Use down arrow key then enter to select the Custom CSS option
- Tab to the input box to input Custom CSS
- Tab to save button to save changes
- Tab to back option to return to main Global Styles panel

## Screenshots or screencast 
https://user-images.githubusercontent.com/3629020/214416473-1cb9cff7-8330-4a8a-9d8a-f59c9a2074e4.mp4
