### PR TITLE
Fix: Make navigation page list load its items on navigation sidebar.

### DIFF
--- a/packages/edit-site/src/components/navigation-inspector/index.js
+++ b/packages/edit-site/src/components/navigation-inspector/index.js
@@ -3,8 +3,13 @@
  */
 import { useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
-import { store as coreStore } from '@wordpress/core-data';
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as coreStore, useEntityBlockEditor } from '@wordpress/core-data';
+import {
+	store as blockEditorStore,
+	BlockEditorProvider,
+	BlockTools,
+	BlockList,
+} from '@wordpress/block-editor';
 import { speak } from '@wordpress/a11y';
 import { __ } from '@wordpress/i18n';
 
@@ -13,38 +18,90 @@ import { __ } from '@wordpress/i18n';
  */
 import NavigationMenu from './navigation-menu';
 
+const NAVIGATION_MENUS_QUERY = [
+	'postType',
+	'wp_navigation',
+	[ { per_page: 1, status: 'publish' } ],
+];
+
+function NavigationBlockEditorLoader( { onSelect, navigationPostId } ) {
+	const [ innerBlocks, onInput, onChange ] = useEntityBlockEditor(
+		'postType',
+		'wp_navigation',
+		{ id: navigationPostId }
+	);
+	return (
+		<BlockEditorProvider
+			value={ innerBlocks }
+			onChange={ onChange }
+			onInput={ onInput }
+		>
+			<NavigationMenu onSelect={ onSelect } />
+			<div style={ { visibility: 'hidden' } }>
+				<BlockTools>
+					<BlockList />
+				</BlockTools>
+			</div>
+		</BlockEditorProvider>
+	);
+}
+
 export default function NavigationInspector( { onSelect } ) {
-	const { navigationBlockId, isLoadingInnerBlocks, hasLoadedInnerBlocks } =
-		useSelect( ( select ) => {
-			const {
-				__experimentalGetActiveBlockIdByBlockNames,
-				__experimentalGetGlobalBlocksByName,
-				getBlock,
-			} = select( blockEditorStore );
-			const { isResolving, hasFinishedResolution } = select( coreStore );
+	const {
+		navigationBlockId,
+		navigationPostId,
+		isLoadingInnerBlocks,
+		hasLoadedInnerBlocks,
+	} = useSelect( ( select ) => {
+		const {
+			__experimentalGetActiveBlockIdByBlockNames,
+			__experimentalGetGlobalBlocksByName,
+			getBlock,
+		} = select( blockEditorStore );
+		const { isResolving, hasFinishedResolution, getEntityRecords } =
+			select( coreStore );
 
-			const selectedNavBlockId =
-				__experimentalGetActiveBlockIdByBlockNames(
-					'core/navigation'
-				) ||
-				__experimentalGetGlobalBlocksByName( 'core/navigation' )?.[ 0 ];
-			const selectedNavigationPost =
-				selectedNavBlockId &&
-				getBlock( selectedNavBlockId )?.attributes?.ref;
+		const selectedNavBlockId =
+			__experimentalGetActiveBlockIdByBlockNames( 'core/navigation' ) ||
+			__experimentalGetGlobalBlocksByName( 'core/navigation' )?.[ 0 ];
 
-			return {
-				navigationBlockId: selectedNavBlockId,
-				isLoadingInnerBlocks: isResolving( 'getEntityRecord', [
-					'postType',
-					'wp_navigation',
-					selectedNavigationPost,
-				] ),
-				hasLoadedInnerBlocks: hasFinishedResolution(
-					'getEntityRecord',
-					[ 'postType', 'wp_navigation', selectedNavigationPost ]
-				),
-			};
-		}, [] );
+		let navigationPost, isLoading, hasLoaded;
+		if ( selectedNavBlockId ) {
+			navigationPost = getBlock( selectedNavBlockId )?.attributes?.ref;
+			isLoading = isResolving( 'getEntityRecord', [
+				'postType',
+				'wp_navigation',
+				navigationPost,
+			] );
+			hasLoaded = hasFinishedResolution( 'getEntityRecord', [
+				'postType',
+				'wp_navigation',
+				navigationPost,
+			] );
+		} else {
+			const navigationMenus = getEntityRecords(
+				...NAVIGATION_MENUS_QUERY
+			);
+			if ( navigationMenus?.length > 0 ) {
+				navigationPost = navigationMenus[ 0 ].id;
+			}
+			isLoading = isResolving(
+				'getEntityRecords',
+				NAVIGATION_MENUS_QUERY
+			);
+			hasLoaded = hasFinishedResolution(
+				'getEntityRecords',
+				NAVIGATION_MENUS_QUERY
+			);
+		}
+
+		return {
+			navigationPostId: navigationPost,
+			navigationBlockId: selectedNavBlockId,
+			isLoadingInnerBlocks: isLoading,
+			hasLoadedInnerBlocks: hasLoaded,
+		};
+	}, [] );
 
 	useEffect( () => {
 		if ( isLoadingInnerBlocks ) {
@@ -60,7 +117,8 @@ export default function NavigationInspector( { onSelect } ) {
 		<div className="edit-site-navigation-inspector">
 			{ hasLoadedInnerBlocks &&
 				! isLoadingInnerBlocks &&
-				! navigationBlockId && (
+				! navigationBlockId &&
+				! navigationPostId && (
 					<p className="edit-site-navigation-inspector__empty-msg">
 						{ __( 'There are no Navigation Menus.' ) }
 					</p>
@@ -76,12 +134,20 @@ export default function NavigationInspector( { onSelect } ) {
 					<div className="edit-site-navigation-inspector__placeholder is-child" />
 				</>
 			) }
-			{ navigationBlockId && hasLoadedInnerBlocks && (
+			{ navigationBlockId && navigationPostId && hasLoadedInnerBlocks && (
 				<NavigationMenu
 					onSelect={ onSelect }
 					navigationBlockId={ navigationBlockId }
 				/>
 			) }
+			{ ! navigationBlockId &&
+				navigationPostId &&
+				hasLoadedInnerBlocks && (
+					<NavigationBlockEditorLoader
+						onSelect={ onSelect }
+						navigationPostId={ navigationPostId }
+					/>
+				) }
 		</div>
 	);
 }

--- a/packages/edit-site/src/components/navigation-inspector/index.js
+++ b/packages/edit-site/src/components/navigation-inspector/index.js
@@ -174,10 +174,7 @@ export default function NavigationInspector( { onSelect } ) {
 					onChange={ onChange }
 					onInput={ onInput }
 				>
-					<NavigationMenu
-						innerBlocks={ publishedInnerBlocks }
-						onSelect={ onSelect }
-					/>
+					<NavigationMenu onSelect={ onSelect } />
 				</BlockEditorProvider>
 			) }
 

--- a/packages/edit-site/src/components/navigation-inspector/index.js
+++ b/packages/edit-site/src/components/navigation-inspector/index.js
@@ -174,7 +174,10 @@ export default function NavigationInspector( { onSelect } ) {
 					onChange={ onChange }
 					onInput={ onInput }
 				>
-					<NavigationMenu onSelect={ onSelect } />
+					<NavigationMenu
+						innerBlocks={ publishedInnerBlocks }
+						onSelect={ onSelect }
+					/>
 				</BlockEditorProvider>
 			) }
 

--- a/packages/edit-site/src/components/navigation-inspector/index.js
+++ b/packages/edit-site/src/components/navigation-inspector/index.js
@@ -2,12 +2,9 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useState, useEffect } from '@wordpress/element';
-import { store as coreStore, useEntityBlockEditor } from '@wordpress/core-data';
-import {
-	store as blockEditorStore,
-	BlockEditorProvider,
-} from '@wordpress/block-editor';
+import { useEffect } from '@wordpress/element';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { speak } from '@wordpress/a11y';
 import { __ } from '@wordpress/i18n';
 
@@ -16,129 +13,38 @@ import { __ } from '@wordpress/i18n';
  */
 import NavigationMenu from './navigation-menu';
 
-const NAVIGATION_MENUS_QUERY = [ { per_page: -1, status: 'publish' } ];
-
 export default function NavigationInspector( { onSelect } ) {
-	const {
-		selectedNavigationBlockId,
-		clientIdToRef,
-		navigationMenus,
-		isResolvingNavigationMenus,
-		hasResolvedNavigationMenus,
-		firstNavigationBlockId,
-	} = useSelect( ( select ) => {
-		const {
-			__experimentalGetActiveBlockIdByBlockNames,
-			__experimentalGetGlobalBlocksByName,
-			getBlock,
-		} = select( blockEditorStore );
-
-		const { getEntityRecords, hasFinishedResolution, isResolving } =
-			select( coreStore );
-
-		const navigationMenusQuery = [
-			'postType',
-			'wp_navigation',
-			NAVIGATION_MENUS_QUERY[ 0 ],
-		];
-
-		// Get the active Navigation block (if present).
-		const selectedNavId =
-			__experimentalGetActiveBlockIdByBlockNames( 'core/navigation' );
-
-		// Get all Navigation blocks currently within the editor canvas.
-		const navBlockIds =
-			__experimentalGetGlobalBlocksByName( 'core/navigation' );
-		const idToRef = {};
-		navBlockIds.forEach( ( id ) => {
-			idToRef[ id ] = getBlock( id )?.attributes?.ref;
-		} );
-		return {
-			selectedNavigationBlockId: selectedNavId,
-			firstNavigationBlockId: navBlockIds?.[ 0 ],
-			clientIdToRef: idToRef,
-			navigationMenus: getEntityRecords( ...navigationMenusQuery ),
-			isResolvingNavigationMenus: isResolving(
-				'getEntityRecords',
-				navigationMenusQuery
-			),
-			hasResolvedNavigationMenus: hasFinishedResolution(
-				'getEntityRecords',
-				navigationMenusQuery
-			),
-		};
-	}, [] );
-
-	const firstNavRefInTemplate = clientIdToRef[ firstNavigationBlockId ];
-	const firstNavigationMenuRef = navigationMenus?.[ 0 ]?.id;
-
-	// Default Navigation Menu is either:
-	// - the Navigation Menu referenced by the first Nav block within the template.
-	// - the first of the available Navigation Menus (`wp_navigation`) posts.
-	const defaultNavigationMenuId =
-		firstNavRefInTemplate || firstNavigationMenuRef;
-
-	// The Navigation Menu manually selected by the user within the Nav inspector.
-	const [ currentMenuId, setCurrentMenuId ] = useState(
-		firstNavRefInTemplate
-	);
-
-	// If a Nav block is selected within the canvas then set the
-	// Navigation Menu referenced by it's `ref` attribute  to be
-	// active within the Navigation sidebar.
-	useEffect( () => {
-		if ( selectedNavigationBlockId ) {
-			setCurrentMenuId( clientIdToRef[ selectedNavigationBlockId ] );
-		}
-	}, [ selectedNavigationBlockId ] );
-
-	const [ innerBlocks, onInput, onChange ] = useEntityBlockEditor(
-		'postType',
-		'wp_navigation',
-		{ id: currentMenuId || defaultNavigationMenuId }
-	);
-
-	const { isLoadingInnerBlocks, hasLoadedInnerBlocks } = useSelect(
-		( select ) => {
+	const { navigationBlockId, isLoadingInnerBlocks, hasLoadedInnerBlocks } =
+		useSelect( ( select ) => {
+			const {
+				__experimentalGetActiveBlockIdByBlockNames,
+				__experimentalGetGlobalBlocksByName,
+				getBlock,
+			} = select( blockEditorStore );
 			const { isResolving, hasFinishedResolution } = select( coreStore );
+
+			const selectedNavBlockId =
+				__experimentalGetActiveBlockIdByBlockNames(
+					'core/navigation'
+				) ||
+				__experimentalGetGlobalBlocksByName( 'core/navigation' )?.[ 0 ];
+			const selectedNavigationPost =
+				selectedNavBlockId &&
+				getBlock( selectedNavBlockId )?.attributes?.ref;
+
 			return {
+				navigationBlockId: selectedNavBlockId,
 				isLoadingInnerBlocks: isResolving( 'getEntityRecord', [
 					'postType',
 					'wp_navigation',
-					currentMenuId || defaultNavigationMenuId,
+					selectedNavigationPost,
 				] ),
 				hasLoadedInnerBlocks: hasFinishedResolution(
 					'getEntityRecord',
-					[
-						'postType',
-						'wp_navigation',
-						currentMenuId || defaultNavigationMenuId,
-					]
+					[ 'postType', 'wp_navigation', selectedNavigationPost ]
 				),
 			};
-		},
-		[ currentMenuId, defaultNavigationMenuId ]
-	);
-
-	const isLoading = ! ( hasResolvedNavigationMenus && hasLoadedInnerBlocks );
-
-	const hasNavigationMenus = !! navigationMenus?.length;
-
-	// Entity block editor will return entities that are not currently published.
-	// Guard by only allowing their usage if there are published Nav Menus.
-	const publishedInnerBlocks = hasNavigationMenus ? innerBlocks : [];
-
-	const hasInnerBlocks = !! publishedInnerBlocks?.length;
-
-	useEffect( () => {
-		if ( isResolvingNavigationMenus ) {
-			speak( 'Loading Navigation sidebar menus.' );
-		}
-
-		if ( hasResolvedNavigationMenus ) {
-			speak( 'Navigation sidebar menus have loaded.' );
-		}
-	}, [ isResolvingNavigationMenus, hasResolvedNavigationMenus ] );
+		}, [] );
 
 	useEffect( () => {
 		if ( isLoadingInnerBlocks ) {
@@ -152,36 +58,29 @@ export default function NavigationInspector( { onSelect } ) {
 
 	return (
 		<div className="edit-site-navigation-inspector">
-			{ hasResolvedNavigationMenus && ! hasNavigationMenus && (
-				<p className="edit-site-navigation-inspector__empty-msg">
-					{ __( 'There are no Navigation Menus.' ) }
-				</p>
-			) }
+			{ hasLoadedInnerBlocks &&
+				! isLoadingInnerBlocks &&
+				! navigationBlockId && (
+					<p className="edit-site-navigation-inspector__empty-msg">
+						{ __( 'There are no Navigation Menus.' ) }
+					</p>
+				) }
 
-			{ ! hasResolvedNavigationMenus && (
+			{ ! hasLoadedInnerBlocks && (
 				<div className="edit-site-navigation-inspector__placeholder" />
 			) }
-			{ isLoading && (
+			{ isLoadingInnerBlocks && (
 				<>
 					<div className="edit-site-navigation-inspector__placeholder is-child" />
 					<div className="edit-site-navigation-inspector__placeholder is-child" />
 					<div className="edit-site-navigation-inspector__placeholder is-child" />
 				</>
 			) }
-			{ hasInnerBlocks && ! isLoading && (
-				<BlockEditorProvider
-					value={ publishedInnerBlocks }
-					onChange={ onChange }
-					onInput={ onInput }
-				>
-					<NavigationMenu onSelect={ onSelect } />
-				</BlockEditorProvider>
-			) }
-
-			{ ! hasInnerBlocks && ! isLoading && (
-				<p className="edit-site-navigation-inspector__empty-msg">
-					{ __( 'Navigation Menu is empty.' ) }
-				</p>
+			{ navigationBlockId && hasLoadedInnerBlocks && (
+				<NavigationMenu
+					onSelect={ onSelect }
+					navigationBlockId={ navigationBlockId }
+				/>
 			) }
 		</div>
 	);

--- a/packages/edit-site/src/components/navigation-inspector/navigation-menu.js
+++ b/packages/edit-site/src/components/navigation-inspector/navigation-menu.js
@@ -4,30 +4,71 @@
 import {
 	privateApis as blockEditorPrivateApis,
 	store as blockEditorStore,
+	BlockList,
+	BlockTools,
 } from '@wordpress/block-editor';
-import { useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../private-apis';
 
-/**
- * Experimental dependencies
- */
-const { OffCanvasEditor, LeafMoreMenu } = unlock( blockEditorPrivateApis );
+const ALLOWED_BLOCKS = {
+	'core/navigation': [
+		'core/navigation-link',
+		'core/search',
+		'core/social-links',
+		'core/page-list',
+		'core/spacer',
+		'core/home-link',
+		'core/site-title',
+		'core/site-logo',
+		'core/navigation-submenu',
+	],
+	'core/social-links': [ 'core/social-link' ],
+	'core/navigation-submenu': [
+		'core/navigation-link',
+		'core/navigation-submenu',
+	],
+	'core/navigation-link': [
+		'core/navigation-link',
+		'core/navigation-submenu',
+	],
+	'core/page-list': [ 'core/page-list-item' ],
+};
 
-export default function NavigationMenu( { onSelect, navigationBlockId } ) {
-	const { clientIdsTree } = useSelect(
-		( select ) => {
-			const { __unstableGetClientIdsTree } = select( blockEditorStore );
-			return {
-				clientIdsTree: __unstableGetClientIdsTree( navigationBlockId ),
-			};
-		},
-		[ navigationBlockId ]
-	);
+export default function NavigationMenu( { onSelect } ) {
+	const { clientIdsTree, innerBlocks } = useSelect( ( select ) => {
+		const { __unstableGetClientIdsTree, getBlocks } =
+			select( blockEditorStore );
+		return {
+			clientIdsTree: __unstableGetClientIdsTree(),
+			innerBlocks: getBlocks(),
+		};
+	} );
+	const { updateBlockListSettings } = useDispatch( blockEditorStore );
 
+	const { OffCanvasEditor, LeafMoreMenu } = unlock( blockEditorPrivateApis );
+
+	//TODO: Block settings are normally updated as a side effect of rendering InnerBlocks in BlockList
+	//Think through a better way of doing this, possible with adding allowed blocks to block library metadata
+	useEffect( () => {
+		updateBlockListSettings( '', {
+			allowedBlocks: ALLOWED_BLOCKS[ 'core/navigation' ],
+		} );
+		innerBlocks.forEach( ( block ) => {
+			if ( ALLOWED_BLOCKS[ block.name ] ) {
+				updateBlockListSettings( block.clientId, {
+					allowedBlocks: ALLOWED_BLOCKS[ block.name ],
+				} );
+			}
+		} );
+	}, [ updateBlockListSettings, innerBlocks ] );
+
+	// The hidden block is needed because it makes block edit side effects trigger.
+	// For example a navigation page list load its items has an effect on edit to load its items.
 	return (
 		<>
 			<OffCanvasEditor
@@ -35,6 +76,11 @@ export default function NavigationMenu( { onSelect, navigationBlockId } ) {
 				onSelect={ onSelect }
 				LeafMoreMenu={ LeafMoreMenu }
 			/>
+			<div style={ { display: 'none' } }>
+				<BlockTools>
+					<BlockList />
+				</BlockTools>
+			</div>
 		</>
 	);
 }

--- a/packages/edit-site/src/components/navigation-inspector/navigation-menu.js
+++ b/packages/edit-site/src/components/navigation-inspector/navigation-menu.js
@@ -4,9 +4,11 @@
 import {
 	privateApis as blockEditorPrivateApis,
 	store as blockEditorStore,
+	BlockList,
+	BlockTools,
 } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -34,9 +36,18 @@ const ALLOWED_BLOCKS = {
 		'core/navigation-link',
 		'core/navigation-submenu',
 	],
+	'core/page-list': [ 'core/page-list-item' ],
 };
 
-export default function NavigationMenu( { innerBlocks, onSelect } ) {
+export default function NavigationMenu( { onSelect } ) {
+	const { clientIdsTree, innerBlocks } = useSelect( ( select ) => {
+		const { __unstableGetClientIdsTree, getBlocks } =
+			select( blockEditorStore );
+		return {
+			clientIdsTree: __unstableGetClientIdsTree(),
+			innerBlocks: getBlocks(),
+		};
+	} );
 	const { updateBlockListSettings } = useDispatch( blockEditorStore );
 
 	const { OffCanvasEditor, LeafMoreMenu } = unlock( blockEditorPrivateApis );
@@ -56,11 +67,20 @@ export default function NavigationMenu( { innerBlocks, onSelect } ) {
 		} );
 	}, [ updateBlockListSettings, innerBlocks ] );
 
+	// The hidden block is needed because it makes block edit side effects trigger.
+	// For example a navigation page list load its items has an effect on edit to load its items.
 	return (
-		<OffCanvasEditor
-			blocks={ innerBlocks }
-			onSelect={ onSelect }
-			LeafMoreMenu={ LeafMoreMenu }
-		/>
+		<>
+			<OffCanvasEditor
+				blocks={ clientIdsTree }
+				onSelect={ onSelect }
+				LeafMoreMenu={ LeafMoreMenu }
+			/>
+			<div style={ { display: 'none' } }>
+				<BlockTools>
+					<BlockList />
+				</BlockTools>
+			</div>
+		</>
 	);
 }

--- a/packages/edit-site/src/components/navigation-inspector/navigation-menu.js
+++ b/packages/edit-site/src/components/navigation-inspector/navigation-menu.js
@@ -4,71 +4,30 @@
 import {
 	privateApis as blockEditorPrivateApis,
 	store as blockEditorStore,
-	BlockList,
-	BlockTools,
 } from '@wordpress/block-editor';
-import { useEffect } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../private-apis';
 
-const ALLOWED_BLOCKS = {
-	'core/navigation': [
-		'core/navigation-link',
-		'core/search',
-		'core/social-links',
-		'core/page-list',
-		'core/spacer',
-		'core/home-link',
-		'core/site-title',
-		'core/site-logo',
-		'core/navigation-submenu',
-	],
-	'core/social-links': [ 'core/social-link' ],
-	'core/navigation-submenu': [
-		'core/navigation-link',
-		'core/navigation-submenu',
-	],
-	'core/navigation-link': [
-		'core/navigation-link',
-		'core/navigation-submenu',
-	],
-	'core/page-list': [ 'core/page-list-item' ],
-};
+/**
+ * Experimental dependencies
+ */
+const { OffCanvasEditor, LeafMoreMenu } = unlock( blockEditorPrivateApis );
 
-export default function NavigationMenu( { onSelect } ) {
-	const { clientIdsTree, innerBlocks } = useSelect( ( select ) => {
-		const { __unstableGetClientIdsTree, getBlocks } =
-			select( blockEditorStore );
-		return {
-			clientIdsTree: __unstableGetClientIdsTree(),
-			innerBlocks: getBlocks(),
-		};
-	} );
-	const { updateBlockListSettings } = useDispatch( blockEditorStore );
+export default function NavigationMenu( { onSelect, navigationBlockId } ) {
+	const { clientIdsTree } = useSelect(
+		( select ) => {
+			const { __unstableGetClientIdsTree } = select( blockEditorStore );
+			return {
+				clientIdsTree: __unstableGetClientIdsTree( navigationBlockId ),
+			};
+		},
+		[ navigationBlockId ]
+	);
 
-	const { OffCanvasEditor, LeafMoreMenu } = unlock( blockEditorPrivateApis );
-
-	//TODO: Block settings are normally updated as a side effect of rendering InnerBlocks in BlockList
-	//Think through a better way of doing this, possible with adding allowed blocks to block library metadata
-	useEffect( () => {
-		updateBlockListSettings( '', {
-			allowedBlocks: ALLOWED_BLOCKS[ 'core/navigation' ],
-		} );
-		innerBlocks.forEach( ( block ) => {
-			if ( ALLOWED_BLOCKS[ block.name ] ) {
-				updateBlockListSettings( block.clientId, {
-					allowedBlocks: ALLOWED_BLOCKS[ block.name ],
-				} );
-			}
-		} );
-	}, [ updateBlockListSettings, innerBlocks ] );
-
-	// The hidden block is needed because it makes block edit side effects trigger.
-	// For example a navigation page list load its items has an effect on edit to load its items.
 	return (
 		<>
 			<OffCanvasEditor
@@ -76,11 +35,6 @@ export default function NavigationMenu( { onSelect } ) {
 				onSelect={ onSelect }
 				LeafMoreMenu={ LeafMoreMenu }
 			/>
-			<div style={ { display: 'none' } }>
-				<BlockTools>
-					<BlockList />
-				</BlockTools>
-			</div>
 		</>
 	);
 }

--- a/packages/edit-site/src/components/navigation-inspector/navigation-menu.js
+++ b/packages/edit-site/src/components/navigation-inspector/navigation-menu.js
@@ -8,7 +8,7 @@ import {
 	BlockTools,
 } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -39,15 +39,7 @@ const ALLOWED_BLOCKS = {
 	'core/page-list': [ 'core/page-list-item' ],
 };
 
-export default function NavigationMenu( { onSelect } ) {
-	const { clientIdsTree, innerBlocks } = useSelect( ( select ) => {
-		const { __unstableGetClientIdsTree, getBlocks } =
-			select( blockEditorStore );
-		return {
-			clientIdsTree: __unstableGetClientIdsTree(),
-			innerBlocks: getBlocks(),
-		};
-	} );
+export default function NavigationMenu( { innerBlocks, onSelect } ) {
 	const { updateBlockListSettings } = useDispatch( blockEditorStore );
 
 	const { OffCanvasEditor, LeafMoreMenu } = unlock( blockEditorPrivateApis );
@@ -72,7 +64,7 @@ export default function NavigationMenu( { onSelect } ) {
 	return (
 		<>
 			<OffCanvasEditor
-				blocks={ clientIdsTree }
+				blocks={ innerBlocks }
 				onSelect={ onSelect }
 				LeafMoreMenu={ LeafMoreMenu }
 			/>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -31,7 +31,6 @@ export default function SidebarNavigationScreenNavigationMenus() {
 				history.push( {
 					postType: 'page',
 					postId: attributes.id,
-					path: '/navigation/single',
 				} );
 			}
 		},

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -15,7 +15,7 @@ export default function SidebarNavigationScreenNavigationMenus() {
 	const history = useHistory();
 	const onSelect = useCallback(
 		( selectedBlock ) => {
-			const { attributes } = selectedBlock;
+			const { attributes, name } = selectedBlock;
 			if (
 				attributes.kind === 'post-type' &&
 				attributes.id &&
@@ -25,6 +25,13 @@ export default function SidebarNavigationScreenNavigationMenus() {
 				history.push( {
 					postType: attributes.type,
 					postId: attributes.id,
+				} );
+			}
+			if ( name === 'core/page-list-item' && attributes.id && history ) {
+				history.push( {
+					postType: 'page',
+					postId: attributes.id,
+					path: '/navigation/single',
 				} );
 			}
 		},


### PR DESCRIPTION
This PR makes sure that if a menu has a page list, on the navigation sidebar, we show each item (page link) of the page list. We also include the functionality to navigate to edit a page if a page item is clicked.
This PR also reduces a lot of complexity and removes unnecessary code. With this change now, the navigation sidebar does not use a separate block editor anymore. This change also seem to fix same unexpected crashes while managing the navigation. The change breaks the inserter and there is a simple fix at https://github.com/WordPress/gutenberg/pull/48049 that should be reviewed separately.

## Testing
- Create a menu with a page list item and verify it appears on the navigation sidebar.