### PR TITLE
Mobile - Fix Experiments native variant breakage

### DIFF
--- a/packages/block-editor/src/experiments.native.js
+++ b/packages/block-editor/src/experiments.native.js
@@ -1,19 +1,9 @@
 /**
- * WordPress dependencies
- */
-import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/experiments';
-
-/**
  * Internal dependencies
  */
 import * as globalStyles from './components/global-styles';
 import { ExperimentalBlockEditorProvider } from './components/provider';
-
-export const { lock, unlock } =
-	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
-		'@wordpress/block-editor'
-	);
+import { lock } from './lock-unlock';
 
 /**
  * Experimental @wordpress/block-editor APIs.


### PR DESCRIPTION
## What?
This PR brings changes from https://github.com/WordPress/gutenberg/pull/47229 to the `experiments` native variant.

## Why?
This change was breaking the editor.

## How?
By bringing the latest changes from the `experiments` file.

## Testing Instructions
CI checks should pass.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A