### PR TITLE
Show a pointer/hint in the settings tab informing the user about the styles tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17309,6 +17309,7 @@
 				"@wordpress/keyboard-shortcuts": "file:packages/keyboard-shortcuts",
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"@wordpress/notices": "file:packages/notices",
+				"@wordpress/preferences": "file:packages/preferences",
 				"@wordpress/rich-text": "file:packages/rich-text",
 				"@wordpress/shortcode": "file:packages/shortcode",
 				"@wordpress/style-engine": "file:packages/style-engine",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -54,6 +54,7 @@
 		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/notices": "file:../notices",
+		"@wordpress/preferences": "file:../preferences",
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/shortcode": "file:../shortcode",
 		"@wordpress/style-engine": "file:../style-engine",

--- a/packages/block-editor/src/components/inspector-controls-tabs/settings-tab-hint.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/settings-tab-hint.js
@@ -36,7 +36,7 @@ export default function InspectorControlsTabsHint() {
 				className="block-editor-inspector-controls-tabs__hint-dismiss"
 				icon={ close }
 				iconSize="16"
-				label={ __( 'Dismiss' ) }
+				label={ __( 'Dismiss hint' ) }
 				onClick={ () => {
 					// Retain focus when dismissing the element.
 					const previousElement = focus.tabbable.findPrevious(

--- a/packages/block-editor/src/components/inspector-controls-tabs/settings-tab-hint.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/settings-tab-hint.js
@@ -3,37 +3,46 @@
  */
 import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { focus } from '@wordpress/dom';
+import { useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
 import { store as preferencesStore } from '@wordpress/preferences';
 
-const PREFERENCE_NAME = 'isInspectorControlsTabsPointerVisible';
+const PREFERENCE_NAME = 'isInspectorControlsTabsHintVisible';
 
-export default function InspectorControlsTabsPointer() {
-	const isInspectorControlsTabsPointerVisible = useSelect(
+export default function InspectorControlsTabsHint() {
+	const isInspectorControlsTabsHintVisible = useSelect(
 		( select ) =>
 			select( preferencesStore ).get( 'core', PREFERENCE_NAME ) ?? true,
 		[]
 	);
 
+	const ref = useRef();
+
 	const { set: setPreference } = useDispatch( preferencesStore );
-	if ( ! isInspectorControlsTabsPointerVisible ) {
+	if ( ! isInspectorControlsTabsHintVisible ) {
 		return null;
 	}
 
 	return (
-		<div className="block-editor-inspector-controls-tabs__pointer">
-			<div className="block-editor-inspector-controls-tabs__pointer-content">
+		<div ref={ ref } className="block-editor-inspector-controls-tabs__hint">
+			<div className="block-editor-inspector-controls-tabs__hint-content">
 				{ __(
 					"Looking for other block settings? They've moved to the styles tab."
 				) }
 			</div>
 			<Button
-				className="block-editor-inspector-controls-tabs__pointer-dismiss"
+				className="block-editor-inspector-controls-tabs__hint-dismiss"
 				icon={ close }
 				iconSize="16"
 				label={ __( 'Dismiss' ) }
 				onClick={ () => {
+					// Retain focus when dismissing the element.
+					const previousElement = focus.tabbable.findPrevious(
+						ref.current
+					);
+					previousElement?.focus();
 					setPreference( 'core', PREFERENCE_NAME, false );
 				} }
 				showTooltip={ false }

--- a/packages/block-editor/src/components/inspector-controls-tabs/settings-tab-pointer.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/settings-tab-pointer.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { speak } from '@wordpress/a11y';
 import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -36,7 +35,6 @@ export default function InspectorControlsTabsPointer() {
 				label={ __( 'Dismiss' ) }
 				onClick={ () => {
 					setPreference( 'core', PREFERENCE_NAME, false );
-					speak( __( 'Notice dismissed.' ) );
 				} }
 				showTooltip={ false }
 			/>

--- a/packages/block-editor/src/components/inspector-controls-tabs/settings-tab-pointer.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/settings-tab-pointer.js
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { close } from '@wordpress/icons';
+import { store as preferencesStore } from '@wordpress/preferences';
+
+const PREFERENCE_NAME = 'isInspectorControlsTabsPointerVisible';
+
+export default function InspectorControlsTabsPointer() {
+	const isInspectorControlsTabsPointerVisible = useSelect(
+		( select ) =>
+			select( preferencesStore ).get( 'core', PREFERENCE_NAME ) ?? true,
+		[]
+	);
+
+	const { set: setPreference } = useDispatch( preferencesStore );
+	if ( ! isInspectorControlsTabsPointerVisible ) {
+		return null;
+	}
+
+	return (
+		<div className="block-editor-inspector-controls-tabs__pointer">
+			<div className="block-editor-inspector-controls-tabs__pointer-content">
+				{ __(
+					"Looking for other block settings? They've moved to the styles tab."
+				) }
+			</div>
+			<Button
+				className="block-editor-inspector-controls-tabs__pointer-dismiss"
+				icon={ close }
+				iconSize="16"
+				label={ __( 'Dismiss' ) }
+				onClick={ () =>
+					setPreference( 'core', PREFERENCE_NAME, false )
+				}
+				showTooltip={ false }
+			/>
+		</div>
+	);
+}

--- a/packages/block-editor/src/components/inspector-controls-tabs/settings-tab-pointer.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/settings-tab-pointer.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { speak } from '@wordpress/a11y';
 import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -33,9 +34,10 @@ export default function InspectorControlsTabsPointer() {
 				icon={ close }
 				iconSize="16"
 				label={ __( 'Dismiss' ) }
-				onClick={ () =>
-					setPreference( 'core', PREFERENCE_NAME, false )
-				}
+				onClick={ () => {
+					setPreference( 'core', PREFERENCE_NAME, false );
+					speak( __( 'Notice dismissed.' ) );
+				} }
 				showTooltip={ false }
 			/>
 		</div>

--- a/packages/block-editor/src/components/inspector-controls-tabs/settings-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/settings-tab.js
@@ -4,7 +4,7 @@
 import AdvancedControls from './advanced-controls-panel';
 import PositionControls from './position-controls-panel';
 import { default as InspectorControls } from '../inspector-controls';
-import SettingsTabPointer from './settings-tab-pointer';
+import SettingsTabHint from './settings-tab-hint';
 
 const SettingsTab = ( { showAdvancedControls = false } ) => (
 	<>
@@ -15,7 +15,7 @@ const SettingsTab = ( { showAdvancedControls = false } ) => (
 				<AdvancedControls />
 			</div>
 		) }
-		<SettingsTabPointer />
+		<SettingsTabHint />
 	</>
 );
 

--- a/packages/block-editor/src/components/inspector-controls-tabs/settings-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/settings-tab.js
@@ -4,6 +4,7 @@
 import AdvancedControls from './advanced-controls-panel';
 import PositionControls from './position-controls-panel';
 import { default as InspectorControls } from '../inspector-controls';
+import SettingsTabPointer from './settings-tab-pointer';
 
 const SettingsTab = ( { showAdvancedControls = false } ) => (
 	<>
@@ -14,6 +15,7 @@ const SettingsTab = ( { showAdvancedControls = false } ) => (
 				<AdvancedControls />
 			</div>
 		) }
+		<SettingsTabPointer />
 	</>
 );
 

--- a/packages/block-editor/src/components/inspector-controls-tabs/style.scss
+++ b/packages/block-editor/src/components/inspector-controls-tabs/style.scss
@@ -17,6 +17,7 @@
 .block-editor-inspector-controls-tabs__pointer {
 	align-items: top;
 	background: $gray-100;
+	border-radius: $radius-block-ui;
 	color: $gray-900;
 	display: flex;
 	flex-direction: row;
@@ -24,11 +25,11 @@
 }
 
 .block-editor-inspector-controls-tabs__pointer-content {
-	margin: $grid-unit-20 0 $grid-unit-20 $grid-unit-20;
+	margin: $grid-unit-15 0 $grid-unit-15 $grid-unit-15;
 }
 
 .block-editor-inspector-controls-tabs__pointer-dismiss {
 	// The dismiss button has a lot of empty space through its padding.
 	// Apply margin to visually align the icon with the top of the text to its left.
-	margin: $grid-unit-10 $grid-unit-10 $grid-unit-10 0;
+	margin: $grid-unit-05 $grid-unit-05 $grid-unit-05 0;
 }

--- a/packages/block-editor/src/components/inspector-controls-tabs/style.scss
+++ b/packages/block-editor/src/components/inspector-controls-tabs/style.scss
@@ -14,7 +14,7 @@
 	}
 }
 
-.block-editor-inspector-controls-tabs__pointer {
+.block-editor-inspector-controls-tabs__hint {
 	align-items: top;
 	background: $gray-100;
 	border-radius: $radius-block-ui;
@@ -24,11 +24,11 @@
 	margin: $grid-unit-20;
 }
 
-.block-editor-inspector-controls-tabs__pointer-content {
+.block-editor-inspector-controls-tabs__hint-content {
 	margin: $grid-unit-15 0 $grid-unit-15 $grid-unit-15;
 }
 
-.block-editor-inspector-controls-tabs__pointer-dismiss {
+.block-editor-inspector-controls-tabs__hint-dismiss {
 	// The dismiss button has a lot of empty space through its padding.
 	// Apply margin to visually align the icon with the top of the text to its left.
 	margin: $grid-unit-05 $grid-unit-05 $grid-unit-05 0;

--- a/packages/block-editor/src/components/inspector-controls-tabs/style.scss
+++ b/packages/block-editor/src/components/inspector-controls-tabs/style.scss
@@ -13,3 +13,22 @@
 		}
 	}
 }
+
+.block-editor-inspector-controls-tabs__pointer {
+	align-items: top;
+	background: $gray-100;
+	color: $gray-900;
+	display: flex;
+	flex-direction: row;
+	margin: $grid-unit-20;
+}
+
+.block-editor-inspector-controls-tabs__pointer-content {
+	margin: $grid-unit-20 0 $grid-unit-20 $grid-unit-20;
+}
+
+.block-editor-inspector-controls-tabs__pointer-dismiss {
+	// The dismiss button has a lot of empty space through its padding.
+	// Apply margin to visually align the icon with the top of the text to its left.
+	margin: $grid-unit-10 $grid-unit-10 $grid-unit-10 0;
+}


### PR DESCRIPTION
## What?
Fixes #47410

## Why?
It's nice to let the user know about this change

## How?
- Implements a new (non-public, non-reusable) component for showing this pointer ([see the discussion in the issue about why `Notice` wasn't used](https://github.com/WordPress/gutenberg/issues/47410#issuecomment-1407969824))
- Uses the preferences package to record the state of whether the notice has been dismissed or not.

## Testing Instructions
Note - if you want to test this multiple times, you can run this snippet in the browser console to bring the dismissed pointer back again:
```js
wp.data.dispatch( 'core/preferences' ).set( 'core', 'isInspectorControlsTabsHintVisible', true )
```

1. Add a block (a good one to test with is 'Group')
2. Observe the 'pointer' in the sidebar
3. Dismiss it (at this point it shouldn't ever come back again)

### Testing Instructions for Keyboard
1. Add a group block by tabbing into the editor content and typing `/group` and hitting the enter key
2. Tab to the 'Editor settings' region. If it's not open you should land upon a button 'Open document settings' first, so use that button to open it.
3. Tab till you get to a 'Dismiss hint' button, optionally read the text that's in the DOM before that button (but not focusable).
4. Select that button.
5. Focus should be transferred to the Advanced section as the hint disappears

## Screenshots or screencast <!-- if applicable -->
![Screen Shot 2023-02-02 at 1 21 21 pm](https://user-images.githubusercontent.com/677833/216238609-05ecf77f-1c1a-44c3-b840-1fa5280ff30f.png)

