### PR TITLE
Navigation: Always create a fallback menu

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -209,6 +209,40 @@ function Navigation( {
 		[ navigationMenus ]
 	);
 
+	// This useEffect adds snackbar and speak status notices when menus are created.
+	// If there are no fallback navigation menus then we don't show these messages,
+	// because this means that we are creating the first, fallback navigation menu.
+	useEffect( () => {
+		hideNavigationMenuStatusNotice();
+
+		if ( fallbackNavigationMenus && isCreatingNavigationMenu ) {
+			speak( __( `Creating Navigation Menu.` ) );
+		}
+
+		if ( createNavigationMenuIsSuccess ) {
+			handleUpdateMenu( createNavigationMenuPost.id, {
+				focusNavigationBlock: true,
+			} );
+
+			if ( fallbackNavigationMenus ) {
+				showNavigationMenuStatusNotice(
+					__( `Navigation Menu successfully created.` )
+				);
+			}
+		}
+
+		if ( createNavigationMenuIsError ) {
+			showNavigationMenuStatusNotice(
+				__( 'Failed to create Navigation Menu.' )
+			);
+		}
+	}, [
+		createNavigationMenuStatus,
+		createNavigationMenuError,
+		createNavigationMenuPost,
+		fallbackNavigationMenus,
+	] );
+
 	// Attempt to retrieve and prioritize any existing navigation menu unless:
 	// - the are uncontrolled inner blocks already present in the block.
 	// - the user is creating a new menu.

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -40,7 +40,7 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, getBlockType } from '@wordpress/blocks';
 import { close, Icon } from '@wordpress/icons';
 
 /**
@@ -316,9 +316,15 @@ function Navigation( {
 		} else {
 			// If there are no fallback navigation menus and no classic menus,
 			// then create a new navigation menu.
+
+			// Check that we have a page-list block type.
+			let defaultBlocks = [];
+			if ( getBlockType( 'core/page-list' ) ) {
+				defaultBlocks = [ createBlock( 'core/page-list' ) ];
+			}
 			createNavigationMenu(
 				'Navigation', // TODO - use the template slug in future
-				[ createBlock( 'core/page-list' ) ],
+				defaultBlocks,
 				'publish'
 			);
 		}

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -246,8 +246,7 @@ function Navigation( {
 		if (
 			! hasResolvedNavigationMenus ||
 			isConvertingClassicMenu ||
-			fallbackNavigationMenus?.length > 0 ||
-			! classicMenus?.length
+			fallbackNavigationMenus?.length > 0
 		) {
 			return;
 		}
@@ -256,28 +255,38 @@ function Navigation( {
 		// a classic menu with a `primary` location or slug,
 		// then create a new navigation menu based on it.
 		// Otherwise, use the most recently created classic menu.
-		const primaryMenus = classicMenus.filter(
-			( classicMenu ) =>
-				classicMenu.locations.includes( 'primary' ) ||
-				classicMenu.slug === 'primary'
-		);
+		if ( classicMenus?.length ) {
+			const primaryMenus = classicMenus.filter(
+				( classicMenu ) =>
+					classicMenu.locations.includes( 'primary' ) ||
+					classicMenu.slug === 'primary'
+			);
 
-		if ( primaryMenus.length ) {
-			convertClassicMenu(
-				primaryMenus[ 0 ].id,
-				primaryMenus[ 0 ].name,
-				'publish'
-			);
-		} else {
-			classicMenus.sort( ( a, b ) => {
-				return b.id - a.id;
-			} );
-			convertClassicMenu(
-				classicMenus[ 0 ].id,
-				classicMenus[ 0 ].name,
-				'publish'
-			);
+			if ( primaryMenus.length ) {
+				convertClassicMenu(
+					primaryMenus[ 0 ].id,
+					primaryMenus[ 0 ].name,
+					'publish'
+				);
+			} else {
+				classicMenus.sort( ( a, b ) => {
+					return b.id - a.id;
+				} );
+				convertClassicMenu(
+					classicMenus[ 0 ].id,
+					classicMenus[ 0 ].name,
+					'publish'
+				);
+			}
 		}
+
+		// If there are no fallback navigation menus and no classic menus,
+		// then create a new navigation menu.
+		createNavigationMenu(
+			'navigation',
+			[ createBlock( 'core/page-list' ) ],
+			'publish'
+		);
 	}, [ hasResolvedNavigationMenus ] );
 
 	const navRef = useRef();

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -278,15 +278,15 @@ function Navigation( {
 					'publish'
 				);
 			}
+		} else {
+			// If there are no fallback navigation menus and no classic menus,
+			// then create a new navigation menu.
+			createNavigationMenu(
+				'Navigation', // TODO - use the template slug in future
+				[ createBlock( 'core/page-list' ) ],
+				'publish'
+			);
 		}
-
-		// If there are no fallback navigation menus and no classic menus,
-		// then create a new navigation menu.
-		createNavigationMenu(
-			'navigation',
-			[ createBlock( 'core/page-list' ) ],
-			'publish'
-		);
 	}, [ hasResolvedNavigationMenus ] );
 
 	const navRef = useRef();

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -244,6 +244,7 @@ function Navigation( {
 
 	useEffect( () => {
 		if (
+			ref ||
 			! hasResolvedNavigationMenus ||
 			isConvertingClassicMenu ||
 			fallbackNavigationMenus?.length > 0

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -308,19 +308,6 @@ function Navigation( {
 		classicMenus?.length === 0 &&
 		! hasUncontrolledInnerBlocks;
 
-	useEffect( () => {
-		if ( isPlaceholder ) {
-			/**
-			 *  this fallback only displays (both in editor and on front)
-			 *  the list of pages block if no menu is available as a fallback.
-			 *  We don't want the fallback to request a save,
-			 *  nor to be undoable, hence we mark it non persistent.
-			 */
-			__unstableMarkNextChangeAsNotPersistent();
-			replaceInnerBlocks( clientId, [ createBlock( 'core/page-list' ) ] );
-		}
-	}, [ clientId, isPlaceholder, ref ] );
-
 	const isEntityAvailable =
 		! isNavigationMenuMissing && isNavigationMenuResolved;
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -431,13 +431,12 @@ function block_core_navigation_block_contains_core_navigation( $inner_blocks ) {
 	return false;
 }
 
