### PR TITLE
Table Block: Don't render empty  section

### DIFF
--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -398,7 +398,7 @@ function TableEdit( {
 		},
 	];
 
-	const renderedSections = [ 'head', 'body', 'foot' ].map( ( name ) => (
+	const renderedSections = sections.map( ( name ) => (
 		<TSection name={ name } key={ name }>
 			{ attributes[ name ].map( ( { cells }, rowIndex ) => (
 				<tr key={ rowIndex }>


### PR DESCRIPTION
## What?
This small PR changes the editor to not render sections without rows (`thead`/`tfoot`).

![table](https://user-images.githubusercontent.com/54422211/216760482-726e4604-8c66-478d-9dd8-a5f1274f2738.png)

## Why?
To match the front-end rendering results.

I also discovered that this issue affects when implementing caption toolbar buttons, as was done in #45112 and #47325. If the caption is hidden, an empty tfoot tag will cause unexpected scrolling.

https://user-images.githubusercontent.com/54422211/216760927-a41ac4a6-2131-46a0-b8e9-24070811e3ad.mp4

## How?
When each section is rendered, I used a `sections` variable with [empty sections removed](https://github.com/WordPress/gutenberg/blob/4f94f097ecf52d145db4563e2da3352c19cb02e2/packages/block-library/src/table/edit.js#L358-L360) instead of a hard-coded section array.

## Testing Instructions

After inserting a table with no header/footer, confirm that it only has a `tbody` element directly below the `table` tag.