### PR TITLE
Border Panel: Add missing dep for `onBorderChange` callback

### DIFF
--- a/packages/edit-site/src/components/global-styles/border-panel.js
+++ b/packages/edit-site/src/components/global-styles/border-panel.js
@@ -170,7 +170,7 @@ export default function BorderPanel( { name, variation = '' } ) {
 			// global styles are saved.
 			setBorder( { radius: border?.radius, ...updatedBorder } );
 		},
-		[ setBorder ]
+		[ setBorder, border?.radius ]
 	);
 
 	return (


### PR DESCRIPTION
## What?

- Add missing dep to keep linter happy.

## Why?
- The `onBorderChange` callback depends on the border-radius style attribute, so needs it in its deps array.

## How?
- Add missing dep to `onBorderChange` callback's dependencies array.

## Testing Instructions
1. Confirm in Global Styles that border-radius values are set correctly and are retained when you adjust other border properties such as color, width, or style.
