### PR TITLE
Move custom css to its own inline style generation method and combine with customizer CSS

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -988,7 +988,6 @@ class WP_Theme_JSON_Gutenberg {
 	 *                       - `variables`: only the CSS Custom Properties for presets & custom ones.
 	 *                       - `styles`: only the styles section in theme.json.
 	 *                       - `presets`: only the classes for the presets.
-	 *                       - `custom-css`: only the css from global styles.css.
 	 * @param array $origins A list of origins to include. By default it includes VALID_ORIGINS.
 	 * @param array $options An array of options for now used for internal purposes only (may change without notice).
 	 *                       The options currently supported are 'scope' that makes sure all style are scoped to a given selector,
@@ -1081,22 +1080,6 @@ class WP_Theme_JSON_Gutenberg {
 			$stylesheet .= $this->get_preset_classes( $setting_nodes, $origins );
 		}
 
-		// Load the custom CSS last so it has the highest specificity.
-		if ( in_array( 'custom-css', $types, true ) ) {
-			// Add the global styles root CSS.
-
-			// Add the global styles block CSS.
-			if ( isset( $this->theme_json['styles']['blocks'] ) ) {
-				foreach ( $this->theme_json['styles']['blocks'] as $name => $node ) {
-					$custom_block_css = _wp_array_get( $this->theme_json, array( 'styles', 'blocks', $name, 'css' ) );
-					if ( $custom_block_css ) {
-						$selector    = static::$blocks_metadata[ $name ]['selector'];
-						$stylesheet .= $this->process_blocks_custom_css( $custom_block_css, $selector );
-					}
-				}
-			}
-		}
-
 		return $stylesheet;
 	}
 
