### PR TITLE
Lodash: Remove from `useDispatchWithMap()`

### DIFF
--- a/packages/data/src/components/use-dispatch/use-dispatch-with-map.js
+++ b/packages/data/src/components/use-dispatch/use-dispatch-with-map.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { mapValues } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useMemo, useRef } from '@wordpress/element';
@@ -41,18 +36,25 @@ const useDispatchWithMap = ( dispatchMap, deps ) => {
 			registry.dispatch,
 			registry
 		);
-		return mapValues( currentDispatchProps, ( dispatcher, propName ) => {
-			if ( typeof dispatcher !== 'function' ) {
-				// eslint-disable-next-line no-console
-				console.warn(
-					`Property ${ propName } returned from dispatchMap in useDispatchWithMap must be a function.`
-				);
-			}
-			return ( ...args ) =>
-				currentDispatchMap
-					.current( registry.dispatch, registry )
-					[ propName ]( ...args );
-		} );
+		return Object.fromEntries(
+			Object.entries( currentDispatchProps ).map(
+				( [ propName, dispatcher ] ) => {
+					if ( typeof dispatcher !== 'function' ) {
+						// eslint-disable-next-line no-console
+						console.warn(
+							`Property ${ propName } returned from dispatchMap in useDispatchWithMap must be a function.`
+						);
+					}
+					return [
+						propName,
+						( ...args ) =>
+							currentDispatchMap
+								.current( registry.dispatch, registry )
+								[ propName ]( ...args ),
+					];
+				}
+			)
+		);
 	}, [ registry, ...deps ] );
 };
 


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.mapValues()` from the `useDispatchWithMap` utility of `@wordpress/data`. There is just a single use in that component and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

We're aiming to reduce the bundle size of `@wordpress/data` since Lodash is [over a quarter of its size](https://bundlephobia.com/package/@wordpress/data@8.3.0).

## How?

We're using `Object.fromEntries( Object.entries().map() )` as a replacement.

## Testing Instructions

Verify checks are green - changes are covered by tests.