### PR TITLE
Site Editor: Improve loading experience (v2)

### DIFF
--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -71,6 +71,7 @@ export { default as __experimentalLinkControlSearchResults } from './link-contro
 export { default as __experimentalLinkControlSearchItem } from './link-control/search-item';
 export { default as LineHeightControl } from './line-height-control';
 export { default as __experimentalListView } from './list-view';
+export { default as __experimentalLoadingScreen } from './loading-screen';
 export { default as MediaReplaceFlow } from './media-replace-flow';
 export { default as MediaPlaceholder } from './media-placeholder';
 export { default as MediaUpload } from './media-upload';

--- a/packages/block-editor/src/components/loading-screen/index.js
+++ b/packages/block-editor/src/components/loading-screen/index.js
@@ -1,0 +1,123 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	createContext,
+	Suspense,
+	useEffect,
+	useState,
+} from '@wordpress/element';
+import { Modal, Spinner } from '@wordpress/components';
+import { useSuspenseSelect } from '@wordpress/data';
+
+const LoadingScreenContext = createContext( false );
+
+/**
+ * Component that declares a data dependency.
+ * Will suspend if data has not resolved.
+ *
+ * @param {Object}                                    props          Component props
+ * @param {import('@wordpress/data').StoreDescriptor} props.store    Data store descriptor
+ * @param {string}                                    props.selector Selector name
+ * @param {Array}                                     props.args     Optional arguments to pass to the selector
+ */
+const SuspenseDataDependency = ( { store, selector, args = [] } ) => {
+	useSuspenseSelect(
+		( select ) => select( store )[ selector ]( ...args ),
+		[]
+	);
+
+	return null;
+};
+
+/**
+ * Component that will render a loading screen if dependencies have not resolved,
+ * or its children if all dependencies have resolved.
+ *
+ * @param {Object} props                  Component props
+ * @param {Array}  props.dataDependencies Array of dependencies
+ * @param {string} props.children         Component children
+ */
+const SuspenseWithLoadingScreen = ( { dataDependencies, children } ) => {
+	const [ loaded, setLoaded ] = useState( false );
+
+	const finishedLoading = () => {
+		if ( ! loaded ) {
+			setLoaded( true );
+		}
+	};
+
+	return (
+		<LoadingScreenContext.Provider value={ loaded }>
+			{ loaded ? (
+				<>
+					<LoadingScreen autoClose />
+					{ children }
+				</>
+			) : (
+				<Suspense
+					fallback={ <LoadingScreen onUnmount={ finishedLoading } /> }
+				>
+					{ dataDependencies.map(
+						( { store, selector, args }, depindex ) => (
+							<SuspenseDataDependency
+								key={ `suspense-dep-${ depindex }-${ store.name }-${ selector }` }
+								store={ store }
+								selector={ selector }
+								args={ args }
+							/>
+						)
+					) }
+					{ children }
+				</Suspense>
+			) }
+		</LoadingScreenContext.Provider>
+	);
+};
+
+/**
+ * Renders a loading screen.
+ * Supports automatic closing with the `autoClose` prop.
+ *
+ * @param {Object}    props           Component props
+ * @param {Function?} props.onUnmount Optional callback to call on unmount.
+ * @param {boolean}   props.autoClose Whether to automatically close.
+ */
+const LoadingScreen = ( { onUnmount, autoClose } ) => {
+	const [ visible, setVisible ] = useState( true );
+
+	useEffect( () => {
+		if ( autoClose ) {
+			setTimeout( () => {
+				setVisible( false );
+			}, 2000 );
+		}
+
+		return () => {
+			if ( onUnmount ) {
+				onUnmount();
+			}
+		};
+	} );
+
+	if ( ! visible ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			isFullScreen
+			isDismissible={ false }
+			onRequestClose={ () => {} }
+			__experimentalHideHeader
+			className="block-editor-loading-screen-modal"
+			overlayClassName="block-editor-loading-screen-modal-overlay"
+		>
+			<div className="block-editor-loading-screen-wrapper">
+				<Spinner />
+			</div>
+		</Modal>
+	);
+};
+
+export default SuspenseWithLoadingScreen;

