### PR TITLE
Pattern Inserter: Fix unintended preview panel display when hovering mouse over pattern

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -113,6 +113,13 @@ function InserterMenu(
 		[ onToggleInsertionPoint, setHoveredItem ]
 	);
 
+	const onHoverPattern = useCallback(
+		( item ) => {
+			onToggleInsertionPoint( !! item );
+		},
+		[ onToggleInsertionPoint ]
+	);
+
 	const onClickPatternCategory = useCallback(
 		( patternCategory ) => {
 			setSelectedPatternCategory( patternCategory );
@@ -296,7 +303,7 @@ function InserterMenu(
 				<BlockPatternsCategoryDialog
 					rootClientId={ destinationRootClientId }
 					onInsert={ onInsertPattern }
-					onHover={ onHover }
+					onHover={ onHoverPattern }
 					category={ selectedPatternCategory }
 					showTitlesAsTooltip
 				/>


### PR DESCRIPTION
Fixed regression that occurred with #47316
See this comment: https://github.com/WordPress/gutenberg/pull/47316#issuecomment-1413587590

## What?
This PR fixes a problem where an unintended block preview panel appears behind you when you mouse over any of the patterns from the pattern inserter.

## Why?

In #47316, changed to call `onHover` to display the insertion indicator when mouse over a pattern. This updates the `hoverdItem` state and causes the preview panel to appear unintentionally in the following locations:

https://github.com/WordPress/gutenberg/blob/c9507b0ca0be76d8e91386cf33969812e1c24ae1/packages/block-editor/src/components/inserter/menu.js#L292-L294

## How?
Added `onHoverPattern` separately from `onHover` to avoid updating the `hoveredItem`. Ideally, it might be better to control the other condition, `showInserterHelpPanel`. However, since this property is passed from a upper component, I thought it may be difficult to control using this variable.

## Testing Instructions

- Mouse over any of the patterns from the Patterns tab in the main inserter.
- Confirm that the insertion indicator is visible and that no preview is displayed behind it.

### Before

https://user-images.githubusercontent.com/54422211/216349186-8a742452-1e5b-4c2a-be51-4ef0d7117c1b.mp4

### After

https://user-images.githubusercontent.com/54422211/216349211-145dd485-f012-4bfe-aec9-0522865d7b0c.mp4