### PR TITLE
Rename `__unstableInserterMediaCategories` to `inserterMediaCategories`

### DIFF
--- a/docs/contributors/code/coding-guidelines.md
+++ b/docs/contributors/code/coding-guidelines.md
@@ -136,7 +136,7 @@ export { __unstableDoTerribleAwfulAction } from './api';
 -   An **experimental API** is one which is planned for eventual public availability, but is subject to further experimentation, testing, and discussion.
 -   An **unstable API** is one which serves as a means to an end. It is not desired to ever be converted into a public API.
 
-In both cases, the API should be made stable or removed at the earliest opportunity. 
+In both cases, the API should be made stable or removed at the earliest opportunity.
 
 While an experimental API may often stabilize into a publicly-available API, there is no guarantee that it will. The conversion to a stable API will inherently be considered a breaking change by the mere fact that the function name must be changed to remove the `__experimental` prefix.
 
@@ -147,14 +147,14 @@ While an experimental API may often stabilize into a publicly-available API, the
 As of June 2022, WordPress Core contains 280 publicly exported experimental APIs. They got merged from the Gutenberg
 plugin during the major WordPress releases. Many plugins and themes rely on these experimental APIs for essential
 features that can't be accessed in any other way. Naturally, these APIs can't be removed without a warning anymore.
