### PR TITLE
Site Editor: Split the templates list

### DIFF
--- a/packages/edit-site/src/components/list/added-by.js
+++ b/packages/edit-site/src/components/list/added-by.js
@@ -6,11 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalHStack as HStack,
-	Icon,
-	Tooltip,
-} from '@wordpress/components';
+import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
@@ -20,56 +16,31 @@ import {
 	plugins as pluginIcon,
 	globe as globeIcon,
 } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
 
 const TEMPLATE_POST_TYPE_NAMES = [ 'wp_template', 'wp_template_part' ];
 
-function CustomizedTooltip( { isCustomized, children } ) {
-	if ( ! isCustomized ) {
-		return children;
-	}
-
-	return (
-		<Tooltip text={ __( 'This template has been customized' ) }>
-			{ children }
-		</Tooltip>
-	);
-}
-
-function BaseAddedBy( { text, icon, imageUrl, isCustomized } ) {
+function BaseAddedBy( { text, icon, imageUrl } ) {
 	const [ isImageLoaded, setIsImageLoaded ] = useState( false );
 
 	return (
 		<HStack alignment="left">
-			<CustomizedTooltip isCustomized={ isCustomized }>
-				{ imageUrl ? (
-					<div
-						className={ classnames(
-							'edit-site-list-added-by__avatar',
-							{
-								'is-loaded': isImageLoaded,
-							}
-						) }
-					>
-						<img
-							onLoad={ () => setIsImageLoaded( true ) }
-							alt=""
-							src={ imageUrl }
-						/>
-					</div>
-				) : (
-					<div
-						className={ classnames(
-							'edit-site-list-added-by__icon',
-							{
-								'is-customized': isCustomized,
-							}
-						) }
-					>
-						<Icon icon={ icon } />
-					</div>
-				) }
-			</CustomizedTooltip>
+			{ imageUrl ? (
+				<div
+					className={ classnames( 'edit-site-list-added-by__avatar', {
+						'is-loaded': isImageLoaded,
+					} ) }
+				>
+					<img
+						onLoad={ () => setIsImageLoaded( true ) }
+						alt=""
+						src={ imageUrl }
+					/>
+				</div>
+			) : (
+				<div className="edit-site-list-added-by__icon">
+					<Icon icon={ icon } />
+				</div>
+			) }
 			<span>{ text }</span>
 		</HStack>
 	);

--- a/packages/edit-site/src/components/list/index.js
+++ b/packages/edit-site/src/components/list/index.js
@@ -94,7 +94,7 @@ export default function List() {
 		}
 
 		return mappedTemplates;
-	}, [ templates ] );
+	}, [ hasResolved, templates ] );
 
 	return (
 		<InterfaceSkeleton

--- a/packages/edit-site/src/components/list/index.js
+++ b/packages/edit-site/src/components/list/index.js
@@ -61,19 +61,23 @@ export default function List() {
 		  }
 		: undefined;
 
-	const { records: templates, isResolving: isLoading } = useEntityRecords(
-		'postType',
-		templateType,
-		{
-			per_page: -1,
-		}
-	);
+	const {
+		records: templates,
+		isResolving,
+		hasResolved,
+	} = useEntityRecords( 'postType', templateType, {
+		per_page: -1,
+	} );
 
 	const { customizedTemplates, nonCustomizedTemplates } = useMemo( () => {
 		let mappedTemplates = {
 			customizedTemplates: [],
 			nonCustomizedTemplates: [],
 		};
+
+		if ( ! hasResolved || ! templates ) {
+			return [];
+		}
 
 		if ( templates.length ) {
 			mappedTemplates = templates.reduce(
@@ -88,6 +92,7 @@ export default function List() {
 				{ customizedTemplates: [], nonCustomizedTemplates: [] }
 			);
 		}
+
 		return mappedTemplates;
 	}, [ templates ] );
 
@@ -102,14 +107,14 @@ export default function List() {
 					<Table
 						templateType={ templateType }
 						templates={ customizedTemplates }
-						isLoading={ isLoading }
+						isLoading={ isResolving }
 						label={ __( 'Customized templates' ) }
 						showActionsColumn
 					/>
 					<Table
 						templateType={ templateType }
 						templates={ nonCustomizedTemplates }
-						isLoading={ isLoading }
+						isLoading={ isResolving }
 						label={ __( 'Other templates' ) }
 					/>
 				</>

--- a/packages/edit-site/src/components/list/index.js
+++ b/packages/edit-site/src/components/list/index.js
@@ -96,6 +96,8 @@ export default function List() {
 		return mappedTemplates;
 	}, [ hasResolved, templates ] );
 
+	const hasCustomizedTemplates = !! customizedTemplates?.length;
+
 	return (
 		<InterfaceSkeleton
 			className="edit-site-list"
@@ -104,18 +106,39 @@ export default function List() {
 			notices={ <EditorSnackbars /> }
 			content={
 				<>
+					{ hasCustomizedTemplates && (
+						<Table
+							templateType={ templateType }
+							postType={ postType }
+							templates={ customizedTemplates }
+							isLoading={ isResolving }
+							heading={
+								postType &&
+								sprintf(
+									// translators: %s: The template type name, either "templates" or "template parts".
+									__( 'Customized %s' ),
+									postType.labels?.name?.toLowerCase()
+								)
+							}
+							templateHeadingLevel={ 3 }
+							showActionsColumn
+						/>
+					) }
 					<Table
 						templateType={ templateType }
-						templates={ customizedTemplates }
-						isLoading={ isResolving }
-						label={ __( 'Customized templates' ) }
-						showActionsColumn
-					/>
-					<Table
-						templateType={ templateType }
+						postType={ postType }
 						templates={ nonCustomizedTemplates }
 						isLoading={ isResolving }
-						label={ __( 'Other templates' ) }
+						heading={
+							hasCustomizedTemplates &&
+							postType &&
+							sprintf(
+								// translators: %s: The template type name, either "templates" or "template parts".
+								__( 'Default %s' ),
+								postType.labels?.name?.toLowerCase()
+							)
+						}
+						templateHeadingLevel={ hasCustomizedTemplates ? 3 : 2 }
 					/>
 				</>
 			}

--- a/packages/edit-site/src/components/list/style.scss
+++ b/packages/edit-site/src/components/list/style.scss
@@ -50,6 +50,11 @@
 				padding: $grid-unit * 9;
 			}
 		}
+
+		.edit-site-list__table-label {
+			align-self: flex-start;
+			margin-bottom: $grid-unit-20;
+		}
 	}
 }
 
