### PR TITLE
Navigation: Remove filters disabling tabs for link and submenu

### DIFF
--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -373,38 +373,6 @@ function register_block_core_navigation_link() {
 add_action( 'init', 'register_block_core_navigation_link' );
 
 /**
- * Disables the display of block inspector tabs for the Navigation Link block.
- *
- * This is only a temporary measure until we have a TabPanel and mechanism that
- * will allow the Navigation Link to programmatically select a tab when edited
- * via a specific context.
- *
- * See:
- * - https://github.com/WordPress/gutenberg/issues/45951
- * - https://github.com/WordPress/gutenberg/pull/46321
- * - https://github.com/WordPress/gutenberg/pull/46271
- *
- * @param array $settings Default editor settings.
- * @return array Filtered editor settings.
- */
-function gutenberg_disable_tabs_for_navigation_link_block( $settings ) {
-	$current_tab_settings = _wp_array_get(
-		$settings,
-		array( 'blockInspectorTabs' ),
-		array()
-	);
-
-	$settings['blockInspectorTabs'] = array_merge(
-		$current_tab_settings,
-		array( 'core/navigation-link' => false )
-	);
-
-	return $settings;
-}
-
-add_filter( 'block_editor_settings_all', 'gutenberg_disable_tabs_for_navigation_link_block' );
-
-/**
  * Enables animation of the block inspector for the Navigation Link block.
  *
  * See:

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -291,38 +291,6 @@ function register_block_core_navigation_submenu() {
 add_action( 'init', 'register_block_core_navigation_submenu' );
 
 /**
- * Disables display of block inspector tabs for the Navigation Submenu block.
- *
- * This is only a temporary measure until we have a TabPanel and mechanism that
- * will allow the Navigation Submenu to programmatically select a tab when
- * edited via a specific context.
- *
- * See:
- * - https://github.com/WordPress/gutenberg/issues/45951
- * - https://github.com/WordPress/gutenberg/pull/46321
- * - https://github.com/WordPress/gutenberg/pull/46271
- *
- * @param array $settings Default editor settings.
- * @return array Filtered editor settings.
- */
-function gutenberg_disable_tabs_for_navigation_submenu_block( $settings ) {
-	$current_tab_settings = _wp_array_get(
-		$settings,
-		array( 'blockInspectorTabs' ),
-		array()
-	);
-
-	$settings['blockInspectorTabs'] = array_merge(
-		$current_tab_settings,
-		array( 'core/navigation-submenu' => false )
-	);
-
-	return $settings;
-}
-
-add_filter( 'block_editor_settings_all', 'gutenberg_disable_tabs_for_navigation_submenu_block' );
-
-/**
  * Enables animation of the block inspector for the Navigation Submenu block.
  *
  * See:


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/47575
- https://github.com/WordPress/gutenberg/pull/47592

## What?

Removes the filters for Navigation Link & Submenu blocks that disable block inspector tab display.

## Why?

Once https://github.com/WordPress/gutenberg/pull/47592 lands, the settings tab will be the default tab. It was the need to display the settings tab by default when we couldn't programmatically change the tab selection that led to these filters being introduced.

## How?

Delete the filters disabling tabs from each block.

## Testing Instructions

1. Apply the changes from https://github.com/WordPress/gutenberg/pull/47592 as well as this PR.
2. Add a Navigation block containing a submenu and additional links.
3. Select the Navigation block and click the edit button beside the submenu within the Nav block's List View tab.
4. The Navigation Submenu block should not display tabs, as it has no controls for the Styles tab.
5. Navigate back to the Navigation block. This time click the edit icon beside one of the Navigation Link blocks in the List View tab.
6. Ensure the Navigation Link block shows both the Settings and Styles tabs. Settings should be selected by default.

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/215677067-85640840-3954-4e1d-8897-92b9a31a48e6.mp4


