### PR TITLE
Navigation: Remove the manage menus button from the selector

### DIFF
--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -20,7 +20,6 @@ import { useEffect, useMemo, useState } from '@wordpress/element';
  */
 import useNavigationMenu from '../use-navigation-menu';
 import useNavigationEntities from '../use-navigation-entities';
-import ManageMenusButton from './manage-menus-button';
 
 function NavigationMenuSelector( {
 	currentMenuId,
@@ -31,7 +30,6 @@ function NavigationMenuSelector( {
 	createNavigationMenuIsSuccess,
 	createNavigationMenuIsError,
 	toggleProps = {},
-	isManageMenusButtonDisabled,
 } ) {
 	const isOffCanvasNavigationEditorEnabled =
 		window?.__experimentalEnableOffCanvasNavigationEditor === true;
@@ -243,14 +241,6 @@ function NavigationMenuSelector( {
 							>
 								{ __( 'Create new menu' ) }
 							</MenuItem>
-							{ isOffCanvasNavigationEditorEnabled && (
-								<ManageMenusButton
-									isManageMenusButtonDisabled={
-										isManageMenusButtonDisabled
-									}
-									isMenuItem={ true }
-								/>
-							) }
 						</MenuGroup>
 					) }
 				</>


### PR DESCRIPTION
## What?
Removes the manage menus links from the navigation menu selector.

## Why?
This link isn't needed as it's also available inside "Advanced":

<img width="319" alt="Screenshot 2023-01-26 at 09 46 39" src="https://user-images.githubusercontent.com/275961/214806029-4e375a6d-b13a-4264-b426-73b98995af62.png">

## Testing Instructions
1. Turn on the off canvas experiment
2. Add a navigation block and open the inspector controls
3. Open the navigation menu selector and confirm that the manage menus link is missing
4. Open the advanced section of the inspector controls and confirm that the manage menus link is there

### Testing Instructions for Keyboard
As above

## Screenshots or screencast <!-- if applicable -->
<img width="319" alt="Screenshot 2023-01-26 at 09 46 39" src="https://user-images.githubusercontent.com/275961/214806673-0acc450d-f8ff-49e5-ae1a-9c1dcb50db10.png">
<img width="312" alt="Screenshot 2023-01-26 at 09 46 30" src="https://user-images.githubusercontent.com/275961/214806680-6b4ea1da-22ae-4338-90f8-2763c01e6b84.png">

