### PR TITLE
Navigation: Only show the deleted menu warning if a ref is specified

### DIFF
--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -48,7 +48,7 @@ const MainContent = ( {
 		return <p>{ __( 'Select or create a menu' ) }</p>;
 	}
 
-	if ( isNavigationMenuMissing ) {
+	if ( currentMenuId && isNavigationMenuMissing ) {
 		return <DeletedNavigationWarning onCreateNew={ onCreateNew } />;
 	}
 


### PR DESCRIPTION
## What?
If a navigation block is in a fallback state, it displays a deleted message. This removes that notice.

## Why?
This message is incorrect and misleading.

## How?
Also check that a ref is set before displaying the notice. This is how the component is displayed in the main edit component.

## Testing Instructions
1. Remove all wp_navigation menus from /wp-admin/edit.php?post_type=wp_navigation
2. Switch to a theme that uses an empty navigation block (e.g. TT3)
3. Open the site editor
4. Select the navigation block
5. Confirm that the block doesn't have a deleted message in the inspector

### Testing Instructions for Keyboard
As above

## Screenshots or screencast <!-- if applicable -->
Before:
<img width="1173" alt="Screenshot 2023-02-02 at 15 35 52" src="https://user-images.githubusercontent.com/275961/216370843-859c2e86-e349-48e0-b6f5-c60634ccc50e.png">


After:
<img width="1119" alt="Screenshot 2023-02-02 at 15 35 07" src="https://user-images.githubusercontent.com/275961/216370867-8a0456f0-9035-4e70-ac16-ff82a6b9a3e8.png">




