### PR TITLE
MediaReplaceFlow: fix styling for LinkControl

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -23,24 +23,22 @@
 	}
 
 	.block-editor-link-control {
-		width: 220px; // Hardcoded width avoids resizing of control when switching between preview/edit.
+		width: 328px; // Hardcoded width avoids resizing of control when switching between preview/edit.
 
 		.block-editor-url-input {
 			padding: 0; // Cancel unnecessary default 1px padding in this case.
 			margin: 0; // Reset default LinkControl margins.
 		}
 
-		.components-base-control .components-base-control__field {
-			margin-bottom: 0;
-		}
-
-		.block-editor-link-control__search-item-title {
-			max-width: 180px;
-			white-space: nowrap;
-		}
-
+		.block-editor-link-control__search-item-title,
 		.block-editor-link-control__search-item-info {
+			max-width: 220px;
 			white-space: nowrap;
+		}
+
+		.block-editor-link-control__tools {
+			justify-content: flex-end;
+			padding: $grid-unit-20 0 0;
 		}
 
 		.block-editor-link-control__search-item.is-current {

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -23,7 +23,7 @@
 	}
 
 	.block-editor-link-control {
-		width: 328px; // Hardcoded width avoids resizing of control when switching between preview/edit.
+		width: 300px; // Hardcoded width avoids resizing of control when switching between preview/edit.
 
 		.block-editor-url-input {
 			padding: 0; // Cancel unnecessary default 1px padding in this case.
@@ -32,7 +32,7 @@
 
 		.block-editor-link-control__search-item-title,
 		.block-editor-link-control__search-item-info {
-			max-width: 220px;
+			max-width: 200px;
 			white-space: nowrap;
 		}
 

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -38,7 +38,7 @@
 
 		.block-editor-link-control__tools {
 			justify-content: flex-end;
-			padding: $grid-unit-20 0 0;
+			padding: $grid-unit-20 var(--wp-admin-border-width-focus) var(--wp-admin-border-width-focus);
 		}
 
 		.block-editor-link-control__search-item.is-current {


### PR DESCRIPTION
## What?

While working on #38730, I came across an issue in Media blocks that contained `LinkControl` through `MediaReplaceFlow.`

The [`text-overflow: ellipsis` ](https://github.com/WordPress/gutenberg/blob/bbf1e85f759173d21c4741bc17a259de313145c5/packages/block-editor/src/components/link-control/style.scss#L228-L231)wasn't applied to `block-editor-link-control__search-item-info` in `LinkPreview` because there wasn't a max-width set on the span. 

And due to the length, the link edit icon was cut off, and the Cancel/Apply button styles were broken as well:

<img width="250" alt="MediaReplaceFlow Link Control bug" src="https://user-images.githubusercontent.com/35543432/217963602-a513fb1c-2863-4ddf-9535-8d597f8449d1.gif">

## Why?

With the edit icon cut off, it's likely difficult for users to find the edit option. The design is also inconsistent; the size changes from previewing to editing, and the buttons aren't in the correct place. 

## How?

Since there was already a fixed-width override on `block-editor-link-control` within the `MediaReplaceFlow` (#33995), the simplest and quickest option is to adjust the size to be wider, to show the icon, and to be consistent with the LinkControl popover size (360px) used in other cases:

<img width="369" alt="Screenshot 2023-02-09 at 4 05 11 PM" src="https://user-images.githubusercontent.com/35543432/217966957-92d64269-8c10-417f-aa49-08723a6dece3.png">

Unfortunately, with `MediaReplaceFlow` using `LinkControl`, it appears that the styles get a bit tangled. So we would also need to add overrides to `block-editor-link-control__tools` to prevent some of the styles from bleeding over from other `LinkControl` cases, i.e. inline links in the Paragraph block. 

cc @getdave, with your recent work on  `LinkControl` #47310, I thought you might be interested to weigh in. 🙂 

## Design feedback request 

There is a bit of extra space for the Image block due to the way that `LinkPreview` handles the length of the filename for images. I am not confident it would be a good idea to adjust the length because this affects many other areas using `LinkControl`. I had originally considered proposing to use the filename instead of the URL for Media blocks so it's shorter like the Image block, but it wouldn't be consistent with other uses of `LinkControl` (and I think this looks better). 

Thoughts? cc @jasmussen as I see you've worked on this before. 😄 

### Image Link Preview:

| Before PR  | After PR |
| ------------- | ------------- |
|  <img width="267" alt="Screenshot 2023-02-09 at 4 01 06 PM" src="https://user-images.githubusercontent.com/35543432/217966435-2f4e1ed2-711d-495f-a468-41519338b356.png"> | <img width="383" alt="Screenshot 2023-02-09 at 2 44 58 PM" src="https://user-images.githubusercontent.com/35543432/217966009-7b970cfa-8419-494d-8f58-5e1067fdbec5.png">  |

## Testing Instructions

1. Check out this branch
2. Add a block that uses `MediaReplaceFlow` with link options (Audio, Video)
3. See that the horizontal scroll is no longer there and the edit icon is visible
4. Click on the edit icon and see that the Cancel/Apply buttons are in the correct space 
5. Add an image block 
6. Verify the spacing 

## Screenshots

### Video/Audio Link Preview

| Before PR  | After PR |
| ------------- | ------------- |
| <img width="268" alt="Screenshot 2023-02-09 at 4 02 56 PM" src="https://user-images.githubusercontent.com/35543432/217966681-e978461d-15bd-4f7f-afe6-db4b61c4b489.png">  | <img width="376" alt="Screenshot 2023-02-09 at 1 56 35 PM" src="https://user-images.githubusercontent.com/35543432/217965593-1bdca2e0-7ba5-4d9f-92a7-4d434f189c9c.png">  |

### Video/Audio Link Edit

| Before PR  | After PR |
| ------------- | ------------- |
| <img width="299" alt="Screenshot 2023-02-09 at 1 48 35 PM" src="https://user-images.githubusercontent.com/35543432/217966769-935efeaf-06af-4f8e-ac3d-85ceb1ca43e9.png">  | <img width="377" alt="Screenshot 2023-02-09 at 1 56 41 PM" src="https://user-images.githubusercontent.com/35543432/217965845-0e1ae8d7-6ad1-42e3-8120-cf64cd9a1d17.png">  |
