### PR TITLE
Add supports.spacing.blockGap to block.json schema

### DIFF
--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -389,7 +389,8 @@
 									"items": {
 										"type": "string",
 										"enum": [ "vertical", "horizontal" ]
-									}
+									},
+									"default": [ "vertical", "horizontal" ]
 								}
 							]
 						}

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -377,6 +377,21 @@
 									}
 								}
 							]
+						},
+						"blockGap": {
+							"default": false,
+							"oneOf": [
+								{
+									"type": "boolean"
+								},
+								{
+									"type": "array",
+									"items": {
+										"type": "string",
+										"enum": [ "vertical", "horizontal" ]
+									}
+								}
+							]
 						}
 					}
 				},

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -379,6 +379,7 @@
 							]
 						},
 						"blockGap": {
+							"description": "Enables block spacing UI control. blockGap may define an array of allowable sides that can be configured, but doesn't support arbitrary edges.",
 							"default": false,
 							"oneOf": [
 								{
@@ -389,8 +390,7 @@
 									"items": {
 										"type": "string",
 										"enum": [ "vertical", "horizontal" ]
-									},
-									"default": [ "vertical", "horizontal" ]
+									}
 								}
 							]
 						}


### PR DESCRIPTION
## What?

This PR adds `supports.spacing.blockGap` property to the `block.json` schema.

![block](https://user-images.githubusercontent.com/54422211/215116173-8242695c-19b1-4925-a9e8-89ae20ce4354.png)

## Why?
To receive input support by auto-completion and to be informed of incorrect value input by validation.

## How?

This new property accepts the following two types:

### Boolean

Opt-in horizontal vertical common gap support:

```json
{
	"supports": {
		"spacing": {
			"blockGap": true
		}
	}
}
```

### Array

Opt-in for separate horizontal and vertical controls ~or one of them~:

```json
{
	"supports": {
		"spacing": {
			"blockGap": [ "horizontal", "vertical" ]
		}
	}
}
```

### About unsupported type

In the column block, the `blockGap` property is an object type and has `__experimentalDefault` property.

```json
{
	"supports": {
		"spacing": {
			"blockGap": {
				"__experimentalDefault": "2em",
				"sides": [ "horizontal", "vertical" ]
			}
		}
	}
}
```

In this case, the `sides` property defines the direction to be supported. However, since experimental properties are not defined in the schema, there is no need to use the sides property. Therefore, I excluded the object type.

## Testing Instructions

Create a JSON file like the following, referencing the JSON schema defined by this PR:

```json
{
	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/fix/block-json-schema-blockgap/schemas/json/block.json",
	"apiVersion": 2,
	"name": "core/test",
	"title": "Test",
	"supports": {
		"spacing": {
		}
	}
}
```
In the `settings.supports.spacing` property, confirm that the code editor assists with auto-completion and validation.

## Screenshots or screencast

https://user-images.githubusercontent.com/54422211/215121502-5003c63f-bd07-41e6-98ef-be05f97358ea.mp4

