### PR TITLE
Page List: Swap the positions of the parent page selector and customize button

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -303,18 +303,6 @@ export default function PageListEdit( {
 	return (
 		<>
 			<InspectorControls>
-				{ allowConvertToLinks && (
-					<PanelBody title={ __( 'Customize this menu' ) }>
-						<p>{ convertDescription }</p>
-						<Button
-							variant="primary"
-							disabled={ ! hasResolvedPages }
-							onClick={ convertToNavigationLinks }
-						>
-							{ __( 'Customize' ) }
-						</Button>
-					</PanelBody>
-				) }
 				{ pagesTree.length > 0 && (
 					<PanelBody>
 						<ComboboxControl
@@ -329,6 +317,18 @@ export default function PageListEdit( {
 								'Choose a page to show only its subpages.'
 							) }
 						/>
+					</PanelBody>
+				) }
+				{ allowConvertToLinks && (
+					<PanelBody title={ __( 'Customize this menu' ) }>
+						<p>{ convertDescription }</p>
+						<Button
+							variant="primary"
+							disabled={ ! hasResolvedPages }
+							onClick={ convertToNavigationLinks }
+						>
+							{ __( 'Customize' ) }
+						</Button>
 					</PanelBody>
 				) }
 			</InspectorControls>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Just swaps around the position of these two controls. Fixes #47236 

## Why?
The parent page selector is probably more useful for more people.

## How?
Swap the code order

## Testing Instructions
1. Add a Page List block
2. Open the inspector controls
3. Confirm that the parent page selector appears before the customize section.

### Testing Instructions for Keyboard
As above

## Screenshots or screencast <!-- if applicable -->
<img width="306" alt="Screenshot 2023-01-30 at 10 51 00" src="https://user-images.githubusercontent.com/275961/215457976-3cb14b26-ccfd-4971-bed2-d4cea5d5cfb3.png">
