### PR TITLE
Update: Disable layout toolbar controls for content locked blocks.

### DIFF
--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -128,13 +128,25 @@ export function useLayoutStyles( block = {}, selector ) {
 	return css;
 }
 
-function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
+function LayoutPanel( {
+	clientId,
+	setAttributes,
+	attributes,
+	name: blockName,
+} ) {
 	const { layout } = attributes;
 	const defaultThemeLayout = useSetting( 'layout' );
-	const themeSupportsLayout = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		return getSettings().supportsLayout;
-	}, [] );
+	const { themeSupportsLayout, isContentLocked } = useSelect(
+		( select ) => {
+			const { getSettings, __unstableGetContentLockingParent } =
+				select( blockEditorStore );
+			return {
+				themeSupportsLayout: getSettings().supportsLayout,
+				isContentLocked: __unstableGetContentLockingParent( clientId ),
+			};
+		},
+		[ clientId ]
+	);
 
 	const layoutBlockSupport = getBlockSupport(
 		blockName,
@@ -254,7 +266,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 					) }
 				</PanelBody>
 			</InspectorControls>
-			{ ! inherit && layoutType && (
+			{ ! inherit && ! isContentLocked && layoutType && (
 				<layoutType.toolBarControls
 					layout={ usedLayout }
 					onChange={ onChangeLayout }


### PR DESCRIPTION
This PR disables the layout toolbar controls for content-locked blocks.
This removes the possibility of changing things like vertical alignment and justification in the button when it is content locked.

## Testing
I pasted the following code on the code editor:
```
<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>P1</p>
<!-- /wp:paragraph -->

<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">b1</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">b2</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons --></div>
<!-- /wp:group -->
```

I verified the button block toolbar looks like the following image:
<img width="250" alt="Screenshot 2023-02-09 at 19 11 35" src="https://user-images.githubusercontent.com/11271197/217914049-f7f8d70c-6383-4891-8787-bc2d9525001b.png">

