### PR TITLE
Support private selectors and actions for stores registered via registry.registerStore() and for sub registries.

### DIFF
--- a/docs/contributors/code/coding-guidelines.md
+++ b/docs/contributors/code/coding-guidelines.md
@@ -330,21 +330,21 @@ function MyComponent() {
 }
 ```
 
-Importantly, some packages call both `createReduxStore` **and** `registerStore`:
+Remember to always register the private actions and selectors on the **registered** store.
 
+Sometimes that's easy:
 ```js
-export const store = createReduxStore( STORE_NAME, {
-	...storeConfig,
-	persist: [ 'preferences' ],
-} );
+export const store = createReduxStore( STORE_NAME, storeConfig() );
 
-registerStore( STORE_NAME, {
-	...storeConfig,
-	persist: [ 'preferences' ],
-} );
+register( store );
+
+unlock( registeredStore ).registerPrivateActions({
+	// ...
+});
 ```
 
-In this scenario, register the private actions and selectors on the **registered** store:
+However, some packages call both `createReduxStore` **and** `registerStore`. In this case,
+always choose the store that gets registered:
 
 ```js
 export const store = createReduxStore( STORE_NAME, {

--- a/docs/contributors/code/coding-guidelines.md
+++ b/docs/contributors/code/coding-guidelines.md
@@ -330,6 +330,38 @@ function MyComponent() {
 }
 ```
 
+Importantly, some packages call both `createReduxStore` **and** `registerStore`:
+
+```js
+export const store = createReduxStore( STORE_NAME, {
+	...storeConfig,
+	persist: [ 'preferences' ],
+} );
+
+registerStore( STORE_NAME, {
+	...storeConfig,
+	persist: [ 'preferences' ],
+} );
+```
+
+In this scenario, register the private actions and selectors on the **registered** store:
+
+```js
+export const store = createReduxStore( STORE_NAME, {
+	...storeConfig,
+	persist: [ 'preferences' ],
+} );
+
+const registeredStore = registerStore( STORE_NAME, {
+	...storeConfig,
+	persist: [ 'preferences' ],
+} );
+
+unlock( registeredStore ).registerPrivateActions({
+	// ...
+});
+```
+
 ##### Experimental functions, classes, and variables
 
 ```js

--- a/docs/contributors/code/coding-guidelines.md
+++ b/docs/contributors/code/coding-guidelines.md
@@ -330,38 +330,6 @@ function MyComponent() {
 }
 ```
 
-Remember to always register the private actions and selectors on the **registered** store.
-
-Sometimes that's easy:
-```js
-export const store = createReduxStore( STORE_NAME, storeConfig() );
-
-register( store );
-
-unlock( registeredStore ).registerPrivateActions({
-	// ...
-});
-```
-
-However, some packages call both `createReduxStore` **and** `registerStore`. In this case,
-always choose the store that gets registered:
-
-```js
-export const store = createReduxStore( STORE_NAME, {
-	...storeConfig,
-	persist: [ 'preferences' ],
-} );
-
-const registeredStore = registerStore( STORE_NAME, {
-	...storeConfig,
-	persist: [ 'preferences' ],
-} );
-
-unlock( registeredStore ).registerPrivateActions({
-	// ...
-});
-```
-
 ##### Experimental functions, classes, and variables
 
 ```js

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -151,6 +151,8 @@ export default function createReduxStore( key, options ) {
 				registry,
 				thunkArgs
 			);
+			// Expose the private registration functions on the store
+			// so they can be copied to a sub registry in registry.js.
 			lock( store, privateRegistrationFunctions );
 			const resolversCache = createResolversCache();
 
@@ -271,6 +273,9 @@ export default function createReduxStore( key, options ) {
 		},
 	};
 
+	// Expose the private registration functions on the store
+	// descriptor. That's a natural choice since that's where the
+	// public actions and selectors are stored .
 	lock( storeDescriptor, privateRegistrationFunctions );
 
 	return storeDescriptor;

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -111,6 +111,16 @@ function createResolversCache() {
 export default function createReduxStore( key, options ) {
 	const privateActions = {};
 	const privateSelectors = {};
+	const privateRegistrationFunctions = {
+		privateActions,
+		registerPrivateActions: ( actions ) => {
+			Object.assign( privateActions, actions );
+		},
+		privateSelectors,
+		registerPrivateSelectors: ( selectors ) => {
+			Object.assign( privateSelectors, selectors );
+		},
+	};
 	const storeDescriptor = {
 		name: key,
 		instantiate: ( registry ) => {
@@ -141,6 +151,7 @@ export default function createReduxStore( key, options ) {
 				registry,
 				thunkArgs
 			);
+			lock( store, privateRegistrationFunctions );
 			const resolversCache = createResolversCache();
 
 			let resolvers;
@@ -260,14 +271,7 @@ export default function createReduxStore( key, options ) {
 		},
 	};
 
-	lock( storeDescriptor, {
-		registerPrivateActions: ( actions ) => {
-			Object.assign( privateActions, actions );
-		},
-		registerPrivateSelectors: ( selectors ) => {
-			Object.assign( privateSelectors, selectors );
-		},
-	} );
+	lock( storeDescriptor, privateRegistrationFunctions );
 
 	return storeDescriptor;
 }

--- a/packages/data/src/test/privateAPIs.js
+++ b/packages/data/src/test/privateAPIs.js
@@ -129,33 +129,6 @@ describe( 'Private data APIs', () => {
 			expect( unlockedSelectors.getPublicPrice() ).toEqual( 1000 );
 		} );
 
-		it( 'should support registerStore', () => {
-			const groceryStore = registry.registerStore(
-				storeName,
-				storeDescriptor
-			);
-			unlock( groceryStore ).registerPrivateSelectors( {
-				getSecretDiscount,
-			} );
-
-			const privateSelectors = unlock( registry.select( storeName ) );
-			expect( privateSelectors.getSecretDiscount() ).toEqual( 800 );
-		} );
-
-		it( 'should support mixing createReduxStore and registerStore', () => {
-			createReduxStore( storeName, storeDescriptor );
-			const groceryStore2 = registry.registerStore(
-				storeName,
-				storeDescriptor
-			);
-			unlock( groceryStore2 ).registerPrivateSelectors( {
-				getSecretDiscount,
-			} );
-
-			const privateSelectors = unlock( registry.select( storeName ) );
-			expect( privateSelectors.getSecretDiscount() ).toEqual( 800 );
-		} );
-
 		it( 'should support sub registries', () => {
 			const groceryStore = registry.registerStore(
 				storeName,
@@ -276,25 +249,8 @@ describe( 'Private data APIs', () => {
 			).toEqual( 100 );
 		} );
 
-		it( 'should support registerStore', () => {
-			const groceryStore = registry.registerStore(
-				storeName,
-				storeDescriptor
-			);
-			unlock( groceryStore ).registerPrivateActions( {
-				setSecretDiscount,
-			} );
-			const privateActions = unlock( registry.dispatch( storeName ) );
-			privateActions.setSecretDiscount( 400 );
-			expect(
-				registry.select( storeName ).getState().secretDiscount
-			).toEqual( 400 );
-		} );
 		it( 'should support sub registries', () => {
-			const groceryStore = registry.registerStore(
-				storeName,
-				storeDescriptor
-			);
+			const groceryStore = createStore();
 			unlock( groceryStore ).registerPrivateSelectors( {
 				getSecretDiscount,
 			} );

--- a/packages/data/src/test/privateAPIs.js
+++ b/packages/data/src/test/privateAPIs.js
@@ -142,6 +142,20 @@ describe( 'Private data APIs', () => {
 			expect( privateSelectors.getSecretDiscount() ).toEqual( 800 );
 		} );
 
+		it( 'should support mixing createReduxStore and registerStore', () => {
+			const groceryStore1 = createReduxStore(
+				storeName,
+				storeDescriptor
+			);
+			const groceryStore2 = registry.registerStore( storeName, storeDescriptor );
+			unlock( groceryStore2 ).registerPrivateSelectors( {
+				getSecretDiscount,
+			} );
+
+			const privateSelectors = unlock( registry.select( storeName ) );
+			expect( privateSelectors.getSecretDiscount() ).toEqual( 800 );
+		} );
+
 		it( 'should support sub registries', () => {
 			const groceryStore = registry.registerStore(
 				storeName,

--- a/packages/data/src/test/privateAPIs.js
+++ b/packages/data/src/test/privateAPIs.js
@@ -143,11 +143,11 @@ describe( 'Private data APIs', () => {
 		} );
 
 		it( 'should support mixing createReduxStore and registerStore', () => {
-			const groceryStore1 = createReduxStore(
+			createReduxStore( storeName, storeDescriptor );
+			const groceryStore2 = registry.registerStore(
 				storeName,
 				storeDescriptor
 			);
-			const groceryStore2 = registry.registerStore( storeName, storeDescriptor );
 			unlock( groceryStore2 ).registerPrivateSelectors( {
 				getSecretDiscount,
 			} );

--- a/packages/data/src/test/privateAPIs.js
+++ b/packages/data/src/test/privateAPIs.js
@@ -38,32 +38,34 @@ describe( 'Private data APIs', () => {
 	function setPublicPrice( price ) {
 		return { type: 'SET_PUBLIC_PRICE', price };
 	}
-	function createStore() {
-		const groceryStore = createReduxStore( 'grocer', {
-			selectors: {
-				getPublicPrice,
-				getState: ( state ) => state,
-			},
-			actions: { setPublicPrice },
-			reducer: ( state, action ) => {
-				if ( action?.type === 'SET_PRIVATE_PRICE' ) {
-					return {
-						...state,
-						secretDiscount: action?.price,
-					};
-				} else if ( action?.type === 'SET_PUBLIC_PRICE' ) {
-					return {
-						...state,
-						price: action?.price,
-					};
-				}
+	const storeName = 'grocer';
+	const storeDescriptor = {
+		selectors: {
+			getPublicPrice,
+			getState: ( state ) => state,
+		},
+		actions: { setPublicPrice },
+		reducer: ( state, action ) => {
+			if ( action?.type === 'SET_PRIVATE_PRICE' ) {
 				return {
-					price: 1000,
-					secretDiscount: 800,
-					...( state || {} ),
+					...state,
+					secretDiscount: action?.price,
 				};
-			},
-		} );
+			} else if ( action?.type === 'SET_PUBLIC_PRICE' ) {
+				return {
+					...state,
+					price: action?.price,
+				};
+			}
+			return {
+				price: 1000,
+				secretDiscount: 800,
+				...( state || {} ),
+			};
+		},
+	};
+	function createStore() {
+		const groceryStore = createReduxStore( storeName, storeDescriptor );
 		registry.register( groceryStore );
 		return groceryStore;
 	}
@@ -125,6 +127,41 @@ describe( 'Private data APIs', () => {
 
 			const unlockedSelectors = unlock( registry.select( groceryStore ) );
 			expect( unlockedSelectors.getPublicPrice() ).toEqual( 1000 );
+		} );
+
+		it( 'should support registerStore', () => {
+			const groceryStore = registry.registerStore(
+				storeName,
+				storeDescriptor
+			);
+			unlock( groceryStore ).registerPrivateSelectors( {
+				getSecretDiscount,
+			} );
+
+			const privateSelectors = unlock( registry.select( storeName ) );
+			expect( privateSelectors.getSecretDiscount() ).toEqual( 800 );
+		} );
+
+		it( 'should support sub registries', () => {
+			const groceryStore = registry.registerStore(
+				storeName,
+				storeDescriptor
+			);
+			unlock( groceryStore ).registerPrivateSelectors( {
+				getSecretDiscount,
+			} );
+			const subRegistry = createRegistry( {}, registry );
+			subRegistry.registerStore( storeName, storeDescriptor );
+
+			const parentPrivateSelectors = unlock(
+				registry.select( storeName )
+			);
+			expect( parentPrivateSelectors.getSecretDiscount() ).toEqual( 800 );
+
+			const subPrivateSelectors = unlock(
+				subRegistry.select( storeName )
+			);
+			expect( subPrivateSelectors.getSecretDiscount() ).toEqual( 800 );
 		} );
 	} );
 
@@ -223,6 +260,55 @@ describe( 'Private data APIs', () => {
 			expect(
 				unlock( registry.select( groceryStore ) ).getSecretDiscount()
 			).toEqual( 100 );
+		} );
+
+		it( 'should support registerStore', () => {
+			const groceryStore = registry.registerStore(
+				storeName,
+				storeDescriptor
+			);
+			unlock( groceryStore ).registerPrivateActions( {
+				setSecretDiscount,
+			} );
+			const privateActions = unlock( registry.dispatch( storeName ) );
+			privateActions.setSecretDiscount( 400 );
+			expect(
+				registry.select( storeName ).getState().secretDiscount
+			).toEqual( 400 );
+		} );
+		it( 'should support sub registries', () => {
+			const groceryStore = registry.registerStore(
+				storeName,
+				storeDescriptor
+			);
+			unlock( groceryStore ).registerPrivateSelectors( {
+				getSecretDiscount,
+			} );
+			unlock( groceryStore ).registerPrivateActions( {
+				setSecretDiscount,
+			} );
+			const subRegistry = createRegistry( {}, registry );
+			subRegistry.registerStore( storeName, storeDescriptor );
+
+			const parentPrivateActions = unlock(
+				registry.dispatch( storeName )
+			);
+			const parentPrivateSelectors = unlock(
+				registry.select( storeName )
+			);
+
+			const subPrivateActions = unlock(
+				subRegistry.dispatch( storeName )
+			);
+			const subPrivateSelectors = unlock(
+				subRegistry.select( storeName )
+			);
+
+			parentPrivateActions.setSecretDiscount( 400 );
+			subPrivateActions.setSecretDiscount( 478 );
+
+			expect( parentPrivateSelectors.getSecretDiscount() ).toEqual( 400 );
+			expect( subPrivateSelectors.getSecretDiscount() ).toEqual( 478 );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Description

`registerPrivateActions` and `registerPrivateSelectors` only supported stores created using `createReduxStore`. On stores registered using the deprecated `registerStore` helper the private actions are not returned upon `unlock()`-ing the `useDispatch()` call (as reported by @talldan in https://github.com/WordPress/gutenberg/pull/47375#discussion_r1084898758).

This PR adds the missing support for the `registerStore()` stores as well as for the children stores in sub registries.

## Test plan

Confirm the CI checks pass, the code updates make sense, and the documentation update is easy to understand.

cc @talldan @noisysocks @ntsekouras @mcsf @Mamaduka 


