### PR TITLE
[RNMobile] Bump Android `minSdkVersion` to 24

### DIFF
--- a/packages/react-native-aztec/android/build.gradle
+++ b/packages/react-native-aztec/android/build.gradle
@@ -37,7 +37,7 @@ android {
     compileSdkVersion 31
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 24
         targetSdkVersion 31
     }
 

--- a/packages/react-native-bridge/android/react-native-bridge/build.gradle
+++ b/packages/react-native-bridge/android/react-native-bridge/build.gradle
@@ -17,7 +17,7 @@ android {
     compileSdkVersion 31
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 24
         targetSdkVersion 31
         buildConfigField "boolean", "SHOULD_ATTACH_JS_BUNDLE", willPublishReactNativeBridgeBinary.toString()
     }

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,6 +10,7 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
+-   [*] Bump Android `minSdkVersion` to 24 [#47604]
 
 ## 1.87.2
 -   [*] Add boolean contentStyle and clientId check to Column Edit InnerBlocks [#47234]

--- a/packages/react-native-editor/android/build.gradle
+++ b/packages/react-native-editor/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         gradlePluginVersion = '7.2.1'
         kotlinVersion = '1.5.32'
         buildToolsVersion = "31.0.0"
-        minSdkVersion = 21
+        minSdkVersion = 24
         compileSdkVersion = 31
         targetSdkVersion = 31
         supportLibVersion = '28.0.0'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Update Android `minSdkVersion` to match [the value set in WordPress-Android](https://github.com/wordpress-mobile/WordPress-Android/blob/7f19109c68368ec90ad68c2a091e6ab99cbf3ad4/build.gradle#L12) ([PR reference](https://github.com/wordpress-mobile/WordPress-Android/pull/15135)).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This change is part of an ongoing effort for updating the `minSdkVersion` to `24` on all libraries used in WordPress-Android.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update the value to `24` in all references of `minSdkVersion` in Gutenberg.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
This change should have no impact on the editor, so there are no specific areas that we'd need to test. It should be enough by smoke testing the demo app and check the app compiles successfully.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A