### PR TITLE
[WIP] Display block shortcuts in Top Bar when Inserter is open

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -6,23 +6,11 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { __, _x } from '@wordpress/i18n';
 import {
 	NavigableToolbar,
-	ToolSelector,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import {
-	EditorHistoryRedo,
-	EditorHistoryUndo,
-	store as editorStore,
-} from '@wordpress/editor';
+import { store as editorStore } from '@wordpress/editor';
 import { Button, ToolbarItem } from '@wordpress/components';
-import {
-	listView,
-	plus,
-	paragraph,
-	heading,
-	list,
-	image,
-} from '@wordpress/icons';
+import { plus } from '@wordpress/icons';
 import { useRef, useCallback } from '@wordpress/element';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 
@@ -30,6 +18,8 @@ import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
  * Internal dependencies
  */
 import { store as editPostStore } from '../../../store';
+import InserterOpenItems from './inserter-open-items';
+import InserterClosedItems from './inserter-closed-items';
 
 const preventDefault = ( event ) => {
 	event.preventDefault();
@@ -71,16 +61,10 @@ function HeaderToolbar() {
 			),
 		};
 	}, [] );
-	const isLargeViewport = useViewportMatch( 'medium' );
 	const isWideViewport = useViewportMatch( 'wide' );
 
 	/* translators: accessibility text for the editor toolbar */
 	const toolbarAriaLabel = __( 'Document tools' );
