### PR TITLE
fix: Patch react-devtools-core to support jsdom-jscore-rn

### DIFF
--- a/packages/react-native-editor/src/globals.js
+++ b/packages/react-native-editor/src/globals.js
@@ -44,6 +44,9 @@ doc.implementation.createHTMLDocument = function ( html ) {
 	return jsdom.html( html, null, null );
 };
 
+// Flag used to enable a patch to `react-devtools` to support `jsdom-jscore-rn`.
+doc.__isJsdom = true;
+
 // `hpq` depends on `document` be available globally.
 global.document = doc;
 

--- a/packages/react-native-editor/src/globals.js
+++ b/packages/react-native-editor/src/globals.js
@@ -44,7 +44,7 @@ doc.implementation.createHTMLDocument = function ( html ) {
 	return jsdom.html( html, null, null );
 };
 
-// Flag used to enable a patch to `react-devtools` to support `jsdom-jscore-rn`.
+// Flag used to enable a patch to `react-devtools-core` to support `jsdom-jscore-rn`.
 doc.__isJsdom = true;
 
 // `hpq` depends on `document` be available globally.

--- a/patches/react-devtools-core+4.24.0.patch
+++ b/patches/react-devtools-core+4.24.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/react-devtools-core/dist/backend.js b/node_modules/react-devtools-core/dist/backend.js
+index b9ada48..135ee39 100644
+--- a/node_modules/react-devtools-core/dist/backend.js
++++ b/node_modules/react-devtools-core/dist/backend.js
+@@ -14106,7 +14106,7 @@ function hideOverlay() {
+ }
+ function showOverlay(elements, componentName, hideAfterTimeout) {
+   // TODO (npm-packages) Detect RN and support it somehow
+-  if (window.document == null) {
++  if (window.document == null || window.document.__isJsdom) {
+     return;
+   }
+ 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Patch `react-devtools-core` to support `jsdom-jscore-rn`, which is used by the
native mobile editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The native editor defines `window.document` which caused `react-devtools-core`
to believe the environment was a browser, not React Native. This resulted in the
following error when inspecting components using the React Dev Tools:

Android:
```
Cannot set property 'zIndex' of undefined
```

iOS:
```
TypeError: undefined is not an object (evaluating
'this.container.style.zIndex = '10000000'')
```

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add a custom property to `window.document` to inform `react-devtools-core` that
the environment is using `jsdom` and it should not presume it is a browser
environment with a fully capable DOM.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. `npm run native start:reset`
1. `npm run native android`
1. Open Flipper or launch the `react-devtools` via CLI.
1. Select a component in the React tree.
1. Verify the aforementioned `zIndex` warnings due not display on the device or
   the server log.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
