### PR TITLE
Rename the "experiments" export to "privateApis"

### DIFF
--- a/docs/contributors/code/coding-guidelines.md
+++ b/docs/contributors/code/coding-guidelines.md
@@ -293,7 +293,6 @@ You can attach private selectors and actions to a public store:
 
 ```js
 // In packages/package1/store.js:
-import { privateApis as daPrivateApis } from '@wordpress/data';
 import { __experimentalHasContentRoleAttribute, ...selectors } from './selectors';
 import { __experimentalToggleFeature, ...actions } from './selectors';
 // The `lock` function is exported from the internal experiments.js file where

--- a/docs/contributors/code/coding-guidelines.md
+++ b/docs/contributors/code/coding-guidelines.md
@@ -293,7 +293,7 @@ You can attach private selectors and actions to a public store:
 
 ```js
 // In packages/package1/store.js:
-import { experiments as dataExperiments } from '@wordpress/data';
+import { privateApis as daPrivateApis } from '@wordpress/data';
 import { __experimentalHasContentRoleAttribute, ...selectors } from './selectors';
 import { __experimentalToggleFeature, ...actions } from './selectors';
 // The `lock` function is exported from the internal experiments.js file where
@@ -340,9 +340,9 @@ function MyComponent() {
 // In packages/package1/index.js:
 import { lock } from './private-apis';
 
-export const experiments = {};
+export const privateApis = {};
 /* Attach private data to the exported object */
-lock( experiments, {
+lock( privateApis, {
 	__experimentalCallback: function () {},
 	__experimentalReactComponent: function ExperimentalComponent() {
 		return <div />;
@@ -352,7 +352,7 @@ lock( experiments, {
 } );
 
 // In packages/package2/index.js:
-import { experiments } from '@wordpress/package1';
+import { privateApis } from '@wordpress/package1';
 import { unlock } from './private-apis';
 
 const {

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -348,10 +348,6 @@ _Returns_
 
 Undocumented declaration.
 
-### experiments
-
-Experimental @wordpress/block-editor APIs.
-
 ### FontSizePicker
 
 _Related_
@@ -638,6 +634,10 @@ Undocumented declaration.
 _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/plain-text/README.md>
+
+### privateApis
+
+Experimental @wordpress/block-editor APIs.
 
 ### RichText
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -637,7 +637,7 @@ _Related_
 
 ### privateApis
 
-Experimental @wordpress/block-editor APIs.
+Private @wordpress/block-editor APIs.
 
 ### RichText
 

--- a/packages/block-editor/src/components/url-popover/index.js
+++ b/packages/block-editor/src/components/url-popover/index.js
@@ -6,7 +6,7 @@ import { useState } from '@wordpress/element';
 import {
 	Button,
 	Popover,
-	experiments as componentsExperiments,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { chevronDown } from '@wordpress/icons';
 import deprecated from '@wordpress/deprecated';
@@ -19,7 +19,7 @@ import LinkEditor from './link-editor';
 import { unlock } from '../../lock-unlock';
 
 const { __experimentalPopoverLegacyPositionToPlacement } = unlock(
-	componentsExperiments
+	componentsPrivateApis
 );
 
 const DEFAULT_PLACEMENT = 'bottom';

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -10,7 +10,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
 import {
 	BaseControl,
-	experiments as componentsExperiments,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { createHigherOrderComponent, useInstanceId } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
@@ -32,7 +32,7 @@ import { cleanEmptyObject } from './utils';
 import { unlock } from '../lock-unlock';
 import { store as blockEditorStore } from '../store';
 
-const { CustomSelectControl } = unlock( componentsExperiments );
+const { CustomSelectControl } = unlock( componentsPrivateApis );
 
 const POSITION_SUPPORT_KEY = 'position';
 

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -20,4 +20,4 @@ export * from './elements';
 export * from './utils';
 export { storeConfig, store } from './store';
 export { SETTINGS_DEFAULTS } from './store/defaults';
-export { experiments } from './private-apis';
+export { privateApis } from './private-apis';

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -10,8 +10,8 @@ import LeafMoreMenu from './components/off-canvas-editor/leaf-more-menu';
 /**
  * Experimental @wordpress/block-editor APIs.
  */
-export const experiments = {};
-lock( experiments, {
+export const privateApis = {};
+lock( privateApis, {
 	...globalStyles,
 	ExperimentalBlockEditorProvider,
 	LeafMoreMenu,

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -8,7 +8,7 @@ import OffCanvasEditor from './components/off-canvas-editor';
 import LeafMoreMenu from './components/off-canvas-editor/leaf-more-menu';
 
 /**
- * Experimental @wordpress/block-editor APIs.
+ * Private @wordpress/block-editor APIs.
  */
 export const privateApis = {};
 lock( privateApis, {

--- a/packages/block-editor/src/private-apis.native.js
+++ b/packages/block-editor/src/private-apis.native.js
@@ -8,8 +8,8 @@ import { lock } from './lock-unlock';
 /**
  * Experimental @wordpress/block-editor APIs.
  */
-export const experiments = {};
-lock( experiments, {
+export const privateApis = {};
+lock( privateApis, {
 	...globalStyles,
 	ExperimentalBlockEditorProvider,
 } );

--- a/packages/block-editor/src/private-apis.native.js
+++ b/packages/block-editor/src/private-apis.native.js
@@ -6,7 +6,7 @@ import { ExperimentalBlockEditorProvider } from './components/provider';
 import { lock } from './lock-unlock';
 
 /**
- * Experimental @wordpress/block-editor APIs.
+ * Private @wordpress/block-editor APIs.
  */
 export const privateApis = {};
 lock( privateApis, {

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import {
-	experiments as blockEditorExperiments,
+	privateApis as blockEditorPrivateApis,
 	InspectorControls,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
@@ -33,7 +33,7 @@ const MainContent = ( {
 	isNavigationMenuMissing,
 	onCreateNew,
 } ) => {
-	const { OffCanvasEditor, LeafMoreMenu } = unlock( blockEditorExperiments );
+	const { OffCanvasEditor, LeafMoreMenu } = unlock( blockEditorPrivateApis );
 	// Provide a hierarchy of clientIds for the given Navigation block (clientId).
 	// This is required else the list view will display the entire block tree.
 	const clientIdsTree = useSelect(

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -213,4 +213,4 @@ export { default as withNotices } from './higher-order/with-notices';
 export { default as withSpokenMessages } from './higher-order/with-spoken-messages';
 
 // Experiments.
-export { experiments } from './private-apis';
+export { privateApis } from './private-apis';

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -212,5 +212,5 @@ export {
 export { default as withNotices } from './higher-order/with-notices';
 export { default as withSpokenMessages } from './higher-order/with-spoken-messages';
 
-// Experiments.
+// Private APIs.
 export { privateApis } from './private-apis';

--- a/packages/components/src/private-apis.js
+++ b/packages/components/src/private-apis.js
@@ -15,8 +15,8 @@ export const { lock, unlock } =
 		'@wordpress/components'
 	);
 
-export const experiments = {};
-lock( experiments, {
+export const privateApis = {};
+lock( privateApis, {
 	CustomSelectControl,
 	__experimentalPopoverLegacyPositionToPlacement,
 } );

--- a/packages/customize-widgets/src/components/sidebar-block-editor/sidebar-editor-provider.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/sidebar-editor-provider.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -11,7 +11,7 @@ import useBlocksFocusControl from '../focus-control/use-blocks-focus-control';
 
 import { unlock } from '../../private-apis';
 
-const { ExperimentalBlockEditorProvider } = unlock( blockEditorExperiments );
+const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 
 export default function SidebarEditorProvider( {
 	sidebar,

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -7,7 +7,7 @@ import {
 	ErrorBoundary,
 	PostLockedModal,
 	store as editorStore,
-	experiments as editorExperiments,
+	privateApis as editorPrivateApis,
 } from '@wordpress/editor';
 import { useMemo } from '@wordpress/element';
 import { SlotFillProvider } from '@wordpress/components';
@@ -23,7 +23,7 @@ import EditorInitialization from './components/editor-initialization';
 import { store as editPostStore } from './store';
 import { unlock } from './private-apis';
 
-const { ExperimentalEditorProvider } = unlock( editorExperiments );
+const { ExperimentalEditorProvider } = unlock( editorPrivateApis );
 
 function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 	const {

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -17,7 +17,7 @@ import {
 	__unstableUseTypingObserver as useTypingObserver,
 	BlockEditorKeyboardShortcuts,
 	store as blockEditorStore,
-	experiments as blockEditorExperiments,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import {
 	useMergeRefs,
@@ -39,7 +39,7 @@ import EditorCanvas from './editor-canvas';
 import StyleBook from '../style-book';
 import { unlock } from '../../private-apis';
 
-const { ExperimentalBlockEditorProvider } = unlock( blockEditorExperiments );
+const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 
 const LAYOUT = {
 	type: 'default',

--- a/packages/edit-site/src/components/global-styles-renderer/index.js
+++ b/packages/edit-site/src/components/global-styles-renderer/index.js
@@ -3,7 +3,7 @@
  */
 import { useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -11,7 +11,7 @@ import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
 import { store as editSiteStore } from '../../store';
 import { unlock } from '../../private-apis';
 
-const { useGlobalStylesOutput } = unlock( blockEditorExperiments );
+const { useGlobalStylesOutput } = unlock( blockEditorPrivateApis );
 
 function useGlobalStylesRenderer() {
 	const [ styles, settings, svgFilters ] = useGlobalStylesOutput();

--- a/packages/edit-site/src/components/global-styles/border-panel.js
+++ b/packages/edit-site/src/components/global-styles/border-panel.js
@@ -3,7 +3,7 @@
  */
 import {
 	__experimentalBorderRadiusControl as BorderRadiusControl,
-	experiments as blockEditorExperiments,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import {
 	__experimentalBorderBoxControl as BorderBoxControl,
@@ -21,7 +21,7 @@ import { __ } from '@wordpress/i18n';
 import { useSupportedStyles, useColorsPerOrigin } from './hooks';
 import { unlock } from '../../private-apis';
 
-const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorExperiments );
+const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 export function useHasBorderPanel( name ) {
 	const controls = [

--- a/packages/edit-site/src/components/global-styles/color-palette-panel.js
+++ b/packages/edit-site/src/components/global-styles/color-palette-panel.js
@@ -6,14 +6,14 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../private-apis';
 
-const { useGlobalSetting } = unlock( blockEditorExperiments );
+const { useGlobalSetting } = unlock( blockEditorPrivateApis );
 
 export default function ColorPalettePanel( { name } ) {
 	const [ themeColors, setThemeColors ] = useGlobalSetting(

--- a/packages/edit-site/src/components/global-styles/context-menu.js
+++ b/packages/edit-site/src/components/global-styles/context-menu.js
@@ -21,7 +21,7 @@ import {
 import { isRTL, __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -37,7 +37,7 @@ import { useHasShadowControl } from './shadow-panel';
 import { unlock } from '../../private-apis';
 
 const { useHasTypographyPanel, useGlobalSetting } = unlock(
-	blockEditorExperiments
+	blockEditorPrivateApis
 );
 
 function ContextMenu( { name, parentMenu = '' } ) {

--- a/packages/edit-site/src/components/global-styles/custom-css.js
+++ b/packages/edit-site/src/components/global-styles/custom-css.js
@@ -12,7 +12,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import {
-	experiments as blockEditorExperiments,
+	privateApis as blockEditorPrivateApis,
 	transformStyles,
 } from '@wordpress/block-editor';
 import { info } from '@wordpress/icons';
@@ -23,7 +23,7 @@ import { info } from '@wordpress/icons';
 import { unlock } from '../../private-apis';
 import Subtitle from './subtitle';
 
-const { useGlobalStyle } = unlock( blockEditorExperiments );
+const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 function CustomCSSControl( { blockName } ) {
 	// If blockName is defined, we are customizing CSS at the block level:
 	// styles.blocks.blockName.css

--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -20,7 +20,7 @@ import {
 	__experimentalUseCustomSides as useCustomSides,
 	HeightControl,
 	__experimentalSpacingSizesControl as SpacingSizesControl,
-	experiments as blockEditorExperiments,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { Icon, positionCenter, stretchWide } from '@wordpress/icons';
 
@@ -30,7 +30,7 @@ import { Icon, positionCenter, stretchWide } from '@wordpress/icons';
 import { useSupportedStyles } from './hooks';
 import { unlock } from '../../private-apis';
 
-const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorExperiments );
+const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 const AXIAL_SIDES = [ 'horizontal', 'vertical' ];
 

--- a/packages/edit-site/src/components/global-styles/global-styles-provider.js
+++ b/packages/edit-site/src/components/global-styles/global-styles-provider.js
@@ -9,7 +9,7 @@ import { mergeWith, isEmpty, mapValues } from 'lodash';
 import { useMemo, useCallback } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -17,7 +17,7 @@ import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
 import CanvasSpinner from '../canvas-spinner';
 import { unlock } from '../../private-apis';
 
-const { GlobalStylesContext } = unlock( blockEditorExperiments );
+const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
 
 function mergeTreesCustomizer( _, srcValue ) {
 	// We only pass as arrays the presets,

--- a/packages/edit-site/src/components/global-styles/gradients-palette-panel.js
+++ b/packages/edit-site/src/components/global-styles/gradients-palette-panel.js
@@ -8,7 +8,7 @@ import {
 	DuotonePicker,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -16,7 +16,7 @@ import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
 import Subtitle from './subtitle';
 import { unlock } from '../../private-apis';
 
-const { useGlobalSetting } = unlock( blockEditorExperiments );
+const { useGlobalSetting } = unlock( blockEditorPrivateApis );
 
 const noop = () => {};
 

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -10,7 +10,7 @@ import a11yPlugin from 'colord/plugins/a11y';
 import { _x } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
 import { store as blocksStore } from '@wordpress/blocks';
-import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -18,7 +18,7 @@ import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
 import { unlock } from '../../private-apis';
 import { useSelect } from '@wordpress/data';
 
-const { useGlobalSetting } = unlock( blockEditorExperiments );
+const { useGlobalSetting } = unlock( blockEditorPrivateApis );
 
 // Enable colord's a11y plugin.
 extend( [ a11yPlugin ] );

--- a/packages/edit-site/src/components/global-styles/palette.js
+++ b/packages/edit-site/src/components/global-styles/palette.js
@@ -13,7 +13,7 @@ import {
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { shuffle } from '@wordpress/icons';
 import { useMemo } from '@wordpress/element';
-import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -24,7 +24,7 @@ import { useColorRandomizer } from './hooks';
 import ColorIndicatorWrapper from './color-indicator-wrapper';
 import { unlock } from '../../private-apis';
 
-const { useGlobalSetting } = unlock( blockEditorExperiments );
+const { useGlobalSetting } = unlock( blockEditorPrivateApis );
 
 const EMPTY_COLORS = [];
 

--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -4,7 +4,7 @@
 import {
 	__unstableIframe as Iframe,
 	__unstableEditorStyles as EditorStyles,
-	experiments as blockEditorExperiments,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import {
 	__unstableMotion as motion,
@@ -20,7 +20,7 @@ import { useState, useMemo } from '@wordpress/element';
 import { unlock } from '../../private-apis';
 
 const { useGlobalSetting, useGlobalStyle, useGlobalStylesOutput } = unlock(
-	blockEditorExperiments
+	blockEditorPrivateApis
 );
 
 const firstFrame = {

--- a/packages/edit-site/src/components/global-styles/screen-background-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-background-color.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import {
 	__experimentalColorGradientControl as ColorGradientControl,
-	experiments as blockEditorExperiments,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 
 /**
@@ -23,7 +23,7 @@ import {
 } from './hooks';
 import { unlock } from '../../private-apis';
 
-const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorExperiments );
+const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 function ScreenBackgroundColor( { name, variation = '' } ) {
 	const prefix = variation ? `variations.${ variation }.` : '';

--- a/packages/edit-site/src/components/global-styles/screen-block-list.js
+++ b/packages/edit-site/src/components/global-styles/screen-block-list.js
@@ -12,7 +12,7 @@ import { useSelect } from '@wordpress/data';
 import { useState, useMemo, useEffect, useRef } from '@wordpress/element';
 import {
 	BlockIcon,
-	experiments as blockEditorExperiments,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { useDebounce } from '@wordpress/compose';
 import { speak } from '@wordpress/a11y';
@@ -29,7 +29,7 @@ import { NavigationButtonAsItem } from './navigation-button';
 import { unlock } from '../../private-apis';
 
 const { useHasTypographyPanel, useGlobalSetting } = unlock(
-	blockEditorExperiments
+	blockEditorPrivateApis
 );
 
 function useSortedBlockTypes() {

--- a/packages/edit-site/src/components/global-styles/screen-button-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-button-color.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import {
 	__experimentalColorGradientControl as ColorGradientControl,
-	experiments as blockEditorExperiments,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 
 /**
@@ -14,7 +14,7 @@ import ScreenHeader from './header';
 import { useSupportedStyles, useColorsPerOrigin } from './hooks';
 import { unlock } from '../../private-apis';
 
-const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorExperiments );
+const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 function ScreenButtonColor( { name, variation = '' } ) {
 	const prefix = variation ? `variations.${ variation }.` : '';

--- a/packages/edit-site/src/components/global-styles/screen-colors.js
+++ b/packages/edit-site/src/components/global-styles/screen-colors.js
@@ -10,7 +10,7 @@ import {
 	FlexItem,
 	ColorIndicator,
 } from '@wordpress/components';
-import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -25,7 +25,7 @@ import BlockPreviewPanel from './block-preview-panel';
 import { getVariationClassName } from './utils';
 import { unlock } from '../../private-apis';
 
-const { useGlobalStyle } = unlock( blockEditorExperiments );
+const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 function BackgroundColorItem( { name, parentMenu, variation = '' } ) {
 	const prefix = variation ? `variations.${ variation }.` : '';

--- a/packages/edit-site/src/components/global-styles/screen-heading-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-heading-color.js
@@ -8,7 +8,7 @@ import {
 } from '@wordpress/components';
 import {
 	__experimentalColorGradientControl as ColorGradientControl,
-	experiments as blockEditorExperiments,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
 
@@ -23,7 +23,7 @@ import {
 } from './hooks';
 import { unlock } from '../../private-apis';
 
-const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorExperiments );
+const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 function ScreenHeadingColor( { name, variation = '' } ) {
 	const prefix = variation ? `variations.${ variation }.` : '';

--- a/packages/edit-site/src/components/global-styles/screen-link-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-link-color.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import {
 	__experimentalColorGradientControl as ColorGradientControl,
-	experiments as blockEditorExperiments,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { TabPanel } from '@wordpress/components';
 
@@ -15,7 +15,7 @@ import ScreenHeader from './header';
 import { useSupportedStyles, useColorsPerOrigin } from './hooks';
 import { unlock } from '../../private-apis';
 
-const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorExperiments );
+const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 function ScreenLinkColor( { name, variation = '' } ) {
 	const prefix = variation ? `variations.${ variation }.` : '';

--- a/packages/edit-site/src/components/global-styles/screen-root.js
+++ b/packages/edit-site/src/components/global-styles/screen-root.js
@@ -16,7 +16,7 @@ import { isRTL, __ } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -28,7 +28,7 @@ import StylesPreview from './preview';
 import { unlock } from '../../private-apis';
 
 function ScreenRoot() {
-	const { useGlobalStyle } = unlock( blockEditorExperiments );
+	const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 	const [ customCSS ] = useGlobalStyle( 'css' );
 
 	const { variations, canEditCSS } = useSelect( ( select ) => {

--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -25,7 +25,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import {
 	store as blockEditorStore,
-	experiments as blockEditorExperiments,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 
 /**
@@ -36,7 +36,7 @@ import StylesPreview from './preview';
 import ScreenHeader from './header';
 import { unlock } from '../../private-apis';
 
-const { GlobalStylesContext } = unlock( blockEditorExperiments );
+const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
 
 function compareVariations( a, b ) {
 	return (

--- a/packages/edit-site/src/components/global-styles/screen-text-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-text-color.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import {
 	__experimentalColorGradientControl as ColorGradientControl,
-	experiments as blockEditorExperiments,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 
 /**
@@ -14,7 +14,7 @@ import ScreenHeader from './header';
 import { useSupportedStyles, useColorsPerOrigin } from './hooks';
 import { unlock } from '../../private-apis';
 
-const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorExperiments );
+const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 function ScreenTextColor( { name, variation = '' } ) {
 	const prefix = variation ? `variations.${ variation }.` : '';

--- a/packages/edit-site/src/components/global-styles/screen-typography.js
+++ b/packages/edit-site/src/components/global-styles/screen-typography.js
@@ -8,7 +8,7 @@ import {
 	__experimentalHStack as HStack,
 	FlexItem,
 } from '@wordpress/components';
-import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -21,7 +21,7 @@ import BlockPreviewPanel from './block-preview-panel';
 import { getVariationClassName } from './utils';
 import { unlock } from '../../private-apis';
 
-const { useGlobalStyle } = unlock( blockEditorExperiments );
+const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 function Item( { name, parentMenu, element, label } ) {
 	const hasSupport = ! name;

--- a/packages/edit-site/src/components/global-styles/shadow-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadow-panel.js
@@ -22,7 +22,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { shadow as shadowIcon, Icon, check } from '@wordpress/icons';
 import { useCallback } from '@wordpress/element';
-import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -31,7 +31,7 @@ import { useSupportedStyles } from './hooks';
 import { IconWithCurrentColor } from './icon-with-current-color';
 import { unlock } from '../../private-apis';
 
-const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorExperiments );
+const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 export function useHasShadowControl( name ) {
 	const supports = useSupportedStyles( name );

--- a/packages/edit-site/src/components/global-styles/typography-panel.js
+++ b/packages/edit-site/src/components/global-styles/typography-panel.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -12,7 +12,7 @@ const {
 	useGlobalStyle,
 	useGlobalSetting,
 	TypographyPanel: StylesTypographyPanel,
-} = unlock( blockEditorExperiments );
+} = unlock( blockEditorPrivateApis );
 
 export default function TypographyPanel( {
 	name,

--- a/packages/edit-site/src/components/global-styles/typography-preview.js
+++ b/packages/edit-site/src/components/global-styles/typography-preview.js
@@ -1,14 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../private-apis';
 
-const { useGlobalStyle } = unlock( blockEditorExperiments );
+const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 export default function TypographyPreview( { name, element, headingLevel } ) {
 	let prefix = '';

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -10,7 +10,7 @@ import {
 } from '@wordpress/components';
 import { getBlockTypes, store as blocksStore } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { experiments as blockEditorExperiments } from '@wordpress/block-editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { moreVertical } from '@wordpress/icons';
@@ -60,7 +60,7 @@ function GlobalStylesActionMenu() {
 				!! globalStyles?._links?.[ 'wp:action-edit-css' ] ?? false,
 		};
 	}, [] );
-	const { useGlobalStylesReset } = unlock( blockEditorExperiments );
+	const { useGlobalStylesReset } = unlock( blockEditorPrivateApis );
 	const [ canReset, onReset ] = useGlobalStylesReset();
 	const { goTo } = useNavigator();
 	const loadCustomCSS = () => goTo( '/css' );

--- a/packages/edit-site/src/components/navigation-inspector/navigation-menu.js
+++ b/packages/edit-site/src/components/navigation-inspector/navigation-menu.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import {
-	experiments as blockEditorExperiments,
+	privateApis as blockEditorPrivateApis,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
@@ -39,7 +39,7 @@ const ALLOWED_BLOCKS = {
 export default function NavigationMenu( { innerBlocks, onSelect } ) {
 	const { updateBlockListSettings } = useDispatch( blockEditorStore );
 
-	const { OffCanvasEditor, LeafMoreMenu } = unlock( blockEditorExperiments );
+	const { OffCanvasEditor, LeafMoreMenu } = unlock( blockEditorPrivateApis );
 
 	//TODO: Block settings are normally updated as a side effect of rendering InnerBlocks in BlockList
 	//Think through a better way of doing this, possible with adding allowed blocks to block library metadata

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -21,7 +21,7 @@ import {
 } from '@wordpress/blocks';
 import {
 	BlockPreview,
-	experiments as blockEditorExperiments,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { closeSmall } from '@wordpress/icons';
 import { useResizeObserver } from '@wordpress/compose';
@@ -32,7 +32,7 @@ import { useMemo, memo } from '@wordpress/element';
  */
 import { unlock } from '../../private-apis';
 
-const { useGlobalStyle } = unlock( blockEditorExperiments );
+const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 const SLOT_FILL_NAME = 'EditSiteStyleBook';
 const { Slot: StyleBookSlot, Fill: StyleBookFill } =

--- a/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
@@ -11,7 +11,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 import {
 	InspectorAdvancedControls,
 	store as blockEditorStore,
-	experiments as blockEditorExperiments,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { BaseControl, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
@@ -29,7 +29,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useSupportedStyles } from '../../components/global-styles/hooks';
 import { unlock } from '../../private-apis';
 
-const { GlobalStylesContext } = unlock( blockEditorExperiments );
+const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
 
 // TODO: Temporary duplication of constant in @wordpress/block-editor. Can be
 // removed by moving PushChangesToGlobalStylesControl to

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -13,7 +13,7 @@ import { useMemo } from '@wordpress/element';
 import {
 	BlockEditorKeyboardShortcuts,
 	CopyHandler,
-	experiments as blockEditorExperiments,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { ReusableBlocksMenuItems } from '@wordpress/reusable-blocks';
 import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
@@ -29,7 +29,7 @@ import { store as editWidgetsStore } from '../../store';
 import { ALLOW_REUSABLE_BLOCKS } from '../../constants';
 import { unlock } from '../../private-apis';
 
-const { ExperimentalBlockEditorProvider } = unlock( blockEditorExperiments );
+const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 
 export default function WidgetAreasBlockEditorProvider( {
 	blockEditorSettings,

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -8,7 +8,7 @@ import { EntityProvider, useEntityBlockEditor } from '@wordpress/core-data';
 import {
 	BlockEditorProvider,
 	BlockContextProvider,
-	experiments as blockEditorExperiments,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { ReusableBlocksMenuItems } from '@wordpress/reusable-blocks';
 import { store as noticesStore } from '@wordpress/notices';
@@ -21,7 +21,7 @@ import { store as editorStore } from '../../store';
 import useBlockEditorSettings from './use-block-editor-settings';
 import { unlock } from '../../lockUnlock';
 
-const { ExperimentalBlockEditorProvider } = unlock( blockEditorExperiments );
+const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 
 export const ExperimentalEditorProvider = withRegistryProvider(
 	( {

--- a/packages/editor/src/private-apis.js
+++ b/packages/editor/src/private-apis.js
@@ -4,7 +4,7 @@
 import { ExperimentalEditorProvider } from './components/provider';
 import { lock } from './lockUnlock';
 
-export const experiments = {};
-lock( experiments, {
+export const privateApis = {};
+lock( privateApis, {
 	ExperimentalEditorProvider,
 } );

--- a/packages/private-apis/README.md
+++ b/packages/private-apis/README.md
@@ -68,7 +68,7 @@ lock( privateApis, {
 import { privateApis } from '@wordpress/package1';
 import { unlock } from './private-apis';
 
-const { __experimentalFunction } = unlock( experiments );
+const { __experimentalFunction } = unlock( privateApis );
 ```
 
 ## Shipping experimental APIs

--- a/packages/private-apis/README.md
+++ b/packages/private-apis/README.md
@@ -58,14 +58,14 @@ Use `lock()` and `unlock()` to privately distribute the `__experimental` APIs ac
 // In packages/package1/index.js:
 import { lock } from './private-apis';
 
-export const experiments = {};
+export const privateApis = {};
 /* Attach private data to the exported object */
-lock( experiments, {
+lock( privateApis, {
 	__experimentalFunction: function () {},
 } );
 
 // In packages/package2/index.js:
-import { experiments } from '@wordpress/package1';
+import { privateApis } from '@wordpress/package1';
 import { unlock } from './private-apis';
 
 const { __experimentalFunction } = unlock( experiments );

--- a/packages/private-apis/src/implementation.js
+++ b/packages/private-apis/src/implementation.js
@@ -1,15 +1,15 @@
 /**
- * wordpress/experimental – the utilities to enable private cross-package
- * exports of experimental APIs.
+ * wordpress/private-apis – the utilities to enable private cross-package
+ * exports of private APIs.
  *
  * This "implementation.js" file is needed for the sake of the unit tests. It
  * exports more than the public API of the package to aid in testing.
  */
 
 /**
- * The list of core modules allowed to opt-in to the experimental APIs.
+ * The list of core modules allowed to opt-in to the private APIs.
  */
-const CORE_MODULES_USING_EXPERIMENTS = [
+const CORE_MODULES_USING_PRIVATE_APIS = [
 	'@wordpress/block-editor',
 	'@wordpress/block-library',
 	'@wordpress/blocks',
@@ -24,21 +24,21 @@ const CORE_MODULES_USING_EXPERIMENTS = [
 
 /**
  * A list of core modules that already opted-in to
- * the experiments package.
+ * the privateApis package.
  *
  * @type {string[]}
  */
-const registeredExperiments = [];
+const registeredPrivateApis = [];
 
 /*
  * Warning for theme and plugin developers.
  *
- * The use of experimental developer APIs is intended for use by WordPress Core
+ * The use of private developer APIs is intended for use by WordPress Core
  * and the Gutenberg plugin exclusively.
  *
  * Dangerously opting in to using these APIs is NOT RECOMMENDED. Furthermore,
  * the WordPress Core philosophy to strive to maintain backward compatibility
- * for third-party developers DOES NOT APPLY to experimental APIs.
+ * for third-party developers DOES NOT APPLY to private APIs.
  *
  * THE CONSENT STRING FOR OPTING IN TO THESE APIS MAY CHANGE AT ANY TIME AND
  * WITHOUT NOTICE. THIS CHANGE WILL BREAK EXISTING THIRD-PARTY CODE. SUCH A
@@ -59,7 +59,7 @@ try {
 
 /**
  * Called by a @wordpress package wishing to opt-in to accessing or exposing
- * private experimental APIs.
+ * private private APIs.
  *
  * @param {string} consent    The consent string.
  * @param {string} moduleName The name of the module that is opting in.
@@ -69,7 +69,7 @@ export const __dangerousOptInToUnstableAPIsOnlyForCoreModules = (
 	consent,
 	moduleName
 ) => {
-	if ( ! CORE_MODULES_USING_EXPERIMENTS.includes( moduleName ) ) {
+	if ( ! CORE_MODULES_USING_PRIVATE_APIS.includes( moduleName ) ) {
 		throw new Error(
 			`You tried to opt-in to unstable APIs as module "${ moduleName }". ` +
 				'This feature is only for JavaScript modules shipped with WordPress core. ' +
@@ -80,7 +80,7 @@ export const __dangerousOptInToUnstableAPIsOnlyForCoreModules = (
 	}
 	if (
 		! allowReRegistration &&
-		registeredExperiments.includes( moduleName )
+		registeredPrivateApis.includes( moduleName )
 	) {
 		// This check doesn't play well with Story Books / Hot Module Reloading
 		// and isn't included in the Gutenberg plugin. It only matters in the
@@ -102,7 +102,7 @@ export const __dangerousOptInToUnstableAPIsOnlyForCoreModules = (
 				'your product will inevitably break on the next WordPress release.'
 		);
 	}
-	registeredExperiments.push( moduleName );
+	registeredPrivateApis.push( moduleName );
 
 	return {
 		lock,
@@ -138,10 +138,10 @@ function lock( object, privateData ) {
 	if ( ! object ) {
 		throw new Error( 'Cannot lock an undefined object.' );
 	}
-	if ( ! ( __experiment in object ) ) {
-		object[ __experiment ] = {};
+	if ( ! ( __private in object ) ) {
+		object[ __private ] = {};
 	}
-	lockedData.set( object[ __experiment ], privateData );
+	lockedData.set( object[ __private ], privateData );
 }
 
 /**
@@ -171,13 +171,13 @@ function unlock( object ) {
 	if ( ! object ) {
 		throw new Error( 'Cannot unlock an undefined object.' );
 	}
-	if ( ! ( __experiment in object ) ) {
+	if ( ! ( __private in object ) ) {
 		throw new Error(
 			'Cannot unlock an object that was not locked before. '
 		);
 	}
 
-	return lockedData.get( object[ __experiment ] );
+	return lockedData.get( object[ __private ] );
 }
 
 const lockedData = new WeakMap();
@@ -186,18 +186,18 @@ const lockedData = new WeakMap();
  * Used by lock() and unlock() to uniquely identify the private data
  * related to a containing object.
  */
-const __experiment = Symbol( 'Experiment ID' );
+const __private = Symbol( 'Private API ID' );
 
 // Unit tests utilities:
 
 /**
  * Private function to allow the unit tests to allow
- * a mock module to access the experimental APIs.
+ * a mock module to access the private APIs.
  *
  * @param {string} name The name of the module.
  */
 export function allowCoreModule( name ) {
-	CORE_MODULES_USING_EXPERIMENTS.push( name );
+	CORE_MODULES_USING_PRIVATE_APIS.push( name );
 }
 
 /**
@@ -205,16 +205,16 @@ export function allowCoreModule( name ) {
  * a custom list of allowed modules.
  */
 export function resetAllowedCoreModules() {
-	while ( CORE_MODULES_USING_EXPERIMENTS.length ) {
-		CORE_MODULES_USING_EXPERIMENTS.pop();
+	while ( CORE_MODULES_USING_PRIVATE_APIS.length ) {
+		CORE_MODULES_USING_PRIVATE_APIS.pop();
 	}
 }
 /**
  * Private function to allow the unit tests to reset
- * the list of registered experiments.
+ * the list of registered private apis.
  */
-export function resetRegisteredExperiments() {
-	while ( registeredExperiments.length ) {
-		registeredExperiments.pop();
+export function resetRegisteredPrivateApis() {
+	while ( registeredPrivateApis.length ) {
+		registeredPrivateApis.pop();
 	}
 }


### PR DESCRIPTION
## What?
A part of https://github.com/WordPress/gutenberg/issues/47785

Now that the `experiments` package is called `private-apis`, it's time to rename the exported variable where the private APIs are locked.

## Why?
To distinguish between private APIs and experiments.

@ntsekouras @Mamaduka @youknowriad 