### PR TITLE
[Layout]: Fix align controls for hybrid themes

### DIFF
--- a/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
+++ b/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
@@ -19,20 +19,25 @@ export default function useAvailableAlignments( controls = DEFAULT_CONTROLS ) {
 	if ( ! controls.includes( 'none' ) ) {
 		controls = [ 'none', ...controls ];
 	}
-	const { wideControlsEnabled = false, themeSupportsLayout } = useSelect(
-		( select ) => {
-			const { getSettings } = select( blockEditorStore );
-			const settings = getSettings();
-			return {
-				wideControlsEnabled: settings.alignWide,
-				themeSupportsLayout: settings.supportsLayout,
-			};
-		},
-		[]
-	);
+	const {
+		wideControlsEnabled = false,
+		themeSupportsLayout,
+		isBlockBasedTheme,
+	} = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		const settings = getSettings();
+		return {
+			wideControlsEnabled: settings.alignWide,
+			themeSupportsLayout: settings.supportsLayout,
+			isBlockBasedTheme: settings.__unstableIsBlockBasedTheme,
+		};
+	}, [] );
 	const layout = useLayout();
 	const layoutType = getLayoutType( layout?.type );
-	const layoutAlignments = layoutType.getAlignments( layout );
+	const layoutAlignments = layoutType.getAlignments(
+		layout,
+		isBlockBasedTheme
+	);
 
 	if ( themeSupportsLayout ) {
 		const alignments = layoutAlignments.filter(

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -56,7 +56,7 @@ export default {
 	getOrientation() {
 		return 'vertical';
 	},
-	getAlignments( layout ) {
+	getAlignments( layout, isBlockBasedTheme ) {
 		const alignmentInfo = getAlignmentsInfo( layout );
 		if ( layout.alignments !== undefined ) {
 			if ( ! layout.alignments.includes( 'none' ) ) {
@@ -73,6 +73,21 @@ export default {
 			{ name: 'center' },
 			{ name: 'right' },
 		];
+
+		// This is for backwards compatibility with hybrid themes.
+		if ( ! isBlockBasedTheme ) {
+			const { contentSize, wideSize } = layout;
+			if ( contentSize ) {
+				alignments.unshift( { name: 'full' } );
+			}
+
+			if ( wideSize ) {
+				alignments.unshift( {
+					name: 'wide',
+					info: alignmentInfo.wide,
+				} );
+			}
+		}
 
 		alignments.unshift( { name: 'none', info: alignmentInfo.none } );
 

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -73,6 +73,7 @@ const BLOCK_EDITOR_SETTINGS = [
 	'__unstableHasCustomAppender',
 	'__unstableIsPreviewMode',
 	'__unstableResolvedAssets',
+	'__unstableIsBlockBasedTheme',
 ];
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/47857

From the issue:
<!-- In a few words, what is the PR actually doing? -->
> When I use hybrid theme in WordPress 6.2 beta1 nightly, wide and full width settings are lost from the toolbar.

> Also, the wide/full-width cover block becomes the content width.

## Step-by-step reproduction instructions
Tested with WordPress 6.2 beta1 nightly without Gutenberg plugin.

1. Use a classic theme without theme.json. I use TT1 (Twenty Twenty-one).
2. Add blocks to the post and set its width to wide or full.
3. Add TT3's theme.json to TT1 theme folder. TT1 is now a hybrid theme.
4. Open the post editor again, wide and full width settings are lost from the toolbar.

