### PR TITLE
Cherry-pick CLI: Fix the default label to match the documentation

### DIFF
--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -6,7 +6,7 @@ import readline from 'readline';
 
 import { spawnSync } from 'node:child_process';
 
-const LABEL = process.argv[ 2 ] || 'Backport to WP Minor Release';
+const LABEL = process.argv[ 2 ] || 'Backport to WP Beta/RC';
 const BRANCH = getCurrentBranch();
 const GITHUB_CLI_AVAILABLE = spawnSync( 'gh', [ 'auth', 'status' ] )
 	?.stderr?.toString()


### PR DESCRIPTION
## What?
PR updates the default label match [documentation](https://developer.wordpress.org/block-editor/contributors/code/release/auto-cherry-picking/) and the label mentioned in original PR #40969.

## Why?
@ntsekouras discovered that the default label mentioned in the documentation doesn't match the CLI default. We use this command more often during Beta/RC release, so I think this label makes more sense as the dafault.

## Testing Instructions
1. Run cherry-picking command without an argument - `npm run other:cherry-pick`
2. Confirm it uses the correct default label.
3. Cancel the command by typing `n`.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-02-07 at 17 03 11](https://user-images.githubusercontent.com/240569/217252946-a280a3f9-7742-4dd8-a0c6-b5664cb82465.png)
