### PR TITLE
Replace registerStore() call with register() in the block-editor store

### DIFF
--- a/packages/block-editor/src/store/index.js
+++ b/packages/block-editor/src/store/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createReduxStore, registerStore } from '@wordpress/data';
+import { createReduxStore, register } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -32,8 +32,4 @@ export const store = createReduxStore( STORE_NAME, {
 	persist: [ 'preferences' ],
 } );
 
-// Ideally we'd use register instead of register stores.
-registerStore( STORE_NAME, {
-	...storeConfig,
-	persist: [ 'preferences' ],
-} );
+register( store );


### PR DESCRIPTION
## What?
`registerStore()` is deprecated – this PR replaces its last usage in the Gutenberg codebase with the new `register()` function call.

## Testing Instructions
Confirm the CI checks pass

cc @ntsekouras 