### PR TITLE
Avatar: Clean up border application in editor

### DIFF
--- a/packages/block-library/src/avatar/edit.js
+++ b/packages/block-library/src/avatar/edit.js
@@ -122,7 +122,6 @@ const ResizableAvatar = ( {
 				<img
 					src={ doubledSizedSrc }
 					alt={ avatar.alt }
-					{ ...borderProps }
 					className={ classnames(
 						'avatar',
 						'avatar-' + attributes.size,
@@ -130,9 +129,7 @@ const ResizableAvatar = ( {
 						'wp-block-avatar__image',
 						borderProps.className
 					) }
-					style={ {
-						...borderProps.style, // Border radius, width and style.
-					} }
+					style={ borderProps.style }
 				/>
 			</ResizableBox>
 		</div>


### PR DESCRIPTION
## What?
Removes duplicate applications of border props to the Avatar block's `img`.

## Why?

Yak shaving, code quality, and readability.

## How?
- Removed the generic spreading of the `borderProps` object when both its possible props are overridden in the following props.
- Opted for setting the `style` prop explicitly to the `borderProps.style`. This option is easier to grok than removing the style prop and relying on the spreading of the `borderProps` and needing to know what the `useBorderProps` hook returns.

## Testing Instructions
1. Edit a post and add an Avatar block
2. Select the block and apply a border with a custom color, style, and width
3. Confirm the styles are still applied correctly to the block's `img` element.
4. Save and confirm border is correct on the frontend.
