### PR TITLE
Lodash: Refactor Tag Cloud block away from `_.unescape()`

### DIFF
--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { unescape } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -18,6 +17,7 @@ import {
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { Spinner, TextControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -120,7 +120,7 @@ export default function PostTermsEdit( {
 								href={ postTerm.link }
 								onClick={ ( event ) => event.preventDefault() }
 							>
-								{ unescape( postTerm.name ) }
+								{ decodeEntities( postTerm.name ) }
 							</a>
 						) )
 						.reduce( ( prev, curr ) => (


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.unescape()` from the `Tag Cloud` block. There is just a single use in that block and conversion is pretty straightforward. 

Similar to #47561

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing `_.unescape()` with `decodeEntities()` from `@wordpress/html-entities`.

## Testing Instructions

* Edit an existing tag's name to contain `>`, `<` and `&nbsp;`.
* Insert a tag cloud block.
* Verify that the tag appears well in the tag cloud in the editor.
* Verify all checks are still green. 