### PR TITLE
Edit Post: Fix the 'inlineToolbar' settings toggle

### DIFF
--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -139,6 +139,7 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 	}, [
 		settings,
 		hasFixedToolbar,
+		hasInlineToolbar,
 		focusMode,
 		isDistractionFree,
 		hiddenBlockTypes,


### PR DESCRIPTION
## What?
PR fixes the bug when activating the `inlineToolbar` feature requires reloading the editor.

Spotted thanks to the `react-hooks/exhaustive-deps` rule.

## Why?
The feature status was missing from the `useMemo` dependencies, and the new settings value was never calculated.

## Testing Instructions
1. Open a Post or Page.
2. Insert any text block and add text.
3. Select text.
4. Toggle the `inlineToolbar` feature using this snippet  - `wp.data.dispatch( 'core/edit-post' ).toggleFeature( 'inlineToolbar' )`.
5. Confim feature is immediately activated/deactivated.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/218063552-dc03aa14-d602-4406-ba63-fb054e607c92.mp4

