### PR TITLE
Navigation List View: Add block movers to the more menu

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/leaf-more-menu.js
+++ b/packages/block-editor/src/components/off-canvas-editor/leaf-more-menu.js
@@ -2,7 +2,12 @@
  * WordPress dependencies
  */
 import { createBlock } from '@wordpress/blocks';
-import { addSubmenu, moreVertical } from '@wordpress/icons';
+import {
+	addSubmenu,
+	chevronUp,
+	chevronDown,
+	moreVertical,
+} from '@wordpress/icons';
 import { DropdownMenu, MenuItem, MenuGroup } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
@@ -111,6 +116,7 @@ export default function LeafMoreMenu( props ) {
 				<MenuGroup>
 					<AddSubmenuItem block={ block } onClose={ onClose } />
 					<MenuItem
+						icon={ chevronUp }
 						onClick={ () => {
 							moveBlocksUp( [ clientId ], rootClientId );
 							onClose();
@@ -119,6 +125,7 @@ export default function LeafMoreMenu( props ) {
 						{ __( 'Move up' ) }
 					</MenuItem>
 					<MenuItem
+						icon={ chevronDown }
 						onClick={ () => {
 							moveBlocksDown( [ clientId ], rootClientId );
 							onClose();

--- a/packages/block-editor/src/components/off-canvas-editor/leaf-more-menu.js
+++ b/packages/block-editor/src/components/off-canvas-editor/leaf-more-menu.js
@@ -113,35 +113,39 @@ export default function LeafMoreMenu( props ) {
 			{ ...props }
 		>
 			{ ( { onClose } ) => (
-				<MenuGroup>
-					<AddSubmenuItem block={ block } onClose={ onClose } />
-					<MenuItem
-						icon={ chevronUp }
-						onClick={ () => {
-							moveBlocksUp( [ clientId ], rootClientId );
-							onClose();
-						} }
-					>
-						{ __( 'Move up' ) }
-					</MenuItem>
-					<MenuItem
-						icon={ chevronDown }
-						onClick={ () => {
-							moveBlocksDown( [ clientId ], rootClientId );
-							onClose();
-						} }
-					>
-						{ __( 'Move down' ) }
-					</MenuItem>
-					<MenuItem
-						onClick={ () => {
-							removeBlocks( [ clientId ], false );
-							onClose();
-						} }
-					>
-						{ removeLabel }
-					</MenuItem>
-				</MenuGroup>
+				<>
+					<MenuGroup>
+						<MenuItem
+							icon={ chevronUp }
+							onClick={ () => {
+								moveBlocksUp( [ clientId ], rootClientId );
+								onClose();
+							} }
+						>
+							{ __( 'Move up' ) }
+						</MenuItem>
+						<MenuItem
+							icon={ chevronDown }
+							onClick={ () => {
+								moveBlocksDown( [ clientId ], rootClientId );
+								onClose();
+							} }
+						>
+							{ __( 'Move down' ) }
+						</MenuItem>
+						<AddSubmenuItem block={ block } onClose={ onClose } />
+					</MenuGroup>
+					<MenuGroup>
+						<MenuItem
+							onClick={ () => {
+								removeBlocks( [ clientId ], false );
+								onClose();
+							} }
+						>
+							{ removeLabel }
+						</MenuItem>
+					</MenuGroup>
+				</>
 			) }
 		</DropdownMenu>
 	);

--- a/packages/block-editor/src/components/off-canvas-editor/leaf-more-menu.js
+++ b/packages/block-editor/src/components/off-canvas-editor/leaf-more-menu.js
@@ -4,7 +4,7 @@
 import { createBlock } from '@wordpress/blocks';
 import { addSubmenu, moreVertical } from '@wordpress/icons';
 import { DropdownMenu, MenuItem, MenuGroup } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -80,12 +80,22 @@ function AddSubmenuItem( { block, onClose } ) {
 export default function LeafMoreMenu( props ) {
 	const { clientId, block } = props;
 
-	const { removeBlocks } = useDispatch( blockEditorStore );
+	const { moveBlocksDown, moveBlocksUp, removeBlocks } =
+		useDispatch( blockEditorStore );
 
-	const label = sprintf(
+	const removeLabel = sprintf(
 		/* translators: %s: block name */
 		__( 'Remove %s' ),
 		BlockTitle( { clientId, maximumLength: 25 } )
+	);
+
+	const rootClientId = useSelect(
+		( select ) => {
+			const { getBlockRootClientId } = select( blockEditorStore );
+
+			return getBlockRootClientId( clientId );
+		},
+		[ clientId ]
 	);
 
 	return (
@@ -102,11 +112,27 @@ export default function LeafMoreMenu( props ) {
 					<AddSubmenuItem block={ block } onClose={ onClose } />
 					<MenuItem
 						onClick={ () => {
+							moveBlocksUp( [ clientId ], rootClientId );
+							onClose();
+						} }
+					>
+						{ __( 'Move up' ) }
+					</MenuItem>
+					<MenuItem
+						onClick={ () => {
+							moveBlocksDown( [ clientId ], rootClientId );
+							onClose();
+						} }
+					>
+						{ __( 'Move down' ) }
+					</MenuItem>
+					<MenuItem
+						onClick={ () => {
 							removeBlocks( [ clientId ], false );
 							onClose();
 						} }
 					>
-						{ label }
+						{ removeLabel }
 					</MenuItem>
 				</MenuGroup>
 			) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This adds block movers to the "more" menu in the Navigation List View.

## Why?
It is possible to move these blocks in the canvas, and in the Navigation List View using drag and drop, but there's no affordance for moving items in the Navigation List View with a keyboard.

In addition, this is something we've been exploring for the page list block in https://github.com/WordPress/gutenberg/issues/48034, so this might be a good first step towards that.

## How?
Just adds a couple of extra options to the more menu that's used in the Navigation List View.

## Testing Instructions
1. Add a navigation block
2. Add some links to the navigation block
3. Open the more menu for one of the links
4. Select the "move up" option
5. Check that the block does indeed move upwards
4. Select the "move down" option
5. Check that the block does indeed move downwards

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
https://user-images.githubusercontent.com/275961/219061644-ad6de587-8e50-498e-90c7-5747dc799c7c.mov

<img width="317" alt="Screenshot 2023-02-15 at 14 58 41" src="https://user-images.githubusercontent.com/275961/219064122-def7cbe2-8f08-4be4-99cc-5b94c2ce5cde.png">

## Question
Should we use the words "up" and "down" even when the block itself its horizontally aligned, because the List View is vertical?

cc @richtabor @SaxonF @jasmussen for design input.

