### PR TITLE
Block Editor: Optimize `__unstableGetVisibleBlocks()`

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -168,7 +168,7 @@ function Items( {
 					value={
 						// Only provide data asynchronously if the block is
 						// not visible and not selected.
-						! visibleBlocks.has( clientId ) &&
+						! visibleBlocks.includes( clientId ) &&
 						! selectedBlocks.includes( clientId )
 					}
 				>

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -168,7 +168,7 @@ function Items( {
 					value={
 						// Only provide data asynchronously if the block is
 						// not visible and not selected.
-						! visibleBlocks.includes( clientId ) &&
+						! visibleBlocks.has( clientId ) &&
 						! selectedBlocks.includes( clientId )
 					}
 				>

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -56,6 +56,17 @@ const MILLISECONDS_PER_WEEK = 7 * 24 * 3600 * 1000;
 const EMPTY_ARRAY = [];
 
 /**
+ * Shared reference to an empty Set for cases where it is important to avoid
+ * returning a new Set reference on every invocation, as in a connected or
+ * other pure component which performs `shouldComponentUpdate` check on props.
+ * This should be used as a last resort, since the normalized data should be
+ * maintained by the reducer result in state.
+ *
+ * @type {Set}
+ */
+const EMPTY_SET = new Set();
+
+/**
  * Returns a block's name given its client ID, or null if no block exists with
  * the client ID.
  *
@@ -2722,11 +2733,13 @@ export function isBlockVisible( state, clientId ) {
  */
 export const __unstableGetVisibleBlocks = createSelector(
 	( state ) => {
-		const visibleBlocks = Object.keys( state.blockVisibility ).filter(
-			( key ) => state.blockVisibility[ key ]
+		const visibleBlocks = new Set(
+			Object.keys( state.blockVisibility ).filter(
+				( key ) => state.blockVisibility[ key ]
+			)
 		);
-		if ( visibleBlocks.length === 0 ) {
-			return EMPTY_ARRAY;
+		if ( visibleBlocks.size === 0 ) {
+			return EMPTY_SET;
 		}
 		return visibleBlocks;
 	},

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2722,11 +2722,13 @@ export function isBlockVisible( state, clientId ) {
  */
 export const __unstableGetVisibleBlocks = createSelector(
 	( state ) => {
-		return new Set(
-			Object.keys( state.blockVisibility ).filter(
-				( key ) => state.blockVisibility[ key ]
-			)
+		const visibleBlocks = Object.keys( state.blockVisibility ).filter(
+			( key ) => state.blockVisibility[ key ]
 		);
+		if ( visibleBlocks.length === 0 ) {
+			return EMPTY_ARRAY;
+		}
+		return visibleBlocks;
 	},
 	( state ) => [ state.blockVisibility ]
 );


### PR DESCRIPTION
## What?
This PR improves the performance of the `__unstableGetVisibleBlocks` selector by changing it to work with an array instead of `Set`. This allows us to avoid unnecessary extra updates when the parent component is re-rendered, but an update is triggered just because we always return a `new Set()`.

## Why?
When typing into the main inserter we see a bunch of updates coming from that selector recalculating on every re-render. I didn't expect that to happen, since I was testing with an empty post that would have no hidden blocks. 

I spotted this while working on #47679.

## How?
We're doing a couple of optimizations:
* We're simplifying the `Set` to an array since there's no good reason to use a `Set` there.
* We're making sure that when we return an empty array, we always return the same one to minimize updates.

I'd love to know if there was some additional purpose behind using a `Set` for the block visibility.

## Testing Instructions
* Follow the test instructions of #44325.
* Verify tests are green.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
None.