### PR TITLE
Refactor the site editor URLs for better backward compatibility

### DIFF
--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -90,7 +90,6 @@ describe( 'Site Editor Performance', () => {
 		await visitSiteEditor( {
 			postId: id,
 			postType: 'page',
-			path: '/navigation/single',
 		} );
 	} );
 

--- a/packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
@@ -265,7 +265,6 @@ describe( 'Multi-entity save flow', () => {
 			await visitSiteEditor( {
 				postId: 'emptytheme//index',
 				postType: 'wp_template',
-				path: '/templates/single',
 			} );
 
 			await enterEditMode();
@@ -305,7 +304,6 @@ describe( 'Multi-entity save flow', () => {
 			await visitSiteEditor( {
 				postId: 'emptytheme//index',
 				postType: 'wp_template',
-				path: '/templates/single',
 			} );
 
 			await enterEditMode();

--- a/packages/e2e-tests/specs/site-editor/settings-sidebar.test.js
+++ b/packages/e2e-tests/specs/site-editor/settings-sidebar.test.js
@@ -69,7 +69,6 @@ describe( 'Settings sidebar', () => {
 			await visitSiteEditor( {
 				postId: 'emptytheme//singular',
 				postType: 'wp_template',
-				path: '/templates/single',
 			} );
 			await enterEditMode();
 			const templateCardAfterNavigation = await getTemplateCard();

--- a/packages/edit-site/src/components/add-new-template/new-template-part.js
+++ b/packages/edit-site/src/components/add-new-template/new-template-part.js
@@ -67,12 +67,9 @@ export default function NewTemplatePart( {
 			setCanvasMode( 'edit' );
 
 			// Navigate to the created template part editor.
-			window.queueMicrotask( () => {
-				history.push( {
-					postId: templatePart.id,
-					postType: 'wp_template_part',
-					path: '/template-parts/single',
-				} );
+			history.push( {
+				postId: templatePart.id,
+				postType: 'wp_template_part',
 			} );
 
 			// TODO: Add a success notice?

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -128,12 +128,9 @@ export default function NewTemplate( {
 			setCanvasMode( 'edit' );
 
 			// Navigate to the created template editor.
-			window.queueMicrotask( () => {
-				history.push( {
-					postId: newTemplate.id,
-					postType: newTemplate.type,
-					path: '/templates/single',
-				} );
+			history.push( {
+				postId: newTemplate.id,
+				postType: newTemplate.type,
 			} );
 
 			createSuccessNotice(

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -84,10 +84,6 @@ export default function Table( { templateType } ) {
 							<Heading level={ 4 }>
 								<Link
 									params={ {
-										path:
-											template.type === 'wp_template'
-												? '/templates/single'
-												: '/template-parts/single',
 										postId: template.id,
 										postType: template.type,
 									} }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -29,7 +29,7 @@ export default function SidebarNavigationScreenMain() {
 
 	return (
 		<SidebarNavigationScreen
-			path="/"
+			isRoot
 			title={ __( 'Design' ) }
 			content={
 				<ItemGroup>
@@ -45,7 +45,7 @@ export default function SidebarNavigationScreenMain() {
 					) }
 					<NavigatorButton
 						as={ SidebarNavigationItem }
-						path="/templates"
+						path="/wp_template"
 						withChevron
 						icon={ layout }
 					>
@@ -53,7 +53,7 @@ export default function SidebarNavigationScreenMain() {
 					</NavigatorButton>
 					<NavigatorButton
 						as={ SidebarNavigationItem }
-						path="/template-parts"
+						path="/wp_template_part"
 						withChevron
 						icon={ symbolFilled }
 					>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-item/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-item/index.js
@@ -3,7 +3,10 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { Button } from '@wordpress/components';
+import {
+	Button,
+	__experimentalUseNavigator as useNavigator,
+} from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 
@@ -16,25 +19,28 @@ import { store as editSiteStore } from '../../store';
 
 export default function SidebarNavigationScreenNavigationItem() {
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
+	const {
+		params: { postType, postId },
+	} = useNavigator();
 
-	const { post } = useSelect( ( select ) => {
-		const { getEditedPostContext } = select( editSiteStore );
-		const { getEntityRecord } = select( coreStore );
-		const { postType, postId } = getEditedPostContext() ?? {};
+	const { post } = useSelect(
+		( select ) => {
+			const { getEntityRecord } = select( coreStore );
 
-		// The currently selected entity to display.
-		// Typically template or template part in the site editor.
-		return {
-			post:
-				postId && postType
-					? getEntityRecord( 'postType', postType, postId )
-					: null,
-		};
-	}, [] );
+			// The currently selected entity to display.
+			// Typically template or template part in the site editor.
+			return {
+				post:
+					postId && postType
+						? getEntityRecord( 'postType', postType, postId )
+						: null,
+			};
+		},
+		[ postType, postId ]
+	);
 
 	return (
 		<SidebarNavigationScreen
-			path="/navigation/single"
 			title={ post ? decodeEntities( post?.title?.rendered ) : null }
 			actions={
 				<Button

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -25,7 +25,6 @@ export default function SidebarNavigationScreenNavigationMenus() {
 				history.push( {
 					postType: attributes.type,
 					postId: attributes.id,
-					path: '/navigation/single',
 				} );
 			}
 		},
@@ -33,7 +32,6 @@ export default function SidebarNavigationScreenNavigationMenus() {
 	);
 	return (
 		<SidebarNavigationScreen
-			path="/navigation"
 			title={ __( 'Navigation' ) }
 			content={
 				<div className="edit-site-sidebar-navigation-screen-navigation-menus">

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
@@ -13,18 +13,7 @@ import useEditedEntityRecord from '../use-edited-entity-record';
 import { unlock } from '../../private-apis';
 import { store as editSiteStore } from '../../store';
 
-const config = {
-	wp_template: {
-		path: '/templates/single',
-	},
-	wp_template_part: {
-		path: '/template-parts/single',
-	},
-};
-
-export default function SidebarNavigationScreenTemplate( {
-	postType = 'wp_template',
-} ) {
+export default function SidebarNavigationScreenTemplate() {
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 	const { getDescription, getTitle, record } = useEditedEntityRecord();
 	let description = getDescription();
@@ -36,7 +25,6 @@ export default function SidebarNavigationScreenTemplate( {
 
 	return (
 		<SidebarNavigationScreen
-			path={ config[ postType ].path }
 			title={ getTitle() }
 			actions={
 				<Button

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { __experimentalUseNavigator as useNavigator } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -10,22 +11,16 @@ import SidebarNavigationScreen from '../sidebar-navigation-screen';
 
 const config = {
 	wp_template: {
-		path: '/templates/all',
 		title: __( 'All templates' ),
 	},
 	wp_template_part: {
-		path: '/template-parts/all',
 		title: __( 'All template parts' ),
 	},
 };
 
-export default function SidebarNavigationScreenTemplatesBrowse( {
-	postType = 'wp_template',
-} ) {
-	return (
-		<SidebarNavigationScreen
-			path={ config[ postType ].path }
-			title={ config[ postType ].title }
-		/>
-	);
+export default function SidebarNavigationScreenTemplatesBrowse() {
+	const {
+		params: { postType },
+	} = useNavigator();
+	return <SidebarNavigationScreen title={ config[ postType ].title } />;
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -4,6 +4,7 @@
 import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
+	__experimentalUseNavigator as useNavigator,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEntityRecords } from '@wordpress/core-data';
@@ -20,7 +21,6 @@ import AddNewTemplate from '../add-new-template';
 
 const config = {
 	wp_template: {
-		path: '/templates',
 		labels: {
 			title: __( 'Templates' ),
 			loading: __( 'Loading templates' ),
@@ -29,7 +29,6 @@ const config = {
 		},
 	},
 	wp_template_part: {
-		path: '/template-parts',
 		labels: {
 			title: __( 'Template parts' ),
 			loading: __( 'Loading template parts' ),
@@ -43,14 +42,14 @@ const TemplateItem = ( { postType, postId, ...props } ) => {
 	const linkInfo = useLink( {
 		postType,
 		postId,
-		path: config[ postType ].path + '/single',
 	} );
 	return <SidebarNavigationItem { ...linkInfo } { ...props } />;
 };
 
-export default function SidebarNavigationScreenTemplates( {
-	postType = 'wp_template',
-} ) {
+export default function SidebarNavigationScreenTemplates() {
+	const {
+		params: { postType },
+	} = useNavigator();
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 
 	const { records: templates, isResolving: isLoading } = useEntityRecords(
@@ -62,14 +61,11 @@ export default function SidebarNavigationScreenTemplates( {
 	);
 
 	const browseAllLink = useLink( {
-		postType,
-		postId: undefined,
-		path: config[ postType ].path + '/all',
+		path: '/' + postType + '/all',
 	} );
 
 	return (
 		<SidebarNavigationScreen
-			path={ config[ postType ].path }
 			title={ config[ postType ].labels.title }
 			actions={
 				! isMobileViewport && (

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -6,7 +6,6 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalNavigatorToParentButton as NavigatorToParentButton,
 	Button,
-	__experimentalNavigatorScreen as NavigatorScreen,
 } from '@wordpress/components';
 import { isRTL, __ } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
@@ -19,7 +18,7 @@ import { store as editSiteStore } from '../../store';
 import { unlock } from '../../private-apis';
 
 export default function SidebarNavigationScreen( {
-	path,
+	isRoot,
 	title,
 	actions,
 	content,
@@ -32,41 +31,36 @@ export default function SidebarNavigationScreen( {
 	}, [] );
 
 	return (
-		<NavigatorScreen
-			className="edit-site-sidebar-navigation-screen"
-			path={ path }
-		>
-			<VStack spacing={ 2 }>
-				<HStack
-					spacing={ 4 }
-					justify="flex-start"
-					className="edit-site-sidebar-navigation-screen__title-icon"
-				>
-					{ path !== '/' ? (
-						<NavigatorToParentButton
-							className="edit-site-sidebar-navigation-screen__back"
-							icon={ isRTL() ? chevronRight : chevronLeft }
-							aria-label={ __( 'Back' ) }
-						/>
-					) : (
-						<Button
-							className="edit-site-sidebar-navigation-screen__back"
-							icon={ isRTL() ? chevronRight : chevronLeft }
-							aria-label={ __( 'Navigate to the Dashboard' ) }
-							href={ dashboardLink || 'index.php' }
-							label={ __( 'Dashboard' ) }
-						/>
-					) }
-					<h2 className="edit-site-sidebar-navigation-screen__title">
-						{ title }
-					</h2>
-					{ actions }
-				</HStack>
+		<VStack spacing={ 2 }>
+			<HStack
+				spacing={ 4 }
+				justify="flex-start"
+				className="edit-site-sidebar-navigation-screen__title-icon"
+			>
+				{ ! isRoot ? (
+					<NavigatorToParentButton
+						className="edit-site-sidebar-navigation-screen__back"
+						icon={ isRTL() ? chevronRight : chevronLeft }
+						aria-label={ __( 'Back' ) }
+					/>
+				) : (
+					<Button
+						className="edit-site-sidebar-navigation-screen__back"
+						icon={ isRTL() ? chevronRight : chevronLeft }
+						aria-label={ __( 'Navigate to the Dashboard' ) }
+						href={ dashboardLink || 'index.php' }
+						label={ __( 'Dashboard' ) }
+					/>
+				) }
+				<h2 className="edit-site-sidebar-navigation-screen__title">
+					{ title }
+				</h2>
+				{ actions }
+			</HStack>
 
-				<nav className="edit-site-sidebar-navigation-screen__content">
-					{ content }
-				</nav>
-			</VStack>
-		</NavigatorScreen>
+			<nav className="edit-site-sidebar-navigation-screen__content">
+				{ content }
+			</nav>
+		</VStack>
 	);
 }

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { memo } from '@wordpress/element';
-import { __experimentalNavigatorProvider as NavigatorProvider } from '@wordpress/components';
+import {
+	__experimentalNavigatorProvider as NavigatorProvider,
+	__experimentalNavigatorScreen as NavigatorScreen,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -21,15 +24,24 @@ function SidebarScreens() {
 
 	return (
 		<>
-			<SidebarNavigationScreenMain />
-			<SidebarNavigationScreenNavigationMenus />
-			<SidebarNavigationScreenNavigationItem />
-			<SidebarNavigationScreenTemplates postType="wp_template" />
-			<SidebarNavigationScreenTemplates postType="wp_template_part" />
-			<SidebarNavigationScreenTemplate postType="wp_template" />
-			<SidebarNavigationScreenTemplate postType="wp_template_part" />
-			<SidebarNavigationScreenTemplatesBrowse postType="wp_template" />
-			<SidebarNavigationScreenTemplatesBrowse postType="wp_template_part" />
+			<NavigatorScreen path="/">
+				<SidebarNavigationScreenMain />
+			</NavigatorScreen>
+			<NavigatorScreen path="/navigation">
+				<SidebarNavigationScreenNavigationMenus />
+			</NavigatorScreen>
+			<NavigatorScreen path="/navigation/:postType/:postId">
+				<SidebarNavigationScreenNavigationItem />
+			</NavigatorScreen>
+			<NavigatorScreen path="/:postType(wp_template|wp_template_part)">
+				<SidebarNavigationScreenTemplates />
+			</NavigatorScreen>
+			<NavigatorScreen path="/:postType(wp_template|wp_template_part)/all">
+				<SidebarNavigationScreenTemplatesBrowse />
+			</NavigatorScreen>
+			<NavigatorScreen path="/:postType(wp_template|wp_template_part)/:postId">
+				<SidebarNavigationScreenTemplate />
+			</NavigatorScreen>
 		</>
 	);
 }

--- a/packages/edit-site/src/components/sync-state-with-url/use-sync-path-with-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-sync-path-with-url.js
@@ -11,26 +11,87 @@ import { useLocation, useHistory } from '../routes';
 
 export default function useSyncPathWithURL() {
 	const history = useHistory();
-	const { params } = useLocation();
-	const { path = '/' } = params;
-	const { location, goTo } = useNavigator();
-	const currentPath = useRef( path );
-	const currentNavigatorLocation = useRef( location.path );
+	const { params: urlParams } = useLocation();
+	const {
+		location: navigatorLocation,
+		params: navigatorParams,
+		goTo,
+	} = useNavigator();
+	const currentUrlParams = useRef( urlParams );
+	const currentPath = useRef();
+
 	useEffect( () => {
-		currentPath.current = path;
-		if ( path !== currentNavigatorLocation.current ) {
-			goTo( path );
+		// Don't trust the navigator path on initial render.
+		if ( currentPath.current === null ) {
+			return;
 		}
-	}, [ path ] );
-	useEffect( () => {
-		currentNavigatorLocation.current = location.path;
-		if ( location.path !== currentPath.current ) {
-			history.push( {
-				...params,
-				path: location.path,
+		function updateUrlParams( newUrlParams ) {
+			if (
+				Object.entries( newUrlParams ).every( ( [ key, value ] ) => {
+					return currentUrlParams.current[ key ] === value;
+				} )
+			) {
+				return;
+			}
+			const updatedParams = {
+				...currentUrlParams.current,
+				...newUrlParams,
+			};
+			currentUrlParams.current = updatedParams;
+			history.push( updatedParams );
+		}
+
+		if ( navigatorParams?.postType && navigatorParams?.postId ) {
+			updateUrlParams( {
+				postType: navigatorParams?.postType,
+				postId: navigatorParams?.postId,
+				path: undefined,
+			} );
+		} else if ( navigatorParams?.postType && ! navigatorParams?.postId ) {
+			updateUrlParams( {
+				postType: navigatorParams?.postType,
+				path: navigatorLocation.path,
+				postId: undefined,
+			} );
+		} else {
+			updateUrlParams( {
+				postType: undefined,
+				postId: undefined,
+				path: navigatorLocation.path,
 			} );
 		}
-	}, [ location.path, history ] );
+	}, [ navigatorLocation?.path, navigatorParams, history ] );
 
-	return path;
+	useEffect( () => {
+		currentUrlParams.current = urlParams;
+		let path = urlParams?.path ?? '/';
+
+		// Compute the navigator path based on the URL params.
+		if (
+			urlParams?.postType &&
+			urlParams?.postId &&
+			// This is just a special case to support old WP versions that perform redirects.
+			// This code should be removed when we minimum WP version becomes 6.2.
+			urlParams?.postId !== 'none'
+		) {
+			switch ( urlParams.postType ) {
+				case 'wp_template':
+				case 'wp_template_part':
+					path = `/${ encodeURIComponent(
+						urlParams.postType
+					) }/${ encodeURIComponent( urlParams.postId ) }`;
+					break;
+				default:
+					path = `/navigation/${ encodeURIComponent(
+						urlParams.postType
+					) }/${ encodeURIComponent( urlParams.postId ) }`;
+			}
+		}
+
+		if ( currentPath.current !== path ) {
+			currentPath.current = path;
+			goTo( path );
+		}
+		goTo( path );
+	}, [ urlParams, goTo ] );
 }

--- a/packages/edit-site/src/utils/get-is-list-page.js
+++ b/packages/edit-site/src/utils/get-is-list-page.js
@@ -7,5 +7,5 @@
  * @return {boolean} Is list page or not.
  */
 export default function getIsListPage( { path } ) {
-	return path === '/templates/all' || path === '/template-parts/all';
+	return path === '/wp_template/all' || path === '/wp_template_part/all';
 }

--- a/test/e2e/specs/site-editor/block-list-panel-preference.spec.js
+++ b/test/e2e/specs/site-editor/block-list-panel-preference.spec.js
@@ -16,7 +16,6 @@ test.describe( 'Block list view', () => {
 		await admin.visitSiteEditor( {
 			postId: 'emptytheme//index',
 			postType: 'wp_template',
-			path: '/templates/single',
 		} );
 
 		await editor.canvas.click( 'body' );

--- a/test/e2e/specs/site-editor/iframe-rendering.spec.js
+++ b/test/e2e/specs/site-editor/iframe-rendering.spec.js
@@ -19,7 +19,6 @@ test.describe( 'Site editor iframe rendering mode', () => {
 		await admin.visitSiteEditor( {
 			postId: 'emptytheme//index',
 			postType: 'wp_template',
-			path: '/templates/single',
 		} );
 
 		const compatMode = await page

--- a/test/e2e/specs/site-editor/style-variations.spec.js
+++ b/test/e2e/specs/site-editor/style-variations.spec.js
@@ -38,7 +38,6 @@ test.describe( 'Global styles variations', () => {
 		await admin.visitSiteEditor( {
 			postId: 'gutenberg-test-themes/style-variations//index',
 			postType: 'wp_template',
-			path: '/templates/single',
 		} );
 		await editor.canvas.click( 'body' );
 
@@ -76,7 +75,6 @@ test.describe( 'Global styles variations', () => {
 		await admin.visitSiteEditor( {
 			postId: 'gutenberg-test-themes/style-variations//index',
 			postType: 'wp_template',
-			path: '/templates/single',
 		} );
 		await editor.canvas.click( 'body' );
 		await siteEditorStyleVariations.browseStyles();
@@ -118,7 +116,6 @@ test.describe( 'Global styles variations', () => {
 		await admin.visitSiteEditor( {
 			postId: 'gutenberg-test-themes/style-variations//index',
 			postType: 'wp_template',
-			path: '/templates/single',
 		} );
 		await editor.canvas.click( 'body' );
 		await siteEditorStyleVariations.browseStyles();
@@ -166,7 +163,6 @@ test.describe( 'Global styles variations', () => {
 		await admin.visitSiteEditor( {
 			postId: 'gutenberg-test-themes/style-variations//index',
 			postType: 'wp_template',
-			path: '/templates/single',
 		} );
 		await editor.canvas.click( 'body' );
 		await siteEditorStyleVariations.browseStyles();
@@ -199,7 +195,6 @@ test.describe( 'Global styles variations', () => {
 		await admin.visitSiteEditor( {
 			postId: 'gutenberg-test-themes/style-variations//index',
 			postType: 'wp_template',
-			path: '/templates/single',
 		} );
 		await editor.canvas.click( 'body' );
 		await siteEditorStyleVariations.browseStyles();

--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -27,7 +27,6 @@ test.describe( 'Template Part', () => {
 		await admin.visitSiteEditor( {
 			postId: 'emptytheme//header',
 			postType: 'wp_template_part',
-			path: '/template-parts/single',
 		} );
 		await editor.canvas.click( 'body' );
 
@@ -185,7 +184,6 @@ test.describe( 'Template Part', () => {
 		await admin.visitSiteEditor( {
 			postId: 'emptytheme//header',
 			postType: 'wp_template_part',
-			path: '/template-parts/single',
 		} );
 		await editor.canvas.click( 'body' );
 		await editor.insertBlock( {
@@ -229,7 +227,6 @@ test.describe( 'Template Part', () => {
 		await admin.visitSiteEditor( {
 			postId: 'emptytheme//header',
 			postType: 'wp_template_part',
-			path: '/template-parts/single',
 		} );
 		await editor.canvas.click( 'body' );
 		// Edit the header.
@@ -263,7 +260,6 @@ test.describe( 'Template Part', () => {
 		await admin.visitSiteEditor( {
 			postId: 'emptytheme//header',
 			postType: 'wp_template_part',
-			path: '/template-parts/single',
 		} );
 		await editor.canvas.click( 'body' );
 		await editor.insertBlock( {

--- a/test/e2e/specs/site-editor/title.spec.js
+++ b/test/e2e/specs/site-editor/title.spec.js
@@ -21,7 +21,6 @@ test.describe( 'Site editor title', () => {
 		await admin.visitSiteEditor( {
 			postId: 'emptytheme//index',
 			postType: 'wp_template',
-			path: '/templates/single',
 		} );
 		await editor.canvas.click( 'body' );
 		const title = await page.locator(
@@ -40,7 +39,6 @@ test.describe( 'Site editor title', () => {
 		await admin.visitSiteEditor( {
 			postId: 'emptytheme//header',
 			postType: 'wp_template_part',
-			path: '/template-parts/single',
 		} );
 		await editor.canvas.click( 'body' );
 		const title = await page.locator(
@@ -58,7 +56,6 @@ test.describe( 'Site editor title', () => {
 		await admin.visitSiteEditor( {
 			postId: 'emptytheme//index',
 			postType: 'wp_template',
-			path: '/templates/single',
 		} );
 		await editor.canvas.click( 'body' );
 		// Select the header template part via list view.

--- a/test/e2e/specs/site-editor/writing-flow.spec.js
+++ b/test/e2e/specs/site-editor/writing-flow.spec.js
@@ -23,7 +23,6 @@ test.describe( 'Site editor writing flow', () => {
 		await admin.visitSiteEditor( {
 			postId: 'emptytheme//header',
 			postType: 'wp_template_part',
-			path: '/template-parts/single',
 		} );
 		await editor.canvas.click( 'body' );
 		// Select the first site title block.
@@ -52,7 +51,6 @@ test.describe( 'Site editor writing flow', () => {
 		await admin.visitSiteEditor( {
 			postId: 'emptytheme//header',
 			postType: 'wp_template_part',
-			path: '/template-parts/single',
 		} );
 		await editor.canvas.click( 'body' );
 		// Make sure the sidebar is open.


### PR DESCRIPTION
## What?

This PR refactors how we deal with URLs in the site editor to avoid the duplication between "path", "postId" and "postType" URLs.

In trunk, for a given postType/postId couple to load in the site editor we'd need both of these in the URL and also a path=/navigation/postType/postId otherwise, the path is considered wrong and the post doesn't load, this PR simplifies that by inverting the source of truth.

1- The URL is the actual source of truth. If there's a postId and postType in the URL, there's no need to provide a "path". It's automatically generated from these arguments.
2- If one of these is missing, it means we need to provide a "path" to avoid ambiguity.
3- The useSyncPathFromURL makes sure to compute the right path based on the url params to initialize the sidebar navigation properly.

## Why?

This ensures the URLs don't change between WP 6.1 and WP 6.2 and also avoids race conditions between hooks updated the URL.

## Testing Instructions

1- Navigate all the different pages and flows of the site editor.