@@ -57,7 +62,7 @@
 	min-width: 100%;
 	border: $border-width solid $gray-300;
 	border-radius: 2px;
-	margin: 0 auto;
+	margin: 0 auto $grid-unit-40;
 	overflow: hidden;
 	border-spacing: 0;
 	max-width: 960px;

--- a/packages/edit-site/src/components/list/style.scss
+++ b/packages/edit-site/src/components/list/style.scss
@@ -157,18 +157,6 @@
 	svg {
 		fill: $white;
 	}
-
-	&.is-customized::after {
-		position: absolute;
-		content: "";
-		background: var(--wp-admin-theme-color);
-		height: $grid-unit-10;
-		width: $grid-unit-10;
-		outline: 2px solid $white;
-		border-radius: 100%;
-		top: -1px;
-		right: -1px;
-	}
 }
 
 .edit-site-list-added-by__avatar {

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -1,8 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
 import { __experimentalHeading as Heading } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -16,16 +14,13 @@ import AddedBy from './added-by';
 
 export default function Table( {
 	templateType,
+	postType,
 	templates,
 	isLoading,
-	label,
+	heading,
+	templateHeadingLevel,
 	showActionsColumn = false,
 } ) {
-	const postType = useSelect(
-		( select ) => select( coreStore ).getPostType( templateType ),
-		[ templateType ]
-	);
-
 	if ( ! templates || isLoading ) {
 		return null;
 	}
@@ -44,13 +39,13 @@ export default function Table( {
 
 	return (
 		<>
-			{ label && (
+			{ heading && (
 				<Heading
 					level={ 2 }
 					size={ 18 }
 					className="edit-site-list__table-label"
 				>
-					{ label }
+					{ heading }
 				</Heading>
 			) }
 			{
@@ -94,7 +89,10 @@ export default function Table( {
 								className="edit-site-list-table-column"
 								role="cell"
 							>
-								<Heading level={ 3 } size={ 16 }>
+								<Heading
+									level={ templateHeadingLevel }
+									size={ 16 }
+								>
 									<Link
 										params={ {
 											postId: template.id,

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -2,12 +2,9 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { store as coreStore, useEntityRecords } from '@wordpress/core-data';
+import { store as coreStore } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
-import {
-	VisuallyHidden,
-	__experimentalHeading as Heading,
-} from '@wordpress/components';
+import { __experimentalHeading as Heading } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
@@ -17,14 +14,13 @@ import Link from '../routes/link';
 import Actions from './actions';
 import AddedBy from './added-by';
 
-export default function Table( { templateType } ) {
-	const { records: templates, isResolving: isLoading } = useEntityRecords(
-		'postType',
-		templateType,
-		{
-			per_page: -1,
-		}
-	);
+export default function Table( {
+	templateType,
+	templates,
+	isLoading,
+	label,
+	showActionsColumn = false,
+} ) {
 	const postType = useSelect(
 		( select ) => select( coreStore ).getPostType( templateType ),
 		[ templateType ]
@@ -47,68 +43,93 @@ export default function Table( { templateType } ) {
 	}
 
 	return (
-		// These explicit aria roles are needed for Safari.
-		// See https://developer.mozilla.org/en-US/docs/Web/CSS/display#tables
-		<table className="edit-site-list-table" role="table">
-			<thead>
-				<tr className="edit-site-list-table-head" role="row">
-					<th
-						className="edit-site-list-table-column"
-						role="columnheader"
-					>
-						{ __( 'Template' ) }
-					</th>
-					<th
-						className="edit-site-list-table-column"
-						role="columnheader"
-					>
-						{ __( 'Added by' ) }
-					</th>
-					<th
-						className="edit-site-list-table-column"
-						role="columnheader"
-					>
-						<VisuallyHidden>{ __( 'Actions' ) }</VisuallyHidden>
-					</th>
-				</tr>
-			</thead>
-
-			<tbody>
-				{ templates.map( ( template ) => (
-					<tr
-						key={ template.id }
-						className="edit-site-list-table-row"
-						role="row"
-					>
-						<td className="edit-site-list-table-column" role="cell">
-							<Heading level={ 4 }>
-								<Link
-									params={ {
-										postId: template.id,
-										postType: template.type,
-									} }
-								>
-									{ decodeEntities(
-										template.title?.rendered ||
-											template.slug
-									) }
-								</Link>
-							</Heading>
-							{ decodeEntities( template.description ) }
-						</td>
-
-						<td className="edit-site-list-table-column" role="cell">
-							<AddedBy
-								templateType={ templateType }
-								template={ template }
-							/>
-						</td>
-						<td className="edit-site-list-table-column" role="cell">
-							<Actions template={ template } />
-						</td>
+		<>
+			{ label && (
+				<Heading
+					level={ 2 }
+					size={ 18 }
+					className="edit-site-list__table-label"
+				>
+					{ label }
+				</Heading>
+			) }
+			{
+				// These explicit aria roles are needed for Safari. See
+				// https://developer.mozilla.org/en-US/docs/Web/CSS/display#tables
+			 }
+			<table className="edit-site-list-table" role="table">
+				<thead>
+					<tr className="edit-site-list-table-head" role="row">
+						<th
+							className="edit-site-list-table-column"
+							role="columnheader"
+						>
+							{ __( 'Template' ) }
+						</th>
+						<th
+							className="edit-site-list-table-column"
+							role="columnheader"
+						>
+							{ __( 'Added by' ) }
+						</th>
+						{ showActionsColumn && (
+							<th
+								className="edit-site-list-table-column"
+								role="columnheader"
+							>
+								{ __( 'Actions' ) }
+							</th>
+						) }
 					</tr>
-				) ) }
-			</tbody>
-		</table>
+				</thead>
+
+				<tbody>
+					{ templates.map( ( template ) => (
+						<tr
+							key={ template.id }
+							className="edit-site-list-table-row"
+							role="row"
+						>
+							<td
+								className="edit-site-list-table-column"
+								role="cell"
+							>
+								<Heading level={ 3 } size={ 16 }>
+									<Link
+										params={ {
+											postId: template.id,
+											postType: template.type,
+										} }
+									>
+										{ decodeEntities(
+											template.title?.rendered ||
+												template.slug
+										) }
+									</Link>
+								</Heading>
+								{ decodeEntities( template.description ) }
+							</td>
+							<td
+								className="edit-site-list-table-column"
+								role="cell"
+							>
+								<AddedBy
+									templateType={ templateType }
+									template={ template }
+								/>
+							</td>
+							{ showActionsColumn && (
+								<td
+									className="edit-site-list-table-column"
+									role="cell"
+								>
+									<Actions template={ template } />
+								</td>
+							) }
+						</tr>
+					) ) }
+				</tbody>
+			</table>
+		</>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/42557
Related: https://github.com/WordPress/gutenberg/issues/42505 / https://github.com/WordPress/gutenberg/pull/42555

## What?
<!-- In a few words, what is the PR actually doing? -->
As suggested in https://github.com/WordPress/gutenberg/pull/42555, a more clear indication of the custom / customized templates and templates parts may benefit from splitting the templates table in two tables. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Right now,  custom / customized templates and templates parts are only distinguished by the other ones by the means of a blue dot and a tooltip that appears only on hover. The blue dot is only visual and it's also a very small target to hover. Teh tooltip is not keyboard accessible. There's no other semantic information.

Splitting the table in two tables, one for the default templates and the other one for custom / customized templates, makes things way cleared and allows to entirely remove the blue dot and tooltip. Headings before the table further clarify what the tables are about.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR splits the array of templates in two, based on whether the template source is `custom`. Based on that, it renders two tables conditionally:
- When there are no custom / customized templates, only one table is rendered. No big visual changes here.
- When there are custom / customized templates, two tables with headings are rendered.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Go to the Site Editor.
- In the navigation sidebar, click Templates > Manage all templates
- Create a custom template.
- Also customize one of the default templates.
- Go back to the navigation sidebar > Templates > Manage all templates.
- Observe there are now two tables.
- Check the headings before the two tables are, respecitvely, 'Custom templates' and 'Default templates'.
- Check the 'Actions' column is shown only in the Custom templates table.
- In the table of the customized templates, observe there's no blue dot and tooltip for the customized template.
- Clear cutomizations of the customized template.
- Delete the custom template.
- Observe the templates list updates and shows only one table.
- Repeat the above steps for the Template parts.
  - Check the headings before the tables are, respecitvely, 'Custom template parts' and 'Default template parts'.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="1792" alt="Screenshot 2023-02-07 at 15 55 00" src="https://user-images.githubusercontent.com/1682452/217290228-a119350e-b9a8-4360-90f8-13b3ff4d5f13.png">
