### PR TITLE
Site Editor: tidy up the generation of the site editor page title

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -125,10 +125,9 @@ export default function Editor() {
 		} ),
 		[ context, setEditedPostContext ]
 	);
-	const isReady = editedPostType !== undefined && editedPostId !== undefined;
 
 	let title;
-	if ( isReady && editedPost ) {
+	if ( hasLoadedPost ) {
 		const type =
 			editedPostType === 'wp_template'
 				? __( 'Template' )
@@ -143,9 +142,9 @@ export default function Editor() {
 
 	// Only announce the title once the editor is ready to prevent "Replace"
 	// action in <URlQueryController> from double-announcing.
-	useTitle( isReady && title );
+	useTitle( hasLoadedPost && title );
 
-	if ( ! isReady ) {
+	if ( ! hasLoadedPost ) {
 		return <CanvasSpinner />;
 	}
 

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -4,7 +4,7 @@
 import { useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Notice } from '@wordpress/components';
-import { EntityProvider, store as coreStore } from '@wordpress/core-data';
+import { EntityProvider } from '@wordpress/core-data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import {
 	BlockContextProvider,
@@ -17,7 +17,7 @@ import {
 	store as interfaceStore,
 } from '@wordpress/interface';
 import { EditorNotices, EditorSnackbars } from '@wordpress/editor';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -36,6 +36,7 @@ import { GlobalStylesProvider } from '../global-styles/global-styles-provider';
 import useTitle from '../routes/use-title';
 import CanvasSpinner from '../canvas-spinner';
 import { unlock } from '../../private-apis';
+import useEditedEntityRecord from '../use-edited-entity-record';
 
 const interfaceLabels = {
 	/* translators: accessibility text for the editor content landmark region. */
@@ -50,11 +51,15 @@ const interfaceLabels = {
 
 export default function Editor() {
 	const {
-		editedPostId,
-		editedPostType,
-		editedPost,
+		record: editedPost,
+		getTitle,
+		isLoaded: hasLoadedPost,
+	} = useEditedEntityRecord();
+
+	const { id: editedPostId, type: editedPostType } = editedPost;
+
+	const {
 		context,
-		hasLoadedPost,
 		editorMode,
 		canvasMode,
 		blockEditorMode,
@@ -64,36 +69,19 @@ export default function Editor() {
 		showIconLabels,
 	} = useSelect( ( select ) => {
 		const {
-			getEditedPostType,
-			getEditedPostId,
 			getEditedPostContext,
 			getEditorMode,
 			getCanvasMode,
 			isInserterOpened,
 			isListViewOpened,
 		} = unlock( select( editSiteStore ) );
-		const { hasFinishedResolution, getEntityRecord } = select( coreStore );
 		const { __unstableGetEditorMode } = select( blockEditorStore );
 		const { getActiveComplementaryArea } = select( interfaceStore );
-		const postType = getEditedPostType();
-		const postId = getEditedPostId();
 
 		// The currently selected entity to display.
 		// Typically template or template part in the site editor.
 		return {
-			editedPostId: postId,
-			editedPostType: postType,
-			editedPost: postId
-				? getEntityRecord( 'postType', postType, postId )
-				: null,
 			context: getEditedPostContext(),
-			hasLoadedPost: postId
-				? hasFinishedResolution( 'getEntityRecord', [
-						'postType',
-						postType,
-						postId,
-				  ] )
-				: false,
 			editorMode: getEditorMode(),
 			canvasMode: getCanvasMode(),
 			blockEditorMode: __unstableGetEditorMode(),
@@ -135,7 +123,7 @@ export default function Editor() {
 					} ),
 			],
 		} ),
-		[ context ]
+		[ context, setEditedPostContext ]
 	);
 	const isReady = editedPostType !== undefined && editedPostId !== undefined;
 
@@ -145,9 +133,12 @@ export default function Editor() {
 			editedPostType === 'wp_template'
 				? __( 'Template' )
 				: __( 'Template Part' );
-		title = `${ editedPost.title?.rendered } ‹ ${ type } ‹ ${ __(
-			'Editor (beta)'
-		) }`;
+		title = sprintf(
+			// translators: A breadcrumb trail in browser tab. %1$s: title of template being edited, %2$s: type of template (Template or Template Part).
+			__( '%1$s ‹ %2$s ‹ Editor' ),
+			getTitle(),
+			type
+		);
 	}
 
 	// Only announce the title once the editor is ready to prevent "Replace"


### PR DESCRIPTION
## What?

- Uses `sprintf` instead of concatination for the generation of page title breadcrumb
- Uses `useEditedEntityRecord` to get current edited post details instead of getting the post info via the useSelect

## Why?
Changes were suggested in [post merge follow up](https://github.com/WordPress/gutenberg/pull/47855#pullrequestreview-1295372973).

## How?
As noted under `What?` above

## Testing Instructions

- Open the Site Editor
- Use the left hand template navigation panel to navigate to different templates and template parts
- Check that the browser page title in tab and history includes the template name and type
- Check that editor loads as expected when going from Dashboard or doing a browser refresh

## Screenshots or screencast <!-- if applicable -->
https://user-images.githubusercontent.com/3629020/217401666-0755bf2e-6e33-486a-afc5-534ebd47bd11.mp4