### PR TITLE
Shuffle `contentOnly` pattern blocks

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -456,7 +456,7 @@ Show a block pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trun
 -	**Name:** core/pattern
 -	**Category:** theme
 -	**Supports:** ~~html~~, ~~inserter~~
--	**Attributes:** slug
+-	**Attributes:** slug, templateLock
 
 ## Post Author
 

--- a/packages/block-library/src/pattern/block.json
+++ b/packages/block-library/src/pattern/block.json
@@ -13,6 +13,10 @@
 	"attributes": {
 		"slug": {
 			"type": "string"
+		},
+		"templateLock": {
+			"type": [ "string", "boolean" ],
+			"enum": [ "all", "insert", "contentOnly", false ]
 		}
 	}
 }

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -69,7 +69,9 @@ const PatternEdit = ( { attributes, clientId, setAttributes } ) => {
 	const innerBlockProps = useInnerBlocksProps( blockProps, {
 		templateLock: attributes.templateLock,
 		onInput: () => {},
-		onChange: () => {},
+		onChange: ( blocks ) => {
+			replaceBlocks( clientId, blocks );
+		},
 		value: selectedPattern?.blocks ?? [],
 	} );
 

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -6,16 +6,43 @@ import { useEffect } from '@wordpress/element';
 import {
 	store as blockEditorStore,
 	useBlockProps,
+	useInnerBlocksProps,
+	BlockControls,
 } from '@wordpress/block-editor';
+import { ToolbarButton } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
-const PatternEdit = ( { attributes, clientId } ) => {
-	const selectedPattern = useSelect(
-		( select ) =>
-			select( blockEditorStore ).__experimentalGetParsedPattern(
-				attributes.slug
-			),
-		[ attributes.slug ]
-	);
+const PatternEdit = ( { attributes, clientId, setAttributes } ) => {
+	const { selectedPattern, isContentLocked, patternsInSameCategories } =
+		useSelect(
+			( select ) => {
+				const {
+					__experimentalGetParsedPattern: getParsedPattern,
+					__unstableGetContentLockingParent: getContentLockingParent,
+					__experimentalGetAllowedPatterns: getAllowedPatterns,
+				} = select( blockEditorStore );
+				const _selectedPattern = getParsedPattern( attributes.slug );
+				return {
+					selectedPattern: _selectedPattern,
+					isContentLocked:
+						! getContentLockingParent( clientId ) &&
+						attributes.templateLock === 'contentOnly',
+					patternsInSameCategories: getAllowedPatterns().filter(
+						( pattern ) =>
+							pattern.name !== _selectedPattern.name &&
+							pattern.categories?.length > 0 &&
+							pattern.categories?.some(
+								( category ) =>
+									_selectedPattern.categories?.length > 0 &&
+									_selectedPattern.categories?.includes(
+										category
+									)
+							)
+					),
+				};
+			},
+			[ attributes.slug, attributes.templateLock, clientId ]
+		);
 
 	const { replaceBlocks, __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
@@ -25,7 +52,7 @@ const PatternEdit = ( { attributes, clientId } ) => {
 	// This change won't be saved.
 	// It will continue to pull from the pattern file unless changes are made to its respective template part.
 	useEffect( () => {
-		if ( selectedPattern?.blocks ) {
+		if ( ! isContentLocked && selectedPattern?.blocks ) {
 			// We batch updates to block list settings to avoid triggering cascading renders
 			// for each container block included in a tree and optimize initial render.
 			// Since the above uses microtasks, we need to use a microtask here as well,
@@ -38,9 +65,39 @@ const PatternEdit = ( { attributes, clientId } ) => {
 		}
 	}, [ clientId, selectedPattern?.blocks ] );
 
-	const props = useBlockProps();
+	const blockProps = useBlockProps();
+	const innerBlockProps = useInnerBlocksProps( blockProps, {
+		templateLock: attributes.templateLock,
+		onInput: () => {},
+		onChange: () => {},
+		value: selectedPattern?.blocks ?? [],
+	} );
 
-	return <div { ...props } />;
+	const canShuffle = isContentLocked && patternsInSameCategories.length > 0;
+
+	function shuffle() {
+		const randomIndex = Math.floor(
+			// We explicitly want the randomness here for shuffling.
+			// eslint-disable-next-line no-restricted-syntax
+			Math.random() * patternsInSameCategories.length
+		);
+		const nextPattern = patternsInSameCategories[ randomIndex ];
+
+		setAttributes( { slug: nextPattern.name } );
+	}
+
+	return (
+		<>
+			<div { ...( canShuffle ? innerBlockProps : blockProps ) } />
+			{ canShuffle && (
+				<BlockControls group="other">
+					<ToolbarButton onClick={ shuffle }>
+						{ __( 'Shuffle' ) }
+					</ToolbarButton>
+				</BlockControls>
+			) }
+		</>
+	);
 };
 
 export default PatternEdit;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR doing? -->
Alternative to #45618. This PR adds `templateLock` to the pattern block, and allows shuffling patterns for `contentOnly` pattern blocks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See https://github.com/WordPress/gutenberg/issues/44581.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR does a couple of things:

1. Add `templateLock` to the pattern block. There is currently no way to edit this attribute in the user interface though, one will need to go to the code editor to manually add the `"templateLock": "contentOnly"` attribute to the pattern block.
2. Add a "Shuffle" button (name TBD) to the block toolbar of the pattern block with `contentOnly`. The logic looks for all the patterns with the same `categories` and replaces the full content of the pattern.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Go to the Site Editor
3. Select a template part like the footer
4. Go to the code editor before it fully reloads, and add `"templateLock": "contentOnly"` to the pattern block. (Reload the page if there isn't a pattern block)
5. Exit code editor
6. Select the pattern block. There should be a `Shuffle` button available in the block toolbar (if there are matched candidates to shuffle to).
7. Clicking on the "Shuffle" button should shuffle the pattern to another pattern with the same categories.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Go to the Site Editor
2. Select a template part like the footer
3. Go to the code editor (<kbd>Shift</kbd>+<kbd>Option</kbd>+<kbd>Command</kbd>+<kbd>M</kbd> on macOS) before it fully reloads, and add `"templateLock": "contentOnly"` to the pattern block. (Reload the page if there isn't a pattern block)
4. Exit code editor (<kbd>Shift</kbd>+<kbd>Option</kbd>+<kbd>Command</kbd>+<kbd>M</kbd> on macOS)
5. Select the pattern block. Press <kbd>Shift</kbd>+<kbd>Tab</kbd> to move focus to the block toolbar. Press <kbd>ArrowRight</kbd> to move focus on the "Shuffle" button.
6. Hit <kbd>Enter</kbd> to shuffle the pattern to another one with the same categories.

## Screenshots or screencast <!-- if applicable -->
https://user-images.githubusercontent.com/7753001/215688892-fb1df7b4-a005-42f9-9d9a-6cac82932b18.mp4