### PR TITLE
Lodash: Refactor flat term selection away from `_.unescape()`

### DIFF
--- a/packages/editor/src/utils/terms.js
+++ b/packages/editor/src/utils/terms.js
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { groupBy, unescape as lodashUnescapeString } from 'lodash';
+import { groupBy } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Returns terms in a tree form.
@@ -41,7 +46,7 @@ export function buildTermsTree( flatTerms ) {
 
 // Lodash unescape function handles &#39; but not &#039; which may be return in some API requests.
 export const unescapeString = ( arg ) => {
-	return lodashUnescapeString( arg.replace( '&#039;', "'" ) );
+	return decodeEntities( arg );
 };
 
 /**

--- a/packages/editor/src/utils/terms.js
+++ b/packages/editor/src/utils/terms.js
@@ -44,7 +44,6 @@ export function buildTermsTree( flatTerms ) {
 	return fillWithChildren( termsByParent[ '0' ] || [] );
 }
 
-// Lodash unescape function handles &#39; but not &#039; which may be return in some API requests.
 export const unescapeString = ( arg ) => {
 	return decodeEntities( arg );
 };


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.unescape()` from the flat term selection interface. There is just a single use in that component and conversion is pretty straightforward. 

Similar to #47561.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing `_.unescape()` with `decodeEntities()` from `@wordpress/html-entities`.

This allows us to simplify the code because `decodeEntities()` will decode `&#039;` while Lodash's `_.unescape()` won't.

## Testing Instructions

* Go to `/wp-admin/edit-tags.php?taxonomy=post_tag`
* Create a tag with the name `test >&#039;<  &nbsp; test`.
* A tag with the name `test >'<   test` will be created.
* Try editing it in place - you'll see the `&nbsp;` is replaced with a regular space. 
* Go to the post editor to edit any post.
* Expand "Tags" in the Post settings sidebar.
* Verify the tag appears properly when selected, and when suggested: `test >'<   test`.
* Verify all checks are still green. 