### PR TITLE
Add back block editor settings filter

### DIFF
--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -19,6 +19,63 @@ import { store as editorStore } from '../../store';
 
 const EMPTY_BLOCKS_LIST = [];
 
+const BLOCK_EDITOR_SETTINGS = [
+	'__experimentalBlockDirectory',
+	'__experimentalBlockInspectorAnimation',
+	'__experimentalClearBlockSelection',
+	'__experimentalDiscussionSettings',
+	'__experimentalFeatures',
+	'__experimentalGlobalStylesBaseStyles',
+	'__experimentalPreferredStyleVariations',
+	'__experimentalSetIsInserterOpened',
+	'__unstableGalleryWithImageBlocks',
+	'alignWide',
+	'allowedBlockTypes',
+	'blockInspectorTabs',
+	'allowedMimeTypes',
+	'bodyPlaceholder',
+	'canLockBlocks',
+	'capabilities',
+	'codeEditingEnabled',
+	'colors',
+	'disableCustomColors',
+	'disableCustomFontSizes',
+	'disableCustomSpacingSizes',
+	'disableCustomGradients',
+	'disableLayoutStyles',
+	'enableCustomLineHeight',
+	'enableCustomSpacing',
+	'enableCustomUnits',
+	'enableOpenverseMediaCategory',
+	'focusMode',
+	'fontSizes',
+	'gradients',
+	'generateAnchors',
+	'hasFixedToolbar',
+	'hasInlineToolbar',
+	'isDistractionFree',
+	'imageDefaultSize',
+	'imageDimensions',
+	'imageEditing',
+	'imageSizes',
+	'isRTL',
+	'keepCaretInsideBlock',
+	'locale',
+	'maxWidth',
+	'onUpdateDefaultBlockStyles',
+	'postsPerPage',
+	'readOnly',
+	'styles',
+	'template',
+	'templateLock',
+	'titlePlaceholder',
+	'supportsLayout',
+	'widgetTypesToHideFromLegacyWidgetBlock',
+	'__unstableHasCustomAppender',
+	'__unstableIsPreviewMode',
+	'__unstableResolvedAssets',
+];
+
 /**
  * React hook used to compute the block editor settings to use for the post editor.
  *
@@ -131,7 +188,11 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 
 	return useMemo(
 		() => ( {
-			...settings,
+			...Object.fromEntries(
+				Object.entries( settings ).filter( ( [ key ] ) =>
+					BLOCK_EDITOR_SETTINGS.includes( key )
+				)
+			),
 			mediaUpload: hasUploadPermissions ? mediaUpload : undefined,
 			__experimentalReusableBlocks: reusableBlocks,
 			__experimentalBlockPatterns: blockPatterns,


### PR DESCRIPTION
Adding back filter of supported block editor settings that I removed in #47287. At this moment I am much more confident about which settings are actually used, and which ones are passed down, especially in mobile editor. And that the list of supported settings is correct.

Before we can merge this PR, we need to first review and merge #47417 that fixes how the `capabilities` settings is used. Without that, mobile app won't propagate some `capabilities` fields to the places that read them.

After auditing block editor settings that are used, I added the following settings that were not in the original list:
- `__unstableHasCustomAppender`
- `__unstableIsPreviewMode`
- `capabilities`
- `locale` (mobile embed preview)
- `readOnly` (mobile blocks list)
- `postsPerPage` (query block)
- `__experimentalBlockInspectorAnimation`
- `__experimentalGlobalStylesBaseStyles`
- `__experimentalClearBlockSelection`

