### PR TITLE
Style Book: Allow button text labels for style book icon

### DIFF
--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -68,7 +68,7 @@ function GlobalStylesActionMenu() {
 		<GlobalStylesMenuFill>
 			<DropdownMenu
 				icon={ moreVertical }
-				label={ __( 'More Styles actions' ) }
+				label={ __( 'Styles actions' ) }
 				controls={ [
 					{
 						title: __( 'Reset to defaults' ),

--- a/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
@@ -44,11 +44,7 @@ export default function GlobalStylesSidebar() {
 					<FlexItem>
 						<Button
 							icon={ seen }
-							label={
-								isStyleBookOpened
-									? __( 'Close Style Book' )
-									: __( 'Open Style Book' )
-							}
+							label={ __( 'Style Book' ) }
 							isPressed={ isStyleBookOpened }
 							disabled={ editorMode !== 'visual' }
 							onClick={ () => {

--- a/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
@@ -37,8 +37,8 @@ export default function GlobalStylesSidebar() {
 			closeLabel={ __( 'Close Styles sidebar' ) }
 			panelClassName="edit-site-global-styles-sidebar__panel"
 			header={
-				<Flex>
-					<FlexBlock>
+				<Flex className="edit-site-global-styles-sidebar__header">
+					<FlexBlock style={ { minWidth: 'min-content' } }>
 						<strong>{ __( 'Styles' ) }</strong>
 					</FlexBlock>
 					<FlexItem>

--- a/packages/edit-site/src/components/sidebar-edit-mode/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/style.scss
@@ -83,3 +83,19 @@
 .edit-site-global-styles-sidebar hr {
 	margin: 0;
 }
+
+.show-icon-labels {
+	.edit-site-global-styles-sidebar__header {
+		.components-button.has-icon {
+			// Hide the button icons when labels are set to display...
+			svg {
+				display: none;
+			}
+			// ... and display labels.
+			&::after {
+				content: attr(aria-label);
+				font-size: $helptext-font-size;
+			}
+		}
+	}
+}

--- a/test/e2e/specs/site-editor/style-book.spec.js
+++ b/test/e2e/specs/site-editor/style-book.spec.js
@@ -119,7 +119,7 @@ test.describe( 'Style Book', () => {
 
 	test( 'should disappear when closed', async ( { page } ) => {
 		await page.click(
-			'role=region[name="Style Book"i] >> role=button[name="Style Book"i]'
+			'role=region[name="Style Book"i] >> role=button[name="Close Style Book"i]'
 		);
 
 		await expect(

--- a/test/e2e/specs/site-editor/style-book.spec.js
+++ b/test/e2e/specs/site-editor/style-book.spec.js
@@ -119,7 +119,7 @@ test.describe( 'Style Book', () => {
 
 	test( 'should disappear when closed', async ( { page } ) => {
 		await page.click(
-			'role=region[name="Style Book"i] >> role=button[name="Close Style Book"i]'
+			'role=region[name="Style Book"i] >> role=button[name="Style Book"i]'
 		);
 
 		await expect(
@@ -145,6 +145,6 @@ class StyleBook {
 	async open() {
 		await this.disableWelcomeGuide();
 		await this.page.click( 'role=button[name="Styles"i]' );
-		await this.page.click( 'role=button[name="Open Style Book"i]' );
+		await this.page.click( 'role=button[name="Style Book"i]' );
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #48051

As raised in the linked issue, when using the `Show button text labels` editor setting, the icon for the Style Book button is still displayed as an icon, rather than its text label. This PR allows that setting to switch the Style Book icon over to using its text label, and also tweaks the text labels in that row.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The style book icon isn't self-explanatory, and for users who use the `Show button text labels` setting, the expectation is that a text label would be used instead of an icon.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add a classname for the header elements of the Global Styles panel.
* Using that classname and the `.show-icon-labels` classname that gets output to the site editor when the `Show button text labels` setting is in use, add CSS rules that hide the `svg` element and display the aria-label text for the button instead.
* Rename `Open Style Book` and `Close Style Book` to `Style Book` based on the feedback in https://github.com/WordPress/gutenberg/issues/48051#issuecomment-1430125214.
* Rename `More styles actions` to `Styles actions` for consistency and to better fit the text labels on a single row.
* Ensure the `Styles` text does not shrink smaller than its content (add a `min-width: min-content` rule).

Note: the close button has not been included in the button label text in this PR as there is currently limited space in this row to fit each of the elements. This could be explored separately in a follow-up if it's desired to include that one, too.

Happy for any feedback on the labelling, though!

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In the site editor, go to Options > Preferences
2. Check 'Show button text labels'
3. Go to the Styles panel and see the Style Book icon should no longer be displayed, and it should instead be a button with the label text `Style Book`

Note: the capitalisation here is a little off — that's because `Style Book` appears to be a proper noun, whereas `Styles actions` is sentence case as it is not a proper noun. Happy for any feedback or suggestions there.

## Screenshots or screencast <!-- if applicable -->

| Icons view | Text labels view |
| --- | --- |
| <img width="924" alt="image" src="https://user-images.githubusercontent.com/14988353/218918415-536d9122-2ba2-421b-97f0-d11eaa53d5da.png"> | <img width="925" alt="image" src="https://user-images.githubusercontent.com/14988353/218918333-dcbdd4cf-5ae9-44b7-8778-43fac2e7c1f9.png"> |