### PR TITLE
Disable Strict Mode, breaks dev site editor

### DIFF
--- a/packages/customize-widgets/src/index.js
+++ b/packages/customize-widgets/src/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { StrictMode, createRoot } from '@wordpress/element';
+import { createRoot } from '@wordpress/element';
 import {
 	registerCoreBlocks,
 	__experimentalGetCoreBlocks,
@@ -92,13 +92,11 @@ export function initialize( editorName, blockEditorSettings ) {
 		} );
 
 		createRoot( container ).render(
-			<StrictMode>
-				<CustomizeWidgets
-					api={ wp.customize }
-					sidebarControls={ sidebarControls }
-					blockEditorSettings={ blockEditorSettings }
-				/>
-			</StrictMode>
+			<CustomizeWidgets
+				api={ wp.customize }
+				sidebarControls={ sidebarControls }
+				blockEditorSettings={ blockEditorSettings }
+			/>
 		);
 	} );
 }

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -9,7 +9,7 @@ import {
 	store as editorStore,
 	experiments as editorExperiments,
 } from '@wordpress/editor';
-import { StrictMode, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { SlotFillProvider } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
@@ -173,28 +173,24 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 	}
 
 	return (
-		<StrictMode>
-			<ShortcutProvider>
-				<SlotFillProvider>
-					<ExperimentalEditorProvider
-						settings={ editorSettings }
-						post={ post }
-						initialEdits={ initialEdits }
-						useSubRegistry={ false }
-						__unstableTemplate={
-							isTemplateMode ? template : undefined
-						}
-						{ ...props }
-					>
-						<ErrorBoundary>
-							<EditorInitialization postId={ postId } />
-							<Layout styles={ styles } />
-						</ErrorBoundary>
-						<PostLockedModal />
-					</ExperimentalEditorProvider>
-				</SlotFillProvider>
-			</ShortcutProvider>
-		</StrictMode>
+		<ShortcutProvider>
+			<SlotFillProvider>
+				<ExperimentalEditorProvider
+					settings={ editorSettings }
+					post={ post }
+					initialEdits={ initialEdits }
+					useSubRegistry={ false }
+					__unstableTemplate={ isTemplateMode ? template : undefined }
+					{ ...props }
+				>
+					<ErrorBoundary>
+						<EditorInitialization postId={ postId } />
+						<Layout styles={ styles } />
+					</ErrorBoundary>
+					<PostLockedModal />
+				</ExperimentalEditorProvider>
+			</SlotFillProvider>
+		</ShortcutProvider>
 	);
 }
 

--- a/packages/edit-site/src/components/app/index.js
+++ b/packages/edit-site/src/components/app/index.js
@@ -3,7 +3,6 @@
  */
 import { SlotFillProvider, Popover } from '@wordpress/components';
 import { UnsavedChangesWarning } from '@wordpress/editor';
-import { StrictMode } from '@wordpress/element';
 import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
 import { store as noticesStore } from '@wordpress/notices';
 import { useDispatch } from '@wordpress/data';
@@ -32,17 +31,15 @@ export default function App() {
 	}
 
 	return (
-		<StrictMode>
-			<ShortcutProvider style={ { height: '100%' } }>
-				<SlotFillProvider>
-					<Popover.Slot />
-					<UnsavedChangesWarning />
-					<Routes>
-						<Layout />
-						<PluginArea onError={ onPluginAreaError } />
-					</Routes>
-				</SlotFillProvider>
-			</ShortcutProvider>
-		</StrictMode>
+		<ShortcutProvider style={ { height: '100%' } }>
+			<SlotFillProvider>
+				<Popover.Slot />
+				<UnsavedChangesWarning />
+				<Routes>
+					<Layout />
+					<PluginArea onError={ onPluginAreaError } />
+				</Routes>
+			</SlotFillProvider>
+		</ShortcutProvider>
 	);
 }

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -9,7 +9,7 @@ import {
 	store as coreStore,
 	useResourcePermissions,
 } from '@wordpress/core-data';
-import { StrictMode, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import {
 	BlockEditorKeyboardShortcuts,
 	CopyHandler,
@@ -99,26 +99,22 @@ export default function WidgetAreasBlockEditorProvider( {
 	);
 
 	return (
-		<StrictMode>
-			<ShortcutProvider>
-				<BlockEditorKeyboardShortcuts.Register />
-				<KeyboardShortcuts.Register />
-				<SlotFillProvider>
-					<ExperimentalBlockEditorProvider
-						value={ blocks }
-						onInput={ onInput }
-						onChange={ onChange }
-						settings={ settings }
-						useSubRegistry={ false }
-						{ ...props }
-					>
-						<CopyHandler>{ children }</CopyHandler>
-						<ReusableBlocksMenuItems
-							rootClientId={ widgetAreaId }
-						/>
-					</ExperimentalBlockEditorProvider>
-				</SlotFillProvider>
-			</ShortcutProvider>
-		</StrictMode>
+		<ShortcutProvider>
+			<BlockEditorKeyboardShortcuts.Register />
+			<KeyboardShortcuts.Register />
+			<SlotFillProvider>
+				<ExperimentalBlockEditorProvider
+					value={ blocks }
+					onInput={ onInput }
+					onChange={ onChange }
+					settings={ settings }
+					useSubRegistry={ false }
+					{ ...props }
+				>
+					<CopyHandler>{ children }</CopyHandler>
+					<ReusableBlocksMenuItems rootClientId={ widgetAreaId } />
+				</ExperimentalBlockEditorProvider>
+			</SlotFillProvider>
+		</ShortcutProvider>
 	);
 }


### PR DESCRIPTION
Reverts #47639, only the `<StrictMode>` wrappers, and keeps all the other changes -- e2e and effect fixes.