### PR TITLE
Global Styles: Make css input fill remainder of screen by default

### DIFF
--- a/packages/edit-site/src/components/global-styles/custom-css.js
+++ b/packages/edit-site/src/components/global-styles/custom-css.js
@@ -1,7 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { TextareaControl, Panel, PanelBody } from '@wordpress/components';
+import {
+	TextareaControl,
+	Panel,
+	PanelBody,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
 
@@ -9,6 +14,7 @@ import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import { unlock } from '../../experiments';
+import Subtitle from './subtitle';
 
 const { useGlobalStyle } = unlock( blockEditorExperiments );
 function CustomCSSControl( { blockName } ) {
@@ -59,24 +65,19 @@ function CustomCSSControl( { blockName } ) {
 					</PanelBody>
 				</Panel>
 			) }
-
-			<Panel className="edit-site-global-styles__custom-css-panel-additional-css">
-				<PanelBody
-					title={ __( 'Additional CSS' ) }
-					initialOpen={ true }
-				>
-					<TextareaControl
-						__nextHasNoMarginBottom
-						value={
-							customCSS?.replace( ignoreThemeCustomCSS, '' ) ||
-							themeCustomCSS
-						}
-						onChange={ ( value ) => handleOnChange( value ) }
-						className="edit-site-global-styles__custom-css-input"
-						spellCheck={ false }
-					/>
-				</PanelBody>
-			</Panel>
+			<VStack spacing={ 3 }>
+				<Subtitle>{ __( 'ADDITIONAL CSS' ) }</Subtitle>
+				<TextareaControl
+					__nextHasNoMarginBottom
+					value={
+						customCSS?.replace( ignoreThemeCustomCSS, '' ) ||
+						themeCustomCSS
+					}
+					onChange={ ( value ) => handleOnChange( value ) }
+					className="edit-site-global-styles__custom-css-input"
+					spellCheck={ false }
+				/>
+			</VStack>
 		</>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/custom-css.js
+++ b/packages/edit-site/src/components/global-styles/custom-css.js
@@ -1,12 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	ExternalLink,
-	TextareaControl,
-	Panel,
-	PanelBody,
-} from '@wordpress/components';
+import { TextareaControl, Panel, PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
 
@@ -52,24 +47,6 @@ function CustomCSSControl( { blockName } ) {
 
 	return (
 		<>
-			<TextareaControl
-				__nextHasNoMarginBottom
-				value={
-					customCSS?.replace( ignoreThemeCustomCSS, '' ) ||
-					themeCustomCSS
-				}
-				onChange={ ( value ) => handleOnChange( value ) }
-				rows={ 15 }
-				className="edit-site-global-styles__custom-css-input"
-				spellCheck={ false }
-				help={
-					<>
-						<ExternalLink href="https://wordpress.org/support/article/css/">
-							{ __( 'Learn more about CSS' ) }
-						</ExternalLink>
-					</>
-				}
-			/>
 			{ originalThemeCustomCSS && (
 				<Panel>
 					<PanelBody
@@ -82,6 +59,24 @@ function CustomCSSControl( { blockName } ) {
 					</PanelBody>
 				</Panel>
 			) }
+
+			<Panel className="edit-site-global-styles__custom-css-panel-additional-css">
+				<PanelBody
+					title={ __( 'Additional CSS' ) }
+					initialOpen={ true }
+				>
+					<TextareaControl
+						__nextHasNoMarginBottom
+						value={
+							customCSS?.replace( ignoreThemeCustomCSS, '' ) ||
+							themeCustomCSS
+						}
+						onChange={ ( value ) => handleOnChange( value ) }
+						className="edit-site-global-styles__custom-css-input"
+						spellCheck={ false }
+					/>
+				</PanelBody>
+			</Panel>
 		</>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/screen-css.js
+++ b/packages/edit-site/src/components/global-styles/screen-css.js
@@ -2,14 +2,13 @@
  * WordPress dependencies
  */
 import { sprintf, __ } from '@wordpress/i18n';
-import { __experimentalVStack as VStack } from '@wordpress/components';
+import { ExternalLink } from '@wordpress/components';
 import { getBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import ScreenHeader from './header';
-import Subtitle from './subtitle';
 import CustomCSSControl from './custom-css';
 
 function ScreenCSS( { name } ) {
@@ -34,11 +33,14 @@ function ScreenCSS( { name } ) {
 	return (
 		<>
 			<ScreenHeader title={ __( 'CSS' ) } description={ description } />
+			<ExternalLink
+				href="https://wordpress.org/support/article/css/"
+				className="edit-site-global-styles-screen-css-help-link"
+			>
+				{ __( 'Learn more about CSS' ) }
+			</ExternalLink>
 			<div className="edit-site-global-styles-screen-css">
-				<VStack spacing={ 3 }>
-					<Subtitle>{ __( 'ADDITIONAL CSS' ) }</Subtitle>
-					<CustomCSSControl blockName={ name } />
-				</VStack>
+				<CustomCSSControl blockName={ name } />
 			</div>
 		</>
 	);

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -136,6 +136,40 @@ $block-preview-height: 150px;
 	border-radius: $radius-block-ui;
 }
 
+.edit-site-global-styles-screen-css {
+	flex: 1 1 auto;
+	display: flex;
+	flex-direction: column;
+
+	.edit-site-global-styles__custom-css-panel-additional-css {
+		flex: 1 1 auto;
+		display: flex;
+		flex-direction: column;
+
+		.components-panel__body.is-opened {
+			flex: 1 1 auto;
+			display: flex;
+			flex-direction: column;
+
+			.edit-site-global-styles__custom-css-input {
+				flex: 1 1 auto;
+				display: flex;
+				flex-direction: column;
+
+				.components-base-control__field {
+					flex: 1 1 auto;
+					display: flex;
+					flex-direction: column;
+
+					.components-textarea-control__input {
+						flex: 1 1 auto;
+					}
+				}
+			}
+		}
+	}
+}
+
 .edit-site-global-styles__custom-css-input textarea {
 	font-family: $editor_html_font;
 }
@@ -148,6 +182,9 @@ $block-preview-height: 150px;
 	overflow-y: scroll;
 }
 
+.edit-site-global-styles-screen-css-help-link {
+	padding-left: $grid-unit-20;
+}
 .edit-site-global-styles-screen-variations {
 	margin-top: $grid-unit-20;
 	border-top: 1px solid $gray-300;
@@ -155,4 +192,9 @@ $block-preview-height: 150px;
 	& > * {
 		margin: $grid-unit-30 $grid-unit-20;
 	}
+}
+
+.edit-site-global-styles-sidebar__navigator-screen {
+	display: flex;
+	flex-direction: column;
 }

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -141,29 +141,21 @@ $block-preview-height: 150px;
 	display: flex;
 	flex-direction: column;
 
-	.edit-site-global-styles__custom-css-panel-additional-css {
+	.components-v-stack {
 		flex: 1 1 auto;
-		display: flex;
-		flex-direction: column;
 
-		.components-panel__body.is-opened {
+		.edit-site-global-styles__custom-css-input {
 			flex: 1 1 auto;
 			display: flex;
 			flex-direction: column;
 
-			.edit-site-global-styles__custom-css-input {
+			.components-base-control__field {
 				flex: 1 1 auto;
 				display: flex;
 				flex-direction: column;
 
-				.components-base-control__field {
+				.components-textarea-control__input {
 					flex: 1 1 auto;
-					display: flex;
-					flex-direction: column;
-
-					.components-textarea-control__input {
-						flex: 1 1 auto;
-					}
 				}
 			}
 		}


### PR DESCRIPTION
## What?
Increases the size of the custom CSS input box by making if fill the remaining space in the column

## Why?
The existing input only has 15 rows by default which makes it hard to view/edit larger chunks of CSS

## How?
Rearranges the CSS input panel so that the additional CSS is the last element so it can fill the remaining space.

## Testing Instructions

- In a block theme add custom CSS and make sure the additional CSS input box resizes to fill remaining space in panel
- Add some custom CSS to the theme.json `styles.css` property and make sure the `Original theme CSS` panel displays correctly when custom CSS is added via global styles input
- Check that block level custom CSS also still works as expected
- Check other global styles input panels as a flex property was added to top level `.edit-site-global-styles-sidebar__navigator-screen` achieve this.


## Screenshots or screencast 

Before:

https://user-images.githubusercontent.com/3629020/214757070-3104330b-0e80-49db-8ed2-6769bd080005.mov

After:

https://user-images.githubusercontent.com/3629020/214756707-6c6d24bb-b60d-4308-bf1c-bcca4ca38190.mov