### PR TITLE
[Quote]: Fix deprectated `large` style specificity rule

### DIFF
--- a/packages/block-library/src/quote/style.scss
+++ b/packages/block-library/src/quote/style.scss
@@ -2,8 +2,8 @@
 	box-sizing: border-box;
 	overflow-wrap: break-word; // Break long strings of text without spaces so they don't overflow the block.
 	// .is-style-large and .is-large are kept for backwards compatibility. The :not pseudo-class is used to enable switching styles. See PR #37580.
-	&.is-style-large:not(.is-style-plain),
-	&.is-large:not(.is-style-plain) {
+	&.is-style-large:where(:not(.is-style-plain)),
+	&.is-large:where(:not(.is-style-plain)) {
 		margin-bottom: 1em;
 		padding: 0 1em;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/40163
<!-- In a few words, what is the PR actually doing? -->

See issue for testing instructions.

This PR applies @MaggieCabrera 's solution: https://github.com/WordPress/gutenberg/issues/40163#issuecomment-1092552259
