### PR TITLE
Navigation: e2e tests: default to classic menu

### DIFF
--- a/packages/e2e-test-utils-playwright/src/request-utils/index.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/index.ts
@@ -21,7 +21,11 @@ import { activateTheme } from './themes';
 import { deleteAllBlocks } from './blocks';
 import { createComment, deleteAllComments } from './comments';
 import { createPost, deleteAllPosts } from './posts';
-import { createNavigationMenu, deleteAllNavigationMenus } from './menus';
+import {
+	createClassicMenu,
+	createNavigationMenu,
+	deleteAllMenus,
+} from './menus';
 import { resetPreferences } from './preferences';
 import { getSiteSettings, updateSiteSettings } from './site-settings';
 import { deleteAllWidgets, addWidgetBlock } from './widgets';
@@ -126,8 +130,9 @@ class RequestUtils {
 	deleteAllBlocks = deleteAllBlocks;
 	createPost = createPost.bind( this );
 	deleteAllPosts = deleteAllPosts.bind( this );
+	createClassicMenu = createClassicMenu.bind( this );
 	createNavigationMenu = createNavigationMenu.bind( this );
-	deleteAllNavigationMenus = deleteAllNavigationMenus.bind( this );
+	deleteAllMenus = deleteAllMenus.bind( this );
 	createComment = createComment.bind( this );
 	deleteAllComments = deleteAllComments.bind( this );
 	deleteAllWidgets = deleteAllWidgets.bind( this );

--- a/packages/e2e-test-utils-playwright/src/request-utils/index.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/index.ts
@@ -21,6 +21,7 @@ import { activateTheme } from './themes';
 import { deleteAllBlocks } from './blocks';
 import { createComment, deleteAllComments } from './comments';
 import { createPost, deleteAllPosts } from './posts';
+import { createNavigationMenu, deleteAllNavigationMenus } from './menus';
 import { resetPreferences } from './preferences';
 import { getSiteSettings, updateSiteSettings } from './site-settings';
 import { deleteAllWidgets, addWidgetBlock } from './widgets';
@@ -125,6 +126,8 @@ class RequestUtils {
 	deleteAllBlocks = deleteAllBlocks;
 	createPost = createPost.bind( this );
 	deleteAllPosts = deleteAllPosts.bind( this );
+	createNavigationMenu = createNavigationMenu.bind( this );
+	deleteAllNavigationMenus = deleteAllNavigationMenus.bind( this );
 	createComment = createComment.bind( this );
 	deleteAllComments = deleteAllComments.bind( this );
 	deleteAllWidgets = deleteAllWidgets.bind( this );

--- a/packages/e2e-test-utils-playwright/src/request-utils/menus.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/menus.ts
@@ -1,0 +1,53 @@
+/**
+ * Internal dependencies
+ */
+import type { RequestUtils } from './index';
+
+export interface MenuData {
+	title: string;
+	content: string;
+}
+export interface Navigation {
+	id: number;
+	content: string;
+	status: 'publish' | 'future' | 'draft' | 'pending' | 'private';
+}
+
+/**
+ * Create a navigation menu
+ *
+ * @param {Object} menuData navigation menu post data.
+ * @return {string} Menu content.
+ */
+export async function createNavigationMenu(
+	this: RequestUtils,
+	menuData: MenuData
+) {
+	return this.rest( {
+		method: 'POST',
+		path: `/wp/v2/navigation/`,
+		data: {
+			status: 'publish',
+			...menuData,
+		},
+	} );
+}
+
+/**
+ * Delete all navigation menus
+ *
+ */
+export async function deleteAllNavigationMenus( this: RequestUtils ) {
+	const menus = await this.rest< Navigation[] >( {
+		path: `/wp/v2/navigation/`,
+	} );
+
+	if ( ! menus?.length ) return;
+
+	await this.batchRest(
+		menus.map( ( menu ) => ( {
+			method: 'DELETE',
+			path: `/wp/v2/navigation/${ menu.id }?force=true`,
+		} ) )
+	);
+}

--- a/packages/e2e-test-utils-playwright/src/request-utils/menus.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/menus.ts
@@ -7,7 +7,7 @@ export interface MenuData {
 	title: string;
 	content: string;
 }
-export interface Menu {
+export interface NavigationMenu {
 	id: number;
 	content: string;
 	status: 'publish' | 'future' | 'draft' | 'pending' | 'private';
@@ -22,14 +22,14 @@ export interface Menu {
 export async function createClassicMenu( this: RequestUtils, name: string ) {
 	const menuItems = [
 		{
-			title: 'Home',
+			title: 'Custom link',
 			url: 'http://localhost:8889/',
 			type: 'custom',
 			menu_order: 1,
 		},
 	];
 
-	const menu = await this.rest< Menu >( {
+	const menu = await this.rest< NavigationMenu >( {
 		method: 'POST',
 		path: `/wp/v2/menus/`,
 		data: {
@@ -80,7 +80,7 @@ export async function createNavigationMenu(
  *
  */
 export async function deleteAllMenus( this: RequestUtils ) {
-	const navMenus = await this.rest< Menu[] >( {
+	const navMenus = await this.rest< NavigationMenu[] >( {
 		path: `/wp/v2/navigation/`,
 	} );
 
@@ -93,7 +93,7 @@ export async function deleteAllMenus( this: RequestUtils ) {
 		);
 	}
 
-	const classicMenus = await this.rest< Menu[] >( {
+	const classicMenus = await this.rest< NavigationMenu[] >( {
 		path: `/wp/v2/menus/`,
 	} );
 

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -13,14 +13,14 @@ test.describe(
 
 		test.beforeEach( async ( { admin, requestUtils } ) => {
 			await Promise.all( [
-				requestUtils.deleteAllNavigationMenus(),
+				requestUtils.deleteAllMenus(),
 				admin.createNewPost(),
 			] );
 		} );
 
 		test.afterAll( async ( { requestUtils } ) => {
 			await Promise.all( [
-				requestUtils.deleteAllNavigationMenus(),
+				requestUtils.deleteAllMenus(),
 				requestUtils.activateTheme( 'twentytwentyone' ),
 			] );
 		} );
@@ -93,6 +93,21 @@ test.describe(
 					'role=navigation >> role=link[name="WordPress"i]'
 				)
 			).toBeVisible();
+		} );
+
+		test( 'default to the only existing classic menu if there are no block menus', async ( {
+			editor,
+			requestUtils,
+		} ) => {
+			//create a classic menu
+			requestUtils.activateTheme( 'twentytwentyone' );
+
+			await requestUtils.createClassicMenu( 'Test Classic 1' );
+			//insert a navigation block
+			await editor.insertBlock( { name: 'core/navigation' } );
+			await editor.page.pause();
+			//check the block in the canvas.
+			//check the block in the frontend.
 		} );
 	}
 );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -75,6 +75,13 @@ test.describe(
 
 			await editor.insertBlock( { name: 'core/navigation' } );
 
+			//check the block in the canvas.
+			await expect(
+				editor.canvas.locator(
+					'role=textbox[name="Navigation link text"i] >> text="WordPress"'
+				)
+			).toBeVisible();
+
 			// Check the markup of the block is correct.
 			await editor.publishPost();
 			await expect.poll( editor.getBlocks ).toMatchObject( [
@@ -85,18 +92,11 @@ test.describe(
 			] );
 			await page.locator( 'role=button[name="Close panel"i]' ).click();
 
-			//check the block in the canvas.
-			await expect(
-				page.locator(
-					'role=gridcell[name="Custom Link link"] >> a:has-text("WordPress")'
-				)
-			).toBeVisible();
-
 			//check the block in the frontend.
 			await page.goto( '/' );
 			await expect(
 				page.locator(
-					'nav:has-text("WordPress") >> role=link[name="WordPress"]'
+					'role=navigation >> nth=1 >> role=link[name="WordPress"]'
 				)
 			).toBeVisible();
 		} );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -77,10 +77,10 @@ test.describe(
 
 			// Check the markup of the block is correct.
 			await editor.publishPost();
-			const content = await editor.getEditedPostContent();
-			expect( content ).toBe(
-				`<!-- wp:navigation {"ref":${ createdMenu.id }} /-->`
-			);
+			await expect.poll( editor.getBlocks ).toEqual( [ {
+				name: 'core/navigation',
+				ref: createdMenu.id,
+			} ] );
 			await page.locator( 'role=button[name="Close panel"i]' ).click();
 
 			//check the block in the canvas.

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -80,9 +80,25 @@ test.describe(
 			expect( content ).toBe(
 				`<!-- wp:navigation {"ref":${ createdMenu.id }} /-->`
 			);
+			await editor.page
+				.locator( 'role=button[name="Close panel"i]' )
+				.click();
 
-			//check the block in the list view?
-			//check the block in the frontend?
+			//check the block in the canvas.
+			await expect(
+				editor.page.locator(
+					'role=gridcell[name="Custom Link link"] >> a:has-text("WordPress")'
+				)
+			).toBeVisible();
+
+			//check the block in the frontend.
+			await editor.page.goto( '/' );
+			await expect(
+				editor.page.locator(
+					'nav:has-text("WordPress") >> role=link[name="WordPress"]'
+				)
+			).toBeVisible();
+
 			await editor.page.pause();
 		} );
 	}

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -66,14 +66,21 @@ test.describe(
 			editor,
 			navBlockUtils,
 		} ) => {
-			//Create a menu
-			await navBlockUtils.createNavigationMenu( {
+			const createdMenu = await navBlockUtils.createNavigationMenu( {
 				title: 'Test Menu 1',
 				content:
 					'<!-- wp:navigation-link {"label":"WordPress","type":"custom","url":"http://www.wordpress.org/","kind":"custom","isTopLevelLink":true} /-->',
 			} );
-			//insert navigation block
-			//check the markup of the block
+
+			await editor.insertBlock( { name: 'core/navigation' } );
+
+			// Check the markup of the block is correct.
+			await editor.publishPost();
+			const content = await editor.getEditedPostContent();
+			expect( content ).toBe(
+				`<!-- wp:navigation {"ref":${ createdMenu.id }} /-->`
+			);
+
 			//check the block in the list view?
 			//check the block in the frontend?
 			await editor.page.pause();
@@ -110,11 +117,13 @@ class NavigationBlockUtils {
 	 *
 	 */
 	async deleteAllNavigationMenus() {
-		const menus = await this.rest( { path: `/wp/v2/navigation/` } );
+		const menus = await this.requestUtils.rest( {
+			path: `/wp/v2/navigation/`,
+		} );
 
 		if ( ! menus?.length ) return;
 
-		await this.batchRest(
+		await this.requestUtils.batchRest(
 			menus.map( ( menu ) => ( {
 				method: 'DELETE',
 				path: `/wp/v2/navigation/${ menu.id }?force=true`,

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -69,7 +69,7 @@ test.describe(
 
 			await editor.insertBlock( { name: 'core/navigation' } );
 
-			//check the block in the canvas.
+			// Check the block in the canvas.
 			await expect(
 				editor.canvas.locator(
 					'role=textbox[name="Navigation link text"i] >> text="WordPress"'
@@ -86,7 +86,7 @@ test.describe(
 			] );
 			await page.locator( 'role=button[name="Close panel"i]' ).click();
 
-			//check the block in the frontend.
+			// Check the block in the frontend.
 			await page.goto( '/' );
 			await expect(
 				page.locator(
@@ -99,15 +99,19 @@ test.describe(
 			editor,
 			requestUtils,
 		} ) => {
-			//create a classic menu
-			requestUtils.activateTheme( 'twentytwentyone' );
-
+			// Create a classic menu.
 			await requestUtils.createClassicMenu( 'Test Classic 1' );
-			//insert a navigation block
+
 			await editor.insertBlock( { name: 'core/navigation' } );
+			// We need to check the canvas after inserting the navigation block to be able to target the block.
+			const navigationBlock = editor.canvas.locator(
+				'role=document[name="Block: Navigation"i]'
+			);
+			await expect( navigationBlock ).toBeVisible();
+
+			// Check the block in the canvas.
+			// Check the block in the frontend.
 			await editor.page.pause();
-			//check the block in the canvas.
-			//check the block in the frontend.
 		} );
 	}
 );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -96,7 +96,7 @@ test.describe(
 			await page.goto( '/' );
 			await expect(
 				page.locator(
-					'role=navigation >> nth=1 >> role=link[name="WordPress"]'
+					'role=navigation >> nth=1 >> role=link[name="WordPress"i]'
 				)
 			).toBeVisible();
 		} );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -77,10 +77,10 @@ test.describe(
 
 			// Check the markup of the block is correct.
 			await editor.publishPost();
-			await expect.poll( editor.getBlocks ).toEqual( [
+			await expect.poll( editor.getBlocks ).toMatchObject( [
 				{
 					name: 'core/navigation',
-					ref: createdMenu.id,
+					attributes: { ref: createdMenu.id },
 				},
 			] );
 			await page.locator( 'role=button[name="Close panel"i]' ).click();

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -77,10 +77,12 @@ test.describe(
 
 			// Check the markup of the block is correct.
 			await editor.publishPost();
-			await expect.poll( editor.getBlocks ).toEqual( [ {
-				name: 'core/navigation',
-				ref: createdMenu.id,
-			} ] );
+			await expect.poll( editor.getBlocks ).toEqual( [
+				{
+					name: 'core/navigation',
+					ref: createdMenu.id,
+				},
+			] );
 			await page.locator( 'role=button[name="Close panel"i]' ).click();
 
 			//check the block in the canvas.

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -3,6 +3,12 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
+test.use( {
+	navBlockUtils: async ( { editor, page, requestUtils }, use ) => {
+		await use( new NavigationBlockUtils( { editor, page, requestUtils } ) );
+	},
+} );
+
 test.describe(
 	'As a user I want the navigation block to fallback to the best possible default',
 	() => {
@@ -11,11 +17,8 @@ test.describe(
 			await requestUtils.activateTheme( 'twentytwentythree' );
 		} );
 
-		test.beforeEach( async ( { admin, requestUtils } ) => {
-			await Promise.all( [
-				requestUtils.deleteAllMenus(),
-				admin.createNewPost(),
-			] );
+		test.beforeEach( async ( { requestUtils } ) => {
+			await Promise.all( [ requestUtils.deleteAllMenus() ] );
 		} );
 
 		test.afterAll( async ( { requestUtils } ) => {
@@ -30,8 +33,10 @@ test.describe(
 		} );
 
 		test( 'default to a list of pages if there are no menus', async ( {
+			admin,
 			editor,
 		} ) => {
+			await admin.createNewPost();
 			await editor.insertBlock( { name: 'core/navigation' } );
 
 			const pageListBlock = editor.canvas.getByRole( 'document', {
@@ -57,10 +62,13 @@ test.describe(
 		} );
 
 		test( 'default to my only existing menu', async ( {
+			admin,
 			editor,
 			page,
 			requestUtils,
+			navBlockUtils,
 		} ) => {
+			await admin.createNewPost();
 			const createdMenu = await requestUtils.createNavigationMenu( {
 				title: 'Test Menu 1',
 				content:
@@ -70,11 +78,7 @@ test.describe(
 			await editor.insertBlock( { name: 'core/navigation' } );
 
 			// Check the block in the canvas.
-			await expect(
-				editor.canvas.locator(
-					'role=textbox[name="Navigation link text"i] >> text="WordPress"'
-				)
-			).toBeVisible();
+			await navBlockUtils.selectNavigationItemOnCanvas( 'WordPress' );
 
 			// Check the markup of the block is correct.
 			await editor.publishPost();
@@ -87,20 +91,18 @@ test.describe(
 			await page.locator( 'role=button[name="Close panel"i]' ).click();
 
 			// Check the block in the frontend.
-			await page.goto( '/' );
-			await expect(
-				page.locator(
-					'role=navigation >> role=link[name="WordPress"i]'
-				)
-			).toBeVisible();
+			await navBlockUtils.selectNavigationItemOnFrontend( 'WordPress' );
 		} );
 
 		test( 'default to the only existing classic menu if there are no block menus', async ( {
+			admin,
 			editor,
 			requestUtils,
+			navBlockUtils,
 		} ) => {
 			// Create a classic menu.
 			await requestUtils.createClassicMenu( 'Test Classic 1' );
+			await admin.createNewPost();
 
 			await editor.insertBlock( { name: 'core/navigation' } );
 			// We need to check the canvas after inserting the navigation block to be able to target the block.
@@ -110,8 +112,38 @@ test.describe(
 			await expect( navigationBlock ).toBeVisible();
 
 			// Check the block in the canvas.
+			await editor.page.pause();
+			await navBlockUtils.selectNavigationItemOnCanvas( 'Home' );
+
 			// Check the block in the frontend.
+			await navBlockUtils.selectNavigationItemOnFrontend( 'Home' );
 			await editor.page.pause();
 		} );
 	}
 );
+
+class NavigationBlockUtils {
+	constructor( { editor, page, requestUtils } ) {
+		this.editor = editor;
+		this.page = page;
+		this.requestUtils = requestUtils;
+	}
+
+	async selectNavigationItemOnCanvas( name ) {
+		await expect(
+			this.editor.canvas.locator(
+				`role=textbox[name="Navigation link text"i] >> text="${ name }"`
+			)
+		).toBeVisible();
+	}
+
+	async selectNavigationItemOnFrontend( name ) {
+		await this.page.goto( '/' );
+		await this.editor.page.pause();
+		await expect(
+			this.page.locator(
+				`role=navigation >> role=link[name="${ name }"i]`
+			)
+		).toBeVisible();
+	}
+}

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -64,41 +64,19 @@ test.describe(
 
 		test( 'default to my only existing menu', async ( {
 			editor,
-			page,
 			navBlockUtils,
 		} ) => {
-			const createdMenu = await navBlockUtils.createNavigationMenu( {
+			//Create a menu
+			await navBlockUtils.createNavigationMenu( {
 				title: 'Test Menu 1',
 				content:
 					'<!-- wp:navigation-link {"label":"WordPress","type":"custom","url":"http://www.wordpress.org/","kind":"custom","isTopLevelLink":true} /-->',
 			} );
-
-			await editor.insertBlock( { name: 'core/navigation' } );
-
-			//check the block in the canvas.
-			await expect(
-				editor.canvas.locator(
-					'role=textbox[name="Navigation link text"i] >> text="WordPress"'
-				)
-			).toBeVisible();
-
-			// Check the markup of the block is correct.
-			await editor.publishPost();
-			await expect.poll( editor.getBlocks ).toMatchObject( [
-				{
-					name: 'core/navigation',
-					attributes: { ref: createdMenu.id },
-				},
-			] );
-			await page.locator( 'role=button[name="Close panel"i]' ).click();
-
-			//check the block in the frontend.
-			await page.goto( '/' );
-			await expect(
-				page.locator(
-					'role=navigation >> role=link[name="WordPress"i]'
-				)
-			).toBeVisible();
+			//insert navigation block
+			//check the markup of the block
+			//check the block in the list view?
+			//check the block in the frontend?
+			await editor.page.pause();
 		} );
 	}
 );
@@ -132,13 +110,11 @@ class NavigationBlockUtils {
 	 *
 	 */
 	async deleteAllNavigationMenus() {
-		const menus = await this.requestUtils.rest( {
-			path: `/wp/v2/navigation/`,
-		} );
+		const menus = await this.rest( { path: `/wp/v2/navigation/` } );
 
 		if ( ! menus?.length ) return;
 
-		await this.requestUtils.batchRest(
+		await this.batchRest(
 			menus.map( ( menu ) => ( {
 				method: 'DELETE',
 				path: `/wp/v2/navigation/${ menu.id }?force=true`,

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -64,6 +64,7 @@ test.describe(
 
 		test( 'default to my only existing menu', async ( {
 			editor,
+			page,
 			navBlockUtils,
 		} ) => {
 			const createdMenu = await navBlockUtils.createNavigationMenu( {
@@ -80,26 +81,22 @@ test.describe(
 			expect( content ).toBe(
 				`<!-- wp:navigation {"ref":${ createdMenu.id }} /-->`
 			);
-			await editor.page
-				.locator( 'role=button[name="Close panel"i]' )
-				.click();
+			await page.locator( 'role=button[name="Close panel"i]' ).click();
 
 			//check the block in the canvas.
 			await expect(
-				editor.page.locator(
+				page.locator(
 					'role=gridcell[name="Custom Link link"] >> a:has-text("WordPress")'
 				)
 			).toBeVisible();
 
 			//check the block in the frontend.
-			await editor.page.goto( '/' );
+			await page.goto( '/' );
 			await expect(
-				editor.page.locator(
+				page.locator(
 					'nav:has-text("WordPress") >> role=link[name="WordPress"]'
 				)
 			).toBeVisible();
-
-			await editor.page.pause();
 		} );
 	}
 );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -106,17 +106,18 @@ test.describe(
 
 			await editor.insertBlock( { name: 'core/navigation' } );
 			// We need to check the canvas after inserting the navigation block to be able to target the block.
-			const navigationBlock = editor.canvas.locator(
-				'role=document[name="Block: Navigation"i]'
-			);
-			await expect( navigationBlock ).toBeVisible();
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/navigation',
+				},
+			] );
 
 			// Check the block in the canvas.
 			await editor.page.pause();
-			await navBlockUtils.selectNavigationItemOnCanvas( 'Home' );
+			await navBlockUtils.selectNavigationItemOnCanvas( 'Custom link' );
 
 			// Check the block in the frontend.
-			await navBlockUtils.selectNavigationItemOnFrontend( 'Home' );
+			await navBlockUtils.selectNavigationItemOnFrontend( 'Custom link' );
 			await editor.page.pause();
 		} );
 	}

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -90,7 +90,7 @@ test.describe(
 			await page.goto( '/' );
 			await expect(
 				page.locator(
-					'role=navigation >> nth=1 >> role=link[name="WordPress"i]'
+					'role=navigation >> role=link[name="WordPress"i]'
 				)
 			).toBeVisible();
 		} );


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This is part of the effort to re work all the navigation block e2e tests and migration to playwright. This is one of the user stories described in https://github.com/WordPress/gutenberg/issues/45199

This test checks that when only one classic menu exists, inserting a Navigation block will default correctly to using said menu.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Run `npm run test:e2e:playwright -- editor/blocks/navigation.spec.js`

