### PR TITLE
Page List: Invoke the convert to links modal on any interactions with the page list item block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -438,7 +438,7 @@ Displays a page inside a list of all pages. ([Source](https://github.com/WordPre
 -	**Name:** core/page-list-item
 -	**Category:** widgets
 -	**Supports:** ~~html~~, ~~inserter~~, ~~lock~~, ~~reusable~~
--	**Attributes:** hasChildren, id, label, link, title
+-	**Attributes:** hasChildren, id, label, link, onSelect, title
 
 ## Paragraph
 

--- a/packages/block-editor/src/components/off-canvas-editor/index.js
+++ b/packages/block-editor/src/components/off-canvas-editor/index.js
@@ -114,10 +114,16 @@ function OffCanvasEditor(
 	} );
 	const selectEditorBlock = useCallback(
 		( event, blockClientId ) => {
-			updateBlockSelection( event, blockClientId );
-			setSelectedTreeId( blockClientId );
+			let blockSelectionResult;
 			if ( onSelect ) {
-				onSelect( getBlock( blockClientId ) );
+				blockSelectionResult = onSelect(
+					getBlock( blockClientId ),
+					event
+				);
+			}
+			if ( blockSelectionResult !== false ) {
+				updateBlockSelection( event, blockClientId );
+				setSelectedTreeId( blockClientId );
 			}
 		},
 		[ setSelectedTreeId, updateBlockSelection, onSelect, getBlock ]

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -76,7 +76,7 @@ const MainContent = ( {
 			onSelect={ ( block ) => {
 				const onSelect = block.attributes?.onSelect;
 				if ( onSelect ) {
-					// If this returns fasle, then the block won't be selected.
+					// If this returns false, then the block won't be selected.
 					return onSelect( block );
 				}
 			} }

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -73,6 +73,13 @@ const MainContent = ( {
 			isExpanded={ true }
 			LeafMoreMenu={ LeafMoreMenu }
 			description={ description }
+			onSelect={ ( block ) => {
+				const onSelect = block.attributes?.onSelect;
+				if ( onSelect ) {
+					// If this returns fasle, then the block won't be selected.
+					return onSelect( block );
+				}
+			} }
 		/>
 	);
 };

--- a/packages/block-library/src/page-list-item/block.json
+++ b/packages/block-library/src/page-list-item/block.json
@@ -23,6 +23,9 @@
 		},
 		"hasChildren": {
 			"type": "boolean"
+		},
+		"onSelect": {
+			"type": "function"
 		}
 	},
 	"usesContext": [

--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -1,53 +1,38 @@
 /**
  * WordPress dependencies
  */
-import { BlockControls } from '@wordpress/block-editor';
-import { ToolbarButton, Button, Modal } from '@wordpress/components';
+import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
 
 export const convertDescription = __(
 	'This menu is automatically kept in sync with pages on your site. You can manage the menu yourself by clicking "Edit" below.'
 );
 
-export function ConvertToLinksModal( { onClick, disabled } ) {
-	const [ isOpen, setOpen ] = useState( false );
-	const openModal = () => setOpen( true );
-	const closeModal = () => setOpen( false );
-
+export function ConvertToLinksModal( { onClick, disabled, closeModal } ) {
 	return (
-		<>
-			<BlockControls group="other">
-				<ToolbarButton title={ __( 'Edit' ) } onClick={ openModal }>
-					{ __( 'Edit' ) }
-				</ToolbarButton>
-			</BlockControls>
-			{ isOpen && (
-				<Modal
-					onRequestClose={ closeModal }
-					title={ __( 'Edit this menu' ) }
-					className={ 'wp-block-page-list-modal' }
-					aria={ {
-						describedby: 'wp-block-page-list-modal__description',
-					} }
+		<Modal
+			onRequestClose={ closeModal }
+			title={ __( 'Edit this menu' ) }
+			className={ 'wp-block-page-list-modal' }
+			aria={ {
+				describedby: 'wp-block-page-list-modal__description',
+			} }
+		>
+			<p id={ 'wp-block-page-list-modal__description' }>
+				{ convertDescription }
+			</p>
+			<div className="wp-block-page-list-modal-buttons">
+				<Button variant="tertiary" onClick={ closeModal }>
+					{ __( 'Cancel' ) }
+				</Button>
+				<Button
+					variant="primary"
+					disabled={ disabled }
+					onClick={ onClick }
 				>
-					<p id={ 'wp-block-page-list-modal__description' }>
-						{ convertDescription }
-					</p>
-					<div className="wp-block-page-list-modal-buttons">
-						<Button variant="tertiary" onClick={ closeModal }>
-							{ __( 'Cancel' ) }
-						</Button>
-						<Button
-							variant="primary"
-							disabled={ disabled }
-							onClick={ onClick }
-						>
-							{ __( 'Edit' ) }
-						</Button>
-					</div>
-				</Modal>
-			) }
-		</>
+					{ __( 'Edit' ) }
+				</Button>
+			</div>
+		</Modal>
 	);
 }

--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+import { BlockControls } from '@wordpress/block-editor';
+import { ToolbarButton, Button, Modal } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+
+export const convertDescription = __(
+	'This menu is automatically kept in sync with pages on your site. You can manage the menu yourself by clicking "Edit" below.'
+);
+
+export function ConvertToLinksModal( { onClick, disabled } ) {
+	const [ isOpen, setOpen ] = useState( false );
+	const openModal = () => setOpen( true );
+	const closeModal = () => setOpen( false );
+
+	return (
+		<>
+			<BlockControls group="other">
+				<ToolbarButton title={ __( 'Edit' ) } onClick={ openModal }>
+					{ __( 'Edit' ) }
+				</ToolbarButton>
+			</BlockControls>
+			{ isOpen && (
+				<Modal
+					onRequestClose={ closeModal }
+					title={ __( 'Edit this menu' ) }
+					className={ 'wp-block-page-list-modal' }
+					aria={ {
+						describedby: 'wp-block-page-list-modal__description',
+					} }
+				>
+					<p id={ 'wp-block-page-list-modal__description' }>
+						{ convertDescription }
+					</p>
+					<div className="wp-block-page-list-modal-buttons">
+						<Button variant="tertiary" onClick={ closeModal }>
+							{ __( 'Cancel' ) }
+						</Button>
+						<Button
+							variant="primary"
+							disabled={ disabled }
+							onClick={ onClick }
+						>
+							{ __( 'Edit' ) }
+						</Button>
+					</div>
+				</Modal>
+			) }
+		</>
+	);
+}

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -8,6 +8,7 @@ import classnames from 'classnames';
  */
 import { createBlock } from '@wordpress/blocks';
 import {
+	BlockControls,
 	InspectorControls,
 	useBlockProps,
 	useInnerBlocksProps,
@@ -21,9 +22,10 @@ import {
 	Notice,
 	ComboboxControl,
 	Button,
+	ToolbarButton,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { useMemo, useEffect } from '@wordpress/element';
+import { useMemo, useState, useEffect } from '@wordpress/element';
 import { useEntityRecords } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
@@ -135,6 +137,10 @@ export default function PageListEdit( {
 		'showSubmenuIcon' in context &&
 		pages?.length > 0 &&
 		pages?.length <= MAX_PAGE_COUNT;
+
+	const [ isModalOpen, setModalOpen ] = useState( false );
+	const openModal = () => setModalOpen( true );
+	const closeModal = () => setModalOpen( false );
 
 	const convertToNavigationLinks = useConvertToNavigationLinks( {
 		clientId,
@@ -266,6 +272,11 @@ export default function PageListEdit( {
 
 	return (
 		<>
+			<BlockControls group="other">
+				<ToolbarButton title={ __( 'Edit' ) } onClick={ openModal }>
+					{ __( 'Edit' ) }
+				</ToolbarButton>
+			</BlockControls>
 			<InspectorControls>
 				{ pagesTree.length > 0 && (
 					<PanelBody>
@@ -296,10 +307,11 @@ export default function PageListEdit( {
 					</PanelBody>
 				) }
 			</InspectorControls>
-			{ allowConvertToLinks && (
+			{ allowConvertToLinks && isModalOpen && (
 				<ConvertToLinksModal
 					disabled={ ! hasResolvedPages }
 					onClick={ convertToNavigationLinks }
+					closeModal={ closeModal }
 				/>
 			) }
 			<BlockContent

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -9,7 +9,6 @@ import classnames from 'classnames';
 import { createBlock } from '@wordpress/blocks';
 import {
 	InspectorControls,
-	BlockControls,
 	useBlockProps,
 	useInnerBlocksProps,
 	getColorClassName,
@@ -18,15 +17,13 @@ import {
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
-	ToolbarButton,
 	Spinner,
 	Notice,
 	ComboboxControl,
 	Button,
-	Modal,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { useMemo, useState, useEffect } from '@wordpress/element';
+import { useMemo, useEffect } from '@wordpress/element';
 import { useEntityRecords } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
@@ -34,16 +31,15 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { useConvertToNavigationLinks } from './use-convert-to-navigation-links';
+import {
+	convertDescription,
+	ConvertToLinksModal,
+} from './convert-to-links-modal';
 
 // We only show the edit option when page count is <= MAX_PAGE_COUNT
 // Performance of Navigation Links is not good past this value.
 const MAX_PAGE_COUNT = 100;
 const NOOP = () => {};
-
-const convertDescription = __(
-	'This menu is automatically kept in sync with pages on your site. You can manage the menu yourself by clicking "Edit" below.'
-);
-
 function BlockContent( {
 	blockProps,
 	innerBlocksProps,
@@ -111,48 +107,6 @@ function BlockContent( {
 	if ( pages.length > 0 ) {
 		return <ul { ...innerBlocksProps }></ul>;
 	}
-}
-
-function ConvertToLinksModal( { onClick, disabled } ) {
-	const [ isOpen, setOpen ] = useState( false );
-	const openModal = () => setOpen( true );
-	const closeModal = () => setOpen( false );
-
-	return (
-		<>
-			<BlockControls group="other">
-				<ToolbarButton title={ __( 'Edit' ) } onClick={ openModal }>
-					{ __( 'Edit' ) }
-				</ToolbarButton>
-			</BlockControls>
-			{ isOpen && (
-				<Modal
-					onRequestClose={ closeModal }
-					title={ __( 'Edit this menu' ) }
-					className={ 'wp-block-page-list-modal' }
-					aria={ {
-						describedby: 'wp-block-page-list-modal__description',
-					} }
-				>
-					<p id={ 'wp-block-page-list-modal__description' }>
-						{ convertDescription }
-					</p>
-					<div className="wp-block-page-list-modal-buttons">
-						<Button variant="tertiary" onClick={ closeModal }>
-							{ __( 'Cancel' ) }
-						</Button>
-						<Button
-							variant="primary"
-							disabled={ disabled }
-							onClick={ onClick }
-						>
-							{ __( 'Edit' ) }
-						</Button>
-					</div>
-				</Modal>
-			) }
-		</>
-	);
 }
 
 export default function PageListEdit( {

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -202,6 +202,10 @@ export default function PageListEdit( {
 				title: page.title?.rendered,
 				link: page.url,
 				hasChildren,
+				onSelect: () => {
+					openModal();
+					return false;
+				},
 			};
 			let item = null;
 			const children = getBlockList( page.id );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
When users interact with the Page List Items in the Navigation List View, we should invoke the "convert to links" modal, to make it clear that these items can't be edited.

Questions
1. Should we also display the modal if I interact with these blocks in the canvas?
2. Should we even show the modal, or should we just do the conversion silently?

cc @SaxonF @richtabor 

Fixes https://github.com/WordPress/gutenberg/issues/47064

## Why?
To make it clear that these items can't be edited, and allow users to do so.

## How?
This allows blocks to create their own `onSelect` attribute which is a function which is called when the block is selected in the OffCanvasEditor.

## Testing Instructions
1. Edit a navigation block which has a page list inside it.
2. Click on/select one of the pages in the page list block.
3. Confirm that you see the convert to links modal.
4. Also test that the page list block can still invoke the modal using the edit button in the toolbar, and the inspector controls.

### Testing Instructions for Keyboard
As above.

## Screenshots or screencast <!-- if applicable -->
https://user-images.githubusercontent.com/275961/216683802-7f596372-d233-4f8a-84d9-53df898e8db6.mov

