### PR TITLE
Extract the getSupportedStyles selector to the blocks store as a private selector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17400,6 +17400,7 @@
 				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/dom": "file:packages/dom",
 				"@wordpress/element": "file:packages/element",
+				"@wordpress/experiments": "file:packages/experiments",
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/html-entities": "file:packages/html-entities",
 				"@wordpress/i18n": "file:packages/i18n",
@@ -29582,7 +29583,7 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
 			"dev": true
 		},
 		"code-point-at": {

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -37,6 +37,7 @@
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",
 		"@wordpress/element": "file:../element",
+		"@wordpress/experiments": "file:../experiments",
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",

--- a/packages/blocks/src/api/raw-handling/test/utils.js
+++ b/packages/blocks/src/api/raw-handling/test/utils.js
@@ -4,46 +4,14 @@
 import deepFreeze from 'deep-freeze';
 
 /**
+ * WordPress dependencies
+ */
+import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
+
+/**
  * Internal dependencies
  */
 import { getBlockContentSchemaFromTransforms, isPlain } from '../utils';
-import { store as mockStore } from '../../../store';
-import { STORE_NAME as mockStoreName } from '../../../store/constants';
-
-jest.mock( '@wordpress/data', () => {
-	return {
-		select: jest.fn( ( store ) => {
-			switch ( store ) {
-				case [ mockStoreName ]:
-				case mockStore: {
-					return {
-						hasBlockSupport: ( blockName, supports ) => {
-							return (
-								blockName === 'core/paragraph' &&
-								supports === 'anchor'
-							);
-						},
-					};
-				}
-			}
-		} ),
-		combineReducers: () => {
-			const mock = jest.fn();
-			return mock;
-		},
-		createReduxStore: () => {
-			const mock = jest.fn();
-			return mock;
-		},
-		register: () => {
-			const mock = jest.fn();
-			return mock;
-		},
-		createRegistryControl() {
-			return jest.fn();
-		},
-	};
-} );
 
 describe( 'isPlain', () => {
 	it( 'should return true for plain text', () => {
@@ -65,6 +33,19 @@ describe( 'isPlain', () => {
 } );
 
 describe( 'getBlockContentSchema', () => {
+	beforeAll( () => {
+		registerBlockType( 'core/paragraph', {
+			title: 'Paragraph',
+			supports: {
+				anchor: true,
+			},
+		} );
+	} );
+
+	afterAll( () => {
+		unregisterBlockType( 'core/paragraph' );
+	} );
+
 	const myContentSchema = {
 		strong: {},
 		em: {},

--- a/packages/blocks/src/experiments.js
+++ b/packages/blocks/src/experiments.js
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/experiments';
+
+export const { lock, unlock } =
+	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'@wordpress/blocks'
+	);

--- a/packages/blocks/src/store/index.js
+++ b/packages/blocks/src/store/index.js
@@ -8,8 +8,10 @@ import { createReduxStore, register } from '@wordpress/data';
  */
 import reducer from './reducer';
 import * as selectors from './selectors';
+import * as privateSelectors from './private-selectors';
 import * as actions from './actions';
 import { STORE_NAME } from './constants';
+import { unlock } from '../experiments';
 
 /**
  * Store definition for the blocks namespace.
@@ -25,3 +27,4 @@ export const store = createReduxStore( STORE_NAME, {
 } );
 
 register( store );
+unlock( store ).registerPrivateSelectors( privateSelectors );

--- a/packages/blocks/src/store/private-selectors.js
+++ b/packages/blocks/src/store/private-selectors.js
@@ -30,8 +30,17 @@ const ROOT_BLOCK_SUPPORTS = [
 	'letterSpacing',
 ];
 
-function filterElementBlockSupports( blockSuppots, name, element ) {
-	return blockSuppots.filter( ( support ) => {
+/**
+ * Filters the list of supported styles for a given element.
+ *
+ * @param {string[]}         blockSupports list of supported styles.
+ * @param {string|undefined} name          block name.
+ * @param {string|undefined} element       element name.
+ *
+ * @return {string[]} filtered list of supported styles.
+ */
+function filterElementBlockSupports( blockSupports, name, element ) {
+	return blockSupports.filter( ( support ) => {
 		if ( support === 'fontSize' && element === 'heading' ) {
 			return false;
 		}
@@ -67,6 +76,9 @@ function filterElementBlockSupports( blockSuppots, name, element ) {
 	} );
 }
 
+/**
+ * Returns the list of supported styles for a given block name and element.
+ */
 export const getSupportedStyles = createSelector(
 	( state, name, element ) => {
 		if ( ! name ) {
@@ -121,7 +133,8 @@ export const getSupportedStyles = createSelector(
 						STYLE_PROPERTY[ styleName ].support
 					) !== false
 				) {
-					return supportKeys.push( styleName );
+					supportKeys.push( styleName );
+					return;
 				}
 			}
 
@@ -132,7 +145,7 @@ export const getSupportedStyles = createSelector(
 					false
 				)
 			) {
-				return supportKeys.push( styleName );
+				supportKeys.push( styleName );
 			}
 		} );
 

--- a/packages/blocks/src/store/private-selectors.js
+++ b/packages/blocks/src/store/private-selectors.js
@@ -1,0 +1,142 @@
+/**
+ * External dependencies
+ */
+import createSelector from 'rememo';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getBlockType } from './selectors';
+import { __EXPERIMENTAL_STYLE_PROPERTY as STYLE_PROPERTY } from '../api/constants';
+
+const ROOT_BLOCK_SUPPORTS = [
+	'background',
+	'backgroundColor',
+	'color',
+	'linkColor',
+	'buttonColor',
+	'fontFamily',
+	'fontSize',
+	'fontStyle',
+	'fontWeight',
+	'lineHeight',
+	'padding',
+	'contentSize',
+	'wideSize',
+	'blockGap',
+	'textDecoration',
+	'textTransform',
+	'letterSpacing',
+];
+
+function filterElementBlockSupports( blockSuppots, name, element ) {
+	return blockSuppots.filter( ( support ) => {
+		if ( support === 'fontSize' && element === 'heading' ) {
+			return false;
+		}
+
+		// This is only available for links
+		if ( support === 'textDecoration' && ! name && element !== 'link' ) {
+			return false;
+		}
+
+		// This is only available for heading
+		if (
+			support === 'textTransform' &&
+			! name &&
+			[ 'heading', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ].includes(
+				element
+			)
+		) {
+			return false;
+		}
+
+		// This is only available for headings
+		if (
+			support === 'letterSpacing' &&
+			! name &&
+			[ 'heading', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ].includes(
+				element
+			)
+		) {
+			return false;
+		}
+
+		return true;
+	} );
+}
+
+export const getSupportedStyles = createSelector(
+	( state, name, element ) => {
+		if ( ! name ) {
+			return filterElementBlockSupports(
+				ROOT_BLOCK_SUPPORTS,
+				name,
+				element
+			);
+		}
+
+		const blockType = getBlockType( state, name );
+
+		if ( ! blockType ) {
+			return [];
+		}
+
+		const supportKeys = [];
+
+		// Check for blockGap support.
+		// Block spacing support doesn't map directly to a single style property, so needs to be handled separately.
+		// Also, only allow `blockGap` support if serialization has not been skipped, to be sure global spacing can be applied.
+		if (
+			blockType?.supports?.spacing?.blockGap &&
+			blockType?.supports?.spacing?.__experimentalSkipSerialization !==
+				true &&
+			! blockType?.supports?.spacing?.__experimentalSkipSerialization?.some?.(
+				( spacingType ) => spacingType === 'blockGap'
+			)
+		) {
+			supportKeys.push( 'blockGap' );
+		}
+
+		// check for shadow support
+		if ( blockType?.supports?.shadow ) {
+			supportKeys.push( 'shadow' );
+		}
+
+		Object.keys( STYLE_PROPERTY ).forEach( ( styleName ) => {
+			if ( ! STYLE_PROPERTY[ styleName ].support ) {
+				return;
+			}
+
+			// Opting out means that, for certain support keys like background color,
+			// blocks have to explicitly set the support value false. If the key is
+			// unset, we still enable it.
+			if ( STYLE_PROPERTY[ styleName ].requiresOptOut ) {
+				if (
+					STYLE_PROPERTY[ styleName ].support[ 0 ] in
+						blockType.supports &&
+					get(
+						blockType.supports,
+						STYLE_PROPERTY[ styleName ].support
+					) !== false
+				) {
+					return supportKeys.push( styleName );
+				}
+			}
+
+			if (
+				get(
+					blockType.supports,
+					STYLE_PROPERTY[ styleName ].support,
+					false
+				)
+			) {
+				return supportKeys.push( styleName );
+			}
+		} );
+
+		return filterElementBlockSupports( supportKeys, name, element );
+	},
+	( state, name ) => [ state.blockTypes[ name ] ]
+);

--- a/packages/blocks/src/store/private-selectors.js
+++ b/packages/blocks/src/store/private-selectors.js
@@ -45,7 +45,7 @@ function filterElementBlockSupports( blockSuppots, name, element ) {
 		if (
 			support === 'textTransform' &&
 			! name &&
-			[ 'heading', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ].includes(
+			! [ 'heading', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ].includes(
 				element
 			)
 		) {
@@ -56,7 +56,7 @@ function filterElementBlockSupports( blockSuppots, name, element ) {
 		if (
 			support === 'letterSpacing' &&
 			! name &&
-			[ 'heading', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ].includes(
+			! [ 'heading', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ].includes(
 				element
 			)
 		) {

--- a/packages/blocks/src/store/test/private-selectors.js
+++ b/packages/blocks/src/store/test/private-selectors.js
@@ -1,0 +1,151 @@
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { getSupportedStyles } from '../private-selectors';
+
+const keyBlocksByName = ( blocks ) =>
+	blocks.reduce(
+		( result, block ) => ( { ...result, [ block.name ]: block } ),
+		{}
+	);
+
+describe( 'private selectors', () => {
+	describe( 'getSupportedStyles', () => {
+		const getState = ( blocks ) => {
+			return deepFreeze( {
+				blockTypes: keyBlocksByName( blocks ),
+			} );
+		};
+
+		it( 'return the list of globally supported panels (no block name)', () => {
+			const supports = getSupportedStyles( getState( [] ) );
+
+			expect( supports ).toEqual( [
+				'background',
+				'backgroundColor',
+				'color',
+				'linkColor',
+				'buttonColor',
+				'fontFamily',
+				'fontSize',
+				'fontStyle',
+				'fontWeight',
+				'lineHeight',
+				'padding',
+				'contentSize',
+				'wideSize',
+				'blockGap',
+			] );
+		} );
+
+		it( 'return the list of globally supported panels including link specific styles', () => {
+			const supports = getSupportedStyles( getState( [] ), null, 'link' );
+
+			expect( supports ).toEqual( [
+				'background',
+				'backgroundColor',
+				'color',
+				'linkColor',
+				'buttonColor',
+				'fontFamily',
+				'fontSize',
+				'fontStyle',
+				'fontWeight',
+				'lineHeight',
+				'padding',
+				'contentSize',
+				'wideSize',
+				'blockGap',
+				'textDecoration',
+			] );
+		} );
+
+		it( 'return the list of globally supported panels including heading specific styles', () => {
+			const supports = getSupportedStyles(
+				getState( [] ),
+				null,
+				'heading'
+			);
+
+			expect( supports ).toEqual( [
+				'background',
+				'backgroundColor',
+				'color',
+				'linkColor',
+				'buttonColor',
+				'fontFamily',
+				'fontStyle',
+				'fontWeight',
+				'lineHeight',
+				'padding',
+				'contentSize',
+				'wideSize',
+				'blockGap',
+				'textTransform',
+				'letterSpacing',
+			] );
+		} );
+
+		it( 'return an empty list for unknown blocks', () => {
+			const supports = getSupportedStyles(
+				getState( [] ),
+				'unkown/block'
+			);
+
+			expect( supports ).toEqual( [] );
+		} );
+
+		it( 'return empty by default for blocks without support keys', () => {
+			const supports = getSupportedStyles(
+				getState( [
+					{
+						name: 'core/example-block',
+						supports: {},
+					},
+				] ),
+				'core/example-block'
+			);
+
+			expect( supports ).toEqual( [] );
+		} );
+
+		it( 'return the allowed styles according to the blocks support keys', () => {
+			const supports = getSupportedStyles(
+				getState( [
+					{
+						name: 'core/example-block',
+						supports: {
+							typography: {
+								__experimentalFontFamily: true,
+								__experimentalFontStyle: true,
+								__experimentalFontWeight: true,
+								__experimentalTextDecoration: true,
+								__experimentalTextTransform: true,
+								__experimentalLetterSpacing: true,
+								fontSize: true,
+								lineHeight: true,
+							},
+						},
+					},
+				] ),
+				'core/example-block'
+			);
+
+			expect( supports ).toEqual( [
+				'fontFamily',
+				'fontSize',
+				'fontStyle',
+				'fontWeight',
+				'lineHeight',
+				'textDecoration',
+				'textTransform',
+				'letterSpacing',
+			] );
+		} );
+	} );
+} );

--- a/packages/edit-site/src/components/global-styles/border-panel.js
+++ b/packages/edit-site/src/components/global-styles/border-panel.js
@@ -18,7 +18,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { getSupportedGlobalStylesPanels, useColorsPerOrigin } from './hooks';
+import { useSupportedStyles, useColorsPerOrigin } from './hooks';
 import { unlock } from '../../experiments';
 
 const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorExperiments );
@@ -35,7 +35,7 @@ export function useHasBorderPanel( name ) {
 }
 
 function useHasBorderColorControl( name ) {
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	return (
 		useGlobalSetting( 'border.color', name )[ 0 ] &&
 		supports.includes( 'borderColor' )
@@ -43,7 +43,7 @@ function useHasBorderColorControl( name ) {
 }
 
 function useHasBorderRadiusControl( name ) {
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	return (
 		useGlobalSetting( 'border.radius', name )[ 0 ] &&
 		supports.includes( 'borderRadius' )
@@ -51,7 +51,7 @@ function useHasBorderRadiusControl( name ) {
 }
 
 function useHasBorderStyleControl( name ) {
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	return (
 		useGlobalSetting( 'border.style', name )[ 0 ] &&
 		supports.includes( 'borderStyle' )
@@ -59,7 +59,7 @@ function useHasBorderStyleControl( name ) {
 }
 
 function useHasBorderWidthControl( name ) {
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	return (
 		useGlobalSetting( 'border.width', name )[ 0 ] &&
 		supports.includes( 'borderWidth' )

--- a/packages/edit-site/src/components/global-styles/color-utils.js
+++ b/packages/edit-site/src/components/global-styles/color-utils.js
@@ -2,10 +2,10 @@
  * Internal dependencies
  */
 
-import { getSupportedGlobalStylesPanels } from './hooks';
+import { useSupportedStyles } from './hooks';
 
 export function useHasColorPanel( name ) {
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	return (
 		supports.includes( 'color' ) ||
 		supports.includes( 'backgroundColor' ) ||

--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -27,7 +27,7 @@ import { Icon, positionCenter, stretchWide } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { getSupportedGlobalStylesPanels } from './hooks';
+import { useSupportedStyles } from './hooks';
 import { unlock } from '../../experiments';
 
 const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorExperiments );
@@ -53,42 +53,42 @@ export function useHasDimensionsPanel( name ) {
 }
 
 function useHasContentSize( name ) {
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	const [ settings ] = useGlobalSetting( 'layout.contentSize', name );
 
 	return settings && supports.includes( 'contentSize' );
 }
 
 function useHasWideSize( name ) {
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	const [ settings ] = useGlobalSetting( 'layout.wideSize', name );
 
 	return settings && supports.includes( 'wideSize' );
 }
 
 function useHasPadding( name ) {
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	const [ settings ] = useGlobalSetting( 'spacing.padding', name );
 
 	return settings && supports.includes( 'padding' );
 }
 
 function useHasMargin( name ) {
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	const [ settings ] = useGlobalSetting( 'spacing.margin', name );
 
 	return settings && supports.includes( 'margin' );
 }
 
 function useHasGap( name ) {
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	const [ settings ] = useGlobalSetting( 'spacing.blockGap', name );
 
 	return settings && supports.includes( 'blockGap' );
 }
 
 function useHasMinHeight( name ) {
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	const [ settings ] = useGlobalSetting( 'dimensions.minHeight', name );
 
 	return settings && supports.includes( 'minHeight' );

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
 import { colord, extend } from 'colord';
 import a11yPlugin from 'colord/plugins/a11y';
 
@@ -10,106 +9,19 @@ import a11yPlugin from 'colord/plugins/a11y';
  */
 import { _x } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
-import {
-	getBlockType,
-	__EXPERIMENTAL_STYLE_PROPERTY as STYLE_PROPERTY,
-} from '@wordpress/blocks';
+import { store as blocksStore } from '@wordpress/blocks';
 import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../experiments';
+import { useSelect } from '@wordpress/data';
 
 const { useGlobalSetting } = unlock( blockEditorExperiments );
 
 // Enable colord's a11y plugin.
 extend( [ a11yPlugin ] );
-
-const ROOT_BLOCK_SUPPORTS = [
-	'background',
-	'backgroundColor',
-	'color',
-	'linkColor',
-	'buttonColor',
-	'fontFamily',
-	'fontSize',
-	'fontStyle',
-	'fontWeight',
-	'lineHeight',
-	'textDecoration',
-	'padding',
-	'contentSize',
-	'wideSize',
-	'blockGap',
-];
-
-export function getSupportedGlobalStylesPanels( name ) {
-	if ( ! name ) {
-		return ROOT_BLOCK_SUPPORTS;
-	}
-
-	const blockType = getBlockType( name );
-
-	if ( ! blockType ) {
-		return [];
-	}
-
-	const supportKeys = [];
-
-	// Check for blockGap support.
-	// Block spacing support doesn't map directly to a single style property, so needs to be handled separately.
-	// Also, only allow `blockGap` support if serialization has not been skipped, to be sure global spacing can be applied.
-	if (
-		blockType?.supports?.spacing?.blockGap &&
-		blockType?.supports?.spacing?.__experimentalSkipSerialization !==
-			true &&
-		! blockType?.supports?.spacing?.__experimentalSkipSerialization?.some?.(
-			( spacingType ) => spacingType === 'blockGap'
-		)
-	) {
-		supportKeys.push( 'blockGap' );
-	}
-
-	// check for shadow support
-	if ( blockType?.supports?.shadow ) {
-		supportKeys.push( 'shadow' );
-	}
-
-	Object.keys( STYLE_PROPERTY ).forEach( ( styleName ) => {
-		if ( ! STYLE_PROPERTY[ styleName ].support ) {
-			return;
-		}
-
-		// Opting out means that, for certain support keys like background color,
-		// blocks have to explicitly set the support value false. If the key is
-		// unset, we still enable it.
-		if ( STYLE_PROPERTY[ styleName ].requiresOptOut ) {
-			if (
-				STYLE_PROPERTY[ styleName ].support[ 0 ] in
-					blockType.supports &&
-				get(
-					blockType.supports,
-					STYLE_PROPERTY[ styleName ].support
-				) !== false
-			) {
-				return supportKeys.push( styleName );
-			}
-		}
-
-		if (
-			get(
-				blockType.supports,
-				STYLE_PROPERTY[ styleName ].support,
-				false
-			)
-		) {
-			return supportKeys.push( styleName );
-		}
-	} );
-
-	return supportKeys;
-}
 
 export function useColorsPerOrigin( name ) {
 	const [ customColors ] = useGlobalSetting( 'color.palette.custom', name );
@@ -239,4 +151,19 @@ export function useColorRandomizer( name ) {
 	return window.__experimentalEnableColorRandomizer
 		? [ randomizeColors ]
 		: [];
+}
+
+export function useSupportedStyles( name, element ) {
+	const { supportedPanels } = useSelect(
+		( select ) => {
+			return {
+				supportedPanels: unlock(
+					select( blocksStore )
+				).getSupportedStyles( name, element ),
+			};
+		},
+		[ name, element ]
+	);
+
+	return supportedPanels;
 }

--- a/packages/edit-site/src/components/global-styles/screen-background-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-background-color.js
@@ -17,7 +17,7 @@ import {
  */
 import ScreenHeader from './header';
 import {
-	getSupportedGlobalStylesPanels,
+	useSupportedStyles,
 	useColorsPerOrigin,
 	useGradientsPerOrigin,
 } from './hooks';
@@ -27,7 +27,7 @@ const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorExperiments );
 
 function ScreenBackgroundColor( { name, variation = '' } ) {
 	const prefix = variation ? `variations.${ variation }.` : '';
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	const [ areCustomSolidsEnabled ] = useGlobalSetting( 'color.custom', name );
 	const [ areCustomGradientsEnabled ] = useGlobalSetting(
 		'color.customGradient',

--- a/packages/edit-site/src/components/global-styles/screen-button-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-button-color.js
@@ -11,14 +11,14 @@ import {
  * Internal dependencies
  */
 import ScreenHeader from './header';
-import { getSupportedGlobalStylesPanels, useColorsPerOrigin } from './hooks';
+import { useSupportedStyles, useColorsPerOrigin } from './hooks';
 import { unlock } from '../../experiments';
 
 const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorExperiments );
 
 function ScreenButtonColor( { name, variation = '' } ) {
 	const prefix = variation ? `variations.${ variation }.` : '';
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	const colorsPerOrigin = useColorsPerOrigin( name );
 	const [ areCustomSolidsEnabled ] = useGlobalSetting( 'color.custom', name );
 	const [ isBackgroundEnabled ] = useGlobalSetting(

--- a/packages/edit-site/src/components/global-styles/screen-colors.js
+++ b/packages/edit-site/src/components/global-styles/screen-colors.js
@@ -18,7 +18,7 @@ import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
 import ScreenHeader from './header';
 import Palette from './palette';
 import { NavigationButtonAsItem } from './navigation-button';
-import { getSupportedGlobalStylesPanels } from './hooks';
+import { useSupportedStyles } from './hooks';
 import Subtitle from './subtitle';
 import ColorIndicatorWrapper from './color-indicator-wrapper';
 import BlockPreviewPanel from './block-preview-panel';
@@ -30,7 +30,7 @@ const { useGlobalStyle } = unlock( blockEditorExperiments );
 function BackgroundColorItem( { name, parentMenu, variation = '' } ) {
 	const prefix = variation ? `variations.${ variation }.` : '';
 	const urlPrefix = variation ? `/variations/${ variation }` : '';
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	const hasSupport =
 		supports.includes( 'backgroundColor' ) ||
 		supports.includes( 'background' );
@@ -67,7 +67,7 @@ function BackgroundColorItem( { name, parentMenu, variation = '' } ) {
 function TextColorItem( { name, parentMenu, variation = '' } ) {
 	const prefix = variation ? `variations.${ variation }.` : '';
 	const urlPrefix = variation ? `/variations/${ variation }` : '';
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	const hasSupport = supports.includes( 'color' );
 	const [ color ] = useGlobalStyle( prefix + 'color.text', name );
 
@@ -98,7 +98,7 @@ function TextColorItem( { name, parentMenu, variation = '' } ) {
 function LinkColorItem( { name, parentMenu, variation = '' } ) {
 	const prefix = variation ? `variations.${ variation }.` : '';
 	const urlPrefix = variation ? `/variations/${ variation }` : '';
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	const hasSupport = supports.includes( 'linkColor' );
 	const [ color ] = useGlobalStyle(
 		prefix + 'elements.link.color.text',
@@ -138,7 +138,7 @@ function LinkColorItem( { name, parentMenu, variation = '' } ) {
 function HeadingColorItem( { name, parentMenu, variation = '' } ) {
 	const prefix = variation ? `variations.${ variation }.` : '';
 	const urlPrefix = variation ? `/variations/${ variation }` : '';
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	const hasSupport = supports.includes( 'color' );
 	const [ color ] = useGlobalStyle(
 		prefix + 'elements.heading.color.text',
@@ -176,7 +176,7 @@ function HeadingColorItem( { name, parentMenu, variation = '' } ) {
 function ButtonColorItem( { name, parentMenu, variation = '' } ) {
 	const prefix = variation ? `variations.${ variation }.` : '';
 	const urlPrefix = variation ? `/variations/${ variation }` : '';
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	const hasSupport = supports.includes( 'buttonColor' );
 	const [ color ] = useGlobalStyle(
 		prefix + 'elements.button.color.text',

--- a/packages/edit-site/src/components/global-styles/screen-heading-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-heading-color.js
@@ -17,7 +17,7 @@ import { useState } from '@wordpress/element';
  */
 import ScreenHeader from './header';
 import {
-	getSupportedGlobalStylesPanels,
+	useSupportedStyles,
 	useColorsPerOrigin,
 	useGradientsPerOrigin,
 } from './hooks';
@@ -28,7 +28,7 @@ const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorExperiments );
 function ScreenHeadingColor( { name, variation = '' } ) {
 	const prefix = variation ? `variations.${ variation }.` : '';
 	const [ selectedLevel, setCurrentTab ] = useState( 'heading' );
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	const [ areCustomSolidsEnabled ] = useGlobalSetting( 'color.custom', name );
 	const [ areCustomGradientsEnabled ] = useGlobalSetting(
 		'color.customGradient',

--- a/packages/edit-site/src/components/global-styles/screen-link-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-link-color.js
@@ -12,14 +12,14 @@ import { TabPanel } from '@wordpress/components';
  * Internal dependencies
  */
 import ScreenHeader from './header';
-import { getSupportedGlobalStylesPanels, useColorsPerOrigin } from './hooks';
+import { useSupportedStyles, useColorsPerOrigin } from './hooks';
 import { unlock } from '../../experiments';
 
 const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorExperiments );
 
 function ScreenLinkColor( { name, variation = '' } ) {
 	const prefix = variation ? `variations.${ variation }.` : '';
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	const [ areCustomSolidsEnabled ] = useGlobalSetting( 'color.custom', name );
 	const colorsPerOrigin = useColorsPerOrigin( name );
 	const [ isLinkEnabled ] = useGlobalSetting( 'color.link', name );

--- a/packages/edit-site/src/components/global-styles/screen-text-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-text-color.js
@@ -11,14 +11,14 @@ import {
  * Internal dependencies
  */
 import ScreenHeader from './header';
-import { getSupportedGlobalStylesPanels, useColorsPerOrigin } from './hooks';
+import { useSupportedStyles, useColorsPerOrigin } from './hooks';
 import { unlock } from '../../experiments';
 
 const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorExperiments );
 
 function ScreenTextColor( { name, variation = '' } ) {
 	const prefix = variation ? `variations.${ variation }.` : '';
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	const [ areCustomSolidsEnabled ] = useGlobalSetting( 'color.custom', name );
 	const [ isTextEnabled ] = useGlobalSetting( 'color.text', name );
 	const colorsPerOrigin = useColorsPerOrigin( name );

--- a/packages/edit-site/src/components/global-styles/shadow-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadow-panel.js
@@ -27,14 +27,14 @@ import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
-import { getSupportedGlobalStylesPanels } from './hooks';
+import { useSupportedStyles } from './hooks';
 import { IconWithCurrentColor } from './icon-with-current-color';
 import { unlock } from '../../experiments';
 
 const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorExperiments );
 
 export function useHasShadowControl( name ) {
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	return supports.includes( 'shadow' );
 }
 

--- a/packages/edit-site/src/components/global-styles/typography-panel.js
+++ b/packages/edit-site/src/components/global-styles/typography-panel.js
@@ -20,7 +20,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { getSupportedGlobalStylesPanels } from './hooks';
+import { useSupportedStyles } from './hooks';
 import { unlock } from '../../experiments';
 
 const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorExperiments );
@@ -30,7 +30,7 @@ export function useHasTypographyPanel( name ) {
 	const hasLineHeight = useHasLineHeightControl( name );
 	const hasFontAppearance = useHasAppearanceControl( name );
 	const hasLetterSpacing = useHasLetterSpacingControl( name );
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	return (
 		hasFontFamily ||
 		hasLineHeight ||
@@ -41,7 +41,7 @@ export function useHasTypographyPanel( name ) {
 }
 
 function useHasFontFamilyControl( name ) {
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	const [ fontFamiliesPerOrigin ] = useGlobalSetting(
 		'typography.fontFamilies',
 		name
@@ -54,7 +54,7 @@ function useHasFontFamilyControl( name ) {
 }
 
 function useHasLineHeightControl( name ) {
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	return (
 		useGlobalSetting( 'typography.lineHeight', name )[ 0 ] &&
 		supports.includes( 'lineHeight' )
@@ -62,7 +62,7 @@ function useHasLineHeightControl( name ) {
 }
 
 function useHasAppearanceControl( name ) {
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	const hasFontStyles =
 		useGlobalSetting( 'typography.fontStyle', name )[ 0 ] &&
 		supports.includes( 'fontStyle' );
@@ -73,7 +73,7 @@ function useHasAppearanceControl( name ) {
 }
 
 function useAppearanceControlLabel( name ) {
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	const hasFontStyles =
 		useGlobalSetting( 'typography.fontStyle', name )[ 0 ] &&
 		supports.includes( 'fontStyle' );
@@ -90,27 +90,19 @@ function useAppearanceControlLabel( name ) {
 }
 
 function useHasLetterSpacingControl( name, element ) {
-	const setting = useGlobalSetting( 'typography.letterSpacing', name )[ 0 ];
-	if ( ! setting ) {
-		return false;
-	}
-	if ( ! name && element === 'heading' ) {
-		return true;
-	}
-	const supports = getSupportedGlobalStylesPanels( name );
-	return supports.includes( 'letterSpacing' );
+	const supports = useSupportedStyles( name, element );
+	return (
+		useGlobalSetting( 'typography.letterSpacing', name )[ 0 ] &&
+		supports.includes( 'letterSpacing' )
+	);
 }
 
 function useHasTextTransformControl( name, element ) {
-	const setting = useGlobalSetting( 'typography.textTransform', name )[ 0 ];
-	if ( ! setting ) {
-		return false;
-	}
-	if ( ! name && element === 'heading' ) {
-		return true;
-	}
-	const supports = getSupportedGlobalStylesPanels( name );
-	return supports.includes( 'textTransform' );
+	const supports = useSupportedStyles( name, element );
+	return (
+		useGlobalSetting( 'typography.textTransform', name )[ 0 ] &&
+		supports.includes( 'textTransform' )
+	);
 }
 
 function useHasTextDecorationControl( name, element ) {
@@ -188,7 +180,7 @@ export default function TypographyPanel( {
 	headingLevel,
 	variation = '',
 } ) {
-	const supports = getSupportedGlobalStylesPanels( name );
+	const supports = useSupportedStyles( name );
 	let prefix = '';
 	if ( element === 'heading' ) {
 		prefix = `elements.${ headingLevel }.`;

--- a/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
@@ -26,7 +26,7 @@ import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
  */
-import { getSupportedGlobalStylesPanels } from '../../components/global-styles/hooks';
+import { useSupportedStyles } from '../../components/global-styles/hooks';
 import { unlock } from '../../experiments';
 
 const { GlobalStylesContext } = unlock( blockEditorExperiments );
@@ -90,22 +90,30 @@ const STYLE_PATH_TO_PRESET_BLOCK_ATTRIBUTE = {
 	'typography.fontFamily': 'fontFamily',
 };
 
-function getChangesToPush( name, attributes ) {
-	return getSupportedGlobalStylesPanels( name ).flatMap( ( key ) => {
-		if ( ! STYLE_PROPERTY[ key ] ) {
-			return [];
-		}
-		const { value: path } = STYLE_PROPERTY[ key ];
-		const presetAttributeKey = path.join( '.' );
-		const presetAttributeValue =
-			attributes[
-				STYLE_PATH_TO_PRESET_BLOCK_ATTRIBUTE[ presetAttributeKey ]
-			];
-		const value = presetAttributeValue
-			? `var:preset|${ STYLE_PATH_TO_CSS_VAR_INFIX[ presetAttributeKey ] }|${ presetAttributeValue }`
-			: get( attributes.style, path );
-		return value ? [ { path, value } ] : [];
-	} );
+function useChangesToPush( name, attributes ) {
+	const supports = useSupportedStyles( name );
+
+	return useMemo(
+		() =>
+			supports.flatMap( ( key ) => {
+				if ( ! STYLE_PROPERTY[ key ] ) {
+					return [];
+				}
+				const { value: path } = STYLE_PROPERTY[ key ];
+				const presetAttributeKey = path.join( '.' );
+				const presetAttributeValue =
+					attributes[
+						STYLE_PATH_TO_PRESET_BLOCK_ATTRIBUTE[
+							presetAttributeKey
+						]
+					];
+				const value = presetAttributeValue
+					? `var:preset|${ STYLE_PATH_TO_CSS_VAR_INFIX[ presetAttributeKey ] }|${ presetAttributeValue }`
+					: get( attributes.style, path );
+				return value ? [ { path, value } ] : [];
+			} ),
+		[ supports, name, attributes ]
+	);
 }
 
 function cloneDeep( object ) {
@@ -117,10 +125,7 @@ function PushChangesToGlobalStylesControl( {
 	attributes,
 	setAttributes,
 } ) {
-	const changes = useMemo(
-		() => getChangesToPush( name, attributes ),
-		[ name, attributes ]
-	);
+	const changes = useChangesToPush( name, attributes );
 
 	const { user: userConfig, setUserConfig } =
 		useContext( GlobalStylesContext );


### PR DESCRIPTION
Extracted from #47356

## What?

This is a small refactoring that extracts the `getSupportedStyles` function as a private selector into the blocks store. 

## Why?

In #47356, we moved the `getSupportedGlobalStylesPanels` function to the block-editor package but in reality it's better suited for the blocks package because it only needs the block registration. 

Also, I'd like to use this function in a follow-up to build a "theme.json" like settings object based on a blockName, selector pair using this function as a starting point.

See related discussion https://github.com/WordPress/gutenberg/pull/47356#discussion_r1087606272 and https://github.com/WordPress/gutenberg/pull/47356#discussion_r1090173363

## Testing Instructions

1- Open the global styles UI (especially typography)
2- Ensure that they show the exact same panels as in trunk.

I've also added some unit tests to this function.