### PR TITLE
Fix GH action warning by upgrading actions/checkout

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -6,5 +6,5 @@ jobs:
         name: 'Validation'
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
             - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
When inspecting GitHub action results, I accidentally noticed this warning for the "Validate Gradle Wrapper" check:

<img width="770" alt="Screenshot 2023-01-27 at 13 25 29" src="https://user-images.githubusercontent.com/664258/215087045-fb34214a-a670-4a1b-ac55-f1f7f77d97c6.png">

Solving it by updating the `actions/checkout` action declaration to v3.1.0. If you search all other references to `actions/checkout` in our other actions, you'll they use the same version with the same hash. The "Validate Gradle Wrapper" action was the only exception. Because it was added recently, after the last mass-upgrade of the action versions.