### PR TITLE
Stabilize the clearBlockSelection editor setting

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -679,8 +679,8 @@ _Properties_
 -   _codeEditingEnabled_ `boolean`: Whether or not the user can switch to the code editor
 -   _generateAnchors_ `boolean`: Enable/Disable auto anchor generation for Heading blocks
 -   _enableOpenverseMediaCategory_ `boolean`: Enable/Disable the Openverse media category in the inserter.
+-   _clearBlockSelection_ `boolean`: Whether the block editor should clear selection on mousedown when a block is not clicked.
 -   _\_\_experimentalCanUserUseUnfilteredHTML_ `boolean`: Whether the user should be able to use unfiltered HTML or the HTML should be filtered e.g., to remove elements considered insecure like iframes.
--   _\_\_experimentalClearBlockSelection_ `boolean`: Whether the block editor should clear selection on mousedown when a block is not clicked.
 -   _\_\_experimentalBlockDirectory_ `boolean`: Whether the user has enabled the Block Directory
 -   _\_\_experimentalBlockPatterns_ `Array`: Array of objects representing the block patterns
 -   _\_\_experimentalBlockPatternCategories_ `Array`: Array of objects representing the block pattern categories

--- a/packages/block-editor/src/components/block-selection-clearer/index.js
+++ b/packages/block-editor/src/components/block-selection-clearer/index.js
@@ -20,7 +20,7 @@ export function useBlockSelectionClearer() {
 	const { getSettings, hasSelectedBlock, hasMultiSelection } =
 		useSelect( blockEditorStore );
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
-	const { __experimentalClearBlockSelection: isEnabled } = getSettings();
+	const { clearBlockSelection: isEnabled } = getSettings();
 
 	return useRefEffect(
 		( node ) => {

--- a/packages/block-editor/src/components/block-selection-clearer/test/index.js
+++ b/packages/block-editor/src/components/block-selection-clearer/test/index.js
@@ -17,7 +17,7 @@ const defaultUseSelectValues = {
 	hasSelectedBlock: jest.fn().mockReturnValue( false ),
 	hasMultiSelection: jest.fn().mockReturnValue( false ),
 	getSettings: jest.fn().mockReturnValue( {
-		__experimentalClearBlockSelection: true,
+		clearBlockSelection: true,
 	} ),
 };
 
@@ -98,7 +98,7 @@ describe( 'BlockSelectionClearer component', () => {
 			...defaultUseSelectValues,
 			hasSelectedBlock: jest.fn().mockReturnValue( true ),
 			getSettings: jest.fn().mockReturnValue( {
-				__experimentalClearBlockSelection: false,
+				clearBlockSelection: false,
 			} ),
 		} ) );
 		useDispatch.mockImplementation( () => ( {

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -27,8 +27,8 @@ export const PREFERENCES_DEFAULTS = {
  * @property {boolean}       codeEditingEnabled                     Whether or not the user can switch to the code editor
  * @property {boolean}       generateAnchors                        Enable/Disable auto anchor generation for Heading blocks
  * @property {boolean}       enableOpenverseMediaCategory           Enable/Disable the Openverse media category in the inserter.
+ * @property {boolean}       clearBlockSelection                    Whether the block editor should clear selection on mousedown when a block is not clicked.
  * @property {boolean}       __experimentalCanUserUseUnfilteredHTML Whether the user should be able to use unfiltered HTML or the HTML should be filtered e.g., to remove elements considered insecure like iframes.
- * @property {boolean}       __experimentalClearBlockSelection      Whether the block editor should clear selection on mousedown when a block is not clicked.
  * @property {boolean}       __experimentalBlockDirectory           Whether the user has enabled the Block Directory
  * @property {Array}         __experimentalBlockPatterns            Array of objects representing the block patterns
  * @property {Array}         __experimentalBlockPatternCategories   Array of objects representing the block pattern categories
@@ -160,8 +160,10 @@ export const SETTINGS_DEFAULTS = {
 	// Allows to disable Openverse media category in the inserter.
 	enableOpenverseMediaCategory: true,
 
+	// Is the selected block cleared upon deselection.
+	clearBlockSelection: true,
+
 	__experimentalCanUserUseUnfilteredHTML: false,
-	__experimentalClearBlockSelection: true,
 	__experimentalBlockDirectory: false,
 	__mobileEnablePageTemplates: false,
 	__experimentalBlockPatterns: [],

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -160,7 +160,6 @@ export const SETTINGS_DEFAULTS = {
 	// Allows to disable Openverse media category in the inserter.
 	enableOpenverseMediaCategory: true,
 
-	// Is the selected block cleared upon deselection.
 	clearBlockSelection: true,
 
 	__experimentalCanUserUseUnfilteredHTML: false,

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -22,7 +22,6 @@ const EMPTY_BLOCKS_LIST = [];
 const BLOCK_EDITOR_SETTINGS = [
 	'__experimentalBlockDirectory',
 	'__experimentalBlockInspectorAnimation',
-	'__experimentalClearBlockSelection',
 	'__experimentalDiscussionSettings',
 	'__experimentalFeatures',
 	'__experimentalGlobalStylesBaseStyles',
@@ -36,6 +35,7 @@ const BLOCK_EDITOR_SETTINGS = [
 	'bodyPlaceholder',
 	'canLockBlocks',
 	'capabilities',
+	'clearBlockSelection',
 	'codeEditingEnabled',
 	'colors',
 	'disableCustomColors',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
See https://github.com/WordPress/gutenberg/issues/47196

Stabilizes the `clearBlockSelection` editor setting, which previously had an experimental prefix. This setting was introduced in a contributor PR - https://github.com/WordPress/gutenberg/pull/44517.

## Why?
With WordPress 6.2 approaching, experimental APIs should be stabilized or locked.

## How?
Remove the __experimental prefix.

## Testing Instructions
There should be no change in the behavior in trunk.

1. Add a block
2. Deselect it.
3. The block should be deselected
