### PR TITLE
Fix clicking on the toggle button not closing the block inserter

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/get-blocks.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/get-blocks.ts
@@ -12,10 +12,19 @@ import type { Editor } from './index';
  */
 export async function getBlocks( this: Editor ) {
 	return await this.page.evaluate( () => {
+		const blocks = window.wp.data.select( 'core/block-editor' ).getBlocks();
+
 		// The editor might still contain an unmodified empty block even when it's technically "empty".
-		if ( window.wp.data.select( 'core/editor' ).isEditedPostEmpty() ) {
-			return [];
+		if ( blocks.length === 1 ) {
+			const blockName = blocks[ 0 ].name;
+			if (
+				blockName === window.wp.blocks.getDefaultBlockName() ||
+				blockName === window.wp.blocks.getFreeformContentHandlerName()
+			) {
+				return [];
+			}
 		}
-		return window.wp.data.select( 'core/block-editor' ).getBlocks();
+
+		return blocks;
 	} );
 }

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -91,10 +91,13 @@ function HeaderToolbar() {
 			/>
 		</>
 	);
-	const openInserter = useCallback( () => {
+	const toggleInserter = useCallback( () => {
 		if ( isInserterOpened ) {
-			// Focusing the inserter button closes the inserter popover.
+			// Focusing the inserter button should close the inserter popover.
+			// However, there are some cases it won't close when the focus is lost.
+			// See https://github.com/WordPress/gutenberg/issues/43090 for more details.
 			inserterButton.current.focus();
+			setIsInserterOpened( false );
 		} else {
 			setIsInserterOpened( true );
 		}
@@ -120,7 +123,7 @@ function HeaderToolbar() {
 					variant="primary"
 					isPressed={ isInserterOpened }
 					onMouseDown={ preventDefault }
-					onClick={ openInserter }
+					onClick={ toggleInserter }
 					disabled={ ! isInserterEnabled }
 					icon={ plus }
 					label={ showIconLabels ? shortLabel : longLabel }

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -100,10 +100,13 @@ export default function HeaderEditMode() {
 
 	const isLargeViewport = useViewportMatch( 'medium' );
 
-	const openInserter = useCallback( () => {
+	const toggleInserter = useCallback( () => {
 		if ( isInserterOpen ) {
-			// Focusing the inserter button closes the inserter popover.
+			// Focusing the inserter button should close the inserter popover.
+			// However, there are some cases it won't close when the focus is lost.
+			// See https://github.com/WordPress/gutenberg/issues/43090 for more details.
 			inserterButton.current.focus();
+			setIsInserterOpened( false );
 		} else {
 			setIsInserterOpened( true );
 		}
@@ -148,7 +151,7 @@ export default function HeaderEditMode() {
 							variant="primary"
 							isPressed={ isInserterOpen }
 							onMouseDown={ preventDefault }
-							onClick={ openInserter }
+							onClick={ toggleInserter }
 							disabled={ ! isVisualMode }
 							icon={ plus }
 							label={ showIconLabels ? shortLabel : longLabel }

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -289,6 +289,31 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 
 		await expect.poll( editor.getEditedPostContent ).toBe( beforeContent );
 	} );
+
+	// A test for https://github.com/WordPress/gutenberg/issues/43090.
+	test( 'should close the inserter when clicking on the toggle button', async ( {
+		page,
+		editor,
+	} ) => {
+		const inserterButton = page.getByRole( 'button', {
+			name: 'Toggle block inserter',
+		} );
+		const blockLibrary = page.getByRole( 'region', {
+			name: 'Block Library',
+		} );
+
+		await inserterButton.click();
+
+		await blockLibrary.getByRole( 'option', { name: 'Buttons' } ).click();
+
+		await expect
+			.poll( editor.getBlocks )
+			.toMatchObject( [ { name: 'core/buttons' } ] );
+
+		await inserterButton.click();
+
+		await expect( blockLibrary ).toBeHidden();
+	} );
 } );
 
 test.describe( 'insert media from inserter', () => {

--- a/test/e2e/specs/site-editor/site-editor-inserter.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-inserter.spec.js
@@ -40,4 +40,31 @@ test.describe( 'Site Editor Inserter', () => {
 			)
 		).toBeHidden();
 	} );
+
+	// A test for https://github.com/WordPress/gutenberg/issues/43090.
+	test( 'should close the inserter when clicking on the toggle button', async ( {
+		page,
+		editor,
+	} ) => {
+		const inserterButton = page.getByRole( 'button', {
+			name: 'Toggle block inserter',
+		} );
+		const blockLibrary = page.getByRole( 'region', {
+			name: 'Block Library',
+		} );
+
+		const beforeBlocks = await editor.getBlocks();
+
+		await inserterButton.click();
+		await blockLibrary.getByRole( 'tab', { name: 'Blocks' } ).click();
+		await blockLibrary.getByRole( 'option', { name: 'Buttons' } ).click();
+
+		await expect
+			.poll( editor.getBlocks )
+			.toMatchObject( [ ...beforeBlocks, { name: 'core/buttons' } ] );
+
+		await inserterButton.click();
+
+		await expect( blockLibrary ).toBeHidden();
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What and why?
<!-- In a few words, what is the PR actually doing? -->
Fix https://github.com/WordPress/gutenberg/issues/43090.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? --> This PR takes an ad-hoc approach to fix the issue. There might be better solutions with focus handling, but it'd be nice to land this until we find a better solution.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Create a new post
2. Click on the block inserter toggle button
3. Click on the "Buttons" option to insert a buttons block
4. Click on the block inserter toggle button again
5. Expect the block inserter to be closed

Also added an e2e test.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
This issue is not reproducible on keyboard.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/7753001/217820201-9637d940-3271-4c58-9603-775df69b7b21.mp4

