### PR TITLE
Components: Remove unnecessary `act()` from `ToolsPanel` tests

### DIFF
--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -169,7 +169,6 @@ const getMenuButton = () => {
 /**
  * Helper to find the menu button and simulate a user click.
  *
- * @return {HTMLElement} The menuButton.
  */
 const openDropdownMenu = async () => {
 	const user = userEvent.setup();

--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { render, screen, fireEvent, within } from '@testing-library/react';
-import { act } from 'react-test-renderer';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -172,16 +172,17 @@ const getMenuButton = () => {
  * @return {HTMLElement} The menuButton.
  */
 const openDropdownMenu = async () => {
+	const user = userEvent.setup();
 	const menuButton = getMenuButton();
-	fireEvent.click( menuButton );
-	await act( () => Promise.resolve() );
+	await user.click( menuButton );
 	return menuButton;
 };
 
 // Opens dropdown then selects the menu item by label before simulating a click.
 const selectMenuItem = async ( label ) => {
+	const user = userEvent.setup();
 	const menuItem = await screen.findByText( label );
-	fireEvent.click( menuItem );
+	await user.click( menuItem );
 };
 
 describe( 'ToolsPanel', () => {


### PR DESCRIPTION
## What?
This PR cleans up a few unnecessary `act()` calls and improves some of the `ToolsPanel` tests.

## Why?
When preparing our tests to work with React 18 we did a bunch of those `act()` calls. It's time to clean them up where possible.

## How?
* We're removing the `fireEvent.click()` calls in favor of `userEvent.click()`, and those are async.
* We're getting rid of an orphan `fireEvent` usage and removing it completely from the tests

## Testing Instructions
Verify tests still pass: `npm run test:unit packages/components/src/tools-panel/test/index.js`

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None
