### PR TITLE
Page List: Respect the selected parent page when converting to a list of navigation links

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -182,11 +182,6 @@ export default function PageListEdit( {
 		pages?.length > 0 &&
 		pages?.length <= MAX_PAGE_COUNT;
 
-	const convertToNavigationLinks = useConvertToNavigationLinks( {
-		clientId,
-		pages,
-	} );
-
 	const pagesByParentId = useMemo( () => {
 		if ( pages === null ) {
 			return new Map();
@@ -212,6 +207,12 @@ export default function PageListEdit( {
 			return accumulator;
 		}, new Map() );
 	}, [ pages ] );
+
+	const convertToNavigationLinks = useConvertToNavigationLinks( {
+		clientId,
+		pages,
+		parentPageID,
+	} );
 
 	const blockProps = useBlockProps( {
 		className: classnames( 'wp-block-page-list', {

--- a/packages/block-library/src/page-list/test/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/test/convert-to-links-modal.js
@@ -383,5 +383,139 @@ describe( 'page list convert to links', () => {
 				},
 			] );
 		} );
+
+		it( 'Can use a different parent page', () => {
+			const pages = [
+				{
+					title: {
+						raw: 'Sample Page',
+						rendered: 'Sample Page',
+					},
+					id: 2,
+					parent: 0,
+					link: 'http://wordpress.local/sample-page/',
+					type: 'page',
+				},
+				{
+					title: {
+						raw: 'About',
+						rendered: 'About',
+					},
+					id: 34,
+					parent: 0,
+					link: 'http://wordpress.local/about/',
+					type: 'page',
+				},
+				{
+					title: {
+						raw: 'Contact Page',
+						rendered: 'Contact Page',
+					},
+					id: 37,
+					parent: 0,
+					link: 'http://wordpress.local/contact-page/',
+					type: 'page',
+				},
+				{
+					title: {
+						raw: 'Test',
+						rendered: 'Test',
+					},
+					id: 229,
+					parent: 0,
+					link: 'http://wordpress.local/test/',
+					type: 'page',
+				},
+				{
+					title: {
+						raw: 'About Sub 1',
+						rendered: 'About Sub 1',
+					},
+					id: 738,
+					parent: 34,
+					link: 'http://wordpress.local/about/about-sub-1/',
+					type: 'page',
+				},
+				{
+					title: {
+						raw: 'About Sub 2',
+						rendered: 'About Sub 2',
+					},
+					id: 740,
+					parent: 34,
+					link: 'http://wordpress.local/about/about-sub-2/',
+					type: 'page',
+				},
+				{
+					title: {
+						raw: 'Test Sub',
+						rendered: 'Test Sub',
+					},
+					id: 742,
+					parent: 229,
+					link: 'http://wordpress.local/test/test-sub/',
+					type: 'page',
+				},
+				{
+					title: {
+						raw: 'Test Sub Sub',
+						rendered: 'Test Sub Sub',
+					},
+					id: 744,
+					parent: 742,
+					link: 'http://wordpress.local/test/test-sub/test-sub-sub/',
+					type: 'page',
+				},
+			];
+
+			const convertLinksWithParentOneLevel = convertToNavigationLinks(
+				pages,
+				34
+			);
+
+			expect( convertLinksWithParentOneLevel ).toEqual( [
+				{
+					attributes: {
+						id: 738,
+						kind: 'post-type',
+						label: 'About Sub 1',
+						type: 'page',
+						url: 'http://wordpress.local/about/about-sub-1/',
+					},
+					innerBlocks: [],
+					name: 'core/navigation-link',
+				},
+				{
+					attributes: {
+						id: 740,
+						kind: 'post-type',
+						label: 'About Sub 2',
+						type: 'page',
+						url: 'http://wordpress.local/about/about-sub-2/',
+					},
+					innerBlocks: [],
+					name: 'core/navigation-link',
+				},
+			] );
+
+			const convertLinksWithParentTwoLevels = convertToNavigationLinks(
+				pages,
+				742
+			);
+
+			expect( convertLinksWithParentTwoLevels ).toEqual( [
+				{
+					attributes: {
+						id: 744,
+						kind: 'post-type',
+						label: 'Test Sub Sub',
+						type: 'page',
+						url: 'http://wordpress.local/test/test-sub/test-sub-sub/',
+					},
+					innerBlocks: [],
+					name: 'core/navigation-link',
+				},
+			] );
+		} );
 	} );
 } );

