### PR TITLE
RichText tests: don't use JSDOM explicitly, it's set up by environment

### DIFF
--- a/packages/rich-text/src/test/create.js
+++ b/packages/rich-text/src/test/create.js
@@ -1,10 +1,4 @@
 /**
- * External dependencies
- */
-
-import { JSDOM } from 'jsdom';
-
-/**
  * Internal dependencies
  */
 import { create, removeReservedCharacters } from '../create';
@@ -13,9 +7,6 @@ import { createElement } from '../create-element';
 import { registerFormatType } from '../register-format-type';
 import { unregisterFormatType } from '../unregister-format-type';
 import { getSparseArrayLength, spec, specWithRegistration } from './helpers';
-
-const { window } = new JSDOM();
-const { document } = window;
 
 describe( 'create', () => {
 	const em = { type: 'em' };

--- a/packages/rich-text/src/test/to-dom.js
+++ b/packages/rich-text/src/test/to-dom.js
@@ -1,19 +1,9 @@
 /**
- * External dependencies
- */
-
-import { JSDOM } from 'jsdom';
-
-/**
  * Internal dependencies
  */
-
 import { toDom, applyValue } from '../to-dom';
 import { createElement } from '../create-element';
 import { spec } from './helpers';
-
-const { window } = new JSDOM();
-const { document } = window;
 
 describe( 'recordToDom', () => {
 	beforeAll( () => {

--- a/packages/rich-text/src/test/to-html-string.js
+++ b/packages/rich-text/src/test/to-html-string.js
@@ -1,21 +1,11 @@
 /**
- * External dependencies
- */
-
-import { JSDOM } from 'jsdom';
-
-/**
  * Internal dependencies
  */
-
 import { create } from '../create';
 import { toHTMLString } from '../to-html-string';
 import { registerFormatType } from '../register-format-type';
 import { unregisterFormatType } from '../unregister-format-type';
 import { specWithRegistration } from './helpers';
-
-const { window } = new JSDOM();
-const { document } = window;
 
 function createNode( HTML ) {
 	const doc = document.implementation.createHTMLDocument( '' );


### PR DESCRIPTION
Simplifies a few `RichText` unit tests by removing explicit setup of JSDOM and `window` and `document`. The Jest test already runs with `@jest-environment jsdom` by default.

Newer version of JSDOM don't like when `jsdom` is imported again inside a `jsdom` environment (i.e., with `jsdom`-exposed globals). Namely, JSDOM doesn't expose the `TextEncoder` global. It's a [known unfixed issue](https://github.com/jsdom/jsdom/issues/2524).

Spinoff from the Jest 29 upgrade in #47388.