### PR TITLE
Navigation tests: Add a describe wrapper

### DIFF
--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -3,106 +3,6 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-test.use( {
-	navBlockUtils: async ( { page, requestUtils }, use ) => {
-		await use( new NavigationBlockUtils( { page, requestUtils } ) );
-	},
-} );
-
-test.describe(
-	'As a user I want the navigation block to fallback to the best possible default',
-	() => {
-		test.beforeAll( async ( { requestUtils } ) => {
-			//TT3 is preferable to emptytheme because it already has the navigation block on its templates.
-			await requestUtils.activateTheme( 'twentytwentythree' );
-		} );
-
-		test.beforeEach( async ( { admin, navBlockUtils } ) => {
-			await Promise.all( [
-				navBlockUtils.deleteAllNavigationMenus(),
-				admin.createNewPost(),
-			] );
-		} );
-
-		test.afterAll( async ( { requestUtils, navBlockUtils } ) => {
-			await Promise.all( [
-				navBlockUtils.deleteAllNavigationMenus(),
-				requestUtils.activateTheme( 'twentytwentyone' ),
-			] );
-		} );
-
-		test.afterEach( async ( { requestUtils } ) => {
-			await requestUtils.deleteAllPosts();
-		} );
-
-		test( 'default to a list of pages if there are no menus', async ( {
-			editor,
-		} ) => {
-			await editor.insertBlock( { name: 'core/navigation' } );
-
-			const pageListBlock = editor.canvas.getByRole( 'document', {
-				name: 'Block: Page List',
-			} );
-
-			await expect( pageListBlock ).toBeVisible( {
-				// Wait for the Nav and Page List block API requests to resolve.
-				// Note: avoid waiting on network requests as these are not perceivable
-				// to the user.
-				// See: https://github.com/WordPress/gutenberg/pull/45070#issuecomment-1373712007.
-				timeout: 10000,
-			} );
-
-			// Check the markup of the block is correct.
-			await editor.publishPost();
-			const content = await editor.getEditedPostContent();
-			expect( content ).toBe(
-				`<!-- wp:navigation -->
-<!-- wp:page-list /-->
-<!-- /wp:navigation -->`
-			);
-		} );
-
-		test( 'default to my only existing menu', async ( {
-			editor,
-			page,
-			navBlockUtils,
-		} ) => {
-			const createdMenu = await navBlockUtils.createNavigationMenu( {
-				title: 'Test Menu 1',
-				content:
-					'<!-- wp:navigation-link {"label":"WordPress","type":"custom","url":"http://www.wordpress.org/","kind":"custom","isTopLevelLink":true} /-->',
-			} );
-
-			await editor.insertBlock( { name: 'core/navigation' } );
-
-			//check the block in the canvas.
-			await expect(
-				editor.canvas.locator(
-					'role=textbox[name="Navigation link text"i] >> text="WordPress"'
-				)
-			).toBeVisible();
-
-			// Check the markup of the block is correct.
-			await editor.publishPost();
-			await expect.poll( editor.getBlocks ).toMatchObject( [
-				{
-					name: 'core/navigation',
-					attributes: { ref: createdMenu.id },
-				},
-			] );
-			await page.locator( 'role=button[name="Close panel"i]' ).click();
-
-			//check the block in the frontend.
-			await page.goto( '/' );
-			await expect(
-				page.locator(
-					'role=navigation >> role=link[name="WordPress"i]'
-				)
-			).toBeVisible();
-		} );
-	}
-);
-
 class NavigationBlockUtils {
 	constructor( { editor, page, requestUtils } ) {
 		this.editor = editor;
@@ -146,3 +46,107 @@ class NavigationBlockUtils {
 		);
 	}
 }
+
+test.describe( 'Navigation block', () => {
+	test.use( {
+		navBlockUtils: async ( { page, requestUtils }, use ) => {
+			await use( new NavigationBlockUtils( { page, requestUtils } ) );
+		},
+	} );
+
+	test.describe(
+		'As a user I want the navigation block to fallback to the best possible default',
+		() => {
+			test.beforeAll( async ( { requestUtils } ) => {
+				//TT3 is preferable to emptytheme because it already has the navigation block on its templates.
+				await requestUtils.activateTheme( 'twentytwentythree' );
+			} );
+
+			test.beforeEach( async ( { admin, navBlockUtils } ) => {
+				await Promise.all( [
+					navBlockUtils.deleteAllNavigationMenus(),
+					admin.createNewPost(),
+				] );
+			} );
+
+			test.afterAll( async ( { requestUtils, navBlockUtils } ) => {
+				await Promise.all( [
+					navBlockUtils.deleteAllNavigationMenus(),
+					requestUtils.activateTheme( 'twentytwentyone' ),
+				] );
+			} );
+
+			test.afterEach( async ( { requestUtils } ) => {
+				await requestUtils.deleteAllPosts();
+			} );
+
+			test( 'default to a list of pages if there are no menus', async ( {
+				editor,
+			} ) => {
+				await editor.insertBlock( { name: 'core/navigation' } );
+
+				const pageListBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Page List',
+				} );
+
+				await expect( pageListBlock ).toBeVisible( {
+					// Wait for the Nav and Page List block API requests to resolve.
+					// Note: avoid waiting on network requests as these are not perceivable
+					// to the user.
+					// See: https://github.com/WordPress/gutenberg/pull/45070#issuecomment-1373712007.
+					timeout: 10000,
+				} );
+
+				// Check the markup of the block is correct.
+				await editor.publishPost();
+				const content = await editor.getEditedPostContent();
+				expect( content ).toBe(
+					`<!-- wp:navigation -->
+<!-- wp:page-list /-->
+<!-- /wp:navigation -->`
+				);
+			} );
+
+			test( 'default to my only existing menu', async ( {
+				editor,
+				page,
+				navBlockUtils,
+			} ) => {
+				const createdMenu = await navBlockUtils.createNavigationMenu( {
+					title: 'Test Menu 1',
+					content:
+						'<!-- wp:navigation-link {"label":"WordPress","type":"custom","url":"http://www.wordpress.org/","kind":"custom","isTopLevelLink":true} /-->',
+				} );
+
+				await editor.insertBlock( { name: 'core/navigation' } );
+
+				//check the block in the canvas.
+				await expect(
+					editor.canvas.locator(
+						'role=textbox[name="Navigation link text"i] >> text="WordPress"'
+					)
+				).toBeVisible();
+
+				// Check the markup of the block is correct.
+				await editor.publishPost();
+				await expect.poll( editor.getBlocks ).toMatchObject( [
+					{
+						name: 'core/navigation',
+						attributes: { ref: createdMenu.id },
+					},
+				] );
+				await page
+					.locator( 'role=button[name="Close panel"i]' )
+					.click();
+
+				//check the block in the frontend.
+				await page.goto( '/' );
+				await expect(
+					page.locator(
+						'role=navigation >> role=link[name="WordPress"i]'
+					)
+				).toBeVisible();
+			} );
+		}
+	);
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds a description to all navigation block e2e tests

## Why?
So that the results are easier to read.

## How?
Adds a describe callback.

## Testing Instructions
Run `npm run test:e2e:playwright -- editor/blocks/navigation.spec.js`

## Screenshots or screencast <!-- if applicable -->
You should
<img width="703" alt="Screenshot 2023-02-09 at 13 42 09" src="https://user-images.githubusercontent.com/275961/217829219-36dbfd9f-40ec-45f2-8335-2145878f9f27.png">
 see this:
