### PR TITLE
Cover: Ensure `url` is not malformed due to sanitization through `wp_kses`

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -116,7 +116,10 @@ function CoverEdit( {
 	// we define the url and background type
 	// depending on the value of the useFeaturedImage flag
 	// to preview in edit the dynamic featured image
-	const url = useFeaturedImage ? mediaUrl : attributes.url;
+	const url = useFeaturedImage
+		? mediaUrl
+		: // Ensure the url is not malformed due to sanitization through `wp_kses`.
+		  attributes.url?.replaceAll( '&amp;', '&' );
 	const backgroundType = useFeaturedImage
 		? IMAGE_BACKGROUND_TYPE
 		: attributes.backgroundType;


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/47636
<!-- In a few words, what is the PR actually doing? -->

## Why?
>In https://github.com/WordPress/gutenberg/pull/46450 we removed some bundled patterns in GB and now we fetch them through Pattern Directory.

> There are some failures in loading some images in some patterns  for Cover block.

 The issue here is a result of GB sanitizing the pattern content through `wp_kses_post`. The flow there is:
- `wp_kses_normalize_entities` replaces `&` to `&amp;`
- `wp_pre_kses_block_attributes` replaces `&` to `\u0026` that results in `\u0026amp;` in the final output.

The above though is for security reasons and normally is not an issue for block attributes that are not URLs. In the `Cover`
block case though it is a problem, as it results to a malformed URL. I'm not confident following a [similar approach to PD](https://github.com/WordPress/pattern-directory/pull/533) to replace`\u0026amp;` to `&`, but maybe ensuring that the url is not malformed inside `Cover` block might be enough and safe.


## Testing Instructions
1. Ensure the patterns fetched from PD that contain Cover blocks with url that have query args(`&`), fetch the images properly. You can check the `headers` pattern category.
2. Ensure no regression is introduced.
