### PR TITLE
Verse: Adopt border supports

### DIFF
--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -47,6 +47,12 @@
 		"spacing": {
 			"margin": true,
 			"padding": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"width": true,
+			"color": true,
+			"style": true
 		}
 	},
 	"style": "wp-block-verse",


### PR DESCRIPTION
## What?
- Adopts border support for the Verse block

## Why?
- Another small step towards consistent design tooling across all blocks.

## How?
- Adopts all border supports for the Verse block
- No border controls are displayed by default

## Testing Instructions
1. Navigate to the Site Editor > Global Styles > Style Book
2. Select the Verse block under the Text tab
3. Within the Global Styles sidebar, select Border
4. Trial adding different border configurations and ensure they are displayed correctly in the preview
5. Save the Global Styles and switch to editing a post in the Block Editor
6. Add a Verse block and confirm it receives the border you set in Global Styles
7. Save the post and confirm border is applied on the front end
8. Back in the editor, select the Verse block and reconfigure its border via the Block Inspector
9. The new border should override the Global Styles you set
10. Save and confirm the new custom border is displayed correctly on the frontend

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/218449873-0742638f-8096-4fbf-a30e-36169446f5b8.mp4

