### PR TITLE
Fix: Issues on block level settings

### DIFF
--- a/lib/block-supports/settings.php
+++ b/lib/block-supports/settings.php
@@ -92,7 +92,7 @@ function _gutenberg_add_block_level_preset_styles( $pre_render, $block ) {
 			$variables_root_selector .= ',' . $block_type->supports['__experimentalSelector'];
 		}
 	}
-	$variables_root_selector = WP_Theme_JSON_6_1::scope_selector( $class_name, $variables_root_selector );
+	$variables_root_selector = WP_Theme_JSON_Gutenberg::scope_selector( $class_name, $variables_root_selector );
 
 	// Remove any potentially unsafe styles.
 	$theme_json_shape  = WP_Theme_JSON_Gutenberg::remove_insecure_properties(

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1551,7 +1551,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @param string $selector Original selector.
 	 * @return string Scoped selector.
 	 */
-	protected static function scope_selector( $scope, $selector ) {
+	public static function scope_selector( $scope, $selector ) {
 		$scopes    = explode( ',', $scope );
 		$selectors = explode( ',', $selector );
 


### PR DESCRIPTION
## What?
During the backport to the core I noticed some regressions on the block-level settings in Gutenberg:
- The property scope_selector was changed back to protected while it should be public.
- Some code references WP_Theme_JSON_6_1, which was meanwhile deleted.

## Testing

I pasted the following code on the code editor, saved the post, and verified everything works well:
```
<!-- wp:group {"settings":{"blocks":{"core/button":{"color":{"palette":{"custom":[{"slug":"button-red","color":"red","name":"button red"},{"slug":"button-blue","color":"blue","name":"button blue"}]}}}},"color":{"palette":{"custom":[{"slug":"global-aquamarine","color":"aquamarine","name":"Global aquamarine"},{"slug":"global-pink","color":"pink","name":"Global Pink"}]}}}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>Leaf paragraph of inner group block.</p>
<!-- /wp:paragraph -->

<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"button-blue"} -->
<div class="wp-block-button"><a class="wp-block-button__link has-button-blue-background-color has-background wp-element-button">blue</a></div>
<!-- /wp:button -->

<!-- wp:button {"backgroundColor":"button-red"} -->
<div class="wp-block-button"><a class="wp-block-button__link has-button-red-background-color has-background wp-element-button">red</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:paragraph {"backgroundColor":"global-aquamarine"} -->
<p class="has-global-aquamarine-background-color has-background">global-aquamarine</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"backgroundColor":"global-pink"} -->
<p class="has-global-pink-background-color has-background">global-pink</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```