### PR TITLE
Fix and simplify the Modal dialog close button label 

### DIFF
--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -88,7 +88,6 @@ export default function BlockLockModal( { clientId, onClose } ) {
 				blockInformation.title
 			) }
 			overlayClassName="block-editor-block-lock-modal"
-			closeLabel={ __( 'Close' ) }
 			onRequestClose={ onClose }
 		>
 			<p>

--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/explorer.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/explorer.js
@@ -38,7 +38,6 @@ function PatternsExplorerModal( { onModalClose, ...restProps } ) {
 	return (
 		<Modal
 			title={ __( 'Patterns' ) }
-			closeLabel={ __( 'Close' ) }
 			onRequestClose={ onModalClose }
 			isFullScreen
 		>

--- a/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
@@ -37,7 +37,6 @@ export default function NavigationMenuDeleteControl( { onDelete } ) {
 						__( 'Delete %s' ),
 						title
 					) }
-					closeLabel={ __( 'Cancel' ) }
 					onRequestClose={ () => setIsConfirmModalVisible( false ) }
 				>
 					<p>

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -116,7 +116,6 @@ function ConvertToLinksModal( { onClick, disabled } ) {
 			</BlockControls>
 			{ isOpen && (
 				<Modal
-					closeLabel={ __( 'Close' ) }
 					onRequestClose={ closeModal }
 					title={ __( 'Customize this menu' ) }
 					className={ 'wp-block-page-list-modal' }

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -84,7 +84,6 @@ function PatternSelectionModal( {
 		<Modal
 			className="block-editor-query-pattern__selection-modal"
 			title={ __( 'Choose a pattern' ) }
-			closeLabel={ __( 'Cancel' ) }
 			onRequestClose={ () => setIsPatternSelectionModalOpen( false ) }
 		>
 			<BlockContextProvider value={ blockPreviewContext }>

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -202,7 +202,6 @@ export default function TemplatePartEdit( {
 						__( 'Choose a %s' ),
 						areaObject.label.toLowerCase()
 					) }
-					closeLabel={ __( 'Cancel' ) }
 					onRequestClose={ () =>
 						setIsTemplatePartSelectionOpen( false )
 					}

--- a/packages/block-library/src/template-part/edit/title-modal.js
+++ b/packages/block-library/src/template-part/edit/title-modal.js
@@ -28,7 +28,6 @@ export default function TitleModal( { areaLabel, onClose, onSubmit } ) {
 				__( 'Name and create your new %s' ),
 				areaLabel.toLowerCase()
 			) }
-			closeLabel={ __( 'Cancel' ) }
 			overlayClassName="wp-block-template-part__placeholder-create-new__title-form"
 			onRequestClose={ onClose }
 		>

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -202,8 +202,7 @@ function UnforwardedModal(
 										onClick={ onRequestClose }
 										icon={ close }
 										label={
-											closeButtonLabel ||
-											__( 'Close dialog' )
+											closeButtonLabel || __( 'Close' )
 										}
 									/>
 								) }

--- a/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/index.js
+++ b/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/index.js
@@ -110,7 +110,6 @@ export default function KeyboardShortcutHelpModal( {
 		<Modal
 			className="customize-widgets-keyboard-shortcut-help-modal"
 			title={ __( 'Keyboard shortcuts' ) }
-			closeLabel={ __( 'Close' ) }
 			onRequestClose={ toggleModal }
 		>
 			<ShortcutSection

--- a/packages/e2e-tests/specs/editor/various/nux.test.js
+++ b/packages/e2e-tests/specs/editor/various/nux.test.js
@@ -105,7 +105,7 @@ describe( 'New User Experience (NUX)', () => {
 		expect( welcomeGuide ).not.toBeNull();
 
 		// Close the guide
-		await page.click( 'button[aria-label="Close dialog"]' );
+		await page.click( '[role="dialog"] button[aria-label="Close"]' );
 
 		// Reload the editor.
 		await page.reload();
@@ -125,7 +125,7 @@ describe( 'New User Experience (NUX)', () => {
 		expect( welcomeGuide ).not.toBeNull();
 
 		// Close the guide.
-		await page.click( 'button[aria-label="Close dialog"]' );
+		await page.click( '[role="dialog"] button[aria-label="Close"]' );
 
 		// Focus should be in post title field.
 		const postTitle = await page.waitForSelector(

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -84,7 +84,7 @@ exports[`EditPostPreferencesModal should match snapshot when the modal is active
         </h1>
       </div>
       <button
-        aria-label="Close dialog"
+        aria-label="Close"
         class="components-button has-icon"
         type="button"
       >
@@ -703,7 +703,7 @@ exports[`EditPostPreferencesModal should match snapshot when the modal is active
         </h1>
       </div>
       <button
-        aria-label="Close dialog"
+        aria-label="Close"
         class="components-button has-icon"
         type="button"
       >

--- a/packages/edit-post/src/components/sidebar/post-template/create-modal.js
+++ b/packages/edit-post/src/components/sidebar/post-template/create-modal.js
@@ -100,7 +100,6 @@ export default function PostTemplateCreateModal( { onClose } ) {
 	return (
 		<Modal
 			title={ __( 'Create custom template' ) }
-			closeLabel={ __( 'Close' ) }
 			onRequestClose={ cancel }
 			className="edit-post-post-template__create-modal"
 		>

--- a/packages/edit-post/src/components/start-page-options/index.js
+++ b/packages/edit-post/src/components/start-page-options/index.js
@@ -113,7 +113,6 @@ export default function StartPageOptions() {
 		<Modal
 			className="edit-post-start-page-options__modal"
 			title={ __( 'Choose a pattern' ) }
-			closeLabel={ __( 'Cancel' ) }
 			onRequestClose={ () => {
 				setModalState( START_PAGE_MODAL_STATES.CLOSED );
 			} }

--- a/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal.js
@@ -52,7 +52,6 @@ function AddCustomGenericTemplateModal( {
 	return (
 		<Modal
 			title={ __( 'Create custom template' ) }
-			closeLabel={ __( 'Close' ) }
 			onRequestClose={ () => {
 				onClose();
 			} }

--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
@@ -184,7 +184,6 @@ function AddCustomTemplateModal( {
 				entityForSuggestions.labels.singular_name
 			) }
 			className={ baseCssClass }
-			closeLabel={ __( 'Close' ) }
 			onRequestClose={ onClose }
 		>
 			{ isCreatingTemplate && <TemplateActionsLoadingScreen /> }

--- a/packages/edit-site/src/components/create-template-part-modal/index.js
+++ b/packages/edit-site/src/components/create-template-part-modal/index.js
@@ -41,7 +41,6 @@ export default function CreateTemplatePartModal( { closeModal, onCreate } ) {
 	return (
 		<Modal
 			title={ __( 'Create a template part' ) }
-			closeLabel={ __( 'Close' ) }
 			onRequestClose={ closeModal }
 			overlayClassName="edit-site-create-template-part-modal"
 		>

--- a/packages/edit-site/src/components/keyboard-shortcut-help-modal/index.js
+++ b/packages/edit-site/src/components/keyboard-shortcut-help-modal/index.js
@@ -94,7 +94,6 @@ export default function KeyboardShortcutHelpModal( {
 		<Modal
 			className="edit-site-keyboard-shortcut-help-modal"
 			title={ __( 'Keyboard shortcuts' ) }
-			closeLabel={ __( 'Close' ) }
 			onRequestClose={ toggleModal }
 		>
 			<ShortcutSection

--- a/packages/edit-site/src/components/list/actions/rename-menu-item.js
+++ b/packages/edit-site/src/components/list/actions/rename-menu-item.js
@@ -75,7 +75,6 @@ export default function RenameMenuItem( { template, onClose } ) {
 			{ isModalOpen && (
 				<Modal
 					title={ __( 'Rename' ) }
-					closeLabel={ __( 'Close' ) }
 					onRequestClose={ () => {
 						setIsModalOpen( false );
 					} }

--- a/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/index.js
+++ b/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/index.js
@@ -101,7 +101,6 @@ export default function KeyboardShortcutHelpModal( {
 		<Modal
 			className="edit-widgets-keyboard-shortcut-help-modal"
 			title={ __( 'Keyboard shortcuts' ) }
-			closeLabel={ __( 'Close' ) }
 			onRequestClose={ toggleModal }
 		>
 			<ShortcutSection

--- a/packages/interface/src/components/preferences-modal/index.js
+++ b/packages/interface/src/components/preferences-modal/index.js
@@ -9,7 +9,6 @@ export default function PreferencesModal( { closeModal, children } ) {
 		<Modal
 			className="interface-preferences-modal"
 			title={ __( 'Preferences' ) }
-			closeLabel={ __( 'Close' ) }
 			onRequestClose={ closeModal }
 		>
 			{ children }

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -120,7 +120,6 @@ export default function ReusableBlockConvertButton( {
 					{ isModalOpen && (
 						<Modal
 							title={ __( 'Create Reusable block' ) }
-							closeLabel={ __( 'Close' ) }
 							onRequestClose={ () => {
 								setIsModalOpen( false );
 								setTitle( '' );

--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -343,6 +343,8 @@ class PreviewUtils {
 			return;
 		}
 
-		await this.page.click( 'role=button[name="Close dialog"i]' );
+		await this.page.click(
+			'role=dialog[name="Preferences"i] >> role=button[name="Close"i]'
+		);
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/47491

## What?
<!-- In a few words, what is the PR actually doing? -->
There are several occurrences of the Modal usage where the passed prop name for the close button label is, incorrectly, `closeLabel`. It should be `closeButtonLabel`. All the strings passed via closeLabel don't have any effect and the default string Close dialog is actually rendered. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The Close button should have a meaningful, simple, label.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Instead of fixing the prop name, I'd like to propose to just remove the passed props and simplify the default from 'Close dialog' to 'Close':

- The X close button belongs to the modal dialog. I'm not sure using a label like 'Cancel' is appropriate. that belongs more to the action flow the modal content provides to users.
- The wrong prop names are in place since a while. Custom labels like 'Cancel' never worked and apparently users didn't suffer that much.
- Screen readers do announce 'dialog' when the modal dialog opens. Users so know they're in a dialog. Repeating the word 'dialog' in 'Close dialog' doesn't add great value. 
- Simplifying the label to 'Close' may help speech recognition software users to issue more reliable voice commands.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Edit a post.
- Select a block. In the block toolbar choose: Options > Lock.
- In the Lock block modal dialog, hover the X close button.
- Check the tooltip text is 'Close'.
- Optionally, check the Close button in other Modal dialogs.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
