### PR TITLE
Image: Allow deprecated blocks to render border-radius

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -141,6 +141,7 @@ figure.wp-block-image:not(.wp-block) {
 	// smoother UX.
 	.reactEasyCrop_Container .reactEasyCrop_Image {
 		border: none;
+		border-radius: 0; // Prevent's theme.json radius bleeding into cropper.
 	}
 }
 

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -6,6 +6,17 @@
 		box-sizing: border-box;
 	}
 
+	// The following style maintains border radius application for deprecated
+	// image blocks that applied border radius to the outer `figure` element.
+	//
+	// See: https://github.com/WordPress/gutenberg/issues/47422
+	&[style*="border-radius"] {
+		> a,
+		img {
+			border-radius: inherit;
+		}
+	}
+
 	&.has-custom-border {
 		img {
 			box-sizing: border-box;


### PR DESCRIPTION
Fixes: #47422 

## What?

Allows deprecated Image blocks to continue rendering custom image border radii without resaving the posts.

## Why?

Without this change, deprecated image blocks lose their border radii on the frontend.

## How?

- Adds a style that targets the inline `border-radius` style present on deprecated image blocks. This style forces the image blocks `img` to inherit the border radius
- Adds an editor-only style that forces the removal of the theme.json border radius from the image while within the cropper. This allows the cropper to apply the correct border radius and the image to be cropped within those constraints.

## Testing Instructions

1. With WP 6.0.3 and without Gutenberg activated, create a post
2. Add several image blocks to the post including 
    - one with a custom radius
    - another with a custom radius and set to link to media file etc
    - one without any radius
3. Save the post and view on the frontend, the radii should be applied
4. Update your test site to WP 6.1.1 or install and activate the latest Gutenberg
5. Reload the frontend and note that the border radii have been lost
6. Apply this PR branch and reload the frontend again. The radii should be restored
7. Switch back to the editor and reload. 
8. Confirm that the image block deprecation runs and its markup has been updated to apply the border radius to the inner image. 
9. Save the post and confirm correct display of radii
10. Repeat steps 1-9 however, before creating the post, tweak your theme.json to apply a border radius
11. After testing the block deprecation runs in the editor, try cropping one of your images with the custom border radius. With the style added by this PR, the cropper should possess the custom radius while the inner img itself has not radius. The result is that the cropper appears to maintain that custom radius correctly.


## Screenshots or screencast <!-- if applicable -->

##### Frontend - Deprecated Image block with custom border radius

| Before | After |
|---|---|
| <img width="315" alt="Screenshot 2023-02-06 at 12 53 00 pm" src="https://user-images.githubusercontent.com/60436221/216872910-ad2a72e0-2f54-4dfd-b9df-69258cf04489.png"> | <img width="315" alt="Screenshot 2023-02-06 at 12 53 08 pm" src="https://user-images.githubusercontent.com/60436221/216872943-262102db-50fe-4819-a455-6cbed6b11f67.png"> |

##### Editor - Cropping image with custom border radius & theme.json border radius style

| Before | After |
|---|---|
| <img width="352" alt="Screenshot 2023-02-06 at 12 52 28 pm" src="https://user-images.githubusercontent.com/60436221/216873098-d40e2c42-5ffb-4e9b-b8e5-9f0a76c3ca2e.png"> | <img width="357" alt="Screenshot 2023-02-06 at 12 52 14 pm" src="https://user-images.githubusercontent.com/60436221/216873129-07a0e058-cec9-41f0-b902-630e9260e5e8.png"> |

_Note: In before image above, a theme.json border-radius of `100px` was being applied to the inner `img` while the cropper possessed the correct custom border radius of `50px`._