### PR TITLE
Shadow: Add option to unset shadow

### DIFF
--- a/packages/edit-site/src/components/global-styles/shadow-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadow-panel.js
@@ -122,6 +122,7 @@ function ShadowPopoverContainer( { shadow, onShadowChange } ) {
 	);
 
 	const shadows = [
+		{ name: 'Unset', slug: 'unset', shadow: 'none' },
 		...( defaultPresetsEnabled ? defaultShadows : [] ),
 		...( themeShadows || [] ),
 	];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This change introduces a new shadow option "Unset" along with the shadow presets, so that a specific block can remove the given shadow.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This option is required in scenarios such as
* a theme provides shadow and it can be removed from the UI
* Block can have shadow, and a specific block variation can `uset` it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Set a shadow to button block
2. Use the unset option on "outline" block variation to remove the shadow.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="558" alt="image" src="https://user-images.githubusercontent.com/1935113/215975356-1a9adb37-4714-4f19-aabc-7f8fd4b94d8c.png">

In the above UI, it is not obvious that the first choice is shadow "unset". 
Adding tooltips might help. Need UX feedback @WordPress/gutenberg-design 

Duotone UI for reference:
<img width="277" alt="image" src="https://user-images.githubusercontent.com/1935113/215976092-cddb8bf7-440a-434b-870d-c82a0f3c330e.png">

## Related

Followup for #44651 
