### PR TITLE
Components: Remove unnecessary `act()` from `DropdownMenu` tests

### DIFF
--- a/packages/components/src/dropdown-menu/test/index.js
+++ b/packages/components/src/dropdown-menu/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { act, render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -63,10 +63,6 @@ describe( 'DropdownMenu', () => {
 
 		await user.keyboard( '[ArrowDown]' );
 
-		// Wait for the `floating-ui` effects in `Dropdown`/`Popover` to finish running
-		// See also: https://floating-ui.com/docs/react-dom#testing
-		await act( () => Promise.resolve() );
-
 		const menu = screen.getByRole( 'menu' );
 
 		// we need to wait because showing the dropdown is animated
@@ -86,14 +82,10 @@ describe( 'DropdownMenu', () => {
 			/>
 		);
 
-		const button = screen.getByRole( 'button' );
-		act( () => button.focus() );
+		// Move focus on the toggle button
+		await user.tab();
 
 		await user.keyboard( '[ArrowDown]' );
-
-		// Wait for the `floating-ui` effects in `Dropdown`/`Popover` to finish running
-		// See also: https://floating-ui.com/docs/react-dom#testing
-		await act( () => Promise.resolve() );
 
 		const menu = screen.getByRole( 'menu' );
 


### PR DESCRIPTION
## What?
This PR cleans up a few unnecessary `act()` calls and improves some of the `DropdownMenu` tests.

## Why?
When preparing our tests to work with React 18 we did a bunch of those `act()` calls. It's time to clean them up where possible.

## How?
* It seems like the `await act( () => Promise.resolve() );` calls are not necessary, so we're just removing them.
* We're using `user.tab()` instead of imperative element focus. Directly focusing an element is not something a user can do; they'd rather focus an element through clicking or tabbing. By using `user.tab()` we alter the tests to better resemble user behavior.

## Testing Instructions
Verify tests still pass: `npm run test:unit packages/components/src/dropdown-menu/test/index.js`

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None
