### PR TITLE
Fix multiple menu creation from unsaved inner blocks in Nav block

### DIFF
--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -43,6 +43,7 @@ export default function UnsavedInnerBlocks( {
 	hasSelection,
 } ) {
 	const originalBlocks = useRef();
+	const isCreatingMenu = useRef( false );
 
 	useEffect( () => {
 		// Initially store the uncontrolled inner blocks for
@@ -125,6 +126,8 @@ export default function UnsavedInnerBlocks( {
 
 	// Automatically save the uncontrolled blocks.
 	useEffect( () => {
+		// Don't allow menus to be created when one is already being created.
+		//
 		// The block will be disabled when used in a BlockPreview.
 		// In this case avoid automatic creation of a wp_navigation post.
 		// Otherwise the user will be spammed with lots of menus!
@@ -138,6 +141,7 @@ export default function UnsavedInnerBlocks( {
 		// And finally only create the menu when the block is selected,
 		// which is an indication they want to start editing.
 		if (
+			isCreatingMenu.current ||
 			isDisabled ||
 			isSaving ||
 			! hasResolvedDraftNavigationMenus ||
@@ -148,7 +152,13 @@ export default function UnsavedInnerBlocks( {
 			return;
 		}
 
-		createNavigationMenu( null, blocks );
+		// Flag that a menu is being created.
+		isCreatingMenu.current = true;
+
+		createNavigationMenu( null, blocks ).finally( () => {
+			// Flag that a menu is no longer being created.
+			isCreatingMenu.current = false;
+		} );
 	}, [
 		isDisabled,
 		isSaving,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix for https://github.com/WordPress/gutenberg/issues/47881.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because auto creation of x2 menus instead of x1 is bad

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add local ref to track whether a menu is being created and "release" when promise settles.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
