### PR TITLE
Perf Tests: Return minimum metric instead of averages.

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -42,7 +42,7 @@ jobs:
 
             - name: Compare performance with trunk
               if: github.event_name == 'pull_request'
-              run: ./bin/plugin/cli.js perf $GITHUB_SHA trunk --tests-branch $GITHUB_SHA
+              run: ./bin/plugin/cli.js perf $GITHUB_SHA trunk --tests-branch $GITHUB_SHA --rounds 18
 
             - name: Compare performance with current WordPress Core and previous Gutenberg versions
               if: github.event_name == 'release'

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -88,7 +88,11 @@ const config = require( '../config' );
  * @return {number} Average.
  */
 function average( array ) {
-	return array.reduce( ( a, b ) => a + b, 0 ) / array.length;
+	// Try returning the minimum value.
+	return array.length > 3
+		? array.slice().sort().slice( 3 )[ 0 ]
+		: array.slice().sort()[ 0 ];
+	// return array.reduce( ( a, b ) => a + b, 0 ) / array.length;
 }
 
 /**


### PR DESCRIPTION
## Status

Reporting minimum values isn't significantly changing the measured metrics at the level of variability we currently have.

## Description

Performance isn't like temperature: it doesn't waver around a mean. Instead, it only wavers _above_ its minimum value. In fairness, lots of things affect performance, but there only exists one theorectical minimum for a given CPU, RAM, system, etc...

In this patch we're looking at that minimum and comparing against test runs to see how it changes the intra-test variability.
