### PR TITLE
Perf Tests: Type 450 times for `type` metric instead of `20`

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -210,6 +210,7 @@ async function runTestSuite( testSuite, performanceTestDirectory, runKey ) {
 	);
 	fs.mkdirSync( './__test-results', { recursive: true } );
 	fs.copyFileSync( resultsFile, `./__test-results/${ runKey }.results.json` );
+	);
 	const rawResults = await readJSONFile(
 		path.join(
 			performanceTestDirectory,

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -210,7 +210,6 @@ async function runTestSuite( testSuite, performanceTestDirectory, runKey ) {
 	);
 	fs.mkdirSync( './__test-results', { recursive: true } );
 	fs.copyFileSync( resultsFile, `./__test-results/${ runKey }.results.json` );
-	);
 	const rawResults = await readJSONFile(
 		path.join(
 			performanceTestDirectory,

--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -145,7 +145,7 @@ describe( 'Post Editor Performance', () => {
 		}
 	} );
 
-	it( 'Typing', async () => {
+	it.only( 'Typing', async () => {
 		await loadHtmlIntoTheBlockEditor(
 			readFile( join( __dirname, '../../assets/large-post.html' ) )
 		);

--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -150,7 +150,7 @@ describe( 'Post Editor Performance', () => {
 			readFile( join( __dirname, '../../assets/large-post.html' ) )
 		);
 		await insertBlock( 'Paragraph' );
-		let i = 200;
+		let i = 800;
 		await page.tracing.start( {
 			path: traceFile,
 			screenshots: false,

--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -150,7 +150,7 @@ describe( 'Post Editor Performance', () => {
 			readFile( join( __dirname, '../../assets/large-post.html' ) )
 		);
 		await insertBlock( 'Paragraph' );
-		let i = 800;
+		let i = 450;
 		await page.tracing.start( {
 			path: traceFile,
 			screenshots: false,

--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -150,7 +150,7 @@ describe( 'Post Editor Performance', () => {
 			readFile( join( __dirname, '../../assets/large-post.html' ) )
 		);
 		await insertBlock( 'Paragraph' );
-		let i = 20;
+		let i = 200;
 		await page.tracing.start( {
 			path: traceFile,
 			screenshots: false,

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -136,7 +136,7 @@ describe( 'Site Editor Performance', () => {
 		}
 	} );
 
-	it( 'Typing', async () => {
+	it.only( 'Typing', async () => {
 		await page.waitForSelector( '.edit-site-visual-editor', {
 			timeout: 120000,
 		} );


### PR DESCRIPTION
## Status

Please ignore for now, this is for testing.

Saw an 8% difference in same-code branches for `type`. Completed in 36 min for 1 round.

## Description

By typing 200 times instead of 20 we will examine if this impacts the measured variability and bias in the `type` performance metric.

## Results

![type-metrics](https://user-images.githubusercontent.com/5431237/220205928-05c3ab89-114b-43af-b223-b79641a0204c.png)

![type-stats](https://user-images.githubusercontent.com/5431237/220205930-529ec4f0-1c39-4907-bf83-9249fba8b16b.png)

