### PR TITLE
Add parent navigation support for the navigator component

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1062,6 +1062,12 @@
 		"parent": "components"
 	},
 	{
+		"title": "NavigatorToParentButton",
+		"slug": "navigator-to-parent-button",
+		"markdown_source": "../packages/components/src/navigator/navigator-to-parent-button/README.md",
+		"parent": "components"
+	},
+	{
 		"title": "Notice",
 		"slug": "notice",
 		"markdown_source": "../packages/components/src/notice/README.md",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,7 @@
 -  `ColorPalette`, `GradientPicker`, `PaletteEdit`, `ToolsPanel`: add new props to set a custom heading level ([43848](https://github.com/WordPress/gutenberg/pull/43848) and [#47788](https://github.com/WordPress/gutenberg/pull/47788)).
 -   `ColorPalette`: ensure text label contrast checking works with CSS variables ([#47373](https://github.com/WordPress/gutenberg/pull/47373)).
 -  `Navigator`: Support dynamic paths with parameters ([#47827](https://github.com/WordPress/gutenberg/pull/47827)).
+-  `Navigator`: Support hierarchical paths navigation and add `NavigatorToParentButton` component ([#47883](https://github.com/WordPress/gutenberg/pull/47883)).
 
 ### Internal
 

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -115,6 +115,7 @@ export {
 	NavigatorScreen as __experimentalNavigatorScreen,
 	NavigatorButton as __experimentalNavigatorButton,
 	NavigatorBackButton as __experimentalNavigatorBackButton,
+	NavigatorToParentButton as __experimentalNavigatorToParentButton,
 	useNavigator as __experimentalUseNavigator,
 } from './navigator';
 export { default as Notice } from './notice';

--- a/packages/components/src/navigator/context.ts
+++ b/packages/components/src/navigator/context.ts
@@ -12,6 +12,7 @@ const initialContextValue: NavigatorContextType = {
 	location: {},
 	goTo: () => {},
 	goBack: () => {},
+	goToParent: () => {},
 	addScreen: () => {},
 	removeScreen: () => {},
 	params: {},

--- a/packages/components/src/navigator/index.ts
+++ b/packages/components/src/navigator/index.ts
@@ -2,4 +2,5 @@ export { NavigatorProvider } from './navigator-provider';
 export { NavigatorScreen } from './navigator-screen';
 export { NavigatorButton } from './navigator-button';
 export { NavigatorBackButton } from './navigator-back-button';
+export { NavigatorToParentButton } from './navigator-to-parent-button';
 export { default as useNavigator } from './use-navigator';

--- a/packages/components/src/navigator/navigator-back-button/README.md
+++ b/packages/components/src/navigator/navigator-back-button/README.md
@@ -12,4 +12,4 @@ Refer to [the `NavigatorProvider` component](/packages/components/src/navigator/
 
 ### Inherited props
 
-`NavigatorBackButton` also inherits all of the [`Button` props](/packages/components/src/button/README.md#props), except for `href`.
+`NavigatorBackButton` also inherits all of the [`Button` props](/packages/components/src/button/README.md#props), except for `href` and `target`.

--- a/packages/components/src/navigator/navigator-back-button/hook.ts
+++ b/packages/components/src/navigator/navigator-back-button/hook.ts
@@ -17,18 +17,23 @@ export function useNavigatorBackButton(
 	const {
 		onClick,
 		as = Button,
+		goToParent: goToParentProp = false,
 		...otherProps
 	} = useContextSystem( props, 'NavigatorBackButton' );
 
-	const { goBack } = useNavigator();
+	const { goBack, goToParent } = useNavigator();
 	const handleClick: React.MouseEventHandler< HTMLButtonElement > =
 		useCallback(
 			( e ) => {
 				e.preventDefault();
-				goBack();
+				if ( goToParentProp ) {
+					goToParent();
+				} else {
+					goBack();
+				}
 				onClick?.( e );
 			},
-			[ goBack, onClick ]
+			[ goToParentProp, goToParent, goBack, onClick ]
 		);
 
 	return {

--- a/packages/components/src/navigator/navigator-back-button/hook.ts
+++ b/packages/components/src/navigator/navigator-back-button/hook.ts
@@ -9,10 +9,10 @@ import { useCallback } from '@wordpress/element';
 import { useContextSystem, WordPressComponentProps } from '../../ui/context';
 import Button from '../../button';
 import useNavigator from '../use-navigator';
-import type { NavigatorBackButtonProps } from '../types';
+import type { NavigatorBackButtonHookProps } from '../types';
 
 export function useNavigatorBackButton(
-	props: WordPressComponentProps< NavigatorBackButtonProps, 'button' >
+	props: WordPressComponentProps< NavigatorBackButtonHookProps, 'button' >
 ) {
 	const {
 		onClick,

--- a/packages/components/src/navigator/navigator-provider/README.md
+++ b/packages/components/src/navigator/navigator-provider/README.md
@@ -4,7 +4,7 @@
 This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
 </div>
 
-The `NavigatorProvider` component allows rendering nested views/panels/menus (via the [`NavigatorScreen` component](/packages/components/src/navigator/navigator-screen/README.md)) and navigate between these different states (via the [`NavigatorButton`](/packages/components/src/navigator/navigator-button/README.md) and [`NavigatorBackButton`](/packages/components/src/navigator/navigator-back-button/README.md) components or the `useNavigator` hook). The Global Styles sidebar is an example of this.
+The `NavigatorProvider` component allows rendering nested views/panels/menus (via the [`NavigatorScreen` component](/packages/components/src/navigator/navigator-screen/README.md)) and navigate between these different states (via the [`NavigatorButton`](/packages/components/src/navigator/navigator-button/README.md), [`NavigatorToParentButton`](/packages/components/src/navigator/navigator-to-parent-button/README.md) and [`NavigatorBackButton`](/packages/components/src/navigator/navigator-back-button/README.md) components or the `useNavigator` hook). The Global Styles sidebar is an example of this.
 
 ## Usage
 
@@ -13,7 +13,7 @@ import {
   __experimentalNavigatorProvider as NavigatorProvider,
   __experimentalNavigatorScreen as NavigatorScreen,
   __experimentalNavigatorButton as NavigatorButton,
-  __experimentalNavigatorBackButton as NavigatorBackButton,
+  __experimentalNavigatorToParentButton as NavigatorToParentButton,
 } from '@wordpress/components';
 
 const MyNavigation = () => (
@@ -27,13 +27,20 @@ const MyNavigation = () => (
 
     <NavigatorScreen path="/child">
       <p>This is the child screen.</p>
-      <NavigatorBackButton>
+      <NavigatorToParentButton>
         Go back
-      </NavigatorBackButton>
+      </NavigatorToParentButton>
     </NavigatorScreen>
   </NavigatorProvider>
 );
 ```
+**Important note**
+
+Parent/child navigation only works if the path you define are hierarchical. For example:
+ - `/` is the root of all paths. 
+ - `/parent/child` is a child of `/parent`. 
+ - `/parent/child/grand-child` is a child of `/parent/child`.
+ - `/parent/:param` is a child of `/parent` as well.
 
 ## Props
 

--- a/packages/components/src/navigator/navigator-provider/README.md
+++ b/packages/components/src/navigator/navigator-provider/README.md
@@ -36,11 +36,12 @@ const MyNavigation = () => (
 ```
 **Important note**
 
-Parent/child navigation only works if the path you define are hierarchical. For example:
- - `/` is the root of all paths. 
- - `/parent/child` is a child of `/parent`. 
- - `/parent/child/grand-child` is a child of `/parent/child`.
- - `/parent/:param` is a child of `/parent` as well.
+Parent/child navigation only works if the path you define are hierarchical, following a URL-like scheme where each path segment is separated by the `/` character.
+For example:
+- `/` is the root of all paths. There should always be a screen with `path="/"`.
+- `/parent/child` is a child of `/parent`.
+- `/parent/child/grand-child` is a child of `/parent/child`.
+- `/parent/:param` is a child of `/parent` as well.
 
 ## Props
 
@@ -65,6 +66,15 @@ The `goTo` function allows navigating to a given path. The second argument can a
 The available options are:
 
 - `focusTargetSelector`: `string`. An optional property used to specify the CSS selector used to restore focus on the matching element when navigating back.
+- `isBack`: `boolean`. An optional property used to specify whether the navigation should be considered as backwards (thus enabling focus restoration when possible, and causing the animation to be backwards too)
+
+### `goToParent`: `() => void;`
+
+The `goToParent` function allows navigating to the parent screen.
+
+Parent/child navigation only works if the path you define are hierarchical (see note above).
+
+When a match is not found, the function will try to recursively navigate the path hierarchy until a matching screen (or the root `/`) are found.
 
 ### `goBack`: `() => void`
 

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -176,7 +176,7 @@ function UnconnectedNavigatorProvider(
 
 				return [
 					...prevLocationHistory.slice(
-						prevLocationHistory.length > MAX_HISTORY_LENGTH - 2
+						prevLocationHistory.length > MAX_HISTORY_LENGTH - 1
 							? 1
 							: 0,
 						-1

--- a/packages/components/src/navigator/navigator-to-parent-button/README.md
+++ b/packages/components/src/navigator/navigator-to-parent-button/README.md
@@ -1,10 +1,10 @@
-# `NavigatorBackButton`
+# `NavigatorToParentButton`
 
 <div class="callout callout-alert">
 This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
 </div>
 
-The `NavigatorBackButton` component can be used to navigate to a screen and should be used in combination with the [`NavigatorProvider`](/packages/components/src/navigator/navigator-provider/README.md), the [`NavigatorScreen`](/packages/components/src/navigator/navigator-screen/README.md) and the [`NavigatorButton`](/packages/components/src/navigator/navigator-button/README.md) components (or the `useNavigator` hook).
+The `NavigatorToParentButton` component can be used to navigate to a screen and should be used in combination with the [`NavigatorProvider`](/packages/components/src/navigator/navigator-provider/README.md), the [`NavigatorScreen`](/packages/components/src/navigator/navigator-screen/README.md) and the [`NavigatorButton`](/packages/components/src/navigator/navigator-button/README.md) components (or the `useNavigator` hook).
 
 ## Usage
 

--- a/packages/components/src/navigator/navigator-to-parent-button/README.md
+++ b/packages/components/src/navigator/navigator-to-parent-button/README.md
@@ -12,4 +12,4 @@ Refer to [the `NavigatorProvider` component](/packages/components/src/navigator/
 
 ### Inherited props
 
-`NavigatorBackButton` also inherits all of the [`Button` props](/packages/components/src/button/README.md#props), except for `href`.
+`NavigatorToParentButton` also inherits all of the [`Button` props](/packages/components/src/button/README.md#props), except for `href` and `target`.

--- a/packages/components/src/navigator/navigator-to-parent-button/component.tsx
+++ b/packages/components/src/navigator/navigator-to-parent-button/component.tsx
@@ -35,7 +35,7 @@ function UnconnectedNavigatorToParentButton(
  *   __experimentalNavigatorProvider as NavigatorProvider,
  *   __experimentalNavigatorScreen as NavigatorScreen,
  *   __experimentalNavigatorButton as NavigatorButton,
- *   __experimentalNavigatorBackButton as NavigatorBackButton,
+ *   __experimentalNavigatorToParentButton as NavigatorToParentButton,
  * } from '@wordpress/components';
  *
  * const MyNavigation = () => (

--- a/packages/components/src/navigator/navigator-to-parent-button/component.tsx
+++ b/packages/components/src/navigator/navigator-to-parent-button/component.tsx
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import type { ForwardedRef } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { contextConnect, WordPressComponentProps } from '../../ui/context';
+import { View } from '../../view';
+import { useNavigatorBackButton } from '../navigator-back-button/hook';
+import type { NavigatorToParentButtonProps } from '../types';
+
+function UnconnectedNavigatorToParentButton(
+	props: WordPressComponentProps< NavigatorToParentButtonProps, 'button' >,
+	forwardedRef: ForwardedRef< any >
+) {
+	const navigatorToParentButtonProps = useNavigatorBackButton( {
+		...props,
+		goToParent: true,
+	} );
+
+	return <View ref={ forwardedRef } { ...navigatorToParentButtonProps } />;
+}
+
+/*
+ * The `NavigatorToParentButton` component can be used to navigate to a screen and
+ * should be used in combination with the `NavigatorProvider`, the
+ * `NavigatorScreen` and the `NavigatorButton` components (or the `useNavigator`
+ * hook).
+ *
+ * @example
+ * ```jsx
+ * import {
+ *   __experimentalNavigatorProvider as NavigatorProvider,
+ *   __experimentalNavigatorScreen as NavigatorScreen,
+ *   __experimentalNavigatorButton as NavigatorButton,
+ *   __experimentalNavigatorBackButton as NavigatorBackButton,
+ * } from '@wordpress/components';
+ *
+ * const MyNavigation = () => (
+ *   <NavigatorProvider initialPath="/">
+ *     <NavigatorScreen path="/">
+ *       <p>This is the home screen.</p>
+ *        <NavigatorButton path="/child">
+ *          Navigate to child screen.
+ *       </NavigatorButton>
+ *     </NavigatorScreen>
+ *
+ *     <NavigatorScreen path="/child">
+ *       <p>This is the child screen.</p>
+ *       <NavigatorToParentButton>
+ *         Go to parent
+ *       </NavigatorToParentButton>
+ *     </NavigatorScreen>
+ *   </NavigatorProvider>
+ * );
+ * ```
+ */
+export const NavigatorToParentButton = contextConnect(
+	UnconnectedNavigatorToParentButton,
+	'NavigatorToParentButton'
+);
+
+export default NavigatorToParentButton;

--- a/packages/components/src/navigator/navigator-to-parent-button/index.ts
+++ b/packages/components/src/navigator/navigator-to-parent-button/index.ts
@@ -1,0 +1,1 @@
+export { default as NavigatorToParentButton } from './component';

--- a/packages/components/src/navigator/stories/index.tsx
+++ b/packages/components/src/navigator/stories/index.tsx
@@ -232,3 +232,64 @@ function ProductDetails() {
 		</Card>
 	);
 }
+
+const NestedNavigatorTemplate: ComponentStory< typeof NavigatorProvider > = ( {
+	style,
+} ) => (
+	<NavigatorProvider
+		style={ { ...style, height: '100vh', maxHeight: '450px' } }
+		initialPath="/"
+	>
+		<NavigatorScreen path="/">
+			<Card>
+				<CardBody>
+					<NavigatorButton variant="secondary" path="/child1">
+						Go to first child.
+					</NavigatorButton>
+					<NavigatorButton variant="secondary" path="/child2">
+						Go to second child.
+					</NavigatorButton>
+				</CardBody>
+			</Card>
+		</NavigatorScreen>
+		<NavigatorScreen path="/child1">
+			<Card>
+				<CardBody>
+					This is the first child
+					<NavigatorBackButton variant="secondary" goToParent>
+						Go back to parent
+					</NavigatorBackButton>
+				</CardBody>
+			</Card>
+		</NavigatorScreen>
+		<NavigatorScreen path="/child2">
+			<Card>
+				<CardBody>
+					This is the second child
+					<NavigatorBackButton variant="secondary" goToParent>
+						Go back to parent
+					</NavigatorBackButton>
+					<NavigatorButton
+						variant="secondary"
+						path="/child2/grandchild"
+					>
+						Go to grand child.
+					</NavigatorButton>
+				</CardBody>
+			</Card>
+		</NavigatorScreen>
+		<NavigatorScreen path="/child2/grandchild">
+			<Card>
+				<CardBody>
+					This is the grand child
+					<NavigatorBackButton variant="secondary" goToParent>
+						Go back to parent
+					</NavigatorBackButton>
+				</CardBody>
+			</Card>
+		</NavigatorScreen>
+	</NavigatorProvider>
+);
+
+export const NestedNavigator: ComponentStory< typeof NavigatorProvider > =
+	NestedNavigatorTemplate.bind( {} );

--- a/packages/components/src/navigator/stories/index.tsx
+++ b/packages/components/src/navigator/stories/index.tsx
@@ -236,10 +236,11 @@ function ProductDetails() {
 
 const NestedNavigatorTemplate: ComponentStory< typeof NavigatorProvider > = ( {
 	style,
+	...props
 } ) => (
 	<NavigatorProvider
 		style={ { ...style, height: '100vh', maxHeight: '450px' } }
-		initialPath="/"
+		{ ...props }
 	>
 		<NavigatorScreen path="/">
 			<Card>
@@ -294,3 +295,6 @@ const NestedNavigatorTemplate: ComponentStory< typeof NavigatorProvider > = ( {
 
 export const NestedNavigator: ComponentStory< typeof NavigatorProvider > =
 	NestedNavigatorTemplate.bind( {} );
+NestedNavigator.args = {
+	initialPath: '/child2/grandchild',
+};

--- a/packages/components/src/navigator/stories/index.tsx
+++ b/packages/components/src/navigator/stories/index.tsx
@@ -15,6 +15,7 @@ import {
 	NavigatorScreen,
 	NavigatorButton,
 	NavigatorBackButton,
+	NavigatorToParentButton,
 	useNavigator,
 } from '..';
 
@@ -256,9 +257,9 @@ const NestedNavigatorTemplate: ComponentStory< typeof NavigatorProvider > = ( {
 			<Card>
 				<CardBody>
 					This is the first child
-					<NavigatorBackButton variant="secondary" goToParent>
+					<NavigatorToParentButton variant="secondary">
 						Go back to parent
-					</NavigatorBackButton>
+					</NavigatorToParentButton>
 				</CardBody>
 			</Card>
 		</NavigatorScreen>
@@ -266,9 +267,9 @@ const NestedNavigatorTemplate: ComponentStory< typeof NavigatorProvider > = ( {
 			<Card>
 				<CardBody>
 					This is the second child
-					<NavigatorBackButton variant="secondary" goToParent>
+					<NavigatorToParentButton variant="secondary">
 						Go back to parent
-					</NavigatorBackButton>
+					</NavigatorToParentButton>
 					<NavigatorButton
 						variant="secondary"
 						path="/child2/grandchild"
@@ -282,9 +283,9 @@ const NestedNavigatorTemplate: ComponentStory< typeof NavigatorProvider > = ( {
 			<Card>
 				<CardBody>
 					This is the grand child
-					<NavigatorBackButton variant="secondary" goToParent>
+					<NavigatorToParentButton variant="secondary">
 						Go back to parent
-					</NavigatorBackButton>
+					</NavigatorToParentButton>
 				</CardBody>
 			</Card>
 		</NavigatorScreen>

--- a/packages/components/src/navigator/test/index.tsx
+++ b/packages/components/src/navigator/test/index.tsx
@@ -13,7 +13,7 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { Button } from '../../';
+import { Button } from '../../button';
 import {
 	NavigatorProvider,
 	NavigatorScreen,
@@ -87,6 +87,7 @@ type CustomTestOnClickHandler = (
 				path: string;
 		  }
 		| { type: 'goBack' }
+		| { type: 'goToParent' }
 ) => void;
 
 function CustomNavigatorButton( {
@@ -123,7 +124,6 @@ function CustomNavigatorGoToBackButton( {
 				// Used to spy on the values passed to `navigator.goTo`.
 				onClick?.( { type: 'goTo', path } );
 			} }
-			path={ path }
 			{ ...props }
 		/>
 	);

--- a/packages/components/src/navigator/test/index.tsx
+++ b/packages/components/src/navigator/test/index.tsx
@@ -13,7 +13,7 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { Button } from '../../button';
+import Button from '../../button';
 import {
 	NavigatorProvider,
 	NavigatorScreen,

--- a/packages/components/src/navigator/test/index.tsx
+++ b/packages/components/src/navigator/test/index.tsx
@@ -13,11 +13,13 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { Button } from '../../';
 import {
 	NavigatorProvider,
 	NavigatorScreen,
 	NavigatorButton,
 	NavigatorBackButton,
+	NavigatorToParentButton,
 	useNavigator,
 } from '..';
 
@@ -75,6 +77,7 @@ const BUTTON_TEXT = {
 	toInvalidHtmlPathScreen:
 		'Navigate to screen with an invalid HTML value as a path.',
 	back: 'Go back',
+	backUsingGoTo: 'Go back using goTo',
 };
 
 type CustomTestOnClickHandler = (
@@ -105,6 +108,27 @@ function CustomNavigatorButton( {
 	);
 }
 
+function CustomNavigatorGoToBackButton( {
+	path,
+	onClick,
+	...props
+}: Omit< ComponentPropsWithoutRef< typeof NavigatorButton >, 'onClick' > & {
+	onClick?: CustomTestOnClickHandler;
+} ) {
+	const { goTo } = useNavigator();
+	return (
+		<Button
+			onClick={ () => {
+				goTo( path, { isBack: true } );
+				// Used to spy on the values passed to `navigator.goTo`.
+				onClick?.( { type: 'goTo', path } );
+			} }
+			path={ path }
+			{ ...props }
+		/>
+	);
+}
+
 function CustomNavigatorBackButton( {
 	onClick,
 	...props
@@ -116,6 +140,23 @@ function CustomNavigatorBackButton( {
 			onClick={ () => {
 				// Used to spy on the values passed to `navigator.goBack`.
 				onClick?.( { type: 'goBack' } );
+			} }
+			{ ...props }
+		/>
+	);
+}
+
+function CustomNavigatorToParentButton( {
+	onClick,
+	...props
+}: Omit< ComponentPropsWithoutRef< typeof NavigatorBackButton >, 'onClick' > & {
+	onClick?: CustomTestOnClickHandler;
+} ) {
+	return (
+		<NavigatorToParentButton
+			onClick={ () => {
+				// Used to spy on the values passed to `navigator.goBack`.
+				onClick?.( { type: 'goToParent' } );
 			} }
 			{ ...props }
 		/>
@@ -257,6 +298,72 @@ const MyNavigation = ( {
 				} }
 				value={ outerInputValue }
 			/>
+		</>
+	);
+};
+
+const MyHierarchicalNavigation = ( {
+	initialPath = PATHS.HOME,
+	onNavigatorButtonClick,
+}: {
+	initialPath?: string;
+	onNavigatorButtonClick?: CustomTestOnClickHandler;
+} ) => {
+	return (
+		<>
+			<NavigatorProvider initialPath={ initialPath }>
+				<NavigatorScreen path={ PATHS.HOME }>
+					<p>{ SCREEN_TEXT.home }</p>
+					{ /*
+					 * A button useful to test focus restoration. This button is the first
+					 * tabbable item in the screen, but should not receive focus when
+					 * navigating to screen as a result of a backwards navigation.
+					 */ }
+					<button>First tabbable home screen button</button>
+					<CustomNavigatorButton
+						path={ PATHS.CHILD }
+						onClick={ onNavigatorButtonClick }
+					>
+						{ BUTTON_TEXT.toChildScreen }
+					</CustomNavigatorButton>
+				</NavigatorScreen>
+
+				<NavigatorScreen path={ PATHS.CHILD }>
+					<p>{ SCREEN_TEXT.child }</p>
+					{ /*
+					 * A button useful to test focus restoration. This button is the first
+					 * tabbable item in the screen, but should not receive focus when
+					 * navigating to screen as a result of a backwards navigation.
+					 */ }
+					<button>First tabbable child screen button</button>
+					<CustomNavigatorButton
+						path={ PATHS.NESTED }
+						onClick={ onNavigatorButtonClick }
+					>
+						{ BUTTON_TEXT.toNestedScreen }
+					</CustomNavigatorButton>
+					<CustomNavigatorToParentButton
+						onClick={ onNavigatorButtonClick }
+					>
+						{ BUTTON_TEXT.back }
+					</CustomNavigatorToParentButton>
+				</NavigatorScreen>
+
+				<NavigatorScreen path={ PATHS.NESTED }>
+					<p>{ SCREEN_TEXT.nested }</p>
+					<CustomNavigatorToParentButton
+						onClick={ onNavigatorButtonClick }
+					>
+						{ BUTTON_TEXT.back }
+					</CustomNavigatorToParentButton>
+					<CustomNavigatorGoToBackButton
+						path={ PATHS.CHILD }
+						onClick={ onNavigatorButtonClick }
+					>
+						{ BUTTON_TEXT.backUsingGoTo }
+					</CustomNavigatorGoToBackButton>
+				</NavigatorScreen>
+			</NavigatorProvider>
 		</>
 	);
 };
@@ -591,6 +698,44 @@ describe( 'Navigator', () => {
 			expect(
 				getNavigationButton( 'toInvalidHtmlPathScreen' )
 			).toHaveFocus();
+		} );
+
+		it( 'should restore focus while using goTo and goToParent', async () => {
+			const user = userEvent.setup();
+
+			render( <MyHierarchicalNavigation /> );
+
+			expect( getScreen( 'home' ) ).toBeInTheDocument();
+
+			// Navigate to child screen.
+			await user.click( getNavigationButton( 'toChildScreen' ) );
+			expect( getScreen( 'child' ) ).toBeInTheDocument();
+
+			// Navigate to nested screen.
+			await user.click( getNavigationButton( 'toNestedScreen' ) );
+			expect( getScreen( 'nested' ) ).toBeInTheDocument();
+			expect( getNavigationButton( 'back' ) ).toBeInTheDocument();
+
+			// Navigate back to child screen using the back button.
+			await user.click( getNavigationButton( 'back' ) );
+			expect( getScreen( 'child' ) ).toBeInTheDocument();
+			expect( getNavigationButton( 'toNestedScreen' ) ).toHaveFocus();
+
+			// Re navigate to nested screen.
+			await user.click( getNavigationButton( 'toNestedScreen' ) );
+			expect( getScreen( 'nested' ) ).toBeInTheDocument();
+			expect(
+				getNavigationButton( 'backUsingGoTo' )
+			).toBeInTheDocument();
+
+			// Navigate back to child screen using the go to button.
+			await user.click( getNavigationButton( 'backUsingGoTo' ) );
+			expect( getScreen( 'child' ) ).toBeInTheDocument();
+			expect( getNavigationButton( 'toNestedScreen' ) ).toHaveFocus();
+
+			// Navigate back to home screen.
+			await user.click( getNavigationButton( 'back' ) );
+			expect( getNavigationButton( 'toChildScreen' ) ).toHaveFocus();
 		} );
 	} );
 } );

--- a/packages/components/src/navigator/test/router.ts
+++ b/packages/components/src/navigator/test/router.ts
@@ -95,4 +95,28 @@ describe( 'findParent', () => {
 		] );
 		expect( result ).toEqual( '/test' );
 	} );
+
+	it( 'should return the root when no grand parent found', () => {
+		const result = findParent( '/test/nested/path', [
+			{ id: 'route1', path: '/other-path' },
+			{ id: 'route2', path: '/yet-another-path' },
+			{ id: 'root', path: '/' },
+		] );
+		expect( result ).toEqual( '/' );
+	} );
+
+	it( 'should return undefined when no potential parent found', () => {
+		const result = findParent( '/test/nested/path', [
+			{ id: 'route1', path: '/other-path' },
+			{ id: 'route2', path: '/yet-another-path' },
+		] );
+		expect( result ).toBeUndefined();
+	} );
+
+	it( 'should return undefined for non supported paths', () => {
+		const result = findParent( 'this-is-a-path', [
+			{ id: 'route', path: '/' },
+		] );
+		expect( result ).toBeUndefined();
+	} );
 } );

--- a/packages/components/src/navigator/test/router.ts
+++ b/packages/components/src/navigator/test/router.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { patternMatch } from '../utils/router';
+import { patternMatch, findParent } from '../utils/router';
 
 describe( 'patternMatch', () => {
 	it( 'should return undefined if not pattern is matched', () => {
@@ -46,5 +46,53 @@ describe( 'patternMatch', () => {
 			id: 'route',
 			params: { test: [ 'some', 'basic', 'route' ] },
 		} );
+	} );
+} );
+
+describe( 'findParent', () => {
+	it( 'should return undefined if no parent is found', () => {
+		const result = findParent( '/test', [
+			{ id: 'route', path: '/test' },
+		] );
+		expect( result ).toBeUndefined();
+	} );
+
+	it( 'should return the parent path', () => {
+		const result = findParent( '/test', [
+			{ id: 'route1', path: '/test' },
+			{ id: 'route2', path: '/' },
+		] );
+		expect( result ).toEqual( '/' );
+	} );
+
+	it( 'should return to another parent path', () => {
+		const result = findParent( '/test/123', [
+			{ id: 'route1', path: '/test/:id' },
+			{ id: 'route2', path: '/test' },
+		] );
+		expect( result ).toEqual( '/test' );
+	} );
+
+	it( 'should return the parent path with params', () => {
+		const result = findParent( '/test/123/456', [
+			{ id: 'route1', path: '/test/:id/:subId' },
+			{ id: 'route2', path: '/test/:id' },
+		] );
+		expect( result ).toEqual( '/test/123' );
+	} );
+
+	it( 'should return the parent path with optional params', () => {
+		const result = findParent( '/test/123', [
+			{ id: 'route', path: '/test/:id?' },
+		] );
+		expect( result ).toEqual( '/test' );
+	} );
+
+	it( 'should return the grand parent if no parent found', () => {
+		const result = findParent( '/test/123/456', [
+			{ id: 'route1', path: '/test/:id/:subId' },
+			{ id: 'route2', path: '/test' },
+		] );
+		expect( result ).toEqual( '/test' );
 	} );
 } );

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -58,7 +58,7 @@ export type NavigatorScreenProps = {
 	children: ReactNode;
 };
 
-export type NavigatorBackButtonProps = ButtonAsButtonProps & {
+export type NavigatorBackButtonHookProps = ButtonAsButtonProps & {
 	/**
 	 * Whether we should navigate to the parent screen.
 	 *
@@ -66,6 +66,10 @@ export type NavigatorBackButtonProps = ButtonAsButtonProps & {
 	 */
 	goToParent?: boolean;
 };
+
+export type NavigatorBackButtonProps = ButtonAsButtonProps;
+
+export type NavigatorToParentButtonProps = ButtonAsButtonProps;
 
 export type NavigatorButtonProps = NavigatorBackButtonProps & {
 	/**

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -12,11 +12,11 @@ export type MatchParams = Record< string, string | string[] >;
 
 type NavigateOptions = {
 	focusTargetSelector?: string;
+	isBack?: boolean;
 };
 
 export type NavigatorLocation = NavigateOptions & {
 	isInitial?: boolean;
-	isBack?: boolean;
 	path?: string;
 	hasRestoredFocus?: boolean;
 };
@@ -27,6 +27,7 @@ export type Navigator = {
 	params: MatchParams;
 	goTo: ( path: string, options?: NavigateOptions ) => void;
 	goBack: () => void;
+	goToParent: () => void;
 };
 
 export type NavigatorContext = Navigator & {
@@ -57,7 +58,14 @@ export type NavigatorScreenProps = {
 	children: ReactNode;
 };
 
-export type NavigatorBackButtonProps = ButtonAsButtonProps;
+export type NavigatorBackButtonProps = ButtonAsButtonProps & {
+	/**
+	 * Whether we should navigate to the parent screen.
+	 *
+	 * @default 'false'
+	 */
+	goToParent?: boolean;
+};
 
 export type NavigatorButtonProps = NavigatorBackButtonProps & {
 	/**

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -58,7 +58,9 @@ export type NavigatorScreenProps = {
 	children: ReactNode;
 };
 
-export type NavigatorBackButtonHookProps = ButtonAsButtonProps & {
+export type NavigatorBackButtonProps = ButtonAsButtonProps;
+
+export type NavigatorBackButtonHookProps = NavigatorBackButtonProps & {
 	/**
 	 * Whether we should navigate to the parent screen.
 	 *
@@ -67,9 +69,7 @@ export type NavigatorBackButtonHookProps = ButtonAsButtonProps & {
 	goToParent?: boolean;
 };
 
-export type NavigatorBackButtonProps = ButtonAsButtonProps;
-
-export type NavigatorToParentButtonProps = ButtonAsButtonProps;
+export type NavigatorToParentButtonProps = NavigatorBackButtonProps;
 
 export type NavigatorButtonProps = NavigatorBackButtonProps & {
 	/**

--- a/packages/components/src/navigator/use-navigator.ts
+++ b/packages/components/src/navigator/use-navigator.ts
@@ -13,12 +13,14 @@ import type { Navigator } from './types';
  * Retrieves a `navigator` instance.
  */
 function useNavigator(): Navigator {
-	const { location, params, goTo, goBack } = useContext( NavigatorContext );
+	const { location, params, goTo, goBack, goToParent } =
+		useContext( NavigatorContext );
 
 	return {
 		location,
 		goTo,
 		goBack,
+		goToParent,
 		params,
 	};
 }

--- a/packages/components/src/navigator/utils/router.ts
+++ b/packages/components/src/navigator/utils/router.ts
@@ -21,3 +21,28 @@ export function patternMatch( path: string, screens: Screen[] ) {
 
 	return undefined;
 }
+
+export function findParent( path: string, screens: Screen[] ) {
+	if ( path[ 0 ] !== '/' ) {
+		return undefined;
+	}
+	const pathParts = path.split( '/' );
+	let parentPath;
+	while ( pathParts.length > 1 && ! parentPath ) {
+		pathParts.pop();
+		const potentialParentPath =
+			pathParts.join( '/' ) === '' ? '/' : pathParts.join( '/' );
+		if (
+			screens.find( ( screen ) => {
+				const matchingFunction = match( screen.path, {
+					decode: decodeURIComponent,
+				} );
+				return matchingFunction( potentialParentPath ) !== false;
+			} )
+		) {
+			parentPath = potentialParentPath;
+		}
+	}
+
+	return parentPath;
+}

--- a/packages/components/src/navigator/utils/router.ts
+++ b/packages/components/src/navigator/utils/router.ts
@@ -8,12 +8,16 @@ import { match } from 'path-to-regexp';
  */
 import type { Screen, MatchParams } from '../types';
 
+function matchPath( path: string, pattern: string ) {
+	const matchingFunction = match< MatchParams >( pattern, {
+		decode: decodeURIComponent,
+	} );
+	return matchingFunction( path );
+}
+
 export function patternMatch( path: string, screens: Screen[] ) {
 	for ( const screen of screens ) {
-		const matchingFunction = match< MatchParams >( screen.path, {
-			decode: decodeURIComponent,
-		} );
-		const matched = matchingFunction( path );
+		const matched = matchPath( path, screen.path );
 		if ( matched ) {
 			return { params: matched.params, id: screen.id };
 		}
@@ -23,21 +27,18 @@ export function patternMatch( path: string, screens: Screen[] ) {
 }
 
 export function findParent( path: string, screens: Screen[] ) {
-	if ( path[ 0 ] !== '/' ) {
+	if ( ! path.startsWith( '/' ) ) {
 		return undefined;
 	}
 	const pathParts = path.split( '/' );
 	let parentPath;
-	while ( pathParts.length > 1 && ! parentPath ) {
+	while ( pathParts.length > 1 && parentPath === undefined ) {
 		pathParts.pop();
 		const potentialParentPath =
 			pathParts.join( '/' ) === '' ? '/' : pathParts.join( '/' );
 		if (
 			screens.find( ( screen ) => {
-				const matchingFunction = match( screen.path, {
-					decode: decodeURIComponent,
-				} );
-				return matchingFunction( potentialParentPath ) !== false;
+				return matchPath( potentialParentPath, screen.path ) !== false;
 			} )
 		) {
 			parentPath = potentialParentPath;

--- a/packages/edit-site/src/components/global-styles/header.js
+++ b/packages/edit-site/src/components/global-styles/header.js
@@ -7,7 +7,7 @@ import {
 	__experimentalSpacer as Spacer,
 	__experimentalHeading as Heading,
 	__experimentalView as View,
-	__experimentalNavigatorBackButton as NavigatorBackButton,
+	__experimentalNavigatorToParentButton as NavigatorToParentButton,
 } from '@wordpress/components';
 import { isRTL, __ } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
@@ -18,7 +18,7 @@ function ScreenHeader( { title, description } ) {
 			<View>
 				<Spacer marginBottom={ 0 } paddingX={ 4 } paddingY={ 3 }>
 					<HStack spacing={ 2 }>
-						<NavigatorBackButton
+						<NavigatorToParentButton
 							style={
 								// TODO: This style override is also used in ToolsPanelHeader.
 								// It should be supported out-of-the-box by Button.
@@ -27,7 +27,6 @@ function ScreenHeader( { title, description } ) {
 							icon={ isRTL() ? chevronRight : chevronLeft }
 							isSmall
 							aria-label={ __( 'Navigate to the previous view' ) }
-							goToParent
 						/>
 						<Spacer>
 							<Heading

--- a/packages/edit-site/src/components/global-styles/header.js
+++ b/packages/edit-site/src/components/global-styles/header.js
@@ -27,6 +27,7 @@ function ScreenHeader( { title, description } ) {
 							icon={ isRTL() ? chevronRight : chevronLeft }
 							isSmall
 							aria-label={ __( 'Navigate to the previous view' ) }
+							goToParent
 						/>
 						<Spacer>
 							<Heading

--- a/packages/edit-site/src/components/global-styles/navigation-button.js
+++ b/packages/edit-site/src/components/global-styles/navigation-button.js
@@ -3,7 +3,7 @@
  */
 import {
 	__experimentalNavigatorButton as NavigatorButton,
-	__experimentalNavigatorBackButton as NavigatorBackButton,
+	__experimentalNavigatorToParentButton as NavigatorToParentButton,
 	__experimentalItem as Item,
 	FlexItem,
 	__experimentalHStack as HStack,
@@ -34,11 +34,7 @@ function NavigationButtonAsItem( props ) {
 
 function NavigationBackButtonAsItem( props ) {
 	return (
-		<NavigatorBackButton
-			as={ GenericNavigationButton }
-			{ ...props }
-			goToParent
-		/>
+		<NavigatorToParentButton as={ GenericNavigationButton } { ...props } />
 	);
 }
 

--- a/packages/edit-site/src/components/global-styles/navigation-button.js
+++ b/packages/edit-site/src/components/global-styles/navigation-button.js
@@ -33,7 +33,13 @@ function NavigationButtonAsItem( props ) {
 }
 
 function NavigationBackButtonAsItem( props ) {
-	return <NavigatorBackButton as={ GenericNavigationButton } { ...props } />;
+	return (
+		<NavigatorBackButton
+			as={ GenericNavigationButton }
+			{ ...props }
+			goToParent
+		/>
+	);
 }
 
 export { NavigationButtonAsItem, NavigationBackButtonAsItem };

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -267,11 +267,6 @@ function GlobalStylesStyleBook( { onClose } ) {
 				)
 			}
 			onSelect={ ( blockName ) => {
-				// Clear navigator history by going back to the root.
-				const depth = path.match( /\//g ).length;
-				for ( let i = 0; i < depth; i++ ) {
-					navigator.goBack();
-				}
 				// Now go to the selected block.
 				navigator.goTo( '/blocks/' + encodeURIComponent( blockName ) );
 			} }

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -37,6 +37,7 @@ export default function SidebarNavigationScreen( {
 								__( 'Navigate to the previous view: %s' ),
 								parentTitle
 							) }
+							goToParent
 						/>
 					) : (
 						<div className="edit-site-sidebar-navigation-screen__icon-placeholder" />

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -4,7 +4,7 @@
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
-	__experimentalNavigatorBackButton as NavigatorBackButton,
+	__experimentalNavigatorToParentButton as NavigatorToParentButton,
 	__experimentalNavigatorScreen as NavigatorScreen,
 } from '@wordpress/components';
 import { isRTL, __, sprintf } from '@wordpress/i18n';
@@ -29,7 +29,7 @@ export default function SidebarNavigationScreen( {
 					className="edit-site-sidebar-navigation-screen__title-icon"
 				>
 					{ parentTitle ? (
-						<NavigatorBackButton
+						<NavigatorToParentButton
 							className="edit-site-sidebar-navigation-screen__back"
 							icon={ isRTL() ? chevronRight : chevronLeft }
 							aria-label={ sprintf(
@@ -37,7 +37,6 @@ export default function SidebarNavigationScreen( {
 								__( 'Navigate to the previous view: %s' ),
 								parentTitle
 							) }
-							goToParent
 						/>
 					) : (
 						<div className="edit-site-sidebar-navigation-screen__icon-placeholder" />

--- a/test/e2e/specs/site-editor/style-book.spec.js
+++ b/test/e2e/specs/site-editor/style-book.spec.js
@@ -98,7 +98,7 @@ test.describe( 'Style Book', () => {
 		).toBeVisible();
 	} );
 
-	test( 'should clear Global Styles navigator history when example is clicked', async ( {
+	test( 'should allow to return Global Styles root when example is clicked', async ( {
 		page,
 	} ) => {
 		await page.click( 'role=button[name="Blocks styles"]' );
@@ -110,10 +110,11 @@ test.describe( 'Style Book', () => {
 		);
 
 		await page.click( 'role=button[name="Navigate to the previous view"]' );
+		await page.click( 'role=button[name="Navigate to the previous view"]' );
 
 		await expect(
-			page.locator( 'role=button[name="Navigate to the previous view"]' )
-		).not.toBeVisible();
+			page.locator( 'role=button[name="Blocks styles"]' )
+		).toBeVisible();
 	} );
 
 	test( 'should disappear when closed', async ( { page } ) => {


### PR DESCRIPTION
Builds on top of https://github.com/WordPress/gutenberg/pull/47827 and addresses an issue raised in #47777 

## What and Why?

Parent or "back" navigation doesn't work as we expect it to work in Global Styles and Site editor. The reason is that `goBack` behaves like a browser history, it shows the previous screen that was visible. Sometimes navigation happens programmatically and sometimes the initial screen rendered is not the top level ones (like after reloading the page). For these situations, goBack doesn't work for us. What we really want is a child/parent relationship where the "back" button always goes back to the parent screen.

This PR adds support for that to the Navigator components.

## How?

There are two main ideas here. A user can define a "tree" of screens by relying on the paths: 

  - `/` is the root screen
  - `/something` is a child of root
  - `/:argument` is also a child of root
  - `/something/grandchild` is a child of `/something` if defined, otherwise it fallback to `/`

Basically to define the hierarchy you can split a path on the `/` character and move up until you find a screen that available.

The second idea of this PR is that `goToParent` is equivalent to `goToBack` and should restore the focus in the same way if the path is the previous in location history.

 - I've added a story to storybook to show how this works.

## Testing Instructions

 1- You can open the "nested navigator" story in storybook and check the behavior.


## ✍️ Dev Note

The `Navigator` component from the `@wordpress/components` package has been enhanced with two additional features:

- it can now match named arguments (ie. `/product/:productId`);
- it now offers a way to navigate to the parent screen via the `goToParent` function and the `NavigatorToParentButton` component.

These two features assume that `NavigatorScreen`s are assigned paths that are hierarchical and follow a URL-like scheme, where each path segment is separated by the `/` character.