### PR TITLE
Plugin: Fix the 'WP_HTML_Tag_Processor' file path

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -95,7 +95,7 @@ if ( ! class_exists( 'WP_HTML_Tag_Processor' ) ) {
 	require __DIR__ . '/compat/wordpress-6.2/html-api/class-wp-html-attribute-token.php';
 	require __DIR__ . '/compat/wordpress-6.2/html-api/class-wp-html-span.php';
 	require __DIR__ . '/compat/wordpress-6.2/html-api/class-wp-html-text-replacement.php';
-	require __DIR__ . '/compat/wordpress-6.2/html-api/class-wp-html-tag_processor.php';
+	require __DIR__ . '/compat/wordpress-6.2/html-api/class-wp-html-tag-processor.php';
 }
 
 // Experimental features.


### PR DESCRIPTION
## What?
This is a follow-up to #47749.

PR fixes PHP fatal error caused by the typo with 'WP_HTML_Tag_Processor' file path when using Gutenberg with WP 6.1.

```
PHP Fatal error:  require(): Failed opening required '~/gutenberg/lib/compat/wordpress-6.2/html-api/class-wp-html-tag_processor.php' in ~/gutenberg/lib/load.php on line 98
```

## Testing Instructions
Use WP 6.1 and check Gutenberg `trunk` vs this branch.