### PR TITLE
ESLint: Fix a bunch of ESLint alignment warnings

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -134,7 +134,7 @@ function formatTime( number ) {
 /**
  * Curate the raw performance results.
  *
- * @param {string} testSuite
+ * @param {string}                  testSuite
  * @param {WPRawPerformanceResults} results
  *
  * @return {WPPerformanceResults} Curated Performance results.

--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -602,7 +602,7 @@ _Parameters_
 
 -   _kind_ `string`: Kind of the edited entity record.
 -   _name_ `string`: Name of the edited entity record.
--   _recordId_ `number`: Record ID of the edited entity record.
+-   _recordId_ `number|string`: Record ID of the edited entity record.
 -   _edits_ `Object`: The edits.
 -   _options_ `Object`: Options for the edit.
 -   _options.undoIgnore_ `[boolean]`: Whether to ignore the edit in undo history or not.

--- a/packages/block-library/src/table-of-contents/utils.ts
+++ b/packages/block-library/src/table-of-contents/utils.ts
@@ -18,7 +18,7 @@ export interface NestedHeadingData {
  * Takes a flat list of heading parameters and nests them based on each header's
  * immediate parent's level.
  *
- * @param  headingList The flat list of headings to nest.
+ * @param headingList The flat list of headings to nest.
  *
  * @return The nested list of headings.
  */

--- a/packages/components/src/alignment-matrix-control/utils.tsx
+++ b/packages/components/src/alignment-matrix-control/utils.tsx
@@ -33,7 +33,7 @@ export const ALIGNMENTS = GRID.flat();
 /**
  * Parses and transforms an incoming value to better match the alignment values
  *
- * @param  value An alignment value to parse.
+ * @param value An alignment value to parse.
  *
  * @return The parsed value.
  */
@@ -46,8 +46,8 @@ export function transformValue( value: AlignmentMatrixControlValue ) {
 /**
  * Creates an item ID based on a prefix ID and an alignment value.
  *
- * @param  prefixId An ID to prefix.
- * @param  value    An alignment value.
+ * @param prefixId An ID to prefix.
+ * @param value    An alignment value.
  *
  * @return The item id.
  */
@@ -63,7 +63,7 @@ export function getItemId(
 /**
  * Retrieves the alignment index from a value.
  *
- * @param  alignment Value to check.
+ * @param alignment Value to check.
  *
  * @return The index of a matching alignment.
  */

--- a/packages/components/src/base-control/hooks.ts
+++ b/packages/components/src/base-control/hooks.ts
@@ -14,7 +14,7 @@ import type { BaseControlProps } from './types';
  *
  * Namely, it takes care of generating a unique `id`, properly associating it with the `label` and `help` elements.
  *
- * @param  props
+ * @param props
  */
 export function useBaseControlProps(
 	props: Omit< BaseControlProps, 'children' >

--- a/packages/components/src/border-box-control/utils.ts
+++ b/packages/components/src/border-box-control/utils.ts
@@ -171,7 +171,7 @@ export const getMostCommonUnit = (
  * Finds the mode value out of the array passed favouring the first value
  * as a tiebreaker.
  *
- * @param  values Values to determine the mode from.
+ * @param values Values to determine the mode from.
  *
  * @return The mode value.
  */

--- a/packages/components/src/date-time/time/index.tsx
+++ b/packages/components/src/date-time/time/index.tsx
@@ -51,7 +51,7 @@ function from12hTo24h( hours: number, isPm: boolean ) {
  * given width. For example, the hours and minutes inputs are padded to 2 so
  * that '4' appears as '04'.
  *
- * @param  pad How many digits the value should be.
+ * @param pad How many digits the value should be.
  */
 function buildPadInputStateReducer( pad: number ) {
 	return ( state: InputState, action: InputAction ) => {

--- a/packages/components/src/date-time/utils.ts
+++ b/packages/components/src/date-time/utils.ts
@@ -7,7 +7,7 @@ import { toDate } from 'date-fns';
  * Like date-fn's toDate, but tries to guess the format when a string is
  * given.
  *
- * @param  input Value to turn into a date.
+ * @param input Value to turn into a date.
  */
 export function inputToDate( input: Date | string | number ): Date {
 	if ( typeof input === 'string' ) {

--- a/packages/components/src/draggable/index.tsx
+++ b/packages/components/src/draggable/index.tsx
@@ -75,7 +75,7 @@ export function Draggable( {
 	/**
 	 * Removes the element clone, resets cursor, and removes drag listener.
 	 *
-	 * @param  event The non-custom DragEvent.
+	 * @param event The non-custom DragEvent.
 	 */
 	function end( event: DragEvent ) {
 		event.preventDefault();
@@ -94,7 +94,7 @@ export function Draggable( {
 	 * - Sets transfer data.
 	 * - Adds dragover listener.
 	 *
-	 * @param  event The non-custom DragEvent.
+	 * @param event The non-custom DragEvent.
 	 */
 	function start( event: DragEvent ) {
 		const { ownerDocument } = event.target as HTMLElement;

--- a/packages/components/src/focal-point-picker/utils.ts
+++ b/packages/components/src/focal-point-picker/utils.ts
@@ -19,7 +19,7 @@ const VIDEO_EXTENSIONS = [
 /**
  * Gets the extension of a file name.
  *
- * @param  filename The file name.
+ * @param filename The file name.
  * @return  The extension of the file name.
  */
 export function getExtension( filename = '' ): string {
@@ -30,7 +30,7 @@ export function getExtension( filename = '' ): string {
 /**
  * Checks if a file is a video.
  *
- * @param  filename The file name.
+ * @param filename The file name.
  * @return Whether the file is a video.
  */
 export function isVideoType( filename: string = '' ): boolean {
@@ -44,7 +44,7 @@ export function isVideoType( filename: string = '' ): boolean {
 /**
  * Transforms a fraction value to a percentage value.
  *
- * @param  fraction The fraction value.
+ * @param fraction The fraction value.
  * @return A percentage value.
  */
 export function fractionToPercentage( fraction: number ): number {

--- a/packages/components/src/font-size-picker/utils.ts
+++ b/packages/components/src/font-size-picker/utils.ts
@@ -13,7 +13,7 @@ import { parseQuantityAndUnitFromRawValue } from '../unit-control';
  * Some themes use css vars for their font sizes, so until we
  * have the way of calculating them don't display them.
  *
- * @param  value The value that is checked.
+ * @param value The value that is checked.
  * @return Whether the value is a simple css value.
  */
 export function isSimpleCssValue(
@@ -27,7 +27,7 @@ export function isSimpleCssValue(
  * If all of the given font sizes have the same unit (e.g. 'px'), return that
  * unit. Otherwise return null.
  *
- * @param  fontSizes List of font sizes.
+ * @param fontSizes List of font sizes.
  * @return The common unit, or null.
  */
 export function getCommonSizeUnit( fontSizes: FontSize[] ) {

--- a/packages/components/src/input-control/reducer/reducer.ts
+++ b/packages/components/src/input-control/reducer/reducer.ts
@@ -23,7 +23,7 @@ import type { InputChangeCallback } from '../types';
 /**
  * Prepares initialState for the reducer.
  *
- * @param  initialState The initial state.
+ * @param initialState The initial state.
  * @return Prepared initialState for the reducer
  */
 function mergeInitialState(
@@ -45,7 +45,7 @@ function mergeInitialState(
  * exception for CONTROL actions is because they represent controlled updates
  * from props and no case has yet presented for their specialization.
  *
- * @param  composedStateReducers A reducer to specialize state changes.
+ * @param composedStateReducers A reducer to specialize state changes.
  * @return The reducer.
  */
 function inputControlStateReducer(
@@ -140,9 +140,9 @@ function inputControlStateReducer(
  * This technique uses the "stateReducer" design pattern:
  * https://kentcdodds.com/blog/the-state-reducer-pattern/
  *
- * @param  stateReducer    An external state reducer.
- * @param  initialState    The initial state for the reducer.
- * @param  onChangeHandler A handler for the onChange event.
+ * @param stateReducer    An external state reducer.
+ * @param initialState    The initial state for the reducer.
+ * @param onChangeHandler A handler for the onChange event.
  * @return State, dispatch, and a collection of actions.
  */
 export function useInputControlStateReducer(

--- a/packages/components/src/input-control/utils.ts
+++ b/packages/components/src/input-control/utils.ts
@@ -21,7 +21,7 @@ import type { InputChangeCallback } from './types';
 /**
  * Gets a CSS cursor value based on a drag direction.
  *
- * @param  dragDirection The drag direction.
+ * @param dragDirection The drag direction.
  * @return  The CSS cursor value.
  */
 export function getDragCursor( dragDirection: string ): string {

--- a/packages/components/src/popover/utils.ts
+++ b/packages/components/src/popover/utils.ts
@@ -74,7 +74,7 @@ const POSITION_TO_PLACEMENT: Record<
  * Converts the `Popover`'s legacy "position" prop to the new "placement" prop
  * (used by `floating-ui`).
  *
- * @param  position The legacy position
+ * @param position The legacy position
  * @return The corresponding placement
  */
 export const positionToPlacement = (
@@ -112,7 +112,7 @@ const PLACEMENT_TO_ANIMATION_ORIGIN: Record<
  * Given the floating-ui `placement`, compute the framer-motion props for the
  * popover's entry animation.
  *
- * @param  placement A placement string from floating ui
+ * @param placement A placement string from floating ui
  * @return The object containing the motion props
  */
 export const placementToMotionAnimationProps = (
@@ -142,7 +142,7 @@ export const placementToMotionAnimationProps = (
 /**
  * Returns the offset of a document's frame element.
  *
- * @param  document The iframe's owner document.
+ * @param document The iframe's owner document.
  *
  * @return The offset of the document's frame element, or undefined if the
  * document has no frame element.

--- a/packages/components/src/query-controls/terms.ts
+++ b/packages/components/src/query-controls/terms.ts
@@ -16,7 +16,7 @@ import type {
 /**
  * Returns terms in a tree form.
  *
- * @param  flatTerms Array of terms in flat format.
+ * @param flatTerms Array of terms in flat format.
  *
  * @return Terms in tree format.
  */

--- a/packages/components/src/range-control/utils.ts
+++ b/packages/components/src/range-control/utils.ts
@@ -14,9 +14,9 @@ import type { UseControlledRangeValueArgs } from './types';
 /**
  * A float supported clamp function for a specific value.
  *
- * @param  value The value to clamp.
- * @param  min   The minimum value.
- * @param  max   The maximum value.
+ * @param value The value to clamp.
+ * @param min   The minimum value.
+ * @param max   The maximum value.
  *
  * @return A (float) number
  */
@@ -31,7 +31,7 @@ export function floatClamp( value: number | null, min: number, max: number ) {
 /**
  * Hook to store a clamped value, derived from props.
  *
- * @param  settings
+ * @param settings
  * @return The controlled value and the value setter.
  */
 export function useControlledRangeValue(

--- a/packages/components/src/resizable-box/resize-tooltip/utils.ts
+++ b/packages/components/src/resizable-box/resize-tooltip/utils.ts
@@ -34,12 +34,12 @@ interface UseResizeLabelArgs {
  * Custom hook that manages resize listener events. It also provides a label
  * based on current resize width x height values.
  *
- * @param  props
- * @param  props.axis        Only shows the label corresponding to the axis.
- * @param  props.fadeTimeout Duration (ms) before deactivating the resize label.
- * @param  props.onResize    Callback when a resize occurs. Provides { width, height } callback.
- * @param  props.position    Adjusts label value.
- * @param  props.showPx      Whether to add `PX` to the label.
+ * @param props
+ * @param props.axis        Only shows the label corresponding to the axis.
+ * @param props.fadeTimeout Duration (ms) before deactivating the resize label.
+ * @param props.onResize    Callback when a resize occurs. Provides { width, height } callback.
+ * @param props.position    Adjusts label value.
+ * @param props.showPx      Whether to add `PX` to the label.
  *
  * @return Properties for hook.
  */
@@ -174,14 +174,14 @@ interface GetSizeLabelArgs {
 /**
  * Gets the resize label based on width and height values (as well as recent changes).
  *
- * @param  props
- * @param  props.axis     Only shows the label corresponding to the axis.
- * @param  props.height   Height value.
- * @param  props.moveX    Recent width (x axis) changes.
- * @param  props.moveY    Recent width (y axis) changes.
- * @param  props.position Adjusts label value.
- * @param  props.showPx   Whether to add `PX` to the label.
- * @param  props.width    Width value.
+ * @param props
+ * @param props.axis     Only shows the label corresponding to the axis.
+ * @param props.height   Height value.
+ * @param props.moveX    Recent width (x axis) changes.
+ * @param props.moveY    Recent width (y axis) changes.
+ * @param props.position Adjusts label value.
+ * @param props.showPx   Whether to add `PX` to the label.
+ * @param props.width    Width value.
  *
  * @return The rendered label.
  */

--- a/packages/components/src/snackbar/index.tsx
+++ b/packages/components/src/snackbar/index.tsx
@@ -26,8 +26,8 @@ const NOTICE_TIMEOUT = 10000;
  * Custom hook which announces the message with the given politeness, if a
  * valid message is provided.
  *
- * @param  message    Message to announce.
- * @param  politeness Politeness to announce.
+ * @param message    Message to announce.
+ * @param politeness Politeness to announce.
  */
 function useSpokenMessage(
 	message: SnackbarProps[ 'spokenMessage' ],

--- a/packages/components/src/ui/context/context-connect.ts
+++ b/packages/components/src/ui/context/context-connect.ts
@@ -29,8 +29,8 @@ type ContextConnectOptions = {
  * Forwards ref (React.ForwardRef) and "Connects" (or registers) a component
  * within the Context system under a specified namespace.
  *
- * @param  Component The component to register into the Context system.
- * @param  namespace The namespace to register the component under.
+ * @param Component The component to register into the Context system.
+ * @param namespace The namespace to register the component under.
  * @return The connected WordPressComponent
  */
 export function contextConnect<
@@ -50,8 +50,8 @@ export function contextConnect<
  * "Connects" (or registers) a component within the Context system under a specified namespace.
  * Does not forward a ref.
  *
- * @param  Component The component to register into the Context system.
- * @param  namespace The namespace to register the component under.
+ * @param Component The component to register into the Context system.
+ * @param namespace The namespace to register the component under.
  * @return The connected WordPressComponent
  */
 export function contextConnectWithoutRef< P >(
@@ -110,7 +110,7 @@ function _contextConnect<
 /**
  * Attempts to retrieve the connected namespace from a component.
  *
- * @param  Component The component to retrieve a namespace from.
+ * @param Component The component to retrieve a namespace from.
  * @return The connected namespaces.
  */
 export function getConnectNamespace(
@@ -138,8 +138,8 @@ export function getConnectNamespace(
 /**
  * Checks to see if a component is connected within the Context system.
  *
- * @param  Component The component to retrieve a namespace from.
- * @param  match     The namespace to check.
+ * @param Component The component to retrieve a namespace from.
+ * @param match     The namespace to check.
  */
 export function hasConnectNamespace(
 	Component: ReactNode,

--- a/packages/components/src/ui/context/get-styled-class-name-from-key.ts
+++ b/packages/components/src/ui/context/get-styled-class-name-from-key.ts
@@ -7,7 +7,7 @@ import memoize from 'memize';
 /**
  * Generates the connected component CSS className based on the namespace.
  *
- * @param  namespace The name of the connected component.
+ * @param namespace The name of the connected component.
  * @return The generated CSS className.
  */
 function getStyledClassName( namespace: string ): string {

--- a/packages/components/src/ui/utils/get-valid-children.ts
+++ b/packages/components/src/ui/utils/get-valid-children.ts
@@ -11,7 +11,7 @@ import { Children, isValidElement } from '@wordpress/element';
 /**
  * Gets a collection of available children elements from a React component's children prop.
  *
- * @param  children
+ * @param children
  *
  * @return An array of available children.
  */

--- a/packages/components/src/ui/utils/space.ts
+++ b/packages/components/src/ui/utils/space.ts
@@ -20,7 +20,7 @@ const GRID_BASE = '4px';
  * When given a unit value or one of the named CSS values like `auto`,
  * it will simply return the value back.
  *
- * @param  value A number, numeric string, or a unit value.
+ * @param value A number, numeric string, or a unit value.
  */
 export function space( value?: SpaceInput ): string | undefined {
 	if ( typeof value === 'undefined' ) {

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -203,8 +203,8 @@ function UnforwardedUnitControl(
 	 * This allows us to tap into actions to transform the (next) state for
 	 * InputControl.
 	 *
-	 * @param  state  State from InputControl
-	 * @param  action Action triggering state change
+	 * @param state  State from InputControl
+	 * @param action Action triggering state change
 	 * @return The updated state to apply to InputControl
 	 */
 	const unitControlStateReducer: StateReducer = ( state, action ) => {

--- a/packages/components/src/unit-control/utils.ts
+++ b/packages/components/src/unit-control/utils.ts
@@ -130,9 +130,9 @@ export const DEFAULT_UNIT = allUnits.px;
  * Moving forward, ideally the value should be a string that contains both
  * the value and unit, example: '10px'
  *
- * @param  rawValue     The raw value as a string (may or may not contain the unit)
- * @param  fallbackUnit The unit used as a fallback, if not unit is detected in the `value`
- * @param  allowedUnits Units to derive from.
+ * @param rawValue     The raw value as a string (may or may not contain the unit)
+ * @param fallbackUnit The unit used as a fallback, if not unit is detected in the `value`
+ * @param allowedUnits Units to derive from.
  * @return The extracted quantity and unit. The quantity can be `undefined` in case the raw value
  * could not be parsed to a number correctly. The unit can be `undefined` in case the unit parse
  * from the raw value could not be matched against the list of allowed units.
@@ -152,7 +152,7 @@ export function getParsedQuantityAndUnit(
 /**
  * Checks if units are defined.
  *
- * @param  units List of units.
+ * @param units List of units.
  * @return Whether the list actually contains any units.
  */
 export function hasUnits(
@@ -168,8 +168,8 @@ export function hasUnits(
  * Parses a quantity and unit from a raw string value, given a list of allowed
  * units and otherwise falling back to the default unit.
  *
- * @param  rawValue     The raw value as a string (may or may not contain the unit)
- * @param  allowedUnits Units to derive from.
+ * @param rawValue     The raw value as a string (may or may not contain the unit)
+ * @param allowedUnits Units to derive from.
  * @return The extracted quantity and unit. The quantity can be `undefined` in case the raw value
  * could not be parsed to a number correctly. The unit can be `undefined` in case the unit parsed
  * from the raw value could not be matched against the list of allowed units.
@@ -208,10 +208,10 @@ export function parseQuantityAndUnitFromRawValue(
  * Parses quantity and unit from a raw value. Validates parsed value, using fallback
  * value if invalid.
  *
- * @param  rawValue         The next value.
- * @param  allowedUnits     Units to derive from.
- * @param  fallbackQuantity The fallback quantity, used in case it's not possible to parse a valid quantity from the raw value.
- * @param  fallbackUnit     The fallback unit, used in case it's not possible to parse a valid unit from the raw value.
+ * @param rawValue         The next value.
+ * @param allowedUnits     Units to derive from.
+ * @param fallbackQuantity The fallback quantity, used in case it's not possible to parse a valid quantity from the raw value.
+ * @param fallbackUnit     The fallback unit, used in case it's not possible to parse a valid unit from the raw value.
  * @return The extracted quantity and unit. The quantity can be `undefined` in case the raw value
  * could not be parsed to a number correctly, and the `fallbackQuantity` was also `undefined`. The
  * unit can be `undefined` only if the unit parsed from the raw value could not be matched against
@@ -248,7 +248,7 @@ export function getValidParsedQuantityAndUnit(
  * Takes a unit value and finds the matching accessibility label for the
  * unit abbreviation.
  *
- * @param  unit Unit value (example: `px`)
+ * @param unit Unit value (example: `px`)
  * @return a11y label for the unit abbreviation
  */
 export function getAccessibleLabelForUnit( unit: string ): string | undefined {
@@ -259,8 +259,8 @@ export function getAccessibleLabelForUnit( unit: string ): string | undefined {
 /**
  * Filters available units based on values defined a list of allowed unit values.
  *
- * @param  allowedUnitValues Collection of allowed unit value strings.
- * @param  availableUnits    Collection of available unit objects.
+ * @param allowedUnitValues Collection of allowed unit value strings.
+ * @param availableUnits    Collection of available unit objects.
  * @return Filtered units.
  */
 export function filterUnitsWithSettings(
@@ -282,10 +282,10 @@ export function filterUnitsWithSettings(
  * TODO: ideally this hook shouldn't be needed
  * https://github.com/WordPress/gutenberg/pull/31822#discussion_r633280823
  *
- * @param  args                An object containing units, settingPath & defaultUnits.
- * @param  args.units          Collection of all potentially available units.
- * @param  args.availableUnits Collection of unit value strings for filtering available units.
- * @param  args.defaultValues  Collection of default values for defined units. Example: `{ px: 350, em: 15 }`.
+ * @param args                An object containing units, settingPath & defaultUnits.
+ * @param args.units          Collection of all potentially available units.
+ * @param args.availableUnits Collection of unit value strings for filtering available units.
+ * @param args.defaultValues  Collection of default values for defined units. Example: `{ px: 350, em: 15 }`.
  *
  * @return Filtered list of units, with their default values updated following the `defaultValues`
  * argument's property.
@@ -327,9 +327,9 @@ export const useCustomUnits = ( {
  * accurately displayed in the UI, even if the intention is to hide
  * the availability of that unit.
  *
- * @param  rawValue   Selected value to parse.
- * @param  legacyUnit Legacy unit value, if rawValue needs it appended.
- * @param  units      List of available units.
+ * @param rawValue   Selected value to parse.
+ * @param legacyUnit Legacy unit value, if rawValue needs it appended.
+ * @param units      List of available units.
  *
  * @return A collection of units containing the unit for the current value.
  */

--- a/packages/components/src/utils/events.ts
+++ b/packages/components/src/utils/events.ts
@@ -4,8 +4,8 @@ type EventHandler< T extends Event > = ( event: T ) => void;
  * Merges event handlers together.
  *
  * @template TEvent
- * @param  handler
- * @param  otherHandler
+ * @param    handler
+ * @param    otherHandler
  */
 function mergeEvent< TEvent extends Event >(
 	handler: EventHandler< TEvent >,
@@ -25,8 +25,8 @@ function mergeEvent< TEvent extends Event >(
  * Merges two sets of event handlers together.
  *
  * @template TEvent
- * @param  handlers
- * @param  extraHandlers
+ * @param    handlers
+ * @param    extraHandlers
  */
 export function mergeEventHandlers<
 	TEvent extends Event,

--- a/packages/components/src/utils/hooks/use-controlled-value.ts
+++ b/packages/components/src/utils/hooks/use-controlled-value.ts
@@ -12,10 +12,10 @@ type Props< T > = {
 /**
  * Simplified and improved implementation of useControlledState.
  *
- * @param  props
- * @param  props.defaultValue
- * @param  props.value
- * @param  props.onChange
+ * @param props
+ * @param props.defaultValue
+ * @param props.value
+ * @param props.onChange
  * @return The controlled value and the value setter.
  */
 export function useControlledValue< T >( {

--- a/packages/components/src/utils/hooks/use-latest-ref.ts
+++ b/packages/components/src/utils/hooks/use-latest-ref.ts
@@ -15,7 +15,7 @@ import { useIsomorphicLayoutEffect } from '@wordpress/compose';
  *
  * @see https://codesandbox.io/s/uselatestref-mlj3i?file=/src/App.tsx
  *
- * @param  value The value to reference
+ * @param value The value to reference
  * @return The prop reference.
  */
 export function useLatestRef< T >( value: T ): RefObject< T > {

--- a/packages/components/src/utils/unit-values.ts
+++ b/packages/components/src/utils/unit-values.ts
@@ -4,7 +4,7 @@ const UNITED_VALUE_REGEX =
 /**
  * Parses a number and unit from a value.
  *
- * @param  toParse Value to parse
+ * @param toParse Value to parse
  *
  * @return  The extracted number and unit.
  */
@@ -27,8 +27,8 @@ export function parseCSSUnitValue(
 /**
  * Combines a value and a unit into a unit value.
  *
- * @param  value
- * @param  unit
+ * @param value
+ * @param unit
  *
  * @return The unit value.
  */

--- a/packages/compose/src/higher-order/if-condition/index.tsx
+++ b/packages/compose/src/higher-order/if-condition/index.tsx
@@ -21,7 +21,7 @@ import { createHigherOrderComponent } from '../../utils/create-higher-order-comp
  * <ConditionalComponent foo="bar" />; // => <div>bar</div>;
  * ```
  *
- * @param  predicate Function to test condition.
+ * @param predicate Function to test condition.
  *
  * @return Higher-order component.
  */

--- a/packages/compose/src/hooks/use-async-list/index.ts
+++ b/packages/compose/src/hooks/use-async-list/index.ts
@@ -11,8 +11,8 @@ type AsyncListConfig = {
 /**
  * Returns the first items from list that are present on state.
  *
- * @param  list  New array.
- * @param  state Current state.
+ * @param list  New array.
+ * @param state Current state.
  * @return First items present iin state.
  */
 function getFirstItemsPresentInState< T >( list: T[], state: T[] ): T[] {
@@ -34,8 +34,8 @@ function getFirstItemsPresentInState< T >( list: T[], state: T[] ): T[] {
  * React hook returns an array which items get asynchronously appended from a source array.
  * This behavior is useful if we want to render a list of items asynchronously for performance reasons.
  *
- * @param  list   Source array.
- * @param  config Configuration object.
+ * @param list   Source array.
+ * @param config Configuration object.
  *
  * @return Async array.
  */

--- a/packages/compose/src/hooks/use-dialog/index.ts
+++ b/packages/compose/src/hooks/use-dialog/index.ts
@@ -44,7 +44,7 @@ type useDialogReturn = [
  *  - return focus on unmount.
  *  - focus outside.
  *
- * @param  options Dialog Options.
+ * @param options Dialog Options.
  */
 function useDialog( options: DialogOptions ): useDialogReturn {
 	const currentOptions = useRef< DialogOptions | undefined >();

--- a/packages/compose/src/hooks/use-focus-outside/index.ts
+++ b/packages/compose/src/hooks/use-focus-outside/index.ts
@@ -38,7 +38,7 @@ type FocusNormalizedButton =
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
  *
- * @param  eventTarget The target from a mouse or touch event.
+ * @param eventTarget The target from a mouse or touch event.
  *
  * @return Whether the element is a button element subject to focus normalization.
  */
@@ -75,8 +75,8 @@ type UseFocusOutsideReturn = {
  * A react hook that can be used to check whether focus has moved outside the
  * element the event handlers are bound to.
  *
- * @param  onFocusOutside A callback triggered when focus moves outside
- *                        the element the event handlers are bound to.
+ * @param onFocusOutside A callback triggered when focus moves outside
+ *                       the element the event handlers are bound to.
  *
  * @return An object containing event handlers. Bind the event handlers to a
  * wrapping element element to capture when focus moves outside that element.
@@ -119,7 +119,7 @@ export default function useFocusOutside(
 	 * button elements when clicked, while others do. The logic here
 	 * intends to normalize this as treating click on buttons as focus.
 	 *
-	 * @param  event
+	 * @param event
 	 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
 	 */
 	const normalizeButtonFocus: EventHandler< MouseEvent | TouchEvent > =

--- a/packages/compose/src/hooks/use-instance-id/index.ts
+++ b/packages/compose/src/hooks/use-instance-id/index.ts
@@ -8,7 +8,7 @@ const instanceMap = new WeakMap< object, number >();
 /**
  * Creates a new id for a given object.
  *
- * @param  object Object reference to create an id for.
+ * @param object Object reference to create an id for.
  * @return The instance id (index).
  */
 function createId( object: object ): number {
@@ -40,9 +40,9 @@ function useInstanceId< T extends string | number >(
 /**
  * Provides a unique instance ID.
  *
- * @param  object        Object reference to create an id for.
- * @param  [prefix]      Prefix for the unique id.
- * @param  [preferredId] Default ID to use.
+ * @param object        Object reference to create an id for.
+ * @param [prefix]      Prefix for the unique id.
+ * @param [preferredId] Default ID to use.
  * @return The unique instance id.
  */
 function useInstanceId(

--- a/packages/compose/src/hooks/use-previous/index.ts
+++ b/packages/compose/src/hooks/use-previous/index.ts
@@ -7,7 +7,7 @@ import { useEffect, useRef } from '@wordpress/element';
  * Use something's value from the previous render.
  * Based on https://usehooks.com/usePrevious/.
  *
- * @param  value The value to track.
+ * @param value The value to track.
  *
  * @return The value from the previous render.
  */

--- a/packages/compose/src/hooks/use-ref-effect/index.ts
+++ b/packages/compose/src/hooks/use-ref-effect/index.ts
@@ -22,8 +22,8 @@ import { useCallback, useRef } from '@wordpress/element';
  * to be removed. It *is* necessary if you add dependencies because the ref
  * callback will be called multiple times for the same node.
  *
- * @param  callback     Callback with ref as argument.
- * @param  dependencies Dependencies of the callback.
+ * @param callback     Callback with ref as argument.
+ * @param dependencies Dependencies of the callback.
  *
  * @return Ref callback.
  */

--- a/packages/compose/src/utils/create-higher-order-component/index.ts
+++ b/packages/compose/src/utils/create-higher-order-component/index.ts
@@ -16,8 +16,8 @@ export type WithInjectedProps< C, I > = ComponentType<
  * Given a function mapping a component to an enhanced component and modifier
  * name, returns the enhanced component augmented with a generated displayName.
  *
- * @param  mapComponent Function mapping component to enhanced component.
- * @param  modifierName Seed name from which to generated display name.
+ * @param mapComponent Function mapping component to enhanced component.
+ * @param modifierName Seed name from which to generated display name.
  *
  * @return Component class with generated display name assigned.
  */
@@ -39,8 +39,8 @@ export function createHigherOrderComponent<
  *     hocName( 'MyMemo', Widget ) === 'MyMemo(Widget)';
  *     hocName( 'MyMemo', <div /> ) === 'MyMemo(Component)';
  *
- * @param  name  Name assigned to higher-order component's wrapper component.
- * @param  Inner Wrapped component inside higher-order component.
+ * @param name  Name assigned to higher-order component's wrapper component.
+ * @param Inner Wrapped component inside higher-order component.
  * @return       Wrapped name of higher-order component.
  */
 const hocName = ( name: string, Inner: ComponentType< any > ) => {

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -81,7 +81,7 @@ _Parameters_
 
 -   _kind_ `string`: Kind of the edited entity record.
 -   _name_ `string`: Name of the edited entity record.
--   _recordId_ `number`: Record ID of the edited entity record.
+-   _recordId_ `number|string`: Record ID of the edited entity record.
 -   _edits_ `Object`: The edits.
 -   _options_ `Object`: Options for the edit.
 -   _options.undoIgnore_ `[boolean]`: Whether to ignore the edit in undo history or not.

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -319,12 +319,12 @@ export const deleteEntityRecord =
  * Returns an action object that triggers an
  * edit to an entity record.
  *
- * @param {string}  kind                 Kind of the edited entity record.
- * @param {string}  name                 Name of the edited entity record.
- * @param {number}  recordId             Record ID of the edited entity record.
- * @param {Object}  edits                The edits.
- * @param {Object}  options              Options for the edit.
- * @param {boolean} [options.undoIgnore] Whether to ignore the edit in undo history or not.
+ * @param {string}        kind                 Kind of the edited entity record.
+ * @param {string}        name                 Name of the edited entity record.
+ * @param {number|string} recordId             Record ID of the edited entity record.
+ * @param {Object}        edits                The edits.
+ * @param {Object}        options              Options for the edit.
+ * @param {boolean}       [options.undoIgnore] Whether to ignore the edit in undo history or not.
  *
  * @return {Object} Action object.
  */

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -86,8 +86,8 @@ const EMPTY_OBJECT = {};
  * Returns true if a request is in progress for embed preview data, or false
  * otherwise.
  *
- * @param  state Data state.
- * @param  url   URL the preview would be for.
+ * @param state Data state.
+ * @param url   URL the preview would be for.
  *
  * @return Whether a request is in progress for an embed preview.
  */
@@ -105,9 +105,9 @@ export const isRequestingEmbedPreview = createRegistrySelector(
  *
  * @deprecated since 11.3. Callers should use `select( 'core' ).getUsers({ who: 'authors' })` instead.
  *
- * @param  state Data state.
- * @param  query Optional object of query parameters to
- *               include with request.
+ * @param      state Data state.
+ * @param      query Optional object of query parameters to
+ *                   include with request.
  * @return Authors list.
  */
 export function getAuthors(
@@ -129,7 +129,7 @@ export function getAuthors(
 /**
  * Returns the current user.
  *
- * @param  state Data state.
+ * @param state Data state.
  *
  * @return Current user object.
  */
@@ -140,8 +140,8 @@ export function getCurrentUser( state: State ): ET.User< 'edit' > {
 /**
  * Returns all the users returned by a query ID.
  *
- * @param  state   Data state.
- * @param  queryID Query ID.
+ * @param state   Data state.
+ * @param queryID Query ID.
  *
  * @return Users list.
  */
@@ -161,8 +161,8 @@ export const getUserQueryResults = createSelector(
  * Returns the loaded entities for the given kind.
  *
  * @deprecated since WordPress 6.0. Use getEntitiesConfig instead
- * @param  state Data state.
- * @param  kind  Entity kind.
+ * @param      state Data state.
+ * @param      kind  Entity kind.
  *
  * @return Array of entities with config matching kind.
  */
@@ -177,8 +177,8 @@ export function getEntitiesByKind( state: State, kind: string ): Array< any > {
 /**
  * Returns the loaded entities for the given kind.
  *
- * @param  state Data state.
- * @param  kind  Entity kind.
+ * @param state Data state.
+ * @param kind  Entity kind.
  *
  * @return Array of entities with config matching kind.
  */
@@ -190,9 +190,9 @@ export function getEntitiesConfig( state: State, kind: string ): Array< any > {
  * Returns the entity config given its kind and name.
  *
  * @deprecated since WordPress 6.0. Use getEntityConfig instead
- * @param  state Data state.
- * @param  kind  Entity kind.
- * @param  name  Entity name.
+ * @param      state Data state.
+ * @param      kind  Entity kind.
+ * @param      name  Entity name.
  *
  * @return Entity config
  */
@@ -207,9 +207,9 @@ export function getEntity( state: State, kind: string, name: string ): any {
 /**
  * Returns the entity config given its kind and name.
  *
- * @param  state Data state.
- * @param  kind  Entity kind.
- * @param  name  Entity name.
+ * @param state Data state.
+ * @param kind  Entity kind.
+ * @param name  Entity name.
  *
  * @return Entity config
  */
@@ -277,12 +277,12 @@ export interface GetEntityRecord {
  * yet received, undefined if the value entity is known to not exist, or the
  * entity object if it exists and is received.
  *
- * @param  state State tree
- * @param  kind  Entity kind.
- * @param  name  Entity name.
- * @param  key   Record's key
- * @param  query Optional query. If requesting specific
- *               fields, fields must always include the ID.
+ * @param state State tree
+ * @param kind  Entity kind.
+ * @param name  Entity name.
+ * @param key   Record's key
+ * @param query Optional query. If requesting specific
+ *              fields, fields must always include the ID.
  *
  * @return Record.
  */
@@ -357,10 +357,10 @@ export const getEntityRecord = createSelector(
 /**
  * Returns the Entity's record object by key. Doesn't trigger a resolver nor requests the entity records from the API if the entity record isn't available in the local state.
  *
- * @param  state State tree
- * @param  kind  Entity kind.
- * @param  name  Entity name.
- * @param  key   Record's key
+ * @param state State tree
+ * @param kind  Entity kind.
+ * @param name  Entity name.
+ * @param key   Record's key
  *
  * @return Record.
  */
@@ -374,10 +374,10 @@ export function __experimentalGetEntityRecordNoResolver<
  * Returns the entity's record object by key,
  * with its attributes mapped to their raw values.
  *
- * @param  state State tree.
- * @param  kind  Entity kind.
- * @param  name  Entity name.
- * @param  key   Record's key.
+ * @param state State tree.
+ * @param kind  Entity kind.
+ * @param name  Entity name.
+ * @param key   Record's key.
  *
  * @return Object with the entity's raw attributes.
  */
@@ -449,10 +449,10 @@ export const getRawEntityRecord = createSelector(
  * Returns true if records have been received for the given set of parameters,
  * or false otherwise.
  *
- * @param  state State tree
- * @param  kind  Entity kind.
- * @param  name  Entity name.
- * @param  query Optional terms query.
+ * @param state State tree
+ * @param kind  Entity kind.
+ * @param name  Entity name.
+ * @param query Optional terms query.
  *
  * @return  Whether entity records have been received.
  */
@@ -499,11 +499,11 @@ export interface GetEntityRecords {
 /**
  * Returns the Entity's records.
  *
- * @param  state State tree
- * @param  kind  Entity kind.
- * @param  name  Entity name.
- * @param  query Optional terms query. If requesting specific
- *               fields, fields must always include the ID.
+ * @param state State tree
+ * @param kind  Entity kind.
+ * @param name  Entity name.
+ * @param query Optional terms query. If requesting specific
+ *              fields, fields must always include the ID.
  *
  * @return Records.
  */
@@ -539,7 +539,7 @@ type DirtyEntityRecord = {
 /**
  * Returns the list of dirty entity records.
  *
- * @param  state State tree.
+ * @param state State tree.
  *
  * @return The list of updated records
  */
@@ -596,7 +596,7 @@ export const __experimentalGetDirtyEntityRecords = createSelector(
 /**
  * Returns the list of entities currently being saved.
  *
- * @param  state State tree.
+ * @param state State tree.
  *
  * @return The list of records being saved.
  */
@@ -648,10 +648,10 @@ export const __experimentalGetEntitiesBeingSaved = createSelector(
 /**
  * Returns the specified entity record's edits.
  *
- * @param  state    State tree.
- * @param  kind     Entity kind.
- * @param  name     Entity name.
- * @param  recordId Record ID.
+ * @param state    State tree.
+ * @param kind     Entity kind.
+ * @param name     Entity name.
+ * @param recordId Record ID.
  *
  * @return The entity record's edits.
  */
@@ -676,10 +676,10 @@ export function getEntityRecordEdits(
  * are not considered for change detection.
  * They are defined in the entity's config.
  *
- * @param  state    State tree.
- * @param  kind     Entity kind.
- * @param  name     Entity name.
- * @param  recordId Record ID.
+ * @param state    State tree.
+ * @param kind     Entity kind.
+ * @param name     Entity name.
+ * @param recordId Record ID.
  *
  * @return The entity record's non transient edits.
  */
@@ -712,10 +712,10 @@ export const getEntityRecordNonTransientEdits = createSelector(
  * Returns true if the specified entity record has edits,
  * and false otherwise.
  *
- * @param  state    State tree.
- * @param  kind     Entity kind.
- * @param  name     Entity name.
- * @param  recordId Record ID.
+ * @param state    State tree.
+ * @param kind     Entity kind.
+ * @param name     Entity name.
+ * @param recordId Record ID.
  *
  * @return Whether the entity record has edits or not.
  */
@@ -736,10 +736,10 @@ export function hasEditsForEntityRecord(
 /**
  * Returns the specified entity record, merged with its edits.
  *
- * @param  state    State tree.
- * @param  kind     Entity kind.
- * @param  name     Entity name.
- * @param  recordId Record ID.
+ * @param state    State tree.
+ * @param kind     Entity kind.
+ * @param name     Entity name.
+ * @param recordId Record ID.
  *
  * @return The entity record, merged with its edits.
  */
@@ -787,10 +787,10 @@ export const getEditedEntityRecord = createSelector(
 /**
  * Returns true if the specified entity record is autosaving, and false otherwise.
  *
- * @param  state    State tree.
- * @param  kind     Entity kind.
- * @param  name     Entity name.
- * @param  recordId Record ID.
+ * @param state    State tree.
+ * @param kind     Entity kind.
+ * @param name     Entity name.
+ * @param recordId Record ID.
  *
  * @return Whether the entity record is autosaving or not.
  */
@@ -811,10 +811,10 @@ export function isAutosavingEntityRecord(
 /**
  * Returns true if the specified entity record is saving, and false otherwise.
  *
- * @param  state    State tree.
- * @param  kind     Entity kind.
- * @param  name     Entity name.
- * @param  recordId Record ID.
+ * @param state    State tree.
+ * @param kind     Entity kind.
+ * @param name     Entity name.
+ * @param recordId Record ID.
  *
  * @return Whether the entity record is saving or not.
  */
@@ -834,10 +834,10 @@ export function isSavingEntityRecord(
 /**
  * Returns true if the specified entity record is deleting, and false otherwise.
  *
- * @param  state    State tree.
- * @param  kind     Entity kind.
- * @param  name     Entity name.
- * @param  recordId Record ID.
+ * @param state    State tree.
+ * @param kind     Entity kind.
+ * @param name     Entity name.
+ * @param recordId Record ID.
  *
  * @return Whether the entity record is deleting or not.
  */
@@ -857,10 +857,10 @@ export function isDeletingEntityRecord(
 /**
  * Returns the specified entity record's last save error.
  *
- * @param  state    State tree.
- * @param  kind     Entity kind.
- * @param  name     Entity name.
- * @param  recordId Record ID.
+ * @param state    State tree.
+ * @param kind     Entity kind.
+ * @param name     Entity name.
+ * @param recordId Record ID.
  *
  * @return The entity record's save error.
  */
@@ -882,10 +882,10 @@ export function getLastEntitySaveError(
 /**
  * Returns the specified entity record's last delete error.
  *
- * @param  state    State tree.
- * @param  kind     Entity kind.
- * @param  name     Entity name.
- * @param  recordId Record ID.
+ * @param state    State tree.
+ * @param kind     Entity kind.
+ * @param name     Entity name.
+ * @param recordId Record ID.
  *
  * @return The entity record's save error.
  */
@@ -911,7 +911,7 @@ export function getLastEntityDeleteError(
  * of the history stack we are at. 0 is the
  * last edit, -1 is the second last, and so on.
  *
- * @param  state State tree.
+ * @param state State tree.
  *
  * @return The current undo offset.
  */
@@ -923,7 +923,7 @@ function getCurrentUndoOffset( state: State ): number {
  * Returns the previous edit from the current undo offset
  * for the entity records edits history, if any.
  *
- * @param  state State tree.
+ * @param state State tree.
  *
  * @return The edit.
  */
@@ -935,7 +935,7 @@ export function getUndoEdit( state: State ): Optional< any > {
  * Returns the next edit from the current undo offset
  * for the entity records edits history, if any.
  *
- * @param  state State tree.
+ * @param state State tree.
  *
  * @return The edit.
  */
@@ -947,7 +947,7 @@ export function getRedoEdit( state: State ): Optional< any > {
  * Returns true if there is a previous edit from the current undo offset
  * for the entity records edits history, and false otherwise.
  *
- * @param  state State tree.
+ * @param state State tree.
  *
  * @return Whether there is a previous edit or not.
  */
@@ -959,7 +959,7 @@ export function hasUndo( state: State ): boolean {
  * Returns true if there is a next edit from the current undo offset
  * for the entity records edits history, and false otherwise.
  *
- * @param  state State tree.
+ * @param state State tree.
  *
  * @return Whether there is a next edit or not.
  */
@@ -970,7 +970,7 @@ export function hasRedo( state: State ): boolean {
 /**
  * Return the current theme.
  *
- * @param  state Data state.
+ * @param state Data state.
  *
  * @return The current theme.
  */
@@ -981,7 +981,7 @@ export function getCurrentTheme( state: State ): any {
 /**
  * Return the ID of the current global styles object.
  *
- * @param  state Data state.
+ * @param state Data state.
  *
  * @return The current global styles ID.
  */
@@ -992,7 +992,7 @@ export function __experimentalGetCurrentGlobalStylesId( state: State ): string {
 /**
  * Return theme supports data in the index.
  *
- * @param  state Data state.
+ * @param state Data state.
  *
  * @return Index data.
  */
@@ -1003,8 +1003,8 @@ export function getThemeSupports( state: State ): any {
 /**
  * Returns the embed preview for the given URL.
  *
- * @param  state Data state.
- * @param  url   Embedded URL.
+ * @param state Data state.
+ * @param url   Embedded URL.
  *
  * @return Undefined if the preview has not been fetched, otherwise, the preview fetched from the embed preview API.
  */
@@ -1019,8 +1019,8 @@ export function getEmbedPreview( state: State, url: string ): any {
  * We need to be able to determine if a URL is embeddable or not, based on what we
  * get back from the oEmbed preview API.
  *
- * @param  state Data state.
- * @param  url   Embedded URL.
+ * @param state Data state.
+ * @param url   Embedded URL.
  *
  * @return Is the preview for the URL an oEmbed link fallback.
  */
@@ -1042,10 +1042,10 @@ export function isPreviewEmbedFallback( state: State, url: string ): boolean {
  *
  * https://developer.wordpress.org/rest-api/reference/
  *
- * @param  state    Data state.
- * @param  action   Action to check. One of: 'create', 'read', 'update', 'delete'.
- * @param  resource REST resource to check, e.g. 'media' or 'posts'.
- * @param  id       Optional ID of the rest resource to check.
+ * @param state    Data state.
+ * @param action   Action to check. One of: 'create', 'read', 'update', 'delete'.
+ * @param resource REST resource to check, e.g. 'media' or 'posts'.
+ * @param id       Optional ID of the rest resource to check.
  *
  * @return Whether or not the user can perform the action,
  *                             or `undefined` if the OPTIONS request is still being made.
@@ -1068,10 +1068,10 @@ export function canUser(
  *
  * https://developer.wordpress.org/rest-api/reference/
  *
- * @param  state    Data state.
- * @param  kind     Entity kind.
- * @param  name     Entity name.
- * @param  recordId Record's id.
+ * @param state    Data state.
+ * @param kind     Entity kind.
+ * @param name     Entity name.
+ * @param recordId Record's id.
  * @return Whether or not the user can edit,
  * or `undefined` if the OPTIONS request is still being made.
  */
@@ -1096,9 +1096,9 @@ export function canUserEditEntityRecord(
  * May return multiple autosaves since the backend stores one autosave per
  * author for each post.
  *
- * @param  state    State tree.
- * @param  postType The type of the parent post.
- * @param  postId   The id of the parent post.
+ * @param state    State tree.
+ * @param postType The type of the parent post.
+ * @param postId   The id of the parent post.
  *
  * @return An array of autosaves for the post, or undefined if there is none.
  */
@@ -1113,10 +1113,10 @@ export function getAutosaves(
 /**
  * Returns the autosave for the post and author.
  *
- * @param  state    State tree.
- * @param  postType The type of the parent post.
- * @param  postId   The id of the parent post.
- * @param  authorId The id of the author.
+ * @param state    State tree.
+ * @param postType The type of the parent post.
+ * @param postId   The id of the parent post.
+ * @param authorId The id of the author.
  *
  * @return The autosave for the post and author.
  */
@@ -1140,9 +1140,9 @@ export function getAutosave< EntityRecord extends ET.EntityRecord< any > >(
 /**
  * Returns true if the REST request for autosaves has completed.
  *
- * @param  state    State tree.
- * @param  postType The type of the parent post.
- * @param  postId   The id of the parent post.
+ * @param state    State tree.
+ * @param postType The type of the parent post.
+ * @param postId   The id of the parent post.
  *
  * @return True if the REST request was completed. False otherwise.
  */
@@ -1174,7 +1174,7 @@ export const hasFetchedAutosaves = createRegistrySelector(
  * );
  * ```
  *
- * @param  state Editor state.
+ * @param state Editor state.
  *
  * @return A value whose reference will change only when an edit occurs.
  */
@@ -1191,8 +1191,8 @@ export const getReferenceByDistinctEdits = createSelector(
 /**
  * Retrieve the frontend template used for a given link.
  *
- * @param  state Editor state.
- * @param  link  Link.
+ * @param state Editor state.
+ * @param link  Link.
  *
  * @return The template record.
  */
@@ -1223,7 +1223,7 @@ export function __experimentalGetTemplateForLink(
 /**
  * Retrieve the current theme's base global styles
  *
- * @param  state Editor state.
+ * @param state Editor state.
  *
  * @return The Global Styles object.
  */
@@ -1240,7 +1240,7 @@ export function __experimentalGetCurrentThemeBaseGlobalStyles(
 /**
  * Return the ID of the current global styles object.
  *
- * @param  state Data state.
+ * @param state Data state.
  *
  * @return The current global styles ID.
  */
@@ -1257,7 +1257,7 @@ export function __experimentalGetCurrentThemeGlobalStylesVariations(
 /**
  * Retrieve the list of registered block patterns.
  *
- * @param  state Data state.
+ * @param state Data state.
  *
  * @return Block pattern list.
  */
@@ -1268,7 +1268,7 @@ export function getBlockPatterns( state: State ): Array< any > {
 /**
  * Retrieve the list of registered block pattern categories.
  *
- * @param  state Data state.
+ * @param state Data state.
  *
  * @return Block pattern category list.
  */

--- a/packages/data/src/components/use-dispatch/use-dispatch.js
+++ b/packages/data/src/components/use-dispatch/use-dispatch.js
@@ -18,7 +18,7 @@ import useRegistry from '../registry-provider/use-registry';
  * Note: The component using this hook must be within the context of a
  * RegistryProvider.
  *
- * @template {undefined | string | StoreDescriptor<any>} [StoreNameOrDescriptor=undefined]
+ * @template {undefined | string | StoreDescriptor<any>} StoreNameOrDescriptor
  * @param {StoreNameOrDescriptor} [storeNameOrDescriptor] Optionally provide the name of the
  *                                                        store or its descriptor from which to
  *                                                        retrieve action creators. If not

--- a/packages/data/src/redux-store/metadata/reducer.ts
+++ b/packages/data/src/redux-store/metadata/reducer.ts
@@ -115,8 +115,8 @@ const subKeysIsResolved: Reducer< Record< string, State >, Action > = onSubKey<
  *
  *   selectorName -> EquivalentKeyMap<Array, boolean>
  *
- * @param  state  Current state.
- * @param  action Dispatched action.
+ * @param state  Current state.
+ * @param action Dispatched action.
  *
  * @return Next state.
  */

--- a/packages/data/src/redux-store/metadata/utils.ts
+++ b/packages/data/src/redux-store/metadata/utils.ts
@@ -7,7 +7,7 @@ import type { AnyAction, Reducer } from 'redux';
  * Higher-order reducer creator which creates a combined reducer object, keyed
  * by a property on the action object.
  *
- * @param  actionProperty Action property by which to key object.
+ * @param actionProperty Action property by which to key object.
  * @return Higher-order reducer.
  */
 export const onSubKey =
@@ -42,7 +42,7 @@ export const onSubKey =
  * Normalize selector argument array by defaulting `undefined` value to an empty array
  * and removing trailing `undefined` values.
  *
- * @param  args Selector argument array
+ * @param args Selector argument array
  * @return Normalized state key array
  */
 export function selectorArgsToStateKey( args: unknown[] | null | undefined ) {

--- a/packages/e2e-test-utils-playwright/src/editor/get-blocks.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/get-blocks.ts
@@ -6,7 +6,7 @@ import type { Editor } from './index';
 /**
  * Returns the edited blocks.
  *
- * @param  this
+ * @param this
  *
  * @return  The blocks.
  */

--- a/packages/e2e-test-utils-playwright/src/editor/set-content.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/set-content.ts
@@ -6,8 +6,8 @@ import type { Editor } from './index';
 /**
  * Set the content of the editor.
  *
- * @param  this
- * @param  html Serialized block HTML.
+ * @param this
+ * @param html Serialized block HTML.
  */
 async function setContent( this: Editor, html: string ) {
 	await this.page.evaluate( ( _html ) => {

--- a/packages/e2e-test-utils-playwright/src/page-utils/drag-files.ts
+++ b/packages/e2e-test-utils-playwright/src/page-utils/drag-files.ts
@@ -24,8 +24,8 @@ type Options = {
 /**
  * Simulate dragging files from outside the current page.
  *
- * @param  this
- * @param  files The files to be dragged.
+ * @param this
+ * @param files The files to be dragged.
  * @return The methods of the drag operation.
  */
 async function dragFiles(
@@ -100,9 +100,9 @@ async function dragFiles(
 		/**
 		 * Drag the files over an element (fires `dragenter` and `dragover` events).
 		 *
-		 * @param  selectorOrLocator A selector or a locator to search for an element.
-		 * @param  options           The optional options.
-		 * @param  options.position  A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
+		 * @param selectorOrLocator A selector or a locator to search for an element.
+		 * @param options           The optional options.
+		 * @param options.position  A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
 		 */
 		dragOver: async (
 			selectorOrLocator: string | Locator,

--- a/packages/e2e-test-utils-playwright/src/page-utils/press-key-with-modifier.ts
+++ b/packages/e2e-test-utils-playwright/src/page-utils/press-key-with-modifier.ts
@@ -27,10 +27,10 @@ let clipboardDataHolder: {
  * Sets the clipboard data that can be pasted with
  * `pressKeyWithModifier( 'primary', 'v' )`.
  *
- * @param  this
- * @param  clipboardData
- * @param  clipboardData.plainText
- * @param  clipboardData.html
+ * @param this
+ * @param clipboardData
+ * @param clipboardData.plainText
+ * @param clipboardData.html
  */
 export function setClipboardData(
 	this: PageUtils,
@@ -95,9 +95,9 @@ async function emulateClipboard( page: Page, type: 'copy' | 'cut' | 'paste' ) {
  * Performs a key press with modifier (Shift, Control, Meta, Alt), where each modifier
  * is normalized to platform-specific modifier.
  *
- * @param  this
- * @param  modifier
- * @param  key
+ * @param this
+ * @param modifier
+ * @param key
  */
 export async function pressKeyWithModifier(
 	this: PageUtils,

--- a/packages/e2e-test-utils-playwright/src/request-utils/comments.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/comments.ts
@@ -22,8 +22,8 @@ export interface User {
 /**
  * Create new comment using the REST API.
  *
- * @param {} this    RequestUtils.
- * @param {} payload CreateCommentPayload.
+ * @param {RequestUtils}         this
+ * @param {CreateCommentPayload} payload
  */
 export async function createComment(
 	this: RequestUtils,
@@ -48,7 +48,7 @@ export async function createComment(
 /**
  * Delete all comments using the REST API.
  *
- * @param {} this RequestUtils.
+ * @param {RequestUtils} this
  */
 export async function deleteAllComments( this: RequestUtils ) {
 	// List all comments.

--- a/packages/e2e-test-utils-playwright/src/request-utils/media.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/media.ts
@@ -25,7 +25,7 @@ export interface Media {
  * List all media files.
  *
  * @see https://developer.wordpress.org/rest-api/reference/media/#list-media
- * @param  this
+ * @param this
  */
 async function listMedia( this: RequestUtils ) {
 	const response = await this.rest< Media[] >( {
@@ -43,8 +43,8 @@ async function listMedia( this: RequestUtils ) {
  * Upload a media file.
  *
  * @see https://developer.wordpress.org/rest-api/reference/media/#create-a-media-item
- * @param  this
- * @param  filePathOrData The path or data of the file being uploaded.
+ * @param this
+ * @param filePathOrData The path or data of the file being uploaded.
  */
 async function uploadMedia(
 	this: RequestUtils,
@@ -70,8 +70,8 @@ async function uploadMedia(
  * delete a media file.
  *
  * @see https://developer.wordpress.org/rest-api/reference/media/#delete-a-media-item
- * @param  this
- * @param  mediaId The ID of the media file.
+ * @param this
+ * @param mediaId The ID of the media file.
  */
 async function deleteMedia( this: RequestUtils, mediaId: number ) {
 	const response = await this.rest( {
@@ -86,7 +86,7 @@ async function deleteMedia( this: RequestUtils, mediaId: number ) {
 /**
  * delete all media files.
  *
- * @param  this
+ * @param this
  */
 async function deleteAllMedia( this: RequestUtils ) {
 	const files = await this.listMedia();

--- a/packages/e2e-test-utils-playwright/src/request-utils/plugins.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/plugins.ts
@@ -12,8 +12,8 @@ import type { RequestUtils } from './index';
  * Fetch the plugins from API and cache them in memory,
  * since they are unlikely to change during testing.
  *
- * @param {} this           RequestUtils.
- * @param {} [forceRefetch] Force refetch the installed plugins to update the cache.
+ * @param {RequestUtils} this
+ * @param {boolean?}     forceRefetch Force refetch the installed plugins to update the cache.
  */
 async function getPluginsMap( this: RequestUtils, forceRefetch = false ) {
 	if ( ! forceRefetch && this.pluginsMap ) {

--- a/packages/e2e-test-utils-playwright/src/request-utils/posts.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/posts.ts
@@ -17,7 +17,7 @@ export interface CreatePostPayload {
 /**
  * Delete all posts using REST API.
  *
- * @param {} this RequestUtils.
+ * @param {RequestUtils} this
  */
 export async function deleteAllPosts( this: RequestUtils ) {
 	// List all posts.
@@ -50,8 +50,8 @@ export async function deleteAllPosts( this: RequestUtils ) {
 /**
  * Creates a new post using the REST API.
  *
- * @param {} this    RequestUtils.
- * @param {} payload Post attributes.
+ * @param {RequestUtils}      this
+ * @param {CreatePostPayload} payload Post attributes.
  */
 export async function createPost(
 	this: RequestUtils,

--- a/packages/e2e-test-utils-playwright/src/request-utils/rest.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/rest.ts
@@ -128,8 +128,8 @@ async function rest< RestResponse = any >(
 /**
  * Get the maximum batch size for the REST API.
  *
- * @param {} this         RequestUtils.
- * @param {} forceRefetch Force revalidate the cached max batch size.
+ * @param {RequestUtils} this
+ * @param {boolean?}     forceRefetch Force revalidate the cached max batch size.
  */
 async function getMaxBatchSize( this: RequestUtils, forceRefetch = false ) {
 	if ( ! forceRefetch && this.maxBatchSize ) {

--- a/packages/e2e-test-utils-playwright/src/request-utils/site-settings.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/site-settings.ts
@@ -26,7 +26,7 @@ type SiteSettings = {
  *
  * @see https://developer.wordpress.org/rest-api/reference/settings/#retrieve-a-site-setting
  *
- * @param  this RequestUtils.
+ * @param this RequestUtils.
  */
 export async function getSiteSettings( this: RequestUtils ) {
 	return await this.rest< SiteSettings >( {
@@ -40,8 +40,8 @@ export async function getSiteSettings( this: RequestUtils ) {
  *
  * @see https://developer.wordpress.org/rest-api/reference/settings/#update-a-site-setting
  *
- * @param  this         RequestUtils.
- * @param  siteSettings The partial settings payload to update.
+ * @param this         RequestUtils.
+ * @param siteSettings The partial settings payload to update.
  */
 export async function updateSiteSettings(
 	this: RequestUtils,

--- a/packages/e2e-test-utils-playwright/src/request-utils/templates.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/templates.ts
@@ -18,8 +18,8 @@ const PATH_MAPPING = {
 /**
  * Delete all the templates of given type.
  *
- * @param  this
- * @param  type - Template type to delete.
+ * @param this
+ * @param type - Template type to delete.
  */
 async function deleteAllTemplates( this: RequestUtils, type: TemplateType ) {
 	const path = PATH_MAPPING[ type ];

--- a/packages/e2e-test-utils-playwright/src/request-utils/users.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/users.ts
@@ -30,7 +30,7 @@ export interface UserRequestData {
  * List all users.
  *
  * @see https://developer.wordpress.org/rest-api/reference/users/#list-users
- * @param  this
+ * @param this
  */
 async function listUsers( this: RequestUtils ) {
 	const response = await this.rest< User[] >( {
@@ -48,8 +48,8 @@ async function listUsers( this: RequestUtils ) {
  * Add a test user.
  *
  * @see https://developer.wordpress.org/rest-api/reference/users/#create-a-user
- * @param  this
- * @param  user User data to create.
+ * @param this
+ * @param user User data to create.
  */
 async function createUser( this: RequestUtils, user: UserData ) {
 	const userData: UserRequestData = {
@@ -86,8 +86,8 @@ async function createUser( this: RequestUtils, user: UserData ) {
  * Delete a user.
  *
  * @see https://developer.wordpress.org/rest-api/reference/users/#delete-a-user
- * @param  this
- * @param  userId The ID of the user.
+ * @param this
+ * @param userId The ID of the user.
  */
 async function deleteUser( this: RequestUtils, userId: number ) {
 	const response = await this.rest( {
@@ -102,7 +102,7 @@ async function deleteUser( this: RequestUtils, userId: number ) {
 /**
  * Delete all users except main root user.
  *
- * @param  this
+ * @param this
  */
 async function deleteAllUsers( this: RequestUtils ) {
 	const users = await listUsers.bind( this )();

--- a/packages/e2e-test-utils-playwright/src/test.ts
+++ b/packages/e2e-test-utils-playwright/src/test.ts
@@ -26,7 +26,7 @@ const OBSERVED_CONSOLE_MESSAGE_TYPES = [ 'warn', 'error' ] as const;
  * Adds a page event handler to emit uncaught exception to process if one of
  * the observed console logging types is encountered.
  *
- * @param  message The console message.
+ * @param message The console message.
  */
 function observeConsoleLogging( message: ConsoleMessage ) {
 	const type = message.type();

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -32,7 +32,7 @@ interface I18nContextProps {
 /**
  * Utility to make a new context value
  *
- * @param  i18n
+ * @param i18n
  */
 function makeContextValue( i18n: I18n ): I18nContextProps {
 	return {
@@ -69,7 +69,7 @@ type I18nProviderProps = PropsWithChildren< { i18n: I18n } >;
  * You can also instantiate the provider without the `i18n` prop. In that case it will use the
  * default `I18n` instance exported from `@wordpress/i18n`.
  *
- * @param  props i18n provider props.
+ * @param props i18n provider props.
  * @return Children wrapped in the I18nProvider.
  */
 export function I18nProvider( props: I18nProviderProps ): JSX.Element {
@@ -125,7 +125,7 @@ type PropsAndI18n< P > = Pick<
  * export default withI18n( MyComponent );
  * ```
  *
- * @param  InnerComponent React component to be wrapped and receive the i18n functions like `__`
+ * @param InnerComponent React component to be wrapped and receive the i18n functions like `__`
  * @return The wrapped component
  */
 export function withI18n< P extends I18nContextProps >(

--- a/packages/redux-routine/src/runtime.ts
+++ b/packages/redux-routine/src/runtime.ts
@@ -13,8 +13,8 @@ import { isActionOfType, isAction } from './is-action';
 /**
  * Create a co-routine runtime.
  *
- * @param  controls Object of control handlers.
- * @param  dispatch Unhandled action dispatch.
+ * @param controls Object of control handlers.
+ * @param dispatch Unhandled action dispatch.
  */
 export default function createRuntime(
 	controls: Record<

--- a/packages/report-flaky-tests/src/strip-ansi.ts
+++ b/packages/report-flaky-tests/src/strip-ansi.ts
@@ -4,7 +4,7 @@
  * @see https://github.com/chalk/strip-ansi
  * Licensed under MIT license.
  *
- * @param  string The ansi string.
+ * @param string The ansi string.
  */
 function stripAnsi( string: string ) {
 	return string.replace(

--- a/packages/style-engine/src/index.ts
+++ b/packages/style-engine/src/index.ts
@@ -19,8 +19,8 @@ import { styleDefinitions } from './styles';
  *
  * @since 6.1.0 Introduced in WordPress core.
  *
- * @param  style   Style object, for example, the value of a block's attributes.style object or the top level styles in theme.json
- * @param  options Options object with settings to adjust how the styles are generated.
+ * @param style   Style object, for example, the value of a block's attributes.style object or the top level styles in theme.json
+ * @param options Options object with settings to adjust how the styles are generated.
  *
  * @return A generated stylesheet or inline style declarations.
  */
@@ -60,8 +60,8 @@ export function compileCSS( style: Style, options: StyleOptions = {} ): string {
  *
  * @since 6.1.0 Introduced in WordPress core.
  *
- * @param  style   Style object, for example, the value of a block's attributes.style object or the top level styles in theme.json
- * @param  options Options object with settings to adjust how the styles are generated.
+ * @param style   Style object, for example, the value of a block's attributes.style object or the top level styles in theme.json
+ * @param options Options object with settings to adjust how the styles are generated.
  *
  * @return A collection of objects containing the selector, if any, the CSS property key (camelcase) and parsed CSS value.
  */

--- a/packages/style-engine/src/styles/border/index.ts
+++ b/packages/style-engine/src/styles/border/index.ts
@@ -7,7 +7,7 @@ import { generateRule, generateBoxRules, camelCaseJoin } from '../utils';
 /**
  * Creates a function for generating CSS rules when the style path is the same as the camelCase CSS property used in React.
  *
- * @param  path An array of strings representing the path to the style value in the style object.
+ * @param path An array of strings representing the path to the style value in the style object.
  *
  * @return A function that generates CSS rules.
  */
@@ -19,7 +19,7 @@ function createBorderGenerateFunction( path: string[] ): GenerateFunction {
 /**
  * Creates a function for generating border-{top,bottom,left,right}-{color,style,width} CSS rules.
  *
- * @param  edge The edge to create CSS rules for.
+ * @param edge The edge to create CSS rules for.
  *
  * @return A function that generates CSS rules.
  */

--- a/packages/style-engine/src/styles/utils.ts
+++ b/packages/style-engine/src/styles/utils.ts
@@ -22,10 +22,10 @@ import {
 /**
  * Returns a JSON representation of the generated CSS rules.
  *
- * @param  style   Style object.
- * @param  options Options object with settings to adjust how the styles are generated.
- * @param  path    An array of strings representing the path to the style value in the style object.
- * @param  ruleKey A CSS property key.
+ * @param style   Style object.
+ * @param options Options object with settings to adjust how the styles are generated.
+ * @param path    An array of strings representing the path to the style value in the style object.
+ * @param ruleKey A CSS property key.
  *
  * @return GeneratedCSSRule[] CSS rules.
  */
@@ -51,11 +51,11 @@ export function generateRule(
 /**
  * Returns a JSON representation of the generated CSS rules taking into account box model properties, top, right, bottom, left.
  *
- * @param  style                Style object.
- * @param  options              Options object with settings to adjust how the styles are generated.
- * @param  path                 An array of strings representing the path to the style value in the style object.
- * @param  ruleKeys             An array of CSS property keys and patterns.
- * @param  individualProperties The "sides" or individual properties for which to generate rules.
+ * @param style                Style object.
+ * @param options              Options object with settings to adjust how the styles are generated.
+ * @param path                 An array of strings representing the path to the style value in the style object.
+ * @param ruleKeys             An array of CSS property keys and patterns.
+ * @param individualProperties The "sides" or individual properties for which to generate rules.
  *
  * @return GeneratedCSSRule[]  CSS rules.
  */
@@ -107,7 +107,7 @@ export function generateBoxRules(
 /**
  * Returns a CSS var value from incoming style value following the pattern `var:description|context|slug`.
  *
- * @param  styleValue A raw style value.
+ * @param styleValue A raw style value.
  *
  * @return string A CSS var value.
  */
@@ -129,7 +129,7 @@ export function getCSSVarFromStyleValue( styleValue: string ): string {
 /**
  * Capitalizes the first letter in a string.
  *
- * @param  string The string whose first letter the function will capitalize.
+ * @param string The string whose first letter the function will capitalize.
  *
  * @return String with the first letter capitalized.
  */
@@ -141,7 +141,7 @@ export function upperFirst( string: string ): string {
 /**
  * Converts an array of strings into a camelCase string.
  *
- * @param  strings The strings to join into a camelCase string.
+ * @param strings The strings to join into a camelCase string.
  *
  * @return camelCase string.
  */


### PR DESCRIPTION
## What?
This PR fixes a bunch of ESLint warnings, as well as a couple of TS errors that were unveiled with those fixes.

## Why?
Ideally, we shouldn't have any ESLint warnings/errors. This fixes 151 of the total 167 existing ones.

## How?
We ran `npm run lint:js:fix` and did a couple of TS massaging changes. Basically `EntityRecordKey` is a `number | string`, which required the additional TS changes.

## Testing Instructions
* Verify there are only 16 `jest/expect-expect` or `jest/no-disabled-tests` warnings when running `npm run lint:js`.
* Verify all checks are green.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None