### PR TITLE
Lodash: Refactor Categories List block away from `_.unescape()`

### DIFF
--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { unescape } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -16,6 +15,7 @@ import {
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { pin } from '@wordpress/icons';
 import { useEntityRecords } from '@wordpress/core-data';
@@ -57,7 +57,7 @@ export default function CategoriesEdit( {
 		setAttributes( { [ attributeName ]: newValue } );
 
 	const renderCategoryName = ( name ) =>
-		! name ? __( '(Untitled)' ) : unescape( name ).trim();
+		! name ? __( '(Untitled)' ) : decodeEntities( name ).trim();
 
 	const renderCategoryList = () => {
 		const parentId = showHierarchy ? 0 : null;


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.unescape()` from the `Categories List` block. There is just a single use in that block and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing `_.unescape()` with `decodeEntities()` from `@wordpress/html-entities`.

This change also introduces a fix. `unescape()` does not escape `&nbsp;` and will render it as-is. So in the current version of the code, if you create a category with `&nbsp;` in it, that `&nbsp;` will be rendered as-is in the Categories List block. I believe that's not desired behavior, and that's confirmed by the fact that when editing a category in the admin, the `&nbsp;` in category titles is converted to a simple space. 

## Testing Instructions

* Go to `/wp-admin/edit-tags.php?taxonomy=category`
* Create a category with the name `<script>alert(1)</script>`.
* A category with an empty name will be created. 
* Create a category with the name `test > <  &nbsp; test`.
* A category with the name `test > <    test` will be created.
* Try editing it in place - you'll see the `&nbsp;` is replaced with a regular space. 
* Go to the post editor.
* Insert a Categories List block
* Enable "Show empty categories" to see categories without posts.
* Verify that the first category appears as `(Untitled)`.
* Verify that the second category appears as `test > <    test`.
* Verify all checks are still green. 