### PR TITLE
Performance: Fix empty results handling in performance test results

### DIFF
--- a/bin/log-perormance-results.js
+++ b/bin/log-perormance-results.js
@@ -39,9 +39,12 @@ const data = new TextEncoder().encode(
 			return {
 				...result,
 				...Object.fromEntries(
-					Object.entries( performanceResults[ index ][ hash ] ).map(
-						( [ key, value ] ) => [ metricsPrefix + key, value ]
-					)
+					Object.entries(
+						performanceResults[ index ][ hash ] ?? {}
+					).map( ( [ key, value ] ) => [
+						metricsPrefix + key,
+						value,
+					] )
 				),
 			};
 		} ),
@@ -51,7 +54,7 @@ const data = new TextEncoder().encode(
 					...result,
 					...Object.fromEntries(
 						Object.entries(
-							performanceResults[ index ][ baseHash ]
+							performanceResults[ index ][ baseHash ] ?? {}
 						).map( ( [ key, value ] ) => [
 							metricsPrefix + key,
 							value,


### PR DESCRIPTION
## What?
This PR is adding handling for non-objects in the performance test results logger script.

## Why?
I think we broke the performance results with #47600. I believe this PR should fix them.

## How?
We're adding a fallback to an empty object to handle the case of no performance results for the specified hash.

## Testing Instructions
Similar to #47442 😅 
