### PR TITLE
Post editor: add temporary flag to disable iframe

### DIFF
--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
+	"temporarilyDisableIframe": "I understand that this flag will only work for two releases (6.2 and 6.3) and that the block must be updated to avoid breakage in WP 6.4.",
 	"name": "core/paragraph",
 	"title": "Paragraph",
 	"category": "text",

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -36,7 +36,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useMergeRefs } from '@wordpress/compose';
 import { arrowLeft } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
-import { parse } from '@wordpress/blocks';
+import { parse, store as blocksStore } from '@wordpress/blocks';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -153,6 +153,17 @@ export default function VisualEditor( { styles } ) {
 	const { isCleanNewPost } = useSelect( editorStore );
 	const hasMetaBoxes = useSelect(
 		( select ) => select( editPostStore ).hasMetaBoxes(),
+		[]
+	);
+	const hasIframeIncompatibleBlocks = useSelect(
+		( select ) =>
+			select( blocksStore )
+				.getBlockTypes()
+				.some(
+					( { temporarilyDisableIframe } ) =>
+						temporarilyDisableIframe ===
+						'I understand that this flag will only work for two releases (6.2 and 6.3) and that the block must be updated to avoid breakage in WP 6.4.'
+				),
 		[]
 	);
 	const { themeHasDisabledLayoutStyles, themeSupportsLayout, isFocusMode } =
@@ -339,7 +350,9 @@ export default function VisualEditor( { styles } ) {
 				>
 					<MaybeIframe
 						shouldIframe={
-							( isBlockBasedTheme && ! hasMetaBoxes ) ||
+							( isBlockBasedTheme &&
+								! hasMetaBoxes &&
+								! hasIframeIncompatibleBlocks ) ||
 							isTemplateMode ||
 							deviceType === 'Tablet' ||
 							deviceType === 'Mobile'

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -21,6 +21,13 @@
 			"default": 1,
 			"enum": [ 1, 2 ]
 		},
+		"temporarilyDisableIframe": {
+			"type": "string",
+			"description": "This property is used to temporarily disable the iframe.",
+			"enum": [
+				"I understand that this flag will only work for two releases (6.2 and 6.3) and that the block must be updated to avoid breakage in WP 6.4."
+			]
+		},
 		"name": {
 			"type": "string",
 			"pattern": "^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR adds a flag for blocks to use in `block.json` to disable the iframe TEMPORARILY to give plugin authors the time to update their blocks. It will be removed after two releases.

## Why?

Some blocks are incompatible with the iframe: for example they use jQuery components in the block edit function which doesn't work in the iframe.

Ideally the block edit function should be a visual representation of the block and ideally it should use the components we provide. Of course you can use third party React components or non React components, but what is rendered in the iframe should be a preview/visual editing field and any UI like popovers and select boxes should be rendered outside of the iframe (for example with the Popover component).

## How?

Adds a check to see if all block types are compatible.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
