### PR TITLE
[Sidebar][BlockPatterns] Prevent pattern previews from rendering in parallel due to React's concurrent mode

### DIFF
--- a/packages/compose/src/hooks/use-async-list/index.ts
+++ b/packages/compose/src/hooks/use-async-list/index.ts
@@ -65,7 +65,10 @@ function useAsyncList< T >(
 				...state,
 				...list.slice( nextIndex, nextIndex + step ),
 			] );
-			asyncQueue.add( {}, append( nextIndex + step ) );
+
+			queueMicrotask( () =>
+				asyncQueue.add( {}, append( nextIndex + step ) )
+			);
 		};
 		asyncQueue.add( {}, append( firstItems.length ) );
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/48084

## What?

Fixes an issue that causes Gutenberg to stop handling UI events and sometimes crashing the browser due to the new concurrent mode implemented and the rendering of too many block pattern preview iframes in the sidebar inserter after searching.

## Why?

After concurrent mode was activated in https://github.com/WordPress/gutenberg/pull/46467, in some scenarios, the sidebar would block the entire Gutenberg UI because the browser is trying to render too many documents inside the block pattern preview iframes in parallel, effectively blocking the event loop and blocking the UI, and sometimes even crashing the browser in some systems ([see issue](https://github.com/WordPress/gutenberg/issues/48084)).

## How?

Use `queueMicroTask` (though `setTimeout` with a timeout of `0` also worked) to schedule the `asynceQueue` `add` call to the next tick. This seems to bring the behavior of block pattern previews closer to how it was before React concurrent mode was implemented, when they were rendered sequentially/with a slight delay, giving the browser time to render the expensive iframes without blocking the UI when there are many instances of them ([see the issue for more info](https://github.com/WordPress/gutenberg/issues/48084)).


## Testing Instructions

First, follow the steps to reproduce [the issue](https://github.com/WordPress/gutenberg/issues/48084), then:

1. Clone Gutenberg locally from this branch, build, and then install/activate it in your WP instance;
2. Open the inserter and search for the term that matches 50-60 patterns. The issue might happen with fewer patterns being rendered, but it might also be system/browser-dependent. To make sure you have the environment closest to the one I used to reproduce it, try to have at least 50 registered block patterns that have actual previews in them. An easy way to do that is to use a Wordpress.com test site, if you have access to one.
3. Immediately after you finish typing the search term in the sidebar inserter's search box, notice how it updates the block and pattern contents below. Try to move the mouse over immediately. The pattern preview buttons should be loaded sequentially, without causing the UI to block. You should be able to see the UI changes reflect without the UI freezing. Try clicking, hovering and scrolling, the UI should work well.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before the fix:

https://user-images.githubusercontent.com/81248/218907999-c80009f7-40ab-4a39-ab69-3b8dd2c443a9.mp4

### After the fix: 

https://user-images.githubusercontent.com/81248/218908031-05ca1ee9-c11e-4a99-8358-153bc4fa6db1.mp4




