### PR TITLE
Handle block metadata attribute and related experimental APIs

### DIFF
--- a/lib/compat/wordpress-6.1/blocks.php
+++ b/lib/compat/wordpress-6.1/blocks.php
@@ -323,28 +323,3 @@ function gutenberg_block_type_metadata_render_template( $settings, $metadata ) {
 	return $settings;
 }
 add_filter( 'block_type_metadata_settings', 'gutenberg_block_type_metadata_render_template', 10, 2 );
-
-/**
- * Registers the metadata block attribute for block types.
- *
- * Once 6.1 is the minimum supported WordPress version for the Gutenberg
- * plugin, this shim can be removed
- *
- * @param array $args Array of arguments for registering a block type.
- * @return array $args
- */
-function gutenberg_register_metadata_attribute( $args ) {
-	// Setup attributes if needed.
-	if ( ! isset( $args['attributes'] ) || ! is_array( $args['attributes'] ) ) {
-		$args['attributes'] = array();
-	}
-
-	if ( ! array_key_exists( 'metadata', $args['attributes'] ) ) {
-		$args['attributes']['metadata'] = array(
-			'type' => 'object',
-		);
-	}
-
-	return $args;
-}
-add_filter( 'register_block_type_args', 'gutenberg_register_metadata_attribute' );

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -77,3 +77,26 @@ if ( ! function_exists( 'wp_enqueue_block_view_script' ) ) {
 		add_filter( 'render_block', $callback, 10, 2 );
 	}
 }
+
+
+/**
+ * Registers the metadata block attribute for block types.
+ *
+ * @param array $args Array of arguments for registering a block type.
+ * @return array $args
+ */
+function gutenberg_register_metadata_attribute( $args ) {
+	// Setup attributes if needed.
+	if ( ! isset( $args['attributes'] ) || ! is_array( $args['attributes'] ) ) {
+		$args['attributes'] = array();
+	}
+
+	if ( ! array_key_exists( 'metadata', $args['attributes'] ) ) {
+		$args['attributes']['metadata'] = array(
+			'type' => 'object',
+		);
+	}
+
+	return $args;
+}
+add_filter( 'register_block_type_args', 'gutenberg_register_metadata_attribute' );

--- a/packages/block-editor/src/hooks/metadata.js
+++ b/packages/block-editor/src/hooks/metadata.js
@@ -8,7 +8,7 @@ const META_ATTRIBUTE_NAME = 'metadata';
 
 export function hasBlockMetadataSupport( blockType, feature = '' ) {
 	// Only core blocks are allowed to use __experimentalMetadata until the fetaure is stablised.
-	if ( ! blockType.startsWith( 'core/' ) ) {
+	if ( ! blockType.name.startsWith( 'core/' ) ) {
 		return false;
 	}
 	const support = getBlockSupport( blockType, '__experimentalMetadata' );

--- a/packages/block-editor/src/hooks/metadata.js
+++ b/packages/block-editor/src/hooks/metadata.js
@@ -7,6 +7,10 @@ import { getBlockSupport } from '@wordpress/blocks';
 const META_ATTRIBUTE_NAME = 'metadata';
 
 export function hasBlockMetadataSupport( blockType, feature = '' ) {
+	// Only core blocks are allowed to use __experimentalMetadata until the fetaure is stablised.
+	if ( ! blockType.startsWith( 'core/' ) ) {
+		return false;
+	}
 	const support = getBlockSupport( blockType, '__experimentalMetadata' );
 	return !! ( true === support || support?.[ feature ] );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Attempts to avoid releasing `__experimentalMetadata` and associated block `metadata` attribute in WP 6.2.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

[Audit of experimental APIs for 6.2 flagged it](https://github.com/WordPress/gutenberg/issues/47196#issue-1535172651).

After discussing with @ntsekouras (away from Github) we settled on avoiding the APIs being released at all outside of the Plugin.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Moving the PHP attribute registration out of `compat/6.1` and into the `lib/experiments/` dir.
- Doing something (TBC) to the JS changes. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
