### PR TITLE
Block Editor: Optimize selected blocks in `BlockSettingsMenuControls`

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -306,6 +306,20 @@ _Returns_
 
 -   `string`: Block name.
 
+### getBlockNamesByClientId
+
+Given an array of block client IDs, returns the corresponding array of block
+names.
+
+_Parameters_
+
+-   _state_ `Object`: Editor state.
+-   _clientIds_ `string[]`: Client IDs for which block names are to be returned.
+
+_Returns_
+
+-   `string[]`: Block names.
+
 ### getBlockOrder
 
 Returns an array containing all block client IDs in the editor in the order

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -28,16 +28,14 @@ const BlockSettingsMenuControlsSlot = ( {
 	const { selectedBlocks, selectedClientIds, canRemove } = useSelect(
 		( select ) => {
 			const {
-				getBlocksByClientId,
+				getBlockNamesByClientId,
 				getSelectedBlockClientIds,
 				canRemoveBlocks,
 			} = select( blockEditorStore );
 			const ids =
 				clientIds !== null ? clientIds : getSelectedBlockClientIds();
 			return {
-				selectedBlocks: getBlocksByClientId( ids )
-					.filter( Boolean )
-					.map( ( block ) => block.name ),
+				selectedBlocks: getBlockNamesByClientId( ids ),
 				selectedClientIds: ids,
 				canRemove: canRemoveBlocks( ids ),
 			};

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -323,6 +323,23 @@ export const getBlocksByClientId = createSelector(
 );
 
 /**
+ * Given an array of block client IDs, returns the corresponding array of block
+ * names.
+ *
+ * @param {Object}   state     Editor state.
+ * @param {string[]} clientIds Client IDs for which block names are to be returned.
+ *
+ * @return {string[]} Block names.
+ */
+export const getBlockNamesByClientId = createSelector(
+	( state, clientIds ) =>
+		getBlocksByClientId( state, clientIds )
+			.filter( Boolean )
+			.map( ( block ) => block.name ),
+	( state, clientIds ) => getBlocksByClientId( state, clientIds )
+);
+
+/**
  * Returns the number of blocks currently present in the post.
  *
  * @param {Object}  state        Editor state.


### PR DESCRIPTION
## What?
This PR ensures that when the `getBlocksByClientId()` selector is used to return block names, we properly memoize that instead of returning a new array every time.

## Why?
I found this by working on #47419 and noticed that in `BlockSettingsMenuControlsSlot` we return a new array every time, without a good reason, because it contains the same block names. 

So when we select a paragraph block, open block settings, and start moving the mouse up and down between the blocks, we'll get a ton of needless recalculations of the `selectedBlocks` property, since it will always call `.filter().map()` on the result of `getBlocksByClientId()` to get the block names out of it.

By introducing a memoized version of that selector we'll spare some unnecessary updates and re-renders.

## How?
We're introducing a new selector that relies on `getBlocksByClientId()`, includes memoization and retrieves the names of blocks with the specified client IDs.

In a follow-up PR, I'm planning to work on reusing this selector where applicable.

## Testing Instructions
Verify that block settings still work well with one and more selected blocks.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
None.