--- a/packages/block-library/src/page-list/use-convert-to-navigation-links.js
+++ b/packages/block-library/src/page-list/use-convert-to-navigation-links.js
@@ -8,7 +8,7 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 /**
  * Converts an array of pages into a nested array of navigation link blocks.
  *
- * @param {Array}  pages An array of pages.
+ * @param {Array} pages An array of pages.
  *
  * @return {Array} A nested array of navigation link blocks.
  */
@@ -53,9 +53,9 @@ function createNavigationLinks( pages = [] ) {
  * @param {Array}  navigationLinks An array of navigation link blocks.
  * @param {number} id              The id of the navigation link to find.
  *
- * @return {Object} The navigation link block with the given id.
+ * @return {Object|null} The navigation link block with the given id.
  */
-function findById( navigationLinks, id ) {
+function findNavigationLinkById( navigationLinks, id ) {
 	for ( const navigationLink of navigationLinks ) {
 		// Is this the link we're looking for?
 		if ( navigationLink.attributes.id === id ) {
@@ -64,17 +64,18 @@ function findById( navigationLinks, id ) {
 
 		// If not does it have innerBlocks?
 		if ( navigationLink.innerBlocks && navigationLink.innerBlocks.length ) {
-			const foundNavigationLink = findById(
+			const foundNavigationLink = findNavigationLinkById(
 				navigationLink.innerBlocks,
 				id
 			);
 
-			// Does the innerBlocks have the link we're looking for?
 			if ( foundNavigationLink ) {
 				return foundNavigationLink;
 			}
 		}
 	}
+
+	return null;
 }
 
 export function convertToNavigationLinks( pages = [], parentPageID = null ) {
@@ -82,7 +83,10 @@ export function convertToNavigationLinks( pages = [], parentPageID = null ) {
 
 	// If a parent page ID is provided, only return the children of that page.
 	if ( parentPageID ) {
-		const parentPage = findById( navigationLinks, parentPageID );
+		const parentPage = findNavigationLinkById(
+			navigationLinks,
+			parentPageID
+		);
 		if ( parentPage && parentPage.innerBlocks ) {
 			navigationLinks = parentPage.innerBlocks;
 		}

--- a/packages/block-library/src/page-list/use-convert-to-navigation-links.js
+++ b/packages/block-library/src/page-list/use-convert-to-navigation-links.js
@@ -5,6 +5,13 @@ import { createBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
+/**
+ * Converts an array of pages into a nested array of navigation link blocks.
+ *
+ * @param {Array}  pages An array of pages.
+ *
+ * @return {Array} A nested array of navigation link blocks.
+ */
 function createNavigationLinks( pages = [] ) {
 	const linkMap = {};
 	const navigationLinks = [];
@@ -41,6 +48,7 @@ function createNavigationLinks( pages = [] ) {
 
 /**
  * Finds a navigation link block by id, recursively.
+ * It might be possible to make this a more generic helper function.
  *
  * @param {Array}  navigationLinks An array of navigation link blocks.
  * @param {number} id              The id of the navigation link to find.
@@ -49,17 +57,19 @@ function createNavigationLinks( pages = [] ) {
  */
 function findById( navigationLinks, id ) {
 	for ( const navigationLink of navigationLinks ) {
+		// Is this the link we're looking for?
 		if ( navigationLink.attributes.id === id ) {
 			return navigationLink;
 		}
-		if (
-			navigationLink.innerBlocks &&
-			navigationLink.innerBlocks.length > 0
-		) {
+
+		// If not does it have innerBlocks?
+		if ( navigationLink.innerBlocks && navigationLink.innerBlocks.length ) {
 			const foundNavigationLink = findById(
 				navigationLink.innerBlocks,
 				id
 			);
+
+			// Does the innerBlocks have the link we're looking for?
 			if ( foundNavigationLink ) {
 				return foundNavigationLink;
 			}


### PR DESCRIPTION
## What?
When converting a Page List block to a list of links we should respect the selected parent, rather than using all pages.

## Why?
This is the expected behaviour.

## How?
We need to do some quite complex recursion over the innerBlocks to ensure that we find the right block to use as a parent. The `findById` function could be made more general. 

## Testing Instructions
1. Create several pages, ensuring that at least one page is a child of another.
2. Add a page list block.
3. Select the block and go to the settings panel.
4. Select a parent page for the page list block that has at least one child.
5. Click on the "Edit" button to convert this block into a list of links.
6. Check that the displayed pages are the same as before.

### Testing Instructions for Keyboard
As above

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/275961/216090659-dbd524f9-4a33-4680-adcc-421be45cdb67.mov

