### PR TITLE
Change 'get_legacy_theme_supports_for_theme_json' compat dir

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -290,7 +290,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		 * So we take theme supports, transform it to theme.json shape
 		 * and merge the static::$theme upon that.
 		 */
-		$theme_support_data = WP_Theme_JSON_Gutenberg::get_from_editor_settings( gutenberg_get_legacy_theme_supports_for_theme_json() );
+		$theme_support_data = WP_Theme_JSON_Gutenberg::get_from_editor_settings( get_classic_theme_supports_block_editor_settings() );
 		if ( ! wp_theme_has_theme_json() ) {
 			if ( ! isset( $theme_support_data['settings']['color'] ) ) {
 				$theme_support_data['settings']['color'] = array();

--- a/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
@@ -54,38 +54,3 @@ function gutenberg_add_global_styles_for_blocks() {
 		}
 	}
 }
-
-/**
- * Repeated logic from `get_default_block_editor_settings` function. When implemented into core,
- * remove logic from `get_default_block_editor_settings` and simple call this function instead.
- *
- * @return array
- */
-function gutenberg_get_legacy_theme_supports_for_theme_json() {
-	$theme_settings = array(
-		'disableCustomColors'    => get_theme_support( 'disable-custom-colors' ),
-		'disableCustomFontSizes' => get_theme_support( 'disable-custom-font-sizes' ),
-		'disableCustomGradients' => get_theme_support( 'disable-custom-gradients' ),
-		'enableCustomLineHeight' => get_theme_support( 'custom-line-height' ),
-		'enableCustomSpacing'    => get_theme_support( 'custom-spacing' ),
-		'enableCustomUnits'      => get_theme_support( 'custom-units' ),
-	);
-
-	// Theme settings.
-	$color_palette = current( (array) get_theme_support( 'editor-color-palette' ) );
-	if ( false !== $color_palette ) {
-		$theme_settings['colors'] = $color_palette;
-	}
-
-	$font_sizes = current( (array) get_theme_support( 'editor-font-sizes' ) );
-	if ( false !== $font_sizes ) {
-		$theme_settings['fontSizes'] = $font_sizes;
-	}
-
-	$gradient_presets = current( (array) get_theme_support( 'editor-gradient-presets' ) );
-	if ( false !== $gradient_presets ) {
-		$theme_settings['gradients'] = $gradient_presets;
-	}
-
-	return $theme_settings;
-}

--- a/lib/compat/wordpress-6.2/block-editor.php
+++ b/lib/compat/wordpress-6.2/block-editor.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Block Editor API.
+ *
+ * @package gutenberg
+ */
+
+if ( ! function_exists( 'get_classic_theme_supports_block_editor_settings' ) ) {
+	/**
+	 * Returns the classic theme supports settings for block editor.
+	 *
+	 * @since 6.2.0
+	 *
+	 * @return array The classic theme supports settings.
+	 */
+	function get_classic_theme_supports_block_editor_settings() {
+		$theme_settings = array(
+			'disableCustomColors'    => get_theme_support( 'disable-custom-colors' ),
+			'disableCustomFontSizes' => get_theme_support( 'disable-custom-font-sizes' ),
+			'disableCustomGradients' => get_theme_support( 'disable-custom-gradients' ),
+			'disableLayoutStyles'    => get_theme_support( 'disable-layout-styles' ),
+			'enableCustomLineHeight' => get_theme_support( 'custom-line-height' ),
+			'enableCustomSpacing'    => get_theme_support( 'custom-spacing' ),
+			'enableCustomUnits'      => get_theme_support( 'custom-units' ),
+		);
+
+		// Theme settings.
+		$color_palette = current( (array) get_theme_support( 'editor-color-palette' ) );
+		if ( false !== $color_palette ) {
+			$theme_settings['colors'] = $color_palette;
+		}
+
+		$font_sizes = current( (array) get_theme_support( 'editor-font-sizes' ) );
+		if ( false !== $font_sizes ) {
+			$theme_settings['fontSizes'] = $font_sizes;
+		}
+
+		$gradient_presets = current( (array) get_theme_support( 'editor-gradient-presets' ) );
+		if ( false !== $gradient_presets ) {
+			$theme_settings['gradients'] = $gradient_presets;
+		}
+
+		return $theme_settings;
+	}
+}

--- a/lib/load.php
+++ b/lib/load.php
@@ -82,6 +82,7 @@ require __DIR__ . '/compat/wordpress-6.2/get-global-styles-and-settings.php';
 require __DIR__ . '/compat/wordpress-6.2/default-filters.php';
 require __DIR__ . '/compat/wordpress-6.2/edit-form-blocks.php';
 require __DIR__ . '/compat/wordpress-6.2/site-editor.php';
+require __DIR__ . '/compat/wordpress-6.2/block-editor.php';
 require __DIR__ . '/compat/wordpress-6.2/block-editor-settings.php';
 require __DIR__ . '/compat/wordpress-6.2/theme.php';
 require __DIR__ . '/compat/wordpress-6.2/widgets.php';


### PR DESCRIPTION
## What?
PR moves the `get_legacy_theme_supports_for_theme_json` method to correct the compat directory. I've also updated the function name to match the core backport. See https://github.com/WordPress/wordpress-develop/pull/3902.

## Testing Instructions
CI checks are green.
