### PR TITLE
quote block border issue solution for twenty twenty three theme

### DIFF
--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -44,6 +44,18 @@
 				"fontAppearance": true
 			}
 		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"style": true,
+				"width": true
+			}
+		},
 		"color": {
 			"gradients": true,
 			"link": true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Resolve the twenty twenty three theme quote block border issue.
#45547 
## What?
<!-- In a few words, what is the PR actually doing? -->
This PR is resolve the issue which is mentioned in this ticket :- #45547

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
As per the discussion in #45547 this issue we need to add support related to border-control so that user can give border as per their requirement.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I have added the border-support for quote block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Choose Quote block in twenty-twenty-three theme.
2. We have a border related setting in our editor side.
3. Choose border-width, color, style as per your requirement.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
**Before:-**

![CleanShot 2023-02-03 at 11 16 50@2x](https://user-images.githubusercontent.com/84835782/216523821-3dc60f4e-b003-4844-81e7-1ab00f80edb8.png)
---------------------------------------------------------------------------------------------------------
**After:-**
**Editor side:-**
![CleanShot 202
![CleanShot 2023-02-03 at 11 28 21@2x](https://user-images.githubusercontent.com/84835782/216524088-45a02bf0-58bb-465f-a301-e508f778dec2.png)
3-02-03 at 11 27 58@2x](https://user-images.githubusercontent.com/84835782/216524043-8c9ab06f-13a4-456d-abd2-bcddd4f21913.png)
**User side:-**
![CleanShot 2023-02-03 at 11 28 21@2x](https://user-images.githubusercontent.com/84835782/216524280-8cdeb746-fcbc-41b0-bd4c-620bbd5d50b3.png)

