### PR TITLE
Block Editor: Memoize `getBlockInsertionPoint` selector

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1384,7 +1384,12 @@ export const getBlockInsertionPoint = createSelector(
 
 		return { rootClientId, index };
 	},
-	( state ) => [ state.blocks.parents, state.blocks.order ]
+	( state ) => [
+		state.insertionPoint,
+		state.selection.selectionEnd,
+		state.blocks.parents,
+		state.blocks.order,
+	]
 );
 
 /**

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1361,28 +1361,31 @@ export function isCaretWithinFormattedText() {
  *
  * @return {Object} Insertion point object with `rootClientId`, `index`.
  */
-export function getBlockInsertionPoint( state ) {
-	let rootClientId, index;
+export const getBlockInsertionPoint = createSelector(
+	( state ) => {
+		let rootClientId, index;
 
-	const {
-		insertionPoint,
-		selection: { selectionEnd },
-	} = state;
-	if ( insertionPoint !== null ) {
-		return insertionPoint;
-	}
+		const {
+			insertionPoint,
+			selection: { selectionEnd },
+		} = state;
+		if ( insertionPoint !== null ) {
+			return insertionPoint;
+		}
 
-	const { clientId } = selectionEnd;
+		const { clientId } = selectionEnd;
 
-	if ( clientId ) {
-		rootClientId = getBlockRootClientId( state, clientId ) || undefined;
-		index = getBlockIndex( state, selectionEnd.clientId ) + 1;
-	} else {
-		index = getBlockOrder( state ).length;
-	}
+		if ( clientId ) {
+			rootClientId = getBlockRootClientId( state, clientId ) || undefined;
+			index = getBlockIndex( state, selectionEnd.clientId ) + 1;
+		} else {
+			index = getBlockOrder( state ).length;
+		}
 
-	return { rootClientId, index };
-}
+		return { rootClientId, index };
+	},
+	( state ) => [ state.blocks.parents, state.blocks.order ]
+);
 
 /**
  * Returns true if we should show the block insertion point.

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -2493,6 +2493,44 @@ describe( 'selectors', () => {
 			} );
 		} );
 
+		it( 'should cache and return the same object if state has not changed', () => {
+			const state = {
+				selection: {
+					selectionStart: { clientId: 'clientId1' },
+					selectionEnd: { clientId: 'clientId1' },
+				},
+				blocks: {
+					byClientId: new Map(
+						Object.entries( {
+							clientId1: { clientId: 'clientId1' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							clientId1: {},
+						} )
+					),
+					order: new Map(
+						Object.entries( {
+							'': [ 'clientId1' ],
+							clientId1: [],
+						} )
+					),
+					parents: new Map(
+						Object.entries( {
+							clientId1: '',
+						} )
+					),
+				},
+				insertionPoint: null,
+			};
+
+			const insertionPoint1 = getBlockInsertionPoint( state );
+			const insertionPoint2 = getBlockInsertionPoint( state );
+
+			expect( insertionPoint1 ).toBe( insertionPoint2 );
+		} );
+
 		it( 'should return an object for the nested selected block', () => {
 			const state = {
 				selection: {


### PR DESCRIPTION
## What?
This PR memoizes the `getBlockInsertionPoint()` to avoid unnecessary extra rerenders when the insertion point is the same but an update is triggered just because we return a new object with the same data.

## Why?
I found this by working on #47419 and noticed that this selector returns the same data in new objects over and over again, without a good reason. By memoizing it we'll spare some unnecessary updates and re-renders.

## How?
We're memoizing the selector by using `createSelector()`. We're introducing a simple test that verifies memoization works as expected - it fails with the non-memoized version of the selector.

## Testing Instructions
* Verify that as you're removing / inserting / moving blocks, the insertion point remains where it should be and works the same way as before - defaulting to the bottom, but staying beside the block if we've selected an empty paragraph for example.
* Verify tests are green.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
None.