### PR TITLE
Image: Simplify the method for getting block editor settings

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -134,19 +134,13 @@ export default function Image( {
 				} = select( blockEditorStore );
 
 				const rootClientId = getBlockRootClientId( clientId );
-				const settings = Object.fromEntries(
-					Object.entries( getSettings() ).filter( ( [ key ] ) =>
-						[
-							'imageEditing',
-							'imageSizes',
-							'maxWidth',
-							'mediaUpload',
-						].includes( key )
-					)
-				);
+				const settings = getSettings();
 
 				return {
-					...settings,
+					imageEditing: settings.imageEditing,
+					imageSizes: settings.imageSizes,
+					maxWidth: settings.maxWidth,
+					mediaUpload: settings.mediaUpload,
 					canInsertCover: canInsertBlockType(
 						'core/cover',
 						rootClientId


### PR DESCRIPTION
## What?
It's similar to #47736.

PR simplifies getting block editor settings in the Image block. The block only needs to pick a few values from the settings object, so there's no need for object manipulations.

## How?
Directly map settings object values to the returned object.

## Testing Instructions
1. Open a Post or Page.
2. Insert an Image block.
3. Confirm image cropping is available in the toolbar.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2023-02-09 at 11 17 50](https://user-images.githubusercontent.com/240569/217744446-e83652a5-40b5-401b-8e53-f4b3723a6e10.png)
