### PR TITLE
[Block Library - Query Loop]: Guard term addtion when the request hasn't resolved

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
@@ -23,7 +23,7 @@ const BASE_QUERY = {
 const getTermIdByTermValue = ( terms, termValue ) => {
 	// First we check for exact match by `term.id` or case sensitive `term.name` match.
 	const termId =
-		termValue?.id || terms.find( ( term ) => term.name === termValue )?.id;
+		termValue?.id || terms?.find( ( term ) => term.name === termValue )?.id;
 	if ( termId ) {
 		return termId;
 	}
@@ -38,7 +38,7 @@ const getTermIdByTermValue = ( terms, termValue ) => {
 	 * In this edge case we always apply the first match from the terms list.
 	 */
 	const termValueLower = termValue.toLocaleLowerCase();
-	return terms.find(
+	return terms?.find(
 		( term ) => term.name.toLocaleLowerCase() === termValueLower
 	)?.id;
 };


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I accidentally discovered a failure in Query Loop, when we're trying to add a taxonomy term through the filters, when the request to fetch terms hasn't resolved.
This PR fixes that by adding the guards against it.

## Testing Instructions
1. Insert a Query Loop with taxonomies(ex postType: post)
2. In the `taxonomies: categories` filter start typing and then press `Enter` or `,` before the request is resolved
3. Observe no errors are thrown.


## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/16275880/216331700-1d4301ce-5586-4882-a056-3f083f8a109b.mov

