### PR TITLE
Show list of patterns in template part sidebar in focus mode

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/template-card/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-card/index.js
@@ -6,6 +6,11 @@ import { Icon } from '@wordpress/components';
 import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	store as blockEditorStore,
+	__experimentalBlockPatternsList as BlockPatternsList,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -14,10 +19,37 @@ import { store as editSiteStore } from '../../../store';
 import TemplateActions from './template-actions';
 import TemplateAreas from './template-areas';
 
+const MaybeBlockPatterns = ( { template, blockPatterns, title } ) => {
+	if ( template.type !== 'wp_template_part' || blockPatterns?.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<>
+			<p>
+				{ sprintf(
+					// translators: %s: Type of template part (i.e. header, footer, etc.)
+					__(
+						'Choose a pre-designed pattern to switch up the look and feel of your %s '
+					),
+					title.toLowerCase()
+				) }
+			</p>
+			<BlockPatternsList
+				blockPatterns={ blockPatterns }
+				shownPatterns={ blockPatterns }
+				onClickPattern={ ( pattern ) => {
+					console.log( 'pattern clicked ', pattern );
+				} }
+			/>
+		</>
+	);
+};
 export default function TemplateCard() {
 	const {
 		info: { title, description, icon },
 		template,
+		blockPatterns,
 	} = useSelect( ( select ) => {
 		const { getEditedPostType, getEditedPostId } = select( editSiteStore );
 		const { getEditedEntityRecord } = select( coreStore );
@@ -30,7 +62,13 @@ export default function TemplateCard() {
 
 		const info = record ? getTemplateInfo( record ) : {};
 
-		return { info, template: record };
+		const patterns = record?.slug
+			? select( blockEditorStore ).getPatternsByBlockTypes(
+					`core/template-part/${ record.slug }`
+			  )
+			: [];
+
+		return { info, template: record, blockPatterns: patterns };
 	}, [] );
 
 	if ( ! title && ! description ) {
@@ -51,6 +89,11 @@ export default function TemplateCard() {
 					{ decodeEntities( description ) }
 				</div>
 				<TemplateAreas />
+				<MaybeBlockPatterns
+					template={ template }
+					blockPatterns={ blockPatterns }
+					title={ title }
+				/>
 			</div>
 		</div>
 	);

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-card/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-card/style.scss
@@ -57,6 +57,10 @@
 			min-width: auto;
 		}
 	}
+
+	& .block-editor-block-patterns-list__item .block-editor-block-preview__container {
+		border: 1px solid $gray-300;
+	}
 }
 
 h3.edit-site-template-card__template-areas-title {


### PR DESCRIPTION
## What

Implements https://github.com/WordPress/gutenberg/issues/44582
Related https://github.com/WordPress/gutenberg/pull/45285

## TODO

- Replace the content of the template part upon clicking one of the patterns.

## Testing instructions

- Open the side editor and select a template part. For example, the header.
- Open the template inspector and verify that it shows a list of patterns whole blockType is that template (header).
- Click on any and verify that the template part is replaced. (TODO)
