### PR TITLE
LocalAutosaveNotice: use stable notice id to prevent double notices 

### DIFF
--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -23,7 +23,6 @@ const requestIdleCallback = window.requestIdleCallback
 	: window.requestAnimationFrame;
 
 let hasStorageSupport;
-let uniqueId = 0;
 
 /**
  * Function which returns true if the current environment supports browser
@@ -100,13 +99,14 @@ function useAutosaveNotice() {
 			return;
 		}
 
-		const noticeId = `wpEditorAutosaveRestore${ ++uniqueId }`;
+		const id = 'wpEditorAutosaveRestore';
+
 		createWarningNotice(
 			__(
 				'The backup of this post in your browser is different from the version below.'
 			),
 			{
-				id: noticeId,
+				id,
 				actions: [
 					{
 						label: __( 'Restore the backup' ),
@@ -117,7 +117,7 @@ function useAutosaveNotice() {
 							} = edits;
 							editPost( editsWithoutContent );
 							resetEditorBlocks( parse( edits.content ) );
-							removeNotice( noticeId );
+							removeNotice( id );
 						},
 					},
 				],

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -30,17 +30,19 @@ let hasStorageSupport;
  * reused in subsequent invocations.
  */
 const hasSessionStorageSupport = () => {
-	if ( typeof hasStorageSupport === 'undefined' ) {
-		try {
-			// Private Browsing in Safari 10 and earlier will throw an error when
-			// attempting to set into sessionStorage. The test here is intentional in
-			// causing a thrown error as condition bailing from local autosave.
-			window.sessionStorage.setItem( '__wpEditorTestSessionStorage', '' );
-			window.sessionStorage.removeItem( '__wpEditorTestSessionStorage' );
-			hasStorageSupport = true;
-		} catch ( error ) {
-			hasStorageSupport = false;
-		}
+	if ( hasStorageSupport !== undefined ) {
+		return hasStorageSupport;
+	}
+
+	try {
+		// Private Browsing in Safari 10 and earlier will throw an error when
+		// attempting to set into sessionStorage. The test here is intentional in
+		// causing a thrown error as condition bailing from local autosave.
+		window.sessionStorage.setItem( '__wpEditorTestSessionStorage', '' );
+		window.sessionStorage.removeItem( '__wpEditorTestSessionStorage' );
+		hasStorageSupport = true;
+	} catch {
+		hasStorageSupport = false;
 	}
 
 	return hasStorageSupport;
@@ -73,7 +75,7 @@ function useAutosaveNotice() {
 
 		try {
 			localAutosave = JSON.parse( localAutosave );
-		} catch ( error ) {
+		} catch {
 			// Not usable if it can't be parsed.
 			return;
 		}
@@ -176,11 +178,9 @@ function LocalAutosaveMonitor() {
 	useAutosaveNotice();
 	useAutosavePurge();
 
-	const { localAutosaveInterval } = useSelect(
-		( select ) => ( {
-			localAutosaveInterval:
-				select( editorStore ).getEditorSettings().localAutosaveInterval,
-		} ),
+	const localAutosaveInterval = useSelect(
+		( select ) =>
+			select( editorStore ).getEditorSettings().localAutosaveInterval,
 		[]
 	);
 


### PR DESCRIPTION
Fixes issue in React strict mode where local autosave notice appears twice, reported by @ntsekouras here: https://github.com/WordPress/gutenberg/pull/47703#issuecomment-1414139498

The notice is created in `useEffect`, and on mount, React strict mode runs effects twice.

I fixed this by giving a stable ID to the notice, instead of making it unique on each call. If the notice is created for the second time, the previous one gets removed. The unique ID was never really needed -- this is the kind of notice that should appear only once.