### PR TITLE
Navigation: Update the dependencies for the useEffect that handles notifications

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -174,6 +174,12 @@ function Navigation( {
 		createNavigationMenuStatus,
 		createNavigationMenuError,
 		createNavigationMenuPost,
+		createNavigationMenuIsError,
+		createNavigationMenuIsSuccess,
+		handleUpdateMenu,
+		hideNavigationMenuStatusNotice,
+		isCreatingNavigationMenu,
+		showNavigationMenuStatusNotice,
 	] );
 
 	const {

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -148,40 +148,6 @@ function Navigation( {
 		createNavigationMenu( '' );
 	};
 
-	useEffect( () => {
-		hideNavigationMenuStatusNotice();
-
-		if ( isCreatingNavigationMenu ) {
-			speak( __( `Creating Navigation Menu.` ) );
-		}
-
-		if ( createNavigationMenuIsSuccess ) {
-			handleUpdateMenu( createNavigationMenuPost.id, {
-				focusNavigationBlock: true,
-			} );
-
-			showNavigationMenuStatusNotice(
-				__( `Navigation Menu successfully created.` )
-			);
-		}
-
-		if ( createNavigationMenuIsError ) {
-			showNavigationMenuStatusNotice(
-				__( 'Failed to create Navigation Menu.' )
-			);
-		}
-	}, [
-		createNavigationMenuStatus,
-		createNavigationMenuError,
-		createNavigationMenuPost,
-		createNavigationMenuIsError,
-		createNavigationMenuIsSuccess,
-		handleUpdateMenu,
-		hideNavigationMenuStatusNotice,
-		isCreatingNavigationMenu,
-		showNavigationMenuStatusNotice,
-	] );
-
 	const {
 		hasUncontrolledInnerBlocks,
 		uncontrolledInnerBlocks,
@@ -426,6 +392,40 @@ function Navigation( {
 	const onSelectNavigationMenu = ( menuId ) => {
 		handleUpdateMenu( menuId );
 	};
+
+	useEffect( () => {
+		hideNavigationMenuStatusNotice();
+
+		if ( isCreatingNavigationMenu ) {
+			speak( __( `Creating Navigation Menu.` ) );
+		}
+
+		if ( createNavigationMenuIsSuccess ) {
+			handleUpdateMenu( createNavigationMenuPost.id, {
+				focusNavigationBlock: true,
+			} );
+
+			showNavigationMenuStatusNotice(
+				__( `Navigation Menu successfully created.` )
+			);
+		}
+
+		if ( createNavigationMenuIsError ) {
+			showNavigationMenuStatusNotice(
+				__( 'Failed to create Navigation Menu.' )
+			);
+		}
+	}, [
+		createNavigationMenuStatus,
+		createNavigationMenuError,
+		createNavigationMenuPost,
+		createNavigationMenuIsError,
+		createNavigationMenuIsSuccess,
+		handleUpdateMenu,
+		hideNavigationMenuStatusNotice,
+		isCreatingNavigationMenu,
+		showNavigationMenuStatusNotice,
+	] );
 
 	useEffect( () => {
 		hideClassicMenuConversionNotice();

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -65,7 +65,7 @@ function NavigationMenuSelector( {
 				};
 			} ) || []
 		);
-	}, [ currentMenuId, navigationMenus, actionLabel ] );
+	}, [ currentMenuId, navigationMenus, actionLabel, isCreatingMenu ] );
 
 	const hasNavigationMenus = !! navigationMenus?.length;
 	const hasClassicMenus = !! classicMenus?.length;

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -38,7 +38,7 @@ export default function NavigationPlaceholder( {
 		if ( hasResolvedMenus ) {
 			speak( __( 'Navigation block setup options ready.' ) );
 		}
-	}, [ isResolvingMenus, isSelected ] );
+	}, [ hasResolvedMenus, isResolvingMenus, isSelected ] );
 
 	const isResolvingActions =
 		isResolvingMenus && isResolvingCanUserCreateNavigationMenu;

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -146,6 +146,8 @@ export default function UnsavedInnerBlocks( {
 
 		createNavigationMenu( null, blocks );
 	}, [
+		blocks,
+		createNavigationMenu,
 		isDisabled,
 		isSaving,
 		hasResolvedDraftNavigationMenus,

--- a/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
+++ b/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
@@ -120,56 +120,59 @@ function useConvertClassicToBlockMenu( clientId ) {
 		return navigationMenu;
 	}
 
-	const convert = useCallback( async ( menuId, menuName, postStatus ) => {
-		// Check whether this classic menu is being imported already.
-		if ( classicMenuBeingConvertedId === menuId ) {
-			return;
-		}
+	const convert = useCallback(
+		async ( menuId, menuName, postStatus ) => {
+			// Check whether this classic menu is being imported already.
+			if ( classicMenuBeingConvertedId === menuId ) {
+				return;
+			}
 
-		// Set the ID for the currently importing classic menu.
-		classicMenuBeingConvertedId = menuId;
+			// Set the ID for the currently importing classic menu.
+			classicMenuBeingConvertedId = menuId;
 
-		if ( ! menuId || ! menuName ) {
-			setError( 'Unable to convert menu. Missing menu details.' );
-			setStatus( CLASSIC_MENU_CONVERSION_ERROR );
-			return;
-		}
-
-		setStatus( CLASSIC_MENU_CONVERSION_PENDING );
-		setError( null );
-
-		return await convertClassicMenuToBlockMenu(
-			menuId,
-			menuName,
-			postStatus
-		)
-			.then( ( navigationMenu ) => {
-				setStatus( CLASSIC_MENU_CONVERSION_SUCCESS );
-				// Reset the ID for the currently importing classic menu.
-				classicMenuBeingConvertedId = null;
-				return navigationMenu;
-			} )
-			.catch( ( err ) => {
-				setError( err?.message );
-				// Reset the ID for the currently importing classic menu.
+			if ( ! menuId || ! menuName ) {
+				setError( 'Unable to convert menu. Missing menu details.' );
 				setStatus( CLASSIC_MENU_CONVERSION_ERROR );
+				return;
+			}
 
-				// Reset the ID for the currently importing classic menu.
-				classicMenuBeingConvertedId = null;
+			setStatus( CLASSIC_MENU_CONVERSION_PENDING );
+			setError( null );
 
-				// Rethrow error for debugging.
-				throw new Error(
-					sprintf(
-						// translators: %s: the name of a menu (e.g. Header navigation).
-						__( `Unable to create Navigation Menu "%s".` ),
-						menuName
-					),
-					{
-						cause: err,
-					}
-				);
-			} );
-	}, [] );
+			return await convertClassicMenuToBlockMenu(
+				menuId,
+				menuName,
+				postStatus
+			)
+				.then( ( navigationMenu ) => {
+					setStatus( CLASSIC_MENU_CONVERSION_SUCCESS );
+					// Reset the ID for the currently importing classic menu.
+					classicMenuBeingConvertedId = null;
+					return navigationMenu;
+				} )
+				.catch( ( err ) => {
+					setError( err?.message );
+					// Reset the ID for the currently importing classic menu.
+					setStatus( CLASSIC_MENU_CONVERSION_ERROR );
+
+					// Reset the ID for the currently importing classic menu.
+					classicMenuBeingConvertedId = null;
+
+					// Rethrow error for debugging.
+					throw new Error(
+						sprintf(
+							// translators: %s: the name of a menu (e.g. Header navigation).
+							__( `Unable to create Navigation Menu "%s".` ),
+							menuName
+						),
+						{
+							cause: err,
+						}
+					);
+				} );
+		},
+		[ convertClassicMenuToBlockMenu ]
+	);
 
 	return {
 		convert,

--- a/packages/block-library/src/navigation/edit/use-create-navigation-menu.js
+++ b/packages/block-library/src/navigation/edit/use-create-navigation-menu.js
@@ -90,7 +90,7 @@ export default function useCreateNavigationMenu( clientId ) {
 					} );
 				} );
 		},
