### PR TITLE
Sync: Widget import changes from the core

### DIFF
--- a/lib/compat/wordpress-6.2/theme.php
+++ b/lib/compat/wordpress-6.2/theme.php
@@ -6,18 +6,18 @@
  */
 
 /**
- * Store legacy sidebars for later use by block themes.
+ * Store classic sidebars for later use by block themes.
  *
  * Note: This can be a part of the `switch_theme` method in `wp-includes/theme.php`.
  *
  * @param string   $new_name  Name of the new theme.
  * @param WP_Theme $new_theme WP_Theme instance of the new theme.
  */
-function gutenberg_set_legacy_sidebars( $new_name, $new_theme ) {
+function gutenberg_set_classic_sidebars( $new_name, $new_theme ) {
 	global $wp_registered_sidebars;
 
 	if ( $new_theme->is_block_theme() ) {
-		set_theme_mod( 'wp_legacy_sidebars', $wp_registered_sidebars );
+		set_theme_mod( 'wp_classic_sidebars', $wp_registered_sidebars );
 	}
 }
-add_action( 'switch_theme', 'gutenberg_set_legacy_sidebars', 10, 2 );
+add_action( 'switch_theme', 'gutenberg_set_classic_sidebars', 10, 2 );

--- a/lib/compat/wordpress-6.2/widgets.php
+++ b/lib/compat/wordpress-6.2/widgets.php
@@ -5,20 +5,23 @@
  * @package gutenberg
  */
 
-if ( ! function_exists( '_wp_block_theme_stub_sidebars' ) ) {
+if ( ! function_exists( '_wp_block_theme_register_classic_sidebars' ) ) {
 	/**
-	 * Register the previous theme's sidebars for the block themes.
+	 * Registers the previous theme's sidebars for the block themes.
 	 *
-	 * @return void
+	 * @since 6.2.0
+	 * @access private
+	 *
+	 * @global array $wp_registered_sidebars Registered sidebars.
 	 */
-	function _wp_block_theme_stub_sidebars() {
+	function _wp_block_theme_register_classic_sidebars() {
 		global $wp_registered_sidebars;
 
 		if ( ! wp_is_block_theme() ) {
 			return;
 		}
 
-		$legacy_sidebars = get_theme_mod( 'wp_legacy_sidebars' );
+		$legacy_sidebars = get_theme_mod( 'wp_classic_sidebars' );
 		if ( empty( $legacy_sidebars ) ) {
 			return;
 		}
@@ -28,5 +31,5 @@ if ( ! function_exists( '_wp_block_theme_stub_sidebars' ) ) {
 			$wp_registered_sidebars[ $sidebar['id'] ] = $sidebar;
 		}
 	}
-	add_action( 'widgets_init', '_wp_block_theme_stub_sidebars' );
+	add_action( 'widgets_init', '_wp_block_theme_register_classic_sidebars' );
 }


### PR DESCRIPTION
## What?
Sync changes from https://github.com/WordPress/wordpress-develop/pull/3893, to avoid registering sidebars twice.

* Changes registration method and theme mod name.

## Testing Instructions
See https://github.com/WordPress/gutenberg/pull/45509

1. Active a classic theme.
2. Insert widgets into the sidebars.
3. Switch to the block theme.
4. Open a template in the Site Editor.
5. Add a new template part to the template.
6. Import widgets.
