### PR TITLE
Shuffle template parts

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -17,7 +17,13 @@ import {
 	__experimentalUseHasRecursion as useHasRecursion,
 	BlockControls,
 } from '@wordpress/block-editor';
-import { Spinner, Modal, MenuItem, ToolbarButton } from '@wordpress/components';
+import {
+	Spinner,
+	Modal,
+	MenuItem,
+	ToolbarButton,
+	Tooltip,
+} from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { useState, createInterpolateElement } from '@wordpress/element';
@@ -188,9 +194,14 @@ export default function TemplatePartEdit( {
 							) }
 						</BlockSettingsMenuControls>
 						<BlockControls group="other">
-							<ToolbarButton onClick={ shuffleTemplatePart }>
-								{ __( 'Shuffle' ) }
-							</ToolbarButton>
+							<Tooltip
+								position="top center"
+								text={ __( 'Try a different design' ) }
+							>
+								<ToolbarButton onClick={ shuffleTemplatePart }>
+									{ __( 'Shuffle' ) }
+								</ToolbarButton>
+							</Tooltip>
 						</BlockControls>
 					</>
 				) }

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -187,7 +187,7 @@ export default function TemplatePartEdit( {
 								</MenuItem>
 							) }
 						</BlockSettingsMenuControls>
-						<BlockControls group="block">
+						<BlockControls group="other">
 							<ToolbarButton onClick={ shuffleTemplatePart }>
 								{ __( 'Shuffle' ) }
 							</ToolbarButton>

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -187,7 +187,7 @@ export default function TemplatePartEdit( {
 								</MenuItem>
 							) }
 						</BlockSettingsMenuControls>
-						<BlockControls group="other">
+						<BlockControls group="block">
 							<ToolbarButton onClick={ shuffleTemplatePart }>
 								{ __( 'Shuffle' ) }
 							</ToolbarButton>

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -15,8 +15,9 @@ import {
 	store as blockEditorStore,
 	__experimentalRecursionProvider as RecursionProvider,
 	__experimentalUseHasRecursion as useHasRecursion,
+	BlockControls,
 } from '@wordpress/block-editor';
-import { Spinner, Modal, MenuItem } from '@wordpress/components';
+import { Spinner, Modal, MenuItem, ToolbarButton } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { useState, createInterpolateElement } from '@wordpress/element';
@@ -33,6 +34,7 @@ import {
 	useAlternativeBlockPatterns,
 	useAlternativeTemplateParts,
 	useTemplatePartArea,
+	useShuffleTemplatePart,
 } from './utils/hooks';
 
 export default function TemplatePartEdit( {
@@ -92,6 +94,12 @@ export default function TemplatePartEdit( {
 	const isPlaceholder = ! slug;
 	const isEntityAvailable = ! isPlaceholder && ! isMissing && isResolved;
 	const TagName = tagName || areaObject.tagName;
+	const shuffleTemplatePart = useShuffleTemplatePart(
+		area,
+		clientId,
+		templatePartId,
+		setAttributes
+	);
 
 	// The `isSelected` check ensures the `BlockSettingsMenuControls` fill
 	// doesn't render multiple times. The block controls has similar internal check.
@@ -157,27 +165,34 @@ export default function TemplatePartEdit( {
 					</TagName>
 				) }
 				{ canReplace && (
-					<BlockSettingsMenuControls>
-						{ () => (
-							<MenuItem
-								onClick={ () => {
-									setIsTemplatePartSelectionOpen( true );
-								} }
-							>
-								{ createInterpolateElement(
-									__( 'Replace <BlockTitle />' ),
-									{
-										BlockTitle: (
-											<BlockTitle
-												clientId={ clientId }
-												maximumLength={ 25 }
-											/>
-										),
-									}
-								) }
-							</MenuItem>
-						) }
-					</BlockSettingsMenuControls>
+					<>
+						<BlockSettingsMenuControls>
+							{ () => (
+								<MenuItem
+									onClick={ () => {
+										setIsTemplatePartSelectionOpen( true );
+									} }
+								>
+									{ createInterpolateElement(
+										__( 'Replace <BlockTitle />' ),
+										{
+											BlockTitle: (
+												<BlockTitle
+													clientId={ clientId }
+													maximumLength={ 25 }
+												/>
+											),
+										}
+									) }
+								</MenuItem>
+							) }
+						</BlockSettingsMenuControls>
+						<BlockControls group="other">
+							<ToolbarButton onClick={ shuffleTemplatePart }>
+								{ __( 'Shuffle' ) }
+							</ToolbarButton>
+						</BlockControls>
+					</>
 				) }
 				{ isEntityAvailable && (
 					<TemplatePartInnerBlocks


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
In addition to #47594. An alternative approach of taking #44581 to shuffle template parts.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See #44581

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add a "Shuffle" button to the template part blocks. We already have the "Replace template part" workflow, this is a different way to do a similar thing via a toolbar button.

Currently, this PR replaces the inner blocks of the template part block when shuffling through patterns, which sometimes isn't ideal as the users probably don't expect their content across different pages to change. This, however, is how template part currently works, and we still have a "note" when users save the entities.

An alternative approach shown in 3d2463303397168e49235084df8ee9c4e5fed9ff follows the same logic as in the "Replace template part" workflow. Instead of replacing the existing template part block's inner blocks, it completely switches the template part to another. The tricky part of this is when handling patterns. We have to create a new template part when first shuffling to a new pattern (there is currently a bug that the focus will be lost during this transition), resulting in the unexpected creation of multiple template parts when the users are just hitting the "Shuffle" button. A pattern will only be created once when converting to a template part though, so that it won't keep creating dummy template parts infinitely.

Another idea shared by @talldan is to have the template part blocks reference patterns in some way. Still not sure how that would work at this stage though.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Go to the Site Editor
2. Select a template part in the editor
3. Click on the "Shuffle" button in the block toolbar
4. See that the content of the template part gets replaced with patterns

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Go to the Site Editor
2. Select a template part in the editor
3. Hit <kbd>Shift</kbd>+<kbd>Tab</kbd> to navigate to the block toolbar
4. Press <kbd>ArrowRight</kbd> to navigate to the "Shuffle" button
5. Press <kbd>Enter</kbd> to shuffle the content of the template part
6. Verify that the content of the template part gets replaced with something else

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/7753001/216836986-48f73d7c-596d-4fdf-b801-41902200ca03.mp4

