### PR TITLE
Front-end classic performance test: set TwentyTwentyOne when running in isolation

### DIFF
--- a/packages/e2e-tests/specs/performance/front-end-classic-theme.test.js
+++ b/packages/e2e-tests/specs/performance/front-end-classic-theme.test.js
@@ -7,7 +7,7 @@ import { writeFileSync } from 'fs';
 /**
  * WordPress dependencies
  */
-import { createURL, logout } from '@wordpress/e2e-test-utils';
+import { activateTheme, createURL, logout } from '@wordpress/e2e-test-utils';
 
 describe( 'Front End Performance', () => {
 	const results = {
@@ -15,6 +15,7 @@ describe( 'Front End Performance', () => {
 	};
 
 	beforeAll( async () => {
+		await activateTheme( 'twentytwentyone' );
 		await logout();
 	} );
 


### PR DESCRIPTION
## What?

Makes sure TwentyTwentyOne is set as the theme for the front-end classic performance test suite.

## Why?

According to the metric reports, it's properly sets when running the whole suite. However, when running this test in isolation (for example, locally), TwentyTwentyThree was in use instead. Make sure it's set properly for all scenarios.

## How?

By activating it before the tests run.

## Testing Instructions

Run the front-end classic test in isolation locally using puppeteer's interactive mode to verify that TwentyTwentyOne is in use:

`npm run test:performance packages/e2e-tests/specs/performance/front-end-classic-theme.test.js  -- --puppeteer-interactive --puppeteer-slowmo=200`