### PR TITLE
Fix flash of unstyled content when loading post editor

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -292,7 +292,6 @@ function Iframe( {
 				{ head &&
 					createPortal(
 						<>
-							{ styleAssets }
 							{ headChildren }
 						</>,
 						head

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -170,7 +170,6 @@ function Iframe( {
 			);
 
 			contentDocument.dir = ownerDocument.dir;
-
 			documentElement.removeChild( contentDocument.body );
 
 			iFrameDocument.addEventListener(

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -219,7 +219,7 @@ function Iframe( {
 				// to initialise.
 				forceRender();
 			} );
-	}, [ head, scripts ] );
+	}, [ head ] );
 
 	const disabledRef = useDisabled( { isDisabled: ! readonly } );
 	const wrapperRef = useMergeRefs( [

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -289,30 +289,22 @@ function Iframe( {
 				srcDoc={ srcDoc }
 				title={ __( 'Editor canvas' ) }
 			>
-				{ head &&
-					createPortal(
-						<>
-							{ headChildren }
-						</>,
-						head
-					) }
+				{ head && createPortal( headChildren, head ) }
 				{ iframeDocument &&
 					createPortal(
-						<>
-							<body
-								ref={ bodyRef }
-								className={ classnames(
-									'block-editor-iframe__body',
-									'editor-styles-wrapper',
-									...bodyClasses
-								) }
-							>
-								{ contentResizeListener }
-								<StyleProvider document={ iframeDocument }>
-									{ children }
-								</StyleProvider>
-							</body>
-						</>,
+						<body
+							ref={ bodyRef }
+							className={ classnames(
+								'block-editor-iframe__body',
+								'editor-styles-wrapper',
+								...bodyClasses
+							) }
+						>
+							{ contentResizeListener }
+							<StyleProvider document={ iframeDocument }>
+								{ children }
+							</StyleProvider>
+						</body>,
 						iframeDocument.documentElement
 					) }
 			</iframe>


### PR DESCRIPTION
## What?
Fixes #47724

## How?
Previously the `Iframe` component was removing its existing `<head>` element from the iframe and attaching a new one.

From my testing, removing the existing `<head>` causes the `styleAssets` loaded in the `srcDoc` (see #46706) to also be removed. Not sure why, but possibly those styles end up attached to the `<head>` even though you can't see them when inspecting.

This PR tries keeping the existing `<head>` which seems to allow the `styleAssets` in the `srcDoc` to be retained and removes the need to add them again to the `<head>`.

## Testing Instructions
1. Create a post with an empty group block and save it
2. Reload the editor (you may need to disable caching or do a hard reload)

In trunk: The group block placeholder and appender are briefly unstyled
In this PR: There's no flash of unstyled content.

## Screenshots or screencast <!-- if applicable -->
#### Before
https://user-images.githubusercontent.com/677833/216228500-6cb53e6f-96c1-4d3d-b186-e966d49b1d87.mp4

#### After
https://user-images.githubusercontent.com/677833/217143592-58c42b71-e21f-436c-a976-14c656896da9.mp4
