### PR TITLE
ColorPalette: Show checkered background through semi-transparent colors

### DIFF
--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -152,7 +152,7 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
               data-wp-component="VStack"
             >
               <div
-                class="components-dropdown"
+                class="components-dropdown components-color-palette__transparent-background"
                 tabindex="-1"
               >
                 <button

--- a/packages/components/src/color-palette/index.tsx
+++ b/packages/components/src/color-palette/index.tsx
@@ -241,6 +241,7 @@ function UnforwardedColorPalette(
 		<VStack spacing={ 3 } ref={ forwardedRef } { ...otherProps }>
 			{ ! disableCustomColors && (
 				<CustomColorPickerDropdown
+					className="components-color-palette__transparent-background"
 					isRenderedInSidebar={ __experimentalIsRenderedInSidebar }
 					renderContent={ renderCustomColorPicker }
 					renderToggle={ ( { isOpen, onToggle } ) => (

--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -1,12 +1,4 @@
-.components-color-palette__custom-color {
-	position: relative;
-	border: none;
-	background: none;
-	border-radius: $radius-block-ui;
-	height: $grid-unit-80;
-	padding: $grid-unit-15;
-	font-family: inherit;
-	width: 100%;
+.components-color-palette__transparent-background {
 	// The background image creates a checkerboard pattern. Ignore rtlcss to
 	// make it work both in LTR and RTL.
 	// See https://github.com/WordPress/gutenberg/pull/42510
@@ -17,6 +9,16 @@
 	background-position: 0 0, 24px 24px;
 	/*rtl:end:ignore*/
 	background-size: calc(2 * 24px) calc(2 * 24px);
+}
+
+.components-color-palette__custom-color {
+	position: relative;
+	border: none;
+	background: none;
+	border-radius: $radius-block-ui;
+	height: $grid-unit-80;
+	padding: $grid-unit-15;
+	font-family: inherit;
 	box-sizing: border-box;
 	color: $white;
 	cursor: pointer;

--- a/packages/components/src/color-palette/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.tsx.snap
@@ -173,7 +173,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
     data-wp-component="VStack"
   >
     <div
-      class="components-dropdown"
+      class="components-dropdown components-color-palette__transparent-background"
       tabindex="-1"
     >
       <button


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix #42715

This PR addresses the above issue for `ColorPalette`, to make it possible to see the color being selected regardless of the set transparency.

This change also highlights an existing issue where when transparency is adjusted, the text becomes inaccessible due to low contrast. 

In the below screencasts, 'what it should look like' is based on the solution proposed here: #47373, which isn't included in this PR. Therefore, there's another screencast to show how the change in this PR differs from that and the current state in trunk.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To improve the UX by showing a preview of the selected color value regardless of transparency. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By adding a class to the parent component and moving the background styles onto that so it is behind the selected custom color. 

## Testing Instructions

1. Look for ColorPalette in storybook or a block with color options (i.e. button) in the block editor
2. Change the transparency of the color to see checkered background show through the selected color preview 
3. After https://github.com/WordPress/gutenberg/pull/47373 is merged, check that the text is accessible over the preview

## Screenshots or screencast <!-- if applicable -->'

| Current behaviour | Changes in this PR | 
| ------------- | ------------- | 
|  <video src="https://user-images.githubusercontent.com/35543432/214984454-5aa429ea-539e-4ef8-aba5-99f91ecea554.mp4" width="50"> | <video src="https://user-images.githubusercontent.com/35543432/214984448-eedeaa36-094a-4684-8df0-afbe46906b5c.mp4">  | 
| **What it should look like** |
| <video src="https://user-images.githubusercontent.com/35543432/214984453-84b7a802-499f-4eb7-a0d2-a3bcb6aa0a8d.mp4"> |

