### PR TITLE
Reset default_comment_status to previous value after post comments form e2e test

### DIFF
--- a/packages/e2e-tests/specs/experiments/blocks/post-comments-form.test.js
+++ b/packages/e2e-tests/specs/experiments/blocks/post-comments-form.test.js
@@ -12,15 +12,23 @@ import {
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Post Comments Form', () => {
+	let previousCommentStatus;
+
 	beforeAll( async () => {
 		await activateTheme( 'emptytheme' );
 		await deleteAllTemplates( 'wp_template' );
+		previousCommentStatus = await setOption(
+			'default_comment_status',
+			'closed'
+		);
+	} );
+
+	afterAll( async () => {
+		await setOption( 'default_comment_status', previousCommentStatus );
 	} );
 
 	describe( 'placeholder', () => {
 		it( 'displays in site editor even when comments are closed by default', async () => {
-			await setOption( 'default_comment_status', 'closed' );
-
 			// Navigate to "Singular" post template
 			await visitSiteEditor();
 			await expect( page ).toClick(


### PR DESCRIPTION
## What?
In passing, I noticed the post comments form e2e test doesn't clean up after itself. It sets the `default_comment_status` option to `closed`, but doesn't return it to the previous value.

This PR updates the test to reset the value of the option.

## Why?
Tests that don't tidy up after themselves can lead to hard to debug test failures.

## How?
The `setOption` util returns the previous value of the option, so that can be used to reset the value.

## Testing Instructions
Tests should still pass.