### PR TITLE
[Block editor]: Add setting to disable Openverse integration

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -659,6 +659,7 @@ _Properties_
 -   _canLockBlocks_ `boolean`: Whether the user can manage Block Lock state
 -   _codeEditingEnabled_ `boolean`: Whether or not the user can switch to the code editor
 -   _generateAnchors_ `boolean`: Enable/Disable auto anchor generation for Heading blocks
+-   _enableOpenverseMediaCategory_ `boolean`: Enable/Disable the Openverse media category in the inserter.
 -   _\_\_experimentalCanUserUseUnfilteredHTML_ `boolean`: Whether the user should be able to use unfiltered HTML or the HTML should be filtered e.g., to remove elements considered insecure like iframes.
 -   _\_\_experimentalClearBlockSelection_ `boolean`: Whether the block editor should clear selection on mousedown when a block is not clicked.
 -   _\_\_experimentalBlockDirectory_ `boolean`: Whether the user has enabled the Block Directory

--- a/packages/block-editor/src/components/inserter/media-tab/hooks.js
+++ b/packages/block-editor/src/components/inserter/media-tab/hooks.js
@@ -76,16 +76,11 @@ function useInserterMediaCategories() {
 		allowedMimeTypes,
 		enableOpenverseMediaCategory,
 	} = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		const {
-			__unstableInserterMediaCategories,
-			allowedMimeTypes: _allowedMimeTypes,
-			enableOpenverseMediaCategory: _enableOpenverseMediaCategory,
-		} = getSettings();
+		const settings = select( blockEditorStore ).getSettings();
 		return {
-			inserterMediaCategories: __unstableInserterMediaCategories,
-			allowedMimeTypes: _allowedMimeTypes,
-			enableOpenverseMediaCategory: _enableOpenverseMediaCategory,
+			inserterMediaCategories: settings.__unstableInserterMediaCategories,
+			allowedMimeTypes: settings.allowedMimeTypes,
+			enableOpenverseMediaCategory: settings.enableOpenverseMediaCategory,
 		};
 	}, [] );
 	// The allowed `mime_types` can be altered by `upload_mimes` filter and restrict

--- a/packages/block-editor/src/components/inserter/media-tab/hooks.js
+++ b/packages/block-editor/src/components/inserter/media-tab/hooks.js
@@ -71,20 +71,23 @@ export function useMediaResults( category, query = {} ) {
 }
 
 function useInserterMediaCategories() {
-	const { inserterMediaCategories, allowedMimeTypes } = useSelect(
-		( select ) => {
-			const { getSettings } = select( blockEditorStore );
-			const {
-				__unstableInserterMediaCategories,
-				allowedMimeTypes: _allowedMimeTypes,
-			} = getSettings();
-			return {
-				inserterMediaCategories: __unstableInserterMediaCategories,
-				allowedMimeTypes: _allowedMimeTypes,
-			};
-		},
-		[]
-	);
+	const {
+		inserterMediaCategories,
+		allowedMimeTypes,
+		enableOpenverseMediaCategory,
+	} = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		const {
+			__unstableInserterMediaCategories,
+			allowedMimeTypes: _allowedMimeTypes,
+			enableOpenverseMediaCategory: _enableOpenverseMediaCategory,
+		} = getSettings();
+		return {
+			inserterMediaCategories: __unstableInserterMediaCategories,
+			allowedMimeTypes: _allowedMimeTypes,
+			enableOpenverseMediaCategory: _enableOpenverseMediaCategory,
+		};
+	}, [] );
 	// The allowed `mime_types` can be altered by `upload_mimes` filter and restrict
 	// some of them. In this case we shouldn't add the category to the available media
 	// categories list in the inserter.
@@ -93,6 +96,13 @@ function useInserterMediaCategories() {
 			return;
 		}
 		return inserterMediaCategories.filter( ( category ) => {
+			// Check if Openverse category is enabled.
+			if (
+				! enableOpenverseMediaCategory &&
+				category.name === 'openverse'
+			) {
+				return false;
+			}
 			// When a category has set `isExternalResource` to `true`, we
 			// don't need to check for allowed mime types, as they are used
 			// for restricting uploads for this media type and not for
@@ -104,7 +114,11 @@ function useInserterMediaCategories() {
 				mimeType.startsWith( `${ category.mediaType }/` )
 			);
 		} );
-	}, [ inserterMediaCategories, allowedMimeTypes ] );
+	}, [
+		inserterMediaCategories,
+		allowedMimeTypes,
+		enableOpenverseMediaCategory,
+	] );
 	return allowedCategories;
 }
 

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -26,6 +26,7 @@ export const PREFERENCES_DEFAULTS = {
  * @property {boolean}       canLockBlocks                          Whether the user can manage Block Lock state
  * @property {boolean}       codeEditingEnabled                     Whether or not the user can switch to the code editor
  * @property {boolean}       generateAnchors                        Enable/Disable auto anchor generation for Heading blocks
+ * @property {boolean}       enableOpenverseMediaCategory           Enable/Disable the Openverse media category in the inserter.
  * @property {boolean}       __experimentalCanUserUseUnfilteredHTML Whether the user should be able to use unfiltered HTML or the HTML should be filtered e.g., to remove elements considered insecure like iframes.
  * @property {boolean}       __experimentalClearBlockSelection      Whether the block editor should clear selection on mousedown when a block is not clicked.
  * @property {boolean}       __experimentalBlockDirectory           Whether the user has enabled the Block Directory
@@ -155,6 +156,9 @@ export const SETTINGS_DEFAULTS = {
 
 	// Allows to disable block locking interface.
 	canLockBlocks: true,
+
+	// Allows to disable Openverse media category in the inserter.
+	enableOpenverseMediaCategory: true,
 
 	__experimentalCanUserUseUnfilteredHTML: false,
 	__experimentalClearBlockSelection: true,

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -171,6 +171,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 						'keepCaretInsideBlock',
 						'maxWidth',
 						'onUpdateDefaultBlockStyles',
+						'enableOpenverseMediaCategory',
 						'styles',
 						'template',
 						'templateLock',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/47363

Recently the `media` tab in the inserter integrated Openverse. While the media categories in the inserter will be locked for `6.2` [here](https://github.com/WordPress/gutenberg/pull/47319)(so they will not be extendable for `6.2`), the Openverse media category can be controlled with a new public block editor setting(`enableOpenverseMediaCategory`).

The default is to show this category, but it can be turned off by updating this setting's value.

example in JS:
```js
settings = wp.data.select('core/block-editor').getSettings();
wp.data.dispatch('core/block-editor').updateSettings({
	...settings,
	enableOpenverseMediaCategory: false
});
```

in PHP:
```php
add_filter(
	'block_editor_settings_all',
	function( $settings ) {
		$settings['enableOpenverseMediaCategory'] = false;

		return $settings;
	},
	10
);
```