@@ -1108,7 +1091,20 @@ class WP_Theme_JSON_Gutenberg {
 	 * @return string
 	 */
 	public function get_custom_css() {
-		return _wp_array_get( $this->theme_json, array( 'styles', 'css' ) );
+		// Add the global styles root CSS.
+		$stylesheet = _wp_array_get( $this->theme_json, array( 'styles', 'css' ) );
+
+		// Add the global styles block CSS.
+		if ( isset( $this->theme_json['styles']['blocks'] ) ) {
+			foreach ( $this->theme_json['styles']['blocks'] as $name => $node ) {
+				$custom_block_css = _wp_array_get( $this->theme_json, array( 'styles', 'blocks', $name, 'css' ) );
+				if ( $custom_block_css ) {
+					$selector    = static::$blocks_metadata[ $name ]['selector'];
+					$stylesheet .= $this->process_blocks_custom_css( $custom_block_css, $selector );
+				}
+			}
+		}
+		return $stylesheet;
 	}
 
 	/**

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1092,7 +1092,7 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	public function get_custom_css() {
 		// Add the global styles root CSS.
-		$stylesheet = _wp_array_get( $this->theme_json, array( 'styles', 'css' ) );
+		$stylesheet = _wp_array_get( $this->theme_json, array( 'styles', 'css' ), '' );
 
 		// Add the global styles block CSS.
 		if ( isset( $this->theme_json['styles']['blocks'] ) ) {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1084,7 +1084,7 @@ class WP_Theme_JSON_Gutenberg {
 		// Load the custom CSS last so it has the highest specificity.
 		if ( in_array( 'custom-css', $types, true ) ) {
 			// Add the global styles root CSS.
-			$stylesheet .= _wp_array_get( $this->theme_json, array( 'styles', 'css' ) );
+			//$stylesheet .= _wp_array_get( $this->theme_json, array( 'styles', 'css' ) );
 
 			// Add the global styles block CSS.
 			if ( isset( $this->theme_json['styles']['blocks'] ) ) {
@@ -1099,6 +1099,10 @@ class WP_Theme_JSON_Gutenberg {
 		}
 
 		return $stylesheet;
+	}
+
+	public function get_custom_css() {
+		return _wp_array_get( $this->theme_json, array( 'styles', 'css' ) );
 	}
 	/**
 	 * Returns the page templates of the active theme.

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1084,7 +1084,6 @@ class WP_Theme_JSON_Gutenberg {
 		// Load the custom CSS last so it has the highest specificity.
 		if ( in_array( 'custom-css', $types, true ) ) {
 			// Add the global styles root CSS.
-			//$stylesheet .= _wp_array_get( $this->theme_json, array( 'styles', 'css' ) );
 
 			// Add the global styles block CSS.
 			if ( isset( $this->theme_json['styles']['blocks'] ) ) {
@@ -1101,9 +1100,17 @@ class WP_Theme_JSON_Gutenberg {
 		return $stylesheet;
 	}
 
+	/**
+	 * Returns the global styles custom css.
+	 *
+	 * @since 6.2.0
+	 *
+	 * @return string
+	 */
 	public function get_custom_css() {
 		return _wp_array_get( $this->theme_json, array( 'styles', 'css' ) );
 	}
+
 	/**
 	 * Returns the page templates of the active theme.
 	 *

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -82,9 +82,11 @@ function gutenberg_enqueue_global_styles_custom_css() {
 	$custom_css     = get_global_styles_custom_css();
 	$is_block_theme = wp_is_block_theme();
 	if ( $custom_css && $is_block_theme ) {
-		wp_register_style( 'global-styles-custom-css', false, array(), true, true );
-		wp_add_inline_style( 'global-styles-custom-css', $custom_css );
-		wp_enqueue_style( 'global-styles-custom-css' );
+		?>
+		<style id="global-styles-custom-css-inline-css" type="text/css">
+			<?php echo $custom_css; ?>
+		</style>
+		<?php
 	}
 }
 

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -73,23 +73,6 @@ function gutenberg_enqueue_global_styles() {
 	gutenberg_add_global_styles_for_blocks();
 }
 
-/**
- * Enqueues the global styles custom css.
- *
- * @since 6.2.0
- */
-function gutenberg_enqueue_global_styles_custom_css() {
-	$custom_css     = get_global_styles_custom_css();
-	$is_block_theme = wp_is_block_theme();
-	if ( $custom_css && $is_block_theme ) {
-		?>
-		<style id="global-styles-custom-css-inline-css" type="text/css">
-			<?php echo $custom_css; ?>
-		</style>
-		<?php
-	}
-}
-
 remove_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles' );
 remove_action( 'wp_footer', 'wp_enqueue_global_styles', 1 );
 remove_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_global_styles_assets' );
@@ -98,7 +81,6 @@ remove_action( 'wp_footer', 'gutenberg_enqueue_global_styles_assets' );
 // Enqueue global styles, and then block supports styles.
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_global_styles' );
 add_action( 'wp_footer', 'gutenberg_enqueue_global_styles', 1 );
-add_action( 'wp_head', 'gutenberg_enqueue_global_styles_custom_css', 102 );
 
 /**
  * Loads classic theme styles on classic themes in the frontend.

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -73,6 +73,16 @@ function gutenberg_enqueue_global_styles() {
 	gutenberg_add_global_styles_for_blocks();
 }
 
+function gutenberg_enqueue_global_styles_custom_css(){
+	$custom_css     = get_global_styles_custom_css();
+	$is_block_theme = wp_is_block_theme();
+	if ( $custom_css && $is_block_theme ) {
+		wp_register_style( 'global-styles-custom-css', false, array(), true, true );
+		wp_add_inline_style( 'global-styles-custom-css', $custom_css );
+		wp_enqueue_style( 'global-styles-custom-css' );
+	}
+}
+
 remove_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles' );
 remove_action( 'wp_footer', 'wp_enqueue_global_styles', 1 );
 remove_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_global_styles_assets' );
@@ -81,6 +91,7 @@ remove_action( 'wp_footer', 'gutenberg_enqueue_global_styles_assets' );
 // Enqueue global styles, and then block supports styles.
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_global_styles' );
 add_action( 'wp_footer', 'gutenberg_enqueue_global_styles', 1 );
+add_action( 'wp_head', 'gutenberg_enqueue_global_styles_custom_css', 102 );
 
 /**
  * Loads classic theme styles on classic themes in the frontend.

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -73,7 +73,12 @@ function gutenberg_enqueue_global_styles() {
 	gutenberg_add_global_styles_for_blocks();
 }
 
-function gutenberg_enqueue_global_styles_custom_css(){
+/**
+ * Enqueues the global styles custom css.
+ *
+ * @since 6.2.0
+ */
+function gutenberg_enqueue_global_styles_custom_css() {
 	$custom_css     = get_global_styles_custom_css();
 	$is_block_theme = wp_is_block_theme();
 	if ( $custom_css && $is_block_theme ) {

--- a/lib/compat/wordpress-6.2/block-editor-settings.php
+++ b/lib/compat/wordpress-6.2/block-editor-settings.php
@@ -16,7 +16,7 @@ function gutenberg_get_block_editor_settings_6_2( $settings ) {
 	if ( wp_theme_has_theme_json() ) {
 		// Add the custom CSS as separate style sheet so any invalid CSS entered by users does not break other global styles.
 		$settings['styles'][] = array(
-			'css'            => gutenberg_get_global_stylesheet( array( 'custom-css' ) ),
+			'css'            => get_global_styles_custom_css(),
 			'__unstableType' => 'user',
 			'isGlobalStyles' => true,
 		);

--- a/lib/compat/wordpress-6.2/block-editor-settings.php
+++ b/lib/compat/wordpress-6.2/block-editor-settings.php
@@ -16,7 +16,7 @@ function gutenberg_get_block_editor_settings_6_2( $settings ) {
 	if ( wp_theme_has_theme_json() ) {
 		// Add the custom CSS as separate style sheet so any invalid CSS entered by users does not break other global styles.
 		$settings['styles'][] = array(
-			'css'            => get_global_styles_custom_css(),
+			'css'            => gutenberg_get_global_styles_custom_css(),
 			'__unstableType' => 'user',
 			'isGlobalStyles' => true,
 		);

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -64,10 +64,10 @@ if ( ! function_exists( 'wp_theme_has_theme_json_clean_cache' ) ) {
  *
  * @return string
  */
-function get_global_styles_custom_css() {
+function gutenberg_get_global_styles_custom_css() {
 	// Ignore cache when `WP_DEBUG` is enabled, so it doesn't interfere with the theme developers workflow.
-	$can_use_cached = empty( $types ) && ! WP_DEBUG;
-	$cache_key      = 'gutenberg_get_global_custom_css_stylesheet';
+	$can_use_cached = ! WP_DEBUG;
+	$cache_key      = 'gutenberg_get_global_custom_css';
 	$cache_group    = 'theme_json';
 	if ( $can_use_cached ) {
 		$cached = wp_cache_get( $cache_key, $cache_group );
@@ -76,20 +76,18 @@ function get_global_styles_custom_css() {
 		}
 	}
 
-	$tree                = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
-	$supports_theme_json = wp_theme_has_theme_json();
-
-	if ( ! $supports_theme_json ) {
-		return;
+	if ( ! wp_theme_has_theme_json() ) {
+		return '';
 	}
 
+	$tree       = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
 	$stylesheet = $tree->get_custom_css();
 
 	if ( $can_use_cached ) {
 		wp_cache_set( $cache_key, $stylesheet, $cache_group );
 	}
 
-	return  $stylesheet;
+	return $stylesheet;
 }
 
 /**
@@ -227,6 +225,7 @@ function _gutenberg_clean_theme_json_caches() {
 	wp_cache_delete( 'gutenberg_get_global_stylesheet', 'theme_json' );
 	wp_cache_delete( 'gutenberg_get_global_settings_custom', 'theme_json' );
 	wp_cache_delete( 'gutenberg_get_global_settings_theme', 'theme_json' );
+	wp_cache_delete( 'gutenberg_get_global_custom_css', 'theme_json' );
 	WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data();
 }
 

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -59,7 +59,12 @@ if ( ! function_exists( 'wp_theme_has_theme_json_clean_cache' ) ) {
 	}
 }
 
-function get_global_styles_custom_css(){
+/**
+ * Gets the global styles custom css from theme.json.
+ *
+ * @return string
+ */
+function get_global_styles_custom_css() {
 	$tree                = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
 	$supports_theme_json = wp_theme_has_theme_json();
 
@@ -69,6 +74,7 @@ function get_global_styles_custom_css(){
 
 	return  $tree->get_custom_css();
 }
+
 /**
  * Returns the stylesheet resulting of merging core, theme, and user data.
  *

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -59,6 +59,16 @@ if ( ! function_exists( 'wp_theme_has_theme_json_clean_cache' ) ) {
 	}
 }
 
+function get_global_styles_custom_css(){
+	$tree                = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+	$supports_theme_json = wp_theme_has_theme_json();
+
+	if ( ! $supports_theme_json ) {
+		return;
+	}
+
+	return  $tree->get_custom_css();
+}
 /**
  * Returns the stylesheet resulting of merging core, theme, and user data.
  *

--- a/lib/compat/wordpress-6.2/script-loader.php
+++ b/lib/compat/wordpress-6.2/script-loader.php
@@ -174,15 +174,18 @@ add_filter(
  * @since 6.2.0
  */
 function gutenberg_enqueue_global_styles_custom_css() {
-	$custom_css     = get_global_styles_custom_css();
-	$is_block_theme = wp_is_block_theme();
-	if ( $custom_css && $is_block_theme ) {
-		?>
-		<style id="global-styles-custom-css-inline-css" type="text/css">
-			<?php echo $custom_css; ?>
-		</style>
-		<?php
+	if ( ! wp_is_block_theme() ) {
+		return;
+	}
+
+	// Don't enqueue Customizer's custom CSS separately.
+	remove_action( 'wp_head', 'wp_custom_css_cb', 101 );
+
+	$custom_css  = wp_get_custom_css();
+	$custom_css .= gutenberg_get_global_styles_custom_css();
+
+	if ( ! empty( $custom_css ) ) {
+		wp_add_inline_style( 'global-styles', $custom_css );
 	}
 }
-
-add_action( 'wp_head', 'gutenberg_enqueue_global_styles_custom_css', 102 );
+add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_global_styles_custom_css' );

--- a/lib/compat/wordpress-6.2/script-loader.php
+++ b/lib/compat/wordpress-6.2/script-loader.php
@@ -167,3 +167,22 @@ add_filter(
 	},
 	100
 );
+
+/**
+ * Enqueues the global styles custom css.
+ *
+ * @since 6.2.0
+ */
+function gutenberg_enqueue_global_styles_custom_css() {
+	$custom_css     = get_global_styles_custom_css();
+	$is_block_theme = wp_is_block_theme();
+	if ( $custom_css && $is_block_theme ) {
+		?>
+		<style id="global-styles-custom-css-inline-css" type="text/css">
+			<?php echo $custom_css; ?>
+		</style>
+		<?php
+	}
+}
+
+add_action( 'wp_head', 'gutenberg_enqueue_global_styles_custom_css', 102 );

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1615,18 +1615,23 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 	}
 
-	public function test_get_stylesheet_handles_custom_css() {
+	public function test_get_custom_css_handles_global_custom_css() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'styles'  => array(
-					'css' => 'body { color:purple; }',
+					'css'    => 'body {color:purple;}',
+					'blocks' => array(
+						'core/paragraph' => array(
+							'css' => 'color:red;',
+						),
+					),
 				),
 			)
 		);
 
-		$custom_css = 'body { color:purple; }';
-		$this->assertEquals( $custom_css, $theme_json->get_stylesheet( array( 'custom-css' ) ) );
+		$custom_css = 'body {color:purple;}p{color:red;}';
+		$this->assertEquals( $custom_css, $theme_json->get_custom_css() );
 	}
 
 	/**


### PR DESCRIPTION
## What?
Moves global styles custom CSS to its own methods so its position in the output can be modified independently to the other global styles

## Why?
This allows the global styles custom CSS to be loaded after any Customizer custom CSS that may have been added in hybrid themes, otherwise [this CSS has higher specificity](https://github.com/WordPress/gutenberg/issues/30142#issuecomment-1372950974).

## How?
Extract the loading of custom CSS into its own method, separate to the other global styles, and include any customizer CSS first in this output.

## Testing Instructions

- Add some custom CSS in global styles, including some block level custom CSS
- Load in front end and make sure styles appear at the bottom of the `global-styles-inline-css` style element
- In a hybrid theme like BlocksBase also add some custom CSS in Customizer and make sure this CSS loads before the Global Style custom CSS in the `global-styles-inline-css` style element

## Screenshots or screencast 

Before:
<img width="508" alt="Screenshot 2023-02-01 at 10 34 49 AM" src="https://user-images.githubusercontent.com/3629020/215888651-4154325c-6a75-4cd9-83bf-02b28942595f.png">

After:

<img width="648" alt="Screenshot 2023-02-01 at 10 32 45 AM" src="https://user-images.githubusercontent.com/3629020/215888700-4066320c-12c7-4a20-a595-16d401753525.png">


