### PR TITLE
Remove obsolete failing test for Font Size Picker

### DIFF
--- a/test/e2e/specs/editor/various/font-size-picker.spec.js
+++ b/test/e2e/specs/editor/various/font-size-picker.spec.js
@@ -19,27 +19,6 @@ test.describe( 'Font Size Picker', () => {
 	} );
 
 	test.describe( 'Common', () => {
-		test( 'should apply a named font size using the font size input', async ( {
-			editor,
-			page,
-		} ) => {
-			await editor.openDocumentSettingsSidebar();
-			await page.click( 'role=button[name="Add default block"i]' );
-			await page.keyboard.type( 'Paragraph to be made "small"' );
-			await page.click(
-				'role=region[name="Editor settings"i] >> role=button[name="Set custom size"i]'
-			);
-			await page.click( 'role=spinbutton[name="Custom"i]' );
-
-			// This should be the "small" font-size of the editor defaults.
-			await page.keyboard.type( '13' );
-
-			await expect.poll( editor.getEditedPostContent )
-				.toBe( `<!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size">Paragraph to be made "small"</p>
-<!-- /wp:paragraph -->` );
-		} );
-
 		test( 'should apply a custom font size using the font size input', async ( {
 			editor,
 			page,


### PR DESCRIPTION
In https://github.com/WordPress/gutenberg/pull/47356#issuecomment-1408410375 the behavior for font size picker was changed to always consider a custom value as `custom`, even there is a matched preset. 

This PR removes the obsolete failing test. The `set custom size` behavior is tested in a separate test(`should apply a custom font size using the font size input`)