### PR TITLE
ESLint: Change `jsdoc/check-line-alignment` from `warn` to `error`

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the severity of the rule `jsdoc/check-line-alignment` from `warn` to `error`. ([#47878](https://github.com/WordPress/gutenberg/pull/47878)).
+
 ## 13.10.0 (2023-02-01)
 
 - The bundled `eslint-plugin-jsdoc` dependency has been updated from requiring `^37.0.3` to requiring `^39.6.9`

--- a/packages/eslint-plugin/configs/jsdoc.js
+++ b/packages/eslint-plugin/configs/jsdoc.js
@@ -113,7 +113,7 @@ module.exports = {
 		'jsdoc/check-access': 'error',
 		'jsdoc/check-alignment': 'error',
 		'jsdoc/check-line-alignment': [
-			'warn',
+			'error',
 			'always',
 			{
 				tags: [ 'param', 'arg', 'argument', 'property', 'prop' ],


### PR DESCRIPTION
## What?
This PR changes the `jsdoc/check-line-alignment` ESLint rule to `error` instead of `warn`.

## Why?
We've recently been fixing a bunch of these warnings, so as suggested by @gziolo [here](https://github.com/WordPress/gutenberg/pull/47811#pullrequestreview-1286665564) and [here](https://github.com/WordPress/gutenberg/pull/47872#issuecomment-1422543517) it might be a good idea to promote it to `error`.

## How?
We're increasing the severity of the rule `jsdoc/check-line-alignment` from `warn` to `error`.

## Testing Instructions
Verify `npm run lint:js` still works well and yields just 16 warnings.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None