### PR TITLE
Fix constrained tabbing failures with  Safari and Firefox

### DIFF
--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -214,7 +214,11 @@ function UnforwardedModal(
 						role="document"
 						onScroll={ onContentContainerScroll }
 						ref={ contentRef }
-						aria-label={ __( 'Scrollable section' ) }
+						aria-label={
+							hasScrollableContent
+								? __( 'Scrollable section' )
+								: undefined
+						}
 						tabIndex={ hasScrollableContent ? 0 : undefined }
 					>
 						{ ! __experimentalHideHeader && (

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -67,7 +67,6 @@ function UnforwardedModal(
 		onKeyDown,
 		isFullScreen = false,
 		__experimentalHideHeader = false,
-		scrollableContentLabel,
 	} = props;
 
 	const ref = useRef< HTMLDivElement >();
@@ -215,12 +214,7 @@ function UnforwardedModal(
 						role="document"
 						onScroll={ onContentContainerScroll }
 						ref={ contentRef }
-						aria-label={
-							hasScrollableContent
-								? scrollableContentLabel ||
-								  __( 'Scrollable section' )
-								: undefined
-						}
+						aria-label={ __( 'Scrollable section' ) }
 						tabIndex={ hasScrollableContent ? 0 : undefined }
 					>
 						{ ! __experimentalHideHeader && (

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -14,6 +14,7 @@ import {
 	useRef,
 	useState,
 	forwardRef,
+	useLayoutEffect,
 } from '@wordpress/element';
 import {
 	useInstanceId,
@@ -25,6 +26,7 @@ import {
 } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
+import { getScrollContainer } from '@wordpress/dom';
 
 /**
  * Internal dependencies
@@ -65,6 +67,7 @@ function UnforwardedModal(
 		onKeyDown,
 		isFullScreen = false,
 		__experimentalHideHeader = false,
+		scrollableContentLabel,
 	} = props;
 
 	const ref = useRef< HTMLDivElement >();
@@ -76,8 +79,26 @@ function UnforwardedModal(
 	const constrainedTabbingRef = useConstrainedTabbing();
 	const focusReturnRef = useFocusReturn();
 	const focusOutsideProps = useFocusOutside( onRequestClose );
+	const contentRef = useRef< HTMLDivElement >( null );
+	const childrenContainerRef = useRef< HTMLDivElement >( null );
 
 	const [ hasScrolledContent, setHasScrolledContent ] = useState( false );
+	const [ hasScrollableContent, setHasScrollableContent ] = useState( false );
+
+	// Determines whether the Modal content is scrollable and updates the state.
+	const isContentScrollable = useCallback( () => {
+		if ( ! contentRef.current ) {
+			return;
+		}
+
+		const closestScrollContainer = getScrollContainer( contentRef.current );
+
+		if ( contentRef.current === closestScrollContainer ) {
+			setHasScrollableContent( true );
+		} else {
+			setHasScrollableContent( false );
+		}
+	}, [ contentRef ] );
 
 	useEffect( () => {
 		openModalCount++;
@@ -96,6 +117,22 @@ function UnforwardedModal(
 			}
 		};
 	}, [ bodyOpenClassName ] );
+
+	// Calls the isContentScrollable callback when the Modal children container resizes.
+	useLayoutEffect( () => {
+		if ( ! window.ResizeObserver || ! childrenContainerRef.current ) {
+			return;
+		}
+
+		const resizeObserver = new ResizeObserver( isContentScrollable );
+		resizeObserver.observe( childrenContainerRef.current );
+
+		isContentScrollable();
+
+		return () => {
+			resizeObserver.disconnect();
+		};
+	}, [ isContentScrollable, childrenContainerRef ] );
 
 	function handleEscapeKeyDown( event: KeyboardEvent< HTMLDivElement > ) {
 		if (
@@ -172,10 +209,19 @@ function UnforwardedModal(
 					<div
 						className={ classnames( 'components-modal__content', {
 							'hide-header': __experimentalHideHeader,
+							'is-scrollable': hasScrollableContent,
 							'has-scrolled-content': hasScrolledContent,
 						} ) }
 						role="document"
 						onScroll={ onContentContainerScroll }
+						ref={ contentRef }
+						aria-label={
+							hasScrollableContent
+								? scrollableContentLabel ||
+								  __( 'Scrollable section' )
+								: undefined
+						}
+						tabIndex={ hasScrollableContent ? 0 : undefined }
 					>
 						{ ! __experimentalHideHeader && (
 							<div className="components-modal__header">
@@ -208,7 +254,7 @@ function UnforwardedModal(
 								) }
 							</div>
 						) }
-						{ children }
+						<div ref={ childrenContainerRef }>{ children }</div>
 					</div>
 				</div>
 			</StyleProvider>

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -129,4 +129,12 @@
 		margin-top: 0;
 		padding-top: $grid-unit-30;
 	}
+
+	&.is-scrollable:focus-visible {
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+
+		// Windows High Contrast mode will show this outline, but not the box-shadow.
+		outline: 2px solid transparent;
+		outline-offset: -2px;
+	}
 }

--- a/packages/components/src/modal/types.ts
+++ b/packages/components/src/modal/types.ts
@@ -51,7 +51,7 @@ export type ModalProps = {
 	/**
 	 * Label on the close button.
 	 *
-	 * @default `__( 'Close dialog' )`
+	 * @default `__( 'Close' )`
 	 */
 	closeButtonLabel?: string;
 	/**

--- a/packages/components/src/modal/types.ts
+++ b/packages/components/src/modal/types.ts
@@ -63,13 +63,6 @@ export type ModalProps = {
 	 */
 	contentLabel?: string;
 	/**
-	 * If this property is added, it will be added to the modal scrollable section `div` as
-	 * `div` as `aria-label`.
-	 *
-	 * @default `__( 'Scrollable section' )`
-	 */
-	scrollableContentLabel?: string;
-	/**
 	 * If this property is true, it will focus the first tabbable element
 	 * rendered in the modal.
 	 *

--- a/packages/components/src/modal/types.ts
+++ b/packages/components/src/modal/types.ts
@@ -50,6 +50,8 @@ export type ModalProps = {
 	className?: string;
 	/**
 	 * Label on the close button.
+	 *
+	 * @default `__( 'Close dialog' )`
 	 */
 	closeButtonLabel?: string;
 	/**
@@ -60,6 +62,13 @@ export type ModalProps = {
 	 * `title` for other ways to provide a title.
 	 */
 	contentLabel?: string;
+	/**
+	 * If this property is added, it will be added to the modal scrollable section `div` as
+	 * `div` as `aria-label`.
+	 *
+	 * @default `__( 'Scrollable section' )`
+	 */
+	scrollableContentLabel?: string;
 	/**
 	 * If this property is true, it will focus the first tabbable element
 	 * rendered in the modal.

--- a/packages/compose/src/hooks/use-constrained-tabbing/index.js
+++ b/packages/compose/src/hooks/use-constrained-tabbing/index.js
@@ -45,14 +45,31 @@ function useConstrainedTabbing() {
 					/** @type {HTMLElement} */ ( target )
 				) || null;
 
-			// If the element that is about to receive focus is outside the
-			// area, move focus to a div and insert it at the start or end of
-			// the area, depending on the direction. Without preventing default
-			// behaviour, the browser will then move focus to the next element.
+			// When the target element contains the element that is about to
+			// receive focus, for example when the target is a tabbable
+			// container, browsers may disagree on where to move focus next.
+			// In this case we can't rely on native browsers behavior. We need
+			// to manage focus instead.
+			// See https://github.com/WordPress/gutenberg/issues/46041.
+			if (
+				/** @type {HTMLElement} */ ( target ).contains( nextElement )
+			) {
+				event.preventDefault();
+				/** @type {HTMLElement} */ ( nextElement )?.focus();
+				return;
+			}
+
+			// If the element that is about to receive focus is inside the
+			// area, rely on native browsers behavior and let tabbing follow
+			// the native tab sequence.
 			if ( node.contains( nextElement ) ) {
 				return;
 			}
 
+			// If the element that is about to receive focus is outside the
+			// area, move focus to a div and insert it at the start or end of
+			// the area, depending on the direction. Without preventing default
+			// behaviour, the browser will then move focus to the next element.
 			const domAction = shiftKey ? 'append' : 'prepend';
 			const { ownerDocument } = node;
 			const trap = ownerDocument.createElement( 'div' );

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -135,7 +135,8 @@ _Returns_
 
 ### getScrollContainer
 
-Given a DOM node, finds the closest scrollable container node.
+Given a DOM node, finds the closest scrollable container node or the node
+itself, if scrollable.
 
 _Parameters_
 

--- a/packages/dom/src/dom/get-scroll-container.js
+++ b/packages/dom/src/dom/get-scroll-container.js
@@ -4,7 +4,8 @@
 import getComputedStyle from './get-computed-style';
 
 /**
- * Given a DOM node, finds the closest scrollable container node.
+ * Given a DOM node, finds the closest scrollable container node or the node
+ * itself, if scrollable.
  *
  * @param {Element | null} node Node from which to start.
  *

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
@@ -43,856 +43,858 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
         </svg>
       </button>
     </div>
-    <section
-      class="edit-post-keyboard-shortcut-help-modal__section edit-post-keyboard-shortcut-help-modal__main-shortcuts"
-    >
-      <ul
-        class="edit-post-keyboard-shortcut-help-modal__shortcut-list"
-        role="list"
+    <div>
+      <section
+        class="edit-post-keyboard-shortcut-help-modal__section edit-post-keyboard-shortcut-help-modal__main-shortcuts"
       >
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        />
-      </ul>
-    </section>
-    <section
-      class="edit-post-keyboard-shortcut-help-modal__section"
-    >
-      <h2
-        class="edit-post-keyboard-shortcut-help-modal__section-title"
+        <ul
+          class="edit-post-keyboard-shortcut-help-modal__shortcut-list"
+          role="list"
+        >
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          />
+        </ul>
+      </section>
+      <section
+        class="edit-post-keyboard-shortcut-help-modal__section"
       >
-        Global shortcuts
-      </h2>
-      <ul
-        class="edit-post-keyboard-shortcut-help-modal__shortcut-list"
-        role="list"
+        <h2
+          class="edit-post-keyboard-shortcut-help-modal__section-title"
+        >
+          Global shortcuts
+        </h2>
+        <ul
+          class="edit-post-keyboard-shortcut-help-modal__shortcut-list"
+          role="list"
+        >
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Navigate to the nearest toolbar.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="Alt + F10"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Alt
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  F10
+                </kbd>
+              </kbd>
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Save your changes.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="Control + S"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  S
+                </kbd>
+              </kbd>
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Undo your last changes.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="Control + Z"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Z
+                </kbd>
+              </kbd>
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Redo your last undo.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="Control + Shift + Z"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Shift
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Z
+                </kbd>
+              </kbd>
+              <kbd
+                aria-label="Control + Y"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Y
+                </kbd>
+              </kbd>
+            </div>
+          </li>
+        </ul>
+      </section>
+      <section
+        class="edit-post-keyboard-shortcut-help-modal__section"
       >
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
+        <h2
+          class="edit-post-keyboard-shortcut-help-modal__section-title"
         >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Navigate to the nearest toolbar.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Alt + F10"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Alt
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                F10
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          Selection shortcuts
+        </h2>
+        <ul
+          class="edit-post-keyboard-shortcut-help-modal__shortcut-list"
+          role="list"
         >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
           >
-            Save your changes.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + S"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Select all text when typing. Press again to select all blocks.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
             >
               <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                aria-label="Control + A"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
               >
-                Ctrl
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  A
+                </kbd>
               </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                S
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
           >
-            Undo your last changes.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + Z"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Clear selection.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
             >
               <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                aria-label="escape"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
               >
-                Ctrl
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  escape
+                </kbd>
               </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Z
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Redo your last undo.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + Shift + Z"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Ctrl
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Shift
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Z
-              </kbd>
-            </kbd>
-            <kbd
-              aria-label="Control + Y"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Ctrl
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Y
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-      </ul>
-    </section>
-    <section
-      class="edit-post-keyboard-shortcut-help-modal__section"
-    >
-      <h2
-        class="edit-post-keyboard-shortcut-help-modal__section-title"
+            </div>
+          </li>
+        </ul>
+      </section>
+      <section
+        class="edit-post-keyboard-shortcut-help-modal__section"
       >
-        Selection shortcuts
-      </h2>
-      <ul
-        class="edit-post-keyboard-shortcut-help-modal__shortcut-list"
-        role="list"
+        <h2
+          class="edit-post-keyboard-shortcut-help-modal__section-title"
+        >
+          Block shortcuts
+        </h2>
+        <ul
+          class="edit-post-keyboard-shortcut-help-modal__shortcut-list"
+          role="list"
+        >
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Duplicate the selected block(s).
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="Control + Shift + D"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Shift
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  D
+                </kbd>
+              </kbd>
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Remove the selected block(s).
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="Shift + Alt + Z"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Shift
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Alt
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Z
+                </kbd>
+              </kbd>
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Insert a new block before the selected block(s).
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="Control + Alt + T"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Alt
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  T
+                </kbd>
+              </kbd>
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Insert a new block after the selected block(s).
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="Control + Alt + Y"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Alt
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Y
+                </kbd>
+              </kbd>
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Delete selection.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="del"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  del
+                </kbd>
+              </kbd>
+              <kbd
+                aria-label="backspace"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  backspace
+                </kbd>
+              </kbd>
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Move the selected block(s) up.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="Control + Shift + Alt + T"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Shift
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Alt
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  T
+                </kbd>
+              </kbd>
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Move the selected block(s) down.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="Control + Shift + Alt + Y"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Shift
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Alt
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Y
+                </kbd>
+              </kbd>
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Change the block type after adding a new paragraph.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="Forward-slash"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  /
+                </kbd>
+              </kbd>
+            </div>
+          </li>
+        </ul>
+      </section>
+      <section
+        class="edit-post-keyboard-shortcut-help-modal__section"
       >
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
+        <h2
+          class="edit-post-keyboard-shortcut-help-modal__section-title"
         >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Select all text when typing. Press again to select all blocks.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + A"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Ctrl
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                A
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          Text formatting
+        </h2>
+        <ul
+          class="edit-post-keyboard-shortcut-help-modal__shortcut-list"
+          role="list"
         >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
           >
-            Clear selection.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="escape"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Make the selected text bold.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
             >
               <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                aria-label="Control + B"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
               >
-                escape
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  B
+                </kbd>
               </kbd>
-            </kbd>
-          </div>
-        </li>
-      </ul>
-    </section>
-    <section
-      class="edit-post-keyboard-shortcut-help-modal__section"
-    >
-      <h2
-        class="edit-post-keyboard-shortcut-help-modal__section-title"
-      >
-        Block shortcuts
-      </h2>
-      <ul
-        class="edit-post-keyboard-shortcut-help-modal__shortcut-list"
-        role="list"
-      >
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
           >
-            Duplicate the selected block(s).
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + Shift + D"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Make the selected text italic.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
             >
               <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                aria-label="Control + I"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
               >
-                Ctrl
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  I
+                </kbd>
               </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Shift
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                D
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
           >
-            Remove the selected block(s).
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Shift + Alt + Z"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Convert the selected text into a link.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
             >
               <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                aria-label="Control + K"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
               >
-                Shift
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  K
+                </kbd>
               </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Alt
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Z
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
           >
-            Insert a new block before the selected block(s).
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + Alt + T"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Remove a link.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
             >
               <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                aria-label="Control + Shift + K"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
               >
-                Ctrl
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Shift
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  K
+                </kbd>
               </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Alt
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                T
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
           >
-            Insert a new block after the selected block(s).
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + Alt + Y"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Insert a link to a post or page.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
             >
               <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                aria-label="[["
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
               >
-                Ctrl
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  [[
+                </kbd>
               </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Alt
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Y
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
           >
-            Delete selection.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="del"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Underline the selected text.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
             >
               <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                aria-label="Control + U"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
               >
-                del
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Ctrl
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  U
+                </kbd>
               </kbd>
-            </kbd>
-            <kbd
-              aria-label="backspace"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Strikethrough the selected text.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
             >
               <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                aria-label="Shift + Alt + D"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
               >
-                backspace
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Shift
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Alt
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  D
+                </kbd>
               </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
           >
-            Move the selected block(s) up.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + Shift + Alt + T"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Make the selected text inline code.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
             >
               <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                aria-label="Shift + Alt + X"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
               >
-                Ctrl
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Shift
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Alt
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  X
+                </kbd>
               </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Shift
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Alt
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                T
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
           >
-            Move the selected block(s) down.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + Shift + Alt + Y"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Convert the current heading to a paragraph.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
             >
               <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                aria-label="Shift + Alt + 0"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
               >
-                Ctrl
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Shift
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Alt
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  0
+                </kbd>
               </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Shift
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Alt
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Y
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            </div>
+          </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
           >
-            Change the block type after adding a new paragraph.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Forward-slash"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Convert the current paragraph or heading to a heading of level 1 to 6.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
             >
               <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                aria-label="Shift + Alt + 1 6"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
               >
-                /
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Shift
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Alt
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  1-6
+                </kbd>
               </kbd>
-            </kbd>
-          </div>
-        </li>
-      </ul>
-    </section>
-    <section
-      class="edit-post-keyboard-shortcut-help-modal__section"
-    >
-      <h2
-        class="edit-post-keyboard-shortcut-help-modal__section-title"
-      >
-        Text formatting
-      </h2>
-      <ul
-        class="edit-post-keyboard-shortcut-help-modal__shortcut-list"
-        role="list"
-      >
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Make the selected text bold.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + B"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Ctrl
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                B
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Make the selected text italic.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + I"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Ctrl
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                I
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Convert the selected text into a link.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + K"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Ctrl
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                K
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Remove a link.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + Shift + K"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Ctrl
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Shift
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                K
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Insert a link to a post or page.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="[["
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                [[
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Underline the selected text.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Control + U"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Ctrl
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                U
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Strikethrough the selected text.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Shift + Alt + D"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Shift
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Alt
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                D
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Make the selected text inline code.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Shift + Alt + X"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Shift
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Alt
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                X
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Convert the current heading to a paragraph.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Shift + Alt + 0"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Shift
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Alt
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                0
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-        <li
-          class="edit-post-keyboard-shortcut-help-modal__shortcut"
-        >
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
-          >
-            Convert the current paragraph or heading to a heading of level 1 to 6.
-          </div>
-          <div
-            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
-          >
-            <kbd
-              aria-label="Shift + Alt + 1 6"
-              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
-            >
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Shift
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                Alt
-              </kbd>
-              +
-              <kbd
-                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-              >
-                1-6
-              </kbd>
-            </kbd>
-          </div>
-        </li>
-      </ul>
-    </section>
+            </div>
+          </li>
+        </ul>
+      </section>
+    </div>
   </div>
 </div>
 `;

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -102,425 +102,427 @@ exports[`EditPostPreferencesModal should match snapshot when the modal is active
         </svg>
       </button>
     </div>
-    <div
-      class="interface-preferences__tabs"
-    >
+    <div>
       <div
-        aria-orientation="vertical"
-        class="components-tab-panel__tabs"
-        role="tablist"
+        class="interface-preferences__tabs"
       >
-        <button
-          aria-controls="tab-panel-0-general-view"
-          aria-selected="true"
-          class="components-button components-tab-panel__tabs-item is-active"
-          id="tab-panel-0-general"
-          role="tab"
-          type="button"
+        <div
+          aria-orientation="vertical"
+          class="components-tab-panel__tabs"
+          role="tablist"
         >
-          General
-        </button>
-        <button
-          aria-controls="tab-panel-0-blocks-view"
-          aria-selected="false"
-          class="components-button components-tab-panel__tabs-item"
-          id="tab-panel-0-blocks"
-          role="tab"
-          tabindex="-1"
-          type="button"
+          <button
+            aria-controls="tab-panel-0-general-view"
+            aria-selected="true"
+            class="components-button components-tab-panel__tabs-item is-active"
+            id="tab-panel-0-general"
+            role="tab"
+            type="button"
+          >
+            General
+          </button>
+          <button
+            aria-controls="tab-panel-0-blocks-view"
+            aria-selected="false"
+            class="components-button components-tab-panel__tabs-item"
+            id="tab-panel-0-blocks"
+            role="tab"
+            tabindex="-1"
+            type="button"
+          >
+            Blocks
+          </button>
+          <button
+            aria-controls="tab-panel-0-panels-view"
+            aria-selected="false"
+            class="components-button components-tab-panel__tabs-item"
+            id="tab-panel-0-panels"
+            role="tab"
+            tabindex="-1"
+            type="button"
+          >
+            Panels
+          </button>
+        </div>
+        <div
+          aria-labelledby="tab-panel-0-general"
+          class="components-tab-panel__tab-content"
+          id="tab-panel-0-general-view"
+          role="tabpanel"
         >
-          Blocks
-        </button>
-        <button
-          aria-controls="tab-panel-0-panels-view"
-          aria-selected="false"
-          class="components-button components-tab-panel__tabs-item"
-          id="tab-panel-0-panels"
-          role="tab"
-          tabindex="-1"
-          type="button"
-        >
-          Panels
-        </button>
-      </div>
-      <div
-        aria-labelledby="tab-panel-0-general"
-        class="components-tab-panel__tab-content"
-        id="tab-panel-0-general-view"
-        role="tabpanel"
-      >
-        <fieldset
-          class="interface-preferences-modal__section"
-        >
-          <legend
-            class="interface-preferences-modal__section-legend"
+          <fieldset
+            class="interface-preferences-modal__section"
           >
-            <h2
-              class="interface-preferences-modal__section-title"
+            <legend
+              class="interface-preferences-modal__section-legend"
             >
-              Publishing
-            </h2>
-            <p
-              class="interface-preferences-modal__section-description"
-            >
-              Change options related to publishing.
-            </p>
-          </legend>
-          <div
-            class="interface-preferences-modal__option"
-          >
+              <h2
+                class="interface-preferences-modal__section-title"
+              >
+                Publishing
+              </h2>
+              <p
+                class="interface-preferences-modal__section-description"
+              >
+                Change options related to publishing.
+              </p>
+            </legend>
             <div
-              class="components-base-control components-toggle-control emotion-0 emotion-1"
+              class="interface-preferences-modal__option"
             >
               <div
-                class="components-base-control__field emotion-2 emotion-3"
+                class="components-base-control components-toggle-control emotion-0 emotion-1"
               >
                 <div
-                  class="components-flex components-h-stack emotion-4 emotion-5"
-                  data-wp-c16t="true"
-                  data-wp-component="HStack"
+                  class="components-base-control__field emotion-2 emotion-3"
                 >
-                  <span
-                    class="components-form-toggle"
-                  >
-                    <input
-                      aria-describedby="inspector-toggle-control-0__help"
-                      class="components-form-toggle__input"
-                      id="inspector-toggle-control-0"
-                      type="checkbox"
-                    />
-                    <span
-                      class="components-form-toggle__track"
-                    />
-                    <span
-                      class="components-form-toggle__thumb"
-                    />
-                  </span>
-                  <label
-                    class="components-flex-item components-flex-block components-toggle-control__label emotion-6 emotion-5"
+                  <div
+                    class="components-flex components-h-stack emotion-4 emotion-5"
                     data-wp-c16t="true"
-                    data-wp-component="FlexBlock"
-                    for="inspector-toggle-control-0"
+                    data-wp-component="HStack"
                   >
-                    Include pre-publish checklist
-                  </label>
+                    <span
+                      class="components-form-toggle"
+                    >
+                      <input
+                        aria-describedby="inspector-toggle-control-0__help"
+                        class="components-form-toggle__input"
+                        id="inspector-toggle-control-0"
+                        type="checkbox"
+                      />
+                      <span
+                        class="components-form-toggle__track"
+                      />
+                      <span
+                        class="components-form-toggle__thumb"
+                      />
+                    </span>
+                    <label
+                      class="components-flex-item components-flex-block components-toggle-control__label emotion-6 emotion-5"
+                      data-wp-c16t="true"
+                      data-wp-component="FlexBlock"
+                      for="inspector-toggle-control-0"
+                    >
+                      Include pre-publish checklist
+                    </label>
+                  </div>
                 </div>
+                <p
+                  class="components-base-control__help emotion-8 emotion-9"
+                  id="inspector-toggle-control-0__help"
+                >
+                  Review settings, such as visibility and tags.
+                </p>
               </div>
-              <p
-                class="components-base-control__help emotion-8 emotion-9"
-                id="inspector-toggle-control-0__help"
-              >
-                Review settings, such as visibility and tags.
-              </p>
             </div>
-          </div>
-        </fieldset>
-        <fieldset
-          class="interface-preferences-modal__section"
-        >
-          <legend
-            class="interface-preferences-modal__section-legend"
+          </fieldset>
+          <fieldset
+            class="interface-preferences-modal__section"
           >
-            <h2
-              class="interface-preferences-modal__section-title"
+            <legend
+              class="interface-preferences-modal__section-legend"
             >
-              Appearance
-            </h2>
-            <p
-              class="interface-preferences-modal__section-description"
-            >
-              Customize options related to the block editor interface and editing flow.
-            </p>
-          </legend>
-          <div
-            class="interface-preferences-modal__option"
-          >
+              <h2
+                class="interface-preferences-modal__section-title"
+              >
+                Appearance
+              </h2>
+              <p
+                class="interface-preferences-modal__section-description"
+              >
+                Customize options related to the block editor interface and editing flow.
+              </p>
+            </legend>
             <div
-              class="components-base-control components-toggle-control emotion-0 emotion-1"
+              class="interface-preferences-modal__option"
             >
               <div
-                class="components-base-control__field emotion-2 emotion-3"
+                class="components-base-control components-toggle-control emotion-0 emotion-1"
               >
                 <div
-                  class="components-flex components-h-stack emotion-4 emotion-5"
-                  data-wp-c16t="true"
-                  data-wp-component="HStack"
+                  class="components-base-control__field emotion-2 emotion-3"
                 >
-                  <span
-                    class="components-form-toggle"
-                  >
-                    <input
-                      aria-describedby="inspector-toggle-control-1__help"
-                      class="components-form-toggle__input"
-                      id="inspector-toggle-control-1"
-                      type="checkbox"
-                    />
-                    <span
-                      class="components-form-toggle__track"
-                    />
-                    <span
-                      class="components-form-toggle__thumb"
-                    />
-                  </span>
-                  <label
-                    class="components-flex-item components-flex-block components-toggle-control__label emotion-6 emotion-5"
+                  <div
+                    class="components-flex components-h-stack emotion-4 emotion-5"
                     data-wp-c16t="true"
-                    data-wp-component="FlexBlock"
-                    for="inspector-toggle-control-1"
+                    data-wp-component="HStack"
                   >
-                    Distraction free
-                  </label>
+                    <span
+                      class="components-form-toggle"
+                    >
+                      <input
+                        aria-describedby="inspector-toggle-control-1__help"
+                        class="components-form-toggle__input"
+                        id="inspector-toggle-control-1"
+                        type="checkbox"
+                      />
+                      <span
+                        class="components-form-toggle__track"
+                      />
+                      <span
+                        class="components-form-toggle__thumb"
+                      />
+                    </span>
+                    <label
+                      class="components-flex-item components-flex-block components-toggle-control__label emotion-6 emotion-5"
+                      data-wp-c16t="true"
+                      data-wp-component="FlexBlock"
+                      for="inspector-toggle-control-1"
+                    >
+                      Distraction free
+                    </label>
+                  </div>
                 </div>
+                <p
+                  class="components-base-control__help emotion-8 emotion-9"
+                  id="inspector-toggle-control-1__help"
+                >
+                  Reduce visual distractions by hiding the toolbar and other elements to focus on writing.
+                </p>
               </div>
-              <p
-                class="components-base-control__help emotion-8 emotion-9"
-                id="inspector-toggle-control-1__help"
-              >
-                Reduce visual distractions by hiding the toolbar and other elements to focus on writing.
-              </p>
             </div>
-          </div>
-          <div
-            class="interface-preferences-modal__option"
-          >
             <div
-              class="components-base-control components-toggle-control emotion-0 emotion-1"
+              class="interface-preferences-modal__option"
             >
               <div
-                class="components-base-control__field emotion-2 emotion-3"
+                class="components-base-control components-toggle-control emotion-0 emotion-1"
               >
                 <div
-                  class="components-flex components-h-stack emotion-4 emotion-5"
-                  data-wp-c16t="true"
-                  data-wp-component="HStack"
+                  class="components-base-control__field emotion-2 emotion-3"
                 >
-                  <span
-                    class="components-form-toggle"
-                  >
-                    <input
-                      aria-describedby="inspector-toggle-control-2__help"
-                      class="components-form-toggle__input"
-                      id="inspector-toggle-control-2"
-                      type="checkbox"
-                    />
-                    <span
-                      class="components-form-toggle__track"
-                    />
-                    <span
-                      class="components-form-toggle__thumb"
-                    />
-                  </span>
-                  <label
-                    class="components-flex-item components-flex-block components-toggle-control__label emotion-6 emotion-5"
+                  <div
+                    class="components-flex components-h-stack emotion-4 emotion-5"
                     data-wp-c16t="true"
-                    data-wp-component="FlexBlock"
-                    for="inspector-toggle-control-2"
+                    data-wp-component="HStack"
                   >
-                    Spotlight mode
-                  </label>
+                    <span
+                      class="components-form-toggle"
+                    >
+                      <input
+                        aria-describedby="inspector-toggle-control-2__help"
+                        class="components-form-toggle__input"
+                        id="inspector-toggle-control-2"
+                        type="checkbox"
+                      />
+                      <span
+                        class="components-form-toggle__track"
+                      />
+                      <span
+                        class="components-form-toggle__thumb"
+                      />
+                    </span>
+                    <label
+                      class="components-flex-item components-flex-block components-toggle-control__label emotion-6 emotion-5"
+                      data-wp-c16t="true"
+                      data-wp-component="FlexBlock"
+                      for="inspector-toggle-control-2"
+                    >
+                      Spotlight mode
+                    </label>
+                  </div>
                 </div>
+                <p
+                  class="components-base-control__help emotion-8 emotion-9"
+                  id="inspector-toggle-control-2__help"
+                >
+                  Highlights the current block and fades other content.
+                </p>
               </div>
-              <p
-                class="components-base-control__help emotion-8 emotion-9"
-                id="inspector-toggle-control-2__help"
-              >
-                Highlights the current block and fades other content.
-              </p>
             </div>
-          </div>
-          <div
-            class="interface-preferences-modal__option"
-          >
             <div
-              class="components-base-control components-toggle-control emotion-0 emotion-1"
+              class="interface-preferences-modal__option"
             >
               <div
-                class="components-base-control__field emotion-2 emotion-3"
+                class="components-base-control components-toggle-control emotion-0 emotion-1"
               >
                 <div
-                  class="components-flex components-h-stack emotion-4 emotion-5"
-                  data-wp-c16t="true"
-                  data-wp-component="HStack"
+                  class="components-base-control__field emotion-2 emotion-3"
                 >
-                  <span
-                    class="components-form-toggle"
-                  >
-                    <input
-                      aria-describedby="inspector-toggle-control-3__help"
-                      class="components-form-toggle__input"
-                      id="inspector-toggle-control-3"
-                      type="checkbox"
-                    />
-                    <span
-                      class="components-form-toggle__track"
-                    />
-                    <span
-                      class="components-form-toggle__thumb"
-                    />
-                  </span>
-                  <label
-                    class="components-flex-item components-flex-block components-toggle-control__label emotion-6 emotion-5"
+                  <div
+                    class="components-flex components-h-stack emotion-4 emotion-5"
                     data-wp-c16t="true"
-                    data-wp-component="FlexBlock"
-                    for="inspector-toggle-control-3"
+                    data-wp-component="HStack"
                   >
-                    Show button text labels
-                  </label>
+                    <span
+                      class="components-form-toggle"
+                    >
+                      <input
+                        aria-describedby="inspector-toggle-control-3__help"
+                        class="components-form-toggle__input"
+                        id="inspector-toggle-control-3"
+                        type="checkbox"
+                      />
+                      <span
+                        class="components-form-toggle__track"
+                      />
+                      <span
+                        class="components-form-toggle__thumb"
+                      />
+                    </span>
+                    <label
+                      class="components-flex-item components-flex-block components-toggle-control__label emotion-6 emotion-5"
+                      data-wp-c16t="true"
+                      data-wp-component="FlexBlock"
+                      for="inspector-toggle-control-3"
+                    >
+                      Show button text labels
+                    </label>
+                  </div>
                 </div>
+                <p
+                  class="components-base-control__help emotion-8 emotion-9"
+                  id="inspector-toggle-control-3__help"
+                >
+                  Show text instead of icons on buttons.
+                </p>
               </div>
-              <p
-                class="components-base-control__help emotion-8 emotion-9"
-                id="inspector-toggle-control-3__help"
-              >
-                Show text instead of icons on buttons.
-              </p>
             </div>
-          </div>
-          <div
-            class="interface-preferences-modal__option"
-          >
             <div
-              class="components-base-control components-toggle-control emotion-0 emotion-1"
+              class="interface-preferences-modal__option"
             >
               <div
-                class="components-base-control__field emotion-2 emotion-3"
+                class="components-base-control components-toggle-control emotion-0 emotion-1"
               >
                 <div
-                  class="components-flex components-h-stack emotion-4 emotion-5"
-                  data-wp-c16t="true"
-                  data-wp-component="HStack"
+                  class="components-base-control__field emotion-2 emotion-3"
                 >
-                  <span
-                    class="components-form-toggle"
-                  >
-                    <input
-                      aria-describedby="inspector-toggle-control-4__help"
-                      class="components-form-toggle__input"
-                      id="inspector-toggle-control-4"
-                      type="checkbox"
-                    />
-                    <span
-                      class="components-form-toggle__track"
-                    />
-                    <span
-                      class="components-form-toggle__thumb"
-                    />
-                  </span>
-                  <label
-                    class="components-flex-item components-flex-block components-toggle-control__label emotion-6 emotion-5"
+                  <div
+                    class="components-flex components-h-stack emotion-4 emotion-5"
                     data-wp-c16t="true"
-                    data-wp-component="FlexBlock"
-                    for="inspector-toggle-control-4"
+                    data-wp-component="HStack"
                   >
-                    Always open list view
-                  </label>
+                    <span
+                      class="components-form-toggle"
+                    >
+                      <input
+                        aria-describedby="inspector-toggle-control-4__help"
+                        class="components-form-toggle__input"
+                        id="inspector-toggle-control-4"
+                        type="checkbox"
+                      />
+                      <span
+                        class="components-form-toggle__track"
+                      />
+                      <span
+                        class="components-form-toggle__thumb"
+                      />
+                    </span>
+                    <label
+                      class="components-flex-item components-flex-block components-toggle-control__label emotion-6 emotion-5"
+                      data-wp-c16t="true"
+                      data-wp-component="FlexBlock"
+                      for="inspector-toggle-control-4"
+                    >
+                      Always open list view
+                    </label>
+                  </div>
                 </div>
+                <p
+                  class="components-base-control__help emotion-8 emotion-9"
+                  id="inspector-toggle-control-4__help"
+                >
+                  Opens the block list view sidebar by default.
+                </p>
               </div>
-              <p
-                class="components-base-control__help emotion-8 emotion-9"
-                id="inspector-toggle-control-4__help"
-              >
-                Opens the block list view sidebar by default.
-              </p>
             </div>
-          </div>
-          <div
-            class="interface-preferences-modal__option"
-          >
             <div
-              class="components-base-control components-toggle-control emotion-0 emotion-1"
+              class="interface-preferences-modal__option"
             >
               <div
-                class="components-base-control__field emotion-2 emotion-3"
+                class="components-base-control components-toggle-control emotion-0 emotion-1"
               >
                 <div
-                  class="components-flex components-h-stack emotion-4 emotion-5"
-                  data-wp-c16t="true"
-                  data-wp-component="HStack"
+                  class="components-base-control__field emotion-2 emotion-3"
                 >
-                  <span
-                    class="components-form-toggle"
-                  >
-                    <input
-                      aria-describedby="inspector-toggle-control-5__help"
-                      class="components-form-toggle__input"
-                      id="inspector-toggle-control-5"
-                      type="checkbox"
-                    />
-                    <span
-                      class="components-form-toggle__track"
-                    />
-                    <span
-                      class="components-form-toggle__thumb"
-                    />
-                  </span>
-                  <label
-                    class="components-flex-item components-flex-block components-toggle-control__label emotion-6 emotion-5"
+                  <div
+                    class="components-flex components-h-stack emotion-4 emotion-5"
                     data-wp-c16t="true"
-                    data-wp-component="FlexBlock"
-                    for="inspector-toggle-control-5"
+                    data-wp-component="HStack"
                   >
-                    Use theme styles
-                  </label>
+                    <span
+                      class="components-form-toggle"
+                    >
+                      <input
+                        aria-describedby="inspector-toggle-control-5__help"
+                        class="components-form-toggle__input"
+                        id="inspector-toggle-control-5"
+                        type="checkbox"
+                      />
+                      <span
+                        class="components-form-toggle__track"
+                      />
+                      <span
+                        class="components-form-toggle__thumb"
+                      />
+                    </span>
+                    <label
+                      class="components-flex-item components-flex-block components-toggle-control__label emotion-6 emotion-5"
+                      data-wp-c16t="true"
+                      data-wp-component="FlexBlock"
+                      for="inspector-toggle-control-5"
+                    >
+                      Use theme styles
+                    </label>
+                  </div>
                 </div>
+                <p
+                  class="components-base-control__help emotion-8 emotion-9"
+                  id="inspector-toggle-control-5__help"
+                >
+                  Make the editor look like your theme.
+                </p>
               </div>
-              <p
-                class="components-base-control__help emotion-8 emotion-9"
-                id="inspector-toggle-control-5__help"
-              >
-                Make the editor look like your theme.
-              </p>
             </div>
-          </div>
-          <div
-            class="interface-preferences-modal__option"
-          >
             <div
-              class="components-base-control components-toggle-control emotion-0 emotion-1"
+              class="interface-preferences-modal__option"
             >
               <div
-                class="components-base-control__field emotion-2 emotion-3"
+                class="components-base-control components-toggle-control emotion-0 emotion-1"
               >
                 <div
-                  class="components-flex components-h-stack emotion-4 emotion-5"
-                  data-wp-c16t="true"
-                  data-wp-component="HStack"
+                  class="components-base-control__field emotion-2 emotion-3"
                 >
-                  <span
-                    class="components-form-toggle"
-                  >
-                    <input
-                      aria-describedby="inspector-toggle-control-6__help"
-                      class="components-form-toggle__input"
-                      id="inspector-toggle-control-6"
-                      type="checkbox"
-                    />
-                    <span
-                      class="components-form-toggle__track"
-                    />
-                    <span
-                      class="components-form-toggle__thumb"
-                    />
-                  </span>
-                  <label
-                    class="components-flex-item components-flex-block components-toggle-control__label emotion-6 emotion-5"
+                  <div
+                    class="components-flex components-h-stack emotion-4 emotion-5"
                     data-wp-c16t="true"
-                    data-wp-component="FlexBlock"
-                    for="inspector-toggle-control-6"
+                    data-wp-component="HStack"
                   >
-                    Display block breadcrumbs
-                  </label>
+                    <span
+                      class="components-form-toggle"
+                    >
+                      <input
+                        aria-describedby="inspector-toggle-control-6__help"
+                        class="components-form-toggle__input"
+                        id="inspector-toggle-control-6"
+                        type="checkbox"
+                      />
+                      <span
+                        class="components-form-toggle__track"
+                      />
+                      <span
+                        class="components-form-toggle__thumb"
+                      />
+                    </span>
+                    <label
+                      class="components-flex-item components-flex-block components-toggle-control__label emotion-6 emotion-5"
+                      data-wp-c16t="true"
+                      data-wp-component="FlexBlock"
+                      for="inspector-toggle-control-6"
+                    >
+                      Display block breadcrumbs
+                    </label>
+                  </div>
                 </div>
+                <p
+                  class="components-base-control__help emotion-8 emotion-9"
+                  id="inspector-toggle-control-6__help"
+                >
+                  Shows block breadcrumbs at the bottom of the editor.
+                </p>
               </div>
-              <p
-                class="components-base-control__help emotion-8 emotion-9"
-                id="inspector-toggle-control-6__help"
-              >
-                Shows block breadcrumbs at the bottom of the editor.
-              </p>
             </div>
-          </div>
-        </fieldset>
+          </fieldset>
+        </div>
       </div>
     </div>
   </div>
@@ -721,198 +723,200 @@ exports[`EditPostPreferencesModal should match snapshot when the modal is active
         </svg>
       </button>
     </div>
-    <div
-      class="components-navigator-provider interface-preferences__provider emotion-0 emotion-1"
-      data-wp-c16t="true"
-      data-wp-component="NavigatorProvider"
-    >
+    <div>
       <div
-        class="emotion-2 components-navigator-screen"
+        class="components-navigator-provider interface-preferences__provider emotion-0 emotion-1"
         data-wp-c16t="true"
-        data-wp-component="NavigatorScreen"
-        style="opacity: 0; transform: translateX(50px) translateZ(0);"
+        data-wp-component="NavigatorProvider"
       >
         <div
-          class="components-surface components-card emotion-3 emotion-1"
+          class="emotion-2 components-navigator-screen"
           data-wp-c16t="true"
-          data-wp-component="Card"
+          data-wp-component="NavigatorScreen"
+          style="opacity: 0; transform: translateX(50px) translateZ(0);"
         >
           <div
-            class="emotion-5 emotion-1"
+            class="components-surface components-card emotion-3 emotion-1"
+            data-wp-c16t="true"
+            data-wp-component="Card"
           >
             <div
-              class="components-card__body components-card-body emotion-7 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="CardBody"
+              class="emotion-5 emotion-1"
             >
               <div
-                class="components-item-group emotion-9 emotion-1"
+                class="components-card__body components-card-body emotion-7 emotion-1"
                 data-wp-c16t="true"
-                data-wp-component="ItemGroup"
-                role="list"
+                data-wp-component="CardBody"
               >
                 <div
-                  class="emotion-11"
-                  role="listitem"
+                  class="components-item-group emotion-9 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="ItemGroup"
+                  role="list"
                 >
-                  <button
-                    class="components-item components-navigator-button emotion-1 emotion-13 emotion-1"
-                    data-wp-c16t="true"
-                    data-wp-component="NavigatorButton"
-                    id="general"
+                  <div
+                    class="emotion-11"
+                    role="listitem"
                   >
-                    <div
-                      class="components-flex components-h-stack emotion-15 emotion-1"
+                    <button
+                      class="components-item components-navigator-button emotion-1 emotion-13 emotion-1"
                       data-wp-c16t="true"
-                      data-wp-component="HStack"
+                      data-wp-component="NavigatorButton"
+                      id="general"
                     >
                       <div
-                        class="components-flex-item emotion-17 emotion-1"
+                        class="components-flex components-h-stack emotion-15 emotion-1"
                         data-wp-c16t="true"
-                        data-wp-component="FlexItem"
+                        data-wp-component="HStack"
                       >
-                        <span
-                          class="components-truncate emotion-19 emotion-1"
+                        <div
+                          class="components-flex-item emotion-17 emotion-1"
                           data-wp-c16t="true"
-                          data-wp-component="Truncate"
+                          data-wp-component="FlexItem"
                         >
-                          General
-                        </span>
-                      </div>
-                      <div
-                        class="components-flex-item emotion-17 emotion-1"
-                        data-wp-c16t="true"
-                        data-wp-component="FlexItem"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          focusable="false"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="components-truncate emotion-19 emotion-1"
+                            data-wp-c16t="true"
+                            data-wp-component="Truncate"
+                          >
+                            General
+                          </span>
+                        </div>
+                        <div
+                          class="components-flex-item emotion-17 emotion-1"
+                          data-wp-c16t="true"
+                          data-wp-component="FlexItem"
                         >
-                          <path
-                            d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z"
-                          />
-                        </svg>
+                          <svg
+                            aria-hidden="true"
+                            focusable="false"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z"
+                            />
+                          </svg>
+                        </div>
                       </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="emotion-11"
-                  role="listitem"
-                >
-                  <button
-                    class="components-item components-navigator-button emotion-1 emotion-13 emotion-1"
-                    data-wp-c16t="true"
-                    data-wp-component="NavigatorButton"
-                    id="blocks"
+                    </button>
+                  </div>
+                  <div
+                    class="emotion-11"
+                    role="listitem"
                   >
-                    <div
-                      class="components-flex components-h-stack emotion-15 emotion-1"
+                    <button
+                      class="components-item components-navigator-button emotion-1 emotion-13 emotion-1"
                       data-wp-c16t="true"
-                      data-wp-component="HStack"
+                      data-wp-component="NavigatorButton"
+                      id="blocks"
                     >
                       <div
-                        class="components-flex-item emotion-17 emotion-1"
+                        class="components-flex components-h-stack emotion-15 emotion-1"
                         data-wp-c16t="true"
-                        data-wp-component="FlexItem"
+                        data-wp-component="HStack"
                       >
-                        <span
-                          class="components-truncate emotion-19 emotion-1"
+                        <div
+                          class="components-flex-item emotion-17 emotion-1"
                           data-wp-c16t="true"
-                          data-wp-component="Truncate"
+                          data-wp-component="FlexItem"
                         >
-                          Blocks
-                        </span>
-                      </div>
-                      <div
-                        class="components-flex-item emotion-17 emotion-1"
-                        data-wp-c16t="true"
-                        data-wp-component="FlexItem"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          focusable="false"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="components-truncate emotion-19 emotion-1"
+                            data-wp-c16t="true"
+                            data-wp-component="Truncate"
+                          >
+                            Blocks
+                          </span>
+                        </div>
+                        <div
+                          class="components-flex-item emotion-17 emotion-1"
+                          data-wp-c16t="true"
+                          data-wp-component="FlexItem"
                         >
-                          <path
-                            d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z"
-                          />
-                        </svg>
+                          <svg
+                            aria-hidden="true"
+                            focusable="false"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z"
+                            />
+                          </svg>
+                        </div>
                       </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="emotion-11"
-                  role="listitem"
-                >
-                  <button
-                    class="components-item components-navigator-button emotion-1 emotion-13 emotion-1"
-                    data-wp-c16t="true"
-                    data-wp-component="NavigatorButton"
-                    id="panels"
+                    </button>
+                  </div>
+                  <div
+                    class="emotion-11"
+                    role="listitem"
                   >
-                    <div
-                      class="components-flex components-h-stack emotion-15 emotion-1"
+                    <button
+                      class="components-item components-navigator-button emotion-1 emotion-13 emotion-1"
                       data-wp-c16t="true"
-                      data-wp-component="HStack"
+                      data-wp-component="NavigatorButton"
+                      id="panels"
                     >
                       <div
-                        class="components-flex-item emotion-17 emotion-1"
+                        class="components-flex components-h-stack emotion-15 emotion-1"
                         data-wp-c16t="true"
-                        data-wp-component="FlexItem"
+                        data-wp-component="HStack"
                       >
-                        <span
-                          class="components-truncate emotion-19 emotion-1"
+                        <div
+                          class="components-flex-item emotion-17 emotion-1"
                           data-wp-c16t="true"
-                          data-wp-component="Truncate"
+                          data-wp-component="FlexItem"
                         >
-                          Panels
-                        </span>
-                      </div>
-                      <div
-                        class="components-flex-item emotion-17 emotion-1"
-                        data-wp-c16t="true"
-                        data-wp-component="FlexItem"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          focusable="false"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="components-truncate emotion-19 emotion-1"
+                            data-wp-c16t="true"
+                            data-wp-component="Truncate"
+                          >
+                            Panels
+                          </span>
+                        </div>
+                        <div
+                          class="components-flex-item emotion-17 emotion-1"
+                          data-wp-c16t="true"
+                          data-wp-component="FlexItem"
                         >
-                          <path
-                            d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z"
-                          />
-                        </svg>
+                          <svg
+                            aria-hidden="true"
+                            focusable="false"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z"
+                            />
+                          </svg>
+                        </div>
                       </div>
-                    </div>
-                  </button>
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation emotion-47 emotion-1"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation emotion-47 emotion-1"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
           </div>
-          <div
-            aria-hidden="true"
-            class="components-elevation emotion-47 emotion-1"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation emotion-47 emotion-1"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
         </div>
       </div>
     </div>

--- a/test/e2e/specs/editor/various/a11y.spec.js
+++ b/test/e2e/specs/editor/various/a11y.spec.js
@@ -3,7 +3,16 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-test.describe( 'a11y', () => {
+test.use( {
+	// Make the viewport tall enough so that some tabs panels within the
+	// Preferences modal are not scrollable and other tab panels are.
+	viewport: {
+		width: 1280,
+		height: 1024,
+	},
+} );
+
+test.describe( 'a11y (@firefox, @webkit)', () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
 	} );
@@ -38,8 +47,12 @@ test.describe( 'a11y', () => {
 		page,
 		pageUtils,
 	} ) => {
-		// Open keyboard help modal.
+		// Open keyboard shortcuts modal.
 		await pageUtils.pressKeyWithModifier( 'access', 'h' );
+
+		const modalContent = page.locator(
+			'role=dialog[name="Keyboard shortcuts"i] >> role=document'
+		);
 
 		const closeButton = page.locator(
 			'role=dialog[name="Keyboard shortcuts"i] >> role=button[name="Close"i]'
@@ -49,10 +62,15 @@ test.describe( 'a11y', () => {
 		// See: https://github.com/WordPress/gutenberg/issues/9410
 		await expect( closeButton ).not.toBeFocused();
 
+		// Open keyboard shortcuts modal.
 		await page.keyboard.press( 'Tab' );
+		await expect( modalContent ).toBeFocused();
 
-		// Ensure the Close button of the modal is focused after tabbing.
+		await page.keyboard.press( 'Tab' );
 		await expect( closeButton ).toBeFocused();
+
+		await page.keyboard.press( 'Tab' );
+		await expect( modalContent ).toBeFocused();
 	} );
 
 	test( 'should return focus to the first tabbable in a modal after blurring a tabbable', async ( {
@@ -92,5 +110,85 @@ test.describe( 'a11y', () => {
 				'role=dialog[name="Keyboard shortcuts"i] >> role=button[name="Close"i]'
 			)
 		).toBeFocused();
+	} );
+
+	test( 'should make the modal content focusable when it is scrollable', async ( {
+		page,
+	} ) => {
+		// Open the top bar Options menu.
+		await page.click(
+			'role=region[name=/Editor top bar/i] >> role=button[name=/Options/i]'
+		);
+
+		// Open the Preferences modal.
+		await page.click(
+			'role=menu[name=/Options/i] >> role=menuitem[name=/Preferences/i]'
+		);
+
+		const preferencesModal = page.locator(
+			'role=dialog[name="Preferences"i]'
+		);
+		const preferencesModalContent =
+			preferencesModal.locator( 'role=document' );
+		const closeButton = page.locator( 'role=button[name="Close dialog"i]' );
+		const generalTab = preferencesModal.locator(
+			'role=tab[name="General"i]'
+		);
+		const blocksTab = preferencesModal.locator(
+			'role=tab[name="Blocks"i]'
+		);
+		const panelsTab = preferencesModal.locator(
+			'role=tab[name="Panels"i]'
+		);
+
+		// Check initial focus is on the modal dialog container.
+		await expect( preferencesModal ).toBeFocused();
+
+		// Check the General tab panel is visible by default.
+		await expect(
+			preferencesModal.locator( 'role=tabpanel[name="General"i]' )
+		).toBeVisible();
+
+		async function clickAndFocusTab( tab ) {
+			await tab.click();
+			await tab.focus();
+		}
+
+		// The General tab panel content is short and not scrollable.
+		// Check it's not focusable.
+		await clickAndFocusTab( generalTab );
+		await page.keyboard.press( 'Shift+Tab' );
+		await expect( closeButton ).toBeFocused();
+		await page.keyboard.press( 'Shift+Tab' );
+		await expect( preferencesModalContent ).not.toBeFocused();
+
+		// The Blocks tab panel content is long and scrollable.
+		// Check it's focusable.
+		await clickAndFocusTab( blocksTab );
+		await page.keyboard.press( 'Shift+Tab' );
+		await expect( closeButton ).toBeFocused();
+		await page.keyboard.press( 'Shift+Tab' );
+		await expect( preferencesModalContent ).toBeFocused();
+
+		// Make the Blocks tab panel content shorter by searching for a block.
+		// It's now not scrollable. Check it's not focusable.
+		await clickAndFocusTab( blocksTab );
+		await page.type(
+			'role=searchbox[name="Search for a block"i]',
+			'cover'
+		);
+		await clickAndFocusTab( blocksTab );
+		await page.keyboard.press( 'Shift+Tab' );
+		await expect( closeButton ).toBeFocused();
+		await page.keyboard.press( 'Shift+Tab' );
+		await expect( preferencesModalContent ).not.toBeFocused();
+
+		// The Panels tab panel content is short and not scrollable.
+		// Check it's not focusable.
+		await clickAndFocusTab( panelsTab );
+		await page.keyboard.press( 'Shift+Tab' );
+		await expect( closeButton ).toBeFocused();
+		await page.keyboard.press( 'Shift+Tab' );
+		await expect( preferencesModalContent ).not.toBeFocused();
 	} );
 } );

--- a/test/e2e/specs/editor/various/a11y.spec.js
+++ b/test/e2e/specs/editor/various/a11y.spec.js
@@ -152,6 +152,9 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 		).toBeVisible();
 
 		async function clickAndFocusTab( tab ) {
+			// Some browsers, e.g. Safari, don't set focus after a click. We need
+			// to ensure focus is set to start tabbing from a predictable place
+			// in the UI. This isn't part of the user flow we want to test.
 			await tab.click();
 			await tab.focus();
 		}

--- a/test/e2e/specs/editor/various/a11y.spec.js
+++ b/test/e2e/specs/editor/various/a11y.spec.js
@@ -130,7 +130,9 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 		);
 		const preferencesModalContent =
 			preferencesModal.locator( 'role=document' );
-		const closeButton = page.locator( 'role=button[name="Close dialog"i]' );
+		const closeButton = preferencesModal.locator(
+			'role=button[name="Close"i]'
+		);
 		const generalTab = preferencesModal.locator(
 			'role=tab[name="General"i]'
 		);

--- a/test/e2e/specs/editor/various/a11y.spec.js
+++ b/test/e2e/specs/editor/various/a11y.spec.js
@@ -170,12 +170,13 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 		await page.keyboard.press( 'Shift+Tab' );
 		await expect( preferencesModalContent ).toBeFocused();
 
-		// Make the Blocks tab panel content shorter by searching for a block.
-		// It's now not scrollable. Check it's not focusable.
+		// Make the Blocks tab panel content shorter by searching for a block
+		// that doesn't exist. The content only shows 'No blocks found' and it's
+		// not scrollable any longer. Check it's not focusable.
 		await clickAndFocusTab( blocksTab );
 		await page.type(
 			'role=searchbox[name="Search for a block"i]',
-			'cover'
+			'qwerty'
 		);
 		await clickAndFocusTab( blocksTab );
 		await page.keyboard.press( 'Shift+Tab' );

--- a/test/e2e/specs/editor/various/a11y.spec.js
+++ b/test/e2e/specs/editor/various/a11y.spec.js
@@ -117,12 +117,12 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 	} ) => {
 		// Open the top bar Options menu.
 		await page.click(
-			'role=region[name=/Editor top bar/i] >> role=button[name=/Options/i]'
+			'role=region[name="Editor top bar"i] >> role=button[name="Options"i]'
 		);
 
 		// Open the Preferences modal.
 		await page.click(
-			'role=menu[name=/Options/i] >> role=menuitem[name=/Preferences/i]'
+			'role=menu[name="Options"i] >> role=menuitem[name="Preferences"i]'
 		);
 
 		const preferencesModal = page.locator(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes https://github.com/WordPress/gutenberg/issues/46041
Fixes https://github.com/WordPress/gutenberg/issues/41500

## What?
<!-- In a few words, what is the PR actually doing? -->
The refactoring of `useConstrainedTabbing` in https://github.com/WordPress/gutenberg/pull/34836 introduced a few regressions and unexpected behaviors. Some of these regressions have been fixed already, see for example https://github.com/WordPress/gutenberg/issues/42652, https://github.com/WordPress/gutenberg/issues/45903, ,and https://github.com/WordPress/gutenberg/pull/42653. 

This PR aims to fix one remaining regression with Safari and some unexpected behavior with Firefox.

## TL;DR
The regression and unexpected behaviors surfaced only when attempting to run the existing [editor/various/a11y.spec.js](https://github.com/WordPress/gutenberg/blob/98ce5c53c9492764aeff88852a4073fb32e784ac/test/e2e/specs/editor/various/a11y.spec.js) test with all browsers in https://github.com/WordPress/gutenberg/pull/46038. The outcome was 1 failure with  webkit (Safari) and 2 failures with Firefox.

That proved the native browsers behavior differs in some cases. Therefore, the current implementation of `useConstrainedTabbing`, which relies on native browser behavior, doesn't appear to be ideal in the first place.

I'd like to note that when it comes to some accessibility features, it is very, very important to run E2E tests with all ajor browsers. In fact, it turned out browser behavior differs in at least two cases:
- Safari: when clicking somewhere after the last tabbable within a modal dialog and then pressing Tab, the modal dialog closes unexpectedly. Instead, wIth Chrome and Firefox the tab sequence restarts from the previous tababble. This seems related to the so called [Sequential focus navigation starting point](https://chromestatus.com/feature/5671747802103808), which is a browser feature that is apparently implemented differently in Safari.
- Firefox: it's the only major browser that natively makes scrollable elements focusable. The `useConstrainedTabbing` current implementation allows to tab to scrollable elements but it doesn't take them into account as 'tabbable' elements, leading to unexpected behavior.

I'd also like to kindly note that it appears the refactoring in https://github.com/WordPress/gutenberg/pull/34836 didn[t introduce any new test for the specific use case it was meant to address, see https://github.com/WordPress/gutenberg/issues/34681. I will create a separate issue for that.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The constrained tabbing feature is broken since more than one year now. It needs to work reliably and consistently across all major browsers. It also needs to be tested more effectively.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Adds some actual focus management when a tabbable element contains the next tabbable element. In this case, Safari seems to disagree with other browsers when there is no focused element and the 'Sequential focus navigation starting point' feature comes into play.
- Determines whether the modal dialog content is scrollable, that is: when there is an actual content overflow.
- Makes the scrollable div focusable, only when there is an actual content overflow. This reproduces the native Firefox behavior for all browsers.
- Use `ResizeObserver` to listen to the modal dialog content size changes and checks again whether it's scrollable. This is necessary because:
  - When resizing browser window, zooming in/out, changing orientation on mobile devices, etc., the content may overflow or not depending on the actual size of the content area.
  - Sometimes the modal dialog content is dynamic so that its size changes on the fly, e.g. the Preferences modal uses tabs. Some tabs produce a content overflow, some don't.
- Wraps the dialog content within a `<div>` element: this is necessary to determine size changes via `ResizeObserver`.
- Adds `aria-label="Scrollable section" tabindex="0"` to the dialog content when it's scrollable 
- Adds a `scrollableContentLabel` prop that can be used to override the default label `Scrollable section`.
- Adds a basic focus style to the content when it's scrollable and focusable.
- Makes the a11y E2E test run also with Firefox and Webkit.
- Adds E2E test for the scrollable section.

Note:
- I opted to not use `useResizeObserver` for now. I'm not sure I like the current implementation which injects an additional `<div>` element and overlays it on the node to check for resizing. Also, that works only when the node to check for is a positioned element. 
- It would be great to abstract and futher improve the scrollable section functionality in https://github.com/WordPress/gutenberg/issues/45809. Before that, it would be great to wait for https://github.com/WordPress/gutenberg/pull/41001 which aims to refactor `useResizeObserver` so that it can be used directly on an element. /Cc @youknowriad 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Run `npm run test:e2e:playwright -- --headed editor/various/a11y.spec.js` and check the tests pass.
- Edit a post and open the Keyboard shortcuts modal dialog.
- Tab through the elements within the modal dialog and check the list of shortcuts container receives focus and shows a focus style.
- With the scrollable element focused, check you can scroll the element by using the Down and Up arrow keys or the Spacebar / Shift+Spacebar. With Safari you may need to press Fn+Down/Up arrow.
- Check you can cycle through the Close button and the scrollable element by pressing Tab and Shift+Tab.
- Close the Keyboard shortcuts modal dialog and open the Preferences one.
- Depending also on your screen size, the General tab should not produce content overflow so it should not be scrollable.
- Inspect the source and check the content area, that is the element with `role=document` does _not_ have an `aria-label` attribute nor a `tabindex` attribute.
- Click on the Blocks tab. This tab has longer content and, depending also on your screen size, it should be scrollable.
- Check the content area is now scrollable and does have `aria-label="Scrollable section" tabindex="0"` attributes.
- Type `qwerty` in the 'Search for a block' search field.
- The modal dialog content will be shorter and only display 'No blocks found'.
- Check the content area is no longer scrollable nor focusable.
- Check it does _not_ have an `aria-label` attribute nor a `tabindex` attribute.
- Clear the search field. The content will show the long list of blocks again.
- Check the content area is scrollable and focusable again.
- Check it does have `aria-label="Scrollable section" tabindex="0"` attributes.
- Check there are no visual regressions in other modal dialogs e.g.:
  - the 'Explore all patterns' modal dialog
  - the confirm dialog when switching back to a draft
  - the confirm dialog when changing post visibility to 'Private'
  - the 'Lock block' modal dialog
  - the Query loop block > 'Choose a pattern' modal dialog
  - any other complex modal dialog e.g. in the Site Editor


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
See above.

## Screenshots or screencast <!-- if applicable -->
