### PR TITLE
CircularOptionPicker: refactor to TypeScript

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -714,6 +714,12 @@
 		"parent": "components"
 	},
 	{
+		"title": "CircularOptionPicker",
+		"slug": "circular-option-picker",
+		"markdown_source": "../packages/components/src/circular-option-picker/README.md",
+		"parent": "components"
+	},
+	{
 		"title": "ClipboardButton",
 		"slug": "clipboard-button",
 		"markdown_source": "../packages/components/src/clipboard-button/README.md",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -  `ToolsPanel`: Separate reset all filter registration from items registration and support global resets ([#48123](https://github.com/WordPress/gutenberg/pull/48123#pullrequestreview-1308386926)).
 
+### Internal
+
+-   `CircularOptionPicker`: Convert to TypeScript ([#47937](https://github.com/WordPress/gutenberg/pull/47937)).
+
 ## 23.4.0 (2023-02-15)
 
 ### Bug Fix

--- a/packages/components/src/circular-option-picker/README.md
+++ b/packages/components/src/circular-option-picker/README.md
@@ -9,7 +9,7 @@ This component is not exported, and therefore can only be used internally to the
 ## Usage
 
 ```jsx
-import { CircularOptionPicker } from '@wordpress/components';
+import { CircularOptionPicker } from '../circular-option-picker';
 import { useState } from '@wordpress/element';
 
 const Example = () => {

--- a/packages/components/src/circular-option-picker/README.md
+++ b/packages/components/src/circular-option-picker/README.md
@@ -1,0 +1,81 @@
+# CircularOptionPicker
+
+CircularOptionPicker is a component that displays a set of options as circular buttons.
+
+## Usage
+
+```jsx
+import { CircularOptionPicker } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+
+const Example = () => {
+	const [ currentColor, setCurrentColor ] = useState();
+	const colors = [
+		{ color: '#f00', name: 'Red' },
+		{ color: '#0f0', name: 'Green' },
+		{ color: '#00f', name: 'Blue' },
+	];
+	const colorOptions = (
+		<>
+			{ colors.map( ( { color, name }, index ) => {
+				return (
+					<CircularOptionPicker.Option
+						key={ `${ color }-${ index }` }
+						tooltipText={ name }
+						style={ { backgroundColor: color, color } }
+						isSelected={ index === currentColor }
+						onClick={ () => setCurrentColor( index ) }
+						aria-label={ name }
+					/>
+				);
+			} ) }
+		</>
+	);
+	return (
+		<CircularOptionPicker
+				options={ colorOptions }
+				actions={
+					<CircularOptionPicker.ButtonAction
+						onClick={ () => setCurrentColor( undefined ) }
+					>
+						{ 'Clear' }
+					</CircularOptionPicker.ButtonAction>
+				}
+			/>
+	);
+};
+```
+
+## Props
+
+### className
+
+A CSS class to apply to the wrapper element.
+
+ - Type: `string`
+ - Required: No
+
+ ### actions
+
+ The action(s) to be rendered after the options, such as a 'clear' button as seen in `ColorPalette'.
+
+ Usually a `CircularOptionPicker.ButtonAction` or `CircularOptionPicker.DropdownLinkAction` component.
+
+ - Type: `ReactNode`
+ - Required: No
+
+ ### options
+
+ The options to be rendered, such as color swatches.
+
+ Usually a `CircularOptionPicker.Option` component.
+
+ - Type: `ReactNode`
+ - Required: No
+
+ ### children
+
+The child elements.
+
+ - Type: `ReactNode`
+ - Required: No

--- a/packages/components/src/circular-option-picker/README.md
+++ b/packages/components/src/circular-option-picker/README.md
@@ -74,7 +74,7 @@ Usually a `CircularOptionPicker.Option` component.
 
 - Required: No
 
-### `children`: `ReactNode
+### `children`: `ReactNode`
 
 The child elements.
 

--- a/packages/components/src/circular-option-picker/README.md
+++ b/packages/components/src/circular-option-picker/README.md
@@ -1,5 +1,9 @@
 # `CircularOptionPicker`
 
+<div class="callout callout-alert">
+This component is not exported, and therefore can only be used internally to the `@wordpress/components` package.
+</div>
+
 `CircularOptionPicker` is a component that displays a set of options as circular buttons.
 
 ## Usage

--- a/packages/components/src/circular-option-picker/README.md
+++ b/packages/components/src/circular-option-picker/README.md
@@ -52,30 +52,96 @@ const Example = () => {
 
 A CSS class to apply to the wrapper element.
 
- - Type: `string`
- - Required: No
+- Type: `string`
+- Required: No
 
- ### actions
+### actions
 
- The action(s) to be rendered after the options, such as a 'clear' button as seen in `ColorPalette'.
+The action(s) to be rendered after the options, such as a 'clear' button as seen in `ColorPalette'.
 
- Usually a `CircularOptionPicker.ButtonAction` or `CircularOptionPicker.DropdownLinkAction` component.
+Usually a `CircularOptionPicker.ButtonAction` or `CircularOptionPicker.DropdownLinkAction` component.
 
- - Type: `ReactNode`
- - Required: No
+- Type: `ReactNode`
+- Required: No
 
- ### options
+### options
 
- The options to be rendered, such as color swatches.
+The options to be rendered, such as color swatches.
 
- Usually a `CircularOptionPicker.Option` component.
+Usually a `CircularOptionPicker.Option` component.
 
- - Type: `ReactNode`
- - Required: No
+- Type: `ReactNode`
+- Required: No
 
- ### children
+### children
 
 The child elements.
 
- - Type: `ReactNode`
- - Required: No
+- Type: `ReactNode`
+- Required: No
+
+## Subcomponents
+
+### CircularOptionPicker.ButtonAction
+
+A `ButtonAction` is an action that is rendered as a button alongside the options themselves.
+
+A common use case is a 'clear' button to deselect the currently selected option.
+
+#### Props
+
+##### className
+
+A CSS class to apply to the underlying `Button` component.
+
+- Type: `string`
+- Required: No
+
+##### children
+
+The button's children.
+
+- Type: `ReactNode`
+- Required: No
+
+##### Inherited props
+
+`CircularOptionPicker.ButtonAction` also inherits all of the [`Button` props](/packages/components/src/button/README.md#props), except for `href` and `target`.
+
+### CircularOptionPicker.DropdownLinkAction
+
+`CircularOptionPicker.DropdownLinkAction` is an action that's hidden behind a dropdown toggle. The button is formatted as a link and rendered as an `anchor` element.
+
+#### Props
+
+##### className
+
+A CSS class to apply to the underlying `Dropdown` component.
+
+- Type: `string`
+- Required: No
+
+##### linkText
+
+The text to be displayed on the button.
+
+- Type: `string`
+- Required: Yes
+
+##### dropdownProps
+
+The props for the underlying `Dropdown` component.
+
+Inherits all of the [`Dropdown` props](/packages/components/src/dropdown/README.md#props), except for `className` and `renderToggle`.
+
+- Type: `object`
+- Required: Yes
+
+##### buttonProps
+
+Props for the underlying `Button` component.
+
+Inherits all of the [`Button` props](/packages/components/src/button/README.md#props), except for `href`, `target`, and `children`. 
+
+- Type: `object`
+- Required: No

--- a/packages/components/src/circular-option-picker/README.md
+++ b/packages/components/src/circular-option-picker/README.md
@@ -1,6 +1,6 @@
-# CircularOptionPicker
+# `CircularOptionPicker`
 
-CircularOptionPicker is a component that displays a set of options as circular buttons.
+`CircularOptionPicker` is a component that displays a set of options as circular buttons.
 
 ## Usage
 
@@ -48,41 +48,37 @@ const Example = () => {
 
 ## Props
 
-### className
+### `className`: `string`
 
 A CSS class to apply to the wrapper element.
 
-- Type: `string`
 - Required: No
 
-### actions
+### `actions`: `ReactNode`
 
-The action(s) to be rendered after the options, such as a 'clear' button as seen in `ColorPalette'.
+The action(s) to be rendered after the options, such as a 'clear' button as seen in `ColorPalette`.
 
 Usually a `CircularOptionPicker.ButtonAction` or `CircularOptionPicker.DropdownLinkAction` component.
 
-- Type: `ReactNode`
 - Required: No
 
-### options
+### `options`: `ReactNode`
 
 The options to be rendered, such as color swatches.
 
 Usually a `CircularOptionPicker.Option` component.
 
-- Type: `ReactNode`
 - Required: No
 
-### children
+### `children`: `ReactNode
 
 The child elements.
 
-- Type: `ReactNode`
 - Required: No
 
 ## Subcomponents
 
-### CircularOptionPicker.ButtonAction
+### `CircularOptionPicker.ButtonAction`
 
 A `ButtonAction` is an action that is rendered as a button alongside the options themselves.
 
@@ -90,58 +86,52 @@ A common use case is a 'clear' button to deselect the currently selected option.
 
 #### Props
 
-##### className
+##### `className`: `string`
 
 A CSS class to apply to the underlying `Button` component.
 
-- Type: `string`
 - Required: No
 
-##### children
+##### `children`: `ReactNode`
 
 The button's children.
 
-- Type: `ReactNode`
 - Required: No
 
 ##### Inherited props
 
 `CircularOptionPicker.ButtonAction` also inherits all of the [`Button` props](/packages/components/src/button/README.md#props), except for `href` and `target`.
 
-### CircularOptionPicker.DropdownLinkAction
+### `CircularOptionPicker.DropdownLinkAction`
 
 `CircularOptionPicker.DropdownLinkAction` is an action that's hidden behind a dropdown toggle. The button is formatted as a link and rendered as an `anchor` element.
 
 #### Props
 
-##### className
+##### `className`: `string`
 
 A CSS class to apply to the underlying `Dropdown` component.
 
-- Type: `string`
 - Required: No
 
-##### linkText
+##### `linkText`: `string`
 
 The text to be displayed on the button.
 
-- Type: `string`
 - Required: Yes
 
-##### dropdownProps
+##### `dropdownProps`: `object`
 
 The props for the underlying `Dropdown` component.
 
 Inherits all of the [`Dropdown` props](/packages/components/src/dropdown/README.md#props), except for `className` and `renderToggle`.
 
-- Type: `object`
 - Required: Yes
 
-##### buttonProps
+##### `buttonProps`: `object`
 
 Props for the underlying `Button` component.
 
 Inherits all of the [`Button` props](/packages/components/src/button/README.md#props), except for `href`, `target`, and `children`. 
 
-- Type: `object`
 - Required: No

--- a/packages/components/src/circular-option-picker/index.tsx
+++ b/packages/components/src/circular-option-picker/index.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * External dependencies
  */

--- a/packages/components/src/circular-option-picker/index.tsx
+++ b/packages/components/src/circular-option-picker/index.tsx
@@ -105,32 +105,6 @@ export function ButtonAction( {
 	);
 }
 
-function CircularOptionPicker( props: CircularOptionPickerProps ) {
-	const { actions, className, options, children } = props;
-	return (
-		<div
-			className={ classnames(
-				'components-circular-option-picker',
-				className
-			) }
-		>
-			<div className="components-circular-option-picker__swatches">
-				{ options }
-			</div>
-			{ children }
-			{ actions && (
-				<div className="components-circular-option-picker__custom-clear-wrapper">
-					{ actions }
-				</div>
-			) }
-		</div>
-	);
-}
-
-CircularOptionPicker.Option = Option;
-CircularOptionPicker.ButtonAction = ButtonAction;
-CircularOptionPicker.DropdownLinkAction = DropdownLinkAction;
-
 /**
  *`CircularOptionPicker` is a component that displays a set of options as circular buttons.
  *
@@ -176,5 +150,31 @@ CircularOptionPicker.DropdownLinkAction = DropdownLinkAction;
  * };
  * ```
  */
+
+function CircularOptionPicker( props: CircularOptionPickerProps ) {
+	const { actions, className, options, children } = props;
+	return (
+		<div
+			className={ classnames(
+				'components-circular-option-picker',
+				className
+			) }
+		>
+			<div className="components-circular-option-picker__swatches">
+				{ options }
+			</div>
+			{ children }
+			{ actions && (
+				<div className="components-circular-option-picker__custom-clear-wrapper">
+					{ actions }
+				</div>
+			) }
+		</div>
+	);
+}
+
+CircularOptionPicker.Option = Option;
+CircularOptionPicker.ButtonAction = ButtonAction;
+CircularOptionPicker.DropdownLinkAction = DropdownLinkAction;
 
 export default CircularOptionPicker;

--- a/packages/components/src/circular-option-picker/index.tsx
+++ b/packages/components/src/circular-option-picker/index.tsx
@@ -14,6 +14,7 @@ import { Icon, check } from '@wordpress/icons';
 import Button from '../button';
 import Dropdown from '../dropdown';
 import Tooltip from '../tooltip';
+import type { CircularOptionPickerProps } from './types';
 
 function Option( props ) {
 	const {
@@ -92,7 +93,9 @@ function ButtonAction( props ) {
 	);
 }
 
-export default function CircularOptionPicker( props ) {
+export default function CircularOptionPicker(
+	props: CircularOptionPickerProps
+) {
 	const { actions, className, options, children } = props;
 	return (
 		<div

--- a/packages/components/src/circular-option-picker/index.tsx
+++ b/packages/components/src/circular-option-picker/index.tsx
@@ -131,4 +131,50 @@ CircularOptionPicker.Option = Option;
 CircularOptionPicker.ButtonAction = ButtonAction;
 CircularOptionPicker.DropdownLinkAction = DropdownLinkAction;
 
+/**
+ *`CircularOptionPicker` is a component that displays a set of options as circular buttons.
+ *
+ * ```jsx
+ * import { CircularOptionPicker } from '../circular-option-picker';
+ * import { useState } from '@wordpress/element';
+ *
+ * const Example = () => {
+ * 	const [ currentColor, setCurrentColor ] = useState();
+ * 	const colors = [
+ * 		{ color: '#f00', name: 'Red' },
+ * 		{ color: '#0f0', name: 'Green' },
+ * 		{ color: '#00f', name: 'Blue' },
+ * 	];
+ * 	const colorOptions = (
+ * 		<>
+ * 			{ colors.map( ( { color, name }, index ) => {
+ * 				return (
+ * 					<CircularOptionPicker.Option
+ * 						key={ `${ color }-${ index }` }
+ * 						tooltipText={ name }
+ * 						style={ { backgroundColor: color, color } }
+ * 						isSelected={ index === currentColor }
+ * 						onClick={ () => setCurrentColor( index ) }
+ * 						aria-label={ name }
+ * 					/>
+ * 				);
+ * 			} ) }
+ * 		</>
+ * 	);
+ * 	return (
+ * 		<CircularOptionPicker
+ * 				options={ colorOptions }
+ * 				actions={
+ * 					<CircularOptionPicker.ButtonAction
+ * 						onClick={ () => setCurrentColor( undefined ) }
+ * 					>
+ * 						{ 'Clear' }
+ * 					</CircularOptionPicker.ButtonAction>
+ * 				}
+ * 			/>
+ * 	);
+ * };
+ * ```
+ */
+
 export default CircularOptionPicker;

--- a/packages/components/src/circular-option-picker/index.tsx
+++ b/packages/components/src/circular-option-picker/index.tsx
@@ -22,7 +22,7 @@ import type {
 import type { WordPressComponentProps } from '../ui/context';
 import type { ButtonAsButtonProps } from '../button/types';
 
-function Option( {
+export function Option( {
 	className,
 	isSelected,
 	selectedIconProps,
@@ -58,7 +58,7 @@ function Option( {
 	);
 }
 
-function DropdownLinkAction( {
+export function DropdownLinkAction( {
 	buttonProps,
 	className,
 	dropdownProps,
@@ -86,7 +86,7 @@ function DropdownLinkAction( {
 	);
 }
 
-function ButtonAction( {
+export function ButtonAction( {
 	className,
 	children,
 	...additionalProps

--- a/packages/components/src/circular-option-picker/index.tsx
+++ b/packages/components/src/circular-option-picker/index.tsx
@@ -15,6 +15,8 @@ import Button from '../button';
 import Dropdown from '../dropdown';
 import Tooltip from '../tooltip';
 import type { CircularOptionPickerProps } from './types';
+import type { WordPressComponentProps } from '../ui/context';
+import type { ButtonAsButtonProps } from '../button/types';
 
 function Option( props ) {
 	const {
@@ -77,8 +79,11 @@ function DropdownLinkAction( props ) {
 	);
 }
 
-function ButtonAction( props ) {
-	const { className, children, ...additionalProps } = props;
+function ButtonAction( {
+	className,
+	children,
+	...additionalProps
+}: WordPressComponentProps< ButtonAsButtonProps, 'button', false > ) {
 	return (
 		<Button
 			className={ classnames(

--- a/packages/components/src/circular-option-picker/index.tsx
+++ b/packages/components/src/circular-option-picker/index.tsx
@@ -14,7 +14,10 @@ import { Icon, check } from '@wordpress/icons';
 import Button from '../button';
 import Dropdown from '../dropdown';
 import Tooltip from '../tooltip';
-import type { CircularOptionPickerProps } from './types';
+import type {
+	CircularOptionPickerProps,
+	DropdownLinkActionProps,
+} from './types';
 import type { WordPressComponentProps } from '../ui/context';
 import type { ButtonAsButtonProps } from '../button/types';
 
@@ -55,8 +58,12 @@ function Option( props ) {
 	);
 }
 
-function DropdownLinkAction( props ) {
-	const { buttonProps, className, dropdownProps, linkText } = props;
+function DropdownLinkAction( {
+	buttonProps,
+	className,
+	dropdownProps,
+	linkText,
+}: DropdownLinkActionProps ) {
 	return (
 		<Dropdown
 			className={ classnames(

--- a/packages/components/src/circular-option-picker/index.tsx
+++ b/packages/components/src/circular-option-picker/index.tsx
@@ -105,9 +105,7 @@ function ButtonAction( {
 	);
 }
 
-export default function CircularOptionPicker(
-	props: CircularOptionPickerProps
-) {
+function CircularOptionPicker( props: CircularOptionPickerProps ) {
 	const { actions, className, options, children } = props;
 	return (
 		<div
@@ -132,3 +130,5 @@ export default function CircularOptionPicker(
 CircularOptionPicker.Option = Option;
 CircularOptionPicker.ButtonAction = ButtonAction;
 CircularOptionPicker.DropdownLinkAction = DropdownLinkAction;
+
+export default CircularOptionPicker;

--- a/packages/components/src/circular-option-picker/index.tsx
+++ b/packages/components/src/circular-option-picker/index.tsx
@@ -17,18 +17,18 @@ import Tooltip from '../tooltip';
 import type {
 	CircularOptionPickerProps,
 	DropdownLinkActionProps,
+	OptionProps,
 } from './types';
 import type { WordPressComponentProps } from '../ui/context';
 import type { ButtonAsButtonProps } from '../button/types';
 
-function Option( props ) {
-	const {
-		className,
-		isSelected,
-		selectedIconProps,
-		tooltipText,
-		...additionalProps
-	} = props;
+function Option( {
+	className,
+	isSelected,
+	selectedIconProps,
+	tooltipText,
+	...additionalProps
+}: OptionProps ) {
 	const optionButton = (
 		<Button
 			isPressed={ isSelected }

--- a/packages/components/src/circular-option-picker/stories/index.tsx
+++ b/packages/components/src/circular-option-picker/stories/index.tsx
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import CircularOptionPicker from '..';
+
+const meta: ComponentMeta< typeof CircularOptionPicker > = {
+	title: 'Components/CircularOptionPicker',
+	component: CircularOptionPicker,
+	parameters: {
+		actions: { argTypesRegex: '^on.*' },
+		controls: { expanded: true },
+		docs: { source: { state: 'open' } },
+	},
+};
+export default meta;
+
+const colors = [
+	{ color: '#f00', name: 'Red' },
+	{ color: '#0f0', name: 'Green' },
+	{ color: '#0af', name: 'Blue' },
+];
+
+// TODO: ask if there's a more elegant way to access a state handler from a second story
+let resetColor: React.Dispatch< React.SetStateAction< number | undefined > >;
+
+const Template: ComponentStory< typeof CircularOptionPicker > = ( props ) => {
+	const [ currentColor, setCurrentColor ] = useState< number >();
+	resetColor = setCurrentColor;
+
+	const colorOptions = (
+		<>
+			{ colors.map( ( { color, name }, index ) => {
+				return (
+					<CircularOptionPicker.Option
+						key={ `${ color }-${ index }` }
+						tooltipText={ name }
+						style={ { backgroundColor: color, color } }
+						isSelected={ index === currentColor }
+						onClick={ () => setCurrentColor( index ) }
+						aria-label={ name }
+					/>
+				);
+			} ) }
+		</>
+	);
+	return <CircularOptionPicker { ...props } options={ colorOptions } />;
+};
+
+export const Default = Template.bind( {} );
+Default.args = { actions: <></> };
+
+export const WithButtonAction = Template.bind( {} );
+WithButtonAction.args = {
+	actions: (
+		<CircularOptionPicker.ButtonAction
+			onClick={ () => resetColor( undefined ) }
+		>
+			{ 'Clear' }
+		</CircularOptionPicker.ButtonAction>
+	),
+};
+WithButtonAction.storyName = 'With ButtonAction';
+
+export const WithDropdownLinkAction = Template.bind( {} );
+WithDropdownLinkAction.args = {
+	actions: (
+		<CircularOptionPicker.DropdownLinkAction
+			dropdownProps={ {
+				popoverProps: { position: 'top right' },
+				renderContent: () => (
+					<div>This is an example of a DropdownLinkAction.</div>
+				),
+			} }
+			linkText="Learn More"
+		></CircularOptionPicker.DropdownLinkAction>
+	),
+};
+WithDropdownLinkAction.storyName = 'With DropdownLinkAction';

--- a/packages/components/src/circular-option-picker/stories/index.tsx
+++ b/packages/components/src/circular-option-picker/stories/index.tsx
@@ -9,7 +9,12 @@ import { useState, createContext, useContext } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import CircularOptionPicker from '..';
+import {
+	default as CircularOptionPicker,
+	ButtonAction,
+	DropdownLinkAction,
+	Option,
+} from '..';
 
 const CircularOptionPickerStoryContext = createContext< {
 	currentColor?: string;
@@ -19,6 +24,11 @@ const CircularOptionPickerStoryContext = createContext< {
 const meta: ComponentMeta< typeof CircularOptionPicker > = {
 	title: 'Components/CircularOptionPicker',
 	component: CircularOptionPicker,
+	subcomponents: {
+		'CircularOptionPicker.Option': Option,
+		'CircularOptionPicker.ButtonAction': ButtonAction,
+		'CircularOptionPicker.DropdownLinkAction': DropdownLinkAction,
+	},
 	argTypes: {
 		actions: { control: { type: null } },
 		options: { control: { type: null } },

--- a/packages/components/src/circular-option-picker/stories/index.tsx
+++ b/packages/components/src/circular-option-picker/stories/index.tsx
@@ -14,6 +14,11 @@ import CircularOptionPicker from '..';
 const meta: ComponentMeta< typeof CircularOptionPicker > = {
 	title: 'Components/CircularOptionPicker',
 	component: CircularOptionPicker,
+	argTypes: {
+		actions: { control: { type: null } },
+		options: { control: { type: null } },
+		children: { control: { type: 'text' } },
+	},
 	parameters: {
 		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },

--- a/packages/components/src/circular-option-picker/stories/index.tsx
+++ b/packages/components/src/circular-option-picker/stories/index.tsx
@@ -107,7 +107,7 @@ const Template: ComponentStory< typeof CircularOptionPicker > = ( props ) => (
 );
 
 export const Default = Template.bind( {} );
-Default.args = { actions: <></>, options: <DefaultOptions /> };
+Default.args = { options: <DefaultOptions /> };
 
 export const WithButtonAction = Template.bind( {} );
 WithButtonAction.args = {

--- a/packages/components/src/circular-option-picker/stories/index.tsx
+++ b/packages/components/src/circular-option-picker/stories/index.tsx
@@ -37,7 +37,7 @@ const meta: ComponentMeta< typeof CircularOptionPicker > = {
 	parameters: {
 		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
-		docs: { source: { state: 'open' } },
+		docs: { source: { state: 'open', excludeDecorators: true } },
 	},
 	decorators: [
 		// Share current color state between main component, `actions` and `options`

--- a/packages/components/src/circular-option-picker/types.ts
+++ b/packages/components/src/circular-option-picker/types.ts
@@ -2,6 +2,12 @@
  * External dependencies
  */
 import type { ReactNode } from 'react';
+/**
+ * Internal dependencies
+ */
+import type { ButtonAsButtonProps } from '../button/types';
+import type Dropdown from '../dropdown';
+import type { WordPressComponentProps } from '../ui/context';
 
 export type CircularOptionPickerProps = {
 	/**
@@ -24,4 +30,17 @@ export type CircularOptionPickerProps = {
 	 * The child elements.
 	 */
 	children?: ReactNode;
+};
+
+export type DropdownLinkActionProps = {
+	buttonProps: Omit<
+		WordPressComponentProps< ButtonAsButtonProps, 'button', false >,
+		'children'
+	>;
+	linkText: string;
+	dropdownProps: Omit<
+		React.ComponentProps< typeof Dropdown >,
+		'className' | 'renderToggle'
+	>;
+	className?: string;
 };

--- a/packages/components/src/circular-option-picker/types.ts
+++ b/packages/components/src/circular-option-picker/types.ts
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import type { ReactNode } from 'react';
+
+export type CircularOptionPickerProps = {
+	/**
+	 * A CSS class to apply to the wrapper element.
+	 */
+	className?: string;
+	/**
+	 * The action(s) to be rendered after the options,
+	 * such as a 'clear' button as seen in `ColorPalette`.
+	 * Usually a `CircularOptionPicker.ButtonAction` or
+	 * `CircularOptionPicker.DropdownLinkAction` component.
+	 */
+	actions?: ReactNode;
+	/**
+	 * The options to be rendered, such as color swatches.
+	 * Usually a `CircularOptionPicker.Option` component.
+	 */
+	options: ReactNode;
+	/**
+	 * The child elements.
+	 */
+	children?: ReactNode;
+};

--- a/packages/components/src/circular-option-picker/types.ts
+++ b/packages/components/src/circular-option-picker/types.ts
@@ -39,7 +39,7 @@ export type CircularOptionPickerProps = {
 };
 
 export type DropdownLinkActionProps = {
-	buttonProps: Omit<
+	buttonProps?: Omit<
 		WordPressComponentProps< ButtonAsButtonProps, 'button', false >,
 		'children'
 	>;

--- a/packages/components/src/circular-option-picker/types.ts
+++ b/packages/components/src/circular-option-picker/types.ts
@@ -2,6 +2,12 @@
  * External dependencies
  */
 import type { ReactNode } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import type { Icon } from '@wordpress/icons';
+
 /**
  * Internal dependencies
  */
@@ -43,4 +49,22 @@ export type DropdownLinkActionProps = {
 		'className' | 'renderToggle'
 	>;
 	className?: string;
+};
+
+export type OptionProps = Omit<
+	WordPressComponentProps< ButtonAsButtonProps, 'button', false >,
+	'isPressed' | 'className'
+> & {
+	className?: string;
+	// TODO: Discuss pros/cons of something like `React.ComponentProps< typeof Tooltip >[ 'text' ];`
+	tooltipText?: string;
+	isSelected: boolean;
+	// `icon` is explicitly defined as 'check' by CircleOptionPicker.Option
+	// and is not intended to be overridden.
+	// `size` relies on the `Icon` component's default size of `24` to fit
+	// `CircularOptionPicker`'s design, and should not be explicitly set.
+	selectedIconProps?: Omit<
+		React.ComponentProps< typeof Icon >,
+		'icon' | 'size'
+	>;
 };

--- a/packages/components/src/circular-option-picker/types.ts
+++ b/packages/components/src/circular-option-picker/types.ts
@@ -56,7 +56,6 @@ export type OptionProps = Omit<
 	'isPressed' | 'className'
 > & {
 	className?: string;
-	// TODO: Discuss pros/cons of something like `React.ComponentProps< typeof Tooltip >[ 'text' ];`
 	tooltipText?: string;
 	isSelected: boolean;
 	// `icon` is explicitly defined as 'check' by CircleOptionPicker.Option


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Refactor `CircularOptionPicker` component to TypeScript

Part of https://github.com/WordPress/gutenberg/issues/35744
Co-authored with @ciampo

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The refactor to TypeScript has many benefits (auto-generated docs, static linting and error prevention, better IDE experience). See https://github.com/WordPress/gutenberg/issues/35744 for more details

## How?
Followed the steps in the [TypeScript migration guide](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/CONTRIBUTING.md?rgh-link-date=2022-11-29T14%3A45%3A34Z#refactoring-a-component-to-typescript)

I've also added a README for the component.

## Testing Instructions
- Ensure all unit and e2e tests still pass
- In Storybook, confirm consumers like `ColorPalette`, `DuotonePicker`, and `GradientPicker` still work as expected.
