### PR TITLE
Fix unbalanced parenthesis in Element README

### DIFF
--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -41,8 +41,7 @@ Let's render a customized greeting into an empty element:
 	wp.element.createRoot(document.getElementById( 'greeting' ))
 		.render(
 			wp.element.createElement( Greeting, { toWhom: 'World' } )
-		)
-	);
+		);
 </script>
 ```
 

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -38,10 +38,9 @@ Let's render a customized greeting into an empty element:
 		);
 	}
 
-	wp.element.createRoot(document.getElementById( 'greeting' ))
-		.render(
-			wp.element.createElement( Greeting, { toWhom: 'World' } )
-		);
+	wp.element
+		.createRoot( document.getElementById( 'greeting' ) )
+		.render( wp.element.createElement( Greeting, { toWhom: 'World' } ) );
 </script>
 ```
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
* Fix unbalanced parenthesis in Element README

## Why?
I copy and pasted the example on https://github.com/WordPress/gutenberg/tree/trunk/packages/element and got a syntax error.

## How?
Removing the extra parenthesis

## Testing Instructions
Manual inspection

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
