### PR TITLE
Backport WP_REST_Pattern_Directory_Controller changes from core

### DIFF
--- a/lib/compat/wordpress-6.2/class-gutenberg-rest-pattern-directory-controller-6-2.php
+++ b/lib/compat/wordpress-6.2/class-gutenberg-rest-pattern-directory-controller-6-2.php
@@ -152,16 +152,21 @@ class Gutenberg_REST_Pattern_Directory_Controller_6_2 extends WP_REST_Pattern_Di
 
 		$gutenberg_data = get_plugin_data( dirname( dirname( dirname( __DIR__ ) ) ) . '/gutenberg.php', false );
 
-		$valid_query_args = array( 'offset', 'order', 'orderby', 'page', 'per_page', 'search', 'slug' );
-		$query_args       = array_merge(
-			array_intersect_key( $request->get_params(), array_flip( $valid_query_args ) ),
-			array(
-				'locale'            => get_user_locale(),
-				'wp-version'        => $wp_version, // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- it's defined in `version.php` above.
-				'gutenberg-version' => $gutenberg_data['Version'],
-			)
+		$valid_query_args = array(
+			'offset'   => true,
+			'order'    => true,
+			'orderby'  => true,
+			'page'     => true,
+			'per_page' => true,
+			'search'   => true,
+			'slug'     => true,
 		);
 
+		$query_args = array_intersect_key( $request->get_params(), $valid_query_args );
+
+		$query_args['locale']             = get_user_locale();
+		$query_args['wp-version']         = $wp_version; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- it's defined in `version.php` above.
+		$query_args['gutenberg-version']  = $gutenberg_data['Version'];
 		$query_args['pattern-categories'] = isset( $request['category'] ) ? $request['category'] : false;
 		$query_args['pattern-keywords']   = isset( $request['keyword'] ) ? $request['keyword'] : false;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR just backports some changes in WP_REST_Pattern_Directory_Controller from core here: https://github.com/WordPress/wordpress-develop/pull/3861


## Testing Instructions
The Pattern Directory requests should work as before.
