### PR TITLE
Image: Revert "Prevent the image from being resized larger than its container"

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -124,30 +124,37 @@ export default function Image( {
 		},
 		[ id, isSelected, clientId ]
 	);
-	const { canInsertCover, imageEditing, imageSizes, mediaUpload } = useSelect(
-		( select ) => {
-			const { getBlockRootClientId, getSettings, canInsertBlockType } =
-				select( blockEditorStore );
+	const { canInsertCover, imageEditing, imageSizes, maxWidth, mediaUpload } =
+		useSelect(
+			( select ) => {
+				const {
+					getBlockRootClientId,
+					getSettings,
+					canInsertBlockType,
+				} = select( blockEditorStore );
 
-			const rootClientId = getBlockRootClientId( clientId );
-			const settings = Object.fromEntries(
-				Object.entries( getSettings() ).filter( ( [ key ] ) =>
-					[ 'imageEditing', 'imageSizes', 'mediaUpload' ].includes(
-						key
+				const rootClientId = getBlockRootClientId( clientId );
+				const settings = Object.fromEntries(
+					Object.entries( getSettings() ).filter( ( [ key ] ) =>
+						[
+							'imageEditing',
+							'imageSizes',
+							'maxWidth',
+							'mediaUpload',
+						].includes( key )
 					)
-				)
-			);
+				);
 
-			return {
-				...settings,
-				canInsertCover: canInsertBlockType(
-					'core/cover',
-					rootClientId
-				),
-			};
-		},
-		[ clientId ]
-	);
+				return {
+					...settings,
+					canInsertCover: canInsertBlockType(
+						'core/cover',
+						rootClientId
+					),
+				};
+			},
+			[ clientId ]
+		);
 	const { replaceBlocks, toggleSelection } = useDispatch( blockEditorStore );
 	const { createErrorNotice, createSuccessNotice } =
 		useDispatch( noticesStore );
@@ -548,9 +555,13 @@ export default function Image( {
 		// With the current implementation of ResizableBox, an image needs an
 		// explicit pixel value for the max-width. In absence of being able to
 		// set the content-width, this max-width is currently dictated by the
-		// vanilla editor style. We'll use the clientWidth here, to prevent the width
-		// of the image growing larger than the width of the block column.
-		const maxWidthBuffer = clientWidth;
+		// vanilla editor style. The following variable adds a buffer to this
+		// vanilla style, so 3rd party themes have some wiggleroom. This does,
+		// in most cases, allow you to scale the image beyond the width of the
+		// main column, though not infinitely.
+		// @todo It would be good to revisit this once a content-width variable
+		// becomes available.
+		const maxWidthBuffer = maxWidth * 2.5;
 
 		let showRightHandle = false;
 		let showLeftHandle = false;


### PR DESCRIPTION
This reverts commit 2e8c7e4e6da4914481117c487ea36547ab5d94af.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
The PR https://github.com/WordPress/gutenberg/pull/45775 aimed to prevent an image from being resized larger than its container. This commit reverts that change.
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The previous PR prevented an inserted image to be larger than its container. However, it created a new issue https://github.com/WordPress/gutenberg/issues/47539, where images are displayed smaller on browser reload when working in the editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Revert https://github.com/WordPress/gutenberg/pull/45775

## Testing Instructions

1. Start from any WP site with only Gutenberg 15.0 or higher active
2. Add an image block to a post (or page, or other custom post type I guess, but I only tried with posts/pages)
3. Center, left-align, or right-align, and ensure there's a caption visible
4. Save or publish
5. Exit editor
6. Re-enter editor to edit your post
7. See image remains the same size.
8. Reload the page and verify that the image remains the same size.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
