### PR TITLE
Fix Post Visibility E2E tests

### DIFF
--- a/test/e2e/specs/editor/various/post-visibility.spec.js
+++ b/test/e2e/specs/editor/various/post-visibility.spec.js
@@ -86,7 +86,7 @@ test.describe( 'Post visibility', () => {
 		await page.click( 'role=button[name="Change date: Immediately"i]' );
 
 		await page.click( 'role=button[name="View next month"i]' );
-		await page.click( 'text=15' );
+		await page.click( 'role=application[name="Calendar"] >> text=15' );
 
 		await page.click( 'role=button[name="Select visibility: Public"i]' );
 


### PR DESCRIPTION
## What?
PR fixes post-visibility e2e tests by using a more specific locator.

Failure error:

```
page.click: Error: strict mode violation: "text=15" resolved to 2 elements:
        1) <button type="button" tabindex="-1" aria-label="February…>15</button> aka playwright.$("role=button[name="February 15, 2023"]")
        2) <p class="alignright" id="footer-upgrade">…</p> aka playwright.$("text=You are using a development version (6.2-alpha-55156). Cool! Please stay updated")
```


## Testing Instructions
CI tests are passing
