### PR TITLE
Adds all allowed innerblocks to the inspector animation experiment

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -176,28 +176,33 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 	const blockInspectorAnimationSettings = useSelect(
 		( select ) => {
 			if ( blockType ) {
-				const { getSelectedBlockClientId, getBlockParentsByBlockName } =
-					select( blockEditorStore );
-
-				const _selectedBlockClientId = getSelectedBlockClientId();
-				const parentNavBlockClientId = getBlockParentsByBlockName(
-					_selectedBlockClientId,
-					'core/navigation',
-					true
-				)[ 0 ];
-
-				// If the selected block is not a child of a navigation block,
-				// and not a navigation block itselt don't animate.
-				if (
-					! parentNavBlockClientId &&
-					blockType.name !== 'core/navigation'
-				) {
-					return null;
-				}
-
+				// Get the global blockInspectorAnimationSettings.
 				const globalBlockInspectorAnimationSettings =
 					select( blockEditorStore ).getSettings()
 						.blockInspectorAnimation;
+
+				// Get the name of the block that will allow it's children to be animated.
+				const animationParent =
+					globalBlockInspectorAnimationSettings?.animationParent;
+
+				// Determin whether the animationParent block is a parent of the selected block.
+				const { getSelectedBlockClientId, getBlockParentsByBlockName } =
+					select( blockEditorStore );
+				const _selectedBlockClientId = getSelectedBlockClientId();
+				const animationParentBlockClientId = getBlockParentsByBlockName(
+					_selectedBlockClientId,
+					animationParent,
+					true
+				)[ 0 ];
+
+				// If the selected block is not a child of the animationParent block,
+				// and not an animationParent block itself, don't animate.
+				if (
+					! animationParentBlockClientId &&
+					blockType.name !== animationParent
+				) {
+					return null;
+				}
 
 				return globalBlockInspectorAnimationSettings?.[
 					blockType.name

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -185,7 +185,7 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 				const animationParent =
 					globalBlockInspectorAnimationSettings?.animationParent;
 
-				// Determin whether the animationParent block is a parent of the selected block.
+				// Determine whether the animationParent block is a parent of the selected block.
 				const { getSelectedBlockClientId, getBlockParentsByBlockName } =
 					select( blockEditorStore );
 				const _selectedBlockClientId = getSelectedBlockClientId();

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -176,9 +176,29 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 	const blockInspectorAnimationSettings = useSelect(
 		( select ) => {
 			if ( blockType ) {
+				const { getSelectedBlockClientId, getBlockParentsByBlockName } =
+					select( blockEditorStore );
+
+				const _selectedBlockClientId = getSelectedBlockClientId();
+				const parentNavBlockClientId = getBlockParentsByBlockName(
+					_selectedBlockClientId,
+					'core/navigation',
+					true
+				)[ 0 ];
+
+				// If the selected block is not a child of a navigation block,
+				// and not a navigation block itselt don't animate.
+				if (
+					! parentNavBlockClientId &&
+					blockType.name !== 'core/navigation'
+				) {
+					return null;
+				}
+
 				const globalBlockInspectorAnimationSettings =
 					select( blockEditorStore ).getSettings()
 						.blockInspectorAnimation;
+
 				return globalBlockInspectorAnimationSettings?.[
 					blockType.name
 				];

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -36,6 +36,7 @@ import { default as InspectorControlsTabs } from '../inspector-controls-tabs';
 import useInspectorControlsTabs from '../inspector-controls-tabs/use-inspector-controls-tabs';
 import AdvancedControls from '../inspector-controls-tabs/advanced-controls-panel';
 import PositionControls from '../inspector-controls-tabs/position-controls-panel';
+import useBlockInspectorAnimationSettings from './useBlockInspectorAnimationSettings';
 
 function useContentBlocks( blockTypes, block ) {
 	const contentBlocksObjectAux = useMemo( () => {
@@ -56,7 +57,7 @@ function useContentBlocks( blockTypes, block ) {
 		( blockName ) => {
 			return !! contentBlocksObjectAux[ blockName ];
 		},
-		[ blockTypes ]
+		[ contentBlocksObjectAux ]
 	);
 	return useMemo( () => {
 		return getContentBlocks( [ block ], isContentBlock );
@@ -173,43 +174,15 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 	const availableTabs = useInspectorControlsTabs( blockType?.name );
 	const showTabs = availableTabs?.length > 1;
 
-	const blockInspectorAnimationSettings = useSelect(
-		( select ) => {
-			if ( blockType ) {
-				const globalBlockInspectorAnimationSettings =
-					select( blockEditorStore ).getSettings()
-						.blockInspectorAnimation;
-
-				// Get the name of the block that will allow it's children to be animated.
-				const animationParent =
-					globalBlockInspectorAnimationSettings?.animationParent;
-
-				// Determine whether the animationParent block is a parent of the selected block.
-				const { getSelectedBlockClientId, getBlockParentsByBlockName } =
-					select( blockEditorStore );
-				const _selectedBlockClientId = getSelectedBlockClientId();
-				const animationParentBlockClientId = getBlockParentsByBlockName(
-					_selectedBlockClientId,
-					animationParent,
-					true
-				)[ 0 ];
-
-				// If the selected block is not a child of the animationParent block,
-				// and not an animationParent block itself, don't animate.
-				if (
-					! animationParentBlockClientId &&
-					blockType.name !== animationParent
-				) {
-					return null;
-				}
-
-				return globalBlockInspectorAnimationSettings?.[
-					blockType.name
-				];
-			}
-			return null;
-		},
-		[ selectedBlockClientId, blockType ]
+	// The block inspector animation settings will be completely
+	// removed in the future to create an API which allows the block
+	// inspector to transition between what it
+	// displays based on the relationship between the selected block
+	// and its parent, and only enable it if the parent is controlling
+	// its children blocks.
+	const blockInspectorAnimationSettings = useBlockInspectorAnimationSettings(
+		blockType,
+		selectedBlockClientId
 	);
 
 	if ( count > 1 ) {

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -176,7 +176,6 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 	const blockInspectorAnimationSettings = useSelect(
 		( select ) => {
 			if ( blockType ) {
-				// Get the global blockInspectorAnimationSettings.
 				const globalBlockInspectorAnimationSettings =
 					select( blockEditorStore ).getSettings()
 						.blockInspectorAnimation;

--- a/packages/block-editor/src/components/block-inspector/useBlockInspectorAnimationSettings.js
+++ b/packages/block-editor/src/components/block-inspector/useBlockInspectorAnimationSettings.js
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
+export default function useBlockInspectorAnimationSettings(
+	blockType,
+	selectedBlockClientId
+) {
+	return useSelect(
+		( select ) => {
+			if ( blockType ) {
+				const globalBlockInspectorAnimationSettings =
+					select( blockEditorStore ).getSettings()
+						.blockInspectorAnimation;
+
+				// Get the name of the block that will allow it's children to be animated.
+				const animationParent =
+					globalBlockInspectorAnimationSettings?.animationParent;
+
+				// Determine whether the animationParent block is a parent of the selected block.
+				const { getSelectedBlockClientId, getBlockParentsByBlockName } =
+					select( blockEditorStore );
+				const _selectedBlockClientId = getSelectedBlockClientId();
+				const animationParentBlockClientId = getBlockParentsByBlockName(
+					_selectedBlockClientId,
+					animationParent,
+					true
+				)[ 0 ];
+
+				// If the selected block is not a child of the animationParent block,
+				// and not an animationParent block itself, don't animate.
+				if (
+					! animationParentBlockClientId &&
+					blockType.name !== animationParent
+				) {
+					return null;
+				}
+
+				return globalBlockInspectorAnimationSettings?.[
+					blockType.name
+				];
+			}
+			return null;
+		},
+		[ selectedBlockClientId, blockType ]
+	);
+}

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -175,6 +175,13 @@ export const SETTINGS_DEFAULTS = {
 		'core/navigation': { enterDirection: 'leftToRight' },
 		'core/navigation-submenu': { enterDirection: 'rightToLeft' },
 		'core/navigation-link': { enterDirection: 'rightToLeft' },
+		'core/search': { enterDirection: 'rightToLeft' },
+		'core/social-links': { enterDirection: 'rightToLeft' },
+		'core/page-list': { enterDirection: 'rightToLeft' },
+		'core/spacer': { enterDirection: 'rightToLeft' },
+		'core/home-link': { enterDirection: 'rightToLeft' },
+		'core/site-title': { enterDirection: 'rightToLeft' },
+		'core/site-logo': { enterDirection: 'rightToLeft' },
 	},
 
 	generateAnchors: false,

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -170,7 +170,12 @@ export const SETTINGS_DEFAULTS = {
 	__unstableGalleryWithImageBlocks: false,
 	__unstableIsPreviewMode: false,
 
-	// This setting is `private` now with `lock` API.
+	// These settings will be completely revamped in the future.
+	// The goal is to evolve this into an API which will instruct
+	// the block inspector to animate transitions between what it
+	// displays based on the relationship between the selected block
+	// and its parent, and only enable it if the parent is controlling
+	// its children blocks.
 	blockInspectorAnimation: {
 		animationParent: 'core/navigation',
 		'core/navigation': { enterDirection: 'leftToRight' },

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -172,6 +172,7 @@ export const SETTINGS_DEFAULTS = {
 
 	// This setting is `private` now with `lock` API.
 	blockInspectorAnimation: {
+		animationParent: 'core/navigation',
 		'core/navigation': { enterDirection: 'leftToRight' },
 		'core/navigation-submenu': { enterDirection: 'rightToLeft' },
 		'core/navigation-link': { enterDirection: 'rightToLeft' },


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #47784

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For consistency.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds all allowed innerblocks to the inspector animation experiment.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In a navigation block
2. Add one of each:
```
'core/navigation-link',
	'core/search',
	'core/social-links',
	'core/page-list',
	'core/spacer',
	'core/home-link',
	'core/site-title',
	'core/site-logo',
	'core/navigation-submenu',
```
3. Test in the block inspector that when you click them in the tree their inspector slides in and does not just appear.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Caveats

I learned that the way this experiemnt works the block inspector of all the blocks in the experiment is animated irrespective or whether they are a child of a navigation block or not.
