### PR TITLE
Fix inline block declaration anti-pattern in global styles UI

### DIFF
--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -72,6 +72,21 @@ function BlockStyleVariationsScreens( { name } ) {
 	) );
 }
 
+function BlockStylesNavigationScreens( {
+	parentMenu,
+	blockStyles,
+	blockName,
+} ) {
+	return blockStyles.map( ( style, index ) => (
+		<GlobalStylesNavigationScreen
+			key={ index }
+			path={ parentMenu + '/variations/' + style.name }
+		>
+			<ScreenVariation blockName={ blockName } style={ style } />
+		</GlobalStylesNavigationScreen>
+	) );
+}
+
 function ContextScreens( { name, parentMenu = '' } ) {
 	const hasVariationPath = parentMenu.search( 'variations' );
 	const variationPath =
@@ -88,17 +103,6 @@ function ContextScreens( { name, parentMenu = '' } ) {
 		},
 		[ name ]
 	);
-
-	const BlockStylesNavigationScreens = ( { blockStyles, blockName } ) => {
-		return blockStyles.map( ( style, index ) => (
-			<GlobalStylesNavigationScreen
-				key={ index }
-				path={ parentMenu + '/variations/' + style.name }
-			>
-				<ScreenVariation blockName={ blockName } style={ style } />
-			</GlobalStylesNavigationScreen>
-		) );
-	};
 
 	return (
 		<>
@@ -198,6 +202,7 @@ function ContextScreens( { name, parentMenu = '' } ) {
 
 			{ !! blockStyleVariations?.length && (
 				<BlockStylesNavigationScreens
+					parentMenu={ parentMenu }
 					blockStyles={ blockStyleVariations }
 					blockName={ name }
 				/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes an anti-pattern - declaring a react component inline within another react component.

## Why?
React's reconciler doesn't know how to handle this. On every render it'll think this is a new component, and unmount/remount the associated elements in the DOM.

This can be bad for performance and cause issues like focus loss. This particular piece of UI doesn't have much interactivity, so it's probably not an issue here, but worth fixing it now as it may change in the future.

## How?
Move the component declaration to the parent module scope.

The component was previously closing over the `parentMenu` variable, so this is now passed as a prop.

## Testing Instructions
1. Open global styles (tab to the 'Styles' button in the 'Editor top bar' region and toggle it open)
2. Open the blocks section in the styles panel (Tab to the 'Blocks' button in the 'Editor settings' region and select it)
3. Open the 'Separator' block section (Tab to the 'Separator' button and select it. Using the search box may make this quicker)
4. Check that the 'Wide Line' and 'Dots' buttons are present. (Tab till you get to the 'Wide Line' and 'Dots' buttons, they should be adjacent siblings)
5. Select the 'Wide Line' or 'Dots' options and ensure you're taken to the associated panel
