### PR TITLE
Refactores __ExperimentalOffCanvasEditor to OffCanvasEditor

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/README.md
+++ b/packages/block-editor/src/components/off-canvas-editor/README.md
@@ -1,5 +1,5 @@
 # Experimental Off Canvas Editor
 
-The __ExperimentalOffCanvasEditor component is a modified ListView compoent. It provides an overview of the hierarchical structure of all blocks in the editor. The blocks are presented vertically one below the other. It enables editing of hierarchy and addition of elements in the block tree without selecting the block instance on the canvas.
+The OffCanvasEditor component is a modified ListView compoent. It provides an overview of the hierarchical structure of all blocks in the editor. The blocks are presented vertically one below the other. It enables editing of hierarchy and addition of elements in the block tree without selecting the block instance on the canvas.
 
 It is an experimental component which may end up completely merged into the ListView component via configuration props.

--- a/packages/block-editor/src/components/off-canvas-editor/README.md
+++ b/packages/block-editor/src/components/off-canvas-editor/README.md
@@ -1,4 +1,4 @@
-# Experimental Off Canvas Editor
+# Off Canvas Editor
 
 The OffCanvasEditor component is a modified ListView compoent. It provides an overview of the hierarchical structure of all blocks in the editor. The blocks are presented vertically one below the other. It enables editing of hierarchy and addition of elements in the block tree without selecting the block instance on the canvas.
 

--- a/packages/block-editor/src/components/off-canvas-editor/index.js
+++ b/packages/block-editor/src/components/off-canvas-editor/index.js
@@ -63,7 +63,7 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
  * @param {Object}  props.LeafMoreMenu        Optional more menu substitution.
  * @param {Object}  ref                       Forwarded ref
  */
-function __ExperimentalOffCanvasEditor(
+function OffCanvasEditor(
 	{
 		id,
 		blocks,
@@ -252,4 +252,4 @@ function __ExperimentalOffCanvasEditor(
 	);
 }
 
-export default forwardRef( __ExperimentalOffCanvasEditor );
+export default forwardRef( OffCanvasEditor );

--- a/packages/block-editor/src/experiments.js
+++ b/packages/block-editor/src/experiments.js
@@ -8,7 +8,7 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/exp
  */
 import * as globalStyles from './components/global-styles';
 import { ExperimentalBlockEditorProvider } from './components/provider';
-import { default as __experimentalOffCanvasEditor } from './components/off-canvas-editor';
+import OffCanvasEditor from './components/off-canvas-editor';
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
@@ -23,5 +23,5 @@ export const experiments = {};
 lock( experiments, {
 	...globalStyles,
 	ExperimentalBlockEditorProvider,
-	__experimentalOffCanvasEditor,
+	OffCanvasEditor,
 } );

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -32,9 +32,7 @@ const ExperimentMainContent = ( {
 	isLoading,
 	isNavigationMenuMissing,
 } ) => {
-	const { __experimentalOffCanvasEditor: OffCanvasEditor } = unlock(
-		blockEditorExperiments
-	);
+	const { OffCanvasEditor } = unlock( blockEditorExperiments );
 	// Provide a hierarchy of clientIds for the given Navigation block (clientId).
 	// This is required else the list view will display the entire block tree.
 	const clientIdsTree = useSelect(

--- a/packages/edit-site/src/components/navigation-inspector/navigation-menu.js
+++ b/packages/edit-site/src/components/navigation-inspector/navigation-menu.js
@@ -39,9 +39,7 @@ const ALLOWED_BLOCKS = {
 export default function NavigationMenu( { innerBlocks } ) {
 	const { updateBlockListSettings } = useDispatch( blockEditorStore );
 
-	const { __experimentalOffCanvasEditor: OffCanvasEditor } = unlock(
-		blockEditorExperiments
-	);
+	const { OffCanvasEditor } = unlock( blockEditorExperiments );
 
 	//TODO: Block settings are normally updated as a side effect of rendering InnerBlocks in BlockList
 	//Think through a better way of doing this, possible with adding allowed blocks to block library metadata


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Since exporting the `__ExperimentalOffCanvasEditor` in #47465 wraps the component in an experiment that needs to be unlocked, the "__Experimental" prefix is not required anymore.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Just code refactoring for a cleaner codebase.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Renamed the component everywhere. I hope.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Use a navigation block and make sure it does not crash

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
