### PR TITLE
OffCanvasEditor: Only allow some blocks to be converted to submenus

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/leaf-more-menu.js
+++ b/packages/block-editor/src/components/off-canvas-editor/leaf-more-menu.js
@@ -30,7 +30,7 @@ function AddSubmenuItem( { block, onClose } ) {
 
 	const clientId = block.clientId;
 	const isDisabled =
-		BLOCKS_THAT_CAN_BE_CONVERTED_TO_SUBMENU.indexOf( block.name ) === -1;
+		! BLOCKS_THAT_CAN_BE_CONVERTED_TO_SUBMENU.includes( block.name );
 	return (
 		<MenuItem
 			icon={ addSubmenu }

--- a/packages/block-editor/src/components/off-canvas-editor/leaf-more-menu.js
+++ b/packages/block-editor/src/components/off-canvas-editor/leaf-more-menu.js
@@ -19,11 +19,69 @@ const POPOVER_PROPS = {
 	variant: 'toolbar',
 };
 
+const BLOCKS_THAT_CAN_BE_CONVERTED_TO_SUBMENU = [
+	'core/navigation-link',
+	'core/navigation-submenu',
+];
+
+function AddSubmenuItem( { block, clientId, onClose } ) {
+	const { insertBlock, replaceBlock, replaceInnerBlocks } =
+		useDispatch( blockEditorStore );
+
+	if (
+		BLOCKS_THAT_CAN_BE_CONVERTED_TO_SUBMENU.indexOf( block.name ) === -1
+	) {
+		return null;
+	}
+
+	return (
+		<MenuItem
+			icon={ addSubmenu }
+			onClick={ () => {
+				const updateSelectionOnInsert = false;
+				const newLink = createBlock( 'core/navigation-link' );
+
+				if ( block.name === 'core/navigation-submenu' ) {
+					insertBlock(
+						newLink,
+						block.innerBlocks.length,
+						clientId,
+						updateSelectionOnInsert
+					);
+				} else {
+					// Convert to a submenu if the block currently isn't one.
+					const newSubmenu = createBlock(
+						'core/navigation-submenu',
+						block.attributes,
+						block.innerBlocks
+					);
+
+					// The following must happen as two independent actions.
+					// Why? Because the offcanvas editor relies on the getLastInsertedBlocksClientIds
+					// selector to determine which block is "active". As the UX needs the newLink to be
+					// the "active" block it must be the last block to be inserted.
+					// Therefore the Submenu is first created and **then** the newLink is inserted
+					// thus ensuring it is the last inserted block.
+					replaceBlock( clientId, newSubmenu );
+
+					replaceInnerBlocks(
+						newSubmenu.clientId,
+						[ newLink ],
+						updateSelectionOnInsert
+					);
+				}
+				onClose();
+			} }
+		>
+			{ __( 'Add submenu link' ) }
+		</MenuItem>
+	);
+}
+
 export default function LeafMoreMenu( props ) {
 	const { clientId, block } = props;
 
-	const { insertBlock, replaceBlock, removeBlocks, replaceInnerBlocks } =
-		useDispatch( blockEditorStore );
+	const { removeBlocks } = useDispatch( blockEditorStore );
 
 	const label = sprintf(
 		/* translators: %s: block name */
@@ -42,47 +100,11 @@ export default function LeafMoreMenu( props ) {
 		>
 			{ ( { onClose } ) => (
 				<MenuGroup>
-					<MenuItem
-						icon={ addSubmenu }
-						onClick={ () => {
-							const updateSelectionOnInsert = false;
-							const newLink = createBlock(
-								'core/navigation-link'
-							);
-							if ( block.name === 'core/navigation-submenu' ) {
-								insertBlock(
-									newLink,
-									block.innerBlocks.length,
-									clientId,
-									updateSelectionOnInsert
-								);
-							} else {
-								// Convert to a submenu if the block currently isn't one.
-								const newSubmenu = createBlock(
-									'core/navigation-submenu',
-									block.attributes,
-									block.innerBlocks
-								);
-
-								// The following must happen as two independent actions.
-								// Why? Because the offcanvas editor relies on the getLastInsertedBlocksClientIds
-								// selector to determine which block is "active". As the UX needs the newLink to be
-								// the "active" block it must be the last block to be inserted.
-								// Therefore the Submenu is first created and **then** the newLink is inserted
-								// thus ensuring it is the last inserted block.
-								replaceBlock( clientId, newSubmenu );
-
-								replaceInnerBlocks(
-									newSubmenu.clientId,
-									[ newLink ],
-									updateSelectionOnInsert
-								);
-							}
-							onClose();
-						} }
-					>
-						{ __( 'Add submenu link' ) }
-					</MenuItem>
+					<AddSubmenuItem
+						block={ block }
+						clientId={ clientId }
+						onClose={ onClose }
+					/>
 					<MenuItem
 						onClick={ () => {
 							removeBlocks( [ clientId ], false );

--- a/packages/block-editor/src/components/off-canvas-editor/leaf-more-menu.js
+++ b/packages/block-editor/src/components/off-canvas-editor/leaf-more-menu.js
@@ -29,8 +29,9 @@ function AddSubmenuItem( { block, onClose } ) {
 		useDispatch( blockEditorStore );
 
 	const clientId = block.clientId;
-	const isDisabled =
-		! BLOCKS_THAT_CAN_BE_CONVERTED_TO_SUBMENU.includes( block.name );
+	const isDisabled = ! BLOCKS_THAT_CAN_BE_CONVERTED_TO_SUBMENU.includes(
+		block.name
+	);
 	return (
 		<MenuItem
 			icon={ addSubmenu }

--- a/packages/block-editor/src/components/off-canvas-editor/leaf-more-menu.js
+++ b/packages/block-editor/src/components/off-canvas-editor/leaf-more-menu.js
@@ -24,19 +24,17 @@ const BLOCKS_THAT_CAN_BE_CONVERTED_TO_SUBMENU = [
 	'core/navigation-submenu',
 ];
 
-function AddSubmenuItem( { block, clientId, onClose } ) {
+function AddSubmenuItem( { block, onClose } ) {
 	const { insertBlock, replaceBlock, replaceInnerBlocks } =
 		useDispatch( blockEditorStore );
 
-	if (
-		BLOCKS_THAT_CAN_BE_CONVERTED_TO_SUBMENU.indexOf( block.name ) === -1
-	) {
-		return null;
-	}
-
+	const clientId = block.clientId;
+	const isDisabled =
+		BLOCKS_THAT_CAN_BE_CONVERTED_TO_SUBMENU.indexOf( block.name ) === -1;
 	return (
 		<MenuItem
 			icon={ addSubmenu }
+			disabled={ isDisabled }
 			onClick={ () => {
 				const updateSelectionOnInsert = false;
 				const newLink = createBlock( 'core/navigation-link' );
@@ -100,11 +98,7 @@ export default function LeafMoreMenu( props ) {
 		>
 			{ ( { onClose } ) => (
 				<MenuGroup>
-					<AddSubmenuItem
-						block={ block }
-						clientId={ clientId }
-						onClose={ onClose }
-					/>
+					<AddSubmenuItem block={ block } onClose={ onClose } />
 					<MenuItem
 						onClick={ () => {
 							removeBlocks( [ clientId ], false );


### PR DESCRIPTION
## What?
The "Add submenu item" option should only be available for navigation link and navigation submenu blocks. Fixes https://github.com/WordPress/gutenberg/issues/47971

## Why?
It's not possible to convert other blocks to navigation submenus.

## How?
Adds an allow list of blocks that can be converted.

## Testing Instructions
1. Add a navigation block
2. Add a Page List block to it (if there's not one there)
3. Open the inspector controls for the navigation block
4. Open the list view tab for the navigation block
5. Select the "more"/"ellipsis" menu next to the Page List block
6. Check that the the "Add submenu item" option is missing
7. Add a custom link to the navigation block
8. Select the "more"/"ellipsis" menu next to the custom link block 
9. Check that the the "Add submenu item" option is present

## Screenshots or screencast <!-- if applicable -->
<img width="355" alt="Screenshot 2023-02-10 at 16 42 11" src="https://user-images.githubusercontent.com/275961/218147210-38fb3345-1872-4bc9-a8fb-02ac66df9f27.png">

<img width="377" alt="Screenshot 2023-02-10 at 16 42 29" src="https://user-images.githubusercontent.com/275961/218147275-8aed8c97-80d7-4f55-b6a7-6b0bc4f20963.png">
