### PR TITLE
Fix Post Excerpt: Read more link is always on new line in the editor

### DIFF
--- a/packages/block-library/src/post-excerpt/editor.scss
+++ b/packages/block-library/src/post-excerpt/editor.scss
@@ -1,5 +1,5 @@
 .wp-block-post-excerpt {
 	.wp-block-post-excerpt__excerpt.is-inline {
-		display: inline-block;
+		display: inline;
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes the read more link position in the post excerpt block.
When the option "Show link on new line" is toggled off, the link should not be on a new line.

Closes https://github.com/WordPress/gutenberg/issues/47458

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
In the editor, the read more link was always on a new line, if there was an excerpt text.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Updates the CSS for the post excerpt, replaces `display: inline-block` with` display:inline`

## Testing Instructions

1. Make sure that your WordPress install has posts with excerpts in different lengths.
2. Open the site Editor
3. Select or add a a new excerpt block inside a query loop.
4. Add a custom text to the read more link.
5. In the block settings sidebar (inspector), toggle the setting "Show link on new line" on and off to compare the two options.
6. When the option is toggled off, the read more link should be on the same line as the content in the excerpt.
(Exceptions are possible if there is no room for the texts to be on the same line).

## Screenshots or screencast <!-- if applicable -->
After: 
https://user-images.githubusercontent.com/7422055/216935918-500c8e6b-4d47-47ee-abc7-a490d6dbe527.mov
