### PR TITLE
Dependency Extraction Webpack Plugin: Update json2php dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17615,7 +17615,7 @@
 			"version": "file:packages/dependency-extraction-webpack-plugin",
 			"dev": true,
 			"requires": {
-				"json2php": "^0.0.5",
+				"json2php": "^0.0.7",
 				"webpack-sources": "^3.2.2"
 			}
 		},
@@ -42543,9 +42543,9 @@
 			"dev": true
 		},
 		"json2php": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/json2php/-/json2php-0.0.5.tgz",
-			"integrity": "sha512-jWpsGAYlQDKOjJcyq3rYaxcZ+5YMhZIKHKTjdIKJPI9zLSX+yRWHSSwtV8hvIg7YMhbKkgPO669Ve2ZgFK5C7w==",
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/json2php/-/json2php-0.0.7.tgz",
+			"integrity": "sha512-dnSoUiLAoVaMXxFsVi4CrPVYMKOuDBXTghXSmMINX44RZ8WM9cXlY7UqrQnlAcODCVO7FV3+8t/5nDKAjimLfg==",
 			"dev": true
 		},
 		"json5": {

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   The bundled `json2php` dependency has been upgraded from requiring `^0.0.5` to `^0.0.7` ([#47831](https://github.com/WordPress/gutenberg/pull/47831)).
+
 ## 4.9.0 (2023-02-01)
 
 ## 4.8.0 (2023-01-11)

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -29,7 +29,7 @@
 	"main": "lib/index.js",
 	"types": "lib/types.d.ts",
 	"dependencies": {
-		"json2php": "^0.0.5",
+		"json2php": "^0.0.7",
 		"webpack-sources": "^3.2.2"
 	},
 	"peerDependencies": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

There were some issues with `json2php` package during the process of backporting changes from the Gutenberg repository to WordPress core described by @youknowriad in https://core.trac.wordpress.org/ticket/57471#comment:17. The resolution required to bring `json2php` to the latest version with the following commit from @desrosj: https://core.trac.wordpress.org/changeset/55232.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We don't have any evidence that there is any issue with the `@wordpress/dependency-extraction-webpack-plugin` because of the potential usage of `json2php` in version `0.0.5` or `0.0.6` but I would prefer to stay on the safe side and prevent that if possible,

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The bundled `json2php` dependency has been upgraded from requiring `^0.0.5` to `^0.0.7` for `@wordpress/dependency-extraction-webpack-plugin`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

All unit tests for the `@wordpress/dependency-extraction-webpack-plugin` should still pass. In general, there should be no impact on CI jobs.