### PR TITLE
Site Editor: Fix custom Template Parts rename action

### DIFF
--- a/packages/edit-site/src/components/list/actions/rename-menu-item.js
+++ b/packages/edit-site/src/components/list/actions/rename-menu-item.js
@@ -24,7 +24,7 @@ export default function RenameMenuItem( { template, onClose } ) {
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
 
-	if ( ! template.is_custom ) {
+	if ( template.type === 'wp_template' && ! template.is_custom ) {
 		return null;
 	}
 


### PR DESCRIPTION
## What?
Fixes #47915.

PR fixes the bug when rename action wasn't rendered for the custom Template Parts.

## Why?
The component incorrectly checked if the template was part of the template hierarchy. This check shouldn't apply to the Template Parts.

## Testing Instructions
1. Open a Site Editor.
2. Create a new template part.
3. Return to the Template Parts list page.
4. Open the newly created template part's actions.
5. Confirm that rename action is available.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-02-09 at 17 48 43](https://user-images.githubusercontent.com/240569/217830510-fe137832-8d4c-4451-831d-a829b7c1b50b.png)

