### PR TITLE
Remove endless spinned for removed navigations

### DIFF
--- a/packages/block-library/src/navigation/edit/deleted-navigation-warning.js
+++ b/packages/block-library/src/navigation/edit/deleted-navigation-warning.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { Warning } from '@wordpress/block-editor';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+function DeletedNavigationWarning( { onCreateNew } ) {
+	return (
+		<Warning>
+			{ __( 'Navigation menu has been deleted or is unavailable. ' ) }
+			<Button onClick={ onCreateNew } variant="link">
+				{ __( 'Create a new menu?' ) }
+			</Button>
+		</Warning>
+	);
+}
+
+export default DeletedNavigationWarning;

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -67,6 +67,7 @@ import { useInnerBlocks } from './use-inner-blocks';
 import { detectColors } from './utils';
 import ManageMenusButton from './manage-menus-button';
 import MenuInspectorControls from './menu-inspector-controls';
+import DeletedNavigationWarning from './deleted-navigation-warning';
 
 function Navigation( {
 	attributes,
@@ -777,17 +778,9 @@ function Navigation( {
 					onSelectNavigationMenu={ onSelectNavigationMenu }
 					isLoading={ isLoading }
 				/>
-				<Warning>
-					{ __(
-						'Navigation menu has been deleted or is unavailable. '
-					) }
-					<Button
-						onClick={ createUntitledEmptyNavigationMenu }
-						variant="link"
-					>
-						{ __( 'Create a new menu?' ) }
-					</Button>
-				</Warning>
+				<DeletedNavigationWarning
+					onCreateNew={ createUntitledEmptyNavigationMenu }
+				/>
 			</TagName>
 		);
 	}

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -5,7 +5,6 @@ import {
 	experiments as blockEditorExperiments,
 	InspectorControls,
 	store as blockEditorStore,
-	Warning,
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -23,6 +22,7 @@ import ManageMenusButton from './manage-menus-button';
 import NavigationMenuSelector from './navigation-menu-selector';
 import { LeafMoreMenu } from '../leaf-more-menu';
 import { unlock } from '../../experiments';
+import DeletedNavigationWarning from './deleted-navigation-warning';
 
 /* translators: %s: The name of a menu. */
 const actionLabel = __( "Switch to '%s'" );
@@ -32,6 +32,7 @@ const ExperimentMainContent = ( {
 	currentMenuId,
 	isLoading,
 	isNavigationMenuMissing,
+	onCreateNew,
 } ) => {
 	const { __experimentalOffCanvasEditor: OffCanvasEditor } = unlock(
 		blockEditorExperiments
@@ -51,11 +52,7 @@ const ExperimentMainContent = ( {
 	}
 
 	if ( isNavigationMenuMissing ) {
-		return (
-			<Warning>
-				{ __( 'Navigation menu has been deleted or is unavailable. ' ) }
-			</Warning>
-		);
+		return <DeletedNavigationWarning onCreateNew={ onCreateNew } />;
 	}
 
 	if ( isLoading ) {

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -5,6 +5,7 @@ import {
 	experiments as blockEditorExperiments,
 	InspectorControls,
 	store as blockEditorStore,
+	Warning,
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -47,6 +48,14 @@ const ExperimentMainContent = ( {
 
 	if ( currentMenuId && isNavigationMenuMissing ) {
 		return <p>{ __( 'Select or create a menu' ) }</p>;
+	}
+
+	if ( isNavigationMenuMissing ) {
+		return (
+			<Warning>
+				{ __( 'Navigation menu has been deleted or is unavailable. ' ) }
+			</Warning>
+		);
 	}
 
 	if ( isLoading ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds a copy of the warning shown in the canvas to the off canvas area for when the navigation post that a navigation block points to has been deleted.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because now there is a spinner that never goes away.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Copy the same warning component in the block inspector.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a navigation block
2. Create a new navigation
3. Add some links
4. Save
5. Go to settings > advanced in the block's inspector
6. Delete the navigation
7. Notice the canvas shows a warning
8. Select the block 
9. Select the list tab in the block's inspector
10. Notice the panel shows a warning

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="1344" alt="Screenshot 2023-01-30 at 19 48 55" src="https://user-images.githubusercontent.com/107534/215554562-1f3c85e5-b5c4-462c-9a52-acd5f7e1690c.png">

