### PR TITLE
Add layout child sizing to Navigation block

### DIFF
--- a/packages/block-editor/src/hooks/child-layout.js
+++ b/packages/block-editor/src/hooks/child-layout.js
@@ -135,9 +135,13 @@ export function hasChildLayoutSupport( {
 } ) {
 	const {
 		type: parentLayoutType = 'default',
+		default: { type: defaultParentLayoutType = 'default' } = {},
 		allowSizingOnChildren = false,
 	} = parentLayout;
-	const support = parentLayoutType === 'flex' && allowSizingOnChildren;
+
+	const support =
+		( defaultParentLayoutType === 'flex' || parentLayoutType === 'flex' ) &&
+		allowSizingOnChildren;
 
 	return support;
 }

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -119,6 +119,7 @@
 			"allowSwitching": false,
 			"allowInheriting": false,
 			"allowVerticalAlignment": false,
+			"allowSizingOnChildren": true,
 			"default": {
 				"type": "flex"
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Allows adding custom sizes to Navigation block children, and fixes a bug in `hasChildLayoutSupport` that wasn't taking into account the possible shapes of the parent layout object.

~Note: this PR depends on #47477 in order to work correctly, because currently the Nav block edit function is passing the [wrong layout config](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/navigation/edit/inner-blocks.js#L33-L34) to its inner blocks.~

**Edit: now that #47477 is merged and I've rebased this branch, this PR can be tested as-is.**

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

~Because of the dependency on #47477, is probably best to check out that branch and then apply this PR as a diff on top of it. Once it's built locally, you can:~

1. Add a Nav block to a post or template;
2. Populate it with several child blocks;
3. Check that its child blocks display a Dimensions section in the sidebar, under "styles" if it's a tabbed sidebar;
4. Click the "+" button next to Dimensions to reveal a "Width"  control;
5. Try the control with different settings and check that they all work.

Note: for vertical Navs, the children will display a "Height" control, but in order for the "Fill" option to work the Nav block will need to have a fixed height value. Given the Nav block doesn't seem to have a min-height control available yet, the only way to do this is to stick the Nav inside a Row block with a sibling that is taller than itself, and set the Row vertical alignment (in the block toolbar) to "stretch".


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Nav item with fixed size in px:

<img width="924" alt="Screenshot 2023-01-31 at 10 35 03 am" src="https://user-images.githubusercontent.com/8096000/215621026-bdc57163-6725-447b-a6e7-1497915aae5e.png">