-		[ serialize, saveEntityRecord ]
+		[ serialize, saveEntityRecord, editEntityRecord, generateDefaultTitle ]
 	);
 
 	return {

--- a/packages/block-library/src/navigation/edit/use-generate-default-navigation-title.js
+++ b/packages/block-library/src/navigation/edit/use-generate-default-navigation-title.js
@@ -75,5 +75,5 @@ export default function useGenerateDefaultNavigationTitle( clientId ) {
 				: title;
 
 		return titleWithCount || '';
-	}, [ isDisabled, area ] );
+	}, [ isDisabled, area, registry ] );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This useEffect doesn't list all of its dependencies.

## Why?
Not listing all dependencies can cause unexpected bugs.

## How?
Add the dependencies to the array.

## Testing Instructions
1. Add a navigation block to a site/post
2. Open the inspector for the block
3. In the inspector use the navigation menu selector to create a new menu (the option is called Create new menu)
4. Check that you see a notice like this:
<img width="312" alt="Screenshot 2023-02-14 at 10 27 16" src="https://user-images.githubusercontent.com/275961/218709843-54fa6fc4-dd8a-40e9-83d5-6a8d82b9236e.png">
5. If you have a classic menu, try converting it to navigation menu.
6. Try creating a new navigation by adding a block to a fallback navigation.
7. Try editing a navigation block that has innerblocks set in a theme.

### Testing Instructions for Keyboard
As above, but for step 4, check that you hear a message saying: `Creating Navigation Menu.`

