### PR TITLE
Revert "Revert "Block Settings/Support: Use Tag Processor to inject class name on wrapper.""

### DIFF
--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -49,29 +49,14 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$class_name = gutenberg_get_elements_class_name( $block );
-
 	// Like the layout hook this assumes the hook only applies to blocks with a single wrapper.
-	// Retrieve the opening tag of the first HTML element.
-	$html_element_matches = array();
-	preg_match( '/<[^>]+>/', $block_content, $html_element_matches, PREG_OFFSET_CAPTURE );
-	$first_element = $html_element_matches[0][0];
-	// If the first HTML element has a class attribute just add the new class
-	// as we do on layout and duotone.
-	if ( str_contains( $first_element, 'class="' ) ) {
-		$content = preg_replace(
-			'/' . preg_quote( 'class="', '/' ) . '/',
-			'class="' . $class_name . ' ',
-			$block_content,
-			1
-		);
-	} else {
-		// If the first HTML element has no class attribute we should inject the attribute before the attribute at the end.
-		$first_element_offset = $html_element_matches[0][1];
-		$content              = substr_replace( $block_content, ' class="' . $class_name . '"', $first_element_offset + strlen( $first_element ) - 1, 0 );
+	// Add the class name to the first element, presuming it's the wrapper, if it exists.
+	$tags = new WP_HTML_Tag_Processor( $block_content );
+	if ( $tags->next_tag() ) {
+		$tags->add_class( gutenberg_get_elements_class_name( $block ) );
 	}
 
-	return $content;
+	return $tags->get_updated_html();
 }
 
 /**

--- a/lib/block-supports/settings.php
+++ b/lib/block-supports/settings.php
@@ -43,29 +43,14 @@ function _gutenberg_add_block_level_presets_class( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$class_name = _gutenberg_get_presets_class_name( $block );
-
 	// Like the layout hook this assumes the hook only applies to blocks with a single wrapper.
-	// Retrieve the opening tag of the first HTML element.
-	$html_element_matches = array();
-	preg_match( '/<[^>]+>/', $block_content, $html_element_matches, PREG_OFFSET_CAPTURE );
-	$first_element = $html_element_matches[0][0];
-	// If the first HTML element has a class attribute just add the new class
-	// as we do on layout and duotone.
-	if ( strpos( $first_element, 'class="' ) !== false ) {
-		$content = preg_replace(
-			'/' . preg_quote( 'class="', '/' ) . '/',
-			'class="' . $class_name . ' ',
-			$block_content,
-			1
-		);
-	} else {
-		// If the first HTML element has no class attribute we should inject the attribute before the attribute at the end.
-		$first_element_offset = $html_element_matches[0][1];
-		$content              = substr_replace( $block_content, ' class="' . $class_name . '"', $first_element_offset + strlen( $first_element ) - 1, 0 );
+	// Add the class name to the first element, presuming it's the wrapper, if it exists.
+	$tags = new WP_HTML_Tag_Processor( $block_content );
+	if ( $tags->next_tag() ) {
+		$tags->add_class( _gutenberg_get_presets_class_name( $block ) );
 	}
 
-	return $content;
+	return $tags->get_updated_html();
 }
 
 /**


### PR DESCRIPTION
Reverts WordPress/gutenberg#47350

Since we're going to include `WP_HTML_Tag_Processor`, we need to back port it and revert 47350, as it was done while we were considering not to include it. See https://github.com/WordPress/gutenberg/issues/47349#issuecomment-1404048599.