### PR TITLE
Navigation: Chore Remove unexistant parameter from selectNavigationMenus call.

### DIFF
--- a/packages/block-library/src/navigation/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/use-navigation-menu.js
@@ -24,7 +24,7 @@ export default function useNavigationMenu( ref ) {
 				navigationMenus,
 				isResolvingNavigationMenus,
 				hasResolvedNavigationMenus,
-			} = selectNavigationMenus( select, ref );
+			} = selectNavigationMenus( select );
 
 			const {
 				navigationMenu,


### PR DESCRIPTION
Function selectNavigationMenus just receives the select parameter and not a ref. We were passing a parameter that does not exist.