### PR TITLE
Fix link UI popover only opens if there's one navigation block in the page

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1424,6 +1424,7 @@ _Parameters_
 -   _blocks_ `Object[]`: Block objects to insert as new InnerBlocks
 -   _updateSelection_ `?boolean`: If true block selection will be updated. If false, block selection will not change. Defaults to false.
 -   _initialPosition_ `0|-1|null`: Initial block position.
+-   _actor_ `string`: Actor who triggered the action.
 
 _Returns_
 

--- a/packages/block-editor/src/components/off-canvas-editor/block-contents.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-contents.js
@@ -46,6 +46,7 @@ const ListViewBlockContents = forwardRef(
 		const {
 			blockMovingClientId,
 			selectedBlockInBlockEditor,
+			lastInsertedBlocksActor,
 			lastInsertedBlockClientId,
 		} = useSelect(
 			( select ) => {
@@ -53,15 +54,19 @@ const ListViewBlockContents = forwardRef(
 					hasBlockMovingClientId,
 					getSelectedBlockClientId,
 					getLastInsertedBlocksClientIds,
+					getLastInsertedBlocksActor,
 				} = unlock( select( blockEditorStore ) );
 				const lastInsertedBlocksClientIds =
 					getLastInsertedBlocksClientIds();
 				return {
 					blockMovingClientId: hasBlockMovingClientId(),
 					selectedBlockInBlockEditor: getSelectedBlockClientId(),
+					lastInsertedBlocksActor: getLastInsertedBlocksActor(),
 					lastInsertedBlockClientId:
 						lastInsertedBlocksClientIds &&
-						lastInsertedBlocksClientIds[ 0 ],
+						lastInsertedBlocksClientIds[
+							lastInsertedBlocksClientIds.length - 1
+						],
 				};
 			},
 			[ clientId ]
@@ -77,6 +82,7 @@ const ListViewBlockContents = forwardRef(
 
 		useEffect( () => {
 			if (
+				lastInsertedBlocksActor !== 'auto' && // don't show the Link UI if the block was inserted by something other than the user.
 				clientId === lastInsertedBlockClientId &&
 				BLOCKS_WITH_LINK_UI_SUPPORT?.includes( insertedBlockName ) &&
 				! hasExistingLinkValue // don't re-show the Link UI if the block already has a link value.
@@ -85,6 +91,7 @@ const ListViewBlockContents = forwardRef(
 			}
 		}, [
 			lastInsertedBlockClientId,
+			lastInsertedBlocksActor,
 			clientId,
 			insertedBlockName,
 			hasExistingLinkValue,

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1230,13 +1230,15 @@ export function removeBlock( clientId, selectPrevious ) {
  * @param {Object[]}  blocks          Block objects to insert as new InnerBlocks
  * @param {?boolean}  updateSelection If true block selection will be updated. If false, block selection will not change. Defaults to false.
  * @param {0|-1|null} initialPosition Initial block position.
+ * @param {string}    actor           Actor who triggered the action.
  * @return {Object} Action object.
  */
 export function replaceInnerBlocks(
 	rootClientId,
 	blocks,
 	updateSelection = false,
-	initialPosition = 0
+	initialPosition = 0,
+	actor = 'auto'
 ) {
 	/* eslint-enable jsdoc/valid-types */
 	return {
@@ -1246,6 +1248,7 @@ export function replaceInnerBlocks(
 		updateSelection,
 		initialPosition: updateSelection ? initialPosition : null,
 		time: Date.now(),
+		meta: { actor },
 	};
 }
 

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -18,3 +18,13 @@ export function isBlockInterfaceHidden( state ) {
 export function getLastInsertedBlocksClientIds( state ) {
 	return state?.lastBlockInserted?.clientIds;
 }
+
+/**
+ * Gets the actor of the last inserted blocks.
+ *
+ * @param {Object} state Global application state.
+ * @return {string|undefined} Actor of the last inserted block(s).
+ */
+export function getLastInsertedBlocksActor( state ) {
+	return state?.lastBlockInserted?.actor;
+}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1840,8 +1840,9 @@ export function lastBlockInserted( state = {}, action ) {
 			} );
 
 			const source = action.meta?.source;
+			const actor = action.meta?.actor;
 
-			return { clientIds, source };
+			return { clientIds, source, actor };
 		case 'RESET_BLOCKS':
 			return {};
 	}

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -865,6 +865,7 @@ describe( 'actions', () => {
 				time: expect.any( Number ),
 				updateSelection: false,
 				initialPosition: null,
+				meta: { actor: 'auto' },
 			} );
 		} );
 
@@ -876,6 +877,7 @@ describe( 'actions', () => {
 				time: expect.any( Number ),
 				updateSelection: true,
 				initialPosition: 0,
+				meta: { actor: 'auto' },
 			} );
 		} );
 	} );

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -4,6 +4,7 @@
 import {
 	isBlockInterfaceHidden,
 	getLastInsertedBlocksClientIds,
+	getLastInsertedBlocksActor,
 } from '../private-selectors';
 
 describe( 'private selectors', () => {
@@ -47,6 +48,18 @@ describe( 'private selectors', () => {
 				'123456',
 				'78910',
 			] );
+		} );
+	} );
+
+	describe( 'getLastInsertedBlocksActor', () => {
+		it( 'should return auto if the block was not inserted manually by the user', () => {
+			const state = {
+				lastBlockInserted: {
+					actor: 'auto',
+				},
+			};
+
+			expect( getLastInsertedBlocksActor( state ) ).toEqual( 'auto' );
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes https://github.com/WordPress/gutenberg/issues/47829

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
