### PR TITLE
Improved description for the post-terms core block

### DIFF
--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -81,8 +81,8 @@ function register_block_core_post_terms() {
 		$variation = array(
 			'name'        => $taxonomy->name,
 			'title'       => $taxonomy->label,
-			/* translators: %s: taxonomy's label */
 			'description' => sprintf(
+				/* translators: %s: taxonomy's label */
 				__( 'Display a list of assigned terms from the taxonomy: %s' ),
 				$taxonomy->label
 			),

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -82,7 +82,10 @@ function register_block_core_post_terms() {
 			'name'        => $taxonomy->name,
 			'title'       => $taxonomy->label,
 			/* translators: %s: taxonomy's label */
-			'description' => sprintf( __( 'Display the assigned taxonomy: %s' ), $taxonomy->label ),
+			'description' => sprintf(
+				__( 'Display a list of assigned terms from the taxonomy: %s' ),
+				$taxonomy->label
+			),
 			'attributes'  => array(
 				'term' => $taxonomy->name,
 			),


### PR DESCRIPTION
## What?
Updates the description of the core/post-terms block to be clearer about what it actually is. 

## Why?
The current description is:
> Display the assigned taxonomy: Categories

This is a little confusing (what does "display the taxonomy" mean?), and doesn't clearly describe what the block does (displays a list of the assigned terms in the selected taxonomy). 

## How?
This patch updates the description to:
> Display a list of assigned terms from the taxonomy: Categories

## Testing Instructions
Add the core/post-terms block (e.g. "Categories", or "Tags" block to a post or page and check that the description is updated.