### PR TITLE
Fix missing hook deps in distraction free mode

### DIFF
--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -31,7 +31,7 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 		isPublishSidebarOpened,
 		isSaving,
 		showIconLabels,
-		isDistractionFree,
+		isDistractionFreeMode,
 	} = useSelect(
 		( select ) => ( {
 			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
@@ -40,12 +40,13 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 			isSaving: select( editPostStore ).isSavingMetaBoxes(),
 			showIconLabels:
 				select( editPostStore ).isFeatureActive( 'showIconLabels' ),
-			isDistractionFree:
-				select( editPostStore ).isFeatureActive( 'distractionFree' ) &&
-				isLargeViewport,
+			isDistractionFreeMode:
+				select( editPostStore ).isFeatureActive( 'distractionFree' ),
 		} ),
-		[ isLargeViewport ]
+		[]
 	);
+
+	const isDistractionFree = isDistractionFreeMode && isLargeViewport;
 
 	const classes = classnames( 'edit-post-header' );
 

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -44,7 +44,7 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 				select( editPostStore ).isFeatureActive( 'distractionFree' ) &&
 				isLargeViewport,
 		} ),
-		[]
+		[ isLargeViewport ]
 	);
 
 	const classes = classnames( 'edit-post-header' );

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -83,56 +83,50 @@ function Layout( { styles } ) {
 		isInserterOpened,
 		isListViewOpened,
 		showIconLabels,
-		isDistractionFree,
+		isDistractionFreeMode,
 		showBlockBreadcrumbs,
 		isTemplateMode,
 		documentLabel,
-	} = useSelect(
-		( select ) => {
-			const { getEditorSettings, getPostTypeLabel } =
-				select( editorStore );
-			const editorSettings = getEditorSettings();
-			const postTypeLabel = getPostTypeLabel();
+	} = useSelect( ( select ) => {
+		const { getEditorSettings, getPostTypeLabel } = select( editorStore );
+		const editorSettings = getEditorSettings();
+		const postTypeLabel = getPostTypeLabel();
 
-			return {
-				isTemplateMode: select( editPostStore ).isEditingTemplate(),
-				hasFixedToolbar:
-					select( editPostStore ).isFeatureActive( 'fixedToolbar' ),
-				sidebarIsOpened: !! (
-					select( interfaceStore ).getActiveComplementaryArea(
-						editPostStore.name
-					) || select( editPostStore ).isPublishSidebarOpened()
-				),
-				isFullscreenActive:
-					select( editPostStore ).isFeatureActive( 'fullscreenMode' ),
-				isInserterOpened: select( editPostStore ).isInserterOpened(),
-				isListViewOpened: select( editPostStore ).isListViewOpened(),
-				mode: select( editPostStore ).getEditorMode(),
-				isRichEditingEnabled: editorSettings.richEditingEnabled,
-				hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
-				previousShortcut: select(
-					keyboardShortcutsStore
-				).getAllShortcutKeyCombinations(
-					'core/edit-post/previous-region'
-				),
-				nextShortcut: select(
-					keyboardShortcutsStore
-				).getAllShortcutKeyCombinations( 'core/edit-post/next-region' ),
-				showIconLabels:
-					select( editPostStore ).isFeatureActive( 'showIconLabels' ),
-				isDistractionFree:
-					select( editPostStore ).isFeatureActive(
-						'distractionFree'
-					) && isLargeViewport,
-				showBlockBreadcrumbs: select( editPostStore ).isFeatureActive(
-					'showBlockBreadcrumbs'
-				),
-				// translators: Default label for the Document in the Block Breadcrumb.
-				documentLabel: postTypeLabel || _x( 'Document', 'noun' ),
-			};
-		},
-		[ isLargeViewport ]
-	);
+		return {
+			isTemplateMode: select( editPostStore ).isEditingTemplate(),
+			hasFixedToolbar:
+				select( editPostStore ).isFeatureActive( 'fixedToolbar' ),
+			sidebarIsOpened: !! (
+				select( interfaceStore ).getActiveComplementaryArea(
+					editPostStore.name
+				) || select( editPostStore ).isPublishSidebarOpened()
+			),
+			isFullscreenActive:
+				select( editPostStore ).isFeatureActive( 'fullscreenMode' ),
+			isInserterOpened: select( editPostStore ).isInserterOpened(),
+			isListViewOpened: select( editPostStore ).isListViewOpened(),
+			mode: select( editPostStore ).getEditorMode(),
+			isRichEditingEnabled: editorSettings.richEditingEnabled,
+			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
+			previousShortcut: select(
+				keyboardShortcutsStore
+			).getAllShortcutKeyCombinations( 'core/edit-post/previous-region' ),
+			nextShortcut: select(
+				keyboardShortcutsStore
+			).getAllShortcutKeyCombinations( 'core/edit-post/next-region' ),
+			showIconLabels:
+				select( editPostStore ).isFeatureActive( 'showIconLabels' ),
+			isDistractionFreeMode:
+				select( editPostStore ).isFeatureActive( 'distractionFree' ),
+			showBlockBreadcrumbs: select( editPostStore ).isFeatureActive(
+				'showBlockBreadcrumbs'
+			),
+			// translators: Default label for the Document in the Block Breadcrumb.
+			documentLabel: postTypeLabel || _x( 'Document', 'noun' ),
+		};
+	}, [] );
+
+	const isDistractionFree = isDistractionFreeMode && isLargeViewport;
 
 	const className = classnames( 'edit-post-layout', 'is-mode-' + mode, {
 		'is-sidebar-opened': sidebarIsOpened,

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -87,45 +87,52 @@ function Layout( { styles } ) {
 		showBlockBreadcrumbs,
 		isTemplateMode,
 		documentLabel,
-	} = useSelect( ( select ) => {
-		const { getEditorSettings, getPostTypeLabel } = select( editorStore );
-		const editorSettings = getEditorSettings();
-		const postTypeLabel = getPostTypeLabel();
+	} = useSelect(
+		( select ) => {
+			const { getEditorSettings, getPostTypeLabel } =
+				select( editorStore );
+			const editorSettings = getEditorSettings();
+			const postTypeLabel = getPostTypeLabel();
 
-		return {
-			isTemplateMode: select( editPostStore ).isEditingTemplate(),
-			hasFixedToolbar:
-				select( editPostStore ).isFeatureActive( 'fixedToolbar' ),
-			sidebarIsOpened: !! (
-				select( interfaceStore ).getActiveComplementaryArea(
-					editPostStore.name
-				) || select( editPostStore ).isPublishSidebarOpened()
-			),
-			isFullscreenActive:
-				select( editPostStore ).isFeatureActive( 'fullscreenMode' ),
-			isInserterOpened: select( editPostStore ).isInserterOpened(),
-			isListViewOpened: select( editPostStore ).isListViewOpened(),
-			mode: select( editPostStore ).getEditorMode(),
-			isRichEditingEnabled: editorSettings.richEditingEnabled,
-			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
-			previousShortcut: select(
-				keyboardShortcutsStore
-			).getAllShortcutKeyCombinations( 'core/edit-post/previous-region' ),
-			nextShortcut: select(
-				keyboardShortcutsStore
-			).getAllShortcutKeyCombinations( 'core/edit-post/next-region' ),
-			showIconLabels:
-				select( editPostStore ).isFeatureActive( 'showIconLabels' ),
-			isDistractionFree:
-				select( editPostStore ).isFeatureActive( 'distractionFree' ) &&
-				isLargeViewport,
-			showBlockBreadcrumbs: select( editPostStore ).isFeatureActive(
-				'showBlockBreadcrumbs'
-			),
-			// translators: Default label for the Document in the Block Breadcrumb.
-			documentLabel: postTypeLabel || _x( 'Document', 'noun' ),
-		};
-	}, [] );
+			return {
+				isTemplateMode: select( editPostStore ).isEditingTemplate(),
+				hasFixedToolbar:
+					select( editPostStore ).isFeatureActive( 'fixedToolbar' ),
+				sidebarIsOpened: !! (
+					select( interfaceStore ).getActiveComplementaryArea(
+						editPostStore.name
+					) || select( editPostStore ).isPublishSidebarOpened()
+				),
+				isFullscreenActive:
+					select( editPostStore ).isFeatureActive( 'fullscreenMode' ),
+				isInserterOpened: select( editPostStore ).isInserterOpened(),
+				isListViewOpened: select( editPostStore ).isListViewOpened(),
+				mode: select( editPostStore ).getEditorMode(),
+				isRichEditingEnabled: editorSettings.richEditingEnabled,
+				hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
+				previousShortcut: select(
+					keyboardShortcutsStore
+				).getAllShortcutKeyCombinations(
+					'core/edit-post/previous-region'
+				),
+				nextShortcut: select(
+					keyboardShortcutsStore
+				).getAllShortcutKeyCombinations( 'core/edit-post/next-region' ),
+				showIconLabels:
+					select( editPostStore ).isFeatureActive( 'showIconLabels' ),
+				isDistractionFree:
+					select( editPostStore ).isFeatureActive(
+						'distractionFree'
+					) && isLargeViewport,
+				showBlockBreadcrumbs: select( editPostStore ).isFeatureActive(
+					'showBlockBreadcrumbs'
+				),
+				// translators: Default label for the Document in the Block Breadcrumb.
+				documentLabel: postTypeLabel || _x( 'Document', 'noun' ),
+			};
+		},
+		[ isLargeViewport ]
+	);
 
 	const className = classnames( 'edit-post-layout', 'is-mode-' + mode, {
 		'is-sidebar-opened': sidebarIsOpened,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds dependency to re-run selectors if viewport changes.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See review comments in https://github.com/WordPress/gutenberg/pull/45591#discussion_r1024239215

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add `isLargeViewport` to `useSelect` deps.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
