### PR TITLE
Global styles: Add check for edit CSS capability to overflow menu

### DIFF
--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -14,6 +14,7 @@ import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { moreVertical } from '@wordpress/icons';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -45,6 +46,20 @@ const { Slot: GlobalStylesMenuSlot, Fill: GlobalStylesMenuFill } =
 
 function GlobalStylesActionMenu() {
 	const { toggle } = useDispatch( preferencesStore );
+	const { canEditCSS } = useSelect( ( select ) => {
+		const { getEntityRecord, __experimentalGetCurrentGlobalStylesId } =
+			select( coreStore );
+
+		const globalStylesId = __experimentalGetCurrentGlobalStylesId();
+		const globalStyles = globalStylesId
+			? getEntityRecord( 'root', 'globalStyles', globalStylesId )
+			: undefined;
+
+		return {
+			canEditCSS:
+				!! globalStyles?._links?.[ 'wp:action-edit-css' ] ?? false,
+		};
+	}, [] );
 	const { useGlobalStylesReset } = unlock( blockEditorExperiments );
 	const [ canReset, onReset ] = useGlobalStylesReset();
 	const { goTo } = useNavigator();
@@ -65,10 +80,14 @@ function GlobalStylesActionMenu() {
 						onClick: () =>
 							toggle( 'core/edit-site', 'welcomeGuideStyles' ),
 					},
-					{
-						title: __( 'Additional CSS' ),
-						onClick: loadCustomCSS,
-					},
+					...( canEditCSS
+						? [
+								{
+									title: __( 'Additional CSS' ),
+									onClick: loadCustomCSS,
+								},
+						  ]
+						: [] ),
 				] }
 			/>
 		</GlobalStylesMenuFill>


### PR DESCRIPTION
## What?
Adds a check for `edit-css` permissions to the Custom CSS overflow menu

## Why?
The Custom CSS feature requires `edit-css` permissions. This is checked for in the display of the Custom CSS global styles panel, but was not copied over when the initial load of this was moved to the sub menu.

For context:

- The initial implementation of Global Styles Custom CSS had to be [reverted to an experiment ](https://href.li/?https://github.com/WordPress/gutenberg/pull/46663) as it was noticed that WP multisite admins could see the option, but their changes were not saved as they don't have `unfiltered_html` capabilities.
- The featured was then placed behind a check for `edit_css` capabilities and the experiment flag was removed [#46815](https://href.li/?https://github.com/WordPress/gutenberg/pull/46815) & [#47062](https://href.li/?https://github.com/WordPress/gutenberg/pull/47062).
- The feature was [moved by default behind the Global Styles ellipsis menu](https://href.li/?https://github.com/WordPress/gutenberg/pull/47371), but the permissions check was not included on the menu item

## How?
Uses the same permissions check as the panel card

## Testing Instructions
1. Check that Custom CSS feature  works as expected still, ie. only appears in overflow menu initially and is added to the global styles panel once some custom CSS is saved
2. Enable multisite with `define( 'WP_ALLOW_MULTISITE', true );` and add a new site (using a subfolder is easiest option) and a site admin for that site
3. Log in as the multisite admin and check that the `Additional CSS` menu option is not available

## Screenshots

Normal site admin:

<img width="283" alt="Screenshot 2023-02-03 at 11 06 45 AM" src="https://user-images.githubusercontent.com/3629020/216460329-62b208ca-1353-43c5-a720-3c6f26865fa3.png">

Multi site admin:

<img width="287" alt="Screenshot 2023-02-03 at 11 07 21 AM" src="https://user-images.githubusercontent.com/3629020/216460376-581a3bab-7822-41f7-a992-463559588143.png">



