### PR TITLE
Embed: Fix: Remove browser default border for iframe in the editor

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -93,3 +93,8 @@
  * These are only output in the editor, but styles here are NOT prefixed .editor-styles-wrapper.
  * This allows us to create normalization styles that are easily overridden by editor styles.
  */
+
+// Remove the browser default border for iframe in Custom HTML block, Embed block, etc.
+.editor-styles-wrapper iframe:not([frameborder]) {
+	border: 0;
+}


### PR DESCRIPTION
Fixes: #47761
Related to: #47818

## What?

This PR applies CSS to iframe elements in the editor content to remove the browser's default border style.

## Why?

The WordPress admin panel defines [CSS to cancel iframe border as a common style](https://github.com/WordPress/wordpress-develop/blob/099ff6c5fe50c9009c79f9bbb9a0422db5e2f51f/src/wp-admin/css/common.css#L241-L244). However, it is not applied inside iframe editor content, so the custom HTML block and the embed block with iframes will display the browser default border.

## How?

Resets the iframe border if the following two conditions are met:

- Must be editor content (i.e., wrapped in an element with the `.editor-styles-wrapper` class)
- The iframe to be rendered doesn't originally have the `frameborder` attribute. This is to respect the `frameborder` attribute that is [intentionally given when an embedded post is rendered in an embedded block](https://github.com/WordPress/gutenberg/blob/ca90b31f832bf773b0e35b169e7d0c74d9fdb531/packages/block-library/src/embed/wp-embed-preview.js#L11).

## Testing Instructions

- Insert a Custom HTML block  and enter some content.
- Switch to preview mode and confirm that no borders appear.
- Insert a Embed block  and confirm that no borders appear.

## Screenshots or screencast

### Before

![before](https://user-images.githubusercontent.com/54422211/218241494-db022c9c-08bd-4889-a6fd-cf8a7d6d88da.png)

### After

![after](https://user-images.githubusercontent.com/54422211/218241497-d49b7dd1-5269-4520-a08f-1679b7820e72.png)

