### PR TITLE
Fix multi entities saved state in the post editor

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/publish-post.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/publish-post.ts
@@ -20,9 +20,7 @@ export async function publishPost( this: Editor ) {
 	// Save any entities.
 	if ( isEntitiesSavePanelVisible ) {
 		// Handle saving entities.
-		await this.page.click(
-			'role=region[name="Editor publish"i] >> role=button[name="Save"i]'
-		);
+		await entitiesSaveButton.click();
 	}
 
 	// Handle saving just the post.

--- a/packages/e2e-test-utils-playwright/src/editor/publish-post.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/publish-post.ts
@@ -11,14 +11,14 @@ import type { Editor } from './index';
  */
 export async function publishPost( this: Editor ) {
 	await this.page.click( 'role=button[name="Publish"i]' );
-	const publishEditorPanel = this.page.locator(
-		'role=region[name="Editor publish"i]'
+	const entitiesSaveButton = this.page.locator(
+		'role=region[name="Editor publish"i] >> role=button[name="Save"i]'
 	);
 
-	const isPublishEditorVisible = await publishEditorPanel.isVisible();
+	const isEntitiesSavePanelVisible = await entitiesSaveButton.isVisible();
 
 	// Save any entities.
-	if ( isPublishEditorVisible ) {
+	if ( isEntitiesSavePanelVisible ) {
 		// Handle saving entities.
 		await this.page.click(
 			'role=region[name="Editor publish"i] >> role=button[name="Save"i]'

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -95,3 +95,7 @@
 		bottom: 0;
 	}
 }
+
+.edit-post-layout .entities-saved-states__panel-header {
+	height: $header-height + $border-width;
+}

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -14,6 +14,7 @@
 }
 
 .entities-saved-states__panel-header {
+	box-sizing: border-box;
 	background: $white;
 	padding-left: $grid-unit-10;
 	padding-right: $grid-unit-10;

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -174,12 +174,26 @@ html.interface-interface-skeleton__html-container {
 	bottom: auto;
 	left: auto;
 	right: 0;
-	width: $sidebar-width;
 	color: $gray-900;
+	background: $white;
+	width: 100vw;
+
+	@include break-medium() {
+		width: $sidebar-width;
+	}
 
 	&:focus,
 	&:focus-within {
-		top: auto;
+		top: $admin-bar-height-big;
+
+		@include break-medium() {
+			border-left: $border-width solid $gray-300;
+			top: $admin-bar-height;
+
+			.is-fullscreen-mode & {
+				top: 0;
+			}
+		}
 		bottom: 0;
 	}
 }


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/47142

## What?

In #47142 we updated the multi entities saved state component to be independent from the place it's rendered in (Don't assume it's a sidebar). It created some small issues in the post editor which are being fixed by this PR.

## Testing Instructions

1- Open the post editor
2- Add a reusable block and edit it 
3- Click the publish button
4- The publish sidebar should show up properly