### PR TITLE
Add an aria label to the site save dialog

### DIFF
--- a/packages/edit-site/src/components/save-panel/index.js
+++ b/packages/edit-site/src/components/save-panel/index.js
@@ -35,6 +35,7 @@ export default function SavePanel() {
 				className="edit-site-save-panel__modal"
 				onRequestClose={ onClose }
 				__experimentalHideHeader
+				contentLabel={ __( 'Save site, content and template changes' ) }
 			>
 				<EntitiesSavedStates close={ onClose } />
 			</Modal>

--- a/packages/edit-site/src/components/save-panel/index.js
+++ b/packages/edit-site/src/components/save-panel/index.js
@@ -35,7 +35,7 @@ export default function SavePanel() {
 				className="edit-site-save-panel__modal"
 				onRequestClose={ onClose }
 				__experimentalHideHeader
-				contentLabel={ __( 'Save site, content and template changes' ) }
+				contentLabel={ __( 'Save site, content, and template changes' ) }
 			>
 				<EntitiesSavedStates close={ onClose } />
 			</Modal>

--- a/packages/edit-site/src/components/save-panel/index.js
+++ b/packages/edit-site/src/components/save-panel/index.js
@@ -35,7 +35,9 @@ export default function SavePanel() {
 				className="edit-site-save-panel__modal"
 				onRequestClose={ onClose }
 				__experimentalHideHeader
-				contentLabel={ __( 'Save site, content, and template changes' ) }
+				contentLabel={ __(
+					'Save site, content, and template changes'
+				) }
 			>
 				<EntitiesSavedStates close={ onClose } />
 			</Modal>


### PR DESCRIPTION
## What?
Adds an `aria-label` to the site save dialog

## Why?
It doesn't currently have one, and also has no heading, so should have the aria-label as a minimum, while options for retaining heading but visually hidden when `__experimentalHideHeader ` is set are explored.

Part of fix for #47885

## How?
Adds the `contentLabel` prop which is converted by the component into an aria-label

## Testing Instructions
Make some changes in the site editor and return to browser mode without saving them
Click on save button at bottom of left panel
Check that the save dialog has an aria label

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="819" alt="Screenshot 2023-02-09 at 5 24 15 PM" src="https://user-images.githubusercontent.com/3629020/217717672-5dd55309-267a-4475-9933-bd2fb40482c4.png">

After:

<img width="817" alt="Screenshot 2023-02-09 at 5 25 36 PM" src="https://user-images.githubusercontent.com/3629020/217717641-5f7db65a-7a29-44ea-8978-1d646f9fd169.png">


