### PR TITLE
ToolsPanel: Display optional items when values are updated externally

### DIFF
--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -58,8 +58,6 @@ export default function BlockActions( {
 		setBlockMovingClientId,
 		setNavigationMode,
 		selectBlock,
-		clearSelectedBlock,
-		multiSelect,
 	} = useDispatch( blockEditorStore );
 
 	const notifyCopy = useNotifyCopy();
@@ -134,13 +132,6 @@ export default function BlockActions( {
 		},
 		async onPasteStyles() {
 			await pasteStyles( blocks );
-
-			// Need to reselect the block(s) in order for optional tool panel control changes to register.
-			clearSelectedBlock();
-			multiSelect(
-				blocks[ 0 ].clientId,
-				blocks[ blocks.length - 1 ].clientId
-			);
 		},
 	} );
 }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -53,6 +53,7 @@
 
 -   `TabPanel`: Fix initial tab selection when the tab declaration is lazily added to the `tabs` array ([47100](https://github.com/WordPress/gutenberg/pull/47100)).
 -   `InputControl`: Avoid the "controlled to uncontrolled" warning by forcing the internal `<input />` element to be always in controlled mode ([47250](https://github.com/WordPress/gutenberg/pull/47250)).
+-   `ToolsPanel`: Allow display of optional items when values are updated externally to item controls ([47727](https://github.com/WordPress/gutenberg/pull/47727)).
 
 ## 23.2.0 (2023-01-11)
 

--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -316,6 +316,37 @@ describe( 'ToolsPanel', () => {
 			expect( announcement ).toHaveAttribute( 'aria-live', 'assertive' );
 		} );
 
+		it( 'should render optional panel item when corresponding value is updated externally', async () => {
+			const ToolsPanelOptional = ( { toolsPanelItemValue } ) => {
+				const itemProps = {
+					attributes: { value: toolsPanelItemValue },
+					hasValue: () => !! toolsPanelItemValue,
+					label: 'Alt',
+					onDeselect: jest.fn(),
+					onSelect: jest.fn(),
+				};
+				altControlProps.attributes.value = toolsPanelItemValue;
+				return (
+					<ToolsPanel { ...defaultProps }>
+						<ToolsPanelItem { ...itemProps }>
+							<div>Optional control</div>
+						</ToolsPanelItem>
+					</ToolsPanel>
+				);
+			};
+			const { rerender } = render( <ToolsPanelOptional /> );
+
+			const control = screen.queryByText( 'Optional control' );
+
+			expect( control ).not.toBeInTheDocument();
+
+			rerender( <ToolsPanelOptional toolsPanelItemValue={ 100 } /> );
+
+			const control2 = screen.queryByText( 'Optional control' );
+
+			expect( control2 ).toBeInTheDocument();
+		} );
+
 		it( 'should continue to render shown by default item after it is toggled off via menu item', async () => {
 			render(
 				<ToolsPanel { ...defaultProps }>

--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -342,9 +342,9 @@ describe( 'ToolsPanel', () => {
 
 			rerender( <ToolsPanelOptional toolsPanelItemValue={ 100 } /> );
 
-			const control2 = screen.queryByText( 'Optional control' );
+			const controlRerendered = screen.queryByText( 'Optional control' );
 
-			expect( control2 ).toBeInTheDocument();
+			expect( controlRerendered ).toBeInTheDocument();
 		} );
 
 		it( 'should continue to render shown by default item after it is toggled off via menu item', async () => {

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -35,12 +35,11 @@ const generateMenuItems = ( {
 	panelItems.forEach( ( { hasValue, isShownByDefault, label } ) => {
 		const group = isShownByDefault ? 'default' : 'optional';
 
-		// If a menu item for this label already exists, do not overwrite its value.
-		// This can cause default controls that have been flagged as customized to
-		// lose their value.
+		// If a menu item for this label has already been flagged as customized
+		// (for default controls), or toggled on (for optional controls), do not
+		// overwrite its value as those controls would lose that state.
 		const existingItemValue = currentMenuItems?.[ group ]?.[ label ];
-		const value =
-			existingItemValue !== undefined ? existingItemValue : hasValue();
+		const value = existingItemValue ? existingItemValue : hasValue();
 
 		menuItems[ group ][ label ] = shouldReset ? false : value;
 	} );


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/47368

Related:
- https://github.com/WordPress/gutenberg/pull/47673
- https://github.com/WordPress/gutenberg/pull/47590


## What?

Potentially fixes design tools not showing in the inspector when pasting block styles.

_Note: If an optional control has been toggled on, or customized previously, then block styles are pasted, that optional control will continue to be displayed. It will reflect the current value though. Reselect the block, and that control will be hidden, as per normal._

_Does this behaviour actually help highlight to the user what's changed?_

## Why?

When pasting styles, their values should be reflected in the design tools without having to de-select and re-select the block.

## How?

Allows optional ToolsPanelItems to override the ToolsPanel's inner menu item state when the optional item previously wasn't toggled on for display. 


## Testing Instructions

1. `npm run test:unit packages/components/src/tools-panel/test`
2. `npm run storybook:dev` - Ensure no behavioural differences between trunk and this branch. Particularly with the conditional item examples.
3. Open the editor, add two heading blocks
4. Select the first heading block and tweak as many design tool values as you like. Make sure to toggle on at least one optional control e.g. Dimensions > padding.
5. Via the block toolbar's overflow menu, choose "Copy styles"
6. Select the second heading block, and choose "Paste styles" under the overflow menu
7. You should see all the copied style values and controls within the block inspector sidebar
8. Repeat steps 3-7, however, this time before pasting styles, tweak an optional design tool that you did not set on the first block (e.g. Dimensions > margin).
9. Note that the optional control that wasn't within the copied styles is reset but still shown.


## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/216564519-79d4b5b2-0eed-4a2c-aa4b-70a6a8ce8218.mp4

