### PR TITLE
Quick update to the Gutenberg plugin description

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Gutenberg
  * Plugin URI: https://github.com/WordPress/gutenberg
- * Description: Printing since 1440. This is the development plugin for the new block editor in core.
+ * Description: Printing since 1440. This is the development plugin for the block editor, site editor, and other future WordPress core functionality.
  * Requires at least: 6.0
  * Requires PHP: 5.6
  * Version: 15.0.1


### PR DESCRIPTION
Addresses https://github.com/WordPress/gutenberg/issues/32544 by offering a slight update to the plugin description to match more of the current efforts underway.
