### PR TITLE
Block Directory: Optimize `DownloadableBlocksPanel`

### DIFF
--- a/packages/block-directory/src/components/downloadable-blocks-panel/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-panel/index.js
@@ -16,6 +16,8 @@ import DownloadableBlocksInserterPanel from './inserter-panel';
 import DownloadableBlocksNoResults from './no-results';
 import { store as blockDirectoryStore } from '../../store';
 
+const EMPTY_ARRAY = [];
+
 function DownloadableBlocksPanel( {
 	downloadableItems,
 	onSelect,
@@ -81,14 +83,25 @@ export default compose( [
 		);
 
 		function getInstallableBlocks( term ) {
-			return getDownloadableBlocks( term ).filter( ( block ) =>
+			const downloadableBlocks = getDownloadableBlocks( term );
+			const installableBlocks = downloadableBlocks.filter( ( block ) =>
 				canInsertBlockType( block, rootClientId, true )
 			);
+
+			if ( downloadableBlocks.length === installableBlocks.length ) {
+				return downloadableBlocks;
+			}
+			return installableBlocks;
 		}
 
-		const downloadableItems = hasPermission
+		let downloadableItems = hasPermission
 			? getInstallableBlocks( filterValue )
 			: [];
+
+		if ( downloadableItems.length === 0 ) {
+			downloadableItems = EMPTY_ARRAY;
+		}
+
 		const isLoading = isRequestingDownloadableBlocks( filterValue );
 
 		return {


### PR DESCRIPTION
## What?
This PR improves the performance of the `DownloadableBlocksPanel` component by reducing the unnecessary updates done to the downloadable blocks (the `downloadableItems` prop). This allows us to avoid unnecessary extra updates when the parent component is re-rendered, but an update is triggered just because we return a new array with the same data.

## Why?
When typing into the main inserter we see a bunch of updates coming from `DownloadableBlocksPanel` with almost always the same `downloadableItems` array contents, but with a different reference.

## How?
We're doing a couple of optimizations:
* When `downloadableItems` is an empty array, we make sure to always return the same empty array.
* If all blocks are installable, we return the `downloadableItems`, since the installable blocks will always contain a new array (as it is the result of `Array.prototype.filter()`).

## Testing Instructions
* Verify inserter search still works well, specifically rendering downloadable blocks.
* Verify tests are green.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
None.