### PR TITLE
Lodash: Remove from `@wordpress/keycodes` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18163,8 +18163,7 @@
 			"requires": {
 				"@babel/runtime": "^7.16.0",
 				"@wordpress/i18n": "file:packages/i18n",
-				"change-case": "^4.1.2",
-				"lodash": "^4.17.21"
+				"change-case": "^4.1.2"
 			}
 		},
 		"@wordpress/lazy-import": {

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -29,8 +29,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
 		"@wordpress/i18n": "file:../i18n",
-		"change-case": "^4.1.2",
-		"lodash": "^4.17.21"
+		"change-case": "^4.1.2"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -13,7 +13,6 @@
  * External dependencies
  */
 import { capitalCase } from 'change-case';
-import { mapValues } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -44,6 +43,8 @@ import { isAppleOS } from './platform';
  * @typedef {(character: string, isApple?: () => boolean) => T} WPKeyHandler
  */
 /** @typedef {(event: KeyboardEvent, character: string, isApple?: () => boolean) => boolean} WPEventKeyHandler */
+
+/** @typedef {( isApple: () => boolean ) => WPModifierPart[]} WPModifier */
 
 /**
  * Keycode for BACKSPACE key.
@@ -148,6 +149,25 @@ export const ZERO = 48;
 export { isAppleOS };
 
 /**
+ * Map the values of an object with a specified callback and return the result object.
+ *
+ * @template T
+ *
+ * @param {T}                     object Object to map values of.
+ * @param {( value: any ) => any} mapFn  Mapping function
+ *
+ * @return {any} Active modifier constants.
+ */
+function mapValues( object, mapFn ) {
+	return Object.fromEntries(
+		Object.entries( object ).map( ( [ key, value ] ) => [
+			key,
+			mapFn( value ),
+		] )
+	);
+}
+
+/**
  * Object that contains functions that return the available modifier
  * depending on platform.
  *
@@ -185,14 +205,19 @@ export const modifiers = {
  * @type {WPModifierHandler<WPKeyHandler<string>>} Keyed map of functions to raw
  *                                                 shortcuts.
  */
-export const rawShortcut = mapValues( modifiers, ( modifier ) => {
-	return /** @type {WPKeyHandler<string>} */ (
-		character,
-		_isApple = isAppleOS
-	) => {
-		return [ ...modifier( _isApple ), character.toLowerCase() ].join( '+' );
-	};
-} );
+export const rawShortcut = mapValues(
+	modifiers,
+	( /** @type {WPModifier} */ modifier ) => {
+		return /** @type {WPKeyHandler<string>} */ (
+			character,
+			_isApple = isAppleOS
+		) => {
+			return [ ...modifier( _isApple ), character.toLowerCase() ].join(
+				'+'
+			);
+		};
+	}
+);
 
 /**
  * Return an array of the parts of a keyboard shortcut chord for display.
@@ -207,42 +232,45 @@ export const rawShortcut = mapValues( modifiers, ( modifier ) => {
  * @type {WPModifierHandler<WPKeyHandler<string[]>>} Keyed map of functions to
  *                                                   shortcut sequences.
  */
-export const displayShortcutList = mapValues( modifiers, ( modifier ) => {
-	return /** @type {WPKeyHandler<string[]>} */ (
-		character,
-		_isApple = isAppleOS
-	) => {
-		const isApple = _isApple();
-		const replacementKeyMap = {
-			[ ALT ]: isApple ? '⌥' : 'Alt',
-			[ CTRL ]: isApple ? '⌃' : 'Ctrl', // Make sure ⌃ is the U+2303 UP ARROWHEAD unicode character and not the caret character.
-			[ COMMAND ]: '⌘',
-			[ SHIFT ]: isApple ? '⇧' : 'Shift',
+export const displayShortcutList = mapValues(
+	modifiers,
+	( /** @type {WPModifier} */ modifier ) => {
+		return /** @type {WPKeyHandler<string[]>} */ (
+			character,
+			_isApple = isAppleOS
+		) => {
+			const isApple = _isApple();
+			const replacementKeyMap = {
+				[ ALT ]: isApple ? '⌥' : 'Alt',
+				[ CTRL ]: isApple ? '⌃' : 'Ctrl', // Make sure ⌃ is the U+2303 UP ARROWHEAD unicode character and not the caret character.
+				[ COMMAND ]: '⌘',
+				[ SHIFT ]: isApple ? '⇧' : 'Shift',
+			};
+
+			const modifierKeys = modifier( _isApple ).reduce(
+				( accumulator, key ) => {
+					const replacementKey = replacementKeyMap[ key ] ?? key;
+					// If on the Mac, adhere to platform convention and don't show plus between keys.
+					if ( isApple ) {
+						return [ ...accumulator, replacementKey ];
+					}
+
+					return [ ...accumulator, replacementKey, '+' ];
+				},
+				/** @type {string[]} */ ( [] )
+			);
+
+			// Symbols (~`,.) are removed by the default regular expression,
+			// so override the rule to allow symbols used for shortcuts.
+			// see: https://github.com/blakeembrey/change-case#options
+			const capitalizedCharacter = capitalCase( character, {
+				stripRegexp: /[^A-Z0-9~`,\.\\\-]/gi,
+			} );
+
+			return [ ...modifierKeys, capitalizedCharacter ];
 		};
-
-		const modifierKeys = modifier( _isApple ).reduce(
-			( accumulator, key ) => {
-				const replacementKey = replacementKeyMap[ key ] ?? key;
-				// If on the Mac, adhere to platform convention and don't show plus between keys.
-				if ( isApple ) {
-					return [ ...accumulator, replacementKey ];
-				}
-
-				return [ ...accumulator, replacementKey, '+' ];
-			},
-			/** @type {string[]} */ ( [] )
-		);
-
-		// Symbols (~`,.) are removed by the default regular expression,
-		// so override the rule to allow symbols used for shortcuts.
-		// see: https://github.com/blakeembrey/change-case#options
-		const capitalizedCharacter = capitalCase( character, {
-			stripRegexp: /[^A-Z0-9~`,\.\\\-]/gi,
-		} );
-
-		return [ ...modifierKeys, capitalizedCharacter ];
-	};
-} );
+	}
+);
 
 /**
  * An object that contains functions to display shortcuts.
@@ -259,7 +287,7 @@ export const displayShortcutList = mapValues( modifiers, ( modifier ) => {
  */
 export const displayShortcut = mapValues(
 	displayShortcutList,
-	( shortcutList ) => {
+	( /** @type {WPKeyHandler<string[]>} */ shortcutList ) => {
 		return /** @type {WPKeyHandler<string>} */ (
 			character,
 			_isApple = isAppleOS
@@ -281,33 +309,38 @@ export const displayShortcut = mapValues(
  * @type {WPModifierHandler<WPKeyHandler<string>>} Keyed map of functions to
  *                                                 shortcut ARIA labels.
  */
-export const shortcutAriaLabel = mapValues( modifiers, ( modifier ) => {
-	return /** @type {WPKeyHandler<string>} */ (
-		character,
-		_isApple = isAppleOS
-	) => {
-		const isApple = _isApple();
-		/** @type {Record<string,string>} */
-		const replacementKeyMap = {
-			[ SHIFT ]: 'Shift',
-			[ COMMAND ]: isApple ? 'Command' : 'Control',
-			[ CTRL ]: 'Control',
-			[ ALT ]: isApple ? 'Option' : 'Alt',
-			/* translators: comma as in the character ',' */
-			',': __( 'Comma' ),
-			/* translators: period as in the character '.' */
-			'.': __( 'Period' ),
-			/* translators: backtick as in the character '`' */
-			'`': __( 'Backtick' ),
-			/* translators: tilde as in the character '~' */
-			'~': __( 'Tilde' ),
-		};
+export const shortcutAriaLabel = mapValues(
+	modifiers,
+	( /** @type {WPModifier} */ modifier ) => {
+		return /** @type {WPKeyHandler<string>} */ (
+			character,
+			_isApple = isAppleOS
+		) => {
+			const isApple = _isApple();
+			/** @type {Record<string,string>} */
+			const replacementKeyMap = {
+				[ SHIFT ]: 'Shift',
+				[ COMMAND ]: isApple ? 'Command' : 'Control',
+				[ CTRL ]: 'Control',
+				[ ALT ]: isApple ? 'Option' : 'Alt',
+				/* translators: comma as in the character ',' */
+				',': __( 'Comma' ),
+				/* translators: period as in the character '.' */
+				'.': __( 'Period' ),
+				/* translators: backtick as in the character '`' */
+				'`': __( 'Backtick' ),
+				/* translators: tilde as in the character '~' */
+				'~': __( 'Tilde' ),
+			};
 
-		return [ ...modifier( _isApple ), character ]
-			.map( ( key ) => capitalCase( replacementKeyMap[ key ] ?? key ) )
-			.join( isApple ? ' ' : ' + ' );
-	};
-} );
+			return [ ...modifier( _isApple ), character ]
+				.map( ( key ) =>
+					capitalCase( replacementKeyMap[ key ] ?? key )
+				)
+				.join( isApple ? ' ' : ' + ' );
+		};
+	}
+);
 
 /**
  * From a given KeyboardEvent, returns an array of active modifier constants for
@@ -347,51 +380,56 @@ function getEventModifiers( event ) {
  * @type {WPModifierHandler<WPEventKeyHandler>} Keyed map of functions
  *                                                       to match events.
  */
-export const isKeyboardEvent = mapValues( modifiers, ( getModifiers ) => {
-	return /** @type {WPEventKeyHandler} */ (
-		event,
-		character,
-		_isApple = isAppleOS
-	) => {
-		const mods = getModifiers( _isApple );
-		const eventMods = getEventModifiers( event );
+export const isKeyboardEvent = mapValues(
+	modifiers,
+	( /** @type {WPModifier} */ getModifiers ) => {
+		return /** @type {WPEventKeyHandler} */ (
+			event,
+			character,
+			_isApple = isAppleOS
+		) => {
+			const mods = getModifiers( _isApple );
+			const eventMods = getEventModifiers( event );
 
-		const modsDiff = mods.filter( ( mod ) => ! eventMods.includes( mod ) );
-		const eventModsDiff = eventMods.filter(
-			( mod ) => ! mods.includes( mod )
-		);
+			const modsDiff = mods.filter(
+				( mod ) => ! eventMods.includes( mod )
+			);
+			const eventModsDiff = eventMods.filter(
+				( mod ) => ! mods.includes( mod )
+			);
 
-		if ( modsDiff.length > 0 || eventModsDiff.length > 0 ) {
-			return false;
-		}
-
-		let key = event.key.toLowerCase();
-
-		if ( ! character ) {
-			return mods.includes( /** @type {WPModifierPart} */ ( key ) );
-		}
-
-		if ( event.altKey && character.length === 1 ) {
-			key = String.fromCharCode( event.keyCode ).toLowerCase();
-		}
-
-		// Replace some characters to match the key indicated
-		// by the shortcut on Windows.
-		if ( ! _isApple() ) {
-			if (
-				event.shiftKey &&
-				character.length === 1 &&
-				event.code === 'Comma'
-			) {
-				key = ',';
+			if ( modsDiff.length > 0 || eventModsDiff.length > 0 ) {
+				return false;
 			}
-		}
 
-		// For backwards compatibility.
-		if ( character === 'del' ) {
-			character = 'delete';
-		}
+			let key = event.key.toLowerCase();
 
-		return key === character.toLowerCase();
-	};
-} );
+			if ( ! character ) {
+				return mods.includes( /** @type {WPModifierPart} */ ( key ) );
+			}
+
+			if ( event.altKey && character.length === 1 ) {
+				key = String.fromCharCode( event.keyCode ).toLowerCase();
+			}
+
+			// Replace some characters to match the key indicated
+			// by the shortcut on Windows.
+			if ( ! _isApple() ) {
+				if (
+					event.shiftKey &&
+					character.length === 1 &&
+					event.code === 'Comma'
+				) {
+					key = ',';
+				}
+			}
+
+			// For backwards compatibility.
+			if ( character === 'del' ) {
+				character = 'delete';
+			}
+
+			return key === character.toLowerCase();
+		};
+	}
+);

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -13,7 +13,7 @@
  * External dependencies
  */
 import { capitalCase } from 'change-case';
-import { get, mapValues } from 'lodash';
+import { mapValues } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -222,7 +222,7 @@ export const displayShortcutList = mapValues( modifiers, ( modifier ) => {
 
 		const modifierKeys = modifier( _isApple ).reduce(
 			( accumulator, key ) => {
-				const replacementKey = get( replacementKeyMap, key, key );
+				const replacementKey = replacementKeyMap[ key ] ?? key;
 				// If on the Mac, adhere to platform convention and don't show plus between keys.
 				if ( isApple ) {
 					return [ ...accumulator, replacementKey ];
@@ -287,6 +287,7 @@ export const shortcutAriaLabel = mapValues( modifiers, ( modifier ) => {
 		_isApple = isAppleOS
 	) => {
 		const isApple = _isApple();
+		/** @type {Record<string,string>} */
 		const replacementKeyMap = {
 			[ SHIFT ]: 'Shift',
 			[ COMMAND ]: isApple ? 'Command' : 'Control',
@@ -303,7 +304,7 @@ export const shortcutAriaLabel = mapValues( modifiers, ( modifier ) => {
 		};
 
 		return [ ...modifier( _isApple ), character ]
-			.map( ( key ) => capitalCase( get( replacementKeyMap, key, key ) ) )
+			.map( ( key ) => capitalCase( replacementKeyMap[ key ] ?? key ) )
 			.join( isApple ? ' ' : ' + ' );
 	};
 } );


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/keycodes` package. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

A motivation to remove Lodash from the `@wordpress/keycodes` package is that it's the last one that needs `lodash` and is a dependency of the widely used `@wordpress/compose` package.

## How?

The PR looks large, but that's mostly whitespace changes, due to the TS changes required for the custom `mapValues()` implementation. I recommend [ignoring whitespace changes](https://github.blog/2018-05-01-ignore-white-space-in-code-review/) while reviewing.

We have to deal with essentially a couple of methods, and migration away from them is pretty straightforward:

#### `get`

Replacing `get` is as simple as using direct access, and optional chaining with nullish coalescing.

#### `mapValues`

Straightforward to replace it with a custom implementation that uses `Object.fromEntries( Object.entries().map() )`. Needs a bit of type massaging as well.

Finally, we're removing the `lodash` dependency from the package completely.

## Testing Instructions
Code is covered by tests - verify all tests pass and all checks are green.