### PR TITLE
Block Editor: Add inert polyfill to iframe

### DIFF
--- a/lib/compat/wordpress-6.2/script-loader.php
+++ b/lib/compat/wordpress-6.2/script-loader.php
@@ -72,7 +72,9 @@ function gutenberg_enqueue_block_support_styles( $style, $priority = 10 ) {
 function gutenberg_resolve_assets_override() {
 	global $pagenow;
 
-	$script_handles = array();
+	$script_handles = array(
+		'wp-polyfill',
+	);
 	// Note for core merge: only 'wp-edit-blocks' should be in this array.
 	$style_handles = array(
 		'wp-edit-blocks',


### PR DESCRIPTION
Closes: #47190

## What?
This PR adds a polyfill script to the iframe to make the `inert` attribute work correctly in Firefox. This solves the problem, as reported in #47190, that the site editor can operate on the block editor in Firefox even in browse mode.

## Why?
The `inert` attribute is intended to render the element and its sub-tree elements inert, but Firefox doesn't support this attribute. Therefore, a polyfill script has been introduced, but as investigated in [this comment](https://github.com/WordPress/gutenberg/issues/47190#issuecomment-1399212646), this polyfill doesn't seem to apply to the `inert` attribute in iframe. In order for the `inert` attribute to work as intended in Firefox, even within an iframe, we need to inject the script into the iframe as well as the global document.

## How?
Added polyfill to script handles for iframes. If this PR is merged, I would like to submit a ticket and PR for backporting to WordPress 6.2 based on #47187.

## Testing Instructions

- Open the site editor in Firefox.
- Before: You would be able to operate the block even though you are in browse mode.
- After: Clicking anywhere in the browse area won't do anything unless you switch to edit mode,
