### PR TITLE
Refactor: usePatternsCategories: simplify category sorting

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -28,7 +28,7 @@ import BlockPatternList from '../block-patterns-list';
 import PatternsExplorerModal from './block-patterns-explorer/explorer';
 import MobileTabNavigation from './mobile-tab-navigation';
 
-// Preffered order of pattern categories. Any other categories should
+// Preferred order of pattern categories. Any other categories should
 // be at the bottom without any re-ordering.
 const patternCategoriesOrder = [
 	'featured',
@@ -68,28 +68,14 @@ function usePatternsCategories( rootClientId ) {
 					pattern.categories?.includes( category.name )
 				)
 			)
-			.sort( ( { name: currentName }, { name: nextName } ) => {
-				// The pattern categories should be ordered as follows:
-				// 1. The categories from `patternCategoriesOrder` in that specific order should be at the top.
-				// 2. The rest categories should be at the bottom without any re-ordering.
-				if (
-					! [ currentName, nextName ].some( ( categoryName ) =>
-						patternCategoriesOrder.includes( categoryName )
-					)
-				) {
-					return 0;
-				}
-				if (
-					[ currentName, nextName ].every( ( categoryName ) =>
-						patternCategoriesOrder.includes( categoryName )
-					)
-				) {
-					return (
-						patternCategoriesOrder.indexOf( currentName ) -
-						patternCategoriesOrder.indexOf( nextName )
-					);
-				}
-				return patternCategoriesOrder.includes( currentName ) ? -1 : 1;
+			.sort( ( { name: aName }, { name: bName } ) => {
+				// Sort categories according to `patternCategoriesOrder`.
+				let aIndex = patternCategoriesOrder.indexOf( aName );
+				let bIndex = patternCategoriesOrder.indexOf( bName );
+				// All other categories should come after that.
+				if ( aIndex < 0 ) aIndex = patternCategoriesOrder.length;
+				if ( bIndex < 0 ) bIndex = patternCategoriesOrder.length;
+				return aIndex - bIndex;
 			} );
 
 		if (


### PR DESCRIPTION
Follows up on #47760.

## What?
Just a minor refactor which I hope makes the sorting in `usePatternsCategories` easier to understand at a glance.

## Testing Instructions
* No change should be observed. Ensure that pattern categories in the global inserter are still listed in the correct order, i.e. _Featured_, _Posts_, …, _Footer_, and that any custom categories are placed at the bottom.
* When testing with custom categories, remember that a category will only be listed if there are patterns available belonging to that category.

<img width="447" alt="patterns-categories-sort-refactor" src="https://user-images.githubusercontent.com/150562/217303699-fa15d254-6d0d-47b4-817e-0f3e9e9ebf73.png">
