### PR TITLE
Replace string concatenation in the read more block

### DIFF
--- a/packages/block-library/src/read-more/index.php
+++ b/packages/block-library/src/read-more/index.php
@@ -23,7 +23,7 @@ function render_block_core_read_more( $attributes, $content, $block ) {
 	$screen_reader_text = sprintf(
 		/* translators: %s is either the post title or post ID to describe the link for screen readers. */
 		__( ': %s' ),
-		'' !== $post_title ? $post_title : __( 'untitled post ' ) . $post_ID
+		'' !== $post_title ? $post_title : sprintf( __( 'untitled post %d' ), $post_ID )
 	);
 	$justify_class_name = empty( $attributes['justifyContent'] ) ? '' : "is-justified-{$attributes['justifyContent']}";
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $justify_class_name ) );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Replaces string concatenation in a translatable string with sprintf, and uses a placeholder for the post ID.

Closes https://github.com/WordPress/gutenberg/issues/47812

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Basically we should avoid concatenation when it comes to translated strings. 

## Testing Instructions

1. Create a new post without a title.
2. Add a read more block. Do not add a custom text.
3. Save the post and view it on the front.
4. View the source of the read more block, the link should have a screen reader text containing "untitled post" followed by the post id.

Example:

`<a class="wp-block-read-more" href="http://localhost:10013/?p=2065" target="_self">Read more<span class="screen-reader-text">: untitled post 2065</span></a>`
