### PR TITLE
Add debounce to border radius update in global styles to improve performance

### DIFF
--- a/packages/edit-site/src/components/global-styles/border-panel.js
+++ b/packages/edit-site/src/components/global-styles/border-panel.js
@@ -14,6 +14,7 @@ import {
 } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { debounce } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -117,6 +118,9 @@ export default function BorderPanel( { name, variation = '' } ) {
 		`${ prefix }border.radius`,
 		name
 	);
+
+	const debouncedSetBorderRadius = debounce( setBorderRadius, 5 );
+
 	const hasBorderRadius = () => {
 		const borderValues = userBorderStyles?.radius;
 		if ( typeof borderValues === 'object' ) {
@@ -205,7 +209,7 @@ export default function BorderPanel( { name, variation = '' } ) {
 					<BorderRadiusControl
 						values={ borderRadiusValues }
 						onChange={ ( value ) => {
-							setBorderRadius( value || undefined );
+							debouncedSetBorderRadius( value || undefined );
 						} }
 					/>
 				</ToolsPanelItem>


### PR DESCRIPTION
## What?
Adds a debounce to the setBorderRadius call in global styles border panel.

## Why?
Potential fix for #47352

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
