### PR TITLE
Global styles: Reselect blocks after pasting styles 

### DIFF
--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -135,7 +135,7 @@ export default function BlockActions( {
 		async onPasteStyles() {
 			await pasteStyles( blocks );
 
-			// Need to reselect the block(s) in order for optional tool panel control changes to register
+			// Need to reselect the block(s) in order for optional tool panel control changes to register.
 			clearSelectedBlock();
 			multiSelect(
 				blocks[ 0 ].clientId,

--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -58,6 +58,8 @@ export default function BlockActions( {
 		setBlockMovingClientId,
 		setNavigationMode,
 		selectBlock,
+		clearSelectedBlock,
+		multiSelect,
 	} = useDispatch( blockEditorStore );
 
 	const notifyCopy = useNotifyCopy();
@@ -132,6 +134,13 @@ export default function BlockActions( {
 		},
 		async onPasteStyles() {
 			await pasteStyles( blocks );
+
+			// Need to reselect the block(s) in order for optional tool panel control changes to register
+			clearSelectedBlock();
+			multiSelect(
+				blocks[ 0 ].clientId,
+				blocks[ blocks.length - 1 ].clientId
+			);
 		},
 	} );
 }


### PR DESCRIPTION
## What?
Reselect blocks on which styles were pasted.

## Why?
In order to ensure that any optional tools panels controls are reloaded to show any related styles that have just been pasted.

Fixes: #47368

## How?
First removes the block selection and then reselects the relevant blocks.

## Testing Instructions

- Add a Paragraph block and add padding and margin styles
- Select the `Copy styles` option from the block actions menu
- Add a new paragraph block and use the `Paste styles` option from the block actions menu
- Check that the new padding and margin settings show in the inspector panel
- Repeat the above but select multiple blocks before pasting the styles (but note that when you paste the styles you will encounter [this issue ](https://github.com/WordPress/gutenberg/issues/47589) which is unrelated to this PR)

## Screenshots or screencast 

Before:

https://user-images.githubusercontent.com/3629020/215655277-b38016fc-e795-4039-9246-1b6a990aff26.mp4

After:

https://user-images.githubusercontent.com/3629020/215655305-1589e5a0-3941-4abc-82cf-e7dc91e0dd06.mp4



