### PR TITLE
Navigation: Allow multiple navigations with the same ref

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -469,9 +469,7 @@ function block_core_navigation_get_fallback_blocks() {
 		$fallback_blocks = ! empty( $maybe_fallback ) ? $maybe_fallback : $fallback_blocks;
 	}
 
-	if ( block_core_navigation_has_nested_core_navigation( $parsed_blocks ) ) {
-		return [];
-	}
+
 
 	/**
 	 * Filters the fallback experience for the Navigation block.
@@ -644,6 +642,11 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		}
 
 		$inner_blocks = new WP_Block_List( $fallback_blocks, $attributes );
+	}
+
+	$parsed_blocks = parse_blocks( $navigation_post->post_content );
+	if ( block_core_navigation_has_nested_core_navigation( $parsed_blocks ) ) {
+		return '';
 	}
 
 	/**

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -416,12 +416,12 @@ function block_core_navigation_filter_out_empty_blocks( $parsed_blocks ) {
  * @param array $parsed_blocks the parsed blocks to be normalized.
  * @return bool true if the navigation block contains a nested navigation block.
  */
-function block_core_navigation_has_nested_core_navigation( $parsed_blocks ) {
+function block_core_navigation_block_contains_core_navigation( $parsed_blocks ) {
 	foreach ( $parsed_blocks as $block ) {
 		if ( 'core/navigation' === $block['blockName'] ) {
 			return true;
 		}
-		if ( block_core_navigation_has_nested_core_navigation( $block['innerBlocks'] ) ) {
+		if ( block_core_navigation_block_contains_core_navigation( $block['innerBlocks'] ) ) {
 			return true;
 		}
 	}
@@ -469,8 +469,6 @@ function block_core_navigation_get_fallback_blocks() {
 		// In this case default to the (Page List) fallback.
 		$fallback_blocks = ! empty( $maybe_fallback ) ? $maybe_fallback : $fallback_blocks;
 	}
-
-
 
 	/**
 	 * Filters the fallback experience for the Navigation block.
@@ -646,7 +644,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	}
 
 	$parsed_blocks = parse_blocks( $navigation_post->post_content );
-	if ( block_core_navigation_has_nested_core_navigation( $parsed_blocks ) ) {
+	if ( block_core_navigation_block_contains_core_navigation( $parsed_blocks ) ) {
 		return '';
 	}
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -462,7 +462,7 @@ function block_core_navigation_get_fallback_blocks() {
 
 	// Use the first non-empty Navigation as fallback if available.
 	if ( $navigation_post ) {
-		$parsed_blocks = parse_blocks( $navigation_post->post_content );
+		$parsed_blocks  = parse_blocks( $navigation_post->post_content );
 		$maybe_fallback = block_core_navigation_filter_out_empty_blocks( $parsed_blocks );
 
 		// Normalizing blocks may result in an empty array of blocks if they were all `null` blocks.

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -411,21 +411,22 @@ function block_core_navigation_filter_out_empty_blocks( $parsed_blocks ) {
 }
 
 /**
- * Bail on rendering nested navigation blocks
+ * Returns true if the navigation block contains a nested navigation block.
  *
  * @param array $parsed_blocks the parsed blocks to be normalized.
- * @return array the normalized parsed blocks.
+ * @return bool true if the navigation block contains a nested navigation block.
  */
 function block_core_navigation_has_nested_core_navigation( $parsed_blocks ) {
-	$filtered = array_filter(
-		$parsed_blocks,
-		function( $block ) {
-			return $block['blockName'] === 'core/navigation';
+	foreach ( $parsed_blocks as $block ) {
+		if ( 'core/navigation' === $block['blockName'] ) {
+			return true;
 		}
-	);
+		if ( block_core_navigation_has_nested_core_navigation( $block['innerBlocks'] ) ) {
+			return true;
+		}
+	}
 
-	// Reset keys.
-	return count( $filtered ) > 0;
+	return false;
 }
 
 /**

--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -66,21 +66,21 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::gutenberg_block_core_navigation_has_nested_core_navigation
+	 * @covers :: gutengberg_block_core_navigation_block_contains_core_navigation
 	 */
-	public function test_gutenberg_block_core_navigation_has_nested_core_navigation() {
+	public function test_gutenberg_block_core_navigation_block_contains_core_navigation() {
 		$parsed_blocks = parse_blocks( '<!-- wp:navigation /-->' );
-		$this->assertTrue( gutenberg_block_core_navigation_has_nested_core_navigation( $parsed_blocks ) );
+		$this->assertTrue( gutenberg_block_core_navigation_block_contains_core_navigation( $parsed_blocks ) );
 	}
 
-	public function test_gutenberg_block_core_navigation_has_nested_core_navigation_deep() {
+	public function test_gutenberg_block_core_navigation_block_contains_core_navigation_deep() {
 		$parsed_blocks = parse_blocks( '<!-- wp:group --><!-- /wp:group --><!-- wp:group --><!-- wp:group --><!-- wp:navigation /--><!-- /wp:group --><!-- /wp:group -->' );
-		$this->assertTrue( gutenberg_block_core_navigation_has_nested_core_navigation( $parsed_blocks ) );
+		$this->assertTrue( gutenberg_block_core_navigation_block_contains_core_navigation( $parsed_blocks ) );
 	}
 
-	public function test_gutenberg_block_core_navigation_has_nested_core_navigation_no_navigation() {
+	public function test_gutenberg_block_core_navigation_block_contains_core_navigation_no_navigation() {
 		$parsed_blocks = parse_blocks( '<!-- wp:group --><!-- wp:group --><!-- /wp:group --><!-- /wp:group -->' );
-		$this->assertFalse( gutenberg_block_core_navigation_has_nested_core_navigation( $parsed_blocks ) );
+		$this->assertFalse( gutenberg_block_core_navigation_block_contains_core_navigation( $parsed_blocks ) );
 	}
 
 }

--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -65,5 +65,22 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 		$this->assertSameSetsWithIndex( array( 755, 789 ), $post_ids );
 	}
 
+	/**
+	 * @covers ::gutenberg_block_core_navigation_has_nested_core_navigation
+	 */
+	public function test_gutenberg_block_core_navigation_has_nested_core_navigation() {
+		$parsed_blocks = parse_blocks( '<!-- wp:navigation /-->' );
+		$this->assertTrue( gutenberg_block_core_navigation_has_nested_core_navigation( $parsed_blocks ) );
+	}
+
+	public function test_gutenberg_block_core_navigation_has_nested_core_navigation_deep() {
+		$parsed_blocks = parse_blocks( '<!-- wp:group --><!-- /wp:group --><!-- wp:group --><!-- wp:group --><!-- wp:navigation /--><!-- /wp:group --><!-- /wp:group -->' );
+		$this->assertTrue( gutenberg_block_core_navigation_has_nested_core_navigation( $parsed_blocks ) );
+	}
+
+	public function test_gutenberg_block_core_navigation_has_nested_core_navigation_no_navigation() {
+		$parsed_blocks = parse_blocks( '<!-- wp:group --><!-- wp:group --><!-- /wp:group --><!-- /wp:group -->' );
+		$this->assertFalse( gutenberg_block_core_navigation_has_nested_core_navigation( $parsed_blocks ) );
+	}
 
 }


### PR DESCRIPTION
## What?
Our last fix for preventing recursive navigation blocks (https://github.com/WordPress/gutenberg/pull/46387) prevents users from having the same navigation twice in one page. This allows that use case while still preventing nested navigation blocks.

Fixes https://github.com/WordPress/gutenberg/issues/47085#issuecomment-1382850424
## Why?
Users should be allowed to create multiple navigation menus on the same page, with the same ref.

## How?
Use a recursive loop to check whether a block or any inner blocks contain a navigation block.

## Testing Instructions
1. Try adding two navigation menus with the same ref to a post/template. You should see both of them.
2. You can also try testing nested navigation menus by adding `<!-- /wp:navigation -->` to a wp_navigation CPT, but you'll need to use mysql. (See https://github.com/WordPress/gutenberg/pull/46387 for instructions).

### Testing Instructions for Keyboard
As above.

## Screenshots or screencast <!-- if applicable -->
Two identical navigations on the same page:
<img width="1245" alt="Screenshot 2023-01-26 at 11 59 28" src="https://user-images.githubusercontent.com/275961/214830088-95c0ca0c-0336-4a0c-b3c7-073c9262b8ef.png">


