### PR TITLE
Update Global Styles Controller PHPUnit tests

### DIFF
--- a/phpunit/class-gutenberg-rest-global-styles-controller-test.php
+++ b/phpunit/class-gutenberg-rest-global-styles-controller-test.php
@@ -11,17 +11,6 @@ class Gutenberg_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controll
 	 */
 	protected static $global_styles_id;
 
-	private function find_and_normalize_global_styles_by_id( $global_styles, $id ) {
-		foreach ( $global_styles as $style ) {
-			if ( $style['id'] === $id ) {
-				unset( $style['_links'] );
-				return $style;
-			}
-		}
-
-		return null;
-	}
-
 	public function set_up() {
 		parent::set_up();
 		switch_theme( 'emptytheme' );

--- a/phpunit/class-gutenberg-rest-global-styles-controller-test.php
+++ b/phpunit/class-gutenberg-rest-global-styles-controller-test.php
@@ -75,9 +75,11 @@ class Gutenberg_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controll
 		);
 	}
 
+	/**
+	 * @doesNotPerformAssertions
+	 */
 	public function test_context_param() {
-		// TODO: Implement test_context_param() method.
-		$this->markTestIncomplete();
+		// Controller does not use get_context_param().
 	}
 
 	public function test_get_theme_items() {
@@ -116,8 +118,11 @@ class Gutenberg_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controll
 		$this->assertSameSetsWithIndex( $data, $expected );
 	}
 
+	/**
+	 * @doesNotPerformAssertions
+	 */
 	public function test_get_items() {
-		$this->markTestIncomplete();
+		// Controller does not implement get_items().
 	}
 
 	public function test_get_item() {
@@ -141,8 +146,11 @@ class Gutenberg_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controll
 		);
 	}
 
+	/**
+	 * @doesNotPerformAssertions
+	 */
 	public function test_create_item() {
-		$this->markTestIncomplete();
+		// Controller does not implement create_item().
 	}
 
 	public function test_update_item() {
@@ -158,17 +166,29 @@ class Gutenberg_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controll
 		$this->assertEquals( 'My new global styles title', $data['title']['raw'] );
 	}
 
+	/**
+	 * @doesNotPerformAssertions
+	 */
 	public function test_delete_item() {
-		$this->markTestIncomplete();
+		// Controller does not implement delete_item().
 	}
 
+	/**
+	 * @doesNotPerformAssertions
+	 */
 	public function test_prepare_item() {
-		// TODO: Implement test_prepare_item() method.
-		$this->markTestIncomplete();
+		// Controller does not implement prepare_item().
 	}
 
 	public function test_get_item_schema() {
-		// TODO: Implement test_get_item_schema() method.
-		$this->markTestIncomplete();
+		$request    = new WP_REST_Request( 'OPTIONS', '/wp/v2/global-styles/' . self::$global_styles_id );
+		$response   = rest_get_server()->dispatch( $request );
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+		$this->assertCount( 4, $properties, 'Schema properties array does not have exactly 4 elements' );
+		$this->assertArrayHasKey( 'id', $properties, 'Schema properties array does not have "id" key' );
+		$this->assertArrayHasKey( 'styles', $properties, 'Schema properties array does not have "styles" key' );
+		$this->assertArrayHasKey( 'settings', $properties, 'Schema properties array does not have "settings" key' );
+		$this->assertArrayHasKey( 'title', $properties, 'Schema properties array does not have "title" key' );
 	}
 }

--- a/phpunit/class-gutenberg-rest-global-styles-controller-test.php
+++ b/phpunit/class-gutenberg-rest-global-styles-controller-test.php
@@ -169,15 +169,10 @@ class Gutenberg_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controll
 		// Controller does not implement prepare_item().
 	}
 
+	/**
+	 * @doesNotPerformAssertions
+	 */
 	public function test_get_item_schema() {
-		$request    = new WP_REST_Request( 'OPTIONS', '/wp/v2/global-styles/' . self::$global_styles_id );
-		$response   = rest_get_server()->dispatch( $request );
-		$data       = $response->get_data();
-		$properties = $data['schema']['properties'];
-		$this->assertCount( 4, $properties, 'Schema properties array does not have exactly 4 elements' );
-		$this->assertArrayHasKey( 'id', $properties, 'Schema properties array does not have "id" key' );
-		$this->assertArrayHasKey( 'styles', $properties, 'Schema properties array does not have "styles" key' );
-		$this->assertArrayHasKey( 'settings', $properties, 'Schema properties array does not have "settings" key' );
-		$this->assertArrayHasKey( 'title', $properties, 'Schema properties array does not have "title" key' );
+		// Covered by the core.
 	}
 }


### PR DESCRIPTION
## What?
PR updates Global Styles Controller PHPUnit tests to match the core and reduce noise when running them.

## How?
* Use `@doesNotPerformAssertions` instead of `$this->markTestIncomplete();` when controlled doesn't implement the method.
* Removed `find_and_normalize_global_styles_by_id` helper method.
* Added `test_get_item_schema` tests.

## Testing Instructions
CI is green.

**Manual**

```
npm run test:unit:php -- --filter Gutenberg_REST_Global_Styles_Controller_Test
```

## Screenshots

**Before**
![CleanShot 2023-01-27 at 18 33 02](https://user-images.githubusercontent.com/240569/215113315-bb27f1e0-4ada-4015-8648-6bbde7c28e0f.png)

**After**
![CleanShot 2023-01-27 at 18 32 00](https://user-images.githubusercontent.com/240569/215113301-cfa1d4e3-49fb-4255-ada2-01a40972ce48.png)
