### PR TITLE
Add: database credentials to wp-env docs

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -14,6 +14,8 @@ $ wp-env start
 
 The local environment will be available at http://localhost:8888 (Username: `admin`, Password: `password`).
 
+The database credentials are: user `root`, password `password`.
+
 ## Prerequisites
 
 `wp-env` requires Docker to be installed. There are instructions available for installing Docker on [Windows](https://docs.docker.com/desktop/install/windows-install/), [macOS](https://docs.docker.com/docker-for-mac/install/), and [Linux](https://docs.docker.com/desktop/install/linux-install/).

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -14,7 +14,7 @@ $ wp-env start
 
 The local environment will be available at http://localhost:8888 (Username: `admin`, Password: `password`).
 
-The database credentials are: user `root`, password `password`.
+The database credentials are: user root, password password. For a comprehensive guide on connecting directly to the database, refer to [Accessing the MySQL Database](https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/code/getting-started-with-code-contribution.md#accessing-the-mysql-database).
 
 ## Prerequisites
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -14,7 +14,7 @@ $ wp-env start
 
 The local environment will be available at http://localhost:8888 (Username: `admin`, Password: `password`).
 
-The database credentials are: user root, password password. For a comprehensive guide on connecting directly to the database, refer to [Accessing the MySQL Database](https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/code/getting-started-with-code-contribution.md#accessing-the-mysql-database).
+The database credentials are: user `root`, password `password`. For a comprehensive guide on connecting directly to the database, refer to [Accessing the MySQL Database](https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/code/getting-started-with-code-contribution.md#accessing-the-mysql-database).
 
 ## Prerequisites
 


### PR DESCRIPTION
I was trying to access the database created by `wp-env` inside docker using phpMyAdmin and I couldn't find the credentials. I needed to search inside the package to find the default ones being set.
(https://github.com/WordPress/gutenberg/blob/d5915916abc45e6682f4bdb70888aa41e98aa395/packages/env/lib/config/db-env.js#L3)

```
const credentials = {
	WORDPRESS_DB_USER: 'root',
	WORDPRESS_DB_PASSWORD: 'password',
};
```