### PR TITLE
New block: Link Preview

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -332,6 +332,15 @@ Display a list of your most recent posts. ([Source](https://github.com/WordPress
 -	**Supports:** align, anchor, color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** addLinkToFeaturedImage, categories, columns, displayAuthor, displayFeaturedImage, displayPostContent, displayPostContentRadio, displayPostDate, excerptLength, featuredImageAlign, featuredImageSizeHeight, featuredImageSizeSlug, featuredImageSizeWidth, order, orderBy, postLayout, postsToShow, selectedAuthor
 
+## Link preview
+
+A link with a preview of the destination site. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/link-preview))
+
+-	**Name:** core/link-preview
+-	**Category:** embed
+-	**Supports:** 
+-	**Attributes:** description, icon, image, title, url
+
 ## List
 
 Create a bulleted or numbered list. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/list))

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -198,6 +198,7 @@ const EmbedEdit = ( props ) => {
 					tryAgain={ () => {
 						invalidateResolution( 'getEmbedPreview', [ url ] );
 					} }
+					onReplace={ onReplace }
 				/>
 			</View>
 		);

--- a/packages/block-library/src/embed/embed-placeholder.js
+++ b/packages/block-library/src/embed/embed-placeholder.js
@@ -4,6 +4,7 @@
 import { __, _x } from '@wordpress/i18n';
 import { Button, Placeholder, ExternalLink } from '@wordpress/components';
 import { BlockIcon } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
 
 const EmbedPlaceholder = ( {
 	icon,
@@ -14,6 +15,7 @@ const EmbedPlaceholder = ( {
 	cannotEmbed,
 	fallback,
 	tryAgain,
+	onReplace,
 } ) => {
 	return (
 		<Placeholder
@@ -56,6 +58,18 @@ const EmbedPlaceholder = ( {
 					</Button>{ ' ' }
 					<Button variant="secondary" onClick={ fallback }>
 						{ _x( 'Convert to link', 'button label' ) }
+					</Button>{ ' ' }
+					<Button
+						variant="secondary"
+						onClick={ () => {
+							onReplace(
+								createBlock( 'core/link-preview', {
+									url: value,
+								} )
+							);
+						} }
+					>
+						{ _x( 'Convert to link preview', 'button label' ) }
 					</Button>
 				</div>
 			) }

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -55,6 +55,7 @@ import * as html from './html';
 import * as image from './image';
 import * as latestComments from './latest-comments';
 import * as latestPosts from './latest-posts';
+import * as linkPreview from './link-preview';
 import * as list from './list';
 import * as listItem from './list-item';
 import * as logInOut from './loginout';
@@ -128,6 +129,7 @@ const getAllBlocks = () =>
 		image,
 		heading,
 		gallery,
+		linkPreview,
 		list,
 		listItem,
 		quote,

--- a/packages/block-library/src/link-preview/block.json
+++ b/packages/block-library/src/link-preview/block.json
@@ -9,6 +9,7 @@
 	"attributes": {
 		"url": {
 			"type": "string",
+			"default": "",
 			"__experimentalRole": "content"
 		},
 		"title": {

--- a/packages/block-library/src/link-preview/block.json
+++ b/packages/block-library/src/link-preview/block.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "core/link-preview",
+	"title": "Link preview",
+	"category": "embed",
+	"description": "A link with a preview of the destination site.",
+	"textdomain": "default",
+	"attributes": {
+		"url": {
+			"type": "string",
+			"__experimentalRole": "content"
+		},
+		"title": {
+			"type": "string"
+		},
+		"description": {
+			"type": "string"
+		},
+		"icon": {
+			"type": "string"
+		},
+		"image": {
+			"type": "string"
+		}
+	},
+	"editorStyle": "wp-block-link-preview-editor",
+	"style": "wp-block-link-preview"
+}

--- a/packages/block-library/src/link-preview/content.js
+++ b/packages/block-library/src/link-preview/content.js
@@ -1,5 +1,6 @@
 export function Content( { props, attributes } ) {
 	const { url, title, image, icon } = attributes;
+	if ( ! url ) return null;
 	return (
 		<a
 			{ ...props }

--- a/packages/block-library/src/link-preview/content.js
+++ b/packages/block-library/src/link-preview/content.js
@@ -1,0 +1,25 @@
+export function Content( { props, attributes } ) {
+	const { url, title, image, icon } = attributes;
+	return (
+		<a
+			{ ...props }
+			href={ url }
+			className={
+				image ? props.className + ' has-image' : props.className
+			}
+		>
+			{ image && <img src={ image } alt={ title } /> }
+			<div>
+				<strong>{ title }</strong>
+				{ icon && (
+					<img
+						className="link-preview__icon"
+						src={ icon }
+						alt={ new URL( url ).host }
+					/>
+				) }
+				{ new URL( url ).host.replace( /^www\./, '' ) }
+			</div>
+		</a>
+	);
+}

--- a/packages/block-library/src/link-preview/edit.js
+++ b/packages/block-library/src/link-preview/edit.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { useBlockProps, BlockControls } from '@wordpress/block-editor';
 import { __experimentalFetchUrlData } from '@wordpress/core-data';
 import {
@@ -32,6 +32,19 @@ export default function LinkPreviewEdit( props ) {
 					event.preventDefault();
 			  },
 	} );
+
+	useEffect( () => {
+		if ( url && ! title && ! icon && ! image ) {
+			setIsFetching( true );
+			__experimentalFetchUrlData( url )
+				.then( ( data ) => {
+					setAttributes( data );
+				} )
+				.finally( () => {
+					setIsFetching( false );
+				} );
+		}
+	}, [] );
 
 	if ( isEditingUrl ) {
 		return (

--- a/packages/block-library/src/link-preview/edit.js
+++ b/packages/block-library/src/link-preview/edit.js
@@ -34,9 +34,12 @@ export default function LinkPreviewEdit( props ) {
 
 	const blockProps = useBlockProps( {
 		href: url,
-		onClick( event ) {
-			event.preventDefault();
-		},
+		onClick:
+			url && title
+				? ( event ) => {
+						event.preventDefault();
+				  }
+				: undefined,
 	} );
 
 	if ( ! url ) {

--- a/packages/block-library/src/link-preview/edit.js
+++ b/packages/block-library/src/link-preview/edit.js
@@ -1,0 +1,102 @@
+/**
+ * WordPress dependencies
+ */
+import { __, _x } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
+import { useBlockProps } from '@wordpress/block-editor';
+import { __experimentalFetchUrlData } from '@wordpress/core-data';
+import { Placeholder, Spinner, Button } from '@wordpress/components';
+
+export default function LinkPreviewEdit( props ) {
+	const {
+		attributes: { url, title, icon, image },
+		setAttributes,
+	} = props;
+	const [ isFetching, setIsFetching ] = useState( false );
+
+	useEffect( () => {
+		if ( ! url ) {
+			return;
+		}
+
+		// Try fetching preview.
+		setIsFetching( true );
+		__experimentalFetchUrlData( url )
+			.then( ( data ) => {
+				setAttributes( data );
+			} )
+			.finally( () => {
+				setIsFetching( false );
+			} );
+	}, [ url ] );
+
+	const [ urlValue, setURLValue ] = useState( '' );
+
+	const blockProps = useBlockProps( {
+		href: url,
+		onClick( event ) {
+			event.preventDefault();
+		},
+	} );
+
+	if ( ! url ) {
+		return (
+			<div { ...blockProps }>
+				<Placeholder
+					icon={ icon }
+					label={ __( 'URL' ) }
+					instructions={ __(
+						'Paste a link to the content you want to display on your site.'
+					) }
+				>
+					<form
+						onSubmit={ () => {
+							setAttributes( { url: urlValue } );
+						} }
+					>
+						<input
+							type="url"
+							value={ urlValue }
+							className="components-placeholder__input"
+							aria-label={ __( 'URL' ) }
+							placeholder={ __( 'Enter URL to embed here…' ) }
+							onChange={ ( event ) => {
+								setURLValue( event.target.value );
+							} }
+						/>
+						<Button variant="primary" type="submit">
+							{ _x( 'Embed', 'button label' ) }
+						</Button>
+					</form>
+				</Placeholder>
+			</div>
+		);
+	}
+
+	if ( ! title ) {
+		return (
+			<a { ...blockProps }>
+				{ url }
+				{ isFetching && <Spinner /> }
+			</a>
+		);
+	}
+
+	return (
+		<a { ...blockProps }>
+			<img src={ image } alt={ title } />
+			<div>
+				<strong>{ title }</strong>
+				<br />
+				<span>
+					<img
+						className="link-preview__icon"
+						src={ icon }
+						alt={ new URL( url ).host }
+					/>{ ' ' }
+					{ new URL( url ).host }
+				</span>
+			</div>
+		</a>
+	);
+}

--- a/packages/block-library/src/link-preview/index.js
+++ b/packages/block-library/src/link-preview/index.js
@@ -1,0 +1,25 @@
+/**
+ * Internal dependencies
+ */
+import initBlock from '../utils/init-block';
+import edit from './edit';
+import save from './save';
+import metadata from './block.json';
+import transforms from './transforms';
+
+/**
+ * WordPress dependencies
+ */
+import { link } from '@wordpress/icons';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	icon: link,
+	edit,
+	save,
+	transforms,
+};
+
+export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/link-preview/init.js
+++ b/packages/block-library/src/link-preview/init.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import { init } from './';
+
+export default init();

--- a/packages/block-library/src/link-preview/save.js
+++ b/packages/block-library/src/link-preview/save.js
@@ -6,24 +6,28 @@ import { useBlockProps } from '@wordpress/block-editor';
 export default function save( { attributes } ) {
 	const { url, title, image, icon } = attributes;
 
-	if ( ! url || ! title ) {
+	if ( ! url ) {
 		return null;
 	}
 
 	return (
-		<a { ...useBlockProps.save( { href: url } ) }>
-			<img src={ image } alt={ title } />
+		<a
+			{ ...useBlockProps.save( {
+				href: url,
+				className: image ? 'has-image' : undefined,
+			} ) }
+		>
+			{ image && <img src={ image } alt={ title } /> }
 			<div>
-				<strong>{ title }</strong>
-				<br />
-				<span>
+				{ title && <strong>{ title }</strong> }
+				{ icon && (
 					<img
 						className="link-preview__icon"
 						src={ icon }
 						alt={ new URL( url ).host }
-					/>{ ' ' }
-					{ new URL( url ).host }
-				</span>
+					/>
+				) }
+				{ title ? new URL( url ).host.replace( /^www\./, '' ) : url }
 			</div>
 		</a>
 	);

--- a/packages/block-library/src/link-preview/save.js
+++ b/packages/block-library/src/link-preview/save.js
@@ -3,32 +3,15 @@
  */
 import { useBlockProps } from '@wordpress/block-editor';
 
-export default function save( { attributes } ) {
-	const { url, title, image, icon } = attributes;
+/**
+ * Internal dependencies
+ */
+import { Content } from './content';
 
-	if ( ! url ) {
+export default function save( { attributes } ) {
+	if ( ! attributes.url ) {
 		return null;
 	}
 
-	return (
-		<a
-			{ ...useBlockProps.save( {
-				href: url,
-				className: image ? 'has-image' : undefined,
-			} ) }
-		>
-			{ image && <img src={ image } alt={ title } /> }
-			<div>
-				{ title && <strong>{ title }</strong> }
-				{ icon && (
-					<img
-						className="link-preview__icon"
-						src={ icon }
-						alt={ new URL( url ).host }
-					/>
-				) }
-				{ title ? new URL( url ).host.replace( /^www\./, '' ) : url }
-			</div>
-		</a>
-	);
+	return <Content props={ useBlockProps.save() } attributes={ attributes } />;
 }

--- a/packages/block-library/src/link-preview/save.js
+++ b/packages/block-library/src/link-preview/save.js
@@ -1,0 +1,30 @@
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+export default function save( { attributes } ) {
+	const { url, title, image, icon } = attributes;
+
+	if ( ! url || ! title ) {
+		return null;
+	}
+
+	return (
+		<a { ...useBlockProps.save( { href: url } ) }>
+			<img src={ image } alt={ title } />
+			<div>
+				<strong>{ title }</strong>
+				<br />
+				<span>
+					<img
+						className="link-preview__icon"
+						src={ icon }
+						alt={ new URL( url ).host }
+					/>{ ' ' }
+					{ new URL( url ).host }
+				</span>
+			</div>
+		</a>
+	);
+}

--- a/packages/block-library/src/link-preview/style.scss
+++ b/packages/block-library/src/link-preview/style.scss
@@ -28,6 +28,10 @@ a.wp-block-link-preview {
 		height: 100%;
 	}
 
+
+}
+
+.wp-block-link-preview {
 	.components-notice {
 		margin: 0 0 1em 0;
 	}

--- a/packages/block-library/src/link-preview/style.scss
+++ b/packages/block-library/src/link-preview/style.scss
@@ -27,4 +27,8 @@ a.wp-block-link-preview {
 		max-width: 50%;
 		height: 100%;
 	}
+
+	.components-notice {
+		margin: 0 0 1em 0;
+	}
 }

--- a/packages/block-library/src/link-preview/style.scss
+++ b/packages/block-library/src/link-preview/style.scss
@@ -1,19 +1,25 @@
-a.wp-block-link-preview.wp-block-link-preview {
+a.wp-block-link-preview {
 	display: block;
 	border: 1px solid #d3d3d3;
-	height: 100px;
+	border-radius: 2px;
 	font-size: smaller;
-	text-decoration: none !important;
-	color: inherit !important;
+
+	&.has-image {
+		height: 100px;
+	}
+
+	strong {
+		display: block;
+	}
 
 	> div {
-		padding: 10px;
-		overflow: hidden;
+		padding: 1em;
 	}
 
 	.link-preview__icon {
 		height: 1em;
 		width: 1em;
+		margin-right: 0.25em;
 	}
 
 	> img {

--- a/packages/block-library/src/link-preview/style.scss
+++ b/packages/block-library/src/link-preview/style.scss
@@ -1,0 +1,24 @@
+a.wp-block-link-preview.wp-block-link-preview {
+	display: block;
+	border: 1px solid #d3d3d3;
+	height: 100px;
+	font-size: smaller;
+	text-decoration: none !important;
+	color: inherit !important;
+
+	> div {
+		padding: 10px;
+		overflow: hidden;
+	}
+
+	.link-preview__icon {
+		height: 1em;
+		width: 1em;
+	}
+
+	> img {
+		float: right;
+		max-width: 50%;
+		height: 100%;
+	}
+}

--- a/packages/block-library/src/link-preview/transforms.js
+++ b/packages/block-library/src/link-preview/transforms.js
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+/**
+ * Default transforms for generic embeds.
+ */
+const transforms = {
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/paragraph' ],
+			isMatch: ( { url } ) => !! url,
+			transform: ( { url } ) => {
+				return createBlock( 'core/paragraph', {
+					content: `<a href="${ url }">${ url }</a>`,
+				} );
+			},
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/embed' ],
+		},
+	],
+};
+
+export default transforms;

--- a/packages/block-library/src/link-preview/transforms.js
+++ b/packages/block-library/src/link-preview/transforms.js
@@ -21,6 +21,22 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/embed' ],
+			transform: ( { url } ) => {
+				return createBlock( 'core/embed', {
+					url,
+				} );
+			},
+		},
+	],
+	from: [
+		{
+			type: 'block',
+			blocks: [ 'core/embed' ],
+			transform: ( { url } ) => {
+				return createBlock( 'core/link-preview', {
+					url,
+				} );
+			},
 		},
 	],
 };

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -19,6 +19,7 @@
 @import "./image/style.scss";
 @import "./latest-comments/style.scss";
 @import "./latest-posts/style.scss";
+@import "./link-preview/style.scss";
 @import "./list/style.scss";
 @import "./media-text/style.scss";
 @import "./navigation/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Adds a new block for previewing links. This could be done as a fallback for embeds, but I think this deserves to be its own block and I don't want to add complexity to the embed block and endpoints (my first attempt at this involved adding it to the embed API and block). We could add a button to convert to a link preview block if embedding fails.

This still needs some design work, and for some reason the stylesheet is not loading on the front end.

<img width="710" alt="Screenshot 2023-02-05 at 23 25 16" src="https://user-images.githubusercontent.com/4710635/216847704-4dcbb7c3-0a77-4e82-a40d-fd53a1db091d.png">


## Why?

I've been missing this feature. I'd love it if we could automatically create this block when pasting a link on an empty line, but we need to see how this works with the embed block.

## How?

Uses the existing `url-details` endpoint. Is might be that we need to improve this, I don't know how good it is. Currently it's only used to preview links in the link editing UI.

## Testing Instructions

Create a link preview block and submit any URL.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
