### PR TITLE
Fix/flex controls bugs

### DIFF
--- a/packages/block-editor/src/components/justify-content-control/ui.js
+++ b/packages/block-editor/src/components/justify-content-control/ui.js
@@ -7,6 +7,7 @@ import {
 	justifyCenter,
 	justifyRight,
 	justifySpaceBetween,
+	justifyStretch,
 } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
@@ -15,6 +16,7 @@ const icons = {
 	center: justifyCenter,
 	right: justifyRight,
 	'space-between': justifySpaceBetween,
+	stretch: justifyStretch,
 };
 
 function JustifyContentUI( {
@@ -65,6 +67,13 @@ function JustifyContentUI( {
 			title: __( 'Space between items' ),
 			isActive: 'space-between' === value,
 			onClick: () => handleClick( 'space-between' ),
+		},
+		{
+			name: 'stretch',
+			icon: justifyStretch,
+			title: __( 'Stretch items' ),
+			isActive: 'stretch' === value,
+			onClick: () => handleClick( 'stretch' ),
 		},
 	];
 

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -314,7 +314,6 @@ function FlexLayoutJustifyContentControl( {
 			label: __( 'Space between items' ),
 		} );
 	} else {
-		// Todo: we also need an icon here.
 		justificationOptions.push( {
 			value: 'stretch',
 			icon: justifyStretch,

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -359,18 +359,42 @@ function FlexWrapControl( { layout, onChange } ) {
 }
 
 function OrientationControl( { layout, onChange } ) {
-	const { orientation = 'horizontal' } = layout;
+	const {
+		orientation = 'horizontal',
+		verticalAlignment,
+		justifyContent,
+	} = layout;
 	return (
 		<ToggleGroupControl
 			className="block-editor-hooks__flex-layout-orientation-controls"
 			label={ __( 'Orientation' ) }
 			value={ orientation }
-			onChange={ ( value ) =>
-				onChange( {
+			onChange={ ( value ) => {
+				// Make sure the vertical alignment and justification are compatible with the new orientation.
+				let newVerticalAlignment = verticalAlignment;
+				let newJustification = justifyContent;
+				if ( value === 'horizontal' ) {
+					if ( verticalAlignment === 'space-between' ) {
+						newVerticalAlignment = 'center';
+					}
+					if ( justifyContent === 'stretch' ) {
+						newJustification = 'left';
+					}
+				} else {
+					if ( verticalAlignment === 'stretch' ) {
+						newVerticalAlignment = 'top';
+					}
+					if ( justifyContent === 'space-between' ) {
+						newJustification = 'left';
+					}
+				}
+				return onChange( {
 					...layout,
 					orientation: value,
-				} )
-			}
+					verticalAlignment: newVerticalAlignment,
+					justifyContent: newJustification,
+				} );
+			} }
 		>
 			<ToggleGroupControlOptionIcon
 				icon={ arrowRight }

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -9,8 +9,6 @@ $blocks-block__margin: 0.5em;
 	text-align: center;
 	word-break: break-word; // overflow-wrap doesn't work well if a link is wrapped in the div, so use word-break here.
 	box-sizing: border-box;
-	// Stretch to button width if it is set.
-	width: 100%;
 
 	&.aligncenter {
 		text-align: center;
@@ -44,6 +42,9 @@ $blocks-block__margin: 0.5em;
 .wp-block-buttons > .wp-block-button {
 	&.has-custom-width {
 		max-width: none;
+		.wp-block-button__link {
+			width: 100%;
+		}
 	}
 
 	&.has-custom-font-size {

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -9,6 +9,8 @@ $blocks-block__margin: 0.5em;
 	text-align: center;
 	word-break: break-word; // overflow-wrap doesn't work well if a link is wrapped in the div, so use word-break here.
 	box-sizing: border-box;
+	// Stretch to button width if it is set.
+	width: 100%;
 
 	&.aligncenter {
 		text-align: center;
@@ -42,9 +44,6 @@ $blocks-block__margin: 0.5em;
 .wp-block-buttons > .wp-block-button {
 	&.has-custom-width {
 		max-width: none;
-		.wp-block-button__link {
-			width: 100%;
-		}
 	}
 
 	&.has-custom-font-size {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Follow-up to #47134.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes issues described in [this comment](https://github.com/WordPress/gutenberg/pull/47134#pullrequestreview-1274330344).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Adds stretch option and icon to JustifyContentControl;
* Adds logic to the Orientation control to reset incorrect justification and alignment values on orientation change.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Set a Row block to `space-between` justification and `stretch` vertical alignment;
2. Switch its orientation to vertical and check that justification and alignment controls are reset.
3. Set a Stack block to `stretch` justification and `space-between` vertical alignment;
4. Switch its orientation to horizontal and check controls are reset.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="320" alt="Screenshot 2023-01-30 at 12 35 00 pm" src="https://user-images.githubusercontent.com/8096000/215369786-106c61fc-0373-476f-8f90-556592492ee7.png">
