### PR TITLE
Performance: Restore initial reduce value in perf results log script

### DIFF
--- a/bin/log-perormance-results.js
+++ b/bin/log-perormance-results.js
@@ -47,7 +47,7 @@ const data = new TextEncoder().encode(
 					] )
 				),
 			};
-		} ),
+		}, {} ),
 		baseMetrics: resultsFiles.reduce(
 			( result, { metricsPrefix }, index ) => {
 				return {


### PR DESCRIPTION
## What?
This PR is adding back the initial value of the `reduce` call in the performance test results logger script.

## Why?
We broke the performance results with #47600 as we inadvertently removed the initial value. I believe this PR should fix them.

## How?
We're adding back the empty object initial value that was removed in #47600.

## Testing Instructions
Similar to #47442 😅 
