### PR TITLE
Use https by default in prependHTTP util

### DIFF
--- a/packages/url/README.md
+++ b/packages/url/README.md
@@ -470,7 +470,7 @@ Prepends "http\://" to a url, if it looks like something that is meant to be a T
 _Usage_
 
 ```js
-const actualURL = prependHTTP( 'wordpress.org' ); // http://wordpress.org
+const actualURL = prependHTTP( 'wordpress.org' ); // https://wordpress.org
 ```
 
 _Parameters_

--- a/packages/url/src/prepend-http.js
+++ b/packages/url/src/prepend-http.js
@@ -12,7 +12,7 @@ const USABLE_HREF_REGEXP = /^(?:[a-z]+:|#|\?|\.|\/)/i;
  *
  * @example
  * ```js
- * const actualURL = prependHTTP( 'wordpress.org' ); // http://wordpress.org
+ * const actualURL = prependHTTP( 'wordpress.org' ); // https://wordpress.org
  * ```
  *
  * @return {string} The updated URL.
@@ -24,7 +24,7 @@ export function prependHTTP( url ) {
 
 	url = url.trim();
 	if ( ! USABLE_HREF_REGEXP.test( url ) && ! isEmail( url ) ) {
-		return 'http://' + url;
+		return 'https://' + url;
 	}
 
 	return url;

--- a/packages/url/src/test/index.js
+++ b/packages/url/src/test/index.js
@@ -823,70 +823,70 @@ describe( 'removeQueryArgs', () => {
 } );
 
 describe( 'prependHTTP', () => {
-	it( 'should prepend http to a domain', () => {
+	it( 'should prepend https to a domain', () => {
 		const url = 'wordpress.org';
 
-		expect( prependHTTP( url ) ).toBe( 'http://' + url );
+		expect( prependHTTP( url ) ).toBe( 'https://' + url );
 	} );
 
-	it( 'shouldn’t prepend http to an email', () => {
+	it( 'shouldn’t prepend https to an email', () => {
 		const url = 'foo@wordpress.org';
 
 		expect( prependHTTP( url ) ).toBe( url );
 	} );
 
-	it( 'shouldn’t prepend http to an absolute URL', () => {
+	it( 'shouldn’t prepend https to an absolute URL', () => {
 		const url = '/wordpress';
 
 		expect( prependHTTP( url ) ).toBe( url );
 	} );
 
-	it( 'shouldn’t prepend http to a relative URL', () => {
+	it( 'shouldn’t prepend https to a relative URL', () => {
 		const url = './wordpress';
 
 		expect( prependHTTP( url ) ).toBe( url );
 	} );
 
-	it( 'shouldn’t prepend http to an anchor URL', () => {
+	it( 'shouldn’t prepend https to an anchor URL', () => {
 		const url = '#wordpress';
 
 		expect( prependHTTP( url ) ).toBe( url );
 	} );
 
-	it( 'shouldn’t prepend http to a URL that already has http', () => {
-		const url = 'http://wordpress.org';
-
-		expect( prependHTTP( url ) ).toBe( url );
-	} );
-
-	it( 'shouldn’t prepend http to a URL that already has https', () => {
+	it( 'shouldn’t prepend https to a URL that already has http', () => {
 		const url = 'https://wordpress.org';
 
 		expect( prependHTTP( url ) ).toBe( url );
 	} );
 
-	it( 'shouldn’t prepend http to a URL that already has ftp', () => {
+	it( 'shouldn’t prepend https to a URL that already has https', () => {
+		const url = 'https://wordpress.org';
+
+		expect( prependHTTP( url ) ).toBe( url );
+	} );
+
+	it( 'shouldn’t prepend https to a URL that already has ftp', () => {
 		const url = 'ftp://wordpress.org';
 
 		expect( prependHTTP( url ) ).toBe( url );
 	} );
 
-	it( 'shouldn’t prepend http to a URL that already has mailto', () => {
+	it( 'shouldn’t prepend https to a URL that already has mailto', () => {
 		const url = 'mailto:foo@wordpress.org';
 
 		expect( prependHTTP( url ) ).toBe( url );
 	} );
 
-	it( 'should remove leading whitespace before prepending HTTP', () => {
+	it( 'should remove leading whitespace before prepending https', () => {
 		const url = ' wordpress.org';
 
-		expect( prependHTTP( url ) ).toBe( 'http://wordpress.org' );
+		expect( prependHTTP( url ) ).toBe( 'https://wordpress.org' );
 	} );
 
 	it( 'should not have trailing whitespaces', () => {
 		const url = 'wordpress.org ';
 
-		expect( prependHTTP( url ) ).toBe( 'http://wordpress.org' );
+		expect( prependHTTP( url ) ).toBe( 'https://wordpress.org' );
 	} );
 } );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Alternative to https://github.com/WordPress/gutenberg/pull/47312.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because @draganescu suggested it in https://github.com/WordPress/gutenberg/pull/47312#pullrequestreview-1270898065 so I'm raising it for consideration.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update the util to always use `https` instead of `http`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Same as https://github.com/WordPress/gutenberg/pull/47312.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
