### PR TITLE
Fix ComplementaryArea's initial isActive state

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/open-document-settings-sidebar.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/open-document-settings-sidebar.ts
@@ -5,14 +5,18 @@ import type { Editor } from './index';
 import { expect } from '../test';
 
 /**
- * Clicks on the button in the header which opens Document Settings sidebar when it is closed.
+ * Clicks on the button in the header which opens Document Settings sidebar when
+ * it is closed.
  *
  * @param {Editor} this
  */
 export async function openDocumentSettingsSidebar( this: Editor ) {
-	const editorSettingsButton = this.page.locator(
-		'role=region[name="Editor top bar"i] >> role=button[name="Settings"i]'
-	);
+	const editorSettingsButton = this.page
+		.getByRole( 'region', { name: 'Editor top bar' } )
+		.getByRole( 'button', {
+			name: 'Settings',
+			disabled: false,
+		} );
 
 	const isEditorSettingsOpened =
 		( await editorSettingsButton.getAttribute( 'aria-expanded' ) ) ===
@@ -22,9 +26,9 @@ export async function openDocumentSettingsSidebar( this: Editor ) {
 		await editorSettingsButton.click();
 
 		await expect(
-			this.page.locator(
-				'role=region[name="Editor settings"i] >> role=button[name^="Close settings"i]'
-			)
+			this.page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Close settings' } )
 		).toBeVisible();
 	}
 }

