### PR TITLE
Block Editor: Improve `getPatternsByBlockTypes()` selector performance

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2338,11 +2338,15 @@ export const getPatternsByBlockTypes = createSelector(
 		const normalizedBlockNames = Array.isArray( blockNames )
 			? blockNames
 			: [ blockNames ];
-		return patterns.filter( ( pattern ) =>
+		const filteredPatterns = patterns.filter( ( pattern ) =>
 			pattern?.blockTypes?.some?.( ( blockName ) =>
 				normalizedBlockNames.includes( blockName )
 			)
 		);
+		if ( filteredPatterns.length === 0 ) {
+			return EMPTY_ARRAY;
+		}
+		return filteredPatterns;
 	},
 	( state, blockNames, rootClientId ) => [
 		...__experimentalGetAllowedPatterns.getDependants(

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -4265,12 +4265,20 @@ describe( 'selectors', () => {
 		it( 'should return empty array if no block name is provided', () => {
 			expect( getPatternsByBlockTypes( state ) ).toEqual( [] );
 		} );
-		it( 'shoud return empty array if no match is found', () => {
+		it( 'should return empty array if no match is found', () => {
 			const patterns = getPatternsByBlockTypes(
 				state,
 				'test/block-not-exists'
 			);
 			expect( patterns ).toEqual( [] );
+		} );
+		it( 'should return the same empty array in both empty array cases', () => {
+			const patterns1 = getPatternsByBlockTypes( state );
+			const patterns2 = getPatternsByBlockTypes(
+				state,
+				'test/block-not-exists'
+			);
+			expect( patterns1 ).toBe( patterns2 );
 		} );
 		it( 'should return proper results when there are matched block patterns', () => {
 			const patterns = getPatternsByBlockTypes( state, 'test/block-a' );


### PR DESCRIPTION
## What?
This PR ensures that when the `getPatternsByBlockTypes()` selector returns an empty array, it always returns the same empty array. 

## Why?
I found this by working on #47419 and noticed that this selector returns a new array every time, without a good reason. This happens particularly when using it in `__experimentalGetPatternsByBlockTypes()`. By memoizing that selector we'll spare some unnecessary updates and re-renders.

## How?
We're returning the same empty array if there are no filtered patterns found. We're also introducing a unit test.

## Testing Instructions
* Verify tests are green.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
None.