### PR TITLE
Style Book: Exclude blocks that are not allowed to insert

### DIFF
--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -485,7 +485,7 @@ supports: {
 -   Type: `boolean`
 -   Default value: `true`
 
-By default, all blocks will appear in the inserter. To hide a block so that it can only be inserted programmatically, set `inserter` to `false`.
+By default, all blocks will appear in the inserter, block transforms menu, Style Book, etc. To hide a block from all parts of the user interface so that it can only be inserted programatically, set `inserter` to `false`.
 
 ```js
 supports: {

--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bug Fix
 
 -   Force visual editor in browse mode ([#47329](https://github.com/WordPress/gutenberg/pull/47329)).
--   Style Book: Exclude blocks that are not allowed to insert or have parent ([#47461](https://github.com/WordPress/gutenberg/pull/47461)).
+-   Style Book: Exclude blocks that are not allowed to insert ([#47461](https://github.com/WordPress/gutenberg/pull/47461)).
 
 ## 5.2.0 (2023-01-11)
 

--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fix
 
 -   Force visual editor in browse mode ([#47329](https://github.com/WordPress/gutenberg/pull/47329)).
+-   Style Book: Exclude blocks that are not allowed to insert or have parent ([#47461](https://github.com/WordPress/gutenberg/pull/47461)).
 
 ## 5.2.0 (2023-01-11)
 

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -70,10 +70,15 @@ function getExamples() {
 	};
 
 	const otherExamples = getBlockTypes()
-		.filter(
-			( blockType ) =>
-				blockType.name !== 'core/heading' && !! blockType.example
-		)
+		.filter( ( blockType ) => {
+			const { name, example, supports, parent } = blockType;
+			return (
+				name !== 'core/heading' &&
+				!! example &&
+				supports.inserter !== false &&
+				! parent
+			);
+		} )
 		.map( ( blockType ) => ( {
 			name: blockType.name,
 			title: blockType.title,

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -71,13 +71,11 @@ function getExamples() {
 
 	const otherExamples = getBlockTypes()
 		.filter( ( blockType ) => {
-			const { name, example, supports, parent, ancestor } = blockType;
+			const { name, example, supports } = blockType;
 			return (
 				name !== 'core/heading' &&
 				!! example &&
-				supports.inserter !== false &&
-				! parent &&
-				! ancestor
+				supports.inserter !== false
 			);
 		} )
 		.map( ( blockType ) => ( {

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -71,12 +71,13 @@ function getExamples() {
 
 	const otherExamples = getBlockTypes()
 		.filter( ( blockType ) => {
-			const { name, example, supports, parent } = blockType;
+			const { name, example, supports, parent, ancestor } = blockType;
 			return (
 				name !== 'core/heading' &&
 				!! example &&
 				supports.inserter !== false &&
-				! parent
+				! parent &&
+				! ancestor
 			);
 		} )
 		.map( ( blockType ) => ( {

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -304,7 +304,7 @@
 				},
 				"inserter": {
 					"type": "boolean",
-					"description": "By default, all blocks will appear in the inserter. To hide a block so that it can only be inserted programmatically, set inserter to false.",
+					"description": "By default, all blocks will appear in the inserter, block transforms menu, Style Book, etc. To hide a block from all parts of the user interface so that it can only be inserted programatically, set inserter to false.",
 					"default": true
 				},
 				"multiple": {


### PR DESCRIPTION
Fixes: #47440

## What?
This PR excludes blocks from the Style Book that are not allowed to insert.

## Why?
The current stylebook displays all blocks that do not have the `example` property. Blocks that are not allowed to be inserted should never be previewed by themselves, even if they have the example property. Therefore, I don't think it should be displayed in the Stylebook.

## How

I considered excluding blocks with `parent` and `ancestor` properties, but the following blocks would not be displayed:

- Page List Item
- Button
- Page Break
- Custom Link
- Home Link
 
To keep the current list of blocks, I didn't take that action.

## Testing Instructions

There is no core block with inserter set to false and example defined. Therefore, in this PR, confirm that the blocks displayed in the stylebook remain the same as shown below:

- Text (9 blocks):
  - Headings, Paragraph, List, Quote, Code, Preformatted, Pullquote, Table, Verse
- Media (7 blocks):
  - Image, Gallery, Audio, Cover, File, Media & Text, Video
- Design (10 blocks):
  - Button, Buttons, Columns, Group, More, Page Break, Separator, Custom Link, Home Link, Table Of Contents
- Widgets (12 blocks):
  - Archives, Calendar, Categories List, Custom HTML, Latest Comments, Latest Posts, Page List, Page List Item, RSS, Search, Social Icons, Tag Cloud
- Theme (3 blocks):
  - Navigation, Site Logo, Site Title 