### PR TITLE
Remove "& Shadow" from the Border ScreenHeader title

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-border.js
+++ b/packages/edit-site/src/components/global-styles/screen-border.js
@@ -16,7 +16,7 @@ function ScreenBorder( { name, variation = '' } ) {
 	const variationClassName = getVariationClassName( variation );
 	return (
 		<>
-			<ScreenHeader title={ __( 'Border & Shadow' ) } />
+			<ScreenHeader title={ __( 'Border' ) } />
 			<BlockPreviewPanel name={ name } variation={ variationClassName } />
 			{ hasBorderPanel && (
 				<BorderPanel name={ name } variation={ variation } />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Remove "& Shadow" from the Border ScreenHeader title — closes https://github.com/WordPress/gutenberg/issues/48038. 

## Why?
The shadow controls are now part of their own panel (https://github.com/WordPress/gutenberg/pull/47634), and no longer combined with border controls. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Minor text string change. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open Global Styles
2. Navigate to the Group block
3. Click on "Border"
4. See the title of the ScreenHeader as "Border" instead of "Border & Shadow"

## Screenshots or screencast <!-- if applicable -->

<img width="738" alt="CleanShot 2023-02-13 at 15 02 59" src="https://user-images.githubusercontent.com/1813435/218562782-de25bc94-8852-4c85-9e16-62a3379fcefc.png">
