### PR TITLE
Table: Display fixed width table cells option by default

### DIFF
--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -464,30 +464,32 @@ function TableEdit( {
 					</BlockControls>
 				</>
 			) }
-			{ ! isEmpty && (
-				<InspectorControls>
-					<PanelBody
-						title={ __( 'Settings' ) }
-						className="blocks-table-settings"
-					>
-						<ToggleControl
-							label={ __( 'Fixed width table cells' ) }
-							checked={ !! hasFixedLayout }
-							onChange={ onChangeFixedLayout }
-						/>
-						<ToggleControl
-							label={ __( 'Header section' ) }
-							checked={ !! ( head && head.length ) }
-							onChange={ onToggleHeaderSection }
-						/>
-						<ToggleControl
-							label={ __( 'Footer section' ) }
-							checked={ !! ( foot && foot.length ) }
-							onChange={ onToggleFooterSection }
-						/>
-					</PanelBody>
-				</InspectorControls>
-			) }
+			<InspectorControls>
+				<PanelBody
+					title={ __( 'Settings' ) }
+					className="blocks-table-settings"
+				>
+					<ToggleControl
+						label={ __( 'Fixed width table cells' ) }
+						checked={ !! hasFixedLayout }
+						onChange={ onChangeFixedLayout }
+					/>
+					{ ! isEmpty && (
+						<>
+							<ToggleControl
+								label={ __( 'Header section' ) }
+								checked={ !! ( head && head.length ) }
+								onChange={ onToggleHeaderSection }
+							/>
+							<ToggleControl
+								label={ __( 'Footer section' ) }
+								checked={ !! ( foot && foot.length ) }
+								onChange={ onToggleFooterSection }
+							/>
+						</>
+					) }
+				</PanelBody>
+			</InspectorControls>
 			{ ! isEmpty && (
 				<table
 					className={ classnames(


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/47474

## What?

Renders the "Fixed width table cells" option for the table block even while it is in its placeholder state.

## Why?

This has the effect of the table block consistently displaying the settings tab, regardless of whether it is in the placeholder state. The Header and Footer settings continue only to be rendered once the table has a set number of rows and columns, as they really don't make a lot of sense while there is no content for the table.

Further discussion can be found on: https://github.com/WordPress/gutenberg/pull/47474#issuecomment-1407963305

## How?

Move the conditional around the table's custom settings to only make the table header and footer settings conditional.

## Testing Instructions

1. Add a table block
2. While it is in its placeholder state, select it and confirm both Styles and Settings tabs are present in the sidebar. The Settings tab should contain the standard advanced panel as well as a "Settings" panel with the "Fixed width table cells" option.
3. Set the Table's number of rows and columns and click Create Table.
4. Select the block if it isn't already and confirm both Styles and Settings tabs are present in the sidebar. The Settings tab should now also contain the table header and footer controls given the block is no longer a placeholder.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/215400529-27c6a3fd-c201-4a6d-ad84-10d85c2a7e80.mp4

