### PR TITLE
E2E: Improve multiple block moving test stability

### DIFF
--- a/packages/e2e-tests/specs/editor/various/block-editor-keyboard-shortcuts.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-editor-keyboard-shortcuts.test.js
@@ -50,9 +50,10 @@ describe( 'block editor keyboard shortcuts', () => {
 			it( 'should move the blocks up', async () => {
 				await createTestParagraphBlocks();
 				expect( await getEditedPostContent() ).toMatchSnapshot();
-				await page.keyboard.down( 'Shift' );
-				await page.keyboard.press( 'ArrowUp' );
-				await page.keyboard.up( 'Shift' );
+				await pressKeyWithModifier( 'shift', 'ArrowUp' );
+				await page.waitForSelector(
+					'[aria-label="Multiple selected blocks"]'
+				);
 				await moveUp();
 				expect( await getEditedPostContent() ).toMatchSnapshot();
 			} );
@@ -61,9 +62,10 @@ describe( 'block editor keyboard shortcuts', () => {
 				await createTestParagraphBlocks();
 				expect( await getEditedPostContent() ).toMatchSnapshot();
 				await page.keyboard.press( 'ArrowUp' );
-				await page.keyboard.down( 'Shift' );
-				await page.keyboard.press( 'ArrowUp' );
-				await page.keyboard.up( 'Shift' );
+				await pressKeyWithModifier( 'shift', 'ArrowUp' );
+				await page.waitForSelector(
+					'[aria-label="Multiple selected blocks"]'
+				);
 				await moveDown();
 				expect( await getEditedPostContent() ).toMatchSnapshot();
 			} );


### PR DESCRIPTION
## What?
The flakiness of these tests has increased after enabling the concurrent mode in https://github.com/WordPress/gutenberg/pull/46467. Let's improve the stability by waiting for the UI to catch up.

Context: https://github.com/WordPress/gutenberg/pull/47173#issuecomment-1386913921

## How?
The UI sometimes doesn't catch up with the keyboard strokes that select multiple blocks. This causes the multiple block moving tests to sometimes move just one block. To address that, we need to wait until the blocks are in the "Multiple selected blocks" state before moving them.

## Testing Instructions
This can be tested locally via the following:
```
npm run test:e2e -- block-editor-keyboard-shortcuts.test.js
```