### PR TITLE
CustomSelectControl: update size prop options to new format in Storybook examples

### DIFF
--- a/packages/components/src/custom-select-control/stories/index.js
+++ b/packages/components/src/custom-select-control/stories/index.js
@@ -10,9 +10,9 @@ export default {
 		__next36pxDefaultSize: { control: { type: 'boolean' } },
 		__experimentalShowSelectedHint: { control: { type: 'boolean' } },
 		size: {
+			options: [ 'small', 'default', '__unstable-large' ],
 			control: {
 				type: 'radio',
-				options: [ 'small', 'default', '__unstable-large' ],
 			},
 		},
 	},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

While reviewing #47229 I noticed a warning in Storybook about an out-of-date format used to list options for the `size` props. This PR updates the code to the new format.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Pre-requisite for the migration to Storybook v7 in the near future.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Followed instructions from https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-controloptions

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- On your machine, run Storybook (`npm run storybook:dev`) and visit `CustomSelectControl`'s examples
- Make sure that the controls for the `size` props work as on [production](https://wordpress.github.io/gutenberg/), showing three options to choose from via a radio interface: `'small'`, `'default'`, `'__unstable-large'`
- Make sure that there's no warning being shown about the out-of-date format used to describe those control options

## Screenshots or screencast <!-- if applicable -->

| `trunk` | This PR |
|---|---|
|  ![Screenshot 2023-02-06 at 13 13 43](https://user-images.githubusercontent.com/1083581/216970035-94d71c66-7d74-49be-908d-1548a2a8cf24.jpg) | ![Screenshot 2023-02-06 at 13 13 26](https://user-images.githubusercontent.com/1083581/216970080-a1c4ff31-65f2-471f-a1ca-65749528e6aa.jpg) |

