### PR TITLE
Block Editor: Improve `getBlockInsertionPoint` memoization

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1402,10 +1402,7 @@ export const getBlockInsertionPoint = createSelector(
 		return { rootClientId, index };
 	},
 	( state ) => [
-		state.insertionPoint?.rootClientId,
-		state.insertionPoint?.index,
-		state.insertionPoint?.__unstableWithInserter,
-		state.insertionPoint?.operation,
+		state.insertionPoint,
 		state.selection.selectionEnd.clientId,
 		state.blocks.parents,
 		state.blocks.order,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1402,8 +1402,11 @@ export const getBlockInsertionPoint = createSelector(
 		return { rootClientId, index };
 	},
 	( state ) => [
-		state.insertionPoint,
-		state.selection.selectionEnd,
+		state.insertionPoint?.rootClientId,
+		state.insertionPoint?.index,
+		state.insertionPoint?.__unstableWithInserter,
+		state.insertionPoint?.operation,
+		state.selection.selectionEnd.clientId,
 		state.blocks.parents,
 		state.blocks.order,
 	]


### PR DESCRIPTION
## What?
This PR improves the memoization of `getBlockInsertionPoint()` by making the list of dependents more specific. This allows us to avoid unnecessary extra rerenders when the insertion point is the same but an update is triggered just because we return a new object with the same data.

## Why?
After landing #47448 I noticed that there are still unnecessary re-renders caused by `getBlockInsertionPoint()`, in cases where we're moving inside the same block, for example. 

## How?
We're listing the dependents specifically and that way we avoid unnecessary updates when new nested objects with the same data are being dispatched. This was particularly a problem for `state.selection.selectionEnd`, which can be a different object but the `state.selection.selectionEnd.clientId` will still be the same, and that's all the selector needs from that state subtree, so the update was unnecessary.

## Testing Instructions
* Verify that as you're removing / inserting / moving blocks, the insertion point remains where it should be and works the same way as before - defaulting to the bottom, but staying beside the block if we've selected an empty paragraph for example.
* Verify tests are green.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
None.