### PR TITLE
Navigation block: e2e code quality fixes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -392,7 +392,7 @@ module.exports = {
 			rules: {
 				'@wordpress/no-global-active-element': 'off',
 				'@wordpress/no-global-get-selection': 'off',
-				'no-page-pause': 'error',
+				'playwright/no-page-pause': 'error',
 				'no-restricted-syntax': [
 					'error',
 					{

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -392,6 +392,7 @@ module.exports = {
 			rules: {
 				'@wordpress/no-global-active-element': 'off',
 				'@wordpress/no-global-get-selection': 'off',
+				'no-page-pause': 'error',
 				'no-restricted-syntax': [
 					'error',
 					{

--- a/packages/e2e-test-utils-playwright/src/request-utils/menus.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/menus.ts
@@ -16,8 +16,8 @@ export interface NavigationMenu {
 /**
  * Create a classic menu
  *
- * @param  name Menu name.
- * @return {string} Menu content.
+ * @param name Menu name.
+ * @return Menu content.
  */
 export async function createClassicMenu( this: RequestUtils, name: string ) {
 	const menuItems = [

--- a/packages/e2e-test-utils-playwright/src/request-utils/menus.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/menus.ts
@@ -16,7 +16,7 @@ export interface NavigationMenu {
 /**
  * Create a classic menu
  *
- * @param {string} name Menu name.
+ * @param  name Menu name.
  * @return {string} Menu content.
  */
 export async function createClassicMenu( this: RequestUtils, name: string ) {
@@ -37,20 +37,18 @@ export async function createClassicMenu( this: RequestUtils, name: string ) {
 		},
 	} );
 
-	if ( menuItems?.length ) {
-		await this.batchRest(
-			menuItems.map( ( menuItem ) => ( {
-				method: 'POST',
-				path: `/wp/v2/menu-items`,
-				body: {
-					menus: menu.id,
-					object_id: undefined,
-					...menuItem,
-					parent: undefined,
-				},
-			} ) )
-		);
-	}
+	await this.batchRest(
+		menuItems.map( ( menuItem ) => ( {
+			method: 'POST',
+			path: `/wp/v2/menu-items`,
+			body: {
+				menus: menu.id,
+				object_id: undefined,
+				...menuItem,
+				parent: undefined,
+			},
+		} ) )
+	);
 
 	return menu;
 }
@@ -58,7 +56,7 @@ export async function createClassicMenu( this: RequestUtils, name: string ) {
 /**
  * Create a navigation menu
  *
- * @param {Object} menuData navigation menu post data.
+ * @param  menuData navigation menu post data.
  * @return {string} Menu content.
  */
 export async function createNavigationMenu(
@@ -84,7 +82,7 @@ export async function deleteAllMenus( this: RequestUtils ) {
 		path: `/wp/v2/navigation/`,
 	} );
 
-	if ( navMenus?.length ) {
+	if ( navMenus.length ) {
 		await this.batchRest(
 			navMenus.map( ( menu ) => ( {
 				method: 'DELETE',
@@ -97,7 +95,7 @@ export async function deleteAllMenus( this: RequestUtils ) {
 		path: `/wp/v2/menus/`,
 	} );
 
-	if ( classicMenus?.length ) {
+	if ( classicMenus.length ) {
 		await this.batchRest(
 			classicMenus.map( ( menu ) => ( {
 				method: 'DELETE',

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -88,9 +88,9 @@ test.describe(
 			await page.locator( 'role=button[name="Close panel"i]' ).click();
 
 			// Check the block in the frontend.
-			await this.page.goto( '/' );
+			await page.goto( '/' );
 			await expect(
-				this.page.locator(
+				page.locator(
 					`role=navigation >> role=link[name="WordPress"i]`
 				)
 			).toBeVisible();

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -115,7 +115,7 @@ test.describe(
 
 			// Check the block in the canvas.
 			await expect(
-				this.editor.canvas.locator(
+				editor.canvas.locator(
 					`role=textbox[name="Navigation link text"i] >> text="Custom link"`
 				)
 			).toBeVisible();

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -72,7 +72,7 @@ test.describe(
 
 			// Check the block in the canvas.
 			await expect(
-				this.editor.canvas.locator(
+				editor.canvas.locator(
 					`role=textbox[name="Navigation link text"i] >> text="WordPress"`
 				)
 			).toBeVisible();

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -98,6 +98,7 @@ test.describe(
 
 		test( 'default to the only existing classic menu if there are no block menus', async ( {
 			admin,
+			page,
 			editor,
 			requestUtils,
 		} ) => {

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -121,9 +121,10 @@ test.describe(
 			).toBeVisible();
 
 			// Check the block in the frontend.
-			await this.page.goto( '/' );
+			await page.goto( '/' );
+
 			await expect(
-				this.page.locator(
+				page.locator(
 					`role=navigation >> role=link[name="Custom link"i]`
 				)
 			).toBeVisible();

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -3,12 +3,6 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-test.use( {
-	navBlockUtils: async ( { editor, page, requestUtils }, use ) => {
-		await use( new NavigationBlockUtils( { editor, page, requestUtils } ) );
-	},
-} );
-
 test.describe(
 	'As a user I want the navigation block to fallback to the best possible default',
 	() => {
@@ -66,7 +60,6 @@ test.describe(
 			editor,
 			page,
 			requestUtils,
-			navBlockUtils,
 		} ) => {
 			await admin.createNewPost();
 			const createdMenu = await requestUtils.createNavigationMenu( {
@@ -78,7 +71,11 @@ test.describe(
 			await editor.insertBlock( { name: 'core/navigation' } );
 
 			// Check the block in the canvas.
-			await navBlockUtils.selectNavigationItemOnCanvas( 'WordPress' );
+			await expect(
+				this.editor.canvas.locator(
+					`role=textbox[name="Navigation link text"i] >> text="WordPress"`
+				)
+			).toBeVisible();
 
 			// Check the markup of the block is correct.
 			await editor.publishPost();
@@ -91,14 +88,18 @@ test.describe(
 			await page.locator( 'role=button[name="Close panel"i]' ).click();
 
 			// Check the block in the frontend.
-			await navBlockUtils.selectNavigationItemOnFrontend( 'WordPress' );
+			await this.page.goto( '/' );
+			await expect(
+				this.page.locator(
+					`role=navigation >> role=link[name="WordPress"i]`
+				)
+			).toBeVisible();
 		} );
 
 		test( 'default to the only existing classic menu if there are no block menus', async ( {
 			admin,
 			editor,
 			requestUtils,
-			navBlockUtils,
 		} ) => {
 			// Create a classic menu.
 			await requestUtils.createClassicMenu( 'Test Classic 1' );
@@ -113,41 +114,22 @@ test.describe(
 			] );
 
 			// Check the block in the canvas.
-			await editor.page.pause();
-			await navBlockUtils.selectNavigationItemOnCanvas( 'Custom link' );
+			await expect(
+				this.editor.canvas.locator(
+					`role=textbox[name="Navigation link text"i] >> text="Custom link"`
+				)
+			).toBeVisible();
 
 			// Check the block in the frontend.
-			await navBlockUtils.selectNavigationItemOnFrontend( 'Custom link' );
-			await editor.page.pause();
+			await this.page.goto( '/' );
+			await expect(
+				this.page.locator(
+					`role=navigation >> role=link[name="Custom link"i]`
+				)
+			).toBeVisible();
 		} );
 	}
 );
-
-class NavigationBlockUtils {
-	constructor( { editor, page, requestUtils } ) {
-		this.editor = editor;
-		this.page = page;
-		this.requestUtils = requestUtils;
-	}
-
-	async selectNavigationItemOnCanvas( name ) {
-		await expect(
-			this.editor.canvas.locator(
-				`role=textbox[name="Navigation link text"i] >> text="${ name }"`
-			)
-		).toBeVisible();
-	}
-
-	async selectNavigationItemOnFrontend( name ) {
-		await this.page.goto( '/' );
-		await this.editor.page.pause();
-		await expect(
-			this.page.locator(
-				`role=navigation >> role=link[name="${ name }"i]`
-			)
-		).toBeVisible();
-	}
-}
 
 test.describe( 'Navigation block', () => {
 	test.describe(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Followup on https://github.com/WordPress/gutenberg/pull/47867 after I missed a couple of things that were found on review after merge.

This PR also includes the `no-page-pause` rule to the linter so people like me won't commit and merge pauses to their e2e tests :D

To test check that the navigation block tests pass (`npm run test:e2e:playwright -- editor/blocks/navigation.spec.js`) and that you can't commit a test containing `page.pause()`.