### PR TITLE
[Block Editor]: Register the store through `registerStore`

### DIFF
--- a/packages/block-editor/src/store/index.js
+++ b/packages/block-editor/src/store/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createReduxStore, register } from '@wordpress/data';
+import { createReduxStore, registerStore } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -35,8 +35,13 @@ export const store = createReduxStore( STORE_NAME, {
 	persist: [ 'preferences' ],
 } );
 
-register( store );
+// We will be able to use the `register` function once we switch
+// the "preferences" persistence to use the new preferences package.
+const registeredStore = registerStore( STORE_NAME, {
+	...storeConfig,
+	persist: [ 'preferences' ],
+} );
 
-unlock( store ).registerPrivateActions( {
+unlock( registeredStore ).registerPrivateActions( {
 	__experimentalUpdateSettings,
 } );

--- a/packages/data/src/test/privateAPIs.js
+++ b/packages/data/src/test/privateAPIs.js
@@ -129,6 +129,33 @@ describe( 'Private data APIs', () => {
 			expect( unlockedSelectors.getPublicPrice() ).toEqual( 1000 );
 		} );
 
+		it( 'should support registerStore', () => {
+			const groceryStore = registry.registerStore(
+				storeName,
+				storeDescriptor
+			);
+			unlock( groceryStore ).registerPrivateSelectors( {
+				getSecretDiscount,
+			} );
+
+			const privateSelectors = unlock( registry.select( storeName ) );
+			expect( privateSelectors.getSecretDiscount() ).toEqual( 800 );
+		} );
+
+		it( 'should support mixing createReduxStore and registerStore', () => {
+			createReduxStore( storeName, storeDescriptor );
+			const groceryStore2 = registry.registerStore(
+				storeName,
+				storeDescriptor
+			);
+			unlock( groceryStore2 ).registerPrivateSelectors( {
+				getSecretDiscount,
+			} );
+
+			const privateSelectors = unlock( registry.select( storeName ) );
+			expect( privateSelectors.getSecretDiscount() ).toEqual( 800 );
+		} );
+
 		it( 'should support sub registries', () => {
 			const groceryStore = registry.registerStore(
 				storeName,
@@ -247,6 +274,21 @@ describe( 'Private data APIs', () => {
 			expect(
 				unlock( registry.select( groceryStore ) ).getSecretDiscount()
 			).toEqual( 100 );
+		} );
+
+		it( 'should support registerStore', () => {
+			const groceryStore = registry.registerStore(
+				storeName,
+				storeDescriptor
+			);
+			unlock( groceryStore ).registerPrivateActions( {
+				setSecretDiscount,
+			} );
+			const privateActions = unlock( registry.dispatch( storeName ) );
+			privateActions.setSecretDiscount( 400 );
+			expect(
+				registry.select( storeName ).getState().secretDiscount
+			).toEqual( 400 );
 		} );
 
 		it( 'should support sub registries', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Reverts: https://github.com/WordPress/gutenberg/pull/47447


## Why?
>I think this PR will introduce a bug that 'Most used blocks' is no longer persisted after reloading the editor.

See details here: https://github.com/WordPress/gutenberg/pull/47447#issuecomment-1405971901


We will be able to use the `register` function once we switch the "preferences" persistence to use the new preferences package.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Everything should work as before
2. We can lock the store through `registerStore`
3. `Most used blocks` are preserved on reload.

