### PR TITLE
Test possibility of adding a filter to override custom css capabilities

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2867,6 +2867,8 @@ class WP_Theme_JSON_Gutenberg {
 		$blocks_metadata = static::get_blocks_metadata();
 		$style_nodes     = static::get_style_nodes( $theme_json, $blocks_metadata );
 
+		$can_user_edit_global_custom_css = apply_filters( 'enable_global_styles_custom_css', current_user_can( 'edit_css' ) );
+
 		foreach ( $style_nodes as $metadata ) {
 			$input = _wp_array_get( $theme_json, $metadata['path'], array() );
 			if ( empty( $input ) ) {
@@ -2874,7 +2876,7 @@ class WP_Theme_JSON_Gutenberg {
 			}
 
 			// The global styles custom CSS is not sanitized, but can only be edited by users with 'edit_css' capability.
-			if ( isset( $input['css'] ) && current_user_can( 'edit_css' ) ) {
+			if ( isset( $input['css'] ) && $can_user_edit_global_custom_css ) {
 				$output = $input;
 			} else {
 				$output = static::remove_insecure_styles( $input );

--- a/lib/compat/wordpress-6.2/class-gutenberg-rest-global-styles-controller-6-2.php
+++ b/lib/compat/wordpress-6.2/class-gutenberg-rest-global-styles-controller-6-2.php
@@ -105,7 +105,9 @@ class Gutenberg_REST_Global_Styles_Controller_6_2 extends WP_REST_Global_Styles_
 			$rels[] = 'https://api.w.org/action-publish';
 		}
 
-		if ( current_user_can( 'edit_css' ) ) {
+		$can_user_edit_css = apply_filters( 'enable_global_styles_custom_css', current_user_can( 'edit_css' ) );
+
+		if ( $can_user_edit_css ) {
 			$rels[] = 'https://api.w.org/action-edit-css';
 		}
 


### PR DESCRIPTION
## What?
Just testing the idea of adding a filter to allow plugins/themes to override the capabilities needed to edit global custom CSS

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
In plugin or theme add:

```
add_filter( 'enable_global_styles_custom_css', 'my_custom_css_capabilities_check' );
```

With `my_custom_css_capabilities_check` being a method that does your own custom check of for the user capability you required to edit CSS.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
