### PR TITLE
Lodash: Refactor persistence plugin away from `_.merge()`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17584,6 +17584,7 @@
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/priority-queue": "file:packages/priority-queue",
 				"@wordpress/redux-routine": "file:packages/redux-routine",
+				"deepmerge": "^4.3.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
 				"is-promise": "^4.0.0",
@@ -17591,6 +17592,13 @@
 				"redux": "^4.1.2",
 				"turbo-combine-reducers": "^1.0.2",
 				"use-memo-one": "^1.1.1"
+			},
+			"dependencies": {
+				"deepmerge": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
+					"integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og=="
+				}
 			}
 		},
 		"@wordpress/data-controls": {
@@ -23182,6 +23190,12 @@
 					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 					"dev": true
 				},
+				"http-cache-semantics": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+					"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+					"dev": true
+				},
 				"http-errors": {
 					"version": "1.7.2",
 					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
@@ -23264,7 +23278,8 @@
 				"immediate": {
 					"version": "3.0.6",
 					"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-					"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+					"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+					"dev": true
 				},
 				"inflight": {
 					"version": "1.0.6",
@@ -23516,6 +23531,35 @@
 						"verror": "1.10.0"
 					}
 				},
+				"jszip": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
+					"integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
+					"dev": true,
+					"requires": {
+						"lie": "~3.3.0",
+						"pako": "~1.0.2",
+						"readable-stream": "~2.3.6",
+						"set-immediate-shim": "~1.0.1"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						}
+					}
+				},
 				"keypather": {
 					"version": "1.10.2",
 					"resolved": "https://registry.npmjs.org/keypather/-/keypather-1.10.2.tgz",
@@ -23588,6 +23632,7 @@
 					"version": "3.3.0",
 					"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
 					"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+					"dev": true,
 					"requires": {
 						"immediate": "~3.0.5"
 					}
@@ -24938,7 +24983,8 @@
 				"set-immediate-shim": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-					"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+					"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+					"dev": true
 				},
 				"setprototypeof": {
 					"version": "1.1.1",
@@ -29546,7 +29592,7 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
 			"dev": true
 		},
 		"code-point-at": {
@@ -37501,12 +37547,6 @@
 			"resolved": "https://registry.npmjs.org/image-size/-/image-size-0.6.3.tgz",
 			"integrity": "sha512-47xSUiQioGaB96nqtp5/q55m0aBQSQdyIloMOc/x+QVTDZLNmXE892IIDrJ0hM1A5vcNUDD5tDffkSP5lCaIIA=="
 		},
-		"immediate": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-			"dev": true
-		},
 		"import-fresh": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
@@ -42724,18 +42764,6 @@
 				}
 			}
 		},
-		"jszip": {
-			"version": "3.10.1",
-			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
-			"integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-			"dev": true,
-			"requires": {
-				"lie": "~3.3.0",
-				"pako": "~1.0.2",
-				"readable-stream": "~2.3.6",
-				"setimmediate": "^1.0.5"
-			}
-		},
 		"junk": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/junk/-/junk-3.1.0.tgz",
@@ -43077,15 +43105,6 @@
 					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 					"dev": true
 				}
-			}
-		},
-		"lie": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-			"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-			"dev": true,
-			"requires": {
-				"immediate": "~3.0.5"
 			}
 		},
 		"lilconfig": {

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -36,6 +36,7 @@
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/priority-queue": "file:../priority-queue",
 		"@wordpress/redux-routine": "file:../redux-routine",
+		"deepmerge": "^4.3.0",
 		"equivalent-key-map": "^0.2.2",
 		"is-plain-object": "^5.0.0",
 		"is-promise": "^4.0.0",

--- a/packages/data/src/plugins/persistence/index.js
+++ b/packages/data/src/plugins/persistence/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { isPlainObject } from 'is-plain-object';
-import { merge } from 'lodash';
+import deepmerge from 'deepmerge';
 
 /**
  * Internal dependencies
@@ -193,7 +193,7 @@ function persistencePlugin( registry, pluginOptions ) {
 					//   subset of keys.
 					// - New keys in what would otherwise be used as initial
 					//   state are deeply merged as base for persisted value.
-					initialState = merge( {}, initialState, persistedState );
+					initialState = deepmerge( initialState, persistedState );
 				} else {
 					// If there is a mismatch in object-likeness of default
 					// initial or persisted state, defer to persisted value.

--- a/packages/data/src/plugins/persistence/index.js
+++ b/packages/data/src/plugins/persistence/index.js
@@ -193,7 +193,9 @@ function persistencePlugin( registry, pluginOptions ) {
 					//   subset of keys.
 					// - New keys in what would otherwise be used as initial
 					//   state are deeply merged as base for persisted value.
-					initialState = deepmerge( initialState, persistedState );
+					initialState = deepmerge( initialState, persistedState, {
+						isMergeableObject: isPlainObject,
+					} );
 				} else {
 					// If there is a mismatch in object-likeness of default
 					// initial or persisted state, defer to persisted value.


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.merge()` from the persistence plugin for `@wordpress/data`. There is just a single use in that component and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing `_.merge()` with the tiny `deepmerge` library, which works well as a drop-in replacement in my tests. I'm hoping to use the same for the other `merge` usages throughout the codebase.

## Testing Instructions

Verify checks are green - changes are covered by tests.