### PR TITLE
Shadow: move shadow into own panel

### DIFF
--- a/packages/edit-site/src/components/global-styles/context-menu.js
+++ b/packages/edit-site/src/components/global-styles/context-menu.js
@@ -32,11 +32,13 @@ import { useHasVariationsPanel } from './variations-panel';
 import { NavigationButtonAsItem } from './navigation-button';
 import { IconWithCurrentColor } from './icon-with-current-color';
 import { ScreenVariations } from './screen-variations';
+import { useHasShadowControl } from './shadow-panel';
 
 function ContextMenu( { name, parentMenu = '' } ) {
 	const hasTypographyPanel = useHasTypographyPanel( name );
 	const hasColorPanel = useHasColorPanel( name );
 	const hasBorderPanel = useHasBorderPanel( name );
+	const hasEffectsPanel = useHasShadowControl( name );
 	const hasDimensionsPanel = useHasDimensionsPanel( name );
 	const hasLayoutPanel = hasDimensionsPanel;
 	const hasVariationsPanel = useHasVariationsPanel( name, parentMenu );
@@ -85,9 +87,18 @@ function ContextMenu( { name, parentMenu = '' } ) {
 					<NavigationButtonAsItem
 						icon={ border }
 						path={ parentMenu + '/border' }
-						aria-label={ __( 'Border & shadow styles' ) }
+						aria-label={ __( 'Border' ) }
 					>
-						{ __( 'Border & Shadow' ) }
+						{ __( 'Border' ) }
+					</NavigationButtonAsItem>
+				) }
+				{ hasEffectsPanel && (
+					<NavigationButtonAsItem
+						icon={ border }
+						path={ parentMenu + '/effects' }
+						aria-label={ __( 'Effects' ) }
+					>
+						{ __( 'Effects' ) }
 					</NavigationButtonAsItem>
 				) }
 				{ hasLayoutPanel && (

--- a/packages/edit-site/src/components/global-styles/context-menu.js
+++ b/packages/edit-site/src/components/global-styles/context-menu.js
@@ -12,6 +12,7 @@ import {
 import {
 	typography,
 	border,
+	shadow,
 	color,
 	layout,
 	chevronLeft,
@@ -94,11 +95,11 @@ function ContextMenu( { name, parentMenu = '' } ) {
 				) }
 				{ hasEffectsPanel && (
 					<NavigationButtonAsItem
-						icon={ border }
+						icon={ shadow }
 						path={ parentMenu + '/effects' }
-						aria-label={ __( 'Effects' ) }
+						aria-label={ __( 'Shadow' ) }
 					>
-						{ __( 'Effects' ) }
+						{ __( 'Shadow' ) }
 					</NavigationButtonAsItem>
 				) }
 				{ hasLayoutPanel && (

--- a/packages/edit-site/src/components/global-styles/screen-effects.js
+++ b/packages/edit-site/src/components/global-styles/screen-effects.js
@@ -7,22 +7,22 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import ScreenHeader from './header';
-import BorderPanel, { useHasBorderPanel } from './border-panel';
 import BlockPreviewPanel from './block-preview-panel';
 import { getVariationClassName } from './utils';
+import ShadowPanel, { useHasShadowControl } from './shadow-panel';
 
-function ScreenBorder( { name, variation = '' } ) {
-	const hasBorderPanel = useHasBorderPanel( name );
+function ScreenEffects( { name, variation = '' } ) {
 	const variationClassName = getVariationClassName( variation );
+	const hasShadowPanel = useHasShadowControl( name );
 	return (
 		<>
-			<ScreenHeader title={ __( 'Border & Shadow' ) } />
+			<ScreenHeader title={ __( 'Effects' ) } />
 			<BlockPreviewPanel name={ name } variation={ variationClassName } />
-			{ hasBorderPanel && (
-				<BorderPanel name={ name } variation={ variation } />
+			{ hasShadowPanel && (
+				<ShadowPanel name={ name } variation={ variation } />
 			) }
 		</>
 	);
 }
 
-export default ScreenBorder;
+export default ScreenEffects;

--- a/packages/edit-site/src/components/global-styles/screen-effects.js
+++ b/packages/edit-site/src/components/global-styles/screen-effects.js
@@ -16,7 +16,7 @@ function ScreenEffects( { name, variation = '' } ) {
 	const hasShadowPanel = useHasShadowControl( name );
 	return (
 		<>
-			<ScreenHeader title={ __( 'Effects' ) } />
+			<ScreenHeader title={ __( 'Shadow' ) } />
 			<BlockPreviewPanel name={ name } variation={ variationClassName } />
 			{ hasShadowPanel && (
 				<ShadowPanel name={ name } variation={ variation } />

--- a/packages/edit-site/src/components/global-styles/shadow-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadow-panel.js
@@ -129,7 +129,7 @@ function ShadowPopoverContainer( { shadow, onShadowChange } ) {
 	return (
 		<div className="edit-site-global-styles__shadow-panel">
 			<VStack spacing={ 4 }>
-				<Heading level={ 5 }>{ __( 'Shadows' ) }</Heading>
+				<Heading level={ 5 }>{ __( 'Shadow' ) }</Heading>
 				<ShadowPresets
 					presets={ shadows }
 					activeShadow={ shadow }

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -37,6 +37,7 @@ import ScreenBorder from './screen-border';
 import StyleBook from '../style-book';
 import ScreenCSS from './screen-css';
 import { unlock } from '../../experiments';
+import ScreenEffects from './screen-effects';
 
 const SLOT_FILL_NAME = 'GlobalStylesMenu';
 const { Slot: GlobalStylesMenuSlot, Fill: GlobalStylesMenuFill } =
@@ -207,6 +208,10 @@ function ContextScreens( { name, parentMenu = '', variation = '' } ) {
 
 			<GlobalStylesNavigationScreen path={ parentMenu + '/border' }>
 				<ScreenBorder name={ name } variation={ variation } />
+			</GlobalStylesNavigationScreen>
+
+			<GlobalStylesNavigationScreen path={ parentMenu + '/effects' }>
+				<ScreenEffects name={ name } variation={ variation } />
 			</GlobalStylesNavigationScreen>
 
 			<GlobalStylesNavigationScreen path={ parentMenu + '/layout' }>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This change moves the shadow from "Border & Shadow" to new panel "Effects".

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Right now the panel is called `Border & Shadow`, and it remains same even though a block doesn't have `shadow` support enabled which is misleading. Instead move it to different menu so it appears only for the support enabled blocks.

reference to the latest design discussions on shadow placement [here](https://github.com/WordPress/gutenberg/issues/44651#issuecomment-1399838132), and start a discussion to check if its a good idea to apply the same in global styles.

![image](https://user-images.githubusercontent.com/1935113/215996506-18110458-e933-4c9b-a94e-5f5974b31cd7.png)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Navigate to global styles -> blocks -> button
2. Observe that Shadow is now moved under new group "Effects"

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="289" alt="image" src="https://user-images.githubusercontent.com/1935113/215997840-7bf31a86-a94e-457d-9673-882579580f31.png"> <img width="289" alt="image" src="https://user-images.githubusercontent.com/1935113/215997902-e1de49fd-25ba-47cf-96a4-5257dd89ae46.png">

@WordPress/gutenberg-design 

Related to #44651 