--- a/packages/block-editor/src/components/loading-screen/index.js
+++ b/packages/block-editor/src/components/loading-screen/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -34,11 +39,16 @@ const SuspenseDataDependency = ( { store, selector, args = [] } ) => {
  * Component that will render a loading screen if dependencies have not resolved,
  * or its children if all dependencies have resolved.
  *
- * @param {Object} props                  Component props
- * @param {Array}  props.dataDependencies Array of dependencies
- * @param {string} props.children         Component children
+ * @param {Object}  props                  Component props
+ * @param {Array}   props.dataDependencies Array of dependencies
+ * @param {string}  props.children         Component children
+ * @param {string?} props.overlayClassName Additional overlay classname
  */
-const SuspenseWithLoadingScreen = ( { dataDependencies, children } ) => {
+const SuspenseWithLoadingScreen = ( {
+	dataDependencies,
+	children,
+	overlayClassName,
+} ) => {
 	const [ loaded, setLoaded ] = useState( false );
 
 	const finishedLoading = () => {
@@ -51,12 +61,20 @@ const SuspenseWithLoadingScreen = ( { dataDependencies, children } ) => {
 		<LoadingScreenContext.Provider value={ loaded }>
 			{ loaded ? (
 				<>
-					<LoadingScreen autoClose />
+					<LoadingScreen
+						overlayClassName={ overlayClassName }
+						autoClose
+					/>
 					{ children }
 				</>
 			) : (
 				<Suspense
-					fallback={ <LoadingScreen onUnmount={ finishedLoading } /> }
+					fallback={
+						<LoadingScreen
+							onUnmount={ finishedLoading }
+							overlayClassName={ overlayClassName }
+						/>
+					}
 				>
 					{ dataDependencies.map(
 						( { store, selector, args }, depindex ) => (
@@ -79,11 +97,12 @@ const SuspenseWithLoadingScreen = ( { dataDependencies, children } ) => {
  * Renders a loading screen.
  * Supports automatic closing with the `autoClose` prop.
  *
- * @param {Object}    props           Component props
- * @param {Function?} props.onUnmount Optional callback to call on unmount.
- * @param {boolean}   props.autoClose Whether to automatically close.
+ * @param {Object}    props                  Component props
+ * @param {Function?} props.onUnmount        Optional callback to call on unmount.
+ * @param {boolean}   props.autoClose        Whether to automatically close.
+ * @param {string?}   props.overlayClassName Additional overlay classname
  */
-const LoadingScreen = ( { onUnmount, autoClose } ) => {
+const LoadingScreen = ( { onUnmount, autoClose, overlayClassName } ) => {
 	const [ visible, setVisible ] = useState( true );
 
 	useEffect( () => {
@@ -111,7 +130,10 @@ const LoadingScreen = ( { onUnmount, autoClose } ) => {
 			onRequestClose={ () => {} }
 			__experimentalHideHeader
 			className="block-editor-loading-screen-modal"
-			overlayClassName="block-editor-loading-screen-modal-overlay"
+			overlayClassName={ classNames(
+				'block-editor-loading-screen-modal-overlay',
+				overlayClassName
+			) }
 		>
 			<div className="block-editor-loading-screen-wrapper">
 				<Spinner />

--- a/packages/block-editor/src/components/loading-screen/style.scss
+++ b/packages/block-editor/src/components/loading-screen/style.scss
@@ -4,6 +4,10 @@
 	padding-top: $header-height;
 }
 
+.block-editor-loading-screen-modal-overlay.is-canvas-view {
+	padding-top: 0;
+}
+
 .block-editor-loading-screen-modal.is-full-screen {
 	box-shadow: 0 0 0 transparent;
 	width: 100%;

--- a/packages/block-editor/src/components/loading-screen/style.scss
+++ b/packages/block-editor/src/components/loading-screen/style.scss
@@ -1,0 +1,20 @@
+.block-editor-loading-screen-modal-overlay {
+	backdrop-filter: none;
+	background-color: transparent;
+	padding-top: $header-height;
+}
+
+.block-editor-loading-screen-modal.is-full-screen {
+	box-shadow: 0 0 0 transparent;
+	width: 100%;
+	max-width: 100%;
+	max-height: 100%;
+	min-height: 100%;
+}
+
+.block-editor-loading-screen-wrapper {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+}

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -35,6 +35,7 @@
 @import "./components/justify-content-control/style.scss";
 @import "./components/link-control/style.scss";
 @import "./components/list-view/style.scss";
+@import "./components/loading-screen/style.scss";
 @import "./components/media-replace-flow/style.scss";
 @import "./components/multi-selection-inspector/style.scss";
 @import "./components/responsive-block-control/style.scss";

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -224,6 +224,11 @@ export default function Editor() {
 								<>
 									<LoadingScreen
 										dataDependencies={ contentDependencies }
+										overlayClassName={
+											isViewMode
+												? 'is-canvas-view'
+												: undefined
+										}
 									>
 										<GlobalStylesRenderer />
 										{ isEditMode && <EditorNotices /> }

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -165,6 +165,12 @@ export default function Editor() {
 	useTitle( hasLoadedPost && title );
 
 	const contentDependencies = [
+		// Current post entity,
+		{
+			store: coreStore,
+			selector: 'getEntityRecord',
+			args: [ 'postType', 'postType', editedPostId ],
+		},
 		// Global styles entity ID
 		{
 			store: coreStore,


### PR DESCRIPTION
## What?
This is an experiment - DO NOT MERGE!

This PR aims to experiment with Suspense, specifically with our `useSuspenseSelect()` implementation to load the site editor behind the scenes and display it once it's finished loading. 

This PR is an alternative to #42525.

## Why?

We're aiming to find a way to improve the editor loading experience.

As @mtias [says](https://github.com/WordPress/gutenberg/issues/35503#issuecomment-973182125):

> The end goal should be that things load like a "screenshot"; all fully loaded when you start interacting.

See #35503 for more details and motivation.

## How?

We're building on what we've learned from #42525 and borrowing the loading screen from there. 

We're also introducing a new concept of `SuspenseDataDependency`. That is essentially a component that corresponds to a particular selector from a store that we know we're going to need somewhere in the app. That component will suspend when the data in question is still resolved. That allows us to use separate Suspense boundaries with separate data dependencies that we can specify declaratively.

With that approach, we won't need to alter blocks and other components to use `useSuspendSelect`.

See my self-review for additional inline information.

This is obviously not landable in this version - we'll need to do a better job tweaking the data dependencies. I'd love some feedback on suggested dependencies. 

E2E tests are also expected to fail right now - they don't know about this new loading screen 😉 

## Testing Instructions
* Load the site editor and observe the loading experience. 
* Observe that at the time the fallback placeholder has been hidden, the editor has more or less fully loaded.


