### PR TITLE
Link Control - Add support for text only labels

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -9,8 +9,6 @@ import classnames from 'classnames';
 import { Button, Spinner, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useRef, useState, useEffect } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
-import { store as preferencesStore } from '@wordpress/preferences';
 import { focus } from '@wordpress/dom';
 import { ENTER } from '@wordpress/keycodes';
 
@@ -137,15 +135,6 @@ function LinkControl( {
 	const wrapperNode = useRef();
 	const textInputRef = useRef();
 	const isEndingEditWithFocus = useRef( false );
-
-	const showIconLabels = useSelect(
-		( select ) =>
-			select( preferencesStore ).get(
-				'core/edit-post',
-				'showIconLabels'
-			),
-		[]
-	);
 
 	const [ settingsOpen, setSettingsOpen ] = useState( false );
 
@@ -294,9 +283,7 @@ function LinkControl( {
 		<div
 			tabIndex={ -1 }
 			ref={ wrapperNode }
-			className={ classnames( 'block-editor-link-control', {
-				'show-icon-labels': showIconLabels,
-			} ) }
+			className="block-editor-link-control"
 		>
 			{ isCreatingPage && (
 				<div className="block-editor-link-control__loading">

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -9,6 +9,8 @@ import classnames from 'classnames';
 import { Button, Spinner, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useRef, useState, useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as preferencesStore } from '@wordpress/preferences';
 import { focus } from '@wordpress/dom';
 import { ENTER } from '@wordpress/keycodes';
 
@@ -135,6 +137,15 @@ function LinkControl( {
 	const wrapperNode = useRef();
 	const textInputRef = useRef();
 	const isEndingEditWithFocus = useRef( false );
+
+	const showIconLabels = useSelect(
+		( select ) =>
+			select( preferencesStore ).get(
+				'core/edit-post',
+				'showIconLabels'
+			),
+		[]
+	);
 
 	const [ settingsOpen, setSettingsOpen ] = useState( false );
 
@@ -283,7 +294,9 @@ function LinkControl( {
 		<div
 			tabIndex={ -1 }
 			ref={ wrapperNode }
-			className="block-editor-link-control"
+			className={ classnames( 'block-editor-link-control', {
+				'show-icon-labels': showIconLabels,
+			} ) }
 		>
 			{ isCreatingPage && (
 				<div className="block-editor-link-control__loading">

--- a/packages/block-editor/src/components/link-control/settings-drawer.js
+++ b/packages/block-editor/src/components/link-control/settings-drawer.js
@@ -11,6 +11,7 @@ import { settings as settingsIcon } from '@wordpress/icons';
 import { useReducedMotion, useInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
+
 /**
  * Internal dependencies
  */

--- a/packages/block-editor/src/components/link-control/settings-drawer.js
+++ b/packages/block-editor/src/components/link-control/settings-drawer.js
@@ -47,7 +47,7 @@ function LinkSettingsDrawer( {
 				aria-expanded={ settingsOpen }
 				onClick={ () => setSettingsOpen( ! settingsOpen ) }
 				icon={ settingsIcon }
-				label={ __( 'Toggle link settings' ) }
+				label={ __( 'Link Settings' ) }
 				aria-controls={ settingsDrawerId }
 			/>
 			<MaybeAnimatePresence>

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -24,7 +24,7 @@ $preview-image-height: 140px;
 		max-width: $modal-min-width;
 	}
 
-	&.show-icon-labels {
+	.show-icon-labels & {
 		#{$root}__tools {
 			.components-button.has-icon {
 				// Hide the button icons when labels are set to display...

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -14,6 +14,7 @@ $preview-image-height: 140px;
 }
 
 .block-editor-link-control {
+	$root: &;
 	position: relative;
 	min-width: $modal-min-width;
 
@@ -21,6 +22,22 @@ $preview-image-height: 140px;
 		min-width: auto;
 		width: 90vw;
 		max-width: $modal-min-width;
+	}
+
+	&.show-icon-labels {
+		#{$root}__tools {
+			.components-button.has-icon {
+				// Hide the button icons when labels are set to display...
+				svg {
+					display: none;
+				}
+				// ... and display labels.
+				// Uses ::before as ::after is already used for active tab styling.
+				&::before {
+					content: attr(aria-label);
+				}
+			}
+		}
 	}
 }
 
@@ -72,7 +89,7 @@ $preview-image-height: 140px;
 }
 
 .block-editor-link-control__search-error {
-	margin: -$grid-unit-20*0.5 $grid-unit-20 $grid-unit-20; // negative margin to bring the error a bit closer to the button
+	margin: -$grid-unit-20 * 0.5 $grid-unit-20 $grid-unit-20; // negative margin to bring the error a bit closer to the button
 }
 
 .block-editor-link-control__search-actions {
@@ -103,7 +120,7 @@ $preview-image-height: 140px;
 	}
 
 	&::before {
-		height: $grid-unit-20*0.5;
+		height: $grid-unit-20 * 0.5;
 		top: 0;
 		bottom: auto;
 	}
@@ -123,7 +140,7 @@ $preview-image-height: 140px;
 
 .block-editor-link-control__search-results {
 	margin: 0;
-	padding: $grid-unit-20*0.5 $grid-unit-20 $grid-unit-20*0.5;
+	padding: $grid-unit-20 * 0.5 $grid-unit-20 $grid-unit-20 * 0.5;
 	max-height: 200px;
 	overflow-y: auto; // allow results list to scroll
 
@@ -223,7 +240,6 @@ $preview-image-height: 140px;
 		width: 32px;
 		max-height: 32px;
 	}
-
 
 	.block-editor-link-control__search-item-info,
 	.block-editor-link-control__search-item-title {
@@ -344,16 +360,13 @@ $preview-image-height: 140px;
 	width: 100%;
 }
 
-
 .block-editor-link-control__search-item.is-fetching {
-
 	.block-editor-link-control__search-item-description {
 		&::before,
 		&::after {
 			animation: loadingpulse 1s linear infinite;
 			animation-delay: 0.5s; // avoid animating for fast network responses
 		}
-
 	}
 
 	.block-editor-link-control__search-item-image {
@@ -403,7 +416,7 @@ $preview-image-height: 140px;
 	&::before {
 		content: "";
 		position: absolute;
-		top: -#{$block-selected-child-margin*2};
+		top: -#{$block-selected-child-margin * 2};
 		left: 0;
 		display: block;
 		width: 100%;

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -14,7 +14,6 @@ $preview-image-height: 140px;
 }
 
 .block-editor-link-control {
-	$root: &;
 	position: relative;
 	min-width: $modal-min-width;
 
@@ -25,17 +24,15 @@ $preview-image-height: 140px;
 	}
 
 	.show-icon-labels & {
-		#{$root}__tools {
-			.components-button.has-icon {
-				// Hide the button icons when labels are set to display...
-				svg {
-					display: none;
-				}
-				// ... and display labels.
-				// Uses ::before as ::after is already used for active tab styling.
-				&::before {
-					content: attr(aria-label);
-				}
+		.components-button.has-icon {
+			// Hide the button icons when labels are set to display...
+			svg {
+				display: none;
+			}
+			// ... and display labels.
+			// Uses ::before as ::after is already used for active tab styling.
+			&::before {
+				content: attr(aria-label);
 			}
 		}
 	}

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -1670,7 +1670,7 @@ describe( 'Addition Settings UI', () => {
 		render( <LinkControlConsumer /> );
 
 		const settingsToggle = screen.queryByRole( 'button', {
-			name: 'Toggle link settings',
+			name: 'Link Settings',
 			ariaControls: 'link-settings-1',
 		} );
 
@@ -1690,7 +1690,7 @@ describe( 'Addition Settings UI', () => {
 		const user = userEvent.setup();
 
 		const settingsToggle = screen.queryByRole( 'button', {
-			name: 'Toggle link settings',
+			name: 'Link Settings',
 			ariaControls: 'link-settings-1',
 		} );
 
@@ -2241,7 +2241,7 @@ describe( 'Controlling link title text', () => {
 
 async function toggleSettingsDrawer( user ) {
 	const settingsToggle = screen.queryByRole( 'button', {
-		name: 'Toggle link settings',
+		name: 'Link Settings',
 	} );
 
 	await user.click( settingsToggle );

--- a/packages/block-editor/src/components/off-canvas-editor/link-ui.js
+++ b/packages/block-editor/src/components/off-canvas-editor/link-ui.js
@@ -137,6 +137,7 @@ export function LinkUI( props ) {
 			placement="bottom"
 			onClose={ props.onClose }
 			anchor={ props.anchor }
+			__unstableSlotName={ '__unstable-block-tools-after' }
 			shift
 		>
 			<LinkControl

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -165,6 +165,7 @@ export function LinkUI( props ) {
 			placement="bottom"
 			onClose={ props.onClose }
 			anchor={ props.anchor }
+			__unstableSlotName={ '__unstable-block-tools-after' }
 			shift
 		>
 			<LinkControl

--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -529,7 +529,7 @@ describe( 'Links', () => {
 		await waitForURLFieldAutoFocus();
 		await page.keyboard.type( 'w.org' );
 
-		// Toggle link settings open
+		// Link settings open
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Space' );
 
@@ -605,7 +605,7 @@ describe( 'Links', () => {
 			await pressKeyWithModifier( 'primary', 'K' );
 
 			const [ settingsToggle ] = await page.$x(
-				'//button[contains(@aria-label, "Toggle link settings")]'
+				'//button[contains(@aria-label, "Link Settings")]'
 			);
 			await settingsToggle.click();
 
@@ -638,7 +638,7 @@ describe( 'Links', () => {
 			await waitForURLFieldAutoFocus();
 
 			const [ settingsToggle ] = await page.$x(
-				'//button[contains(@aria-label, "Toggle link settings")]'
+				'//button[contains(@aria-label, "Link Settings")]'
 			);
 			await settingsToggle.click();
 
@@ -702,7 +702,7 @@ describe( 'Links', () => {
 			await waitForURLFieldAutoFocus();
 
 			const [ settingsToggle ] = await page.$x(
-				'//button[contains(@aria-label, "Toggle link settings")]'
+				'//button[contains(@aria-label, "Link Settings")]'
 			);
 			await settingsToggle.click();
 
@@ -737,7 +737,7 @@ describe( 'Links', () => {
 			await waitForURLFieldAutoFocus();
 
 			const [ settingsToggle ] = await page.$x(
-				'//button[contains(@aria-label, "Toggle link settings")]'
+				'//button[contains(@aria-label, "Link Settings")]'
 			);
 			await settingsToggle.click();
 
@@ -788,7 +788,7 @@ describe( 'Links', () => {
 			await waitForURLFieldAutoFocus();
 
 			const [ settingsToggle ] = await page.$x(
-				'//button[contains(@aria-label, "Toggle link settings")]'
+				'//button[contains(@aria-label, "Link Settings")]'
 			);
 			await settingsToggle.click();
 
@@ -1001,7 +1001,7 @@ describe( 'Links', () => {
 
 			await waitForURLFieldAutoFocus();
 
-			// Toggle link settings open
+			// Link settings open
 			await page.keyboard.press( 'Tab' );
 			await page.keyboard.press( 'Space' );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Shows the text labels only in the Link Control popover.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
#47545 
When the `Show button text labels` toggle is enabled from the Gutenberg preferences, LinkControl is only showing the setting icon. This PR will display the text label or icon in LinkControl according to preferences.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Getting the `showIconLabels` from the preferences data store.
- Add the `show-icon-labels` CSS class to the component accordingly to hide or display the icon/text.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Open the Gutenberg preferences and toggle the `Show button text labels`.
- Check if the icon and text labels are showing accordingly in the LinkControl.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

![image](https://user-images.githubusercontent.com/43412958/217822176-71764c5d-51c7-4fc4-ac6c-c6775d8b50f6.png)