### PR TITLE
Add aspect-ratio to post featured image block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -555,7 +555,7 @@ Display a post's featured image. ([Source](https://github.com/WordPress/gutenber
 -	**Name:** core/post-featured-image
 -	**Category:** theme
 -	**Supports:** align (center, full, left, right, wide), anchor, color (~~background~~, ~~text~~), spacing (margin, padding), ~~html~~
--	**Attributes:** customGradient, customOverlayColor, dimRatio, gradient, height, isLink, linkTarget, overlayColor, rel, scale, sizeSlug, width
+-	**Attributes:** aspectRatio, customGradient, customOverlayColor, dimRatio, gradient, height, isLink, linkTarget, overlayColor, rel, scale, sizeSlug, width
 
 ## Post Navigation Link
 

--- a/lib/compat/wordpress-6.2/blocks.php
+++ b/lib/compat/wordpress-6.2/blocks.php
@@ -21,6 +21,7 @@ function gutenberg_safe_style_attrs_6_2( $attrs ) {
 	$attrs[] = 'left';
 	$attrs[] = 'z-index';
 	$attrs[] = 'box-shadow';
+	$attrs[] = 'aspect-ratio';
 
 	return $attrs;
 }

--- a/packages/block-editor/src/components/image-editor/aspect-ratio-dropdown.js
+++ b/packages/block-editor/src/components/image-editor/aspect-ratio-dropdown.js
@@ -54,6 +54,7 @@ export default function AspectRatioDropdown( { toggleProps } ) {
 						} }
 						value={ aspect }
 						aspectRatios={ [
+							// All ratios should be mirrored in PostFeaturedImage in @wordpress/block-library
 							{
 								title: __( 'Original' ),
 								aspect: defaultAspect,

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -11,6 +11,9 @@
 			"type": "boolean",
 			"default": false
 		},
+		"aspectRatio": {
+			"type": "string"
+		},
 		"width": {
 			"type": "string"
 		},

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -49,7 +49,7 @@ const scaleHelp = {
 
 const DimensionControls = ( {
 	clientId,
-	attributes: { width, height, scale, sizeSlug },
+	attributes: { aspectRatio, width, height, scale, sizeSlug },
 	setAttributes,
 	imageSizeOptions = [],
 } ) => {
@@ -72,6 +72,68 @@ const DimensionControls = ( {
 	const scaleLabel = _x( 'Scale', 'Image scaling options' );
 	return (
 		<InspectorControls group="dimensions">
+			<ToolsPanelItem
+				hasValue={ () => !! aspectRatio }
+				label={ __( 'Aspect ratio' ) }
+				onDeselect={ () => setAttributes( { aspectRatio: undefined } ) }
+				resetAllFilter={ () => ( {
+					aspectRatio: undefined,
+				} ) }
+				isShownByDefault={ true }
+				panelId={ clientId }
+			>
+				<SelectControl
+					__nextHasNoMarginBottom
+					label={ __( 'Aspect ratio' ) }
+					value={ aspectRatio }
+					options={ [
+						// These should use the same values as AspectRatioDropdown in @wordpress/block-editor
+						{
+							label: __( 'Original' ),
+							value: 'auto',
+						},
+						{
+							label: __( 'Square' ),
+							value: '1 / 1',
+						},
+						{
+							label: __( '16:10' ),
+							value: '16 / 10',
+						},
+						{
+							label: __( '16:9' ),
+							value: '16 / 9',
+						},
+						{
+							label: __( '4:3' ),
+							value: '4 / 3',
+						},
+						{
+							label: __( '3:2' ),
+							value: '3 / 2',
+						},
+						{
+							label: __( '10:16' ),
+							value: '10 / 16',
+						},
+						{
+							label: __( '9:16' ),
+							value: '9 / 16',
+						},
+						{
+							label: __( '3:4' ),
+							value: '3 / 4',
+						},
+						{
+							label: __( '2:3' ),
+							value: '2 / 3',
+						},
+					] }
+					onChange={ ( nextAspectRatio ) =>
+						setAttributes( { aspectRatio: nextAspectRatio } )
+					}
+				/>
+			</ToolsPanelItem>
 			<ToolsPanelItem
 				className="single-column"
 				hasValue={ () => !! height }
@@ -116,7 +178,7 @@ const DimensionControls = ( {
 					units={ units }
 				/>
 			</ToolsPanelItem>
-			{ !! height && (
+			{ ( height || aspectRatio ) && (
 				<ToolsPanelItem
 					hasValue={ () => !! scale && scale !== DEFAULT_SCALE }
 					label={ scaleLabel }

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -94,39 +94,39 @@ const DimensionControls = ( {
 						},
 						{
 							label: __( 'Square' ),
-							value: '1 / 1',
+							value: '1',
 						},
 						{
 							label: __( '16:10' ),
-							value: '16 / 10',
+							value: '16/10',
 						},
 						{
 							label: __( '16:9' ),
-							value: '16 / 9',
+							value: '16/9',
 						},
 						{
 							label: __( '4:3' ),
-							value: '4 / 3',
+							value: '4/3',
 						},
 						{
 							label: __( '3:2' ),
-							value: '3 / 2',
+							value: '3/2',
 						},
 						{
 							label: __( '10:16' ),
-							value: '10 / 16',
+							value: '10/16',
 						},
 						{
 							label: __( '9:16' ),
-							value: '9 / 16',
+							value: '9/16',
 						},
 						{
 							label: __( '3:4' ),
-							value: '3 / 4',
+							value: '3/4',
 						},
 						{
 							label: __( '2:3' ),
-							value: '2 / 3',
+							value: '2/3',
 						},
 					] }
 					onChange={ ( nextAspectRatio ) =>

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -229,6 +229,7 @@ export default function PostFeaturedImageEdit( {
 		height,
 		aspectRatio,
 		objectFit: !! ( height || aspectRatio ) && scale,
+		width: !! ( height && aspectRatio ) && 'auto',
 	};
 
 	/**

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -109,7 +109,10 @@ export default function PostFeaturedImageEdit( {
 					borderProps.className
 				) }
 				withIllustration={ true }
-				style={ borderProps.style }
+				style={ {
+					...blockProps.style,
+					...borderProps.style,
+				} }
 			>
 				{ content }
 			</Placeholder>

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -50,8 +50,16 @@ export default function PostFeaturedImageEdit( {
 	context: { postId, postType: postTypeSlug, queryId },
 } ) {
 	const isDescendentOfQueryLoop = Number.isFinite( queryId );
-	const { isLink, height, width, scale, sizeSlug, rel, linkTarget } =
-		attributes;
+	const {
+		isLink,
+		aspectRatio,
+		height,
+		width,
+		scale,
+		sizeSlug,
+		rel,
+		linkTarget,
+	} = attributes;
 	const [ featuredImage, setFeaturedImage ] = useEntityProp(
 		'postType',
 		postTypeSlug,
@@ -219,7 +227,8 @@ export default function PostFeaturedImageEdit( {
 	const imageStyles = {
 		...borderProps.style,
 		height,
-		objectFit: height && scale,
+		aspectRatio,
+		objectFit: ( height || aspectRatio ) && scale,
 	};
 
 	/**

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -97,7 +97,7 @@ export default function PostFeaturedImageEdit( {
 		} ) );
 
 	const blockProps = useBlockProps( {
-		style: { width, height },
+		style: { width, height, aspectRatio },
 	} );
 	const borderProps = useBorderProps( attributes );
 
@@ -226,10 +226,9 @@ export default function PostFeaturedImageEdit( {
 	const label = __( 'Add a featured image' );
 	const imageStyles = {
 		...borderProps.style,
-		height,
-		aspectRatio,
+		height: ( !! aspectRatio && '100%' ) || height,
+		width: !! aspectRatio && '100%',
 		objectFit: !! ( height || aspectRatio ) && scale,
-		width: !! ( height && aspectRatio ) && 'auto',
 	};
 
 	/**

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -228,7 +228,7 @@ export default function PostFeaturedImageEdit( {
 		...borderProps.style,
 		height,
 		aspectRatio,
-		objectFit: ( height || aspectRatio ) && scale,
+		objectFit: !! ( height || aspectRatio ) && scale,
 	};
 
 	/**

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -42,11 +42,21 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 		}
 	}
 
+	$extra_styles = '';
+
 	if ( ! empty( $attributes['height'] ) ) {
-		$extra_styles = "height:{$attributes['height']};";
-		if ( ! empty( $attributes['scale'] ) ) {
-			$extra_styles .= "object-fit:{$attributes['scale']};";
-		}
+		$extra_styles .= "height:{$attributes['height']};";
+	}
+
+	if ( ! empty( $attributes['aspectRatio'] ) ) {
+		$extra_styles .= "aspect-ratio:{$attributes['aspectRatio']};";
+	}
+
+	if ( ! empty( $attributes['scale'] ) ) {
+		$extra_styles .= "object-fit:{$attributes['scale']};";
+	}
+
+	if ( ! empty( $extra_styles ) ) {
 		$attr['style'] = empty( $attr['style'] ) ? $extra_styles : $attr['style'] . $extra_styles;
 	}
 

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -44,17 +44,11 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 
 	$extra_styles = '';
 
-	if ( ! empty( $attributes['height'] ) ) {
-		$extra_styles .= "height:{$attributes['height']};";
-	}
-
+	// Aspect ratio with a height set needs to override the default width/height.
 	if ( ! empty( $attributes['aspectRatio'] ) ) {
-		$extra_styles .= "aspect-ratio:{$attributes['aspectRatio']};";
-
-		// Aspect ratio with a height set needs to override the 100% width
-		if ( ! empty( $attributes['height'] ) ) {
-			$extra_styles .= 'width:auto;';
-		}
+		$extra_styles .= 'width:100%;height:100%;';
+	} elseif ( ! empty( $attributes['height'] ) ) {
+		$extra_styles .= "height:{$attributes['height']};";
 	}
 
 	if ( ! empty( $attributes['scale'] ) ) {
@@ -86,12 +80,19 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 		$featured_image = $featured_image . $overlay_markup;
 	}
 
-	$width  = ! empty( $attributes['width'] ) ? esc_attr( safecss_filter_attr( 'width:' . $attributes['width'] ) ) . ';' : '';
-	$height = ! empty( $attributes['height'] ) ? esc_attr( safecss_filter_attr( 'height:' . $attributes['height'] ) ) . ';' : '';
-	if ( ! $height && ! $width ) {
+	$aspect_ratio  = ! empty( $attributes['aspectRatio'] )
+		? esc_attr( safecss_filter_attr( 'aspect-ratio:' . $attributes['aspectRatio'] ) ) . ';'
+		: '';
+	$width         = ! empty( $attributes['width'] )
+		? esc_attr( safecss_filter_attr( 'width:' . $attributes['width'] ) ) . ';'
+		: '';
+	$height        = ! empty( $attributes['height'] )
+		? esc_attr( safecss_filter_attr( 'height:' . $attributes['height'] ) ) . ';'
+		: '';
+	if ( ! $height && ! $width && ! $aspect_ratio ) {
 		$wrapper_attributes = get_block_wrapper_attributes();
 	} else {
-		$wrapper_attributes = get_block_wrapper_attributes( array( 'style' => $width . $height ) );
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'style' => $aspect_ratio . $width . $height ) );
 	}
 	return "<figure {$wrapper_attributes}>{$featured_image}</figure>";
 }

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -50,6 +50,11 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 
 	if ( ! empty( $attributes['aspectRatio'] ) ) {
 		$extra_styles .= "aspect-ratio:{$attributes['aspectRatio']};";
+
+		// Aspect ratio with a height set needs to override the 100% width
+		if ( ! empty( $attributes['height'] ) ) {
+			$extra_styles .= 'width:auto;';
+		}
 	}
 
 	if ( ! empty( $attributes['scale'] ) ) {

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -80,13 +80,13 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 		$featured_image = $featured_image . $overlay_markup;
 	}
 
-	$aspect_ratio  = ! empty( $attributes['aspectRatio'] )
+	$aspect_ratio = ! empty( $attributes['aspectRatio'] )
 		? esc_attr( safecss_filter_attr( 'aspect-ratio:' . $attributes['aspectRatio'] ) ) . ';'
 		: '';
-	$width         = ! empty( $attributes['width'] )
+	$width        = ! empty( $attributes['width'] )
 		? esc_attr( safecss_filter_attr( 'width:' . $attributes['width'] ) ) . ';'
 		: '';
-	$height        = ! empty( $attributes['height'] )
+	$height       = ! empty( $attributes['height'] )
 		? esc_attr( safecss_filter_attr( 'height:' . $attributes['height'] ) ) . ';'
 		: '';
 	if ( ! $height && ! $width && ! $aspect_ratio ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

This requires a change to kses to allow the aspect-ratio property. WordPress/wordpress-develop#4032.

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #47274. Does not include the sectioned select dropdown UI which can come as a follow-up.

Adds CSS aspect-ratio controls to the Post Featured Image block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

A simpler starting place for aspect ratio is in the context of the Post Featured Image block since it doesn't already have cropping options and it is displaying dynamic content.

It gives more options for controlling the size of the image without needing to explicitly set width or height parameters.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds controls for the aspect ratio above width and height that apply the aspect-ratio CSS property to the container of the block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

This requires a change to kses to allow the aspect-ratio property. https://github.com/WordPress/wordpress-develop/pull/4032.

1. Insert Post Featured Image blocks
2. Use various combinations of settings under Styles > Dimensions

<details>
<summary>Block examples html</summary>

```html
<!-- wp:heading -->
<h2 class="wp-block-heading">Default</h2>
<!-- /wp:heading -->

<!-- wp:post-featured-image /-->

<!-- wp:heading -->
<h2 class="wp-block-heading">Small w/h</h2>
<!-- /wp:heading -->

<!-- wp:post-featured-image {"width":"400px","height":"400px"} /-->

<!-- wp:heading -->
<h2 class="wp-block-heading">Large w/h</h2>
<!-- /wp:heading -->

<!-- wp:post-featured-image {"width":"600px","height":"600px"} /-->

<!-- wp:heading -->
<h2 class="wp-block-heading">Small width</h2>
<!-- /wp:heading -->

<!-- wp:post-featured-image {"width":"400px"} /-->

<!-- wp:heading -->
<h2 class="wp-block-heading">Large width</h2>
<!-- /wp:heading -->

<!-- wp:post-featured-image {"width":"600px"} /-->

<!-- wp:heading -->
<h2 class="wp-block-heading">Small height</h2>
<!-- /wp:heading -->

<!-- wp:post-featured-image {"height":"400px"} /-->

<!-- wp:heading -->
<h2 class="wp-block-heading">Large height</h2>
<!-- /wp:heading -->

<!-- wp:post-featured-image {"height":"600px"} /-->

<!-- wp:heading -->
<h2 class="wp-block-heading">Horizontal no w/h</h2>
<!-- /wp:heading -->

<!-- wp:post-featured-image {"aspectRatio":"3/2","width":"","height":""} /-->

<!-- wp:heading -->
<h2 class="wp-block-heading">Horizontal small w/h</h2>
<!-- /wp:heading -->

<!-- wp:post-featured-image {"aspectRatio":"3/2","width":"400px","height":"400px"} /-->

<!-- wp:heading -->
<h2 class="wp-block-heading">Horizontal large w/h</h2>
<!-- /wp:heading -->

<!-- wp:post-featured-image {"aspectRatio":"3/2","width":"600px","height":"600px"} /-->

<!-- wp:heading -->
<h2 class="wp-block-heading">Horizontal small width</h2>
<!-- /wp:heading -->

<!-- wp:post-featured-image {"aspectRatio":"3/2","width":"400px"} /-->

<!-- wp:heading -->
<h2 class="wp-block-heading">Horizontal large width</h2>
<!-- /wp:heading -->

<!-- wp:post-featured-image {"aspectRatio":"3/2","width":"600px"} /-->

<!-- wp:heading -->
<h2 class="wp-block-heading">Horizontal small height</h2>
<!-- /wp:heading -->

<!-- wp:post-featured-image {"aspectRatio":"3/2","height":"400px"} /-->

<!-- wp:heading -->
<h2 class="wp-block-heading">Horizontal large height</h2>
<!-- /wp:heading -->

<!-- wp:post-featured-image {"aspectRatio":"3/2","height":"600px"} /-->

<!-- wp:heading -->
<h2 class="wp-block-heading">Vertical no w/h</h2>
<!-- /wp:heading -->

<!-- wp:post-featured-image {"aspectRatio":"2/3"} /-->

<!-- wp:heading -->
<h2 class="wp-block-heading">Vertical small w/h</h2>
<!-- /wp:heading -->

<!-- wp:post-featured-image {"aspectRatio":"2/3","width":"400px","height":"400px"} /-->

<!-- wp:heading -->
<h2 class="wp-block-heading">Vertical large w/h</h2>
<!-- /wp:heading -->

<!-- wp:post-featured-image {"aspectRatio":"2/3","width":"600px","height":"600px"} /-->

<!-- wp:heading -->
<h2 class="wp-block-heading">Vertical small width</h2>
<!-- /wp:heading -->

<!-- wp:post-featured-image {"aspectRatio":"2/3","width":"500px"} /-->

<!-- wp:heading -->
<h2 class="wp-block-heading">Vertical large width</h2>
<!-- /wp:heading -->

<!-- wp:post-featured-image {"aspectRatio":"2/3","width":"600px"} /-->

<!-- wp:heading -->
<h2 class="wp-block-heading">Vertical small height</h2>
<!-- /wp:heading -->

<!-- wp:post-featured-image {"aspectRatio":"2/3","height":"400px"} /-->

<!-- wp:heading -->
<h2 class="wp-block-heading">Vertical large height</h2>
<!-- /wp:heading -->

<!-- wp:post-featured-image {"aspectRatio":"2/3","height":"600px"} /-->
```

</details>

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

1. Navigate to the block inspector under Styles > Dimensions
2. Ensure aspect ratio can be selected with keyboard

## Screenshots or screencast <!-- if applicable -->

### UI

![aspect-ratio-ui](https://user-images.githubusercontent.com/5129775/217396486-9dff38f5-27ff-4389-9f48-9b3edd2878e2.png)

### Output

I tested several combinations which can be copied under "Testing Instructions". The featured image was 512px square. I tested with a width/height smaller than that (400px) and a width/height larger than that (600px). The max-width for the page was 650px.

Pay special attention to "Horizontal large height". The aspect ratio of the image does not match the settings because the height and max-width properties take precedence over aspect-ratio.

![aspect-ratio-examples](https://user-images.githubusercontent.com/5129775/217394569-15c88e06-d48b-48c2-bc8a-c8a31b5fb0e7.png)
