### PR TITLE
Lodash: Refactor `HierarchicalTermSelector` away from `_.unescape()`

### DIFF
--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, unescape as unescapeString } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -20,6 +20,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useDebounce } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
 import { speak } from '@wordpress/a11y';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -365,7 +366,7 @@ export function HierarchicalTermSelector( { slug } ) {
 							const termId = parseInt( term.id, 10 );
 							onChange( termId );
 						} }
-						label={ unescapeString( term.name ) }
+						label={ decodeEntities( term.name ) }
 					/>
 					{ !! term.children.length && (
 						<div className="editor-post-taxonomies__hierarchical-terms-subchoices">


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.unescape()` from the `HierarchicalTermSelector` component. There is just a single use in that component and conversion is pretty straightforward. 

Similar to #47561.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing `_.unescape()` with `decodeEntities()` from `@wordpress/html-entities`.

This change also introduces a fix. `unescape()` does not escape `&nbsp;` and will render it as-is. So in the current version of the code, if you create a category with `&nbsp;` in it, that `&nbsp;` will be rendered as-is in the list of categories. I believe that's not desired behavior, and that's confirmed by the fact that when editing a category in the admin, the `&nbsp;` in category titles is converted to a simple space. 

## Testing Instructions

* Go to `/wp-admin/edit-tags.php?taxonomy=category`
* Create a category with the name `test > <  &nbsp; test`.
* A category with the name `test > <    test` will be created.
* Try editing it in place - you'll see the `&nbsp;` is replaced with a regular space. 
* Go to the post editor to edit any post.
* Expand "Categories" in the Post settings sidebar.
* Verify the category appears properly next to the checkbox: `Test <>  Test`
* Verify all checks are still green. 