### PR TITLE
Block Supports: Add non-default ToolsPanel items if props change, eg. on styles paste

### DIFF
--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -58,8 +58,6 @@ export default function BlockActions( {
 		setBlockMovingClientId,
 		setNavigationMode,
 		selectBlock,
-		clearSelectedBlock,
-		multiSelect,
 	} = useDispatch( blockEditorStore );
 
 	const notifyCopy = useNotifyCopy();
@@ -134,13 +132,6 @@ export default function BlockActions( {
 		},
 		async onPasteStyles() {
 			await pasteStyles( blocks );
-
-			// Need to reselect the block(s) in order for optional tool panel control changes to register.
-			clearSelectedBlock();
-			multiSelect(
-				blocks[ 0 ].clientId,
-				blocks[ blocks.length - 1 ].clientId
-			);
 		},
 	} );
 }

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -148,10 +148,7 @@ export function DimensionsPanel( props ) {
 							'padding',
 							'spacing'
 						) }
-						isShownByDefault={
-							defaultSpacingControls?.padding ||
-							hasPaddingValue( props )
-						}
+						isShownByDefault={ defaultSpacingControls?.padding }
 						panelId={ props.clientId }
 					>
 						<PaddingEdit
@@ -171,10 +168,7 @@ export function DimensionsPanel( props ) {
 							'margin',
 							'spacing'
 						) }
-						isShownByDefault={
-							defaultSpacingControls?.margin ||
-							hasMarginValue( props )
-						}
+						isShownByDefault={ defaultSpacingControls?.margin }
 						panelId={ props.clientId }
 					>
 						<MarginEdit
@@ -194,10 +188,7 @@ export function DimensionsPanel( props ) {
 							'blockGap',
 							'spacing'
 						) }
-						isShownByDefault={
-							defaultSpacingControls?.blockGap ||
-							hasGapValue( props )
-						}
+						isShownByDefault={ defaultSpacingControls?.blockGap }
 						panelId={ props.clientId }
 					>
 						<GapEdit { ...props } />
@@ -213,8 +204,7 @@ export function DimensionsPanel( props ) {
 							'dimensions'
 						) }
 						isShownByDefault={
-							defaultDimensionsControls?.minHeight ||
-							hasMinHeightValue( props )
+							defaultDimensionsControls?.minHeight
 						}
 						panelId={ props.clientId }
 					>

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -148,7 +148,10 @@ export function DimensionsPanel( props ) {
 							'padding',
 							'spacing'
 						) }
-						isShownByDefault={ defaultSpacingControls?.padding }
+						isShownByDefault={
+							defaultSpacingControls?.padding ||
+							hasPaddingValue( props )
+						}
 						panelId={ props.clientId }
 					>
 						<PaddingEdit
@@ -168,7 +171,10 @@ export function DimensionsPanel( props ) {
 							'margin',
 							'spacing'
 						) }
-						isShownByDefault={ defaultSpacingControls?.margin }
+						isShownByDefault={
+							defaultSpacingControls?.margin ||
+							hasMarginValue( props )
+						}
 						panelId={ props.clientId }
 					>
 						<MarginEdit
@@ -188,7 +194,10 @@ export function DimensionsPanel( props ) {
 							'blockGap',
 							'spacing'
 						) }
-						isShownByDefault={ defaultSpacingControls?.blockGap }
+						isShownByDefault={
+							defaultSpacingControls?.blockGap ||
+							hasGapValue( props )
+						}
 						panelId={ props.clientId }
 					>
 						<GapEdit { ...props } />
@@ -204,7 +213,8 @@ export function DimensionsPanel( props ) {
 							'dimensions'
 						) }
 						isShownByDefault={
-							defaultDimensionsControls?.minHeight
+							defaultDimensionsControls?.minHeight ||
+							hasMinHeightValue( props )
 						}
 						panelId={ props.clientId }
 					>

--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -103,6 +103,14 @@ export function useToolsPanelItem(
 		flagItemCustomization,
 	] );
 
+	useEffect( () => {
+		if ( ! isShownByDefault && isValueSet && ! wasValueSet ) {
+			console.log(
+				'Do something here to make non-default items with values updated show'
+			);
+		}
+	} );
+
 	// Note: `label` is used as a key when building menu item state in
 	// `ToolsPanel`.
 	const menuGroup = isShownByDefault ? 'default' : 'optional';

--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -109,7 +109,7 @@ export function useToolsPanelItem(
 				'Do something here to make non-default items with values updated show'
 			);
 		}
-	} );
+	}, [ isShownByDefault, isValueSet, wasValueSet ] );
 
 	// Note: `label` is used as a key when building menu item state in
 	// `ToolsPanel`.


### PR DESCRIPTION
## What?
Trying a more robust fix for #47368

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
