### PR TITLE
Lodash: Refactor away from `_.get()` in resolvers cache middleware

### DIFF
--- a/packages/data/src/resolvers-cache-middleware.js
+++ b/packages/data/src/resolvers-cache-middleware.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import coreDataStore from './store';
@@ -27,11 +22,10 @@ const createResolversCacheMiddleware =
 			.getCachedResolvers( reducerKey );
 		Object.entries( resolvers ).forEach(
 			( [ selectorName, resolversByArgs ] ) => {
-				const resolver = get( registry.stores, [
-					reducerKey,
-					'resolvers',
-					selectorName,
-				] );
+				const resolver =
+					registry.stores?.[ reducerKey ]?.resolvers?.[
+						selectorName
+					];
 				if ( ! resolver || ! resolver.shouldInvalidate ) {
 					return;
 				}


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.get()` from the `@wordpress/data` resolvers cache middleware module. There is just a single use in that module and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing `_.get()` with a combination of direct access and optional chaining. We're using optional chaining everywhere just in case because this middleware could be used externally and our best bet is to preserve backward compatibility and guard against any missing properties along the line. That also makes the PR pretty safe to land.

## Testing Instructions

* Smoke test the post editor and verify all requests still resolve well.
* Verify all checks are green.