### PR TITLE
test: Add separate mobile experiments file

### DIFF
--- a/packages/block-editor/src/experiments.native.js
+++ b/packages/block-editor/src/experiments.native.js
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/experiments';
+
+/**
+ * Internal dependencies
+ */
+import * as globalStyles from './components/global-styles';
+import { ExperimentalBlockEditorProvider } from './components/provider';
+
+export const { lock, unlock } =
+	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'@wordpress/block-editor'
+	);
+
+/**
+ * Experimental @wordpress/block-editor APIs.
+ */
+export const experiments = {};
+lock( experiments, {
+	...globalStyles,
+	ExperimentalBlockEditorProvider,
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix the currently failing mobile unit tests after #47465 merged.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The experiments file recently began importing the experimental
`off-canvas-editor`. This module eventually imports `@react-spring/web`
within its `leaf` module and the `useMovingAnimation` hook. Importing
the `@react-spring/web` library results in `react-dom` loading within
the React Native testing environment causing test failures.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
To avoid this scenario, a separate experiments file excluding the
`off-canvas-editor` was added for the mobile project. This felt more
appropriate than implementing a native version of `off-canvas-editor` or
its sibling `list-view` as neither are currently leveraged by the mobile
project.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Verify all CI test suites pass.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
