### PR TITLE
[Block Editor]: Fix `onHover` errors at BlockPattern

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -51,7 +51,7 @@ function BlockPattern( {
 					onDragStart={ ( event ) => {
 						setIsDragging( true );
 						if ( onDragStart ) {
-							onHover( null );
+							onHover?.( null );
 							onDragStart( event );
 						}
 					} }
@@ -73,15 +73,15 @@ function BlockPattern( {
 							className="block-editor-block-patterns-list__item"
 							onClick={ () => {
 								onClick( pattern, blocks );
-								onHover( null );
+								onHover?.( null );
 							} }
 							onMouseEnter={ () => {
 								if ( isDragging ) {
 									return;
 								}
-								onHover( pattern );
+								onHover?.( pattern );
 							} }
-							onMouseLeave={ () => onHover( null ) }
+							onMouseLeave={ () => onHover?.( null ) }
 							aria-label={ pattern.title }
 							aria-describedby={
 								pattern.description ? descriptionId : undefined


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A small follow up for: https://github.com/WordPress/gutenberg/pull/47316

BlockPattern component is used in more places where `onHover` is not defined. This PR fixes that. I didn't add a default `noop` function, because I don't think there is the need to even call something if not defined.

## Testing Instructions
1. Open `Patterns Explorer` or `replace`(block settings menu) in a Template Part
2. hover patterns
3. observe no errors are thrown
