### PR TITLE
E2E perf tests: run each test in a separate page

### DIFF
--- a/packages/e2e-tests/config/setup-performance-test.js
+++ b/packages/e2e-tests/config/setup-performance-test.js
@@ -19,9 +19,11 @@ const PUPPETEER_TIMEOUT = process.env.PUPPETEER_TIMEOUT;
 // The Jest timeout is increased because these tests are a bit slow.
 jest.setTimeout( PUPPETEER_TIMEOUT || 100000 );
 
-async function setupBrowser() {
-	await clearLocalStorage();
+async function setupPage() {
 	await setBrowserViewport( 'large' );
+	await page.emulateMediaFeatures( [
+		{ name: 'prefers-reduced-motion', value: 'reduce' },
+	] );
 }
 
 // Before every test suite run, delete all content created by the test. This ensures
@@ -32,13 +34,18 @@ beforeAll( async () => {
 
 	await trashAllPosts();
 	await trashAllPosts( 'wp_block' );
-	await setupBrowser();
+	await clearLocalStorage();
+	await setupPage();
 	await activatePlugin( 'gutenberg-test-plugin-disables-the-css-animations' );
-	await page.emulateMediaFeatures( [
-		{ name: 'prefers-reduced-motion', value: 'reduce' },
-	] );
 } );
 
 afterEach( async () => {
-	await setupBrowser();
+	// Clear localStorage between tests so that the next test starts clean.
+	await clearLocalStorage();
+	// Close the previous page entirely and create a new page, so that the next test
+	// isn't affected by page unload work.
+	await page.close();
+	page = await browser.newPage();
+	// Set up testing config on new page.
+	await setupPage();
 } );

--- a/packages/e2e-tests/config/setup-performance-test.js
+++ b/packages/e2e-tests/config/setup-performance-test.js
@@ -35,19 +35,17 @@ beforeAll( async () => {
 	await trashAllPosts();
 	await trashAllPosts( 'wp_block' );
 	await clearLocalStorage();
-	await activatePlugin( 'gutenberg-test-plugin-disables-the-css-animations' );
-} );
-
-beforeEach( async () => {
-	// Close the previous page entirely and create a new page, so that the test
-	// isn't affected by page unload work.
-	await page.close();
-	page = await browser.newPage();
-	// Set up testing config on new page.
 	await setupPage();
+	await activatePlugin( 'gutenberg-test-plugin-disables-the-css-animations' );
 } );
 
 afterEach( async () => {
 	// Clear localStorage between tests so that the next test starts clean.
 	await clearLocalStorage();
+	// Close the previous page entirely and create a new page, so that the next test
+	// isn't affected by page unload work.
+	await page.close();
+	page = await browser.newPage();
+	// Set up testing config on new page.
+	await setupPage();
 } );

--- a/packages/e2e-tests/config/setup-performance-test.js
+++ b/packages/e2e-tests/config/setup-performance-test.js
@@ -35,17 +35,19 @@ beforeAll( async () => {
 	await trashAllPosts();
 	await trashAllPosts( 'wp_block' );
 	await clearLocalStorage();
-	await setupPage();
 	await activatePlugin( 'gutenberg-test-plugin-disables-the-css-animations' );
 } );
 
-afterEach( async () => {
-	// Clear localStorage between tests so that the next test starts clean.
-	await clearLocalStorage();
-	// Close the previous page entirely and create a new page, so that the next test
+beforeEach( async () => {
+	// Close the previous page entirely and create a new page, so that the test
 	// isn't affected by page unload work.
 	await page.close();
 	page = await browser.newPage();
 	// Set up testing config on new page.
 	await setupPage();
+} );
+
+afterEach( async () => {
+	// Clear localStorage between tests so that the next test starts clean.
+	await clearLocalStorage();
 } );

--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -124,16 +124,17 @@ describe( 'Post Editor Performance', () => {
 				timeout: 120000,
 			} );
 			await canvas().waitForSelector( '.wp-block', { timeout: 120000 } );
-			const {
-				serverResponse,
-				firstPaint,
-				domContentLoaded,
-				loaded,
-				firstContentfulPaint,
-				firstBlock,
-			} = await getLoadingDurations();
 
 			if ( i < samples ) {
+				const {
+					serverResponse,
+					firstPaint,
+					domContentLoaded,
+					loaded,
+					firstContentfulPaint,
+					firstBlock,
+				} = await getLoadingDurations();
+
 				results.serverResponse.push( serverResponse );
 				results.firstPaint.push( firstPaint );
 				results.domContentLoaded.push( domContentLoaded );

--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -105,9 +105,14 @@ describe( 'Post Editor Performance', () => {
 			readFile( join( __dirname, '../../assets/large-post.html' ) )
 		);
 		await saveDraft();
+		const draftURL = await page.url();
+
 		let i = 5;
 		while ( i-- ) {
-			await page.reload();
+			await page.close();
+			page = await browser.newPage();
+
+			await page.goto( draftURL );
 			await page.waitForSelector( '.edit-post-layout', {
 				timeout: 120000,
 			} );

--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -107,7 +107,14 @@ describe( 'Post Editor Performance', () => {
 		await saveDraft();
 		const draftURL = await page.url();
 
-		let i = 5;
+		// Number of sample measurements to take.
+		const samples = 5;
+		// Number of throwaway measurements to perform before recording samples.
+		// Having at least one helps ensure that caching quirks don't manifest in
+		// the results.
+		const throwaway = 1;
+
+		let i = throwaway + samples;
 		while ( i-- ) {
 			await page.close();
 			page = await browser.newPage();
@@ -126,12 +133,14 @@ describe( 'Post Editor Performance', () => {
 				firstBlock,
 			} = await getLoadingDurations();
 
-			results.serverResponse.push( serverResponse );
-			results.firstPaint.push( firstPaint );
-			results.domContentLoaded.push( domContentLoaded );
-			results.loaded.push( loaded );
-			results.firstContentfulPaint.push( firstContentfulPaint );
-			results.firstBlock.push( firstBlock );
+			if ( i < samples ) {
+				results.serverResponse.push( serverResponse );
+				results.firstPaint.push( firstPaint );
+				results.domContentLoaded.push( domContentLoaded );
+				results.loaded.push( loaded );
+				results.firstContentfulPaint.push( firstContentfulPaint );
+				results.firstBlock.push( firstBlock );
+			}
 		}
 	} );
 

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -112,16 +112,17 @@ describe( 'Site Editor Performance', () => {
 				timeout: 120000,
 			} );
 			await canvas().waitForSelector( '.wp-block', { timeout: 120000 } );
-			const {
-				serverResponse,
-				firstPaint,
-				domContentLoaded,
-				loaded,
-				firstContentfulPaint,
-				firstBlock,
-			} = await getLoadingDurations();
 
 			if ( i < samples ) {
+				const {
+					serverResponse,
+					firstPaint,
+					domContentLoaded,
+					loaded,
+					firstContentfulPaint,
+					firstBlock,
+				} = await getLoadingDurations();
+
 				results.serverResponse.push( serverResponse );
 				results.firstPaint.push( firstPaint );
 				results.domContentLoaded.push( domContentLoaded );

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -93,7 +93,14 @@ describe( 'Site Editor Performance', () => {
 	it( 'Loading', async () => {
 		const editorURL = await page.url();
 
-		let i = 3;
+		// Number of sample measurements to take.
+		const samples = 3;
+		// Number of throwaway measurements to perform before recording samples.
+		// Having at least one helps ensure that caching quirks don't manifest in
+		// the results.
+		const throwaway = 1;
+
+		let i = throwaway + samples;
 
 		// Measuring loading time.
 		while ( i-- ) {
@@ -114,16 +121,23 @@ describe( 'Site Editor Performance', () => {
 				firstBlock,
 			} = await getLoadingDurations();
 
-			results.serverResponse.push( serverResponse );
-			results.firstPaint.push( firstPaint );
-			results.domContentLoaded.push( domContentLoaded );
-			results.loaded.push( loaded );
-			results.firstContentfulPaint.push( firstContentfulPaint );
-			results.firstBlock.push( firstBlock );
+			if ( i < samples ) {
+				results.serverResponse.push( serverResponse );
+				results.firstPaint.push( firstPaint );
+				results.domContentLoaded.push( domContentLoaded );
+				results.loaded.push( loaded );
+				results.firstContentfulPaint.push( firstContentfulPaint );
+				results.firstBlock.push( firstBlock );
+			}
 		}
 	} );
 
 	it( 'Typing', async () => {
+		await page.waitForSelector( '.edit-site-visual-editor', {
+			timeout: 120000,
+		} );
+		await canvas().waitForSelector( '.wp-block', { timeout: 120000 } );
+
 		// Measuring typing performance inside the post content.
 		await canvas().waitForSelector(
 			'[data-type="core/post-content"] [data-type="core/paragraph"]'


### PR DESCRIPTION
## What?
Run each performance test in a separate Puppeteer page.

## Why?
The loading performance tests are currently unreliable, producing values up to two orders of magnitude apart between individual test runs. After some investigation, I determined that this appears to be due to the same page being reused for all tests, with the unloading work from the previous test bleeding into the measurements on the following test.

## How?
This PR applies three separate changes to ensure that each performance test runs on its own page:
- It modifies `setup-performance-test.js` to create and initialise new pages between tests
- It modifies the post editor loading tests to ensure that the loop creates a new page for each iteration
- It modifies the site editor tests to properly separate them into loading and typing tests, and modifies the loading tests to ensure that the loop creates a new page for each iteration

To further reduce the variability of results, this PR also adds a configurable number of "throwaway" measurements before the recorded measurements, and sets it at 1. This eliminates the apparent bias in the first result being larger than the rest, likely due to some sort of caching quirk.

With these changes, all the individual runs for the loading tests should now be in the same order of magnitude.

## Testing Instructions
- Run the performance tests without these changes
- Look at the generated `post-editor.test.results` and observe that the loading metrics have unusable variability
- Run the performance tests with these changes
- Look at the generated `post-editor.test.results` and observe that the loading metrics have substantially reduced variability

### Testing Instructions for Keyboard
N/A, this change only affects tests

## Screenshots or screencast <!-- if applicable -->
N/A

CC @dmsnell, who has been looking at performance test reliability 
CC @youknowriad, who was also involved in the discussions