### PR TITLE
[Block Library - Navigation]: Update example with no mobile view

### DIFF
--- a/packages/block-library/src/navigation/index.js
+++ b/packages/block-library/src/navigation/index.js
@@ -20,6 +20,9 @@ export { metadata, name };
 export const settings = {
 	icon,
 	example: {
+		attributes: {
+			overlayMenu: 'never',
+		},
 		innerBlocks: [
 			{
 				name: 'core/navigation-link',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/47130



## Testing Instructions
1. The `Navigation` block preview is not showing the mobile view

This will be effective for any preview of the block, but you can test for example in:
1. Hover of the block in the inserter
2. In site editor under the `blocks` section


#### Before
<img width="852" alt="Screenshot 2023-01-27 at 7 18 17 PM" src="https://user-images.githubusercontent.com/16275880/215153050-f754b3da-fc2a-4321-90ef-be2b37251907.png">


#### After

<img width="852" alt="Screenshot 2023-01-27 at 7 16 14 PM" src="https://user-images.githubusercontent.com/16275880/215153073-d99cab9e-819f-45d0-b152-f6df6270b13e.png">
