### PR TITLE
Disable `fail-fast` for the PHPUnit testing matrix.

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -59,7 +59,7 @@ jobs:
         timeout-minutes: 20
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
-            fail-fast: true
+            fail-fast: false
             matrix:
                 php:
                     - '5.6'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR is proposing that the `fail-fast` option be disabled in the PHPUnit test matrix.

## Why?
At the surface, automatically cancelling all jobs within a matrix when any one encounters a problem seems like the right option (and sometimes it is), there are benefits to allowing each individual job to finish in this job strategy.

It's not uncommon for one or more jobs to encounter a connection issue, or something else that results in a failure. When this happens, it doesn't necessarily mean all of them will fail. [GitHub Actions allows only failed jobs to be rerun within a workflow](https://docs.github.com/en/actions/managing-workflow-runs/re-running-workflows-and-jobs). By cancelling all of the PHP jobs when one encounters a problem, the benefit of only re-running the failures is eliminated entirely, and the time spent by any of the jobs that may have succeeded is wasted as they all will be rerun (cancelled is considered failed).

Another instance where it's valuable to know which jobs fail and which pass is when code is incompatible with a specific version of PHP. For example, code may work on PHP 7.x but trigger a fatal error on 8.x. Allowing all jobs to finish will make this scenario more clear and more discoverable, especially since contributors do not commonly test against multiple versions of PHP locally.

It looks like `fail-fast` was enabled in #46510.