### PR TITLE
Rich text: stabilise onFocus

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -110,7 +110,6 @@ function RichTextWrapper(
 		__unstableEmbedURLOnPaste,
 		__unstableDisableFormats: disableFormats,
 		disableLineBreaks,
-		unstableOnFocus,
 		__unstableAllowPrefixTransformations,
 		...props
 	},
@@ -449,7 +448,6 @@ function RichTextWrapper(
 					props.className,
 					'rich-text'
 				) }
-				onFocus={ unstableOnFocus }
 				onKeyDown={ onKeyDown }
 			/>
 		</>

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -428,7 +428,7 @@ function TableEdit( {
 								rowSpan={ rowspan }
 								value={ content }
 								onChange={ onChange }
-								unstableOnFocus={ () => {
+								onFocus={ () => {
 									setSelectedCell( {
 										sectionName: name,
 										rowIndex,
@@ -530,7 +530,7 @@ function TableEdit( {
 						setAttributes( { caption: value } )
 					}
 					// Deselect the selected table cell when the caption is focused.
-					unstableOnFocus={ () => setSelectedCell() }
+					onFocus={ () => setSelectedCell() }
 					__unstableOnSplitAtEnd={ () =>
 						insertBlocksAfter(
 							createBlock( getDefaultBlockName() )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #32415.

Not sure why this unstable props is still around. It prevents the proper `onFocus` prop from spreading. Let's "stabilise" it now by removing it so spreading works.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
