### PR TITLE
Navigation Block inspector: fix link UI popover opening on links that have a url

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/block-contents.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-contents.js
@@ -73,7 +73,7 @@ const ListViewBlockContents = forwardRef(
 			setInsertedBlockAttributes,
 		} = useInsertedBlock( lastInsertedBlockClientId );
 
-		const hasExistingLinkValue = insertedBlockAttributes?.id;
+		const hasExistingLinkValue = insertedBlockAttributes?.url;
 
 		useEffect( () => {
 			if (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This fixes a bug when you have a navigation menu with a custom link and you try to insert the navigation block and that triggers the link UI popover on every insert.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It's a bad bug :D

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
We are checking for the URL instead of the id of the last inserted block before deciding to trigger the link UI popover open.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
To reproduce the original bug:
On a clean install, create and save a navigation menu with a custom link.
On a new post, insert a navigation block, you will see the the popover showing even if the link in the menu has a URL.
After the fix, the popover shouldn't show. 
If you click on the inserter to add a new custom link to the menu, it should trigger the popover for you to customize the new link.


## Screenshots or screencast <!-- if applicable -->
The bug:
<img width="1101" alt="Screenshot 2023-02-06 at 18 11 35" src="https://user-images.githubusercontent.com/3593343/217227713-6526615a-e097-4365-be97-8c5239a172b8.png">


