### PR TITLE
Move copy and pasting styles menu items to a separate menu group

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -39,10 +39,11 @@ const POPOVER_PROPS = {
 	variant: 'toolbar',
 };
 
-function CopyMenuItem( { blocks, onCopy } ) {
+function CopyMenuItem( { blocks, onCopy, label } ) {
 	const ref = useCopyToClipboard( () => serialize( blocks ), onCopy );
-	const copyMenuItemLabel =
+	const copyMenuItemBlocksLabel =
 		blocks.length > 1 ? __( 'Copy blocks' ) : __( 'Copy block' );
+	const copyMenuItemLabel = label ? label : copyMenuItemBlocksLabel;
 	return <MenuItem ref={ ref }>{ copyMenuItemLabel }</MenuItem>;
 }
 
@@ -263,9 +264,6 @@ export function BlockSettingsDropdown( {
 									blocks={ blocks }
 									onCopy={ onCopy }
 								/>
-								<MenuItem onClick={ onPasteStyles }>
-									{ __( 'Paste styles' ) }
-								</MenuItem>
 								{ canDuplicate && (
 									<MenuItem
 										onClick={ pipe(
@@ -313,6 +311,16 @@ export function BlockSettingsDropdown( {
 										onToggle={ onClose }
 									/>
 								) }
+							</MenuGroup>
+							<MenuGroup>
+								<CopyMenuItem
+									blocks={ blocks }
+									onCopy={ onCopy }
+									label={ __( 'Copy styles' ) }
+								/>
+								<MenuItem onClick={ onPasteStyles }>
+									{ __( 'Paste styles' ) }
+								</MenuItem>
 							</MenuGroup>
 							<BlockSettingsMenuControls.Slot
 								fillProps={ { onClose } }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #47164 by adding a MenuGroup with "Copy styles" and "Paste styles" within and removing the standalone "Copy styles" MenuItem. 

Technically, "Copy styles" and "Copy block" are the same functionality, but having a separate control for copying styles makes this more discoverable.

## Why?
Makes the copy/pasting of styles more discoverable, as in the current state copying styles is undiscoverable. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page.
2. Insert a Heading Block.
3. Add styling to it, like setting the typography to uppercase.
4. Click on the block toolbar, more options popover.
5. See "Copy styles" and "Paste styles" within a separate MenuGroup. 

The functionality has not changed, just the presentation. 

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/1813435/214665116-1f0624a0-81e6-4f51-bb43-e7ace8a73b45.mp4

