### PR TITLE
Remove double edit button in LinkUI

### DIFF
--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -7,11 +7,10 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useCallback, useMemo, useRef } from '@wordpress/element';
+import { useMemo, useRef } from '@wordpress/element';
 import { useEntityBlockEditor, store as coreStore } from '@wordpress/core-data';
 import {
 	BlockList,
-	__experimentalLinkControl,
 	BlockInspector,
 	BlockTools,
 	__unstableUseClipboardHandler as useClipboardHandler,
@@ -32,7 +31,6 @@ import { ReusableBlocksMenuItems } from '@wordpress/reusable-blocks';
  */
 import inserterMediaCategories from './inserter-media-categories';
 import TemplatePartConverter from '../template-part-converter';
-import NavigateToLink from '../navigate-to-link';
 import { SidebarInspectorFill } from '../sidebar-edit-mode';
 import { store as editSiteStore } from '../../store';
 import BackButton from './back-button';
@@ -50,7 +48,7 @@ const LAYOUT = {
 };
 
 export default function BlockEditor() {
-	const { setPage, setIsInserterOpened } = useDispatch( editSiteStore );
+	const { setIsInserterOpened } = useDispatch( editSiteStore );
 	const { storedSettings, templateType, canvasMode } = useSelect(
 		( select ) => {
 			const { getSettings, getEditedPostType, __unstableGetCanvasMode } =
@@ -163,17 +161,6 @@ export default function BlockEditor() {
 			useSubRegistry={ false }
 		>
 			<TemplatePartConverter />
-			<__experimentalLinkControl.ViewerFill>
-				{ useCallback(
-					( fillProps ) => (
-						<NavigateToLink
-							{ ...fillProps }
-							onActivePageChange={ setPage }
-						/>
-					),
-					[]
-				) }
-			</__experimentalLinkControl.ViewerFill>
 			<SidebarInspectorFill>
 				<BlockInspector />
 			</SidebarInspectorFill>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Closes #47413
## What?
<!-- In a few words, what is the PR actually doing? -->


In #20366 a button to navigate to the link inside the site editor was added. In the mean time LinkUI got its own edit button 
to edit the set link for inline links. The two buttons now collide. 


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because there are two buttons that look the same and do differnt things.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->


I left the infrastructure built by #20366 - e.g. a slot in LinkUI button area - for a future where we may want this back. 
Only removed the button addition in the block editor component in the site editor.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In the site editor
2. With theme TT3
3. Edit the 404 template
4. Select " page could not be found" and link it to an internal page or post
5. See only one edit pencil button

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
