### PR TITLE
Sticky Position: Fix top position while logged in on mobile

### DIFF
--- a/lib/block-supports/position.php
+++ b/lib/block-supports/position.php
@@ -87,7 +87,7 @@ function gutenberg_render_position_support( $block_content, $block ) {
 					}
 
 					// Ensure current side value also factors in the height of the logged in admin bar.
-					$side_value = "calc($side_value + var(--wp-admin--admin-bar--height, 0px))";
+					$side_value = "calc($side_value + var(--wp-admin--admin-bar--position-offset, 0px))";
 				}
 
 				$position_styles[] =

--- a/lib/block-supports/position.php
+++ b/lib/block-supports/position.php
@@ -68,7 +68,7 @@ function gutenberg_render_position_support( $block_content, $block ) {
 	) {
 		$wrapper_classes[] = $class_name;
 		$wrapper_classes[] = 'is-position-' . $position_type;
-		$sides = array( 'top', 'right', 'bottom', 'left' );
+		$sides             = array( 'top', 'right', 'bottom', 'left' );
 
 		foreach ( $sides as $side ) {
 			$side_value = _wp_array_get( $style_attribute, array( 'position', $side ) );

--- a/lib/block-supports/position.php
+++ b/lib/block-supports/position.php
@@ -61,19 +61,22 @@ function gutenberg_render_position_support( $block_content, $block ) {
 	$selector        = ".$class_name";
 	$position_styles = array();
 	$position_type   = _wp_array_get( $style_attribute, array( 'position', 'type' ), '' );
+	$wrapper_classes = array();
 
 	if (
 		in_array( $position_type, $allowed_position_types, true )
 	) {
+		$wrapper_classes[] = $class_name;
+		$wrapper_classes[] = 'is-position-' . $position_type;
 		$sides = array( 'top', 'right', 'bottom', 'left' );
 
 		foreach ( $sides as $side ) {
 			$side_value = _wp_array_get( $style_attribute, array( 'position', $side ) );
 			if ( null !== $side_value ) {
 				/*
-				* For fixed or sticky top positions,
-				* ensure the value includes an offset for the logged in admin bar.
-				*/
+				 * For fixed or sticky top positions,
+				 * ensure the value includes an offset for the logged in admin bar.
+				 */
 				if (
 					'top' === $side &&
 					( 'fixed' === $position_type || 'sticky' === $position_type )
@@ -122,7 +125,9 @@ function gutenberg_render_position_support( $block_content, $block ) {
 		// Inject class name to block container markup.
 		$content = new WP_HTML_Tag_Processor( $block_content );
 		$content->next_tag();
-		$content->add_class( $class_name );
+		foreach ( $wrapper_classes as $class ) {
+			$content->add_class( $class );
+		}
 		return (string) $content;
 	}
 

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -365,6 +365,10 @@ export const withPositionStyles = createHigherOrderComponent(
 		// Attach a `wp-container-` id-based class name.
 		const className = classnames( props?.className, {
 			[ `wp-container-${ id }` ]: allowPositionStyles && !! css, // Only attach a container class if there is generated CSS to be attached.
+			[ `is-position-${ attributes?.style?.position?.type }` ]:
+				allowPositionStyles &&
+				!! css &&
+				!! attributes?.style?.position?.type,
 		} );
 
 		return (

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -174,7 +174,7 @@ html :where(.is-position-sticky) {
 // within the scope of the position classname. This is required because the admin bar
 // is not fixed to the top on mobile devices, but is fixed on viewports larger than 600px.
 @media screen and (max-width: 600px) {
-	.is-position-sticky {
+	html :where(.is-position-sticky) {
 		/* stylelint-disable length-zero-no-unit */
 		--wp-admin--admin-bar--position-offset: 0px; // 0px is set explicitly so that it can be used in a calc value.
 		/* stylelint-enable length-zero-no-unit */

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -161,3 +161,22 @@ html :where(img[class*="wp-image-"]) {
 figure {
 	margin: 0 0 1em 0;
 }
+
+// Set the admin bar offset for sticky positioned blocks to the height of the admin bar.
+// This allows sticky positioned blocks to be positioned correctly when the admin bar is visible.
+html :where(.is-position-sticky) {
+	/* stylelint-disable length-zero-no-unit */
+	--wp-admin--admin-bar--position-offset: var(--wp-admin--admin-bar--height, 0px); // 0px is set explicitly so that it can be used in a calc value.
+	/* stylelint-enable length-zero-no-unit */
+}
+
+// To support sticky positioning, reset the admin bar offset to 0px on mobile devices,
+// within the scope of the position classname. This is required because the admin bar
+// is not fixed to the top on mobile devices, but is fixed on viewports larger than 600px.
+@media screen and (max-width: 600px) {
+	.is-position-sticky {
+		/* stylelint-disable length-zero-no-unit */
+		--wp-admin--admin-bar--position-offset: 0px; // 0px is set explicitly so that it can be used in a calc value.
+		/* stylelint-enable length-zero-no-unit */
+	}
+}

--- a/packages/block-library/src/group/style.scss
+++ b/packages/block-library/src/group/style.scss
@@ -3,9 +3,10 @@
 	box-sizing: border-box;
 }
 
-// To support sticky positioning, reset the admin bar height to 0px on mobile devices.
+// To support sticky positioning, reset the admin bar CSS variable height
+// to 0px on mobile devices, within the scope of the group block and position classname.
 // This is required because the admin bar is not fixed to the top on mobile devices,
-// but is on viewports larger than 600px.
+// but is fixed on viewports larger than 600px.
 @media screen and (max-width: 600px) {
 	.wp-block-group.is-position-sticky {
 		/* stylelint-disable length-zero-no-unit */

--- a/packages/block-library/src/group/style.scss
+++ b/packages/block-library/src/group/style.scss
@@ -2,15 +2,3 @@
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 }
-
-// To support sticky positioning, reset the admin bar CSS variable height
-// to 0px on mobile devices, within the scope of the group block and position classname.
-// This is required because the admin bar is not fixed to the top on mobile devices,
-// but is fixed on viewports larger than 600px.
-@media screen and (max-width: 600px) {
-	.wp-block-group.is-position-sticky {
-		/* stylelint-disable length-zero-no-unit */
-		--wp-admin--admin-bar--height: 0px; // 0px is set explicitly so that it can be used in a calc value.
-		/* stylelint-enable length-zero-no-unit */
-	}
-}

--- a/packages/block-library/src/group/style.scss
+++ b/packages/block-library/src/group/style.scss
@@ -2,3 +2,14 @@
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 }
+
+// To support sticky positioning, reset the admin bar height to 0px on mobile devices.
+// This is required because the admin bar is not fixed to the top on mobile devices,
+// but is on viewports larger than 600px.
+@media screen and (max-width: 600px) {
+	.wp-block-group.is-position-sticky {
+		/* stylelint-disable length-zero-no-unit */
+		--wp-admin--admin-bar--height: 0px; // 0px is set explicitly so that it can be used in a calc value.
+		/* stylelint-enable length-zero-no-unit */
+	}
+}

--- a/phpunit/block-supports/position-test.php
+++ b/phpunit/block-supports/position-test.php
@@ -131,7 +131,7 @@ class WP_Block_Supports_Position_Test extends WP_UnitTestCase {
 					'type' => 'sticky',
 					'top'  => '0px',
 				),
-				'expected_wrapper'  => '/^<div class="wp-container-\d+">Content<\/div>$/',
+				'expected_wrapper'  => '/^<div class="wp-container-\d+ is-position-sticky">Content<\/div>$/',
 				'expected_styles'   => '/^.wp-container-\d+' . preg_quote( '{top:calc(0px + var(--wp-admin--admin-bar--height, 0px));position:sticky;z-index:10;}' ) . '$/',
 			),
 			'sticky position style is not applied if theme does not support it' => array(

--- a/phpunit/block-supports/position-test.php
+++ b/phpunit/block-supports/position-test.php
@@ -132,7 +132,7 @@ class WP_Block_Supports_Position_Test extends WP_UnitTestCase {
 					'top'  => '0px',
 				),
 				'expected_wrapper'  => '/^<div class="wp-container-\d+ is-position-sticky">Content<\/div>$/',
-				'expected_styles'   => '/^.wp-container-\d+' . preg_quote( '{top:calc(0px + var(--wp-admin--admin-bar--height, 0px));position:sticky;z-index:10;}' ) . '$/',
+				'expected_styles'   => '/^.wp-container-\d+' . preg_quote( '{top:calc(0px + var(--wp-admin--admin-bar--position-offset, 0px));position:sticky;z-index:10;}' ) . '$/',
 			),
 			'sticky position style is not applied if theme does not support it' => array(
 				'theme_name'        => 'default',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #47566, part of #47043, following on from #46142

Fix the issue where the top position for sticky positioned group blocks is incorrect while logged in on mobile. This is achieved by adding a classname to the position markup, and a CSS rule to the common CSS to reset the admin height CSS variable within the scope of the sticky position classname.

Kudos @carolinan for opening the issue and the suggestion for the fix.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As reported in #47566, the logged in CSS for the admin bar has it absolutely positioned to the top of the page within the mobile breakpoint, rather than fixed to the top of the page. For viewports larger than `600px` the existing calculation to offset the area of the admin bar works correctly, however for viewports smaller than `600px` the sticky position output resulted in the sticky block being too low (not flush with the top of the page).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* In the output of the sticky position block support, also output a classname with the position type (e.g. `is-position-sticky`).
* In the common CSS, add a new CSS variable for position offset (set to the admin height CSS variable), and include a rule to reset the offset CSS variable within the same media query used by the admin bar CSS.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In a post or at the root level of the site editor, add a group block with a background color and some content, and set the group block to sticky
2. On the site frontend, while logged in, scroll the page so that the block sticks to the top of the screen — it should be at the top of the screen, but offset by the visible area of the logged in admin bar
3. Set the viewport to be narrow (e.g. less than 600px wide) and ensure that when you scroll down the page, the sticky block is flush with the top of the screen

A question for the reviewer: is there a better place to put the override CSS? Does the solution here seem reasonable enough for the time-being? I'd love it if there was a way to avoid introducing this media query, but I couldn't think of an alternative 🤔

## Screenshots or screencast <!-- if applicable -->

| Before: While logged in, and scrolled down the page, there is space at the top | After: While logged in, and scrolled down the page, there is no space at the top |
| --- | --- |
| <img width="382" alt="image" src="https://user-images.githubusercontent.com/14988353/216225594-8bcb26f3-983d-4016-9eee-2026412552ff.png"> | <img width="381" alt="image" src="https://user-images.githubusercontent.com/14988353/216225630-7b734040-33ba-43c7-b4fc-41733ae24405.png"> |