### PR TITLE
`Guide`: refactor to TypeScript

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -16,6 +16,7 @@
 -   `Higher Order` -- `with-constrained-tabbing`: Convert to TypeScript ([#48162](https://github.com/WordPress/gutenberg/pull/48162)).
 -   `Autocomplete`: Convert to TypeScript ([#47751](https://github.com/WordPress/gutenberg/pull/47751)).
 -   `Autocomplete`: avoid calling setState on input ([#48565](https://github.com/WordPress/gutenberg/pull/48565)).
+-   `Guide`: Convert to TypeScript ([#47493](https://github.com/WordPress/gutenberg/pull/47493)).
 
 ## 23.4.0 (2023-02-15)
 
@@ -50,7 +51,6 @@
 -   `Navigator`: add more pattern matching tests, refine existing tests ([47910](https://github.com/WordPress/gutenberg/pull/47910)).
 -   `ToolsPanel`: Refactor Storybook examples to TypeScript ([47944](https://github.com/WordPress/gutenberg/pull/47944)).
 -   `ToolsPanel`: Refactor unit tests to TypeScript ([48275](https://github.com/WordPress/gutenberg/pull/48275)).
--   `Guide`: Convert to TypeScript ([#47493](https://github.com/WordPress/gutenberg/pull/47493)).
 
 ## 23.3.0 (2023-02-01)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -50,6 +50,7 @@
 -   `Navigator`: add more pattern matching tests, refine existing tests ([47910](https://github.com/WordPress/gutenberg/pull/47910)).
 -   `ToolsPanel`: Refactor Storybook examples to TypeScript ([47944](https://github.com/WordPress/gutenberg/pull/47944)).
 -   `ToolsPanel`: Refactor unit tests to TypeScript ([48275](https://github.com/WordPress/gutenberg/pull/48275)).
+-   `Guide`: Convert to TypeScript ([#47493](https://github.com/WordPress/gutenberg/pull/47493)).
 
 ## 23.3.0 (2023-02-01)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   `Guide`: Convert to TypeScript ([#47493](https://github.com/WordPress/gutenberg/pull/47493)).
+
 ## 23.5.0 (2023-03-01)
 
 ### Enhancements
@@ -16,7 +20,6 @@
 -   `Higher Order` -- `with-constrained-tabbing`: Convert to TypeScript ([#48162](https://github.com/WordPress/gutenberg/pull/48162)).
 -   `Autocomplete`: Convert to TypeScript ([#47751](https://github.com/WordPress/gutenberg/pull/47751)).
 -   `Autocomplete`: avoid calling setState on input ([#48565](https://github.com/WordPress/gutenberg/pull/48565)).
--   `Guide`: Convert to TypeScript ([#47493](https://github.com/WordPress/gutenberg/pull/47493)).
 
 ## 23.4.0 (2023-02-15)
 

--- a/packages/components/src/guide/README.md
+++ b/packages/components/src/guide/README.md
@@ -37,20 +37,6 @@ function MyTutorial() {
 
 The component accepts the following props:
 
-### onFinish
-
-A function which is called when the guide is finished. The guide is finished when the modal is closed or when the user clicks _Finish_ on the last page of the guide.
-
--   Type: `function`
--   Required: Yes
-
-### pages
-
-A list of objects describing each page in the guide. Each object **must** contain a `'content'` property and may optionally contain a `'image'` property.
-
--   Type: `array`
--   Required: Yes
-
 ### className
 
 A custom class to add to the modal.
@@ -62,7 +48,7 @@ A custom class to add to the modal.
 
 This property is used as the modal's accessibility label. It is required for accessibility reasons.
 
--   Type: `String`
+-   Type: `string`
 -   Required: Yes
 
 ### finishButtonText
@@ -71,3 +57,19 @@ Use this to customize the label of the _Finish_ button shown at the end of the g
 
 -   Type: `string`
 -   Required: No
+-	Default: `'Finish'`
+
+### onFinish
+
+A function which is called when the guide is finished. The guide is finished when the modal is closed or when the user clicks _Finish_ on the last page of the guide.
+
+-   Type: `( event?: KeyboardEvent< HTMLDivElement > | SyntheticEvent ) => void`
+-   Required: Yes
+
+### pages
+
+A list of objects describing each page in the guide. Each object **must** contain a `'content'` property and may optionally contain a `'image'` property.
+
+-   Type: `{ content: ReactNode; image?: ReactNode; }[]`
+-   Required: No
+-   Default: `[]`

--- a/packages/components/src/guide/icons.tsx
+++ b/packages/components/src/guide/icons.tsx
@@ -3,7 +3,12 @@
  */
 import { SVG, Circle } from '@wordpress/primitives';
 
-export const PageControlIcon = ( { isSelected } ) => (
+/**
+ * Internal dependencies
+ */
+import type { PageControlIconProps } from './types';
+
+export const PageControlIcon = ( { isSelected }: PageControlIconProps ) => (
 	<SVG width="8" height="8" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<Circle
 			cx="4"

--- a/packages/components/src/guide/icons.tsx
+++ b/packages/components/src/guide/icons.tsx
@@ -3,12 +3,7 @@
  */
 import { SVG, Circle } from '@wordpress/primitives';
 
-/**
- * Internal dependencies
- */
-import type { PageControlIconProps } from './types';
-
-export const PageControlIcon = ( { isSelected }: PageControlIconProps ) => (
+export const PageControlIcon = ( { isSelected }: { isSelected: boolean } ) => (
 	<SVG width="8" height="8" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<Circle
 			cx="4"

--- a/packages/components/src/guide/index.tsx
+++ b/packages/components/src/guide/index.tsx
@@ -24,7 +24,7 @@ export default function Guide( {
 	className,
 	contentLabel,
 	finishButtonText,
-	onFinish = () => {},
+	onFinish,
 	pages = [],
 }: GuideProps ) {
 	const guideContainer = useRef< HTMLDivElement >( null );

--- a/packages/components/src/guide/index.tsx
+++ b/packages/components/src/guide/index.tsx
@@ -19,6 +19,38 @@ import Button from '../button';
 import PageControl from './page-control';
 import type { GuideProps } from './types';
 
+/**
+ * `Guide` is a React component that renders a _user guide_ in a modal. The guide consists of several pages which the user can step through one by one. The guide is finished when the modal is closed or when the user clicks _Finish_ on the last page of the guide.
+ *
+ * ```jsx
+ * function MyTutorial() {
+ * 	const [ isOpen, setIsOpen ] = useState( true );
+ *
+ * 	if ( ! isOpen ) {
+ * 		return null;
+ * 	}
+ *
+ * 	return (
+ * 		<Guide
+ * 			onFinish={ () => setIsOpen( false ) }
+ * 			pages={ [
+ * 				{
+ * 					content: <p>Welcome to the ACME Store!</p>,
+ * 				},
+ * 				{
+ * 					image: <img src="https://acmestore.com/add-to-cart.png" />,
+ * 					content: (
+ * 						<p>
+ * 							Click <i>Add to Cart</i> to buy a product.
+ * 						</p>
+ * 					),
+ * 				},
+ * 			] }
+ * 		/>
+ * 	);
+ * }
+ * ```
+ */
 function Guide( {
 	children,
 	className,

--- a/packages/components/src/guide/index.tsx
+++ b/packages/components/src/guide/index.tsx
@@ -27,7 +27,7 @@ export default function Guide( {
 	onFinish = () => {},
 	pages = [],
 }: GuideProps ) {
-	const guideContainer = useRef();
+	const guideContainer = useRef< HTMLDivElement >( null );
 	const [ currentPage, setCurrentPage ] = useState( 0 );
 
 	useEffect( () => {
@@ -43,8 +43,9 @@ export default function Guide( {
 		// Each time we change the current page, start from the first element of the page.
 		// This also solves any focus loss that can happen.
 		if ( guideContainer.current ) {
-			// @ts-expect-error
-			focus.tabbable.find( guideContainer.current )?.[ 0 ]?.focus();
+			(
+				focus.tabbable.find( guideContainer.current ) as HTMLElement[]
+			 )[ 0 ]?.focus();
 		}
 	}, [ currentPage ] );
 
@@ -90,7 +91,6 @@ export default function Guide( {
 					event.preventDefault();
 				}
 			} }
-			// @ts-expect-error
 			ref={ guideContainer }
 		>
 			<div className="components-guide__container">

--- a/packages/components/src/guide/index.tsx
+++ b/packages/components/src/guide/index.tsx
@@ -19,7 +19,7 @@ import Button from '../button';
 import PageControl from './page-control';
 import type { GuideProps } from './types';
 
-export default function Guide( {
+function Guide( {
 	children,
 	className,
 	contentLabel,
@@ -138,3 +138,5 @@ export default function Guide( {
 		</Modal>
 	);
 }
+
+export default Guide;

--- a/packages/components/src/guide/index.tsx
+++ b/packages/components/src/guide/index.tsx
@@ -55,7 +55,7 @@ function Guide( {
 	children,
 	className,
 	contentLabel,
-	finishButtonText,
+	finishButtonText = __( 'Finish' ),
 	onFinish,
 	pages = [],
 }: GuideProps ) {
@@ -162,7 +162,7 @@ function Guide( {
 							className="components-guide__finish-button"
 							onClick={ onFinish }
 						>
-							{ finishButtonText || __( 'Finish' ) }
+							{ finishButtonText }
 						</Button>
 					) }
 				</div>

--- a/packages/components/src/guide/index.tsx
+++ b/packages/components/src/guide/index.tsx
@@ -17,15 +17,16 @@ import { focus } from '@wordpress/dom';
 import Modal from '../modal';
 import Button from '../button';
 import PageControl from './page-control';
+import type { GuideProps } from './types';
 
 export default function Guide( {
 	children,
 	className,
 	contentLabel,
 	finishButtonText,
-	onFinish,
+	onFinish = () => {},
 	pages = [],
-} ) {
+}: GuideProps ) {
 	const guideContainer = useRef();
 	const [ currentPage, setCurrentPage ] = useState( 0 );
 
@@ -42,12 +43,16 @@ export default function Guide( {
 		// Each time we change the current page, start from the first element of the page.
 		// This also solves any focus loss that can happen.
 		if ( guideContainer.current ) {
+			// @ts-expect-error
 			focus.tabbable.find( guideContainer.current )?.[ 0 ]?.focus();
 		}
 	}, [ currentPage ] );
 
 	if ( Children.count( children ) ) {
-		pages = Children.map( children, ( child ) => ( { content: child } ) );
+		pages =
+			Children.map( children, ( child ) => ( {
+				content: child,
+			} ) ) ?? [];
 	}
 
 	const canGoBack = currentPage > 0;
@@ -85,6 +90,7 @@ export default function Guide( {
 					event.preventDefault();
 				}
 			} }
+			// @ts-expect-error
 			ref={ guideContainer }
 		>
 			<div className="components-guide__container">

--- a/packages/components/src/guide/page-control.tsx
+++ b/packages/components/src/guide/page-control.tsx
@@ -8,12 +8,13 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import Button from '../button';
 import { PageControlIcon } from './icons';
+import type { PageControlProps } from './types';
 
 export default function PageControl( {
 	currentPage,
 	numberOfPages,
 	setCurrentPage,
-} ) {
+}: PageControlProps ) {
 	return (
 		<ul
 			className="components-guide__page-control"

--- a/packages/components/src/guide/page.tsx
+++ b/packages/components/src/guide/page.tsx
@@ -10,7 +10,7 @@ import deprecated from '@wordpress/deprecated';
 import type { WordPressComponentProps } from '../ui/context';
 
 export default function GuidePage(
-	props: WordPressComponentProps< {}, 'div' >
+	props: WordPressComponentProps< {}, 'div', false >
 ) {
 	useEffect( () => {
 		deprecated( '<GuidePage>', {

--- a/packages/components/src/guide/page.tsx
+++ b/packages/components/src/guide/page.tsx
@@ -4,7 +4,14 @@
 import { useEffect } from '@wordpress/element';
 import deprecated from '@wordpress/deprecated';
 
-export default function GuidePage( props ) {
+/**
+ * Internal dependencies
+ */
+import type { WordPressComponentProps } from '../ui/context';
+
+export default function GuidePage(
+	props: WordPressComponentProps< {}, 'div' >
+) {
 	useEffect( () => {
 		deprecated( '<GuidePage>', {
 			since: '5.5',

--- a/packages/components/src/guide/stories/index.tsx
+++ b/packages/components/src/guide/stories/index.tsx
@@ -40,7 +40,7 @@ const Template: ComponentStory< typeof Guide > = ( { onFinish, ...props } ) => {
 				<Guide
 					{ ...props }
 					onFinish={ ( ...finishArgs ) => {
-						closeGuide( ...finishArgs );
+						closeGuide();
 						onFinish?.( ...finishArgs );
 					} }
 				/>

--- a/packages/components/src/guide/stories/index.tsx
+++ b/packages/components/src/guide/stories/index.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+
+/**
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
@@ -7,9 +12,9 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import Button from '../../button';
-import Guide from '../';
+import Guide from '..';
 
-export default {
+const meta: ComponentMeta< typeof Guide > = {
 	title: 'Components/Guide',
 	component: Guide,
 	argTypes: {
@@ -18,8 +23,9 @@ export default {
 		onFinish: { action: 'onFinish' },
 	},
 };
+export default meta;
 
-const Template = ( { onFinish, ...props } ) => {
+const Template: ComponentStory< typeof Guide > = ( { onFinish, ...props } ) => {
 	const [ isOpen, setOpen ] = useState( false );
 
 	const openGuide = () => setOpen( true );
@@ -35,7 +41,7 @@ const Template = ( { onFinish, ...props } ) => {
 					{ ...props }
 					onFinish={ ( ...finishArgs ) => {
 						closeGuide( ...finishArgs );
-						onFinish( ...finishArgs );
+						onFinish?.( ...finishArgs );
 					} }
 				/>
 			) }

--- a/packages/components/src/guide/test/index.tsx
+++ b/packages/components/src/guide/test/index.tsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 /**
  * Internal dependencies
  */
-import Guide from '../';
+import Guide from '..';
 
 describe( 'Guide', () => {
 	it( 'renders nothing when there are no pages', () => {

--- a/packages/components/src/guide/test/index.tsx
+++ b/packages/components/src/guide/test/index.tsx
@@ -9,15 +9,21 @@ import userEvent from '@testing-library/user-event';
  */
 import Guide from '..';
 
+const defaultProps = {
+	onFinish: () => {},
+	contentLabel: 'Arbitrary Content Label',
+};
+
 describe( 'Guide', () => {
 	it( 'renders nothing when there are no pages', () => {
-		render( <Guide pages={ [] } /> );
+		render( <Guide { ...defaultProps } pages={ [] } /> );
 		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders one page at a time', () => {
 		render(
 			<Guide
+				{ ...defaultProps }
 				pages={ [
 					{ content: <p>Page 1</p> },
 					{ content: <p>Page 2</p> },
@@ -33,6 +39,7 @@ describe( 'Guide', () => {
 	it( 'hides back button and shows forward button on the first page', () => {
 		render(
 			<Guide
+				{ ...defaultProps }
 				pages={ [
 					{ content: <p>Page 1</p> },
 					{ content: <p>Page 2</p> },
@@ -55,6 +62,7 @@ describe( 'Guide', () => {
 		const user = userEvent.setup();
 		render(
 			<Guide
+				{ ...defaultProps }
 				pages={ [
 					{ content: <p>Page 1</p> },
 					{ content: <p>Page 2</p> },
@@ -78,7 +86,12 @@ describe( 'Guide', () => {
 	} );
 
 	it( "doesn't display the page control if there is only one page", () => {
-		render( <Guide pages={ [ { content: <p>Page 1</p> } ] } /> );
+		render(
+			<Guide
+				{ ...defaultProps }
+				pages={ [ { content: <p>Page 1</p> } ] }
+			/>
+		);
 		expect(
 			screen.queryByRole( 'list', { name: 'Guide controls' } )
 		).not.toBeInTheDocument();
@@ -89,6 +102,7 @@ describe( 'Guide', () => {
 		const onFinish = jest.fn();
 		render(
 			<Guide
+				{ ...defaultProps }
 				onFinish={ onFinish }
 				pages={ [ { content: <p>Page 1</p> } ] }
 			/>
@@ -103,6 +117,7 @@ describe( 'Guide', () => {
 		const onFinish = jest.fn();
 		render(
 			<Guide
+				{ ...defaultProps }
 				onFinish={ onFinish }
 				pages={ [ { content: <p>Page 1</p> } ] }
 			/>
@@ -115,7 +130,7 @@ describe( 'Guide', () => {
 
 	describe( 'page navigation', () => {
 		it( 'renders an empty list when there are no pages', () => {
-			render( <Guide pages={ [] } /> );
+			render( <Guide { ...defaultProps } pages={ [] } /> );
 			expect(
 				screen.queryByRole( 'list', {
 					name: 'Guide controls',
@@ -131,6 +146,7 @@ describe( 'Guide', () => {
 		it( 'renders a button for each page', () => {
 			render(
 				<Guide
+					{ ...defaultProps }
 					pages={ [
 						{ content: <p>Page 1</p> },
 						{ content: <p>Page 2</p> },
@@ -154,6 +170,7 @@ describe( 'Guide', () => {
 
 			render(
 				<Guide
+					{ ...defaultProps }
 					pages={ [
 						{ content: <p>Page 1</p> },
 						{ content: <p>Page 2</p> },
@@ -196,6 +213,7 @@ describe( 'Guide', () => {
 
 			render(
 				<Guide
+					{ ...defaultProps }
 					pages={ [
 						{ content: <p>Page 1</p> },
 						{ content: <p>Page 2</p> },

--- a/packages/components/src/guide/types.ts
+++ b/packages/components/src/guide/types.ts
@@ -36,6 +36,8 @@ export type GuideProps = {
 	contentLabel: ModalProps[ 'contentLabel' ];
 	/**
 	 * Use this to customize the label of the _Finish_ button shown at the end of the guide.
+	 *
+	 * @default 'Finish'
 	 */
 	finishButtonText?: string;
 	/**
@@ -44,6 +46,8 @@ export type GuideProps = {
 	onFinish: ModalProps[ 'onRequestClose' ];
 	/**
 	 * An array of objects describing each page in the guide.
+	 *
+	 * @default []
 	 */
 	pages?: Page[];
 };

--- a/packages/components/src/guide/types.ts
+++ b/packages/components/src/guide/types.ts
@@ -45,7 +45,7 @@ export type GuideProps = {
 	 */
 	onFinish: ModalProps[ 'onRequestClose' ];
 	/**
-	 * An array of objects describing each page in the guide.
+	 * A list of objects describing each page in the guide. Each object **must** contain a `'content'` property and may optionally contain a `'image'` property.
 	 *
 	 * @default []
 	 */

--- a/packages/components/src/guide/types.ts
+++ b/packages/components/src/guide/types.ts
@@ -9,21 +9,54 @@ import type { ReactNode } from 'react';
 import type { ModalProps } from '../modal/types';
 
 export type Page = {
+	/**
+	 * Content of the page.
+	 */
 	content: ReactNode;
+	/**
+	 * Image displayed above the page content.
+	 */
 	image?: ReactNode;
 };
 
 export type GuideProps = {
+	/**
+	 * @deprecated since 5.5 – use `pages` prop instead
+	 */
 	children?: ReactNode;
+	/**
+	 * A custom class to add to the modal.
+	 */
 	className?: string;
+	/**
+	 * Used as the modal's accessibility label.
+	 */
 	contentLabel: ModalProps[ 'contentLabel' ];
+	/**
+	 * Use this to customize the label of the _Finish_ button shown at the end of the guide.
+	 */
 	finishButtonText?: string;
+	/**
+	 * A function which is called when the guide is finished.
+	 */
 	onFinish: ModalProps[ 'onRequestClose' ];
+	/**
+	 * An array of objects describing each page in the guide.
+	 */
 	pages?: Page[];
 };
 
 export type PageControlProps = {
+	/**
+	 * Current page index.
+	 */
 	currentPage: number;
+	/**
+	 * Total number of pages.
+	 */
 	numberOfPages: number;
+	/**
+	 * Called when user clicks on a `PageControlIcon` button.
+	 */
 	setCurrentPage: ( page: number ) => void;
 };

--- a/packages/components/src/guide/types.ts
+++ b/packages/components/src/guide/types.ts
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import type { ReactNode } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import type { ModalProps } from '../modal/types';
+
+export type Page = {
+	content: ReactNode;
+	image?: ReactNode;
+};
+
+export type GuideProps = {
+	children?: ReactNode;
+	className?: string;
+	contentLabel?: ModalProps[ 'contentLabel' ];
+	finishButtonText?: string;
+	onFinish?: () => void;
+	pages?: Page[];
+};
+
+export type PageControlProps = {
+	currentPage: number;
+	numberOfPages: number;
+	setCurrentPage: ( page: number ) => void;
+};
+
+export type PageControlIconProps = {
+	isSelected: boolean;
+};

--- a/packages/components/src/guide/types.ts
+++ b/packages/components/src/guide/types.ts
@@ -18,7 +18,7 @@ export type GuideProps = {
 	className?: string;
 	contentLabel?: ModalProps[ 'contentLabel' ];
 	finishButtonText?: string;
-	onFinish?: () => void;
+	onFinish?: ModalProps[ 'onRequestClose' ];
 	pages?: Page[];
 };
 

--- a/packages/components/src/guide/types.ts
+++ b/packages/components/src/guide/types.ts
@@ -27,7 +27,3 @@ export type PageControlProps = {
 	numberOfPages: number;
 	setCurrentPage: ( page: number ) => void;
 };
-
-export type PageControlIconProps = {
-	isSelected: boolean;
-};

--- a/packages/components/src/guide/types.ts
+++ b/packages/components/src/guide/types.ts
@@ -16,9 +16,9 @@ export type Page = {
 export type GuideProps = {
 	children?: ReactNode;
 	className?: string;
-	contentLabel?: ModalProps[ 'contentLabel' ];
+	contentLabel: ModalProps[ 'contentLabel' ];
 	finishButtonText?: string;
-	onFinish?: ModalProps[ 'onRequestClose' ];
+	onFinish: ModalProps[ 'onRequestClose' ];
 	pages?: Page[];
 };
 

--- a/packages/components/src/guide/types.ts
+++ b/packages/components/src/guide/types.ts
@@ -21,7 +21,9 @@ export type Page = {
 
 export type GuideProps = {
 	/**
-	 * @deprecated since 5.5 – use `pages` prop instead
+	 * Deprecated. Use `pages` prop instead.
+	 *
+	 * @deprecated since 5.5
 	 */
 	children?: ReactNode;
 	/**

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -49,7 +49,6 @@
 		"src/dimension-control",
 		"src/duotone-picker",
 		"src/gradient-picker",
-		"src/guide",
 		"src/higher-order/navigate-regions",
 		"src/higher-order/with-fallback-styles",
 		"src/higher-order/with-filters",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Refactor the `Guide` component to TypeScript

Part of #35744

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The refactor to TypeScript has many benefits (auto-generated docs, static linting and error prevention, better IDE experience). See #35744 for more details

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Followed the steps highlighted in the [TypeScript migration guide](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/CONTRIBUTING.md#refactoring-a-component-to-typescript).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Tests pass
- Make sure that the component behaves as expected:
  - in its Storybook example