### PR TITLE
Extract TTFB metric to getLoadingDurations util

### DIFF
--- a/packages/e2e-tests/specs/performance/front-end-block-theme.test.js
+++ b/packages/e2e-tests/specs/performance/front-end-block-theme.test.js
@@ -9,6 +9,11 @@ import { writeFileSync } from 'fs';
  */
 import { activateTheme, createURL, logout } from '@wordpress/e2e-test-utils';
 
+/**
+ * Internal dependencies
+ */
+import { getLoadingDurations } from './utils';
+
 describe( 'Front End Performance', () => {
 	const results = {
 		timeToFirstByte: [],
@@ -35,13 +40,8 @@ describe( 'Front End Performance', () => {
 		let i = 16;
 		while ( i-- ) {
 			await page.goto( createURL( '/' ) );
-			const navigationTimingJson = await page.evaluate( () =>
-				JSON.stringify( performance.getEntriesByType( 'navigation' ) )
-			);
-			const [ navigationTiming ] = JSON.parse( navigationTimingJson );
-			results.timeToFirstByte.push(
-				navigationTiming.responseStart - navigationTiming.startTime
-			);
+			const { timeToFirstByte } = await getLoadingDurations();
+			results.timeToFirstByte.push( timeToFirstByte );
 		}
 	} );
 } );

--- a/packages/e2e-tests/specs/performance/front-end-classic-theme.test.js
+++ b/packages/e2e-tests/specs/performance/front-end-classic-theme.test.js
@@ -9,6 +9,11 @@ import { writeFileSync } from 'fs';
  */
 import { createURL, logout } from '@wordpress/e2e-test-utils';
 
+/**
+ * Internal dependencies
+ */
+import { getLoadingDurations } from './utils';
+
 describe( 'Front End Performance', () => {
 	const results = {
 		timeToFirstByte: [],
@@ -33,13 +38,8 @@ describe( 'Front End Performance', () => {
 		let i = 16;
 		while ( i-- ) {
 			await page.goto( createURL( '/' ) );
-			const navigationTimingJson = await page.evaluate( () =>
-				JSON.stringify( performance.getEntriesByType( 'navigation' ) )
-			);
-			const [ navigationTiming ] = JSON.parse( navigationTimingJson );
-			results.timeToFirstByte.push(
-				navigationTiming.responseStart - navigationTiming.startTime
-			);
+			const { timeToFirstByte } = await getLoadingDurations();
+			results.timeToFirstByte.push( timeToFirstByte );
 		}
 	} );
 } );

--- a/packages/e2e-tests/specs/performance/utils.js
+++ b/packages/e2e-tests/specs/performance/utils.js
@@ -89,7 +89,6 @@ export async function getLoadingDurations() {
 				requestStart,
 				responseStart,
 				responseEnd,
-				startTime,
 				domContentLoadedEventEnd,
 				loadEventEnd,
 			},
@@ -111,7 +110,8 @@ export async function getLoadingDurations() {
 				).startTime - responseEnd,
 			// This is evaluated right after Puppeteer found the block selector.
 			firstBlock: performance.now() - responseEnd,
-			timeToFirstByte: responseStart - startTime,
+			// As defined by https://web.dev/ttfb/#measure-ttfb-in-javascript
+			timeToFirstByte: responseStart,
 		};
 	} );
 }

--- a/packages/e2e-tests/specs/performance/utils.js
+++ b/packages/e2e-tests/specs/performance/utils.js
@@ -89,6 +89,7 @@ export async function getLoadingDurations() {
 				requestStart,
 				responseStart,
 				responseEnd,
+				startTime,
 				domContentLoadedEventEnd,
 				loadEventEnd,
 			},
@@ -110,6 +111,7 @@ export async function getLoadingDurations() {
 				).startTime - responseEnd,
 			// This is evaluated right after Puppeteer found the block selector.
 			firstBlock: performance.now() - responseEnd,
+			timeToFirstByte: responseStart - startTime,
 		};
 	} );
 }


### PR DESCRIPTION
## What?

Refactors the TimeToFirstByte performance metric to the `getLoadingDurations` utility.

## Why?

This makes it work like any other metric.

## How?

By moving the calculation to the `getLoadingDurations` utility and use it directly in the test.

## Testing Instructions

Go to the performance CI job of this PR and verify that the front-end metrics are still reported and work as expected.
