### PR TITLE
Display a document icon when using the site editor

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -57,9 +57,11 @@ function useSecondaryText() {
 
 	if ( activeEntityBlockId ) {
 		return {
-			label: getBlockDisplayText( getBlock( activeEntityBlockId ) ),
+			secondaryLabel: getBlockDisplayText(
+				getBlock( activeEntityBlockId )
+			),
 			isActive: true,
-			icon: blockInformation?.icon,
+			secondaryIcon: blockInformation?.icon,
 		};
 	}
 
@@ -75,8 +77,8 @@ export default function DocumentActions() {
 			),
 		[]
 	);
-	const { isLoaded, record, getTitle } = useEditedEntityRecord();
-	const { label, icon } = useSecondaryText();
+	const { isLoaded, record, getTitle, icon } = useEditedEntityRecord();
+	const { secondaryLabel, secondaryIcon } = useSecondaryText();
 
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
@@ -119,7 +121,7 @@ export default function DocumentActions() {
 	return (
 		<div
 			className={ classnames( 'edit-site-document-actions', {
-				'has-secondary-label': !! label,
+				'has-secondary-label': !! secondaryLabel,
 			} ) }
 		>
 			<div
@@ -131,6 +133,7 @@ export default function DocumentActions() {
 					className="edit-site-document-actions__title"
 					as="h1"
 				>
+					<BlockIcon icon={ icon } />
 					<VisuallyHidden as="span">
 						{ sprintf(
 							/* translators: %s: the entity being edited, like "template"*/
@@ -141,8 +144,8 @@ export default function DocumentActions() {
 					{ getTitle() }
 				</Text>
 				<div className="edit-site-document-actions__secondary-item">
-					<BlockIcon icon={ icon } showColors />
-					<Text size="body">{ label ?? '' }</Text>
+					<BlockIcon icon={ secondaryIcon } showColors />
+					<Text size="body">{ secondaryLabel ?? '' }</Text>
 				</div>
 
 				<Dropdown

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -44,7 +44,7 @@
 		color: currentColor;
 		align-items: center;
 		display: inline-flex;
-		gap: 4px;
+		gap: $grid-unit-05;
 	}
 
 	.edit-site-document-actions__secondary-item {
@@ -71,8 +71,8 @@
 			opacity: 1;
 			padding: 0 4px;
 			max-width: 180px;
-			margin-left: 12px;
-			gap: 4px;
+			margin-left: $grid-unit-15;
+			gap: $grid-unit-05;
 		}
 	}
 }

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -42,6 +42,8 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		color: currentColor;
+		align-items: center;
+		display: inline-flex;
 	}
 
 	.edit-site-document-actions__secondary-item {

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -44,6 +44,7 @@
 		color: currentColor;
 		align-items: center;
 		display: inline-flex;
+		gap: 4px;
 	}
 
 	.edit-site-document-actions__secondary-item {
@@ -70,7 +71,8 @@
 			opacity: 1;
 			padding: 0 4px;
 			max-width: 180px;
-			margin-left: 6px;
+			margin-left: 12px;
+			gap: 4px;
 		}
 	}
 }

--- a/packages/edit-site/src/components/use-edited-entity-record/index.js
+++ b/packages/edit-site/src/components/use-edited-entity-record/index.js
@@ -12,7 +12,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { store as editSiteStore } from '../../store';
 
 export default function useEditedEntityRecord( postType, postId ) {
-	const { record, title, description, isLoaded } = useSelect(
+	const { record, title, description, isLoaded, icon } = useSelect(
 		( select ) => {
 			const { getEditedPostType, getEditedPostId } =
 				select( editSiteStore );
@@ -34,6 +34,7 @@ export default function useEditedEntityRecord( postType, postId ) {
 				title: templateInfo.title,
 				description: templateInfo.description,
 				isLoaded: _isLoaded,
+				icon: templateInfo.icon,
 			};
 		},
 		[ postType, postId ]
@@ -41,6 +42,7 @@ export default function useEditedEntityRecord( postType, postId ) {
 
 	return {
 		isLoaded,
+		icon,
 		record,
 		getTitle: () => ( title ? decodeEntities( title ) : null ),
 		getDescription: () =>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Displaying an icon next to the title when using the site editor. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Many users are confused when entering the Site Editor - not understanding the context that they are editing elements under (within templates). This often results in content which is intended for a single page being added as content to the template (amongst other things). The Site Editor header displays the current document's name, but not its type. This change gives an additional hint to users what is being edited.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The `useEditedEntityRecord` hook now returns an icon for the entity being edited.
The `DocumentActions` component displays this icon in the document action title

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
 1. Open the site editor and edit a template - you should now see a template icon
 3. Open the site editor and edit a header template part - you should now see a header icon
 4. Open the site editor and edit a template part that isn't a header or footer - you should now see a template-part icon

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

Keyboard navigation is unaffected.

## Screenshots or screencast <!-- if applicable -->



Title | Before | After
------|--------|------
 Editing template | <img width="1468" alt="Screenshot 2023-02-13 at 18 57 39" src="https://user-images.githubusercontent.com/93301/218588662-ec197250-0ebb-4ffe-b527-09bc34a8338a.png"> | <img width="1336" alt="image" src="https://user-images.githubusercontent.com/93301/233079662-c4d241db-a920-4423-87b2-c08b6c98e047.png">
 Editing header | <img width="1468" alt="Screenshot 2023-02-13 at 18 58 29" src="https://user-images.githubusercontent.com/93301/218588773-135d6e59-9c66-49b4-a4c9-bf0e7e0198d8.png"> | <img width="1336" alt="image" src="https://user-images.githubusercontent.com/93301/233079591-da70aa65-5755-4e3d-8f89-57d750b90379.png">
 Editing header as part of a template | <img width="1468" alt="Screenshot 2023-02-13 at 18 57 52" src="https://user-images.githubusercontent.com/93301/218588900-52392622-42d3-48fe-ab36-e3cb1216e0da.png"> | <img width="1336" alt="image" src="https://user-images.githubusercontent.com/93301/233079486-8ddcd382-54bd-471f-9bee-3e06a5203ec0.png">
 Editing template part | <img width="1468" alt="Screenshot 2023-02-13 at 18 58 40" src="https://user-images.githubusercontent.com/93301/218588962-3e782893-21d0-4177-bd4f-896710972c71.png"> | <img width="1336" alt="image" src="https://user-images.githubusercontent.com/93301/233079318-6a4a2442-eb63-4778-940e-deb4c0011a01.png">


