### PR TITLE
Make process_blocks_custom_css method protected

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -971,7 +971,7 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * @return string The processed CSS.
 	 */
-	public function process_blocks_custom_css( $css, $selector ) {
+	protected function process_blocks_custom_css( $css, $selector ) {
 		$processed_css = '';
 
 		// Split CSS nested rules.

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -2010,8 +2010,10 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'styles'  => array(),
 			)
 		);
+		$reflection = new ReflectionMethod( $theme_json, 'process_blocks_custom_css' );
+		$reflection->setAccessible( true );
 
-		$this->assertEquals( $expected, $theme_json->process_blocks_custom_css( $input['css'], $input['selector'] ) );
+		$this->assertEquals( $expected, $reflection->invoke( $theme_json, $input['css'], $input['selector'] ) );
 	}
 
 	/**


### PR DESCRIPTION
## What?
Following the comments on https://github.com/WordPress/gutenberg/pull/46571#discussion_r1088049807 and https://github.com/WordPress/wordpress-develop/pull/3977#discussion_r1095436019, this PR changes the visibility of the `process_blocks_custom_css` from `public` to `protected`.

## Why?
To avoid exposing the method publicly

## How?
Changed the visibility of the method, and then used `ReflectionMethod` in PHPUnit tests.

## Testing Instructions
Nothing to test. If PHP tests pass, this is good to go.
