### PR TITLE
Copy failing WP_HTML_Tag_Processor_Bookmark_Test tests from Core

### DIFF
--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -598,9 +598,10 @@ class WP_HTML_Tag_Processor {
 		}
 
 		if ( ! array_key_exists( $name, $this->bookmarks ) && count( $this->bookmarks ) >= self::MAX_BOOKMARKS ) {
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-				throw new Exception( "Tried to jump to a non-existent HTML bookmark {$name}." );
-			}
+			_doing_it_wrong(
+				__METHOD__,
+				__( 'Too many bookmarks: cannot create any more.', 'gutenberg' )
+			);
 			return false;
 		}
 

--- a/phpunit/html/wp-html-tag-processor-bookmark-test.php
+++ b/phpunit/html/wp-html-tag-processor-bookmark-test.php
@@ -341,13 +341,12 @@ HTML;
 		$p = new WP_HTML_Tag_Processor( '<ul><li>One</li><li>Two</li><li>Three</li></ul>' );
 		$p->next_tag( 'li' );
 
-		$this->expectException( Exception::class );
-
-		for ( $i = 0;$i < WP_HTML_Tag_Processor::MAX_BOOKMARKS;$i++ ) {
+		for ( $i = 0; $i < WP_HTML_Tag_Processor::MAX_BOOKMARKS; $i++ ) {
 			$this->assertTrue( $p->set_bookmark( "bookmark $i" ), "Could not allocate the bookmark #$i" );
 		}
 
-		$this->assertFalse( $p->set_bookmark( 'final bookmark' ), "Allocated $i bookmarks, which is one above the limit." );
+		$this->setExpectedIncorrectUsage( 'WP_HTML_Tag_Processor::set_bookmark' );
+		$this->assertFalse( $p->set_bookmark( 'final bookmark' ), "Allocated $i bookmarks, which is one above the limit" );
 	}
 
 	/**
@@ -360,11 +359,11 @@ HTML;
 		$p->next_tag( 'li' );
 		$p->set_bookmark( 'bookmark' );
 
-		$this->expectException( Exception::class );
-
 		for ( $i = 0; $i < WP_HTML_Tag_Processor::MAX_SEEK_OPS; $i++ ) {
 			$this->assertTrue( $p->seek( 'bookmark' ), 'Could not seek to the "bookmark"' );
 		}
-		$this->assertFalse( $p->seek( 'bookmark' ), "$i-th seek() to the bookmark succeeded, even though it should exceed the allowed limit." );
+
+		$this->setExpectedIncorrectUsage( 'WP_HTML_Tag_Processor::seek' );
+		$this->assertFalse( $p->seek( 'bookmark' ), "$i-th seek() to the bookmark succeeded, even though it should exceed the allowed limit" );
 	}
 }


### PR DESCRIPTION
PHP unit tests are failing on `trunk`:

https://github.com/WordPress/gutenberg/actions/runs/4080664124/jobs/7033415868

I noticed the two failing tag processor tests were different to what's in Core. Assumedly something changed in the implementation during the process of committing. To fix, I simply replaced the implementation of these failing tests with the one that's in Core.