### PR TITLE
SelectControl: Fix `multiple` prop styling

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   `SelectControl`: Fix styling when `multiple` prop is enabled ([#47893](https://github.com/WordPress/gutenberg/pull/43213)).
+
 ### Enhancements
 
 -  `ColorPalette`, `GradientPicker`, `PaletteEdit`, `ToolsPanel`: add new props to set a custom heading level ([43848](https://github.com/WordPress/gutenberg/pull/43848) and [#47788](https://github.com/WordPress/gutenberg/pull/47788)).

--- a/packages/components/src/dimension-control/test/__snapshots__/index.test.js.snap
+++ b/packages/components/src/dimension-control/test/__snapshots__/index.test.js.snap
@@ -116,7 +116,6 @@ exports[`DimensionControl rendering renders with custom sizes 1`] = `
   width: 100%;
   max-width: none;
   cursor: pointer;
-  overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
   font-size: 16px;
@@ -126,6 +125,7 @@ exports[`DimensionControl rendering renders with custom sizes 1`] = `
   padding-bottom: 0;
   padding-left: 8px;
   padding-right: 26px;
+  overflow: hidden;
 }
 
 @media ( min-width: 600px ) {
@@ -387,7 +387,6 @@ exports[`DimensionControl rendering renders with defaults 1`] = `
   width: 100%;
   max-width: none;
   cursor: pointer;
-  overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
   font-size: 16px;
@@ -397,6 +396,7 @@ exports[`DimensionControl rendering renders with defaults 1`] = `
   padding-bottom: 0;
   padding-left: 8px;
   padding-right: 26px;
+  overflow: hidden;
 }
 
 @media ( min-width: 600px ) {
@@ -668,7 +668,6 @@ exports[`DimensionControl rendering renders with icon and custom icon label 1`] 
   width: 100%;
   max-width: none;
   cursor: pointer;
-  overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
   font-size: 16px;
@@ -678,6 +677,7 @@ exports[`DimensionControl rendering renders with icon and custom icon label 1`] 
   padding-bottom: 0;
   padding-left: 8px;
   padding-right: 26px;
+  overflow: hidden;
 }
 
 @media ( min-width: 600px ) {
@@ -961,7 +961,6 @@ exports[`DimensionControl rendering renders with icon and default icon label 1`]
   width: 100%;
   max-width: none;
   cursor: pointer;
-  overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
   font-size: 16px;
@@ -971,6 +970,7 @@ exports[`DimensionControl rendering renders with icon and default icon label 1`]
   padding-bottom: 0;
   padding-left: 8px;
   padding-right: 26px;
+  overflow: hidden;
 }
 
 @media ( min-width: 600px ) {

--- a/packages/components/src/select-control/README.md
+++ b/packages/components/src/select-control/README.md
@@ -187,7 +187,9 @@ If this property is added, a help text will be generated using help property as 
 
 #### multiple
 
-If this property is added, multiple values can be selected. The value passed should be an array.
+If this property is added, multiple values can be selected. The `value` passed should be an array.
+
+In most cases, it is preferable to use the `FormTokenField` or `CheckboxControl` components instead.
 
 -   Type: `Boolean`
 -   Required: No

--- a/packages/components/src/select-control/index.tsx
+++ b/packages/components/src/select-control/index.tsx
@@ -101,7 +101,9 @@ function UnforwardedSelectControl(
 				isFocused={ isFocused }
 				label={ label }
 				size={ size }
-				suffix={ suffix || <SelectControlChevronDown /> }
+				suffix={
+					suffix || ( ! multiple && <SelectControlChevronDown /> )
+				}
 				prefix={ prefix }
 				labelPosition={ labelPosition }
 				__next36pxDefaultSize={ __next36pxDefaultSize }

--- a/packages/components/src/select-control/style.scss
+++ b/packages/components/src/select-control/style.scss
@@ -1,16 +1,6 @@
 .components-select-control__input {
-	background: $white;
-	height: 36px;
-	line-height: 36px;
-	margin: 1px;
 	outline: 0;
-	width: 100%;
 	-webkit-tap-highlight-color: rgba(0, 0, 0, 0) !important;
-
-	@include break-medium() {
-		height: 28px;
-		line-height: 28px;
-	}
 }
 
 @media (max-width: #{ ($break-medium) }) {

--- a/packages/components/src/select-control/styles/select-control-styles.ts
+++ b/packages/components/src/select-control/styles/select-control-styles.ts
@@ -128,6 +128,12 @@ const sizePaddings = ( {
 	} );
 };
 
+const overflowStyles = ( { multiple }: SelectProps ) => {
+	return {
+		overflow: multiple ? 'auto' : 'hidden',
+	};
+};
+
 // TODO: Resolve need to use &&& to increase specificity
 // https://github.com/WordPress/gutenberg/issues/18483
 
@@ -145,7 +151,6 @@ export const Select = styled.select< SelectProps >`
 		width: 100%;
 		max-width: none;
 		cursor: pointer;
-		overflow: hidden;
 		white-space: nowrap;
 		text-overflow: ellipsis;
 
@@ -153,6 +158,7 @@ export const Select = styled.select< SelectProps >`
 		${ fontSizeStyles };
 		${ sizeStyles };
 		${ sizePaddings };
+		${ overflowStyles }
 	}
 `;
 

--- a/packages/components/src/select-control/styles/select-control-styles.ts
+++ b/packages/components/src/select-control/styles/select-control-styles.ts
@@ -102,38 +102,25 @@ const sizePaddings = ( {
 	multiple,
 	selectSize = 'default',
 }: SelectProps ) => {
-	const iconWidth = chevronIconSize;
-
-	const sizes = {
-		default: {
-			paddingLeft: 16,
-			paddingRight: 16 + iconWidth,
-		},
-		small: {
-			paddingLeft: 8,
-			paddingRight: 8 + iconWidth,
-		},
-		'__unstable-large': {
-			paddingLeft: 16,
-			paddingRight: 16 + iconWidth,
-		},
+	const padding = {
+		default: 16,
+		small: 8,
+		'__unstable-large': 16,
 	};
 
 	if ( ! __next36pxDefaultSize ) {
-		sizes.default = {
-			paddingLeft: 8,
-			paddingRight: 8 + iconWidth,
-		};
+		padding.default = 8;
 	}
 
-	const selectedSize = sizes[ selectSize ] || sizes.default;
+	const selectedPadding = padding[ selectSize ] || padding.default;
 
 	return rtl( {
-		...selectedSize,
+		paddingLeft: selectedPadding,
+		paddingRight: selectedPadding + chevronIconSize,
 		...( multiple
 			? {
-					paddingTop: selectedSize.paddingLeft,
-					paddingBottom: selectedSize.paddingLeft,
+					paddingTop: selectedPadding,
+					paddingBottom: selectedPadding,
 			  }
 			: {} ),
 	} );

--- a/packages/components/src/select-control/styles/select-control-styles.ts
+++ b/packages/components/src/select-control/styles/select-control-styles.ts
@@ -57,6 +57,8 @@ const sizeStyles = ( {
 	selectSize = 'default',
 }: SelectProps ) => {
 	if ( multiple ) {
+		// When `multiple`, just use the native browser styles
+		// without setting explicit height.
 		return;
 	}
 

--- a/packages/components/src/select-control/styles/select-control-styles.ts
+++ b/packages/components/src/select-control/styles/select-control-styles.ts
@@ -13,7 +13,10 @@ import type { SelectControlProps } from '../types';
 import InputControlSuffixWrapper from '../../input-control/input-suffix-wrapper';
 
 interface SelectProps
-	extends Pick< SelectControlProps, '__next36pxDefaultSize' | 'disabled' > {
+	extends Pick<
+		SelectControlProps,
+		'__next36pxDefaultSize' | 'disabled' | 'multiple'
+	> {
 	// Using `selectSize` instead of `size` to avoid a type conflict with the
 	// `size` HTML attribute of the `select` element.
 	selectSize?: SelectControlProps[ 'size' ];
@@ -50,8 +53,13 @@ const fontSizeStyles = ( { selectSize = 'default' }: SelectProps ) => {
 
 const sizeStyles = ( {
 	__next36pxDefaultSize,
+	multiple,
 	selectSize = 'default',
 }: SelectProps ) => {
+	if ( multiple ) {
+		return;
+	}
+
 	const sizes = {
 		default: {
 			height: 36,
@@ -91,6 +99,7 @@ export const chevronIconSize = 18;
 
 const sizePaddings = ( {
 	__next36pxDefaultSize,
+	multiple,
 	selectSize = 'default',
 }: SelectProps ) => {
 	const iconWidth = chevronIconSize;
@@ -117,7 +126,17 @@ const sizePaddings = ( {
 		};
 	}
 
-	return rtl( sizes[ selectSize ] || sizes.default );
+	const selectedSize = sizes[ selectSize ] || sizes.default;
+
+	return rtl( {
+		...selectedSize,
+		...( multiple
+			? {
+					paddingTop: selectedSize.paddingLeft,
+					paddingBottom: selectedSize.paddingLeft,
+			  }
+			: {} ),
+	} );
 };
 
 // TODO: Resolve need to use &&& to increase specificity

--- a/packages/components/src/select-control/types.ts
+++ b/packages/components/src/select-control/types.ts
@@ -23,7 +23,9 @@ export interface SelectControlProps
 		>,
 		Pick< BaseControlProps, 'help' | '__nextHasNoMarginBottom' > {
 	/**
-	 * If this property is added, multiple values can be selected. The value passed should be an array.
+	 * If this property is added, multiple values can be selected. The `value` passed should be an array.
+	 *
+	 * In most cases, it is preferable to use the `FormTokenField` or `CheckboxControl` components instead.
 	 *
 	 * @default false
 	 */


### PR DESCRIPTION
Fixes #27166
Continuation of #43213 (props @mediaformat!)

## What?

Fixes the broken styling when the `multiple` prop is enabled on SelectControl.

## Why?

Although the `multiple` select never appears in Gutenberg UI, it is an officially supported prop so it should be at least minimally usable.

## How?

- Removes the fixed height to allow the entire select to show when `multiple` is enabled.
- Removes some outdated CSS in the sass file which was already being overridden by newer CSS in the Emotion file.
- Adds guidance to the docs to prefer `FormTokenField` or `CheckboxControl` instead.

## Testing Instructions

1. `npm run storybook:dev` and see the story for SelectControl.
2. Enable the `multiple` prop. The entire select with all the options should be visible. It should look good in all size variants.
3. There should be no visual changes when the `multiple` prop is disabled.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img width="272" alt="The select is cut off at the bottom" src="https://user-images.githubusercontent.com/555336/217631249-5c1329d3-5bca-436e-a148-46c8639bea9f.png">|<img width="277" alt="The select looks like a default browser multiple select" src="https://user-images.githubusercontent.com/555336/217631272-5d621f82-5bc4-4e59-9623-2f6bfbbf06ae.png">|