### PR TITLE
Navigation: e2e tests: default to my only existing menu

### DIFF
--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -75,6 +75,13 @@ test.describe(
 
 			await editor.insertBlock( { name: 'core/navigation' } );
 
+			//check the block in the canvas.
+			await expect(
+				editor.canvas.locator(
+					'role=textbox[name="Navigation link text"i] >> text="WordPress"'
+				)
+			).toBeVisible();
+
 			// Check the markup of the block is correct.
 			await editor.publishPost();
 			await expect.poll( editor.getBlocks ).toMatchObject( [
@@ -85,18 +92,11 @@ test.describe(
 			] );
 			await page.locator( 'role=button[name="Close panel"i]' ).click();
 
-			//check the block in the canvas.
-			await expect(
-				page.locator(
-					'role=gridcell[name="Custom Link link"] >> a:has-text("WordPress")'
-				)
-			).toBeVisible();
-
 			//check the block in the frontend.
 			await page.goto( '/' );
 			await expect(
 				page.locator(
-					'nav:has-text("WordPress") >> role=link[name="WordPress"]'
+					'role=navigation >> nth=1 >> role=link[name="WordPress"]'
 				)
 			).toBeVisible();
 		} );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -63,6 +63,7 @@ test.describe(
 
 		test( 'default to my only existing menu', async ( {
 			editor,
+			page,
 			navBlockUtils,
 		} ) => {
 			const createdMenu = await navBlockUtils.createNavigationMenu( {
@@ -79,26 +80,22 @@ test.describe(
 			expect( content ).toBe(
 				`<!-- wp:navigation {"ref":${ createdMenu.id }} /-->`
 			);
-			await editor.page
-				.locator( 'role=button[name="Close panel"i]' )
-				.click();
+			await page.locator( 'role=button[name="Close panel"i]' ).click();
 
 			//check the block in the canvas.
 			await expect(
-				editor.page.locator(
+				page.locator(
 					'role=gridcell[name="Custom Link link"] >> a:has-text("WordPress")'
 				)
 			).toBeVisible();
 
 			//check the block in the frontend.
-			await editor.page.goto( '/' );
+			await page.goto( '/' );
 			await expect(
-				editor.page.locator(
+				page.locator(
 					'nav:has-text("WordPress") >> role=link[name="WordPress"]'
 				)
 			).toBeVisible();
-
-			await editor.page.pause();
 		} );
 	}
 );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -96,7 +96,7 @@ test.describe(
 			await page.goto( '/' );
 			await expect(
 				page.locator(
-					'role=navigation >> nth=1 >> role=link[name="WordPress"]'
+					'role=navigation >> nth=1 >> role=link[name="WordPress"i]'
 				)
 			).toBeVisible();
 		} );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -65,14 +65,21 @@ test.describe(
 			editor,
 			navBlockUtils,
 		} ) => {
-			//Create a menu
-			await navBlockUtils.createNavigationMenu( {
+			const createdMenu = await navBlockUtils.createNavigationMenu( {
 				title: 'Test Menu 1',
 				content:
 					'<!-- wp:navigation-link {"label":"WordPress","type":"custom","url":"http://www.wordpress.org/","kind":"custom","isTopLevelLink":true} /-->',
 			} );
-			//insert navigation block
-			//check the markup of the block
+
+			await editor.insertBlock( { name: 'core/navigation' } );
+
+			// Check the markup of the block is correct.
+			await editor.publishPost();
+			const content = await editor.getEditedPostContent();
+			expect( content ).toBe(
+				`<!-- wp:navigation {"ref":${ createdMenu.id }} /-->`
+			);
+
 			//check the block in the list view?
 			//check the block in the frontend?
 			await editor.page.pause();
@@ -109,11 +116,13 @@ class NavigationBlockUtils {
 	 *
 	 */
 	async deleteAllNavigationMenus() {
-		const menus = await this.rest( { path: `/wp/v2/navigation/` } );
+		const menus = await this.requestUtils.rest( {
+			path: `/wp/v2/navigation/`,
+		} );
 
 		if ( ! menus?.length ) return;
 
-		await this.batchRest(
+		await this.requestUtils.batchRest(
 			menus.map( ( menu ) => ( {
 				method: 'DELETE',
 				path: `/wp/v2/navigation/${ menu.id }?force=true`,

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -76,10 +76,10 @@ test.describe(
 
 			// Check the markup of the block is correct.
 			await editor.publishPost();
-			const content = await editor.getEditedPostContent();
-			expect( content ).toBe(
-				`<!-- wp:navigation {"ref":${ createdMenu.id }} /-->`
-			);
+			await expect.poll( editor.getBlocks ).toEqual( [ {
+				name: 'core/navigation',
+				ref: createdMenu.id,
+			} ] );
 			await page.locator( 'role=button[name="Close panel"i]' ).click();
 
 			//check the block in the canvas.

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -77,10 +77,10 @@ test.describe(
 
 			// Check the markup of the block is correct.
 			await editor.publishPost();
-			await expect.poll( editor.getBlocks ).toEqual( [
+			await expect.poll( editor.getBlocks ).toMatchObject( [
 				{
 					name: 'core/navigation',
-					ref: createdMenu.id,
+					attributes: { ref: createdMenu.id },
 				},
 			] );
 			await page.locator( 'role=button[name="Close panel"i]' ).click();

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -13,6 +13,7 @@ test.describe(
 	'As a user I want the navigation block to fallback to the best possible default',
 	() => {
 		test.beforeAll( async ( { requestUtils } ) => {
+			//TT3 is preferable to emptytheme because it already has the navigation block on its templates.
 			await requestUtils.activateTheme( 'twentytwentythree' );
 		} );
 
@@ -76,10 +77,12 @@ test.describe(
 
 			// Check the markup of the block is correct.
 			await editor.publishPost();
-			await expect.poll( editor.getBlocks ).toEqual( [ {
-				name: 'core/navigation',
-				ref: createdMenu.id,
-			} ] );
+			await expect.poll( editor.getBlocks ).toEqual( [
+				{
+					name: 'core/navigation',
+					ref: createdMenu.id,
+				},
+			] );
 			await page.locator( 'role=button[name="Close panel"i]' ).click();
 
 			//check the block in the canvas.

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -96,7 +96,7 @@ test.describe(
 			await page.goto( '/' );
 			await expect(
 				page.locator(
-					'role=navigation >> nth=1 >> role=link[name="WordPress"i]'
+					'role=navigation >> role=link[name="WordPress"i]'
 				)
 			).toBeVisible();
 		} );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -13,7 +13,7 @@ test.describe(
 	'As a user I want the navigation block to fallback to the best possible default',
 	() => {
 		test.beforeAll( async ( { requestUtils } ) => {
-			await requestUtils.activateTheme( 'emptytheme' );
+			await requestUtils.activateTheme( 'twentytwentythree' );
 		} );
 
 		test.beforeEach( async ( { admin, navBlockUtils } ) => {
@@ -79,9 +79,25 @@ test.describe(
 			expect( content ).toBe(
 				`<!-- wp:navigation {"ref":${ createdMenu.id }} /-->`
 			);
+			await editor.page
+				.locator( 'role=button[name="Close panel"i]' )
+				.click();
 
-			//check the block in the list view?
-			//check the block in the frontend?
+			//check the block in the canvas.
+			await expect(
+				editor.page.locator(
+					'role=gridcell[name="Custom Link link"] >> a:has-text("WordPress")'
+				)
+			).toBeVisible();
+
+			//check the block in the frontend.
+			await editor.page.goto( '/' );
+			await expect(
+				editor.page.locator(
+					'nav:has-text("WordPress") >> role=link[name="WordPress"]'
+				)
+			).toBeVisible();
+
 			await editor.page.pause();
 		} );
 	}


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This is part of the effort to re work all the navigation block e2e tests and migration to playwright. This is one of the user stories described in https://github.com/WordPress/gutenberg/issues/45199

This test checks that when only one navigation menu exists, inserting a Navigation block will default correctly to using said menu.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Run npm run test:e2e:playwright -- editor/blocks/navigation.spec.js