-They are a part of the WordPress public API and fall under the 
-[WordPress Backwards Compatibility policy](https://developer.wordpress.org/block-editor/contributors/code/backward-compatibility/). 
+They are a part of the WordPress public API and fall under the
+[WordPress Backwards Compatibility policy](https://developer.wordpress.org/block-editor/contributors/code/backward-compatibility/).
 Removing them involves a deprecation process. It may be relatively easy for some APIs, but it may require effort and
 span multiple WordPress releases for others.
 
 **Use private experimental APIs instead.**
 
-Make your experimental APIs private and don't expose them to WordPress extenders. 
+Make your experimental APIs private and don't expose them to WordPress extenders.
 
 This way they'll remain internal implementation details that can be changed or removed
  without a warning and without breaking WordPress plugins.
@@ -203,7 +203,7 @@ Sometimes a non-exported React hook suffices as a substitute for introducing a n
 	function hasActiveBlockOverlayActive ( selectors, parent ) { /* ... */ }
 	function useIsWithinBlockOverlay( clientId ) {
 		return useSelect( ( select ) => {
-			const selectors = select( blockEditorStore ); 
+			const selectors = select( blockEditorStore );
 			let parent = selectors.getBlockRootClientId( clientId );
 			while ( !!parent ) {
 				if ( hasActiveBlockOverlayActive( selectors, parent ) ) {
@@ -412,17 +412,17 @@ import { lock } from './experiments';
 // The experimental component contains all the logic
 const ExperimentalMyButton = ( { title, __experimentalShowIcon = true } ) => {
 	// ...complex logic we don't want to duplicate...
-  
+
 	return (
 		<button>
-			{ __experimentalShowIcon  && <Icon src={some icon} /> } { title }  
+			{ __experimentalShowIcon  && <Icon src={some icon} /> } { title }
 		</button>
 	);
 }
 
 // The stable public component is a thin wrapper that calls the
 // experimental component with the experimental features disabled
-export const MyButton = ( { title } ) => 
+export const MyButton = ( { title } ) =>
     <ExperimentalMyButton title={ title } __experimentalShowIcon={ false } />
 
 lock(MyButton, ExperimentalMyButton);
@@ -449,7 +449,7 @@ To privatize a block editor setting, add it to the `privateSettings` list in [/p
 
 ```js
 const privateSettings = [
-	'__unstableInserterMediaCategories',
+	'inserterMediaCategories',
 	// List a block editor setting here to make it private
 ];
 ```

--- a/packages/block-editor/src/components/inserter/media-tab/hooks.js
+++ b/packages/block-editor/src/components/inserter/media-tab/hooks.js
@@ -78,7 +78,7 @@ function useInserterMediaCategories() {
 	} = useSelect( ( select ) => {
 		const settings = select( blockEditorStore ).getSettings();
 		return {
-			inserterMediaCategories: settings.__unstableInserterMediaCategories,
+			inserterMediaCategories: settings.inserterMediaCategories,
 			allowedMimeTypes: settings.allowedMimeTypes,
 			enableOpenverseMediaCategory: settings.enableOpenverseMediaCategory,
 		};
@@ -143,7 +143,7 @@ export function useMediaCategories( rootClientId ) {
 	useEffect( () => {
 		( async () => {
 			const _categories = [];
-			// If `__unstableInserterMediaCategories` is not defined in
+			// If `inserterMediaCategories` is not defined in
 			// block editor settings, do not show any media categories.
 			if ( ! inserterMediaCategories ) {
 				return;

--- a/packages/block-editor/src/components/provider/test/experimental-provider.js
+++ b/packages/block-editor/src/components/provider/test/experimental-provider.js
@@ -33,16 +33,14 @@ describe( 'BlockEditorProvider', () => {
 		render(
 			<BlockEditorProvider
 				settings={ {
-					__unstableInserterMediaCategories: true,
+					inserterMediaCategories: true,
 				} }
 			>
 				<HasEditorSetting setRegistry={ setRegistry } />
 			</BlockEditorProvider>
 		);
 		const settings = registry.select( blockEditorStore ).getSettings();
-		expect( settings ).not.toHaveProperty(
-			'__unstableInserterMediaCategories'
-		);
+		expect( settings ).not.toHaveProperty( 'inserterMediaCategories' );
 	} );
 	it( 'should preserve stable settings', async () => {
 		render(
@@ -71,16 +69,14 @@ describe( 'ExperimentalBlockEditorProvider', () => {
 		render(
 			<ExperimentalBlockEditorProvider
 				settings={ {
-					__unstableInserterMediaCategories: true,
+					inserterMediaCategories: true,
 				} }
 			>
 				<HasEditorSetting setRegistry={ setRegistry } />
 			</ExperimentalBlockEditorProvider>
 		);
 		const settings = registry.select( blockEditorStore ).getSettings();
-		expect( settings ).toHaveProperty(
-			'__unstableInserterMediaCategories'
-		);
+		expect( settings ).toHaveProperty( 'inserterMediaCategories' );
 	} );
 	it( 'should preserve stable settings', async () => {
 		render(

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1454,7 +1454,7 @@ export function updateSettings( settings ) {
  *
  * @see https://github.com/WordPress/gutenberg/pull/46131
  */
-const privateSettings = [ '__unstableInserterMediaCategories' ];
+const privateSettings = [ 'inserterMediaCategories' ];
 
 /**
  * Action that updates the block editor settings and

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -122,7 +122,7 @@ export default function BlockEditor() {
 
 		return {
 			...restStoredSettings,
-			__unstableInserterMediaCategories: inserterMediaCategories,
+			inserterMediaCategories,
 			__experimentalBlockPatterns: blockPatterns,
 			__experimentalBlockPatternCategories: blockPatternCategories,
 		};

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -188,7 +188,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			__experimentalBlockPatternCategories: blockPatternCategories,
 			__experimentalFetchLinkSuggestions: ( search, searchOptions ) =>
 				fetchLinkSuggestions( search, searchOptions, settings ),
-			__unstableInserterMediaCategories: inserterMediaCategories,
+			inserterMediaCategories,
 			__experimentalFetchRichUrlData: fetchUrlData,
 			__experimentalCanUserUseUnfilteredHTML: canUseUnfilteredHTML,
 			__experimentalUndo: undo,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
We locked `__unstableInserterMediaCategories` block editor setting [here](https://github.com/WordPress/gutenberg/pull/47319) and since it's locked, this PR just renames it to `inserterMediaCategories`.
<!-- In a few words, what is the PR actually doing? -->

## Testing Instructions
1. Media tab in the inserter should work exactly as before.