--- a/packages/e2e-test-utils-playwright/src/editor/open-document-settings-sidebar.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/open-document-settings-sidebar.ts
@@ -11,19 +11,18 @@ import { expect } from '../test';
  * @param {Editor} this
  */
 export async function openDocumentSettingsSidebar( this: Editor ) {
-	const editorSettingsButton = this.page
+	const toggleButton = this.page
 		.getByRole( 'region', { name: 'Editor top bar' } )
 		.getByRole( 'button', {
 			name: 'Settings',
 			disabled: false,
 		} );
 
-	const isEditorSettingsOpened =
-		( await editorSettingsButton.getAttribute( 'aria-expanded' ) ) ===
-		'true';
+	const isClosed =
+		( await toggleButton.getAttribute( 'aria-expanded' ) ) === 'false';
 
-	if ( ! isEditorSettingsOpened ) {
-		await editorSettingsButton.click();
+	if ( isClosed ) {
+		await toggleButton.click();
 
 		await expect(
 			this.page

--- a/packages/e2e-test-utils-playwright/src/editor/open-document-settings-sidebar.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/open-document-settings-sidebar.ts
@@ -2,7 +2,6 @@
  * Internal dependencies
  */
 import type { Editor } from './index';
-import { expect } from '../test';
 
 /**
  * Clicks on the button in the header which opens Document Settings sidebar when
@@ -23,11 +22,9 @@ export async function openDocumentSettingsSidebar( this: Editor ) {
 
 	if ( isClosed ) {
 		await toggleButton.click();
-
-		await expect(
-			this.page
-				.getByRole( 'region', { name: 'Editor settings' } )
-				.getByRole( 'button', { name: 'Close settings' } )
-		).toBeVisible();
+		await this.page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Close settings' } )
+			.waitFor();
 	}
 }

--- a/packages/e2e-test-utils/src/open-document-settings-sidebar.js
+++ b/packages/e2e-test-utils/src/open-document-settings-sidebar.js
@@ -2,12 +2,17 @@
  * Clicks on the button in the header which opens Document Settings sidebar when it is closed.
  */
 export async function openDocumentSettingsSidebar() {
-	const openButton = await page.$(
-		'.edit-post-header__settings button[aria-label="Settings"][aria-expanded="false"]'
+	const toggleButton = await page.waitForSelector(
+		'.edit-post-header__settings button[aria-label="Settings"][aria-disabled="false"]'
 	);
 
-	if ( openButton ) {
-		await openButton.click();
+	const isClosed = await page.evaluate(
+		( element ) => element.getAttribute( 'aria-expanded' ) === 'false',
+		toggleButton
+	);
+
+	if ( isClosed ) {
+		await toggleButton.click();
 		await page.waitForSelector( '.edit-post-sidebar' );
 	}
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/index.js
@@ -69,7 +69,7 @@ export function SidebarComplementaryAreaFills() {
 				identifier={ sidebarName }
 				title={ __( 'Settings' ) }
 				icon={ isRTL() ? drawerLeft : drawerRight }
-				closeLabel={ __( 'Close settings sidebar' ) }
+				closeLabel={ __( 'Close settings' ) }
 				header={ <SettingsHeader sidebarName={ sidebarName } /> }
 				headerClassName="edit-site-sidebar-edit-mode__panel-tabs"
 			>

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -12,7 +12,6 @@ import { __ } from '@wordpress/i18n';
 import { check, starEmpty, starFilled } from '@wordpress/icons';
 import { useEffect, useRef } from '@wordpress/element';
 import { store as viewportStore } from '@wordpress/viewport';
-import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -104,17 +103,16 @@ function ComplementaryArea( {
 	const { isLoading, isActive, isPinned, activeArea, isSmall, isLarge } =
 		useSelect(
 			( select ) => {
-				const { getActiveComplementaryArea, isItemPinned } =
-					select( interfaceStore );
+				const {
+					getActiveComplementaryArea,
+					isComplementaryAreaLoading,
+					isItemPinned,
+				} = select( interfaceStore );
 
-				const isVisible = select( preferencesStore ).get(
-					scope,
-					'isComplementaryAreaVisible'
-				);
 				const _activeArea = getActiveComplementaryArea( scope );
 
 				return {
-					isLoading: isVisible && _activeArea === undefined,
+					isLoading: isComplementaryAreaLoading( scope ),
 					isActive: _activeArea === identifier,
 					isPinned: isItemPinned( scope, identifier ),
 					activeArea: _activeArea,
@@ -147,14 +145,7 @@ function ComplementaryArea( {
 		} else if ( activeArea === undefined && isSmall ) {
 			disableComplementaryArea( scope, identifier );
 		}
-	}, [
-		activeArea,
-		isActiveByDefault,
-		scope,
-		identifier,
-		isSmall,
-		isLoading,
-	] );
+	}, [ activeArea, isActiveByDefault, scope, identifier, isSmall ] );
 
 	return (
 		<>

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -140,12 +140,11 @@ function ComplementaryArea( {
 	} = useDispatch( interfaceStore );
 
 	useEffect( () => {
+		// Set initial visibility: For large screens, enable if it's active by
+		// default. For small screens, always initially disable.
 		if ( isActiveByDefault && activeArea === undefined && ! isSmall ) {
 			enableComplementaryArea( scope, identifier );
 		} else if ( activeArea === undefined && isSmall ) {
-			// The isComplementaryAreaVisible state is preserved, so in case it
-			// was previously true, we need to adjust and initially disable for
-			// small screens.
 			disableComplementaryArea( scope, identifier );
 		}
 	}, [

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -48,26 +48,29 @@ function useAdjustComplementaryListener(
 	const { enableComplementaryArea, disableComplementaryArea } =
 		useDispatch( interfaceStore );
 	useEffect( () => {
-		// If the complementary area is active and the editor is switching from a big to a small window size.
+		// If the complementary area is active and the editor is switching from
+		// a big to a small window size.
 		if ( isActive && isSmall && ! previousIsSmall.current ) {
-			// Disable the complementary area.
 			disableComplementaryArea( scope );
-			// Flag the complementary area to be reopened when the window size goes from small to big.
+			// Flag the complementary area to be reopened when the window size
+			// goes from small to big.
 			shouldOpenWhenNotSmall.current = true;
 		} else if (
-			// If there is a flag indicating the complementary area should be enabled when we go from small to big window size
-			// and we are going from a small to big window size.
+			// If there is a flag indicating the complementary area should be
+			// enabled when we go from small to big window size and we are going
+			// from a small to big window size.
 			shouldOpenWhenNotSmall.current &&
 			! isSmall &&
 			previousIsSmall.current
 		) {
-			// Remove the flag indicating the complementary area should be enabled.
+			// Remove the flag indicating the complementary area should be
+			// enabled.
 			shouldOpenWhenNotSmall.current = false;
-			// Enable the complementary area.
 			enableComplementaryArea( scope, identifier );
 		} else if (
-			// If the flag is indicating the current complementary should be reopened but another complementary area becomes active,
-			// remove the flag.
+			// If the flag is indicating the current complementary should be
+			// reopened but another complementary area becomes active, remove
+			// the flag.
 			shouldOpenWhenNotSmall.current &&
 			activeArea &&
 			activeArea !== identifier
@@ -104,18 +107,14 @@ function ComplementaryArea( {
 				const { getActiveComplementaryArea, isItemPinned } =
 					select( interfaceStore );
 
-				const isComplementaryAreaVisible = select(
-					preferencesStore
-				).get( scope, 'isComplementaryAreaVisible' );
+				const isVisible = select( preferencesStore ).get(
+					scope,
+					'isComplementaryAreaVisible'
+				);
 				const _activeArea = getActiveComplementaryArea( scope );
-				const _isSmall =
-					select( viewportStore ).isViewportMatch( '< medium' );
 
 				return {
-					isLoading:
-						isComplementaryAreaVisible &&
-						_activeArea === undefined &&
-						! _isSmall,
+					isLoading: isVisible && _activeArea === undefined,
 					isActive: _activeArea === identifier,
 					isPinned: isItemPinned( scope, identifier ),
 					activeArea: _activeArea,
@@ -143,8 +142,20 @@ function ComplementaryArea( {
 	useEffect( () => {
 		if ( isActiveByDefault && activeArea === undefined && ! isSmall ) {
 			enableComplementaryArea( scope, identifier );
+		} else if ( activeArea === undefined && isSmall ) {
+			// The isComplementaryAreaVisible state is preserved, so in case it
+			// was previously true, we need to adjust and initially disable for
+			// small screens.
+			disableComplementaryArea( scope, identifier );
 		}
-	}, [ activeArea, isActiveByDefault, scope, identifier, isSmall ] );
+	}, [
+		activeArea,
+		isActiveByDefault,
+		scope,
+		identifier,
+		isSmall,
+		isLoading,
+	] );
 
 	return (
 		<>

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -102,8 +102,12 @@ function ComplementaryArea( {
 			const { getActiveComplementaryArea, isItemPinned } =
 				select( interfaceStore );
 			const _activeArea = getActiveComplementaryArea( scope );
+
 			return {
-				isActive: _activeArea === identifier,
+				isActive:
+					_activeArea === undefined
+						? undefined
+						: _activeArea === identifier,
 				isPinned: isItemPinned( scope, identifier ),
 				activeArea: _activeArea,
 				isSmall: select( viewportStore ).isViewportMatch( '< medium' ),
@@ -144,6 +148,7 @@ function ComplementaryArea( {
 								isActive && ( ! showIconLabels || isLarge )
 							}
 							aria-expanded={ isActive }
+							disabled={ isActive === undefined }
 							label={ title }
 							icon={ showIconLabels ? check : icon }
 							showTooltip={ ! showIconLabels }

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -102,15 +102,17 @@ function ComplementaryArea( {
 			const { getActiveComplementaryArea, isItemPinned } =
 				select( interfaceStore );
 			const _activeArea = getActiveComplementaryArea( scope );
+			const _isSmall =
+				select( viewportStore ).isViewportMatch( '< medium' );
 
 			return {
 				isActive:
-					_activeArea === undefined
+					_activeArea === undefined && ! _isSmall
 						? undefined
 						: _activeArea === identifier,
 				isPinned: isItemPinned( scope, identifier ),
 				activeArea: _activeArea,
-				isSmall: select( viewportStore ).isViewportMatch( '< medium' ),
+				isSmall: _isSmall,
 				isLarge: select( viewportStore ).isViewportMatch( 'large' ),
 			};
 		},

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -148,7 +148,7 @@ function ComplementaryArea( {
 								isActive && ( ! showIconLabels || isLarge )
 							}
 							aria-expanded={ isActive }
-							disabled={ isActive === undefined }
+							aria-disabled={ isActive === undefined }
 							label={ title }
 							icon={ showIconLabels ? check : icon }
 							showTooltip={ ! showIconLabels }

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -12,6 +12,7 @@ import { __ } from '@wordpress/i18n';
 import { check, starEmpty, starFilled } from '@wordpress/icons';
 import { useEffect, useRef } from '@wordpress/element';
 import { store as viewportStore } from '@wordpress/viewport';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -97,27 +98,34 @@ function ComplementaryArea( {
 	isActiveByDefault,
 	showIconLabels = false,
 } ) {
-	const { isActive, isPinned, activeArea, isSmall, isLarge } = useSelect(
-		( select ) => {
-			const { getActiveComplementaryArea, isItemPinned } =
-				select( interfaceStore );
-			const _activeArea = getActiveComplementaryArea( scope );
-			const _isSmall =
-				select( viewportStore ).isViewportMatch( '< medium' );
+	const { isLoading, isActive, isPinned, activeArea, isSmall, isLarge } =
+		useSelect(
+			( select ) => {
+				const { getActiveComplementaryArea, isItemPinned } =
+					select( interfaceStore );
 
-			return {
-				isActive:
-					_activeArea === undefined && ! _isSmall
-						? undefined
-						: _activeArea === identifier,
-				isPinned: isItemPinned( scope, identifier ),
-				activeArea: _activeArea,
-				isSmall: _isSmall,
-				isLarge: select( viewportStore ).isViewportMatch( 'large' ),
-			};
-		},
-		[ identifier, scope ]
-	);
+				const isComplementaryAreaVisible = select(
+					preferencesStore
+				).get( scope, 'isComplementaryAreaVisible' );
+				const _activeArea = getActiveComplementaryArea( scope );
+				const _isSmall =
+					select( viewportStore ).isViewportMatch( '< medium' );
+
+				return {
+					isLoading:
+						isComplementaryAreaVisible &&
+						_activeArea === undefined &&
+						! _isSmall,
+					isActive: _activeArea === identifier,
+					isPinned: isItemPinned( scope, identifier ),
+					activeArea: _activeArea,
+					isSmall:
+						select( viewportStore ).isViewportMatch( '< medium' ),
+					isLarge: select( viewportStore ).isViewportMatch( 'large' ),
+				};
+			},
+			[ identifier, scope ]
+		);
 	useAdjustComplementaryListener(
 		scope,
 		identifier,
@@ -150,7 +158,7 @@ function ComplementaryArea( {
 								isActive && ( ! showIconLabels || isLarge )
 							}
 							aria-expanded={ isActive }
-							aria-disabled={ isActive === undefined }
+							aria-disabled={ isLoading }
 							label={ title }
 							icon={ showIconLabels ? check : icon }
 							showTooltip={ ! showIconLabels }

--- a/packages/interface/src/store/selectors.js
+++ b/packages/interface/src/store/selectors.js
@@ -28,11 +28,23 @@ export const getActiveComplementaryArea = createRegistrySelector(
 		}
 
 		// Return `null` to indicate the user hid the complementary area.
-		if ( ! isComplementaryAreaVisible ) {
+		if ( isComplementaryAreaVisible === false ) {
 			return null;
 		}
 
 		return state?.complementaryAreas?.[ scope ];
+	}
+);
+
+export const isComplementaryAreaLoading = createRegistrySelector(
+	( select ) => ( state, scope ) => {
+		const isVisible = select( preferencesStore ).get(
+			scope,
+			'isComplementaryAreaVisible'
+		);
+		const identifier = state?.complementaryAreas?.[ scope ];
+
+		return isVisible && identifier === undefined;
 	}
 );
 


### PR DESCRIPTION
## What?
- Define the loading state for the `ComplementaryArea` component,
- Update related E2E utilities.

## Why?
The active complementary area identifier is initially unavailable as it needs to be loaded into the store. This leads to a situation where the initial `isActive` state of the `ComplementaryArea` component is `false` and, after one or more cycles, becomes `true`.

While this change doesn't really manifest itself visually (it lasts only a few milliseconds), it is a good practice in the E2E testing context because it reliably signals when the component is ready to interact.

For example, if an E2E test wants to open the `Editor settings` sidebar (which uses the `ComplementaryArea` component), it needs to check whether that sidebar is already opened before it clicks the toggle button. If that sidebar's initial `isActive` state is `false`, but the actual state is `true` (which will kick in with a delay), we might end up closing the sidebar instead if the click is late by a few milliseconds.

Also, as @kevin940726 [mentioned](https://github.com/WordPress/gutenberg/pull/47498#pullrequestreview-1274506872), this change "might also have a positive impact for assistive technologies, which they usually evaluate the context of the page as soon as possible for performance reasons."

## How to test

The E2E tests should cover this change, so it shouldn't need manual testing.

## Related
- https://github.com/WordPress/gutenberg/pull/43506
- https://github.com/WordPress/gutenberg/pull/46467#issuecomment-1404965411
- https://github.com/WordPress/gutenberg/pull/40923