### PR TITLE
[Mobile] - E2E tests - Only upload artifacts when the tests fail to pass

### DIFF
--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -75,7 +75,7 @@ jobs:
                   script: npm run native test:e2e:android:local ${{ matrix.native-test-name }}
 
             - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-              if: always()
+              if: failure()
               with:
                   name: android-screen-recordings
                   path: packages/react-native-editor/android-screen-recordings

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -72,16 +72,16 @@ jobs:
             - name: Run iOS Device Tests
               run: TEST_RN_PLATFORM=ios npm run native device-tests:local  ${{ matrix.native-test-name }}
 
-            - name: Prepare build cache
-              run: |
-                  rm packages/react-native-editor/ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app/main.jsbundle
-                  rm -rf packages/react-native-editor/ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app/assets
-
             - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-              if: always()
+              if: failure()
               with:
                   name: ios-screen-recordings
                   path: packages/react-native-editor/ios-screen-recordings
+
+            - name: Prepare build cache
+              run: |
+                  rm packages/react-native-editor/ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app/main.jsbundle
+                  rm -rf packages/react-native-editor/ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app/asset
 
             - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
               if: always()


### PR DESCRIPTION
## What?
I've been seeing a few issues where the E2E tests would pass but the job would fail during the `upload-artifacts` step, I think it might be an issue with GitHub Actions itself but for now, I think we should only upload the artifacts if it fails.

## Why?
To avoid disruptions while developing in this repo and constant CI failures.

## How?
By changing from `always` to `failure`.

As it says in [the docs](https://github.com/actions/upload-artifact#conditional-artifact-upload) leveraging on conditional artifact uploads.

## Testing Instructions
CI checks should pass.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A