### PR TITLE
Block Library: Decode entities in page list item title

### DIFF
--- a/packages/block-library/src/page-list-item/edit.js
+++ b/packages/block-library/src/page-list-item/edit.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -67,7 +68,7 @@ export default function PageListItemEdit( { context, attributes } ) {
 						className="wp-block-navigation-item__content wp-block-navigation-submenu__toggle"
 						aria-expanded="false"
 					>
-						{ label }
+						{ decodeEntities( label ) }
 					</button>
 					<span className="wp-block-page-list__submenu-icon wp-block-navigation__submenu-icon">
 						<ItemSubmenuIcon />
@@ -80,7 +81,7 @@ export default function PageListItemEdit( { context, attributes } ) {
 					} ) }
 					href={ link }
 				>
-					{ label }
+					{ decodeEntities( label ) }
 				</a>
 			) }
 			{ hasChildren && (


### PR DESCRIPTION
## What?
While working on #47570, I noticed that we're not decoding the entities in page titles. This PR addresses that.

## Why?
Some HTML entities might appear odd in the page list block:

![Screenshot 2023-01-30 at 18 11 41](https://user-images.githubusercontent.com/8436925/215531210-07b33795-0b09-4644-be0e-f02324ee24b4.png)

The first block is a customized Navigation block, and the second one is a Navigation that renders as a Page List block. 

You can see how in the Page List block, there's a title containing `&nbsp;` that is properly rendered as a space in the first block.

## How?
We're escaping entities in the page list item, just like in #47570.

## Testing Instructions
* Insert a page with the title `Test <>&nbsp; Test`.
* Insert a `Page List` block.
* Verify the page title appears properly while editing the menu: `Test <>  Test`, without the `&nbsp;`.
* Verify all checks are still green. 
