### PR TITLE
Performance suite: track Largest Contentful Paint in the front-end

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -30,54 +30,57 @@ const config = require( '../config' );
 /**
  * @typedef WPRawPerformanceResults
  *
- * @property {number[]} timeToFirstByte      Represents the time since the browser started the request until it received a response.
- * @property {number[]} serverResponse       Represents the time the server takes to respond.
- * @property {number[]} firstPaint           Represents the time when the user agent first rendered after navigation.
- * @property {number[]} domContentLoaded     Represents the time immediately after the document's DOMContentLoaded event completes.
- * @property {number[]} loaded               Represents the time when the load event of the current document is completed.
- * @property {number[]} firstContentfulPaint Represents the time when the browser first renders any text or media.
- * @property {number[]} firstBlock           Represents the time when Puppeteer first sees a block selector in the DOM.
- * @property {number[]} type                 Average type time.
- * @property {number[]} typeContainer        Average type time within a container.
- * @property {number[]} focus                Average block selection time.
- * @property {number[]} inserterOpen         Average time to open global inserter.
- * @property {number[]} inserterSearch       Average time to search the inserter.
- * @property {number[]} inserterHover        Average time to move mouse between two block item in the inserter.
- * @property {number[]} listViewOpen         Average time to open listView
+ * @property {number[]} timeToFirstByte        Represents the time since the browser started the request until it received a response.
+ * @property {number[]} largestContentfulPaint Represents the time when the main content of the page has likely loaded.
+ * @property {number[]} serverResponse         Represents the time the server takes to respond.
+ * @property {number[]} firstPaint             Represents the time when the user agent first rendered after navigation.
+ * @property {number[]} domContentLoaded       Represents the time immediately after the document's DOMContentLoaded event completes.
+ * @property {number[]} loaded                 Represents the time when the load event of the current document is completed.
+ * @property {number[]} firstContentfulPaint   Represents the time when the browser first renders any text or media.
+ * @property {number[]} firstBlock             Represents the time when Puppeteer first sees a block selector in the DOM.
+ * @property {number[]} type                   Average type time.
+ * @property {number[]} typeContainer          Average type time within a container.
+ * @property {number[]} focus                  Average block selection time.
+ * @property {number[]} inserterOpen           Average time to open global inserter.
+ * @property {number[]} inserterSearch         Average time to search the inserter.
+ * @property {number[]} inserterHover          Average time to move mouse between two block item in the inserter.
+ * @property {number[]} listViewOpen           Average time to open listView
  */
 
 /**
  * @typedef WPPerformanceResults
  *
- * @property {number=} timeToFirstByteMedian Represents the time since the browser started the request until it received a response (median).
- * @property {number=} timeToFirstByteP75    Represents the time since the browser started the request until it received a response (75th percentile).
- * @property {number=} serverResponse        Represents the time the server takes to respond.
- * @property {number=} firstPaint            Represents the time when the user agent first rendered after navigation.
- * @property {number=} domContentLoaded      Represents the time immediately after the document's DOMContentLoaded event completes.
- * @property {number=} loaded                Represents the time when the load event of the current document is completed.
- * @property {number=} firstContentfulPaint  Represents the time when the browser first renders any text or media.
- * @property {number=} firstBlock            Represents the time when Puppeteer first sees a block selector in the DOM.
- * @property {number=} type                  Average type time.
- * @property {number=} minType               Minimum type time.
- * @property {number=} maxType               Maximum type time.
- * @property {number=} typeContainer         Average type time within a container.
- * @property {number=} minTypeContainer      Minimum type time within a container.
- * @property {number=} maxTypeContainer      Maximum type time within a container.
- * @property {number=} focus                 Average block selection time.
- * @property {number=} minFocus              Min block selection time.
- * @property {number=} maxFocus              Max block selection time.
- * @property {number=} inserterOpen          Average time to open global inserter.
- * @property {number=} minInserterOpen       Min time to open global inserter.
- * @property {number=} maxInserterOpen       Max time to open global inserter.
- * @property {number=} inserterSearch        Average time to open global inserter.
- * @property {number=} minInserterSearch     Min time to open global inserter.
- * @property {number=} maxInserterSearch     Max time to open global inserter.
- * @property {number=} inserterHover         Average time to move mouse between two block item in the inserter.
- * @property {number=} minInserterHover      Min time to move mouse between two block item in the inserter.
- * @property {number=} maxInserterHover      Max time to move mouse between two block item in the inserter.
- * @property {number=} listViewOpen          Average time to open list view.
- * @property {number=} minListViewOpen       Min time to open list view.
- * @property {number=} maxListViewOpen       Max time to open list view.
+ * @property {number=} timeToFirstByteMedian        Represents the time since the browser started the request until it received a response (median).
+ * @property {number=} timeToFirstByteP75           Represents the time since the browser started the request until it received a response (75th percentile).
+ * @property {number=} largestContentfulPaintMedian Represents the time when the main content of the page has likely loaded (median).
+ * @property {number=} largestContentfulPaintP75    Represents the time when the main content of the page has likely loaded (75th percentile).
+ * @property {number=} serverResponse               Represents the time the server takes to respond.
+ * @property {number=} firstPaint                   Represents the time when the user agent first rendered after navigation.
+ * @property {number=} domContentLoaded             Represents the time immediately after the document's DOMContentLoaded event completes.
+ * @property {number=} loaded                       Represents the time when the load event of the current document is completed.
+ * @property {number=} firstContentfulPaint         Represents the time when the browser first renders any text or media.
+ * @property {number=} firstBlock                   Represents the time when Puppeteer first sees a block selector in the DOM.
+ * @property {number=} type                         Average type time.
+ * @property {number=} minType                      Minimum type time.
+ * @property {number=} maxType                      Maximum type time.
+ * @property {number=} typeContainer                Average type time within a container.
+ * @property {number=} minTypeContainer             Minimum type time within a container.
+ * @property {number=} maxTypeContainer             Maximum type time within a container.
+ * @property {number=} focus                        Average block selection time.
+ * @property {number=} minFocus                     Min block selection time.
+ * @property {number=} maxFocus                     Max block selection time.
+ * @property {number=} inserterOpen                 Average time to open global inserter.
+ * @property {number=} minInserterOpen              Min time to open global inserter.
+ * @property {number=} maxInserterOpen              Max time to open global inserter.
+ * @property {number=} inserterSearch               Average time to open global inserter.
+ * @property {number=} minInserterSearch            Min time to open global inserter.
+ * @property {number=} maxInserterSearch            Max time to open global inserter.
+ * @property {number=} inserterHover                Average time to move mouse between two block item in the inserter.
+ * @property {number=} minInserterHover             Min time to move mouse between two block item in the inserter.
+ * @property {number=} maxInserterHover             Max time to move mouse between two block item in the inserter.
+ * @property {number=} listViewOpen                 Average time to open list view.
+ * @property {number=} minListViewOpen              Min time to open list view.
+ * @property {number=} maxListViewOpen              Max time to open list view.
  */
 
 /**
@@ -147,6 +150,12 @@ function curateResults( testSuite, results ) {
 		return {
 			timeToFirstByteMedian: median( results.timeToFirstByte ),
 			timeToFirstByteP75: percentile75( results.timeToFirstByte ),
+			largestContentfulPaintMedian: median(
+				results.largestContentfulPaint
+			),
+			largestContentfulPaintP75: percentile75(
+				results.largestContentfulPaint
+			),
 		};
 	}
 

--- a/packages/e2e-tests/specs/performance/front-end-block-theme.test.js
+++ b/packages/e2e-tests/specs/performance/front-end-block-theme.test.js
@@ -12,6 +12,7 @@ import { activateTheme, createURL, logout } from '@wordpress/e2e-test-utils';
 describe( 'Front End Performance', () => {
 	const results = {
 		timeToFirstByte: [],
+		largestContentfulPaint: [],
 	};
 
 	beforeAll( async () => {
@@ -42,6 +43,46 @@ describe( 'Front End Performance', () => {
 			results.timeToFirstByte.push(
 				navigationTiming.responseStart - navigationTiming.startTime
 			);
+		}
+	} );
+
+	it( 'Largest Contentful Paint (LCP)', async () => {
+		// Based on https://addyosmani.com/blog/puppeteer-recipes/#performance-observer-lcp
+		function calcLCP() {
+			window.largestContentfulPaint = 0;
+
+			const observer = new PerformanceObserver( ( entryList ) => {
+				const entries = entryList.getEntries();
+				const lastEntry = entries[ entries.length - 1 ];
+				window.largestContentfulPaint =
+					lastEntry.renderTime || lastEntry.loadTime;
+			} );
+
+			observer.observe( {
+				type: 'largest-contentful-paint',
+				buffered: true,
+			} );
+
+			document.addEventListener( 'visibilitychange', () => {
+				if ( document.visibilityState === 'hidden' ) {
+					observer.takeRecords();
+					observer.disconnect();
+				}
+			} );
+		}
+
+		// We derive the 75th percentile of the TTFB based on these results.
+		// By running it 16 times, the percentile value would be (75/100)*16=12,
+		// meaning that we discard the worst 4 values.
+		let i = 16;
+		while ( i-- ) {
+			await page.evaluateOnNewDocument( calcLCP );
+			await page.goto( createURL( '/' ) );
+
+			const lcp = await page.evaluate(
+				() => window.largestContentfulPaint
+			);
+			results.largestContentfulPaint.push( lcp );
 		}
 	} );
 } );

--- a/packages/e2e-tests/specs/performance/front-end-classic-theme.test.js
+++ b/packages/e2e-tests/specs/performance/front-end-classic-theme.test.js
@@ -12,6 +12,7 @@ import { createURL, logout } from '@wordpress/e2e-test-utils';
 describe( 'Front End Performance', () => {
 	const results = {
 		timeToFirstByte: [],
+		largestContentfulPaint: [],
 	};
 
 	beforeAll( async () => {
@@ -40,6 +41,46 @@ describe( 'Front End Performance', () => {
 			results.timeToFirstByte.push(
 				navigationTiming.responseStart - navigationTiming.startTime
 			);
+		}
+	} );
+
+	it( 'Largest Contentful Paint (LCP)', async () => {
+		// Based on https://addyosmani.com/blog/puppeteer-recipes/#performance-observer-lcp
+		function calcLCP() {
+			window.largestContentfulPaint = 0;
+
+			const observer = new PerformanceObserver( ( entryList ) => {
+				const entries = entryList.getEntries();
+				const lastEntry = entries[ entries.length - 1 ];
+				window.largestContentfulPaint =
+					lastEntry.renderTime || lastEntry.loadTime;
+			} );
+
+			observer.observe( {
+				type: 'largest-contentful-paint',
+				buffered: true,
+			} );
+
+			document.addEventListener( 'visibilitychange', () => {
+				if ( document.visibilityState === 'hidden' ) {
+					observer.takeRecords();
+					observer.disconnect();
+				}
+			} );
+		}
+
+		// We derive the 75th percentile of the TTFB based on these results.
+		// By running it 16 times, the percentile value would be (75/100)*16=12,
+		// meaning that we discard the worst 4 values.
+		let i = 16;
+		while ( i-- ) {
+			await page.evaluateOnNewDocument( calcLCP );
+			await page.goto( createURL( '/' ) );
+
+			const lcp = await page.evaluate(
+				() => window.largestContentfulPaint
+			);
+			results.largestContentfulPaint.push( lcp );
 		}
 	} );
 } );

--- a/packages/e2e-tests/specs/performance/front-end-classic-theme.test.js
+++ b/packages/e2e-tests/specs/performance/front-end-classic-theme.test.js
@@ -47,13 +47,16 @@ describe( 'Front End Performance', () => {
 	it( 'Largest Contentful Paint (LCP)', async () => {
 		// Based on https://addyosmani.com/blog/puppeteer-recipes/#performance-observer-lcp
 		function calcLCP() {
-			window.largestContentfulPaint = 0;
+			// By using -1 we know when it didn't record any event.
+			window.largestContentfulPaint = -1;
 
 			const observer = new PerformanceObserver( ( entryList ) => {
 				const entries = entryList.getEntries();
 				const lastEntry = entries[ entries.length - 1 ];
-				window.largestContentfulPaint =
-					lastEntry.renderTime || lastEntry.loadTime;
+				// According to the spec, we can use startTime
+				// as it'll report renderTime || loadTime:
+				// https://www.w3.org/TR/largest-contentful-paint/#largestcontentfulpaint
+				window.largestContentfulPaint = lastEntry.startTime;
 			} );
 
 			observer.observe( {
@@ -75,7 +78,10 @@ describe( 'Front End Performance', () => {
 		let i = 16;
 		while ( i-- ) {
 			await page.evaluateOnNewDocument( calcLCP );
-			await page.goto( createURL( '/' ) );
+			// By waiting for networkidle we make sure navigation won't be considered finished on load,
+			// hence, it'll paint the page and largest-contentful-paint events will be dispatched.
+			// https://pptr.dev/api/puppeteer.page.goto#remarks
+			await page.goto( createURL( '/' ), { waitUntil: 'networkidle0' } );
 
 			const lcp = await page.evaluate(
 				() => window.largestContentfulPaint


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/33645
Follow-up to https://github.com/WordPress/gutenberg/pull/47037

## What?

Adds a new metric to the front-end performance suite: [Largest Contentful Paint](https://web.dev/lcp/) (LCP).

## Why?

We want to know how the front-end performs for the user, and the existing metric we track (TTFB) only tells us a partial picture.

Time To First Byte (TTFB) is a good metric to know what happens in the server. However, it's not a user-centered metric: taking more time in the server doesn't necessarily mean taking more time to render in the client. For example, WordPress processes the post to render so it can identify the blocks in use. With that information, it enqueues the CSS of those blocks instead of the CSS of the whole block library. This certainly takes more time in the server, though we expect it to improve the perceived performance by the user (LCP).

By having LCP available as a metric, we will have a more balanced story of the performance impact of our work.

## How?

Add support for it in the existing e2e test suite.

## Testing Instructions

Verify that the results for largest contentful paint (median and p75) are reported in the Performance Test job as part of the front-end test suite:

![image](https://user-images.githubusercontent.com/583546/218071919-2634445f-150f-48ce-96f8-9f5e42e17f65.png)

