### PR TITLE
Use the blog prefix to store preferences by site in localstorage

### DIFF
--- a/lib/compat/wordpress-6.1/persisted-preferences.php
+++ b/lib/compat/wordpress-6.1/persisted-preferences.php
@@ -53,7 +53,8 @@ function gutenberg_configure_persisted_preferences() {
 	}
 
 	global $wpdb;
-	$meta_key = $wpdb->get_blog_prefix() . 'persisted_preferences';
+	$blog_prefix = $wpdb->get_blog_prefix();
+	$meta_key = $blog_prefix . 'persisted_preferences';
 
 	$preload_data = get_user_meta( $user_id, $meta_key, true );
 
@@ -63,12 +64,14 @@ function gutenberg_configure_persisted_preferences() {
 			'( function() {
 				var serverData = %s;
 				var userId = "%s";
-				var persistenceLayer = wp.preferencesPersistence.__unstableCreatePersistenceLayer( serverData, userId );
+				var blogPrefix = "%s";
+				var persistenceLayer = wp.preferencesPersistence.__unstableCreatePersistenceLayer( serverData, userId, blogPrefix );
 				var preferencesStore = wp.preferences.store;
 				wp.data.dispatch( preferencesStore ).setPersistenceLayer( persistenceLayer );
 			} ) ();',
 			wp_json_encode( $preload_data ),
-			$user_id
+			$user_id,
+			$blog_prefix
 		),
 		'after'
 	);

--- a/lib/compat/wordpress-6.1/persisted-preferences.php
+++ b/lib/compat/wordpress-6.1/persisted-preferences.php
@@ -54,7 +54,7 @@ function gutenberg_configure_persisted_preferences() {
 
 	global $wpdb;
 	$blog_prefix = $wpdb->get_blog_prefix();
-	$meta_key = $blog_prefix . 'persisted_preferences';
+	$meta_key    = $blog_prefix . 'persisted_preferences';
 
 	$preload_data = get_user_meta( $user_id, $meta_key, true );
 

--- a/packages/preferences-persistence/src/index.js
+++ b/packages/preferences-persistence/src/index.js
@@ -16,9 +16,9 @@ export { create };
  * This function is used internally by WordPress in an inline script, so
  * prefixed with `__unstable`.
  *
- * @param {Object} serverData Preferences data preloaded from the server.
- * @param {string} userId     The user id.
- * @param {string} blogPrefix The site prefix.
+ * @param {Object}  serverData Preferences data preloaded from the server.
+ * @param {string}  userId     The user id.
+ * @param {?string} blogPrefix The site prefix.
  *
  * @return {Object} The persistence layer initialized with the preloaded data.
  */

--- a/packages/preferences-persistence/src/index.js
+++ b/packages/preferences-persistence/src/index.js
@@ -18,11 +18,18 @@ export { create };
  *
  * @param {Object} serverData Preferences data preloaded from the server.
  * @param {string} userId     The user id.
+ * @param {string} blogPrefix The site prefix.
  *
  * @return {Object} The persistence layer initialized with the preloaded data.
  */
-export function __unstableCreatePersistenceLayer( serverData, userId ) {
-	const localStorageRestoreKey = `WP_PREFERENCES_USER_${ userId }`;
+export function __unstableCreatePersistenceLayer(
+	serverData,
+	userId,
+	blogPrefix
+) {
+	const localStorageRestoreKey = blogPrefix
+		? `WP_PREFERENCES_USER_${ blogPrefix }_${ userId }`
+		: `WP_PREFERENCES_USER_${ userId }`;
 	const localData = JSON.parse(
 		window.localStorage.getItem( localStorageRestoreKey )
 	);


### PR DESCRIPTION
## What? Why?
The preferences persistence system primarily stores data in user meta (within the WordPress database), but also saves to localstorage as a failsafe (in case the HTTP request to save to user meta doesn't complete).

When saving to user meta, data is stored by blog prefix and user id, so that any retrieved preferences are specific to the individual blog (on a multisite) and user.

There's a bug in that the localstorage system only uses the user id, so the same user with multiple sites on a multisite installation that uses subdirectories might end up incorrectly overwriting their preferences with those from another site.

Hopefully the impact of this is fairly small, as the user meta data is the preferred storage medium and instances of data needing to be retrieved from localstorage shouldn't be common.

## How?
Use the `blog_prefix` as part of the localstorage key.

## Testing Instructions
This is a tricky one to test, as it requires a multisite installation. 

It's also hard to write e2e tests (I don't think we have multisite e2e tests), or php unit tests (as it involves a client side script). Any suggestions welcome.

On one site:
1. Load the post editor
2. Using the browser dev tools network tab, simulate being offline
3. Change a preference (e.g. top toolbar being on or off) in a way that makes it deviate from another site.

On another site:
4. Set yourself back to being online
5. Load the post editor
6. The preference you changed should be unaffected by the change in step 3.

## Screenshots or screencast <!-- if applicable -->
