### PR TITLE
Edit Post: Remove unnecessary 'classnames' in Header component

### DIFF
--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { PostSavedState, PostPreviewButton } from '@wordpress/editor';
@@ -48,8 +43,6 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 
 	const isDistractionFree = isDistractionFreeMode && isLargeViewport;
 
-	const classes = classnames( 'edit-post-header' );
-
 	const slideY = {
 		hidden: isDistractionFree ? { y: '-50' } : { y: 0 },
 		hover: { y: 0, transition: { type: 'tween', delay: 0.2 } },
@@ -61,7 +54,7 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 	};
 
 	return (
-		<div className={ classes }>
+		<div className="edit-post-header">
 			<MainDashboardButton.Slot>
 				<motion.div
 					variants={ slideX }


### PR DESCRIPTION
## What?
PR removes unnecessary `classnames` usage in the Header component.

## Why?
The component has a single class, so no need to use the library.

## Testing Instructions
1. Open a Post or Page.
2. Confirm that the Header component has the correct class.
