### PR TITLE
Visual Regression tests: use default playwright utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ phpunit-watcher.yml
 .tool-versions
 test/storybook-playwright/test-results
 test/storybook-playwright/specs/__snapshots__
+test/storybook-playwright/specs/*-snapshots/**

--- a/test/storybook-playwright/specs/font-size-picker.spec.ts
+++ b/test/storybook-playwright/specs/font-size-picker.spec.ts
@@ -1,7 +1,7 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
-import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+import { test, expect } from '@playwright/test';
 
 /**
  * Internal dependencies

--- a/test/storybook-playwright/specs/popover.spec.ts
+++ b/test/storybook-playwright/specs/popover.spec.ts
@@ -1,7 +1,7 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
-import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+import { test, expect } from '@playwright/test';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #47988

Use PlayWright default `test` and `expect` utils for Visual Regression tests running on Storybook stories.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This fixes an issue introduced by #46459, where Visual Regression tests would timeout indefinitely. This is caused by the fact that utils from the `'@wordpress/e2e-test-utils-playwright'` package would assume that the e2e would load the editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Since Visual Regression test don't seem to need any of the additions introduced by `'@wordpress/e2e-test-utils-playwright'`, switching to the default versions from PlayWright seems the correct fix.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- `npm run distclean && npm ci`
- In two separate tabs:
  - First run `npm run storybook:e2e:dev`
  - Once storybook has launched, in a separate tab run `npm run test:e2e:storybook -- --update-snapshots`

- [ ] Make sure that tests don't time out
- [ ] Make sure that the generated snapshot images are gitignored