### PR TITLE
Make the performance tests more stable

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -323,13 +323,13 @@ async function runPerformanceTests( branches, options ) {
 			log( `        >> Fetching the ${ fancyBranch } branch` );
 			// @ts-ignore
 			await SimpleGit( buildPath ).reset( 'hard' ).checkout( branch );
-
-			log( `        >> Building the ${ fancyBranch } branch` );
-			await runShellScript(
-				'npm ci && npm run prebuild:packages && node ./bin/packages/build.js && npx wp-scripts build',
-				buildPath
-			);
 		}
+
+		log( `        >> Building the ${ fancyBranch } branch` );
+		await runShellScript(
+			'npm ci && npm run prebuild:packages && node ./bin/packages/build.js && npx wp-scripts build',
+			buildPath
+		);
 
 		await runShellScript(
 			'cp ' +

--- a/packages/e2e-test-utils/src/site-editor.js
+++ b/packages/e2e-test-utils/src/site-editor.js
@@ -168,7 +168,7 @@ export async function openPreviousGlobalStylesPanel() {
 export async function enterEditMode() {
 	try {
 		await page.waitForSelector(
-			'.edit-site-visual-editor__editor-canva[role="button"]',
+			'.edit-site-visual-editor__editor-canvas[role="button"]',
 			{ timeout: 3000 }
 		);
 

--- a/packages/e2e-test-utils/src/site-editor.js
+++ b/packages/e2e-test-utils/src/site-editor.js
@@ -166,13 +166,14 @@ export async function openPreviousGlobalStylesPanel() {
  * Enters edit mode.
  */
 export async function enterEditMode() {
-	const isViewMode = await page.$(
-		'.edit-site-visual-editor__editor-canvas[role="button"]'
-	);
+	const isSidebarVisible = await page.$( '.edit-site-layout__sidebar' );
 	// This check is necessary for the performance tests in old branches
 	// where the site editor toggle was not implemented yet.
-	if ( ! isViewMode ) {
+	if ( ! isSidebarVisible ) {
 		return;
 	}
+	await page.waitForSelector(
+		'.edit-site-visual-editor__editor-canvas[role="button"]'
+	);
 	await canvas().click( 'body' );
 }

--- a/packages/e2e-test-utils/src/site-editor.js
+++ b/packages/e2e-test-utils/src/site-editor.js
@@ -166,14 +166,15 @@ export async function openPreviousGlobalStylesPanel() {
  * Enters edit mode.
  */
 export async function enterEditMode() {
-	const isSidebarVisible = await page.$( '.edit-site-layout__sidebar' );
-	// This check is necessary for the performance tests in old branches
-	// where the site editor toggle was not implemented yet.
-	if ( ! isSidebarVisible ) {
-		return;
+	try {
+		await page.waitForSelector(
+			'.edit-site-visual-editor__editor-canva[role="button"]',
+			{ timeout: 3000 }
+		);
+
+		await canvas().click( 'body' );
+	} catch {
+		// This catch is necessary for the performance tests in old branches
+		// where the site editor toggle was not implemented yet.
 	}
-	await page.waitForSelector(
-		'.edit-site-visual-editor__editor-canvas[role="button"]'
-	);
-	await canvas().click( 'body' );
 }

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -90,10 +90,6 @@ describe( 'Site Editor Performance', () => {
 		await visitSiteEditor( {
 			postId: id,
 			postType: 'page',
-			// This shouldn't be necessary, but without it the tests fail.
-			// Could be related to having the necessary cookies in the browser.
-			// See https://github.com/WordPress/gutenberg/pull/48240/files#r1111760556
-			path: '/navigation/single',
 		} );
 	} );
 


### PR DESCRIPTION
Recently, the performance job has been unstable. This PR tries to solve that.

It turns out the job was broken for a long time. Read [this comment](https://github.com/WordPress/gutenberg/pull/48094#discussion_r1112904171) for the details. 