### PR TITLE
Allow clicking the site editor frame to enter edit mode

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -19,6 +19,7 @@ import {
 	useResizeObserver,
 	useMergeRefs,
 	useRefEffect,
+	useDisabled,
 } from '@wordpress/compose';
 import { __experimentalStyleProvider as StyleProvider } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -207,7 +208,13 @@ function Iframe( {
 				forceRender();
 			} );
 	}, [] );
-	const bodyRef = useMergeRefs( [ contentRef, clearerRef, writingFlowRef ] );
+	const disabledRef = useDisabled( { isDisabled: ! readonly } );
+	const bodyRef = useMergeRefs( [
+		contentRef,
+		clearerRef,
+		writingFlowRef,
+		disabledRef,
+	] );
 
 	const styleAssets = (
 		<>
@@ -284,7 +291,6 @@ function Iframe( {
 									marginTop: frameSize,
 									transform: `scale( ${ scale } )`,
 								} }
-								inert={ readonly ? 'true' : undefined }
 							>
 								{ contentResizeListener }
 								<StyleProvider document={ iframeDocument }>

--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -13,6 +13,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import { unlock } from '../../experiments';
 import { store as editSiteStore } from '../../store';
 
 function EditorCanvas( { enableResizing, settings, children, ...props } ) {
@@ -23,11 +24,11 @@ function EditorCanvas( { enableResizing, settings, children, ...props } ) {
 			isZoomOutMode:
 				select( blockEditorStore ).__unstableGetEditorMode() ===
 				'zoom-out',
-			canvasMode: select( editSiteStore ).__unstableGetCanvasMode(),
+			canvasMode: unlock( select( editSiteStore ) ).getCanvasMode(),
 		} ),
 		[]
 	);
-	const { __unstableSetCanvasMode } = useDispatch( editSiteStore );
+	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 	const deviceStyles = useResizeCanvas( deviceType );
 	const mouseMoveTypingRef = useMouseMoveTypingReset();
 	return (
@@ -62,9 +63,7 @@ function EditorCanvas( { enableResizing, settings, children, ...props } ) {
 			role={ canvasMode === 'view' ? 'button' : undefined }
 			onClick={
 				canvasMode === 'view'
-					? () => {
-							__unstableSetCanvasMode( 'edit' );
-					  }
+					? () => setCanvasMode( 'edit' )
 					: undefined
 			}
 			readonly={ canvasMode === 'view' }

--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -8,7 +13,7 @@ import {
 	__unstableUseMouseMoveTypingReset as useMouseMoveTypingReset,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -16,16 +21,18 @@ import { useSelect } from '@wordpress/data';
 import { store as editSiteStore } from '../../store';
 
 function EditorCanvas( { enableResizing, settings, children, ...props } ) {
-	const { deviceType, isZoomOutMode } = useSelect(
+	const { canvasMode, deviceType, isZoomOutMode } = useSelect(
 		( select ) => ( {
 			deviceType:
 				select( editSiteStore ).__experimentalGetPreviewDeviceType(),
 			isZoomOutMode:
 				select( blockEditorStore ).__unstableGetEditorMode() ===
 				'zoom-out',
+			canvasMode: select( editSiteStore ).__unstableGetCanvasMode(),
 		} ),
 		[]
 	);
+	const { __unstableSetCanvasMode } = useDispatch( editSiteStore );
 	const deviceStyles = useResizeCanvas( deviceType );
 	const mouseMoveTypingRef = useMouseMoveTypingReset();
 	return (
@@ -55,8 +62,20 @@ function EditorCanvas( { enableResizing, settings, children, ...props } ) {
 			}
 			ref={ mouseMoveTypingRef }
 			name="editor-canvas"
-			className="edit-site-visual-editor__editor-canvas"
+			className={ classnames(
+				'edit-site-visual-editor__editor-canvas',
+				`is-canvas-${ canvasMode }`
+			) }
 			{ ...props }
+			role={ canvasMode === 'view' ? 'button' : undefined }
+			onClick={
+				canvasMode === 'view'
+					? () => {
+							__unstableSetCanvasMode( 'edit' );
+					  }
+					: undefined
+			}
+			readonly={ canvasMode === 'view' }
 		>
 			{ /* Filters need to be rendered before children to avoid Safari rendering issues. */ }
 			{ settings.svgFilters }

--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -62,10 +57,7 @@ function EditorCanvas( { enableResizing, settings, children, ...props } ) {
 			}
 			ref={ mouseMoveTypingRef }
 			name="editor-canvas"
-			className={ classnames(
-				'edit-site-visual-editor__editor-canvas',
-				`is-canvas-${ canvasMode }`
-			) }
+			className="edit-site-visual-editor__editor-canvas"
 			{ ...props }
 			role={ canvasMode === 'view' ? 'button' : undefined }
 			onClick={

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -159,6 +159,3 @@
 	}
 }
 
-.edit-site-visual-editor__editor-canvas.is-canvas-view {
-	cursor: pointer;
-}

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -158,3 +158,7 @@
 		box-shadow: inset 0 0 0 2px var(--wp-admin-theme-color);
 	}
 }
+
+.edit-site-visual-editor__editor-canvas.is-canvas-view {
+	cursor: pointer;
+}


### PR DESCRIPTION
Related to #36667 

## What?

This PR simplifies the flows in the site editor by allowing users to click the "frame" to enter edit mode.

## Testing Instructions

1- Open the site editor.
2- you should be able to tab and click the frame or just click using the mouse to enter edit mode.