### PR TITLE
Show the variation picker if there are no query patterns available.

### DIFF
--- a/packages/block-library/src/query/edit/query-placeholder.js
+++ b/packages/block-library/src/query/edit/query-placeholder.js
@@ -59,7 +59,7 @@ export default function QueryPlaceholder( {
 		matchingVariation?.icon ||
 		blockType?.icon?.src;
 	const label = matchingVariation?.title || blockType?.title;
-	if ( isStartingBlank ) {
+	if ( ! hasPatterns || isStartingBlank ) {
 		return (
 			<QueryVariationPicker
 				clientId={ clientId }

--- a/packages/block-library/src/query/edit/query-placeholder.js
+++ b/packages/block-library/src/query/edit/query-placeholder.js
@@ -6,7 +6,7 @@ import {
 	createBlocksFromInnerBlocksTemplate,
 	store as blocksStore,
 } from '@wordpress/blocks';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import {
 	useBlockProps,
 	store as blockEditorStore,
@@ -53,13 +53,19 @@ export default function QueryPlaceholder( {
 		[ name, blockNameForPatterns, clientId ]
 	);
 
+	useEffect( () => {
+		if ( ! hasPatterns ) {
+			setIsStartingBlank( true );
+		}
+	}, [ hasPatterns ] );
+
 	const matchingVariation = getMatchingVariation( attributes, allVariations );
 	const icon =
 		matchingVariation?.icon?.src ||
 		matchingVariation?.icon ||
 		blockType?.icon?.src;
 	const label = matchingVariation?.title || blockType?.title;
-	if ( ! hasPatterns || isStartingBlank ) {
+	if ( isStartingBlank ) {
 		return (
 			<QueryVariationPicker
 				clientId={ clientId }


### PR DESCRIPTION
Fixes #47888

## What?
<!-- In a few words, what is the PR actually doing? -->
If there are no query patterns available to choose, do not show the option to choose a pattern in the Query block placeholder, go straight to selecting a variation.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Some users of WordPress disable these patterns leaving no theme or core patterns to select. In this scenario we should hide the option to select no existent patterns. See #47888.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
In the check for showing the variation picker, also check if there any patterns available, not just if the starting blank button has been clicked.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Create a remove-patterns.php plugin file in your plugins directory and add the following code to remove patterns: https://gist.github.com/apeatling/ba8ad18b931712133561e832f223adc4
2. Activate the plugin.
3. Open the post editor and insert a query block. Confirm you see the variation picker placeholder screen
4. Deactivate the remove-patterns.php plugin
5. Open the post editor and insert a query block. Confirm you see the "Choose" / "Start New" placeholder screen.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
**Before (first screen with no patterns available)**:
<img width="701" alt="Screenshot 2023-02-10 at 10 07 36 AM" src="https://user-images.githubusercontent.com/1464705/218164766-8df23d97-15da-48d5-8a37-b3b9236c8021.png">

**After (first screen with no patterns available)**:
<img width="684" alt="Screenshot 2023-02-10 at 10 07 43 AM" src="https://user-images.githubusercontent.com/1464705/218164797-5ee22cb9-2946-4dc5-adbb-62e2b1eaf507.png">





