### PR TITLE
Fix site editor navigation

### DIFF
--- a/packages/edit-site/src/components/add-new-template/new-template-part.js
+++ b/packages/edit-site/src/components/add-new-template/new-template-part.js
@@ -67,9 +67,12 @@ export default function NewTemplatePart( {
 			setCanvasMode( 'edit' );
 
 			// Navigate to the created template part editor.
-			history.push( {
-				postId: templatePart.id,
-				postType: templatePart.type,
+			window.queueMicrotask( () => {
+				history.push( {
+					postId: templatePart.id,
+					postType: 'wp_template_part',
+					path: '/template-parts/single',
+				} );
 			} );
 
 			// TODO: Add a success notice?

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -100,7 +100,6 @@ export default function NewTemplate( {
 	const { setTemplate, setCanvasMode } = unlock(
 		useDispatch( editSiteStore )
 	);
-
 	async function createTemplate( template, isWPSuggestion = true ) {
 		if ( isCreatingTemplate ) {
 			return;
@@ -125,15 +124,18 @@ export default function NewTemplate( {
 
 			// Set template before navigating away to avoid initial stale value.
 			setTemplate( newTemplate.id, newTemplate.slug );
-
 			// Switch to edit mode.
 			setCanvasMode( 'edit' );
 
 			// Navigate to the created template editor.
-			history.push( {
-				postId: newTemplate.id,
-				postType: newTemplate.type,
+			window.queueMicrotask( () => {
+				history.push( {
+					postId: newTemplate.id,
+					postType: newTemplate.type,
+					path: '/templates/single',
+				} );
 			} );
+
 			createSuccessNotice(
 				sprintf(
 					// translators: %s: Title of the created template e.g: "Category".

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-item/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-item/index.js
@@ -1,0 +1,52 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { Button } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * Internal dependencies
+ */
+import SidebarNavigationScreen from '../sidebar-navigation-screen';
+import { unlock } from '../../private-apis';
+import { store as editSiteStore } from '../../store';
+
+export default function SidebarNavigationScreenNavigationItem() {
+	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
+
+	const { post } = useSelect( ( select ) => {
+		const { getEditedPostContext } = select( editSiteStore );
+		const { getEntityRecord } = select( coreStore );
+		const { postType, postId } = getEditedPostContext() ?? {};
+
+		// The currently selected entity to display.
+		// Typically template or template part in the site editor.
+		return {
+			post:
+				postId && postType
+					? getEntityRecord( 'postType', postType, postId )
+					: null,
+		};
+	}, [] );
+
+	return (
+		<SidebarNavigationScreen
+			path="/navigation/single"
+			title={ post ? decodeEntities( post?.title?.rendered ) : null }
+			actions={
+				<Button
+					variant="primary"
+					onClick={ () => setCanvasMode( 'edit' ) }
+				>
+					{ __( 'Edit' ) }
+				</Button>
+			}
+			content={
+				post ? decodeEntities( post?.description?.rendered ) : null
+			}
+		/>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -25,6 +25,7 @@ export default function SidebarNavigationScreenNavigationMenus() {
 				history.push( {
 					postType: attributes.type,
 					postId: attributes.id,
+					path: '/navigation/single',
 				} );
 			}
 		},

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -16,6 +16,7 @@ import useSyncPathWithURL from '../sync-state-with-url/use-sync-path-with-url';
 import SidebarNavigationScreenNavigationMenus from '../sidebar-navigation-screen-navigation-menus';
 import SidebarNavigationScreenTemplatesBrowse from '../sidebar-navigation-screen-templates-browse';
 import SaveButton from '../save-button';
+import SidebarNavigationScreenNavigationItem from '../sidebar-navigation-screen-navigation-item';
 
 function SidebarScreens() {
 	useSyncPathWithURL();
@@ -24,6 +25,7 @@ function SidebarScreens() {
 		<>
 			<SidebarNavigationScreenMain />
 			<SidebarNavigationScreenNavigationMenus />
+			<SidebarNavigationScreenNavigationItem />
 			<SidebarNavigationScreenTemplates postType="wp_template" />
 			<SidebarNavigationScreenTemplates postType="wp_template_part" />
 			<SidebarNavigationScreenTemplate postType="wp_template" />


### PR DESCRIPTION
## What?

I've noticed some small bugs after #47777 

 - Creating templates and template parts don't redirect properly to the site editor in edit mode.
 - Clicking menu items in the "navigation" sidebar don't open the page/post in the site editor. 

This PR fixes both of these issues.

## Testing Instructions

1- Open the site editor
2- Open the "templates" sidebar
3- Create a new custom template
4- You should be redirected properly to the template in edit mode
5- Click the "w" menu brings back the sidebar with the template open on the sidebar.


1- Open the site editor
2- Click "Navigation" in the sidebar
3- Click a page or post from your menu 
4- the target page is opened in the site editor
