### PR TITLE
Site Editor: Append template type and name to the site editor page title

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -137,10 +137,19 @@ export default function Editor() {
 		[ context ]
 	);
 	const isReady = editedPostType !== undefined && editedPostId !== undefined;
+	const type =
+		editedPostType === 'wp_template'
+			? __( 'Template' )
+			: __( 'Template Part' );
+	let titleBreadcrumb;
+
+	if ( isReady && editedPost ) {
+		titleBreadcrumb = `${ editedPost.title?.rendered } ‹ ${ type } ‹ `;
+	}
 
 	// Only announce the title once the editor is ready to prevent "Replace"
 	// action in <URlQueryController> from double-announcing.
-	useTitle( isReady && __( 'Editor (beta)' ) );
+	useTitle( isReady && `${ titleBreadcrumb }${ __( 'Editor (beta)' ) }` );
 
 	if ( ! isReady ) {
 		return <CanvasSpinner />;

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -137,13 +137,13 @@ export default function Editor() {
 		[ context ]
 	);
 	const isReady = editedPostType !== undefined && editedPostId !== undefined;
-	const type =
-		editedPostType === 'wp_template'
-			? __( 'Template' )
-			: __( 'Template Part' );
-	let titleBreadcrumb;
 
+	let titleBreadcrumb;
 	if ( isReady && editedPost ) {
+		const type =
+			editedPostType === 'wp_template'
+				? __( 'Template' )
+				: __( 'Template Part' );
 		titleBreadcrumb = `${ editedPost.title?.rendered } ‹ ${ type } ‹ `;
 	}
 

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -138,18 +138,20 @@ export default function Editor() {
 	);
 	const isReady = editedPostType !== undefined && editedPostId !== undefined;
 
-	let titleBreadcrumb;
+	let title;
 	if ( isReady && editedPost ) {
 		const type =
 			editedPostType === 'wp_template'
 				? __( 'Template' )
 				: __( 'Template Part' );
-		titleBreadcrumb = `${ editedPost.title?.rendered } ‹ ${ type } ‹ `;
+		title = `${ editedPost.title?.rendered } ‹ ${ type } ‹ ${ __(
+			'Editor (beta)'
+		) }`;
 	}
 
 	// Only announce the title once the editor is ready to prevent "Replace"
 	// action in <URlQueryController> from double-announcing.
-	useTitle( isReady && `${ titleBreadcrumb }${ __( 'Editor (beta)' ) }` );
+	useTitle( isReady && title );
 
 	if ( ! isReady ) {
 		return <CanvasSpinner />;


### PR DESCRIPTION
## What?
Adds the template name and type to the page title

## Why?
Currently every page in the editor has the same tile, which makes navigating the history impossible.

Fixes: #47730

## How?
Passes the page template name and type into the `useTitle` hook.

## Testing Instructions
Open the site editor
Navigate to different templates and template parts
Check that the page title updates with the template type and name as you navigate, and that the browser history shows the full page titles

## Screenshots or screencast <!-- if applicable -->

Before:

https://user-images.githubusercontent.com/3629020/217401640-da2d8728-9630-4409-a336-bd3d7a81900e.mp4

After:

https://user-images.githubusercontent.com/3629020/217401666-0755bf2e-6e33-486a-afc5-534ebd47bd11.mp4




