### PR TITLE
Navigation: Add integration tests for NavigationMenuSelector component 

### DIFF
--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -40,7 +40,6 @@ function NavigationMenuSelector( {
 	const {
 		navigationMenus,
 		hasResolvedNavigationMenus,
-		isNavigationMenuResolved,
 		canUserCreateNavigationMenu,
 		canSwitchNavigationMenu,
 	} = useNavigationMenu();
@@ -91,13 +90,7 @@ function NavigationMenuSelector( {
 		) {
 			setIsCreatingMenu( false );
 		}
-	}, [
-		currentMenuId,
-		hasNavigationMenus,
-		hasResolvedNavigationMenus,
-		createNavigationMenuIsSuccess,
-		isNavigationMenuResolved,
-	] );
+	}, [ hasResolvedNavigationMenus, createNavigationMenuIsSuccess ] );
 
 	const NavigationMenuSelectorDropdown = (
 		<DropdownMenu

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -105,9 +105,13 @@ function NavigationMenuSelector( {
 							<MenuItemsChoice
 								value={ currentMenuId }
 								onSelect={ ( menuId ) => {
+									setSelectorLabel( __( 'Loading …' ) );
+									setIsCreatingMenu( true );
 									onSelectNavigationMenu( menuId );
+									onClose();
 								} }
 								choices={ menuChoices }
+								disabled={ isCreatingMenu }
 							/>
 						</MenuGroup>
 					) }
@@ -121,6 +125,7 @@ function NavigationMenuSelector( {
 											setSelectorLabel(
 												__( 'Loading …' )
 											);
+											setIsCreatingMenu( true );
 											onSelectClassicMenu( menu );
 											onClose();
 										} }
@@ -129,6 +134,7 @@ function NavigationMenuSelector( {
 											createActionLabel,
 											label
 										) }
+										disabled={ isCreatingMenu }
 									>
 										{ label }
 									</MenuItem>

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -140,6 +140,7 @@ function NavigationMenuSelector( {
 					{ canUserCreateNavigationMenu && (
 						<MenuGroup label={ __( 'Tools' ) }>
 							<MenuItem
+								disabled={ isCreatingMenu }
 								onClick={ () => {
 									onClose();
 									onCreateNew();

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -7,7 +7,6 @@ import {
 	MenuItemsChoice,
 	DropdownMenu,
 } from '@wordpress/components';
-import { useEntityProp } from '@wordpress/core-data';
 import { moreVertical } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -46,12 +45,6 @@ function NavigationMenuSelector( {
 		canSwitchNavigationMenu,
 	} = useNavigationMenu();
 
-	const [ currentTitle ] = useEntityProp(
-		'postType',
-		'wp_navigation',
-		'title'
-	);
-
 	const menuChoices = useMemo( () => {
 		return (
 			navigationMenus?.map( ( { id, title }, index ) => {
@@ -73,14 +66,7 @@ function NavigationMenuSelector( {
 				};
 			} ) || []
 		);
-	}, [
-		currentTitle,
-		currentMenuId,
-		navigationMenus,
-		createNavigationMenuIsSuccess,
-		isNavigationMenuResolved,
-		hasResolvedNavigationMenus,
-	] );
+	}, [ currentMenuId, navigationMenus, actionLabel ] );
 
 	const hasNavigationMenus = !! navigationMenus?.length;
 	const hasClassicMenus = !! classicMenus?.length;

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -96,7 +96,7 @@ function NavigationMenuSelector( {
 		if ( ! hasResolvedNavigationMenus ) {
 			setSelectorLabel( __( 'Loading …' ) );
 		} else if ( noMenuSelected || noBlockMenus || menuUnavailable ) {
-			setSelectorLabel( __( 'Choose a Navigation menu' ) );
+			setSelectorLabel( __( 'Choose or create a Navigation menu' ) );
 		}
 
 		if (

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -93,7 +93,7 @@ function NavigationMenuSelector( {
 		hasResolvedNavigationMenus && currentMenuId === null;
 
 	useEffect( () => {
-		if ( ! hasResolvedNavigationMenus ) {
+		if ( ! hasResolvedNavigationMenus && ! canUserCreateNavigationMenu ) {
 			setSelectorLabel( __( 'Loading …' ) );
 		} else if ( noMenuSelected || noBlockMenus || menuUnavailable ) {
 			setSelectorLabel( __( 'Choose or create a Navigation menu' ) );

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -56,7 +56,7 @@ function NavigationMenuSelector( {
 		return (
 			navigationMenus?.map( ( { id, title }, index ) => {
 				const label =
-					decodeEntities( title.rendered ) ||
+					decodeEntities( title?.rendered ) ||
 					/* translators: %s is the index of the menu in the list of menus. */
 					sprintf( __( '(no title %s)' ), index + 1 );
 

--- a/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
@@ -197,7 +197,7 @@ describe( 'NavigationMenuSelector', () => {
 			} );
 		} );
 
-		describe( 'Navigation menus listing', () => {
+		describe( 'Navigation menus', () => {
 			it( 'should not show a list of menus when menus exist but user does not have permission to switch menus', async () => {
 				const user = userEvent.setup();
 
@@ -293,6 +293,39 @@ describe( 'NavigationMenuSelector', () => {
 						name: '(no title 2)',
 					} )
 				).toBeInTheDocument();
+			} );
+
+			it( 'should correctly call handler when navigation menu item is clicked', async () => {
+				const user = userEvent.setup();
+
+				const clickHandler = jest.fn();
+
+				useNavigationMenu.mockReturnValue( {
+					navigationMenus: navigationMenusFixture,
+					isResolvingNavigationMenus: false,
+					hasResolvedNavigationMenus: true,
+					canUserCreateNavigationMenu: true,
+					canSwitchNavigationMenu: true,
+				} );
+
+				render(
+					<NavigationMenuSelector
+						onSelectNavigationMenu={ clickHandler }
+					/>
+				);
+
+				const toggleButton = screen.getByRole( 'button' );
+				await user.click( toggleButton );
+
+				const menuItem = screen.getByRole( 'menuitemradio', {
+					name: navigationMenusFixture[ 0 ].title.rendered,
+				} );
+
+				await user.click( menuItem );
+
+				expect( clickHandler ).toHaveBeenCalledWith(
+					navigationMenusFixture[ 0 ].id
+				);
 			} );
 		} );
 	} );

--- a/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
@@ -29,7 +29,7 @@ describe( 'NavigationMenuSelector', () => {
 
 			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
 				'aria-label',
-				'Loading …'
+				expect.stringContaining( 'Loading' )
 			);
 		} );
 
@@ -40,16 +40,36 @@ describe( 'NavigationMenuSelector', () => {
 				hasResolvedNavigationMenus: true,
 			} );
 
-			const user = userEvent.setup();
 			render( <NavigationMenuSelector /> );
 
 			const button = screen.getByRole( 'button' );
 
-			await user.click( button );
-
-			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
+			expect( button ).toHaveAttribute(
 				'aria-label',
 				'Choose a Navigation menu'
+			);
+		} );
+	} );
+
+	describe( 'Dropdown', () => {
+		it( 'should show dropdown with loading message when menus have not resolved', async () => {
+			const user = userEvent.setup();
+
+			useNavigationMenu.mockReturnValue( {
+				navigationMenus: [],
+				isResolvingNavigationMenus: true,
+				hasResolvedNavigationMenus: false,
+			} );
+
+			render( <NavigationMenuSelector /> );
+
+			const button = screen.getByRole( 'button' );
+			await user.click( button );
+
+			const menuPopover = screen.getByRole( 'menu' );
+			expect( menuPopover ).toHaveAttribute(
+				'aria-label',
+				expect.stringContaining( 'Loading' )
 			);
 		} );
 	} );

--- a/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
@@ -190,27 +190,56 @@ describe( 'NavigationMenuSelector', () => {
 			expect( toolsGroup ).not.toBeInTheDocument();
 		} );
 
-		it( 'should show a list of menus when menus exist', async () => {
-			const user = userEvent.setup();
+		describe( 'Navigation menus listing', () => {
+			it( 'should show a list of menus when menus exist', async () => {
+				const user = userEvent.setup();
 
-			useNavigationMenu.mockReturnValue( {
-				navigationMenus: navigationMenusFixture,
-				isResolvingNavigationMenus: false,
-				hasResolvedNavigationMenus: true,
-				canUserCreateNavigationMenu: false,
-				canSwitchNavigationMenu: true,
+				useNavigationMenu.mockReturnValue( {
+					navigationMenus: navigationMenusFixture,
+					isResolvingNavigationMenus: false,
+					hasResolvedNavigationMenus: true,
+					canUserCreateNavigationMenu: false,
+					canSwitchNavigationMenu: true,
+				} );
+
+				render( <NavigationMenuSelector /> );
+
+				const toggleButton = screen.getByRole( 'button' );
+				await user.click( toggleButton );
+
+				const menusGroup = screen.queryByRole( 'group', {
+					name: 'Menus',
+				} );
+				expect( menusGroup ).toBeInTheDocument();
+
+				navigationMenusFixture.forEach( ( item ) => {
+					const menuItem = screen.queryByRole( 'menuitemradio', {
+						name: item?.title?.rendered,
+					} );
+					expect( menuItem ).toBeInTheDocument();
+				} );
 			} );
 
-			render( <NavigationMenuSelector /> );
+			it( 'should not show a list of menus when menus exist but user does not have permission to switch menus', async () => {
+				const user = userEvent.setup();
 
-			const toggleButton = screen.getByRole( 'button' );
-			await user.click( toggleButton );
-
-			navigationMenusFixture.forEach( ( item ) => {
-				const menuItem = screen.queryByRole( 'menuitemradio', {
-					name: item?.title?.rendered,
+				useNavigationMenu.mockReturnValue( {
+					navigationMenus: navigationMenusFixture,
+					isResolvingNavigationMenus: false,
+					hasResolvedNavigationMenus: true,
+					canUserCreateNavigationMenu: true,
+					canSwitchNavigationMenu: false,
 				} );
-				expect( menuItem ).toBeInTheDocument();
+
+				render( <NavigationMenuSelector /> );
+
+				const toggleButton = screen.getByRole( 'button' );
+				await user.click( toggleButton );
+
+				const menusGroup = screen.queryByRole( 'group', {
+					name: 'Menus',
+				} );
+				expect( menusGroup ).not.toBeInTheDocument();
 			} );
 		} );
 	} );

--- a/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
@@ -66,7 +66,6 @@ describe( 'NavigationMenuSelector', () => {
 		it( 'should show correct dropdown toggle prompt to choose a menu when navigation menus have resolved', async () => {
 			useNavigationMenu.mockReturnValue( {
 				navigationMenus: [],
-				isResolvingNavigationMenus: false,
 				hasResolvedNavigationMenus: true,
 				canUserCreateNavigationMenu: true,
 				canSwitchNavigationMenu: true,
@@ -120,13 +119,12 @@ describe( 'NavigationMenuSelector', () => {
 			expect( toolsGroup ).not.toBeInTheDocument();
 		} );
 
-		describe( 'Create Menu Button', () => {
+		describe( 'Creating new menus', () => {
 			it( 'should show option to create a menu when no menus exist but user can create menus', async () => {
 				const user = userEvent.setup();
 
 				useNavigationMenu.mockReturnValue( {
 					navigationMenus: [],
-					isResolvingNavigationMenus: false,
 					hasResolvedNavigationMenus: true,
 					canUserCreateNavigationMenu: true,
 					canSwitchNavigationMenu: true,
@@ -178,7 +176,6 @@ describe( 'NavigationMenuSelector', () => {
 
 				useNavigationMenu.mockReturnValue( {
 					navigationMenus: [],
-					isResolvingNavigationMenus: false,
 					hasResolvedNavigationMenus: true,
 					canUserCreateNavigationMenu: false,
 					canSwitchNavigationMenu: true,
@@ -195,6 +192,87 @@ describe( 'NavigationMenuSelector', () => {
 				} );
 				expect( toolsGroup ).not.toBeInTheDocument();
 			} );
+
+			it( 'should call handler callback and close popover when create menu button is clicked', async () => {
+				const user = userEvent.setup();
+				const handler = jest.fn();
+
+				useNavigationMenu.mockReturnValue( {
+					navigationMenus: [],
+					hasResolvedNavigationMenus: true,
+					canUserCreateNavigationMenu: true,
+					canSwitchNavigationMenu: true,
+				} );
+
+				render( <NavigationMenuSelector onCreateNew={ handler } /> );
+
+				const toggleButton = screen.getByRole( 'button' );
+				await user.click( toggleButton );
+
+				const createMenuButton = screen.getByRole( 'menuitem', {
+					name: 'Create new menu',
+				} );
+
+				await user.click( createMenuButton );
+
+				expect( handler ).toHaveBeenCalled();
+
+				expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
+			} );
+
+			it( 'should disable the create menu button when the menu is loading', async () => {
+				const user = userEvent.setup();
+				const handler = jest.fn();
+
+				useNavigationMenu.mockReturnValue( {
+					navigationMenus: [],
+					hasResolvedNavigationMenus: true,
+					canUserCreateNavigationMenu: true,
+					canSwitchNavigationMenu: true,
+				} );
+
+				const { rerender } = render(
+					<NavigationMenuSelector onCreateNew={ handler } />
+				);
+
+				const toggleButton = screen.getByRole( 'button' );
+
+				await user.click( toggleButton );
+
+				await user.click(
+					screen.getByRole( 'menuitem', {
+						name: 'Create new menu',
+					} )
+				);
+
+				// Re-open the dropdown (it's closed when the "Create menu" button is clicked).
+				await user.click( toggleButton );
+
+				// Check the dropdown is open again.
+				expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
+
+				// Check the "Create menu" button is disabled.
+				expect(
+					screen.queryByRole( 'menuitem', {
+						name: 'Create new menu',
+					} )
+				).toBeDisabled();
+
+				// Simulate the menu being created and component being re-rendered.
+				rerender(
+					<NavigationMenuSelector
+						onCreateNew={ handler }
+						createNavigationMenuIsSuccess={ true }
+					/>
+				);
+
+				// Check the button is enabled again.
+				expect(
+					screen.queryByRole( 'menuitem', {
+						name: 'Create new menu',
+					} )
+				).toBeEnabled();
+			} );
 		} );
 
 		describe( 'Navigation menus', () => {
@@ -203,7 +281,6 @@ describe( 'NavigationMenuSelector', () => {
 
 				useNavigationMenu.mockReturnValue( {
 					navigationMenus: navigationMenusFixture,
-					isResolvingNavigationMenus: false,
 					hasResolvedNavigationMenus: true,
 					canUserCreateNavigationMenu: true,
 					canSwitchNavigationMenu: false,
@@ -225,7 +302,6 @@ describe( 'NavigationMenuSelector', () => {
 
 				useNavigationMenu.mockReturnValue( {
 					navigationMenus: navigationMenusFixture,
-					isResolvingNavigationMenus: false,
 					hasResolvedNavigationMenus: true,
 					canUserCreateNavigationMenu: false,
 					canSwitchNavigationMenu: true,
@@ -265,7 +341,6 @@ describe( 'NavigationMenuSelector', () => {
 
 				useNavigationMenu.mockReturnValue( {
 					navigationMenus: menusWithNoTitle,
-					isResolvingNavigationMenus: false,
 					hasResolvedNavigationMenus: true,
 					canUserCreateNavigationMenu: true,
 					canSwitchNavigationMenu: true,
@@ -302,7 +377,6 @@ describe( 'NavigationMenuSelector', () => {
 
 				useNavigationMenu.mockReturnValue( {
 					navigationMenus: navigationMenusFixture,
-					isResolvingNavigationMenus: false,
 					hasResolvedNavigationMenus: true,
 					canUserCreateNavigationMenu: true,
 					canSwitchNavigationMenu: true,
@@ -333,7 +407,6 @@ describe( 'NavigationMenuSelector', () => {
 
 				useNavigationMenu.mockReturnValue( {
 					navigationMenus: navigationMenusFixture,
-					isResolvingNavigationMenus: false,
 					hasResolvedNavigationMenus: true,
 					canUserCreateNavigationMenu: true,
 					canSwitchNavigationMenu: true,

--- a/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
@@ -327,6 +327,33 @@ describe( 'NavigationMenuSelector', () => {
 					navigationMenusFixture[ 0 ].id
 				);
 			} );
+
+			it( 'should pre-select the correct menu in the menu list if a menu ID is passed', async () => {
+				const user = userEvent.setup();
+
+				useNavigationMenu.mockReturnValue( {
+					navigationMenus: navigationMenusFixture,
+					isResolvingNavigationMenus: false,
+					hasResolvedNavigationMenus: true,
+					canUserCreateNavigationMenu: true,
+					canSwitchNavigationMenu: true,
+				} );
+
+				render(
+					<NavigationMenuSelector
+						currentMenuId={ navigationMenusFixture[ 0 ].id }
+					/>
+				);
+
+				const toggleButton = screen.getByRole( 'button' );
+				await user.click( toggleButton );
+
+				const menuItem = screen.getByRole( 'menuitemradio', {
+					name: navigationMenusFixture[ 0 ].title.rendered,
+				} );
+
+				expect( menuItem ).toBeChecked();
+			} );
 		} );
 	} );
 } );

--- a/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
@@ -38,6 +38,7 @@ describe( 'NavigationMenuSelector', () => {
 				navigationMenus: [],
 				isResolvingNavigationMenus: false,
 				hasResolvedNavigationMenus: true,
+				canUserCreateNavigationMenu: true,
 			} );
 
 			render( <NavigationMenuSelector /> );
@@ -52,7 +53,7 @@ describe( 'NavigationMenuSelector', () => {
 	} );
 
 	describe( 'Dropdown', () => {
-		it( 'should show dropdown with loading message when menus have not resolved', async () => {
+		it( 'should show in loading state with no options when menus have not resolved', async () => {
 			const user = userEvent.setup();
 
 			useNavigationMenu.mockReturnValue( {
@@ -71,6 +72,63 @@ describe( 'NavigationMenuSelector', () => {
 				'aria-label',
 				expect.stringContaining( 'Loading' )
 			);
+
+			// Check that all the option groups are *not* present.
+			const menusGroup = screen.queryByRole( 'group', { name: 'Menus' } );
+			expect( menusGroup ).not.toBeInTheDocument();
+
+			const classicMenusGroup = screen.queryByRole( 'group', {
+				name: 'Import Classic Menus',
+			} );
+			expect( classicMenusGroup ).not.toBeInTheDocument();
+
+			const toolsGroup = screen.queryByRole( 'group', {
+				name: 'Tools',
+			} );
+			expect( toolsGroup ).not.toBeInTheDocument();
+		} );
+
+		it( 'should only show option to create a menu when no menus exist', async () => {
+			const user = userEvent.setup();
+
+			useNavigationMenu.mockReturnValue( {
+				navigationMenus: [],
+				isResolvingNavigationMenus: false,
+				hasResolvedNavigationMenus: true,
+				canUserCreateNavigationMenu: true,
+			} );
+
+			render( <NavigationMenuSelector /> );
+
+			const button = screen.getByRole( 'button' );
+			await user.click( button );
+
+			const menuPopover = screen.getByRole( 'menu' );
+
+			expect( menuPopover ).toHaveAttribute(
+				'aria-label',
+				expect.stringContaining( 'Choose a Navigation menu' )
+			);
+
+			// Check that all the option groups are *not* present.
+			const menusGroup = screen.queryByRole( 'group', { name: 'Menus' } );
+			expect( menusGroup ).not.toBeInTheDocument();
+
+			const classicMenusGroup = screen.queryByRole( 'group', {
+				name: 'Import Classic Menus',
+			} );
+			expect( classicMenusGroup ).not.toBeInTheDocument();
+
+			const toolsGroup = screen.queryByRole( 'group', {
+				name: 'Tools',
+			} );
+			expect( toolsGroup ).toBeInTheDocument();
+
+			const createMenuButton = screen.getByRole( 'menuitem', {
+				name: 'Create new menu',
+			} );
+
+			expect( createMenuButton ).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { prettyDOM } from '@testing-library/dom';
+import NavigationMenuSelector from '../navigation-menu-selector';
+// import useNavigationMenu from '../../use-navigation-menu';
+
+jest.mock( '../../use-navigation-menu', () => {} );
+
+describe( 'NavigationMenuSelector', () => {
+	describe( 'Toggle', () => {
+		it( 'should show dropdown toggle with loading state', async () => {
+			render( <NavigationMenuSelector /> );
+
+			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
+				'aria-label',
+				'Loading …'
+			);
+		} );
+
+		it( 'should show dropdown toggle with loading state', async () => {
+			const user = userEvent.setup();
+			render( <NavigationMenuSelector /> );
+
+			const button = screen.getByRole( 'button' );
+
+			await user.click( button );
+		} );
+	} );
+} );

--- a/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
@@ -220,7 +220,7 @@ describe( 'NavigationMenuSelector', () => {
 				expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
 			} );
 
-			it( 'should disable the create menu button when the menu is loading', async () => {
+			it( 'should handle disabled state of the create menu button during the creation process', async () => {
 				const user = userEvent.setup();
 				const handler = jest.fn();
 

--- a/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
@@ -16,6 +16,33 @@ jest.mock( '../../use-navigation-menu', () => {
 	return mock;
 } );
 
+const navigationMenu1 = {
+	id: 1,
+	title: {
+		rendered: 'Menu 1',
+	},
+	status: 'publish',
+};
+const navigationMenu2 = {
+	id: 2,
+	title: {
+		rendered: 'Menu 2',
+	},
+	status: 'publish',
+};
+const navigationMenu3 = {
+	id: 3,
+	title: {
+		rendered: 'Menu 3',
+	},
+	status: 'publish',
+};
+const navigationMenusFixture = [
+	navigationMenu1,
+	navigationMenu2,
+	navigationMenu3,
+];
+
 describe( 'NavigationMenuSelector', () => {
 	describe( 'Toggle', () => {
 		it( 'should show dropdown toggle with loading message when menus have not resolved', async () => {
@@ -23,6 +50,7 @@ describe( 'NavigationMenuSelector', () => {
 				navigationMenus: [],
 				isResolvingNavigationMenus: true,
 				hasResolvedNavigationMenus: false,
+				canSwitchNavigationMenu: true,
 			} );
 
 			render( <NavigationMenuSelector /> );
@@ -39,6 +67,7 @@ describe( 'NavigationMenuSelector', () => {
 				isResolvingNavigationMenus: false,
 				hasResolvedNavigationMenus: true,
 				canUserCreateNavigationMenu: true,
+				canSwitchNavigationMenu: true,
 			} );
 
 			render( <NavigationMenuSelector /> );
@@ -60,6 +89,7 @@ describe( 'NavigationMenuSelector', () => {
 				navigationMenus: [],
 				isResolvingNavigationMenus: true,
 				hasResolvedNavigationMenus: false,
+				canSwitchNavigationMenu: true,
 			} );
 
 			render( <NavigationMenuSelector /> );
@@ -96,6 +126,7 @@ describe( 'NavigationMenuSelector', () => {
 				isResolvingNavigationMenus: false,
 				hasResolvedNavigationMenus: true,
 				canUserCreateNavigationMenu: true,
+				canSwitchNavigationMenu: true,
 			} );
 
 			render( <NavigationMenuSelector /> );
@@ -119,6 +150,7 @@ describe( 'NavigationMenuSelector', () => {
 			} );
 			expect( classicMenusGroup ).not.toBeInTheDocument();
 
+			// Check the Tools Group and Create Menu Button are present.
 			const toolsGroup = screen.queryByRole( 'group', {
 				name: 'Tools',
 			} );
@@ -129,6 +161,53 @@ describe( 'NavigationMenuSelector', () => {
 			} );
 
 			expect( createMenuButton ).toBeInTheDocument();
+		} );
+
+		it( 'should not show option to create a menu when user does not have permission to create menus', async () => {
+			const user = userEvent.setup();
+
+			useNavigationMenu.mockReturnValue( {
+				navigationMenus: [],
+				isResolvingNavigationMenus: false,
+				hasResolvedNavigationMenus: true,
+				canUserCreateNavigationMenu: false,
+				canSwitchNavigationMenu: true,
+			} );
+
+			render( <NavigationMenuSelector /> );
+
+			const button = screen.getByRole( 'button' );
+			await user.click( button );
+
+			// Check the Tools Group and Create Menu Button are present.
+			const toolsGroup = screen.queryByRole( 'group', {
+				name: 'Tools',
+			} );
+			expect( toolsGroup ).not.toBeInTheDocument();
+		} );
+
+		it( 'should show a list of menus when menus exist', async () => {
+			const user = userEvent.setup();
+
+			useNavigationMenu.mockReturnValue( {
+				navigationMenus: navigationMenusFixture,
+				isResolvingNavigationMenus: false,
+				hasResolvedNavigationMenus: true,
+				canUserCreateNavigationMenu: false,
+				canSwitchNavigationMenu: true,
+			} );
+
+			render( <NavigationMenuSelector /> );
+
+			const button = screen.getByRole( 'button' );
+			await user.click( button );
+
+			navigationMenusFixture.forEach( ( item ) => {
+				const menuItem = screen.queryByRole( 'menuitemradio', {
+					name: item?.title?.rendered,
+				} );
+				expect( menuItem ).toBeInTheDocument();
+			} );
 		} );
 	} );
 } );

--- a/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
@@ -1,17 +1,30 @@
 /**
  * External dependencies
  */
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { prettyDOM } from '@testing-library/dom';
-import NavigationMenuSelector from '../navigation-menu-selector';
-// import useNavigationMenu from '../../use-navigation-menu';
 
-jest.mock( '../../use-navigation-menu', () => {} );
+/**
+ * Internal dependencies
+ */
+import NavigationMenuSelector from '../navigation-menu-selector';
+import useNavigationMenu from '../../use-navigation-menu';
+
+jest.mock( '../../use-navigation-menu', () => {
+	// This allows us to tweak the returned value on each test.
+	const mock = jest.fn();
+	return mock;
+} );
 
 describe( 'NavigationMenuSelector', () => {
 	describe( 'Toggle', () => {
-		it( 'should show dropdown toggle with loading state', async () => {
+		it( 'should show dropdown toggle with loading message when menus have not resolved', async () => {
+			useNavigationMenu.mockReturnValue( {
+				navigationMenus: [],
+				isResolvingNavigationMenus: true,
+				hasResolvedNavigationMenus: false,
+			} );
+
 			render( <NavigationMenuSelector /> );
 
 			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
@@ -20,13 +33,24 @@ describe( 'NavigationMenuSelector', () => {
 			);
 		} );
 
-		it( 'should show dropdown toggle with loading state', async () => {
+		it( 'should show dropdown toggle correct prompt when navigation menus have resolved', async () => {
+			useNavigationMenu.mockReturnValue( {
+				navigationMenus: [],
+				isResolvingNavigationMenus: false,
+				hasResolvedNavigationMenus: true,
+			} );
+
 			const user = userEvent.setup();
 			render( <NavigationMenuSelector /> );
 
 			const button = screen.getByRole( 'button' );
 
 			await user.click( button );
+
+			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
+				'aria-label',
+				'Choose a Navigation menu'
+			);
 		} );
 	} );
 } );

--- a/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
@@ -55,13 +55,14 @@ describe( 'NavigationMenuSelector', () => {
 
 			render( <NavigationMenuSelector /> );
 
-			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
-				'aria-label',
-				expect.stringContaining( 'Loading' )
-			);
+			expect(
+				screen.getByRole( 'button', {
+					name: /Loading/,
+				} )
+			).toBeInTheDocument();
 		} );
 
-		it( 'should show dropdown toggle correct prompt when navigation menus have resolved', async () => {
+		it( 'should show correct dropdown toggle prompt to choose a menu when navigation menus have resolved', async () => {
 			useNavigationMenu.mockReturnValue( {
 				navigationMenus: [],
 				isResolvingNavigationMenus: false,
@@ -72,12 +73,11 @@ describe( 'NavigationMenuSelector', () => {
 
 			render( <NavigationMenuSelector /> );
 
-			const button = screen.getByRole( 'button' );
-
-			expect( button ).toHaveAttribute(
-				'aria-label',
-				'Choose a Navigation menu'
-			);
+			expect(
+				screen.getByRole( 'button', {
+					name: 'Choose a Navigation menu',
+				} )
+			).toBeInTheDocument();
 		} );
 	} );
 
@@ -94,14 +94,14 @@ describe( 'NavigationMenuSelector', () => {
 
 			render( <NavigationMenuSelector /> );
 
-			const button = screen.getByRole( 'button' );
-			await user.click( button );
+			const toggleButton = screen.getByRole( 'button' );
+			await user.click( toggleButton );
 
-			const menuPopover = screen.getByRole( 'menu' );
-			expect( menuPopover ).toHaveAttribute(
-				'aria-label',
-				expect.stringContaining( 'Loading' )
-			);
+			expect(
+				screen.getByRole( 'menu', {
+					name: /Loading/,
+				} )
+			).toBeInTheDocument();
 
 			// Check that all the option groups are *not* present.
 			const menusGroup = screen.queryByRole( 'group', { name: 'Menus' } );
@@ -131,8 +131,10 @@ describe( 'NavigationMenuSelector', () => {
 
 			render( <NavigationMenuSelector /> );
 
-			const button = screen.getByRole( 'button' );
-			await user.click( button );
+			const toggleButton = screen.getByRole( 'button', {
+				name: 'Choose a Navigation menu',
+			} );
+			await user.click( toggleButton );
 
 			const menuPopover = screen.getByRole( 'menu' );
 
@@ -176,8 +178,8 @@ describe( 'NavigationMenuSelector', () => {
 
 			render( <NavigationMenuSelector /> );
 
-			const button = screen.getByRole( 'button' );
-			await user.click( button );
+			const toggleButton = screen.getByRole( 'button' );
+			await user.click( toggleButton );
 
 			// Check the Tools Group and Create Menu Button are present.
 			const toolsGroup = screen.queryByRole( 'group', {
@@ -199,8 +201,8 @@ describe( 'NavigationMenuSelector', () => {
 
 			render( <NavigationMenuSelector /> );
 
-			const button = screen.getByRole( 'button' );
-			await user.click( button );
+			const toggleButton = screen.getByRole( 'button' );
+			await user.click( toggleButton );
 
 			navigationMenusFixture.forEach( ( item ) => {
 				const menuItem = screen.queryByRole( 'menuitemradio', {

--- a/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
@@ -82,13 +82,14 @@ describe( 'NavigationMenuSelector', () => {
 	} );
 
 	describe( 'Dropdown', () => {
-		it( 'should show in loading state with no options when menus have not resolved', async () => {
+		it( 'should show in loading state with no options when menus have not resolved and user cannot create menus', async () => {
 			const user = userEvent.setup();
 
 			useNavigationMenu.mockReturnValue( {
 				navigationMenus: [],
 				isResolvingNavigationMenus: true,
 				hasResolvedNavigationMenus: false,
+				canUserCreateNavigationMenu: false,
 				canSwitchNavigationMenu: true,
 			} );
 
@@ -118,7 +119,7 @@ describe( 'NavigationMenuSelector', () => {
 			expect( toolsGroup ).not.toBeInTheDocument();
 		} );
 
-		it( 'should only show option to create a menu when no menus exist', async () => {
+		it( 'should show option to create a menu when no menus exist but user can create menus', async () => {
 			const user = userEvent.setup();
 
 			useNavigationMenu.mockReturnValue( {
@@ -134,6 +135,7 @@ describe( 'NavigationMenuSelector', () => {
 			const toggleButton = screen.getByRole( 'button', {
 				name: 'Choose or create a Navigation menu',
 			} );
+
 			await user.click( toggleButton );
 
 			const menuPopover = screen.getByRole( 'menu' );

--- a/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
@@ -75,7 +75,7 @@ describe( 'NavigationMenuSelector', () => {
 
 			expect(
 				screen.getByRole( 'button', {
-					name: 'Choose a Navigation menu',
+					name: 'Choose or create a Navigation menu',
 				} )
 			).toBeInTheDocument();
 		} );
@@ -132,7 +132,7 @@ describe( 'NavigationMenuSelector', () => {
 			render( <NavigationMenuSelector /> );
 
 			const toggleButton = screen.getByRole( 'button', {
-				name: 'Choose a Navigation menu',
+				name: 'Choose or create a Navigation menu',
 			} );
 			await user.click( toggleButton );
 
@@ -140,7 +140,7 @@ describe( 'NavigationMenuSelector', () => {
 
 			expect( menuPopover ).toHaveAttribute(
 				'aria-label',
-				expect.stringContaining( 'Choose a Navigation menu' )
+				expect.stringContaining( 'Choose or create a Navigation menu' )
 			);
 
 			// Check that all the option groups are *not* present.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds a suite of integration/component level tests for the `<NavigationMenuSelector>` component in the Nav block.

Also fixes a few bugs discovered along the way.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This component has suffered from a number of regressions. Moreover it has a number of states and potential edge cases that are too difficult for humans to manually test. This makes the component brittle and difficult to change.

Adding these tests provides an intial measure of confidence in the component's behaviour. After this it will be necessary to refactor the component to remove some of the unusual patterns that are in evidence (e.g. setState on render). This should help to simplify it but should not be done without the backing of tests.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds integration tests that assert on all the states of the component. Various hooks are mocked to control the state of the component. That's ok. We sacrifice some certainty/accuracy for speed and ease of use. It's gets us 80% of the coverage with 20% of the effort relative to e2e tests.



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

It's critical we try and verify the original behaviour from `trunk` is maintained:

- Remove all Nav Menus and Classic Menus
- New Post -> Nav block
- Check dropdown has only "Create new menu" option.
- Check clicking on that works as expected.
- Create some more menus. Check you can switch between them and the menu updaes correctly.
- Switch to Classic Theme and create some classic menus.
- Switch back to block theme.
- Check classic menus are shown and you can successfully import them and switch between them.

With that checked you can run the test suite:

```
npm run test:unit packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
