### PR TITLE
Components: Remove unnecessary `act()` from `Popover` tests

### DIFF
--- a/packages/components/src/popover/test/index.tsx
+++ b/packages/components/src/popover/test/index.tsx
@@ -148,7 +148,8 @@ describe( 'Popover', () => {
 				const popover = screen.getByTestId( 'popover-element' );
 
 				await waitFor( () => expect( popover ).toBeVisible() );
-				await waitFor( () => expect( popover ).toHaveFocus() );
+
+				expect( popover ).toHaveFocus();
 			} );
 
 			it( 'should allow focus-on-open behavior to be disabled', async () => {

--- a/packages/components/src/popover/test/index.tsx
+++ b/packages/components/src/popover/test/index.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { act, render, screen } from '@testing-library/react';
-import type { CSSProperties, ReactElement } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { CSSProperties } from 'react';
 
 /**
  * WordPress dependencies
@@ -91,25 +91,21 @@ const ALL_POSITIONS_TO_EXPECTED_PLACEMENTS: PositionToPlacementTuple[] = [
 
 describe( 'Popover', () => {
 	describe( 'Component', () => {
-		// Render UI and then wait for the `floating-ui` effects inside `Popover` to finish running
-		// See also: https://floating-ui.com/docs/react-dom#testing
-		async function renderAsync( ui: ReactElement ) {
-			const view = render( ui );
-			await act( () => Promise.resolve() );
-			return view;
-		}
-
 		describe( 'basic behavior', () => {
 			it( 'should render content', async () => {
-				await renderAsync( <Popover>Hello</Popover> );
+				render( <Popover>Hello</Popover> );
 
-				expect( screen.getByText( 'Hello' ) ).toBeInTheDocument();
+				await waitFor( () =>
+					expect( screen.getByText( 'Hello' ) ).toBeVisible()
+				);
 			} );
 
 			it( 'should forward additional props to portaled element', async () => {
-				await renderAsync( <Popover role="tooltip">Hello</Popover> );
+				render( <Popover role="tooltip">Hello</Popover> );
 
-				expect( screen.getByRole( 'tooltip' ) ).toBeInTheDocument();
+				await waitFor( () =>
+					expect( screen.getByRole( 'tooltip' ) ).toBeVisible()
+				);
 			} );
 		} );
 
@@ -129,30 +125,41 @@ describe( 'Popover', () => {
 					);
 				};
 
-				await renderAsync(
+				render(
 					<PopoverWithAnchor>Popover content</PopoverWithAnchor>
 				);
 
-				expect(
-					screen.getByText( 'Popover content' )
-				).toBeInTheDocument();
+				await waitFor( () =>
+					expect(
+						screen.getByText( 'Popover content' )
+					).toBeVisible()
+				);
 			} );
 		} );
 
 		describe( 'focus behavior', () => {
 			it( 'should focus the popover by default when opened', async () => {
-				await renderAsync(
+				render(
 					<Popover data-testid="popover-element">
 						Popover content
 					</Popover>
 				);
 
-				expect( screen.getByTestId( 'popover-element' ) ).toHaveFocus();
+				const popover = screen.getByTestId( 'popover-element' );
+
+				await waitFor( () => expect( popover ).toBeVisible() );
+				await waitFor( () => expect( popover ).toHaveFocus() );
 			} );
 
 			it( 'should allow focus-on-open behavior to be disabled', async () => {
-				await renderAsync(
+				render(
 					<Popover focusOnMount={ false }>Popover content</Popover>
+				);
+
+				await waitFor( () =>
+					expect(
+						screen.getByText( 'Popover content' )
+					).toBeVisible()
 				);
 
 				expect( document.body ).toHaveFocus();


### PR DESCRIPTION
## What?
This PR cleans up a few unnecessary `act()` calls and improves some of the `Popover` tests.

## Why?
When preparing our tests to work with React 18 we did a bunch of those `act()` calls. It's time to clean them up where possible.

## How?
* We're relying on the element to be visible instead of the `act` call.
* We're removing the `renderAsync()` helper and inlining the rendering for clarity and simplicity. IMO it wasn't adding value to the tests, but rather was creating indirection when reading the tests.

## Testing Instructions
Verify tests still pass: `npm run test:unit packages/components/src/popover/test/index.tsx`

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None
