### PR TITLE
useResizeObserver: handle strict mode double effects

### DIFF
--- a/packages/compose/src/hooks/use-resize-observer/index.tsx
+++ b/packages/compose/src/hooks/use-resize-observer/index.tsx
@@ -203,6 +203,7 @@ function useResizeObserver< T extends HTMLElement >(
 	// the component unmounted.
 	const didUnmount = useRef( false );
 	useEffect( () => {
+		didUnmount.current = false;
 		return () => {
 			didUnmount.current = true;
 		};


### PR DESCRIPTION
Fixes `useResizeObserver` in strict mode. Which unmounts and remounts effects twice, and the second mount didn't update `didUnmount.current` back to `false`, so the hook was considered permanently unmounted.