### PR TITLE
URLInput test: use valid url value to pass through validation

### DIFF
--- a/packages/block-editor/src/components/url-input/test/button.js
+++ b/packages/block-editor/src/components/url-input/test/button.js
@@ -134,12 +134,13 @@ describe( 'URLInputButton', () => {
 	it( 'should close the form when user submits it', async () => {
 		const user = userEvent.setup();
 
-		function TestInputButton() {
-			const [ url, onChange ] = useState( '' );
-			return <URLInputButton url={ url } onChange={ onChange } />;
+		function TestURLInputButton() {
+			// maintain state for the controlled component and process value changes
+			const [ url, setUrl ] = useState( '' );
+			return <URLInputButton url={ url } onChange={ setUrl } />;
 		}
 
-		render( <TestInputButton /> );
+		render( <TestURLInputButton /> );
 
 		// Click the button to insert a link.
 		await user.click(

--- a/packages/block-editor/src/components/url-input/test/button.js
+++ b/packages/block-editor/src/components/url-input/test/button.js
@@ -5,6 +5,11 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import URLInputButton from '../button';
@@ -128,9 +133,13 @@ describe( 'URLInputButton', () => {
 
 	it( 'should close the form when user submits it', async () => {
 		const user = userEvent.setup();
-		const onChangeMock = jest.fn();
 
-		render( <URLInputButton onChange={ onChangeMock } /> );
+		function TestInputButton() {
+			const [ url, onChange ] = useState( '' );
+			return <URLInputButton url={ url } onChange={ onChange } />;
+		}
+
+		render( <TestInputButton /> );
 
 		// Click the button to insert a link.
 		await user.click(
@@ -143,15 +152,15 @@ describe( 'URLInputButton', () => {
 		// Type something into the URL field.
 		await user.type( screen.getByRole( 'combobox' ), 'foo' );
 
-		// Submit the form.
-		await user.click(
-			screen.getByRole( 'button', {
-				name: 'Submit',
-			} )
-		);
+		const submitButton = screen.getByRole( 'button', {
+			name: 'Submit',
+		} );
 
-		expect(
-			screen.queryByRole( 'button', { name: 'Submit' } )
-		).not.toBeInTheDocument();
+		expect( submitButton ).toBeInTheDocument();
+
+		// Submit the form.
+		await user.click( submitButton );
+
+		expect( submitButton ).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
Fixes one `URLInput` unit test that starts failing after Jest upgrade (WIP in #47388), namely after upgrade of the bundled JSDOM (from 16.0 to 20.0).

The "should close the form when user submits it" test is rendering a controlled `<URLInputButton>` component without a `url` value prop, and then types something into that component's `<input>` field. But because there's no value, the `input`'s value doesn't really change. It remains empty.

The `URLInputButton` renders a form that's like:
```
<form>
  <input required type="text">
  <button type="submit">
</form>
```
and our test clicks the "submit" button. However, JSDOM implemented form validation in v18, and because the `required` input is empty, it won't submit the form.

This PR fixes the test by rendering a helper component that maintains the input state.