### PR TITLE
Page List: Add extra safety around warnings.

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -84,15 +84,26 @@ function BlockContent( {
 		const parentPageDetails = pages.find(
 			( page ) => page.id === parentPageID
 		);
+
+		if ( parentPageDetails?.title?.rendered ) {
+			return (
+				<div { ...blockProps }>
+					<Warning>
+						{ sprintf(
+							// translators: %s: Page title.
+							__( 'Page List: "%s" page has no children.' ),
+							parentPageDetails.title.rendered
+						) }
+					</Warning>
+				</div>
+			);
+		}
+
 		return (
 			<div { ...blockProps }>
-				<Warning>
-					{ sprintf(
-						// translators: %s: Page title.
-						__( '"%s" page has no children.' ),
-						parentPageDetails.title.rendered
-					) }
-				</Warning>
+				<Notice status={ 'warning' } isDismissible={ false }>
+					{ __( 'Page List: Cannot retrieve Pages.' ) }
+				</Notice>
 			</div>
 		);
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
See https://github.com/WordPress/gutenberg/pull/46930#discussion_r1091596761.

It's possible to get the page list to throw an error when the user has a particular page structure as the code doesn't check if `parentPageDetails.title.rendered` is defined before attempting to access it.

## How?
The fix is to add some extra safety to the warning message.

I've also added an extra message, as otherwise the block renders completely empty.

## Testing Instructions
1. Ensure your site only has two published pages and make one the parent of the other
2. Make the parent page a draft
3. Add the page list to a post or template

This PR: A notice displays "Page List: Cannot retrieve Pages."
In trunk: The block throws an error.

## Screenshots or screencast <!-- if applicable -->
#### Before
![Screen Shot 2023-01-31 at 5 46 02 pm](https://user-images.githubusercontent.com/677833/215725404-2949ccc6-e16f-451c-8a55-6f1bf0ab80f6.png)

#### After
![Screen Shot 2023-01-31 at 5 45 36 pm](https://user-images.githubusercontent.com/677833/215725449-2c337675-3013-4c61-9dd5-7d674ef971a5.png)

