### PR TITLE
React Native: remove duplicate metro packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8902,107 +8902,6 @@
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 				},
-				"hermes-parser": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.6.0.tgz",
-					"integrity": "sha512-Vf58jBZca2+QBLR9h7B7mdg8oFz2g5ILz1iVouZ5DOrOrAfBmPfJjdjDT8jrO0f+iJ4/hSRrQHqHIjSnTaLUDQ==",
-					"requires": {
-						"hermes-estree": "0.6.0"
-					}
-				},
-				"metro-react-native-babel-preset": {
-					"version": "0.70.3",
-					"resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.70.3.tgz",
-					"integrity": "sha512-4Nxc1zEiHEu+GTdEMEsHnRgfaBkg8f/Td3+FcQ8NTSvs+xL3LBrQy6N07idWSQZHIdGFf+tTHvRfSIWLD8u8Tg==",
-					"requires": {
-						"@babel/core": "^7.14.0",
-						"@babel/plugin-proposal-async-generator-functions": "^7.0.0",
-						"@babel/plugin-proposal-class-properties": "^7.0.0",
-						"@babel/plugin-proposal-export-default-from": "^7.0.0",
-						"@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
-						"@babel/plugin-proposal-object-rest-spread": "^7.0.0",
-						"@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
-						"@babel/plugin-proposal-optional-chaining": "^7.0.0",
-						"@babel/plugin-syntax-dynamic-import": "^7.0.0",
-						"@babel/plugin-syntax-export-default-from": "^7.0.0",
-						"@babel/plugin-syntax-flow": "^7.2.0",
-						"@babel/plugin-syntax-nullish-coalescing-operator": "^7.0.0",
-						"@babel/plugin-syntax-optional-chaining": "^7.0.0",
-						"@babel/plugin-transform-arrow-functions": "^7.0.0",
-						"@babel/plugin-transform-async-to-generator": "^7.0.0",
-						"@babel/plugin-transform-block-scoping": "^7.0.0",
-						"@babel/plugin-transform-classes": "^7.0.0",
-						"@babel/plugin-transform-computed-properties": "^7.0.0",
-						"@babel/plugin-transform-destructuring": "^7.0.0",
-						"@babel/plugin-transform-exponentiation-operator": "^7.0.0",
-						"@babel/plugin-transform-flow-strip-types": "^7.0.0",
-						"@babel/plugin-transform-function-name": "^7.0.0",
-						"@babel/plugin-transform-literals": "^7.0.0",
-						"@babel/plugin-transform-modules-commonjs": "^7.0.0",
-						"@babel/plugin-transform-named-capturing-groups-regex": "^7.0.0",
-						"@babel/plugin-transform-parameters": "^7.0.0",
-						"@babel/plugin-transform-react-display-name": "^7.0.0",
-						"@babel/plugin-transform-react-jsx": "^7.0.0",
-						"@babel/plugin-transform-react-jsx-self": "^7.0.0",
-						"@babel/plugin-transform-react-jsx-source": "^7.0.0",
-						"@babel/plugin-transform-runtime": "^7.0.0",
-						"@babel/plugin-transform-shorthand-properties": "^7.0.0",
-						"@babel/plugin-transform-spread": "^7.0.0",
-						"@babel/plugin-transform-sticky-regex": "^7.0.0",
-						"@babel/plugin-transform-template-literals": "^7.0.0",
-						"@babel/plugin-transform-typescript": "^7.5.0",
-						"@babel/plugin-transform-unicode-regex": "^7.0.0",
-						"@babel/template": "^7.0.0",
-						"react-refresh": "^0.4.0"
-					}
-				},
-				"metro-react-native-babel-transformer": {
-					"version": "0.70.3",
-					"resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.70.3.tgz",
-					"integrity": "sha512-WKBU6S/G50j9cfmFM4k4oRYprd8u3qjleD4so1E2zbTNILg+gYla7ZFGCAvi2G0ZcqS2XuGCR375c2hF6VVvwg==",
-					"requires": {
-						"@babel/core": "^7.14.0",
-						"babel-preset-fbjs": "^3.4.0",
-						"hermes-parser": "0.6.0",
-						"metro-babel-transformer": "0.70.3",
-						"metro-react-native-babel-preset": "0.70.3",
-						"metro-source-map": "0.70.3",
-						"nullthrows": "^1.1.1"
-					}
-				},
-				"metro-source-map": {
-					"version": "0.70.3",
-					"resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.70.3.tgz",
-					"integrity": "sha512-zsYtZGrwRbbGEFHtmMqqeCH9K9aTGNVPsurMOWCUeQA3VGyVGXPGtLMC+CdAM9jLpUyg6jw2xh0esxi+tYH7Uw==",
-					"requires": {
-						"@babel/traverse": "^7.14.0",
-						"@babel/types": "^7.0.0",
-						"invariant": "^2.2.4",
-						"metro-symbolicate": "0.70.3",
-						"nullthrows": "^1.1.1",
-						"ob1": "0.70.3",
-						"source-map": "^0.5.6",
-						"vlq": "^1.0.0"
-					}
-				},
-				"metro-symbolicate": {
-					"version": "0.70.3",
-					"resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.70.3.tgz",
-					"integrity": "sha512-JTYkF1dpeDUssQ84juE1ycnhHki2ylJBBdJE1JHtfu5oC+z1ElDbBdPHq90Uvt8HbRov/ZAnxvv7Zy6asS+WCA==",
-					"requires": {
-						"invariant": "^2.2.4",
-						"metro-source-map": "0.70.3",
-						"nullthrows": "^1.1.1",
-						"source-map": "^0.5.6",
-						"through2": "^2.0.1",
-						"vlq": "^1.0.0"
-					}
-				},
-				"ob1": {
-					"version": "0.70.3",
-					"resolved": "https://registry.npmjs.org/ob1/-/ob1-0.70.3.tgz",
-					"integrity": "sha512-Vy9GGhuXgDRY01QA6kdhToPd8AkLdLpX9GjH5kpqluVqTu70mgOm7tpGoJDZGaNbr9nJlJgnipqHJQRPORixIQ=="
-				},
 				"react-refresh": {
 					"version": "0.4.3",
 					"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",
@@ -19455,7 +19354,7 @@
 		"app-root-dir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/app-root-dir/-/app-root-dir-1.0.2.tgz",
-			"integrity": "sha1-OBh+wt6nV3//Az/8sSFyaS/24Rg=",
+			"integrity": "sha512-jlpIfsOoNoafl92Sz//64uQHGSyMrD2vYG5d8o2a4qGvyNCvXur7bzIsWtAC/6flI2RYAp3kv8rsfBtaLm7w0g==",
 			"dev": true
 		},
 		"app-root-path": {
@@ -26113,7 +26012,7 @@
 		"array-ify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-			"integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
 			"dev": true
 		},
 		"array-includes": {
@@ -27748,7 +27647,7 @@
 		"babel-plugin-add-react-displayname": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.5.tgz",
-			"integrity": "sha1-M51M3be2X9YtHfnbn+BN4TQSK9U=",
+			"integrity": "sha512-LY3+Y0XVDYcShHHorshrDbt4KFWL4bSeniCtl4SYZbask+Syngk1uMPCeN9+nSiZo6zX5s0RTq/J9Pnaaf/KHw==",
 			"dev": true
 		},
 		"babel-plugin-apply-mdx-type-prop": {
@@ -28120,7 +28019,7 @@
 		"batch-processor": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/batch-processor/-/batch-processor-1.0.0.tgz",
-			"integrity": "sha1-dclcMrdI4IUNEMKxaPa9vpiRrOg=",
+			"integrity": "sha512-xoLQD8gmmR32MeuBHgH0Tzd5PuSZx71ZsbhVxOCRbgktZEPe4SQy7s9Z50uPp0F/f7iw2XmkHN2xkgbMfckMDA==",
 			"dev": true
 		},
 		"bcrypt-pbkdf": {
@@ -29720,7 +29619,7 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
 			"dev": true
 		},
 		"code-point-at": {
@@ -31437,7 +31336,7 @@
 		"debuglog": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-			"integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
+			"integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
 			"dev": true
 		},
 		"decache": {
@@ -36341,7 +36240,7 @@
 		"git-remote-origin-url": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
-			"integrity": "sha512-eU+GGrZgccNJcsDH5LkXR3PB9M958hxc7sbA8DFJjrv9j4L2P/eZfKhM+QD6wyzpiv+b1BpK0XrYCxkovtjSLw==",
+			"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
 			"dev": true,
 			"requires": {
 				"gitconfiglocal": "^1.0.0",
@@ -36388,7 +36287,7 @@
 		"gitconfiglocal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
-			"integrity": "sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ==",
+			"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
 			"dev": true,
 			"requires": {
 				"ini": "^1.3.2"
@@ -36736,7 +36635,7 @@
 		"has-glob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-glob/-/has-glob-1.0.0.tgz",
-			"integrity": "sha1-mqqe7b/7G6OZCnsAEPtnjuAIEgc=",
+			"integrity": "sha512-D+8A457fBShSEI3tFCj65PAbT++5sKiFtdCdOam0gnfBgw9D277OERk+HM9qYJXmdVLZ/znez10SqHN0BBQ50g==",
 			"dev": true,
 			"requires": {
 				"is-glob": "^3.0.0"
@@ -36745,7 +36644,7 @@
 				"is-glob": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
 					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.0"
@@ -37090,7 +36989,6 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.6.0.tgz",
 			"integrity": "sha512-Vf58jBZca2+QBLR9h7B7mdg8oFz2g5ILz1iVouZ5DOrOrAfBmPfJjdjDT8jrO0f+iJ4/hSRrQHqHIjSnTaLUDQ==",
-			"dev": true,
 			"requires": {
 				"hermes-estree": "0.6.0"
 			}
@@ -37591,7 +37489,7 @@
 		"humanize-ms": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+			"integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
 			"dev": true,
 			"requires": {
 				"ms": "^2.0.0"
@@ -38608,7 +38506,7 @@
 		"is-text-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-			"integrity": "sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==",
+			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
 			"dev": true,
 			"requires": {
 				"text-extensions": "^1.0.0"
@@ -38920,7 +38818,7 @@
 		"is-window": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-window/-/is-window-1.0.2.tgz",
-			"integrity": "sha1-LIlspT25feRdPDMTOmXYyfVjSA0=",
+			"integrity": "sha512-uj00kdXyZb9t9RcAUAwMZAnkBUwdYGhYlt7djMXhfyhUCzwNba50tIiBKR7q0l7tdoBtFVw/3JmLY6fI3rmZmg==",
 			"dev": true
 		},
 		"is-windows": {
@@ -42320,7 +42218,7 @@
 		"js-string-escape": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-			"integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=",
+			"integrity": "sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==",
 			"dev": true
 		},
 		"js-tokens": {
@@ -42711,7 +42609,7 @@
 		"jsonparse": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-			"integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
 			"dev": true
 		},
 		"jsprim": {
@@ -43792,7 +43690,7 @@
 		"lodash.ismatch": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
-			"integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
+			"integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
 			"dev": true
 		},
 		"lodash.isplainobject": {
@@ -45106,80 +45004,6 @@
 						"p-locate": "^4.1.0"
 					}
 				},
-				"metro-react-native-babel-preset": {
-					"version": "0.70.3",
-					"resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.70.3.tgz",
-					"integrity": "sha512-4Nxc1zEiHEu+GTdEMEsHnRgfaBkg8f/Td3+FcQ8NTSvs+xL3LBrQy6N07idWSQZHIdGFf+tTHvRfSIWLD8u8Tg==",
-					"requires": {
-						"@babel/core": "^7.14.0",
-						"@babel/plugin-proposal-async-generator-functions": "^7.0.0",
-						"@babel/plugin-proposal-class-properties": "^7.0.0",
-						"@babel/plugin-proposal-export-default-from": "^7.0.0",
-						"@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
-						"@babel/plugin-proposal-object-rest-spread": "^7.0.0",
-						"@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
-						"@babel/plugin-proposal-optional-chaining": "^7.0.0",
-						"@babel/plugin-syntax-dynamic-import": "^7.0.0",
-						"@babel/plugin-syntax-export-default-from": "^7.0.0",
-						"@babel/plugin-syntax-flow": "^7.2.0",
-						"@babel/plugin-syntax-nullish-coalescing-operator": "^7.0.0",
-						"@babel/plugin-syntax-optional-chaining": "^7.0.0",
-						"@babel/plugin-transform-arrow-functions": "^7.0.0",
-						"@babel/plugin-transform-async-to-generator": "^7.0.0",
-						"@babel/plugin-transform-block-scoping": "^7.0.0",
-						"@babel/plugin-transform-classes": "^7.0.0",
-						"@babel/plugin-transform-computed-properties": "^7.0.0",
-						"@babel/plugin-transform-destructuring": "^7.0.0",
-						"@babel/plugin-transform-exponentiation-operator": "^7.0.0",
-						"@babel/plugin-transform-flow-strip-types": "^7.0.0",
-						"@babel/plugin-transform-function-name": "^7.0.0",
-						"@babel/plugin-transform-literals": "^7.0.0",
-						"@babel/plugin-transform-modules-commonjs": "^7.0.0",
-						"@babel/plugin-transform-named-capturing-groups-regex": "^7.0.0",
-						"@babel/plugin-transform-parameters": "^7.0.0",
-						"@babel/plugin-transform-react-display-name": "^7.0.0",
-						"@babel/plugin-transform-react-jsx": "^7.0.0",
-						"@babel/plugin-transform-react-jsx-self": "^7.0.0",
-						"@babel/plugin-transform-react-jsx-source": "^7.0.0",
-						"@babel/plugin-transform-runtime": "^7.0.0",
-						"@babel/plugin-transform-shorthand-properties": "^7.0.0",
-						"@babel/plugin-transform-spread": "^7.0.0",
-						"@babel/plugin-transform-sticky-regex": "^7.0.0",
-						"@babel/plugin-transform-template-literals": "^7.0.0",
-						"@babel/plugin-transform-typescript": "^7.5.0",
-						"@babel/plugin-transform-unicode-regex": "^7.0.0",
-						"@babel/template": "^7.0.0",
-						"react-refresh": "^0.4.0"
-					}
-				},
-				"metro-source-map": {
-					"version": "0.70.3",
-					"resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.70.3.tgz",
-					"integrity": "sha512-zsYtZGrwRbbGEFHtmMqqeCH9K9aTGNVPsurMOWCUeQA3VGyVGXPGtLMC+CdAM9jLpUyg6jw2xh0esxi+tYH7Uw==",
-					"requires": {
-						"@babel/traverse": "^7.14.0",
-						"@babel/types": "^7.0.0",
-						"invariant": "^2.2.4",
-						"metro-symbolicate": "0.70.3",
-						"nullthrows": "^1.1.1",
-						"ob1": "0.70.3",
-						"source-map": "^0.5.6",
-						"vlq": "^1.0.0"
-					}
-				},
-				"metro-symbolicate": {
-					"version": "0.70.3",
-					"resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.70.3.tgz",
-					"integrity": "sha512-JTYkF1dpeDUssQ84juE1ycnhHki2ylJBBdJE1JHtfu5oC+z1ElDbBdPHq90Uvt8HbRov/ZAnxvv7Zy6asS+WCA==",
-					"requires": {
-						"invariant": "^2.2.4",
-						"metro-source-map": "0.70.3",
-						"nullthrows": "^1.1.1",
-						"source-map": "^0.5.6",
-						"through2": "^2.0.1",
-						"vlq": "^1.0.0"
-					}
-				},
 				"micromatch": {
 					"version": "4.0.5",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -45213,11 +45037,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
-				},
-				"ob1": {
-					"version": "0.70.3",
-					"resolved": "https://registry.npmjs.org/ob1/-/ob1-0.70.3.tgz",
-					"integrity": "sha512-Vy9GGhuXgDRY01QA6kdhToPd8AkLdLpX9GjH5kpqluVqTu70mgOm7tpGoJDZGaNbr9nJlJgnipqHJQRPORixIQ=="
 				},
 				"p-limit": {
 					"version": "2.3.0",
@@ -45335,49 +45154,6 @@
 				"hermes-parser": "0.6.0",
 				"metro-source-map": "0.70.3",
 				"nullthrows": "^1.1.1"
-			},
-			"dependencies": {
-				"hermes-parser": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.6.0.tgz",
-					"integrity": "sha512-Vf58jBZca2+QBLR9h7B7mdg8oFz2g5ILz1iVouZ5DOrOrAfBmPfJjdjDT8jrO0f+iJ4/hSRrQHqHIjSnTaLUDQ==",
-					"requires": {
-						"hermes-estree": "0.6.0"
-					}
-				},
-				"metro-source-map": {
-					"version": "0.70.3",
-					"resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.70.3.tgz",
-					"integrity": "sha512-zsYtZGrwRbbGEFHtmMqqeCH9K9aTGNVPsurMOWCUeQA3VGyVGXPGtLMC+CdAM9jLpUyg6jw2xh0esxi+tYH7Uw==",
-					"requires": {
-						"@babel/traverse": "^7.14.0",
-						"@babel/types": "^7.0.0",
-						"invariant": "^2.2.4",
-						"metro-symbolicate": "0.70.3",
-						"nullthrows": "^1.1.1",
-						"ob1": "0.70.3",
-						"source-map": "^0.5.6",
-						"vlq": "^1.0.0"
-					}
-				},
-				"metro-symbolicate": {
-					"version": "0.70.3",
-					"resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.70.3.tgz",
-					"integrity": "sha512-JTYkF1dpeDUssQ84juE1ycnhHki2ylJBBdJE1JHtfu5oC+z1ElDbBdPHq90Uvt8HbRov/ZAnxvv7Zy6asS+WCA==",
-					"requires": {
-						"invariant": "^2.2.4",
-						"metro-source-map": "0.70.3",
-						"nullthrows": "^1.1.1",
-						"source-map": "^0.5.6",
-						"through2": "^2.0.1",
-						"vlq": "^1.0.0"
-					}
-				},
-				"ob1": {
-					"version": "0.70.3",
-					"resolved": "https://registry.npmjs.org/ob1/-/ob1-0.70.3.tgz",
-					"integrity": "sha512-Vy9GGhuXgDRY01QA6kdhToPd8AkLdLpX9GjH5kpqluVqTu70mgOm7tpGoJDZGaNbr9nJlJgnipqHJQRPORixIQ=="
-				}
 			}
 		},
 		"metro-cache": {
@@ -45803,7 +45579,6 @@
 			"version": "0.70.3",
 			"resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.70.3.tgz",
 			"integrity": "sha512-4Nxc1zEiHEu+GTdEMEsHnRgfaBkg8f/Td3+FcQ8NTSvs+xL3LBrQy6N07idWSQZHIdGFf+tTHvRfSIWLD8u8Tg==",
-			"dev": true,
 			"requires": {
 				"@babel/core": "^7.14.0",
 				"@babel/plugin-proposal-async-generator-functions": "^7.0.0",
@@ -45849,8 +45624,7 @@
 				"react-refresh": {
 					"version": "0.4.3",
 					"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",
-					"integrity": "sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA==",
-					"dev": true
+					"integrity": "sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA=="
 				}
 			}
 		},
@@ -45858,7 +45632,6 @@
 			"version": "0.70.3",
 			"resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.70.3.tgz",
 			"integrity": "sha512-WKBU6S/G50j9cfmFM4k4oRYprd8u3qjleD4so1E2zbTNILg+gYla7ZFGCAvi2G0ZcqS2XuGCR375c2hF6VVvwg==",
-			"dev": true,
 			"requires": {
 				"@babel/core": "^7.14.0",
 				"babel-preset-fbjs": "^3.4.0",
@@ -45889,7 +45662,6 @@
 			"version": "0.70.3",
 			"resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.70.3.tgz",
 			"integrity": "sha512-zsYtZGrwRbbGEFHtmMqqeCH9K9aTGNVPsurMOWCUeQA3VGyVGXPGtLMC+CdAM9jLpUyg6jw2xh0esxi+tYH7Uw==",
-			"dev": true,
 			"requires": {
 				"@babel/traverse": "^7.14.0",
 				"@babel/types": "^7.0.0",
@@ -45905,7 +45677,6 @@
 			"version": "0.70.3",
 			"resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.70.3.tgz",
 			"integrity": "sha512-JTYkF1dpeDUssQ84juE1ycnhHki2ylJBBdJE1JHtfu5oC+z1ElDbBdPHq90Uvt8HbRov/ZAnxvv7Zy6asS+WCA==",
-			"dev": true,
 			"requires": {
 				"invariant": "^2.2.4",
 				"metro-source-map": "0.70.3",
@@ -45945,41 +45716,6 @@
 				"metro-source-map": "0.70.3",
 				"metro-transform-plugins": "0.70.3",
 				"nullthrows": "^1.1.1"
-			},
-			"dependencies": {
-				"metro-source-map": {
-					"version": "0.70.3",
-					"resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.70.3.tgz",
-					"integrity": "sha512-zsYtZGrwRbbGEFHtmMqqeCH9K9aTGNVPsurMOWCUeQA3VGyVGXPGtLMC+CdAM9jLpUyg6jw2xh0esxi+tYH7Uw==",
-					"requires": {
-						"@babel/traverse": "^7.14.0",
-						"@babel/types": "^7.0.0",
-						"invariant": "^2.2.4",
-						"metro-symbolicate": "0.70.3",
-						"nullthrows": "^1.1.1",
-						"ob1": "0.70.3",
-						"source-map": "^0.5.6",
-						"vlq": "^1.0.0"
-					}
-				},
-				"metro-symbolicate": {
-					"version": "0.70.3",
-					"resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.70.3.tgz",
-					"integrity": "sha512-JTYkF1dpeDUssQ84juE1ycnhHki2ylJBBdJE1JHtfu5oC+z1ElDbBdPHq90Uvt8HbRov/ZAnxvv7Zy6asS+WCA==",
-					"requires": {
-						"invariant": "^2.2.4",
-						"metro-source-map": "0.70.3",
-						"nullthrows": "^1.1.1",
-						"source-map": "^0.5.6",
-						"through2": "^2.0.1",
-						"vlq": "^1.0.0"
-					}
-				},
-				"ob1": {
-					"version": "0.70.3",
-					"resolved": "https://registry.npmjs.org/ob1/-/ob1-0.70.3.tgz",
-					"integrity": "sha512-Vy9GGhuXgDRY01QA6kdhToPd8AkLdLpX9GjH5kpqluVqTu70mgOm7tpGoJDZGaNbr9nJlJgnipqHJQRPORixIQ=="
-				}
 			}
 		},
 		"microevent.ts": {
@@ -47520,7 +47256,7 @@
 		"num2fraction": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-			"integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+			"integrity": "sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg==",
 			"dev": true
 		},
 		"number-is-nan": {
@@ -47939,8 +47675,7 @@
 		"ob1": {
 			"version": "0.70.3",
 			"resolved": "https://registry.npmjs.org/ob1/-/ob1-0.70.3.tgz",
-			"integrity": "sha512-Vy9GGhuXgDRY01QA6kdhToPd8AkLdLpX9GjH5kpqluVqTu70mgOm7tpGoJDZGaNbr9nJlJgnipqHJQRPORixIQ==",
-			"dev": true
+			"integrity": "sha512-Vy9GGhuXgDRY01QA6kdhToPd8AkLdLpX9GjH5kpqluVqTu70mgOm7tpGoJDZGaNbr9nJlJgnipqHJQRPORixIQ=="
 		},
 		"object-assign": {
 			"version": "4.1.1",
@@ -48989,7 +48724,7 @@
 		"p-defer": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+			"integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
 			"dev": true
 		},
 		"p-event": {
@@ -50545,7 +50280,7 @@
 		"pretty-hrtime": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-			"integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
+			"integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==",
 			"dev": true
 		},
 		"private": {
@@ -51104,7 +50839,7 @@
 		"promzard": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-			"integrity": "sha512-JZeYqd7UAcHCwI+sTOeUDYkvEU+1bQ7iE0UT1MgB/tERkAPkesW46MrpIySzODi+owTjZtiF8Ay5j9m60KmMBw==",
+			"integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
 			"dev": true,
 			"requires": {
 				"read": "1"
@@ -51138,7 +50873,7 @@
 		"proto-list": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-			"integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
 			"dev": true
 		},
 		"protocols": {
@@ -51865,99 +51600,6 @@
 						"p-locate": "^4.1.0"
 					}
 				},
-				"metro-react-native-babel-preset": {
-					"version": "0.70.3",
-					"resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.70.3.tgz",
-					"integrity": "sha512-4Nxc1zEiHEu+GTdEMEsHnRgfaBkg8f/Td3+FcQ8NTSvs+xL3LBrQy6N07idWSQZHIdGFf+tTHvRfSIWLD8u8Tg==",
-					"requires": {
-						"@babel/core": "^7.14.0",
-						"@babel/plugin-proposal-async-generator-functions": "^7.0.0",
-						"@babel/plugin-proposal-class-properties": "^7.0.0",
-						"@babel/plugin-proposal-export-default-from": "^7.0.0",
-						"@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
-						"@babel/plugin-proposal-object-rest-spread": "^7.0.0",
-						"@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
-						"@babel/plugin-proposal-optional-chaining": "^7.0.0",
-						"@babel/plugin-syntax-dynamic-import": "^7.0.0",
-						"@babel/plugin-syntax-export-default-from": "^7.0.0",
-						"@babel/plugin-syntax-flow": "^7.2.0",
-						"@babel/plugin-syntax-nullish-coalescing-operator": "^7.0.0",
-						"@babel/plugin-syntax-optional-chaining": "^7.0.0",
-						"@babel/plugin-transform-arrow-functions": "^7.0.0",
-						"@babel/plugin-transform-async-to-generator": "^7.0.0",
-						"@babel/plugin-transform-block-scoping": "^7.0.0",
-						"@babel/plugin-transform-classes": "^7.0.0",
-						"@babel/plugin-transform-computed-properties": "^7.0.0",
-						"@babel/plugin-transform-destructuring": "^7.0.0",
-						"@babel/plugin-transform-exponentiation-operator": "^7.0.0",
-						"@babel/plugin-transform-flow-strip-types": "^7.0.0",
-						"@babel/plugin-transform-function-name": "^7.0.0",
-						"@babel/plugin-transform-literals": "^7.0.0",
-						"@babel/plugin-transform-modules-commonjs": "^7.0.0",
-						"@babel/plugin-transform-named-capturing-groups-regex": "^7.0.0",
-						"@babel/plugin-transform-parameters": "^7.0.0",
-						"@babel/plugin-transform-react-display-name": "^7.0.0",
-						"@babel/plugin-transform-react-jsx": "^7.0.0",
-						"@babel/plugin-transform-react-jsx-self": "^7.0.0",
-						"@babel/plugin-transform-react-jsx-source": "^7.0.0",
-						"@babel/plugin-transform-runtime": "^7.0.0",
-						"@babel/plugin-transform-shorthand-properties": "^7.0.0",
-						"@babel/plugin-transform-spread": "^7.0.0",
-						"@babel/plugin-transform-sticky-regex": "^7.0.0",
-						"@babel/plugin-transform-template-literals": "^7.0.0",
-						"@babel/plugin-transform-typescript": "^7.5.0",
-						"@babel/plugin-transform-unicode-regex": "^7.0.0",
-						"@babel/template": "^7.0.0",
-						"react-refresh": "^0.4.0"
-					}
-				},
-				"metro-react-native-babel-transformer": {
-					"version": "0.70.3",
-					"resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.70.3.tgz",
-					"integrity": "sha512-WKBU6S/G50j9cfmFM4k4oRYprd8u3qjleD4so1E2zbTNILg+gYla7ZFGCAvi2G0ZcqS2XuGCR375c2hF6VVvwg==",
-					"requires": {
-						"@babel/core": "^7.14.0",
-						"babel-preset-fbjs": "^3.4.0",
-						"hermes-parser": "0.6.0",
-						"metro-babel-transformer": "0.70.3",
-						"metro-react-native-babel-preset": "0.70.3",
-						"metro-source-map": "0.70.3",
-						"nullthrows": "^1.1.1"
-					}
-				},
-				"metro-source-map": {
-					"version": "0.70.3",
-					"resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.70.3.tgz",
-					"integrity": "sha512-zsYtZGrwRbbGEFHtmMqqeCH9K9aTGNVPsurMOWCUeQA3VGyVGXPGtLMC+CdAM9jLpUyg6jw2xh0esxi+tYH7Uw==",
-					"requires": {
-						"@babel/traverse": "^7.14.0",
-						"@babel/types": "^7.0.0",
-						"invariant": "^2.2.4",
-						"metro-symbolicate": "0.70.3",
-						"nullthrows": "^1.1.1",
-						"ob1": "0.70.3",
-						"source-map": "^0.5.6",
-						"vlq": "^1.0.0"
-					}
-				},
-				"metro-symbolicate": {
-					"version": "0.70.3",
-					"resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.70.3.tgz",
-					"integrity": "sha512-JTYkF1dpeDUssQ84juE1ycnhHki2ylJBBdJE1JHtfu5oC+z1ElDbBdPHq90Uvt8HbRov/ZAnxvv7Zy6asS+WCA==",
-					"requires": {
-						"invariant": "^2.2.4",
-						"metro-source-map": "0.70.3",
-						"nullthrows": "^1.1.1",
-						"source-map": "^0.5.6",
-						"through2": "^2.0.1",
-						"vlq": "^1.0.0"
-					}
-				},
-				"ob1": {
-					"version": "0.70.3",
-					"resolved": "https://registry.npmjs.org/ob1/-/ob1-0.70.3.tgz",
-					"integrity": "sha512-Vy9GGhuXgDRY01QA6kdhToPd8AkLdLpX9GjH5kpqluVqTu70mgOm7tpGoJDZGaNbr9nJlJgnipqHJQRPORixIQ=="
-				},
 				"p-limit": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -52566,7 +52208,7 @@
 		"read": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-			"integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
+			"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
 			"dev": true,
 			"requires": {
 				"mute-stream": "~0.0.4"
@@ -53131,7 +52773,7 @@
 		"relateurl": {
 			"version": "0.2.7",
 			"resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+			"integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
 			"dev": true
 		},
 		"remark": {
@@ -58184,7 +57826,7 @@
 		"temp-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-			"integrity": "sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==",
+			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
 			"dev": true
 		},
 		"terminal-link": {


### PR DESCRIPTION
While debugging Babel transpilation for React Native, I noticed that we install multiple copies of `metro-react-native-babel-preset` and other `metro-*` packages. There's not only one copy in the root `node_modules`, but multiple ones in subdirectories like `node_modules/react-native/node_modules`. As they all have the same version, they can be deduplicated. In this PR I'm updating the lockfile to remove them.

**How to test:** Mobile CI checks (app builds, unit and e2e tests) should pass. If some package was installed incorrectly, the checks would fail.