### PR TITLE
Improve post visibility test to reduce the risk of a selector matching multiple elements

### DIFF
--- a/test/e2e/specs/editor/various/post-visibility.spec.js
+++ b/test/e2e/specs/editor/various/post-visibility.spec.js
@@ -84,15 +84,17 @@ test.describe( 'Post visibility', () => {
 
 		// Set a publish date for the next month.
 		await page.click( 'role=button[name="Change date: Immediately"i]' );
+		const calender = page.locator( 'role=application[name="Calendar"i]' );
+		await calender
+			.locator( 'role=button[name="View next month"i]' )
+			.click();
+		// The aria label contains the full date, so use the
+		await calender.locator( 'text=15' ).click();
 
-		await page.click( 'role=button[name="View next month"i]' );
-		await page.click( 'text=15' );
-
+		// Change the visibility to private.
 		await page.click( 'role=button[name="Select visibility: Public"i]' );
-
 		await page.click( 'role=radio[name="Private"i]' );
-
-		await page.click( 'role=button[name="OK"i]' );
+		await page.click( 'role=dialog >> role=button[name="OK"i]' );
 
 		const currentStatus = await page.evaluate( () => {
 			return window.wp.data


### PR DESCRIPTION
## What?
Improve the post visibility test. It failed over on #47512 with this message:
```js
page.click: Error: strict mode violation: "text=15" resolved to 2 elements:
        1) <button type="button" tabindex="-1" aria-label="February…>15</button> aka playwright.$("role=button[name="February 15, 2023"]")
        2) <p class="alignright" id="footer-upgrade">…</p> aka playwright.$("text=You are using a development version (6.2-alpha-55153). Cool! Please stay updated")
 ```
 
## Why?
The selector `text=15` is too likely to match other elements. In this case the WordPress version number.

## How?
Use a parent element to provide scope.

## Testing Instructions
e2e test should pass.