### PR TITLE
Make getLastInsertedBlocksClientIds selector private

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -583,18 +583,6 @@ _Properties_
 -   _isDisabled_ `boolean`: Whether or not the user should be prevented from inserting this item.
 -   _frecency_ `number`: Heuristic that combines frequency and recency.
 
-### getLastInsertedBlocksClientIds
-
-Gets the client ids of the last inserted blocks.
-
-_Parameters_
-
--   _state_ `Object`: Global application state.
-
-_Returns_
-
--   `Array|undefined`: Client Ids of the last inserted block(s).
-
 ### getLastMultiSelectedBlockClientId
 
 Returns the client ID of the last block in the multi-selection set, or null

--- a/packages/block-editor/src/components/off-canvas-editor/block-contents.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-contents.js
@@ -12,6 +12,7 @@ import { forwardRef, useEffect, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { unlock } from '../../experiments';
 import ListViewBlockSelectButton from './block-select-button';
 import BlockDraggable from '../block-draggable';
 import { store as blockEditorStore } from '../../store';
@@ -52,7 +53,7 @@ const ListViewBlockContents = forwardRef(
 					hasBlockMovingClientId,
 					getSelectedBlockClientId,
 					getLastInsertedBlocksClientIds,
-				} = select( blockEditorStore );
+				} = unlock( select( blockEditorStore ) );
 				const lastInsertedBlocksClientIds =
 					getLastInsertedBlocksClientIds();
 				return {

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -8,3 +8,13 @@
 export function isBlockInterfaceHidden( state ) {
 	return state.isBlockInterfaceHidden;
 }
+
+/**
+ * Gets the client ids of the last inserted blocks.
+ *
+ * @param {Object} state Global application state.
+ * @return {Array|undefined} Client Ids of the last inserted block(s).
+ */
+export function getLastInsertedBlocksClientIds( state ) {
+	return state?.lastBlockInserted?.clientIds;
+}

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2704,16 +2704,6 @@ export function wasBlockJustInserted( state, clientId, source ) {
 }
 
 /**
- * Gets the client ids of the last inserted blocks.
- *
- * @param {Object} state Global application state.
- * @return {Array|undefined} Client Ids of the last inserted block(s).
- */
-export function getLastInsertedBlocksClientIds( state ) {
-	return state?.lastBlockInserted?.clientIds;
-}
-
-/**
  * Tells if the block is visible on the canvas or not.
  *
  * @param {Object} state    Global application state.

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -1,7 +1,10 @@
 /**
  * Internal dependencies
  */
-import { isBlockInterfaceHidden } from '../private-selectors';
+import {
+	isBlockInterfaceHidden,
+	getLastInsertedBlocksClientIds,
+} from '../private-selectors';
 
 describe( 'private selectors', () => {
 	describe( 'isBlockInterfaceHidden', () => {
@@ -19,6 +22,31 @@ describe( 'private selectors', () => {
 			};
 
 			expect( isBlockInterfaceHidden( state ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'getLastInsertedBlocksClientIds', () => {
+		it( 'should return undefined if no blocks have been inserted', () => {
+			const state = {
+				lastBlockInserted: {},
+			};
+
+			expect( getLastInsertedBlocksClientIds( state ) ).toEqual(
+				undefined
+			);
+		} );
+
+		it( 'should return clientIds if blocks have been inserted', () => {
+			const state = {
+				lastBlockInserted: {
+					clientIds: [ '123456', '78910' ],
+				},
+			};
+
+			expect( getLastInsertedBlocksClientIds( state ) ).toEqual( [
+				'123456',
+				'78910',
+			] );
 		} );
 	} );
 } );

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -72,7 +72,6 @@ const {
 	__experimentalGetPatternTransformItems,
 	wasBlockJustInserted,
 	__experimentalGetGlobalBlocksByName,
-	getLastInsertedBlocksClientIds,
 } = selectors;
 
 describe( 'selectors', () => {
@@ -4685,29 +4684,6 @@ describe( '__unstableGetClientIdsTree', () => {
 					{ clientId: 'baz', innerBlocks: [] },
 				],
 			},
-		] );
-	} );
-} );
-
-describe( 'getLastInsertedBlocksClientIds', () => {
-	it( 'should return undefined if no blocks have been inserted', () => {
-		const state = {
-			lastBlockInserted: {},
-		};
-
-		expect( getLastInsertedBlocksClientIds( state ) ).toEqual( undefined );
-	} );
-
-	it( 'should return clientIds if blocks have been inserted', () => {
-		const state = {
-			lastBlockInserted: {
-				clientIds: [ '123456', '78910' ],
-			},
-		};
-
-		expect( getLastInsertedBlocksClientIds( state ) ).toEqual( [
-			'123456',
-			'78910',
 		] );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Makes the `getLastInsertedBlocksClientIds` selector introduced in https://github.com/WordPress/gutenberg/pull/46531 a private selector.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In preparation for WP 6.2 we need to audit APIs that should be experimental.

In https://github.com/WordPress/gutenberg/pull/46531/ I introduced a new selector. This should probably be experimental as it's very new and unproven and the API may still be in flux as evidenced by the changes required to it since it was originally added.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Use the new `lock` / `unlock` API to make an experimental selector following the pattern already in place within the block editor package.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Check tests pass

````
 npm run test:unit packages/block-editor/src/store/test
```

Also check that the Nav block list view editing mode functions without errors. Particularly when inserting new blocks using the appender as this is where the `getLastInsertedBlocksClientIds` selector is used.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
