### PR TITLE
ToolsPanel: Remove unnecessary dep from resetAll callback

### DIFF
--- a/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
+++ b/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
@@ -52,7 +52,6 @@ export default function BlockSupportToolsPanel( { children, group, label } ) {
 			updateBlockAttributes( clientIds, newAttributes, true );
 		},
 		[
-			cleanEmptyObject,
 			getBlockAttributes,
 			getMultiSelectedBlockClientIds,
 			hasMultiSelection,


### PR DESCRIPTION
## What?

Remove unnecessary dependency from the `BlockSupportToolsPanel`'s reset all callback.

## Why?
Keeps the linter happy.

## How?
Select > Delete > Save 🙂 

## Testing Instructions

1. Confirm there are no linter warnings or errors in `packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js`
2. Open the editor, insert Group block, select it and configure some custom colors, dimensions, or border
3. Confirm that the color, dimensions, or border panel's reset all menu item successfully resets the panel's values.

