### PR TITLE
[Mobile] - E2E Initial HTML Test - Update test to use the Paste functionality for Android

### DIFF
--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -231,8 +231,6 @@ class EditorPage {
 
 		await htmlContentView.click();
 		await doubleTap( this.driver, htmlContentView );
-		// Sometimes double tap is not enough for paste menu to appear, so we also long press.
-
 		await tapPasteAboveElement( this.driver, htmlContentView );
 
 		await toggleHtmlMode( this.driver, false );

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -13,6 +13,7 @@ const {
 	swipeDown,
 	swipeFromTo,
 	swipeUp,
+	tapPasteAboveElement,
 	toggleHtmlMode,
 	typeString,
 	waitForVisible,
@@ -228,22 +229,11 @@ class EditorPage {
 
 		const htmlContentView = await this.getTextViewForHtmlViewContent();
 
-		if ( isAndroid() ) {
-			// Attention! On Android `.type()` replaces the content of htmlContentView instead of appending
-			// contrary to what iOS is doing. On Android tried calling `driver.pressKeycode( 279 ) // KEYCODE_PASTE`
-			// before to paste, but for some reason it didn't work on GitHub Actions but worked only on Sauce Labs
-			await htmlContentView.type( html );
-		} else {
-			await htmlContentView.click();
-			await doubleTap( this.driver, htmlContentView );
-			// Sometimes double tap is not enough for paste menu to appear, so we also long press.
-			await longPressMiddleOfElement( this.driver, htmlContentView );
+		await htmlContentView.click();
+		await doubleTap( this.driver, htmlContentView );
+		// Sometimes double tap is not enough for paste menu to appear, so we also long press.
 
-			await clickIfClickable(
-				this.driver,
-				'//XCUIElementTypeMenuItem[@name="Paste"]'
-			);
-		}
+		await tapPasteAboveElement( this.driver, htmlContentView );
 
 		await toggleHtmlMode( this.driver, false );
 	}


### PR DESCRIPTION
Closes https://github.com/wordpress-mobile/gutenberg-mobile/issues/3370
Closes https://github.com/WordPress/gutenberg/issues/43639

**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/5444

## What?
We've had issues before with the initial HTML E2E test on Android when it has a lot of content and it's set in the editor, this PR solves it by using the same functionality as iOS.

## Why?
E2E test fails with `Error response status: 13, UnknownError - An unknown server-side error occurred while processing the command` when the initial HTML content increases and using the `type` feature to set the content in the editor. This was limiting us before adding more blocks.

## How?
By using the `Paste` functionality as iOS does, as suggested in https://github.com/wordpress-mobile/gutenberg-mobile/issues/3370.

## Testing Instructions
CI checks should pass.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A