### PR TITLE
Lodash: Remove from `@wordpress/data`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17588,7 +17588,6 @@
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
 				"is-promise": "^4.0.0",
-				"lodash": "^4.17.21",
 				"redux": "^4.1.2",
 				"turbo-combine-reducers": "^1.0.2",
 				"use-memo-one": "^1.1.1"
@@ -29592,7 +29591,7 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
 			"dev": true
 		},
 		"code-point-at": {
@@ -43686,7 +43685,7 @@
 		"lodash.isequal": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
 		},
 		"lodash.ismatch": {
 			"version": "4.4.0",

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -164,13 +164,21 @@ Integrating an existing redux store with its own reducers, store enhancers and m
 _Example:_
 
 ```js
-import { mapValues } from 'lodash';
 import { register } from '@wordpress/data';
 import existingSelectors from './existing-app/selectors';
 import existingActions from './existing-app/actions';
 import createStore from './existing-app/store';
 
 const reduxStore = createStore();
+
+const mapValues = ( obj, callback ) =>
+	Object.entries( obj ).reduce(
+		( acc, [ key, value ] ) => ( {
+			...acc,
+			[ key ]: callback( value ),
+		} ),
+		{}
+	);
 
 const boundSelectors = mapValues(
 	existingSelectors,

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -40,7 +40,6 @@
 		"equivalent-key-map": "^0.2.2",
 		"is-plain-object": "^5.0.0",
 		"is-promise": "^4.0.0",
-		"lodash": "^4.17.21",
 		"redux": "^4.1.2",
 		"turbo-combine-reducers": "^1.0.2",
 		"use-memo-one": "^1.1.1"

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { createStore, applyMiddleware } from 'redux';
-import { get, mapValues } from 'lodash';
 import combineReducers from 'turbo-combine-reducers';
 import EquivalentKeyMap from 'equivalent-key-map';
 
@@ -44,6 +43,23 @@ const trimUndefinedValues = ( array ) => {
 	}
 	return result;
 };
+
+/**
+ * Creates a new object with the same keys, but with `callback()` called as
+ * a transformer function on each of the values.
+ *
+ * @param {Object}   obj      The object to transform.
+ * @param {Function} callback The function to transform each object value.
+ * @return {Array} Transformed object.
+ */
+const mapValues = ( obj, callback ) =>
+	Object.entries( obj ?? {} ).reduce(
+		( acc, [ key, value ] ) => ( {
+			...acc,
+			[ key ]: callback( value, key ),
+		} ),
+		{}
+	);
 
 // Convert Map objects to plain objects
 const mapToObject = ( key, state ) => {
@@ -608,7 +624,7 @@ function mapResolvers( resolvers, selectors, store, resolversCache ) {
  * @param {Array}  args         Selector Arguments.
  */
 async function fulfillResolver( store, resolvers, selectorName, ...args ) {
-	const resolver = get( resolvers, [ selectorName ] );
+	const resolver = resolvers[ selectorName ];
 	if ( ! resolver ) {
 		return;
 	}


### PR DESCRIPTION
## What?
This PR removes the last Lodash from `@wordpress/data` and removes the dependency from the package. There is just a single use in that component and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

We're aiming to reduce the bundle size of `@wordpress/data` since Lodash is [over a quarter of its size](https://bundlephobia.com/package/@wordpress/data@8.3.0). This is the last PR of that series.

## How?

We're using `Object.fromEntries( Object.entries().map() )` as a replacement of `_.mapValues()` and direct access instead of `_.get()`.

## Testing Instructions

* Smoke test all editors.
* Verify checks are green - changes are covered by tests.
