### PR TITLE
Set the timezone correctly.

### DIFF
--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -227,17 +227,19 @@ export function __experimentalGetSettings() {
 
 function setupWPTimezone() {
 	// Get the current timezone settings from the WP timezone string.
-	const currentTimeZone = momentLib.tz.zone( settings.timezone.string );
+	const currentTimezone = momentLib.tz.zone( settings.timezone.string );
 
-	// Check to see if we have a valid TZ data, if so, use it fro the custom WP_ZONE timezone, otherwise just use the offset.
-	if ( currentTimeZone ) {
-		// Create WP timezone based off dateSettings.
+	// Check to see if we have a valid TZ data, if so, use it for the custom WP_ZONE timezone, otherwise just use the offset.
+	if ( currentTimezone ) {
+		// Create WP timezone based off settings.timezone.string.  We need to include the additional data so that we
+		// don't lose information about daylight savings time and other items.
+		// See https://github.com/WordPress/gutenberg/pull/48083
 		momentLib.tz.add(
 			momentLib.tz.pack( {
 				name: WP_ZONE,
-				abbrs: currentTimeZone.abbrs,
-				untils: currentTimeZone.untils,
-				offsets: currentTimeZone.offsets,
+				abbrs: currentTimezone.abbrs,
+				untils: currentTimezone.untils,
+				offsets: currentTimezone.offsets,
 			} )
 		);
 	} else {

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -226,15 +226,31 @@ export function __experimentalGetSettings() {
 }
 
 function setupWPTimezone() {
-	// Create WP timezone based off dateSettings.
-	momentLib.tz.add(
-		momentLib.tz.pack( {
-			name: WP_ZONE,
-			abbrs: [ WP_ZONE ],
-			untils: [ null ],
-			offsets: [ -settings.timezone.offset * 60 || 0 ],
-		} )
-	);
+	// Get the current timezone settings from the WP timezone string.
+	const currentTimeZone = momentLib.tz.zone( settings.timezone.string );
+
+	// Check to see if we have a valid TZ data, if so, use it fro the custom WP_ZONE timezone, otherwise just use the offset.
+	if ( currentTimeZone ) {
+		// Create WP timezone based off dateSettings.
+		momentLib.tz.add(
+			momentLib.tz.pack( {
+				name: WP_ZONE,
+				abbrs: currentTimeZone.abbrs,
+				untils: currentTimeZone.untils,
+				offsets: currentTimeZone.offsets,
+			} )
+		);
+	} else {
+		// Create WP timezone based off dateSettings.
+		momentLib.tz.add(
+			momentLib.tz.pack( {
+				name: WP_ZONE,
+				abbrs: [ WP_ZONE ],
+				untils: [ null ],
+				offsets: [ -settings.timezone.offset * 60 || 0 ],
+			} )
+		);
+	}
 }
 
 // Date constants.


### PR DESCRIPTION
This avoids daylight savings zone problems with future dates.

## What?
Fixes #46333, which shows the wrong time in Gutenberg if the post is in the future and crosses the daylight savings time boundries.

## Why?
See #46333, showing the incorrect publish time in the UI is bad.

## How?
Instead of using a fixed "WP" timezone, that is added to moment.tz's zones table, use the "proper" timezone as supplied by WP if possible.

## Testing Instructions
1. Make sure you are in a timezone that uses daylight savings time.
2. Create a post.
3. Set it to publish after the next daylight savings time change.
4. See the date reported in Gutenberg's summary widget  is off by an hour, but nowhere else (aka the datepicker is fine, and the post list is fine, and the post will be published on the date you entered in the datepicker).

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast
See #46333 for screenshots.
