### PR TITLE
Lodash: Refactor away from `_.mapValues()` in data registry

### DIFF
--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { mapValues } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import deprecated from '@wordpress/deprecated';
@@ -198,14 +193,19 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 	// Deprecated
 	// TODO: Remove this after `use()` is removed.
 	function withPlugins( attributes ) {
-		return mapValues( attributes, ( attribute, key ) => {
-			if ( typeof attribute !== 'function' ) {
-				return attribute;
-			}
-			return function () {
-				return registry[ key ].apply( null, arguments );
-			};
-		} );
+		return Object.fromEntries(
+			Object.entries( attributes ).map( ( [ key, attribute ] ) => {
+				if ( typeof attribute !== 'function' ) {
+					return [ key, attribute ];
+				}
+				return [
+					key,
+					function () {
+						return registry[ key ].apply( null, arguments );
+					},
+				];
+			} )
+		);
 	}
 
 	/**


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.mapValues()` from the `@wordpress/data` registry creation module. There is just a single use in that module and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing `_.mapValues()` with `Object.fromEntries( Object.entries().map() )`.

## Testing Instructions

* Smoke test the post editor.
* Verify checks are green - changes are well covered by unit tests.