### PR TITLE
Try: Zero out excerpt paragraph margins.

### DIFF
--- a/packages/block-library/src/post-excerpt/style.scss
+++ b/packages/block-library/src/post-excerpt/style.scss
@@ -1,3 +1,8 @@
+.wp-block-post-excerpt {
+	margin-top: var(--wp--style--block-gap);
+	margin-bottom: var(--wp--style--block-gap);
+}
+
 // Zero out the margin on the excerpt paragraph, to match the body paragraphs.
 .wp-block-post-excerpt__excerpt {
 	margin-top: 0;
@@ -13,3 +18,4 @@
 .wp-block-post-excerpt__more-link {
 	display: inline-block;
 }
+

--- a/packages/block-library/src/post-excerpt/style.scss
+++ b/packages/block-library/src/post-excerpt/style.scss
@@ -1,3 +1,9 @@
+// Zero out the margin on the excerpt paragraph, to match the body paragragraphs.
+.wp-block-post-excerpt p {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
 .wp-block-post-excerpt__more-link {
 	display: inline-block;
 }

--- a/packages/block-library/src/post-excerpt/style.scss
+++ b/packages/block-library/src/post-excerpt/style.scss
@@ -1,6 +1,12 @@
-// Zero out the margin on the excerpt paragraph, to match the body paragragraphs.
-.wp-block-post-excerpt p {
+// Zero out the margin on the excerpt paragraph, to match the body paragraphs.
+.wp-block-post-excerpt__excerpt {
 	margin-top: 0;
+	margin-bottom: 0;
+}
+
+// Matches block gap.
+.wp-block-post-excerpt__more-text {
+	margin-top: var(--wp--style--block-gap);
 	margin-bottom: 0;
 }
 


### PR DESCRIPTION
## What?

Fixes #47457. 

This PR attempts to zero out the paragraph margins on the post excerpt block. Before, showing the default browser-style inherited margins:

<img width="900" alt="before" src="https://user-images.githubusercontent.com/1204802/215430507-17d634df-0f98-4862-ac3e-a7f4aadee0b4.png">

After, no margins:

<img width="886" alt="after" src="https://user-images.githubusercontent.com/1204802/215430584-79d0c5c7-3d01-4158-9e69-95a6b583d6e7.png">

## Why?

Two main reasons: firstly, at the moment, the excerpt paragraph is essentially unstyled. By inheriting from the browser stylesheet, there's no connection to the rest of the site. 

Note how paragraphs in the rest of the site have a more gap behavior:

![default paragraph margins](https://user-images.githubusercontent.com/1204802/215430808-7f5db24f-4ef9-4cb1-8641-f9e5c9d73186.gif)

There's a collapsing happening when the Read More block is filled in:

<img width="766" alt="after, read more" src="https://user-images.githubusercontent.com/1204802/215430967-031ded36-b1e0-4129-a5f5-2141504c7d12.png">

I'd like your feedback on that one. I think it looks good, but if we want to be safe, we can add some top margin to the read more block and fix this.


## Testing Instructions

Test the excerpt block in the site editor.
