### PR TITLE
Shadow: Wrap `resetShadow` in `useCallback`

### DIFF
--- a/packages/edit-site/src/components/global-styles/shadow-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadow-panel.js
@@ -44,7 +44,10 @@ export default function ShadowPanel( { name, variation = '' } ) {
 	const [ userShadow ] = useGlobalStyle( `${ prefix }shadow`, name, 'user' );
 	const hasShadow = () => !! userShadow;
 
-	const resetShadow = () => setShadow( undefined );
+	const resetShadow = useCallback(
+		() => setShadow( undefined ),
+		[ setShadow ]
+	);
 	const resetAll = useCallback(
 		() => resetShadow( undefined ),
 		[ resetShadow ]


### PR DESCRIPTION
## What?

Wraps `resetShadow` in `useCallback`.

## Why?

Without this change, `resetShadow` causes the dependencies of the `resetAll` `useCallback` to change on every render.

## How?

Leverages `useCallback` for `resetShadow` itself.

Optionally, we could choose to remove the `resetAll` function altogether and instead use `resetShadow` for the `ToolsPanel`'s `resetAll` prop as it only contains the one `ToolsPanelItem` and there's no Slot being rendered for others to be injected.

I choose to leave it in place as I recall there being discussions on extending this shadow panel to include more items.

## Testing Instructions

1. Before checking out this branch, open up `packages/edit-site/src/components/global-styles/shadow-panel.js` and note the linting error.
2. Checkout this PR, confirm there is no linting error.
3. Navigate to Site Editor > Global Styles > Style Book > Design tab
4. Select a button block, then Shadow from the global styles sidebar
5. Check that the shadow control continues to function correctly and that you can reset it via both the individual and the reset all menu options.

