### PR TITLE
Site editor: specify active state color for template navigation button

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -31,7 +31,8 @@
 .edit-site-sidebar-navigation-screen__back {
 	color: $gray-200;
 
-	&:hover {
+	&:hover,
+	&:not([aria-disabled="true"]):active {
 		color: $white;
 	}
 }


### PR DESCRIPTION
## What?
Sets the active state color of template navigation back icon

## Why?
So it doesn't disappear when you click on it.
Fixes: #47805

## How?
Set the color on `:active`, and combines with `:not([aria-disabled="true"])` so specificity is high enough to override the default.

## Testing Instructions

- Open the site Editor
- Click on the Templates link under Design
- Click on back navigation link and make sure it doesn't disappear

## Screenshots or screencast 

Before:

https://user-images.githubusercontent.com/3629020/217373408-4a26e5bf-d681-4b25-8325-d8245416bc3f.mp4

After:

https://user-images.githubusercontent.com/3629020/217373556-d8cdc9a8-601e-4fb9-b4b2-c0292c30971b.mp4



