### PR TITLE
Site Editor: Update 'Additional CSS' subtitle string

### DIFF
--- a/packages/edit-site/src/components/global-styles/custom-css.js
+++ b/packages/edit-site/src/components/global-styles/custom-css.js
@@ -101,7 +101,7 @@ function CustomCSSControl( { blockName } ) {
 				</Panel>
 			) }
 			<VStack spacing={ 3 }>
-				<Subtitle>{ __( 'ADDITIONAL CSS' ) }</Subtitle>
+				<Subtitle>{ __( 'Additional CSS' ) }</Subtitle>
 				<TextareaControl
 					__nextHasNoMarginBottom
 					value={


### PR DESCRIPTION
## What?
PR updates the 'Additional CSS' subtitle string to be in the title case and lets CSS handle the transformation.

## Why?
* The `Subtitle` already displays text in uppercase.
* Matches the exact string used elsewhere in the editor, making it easier to translate.

## Testing Instructions
1. Go to the Site Editor.
2. Open the Styles sidebar.
3. Navigate to the "Additional CSS" panel. You might need to toggle it from the ellipsis dropdown.
4. Confirm subtitle is displayed as before - in uppercase.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-02-02 at 10 03 20](https://user-images.githubusercontent.com/240569/216244842-73aa1a39-36f9-410c-9f45-ea3f84da4583.png)
