### PR TITLE
Fix `editor.getBlocks` for unmodified default block

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/get-blocks.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/get-blocks.ts
@@ -15,14 +15,11 @@ export async function getBlocks( this: Editor ) {
 		const blocks = window.wp.data.select( 'core/block-editor' ).getBlocks();
 
 		// The editor might still contain an unmodified empty block even when it's technically "empty".
-		if ( blocks.length === 1 ) {
-			const blockName = blocks[ 0 ].name;
-			if (
-				blockName === window.wp.blocks.getDefaultBlockName() ||
-				blockName === window.wp.blocks.getFreeformContentHandlerName()
-			) {
-				return [];
-			}
+		if (
+			blocks.length === 1 &&
+			window.wp.blocks.isUnmodifiedDefaultBlock( blocks[ 0 ] )
+		) {
+			return [];
 		}
 
 		return blocks;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
A recent change in #47926 broke `editor.getBlocks`. A single paragraph block in the content will still return an empty array by `editor.getBlocks()`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
I was not checking for the content of the default block 😞 .

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Use `wp.blocks.isUnmodifiedDefaultBlock`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
CI should pass.
