### PR TITLE
Lodash: Remove from `@wordpress/data`'s `getResolutionState()`

### DIFF
--- a/packages/data/src/redux-store/metadata/selectors.js
+++ b/packages/data/src/redux-store/metadata/selectors.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { selectorArgsToStateKey } from './utils';
@@ -25,7 +20,7 @@ import { selectorArgsToStateKey } from './utils';
  * @return {StateValue|undefined} isResolving value.
  */
 export function getResolutionState( state, selectorName, args ) {
-	const map = get( state, [ selectorName ] );
+	const map = state[ selectorName ];
 	if ( ! map ) {
 		return;
 	}


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.get()` from the `getResolutionState` selector of `@wordpress/data`. There is just a single use in that function and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

We're aiming to reduce the bundle size of `@wordpress/data` since Lodash is [over a quarter of its size](https://bundlephobia.com/package/@wordpress/data@8.3.0).

## How?

We're using direct access as a replacement. There's no need for a `_.get()` use, especially considering that we're handling any falsy values on the next line.

## Testing Instructions

Verify checks are green - changes are covered by tests.