### PR TITLE
Site Logo: Simplify the method for getting block editor settings

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -78,18 +78,15 @@ const SiteLogo = ( {
 		'is-transient': isBlobURL( logoUrl ),
 	} );
 	const { imageEditing, maxWidth, title } = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
+		const settings = select( blockEditorStore ).getSettings();
 		const siteEntities = select( coreStore ).getEntityRecord(
 			'root',
 			'__unstableBase'
 		);
 		return {
 			title: siteEntities?.name,
-			...Object.fromEntries(
-				Object.entries( getSettings() ).filter( ( [ key ] ) =>
-					[ 'imageEditing', 'maxWidth' ].includes( key )
-				)
-			),
+			imageEditing: settings.imageEditing,
+			maxWidth: settings.maxWidth,
 		};
 	}, [] );
 


### PR DESCRIPTION
## What?
PR simplifies getting block editor settings in the Site Logo block. The block only needs to pick two values from the settings object, so there's no need for object manipulations.

## How?
Directly map settings object values to the returned object.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Site Logo block.
3. Confirm image Cropping is available in the toolbar.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2023-02-03 at 16 49 49](https://user-images.githubusercontent.com/240569/216607652-9164f715-700a-41cc-b955-699bbcd5edc7.png)