+/**
+ * Create and returns a navigation menu containing a page-list as a fallback.
+ *
+ * @return array the newly created navigation menu.
+ */
 function block_core_navigation_get_default_pages_fallback() {
-	$page_list_fallback = array(
-		array(
-			'blockName' => 'core/page-list',
-		),
-	);
-
 	$registry = WP_Block_Type_Registry::get_instance();
 
 	// If `core/page-list` is not registered then use empty blocks.
@@ -447,8 +446,8 @@ function block_core_navigation_get_default_pages_fallback() {
 	$wp_insert_post_result = wp_insert_post(
 		array(
 			'post_content' => $default_blocks,
-			'post_title'   => 'navigation', // TODO - use the template slug in future
-			'post_name'    => 'navigation', // TODO - use the template slug in future
+			'post_title'   => 'Navigation', // TODO - use the template slug in future
+			'post_name'    => 'Navigation', // TODO - use the template slug in future
 			'post_status'  => 'publish',
 			'post_type'    => 'wp_navigation',
 		),
@@ -556,7 +555,6 @@ function block_core_navigation_from_block_get_post_ids( $block ) {
  * @return string Returns the post content with the legacy widget added.
  */
 function render_block_core_navigation( $attributes, $content, $block ) {
-	error_log( 'render_block_core_navigation' );
 	static $seen_menu_names = array();
 
 	// Flag used to indicate whether the rendered output is considered to be

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -446,8 +446,8 @@ function block_core_navigation_get_default_pages_fallback() {
 	$wp_insert_post_result = wp_insert_post(
 		array(
 			'post_content' => $default_blocks,
-			'post_title'   => 'Navigation', // TODO - use the template slug in future
-			'post_name'    => 'Navigation', // TODO - use the template slug in future
+			'post_title'   => 'Navigation', // TODO - use the template slug in future.
+			'post_name'    => 'Navigation', // TODO - use the template slug in future.
 			'post_status'  => 'publish',
 			'post_type'    => 'wp_navigation',
 		),
@@ -493,7 +493,7 @@ function block_core_navigation_get_fallback_blocks() {
 	}
 
 	// Normalizing blocks may result in an empty array of blocks if they were all `null` blocks.
-	// In this case default empty blocks
+	// In this case default empty blocks.
 	$fallback_blocks = ! empty( $maybe_fallback ) ? $maybe_fallback : array();
 
 	/**

--- a/packages/e2e-test-utils-playwright/src/request-utils/index.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/index.ts
@@ -25,6 +25,7 @@ import {
 	createClassicMenu,
 	createNavigationMenu,
 	deleteAllMenus,
+	getNavigationMenus,
 } from './menus';
 import { deleteAllPages, createPage } from './pages';
 import { resetPreferences } from './preferences';
@@ -134,6 +135,7 @@ class RequestUtils {
 	createClassicMenu = createClassicMenu.bind( this );
 	createNavigationMenu = createNavigationMenu.bind( this );
 	deleteAllMenus = deleteAllMenus.bind( this );
+	getNavigationMenus = getNavigationMenus.bind( this );
 	createComment = createComment.bind( this );
 	deleteAllComments = deleteAllComments.bind( this );
 	deleteAllWidgets = deleteAllWidgets.bind( this );

--- a/packages/e2e-test-utils-playwright/src/request-utils/menus.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/menus.ts
@@ -104,3 +104,19 @@ export async function deleteAllMenus( this: RequestUtils ) {
 		);
 	}
 }
+
+/**
+ * Get latest navigation menus
+ *
+ * @return {string} Menu content.
+ */
+export async function getNavigationMenus( this: RequestUtils ) {
+	const navigationMenus = await this.rest< NavigationMenu[] >( {
+		method: 'GET',
+		path: `/wp/v2/navigation/`,
+		data: {
+			status: 'publish',
+		},
+	} );
+	return navigationMenus;
+}

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -29,6 +29,7 @@ test.describe(
 		test( 'default to a list of pages if there are no menus', async ( {
 			admin,
 			editor,
+			requestUtils,
 		} ) => {
 			await admin.createNewPost();
 			await editor.insertBlock( { name: 'core/navigation' } );
@@ -48,10 +49,10 @@ test.describe(
 			// Check the markup of the block is correct.
 			await editor.publishPost();
 			const content = await editor.getEditedPostContent();
+			const navigationMenus = await requestUtils.getNavigationMenus();
+			const latestNavigationMenu = navigationMenus[ 0 ];
 			expect( content ).toBe(
-				`<!-- wp:navigation -->
-<!-- wp:page-list /-->
-<!-- /wp:navigation -->`
+				`<!-- wp:navigation {"ref":${ latestNavigationMenu.id }} /-->`
 			);
 		} );
 

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -48,12 +48,14 @@ test.describe(
 
 			// Check the markup of the block is correct.
 			await editor.publishPost();
-			const content = await editor.getEditedPostContent();
 			const navigationMenus = await requestUtils.getNavigationMenus();
 			const latestNavigationMenu = navigationMenus[ 0 ];
-			expect( content ).toBe(
-				`<!-- wp:navigation {"ref":${ latestNavigationMenu.id }} /-->`
-			);
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/navigation',
+					attributes: { ref: latestNavigationMenu.id },
+				},
+			] );
 		} );
 
 		test( 'default to my only existing menu', async ( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This creates a fallback navigation CPT when there isn't one. Fixes #47058

## Why?
This should simplify several things
- we no longer will need to create a new menu when a user tries to edit the fallback
- we should be able to simplify the code around fallbacks, drafts and undo levels

## How?
We automatically create a wp_navigation CPT in both the editor and the frontend, if a user doesn't have one.

## Testing Instructions
1. Go to wp-admin/edit.php?post_type=wp_navigation&paged=1
2. Delete all your navigation menus
3. If you have any classic menus, delete them as well
4. Switch to a theme with a navigation block in a template
5. Open the frontend of the site
6. Confirm that you see a page list in the navigation block
7. Go to wp-admin/edit.php?post_type=wp_navigation&paged=1 and check that you see a CPT called "navigation"
8. Delete this new navigation
9. Open the site editor
10. Confirm that you see a page list in the navigation block
11. Go to wp-admin/edit.php?post_type=wp_navigation&paged=1 and check that you see a CPT called "navigation"

### Testing Instructions for Keyboard
As above.
