### PR TITLE
Fix param type in Theme_JSON_Resolver DocBlock

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -673,7 +673,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 *
 	 * @since 6.2.0
 	 *
-	 * @param dir $dir The directory to recursively iterate and list files of.
+	 * @param string $dir The directory to recursively iterate and list files of.
 	 * @return array The merged array.
 	 */
 	private static function recursively_iterate_json( $dir ) {


### PR DESCRIPTION
## What?
Fixes incorrect param type in the `WP_Theme_JSON_Resolver_Gutenberg` docblock. Noticed while working on backports.
## Testing Instructions
Tests on CI are passing.
