### PR TITLE
Add Crowdsignal Embed Variation for a new oEmbed endpoint

### DIFF
--- a/packages/block-library/src/embed/variations.js
+++ b/packages/block-library/src/embed/variations.js
@@ -168,7 +168,7 @@ const variations = [
 		keywords: [ 'polldaddy', __( 'survey' ) ],
 		description: __( 'Embed Crowdsignal (formerly Polldaddy) content.' ),
 		patterns: [
-			/^https?:\/\/((.+\.)?polldaddy\.com|poll\.fm|.+\.survey\.fm)\/.+/i,
+			/^https?:\/\/((.+\.)?polldaddy\.com|poll\.fm|.+\.crowdsignal\.net|.+\.survey\.fm)\/.+/i,
 		],
 		attributes: { providerNameSlug: 'crowdsignal', responsive: true },
 	},


### PR DESCRIPTION
## What?
This PR is a follow-up to this WordPress Core Trac ticket: https://core.trac.wordpress.org/ticket/57543

## Why?
This adds a new variation for another CrownSignal oEmbed endpoint, which is going to be added on WordPress Core side.

## How?
Add a new oEmbed endpoint for Crowdsignal.
See this patch, proposed on the related Core Trac ticket: https://core.trac.wordpress.org/attachment/ticket/57543/crowdsignalnet.diff