### PR TITLE
Page List: Update the edit/customize copy

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -41,7 +41,7 @@ const MAX_PAGE_COUNT = 100;
 const NOOP = () => {};
 
 const convertDescription = __(
-	'This menu is automatically kept in sync with pages on your site. You can manage the menu yourself by clicking customize below.'
+	'This menu is automatically kept in sync with pages on your site. You can manage the menu yourself by clicking "Edit" below.'
 );
 
 function BlockContent( {
@@ -117,7 +117,7 @@ function ConvertToLinksModal( { onClick, disabled } ) {
 			{ isOpen && (
 				<Modal
 					onRequestClose={ closeModal }
-					title={ __( 'Customize this menu' ) }
+					title={ __( 'Edit this menu' ) }
 					className={ 'wp-block-page-list-modal' }
 					aria={ {
 						describedby: 'wp-block-page-list-modal__description',
@@ -135,7 +135,7 @@ function ConvertToLinksModal( { onClick, disabled } ) {
 							disabled={ disabled }
 							onClick={ onClick }
 						>
-							{ __( 'Customize' ) }
+							{ __( 'Edit' ) }
 						</Button>
 					</div>
 				</Modal>
@@ -319,14 +319,14 @@ export default function PageListEdit( {
 					</PanelBody>
 				) }
 				{ allowConvertToLinks && (
-					<PanelBody title={ __( 'Customize this menu' ) }>
+					<PanelBody title={ __( 'Edit this menu' ) }>
 						<p>{ convertDescription }</p>
 						<Button
 							variant="primary"
 							disabled={ ! hasResolvedPages }
 							onClick={ convertToNavigationLinks }
 						>
-							{ __( 'Customize' ) }
+							{ __( 'Edit' ) }
 						</Button>
 					</PanelBody>
 				) }


### PR DESCRIPTION
## What?
Updates the copy of the "convert to links" actions in the Page List block.

## Why?
I think "Edit" is a better verb here than customize, which is more connected to making stylistic changes than content changes.

## How?
Just simple copy edits.

## Testing Instructions
1. Add a Page List block
2. Open the inspector controls
3. Check that the copy uses the word "edit" rather than "customize"
4. Click/hit enter on the "edit" button in the block toolbar
5. Check that the copy in the modal uses the word "edit" rather than "customize"

### Testing Instructions for Keyboard
As above

## Screenshots or screencast <!-- if applicable -->

<img width="298" alt="Screenshot 2023-01-30 at 11 07 29" src="https://user-images.githubusercontent.com/275961/215461355-ca624e3d-57a7-4f4d-9b93-1cdb2735d585.png">
<img width="631" alt="Screenshot 2023-01-30 at 11 07 23" src="https://user-images.githubusercontent.com/275961/215461357-0bec72d5-9231-4858-a22b-595ab6bd5de1.png">
