### PR TITLE
Remove lodash mapKeys usage

### DIFF
--- a/bin/log-perormance-results.js
+++ b/bin/log-perormance-results.js
@@ -6,7 +6,6 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 const https = require( 'https' );
-const { mapKeys } = require( 'lodash' );
 const [ token, branch, hash, baseHash, timestamp ] = process.argv.slice( 2 );
 
 const resultsFiles = [
@@ -39,20 +38,27 @@ const data = new TextEncoder().encode(
 		metrics: resultsFiles.reduce( ( result, { metricsPrefix }, index ) => {
 			return {
 				...result,
-				...mapKeys(
-					performanceResults[ index ][ hash ],
-					( _, key ) => metricsPrefix + key
+				...Object.keys( performanceResults[ index ][ hash ] ).reduce(
+					( accumulator, key ) => {
+						accumulator[ metricsPrefix + key ] =
+							performanceResults[ index ][ hash ][ key ];
+						return accumulator;
+					},
+					{}
 				),
 			};
-		}, {} ),
+		} ),
 		baseMetrics: resultsFiles.reduce(
 			( result, { metricsPrefix }, index ) => {
 				return {
 					...result,
-					...mapKeys(
-						performanceResults[ index ][ baseHash ],
-						( _, key ) => metricsPrefix + key
-					),
+					...Object.keys(
+						performanceResults[ index ][ baseHash ]
+					).reduce( ( accumulator, key ) => {
+						accumulator[ metricsPrefix + key ] =
+							performanceResults[ index ][ hash ][ key ];
+						return accumulator;
+					}, {} ),
 				};
 			},
 			{}

--- a/bin/log-perormance-results.js
+++ b/bin/log-perormance-results.js
@@ -38,13 +38,10 @@ const data = new TextEncoder().encode(
 		metrics: resultsFiles.reduce( ( result, { metricsPrefix }, index ) => {
 			return {
 				...result,
-				...Object.keys( performanceResults[ index ][ hash ] ).reduce(
-					( accumulator, key ) => {
-						accumulator[ metricsPrefix + key ] =
-							performanceResults[ index ][ hash ][ key ];
-						return accumulator;
-					},
-					{}
+				...Object.fromEntries(
+					Object.entries( performanceResults[ index ][ hash ] ).map(
+						( [ key, value ] ) => [ metricsPrefix + key, value ]
+					)
 				),
 			};
 		} ),
@@ -52,13 +49,14 @@ const data = new TextEncoder().encode(
 			( result, { metricsPrefix }, index ) => {
 				return {
 					...result,
-					...Object.keys(
-						performanceResults[ index ][ baseHash ]
-					).reduce( ( accumulator, key ) => {
-						accumulator[ metricsPrefix + key ] =
-							performanceResults[ index ][ hash ][ key ];
-						return accumulator;
-					}, {} ),
+					...Object.fromEntries(
+						Object.entries(
+							performanceResults[ index ][ baseHash ]
+						).map( ( [ key, value ] ) => [
+							metricsPrefix + key,
+							value,
+						] )
+					),
 				};
 			},
 			{}


### PR DESCRIPTION
Follow-up to #47442 to address this comment https://github.com/WordPress/gutenberg/pull/47442#pullrequestreview-1275050802

## What?

We're in a middle of an effort to remove lodash from our dependencies. This PR replaces mapKeys with a Object.keys + reduce 