### PR TITLE
Block Library: Don't use methods with the 'gutenberg_' prefix

### DIFF
--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -53,7 +53,7 @@ function render_block_core_calendar( $attributes ) {
 	$color_block_styles['background'] = $preset_background_color ? $preset_background_color : $custom_background_color;
 
 	// Generate color styles and classes.
-	$styles        = gutenberg_style_engine_get_styles( array( 'color' => $color_block_styles ), array( 'convert_vars_to_classnames' => true ) );
+	$styles        = wp_style_engine_get_styles( array( 'color' => $color_block_styles ), array( 'convert_vars_to_classnames' => true ) );
 	$inline_styles = empty( $styles['css'] ) ? '' : sprintf( ' style="%s"', esc_attr( $styles['css'] ) );
 	$classnames    = empty( $styles['classnames'] ) ? '' : ' ' . esc_attr( $styles['classnames'] );
 	if ( isset( $attributes['style']['elements']['link']['color']['text'] ) ) {

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -108,7 +108,7 @@ function block_core_gallery_render( $attributes, $content ) {
 		),
 	);
 
-	gutenberg_style_engine_get_stylesheet_from_css_rules(
+	wp_style_engine_get_stylesheet_from_css_rules(
 		$gallery_styles,
 		array(
 			'context' => 'block-supports',

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -382,7 +382,7 @@ add_action( 'init', 'register_block_core_navigation_link' );
  * @param array $settings Default editor settings.
  * @return array Filtered editor settings.
  */
-function gutenberg_enable_animation_for_navigation_link_inspector( $settings ) {
+function block_core_navigation_link_enable_inspector_animation( $settings ) {
 	$current_animation_settings = _wp_array_get(
 		$settings,
 		array( '__experimentalBlockInspectorAnimation' ),
@@ -402,4 +402,4 @@ function gutenberg_enable_animation_for_navigation_link_inspector( $settings ) {
 	return $settings;
 }
 
-add_filter( 'block_editor_settings_all', 'gutenberg_enable_animation_for_navigation_link_inspector' );
+add_filter( 'block_editor_settings_all', 'block_core_navigation_link_enable_inspector_animation' );

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -300,7 +300,7 @@ add_action( 'init', 'register_block_core_navigation_submenu' );
  * @param array $settings Default editor settings.
  * @return array Filtered editor settings.
  */
-function gutenberg_enable_animation_for_navigation_submenu_inspector( $settings ) {
+function block_core_navigation_submenu_enable_inspector_animation( $settings ) {
 	$current_animation_settings = _wp_array_get(
 		$settings,
 		array( '__experimentalBlockInspectorAnimation' ),
@@ -320,4 +320,4 @@ function gutenberg_enable_animation_for_navigation_submenu_inspector( $settings 
 	return $settings;
 }
 
-add_filter( 'block_editor_settings_all', 'gutenberg_enable_animation_for_navigation_submenu_inspector' );
+add_filter( 'block_editor_settings_all', 'block_core_navigation_submenu_enable_inspector_animation' );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -885,7 +885,7 @@ add_filter( 'render_block_data', 'block_core_navigation_typographic_presets_back
  * @param array $settings Default editor settings.
  * @return array Filtered editor settings.
  */
-function gutenberg_enable_animation_for_navigation_inspector( $settings ) {
+function block_core_navigation_enable_inspector_animation( $settings ) {
 	$current_animation_settings = _wp_array_get(
 		$settings,
 		array( '__experimentalBlockInspectorAnimation' ),
@@ -905,4 +905,4 @@ function gutenberg_enable_animation_for_navigation_inspector( $settings ) {
 	return $settings;
 }
 
-add_filter( 'block_editor_settings_all', 'gutenberg_enable_animation_for_navigation_inspector' );
+add_filter( 'block_editor_settings_all', 'block_core_navigation_enable_inspector_animation' );


### PR DESCRIPTION
## What
PR replaces the `gutenberg_` prefix in block PHP files.

## Why?
These files are bundled with the package and should use methods also available in WP Core.

## How?
* Updates the styles engine function to use core alternatives.
* Renamed filter callbacks to match the general naming convention.

## Testing Instructions
CI tests should be green.

The navigation inspector animation testing instructions - https://github.com/WordPress/gutenberg/pull/46342
