### PR TITLE
Navigation: Remove the Gutenberg plugin check

### DIFF
--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -18,7 +18,6 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import ManageMenusButton from './manage-menus-button';
 import NavigationMenuSelector from './navigation-menu-selector';
 import { LeafMoreMenu } from '../leaf-more-menu';
 import { unlock } from '../../experiments';
@@ -26,7 +25,7 @@ import { unlock } from '../../experiments';
 /* translators: %s: The name of a menu. */
 const actionLabel = __( "Switch to '%s'" );
 
-const ExperimentMainContent = ( {
+const MainContent = ( {
 	clientId,
 	currentMenuId,
 	isLoading,
@@ -63,84 +62,47 @@ const ExperimentMainContent = ( {
 	);
 };
 
-const ExperimentControls = ( props ) => {
-	const {
-		createNavigationMenuIsSuccess,
-		createNavigationMenuIsError,
-		currentMenuId = null,
-		onCreateNew,
-		onSelectClassicMenu,
-		onSelectNavigationMenu,
-		isManageMenusButtonDisabled,
-	} = props;
-
-	return (
-		<>
-			<HStack className="wp-block-navigation-off-canvas-editor__header">
-				<Heading
-					className="wp-block-navigation-off-canvas-editor__title"
-					level={ 2 }
-				>
-					{ __( 'Menu' ) }
-				</Heading>
-				<NavigationMenuSelector
-					currentMenuId={ currentMenuId }
-					onSelectClassicMenu={ onSelectClassicMenu }
-					onSelectNavigationMenu={ onSelectNavigationMenu }
-					onCreateNew={ onCreateNew }
-					createNavigationMenuIsSuccess={
-						createNavigationMenuIsSuccess
-					}
-					createNavigationMenuIsError={ createNavigationMenuIsError }
-					actionLabel={ actionLabel }
-					isManageMenusButtonDisabled={ isManageMenusButtonDisabled }
-				/>
-			</HStack>
-			<ExperimentMainContent { ...props } />
-		</>
-	);
-};
-
-const DefaultControls = ( props ) => {
-	const {
-		createNavigationMenuIsSuccess,
-		createNavigationMenuIsError,
-		currentMenuId = null,
-		isManageMenusButtonDisabled,
-		onCreateNew,
-		onSelectClassicMenu,
-		onSelectNavigationMenu,
-	} = props;
-
-	return (
-		<>
-			<NavigationMenuSelector
-				currentMenuId={ currentMenuId }
-				onSelectClassicMenu={ onSelectClassicMenu }
-				onSelectNavigationMenu={ onSelectNavigationMenu }
-				onCreateNew={ onCreateNew }
-				createNavigationMenuIsSuccess={ createNavigationMenuIsSuccess }
-				createNavigationMenuIsError={ createNavigationMenuIsError }
-				actionLabel={ actionLabel }
-				isManageMenusButtonDisabled={ isManageMenusButtonDisabled }
-			/>
-			<ManageMenusButton disabled={ isManageMenusButtonDisabled } />
-		</>
-	);
-};
-
 const MenuInspectorControls = ( props ) => {
-	// Show the OffCanvasEditor controls if we're in the Gutenberg plugin. Previously used isOffCanvasNavigationEditorEnabled.
+	const {
+		createNavigationMenuIsSuccess,
+		createNavigationMenuIsError,
+		currentMenuId = null,
+		onCreateNew,
+		onSelectClassicMenu,
+		onSelectNavigationMenu,
+		isManageMenusButtonDisabled,
+	} = props;
+
 	return (
 		<InspectorControls group="list">
 			<PanelBody
 				title={ process.env.IS_GUTENBERG_PLUGIN ? null : __( 'Menu' ) }
 			>
-				{ process.env.IS_GUTENBERG_PLUGIN ? (
-					<ExperimentControls { ...props } />
-				) : (
-					<DefaultControls { ...props } />
-				) }
+				<HStack className="wp-block-navigation-off-canvas-editor__header">
+					<Heading
+						className="wp-block-navigation-off-canvas-editor__title"
+						level={ 2 }
+					>
+						{ __( 'Menu' ) }
+					</Heading>
+					<NavigationMenuSelector
+						currentMenuId={ currentMenuId }
+						onSelectClassicMenu={ onSelectClassicMenu }
+						onSelectNavigationMenu={ onSelectNavigationMenu }
+						onCreateNew={ onCreateNew }
+						createNavigationMenuIsSuccess={
+							createNavigationMenuIsSuccess
+						}
+						createNavigationMenuIsError={
+							createNavigationMenuIsError
+						}
+						actionLabel={ actionLabel }
+						isManageMenusButtonDisabled={
+							isManageMenusButtonDisabled
+						}
+					/>
+				</HStack>
+				<MainContent { ...props } />
 			</PanelBody>
 		</InspectorControls>
 	);

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -6,11 +6,9 @@ import {
 	MenuItem,
 	MenuItemsChoice,
 	DropdownMenu,
-	Button,
-	VisuallyHidden,
 } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
-import { Icon, chevronUp, chevronDown, moreVertical } from '@wordpress/icons';
+import { moreVertical } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useEffect, useMemo, useState } from '@wordpress/element';
@@ -29,14 +27,11 @@ function NavigationMenuSelector( {
 	actionLabel,
 	createNavigationMenuIsSuccess,
 	createNavigationMenuIsError,
-	toggleProps = {},
 } ) {
 	/* translators: %s: The name of a menu. */
 	const createActionLabel = __( "Create from '%s'" );
 
 	const [ selectorLabel, setSelectorLabel ] = useState( '' );
-	const [ isPressed, setIsPressed ] = useState( false );
-	const [ enableOptions, setEnableOptions ] = useState( false );
 	const [ isCreatingMenu, setIsCreatingMenu ] = useState( false );
 
 	actionLabel = actionLabel || createActionLabel;
@@ -57,11 +52,6 @@ function NavigationMenuSelector( {
 		'title'
 	);
 
-	const shouldEnableMenuSelector =
-		( canSwitchNavigationMenu || canUserCreateNavigationMenu ) &&
-		hasResolvedNavigationMenus &&
-		! isCreatingMenu;
-
 	const menuChoices = useMemo( () => {
 		return (
 			navigationMenus?.map( ( { id, title }, index ) => {
@@ -75,7 +65,6 @@ function NavigationMenuSelector( {
 						/* translators: %s is the name of a navigation menu. */
 						sprintf( __( 'You are currently editing %s' ), label )
 					);
-					setEnableOptions( shouldEnableMenuSelector );
 				}
 				return {
 					value: id,
@@ -108,7 +97,6 @@ function NavigationMenuSelector( {
 			setSelectorLabel( __( 'Loading …' ) );
 		} else if ( noMenuSelected || noBlockMenus || menuUnavailable ) {
 			setSelectorLabel( __( 'Choose a Navigation menu' ) );
-			setEnableOptions( shouldEnableMenuSelector );
 		}
 
 		if (
@@ -125,43 +113,11 @@ function NavigationMenuSelector( {
 		isNavigationMenuResolved,
 	] );
 
-	toggleProps = {
-		...toggleProps,
-		className: 'wp-block-navigation__navigation-selector-button',
-		children: (
-			<>
-				<VisuallyHidden as="span">
-					{ __( 'Select Menu' ) }
-				</VisuallyHidden>
-				<Icon
-					icon={ isPressed ? chevronUp : chevronDown }
-					className="wp-block-navigation__navigation-selector-button__icon"
-				/>
-			</>
-		),
-		isBusy: ! enableOptions,
-		disabled: ! enableOptions,
-		__experimentalIsFocusable: true,
-		onClick: () => {
-			setIsPressed( ! isPressed );
-		},
-	};
-
 	const NavigationMenuSelectorDropdown = (
 		<DropdownMenu
-			className={
-				process.env.IS_GUTENBERG_PLUGIN // Previously isOffCanvasNavigationEditorEnabled
-					? ''
-					: 'wp-block-navigation__navigation-selector'
-			}
 			label={ selectorLabel }
-			text={ process.env.IS_GUTENBERG_PLUGIN ? '' : selectorLabel } // Previously isOffCanvasNavigationEditorEnabled
-			icon={ process.env.IS_GUTENBERG_PLUGIN ? moreVertical : null } // Previously isOffCanvasNavigationEditorEnabled
-			toggleProps={
-				process.env.IS_GUTENBERG_PLUGIN
-					? { isSmall: true }
-					: toggleProps // Previously isOffCanvasNavigationEditorEnabled
-			}
+			icon={ moreVertical }
+			toggleProps={ { isSmall: true } }
 		>
 			{ ( { onClose } ) => (
 				<>
@@ -186,7 +142,6 @@ function NavigationMenuSelector( {
 											setSelectorLabel(
 												__( 'Loading …' )
 											);
-											setEnableOptions( false );
 											onSelectClassicMenu( menu );
 											onClose();
 										} }
@@ -211,7 +166,6 @@ function NavigationMenuSelector( {
 									onCreateNew();
 									setIsCreatingMenu( true );
 									setSelectorLabel( __( 'Loading …' ) );
-									setEnableOptions( false );
 								} }
 							>
 								{ __( 'Create new menu' ) }
@@ -222,30 +176,6 @@ function NavigationMenuSelector( {
 			) }
 		</DropdownMenu>
 	);
-
-	const NavigationMenuSelectorButton = (
-		<Button
-			className="wp-block-navigation__navigation-selector-button--createnew"
-			isBusy={ ! enableOptions }
-			disabled={ ! enableOptions }
-			__experimentalIsFocusable
-			onClick={ () => {
-				onCreateNew();
-				setIsCreatingMenu( true );
-				setSelectorLabel( __( 'Loading …' ) );
-				setEnableOptions( false );
-			} }
-		>
-			{ __( 'Create new menu' ) }
-		</Button>
-	);
-
-	if ( ! hasNavigationMenus && ! hasClassicMenus ) {
-		if ( ! process.env.IS_GUTENBERG_PLUGIN ) {
-			// This has to be in it's own conditional so it is removed by dead code elimination. Previously used isOffCanvasNavigationEditorEnabled.
-			return NavigationMenuSelectorButton;
-		}
-	}
 
 	return NavigationMenuSelectorDropdown;
 }


### PR DESCRIPTION
## What?
Now that this component is marked as an experiment (https://github.com/WordPress/gutenberg/pull/47465), we can remove the IS_GUTENBERG_PLUGIN check from this code.

## Why?
This will allow the experimental component to be part of the 6.2 release without risking other developers using it.

## How?
Just removes the IS_GUTENBERG_PLUGIN conditionals.

## Testing Instructions
- Add a navigation block to a new post
- Open the inspector controls for the block
- Confirm that you see the list view in the inspector controls

### Testing Instructions for Keyboard
As above


