### PR TITLE
No need to remove the 'gutenberg_enqueue_global_styles_assets' action

### DIFF
--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -75,8 +75,6 @@ function gutenberg_enqueue_global_styles() {
 
 remove_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles' );
 remove_action( 'wp_footer', 'wp_enqueue_global_styles', 1 );
-remove_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_global_styles_assets' );
-remove_action( 'wp_footer', 'gutenberg_enqueue_global_styles_assets' );
 
 // Enqueue global styles, and then block supports styles.
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_global_styles' );


### PR DESCRIPTION
## What?
There's no need for those function calls; the `gutenberg_enqueue_global_styles_assets` method was removed in #41306.

## Testing Instructions
CI tests should pass.
