### PR TITLE
[Experiment] Navigator: add initialLocationHistory prop

### DIFF
--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -30,16 +30,25 @@ function UnconnectedNavigatorProvider(
 	props: WordPressComponentProps< NavigatorProviderProps, 'div' >,
 	forwardedRef: ForwardedRef< any >
 ) {
-	const { initialPath, children, className, ...otherProps } =
-		useContextSystem( props, 'NavigatorProvider' );
+	const {
+		initialLocationHistory = [],
+		initialPath,
+		children,
+		className,
+		...otherProps
+	} = useContextSystem( props, 'NavigatorProvider' );
 
 	const [ locationHistory, setLocationHistory ] = useState<
 		NavigatorLocation[]
-	>( [
-		{
-			path: initialPath,
-		},
-	] );
+	>(
+		initialLocationHistory.length
+			? initialLocationHistory
+			: [
+					{
+						path: initialPath,
+					},
+			  ]
+	);
 
 	const goTo: NavigatorContextType[ 'goTo' ] = useCallback(
 		( path, options = {} ) => {

--- a/packages/components/src/navigator/stories/index.tsx
+++ b/packages/components/src/navigator/stories/index.tsx
@@ -208,3 +208,128 @@ function MetaphorIpsum( { quantity }: { quantity: number } ) {
 		</>
 	);
 }
+
+type MenuItem = {
+	path: string;
+	content: string;
+	items?: MenuItem[];
+};
+
+const MENU_STRUCTURE: MenuItem[] = [
+	{
+		path: '/',
+		content: 'Pick a category',
+		items: [
+			{
+				path: '/starters',
+				content: 'Starters',
+				items: [
+					{
+						path: '/starters/onion-soup',
+						content: 'Onion soup',
+					},
+					{
+						path: '/starters/vegetable-gyoza',
+						content: 'Vegetable Gyoza',
+					},
+					{
+						path: '/starters/caprese-salad',
+						content: 'Caprese salad',
+					},
+				],
+			},
+			{
+				path: '/mains',
+				content: 'Mains',
+				items: [
+					{
+						path: '/mains/roast-chicken',
+						content: 'Roast chicken',
+					},
+					{
+						path: '/mains/masamman-curry',
+						content: 'Masamman curry',
+					},
+					{
+						path: '/mains/spaghetti-carbonara',
+						content: 'Spaghetti alla carbonara',
+					},
+				],
+			},
+			{
+				path: '/desserts',
+				content: 'Desserts',
+				items: [
+					{
+						path: '/desserts/brownie',
+						content: 'Brownie',
+					},
+					{
+						path: '/desserts/cheese-platter',
+						content: 'Cheese platter',
+					},
+				],
+			},
+		],
+	},
+];
+
+const FLATTENED_MENU: MenuItem[] = [];
+
+const flattenRecursively = ( menuItems: MenuItem[] ) => {
+	for ( const menuItem of menuItems ) {
+		FLATTENED_MENU.push( menuItem );
+
+		if ( menuItem.items ) {
+			flattenRecursively( menuItem.items );
+		}
+	}
+};
+flattenRecursively( MENU_STRUCTURE );
+
+export const WithInitialLocationHistory: ComponentStory<
+	typeof NavigatorProvider
+> = ( { style, ...props } ) => (
+	<NavigatorProvider
+		style={ { ...style, height: '100vh', maxHeight: '450px' } }
+		{ ...props }
+	>
+		{ FLATTENED_MENU.map( ( { path, content, items } ) => (
+			<NavigatorScreen path={ path } key={ path }>
+				<h2>{ content }</h2>
+				{ items?.length ? (
+					<ul>
+						{ items.map(
+							( {
+								path: subItemPath,
+								content: subItemContent,
+							} ) => (
+								<li key={ subItemPath }>
+									<NavigatorButton
+										variant="secondary"
+										path={ subItemPath }
+									>
+										Navigate to &quot;{ subItemContent }
+										&quot; screen.
+									</NavigatorButton>
+								</li>
+							)
+						) }
+					</ul>
+				) : null }
+				{ path !== '/' ? (
+					<NavigatorBackButton variant="secondary">
+						Go back
+					</NavigatorBackButton>
+				) : null }
+			</NavigatorScreen>
+		) ) }
+	</NavigatorProvider>
+);
+WithInitialLocationHistory.args = {
+	initialLocationHistory: [
+		{ path: '/' },
+		{ path: '/mains', focusTargetSelector: '[id="/"]' },
+		{ path: '/mains/masamman-curry', focusTargetSelector: '[id="/mains"]' },
+	],
+};

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -15,9 +15,14 @@ type NavigateOptions = {
 export type NavigatorLocation = NavigateOptions & {
 	isInitial?: boolean;
 	isBack?: boolean;
-	path?: string;
+	path: string;
 	hasRestoredFocus?: boolean;
 };
+
+type PublicNavigatorLocation = Pick<
+	NavigatorLocation,
+	'path' | 'focusTargetSelector'
+>;
 
 export type NavigatorContext = {
 	location: NavigatorLocation;
@@ -29,6 +34,12 @@ export type NavigatorContext = {
 export type Navigator = NavigatorContext;
 
 export type NavigatorProviderProps = {
+	/**
+	 * The initial location history array.
+	 *
+	 * @default []
+	 */
+	initialLocationHistory?: PublicNavigatorLocation[];
 	/**
 	 * The initial active path.
 	 */

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -15,7 +15,7 @@ type NavigateOptions = {
 export type NavigatorLocation = NavigateOptions & {
 	isInitial?: boolean;
 	isBack?: boolean;
-	path: string;
+	path?: string;
 	hasRestoredFocus?: boolean;
 };
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This is an experiment to see if it's possible (and does it feel like) to use `Navigator` to navigate hierarchically defined screens, starting from a specific screen and with the possibility of navigating "back" to the screen's parent.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This feature may work well to satisfy some recent requirements that came up for the `Navigator` component.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The idea is that, by accepting an `initialLocationHistory`, the `NavigatorScreen` component can be set up to display a specific screen (rather than the initial one), with the possibility of making the "Back" button work as intended.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

See the `WithInitialLocationHistory` new Storybook example

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
