### PR TITLE
Block Spacing: Don't show UI when only one direction is supported

### DIFF
--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -347,5 +347,17 @@ export function useIsDimensionsSupportValid( blockName, feature ) {
 		return false;
 	}
 
+	if (
+		sides?.length &&
+		feature === 'blockGap' &&
+		! AXIAL_SIDES.every( ( side ) => sides.includes( side ) )
+	) {
+		// eslint-disable-next-line no-console
+		console.warn(
+			`The ${ feature } support for the "${ blockName }" block can not be configured to support arbitrary sides.`
+		);
+		return false;
+	}
+
 	return true;
 }

--- a/packages/block-editor/src/hooks/gap.js
+++ b/packages/block-editor/src/hooks/gap.js
@@ -17,7 +17,12 @@ import { __unstableUseBlockRef as useBlockRef } from '../components/block-list/u
 import { getSpacingPresetCssVar } from '../components/spacing-sizes-control/utils';
 import SpacingSizesControl from '../components/spacing-sizes-control';
 import useSetting from '../components/use-setting';
-import { AXIAL_SIDES, SPACING_SUPPORT_KEY, useCustomSides } from './dimensions';
+import {
+	AXIAL_SIDES,
+	SPACING_SUPPORT_KEY,
+	useCustomSides,
+	useIsDimensionsSupportValid,
+} from './dimensions';
 import { cleanEmptyObject } from './utils';
 
 /**
@@ -113,7 +118,9 @@ export function resetGap( { attributes = {}, setAttributes } ) {
  */
 export function useIsGapDisabled( { name: blockName } = {} ) {
 	const isDisabled = ! useSetting( 'spacing.blockGap' );
-	return ! hasGapSupport( blockName ) || isDisabled;
+	const isInvalid = ! useIsDimensionsSupportValid( blockName, 'blockGap' );
+
+	return ! hasGapSupport( blockName ) || isDisabled || isInvalid;
 }
 
 /**

--- a/packages/block-editor/src/hooks/gap.js
+++ b/packages/block-editor/src/hooks/gap.js
@@ -203,6 +203,13 @@ export function GapEdit( props ) {
 				top: gapValue?.top,
 		  };
 
+	// Remove undefined properties from the box control value.
+	const cleanedBoxControlGapValue = Object.fromEntries(
+		Object.entries( boxControlGapValue ).filter(
+			( [ , value ] ) => value !== undefined
+		)
+	);
+
 	return Platform.select( {
 		web: (
 			<>
@@ -214,7 +221,7 @@ export function GapEdit( props ) {
 							onChange={ onChange }
 							units={ units }
 							sides={ sides }
-							values={ boxControlGapValue }
+							values={ cleanedBoxControlGapValue }
 							allowReset={ false }
 							splitOnAxis={ splitOnAxis }
 						/>
@@ -226,12 +233,12 @@ export function GapEdit( props ) {
 							onChange={ onChange }
 							units={ units }
 							// Default to `row` for combined values.
-							value={ boxControlGapValue }
+							value={ cleanedBoxControlGapValue }
 						/>
 					) ) }
 				{ spacingSizes?.length > 0 && (
 					<SpacingSizesControl
-						values={ boxControlGapValue }
+						values={ cleanedBoxControlGapValue }
 						onChange={ onChange }
 						label={ __( 'Block spacing' ) }
 						sides={ splitOnAxis ? sides : [ 'top' ] } // Use 'top' as the shorthand property in non-axial configurations.

--- a/packages/block-editor/src/hooks/gap.js
+++ b/packages/block-editor/src/hooks/gap.js
@@ -210,13 +210,6 @@ export function GapEdit( props ) {
 				top: gapValue?.top,
 		  };
 
-	// Remove undefined properties from the box control value.
-	const cleanedBoxControlGapValue = Object.fromEntries(
-		Object.entries( boxControlGapValue ).filter(
-			( [ , value ] ) => value !== undefined
-		)
-	);
-
 	return Platform.select( {
 		web: (
 			<>
@@ -228,7 +221,7 @@ export function GapEdit( props ) {
 							onChange={ onChange }
 							units={ units }
 							sides={ sides }
-							values={ cleanedBoxControlGapValue }
+							values={ boxControlGapValue }
 							allowReset={ false }
 							splitOnAxis={ splitOnAxis }
 						/>
@@ -240,12 +233,12 @@ export function GapEdit( props ) {
 							onChange={ onChange }
 							units={ units }
 							// Default to `row` for combined values.
-							value={ cleanedBoxControlGapValue }
+							value={ boxControlGapValue }
 						/>
 					) ) }
 				{ spacingSizes?.length > 0 && (
 					<SpacingSizesControl
-						values={ cleanedBoxControlGapValue }
+						values={ boxControlGapValue }
 						onChange={ onChange }
 						label={ __( 'Block spacing' ) }
 						sides={ splitOnAxis ? sides : [ 'top' ] } // Use 'top' as the shorthand property in non-axial configurations.


### PR DESCRIPTION
Fixes #47518

## What?
This PR ~fixes a problem in which values are not reflected correctly in the control~ doesnt't display the UI control and output a console warning message when the block supports only one direction in `supports.spacing.blockGap` property.

## Why?
The attribute stored by `blockGap` holds only two properties, top and left. However, components such as `BoxControl` that pass this value must specify all side values. Therefore, property mapping is performed in the following part:

(Deleted)

If only one direction is supported (i.e., `splitOnAxis` is `true`), `undefined` values may enter some of the properties in this part of the property mapping.


This will cause the component receiving the value to behave in an unintended way.

_@update_: Based on [this discussion](https://github.com/WordPress/gutenberg/issues/47518#issuecomment-1409694415), the UI itself should not be displayed as it is not intended to support only one direction.

## How?
~Remove properties with undefined values.~

~This process could be accomplished with the cleanEmptyObject function alone, but this function depends on lodash. I used this approach because I know that the move away from lodash is being promoted by #17025.~

If blockGap does not support both axes, the UI is not displayed and a warning message is displayed in the browser console.

## Testing Instructions

- Insert a block that supports `blockGap`.
- In `block.json`, change this support as follows and confirm that the expected results are obtained.


### A common UI for both axis sides should be displayed

- `"blockGap": [],`
- `"blockGap": true,`
- `"blockGap": { "sides": [] },`
- `"blockGap": { "sides": false },`

### UI should not be displayed

Behavior is the same as before.

`"blockGap": false,`

### A single UI control for each axial pair should be displayed

Behavior is the same as before.

- `"blockGap": [ "vertical", "horizontal" ],`
- `"blockGap": [ "vertical", "horizontal", "other" ],`
- `"blockGap": { "sides": [ "vertical", "horizontal" ] },`
- `"blockGap": { "sides": [ "vertical", "horizontal", "other" ] },`

### Critical Error

Behavior is the same as before.

- `"blockGap": { "sides": true },`

### UI should not be displayed with console warning

This PR prevents unintended UI rendering in the following variations.

- `"blockGap": [ "vertical" ],`
- `"blockGap": [ "horizontal" ],`
- `"blockGap": [ "vertical", "other" ],`
- `"blockGap": { "sides": [ "vertical" ] },`
- `"blockGap": { "sides": [ "horizontal" ] },`
- `"blockGap": { "sides": [ "vertical", "other" ] },`

