### PR TITLE
Fix padding and margin visualizer positioning

### DIFF
--- a/packages/block-editor/src/content.scss
+++ b/packages/block-editor/src/content.scss
@@ -12,4 +12,3 @@
 @import "./components/plain-text/content.scss";
 @import "./components/rich-text/content.scss";
 @import "./components/warning/content.scss";
-@import "./hooks/padding.scss";

--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -237,6 +237,7 @@ export function MarginVisualizer( { clientId, attributes, forceShow } ) {
 			clientId={ clientId }
 			__unstableCoverTarget
 			__unstableRefreshSize={ margin }
+			__unstablePopoverSlot="block-toolbar"
 			shift={ false }
 		>
 			<div className="block-editor__padding-visualizer" style={ style } />

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -226,6 +226,7 @@ export function PaddingVisualizer( { clientId, attributes, forceShow } ) {
 			clientId={ clientId }
 			__unstableCoverTarget
 			__unstableRefreshSize={ padding }
+			__unstablePopoverSlot="block-toolbar"
 			shift={ false }
 		>
 			<div className="block-editor__padding-visualizer" style={ style } />

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -45,12 +45,13 @@
 @import "./components/url-input/style.scss";
 @import "./components/url-popover/style.scss";
 @import "./hooks/anchor.scss";
-@import "./hooks/layout.scss";
 @import "./hooks/border.scss";
+@import "./hooks/color.scss";
 @import "./hooks/dimensions.scss";
+@import "./hooks/layout.scss";
+@import "./hooks/padding.scss";
 @import "./hooks/position.scss";
 @import "./hooks/typography.scss";
-@import "./hooks/color.scss";
 
 @import "./components/block-toolbar/style.scss";
 @import "./components/inserter/style.scss";


### PR DESCRIPTION
## What?
Fixes #47471, an issue where the margin and padding visualizers became misaligned whenever block spacing is applied to the layout.

## Why?
The visualizer popovers were rendering within the editor canvas `iframe`, inline within the block list. This made them susceptible to CSS that's meant to be applied to blocks.

In this case, the block spacing's `margin-block-start` style was being applied to the popover, making it appear misaligned with the block itself.

## How?
This PR makes the visualizer popovers use the `block-toolbar` slot, so that they render outside of the editor canvas iframe.

I did try this originally when trying to fix #47139, and noticed some other problems with the visualizers, but I'm not seeing any issues in this PR 🤔 

## Testing Instructions
1. Add several paragraphs and group them
2. Apply block spacing to the group
3. Select the last paragraph in the group and adjust the padding or margin in the dimensions panel

Expected: the visualizer should appear correctly overlayed on top of the block.
In trunk: the visualizer is misaligned

## Screenshots or screencast <!-- if applicable -->
### Before
![Screen Shot 2023-01-27 at 3 27 02 pm](https://user-images.githubusercontent.com/677833/215031400-af40802a-97ca-47a4-93de-1cbcae04b5c3.png)

### After
![Screen Shot 2023-01-27 at 3 26 39 pm](https://user-images.githubusercontent.com/677833/215031426-6cb68366-6399-41ed-a05e-ad023ffb5949.png)
