### PR TITLE
Components: Add support for named arguments in the navigator components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17466,6 +17466,7 @@
 				"highlight-words-core": "^1.2.2",
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
+				"path-to-regexp": "^6.2.1",
 				"re-resizable": "^6.4.0",
 				"react-colorful": "^5.3.1",
 				"reakit": "^1.3.8",
@@ -17479,6 +17480,11 @@
 					"version": "2.29.3",
 					"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
 					"integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
+				},
+				"path-to-regexp": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+					"integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
 				}
 			}
 		},
@@ -43686,7 +43692,7 @@
 		"lodash.isequal": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
 		},
 		"lodash.ismatch": {
 			"version": "4.4.0",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -  `ColorPalette`, `GradientPicker`, `PaletteEdit`, `ToolsPanel`: add new props to set a custom heading level ([43848](https://github.com/WordPress/gutenberg/pull/43848) and [#47788](https://github.com/WordPress/gutenberg/pull/47788)).
 -   `ColorPalette`: ensure text label contrast checking works with CSS variables ([#47373](https://github.com/WordPress/gutenberg/pull/47373)).
+-  `Navigator`: Support dynamic paths with parameters ([#47827](https://github.com/WordPress/gutenberg/pull/47827)).
 
 ### Internal
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -67,6 +67,7 @@
 		"highlight-words-core": "^1.2.2",
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
+		"path-to-regexp": "^6.2.1",
 		"re-resizable": "^6.4.0",
 		"react-colorful": "^5.3.1",
 		"reakit": "^1.3.8",

--- a/packages/components/src/navigator/context.ts
+++ b/packages/components/src/navigator/context.ts
@@ -12,5 +12,8 @@ const initialContextValue: NavigatorContextType = {
 	location: {},
 	goTo: () => {},
 	goBack: () => {},
+	addScreen: () => {},
+	removeScreen: () => {},
+	params: {},
 };
 export const NavigatorContext = createContext( initialContextValue );

--- a/packages/components/src/navigator/navigator-provider/README.md
+++ b/packages/components/src/navigator/navigator-provider/README.md
@@ -70,3 +70,7 @@ The `location` object represent the current location, and has a few properties:
 - `path`: `string`. The path associated to the location.
 - `isBack`: `boolean`. A flag that is `true` when the current location was reached by navigating backwards in the location stack.
 - `isInitial`: `boolean`. A flag that is `true` only for the first (root) location in the location stack.
+
+### `params`: `Record< string, string | string[] >`
+
+The parsed record of parameters from the current location. For example if the current screen path is `/product/:productId` and the location is `/product/123`, then `params` will be `{ productId: '123' }`.

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -35,7 +35,7 @@ import type {
 } from '../types';
 import { patternMatch } from '../utils/router';
 
-type MatchedPath = { params: object; id: string } | false;
+type MatchedPath = ReturnType< typeof patternMatch >;
 type ScreenAction = { type: string; screen: NavigatorScreenType };
 
 function screensReducer(

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -31,24 +31,22 @@ import type {
 	NavigatorProviderProps,
 	NavigatorLocation,
 	NavigatorContext as NavigatorContextType,
-	NavigatorScreen as NavigatorScreenType,
+	Screen,
 } from '../types';
 import { patternMatch } from '../utils/router';
 
 type MatchedPath = ReturnType< typeof patternMatch >;
-type ScreenAction = { type: string; screen: NavigatorScreenType };
+type ScreenAction = { type: string; screen: Screen };
 
 function screensReducer(
-	state: NavigatorScreenType[] = [],
+	state: Screen[] = [],
 	action: ScreenAction
-): NavigatorScreenType[] {
+): Screen[] {
 	switch ( action.type ) {
 		case 'add':
 			return [ ...state, action.screen ];
 		case 'remove':
-			return state.filter(
-				( s: NavigatorScreenType ) => s.id !== action.screen.id
-			);
+			return state.filter( ( s: Screen ) => s.id !== action.screen.id );
 	}
 
 	return state;
@@ -105,13 +103,12 @@ function UnconnectedNavigatorProvider(
 	}, [ screens, locationHistory ] );
 
 	const addScreen = useCallback(
-		( screen: NavigatorScreenType ) => dispatch( { type: 'add', screen } ),
+		( screen: Screen ) => dispatch( { type: 'add', screen } ),
 		[]
 	);
 
 	const removeScreen = useCallback(
-		( screen: NavigatorScreenType ) =>
-			dispatch( { type: 'remove', screen } ),
+		( screen: Screen ) => dispatch( { type: 'remove', screen } ),
 		[]
 	);
 

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -117,15 +117,33 @@ function UnconnectedNavigatorProvider(
 
 	const goTo: NavigatorContextType[ 'goTo' ] = useCallback(
 		( path, options = {} ) => {
-			setLocationHistory( ( prevLocationHistory ) => [
-				...prevLocationHistory,
-				{
-					...options,
+			setLocationHistory( ( prevLocationHistory ) => {
+				const { focusTargetSelector, ...restOptions } = options;
+
+				const newLocation = {
+					...restOptions,
 					path,
 					isBack: false,
 					hasRestoredFocus: false,
-				},
-			] );
+				};
+
+				if ( prevLocationHistory.length < 1 ) {
+					return [ newLocation ];
+				}
+
+				return [
+					...prevLocationHistory.slice( 0, -1 ),
+					// Assign `focusTargetSelector` to the previous location in history
+					// (the one we just navigated from).
+					{
+						...prevLocationHistory[
+							prevLocationHistory.length - 1
+						],
+						focusTargetSelector,
+					},
+					newLocation,
+				];
+			} );
 		},
 		[]
 	);
@@ -141,9 +159,6 @@ function UnconnectedNavigatorProvider(
 					...prevLocationHistory[ prevLocationHistory.length - 2 ],
 					isBack: true,
 					hasRestoredFocus: false,
-					restoreFocusTo:
-						prevLocationHistory[ prevLocationHistory.length - 1 ]
-							.focusTargetSelector,
 				},
 			];
 		} );

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -69,6 +69,17 @@ function UnconnectedNavigatorProvider(
 	const [ screens, dispatch ] = useReducer( screensReducer, [] );
 	const currentMatch = useRef< MatchedPath >();
 	const matchedPath = useMemo( () => {
+		let currentPath: string | undefined;
+		if (
+			locationHistory.length === 0 ||
+			( currentPath =
+				locationHistory[ locationHistory.length - 1 ].path ) ===
+				undefined
+		) {
+			currentMatch.current = undefined;
+			return undefined;
+		}
+
 		const resolvePath = ( path: string ) => {
 			const newMatch = patternMatch( path, screens );
 
@@ -89,17 +100,9 @@ function UnconnectedNavigatorProvider(
 			return newMatch;
 		};
 
-		if ( locationHistory.length > 0 ) {
-			const path = locationHistory[ locationHistory.length - 1 ].path;
-			if ( path !== undefined ) {
-				const newMatch = resolvePath( path );
-				currentMatch.current = newMatch;
-				return newMatch;
-			}
-		}
-
-		currentMatch.current = undefined;
-		return undefined;
+		const newMatch = resolvePath( currentPath );
+		currentMatch.current = newMatch;
+		return newMatch;
 	}, [ screens, locationHistory ] );
 
 	const addScreen = useCallback(

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -5,13 +5,18 @@ import type { ForwardedRef } from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { motion, MotionProps } from 'framer-motion';
 import { css } from '@emotion/react';
-import { v4 as uuid } from 'uuid';
 
 /**
  * WordPress dependencies
  */
 import { focus } from '@wordpress/dom';
-import { useContext, useEffect, useMemo, useRef } from '@wordpress/element';
+import {
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useId,
+} from '@wordpress/element';
 import { useReducedMotion, useMergeRefs } from '@wordpress/compose';
 import { isRTL } from '@wordpress/i18n';
 import { escapeAttribute } from '@wordpress/escape-html';
@@ -45,7 +50,7 @@ function UnconnectedNavigatorScreen(
 	props: Props,
 	forwardedRef: ForwardedRef< any >
 ) {
-	const screenId = useRef( uuid() );
+	const screenId = useId();
 	const { children, className, path, ...otherProps } = useContextSystem(
 		props,
 		'NavigatorScreen'
@@ -54,17 +59,17 @@ function UnconnectedNavigatorScreen(
 	const prefersReducedMotion = useReducedMotion();
 	const { location, match, addScreen, removeScreen } =
 		useContext( NavigatorContext );
-	const isMatch = match === screenId.current;
+	const isMatch = match === screenId;
 	const wrapperRef = useRef< HTMLDivElement >( null );
 
 	useEffect( () => {
 		const screen = {
-			id: screenId.current,
+			id: screenId,
 			path: escapeAttribute( path ),
 		};
 		addScreen( screen );
 		return () => removeScreen( screen );
-	}, [ path, addScreen, removeScreen ] );
+	}, [ screenId, path, addScreen, removeScreen ] );
 
 	const cx = useCx();
 	const classes = useMemo(

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -121,9 +121,9 @@ function UnconnectedNavigatorScreen(
 
 		// When navigating back, if a selector is provided, use it to look for the
 		// target element (assumed to be a node inside the current NavigatorScreen)
-		if ( location.isBack && location?.restoreFocusTo ) {
+		if ( location.isBack && location?.focusTargetSelector ) {
 			elementToFocus = wrapperRef.current.querySelector(
-				location.restoreFocusTo
+				location.focusTargetSelector
 			);
 		}
 
@@ -142,7 +142,7 @@ function UnconnectedNavigatorScreen(
 		isInitialLocation,
 		isMatch,
 		location.isBack,
-		location.restoreFocusTo,
+		location.focusTargetSelector,
 	] );
 
 	const mergedWrapperRef = useMergeRefs( [ forwardedRef, wrapperRef ] );

--- a/packages/components/src/navigator/stories/index.tsx
+++ b/packages/components/src/navigator/stories/index.tsx
@@ -8,13 +8,14 @@ import type { ComponentMeta, ComponentStory } from '@storybook/react';
  */
 import Button from '../../button';
 import { Card, CardBody, CardFooter, CardHeader } from '../../card';
-import { HStack } from '../../h-stack';
+import { VStack } from '../../v-stack';
 import Dropdown from '../../dropdown';
 import {
 	NavigatorProvider,
 	NavigatorScreen,
 	NavigatorButton,
 	NavigatorBackButton,
+	useNavigator,
 } from '..';
 
 const meta: ComponentMeta< typeof NavigatorProvider > = {
@@ -46,7 +47,7 @@ const Template: ComponentStory< typeof NavigatorProvider > = ( {
 				<CardBody>
 					<p>This is the home screen.</p>
 
-					<HStack justify="flex-start" wrap>
+					<VStack alignment="left">
 						<NavigatorButton variant="secondary" path="/child">
 							Navigate to child screen.
 						</NavigatorButton>
@@ -60,6 +61,10 @@ const Template: ComponentStory< typeof NavigatorProvider > = ( {
 
 						<NavigatorButton variant="secondary" path="/stickies">
 							Navigate to screen with sticky content.
+						</NavigatorButton>
+
+						<NavigatorButton variant="secondary" path="/product/1">
+							Navigate to product screen with id 1.
 						</NavigatorButton>
 
 						<Dropdown
@@ -86,7 +91,7 @@ const Template: ComponentStory< typeof NavigatorProvider > = ( {
 								</Card>
 							) }
 						/>
-					</HStack>
+					</VStack>
 				</CardBody>
 			</Card>
 		</NavigatorScreen>
@@ -166,6 +171,10 @@ const Template: ComponentStory< typeof NavigatorProvider > = ( {
 				</CardFooter>
 			</Card>
 		</NavigatorScreen>
+
+		<NavigatorScreen path="/product/:id">
+			<ProductDetails />
+		</NavigatorScreen>
 	</NavigatorProvider>
 );
 
@@ -206,5 +215,20 @@ function MetaphorIpsum( { quantity }: { quantity: number } ) {
 				</p>
 			) ) }
 		</>
+	);
+}
+
+function ProductDetails() {
+	const { params } = useNavigator();
+
+	return (
+		<Card>
+			<CardBody>
+				<NavigatorBackButton variant="secondary">
+					Go back
+				</NavigatorBackButton>
+				<p>This is the screen for the product with id: { params.id }</p>
+			</CardBody>
+		</Card>
 	);
 }

--- a/packages/components/src/navigator/test/router.ts
+++ b/packages/components/src/navigator/test/router.ts
@@ -1,0 +1,40 @@
+/**
+ * Internal dependencies
+ */
+import { patternMatch } from '../utils/router';
+
+describe( 'patternMatch', () => {
+	it( 'should return undefined if not pattern is matched', () => {
+		const result = patternMatch( '/test', [ { id: 'route', path: '/' } ] );
+		expect( result ).toBeUndefined();
+	} );
+
+	it( 'should match a pattern with no params', () => {
+		const result = patternMatch( '/test', [
+			{ id: 'route', path: '/test' },
+		] );
+		expect( result ).toEqual( { id: 'route', params: {} } );
+	} );
+
+	it( 'should match a pattern with params', () => {
+		const result = patternMatch( '/test/123', [
+			{ id: 'route', path: '/test/:id' },
+		] );
+		expect( result ).toEqual( { id: 'route', params: { id: '123' } } );
+	} );
+
+	it( 'should match the first pattern in case of ambiguity', () => {
+		const result = patternMatch( '/test/123', [
+			{ id: 'route1', path: '/test/:id' },
+			{ id: 'route2', path: '/test/123' },
+		] );
+		expect( result ).toEqual( { id: 'route1', params: { id: '123' } } );
+	} );
+
+	it( 'should match a pattern with optional params', () => {
+		const result = patternMatch( '/test', [
+			{ id: 'route', path: '/test/:id?' },
+		] );
+		expect( result ).toEqual( { id: 'route', params: {} } );
+	} );
+} );

--- a/packages/components/src/navigator/test/router.ts
+++ b/packages/components/src/navigator/test/router.ts
@@ -37,4 +37,14 @@ describe( 'patternMatch', () => {
 		] );
 		expect( result ).toEqual( { id: 'route', params: {} } );
 	} );
+
+	it( 'should return an array of matches for the same param', () => {
+		const result = patternMatch( '/some/basic/route', [
+			{ id: 'route', path: '/:test+' },
+		] );
+		expect( result ).toEqual( {
+			id: 'route',
+			params: { test: [ 'some', 'basic', 'route' ] },
+		} );
+	} );
 } );

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -20,16 +20,6 @@ export type NavigatorLocation = NavigateOptions & {
 	restoreFocusTo?: string;
 };
 
-export type NavigatorContext = {
-	location: NavigatorLocation;
-	params: any;
-	match?: string;
-	goTo: ( path: string, options?: NavigateOptions ) => void;
-	goBack: () => void;
-	addScreen: ( screen: NavigatorScreen ) => void;
-	removeScreen: ( screen: NavigatorScreen ) => void;
-};
-
 // Returned by the `useNavigator` hook.
 export type Navigator = {
 	location: NavigatorLocation;
@@ -37,6 +27,11 @@ export type Navigator = {
 	match?: string;
 	goTo: ( path: string, options?: NavigateOptions ) => void;
 	goBack: () => void;
+};
+
+export type NavigatorContext = Navigator & {
+	addScreen: ( screen: NavigatorScreen ) => void;
+	removeScreen: ( screen: NavigatorScreen ) => void;
 };
 
 export type NavigatorProviderProps = {

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -8,6 +8,8 @@ import type { ReactNode } from 'react';
  */
 import type { ButtonAsButtonProps } from '../button/types';
 
+export type MatchParams = Record< string, string | string[] >;
+
 type NavigateOptions = {
 	focusTargetSelector?: string;
 };
@@ -22,8 +24,7 @@ export type NavigatorLocation = NavigateOptions & {
 // Returned by the `useNavigator` hook.
 export type Navigator = {
 	location: NavigatorLocation;
-	params: any;
-	match?: string;
+	params: MatchParams;
 	goTo: ( path: string, options?: NavigateOptions ) => void;
 	goBack: () => void;
 };
@@ -31,6 +32,7 @@ export type Navigator = {
 export type NavigatorContext = Navigator & {
 	addScreen: ( screen: Screen ) => void;
 	removeScreen: ( screen: Screen ) => void;
+	match?: string;
 };
 
 export type NavigatorProviderProps = {

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -29,8 +29,8 @@ export type Navigator = {
 };
 
 export type NavigatorContext = Navigator & {
-	addScreen: ( screen: NavigatorScreen ) => void;
-	removeScreen: ( screen: NavigatorScreen ) => void;
+	addScreen: ( screen: Screen ) => void;
+	removeScreen: ( screen: Screen ) => void;
 };
 
 export type NavigatorProviderProps = {
@@ -72,7 +72,7 @@ export type NavigatorButtonProps = NavigatorBackButtonProps & {
 	attributeName?: string;
 };
 
-export type NavigatorScreen = {
+export type Screen = {
 	id: string;
 	path: string;
 };

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -17,7 +17,6 @@ export type NavigatorLocation = NavigateOptions & {
 	isBack?: boolean;
 	path?: string;
 	hasRestoredFocus?: boolean;
-	restoreFocusTo?: string;
 };
 
 // Returned by the `useNavigator` hook.

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -17,16 +17,27 @@ export type NavigatorLocation = NavigateOptions & {
 	isBack?: boolean;
 	path?: string;
 	hasRestoredFocus?: boolean;
+	restoreFocusTo?: string;
 };
 
 export type NavigatorContext = {
 	location: NavigatorLocation;
+	params: any;
+	match?: string;
 	goTo: ( path: string, options?: NavigateOptions ) => void;
 	goBack: () => void;
+	addScreen: ( screen: NavigatorScreen ) => void;
+	removeScreen: ( screen: NavigatorScreen ) => void;
 };
 
 // Returned by the `useNavigator` hook.
-export type Navigator = NavigatorContext;
+export type Navigator = {
+	location: NavigatorLocation;
+	params: any;
+	match?: string;
+	goTo: ( path: string, options?: NavigateOptions ) => void;
+	goBack: () => void;
+};
 
 export type NavigatorProviderProps = {
 	/**
@@ -65,4 +76,9 @@ export type NavigatorButtonProps = NavigatorBackButtonProps & {
 	 * @default 'id'
 	 */
 	attributeName?: string;
+};
+
+export type NavigatorScreen = {
+	id: string;
+	path: string;
 };

--- a/packages/components/src/navigator/use-navigator.ts
+++ b/packages/components/src/navigator/use-navigator.ts
@@ -13,12 +13,15 @@ import type { Navigator } from './types';
  * Retrieves a `navigator` instance.
  */
 function useNavigator(): Navigator {
-	const { location, goTo, goBack } = useContext( NavigatorContext );
+	const { location, match, params, goTo, goBack } =
+		useContext( NavigatorContext );
 
 	return {
 		location,
 		goTo,
 		goBack,
+		match,
+		params,
 	};
 }
 

--- a/packages/components/src/navigator/use-navigator.ts
+++ b/packages/components/src/navigator/use-navigator.ts
@@ -13,14 +13,12 @@ import type { Navigator } from './types';
  * Retrieves a `navigator` instance.
  */
 function useNavigator(): Navigator {
-	const { location, match, params, goTo, goBack } =
-		useContext( NavigatorContext );
+	const { location, params, goTo, goBack } = useContext( NavigatorContext );
 
 	return {
 		location,
 		goTo,
 		goBack,
-		match,
 		params,
 	};
 }

--- a/packages/components/src/navigator/utils/router.ts
+++ b/packages/components/src/navigator/utils/router.ts
@@ -6,9 +6,9 @@ import { match } from 'path-to-regexp';
 /**
  * Internal dependencies
  */
-import type { NavigatorScreen } from '../types';
+import type { Screen } from '../types';
 
-export function patternMatch( path: string, screens: NavigatorScreen[] ) {
+export function patternMatch( path: string, screens: Screen[] ) {
 	for ( const screen of screens ) {
 		const matchingFunction = match( screen.path, {
 			decode: decodeURIComponent,

--- a/packages/components/src/navigator/utils/router.ts
+++ b/packages/components/src/navigator/utils/router.ts
@@ -19,5 +19,5 @@ export function patternMatch( path: string, screens: NavigatorScreen[] ) {
 		}
 	}
 
-	return false;
+	return undefined;
 }

--- a/packages/components/src/navigator/utils/router.ts
+++ b/packages/components/src/navigator/utils/router.ts
@@ -6,11 +6,11 @@ import { match } from 'path-to-regexp';
 /**
  * Internal dependencies
  */
-import type { Screen } from '../types';
+import type { Screen, MatchParams } from '../types';
 
 export function patternMatch( path: string, screens: Screen[] ) {
 	for ( const screen of screens ) {
-		const matchingFunction = match( screen.path, {
+		const matchingFunction = match< MatchParams >( screen.path, {
 			decode: decodeURIComponent,
 		} );
 		const matched = matchingFunction( path );

--- a/packages/components/src/navigator/utils/router.ts
+++ b/packages/components/src/navigator/utils/router.ts
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { match } from 'path-to-regexp';
+
+/**
+ * Internal dependencies
+ */
+import type { NavigatorScreen } from '../types';
+
+export function patternMatch( path: string, screens: NavigatorScreen[] ) {
+	for ( const screen of screens ) {
+		const matchingFunction = match( screen.path, {
+			decode: decodeURIComponent,
+		} );
+		const matched = matchingFunction( path );
+		if ( matched ) {
+			return { params: matched.params, id: screen.id };
+		}
+	}
+
+	return false;
+}


### PR DESCRIPTION
## What?

Closes #45913

This PR adds supports for named arguments to the Navigator components. In other words, we now support paths with arguments like: `/product/:productId`.

## Why?

In different places we rely on a pattern like this

```
products.map( product => <NavigatorScreen path={ `product/${product.id}` } /> )
```

This loop is actually not necessary if we had support for named arguments. So what I'm proposing in this PR is to replace the above code with `<NavigatorScreen path="product/:id" />

An example has been added to the storybook.

In #47777 we don't have the list of all available templates (and we don't want to fetch all of them) so I was forced to separate that "argument" outside of the path (I've used a query arg in location) In order to solve this issue. Basically even the mapping above was not an option. 

## How?

 - I've used `path-to-regexp` patch (very widely used in the JS community) to parse patterns like that. 
 - I've added a few keys to the result of `useNavigator`. We now have a `match` key that stores the "id" of the active screen/route and the `params` keys with the parsed arguments from the path.

## Testing Instructions

1- Run `npm run storybook:dev`
2- Click the "open product 1" button in the "Navigator" story.

## ✍️ Dev Note

The dev note from #47883 includes changes from this PR too.