### PR TITLE
Mobile: cleanup usage of settings.capabilities

### DIFF
--- a/packages/block-editor/src/components/media-upload/index.native.js
+++ b/packages/block-editor/src/components/media-upload/index.native.js
@@ -315,10 +315,10 @@ export class MediaUpload extends Component {
 
 export default compose( [
 	withSelect( ( select ) => {
+		const { capabilities } = select( blockEditorStore ).getSettings();
 		return {
 			isAudioBlockMediaUploadEnabled:
-				select( blockEditorStore ).getSettings( 'capabilities' )
-					.isAudioBlockMediaUploadEnabled === true,
+				capabilities?.isAudioBlockMediaUploadEnabled === true,
 		};
 	} ),
 ] )( MediaUpload );

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -913,8 +913,7 @@ export default compose( [
 			isSelected,
 			clientId,
 		} = props;
-		const { imageSizes, imageDefaultSize, shouldUseFastImage } =
-			getSettings();
+		const { imageSizes, imageDefaultSize, capabilities } = getSettings();
 		const isNotFileUrl = id && getProtocol( url ) !== 'file:';
 		const featuredImageId = getEditedPostAttribute( 'featured_media' );
 
@@ -932,7 +931,7 @@ export default compose( [
 			image,
 			imageSizes,
 			imageDefaultSize,
-			shouldUseFastImage,
+			shouldUseFastImage: capabilities?.shouldUseFastImage === true,
 			featuredImageId,
 			wasBlockJustInserted: wasBlockJustInserted(
 				clientId,

--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -298,13 +298,12 @@ export class UnsupportedBlockEdit extends Component {
 
 export default compose( [
 	withSelect( ( select, { attributes } ) => {
-		const { getSettings } = select( blockEditorStore );
+		const { capabilities } = select( blockEditorStore ).getSettings();
 		return {
 			isUnsupportedBlockEditorSupported:
-				getSettings( 'capabilities' ).unsupportedBlockEditor === true,
+				capabilities?.unsupportedBlockEditor === true,
 			canEnableUnsupportedBlockEditor:
-				getSettings( 'capabilities' )
-					.canEnableUnsupportedBlockEditor === true,
+				capabilities?.canEnableUnsupportedBlockEditor === true,
 			isEditableInUnsupportedBlockEditor:
 				! UBE_INCOMPATIBLE_BLOCKS.includes( attributes.originalName ),
 		};

--- a/packages/block-library/src/missing/test/edit.native.js
+++ b/packages/block-library/src/missing/test/edit.native.js
@@ -68,7 +68,7 @@ describe( 'Missing block', () => {
 			beforeEach( () => {
 				// By default we set the web editor as available.
 				storeConfig.selectors.getSettings.mockReturnValue( {
-					unsupportedBlockEditor: true,
+					capabilities: { unsupportedBlockEditor: true },
 				} );
 			} );
 
@@ -86,7 +86,7 @@ describe( 'Missing block', () => {
 
 			it( 'does not render edit action if UBE is not available', () => {
 				storeConfig.selectors.getSettings.mockReturnValue( {
-					unsupportedBlockEditor: false,
+					capabilities: { unsupportedBlockEditor: false },
 				} );
 
 				const testInstance = getTestComponentWithContent();

--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -101,7 +101,7 @@ class NativeEditorProvider extends Component {
 		} = this.props;
 
 		updateEditorSettings( {
-			...capabilities,
+			capabilities,
 			...this.getThemeColors( this.props ),
 			locale,
 			hostAppNamespace,

--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -325,7 +325,7 @@ class NativeEditorProvider extends Component {
 	}
 
 	updateCapabilitiesAction( capabilities ) {
-		this.props.updateEditorSettings( capabilities );
+		this.props.updateEditorSettings( { capabilities } );
 	}
 
 	render() {

--- a/packages/editor/src/components/provider/use-block-editor-settings.native.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.native.js
@@ -14,10 +14,9 @@ import { store as editorStore } from '../../store';
 const EMPTY_BLOCKS_LIST = [];
 
 function useNativeBlockEditorSettings( settings, hasTemplate ) {
-	const capabilities = settings.capabilities ?? {};
 	const editorSettings = useBlockEditorSettings( settings, hasTemplate );
+	const supportReusableBlock = settings.capabilities?.reusableBlock === true;
 
-	const supportReusableBlock = capabilities.reusableBlock === true;
 	const { reusableBlocks, isTitleSelected } = useSelect(
 		( select ) => {
 			return {

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -1310,10 +1310,9 @@ export default compose( [
 			: settings?.colors;
 
 		return {
-			areMentionsSupported:
-				getSettings( 'capabilities' ).mentions === true,
-			areXPostsSupported: getSettings( 'capabilities' ).xposts === true,
-			...{ parentBlockStyles },
+			areMentionsSupported: settings?.capabilities?.mentions === true,
+			areXPostsSupported: settings?.capabilities?.xposts === true,
+			parentBlockStyles,
 			baseGlobalStyles,
 			colorPalette,
 		};


### PR DESCRIPTION
While working on #47287 I noticed that the `capabilities` object, which is passed as a prop to the mobile editor and then propagated to block editor settings, is used in a confused way.

Instead of setting it as another settings field, it was spread as `...capabilities` into the block settings object, and its fields were used directly. Better to pass it as a `capabilities` object, so that the settings namespace is not polluted with all the `capabilities` fields (defined e.g. [here](https://github.com/WordPress/gutenberg/blob/trunk/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt#L109-L127)).

In many cases the capabilities were accessed as:
```js
getSettings( 'capabilities' ).mentions
```
That is confusing, because `getSettings` doesn't take any parameters and returns the whole settings object, but because the `capabilities` object was spread into settings, the `mentions` field was there and it worked. The fixed way to write this is:
```js
getSettings().capabilities?.mentions
```

The only `capabilities` usage that IMO didn't work was accessing `reusableBlock` in `useBlockEditorSettings`. There it was looking at the correct `settings.capabilities` object, but it was never there.

Big part of the code I'm fixing here was added in #24476.