### PR TITLE
Tag Processor: Add bookmark invalidation logic

### DIFF
--- a/lib/compat/wordpress-6.3/html-api/class-gutenberg-html-tag-processor-6-3.php
+++ b/lib/compat/wordpress-6.3/html-api/class-gutenberg-html-tag-processor-6-3.php
@@ -1443,35 +1443,24 @@ class Gutenberg_HTML_Tag_Processor_6_3 {
 			$tail_delta = 0;
 
 			foreach ( $this->lexical_updates as $diff ) {
-				$bookmark_start_is_after_diff_start = $bookmark->start >= $diff->start;
-				$bookmark_end_is_after_diff_end     = $bookmark->end >= $diff->start;
-
-				if ( $bookmark_start_is_after_diff_start ) {
-					$bookmark_end_is_before_diff_end = $bookmark->end < $diff->end;
-					if ( $bookmark_end_is_before_diff_end ) {
-						// The bookmark is fully contained within the diff. We need to invalidate it.
-						$this->release_bookmark( $bookmark_name );
-					}
+				if ( ! $bookmark->start >= $diff->start && ! $bookmark->end >= $diff->start ) {
+					break;
 				}
 
-				if ( ! $bookmark_start_is_after_diff_start && ! $bookmark_end_is_after_diff_end ) {
-					break;
+				if ( $bookmark->start >= $diff->start && $bookmark->end < $diff->end ) {
+					$this->release_bookmark( $bookmark_name );
+					continue 2;
 				}
 
 				$delta = strlen( $diff->text ) - ( $diff->end - $diff->start );
 
-				if ( $bookmark_start_is_after_diff_start ) {
+				if ( $bookmark->start >= $diff->start ) {
 					$head_delta += $delta;
 				}
 
-				if ( $bookmark_end_is_after_diff_end ) {
+				if ( $bookmark->end >= $diff->end ) {
 					$tail_delta += $delta;
 				}
-			}
-
-			// Did we end up invalidating the bookmark?
-			if ( ! isset( $this->bookmarks[ $bookmark_name ] ) ) {
-				continue;
 			}
 
 			$bookmark->start += $head_delta;

--- a/lib/compat/wordpress-6.3/html-api/class-gutenberg-html-tag-processor-6-3.php
+++ b/lib/compat/wordpress-6.3/html-api/class-gutenberg-html-tag-processor-6-3.php
@@ -1482,6 +1482,18 @@ class Gutenberg_HTML_Tag_Processor_6_3 {
 	}
 
 	/**
+	 * Whether a bookmark with the given name exists.
+	 *
+	 * @since 6.3.0
+	 *
+	 * @param string $bookmark_name Name to identify a bookmark that potentially exists.
+	 * @return bool Whether that bookmark exists.
+	 */
+	public function has_bookmark( $bookmark_name ) {
+		return array_key_exists( $bookmark_name, $this->bookmarks );
+	}
+
+	/**
 	 * Move the internal cursor in the Tag Processor to a given bookmark's location.
 	 *
 	 * In order to prevent accidental infinite loops, there's a

--- a/lib/compat/wordpress-6.3/html-api/class-gutenberg-html-tag-processor-6-3.php
+++ b/lib/compat/wordpress-6.3/html-api/class-gutenberg-html-tag-processor-6-3.php
@@ -1443,7 +1443,7 @@ class Gutenberg_HTML_Tag_Processor_6_3 {
 			$tail_delta = 0;
 
 			foreach ( $this->lexical_updates as $diff ) {
-				if ( ! $bookmark->start >= $diff->start && ! $bookmark->end >= $diff->start ) {
+				if ( $bookmark->start < $diff->start && $bookmark->end < $diff->start ) {
 					break;
 				}
 

--- a/lib/compat/wordpress-6.3/html-api/class-gutenberg-html-tag-processor-6-3.php
+++ b/lib/compat/wordpress-6.3/html-api/class-gutenberg-html-tag-processor-6-3.php
@@ -1471,7 +1471,7 @@ class Gutenberg_HTML_Tag_Processor_6_3 {
 	}
 
 	/**
-	 * Whether a bookmark with the given name exists.
+	 * Checks whether a bookmark with the given name exists.
 	 *
 	 * @since 6.3.0
 	 *

--- a/lib/compat/wordpress-6.3/html-api/class-gutenberg-html-tag-processor-6-3.php
+++ b/lib/compat/wordpress-6.3/html-api/class-gutenberg-html-tag-processor-6-3.php
@@ -1401,6 +1401,7 @@ class Gutenberg_HTML_Tag_Processor_6_3 {
 	 * Applies attribute updates to HTML document.
 	 *
 	 * @since 6.2.0
+	 * @since 6.3.0 Invalidate any bookmarks whose targets are overwritten.
 	 *
 	 * @return void
 	 */

--- a/phpunit/html-api/class-gutenberg-html-tag-processor-6-3-bookmark-test.php
+++ b/phpunit/html-api/class-gutenberg-html-tag-processor-6-3-bookmark-test.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/../../lib/compat/wordpress-6.3/html-api/class-gutenberg
  *
  * @coversDefaultClass Gutenberg_HTML_Tag_Processor_6_3
  */
-class Gutenberg_HTML_Tag_Processor_6_3_Test extends WP_UnitTestCase {
+class Gutenberg_HTML_Tag_Processor_6_3_Bookmark_Test extends WP_UnitTestCase {
 	/**
 	 * @covers has_bookmark
 	 */

--- a/phpunit/html-api/class-gutenberg-html-tag-processor-6-3-test.php
+++ b/phpunit/html-api/class-gutenberg-html-tag-processor-6-3-test.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Unit tests covering Gutenberg_HTML_Tag_Processor_6_3 functionality.
+ *
+ * @package WordPress
+ * @subpackage HTML
+ */
+
+require_once __DIR__ . '/../../lib/compat/wordpress-6.3/html-api/class-gutenberg-html-tag-processor-6-3.php';
+
+/**
+ * @group html-api
+ *
+ * @coversDefaultClass Gutenberg_HTML_Tag_Processor_6_3
+ */
+class Gutenberg_HTML_Tag_Processor_6_3_Test extends WP_UnitTestCase {
+	/**
+	 * @covers has_bookmark
+	 */
+	public function test_has_bookmark_returns_false_if_bookmark_does_not_exist() {
+		$p = new Gutenberg_HTML_Tag_Processor_6_3( '<div>Test</div>' );
+		$this->assertFalse( $p->has_bookmark( 'my-bookmark' ) );
+	}
+
+	/**
+	 * @covers has_bookmark
+	 */
+	public function test_has_bookmark_returns_true_if_bookmark_exists() {
+		$p = new Gutenberg_HTML_Tag_Processor_6_3( '<div>Test</div>' );
+		$p->next_tag();
+		$p->set_bookmark( 'my-bookmark' );
+		$this->assertTrue( $p->has_bookmark( 'my-bookmark' ) );
+	}
+
+	/**
+	 * @covers has_bookmark
+	 */
+	public function test_has_bookmark_returns_false_if_bookmark_has_been_released() {
+		$p = new Gutenberg_HTML_Tag_Processor_6_3( '<div>Test</div>' );
+		$p->next_tag();
+		$p->set_bookmark( 'my-bookmark' );
+		$p->release_bookmark( 'my-bookmark' );
+		$this->assertFalse( $p->has_bookmark( 'my-bookmark' ) );
+	}
+}


### PR DESCRIPTION
## What?

Part of #44410.

Invalidate bookmarks in a `WP_HTML_Tag_Processor` instance if the tags that they're pointing to have been replaced.

## Why?
While `WP_HTML_Tag_Processor` currently only supports changing a given tag's attributes, we plan to also provide methods to make broader changes (e.g. [`set_content_inside_balanced_tags `](https://github.com/WordPress/gutenberg/pull/47036)) (probably through a subclass of `WP_HTML_Tag_Processor`).

An API like that will have the potential of replacing a tag that a bookmark points to. As a preparation, we thus need to make sure that all bookmarks affected by a HTML replacement are invalidated (i.e. released).

## How?
By extending the existing loop in `apply_attributes_updates` that adjusts bookmarks' start and end positions upon HTML changes to check if the entire bookmark is within a portion of the HTML that has been replaced.

Note that this PR is extracted from https://github.com/WordPress/gutenberg/pull/47068, per [this suggestion](https://github.com/WordPress/gutenberg/pull/47068#issuecomment-1405439927).

## Testing Instructions
As stated above, there aren't currently any methods that actually replace existing bookmarks, so the relevant codepath should never be hit. Furthermore, `apply_attributes_updates` is a `private` method, so we cannot directly test it.

However, we have extensive unit test coverage of `WP_HTML_Tag_Processor`'s public methods which guarantee that their desired behavior is still warranted.

Finally, https://github.com/WordPress/gutenberg/pull/47036 [contains](https://github.com/WordPress/gutenberg/pull/47036/files#diff-93724b2f6e5dbf16c2b3c0efea57fa442b572f75f325d1cb185cf614b692cf9fR1306-R1347) the code from this PR, and has [unit test coverage for bookmark invalidation](https://github.com/WordPress/gutenberg/pull/47036/files#diff-46de4f3b288b4df1647366b416c84f02b7296f8a3040123513021662c2aab15fR288-R303).
