### PR TITLE
Most Used Terms: Pass dependency to the useSelect

### DIFF
--- a/packages/editor/src/components/post-taxonomies/most-used-terms.js
+++ b/packages/editor/src/components/post-taxonomies/most-used-terms.js
@@ -26,17 +26,20 @@ const DEFAULT_QUERY = {
 };
 
 export default function MostUsedTerms( { onSelect, taxonomy } ) {
-	const { _terms, showTerms } = useSelect( ( select ) => {
-		const mostUsedTerms = select( coreStore ).getEntityRecords(
-			'taxonomy',
-			taxonomy.slug,
-			DEFAULT_QUERY
-		);
-		return {
-			_terms: mostUsedTerms,
-			showTerms: mostUsedTerms?.length >= MIN_MOST_USED_TERMS,
-		};
-	}, [] );
+	const { _terms, showTerms } = useSelect(
+		( select ) => {
+			const mostUsedTerms = select( coreStore ).getEntityRecords(
+				'taxonomy',
+				taxonomy.slug,
+				DEFAULT_QUERY
+			);
+			return {
+				_terms: mostUsedTerms,
+				showTerms: mostUsedTerms?.length >= MIN_MOST_USED_TERMS,
+			};
+		},
+		[ taxonomy.slug ]
+	);
 
 	if ( ! showTerms ) {
 		return null;


### PR DESCRIPTION
## What?
PR adds a missing dependency to the `useSelect` hook in the `MostUsedTerms` component.

Noticed while reviewing a different PR.

## Testing Instructions
1. Make sure to have at least 3 tags assigned to published posts.
2. Open a Post or Page.
3. Confirm Tags panel correctly displays the "Most Used" section.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-02-07 at 09 00 00](https://user-images.githubusercontent.com/240569/217153450-5913bfad-1844-4e4b-95da-f105c5f9fc6d.png)
