### PR TITLE
File block: Re-add editor styles for classic themes

### DIFF
--- a/packages/block-library/src/classic.scss
+++ b/packages/block-library/src/classic.scss
@@ -13,3 +13,8 @@
 
 	font-size: 1.125em;
 }
+
+.wp-block-file__button {
+	background: #32373c;
+	color: $white;
+}


### PR DESCRIPTION
Fixes: #45399

## What?
This PR adds text color and background color to the file block, which is lost in the Classic theme.

## Why?

If **the classic theme** didn't apply any styles to the file block, WordPres 6.0 would apply the following styles.

Editor:

![editor-6 0](https://user-images.githubusercontent.com/54422211/216330577-eeb5662f-f53c-4c98-87b7-2331e8328695.png)

Frontend:

![front-6 0](https://user-images.githubusercontent.com/54422211/216332249-e086b13b-f8f2-4705-98f4-b8cd5a42f3b0.png)

WordPress 6.1, on the other hand, does not apply font size, background color, or text color, regardless of whether the Gutenberg plugin is enabled.

Editor:

![editor-6 1](https://user-images.githubusercontent.com/54422211/216332724-dfa9b9a7-4c37-422b-9bf8-e8552ebd3d67.png)

Frontend:

![front-6 1](https://user-images.githubusercontent.com/54422211/216332745-647fb59e-2436-449b-b544-50db56fd37ab.png)

As far as I can tell, these styles were removed in #41822. However, just as backward-compatible styles for the classic theme were added to the button block in #44334, I believe similar action is needed for the file block.

## How?

Among the missing styles, text color and background color were added; `font-size: 0.8em;` was excluded because it is [already defined as the default style](https://github.com/WordPress/gutenberg/blob/2f24c67d9e3605e486d88f395b0fad9541296ac7/packages/block-library/src/file/style.scss#L4-L6).

However, this style applies _only_ to the editor. As for the front end styles, **I think they need to be added directly to the core**, just as [the button block is](https://github.com/WordPress/wordpress-develop/blob/0c97bbc1189800763203f20ed612339472150121/src/wp-includes/css/classic-themes.css).

## Testing Instructions

Classic themes such as Twenty Twenty One and Twenty Twenty cannot be reproduced because they have styles for file blocks. Therefore, create a plain theme with the following files:

empty-classic/style.css

```css
/*
Theme Name: Empty Classic
*/
```

empty-classic/index.php

```php
<?php
wp_head();
the_post();
the_content();
wp_footer();
```

Insert the file block and confirm that the text color and background color are applied correctly:

![pr](https://user-images.githubusercontent.com/54422211/216336568-222c1bc9-0d29-4653-8146-faa3f9483ece.png)
