### PR TITLE
useBlockSync: change subscribed.current on unsubscribe

### DIFF
--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -265,6 +265,9 @@ export default function useBlockSync( {
 			previousAreBlocksDifferent = areBlocksDifferent;
 		} );
 
-		return () => unsubscribe();
+		return () => {
+			subscribed.current = false;
+			unsubscribe();
+		};
 	}, [ registry, clientId ] );
 }


### PR DESCRIPTION
Fixed broken undo in strict mode reported by @ntsekouras here: https://github.com/WordPress/gutenberg/pull/47703#issuecomment-1414132456

Was caused by missing `subscribed.current = false` when cleaning up an effect and unsubscribing. In another effect in the same hook, there is code like:
```js
if ( subscribed.current ) {
  pendingChanges.current.incoming = controlledBlocks;
}
```
which says "assign to `incoming` changes if already subscribed", and "already subscribed" is the same as "this is not the first, initial run of the effect". In other words, we want to assign to `incoming` only when the blocks change, not their initial value.

**How to test:** Test this together with `<StrictMode>` in the post editor, and verify that undo works. Undo was broken when you did the first change, on subsequent changes it started working again. 