-
-	const toggleListView = useCallback(
-		() => setIsListViewOpened( ! isListViewOpen ),
-		[ setIsListViewOpened, isListViewOpen ]
-	);
 	const openInserter = useCallback( () => {
 		if ( isInserterOpened ) {
 			// Focusing the inserter button closes the inserter popover.
@@ -96,93 +80,6 @@ function HeaderToolbar() {
 		'Generic label for block inserter button'
 	);
 	const shortLabel = ! isInserterOpened ? __( 'Add' ) : __( 'Close' );
-
-	const inserterClosedItems = (
-		<>
-			{ isLargeViewport && (
-				<ToolbarItem
-					as={ ToolSelector }
-					showTooltip={ ! showIconLabels }
-					variant={ showIconLabels ? 'tertiary' : undefined }
-					disabled={ isTextModeEnabled }
-				/>
-			) }
-			<ToolbarItem
-				as={ EditorHistoryUndo }
-				showTooltip={ ! showIconLabels }
-				variant={ showIconLabels ? 'tertiary' : undefined }
-			/>
-			<ToolbarItem
-				as={ EditorHistoryRedo }
-				showTooltip={ ! showIconLabels }
-				variant={ showIconLabels ? 'tertiary' : undefined }
-			/>
-			<ToolbarItem
-				as={ Button }
-				className="edit-post-header-toolbar__document-overview-toggle"
-				icon={ listView }
-				disabled={ isTextModeEnabled }
-				isPressed={ isListViewOpen }
-				/* translators: button label text should, if possible, be under 16 characters. */
-				label={ __( 'Document Overview' ) }
-				onClick={ toggleListView }
-				shortcut={ listViewShortcut }
-				showTooltip={ ! showIconLabels }
-				variant={ showIconLabels ? 'tertiary' : undefined }
-			/>
-		</>
-	);
-
-	const inserterOpenItems = (
-		<>
-			<ToolbarItem
-				as={ Button }
-				className="edit-post-header-toolbar__insert-block"
-				variant="secondary"
-				onClick={ openInserter }
-				icon={ paragraph }
-				label={ __( 'Insert Paragraph Block' ) }
-				showTooltip={ ! showIconLabels }
-			/>
-			<ToolbarItem
-				as={ Button }
-				className="edit-post-header-toolbar__insert-block"
-				variant="secondary"
-				onClick={ openInserter }
-				icon={ heading }
-				label={ __( 'Insert Heading Block' ) }
-				showTooltip={ ! showIconLabels }
-			/>
-			<ToolbarItem
-				as={ Button }
-				className="edit-post-header-toolbar__insert-block"
-				variant="secondary"
-				onClick={ openInserter }
-				icon={ list }
-				label={ __( 'Insert List Block' ) }
-				showTooltip={ ! showIconLabels }
-			/>
-			<ToolbarItem
-				as={ Button }
-				className="edit-post-header-toolbar__insert-block"
-				variant="secondary"
-				onClick={ openInserter }
-				icon={ image }
-				label={ __( 'Insert Image Block' ) }
-				showTooltip={ ! showIconLabels }
-			/>
-			<ToolbarItem
-				as={ EditorHistoryUndo }
-				showTooltip={ ! showIconLabels }
-				variant={ showIconLabels ? 'tertiary' : undefined }
-			/>
-			<ToolbarItem
-				as={ EditorHistoryRedo }
-				showTooltip={ ! showIconLabels }
-				variant={ showIconLabels ? 'tertiary' : undefined }
-			/>
-		</>
-	);
 
 	return (
 		<NavigableToolbar
@@ -204,10 +101,21 @@ function HeaderToolbar() {
 					showTooltip={ ! showIconLabels }
 				/>
 				{ ( isWideViewport || ! showIconLabels ) && (
-					<>
-						{ isInserterOpened && inserterOpenItems }
-						{ ! isInserterOpened && inserterClosedItems }
-					</>
+					<div className="edit-post-header-toolbar__toolbar-items">
+						<InserterClosedItems
+							isInserterOpened={ isInserterOpened }
+							showIconLabels={ showIconLabels }
+							isTextModeEnabled={ isTextModeEnabled }
+							isListViewOpen={ isListViewOpen }
+							listViewShortcut={ listViewShortcut }
+							setIsListViewOpened={ setIsListViewOpened }
+						/>
+
+						<InserterOpenItems
+							isInserterOpened={ isInserterOpened }
+							showIconLabels={ showIconLabels }
+						/>
+					</div>
 				) }
 			</div>
 		</NavigableToolbar>

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -15,7 +15,14 @@ import {
 	store as editorStore,
 } from '@wordpress/editor';
 import { Button, ToolbarItem } from '@wordpress/components';
-import { listView, plus } from '@wordpress/icons';
+import {
+	listView,
+	plus,
+	paragraph,
+	heading,
+	list,
+	image,
+} from '@wordpress/icons';
 import { useRef, useCallback } from '@wordpress/element';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 
@@ -74,23 +81,6 @@ function HeaderToolbar() {
 		() => setIsListViewOpened( ! isListViewOpen ),
 		[ setIsListViewOpened, isListViewOpen ]
 	);
-	const overflowItems = (
-		<>
-			<ToolbarItem
-				as={ Button }
-				className="edit-post-header-toolbar__document-overview-toggle"
-				icon={ listView }
-				disabled={ isTextModeEnabled }
-				isPressed={ isListViewOpen }
-				/* translators: button label text should, if possible, be under 16 characters. */
-				label={ __( 'Document Overview' ) }
-				onClick={ toggleListView }
-				shortcut={ listViewShortcut }
-				showTooltip={ ! showIconLabels }
-				variant={ showIconLabels ? 'tertiary' : undefined }
-			/>
-		</>
-	);
 	const openInserter = useCallback( () => {
 		if ( isInserterOpened ) {
 			// Focusing the inserter button closes the inserter popover.
@@ -106,6 +96,93 @@ function HeaderToolbar() {
 		'Generic label for block inserter button'
 	);
 	const shortLabel = ! isInserterOpened ? __( 'Add' ) : __( 'Close' );
+
+	const inserterClosedItems = (
+		<>
+			{ isLargeViewport && (
+				<ToolbarItem
+					as={ ToolSelector }
+					showTooltip={ ! showIconLabels }
+					variant={ showIconLabels ? 'tertiary' : undefined }
+					disabled={ isTextModeEnabled }
+				/>
+			) }
+			<ToolbarItem
+				as={ EditorHistoryUndo }
+				showTooltip={ ! showIconLabels }
+				variant={ showIconLabels ? 'tertiary' : undefined }
+			/>
+			<ToolbarItem
+				as={ EditorHistoryRedo }
+				showTooltip={ ! showIconLabels }
+				variant={ showIconLabels ? 'tertiary' : undefined }
+			/>
+			<ToolbarItem
+				as={ Button }
+				className="edit-post-header-toolbar__document-overview-toggle"
+				icon={ listView }
+				disabled={ isTextModeEnabled }
+				isPressed={ isListViewOpen }
+				/* translators: button label text should, if possible, be under 16 characters. */
+				label={ __( 'Document Overview' ) }
+				onClick={ toggleListView }
+				shortcut={ listViewShortcut }
+				showTooltip={ ! showIconLabels }
+				variant={ showIconLabels ? 'tertiary' : undefined }
+			/>
+		</>
+	);
+
+	const inserterOpenItems = (
+		<>
+			<ToolbarItem
+				as={ Button }
+				className="edit-post-header-toolbar__insert-block"
+				variant="secondary"
+				onClick={ openInserter }
+				icon={ paragraph }
+				label={ __( 'Insert Paragraph Block' ) }
+				showTooltip={ ! showIconLabels }
+			/>
+			<ToolbarItem
+				as={ Button }
+				className="edit-post-header-toolbar__insert-block"
+				variant="secondary"
+				onClick={ openInserter }
+				icon={ heading }
+				label={ __( 'Insert Heading Block' ) }
+				showTooltip={ ! showIconLabels }
+			/>
+			<ToolbarItem
+				as={ Button }
+				className="edit-post-header-toolbar__insert-block"
+				variant="secondary"
+				onClick={ openInserter }
+				icon={ list }
+				label={ __( 'Insert List Block' ) }
+				showTooltip={ ! showIconLabels }
+			/>
+			<ToolbarItem
+				as={ Button }
+				className="edit-post-header-toolbar__insert-block"
+				variant="secondary"
+				onClick={ openInserter }
+				icon={ image }
+				label={ __( 'Insert Image Block' ) }
+				showTooltip={ ! showIconLabels }
+			/>
+			<ToolbarItem
+				as={ EditorHistoryUndo }
+				showTooltip={ ! showIconLabels }
+				variant={ showIconLabels ? 'tertiary' : undefined }
+			/>
+			<ToolbarItem
+				as={ EditorHistoryRedo }
+				showTooltip={ ! showIconLabels }
+				variant={ showIconLabels ? 'tertiary' : undefined }
+			/>
+		</>
+	);
 
 	return (
 		<NavigableToolbar
@@ -128,27 +205,8 @@ function HeaderToolbar() {
 				/>
 				{ ( isWideViewport || ! showIconLabels ) && (
 					<>
-						{ isLargeViewport && (
-							<ToolbarItem
-								as={ ToolSelector }
-								showTooltip={ ! showIconLabels }
-								variant={
-									showIconLabels ? 'tertiary' : undefined
-								}
-								disabled={ isTextModeEnabled }
-							/>
-						) }
-						<ToolbarItem
-							as={ EditorHistoryUndo }
-							showTooltip={ ! showIconLabels }
-							variant={ showIconLabels ? 'tertiary' : undefined }
-						/>
-						<ToolbarItem
-							as={ EditorHistoryRedo }
-							showTooltip={ ! showIconLabels }
-							variant={ showIconLabels ? 'tertiary' : undefined }
-						/>
-						{ overflowItems }
+						{ isInserterOpened && inserterOpenItems }
+						{ ! isInserterOpened && inserterClosedItems }
 					</>
 				) }
 			</div>

--- a/packages/edit-post/src/components/header/header-toolbar/inserter-closed-items.js
+++ b/packages/edit-post/src/components/header/header-toolbar/inserter-closed-items.js
@@ -1,0 +1,98 @@
+/**
+ * WordPress dependencies
+ */
+import { useViewportMatch, useReducedMotion } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+import { ToolSelector } from '@wordpress/block-editor';
+import {
+	Button,
+	ToolbarItem,
+	__unstableMotion as motion,
+	__unstableAnimatePresence as AnimatePresence,
+} from '@wordpress/components';
+import { EditorHistoryRedo, EditorHistoryUndo } from '@wordpress/editor';
+import { useCallback } from '@wordpress/element';
+import { listView } from '@wordpress/icons';
+
+const ANIMATION_VARIANTS = {
+	init: {
+		opacity: 0,
+	},
+	visible: {
+		opacity: 1,
+		transition: {
+			delay: 0.25,
+			duration: 0.2,
+		},
+	},
+	exit: {
+		opacity: 0,
+		transition: {
+			duration: 0.05,
+		},
+	},
+};
+
+export default function InserterClosedItems( {
+	isInserterOpened,
+	isTextModeEnabled,
+	showIconLabels,
+	isListViewOpen,
+	listViewShortcut,
+	setIsListViewOpened,
+} ) {
+	const isReducedMotion = useReducedMotion();
+	const isLargeViewport = useViewportMatch( 'medium' );
+	const toggleListView = useCallback(
+		() => setIsListViewOpened( ! isListViewOpen ),
+		[ setIsListViewOpened, isListViewOpen ]
+	);
+
+	return (
+		<AnimatePresence initial={ false }>
+			{ ! isInserterOpened && (
+				<motion.div
+					initial={ 'init' }
+					animate={ 'visible' }
+					exit={ 'exit' }
+					variants={
+						isReducedMotion ? undefined : ANIMATION_VARIANTS
+					}
+					className="edit-post-header-toolbar__inserter-closed-items"
+				>
+					{ isLargeViewport && (
+						<ToolbarItem
+							as={ ToolSelector }
+							showTooltip={ ! showIconLabels }
+							variant={ showIconLabels ? 'tertiary' : undefined }
+							disabled={ isTextModeEnabled }
+						/>
+					) }
+					<ToolbarItem
+						as={ EditorHistoryUndo }
+						showTooltip={ ! showIconLabels }
+						variant={ showIconLabels ? 'tertiary' : undefined }
+					/>
+					<ToolbarItem
+						as={ EditorHistoryRedo }
+						showTooltip={ ! showIconLabels }
+						variant={ showIconLabels ? 'tertiary' : undefined }
+					/>
+					<ToolbarItem
+						as={ Button }
+						className="edit-post-header-toolbar__document-overview-toggle"
+						icon={ listView }
+						disabled={ isTextModeEnabled }
+						isPressed={ isListViewOpen }
+						/* translators: button label text should, if possible, be under 16 characters. */
+						label={ __( 'Document Overview' ) }
+						onClick={ toggleListView }
+						shortcut={ listViewShortcut }
+						showTooltip={ ! showIconLabels }
+						variant={ showIconLabels ? 'tertiary' : undefined }
+					/>
+				</motion.div>
+			) }
+		</AnimatePresence>
+	);
+}

--- a/packages/edit-post/src/components/header/header-toolbar/inserter-open-items.js
+++ b/packages/edit-post/src/components/header/header-toolbar/inserter-open-items.js
@@ -1,0 +1,144 @@
+/**
+ * WordPress dependencies
+ */
+import { useReducedMotion } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+import {
+	Button,
+	ToolbarItem,
+	__unstableMotion as motion,
+	__unstableAnimatePresence as AnimatePresence,
+} from '@wordpress/components';
+import { paragraph, heading, list, image } from '@wordpress/icons';
+
+const BUTTON_CONTAINER_VARIANTS = {
+	hidden: {
+		opacity: 0,
+	},
+	visible: {
+		opacity: 1,
+		transition: {
+			staggerChildren: 0.05,
+			staggerDirection: 1,
+		},
+	},
+	exit: {
+		opacity: 0,
+		transition: {
+			staggerChildren: 0.05,
+			staggerDirection: -1,
+		},
+	},
+};
+
+const BUTTON_ANIMATION_VARIANTS = {
+	hidden: {
+		x: -40,
+		opacity: 0,
+	},
+	visible: {
+		x: 0,
+		opacity: 1,
+	},
+	exit: {
+		x: -40,
+		opacity: 0,
+		transition: {
+			duration: 0.05,
+		},
+	},
+};
+
+export default function InserterOpenItems( {
+	isInserterOpened,
+	showIconLabels,
+} ) {
+	const isReducedMotion = useReducedMotion();
+	const containerVariants = isReducedMotion
+		? undefined
+		: BUTTON_CONTAINER_VARIANTS;
+	const itemVariants = isReducedMotion
+		? undefined
+		: BUTTON_ANIMATION_VARIANTS;
+
+	return (
+		<AnimatePresence>
+			{ isInserterOpened && (
+				<motion.div
+					initial={ 'hidden' }
+					animate={ 'visible' }
+					exit={ 'exit' }
+					variants={ containerVariants }
+					className="edit-post-header-toolbar__inserter-open-items"
+				>
+					<motion.div
+						variants={ itemVariants }
+						className="edit-post-header-toolbar__animated-button-container"
+					>
+						<ToolbarItem
+							as={ Button }
+							className="edit-post-header-toolbar__insert-block"
+							variant="secondary"
+							icon={ paragraph }
+							label={ __( 'Insert Paragraph Block' ) }
+							showTooltip={ ! showIconLabels }
+						/>
+					</motion.div>
+
+					<motion.div
+						variants={ itemVariants }
+						className="edit-post-header-toolbar__animated-button-container"
+					>
+						<ToolbarItem
+							as={ Button }
+							className="edit-post-header-toolbar__insert-block"
+							variant="secondary"
+							icon={ heading }
+							label={ __( 'Insert Heading Block' ) }
+							showTooltip={ ! showIconLabels }
+						/>
+					</motion.div>
+
+					<motion.div
+						variants={ itemVariants }
+						className="edit-post-header-toolbar__animated-button-container"
+					>
+						<ToolbarItem
+							as={ Button }
+							className="edit-post-header-toolbar__insert-block"
+							variant="secondary"
+							icon={ list }
+							label={ __( 'Insert List Block' ) }
+							showTooltip={ ! showIconLabels }
+						/>
+					</motion.div>
+
+					<motion.div
+						variants={ itemVariants }
+						className="edit-post-header-toolbar__animated-button-container"
+					>
+						<ToolbarItem
+							as={ Button }
+							className="edit-post-header-toolbar__insert-block"
+							variant="secondary"
+							icon={ image }
+							label={ __( 'Insert Image Block' ) }
+							showTooltip={ ! showIconLabels }
+						/>
+					</motion.div>
+
+					{ /* <ToolbarItem
+						as={ EditorHistoryUndo }
+						showTooltip={ ! showIconLabels }
+						variant={ showIconLabels ? 'tertiary' : undefined }
+					/>
+					<ToolbarItem
+						as={ EditorHistoryRedo }
+						showTooltip={ ! showIconLabels }
+						variant={ showIconLabels ? 'tertiary' : undefined }
+					/> */ }
+				</motion.div>
+			) }
+		</AnimatePresence>
+	);
+}

--- a/packages/edit-post/src/components/header/header-toolbar/inserter-open-items.js
+++ b/packages/edit-post/src/components/header/header-toolbar/inserter-open-items.js
@@ -49,6 +49,10 @@ const BUTTON_ANIMATION_VARIANTS = {
 	},
 };
 
+const preventDefault = ( event ) => {
+	event.preventDefault();
+};
+
 export default function InserterOpenItems( {
 	isInserterOpened,
 	showIconLabels,
@@ -82,6 +86,7 @@ export default function InserterOpenItems( {
 							icon={ paragraph }
 							label={ __( 'Insert Paragraph Block' ) }
 							showTooltip={ ! showIconLabels }
+							onMouseDown={ preventDefault }
 						/>
 					</motion.div>
 
@@ -96,6 +101,7 @@ export default function InserterOpenItems( {
 							icon={ heading }
 							label={ __( 'Insert Heading Block' ) }
 							showTooltip={ ! showIconLabels }
+							onMouseDown={ preventDefault }
 						/>
 					</motion.div>
 
@@ -110,6 +116,7 @@ export default function InserterOpenItems( {
 							icon={ list }
 							label={ __( 'Insert List Block' ) }
 							showTooltip={ ! showIconLabels }
+							onMouseDown={ preventDefault }
 						/>
 					</motion.div>
 
@@ -124,6 +131,7 @@ export default function InserterOpenItems( {
 							icon={ image }
 							label={ __( 'Insert Image Block' ) }
 							showTooltip={ ! showIconLabels }
+							onMouseDown={ preventDefault }
 						/>
 					</motion.div>
 

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -16,6 +16,9 @@
 		top: 0;
 		left: 0;
 	}
+	.edit-post-header-toolbar__inserter-open-items {
+		left: $grid-unit-05;
+	}
 
 	// Hide all action buttons except the inserter on mobile.
 	.edit-post-header-toolbar__left > .components-button {
@@ -79,7 +82,7 @@
 		color: $black;
 		outline: none;
 		box-shadow: none;
-		margin-right: $grid-unit-10;
+		margin-right: $grid-unit-15;
 		min-width: 32px;
 		width: 32px;
 		height: 32px;

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -4,6 +4,19 @@
 	align-items: center;
 	border: none;
 
+	.edit-post-header-toolbar__toolbar-items {
+		position: relative;
+		height: 32px; // Match inserter button height below.
+	}
+
+	.edit-post-header-toolbar__inserter-open-items,
+	.edit-post-header-toolbar__inserter-closed-items {
+		position: absolute;
+		display: flex;
+		top: 0;
+		left: 0;
+	}
+
 	// Hide all action buttons except the inserter on mobile.
 	.edit-post-header-toolbar__left > .components-button {
 		display: none;
@@ -39,8 +52,8 @@
 
 	// The Toolbar component adds different styles to buttons, so we reset them
 	// here to the original button styles
-	.edit-post-header-toolbar__left > .components-button.has-icon,
-	.edit-post-header-toolbar__left > .components-dropdown > .components-button.has-icon {
+	.edit-post-header-toolbar__left .components-button.has-icon,
+	.edit-post-header-toolbar__left .components-dropdown > .components-button.has-icon {
 		height: $button-size;
 		min-width: $button-size;
 		padding: 6px;
@@ -67,6 +80,10 @@
 		outline: none;
 		box-shadow: none;
 		margin-right: $grid-unit-10;
+		min-width: 32px;
+		width: 32px;
+		height: 32px;
+		padding: 0;
 
 		&:hover,
 		&:active,
@@ -122,10 +139,9 @@
 	}
 }
 
-.edit-post-header-toolbar .edit-post-header-toolbar__left > .edit-post-header-toolbar__inserter-toggle.has-icon,
-.edit-post-header-toolbar .edit-post-header-toolbar__left > .components-button.edit-post-header-toolbar__insert-block {
+.edit-post-header-toolbar .edit-post-header-toolbar__left > .edit-post-header-toolbar__inserter-toggle.has-icon {
 	margin-right: $grid-unit-10;
-	// Special dimensions for inserter toggle and block insert buttons.
+	// Special dimensions for inserter toggle
 	min-width: 32px;
 	width: 32px;
 	height: 32px;

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -58,6 +58,36 @@
 			display: none;
 		}
 	}
+
+	// Adjust the button styles for the insert block buttons when the inserter is open.
+	.components-button.is-secondary.edit-post-header-toolbar__insert-block {
+		border: none;
+		background: $gray-100;
+		color: $black;
+		outline: none;
+		box-shadow: none;
+		margin-right: $grid-unit-10;
+
+		&:hover,
+		&:active,
+		&:focus {
+			color: var(--wp-admin-theme-color);
+
+			&::after {
+				content: "";
+				position: absolute;
+				top: 0;
+				bottom: 0;
+				left: 0;
+				right: 0;
+				border-radius: $radius-block-ui;
+				opacity: 0.04;
+				background: var(--wp-admin-theme-color);
+				// This fixes drag-and-drop in Firefox.
+				pointer-events: none;
+			}
+		}
+	}
 }
 
 // Reduced UI.
@@ -92,9 +122,10 @@
 	}
 }
 
-.edit-post-header-toolbar .edit-post-header-toolbar__left > .edit-post-header-toolbar__inserter-toggle.has-icon {
+.edit-post-header-toolbar .edit-post-header-toolbar__left > .edit-post-header-toolbar__inserter-toggle.has-icon,
+.edit-post-header-toolbar .edit-post-header-toolbar__left > .components-button.edit-post-header-toolbar__insert-block {
 	margin-right: $grid-unit-10;
-	// Special dimensions for this button.
+	// Special dimensions for inserter toggle and block insert buttons.
 	min-width: 32px;
 	width: 32px;
 	height: 32px;


### PR DESCRIPTION
[WIP] Fixes https://github.com/WordPress/gutenberg/issues/45722
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Show block shortcuts in the top header bar when the inserter is open.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Based on inserter design changes, you may no longer see blocks as the first selected tab. These quick shortcuts allow easy access to inserting a block, regardless of tab selected.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
WIP

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
WIP

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/1464705/215179680-40300304-025c-4125-aad2-cb775da97180.mp4
