### PR TITLE
LinkControl: fix scrollbar displayed on toggle link settings

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   `LinkControl`: fix scrollbar displayed on toggle link settings ([#47986](https://github.com/WordPress/gutenberg/pull/47986)).
+
 ## 11.3.0 (2023-02-01)
 
 ## 11.2.0 (2023-01-11)

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -462,8 +462,10 @@ $preview-image-height: 140px;
 	align-items: center;
 	justify-content: space-between;
 	margin: 0;
+	margin-top: calc(var(--wp-admin-border-width-focus) * -1);
 	padding: $grid-unit-20;
-	padding-top: 0;
+	padding-top: var(--wp-admin-border-width-focus);
+	overflow: hidden;
 }
 
 .block-editor-link-control__unlink {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -462,8 +462,12 @@ $preview-image-height: 140px;
 	align-items: center;
 	justify-content: space-between;
 	margin: 0;
-	margin-top: calc(var(--wp-admin-border-width-focus) * -1);
 	padding: $grid-unit-20;
+
+	// To hide the horizontal scrollbar on toggle.
+	// Margin and padding are needed to prevent cutoff of the toggle button focus outline.
+	// See: https://github.com/WordPress/gutenberg/pull/47986/files
+	margin-top: calc(var(--wp-admin-border-width-focus) * -1);
 	padding-top: var(--wp-admin-border-width-focus);
 	overflow: hidden;
 }

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -466,7 +466,7 @@ $preview-image-height: 140px;
 
 	// To hide the horizontal scrollbar on toggle.
 	// Margin and padding are needed to prevent cutoff of the toggle button focus outline.
-	// See: https://github.com/WordPress/gutenberg/pull/47986/files
+	// See: https://github.com/WordPress/gutenberg/pull/47986
 	margin-top: calc(var(--wp-admin-border-width-focus) * -1);
 	padding-top: var(--wp-admin-border-width-focus);
 	overflow: hidden;


### PR DESCRIPTION
Fixes: #47876

## What?

This PR hides the scrollbar that appears when toggling settings in the `LinkControl` component. This problem occurs on Windows; Mac users may be able to reproduce it if the scrollbars are set to "Always".

## Why?

I think it is due to the popover content having `overflow:auto`.

https://user-images.githubusercontent.com/54422211/218237705-f0099715-4004-436e-b4ea-1b0d2da12530.mp4

## How?

Applied `overflow:hidden;` to the parent element of the motion element. However, this style alone will result in a cut-off focus outline:

![cut-off](https://user-images.githubusercontent.com/54422211/218237909-5c114901-3f87-4b75-a5f3-0f7fd6556704.png)

Therefore, I applied padding-top value by the width of the outline border. At the same time, a negative margin-top with the same value was applied on top to avoid changing the appearance.

## Testing Instructions

- Toggle the link setting and confirm that the scroll bar appears.
- Confirm that the focus outline of the button is not cut off.

Note:  On Mac, you might be able to reproduce this by changing the "General > Show scroll bars" setting to "Always".

## Screenshots or screencast <!-- if applicable -->

### Before

https://user-images.githubusercontent.com/54422211/218238040-78a88103-1bbd-4930-9464-0879523ddbb7.mp4

### After

https://user-images.githubusercontent.com/54422211/218238050-3fe6bdca-e724-44ec-9c91-3e8f08664820.mp4