### PR TITLE
Lodash: Refactor away from `_.unescape()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -140,6 +140,7 @@ const restrictedImports = [
 			'toString',
 			'trim',
 			'truncate',
+			'unescape',
 			'unionBy',
 			'uniq',
 			'uniqBy',

--- a/package-lock.json
+++ b/package-lock.json
@@ -17443,6 +17443,7 @@
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/escape-html": "file:packages/escape-html",
 				"@wordpress/hooks": "file:packages/hooks",
+				"@wordpress/html-entities": "file:packages/html-entities",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/icons": "file:packages/icons",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -46,6 +46,7 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/escape-html": "file:../escape-html",
 		"@wordpress/hooks": "file:../hooks",
+		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",

--- a/packages/components/src/tree-select/index.tsx
+++ b/packages/components/src/tree-select/index.tsx
@@ -1,12 +1,9 @@
 /**
- * External dependencies
- */
-import { unescape as unescapeString } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useMemo } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+
 /**
  * Internal dependencies
  */
@@ -18,7 +15,7 @@ function getSelectOptions( tree: Tree[], level = 0 ): SelectOptions {
 		{
 			value: treeNode.id,
 			label:
-				'\u00A0'.repeat( level * 3 ) + unescapeString( treeNode.name ),
+				'\u00A0'.repeat( level * 3 ) + decodeEntities( treeNode.name ),
 		},
 		...getSelectOptions( treeNode.children || [], level + 1 ),
 	] );

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -24,6 +24,7 @@
 		{ "path": "../deprecated" },
 		{ "path": "../dom" },
 		{ "path": "../element" },
+		{ "path": "../html-entities" },
 		{ "path": "../hooks" },
 		{ "path": "../icons" },
 		{ "path": "../is-shallow-equal" },

--- a/packages/editor/src/utils/terms.js
+++ b/packages/editor/src/utils/terms.js
@@ -50,7 +50,6 @@ export const unescapeString = ( arg ) => {
 
 /**
  * Returns a term object with name unescaped.
- * The unescape of the name property is done using lodash unescape function.
  *
  * @param {Object} term The term object to unescape.
  *


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.unescape()` from the `TreeSelect` component and deprecates the function. There is just a single use in that component and conversion is pretty straightforward. 

Similar to #47561 and #47567.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing `_.unescape()` with `decodeEntities()` from `@wordpress/html-entities`.

I'm using the opportunity to remove an obsolete comment that we forgot to remove in #47572.

## Testing Instructions

* Go to `/wp-admin/edit-tags.php?taxonomy=category`
* Create a category with the name `test > <  &nbsp; test`.
* A category with the name `test > <    test` will be created.
* Try editing it in place - you'll see the `&nbsp;` is replaced with a regular space. 
* Go to the post editor to edit any post.
* Expand "Categories" in the Post settings sidebar.
* Click "Add new category".
* Verify the category name appears well (`test > <    test`) in the "Parent Category" field.
* Run `npm run storybook:dev` and verify `TreeSelect` still works well: http://localhost:50240/?path=/story/components-treeselect--default
* Verify all checks are still green. 