### PR TITLE
Block Inspector: Avoid advanced panel only settings tab

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -62,12 +62,17 @@ export default function useInspectorControlsTabs( blockName ) {
 		tabs.push( TAB_STYLES );
 	}
 
-	// Settings Tab: If there are any fills for the general InspectorControls
-	// or Advanced Controls slot, then add this tab.
+	// Settings Tab: If we don't already have multiple tabs to display
+	// (i.e. both list view and styles), check only the default and position
+	// InspectorControls slots. If we have multiple tabs, we'll need to check
+	// the advanced controls slot as well to ensure they are rendered.
+	const advancedFills =
+		useSlotFills( InspectorAdvancedControls.slotName ) || [];
+
 	const settingsFills = [
 		...( useSlotFills( defaultGroup.Slot.__unstableName ) || [] ),
 		...( useSlotFills( positionGroup.Slot.__unstableName ) || [] ),
-		...( useSlotFills( InspectorAdvancedControls.slotName ) || [] ),
+		...( tabs.length > 1 ? advancedFills : [] ),
 	];
 
 	if ( settingsFills.length ) {

--- a/test/e2e/specs/editor/blocks/table.spec.js
+++ b/test/e2e/specs/editor/blocks/table.spec.js
@@ -93,6 +93,9 @@ test.describe( 'Table', () => {
 		await page.click( 'role=button[name="Create Table"i]' );
 
 		// Expect the header and footer switches to be present now that the table has been created.
+		await page.click(
+			`role=region[name="Editor settings"i] >> role=tab[name="Settings"i]`
+		);
 		await expect( headerSwitch ).toBeVisible();
 		await expect( footerSwitch ).toBeVisible();
 

--- a/test/e2e/specs/editor/blocks/table.spec.js
+++ b/test/e2e/specs/editor/blocks/table.spec.js
@@ -77,9 +77,6 @@ test.describe( 'Table', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/table' } );
 		await editor.openDocumentSettingsSidebar();
-		await page.click(
-			`role=region[name="Editor settings"i] >> role=tab[name="Settings"i]`
-		);
 
 		const headerSwitch = page.locator(
 			'role=checkbox[name="Header section"i]'
@@ -135,9 +132,6 @@ test.describe( 'Table', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/table' } );
 		await editor.openDocumentSettingsSidebar();
-		await page.click(
-			`role=region[name="Editor settings"i] >> role=tab[name="Settings"i]`
-		);
 
 		// Create the table.
 		await page.click( 'role=button[name="Create Table"i]' );
@@ -211,14 +205,14 @@ test.describe( 'Table', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/table' } );
 		await editor.openDocumentSettingsSidebar();
-		await page.click(
-			`role=region[name="Editor settings"i] >> role=tab[name="Settings"i]`
-		);
 
 		// Create the table.
 		await page.click( 'role=button[name="Create Table"i]' );
 
 		// Enable fixed width as it exacerbates the amount of empty space around the RichText.
+		await page.click(
+			`role=region[name="Editor settings"i] >> role=tab[name="Settings"i]`
+		);
 		await page
 			.locator( 'role=checkbox[name="Fixed width table cells"i]' )
 			.check();

--- a/test/e2e/specs/site-editor/push-to-global-styles.spec.js
+++ b/test/e2e/specs/site-editor/push-to-global-styles.spec.js
@@ -42,9 +42,8 @@ test.describe( 'Push to Global Styles button', () => {
 			page.getByRole( 'button', { name: 'Uppercase' } )
 		).toHaveAttribute( 'aria-pressed', 'false' );
 
-		// Go to block settings, select inner tab, and open the Advanced panel
+		// Go to block settings and open the Advanced panel
 		await page.getByRole( 'button', { name: 'Settings' } ).click();
-		await page.getByRole( 'tab', { name: 'Settings' } ).click();
 		await page.getByRole( 'button', { name: 'Advanced' } ).click();
 
 		// Push button should be disabled
@@ -54,15 +53,8 @@ test.describe( 'Push to Global Styles button', () => {
 			} )
 		).toBeDisabled();
 
-		// Switch back to the Styles inspector tab to check typography style
-		await page.getByRole( 'tab', { name: 'Styles' } ).click();
-
 		// Make the Heading block uppercase
 		await page.getByRole( 'button', { name: 'Uppercase' } ).click();
-
-		// Switch back to the Settings inspector tab to check for enabled button
-		await page.getByRole( 'tab', { name: 'Settings' } ).click();
-		await page.getByRole( 'button', { name: 'Advanced' } ).click();
 
 		// Push button should now be enabled
 		await expect(


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/47463

## What?

It avoids rendering a Settings tab in the majority of cases where it would only contain an advanced panel. 

The only exception here is when a block already has multiple tabs (i.e. both the list view and style tabs) as the advanced panel doesn't really fit within the other available tabs or beneath the entire tab panel.

## Why?

We don't need a tab for only the advanced panel. It is standard across almost all blocks.

## How?

- Updates the `useInspectorControlsTabs` hooks logic to omit the check for advanced panel fills when determining which tabs should be rendered unless the block has the list view tab.
- When the Settings tab would only have the advanced panel fills, it isn't included in the tabs for display. In most cases, this would result in only the styles tab for display. When we only have a single tab, no tabs are displayed with all controls instead rendered directly to the sidebar.


## Testing Instructions

- Edit a post, adding paragraph, group, and navigation blocks
- Select the paragraph block and confirm that all controls are rendered directly to the sidebar i.e. there are no tabs in the block inspector
- Select the group block and confirm both Styles and Settings tabs are rendered with the advanced panel under Settings
- Select the navigation block and confirm three tabs are present; List View, Styles, and Settings.

### Testing Instructions for Keyboard

- Edit a post, adding paragraph, group, and navigation blocks
- Select the paragraph block and tab into the block inspector, ensure you can tab through the block's controls
- Select the group block and tab into the inspector controls, ensure you can reach the tabs and navigate them
- Select the navigation block and confirm you can reach the tabs and navigate them in the sidebar

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="250" alt="Screenshot 2023-01-27 at 10 14 12 am" src="https://user-images.githubusercontent.com/60436221/214978766-c6a11894-8d9e-4963-a607-80407b5de82c.png"> | <img width="250" alt="Screenshot 2023-01-27 at 10 13 20 am" src="https://user-images.githubusercontent.com/60436221/214978696-8a0fb758-3ced-4376-b1dc-f2b3df3cc3a1.png"> |
