### PR TITLE
Remove use of WP_HTML_Tag_Processor in navigation-submenu block

### DIFF
--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -256,11 +256,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		}
 
 		if ( strpos( $inner_blocks_html, 'current-menu-item' ) ) {
-			$tag_processor = new WP_HTML_Tag_Processor( $html );
-			while ( $tag_processor->next_tag( array( 'class_name' => 'wp-block-navigation-item__content' ) ) ) {
-				$tag_processor->add_class( 'current-menu-ancestor' );
-			}
-			$html = $tag_processor->get_updated_html();
+			$html = str_replace( 'wp-block-navigation-item__content', 'wp-block-navigation-item__content current-menu-ancestor', $html );
 		}
 
 		$html .= sprintf(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Following the discussion on https://github.com/WordPress/gutenberg/issues/47349, this PR removes the use of the `WP_HTML_Tag_Processor` object in the `navigation-submenu` block.
This was introduced in https://github.com/WordPress/gutenberg/pull/40778 and can be replaced by a simple `str_replace` call.

## Why?
See #47349 for details

## How?
Replacing the call to `WP_HTML_Tag_Processor` with an `str_replace()` call. It's simple, effective, and it works.
