### PR TITLE
Lodash: Refactor `PageAttributesParent` away from `_.unescape()`

### DIFF
--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, unescape as unescapeString } from 'lodash';
+import { get } from 'lodash';
 import removeAccents from 'remove-accents';
 
 /**
@@ -93,7 +93,7 @@ export function PageAttributesParent() {
 				{
 					value: treeNode.id,
 					label:
-						'— '.repeat( level ) + unescapeString( treeNode.name ),
+						'— '.repeat( level ) + decodeEntities( treeNode.name ),
 					rawName: treeNode.name,
 				},
 				...getOptionsFromTree( treeNode.children || [], level + 1 ),


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.unescape()` from the `PageAttributesParent` component. There is just a single use in that component and conversion is pretty straightforward. 

Similar to #47561 and #47562.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing `_.unescape()` with `decodeEntities()` from `@wordpress/html-entities`. It's already being used in that component.

## Testing Instructions

* Insert a page with the title `Test <>&nbsp; Test`.
* Insert another page with any title.
* While editing the second page, go to set its parent in the Sidebar, in the Page Attributes section.
* Verify the title of the page appears properly in the list and after selection: `Test <>  Test`
* Verify all checks are still green. 