### PR TITLE
Global Styles: Alternative method for enqueueing custom CSS

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1092,7 +1092,7 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	public function get_custom_css() {
 		// Add the global styles root CSS.
-		$stylesheet = _wp_array_get( $this->theme_json, array( 'styles', 'css' ) );
+		$stylesheet = _wp_array_get( $this->theme_json, array( 'styles', 'css' ), '' );
 
 		// Add the global styles block CSS.
 		if ( isset( $this->theme_json['styles']['blocks'] ) ) {

--- a/lib/compat/wordpress-6.2/block-editor-settings.php
+++ b/lib/compat/wordpress-6.2/block-editor-settings.php
@@ -16,7 +16,7 @@ function gutenberg_get_block_editor_settings_6_2( $settings ) {
 	if ( wp_theme_has_theme_json() ) {
 		// Add the custom CSS as separate style sheet so any invalid CSS entered by users does not break other global styles.
 		$settings['styles'][] = array(
-			'css'            => get_global_styles_custom_css(),
+			'css'            => gutenberg_get_global_styles_custom_css(),
 			'__unstableType' => 'user',
 			'isGlobalStyles' => true,
 		);

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -77,7 +77,7 @@ function gutenberg_get_global_styles_custom_css() {
 	}
 
 	if ( ! wp_theme_has_theme_json() ) {
-		return;
+		return '';
 	}
 
 	$tree       = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -64,10 +64,10 @@ if ( ! function_exists( 'wp_theme_has_theme_json_clean_cache' ) ) {
  *
  * @return string
  */
-function get_global_styles_custom_css() {
+function gutenberg_get_global_styles_custom_css() {
 	// Ignore cache when `WP_DEBUG` is enabled, so it doesn't interfere with the theme developers workflow.
-	$can_use_cached = empty( $types ) && ! WP_DEBUG;
-	$cache_key      = 'gutenberg_get_global_custom_css_stylesheet';
+	$can_use_cached = ! WP_DEBUG;
+	$cache_key      = 'gutenberg_get_global_custom_css';
 	$cache_group    = 'theme_json';
 	if ( $can_use_cached ) {
 		$cached = wp_cache_get( $cache_key, $cache_group );
@@ -76,20 +76,18 @@ function get_global_styles_custom_css() {
 		}
 	}
 
-	$tree                = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
-	$supports_theme_json = wp_theme_has_theme_json();
-
-	if ( ! $supports_theme_json ) {
+	if ( ! wp_theme_has_theme_json() ) {
 		return;
 	}
 
+	$tree       = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
 	$stylesheet = $tree->get_custom_css();
 
 	if ( $can_use_cached ) {
 		wp_cache_set( $cache_key, $stylesheet, $cache_group );
 	}
 
-	return  $stylesheet;
+	return $stylesheet;
 }
 
 /**
@@ -227,6 +225,7 @@ function _gutenberg_clean_theme_json_caches() {
 	wp_cache_delete( 'gutenberg_get_global_stylesheet', 'theme_json' );
 	wp_cache_delete( 'gutenberg_get_global_settings_custom', 'theme_json' );
 	wp_cache_delete( 'gutenberg_get_global_settings_theme', 'theme_json' );
+	wp_cache_delete( 'gutenberg_get_global_custom_css', 'theme_json' );
 	WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data();
 }
 

--- a/lib/compat/wordpress-6.2/script-loader.php
+++ b/lib/compat/wordpress-6.2/script-loader.php
@@ -181,8 +181,8 @@ function gutenberg_enqueue_global_styles_custom_css() {
 	// Don't enqueue Customizer's custom CSS separately.
 	remove_action( 'wp_head', 'wp_custom_css_cb', 101 );
 
-	$custom_css = wp_get_custom_css();
-	$custom_css .= get_global_styles_custom_css();
+	$custom_css  = wp_get_custom_css();
+	$custom_css .= gutenberg_get_global_styles_custom_css();
 
 	if ( ! empty( $custom_css ) ) {
 		wp_add_inline_style( 'global-styles', $custom_css );

--- a/lib/compat/wordpress-6.2/script-loader.php
+++ b/lib/compat/wordpress-6.2/script-loader.php
@@ -174,15 +174,18 @@ add_filter(
  * @since 6.2.0
  */
 function gutenberg_enqueue_global_styles_custom_css() {
-	$custom_css     = get_global_styles_custom_css();
-	$is_block_theme = wp_is_block_theme();
-	if ( $custom_css && $is_block_theme ) {
-		?>
-		<style id="global-styles-custom-css-inline-css" type="text/css">
-			<?php echo $custom_css; ?>
-		</style>
-		<?php
+	if ( ! wp_is_block_theme() ) {
+		return;
+	}
+
+	// Don't enqueue Customizer's custom CSS separately.
+	remove_action( 'wp_head', 'wp_custom_css_cb', 101 );
+
+	$custom_css = wp_get_custom_css();
+	$custom_css .= get_global_styles_custom_css();
+
+	if ( ! empty( $custom_css ) ) {
+		wp_add_inline_style( 'global-styles', $custom_css );
 	}
 }
-
-add_action( 'wp_head', 'gutenberg_enqueue_global_styles_custom_css', 102 );
+add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_global_styles_custom_css' );


### PR DESCRIPTION
## What?
My alternative to the enqueueing method is proposed at https://github.com/WordPress/gutenberg/pull/47396.

Instead of using two separate callbacks for loading custom CSS from Customizer and Site Editor, the new method removes Customzer callback, combines custom CSS values, and enqueues styles after `global-styles`.

I've also made the following changes to the `get_global_styles_custom_css` method:

* Added prefix to avoid conflicts when the function is backported.
* Removed checks for the `$types` variable - the function doesn't accept arguments.
* Update the cache key name and added it to the clean function.
* Avoid calling the `::get_merged_data` if a theme does not have a `theme.json` file.

## Testing Instructions
Please take a look at the instructions in the original PR.
