### PR TITLE
`useDisabled` hook: Fix problem with not working in iframe

### DIFF
--- a/packages/compose/src/hooks/use-disabled/index.ts
+++ b/packages/compose/src/hooks/use-disabled/index.ts
@@ -39,11 +39,16 @@ export default function useDisabled( {
 				return;
 			}
 
+			const defaultView = node?.ownerDocument?.defaultView;
+			if ( ! defaultView ) {
+				return;
+			}
+
 			/** A variable keeping track of the previous updates in order to restore them. */
 			const updates: Function[] = [];
 			const disable = () => {
 				node.childNodes.forEach( ( child ) => {
-					if ( ! ( child instanceof HTMLElement ) ) {
+					if ( ! ( child instanceof defaultView.HTMLElement ) ) {
 						return;
 					}
 					if ( ! child.getAttribute( 'inert' ) ) {


### PR DESCRIPTION
Fixes: #47293
More fundamental solution than #47331

## What?
This PR solves the problem of the `useDisabled` hook not working on iframes and ensures that the `inert` attribute is properly applied to the child element.

As a result, the issue reported in #47293, where tools are duplicated, will be fixed.

## Why?
The `useDisabled` hook grants the inert attribute if its child element is a instance of `HTMLElement`. However, as far as I know,  `instanceof HTMLElement` is implicitly treated as a `window.HTMLElement`, so it does not meet this condition in an iframe.
As a result, within the iframe, this hook does not grant the `inert` attribute.

As you can see in the video below, in the classic theme, the post editor is not an iframe, so the inert attribute is given and the issue reported in #47293 does not occur. However, in the case of the block theme, because it is an iframe, the inert attribute is not given and the problem occurs:

https://user-images.githubusercontent.com/54422211/214849737-d131a724-595b-480d-982f-e2d3f5834a3d.mp4

## How?
Refer to `defaultView` to check instances relative to the `defaultView`.

More fundamentally, as pointed out in [this comment](https://github.com/WordPress/gutenberg/pull/47331#issuecomment-1403131645), the problem might be that the clientId is shared within the hoge block.
This issue may need to be investigated separately.

## Testing Instructions

- Activate Thwenty Twenty Three theme.
- Open the site editor.
- Open the Home template containing the query loop block.
- Click on various locations in the query loop to confirm that the problem reported in #47293 does not occur.
- Paste this query loop into the content of the post editor.
- Similarly, confirm that no problems occur.
