### PR TITLE
Always pass layout to inner blocks

### DIFF
--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -3,6 +3,7 @@
  */
 import { useMemo } from '@wordpress/element';
 
+import { hasBlockSupport } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
@@ -28,11 +29,16 @@ export default function BlockEdit( props ) {
 		__unstableLayoutClassNames,
 	} = props;
 	const { layout = null } = attributes;
+	const layoutSupport = hasBlockSupport(
+		name,
+		'__experimentalLayout',
+		false
+	);
 	const context = {
 		name,
 		isSelected,
 		clientId,
-		layout,
+		layout: layoutSupport ? layout : null,
 		__unstableLayoutClassNames,
 	};
 	return (

--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -20,11 +20,19 @@ import { BlockEditContextProvider, useBlockEditContext } from './context';
 export { useBlockEditContext };
 
 export default function BlockEdit( props ) {
-	const { name, isSelected, clientId, __unstableLayoutClassNames } = props;
+	const {
+		name,
+		isSelected,
+		clientId,
+		attributes = {},
+		__unstableLayoutClassNames,
+	} = props;
+	const { layout = null } = attributes;
 	const context = {
 		name,
 		isSelected,
 		clientId,
+		layout,
 		__unstableLayoutClassNames,
 	};
 	return (

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -82,12 +82,15 @@ function UncontrolledInnerBlocks( props ) {
 		[ clientId ]
 	);
 
+	// Avoid creating new objects if there is no layout defined.
+	const emptyLayout = {};
+
 	const defaultLayoutBlockSupport =
-		getBlockSupport( name, '__experimentalLayout' ) || {};
+		getBlockSupport( name, '__experimentalLayout' ) || emptyLayout;
 
 	const { allowSizingOnChildren = false } = defaultLayoutBlockSupport;
 
-	const defaultLayout = useSetting( 'layout' ) || {};
+	const defaultLayout = useSetting( 'layout' ) || emptyLayout;
 
 	const usedLayout = layout || defaultLayoutBlockSupport;
 

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -30,6 +30,9 @@ import useBlockSync from '../provider/use-block-sync';
 import { store as blockEditorStore } from '../../store';
 import useBlockDropZone from '../use-block-drop-zone';
 import useSetting from '../use-setting';
+
+const EMPTY_OBJECT = {};
+
 /**
  * InnerBlocks is a component which allows a single block to have multiple blocks
  * as children. The UncontrolledInnerBlocks component is used whenever the inner
@@ -82,15 +85,12 @@ function UncontrolledInnerBlocks( props ) {
 		[ clientId ]
 	);
 
-	// Avoid creating new objects if there is no layout defined.
-	const emptyLayout = {};
-
 	const defaultLayoutBlockSupport =
-		getBlockSupport( name, '__experimentalLayout' ) || emptyLayout;
+		getBlockSupport( name, '__experimentalLayout' ) || EMPTY_OBJECT;
 
 	const { allowSizingOnChildren = false } = defaultLayoutBlockSupport;
 
-	const defaultLayout = useSetting( 'layout' ) || emptyLayout;
+	const defaultLayout = useSetting( 'layout' ) || EMPTY_OBJECT;
 
 	const usedLayout = layout || defaultLayoutBlockSupport;
 

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -67,21 +67,12 @@ export default {
 				info: alignmentInfo[ alignment ],
 			} ) );
 		}
-		const { contentSize, wideSize } = layout;
 
 		const alignments = [
 			{ name: 'left' },
 			{ name: 'center' },
 			{ name: 'right' },
 		];
-
-		if ( contentSize ) {
-			alignments.unshift( { name: 'full' } );
-		}
-
-		if ( wideSize ) {
-			alignments.unshift( { name: 'wide', info: alignmentInfo.wide } );
-		}
 
 		alignments.unshift( { name: 'none', info: alignmentInfo.none } );
 

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -36,7 +36,7 @@ const DEFAULT_BLOCK = {
 };
 
 function ButtonsEdit( { attributes, className } ) {
-	const { fontSize, layout = {}, style } = attributes;
+	const { fontSize, style } = attributes;
 	const blockProps = useBlockProps( {
 		className: classnames( className, {
 			'has-custom-font-size': fontSize || style?.typography?.fontSize,
@@ -59,7 +59,7 @@ function ButtonsEdit( { attributes, className } ) {
 				{ className: preferredStyle && `is-style-${ preferredStyle }` },
 			],
 		],
-		__experimentalLayout: layout,
+
 		templateInsertUpdatesSelection: true,
 	} );
 

--- a/packages/block-library/src/comments-pagination/edit.js
+++ b/packages/block-library/src/comments-pagination/edit.js
@@ -10,7 +10,6 @@ import {
 	Warning,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
-import { getBlockSupport } from '@wordpress/blocks';
 import { PanelBody } from '@wordpress/components';
 
 /**
@@ -29,21 +28,11 @@ const ALLOWED_BLOCKS = [
 	'core/comments-pagination-next',
 ];
 
-const getDefaultBlockLayout = ( blockTypeOrName ) => {
-	const layoutBlockSupportConfig = getBlockSupport(
-		blockTypeOrName,
-		'__experimentalLayout'
-	);
-	return layoutBlockSupportConfig?.default;
-};
-
 export default function QueryPaginationEdit( {
-	attributes: { paginationArrow, layout },
+	attributes: { paginationArrow },
 	setAttributes,
 	clientId,
-	name,
 } ) {
-	const usedLayout = layout || getDefaultBlockLayout( name );
 	const hasNextPreviousBlocks = useSelect( ( select ) => {
 		const { getBlocks } = select( blockEditorStore );
 		const innerBlocks = getBlocks( clientId );
@@ -64,7 +53,6 @@ export default function QueryPaginationEdit( {
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
 		allowedBlocks: ALLOWED_BLOCKS,
-		__experimentalLayout: usedLayout,
 	} );
 
 	// Get the Discussion settings

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -73,7 +73,6 @@ const linkOptions = [
 ];
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 const allowedBlocks = [ 'core/image' ];
-const LAYOUT = { type: 'default', alignments: [] };
 
 const PLACEHOLDER_TEXT = Platform.isNative
 	? __( 'ADD MEDIA' )
@@ -531,7 +530,6 @@ function GalleryEdit( props ) {
 		allowedBlocks,
 		orientation: 'horizontal',
 		renderAppender: false,
-		__experimentalLayout: LAYOUT,
 		...nativeInnerBlockProps,
 	} );
 

--- a/packages/block-library/src/group/deprecated.js
+++ b/packages/block-library/src/group/deprecated.js
@@ -108,7 +108,9 @@ const deprecated = [
 			);
 		},
 		isEligible: ( { layout } ) =>
-			! layout || layout.inherit || layout.contentSize,
+			! layout ||
+			layout.inherit ||
+			( layout.contentSize && layout.type !== 'constrained' ),
 		migrate: ( attributes ) => {
 			const { layout = null } = attributes;
 			if ( ! layout ) {

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -117,7 +117,6 @@ function GroupEdit( {
 			renderAppender: hasInnerBlocks
 				? undefined
 				: InnerBlocks.ButtonBlockAppender,
-			__experimentalLayout: layoutSupportEnabled ? usedLayout : undefined,
 			__unstableDisableLayoutClassNames: ! layoutSupportEnabled,
 		}
 	);

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -31,11 +31,6 @@ const DEFAULT_BLOCK = {
 	name: 'core/navigation-link',
 };
 
-const LAYOUT = {
-	type: 'default',
-	alignments: [],
-};
-
 export default function NavigationInnerBlocks( {
 	clientId,
 	hasCustomPlaceholder,
@@ -131,7 +126,6 @@ export default function NavigationInnerBlocks( {
 				parentOrChildHasSelection
 					? InnerBlocks.ButtonBlockAppender
 					: false,
-			__experimentalLayout: LAYOUT,
 			placeholder: showPlaceholder ? placeholder : undefined,
 		}
 	);

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -2,14 +2,11 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
 import {
 	useBlockProps,
 	useInnerBlocksProps,
-	useSetting,
 	__experimentalRecursionProvider as RecursionProvider,
 	__experimentalUseHasRecursion as useHasRecursion,
-	store as blockEditorStore,
 	Warning,
 } from '@wordpress/block-editor';
 import { useEntityProp, useEntityBlockEditor } from '@wordpress/core-data';
@@ -39,16 +36,9 @@ function ReadOnlyContent( { userCanEdit, postType, postId } ) {
 	);
 }
 
-function EditableContent( { layout, context = {} } ) {
+function EditableContent( { context = {} } ) {
 	const { postType, postId } = context;
-	const themeSupportsLayout = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		return getSettings()?.supportsLayout;
-	}, [] );
-	const defaultLayout = useSetting( 'layout' ) || {};
-	const usedLayout = ! layout?.type
-		? { ...defaultLayout, ...layout, type: 'default' }
-		: { ...defaultLayout, ...layout };
+
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		'postType',
 		postType,
@@ -61,7 +51,6 @@ function EditableContent( { layout, context = {} } ) {
 			value: blocks,
 			onInput,
 			onChange,
-			__experimentalLayout: themeSupportsLayout ? usedLayout : undefined,
 		}
 	);
 	return <div { ...props } />;

--- a/packages/block-library/src/query-pagination/edit.js
+++ b/packages/block-library/src/query-pagination/edit.js
@@ -9,7 +9,6 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
-import { getBlockSupport } from '@wordpress/blocks';
 import { PanelBody } from '@wordpress/components';
 
 /**
@@ -28,21 +27,11 @@ const ALLOWED_BLOCKS = [
 	'core/query-pagination-next',
 ];
 
-const getDefaultBlockLayout = ( blockTypeOrName ) => {
-	const layoutBlockSupportConfig = getBlockSupport(
-		blockTypeOrName,
-		'__experimentalLayout'
-	);
-	return layoutBlockSupportConfig?.default;
-};
-
 export default function QueryPaginationEdit( {
-	attributes: { paginationArrow, layout },
+	attributes: { paginationArrow },
 	setAttributes,
 	clientId,
-	name,
 } ) {
-	const usedLayout = layout || getDefaultBlockLayout( name );
 	const hasNextPreviousBlocks = useSelect( ( select ) => {
 		const { getBlocks } = select( blockEditorStore );
 		const innerBlocks = getBlocks( clientId );
@@ -61,7 +50,6 @@ export default function QueryPaginationEdit( {
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
 		allowedBlocks: ALLOWED_BLOCKS,
-		__experimentalLayout: usedLayout,
 	} );
 	return (
 		<>

--- a/packages/block-library/src/query/deprecated.js
+++ b/packages/block-library/src/query/deprecated.js
@@ -296,6 +296,80 @@ const v3 = {
 	},
 };
 
-const deprecated = [ v3, v2, v1 ];
+const v4 = {
+	attributes: {
+		queryId: {
+			type: 'number',
+		},
+		query: {
+			type: 'object',
+			default: {
+				perPage: null,
+				pages: 0,
+				offset: 0,
+				postType: 'post',
+				order: 'desc',
+				orderBy: 'date',
+				author: '',
+				search: '',
+				exclude: [],
+				sticky: '',
+				inherit: true,
+				taxQuery: null,
+				parents: [],
+			},
+		},
+		tagName: {
+			type: 'string',
+			default: 'div',
+		},
+		displayLayout: {
+			type: 'object',
+			default: {
+				type: 'list',
+			},
+		},
+		namespace: {
+			type: 'string',
+		},
+	},
+	supports: {
+		align: [ 'wide', 'full' ],
+		html: false,
+		color: {
+			gradients: true,
+			link: true,
+			__experimentalDefaultControls: {
+				background: true,
+				text: true,
+			},
+		},
+		__experimentalLayout: true,
+	},
+	save( { attributes: { tagName: Tag = 'div' } } ) {
+		const blockProps = useBlockProps.save();
+		const innerBlocksProps = useInnerBlocksProps.save( blockProps );
+		return <Tag { ...innerBlocksProps } />;
+	},
+	isEligible: ( { layout } ) =>
+		! layout || layout.inherit || layout.contentSize,
+	migrate: ( attributes ) => {
+		const { layout = null } = attributes;
+		if ( ! layout ) {
+			return attributes;
+		}
+		if ( layout.inherit || layout.contentSize ) {
+			return {
+				...attributes,
+				layout: {
+					...layout,
+					type: 'constrained',
+				},
+			};
+		}
+	},
+};
+
+const deprecated = [ v4, v3, v2, v1 ];
 
 export default deprecated;

--- a/packages/block-library/src/query/deprecated.js
+++ b/packages/block-library/src/query/deprecated.js
@@ -352,7 +352,9 @@ const v4 = {
 		return <Tag { ...innerBlocksProps } />;
 	},
 	isEligible: ( { layout } ) =>
-		! layout || layout.inherit || layout.contentSize,
+		! layout ||
+		layout.inherit ||
+		( layout.contentSize && layout.type !== 'constrained' ),
 	migrate: ( attributes ) => {
 		const { layout = null } = attributes;
 		if ( ! layout ) {

--- a/packages/block-library/src/query/edit/query-content.js
+++ b/packages/block-library/src/query/edit/query-content.js
@@ -8,7 +8,6 @@ import {
 	BlockControls,
 	InspectorControls,
 	useBlockProps,
-	useSetting,
 	store as blockEditorStore,
 	useInnerBlocksProps,
 } from '@wordpress/block-editor';
@@ -36,23 +35,13 @@ export default function QueryContent( {
 		query,
 		displayLayout,
 		tagName: TagName = 'div',
-		layout = {},
 	} = attributes;
 	const { __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
 	const instanceId = useInstanceId( QueryContent );
-	const { themeSupportsLayout } = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		return { themeSupportsLayout: getSettings()?.supportsLayout };
-	}, [] );
-	const defaultLayout = useSetting( 'layout' ) || {};
-	const usedLayout = ! layout?.type
-		? { ...defaultLayout, ...layout, type: 'default' }
-		: { ...defaultLayout, ...layout };
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
-		__experimentalLayout: themeSupportsLayout ? usedLayout : undefined,
 	} );
 	const { postsPerPage } = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -6,7 +6,6 @@ import classNames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { getBlockSupport } from '@wordpress/blocks';
 import { useEffect, useRef } from '@wordpress/element';
 import {
 	BlockControls,
@@ -37,18 +36,9 @@ const sizeOptions = [
 	{ name: __( 'Huge' ), value: 'has-huge-icon-size' },
 ];
 
-const getDefaultBlockLayout = ( blockTypeOrName ) => {
-	const layoutBlockSupportConfig = getBlockSupport(
-		blockTypeOrName,
-		'__experimentalLayout'
-	);
-	return layoutBlockSupportConfig?.default;
-};
-
 export function SocialLinksEdit( props ) {
 	const {
 		clientId,
-		name,
 		attributes,
 		iconBackgroundColor,
 		iconColor,
@@ -65,9 +55,7 @@ export function SocialLinksEdit( props ) {
 		openInNewTab,
 		showLabels,
 		size,
-		layout,
 	} = attributes;
-	const usedLayout = layout || getDefaultBlockLayout( name );
 
 	const logosOnly = attributes.className?.includes( 'is-style-logos-only' );
 
@@ -122,7 +110,6 @@ export function SocialLinksEdit( props ) {
 		placeholder: isSelected ? SelectedSocialPlaceholder : SocialPlaceholder,
 		templateLock: false,
 		__experimentalAppenderTagName: 'li',
-		__experimentalLayout: usedLayout,
 	} );
 
 	const POPOVER_PROPS = {

--- a/test/integration/fixtures/blocks/core__query.serialized.html
+++ b/test/integration/fixtures/blocks/core__query.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:query -->
+<!-- wp:query {"query":{"perPage":null,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"displayLayout":{"type":"list"}} -->
 <div class="wp-block-query"></div>
 <!-- /wp:query -->

--- a/test/integration/fixtures/blocks/core__query__deprecated-4.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-4.html
@@ -1,25 +1,6 @@
-<!-- wp:query {"queryId":3,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"flex","columns":3},"align":"wide","style":{"color":{"background":"#284d5f"},"elements":{"link":{"color":{"text":"var:preset|color|luminous-vivid-amber"}}}},"textColor":"pale-cyan-blue","layout":{"inherit":true}} -->
-<div class="wp-block-query alignwide has-pale-cyan-blue-color has-text-color has-background has-link-color"
-    style="background-color:#284d5f"><!-- wp:post-template {"fontSize":"large"} -->
+<!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"main","displayLayout":{"type":"list"},"layout":{"inherit":true}} -->
+<div class="wp-block-query"><!-- wp:post-template -->
     <!-- wp:post-title /-->
-
-    <!-- wp:post-date /-->
-
-    <!-- wp:post-excerpt /-->
     <!-- /wp:post-template -->
-
-    <!-- wp:query-pagination -->
-    <!-- wp:query-pagination-previous /-->
-
-    <!-- wp:query-pagination-numbers /-->
-
-    <!-- wp:query-pagination-next /-->
-    <!-- /wp:query-pagination -->
-
-    <!-- wp:query-no-results -->
-    <!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
-    <p>No results found.</p>
-    <!-- /wp:paragraph -->
-    <!-- /wp:query-no-results -->
 </div>
 <!-- /wp:query -->

--- a/test/integration/fixtures/blocks/core__query__deprecated-4.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-4.html
@@ -1,0 +1,25 @@
+<!-- wp:query {"queryId":3,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"flex","columns":3},"align":"wide","style":{"color":{"background":"#284d5f"},"elements":{"link":{"color":{"text":"var:preset|color|luminous-vivid-amber"}}}},"textColor":"pale-cyan-blue","layout":{"inherit":true}} -->
+<div class="wp-block-query alignwide has-pale-cyan-blue-color has-text-color has-background has-link-color"
+    style="background-color:#284d5f"><!-- wp:post-template {"fontSize":"large"} -->
+    <!-- wp:post-title /-->
+
+    <!-- wp:post-date /-->
+
+    <!-- wp:post-excerpt /-->
+    <!-- /wp:post-template -->
+
+    <!-- wp:query-pagination -->
+    <!-- wp:query-pagination-previous /-->
+
+    <!-- wp:query-pagination-numbers /-->
+
+    <!-- wp:query-pagination-next /-->
+    <!-- /wp:query-pagination -->
+
+    <!-- wp:query-no-results -->
+    <!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+    <p>No results found.</p>
+    <!-- /wp:paragraph -->
+    <!-- /wp:query-no-results -->
+</div>
+<!-- /wp:query -->

--- a/test/integration/fixtures/blocks/core__query__deprecated-4.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-4.json
@@ -1,0 +1,136 @@
+[
+	{
+		"name": "core/query",
+		"isValid": true,
+		"attributes": {
+			"queryId": 3,
+			"query": {
+				"perPage": 3,
+				"pages": 0,
+				"offset": 0,
+				"postType": "post",
+				"order": "desc",
+				"orderBy": "date",
+				"author": "",
+				"search": "",
+				"exclude": [],
+				"sticky": "",
+				"inherit": false
+			},
+			"tagName": "div",
+			"displayLayout": {
+				"type": "flex",
+				"columns": 3
+			},
+			"align": "wide",
+			"layout": {
+				"inherit": true
+			}
+		},
+		"innerBlocks": [
+			{
+				"name": "core/group",
+				"isValid": true,
+				"attributes": {
+					"tagName": "div",
+					"textColor": "pale-cyan-blue",
+					"style": {
+						"color": {
+							"background": "#284d5f"
+						},
+						"elements": {
+							"link": {
+								"color": {
+									"text": "var:preset|color|luminous-vivid-amber"
+								}
+							}
+						}
+					}
+				},
+				"innerBlocks": [
+					{
+						"name": "core/post-template",
+						"isValid": true,
+						"attributes": {
+							"fontSize": "large"
+						},
+						"innerBlocks": [
+							{
+								"name": "core/post-title",
+								"isValid": true,
+								"attributes": {
+									"level": 2,
+									"isLink": false,
+									"rel": "",
+									"linkTarget": "_self"
+								},
+								"innerBlocks": []
+							},
+							{
+								"name": "core/post-date",
+								"isValid": true,
+								"attributes": {
+									"isLink": false,
+									"displayType": "date"
+								},
+								"innerBlocks": []
+							},
+							{
+								"name": "core/post-excerpt",
+								"isValid": true,
+								"attributes": {
+									"showMoreOnNewLine": true
+								},
+								"innerBlocks": []
+							}
+						]
+					},
+					{
+						"name": "core/query-pagination",
+						"isValid": true,
+						"attributes": {
+							"paginationArrow": "none"
+						},
+						"innerBlocks": [
+							{
+								"name": "core/query-pagination-previous",
+								"isValid": true,
+								"attributes": {},
+								"innerBlocks": []
+							},
+							{
+								"name": "core/query-pagination-numbers",
+								"isValid": true,
+								"attributes": {},
+								"innerBlocks": []
+							},
+							{
+								"name": "core/query-pagination-next",
+								"isValid": true,
+								"attributes": {},
+								"innerBlocks": []
+							}
+						]
+					},
+					{
+						"name": "core/query-no-results",
+						"isValid": true,
+						"attributes": {},
+						"innerBlocks": [
+							{
+								"name": "core/paragraph",
+								"isValid": true,
+								"attributes": {
+									"content": "No results found.",
+									"dropCap": false,
+									"placeholder": "Add text or blocks that will display when a query returns no results."
+								},
+								"innerBlocks": []
+							}
+						]
+					}
+				]
+			}
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__query__deprecated-4.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-4.json
@@ -1,11 +1,11 @@
 [
 	{
 		"name": "core/query",
-		"isValid": true,
+		"isValid": false,
 		"attributes": {
-			"queryId": 3,
+			"queryId": 0,
 			"query": {
-				"perPage": 3,
+				"perPage": 10,
 				"pages": 0,
 				"offset": 0,
 				"postType": "post",
@@ -15,119 +15,32 @@
 				"search": "",
 				"exclude": [],
 				"sticky": "",
-				"inherit": false
+				"inherit": true
 			},
-			"tagName": "div",
+			"tagName": "main",
 			"displayLayout": {
-				"type": "flex",
-				"columns": 3
+				"type": "list"
 			},
-			"align": "wide",
 			"layout": {
 				"inherit": true
 			}
 		},
 		"innerBlocks": [
 			{
-				"name": "core/group",
+				"name": "core/post-template",
 				"isValid": true,
-				"attributes": {
-					"tagName": "div",
-					"textColor": "pale-cyan-blue",
-					"style": {
-						"color": {
-							"background": "#284d5f"
-						},
-						"elements": {
-							"link": {
-								"color": {
-									"text": "var:preset|color|luminous-vivid-amber"
-								}
-							}
-						}
-					}
-				},
+				"attributes": {},
 				"innerBlocks": [
 					{
-						"name": "core/post-template",
+						"name": "core/post-title",
 						"isValid": true,
 						"attributes": {
-							"fontSize": "large"
+							"level": 2,
+							"isLink": false,
+							"rel": "",
+							"linkTarget": "_self"
 						},
-						"innerBlocks": [
-							{
-								"name": "core/post-title",
-								"isValid": true,
-								"attributes": {
-									"level": 2,
-									"isLink": false,
-									"rel": "",
-									"linkTarget": "_self"
-								},
-								"innerBlocks": []
-							},
-							{
-								"name": "core/post-date",
-								"isValid": true,
-								"attributes": {
-									"isLink": false,
-									"displayType": "date"
-								},
-								"innerBlocks": []
-							},
-							{
-								"name": "core/post-excerpt",
-								"isValid": true,
-								"attributes": {
-									"showMoreOnNewLine": true
-								},
-								"innerBlocks": []
-							}
-						]
-					},
-					{
-						"name": "core/query-pagination",
-						"isValid": true,
-						"attributes": {
-							"paginationArrow": "none"
-						},
-						"innerBlocks": [
-							{
-								"name": "core/query-pagination-previous",
-								"isValid": true,
-								"attributes": {},
-								"innerBlocks": []
-							},
-							{
-								"name": "core/query-pagination-numbers",
-								"isValid": true,
-								"attributes": {},
-								"innerBlocks": []
-							},
-							{
-								"name": "core/query-pagination-next",
-								"isValid": true,
-								"attributes": {},
-								"innerBlocks": []
-							}
-						]
-					},
-					{
-						"name": "core/query-no-results",
-						"isValid": true,
-						"attributes": {},
-						"innerBlocks": [
-							{
-								"name": "core/paragraph",
-								"isValid": true,
-								"attributes": {
-									"content": "No results found.",
-									"dropCap": false,
-									"placeholder": "Add text or blocks that will display when a query returns no results."
-								},
-								"innerBlocks": []
-							}
-						]
+						"innerBlocks": []
 					}
 				]
 			}

--- a/test/integration/fixtures/blocks/core__query__deprecated-4.parsed.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-4.parsed.json
@@ -2,9 +2,9 @@
 	{
 		"blockName": "core/query",
 		"attrs": {
-			"queryId": 3,
+			"queryId": 0,
 			"query": {
-				"perPage": 3,
+				"perPage": 10,
 				"pages": 0,
 				"offset": 0,
 				"postType": "post",
@@ -14,26 +14,12 @@
 				"search": "",
 				"exclude": [],
 				"sticky": "",
-				"inherit": false
+				"inherit": true
 			},
+			"tagName": "main",
 			"displayLayout": {
-				"type": "flex",
-				"columns": 3
+				"type": "list"
 			},
-			"align": "wide",
-			"style": {
-				"color": {
-					"background": "#284d5f"
-				},
-				"elements": {
-					"link": {
-						"color": {
-							"text": "var:preset|color|luminous-vivid-amber"
-						}
-					}
-				}
-			},
-			"textColor": "pale-cyan-blue",
 			"layout": {
 				"inherit": true
 			}
@@ -41,9 +27,7 @@
 		"innerBlocks": [
 			{
 				"blockName": "core/post-template",
-				"attrs": {
-					"fontSize": "large"
-				},
+				"attrs": {},
 				"innerBlocks": [
 					{
 						"blockName": "core/post-title",
@@ -51,97 +35,15 @@
 						"innerBlocks": [],
 						"innerHTML": "",
 						"innerContent": []
-					},
-					{
-						"blockName": "core/post-date",
-						"attrs": {},
-						"innerBlocks": [],
-						"innerHTML": "",
-						"innerContent": []
-					},
-					{
-						"blockName": "core/post-excerpt",
-						"attrs": {},
-						"innerBlocks": [],
-						"innerHTML": "",
-						"innerContent": []
-					}
-				],
-				"innerHTML": "\n    \n\n    \n\n    \n    ",
-				"innerContent": [
-					"\n    ",
-					null,
-					"\n\n    ",
-					null,
-					"\n\n    ",
-					null,
-					"\n    "
-				]
-			},
-			{
-				"blockName": "core/query-pagination",
-				"attrs": {},
-				"innerBlocks": [
-					{
-						"blockName": "core/query-pagination-previous",
-						"attrs": {},
-						"innerBlocks": [],
-						"innerHTML": "",
-						"innerContent": []
-					},
-					{
-						"blockName": "core/query-pagination-numbers",
-						"attrs": {},
-						"innerBlocks": [],
-						"innerHTML": "",
-						"innerContent": []
-					},
-					{
-						"blockName": "core/query-pagination-next",
-						"attrs": {},
-						"innerBlocks": [],
-						"innerHTML": "",
-						"innerContent": []
-					}
-				],
-				"innerHTML": "\n    \n\n    \n\n    \n    ",
-				"innerContent": [
-					"\n    ",
-					null,
-					"\n\n    ",
-					null,
-					"\n\n    ",
-					null,
-					"\n    "
-				]
-			},
-			{
-				"blockName": "core/query-no-results",
-				"attrs": {},
-				"innerBlocks": [
-					{
-						"blockName": "core/paragraph",
-						"attrs": {
-							"placeholder": "Add text or blocks that will display when a query returns no results."
-						},
-						"innerBlocks": [],
-						"innerHTML": "\n    <p>No results found.</p>\n    ",
-						"innerContent": [
-							"\n    <p>No results found.</p>\n    "
-						]
 					}
 				],
 				"innerHTML": "\n    \n    ",
 				"innerContent": [ "\n    ", null, "\n    " ]
 			}
 		],
-		"innerHTML": "\n<div class=\"wp-block-query alignwide has-pale-cyan-blue-color has-text-color has-background has-link-color\"\n    style=\"background-color:#284d5f\">\n\n    \n\n    \n</div>\n",
+		"innerHTML": "\n<div class=\"wp-block-query\">\n</div>\n",
 		"innerContent": [
-			"\n<div class=\"wp-block-query alignwide has-pale-cyan-blue-color has-text-color has-background has-link-color\"\n    style=\"background-color:#284d5f\">",
-			null,
-			"\n\n    ",
-			null,
-			"\n\n    ",
+			"\n<div class=\"wp-block-query\">",
 			null,
 			"\n</div>\n"
 		]

--- a/test/integration/fixtures/blocks/core__query__deprecated-4.parsed.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-4.parsed.json
@@ -1,0 +1,149 @@
+[
+	{
+		"blockName": "core/query",
+		"attrs": {
+			"queryId": 3,
+			"query": {
+				"perPage": 3,
+				"pages": 0,
+				"offset": 0,
+				"postType": "post",
+				"order": "desc",
+				"orderBy": "date",
+				"author": "",
+				"search": "",
+				"exclude": [],
+				"sticky": "",
+				"inherit": false
+			},
+			"displayLayout": {
+				"type": "flex",
+				"columns": 3
+			},
+			"align": "wide",
+			"style": {
+				"color": {
+					"background": "#284d5f"
+				},
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var:preset|color|luminous-vivid-amber"
+						}
+					}
+				}
+			},
+			"textColor": "pale-cyan-blue",
+			"layout": {
+				"inherit": true
+			}
+		},
+		"innerBlocks": [
+			{
+				"blockName": "core/post-template",
+				"attrs": {
+					"fontSize": "large"
+				},
+				"innerBlocks": [
+					{
+						"blockName": "core/post-title",
+						"attrs": {},
+						"innerBlocks": [],
+						"innerHTML": "",
+						"innerContent": []
+					},
+					{
+						"blockName": "core/post-date",
+						"attrs": {},
+						"innerBlocks": [],
+						"innerHTML": "",
+						"innerContent": []
+					},
+					{
+						"blockName": "core/post-excerpt",
+						"attrs": {},
+						"innerBlocks": [],
+						"innerHTML": "",
+						"innerContent": []
+					}
+				],
+				"innerHTML": "\n    \n\n    \n\n    \n    ",
+				"innerContent": [
+					"\n    ",
+					null,
+					"\n\n    ",
+					null,
+					"\n\n    ",
+					null,
+					"\n    "
+				]
+			},
+			{
+				"blockName": "core/query-pagination",
+				"attrs": {},
+				"innerBlocks": [
+					{
+						"blockName": "core/query-pagination-previous",
+						"attrs": {},
+						"innerBlocks": [],
+						"innerHTML": "",
+						"innerContent": []
+					},
+					{
+						"blockName": "core/query-pagination-numbers",
+						"attrs": {},
+						"innerBlocks": [],
+						"innerHTML": "",
+						"innerContent": []
+					},
+					{
+						"blockName": "core/query-pagination-next",
+						"attrs": {},
+						"innerBlocks": [],
+						"innerHTML": "",
+						"innerContent": []
+					}
+				],
+				"innerHTML": "\n    \n\n    \n\n    \n    ",
+				"innerContent": [
+					"\n    ",
+					null,
+					"\n\n    ",
+					null,
+					"\n\n    ",
+					null,
+					"\n    "
+				]
+			},
+			{
+				"blockName": "core/query-no-results",
+				"attrs": {},
+				"innerBlocks": [
+					{
+						"blockName": "core/paragraph",
+						"attrs": {
+							"placeholder": "Add text or blocks that will display when a query returns no results."
+						},
+						"innerBlocks": [],
+						"innerHTML": "\n    <p>No results found.</p>\n    ",
+						"innerContent": [
+							"\n    <p>No results found.</p>\n    "
+						]
+					}
+				],
+				"innerHTML": "\n    \n    ",
+				"innerContent": [ "\n    ", null, "\n    " ]
+			}
+		],
+		"innerHTML": "\n<div class=\"wp-block-query alignwide has-pale-cyan-blue-color has-text-color has-background has-link-color\"\n    style=\"background-color:#284d5f\">\n\n    \n\n    \n</div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-query alignwide has-pale-cyan-blue-color has-text-color has-background has-link-color\"\n    style=\"background-color:#284d5f\">",
+			null,
+			"\n\n    ",
+			null,
+			"\n\n    ",
+			null,
+			"\n</div>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__query__deprecated-4.serialized.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-4.serialized.html
@@ -1,25 +1,7 @@
-<!-- wp:query {"queryId":3,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
-<div class="wp-block-query alignwide"><!-- wp:group {"textColor":"pale-cyan-blue","style":{"color":{"background":"#284d5f"},"elements":{"link":{"color":{"text":"var:preset|color|luminous-vivid-amber"}}}}} -->
-<div class="wp-block-group has-pale-cyan-blue-color has-text-color has-background has-link-color" style="background-color:#284d5f"><!-- wp:post-template {"fontSize":"large"} -->
+<!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"main","displayLayout":{"type":"list"},"layout":{"inherit":true}} -->
+<div class="wp-block-query">
+<!-- wp:post-template -->
 <!-- wp:post-title /-->
-
-<!-- wp:post-date /-->
-
-<!-- wp:post-excerpt /-->
 <!-- /wp:post-template -->
-
-<!-- wp:query-pagination -->
-<!-- wp:query-pagination-previous /-->
-
-<!-- wp:query-pagination-numbers /-->
-
-<!-- wp:query-pagination-next /-->
-<!-- /wp:query-pagination -->
-
-<!-- wp:query-no-results -->
-<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
-<p>No results found.</p>
-<!-- /wp:paragraph -->
-<!-- /wp:query-no-results --></div>
-<!-- /wp:group --></div>
+</div>
 <!-- /wp:query -->

--- a/test/integration/fixtures/blocks/core__query__deprecated-4.serialized.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-4.serialized.html
@@ -1,0 +1,25 @@
+<!-- wp:query {"queryId":3,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
+<div class="wp-block-query alignwide"><!-- wp:group {"textColor":"pale-cyan-blue","style":{"color":{"background":"#284d5f"},"elements":{"link":{"color":{"text":"var:preset|color|luminous-vivid-amber"}}}}} -->
+<div class="wp-block-group has-pale-cyan-blue-color has-text-color has-background has-link-color" style="background-color:#284d5f"><!-- wp:post-template {"fontSize":"large"} -->
+<!-- wp:post-title /-->
+
+<!-- wp:post-date /-->
+
+<!-- wp:post-excerpt /-->
+<!-- /wp:post-template -->
+
+<!-- wp:query-pagination -->
+<!-- wp:query-pagination-previous /-->
+
+<!-- wp:query-pagination-numbers /-->
+
+<!-- wp:query-pagination-next /-->
+<!-- /wp:query-pagination -->
+
+<!-- wp:query-no-results -->
+<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+<p>No results found.</p>
+<!-- /wp:paragraph -->
+<!-- /wp:query-no-results --></div>
+<!-- /wp:group --></div>
+<!-- /wp:query -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This enables the layout config of a parent block to always be passed to its inner blocks by default. It's one of the remaining steps towards the stabilisation of layout support 🙂 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Addresses [this comment](https://github.com/WordPress/gutenberg/pull/45326#discussion_r1006628243), as well as miscellaneous unexpected behaviour around the ability to set wide/full alignments on child blocks.

It also removes a bunch of logic that wasn't actually doing anything from some of the core block edit functions 😅 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

### Main Features

* Makes layout available as context from the `BlockEdit` function;
* Retrieves layout from block edit context in `useInnerBlocksProps`;

### Cleanup

* Removes alignment logic from flow layout altogether;
* Fixes the issue reported in #43502 by adding a deprecation to the Query block;
* Removes all logic around passing layout to inner blocks from all the block edit functions.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Test Buttons, Comments Pagination, Gallery, Group, Navigation, Post Content, Query, Query Pagination and Social Links blocks layout controls and make sure they still work as expected.
2. In the Group block, check that wide/full alignment appears for a child Image block by default;
3. In the same Group block, toggle "Inner blocks use content width" off. Check that wide/full controls no longer appear for the child Image block.
4. Check that the scenario described in #43502 is fixed.
5. In a Column block, toggle "Inner blocks use content width" on. A child Image block should now display wide/full alignment controls.
6. Check that children of Row block still show a "Width" control under dimensions and it still works as expected.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
