### PR TITLE
Template editor: only disable the save button if no changes rather than hiding it 

### DIFF
--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -6,7 +6,6 @@ import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { displayShortcut } from '@wordpress/keycodes';
-import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -14,10 +13,6 @@ import { useState } from '@wordpress/element';
 import { store as editSiteStore } from '../../store';
 
 export default function SaveButton() {
-	// We only want to show the saving state of the button if the button itself initiated the save,
-	// otherwise, the button will show in the side bar when saving is initiated from template save models, etc.
-	const [ selfInitiatedSave, setSelfInitiatedSave ] = useState( false );
-
 	const { isDirty, isSaving, isSaveViewOpen } = useSelect( ( select ) => {
 		const { __experimentalGetDirtyEntityRecords, isSavingEntityRecord } =
 			select( coreStore );
@@ -37,43 +32,29 @@ export default function SaveButton() {
 
 	const label = __( 'Save' );
 
-	const showButton =
-		( isDirty && ! isSaving ) || ( isSaving && selfInitiatedSave );
-
 	return (
-		showButton && (
-			<Button
-				variant="primary"
-				className="edit-site-save-button__button"
-				aria-disabled={ disabled }
-				aria-expanded={ isSaveViewOpen }
-				isBusy={ isSaving }
-				onClick={
-					disabled
-						? undefined
-						: () => {
-								setIsSaveViewOpened( true );
-								setSelfInitiatedSave( true );
-						  }
-				}
-				label={ label }
-				/*
-				 * We want the tooltip to show the keyboard shortcut only when the
-				 * button does something, i.e. when it's not disabled.
-				 */
-				shortcut={
-					disabled ? undefined : displayShortcut.primary( 's' )
-				}
-				/*
+		<Button
+			variant="primary"
+			className="edit-site-save-button__button"
+			aria-disabled={ disabled }
+			aria-expanded={ isSaveViewOpen }
+			isBusy={ isSaving }
+			onClick={ disabled ? undefined : () => setIsSaveViewOpened( true ) }
+			label={ label }
+			/*
+			 * We want the tooltip to show the keyboard shortcut only when the
+			 * button does something, i.e. when it's not disabled.
+			 */
+			shortcut={ disabled ? undefined : displayShortcut.primary( 's' ) }
+			/*
 			 * Displaying the keyboard shortcut conditionally makes the tooltip
 			 * itself show conditionally. This would trigger a full-rerendering
 			 * of the button that we want to avoid. By setting `showTooltip`,
 			 & the tooltip is always rendered even when there's no keyboard shortcut.
 			 */
-				showTooltip
-			>
-				{ label }
-			</Button>
-		)
+			showTooltip
+		>
+			{ label }
+		</Button>
 	);
 }

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -2,9 +2,7 @@
  * WordPress dependencies
  */
 import { memo } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
 import { __experimentalNavigatorProvider as NavigatorProvider } from '@wordpress/components';
-import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -29,16 +27,6 @@ function SidebarScreens() {
 }
 
 function Sidebar() {
-	const { isDirty } = useSelect( ( select ) => {
-		const { __experimentalGetDirtyEntityRecords } = select( coreStore );
-		const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
-		// The currently selected entity to display.
-		// Typically template or template part in the site editor.
-		return {
-			isDirty: dirtyEntityRecords.length > 0,
-		};
-	}, [] );
-
 	return (
 		<>
 			<NavigatorProvider
@@ -47,11 +35,10 @@ function Sidebar() {
 			>
 				<SidebarScreens />
 			</NavigatorProvider>
-			{ isDirty && (
-				<div className="edit-site-sidebar__footer">
-					<SaveButton />
-				</div>
-			) }
+
+			<div className="edit-site-sidebar__footer">
+				<SaveButton />
+			</div>
 		</>
 	);
 }


### PR DESCRIPTION
## What?
Makes the save button always visible, but disabled if no changes, rather than hiding it.

## Why?
There are accessibility issues with adding and removing the save button from the DOM, and this change makes it behave the same as the Save buttons in the Site and Post editor.

Also, currently the buttons saving state suddenly shows when saves have been initiated from other places, eg. the template rename dialog - this change avoids this confusion. 

Fixes: #47882

## How?
Always shows the button rather than only for an isDirty state.

## Testing Instructions

- In the Template Editor/Browse pages check that the 'Save' button is visible but disabled if no changes
- In the site editor make some changes to global style settings, eg. background color
- Return to the site editor browse mode without saving and make sure the save button is now enabled and works as expected

## Screenshots or screencast 

Before:

https://user-images.githubusercontent.com/3629020/217946606-7156e058-9031-4fbc-8c42-6df6cb1dc0da.mov

After:

https://user-images.githubusercontent.com/3629020/217946676-ba953520-8915-40fa-a69e-9cbfd896b8e7.mov

After with template change save:

https://user-images.githubusercontent.com/3629020/217949940-404f4965-f485-43bf-833d-c658c6e5d718.mov


