### PR TITLE
Chore: Move Gutenberg_REST_Templates_Controller from 6.2 to 6.3 compatibility.

### DIFF
--- a/lib/compat/wordpress-6.2/rest-api.php
+++ b/lib/compat/wordpress-6.2/rest-api.php
@@ -6,21 +6,6 @@
  */
 
 /**
- * Update `wp_template` and `wp_template-part` post types to use
- * Gutenberg's REST controller.
- *
- * @param array  $args Array of arguments for registering a post type.
- * @param string $post_type Post type key.
- */
-function gutenberg_update_templates_template_parts_rest_controller( $args, $post_type ) {
-	if ( in_array( $post_type, array( 'wp_template', 'wp_template-part' ), true ) ) {
-		$args['rest_controller_class'] = 'Gutenberg_REST_Templates_Controller_6_2';
-	}
-	return $args;
-}
-add_filter( 'register_post_type_args', 'gutenberg_update_templates_template_parts_rest_controller', 10, 2 );
-
-/**
  * Registers the block pattern categories REST API routes.
  */
 function gutenberg_register_rest_block_pattern_categories() {

--- a/lib/compat/wordpress-6.3/class-gutenberg-rest-templates-controller-6-3.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-rest-templates-controller-6-3.php
@@ -9,7 +9,7 @@
 /**
  * Base Templates REST API Controller.
  */
-class Gutenberg_REST_Templates_Controller_6_2 extends Gutenberg_REST_Templates_Controller {
+class Gutenberg_REST_Templates_Controller_6_3 extends Gutenberg_REST_Templates_Controller {
 
 	/**
 	 * Registers the controllers routes.

--- a/lib/compat/wordpress-6.3/rest-api.php
+++ b/lib/compat/wordpress-6.3/rest-api.php
@@ -13,3 +13,18 @@ function gutenberg_register_rest_pattern_directory() {
 	$pattern_directory_controller->register_routes();
 }
 add_action( 'rest_api_init', 'gutenberg_register_rest_pattern_directory' );
+
+/**
+ * Update `wp_template` and `wp_template-part` post types to use
+ * Gutenberg's REST controller.
+ *
+ * @param array  $args Array of arguments for registering a post type.
+ * @param string $post_type Post type key.
+ */
+function gutenberg_update_templates_template_parts_rest_controller( $args, $post_type ) {
+	if ( in_array( $post_type, array( 'wp_template', 'wp_template-part' ), true ) ) {
+		$args['rest_controller_class'] = 'Gutenberg_REST_Templates_Controller_6_3';
+	}
+	return $args;
+}
+add_filter( 'register_post_type_args', 'gutenberg_update_templates_template_parts_rest_controller', 10, 2 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -44,13 +44,13 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require_once __DIR__ . '/compat/wordpress-6.2/class-gutenberg-rest-block-patterns-controller-6-2.php';
 	require_once __DIR__ . '/compat/wordpress-6.2/class-gutenberg-rest-block-pattern-categories-controller.php';
 	require_once __DIR__ . '/compat/wordpress-6.2/class-gutenberg-rest-pattern-directory-controller-6-2.php';
-	require_once __DIR__ . '/compat/wordpress-6.2/class-gutenberg-rest-templates-controller-6-2.php';
 	require_once __DIR__ . '/compat/wordpress-6.2/rest-api.php';
 	require_once __DIR__ . '/compat/wordpress-6.2/block-patterns.php';
 	require_once __DIR__ . '/compat/wordpress-6.2/class-gutenberg-rest-global-styles-controller-6-2.php';
 
 	// WordPress 6.3 compat.
 	require_once __DIR__ . '/compat/wordpress-6.3/class-gutenberg-rest-pattern-directory-controller-6-3.php';
+	require_once __DIR__ . '/compat/wordpress-6.3/class-gutenberg-rest-templates-controller-6-3.php';
 	require_once __DIR__ . '/compat/wordpress-6.3/rest-api.php';
 
 	// Experimental.


### PR DESCRIPTION
The changes in Gutenberg_REST_Templates_Controller_6_3 will not be part of the 6.2 release so this PR just moves them to the 6.3 compatibility folder.
