### PR TITLE
[Mobile] Native Bridge: Fix insert blocks not handling raw string properly in unsupported block editor

### DIFF
--- a/packages/react-native-bridge/common/gutenberg-web-single-block/insert-block.js
+++ b/packages/react-native-bridge/common/gutenberg-web-single-block/insert-block.js
@@ -1,3 +1,3 @@
 if ( window.insertBlock && window.contentIncerted !== true ) {
-	window.insertBlock( `%@` );
+	window.insertBlock( String.raw`%@` );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixing `insertBlocks` at the `react-native-bridge` call not dealing with strings that contain complex chars (like unicode).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Attributes could contain HTML code, which is serialized with special chars.

Example: 

```code
<!-- wp:videopress/video {"title":"174023215_5408417369200486_4341486698209593172_n-mp4","description":"","id":29,"guid":"YzEZpv1G","src":"https://videopress.com/v/YzEZpv1G","cacheHtml":"\u003ciframe title=\u0022VideoPress Video Player\u0022 aria-label='VideoPress Video Player' width='600' height='750' src='https://videopress.com/embed/YzEZpv1G?cover=1\u0026amp;preloadContent=metadata\u0026amp;useAverageColor=1\u0026amp;hd=1' frameborder='0' allowfullscreen data-resize-to-parent=\u0022true\u0022 allow='clipboard-write'\u003e\u003c/iframe\u003e\u003cscript src='https://v0.wordpress.com/js/next/videopress-iframe.js?m=1658470809'\u003e\u003c/script\u003e","videoRatio":125,"privacySetting":2,"allowDownload":false,"rating":"G","isPrivate":false,"className":"\\\u0022wp-block-videopress-video"} -->
  <figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player \&quot;wp-block-videopress-video">
    <div class="jetpack-videopress-player__wrapper">
https://videopress.com/v/YzEZpv1G?resizeToParent=true&amp;cover=true&amp;preloadContent=metadata&amp;useAverageColor=true
    </div>
  </figure>
<!-- /wp:videopress/video -->
```

In the current way, it parses the `\u` and other chars, which breaks the block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Inserting `String.raw` on `insertBlocks` call.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Run WordPress Mobile (iOs or Android) with `gutenberg-mobile` [running locally](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/WPAndroid%20Integration.md).
2. Open a post that contains an unsupported block that has complex attributes (new VideoPress block for example).
3. Click on `?` and try to edit it on the web editor.
4. It should work.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| ----- | ----- |
| <video src="https://user-images.githubusercontent.com/1663717/214964052-a25f097e-78b3-4d91-bd09-5ef63708a48f.mp4" /> | <video src="https://user-images.githubusercontent.com/1663717/214964212-af397eb7-610a-4387-a4ad-ced3fd29ed1f.mp4" /> |