### PR TITLE
Storybook: Update `storybook-source-link` dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29620,7 +29620,7 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
 			"dev": true
 		},
 		"code-point-at": {
@@ -55509,9 +55509,9 @@
 			"dev": true
 		},
 		"storybook-source-link": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/storybook-source-link/-/storybook-source-link-2.0.3.tgz",
-			"integrity": "sha512-Vw/ECmTObbcGbS6mX2bolQUF6c/Z4iBtcJBQh6T/3uFDz8pmzGo840hfSJDKXwwatHWDZ1V70jDLCDb4fbXQYg==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/storybook-source-link/-/storybook-source-link-2.0.4.tgz",
+			"integrity": "sha512-R6kqzsVwK5sADoIPaN4x6UUYB7MuQMYj4uaRtU/yv9RU6WHWzkb64Zae3sRoO6Ld+cro/ZYkzkLMXXm7o3bhoA==",
 			"dev": true
 		},
 		"stream-browserify": {

--- a/package.json
+++ b/package.json
@@ -233,7 +233,7 @@
 		"snapshot-diff": "0.8.1",
 		"source-map-loader": "3.0.0",
 		"sprintf-js": "1.1.1",
-		"storybook-source-link": "2.0.3",
+		"storybook-source-link": "2.0.4",
 		"style-loader": "3.2.1",
 		"terser-webpack-plugin": "5.1.4",
 		"typescript": "4.4.2",


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/46443#issuecomment-1403745583

## What?

Updates the `storybook-source-link` dependency to [2.0.4](https://github.com/Sirrine-Jonathan/storybook-source-link/releases/tag/v2.0.4).

## Why?

To allow React 18 as a peer dependency.

### Testing Instructions

1. `npm run storybook:dev`
2. Go to one of the component stories, and see that the "View Source Repository" button in the top right still takes you to the source code on GitHub.

<img src="https://user-images.githubusercontent.com/555336/214606695-25608a8b-4a32-4cd1-a39b-6e74ec17880a.png" alt="View Source Repository button in the Storybook toolbar" width="500">

