### PR TITLE
Keep the Link Control settings drawer persistent

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -9,6 +9,8 @@ import classnames from 'classnames';
 import { Button, Spinner, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useRef, useState, useEffect } from '@wordpress/element';
+import { select, dispatch } from '@wordpress/data';
+import { store as preferencesStore } from '@wordpress/preferences';
 import { focus } from '@wordpress/dom';
 import { ENTER } from '@wordpress/keycodes';
 
@@ -136,7 +138,14 @@ function LinkControl( {
 	const textInputRef = useRef();
 	const isEndingEditWithFocus = useRef( false );
 
-	const [ settingsOpen, setSettingsOpen ] = useState( false );
+	const isSettingsOpen = select( preferencesStore ).get(
+		'core/editor',
+		'linkControlSettingsOpen'
+	);
+
+	const [ settingsOpen, setSettingsOpen ] = useState(
+		isSettingsOpen || false
+	);
 
 	const [ internalUrlInputValue, setInternalUrlInputValue ] =
 		useInternalInputValue( value?.url || '' );
@@ -191,6 +200,14 @@ function LinkControl( {
 
 		isEndingEditWithFocus.current = false;
 	}, [ isEditingLink, isCreatingPage ] );
+
+	useEffect( () => {
+		dispatch( preferencesStore ).set(
+			'core/editor',
+			'linkControlSettingsOpen',
+			settingsOpen
+		);
+	}, [ settingsOpen ] );
 
 	const hasLinkValue = value?.url?.trim()?.length > 0;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR will keep the Link Control setting open if it is opened or closed if it was closed earlier.
By default, the setting drawer will be closed.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
https://github.com/WordPress/gutenberg/issues/47821
https://github.com/WordPress/gutenberg/issues/47821#issuecomment-1420673564

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Get the state of the setting drawer from the preferences store.
- Add a useEffect to set the preference whenever the setting drawer is opened/closed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Go to the Gutenberg Editor.
- Open/close the setting drawer of Link Control.
- Check if the setting drawer is keeping the state.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

![GIF Recording 2023-02-11 at 2 54 04 PM](https://user-images.githubusercontent.com/43412958/218250883-50dc0455-c128-486e-8113-649dd583b86d.gif)
