### PR TITLE
[RNMobile] Bump Aztec-Android version to `1.6.3`

### DIFF
--- a/packages/react-native-aztec/android/build.gradle
+++ b/packages/react-native-aztec/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         jSoupVersion = '1.10.3'
         wordpressUtilsVersion = '2.3.0'
         espressoVersion = '3.0.1'
-        aztecVersion = 'v1.6.2'
+        aztecVersion = 'v1.6.3'
     }
 }
 

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,6 +11,7 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 -   [*] Bump Android `minSdkVersion` to 24 [#47604]
+-   [*] Bump Aztec version to `1.6.3` [#47610]
 
 ## 1.87.3
 -   [*] Fix insert blocks not handling raw string properly in unsupported block editor [#47472]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Bump Aztec library version to the latest version (`1.6.3`).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This PR is a follow-up of https://github.com/WordPress/gutenberg/pull/47604 in order to update Android `minSdkVersion` to 24. The [`minSdkVersion` parameter was updated in Aztec version `1.6.3`](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.6.3), therefore to have this parameter with the same value across the Android libraries, we need to bump the Aztec version.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update Aztec version to version `1.6.3` in the `react-native-aztec` package.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Aztec is used to render the `RichText` component, so we'd need to test that no regressions have been introduced in blocks that use that component:
- Paragraph block
- Heading block
- Search block
- Pullquote block
- File block
- Button block
- Shortcode block
- Contact Info block
- Gallery block (caption element)
- Audio block (caption element)
- Video block (caption element)
- Embed block (caption element)

Regarding the [new changes in Aztec `1.6.3`](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.6.3), seems none of them that should impact the `RichText` component, so it's not needed to test a specific functionality apart from smoke testing the components listed above.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A
