### PR TITLE
Fix the Publish region position and focus style.

### DIFF
--- a/packages/components/src/higher-order/navigate-regions/style.scss
+++ b/packages/components/src/higher-order/navigate-regions/style.scss
@@ -24,13 +24,14 @@
 	// visible. For the future, it's important to take into consideration that
 	// the navigable regions should always have a computed size. For now, we can
 	// fix some edge cases but these CSS rules should be later removed in favor of
-	// a more abstracted approach to make the navigabel regions focus style work
+	// a more abstracted approach to make the navigable regions focus style work
 	// regardles of the CSS used on other components.
 
 	// Header top bar when Distraction free mode is on.
 	&.is-distraction-free .interface-interface-skeleton__header .edit-post-header,
 	.interface-interface-skeleton__sidebar .edit-post-layout__toggle-sidebar-panel,
 	.interface-interface-skeleton__actions .edit-post-layout__toggle-publish-panel,
+	.interface-interface-skeleton__actions .edit-post-layout__toggle-entities-saved-states-panel,
 	.editor-post-publish-panel {
 		outline: 4px solid $components-color-accent;
 		outline-offset: -4px;

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -128,13 +128,6 @@ function Layout( { styles } ) {
 
 	const isDistractionFree = isDistractionFreeMode && isLargeViewport;
 
-	const className = classnames( 'edit-post-layout', 'is-mode-' + mode, {
-		'is-sidebar-opened': sidebarIsOpened,
-		'has-fixed-toolbar': hasFixedToolbar,
-		'has-metaboxes': hasActiveMetaboxes,
-		'show-icon-labels': showIconLabels,
-		'is-distraction-free': isDistractionFree,
-	} );
 	const openSidebarPanel = () =>
 		openGeneralSidebar(
 			hasBlockSelected ? 'edit-post/block' : 'edit-post/document'
@@ -165,6 +158,15 @@ function Layout( { styles } ) {
 		},
 		[ entitiesSavedStatesCallback ]
 	);
+
+	const className = classnames( 'edit-post-layout', 'is-mode-' + mode, {
+		'is-sidebar-opened': sidebarIsOpened,
+		'has-fixed-toolbar': hasFixedToolbar,
+		'has-metaboxes': hasActiveMetaboxes,
+		'show-icon-labels': showIconLabels,
+		'is-distraction-free': isDistractionFree,
+		'is-entity-save-view-open': !! entitiesSavedStatesCallback,
+	} );
 
 	const secondarySidebarLabel = isListViewOpened
 		? __( 'Document Overview' )

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -6,12 +6,6 @@
 	padding: $grid-unit-30;
 	display: flex;
 	justify-content: center;
-
-	.edit-site-layout__actions:focus &,
-	.edit-site-layout__actions:focus-within & {
-		top: auto;
-		bottom: 0;
-	}
 }
 
 // Adjust the position of the notices

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -207,8 +207,15 @@
 
 	&:focus,
 	&:focus-within {
-		top: 0;
+		top: auto;
 		bottom: 0;
+	}
+
+	&.is-entity-save-view-open {
+		&:focus,
+		&:focus-within {
+			top: 0;
+		}
 	}
 
 	@include break-medium {

--- a/packages/edit-site/src/components/save-panel/index.js
+++ b/packages/edit-site/src/components/save-panel/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { Button, Modal } from '@wordpress/components';
@@ -46,7 +51,9 @@ export default function SavePanel() {
 
 	return (
 		<NavigableRegion
-			className="edit-site-layout__actions"
+			className={ classnames( 'edit-site-layout__actions', {
+				'is-entity-save-view-open': isSaveViewOpen,
+			} ) }
 			ariaLabel={ __( 'Save sidebar' ) }
 		>
 			{ isSaveViewOpen ? (

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -184,16 +184,20 @@ html.interface-interface-skeleton__html-container {
 
 	&:focus,
 	&:focus-within {
-		top: $admin-bar-height-big;
+		top: auto;
+		bottom: 0;
 
-		@include break-medium() {
-			border-left: $border-width solid $gray-300;
-			top: $admin-bar-height;
+		.is-entity-save-view-open & {
+			top: $admin-bar-height-big;
 
-			.is-fullscreen-mode & {
-				top: 0;
+			@include break-medium() {
+				border-left: $border-width solid $gray-300;
+				top: $admin-bar-height;
+
+				.is-fullscreen-mode & {
+					top: 0;
+				}
 			}
 		}
-		bottom: 0;
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/48031

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR seeks to fix regressions after https://github.com/WordPress/gutenberg/pull/47734. (and maybe also https://github.com/WordPress/gutenberg/pull/47142) where the position of the Publish/Save panel is off when navigating through the editor regions. 

#47734 fixed the position of the multi-entity save panel but broke the position of the Publish/Save panel when navigating through the editor regions.

It would be great to include this fix in the WP beta, as it fixes a regression. Cc @youknowriad 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
 Layout and focus style are off, see screenshots on https://github.com/WordPress/gutenberg/issues/48031

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Keeps the CSS default `top` position to `auto`.
- Sets the CSS `top` position to `0` only when the multi-entity save panel is rendered.
- Fixes missing focus style on the 'Open save panel' button container.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

**Post editor:**
- Edit a post draft, add a reusable block and save.
- Navigate through the editor regions (by pressing Control + backtick or Control+Option+N).
- Check all the regions have a correct focus style.
- When the Publish region is focused, it shows the 'Open publish panel' button.
- Check that it shows at the bottom right of the screen. Also check it has a correct focus style. Screenshot:

<img width="327" alt="Screenshot 2023-02-15 at 15 53 51" src="https://user-images.githubusercontent.com/1682452/219078299-757bc4f8-826f-425a-8744-c947778fe25c.png">

- Make a change to the reusable block.
- Navigate through the editor regions.
- When the Publish region is focused, it now shows the 'Open save panel' button.
- Check that it shows at the bottom right of the screen. Also check it has a correct focus style. Screenshot:

<img width="317" alt="Screenshot 2023-02-15 at 15 54 18" src="https://user-images.githubusercontent.com/1682452/219078607-a0d86133-74a7-491d-8833-7b599b0f637a.png">

- Click 'Open save panel' or click 'Publish' in the top bar.
- The multi-entity save panel opens.
- Check it shows at the op of the right sidebar.

**Site editor:**
- Basically, repeat the steps above but keep in mind the Site Editor has only the 'Save' region (there's no 'Publish' UI).


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
See above.

## Screenshots or screencast <!-- if applicable -->
