### PR TITLE
Add back link to Design heading in site editor navigation to return to Dashboard

### DIFF
--- a/packages/components/src/navigator/navigator-back-button/hook.ts
+++ b/packages/components/src/navigator/navigator-back-button/hook.ts
@@ -16,6 +16,7 @@ export function useNavigatorBackButton(
 ) {
 	const {
 		onClick,
+		href,
 		as = Button,
 		goToParent: goToParentProp = false,
 		...otherProps
@@ -38,6 +39,7 @@ export function useNavigatorBackButton(
 
 	return {
 		as,
+		href,
 		onClick: handleClick,
 		...otherProps,
 	};

--- a/packages/components/src/navigator/navigator-back-button/hook.ts
+++ b/packages/components/src/navigator/navigator-back-button/hook.ts
@@ -16,7 +16,6 @@ export function useNavigatorBackButton(
 ) {
 	const {
 		onClick,
-		href,
 		as = Button,
 		goToParent: goToParentProp = false,
 		...otherProps
@@ -39,7 +38,6 @@ export function useNavigatorBackButton(
 
 	return {
 		as,
-		href,
 		onClick: handleClick,
 		...otherProps,
 	};

--- a/packages/components/src/navigator/navigator-back-button/hook.ts
+++ b/packages/components/src/navigator/navigator-back-button/hook.ts
@@ -22,7 +22,6 @@ export function useNavigatorBackButton(
 	} = useContextSystem( props, 'NavigatorBackButton' );
 
 	const { goBack, goToParent } = useNavigator();
-
 	const handleClick: React.MouseEventHandler< HTMLButtonElement > =
 		useCallback(
 			( e ) => {

--- a/packages/components/src/navigator/navigator-back-button/hook.ts
+++ b/packages/components/src/navigator/navigator-back-button/hook.ts
@@ -22,6 +22,7 @@ export function useNavigatorBackButton(
 	} = useContextSystem( props, 'NavigatorBackButton' );
 
 	const { goBack, goToParent } = useNavigator();
+
 	const handleClick: React.MouseEventHandler< HTMLButtonElement > =
 		useCallback(
 			( e ) => {

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -5,10 +5,18 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalNavigatorToParentButton as NavigatorToParentButton,
+	Button,
 	__experimentalNavigatorScreen as NavigatorScreen,
 } from '@wordpress/components';
 import { isRTL, __ } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../../store';
+import { unlock } from '../../private-apis';
 
 export default function SidebarNavigationScreen( {
 	path,
@@ -16,6 +24,13 @@ export default function SidebarNavigationScreen( {
 	actions,
 	content,
 } ) {
+	const { dashboardLink } = useSelect( ( select ) => {
+		const { getSettings } = unlock( select( editSiteStore ) );
+		return {
+			dashboardLink: getSettings().__experimentalDashboardLink,
+		};
+	}, [] );
+
 	return (
 		<NavigatorScreen
 			className="edit-site-sidebar-navigation-screen"
@@ -34,19 +49,13 @@ export default function SidebarNavigationScreen( {
 							aria-label={ __( 'Back' ) }
 						/>
 					) : (
-						<NavigatorBackButton
+						<Button
 							className="edit-site-sidebar-navigation-screen__back"
 							icon={ isRTL() ? chevronRight : chevronLeft }
 							aria-label={ __( 'Navigate to the Dashboard' ) }
-							href="../wp-admin"
+							href={ dashboardLink || 'index.php' }
+							label={ __( 'Dashboard' ) }
 						/>
-						// <NavigationBackButton
-						// 	className="edit-site-sidebar-navigation-screen__back"
-						// 	icon={ isRTL() ? chevronRight : chevronLeft }
-						// 	aria-label={ __( 'Navigate to the Dashboard' ) }
-						// 	href="../wp-admin"
-						// 	backButtonLabel=" "
-						// />
 					) }
 					<h2 className="edit-site-sidebar-navigation-screen__title">
 						{ title }

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -34,7 +34,19 @@ export default function SidebarNavigationScreen( {
 							aria-label={ __( 'Back' ) }
 						/>
 					) : (
-						<div className="edit-site-sidebar-navigation-screen__icon-placeholder" />
+						<NavigatorBackButton
+							className="edit-site-sidebar-navigation-screen__back"
+							icon={ isRTL() ? chevronRight : chevronLeft }
+							aria-label={ __( 'Navigate to the Dashboard' ) }
+							href="../wp-admin"
+						/>
+						// <NavigationBackButton
+						// 	className="edit-site-sidebar-navigation-screen__back"
+						// 	icon={ isRTL() ? chevronRight : chevronLeft }
+						// 	aria-label={ __( 'Navigate to the Dashboard' ) }
+						// 	href="../wp-admin"
+						// 	backButtonLabel=" "
+						// />
 					) }
 					<h2 className="edit-site-sidebar-navigation-screen__title">
 						{ title }

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -37,7 +37,3 @@
 		color: $white;
 	}
 }
-
-.edit-site-sidebar-navigation-screen__icon-placeholder {
-	width: $button-size;
-}


### PR DESCRIPTION
## What?

Adds a backlink to the Design heading in the Site Editor browse mode nav panel

## Why?
To provide a more obvious link back to the Dashboard

Fixes: #47583

## How?
Adds a `Button` component with an `href` back to the Dashboard. A `NavigatorBackButton` was not used as it does not have an `href` param and is designed for navigation within the `Navigator` component only.

## Testing Instructions

- Go to Site editor browse mode and make sure the back icon is showing next to Design, and that clicking on it takes you back to the Dashboard

## Screenshots or screencast 

Before:

<img width="341" alt="Screenshot 2023-02-13 at 12 52 28 PM" src="https://user-images.githubusercontent.com/3629020/218344743-fe7eb01b-5808-478d-9bd5-41c28a64cf13.png">

After:

<img width="344" alt="Screenshot 2023-02-13 at 12 46 18 PM" src="https://user-images.githubusercontent.com/3629020/218344754-258d155d-fe89-46b1-af5a-7105c8a6101a.png">

