### PR TITLE
[RNMobile] Add metadata parameter to media upload events

### DIFF
--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
@@ -5,6 +5,7 @@ import androidx.core.util.Consumer;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeMap;
 
 import org.wordpress.mobile.WPAndroidGlue.MediaOption;
 import org.wordpress.mobile.WPAndroidGlue.RequestExecutor;
@@ -29,7 +30,7 @@ public interface GutenbergBridgeJS2Parent extends RequestExecutor {
     interface MediaUploadEventEmitter {
         void onUploadMediaFileClear(int mediaId);
         void onMediaFileUploadProgress(int mediaId, float progress);
-        void onMediaFileUploadSucceeded(int mediaId, String mediaUrl, int serverId);
+        void onMediaFileUploadSucceeded(int mediaId, String mediaUrl, int serverId, WritableNativeMap metadata);
         void onMediaFileUploadFailed(int mediaId);
     }
 

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/DeferredEventEmitter.java
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/DeferredEventEmitter.java
@@ -47,6 +47,8 @@ public class DeferredEventEmitter implements MediaUploadEventEmitter, MediaSaveE
     private static final String MAP_KEY_MEDIA_FILE_STATE = "state";
     private static final String MAP_KEY_MEDIA_FILE_MEDIA_ACTION_PROGRESS = "progress";
     private static final String MAP_KEY_MEDIA_FILE_MEDIA_SERVER_ID = "mediaServerId";
+    private static final String MAP_KEY_MEDIA_FILE_METADATA = "metadata";
+
     private static final String MAP_KEY_UPDATE_CAPABILITIES = "updateCapabilities";
 
     private static final String MAP_KEY_REPLACE_BLOCK_HTML = "html";
@@ -99,15 +101,20 @@ public class DeferredEventEmitter implements MediaUploadEventEmitter, MediaSaveE
     }
 
     private void setMediaFileUploadDataInJS(int state, int mediaId, String mediaUrl, float progress) {
-        setMediaFileUploadDataInJS(state, mediaId, mediaUrl, progress, MEDIA_SERVER_ID_UNKNOWN);
+        setMediaFileUploadDataInJS(state, mediaId, mediaUrl, progress, MEDIA_SERVER_ID_UNKNOWN, new WritableNativeMap());
     }
 
     private void setMediaFileUploadDataInJS(int state, int mediaId, String mediaUrl, float progress, int mediaServerId) {
+        setMediaFileUploadDataInJS(state, mediaId, mediaUrl, progress, mediaServerId, new WritableNativeMap());
+    }
+
+    private void setMediaFileUploadDataInJS(int state, int mediaId, String mediaUrl, float progress, int mediaServerId, WritableNativeMap metadata) {
         WritableMap writableMap = new WritableNativeMap();
         writableMap.putInt(MAP_KEY_MEDIA_FILE_STATE, state);
         writableMap.putInt(MAP_KEY_MEDIA_FILE_UPLOAD_MEDIA_ID, mediaId);
         writableMap.putString(MAP_KEY_MEDIA_FILE_UPLOAD_MEDIA_URL, mediaUrl);
         writableMap.putDouble(MAP_KEY_MEDIA_FILE_MEDIA_ACTION_PROGRESS, progress);
+        writableMap.putMap(MAP_KEY_MEDIA_FILE_METADATA, metadata);
         if (mediaServerId != MEDIA_SERVER_ID_UNKNOWN) {
             writableMap.putInt(MAP_KEY_MEDIA_FILE_MEDIA_SERVER_ID, mediaServerId);
         }
@@ -161,8 +168,8 @@ public class DeferredEventEmitter implements MediaUploadEventEmitter, MediaSaveE
     }
 
     @Override
-    public void onMediaFileUploadSucceeded(int mediaId, String mediaUrl, int mediaServerId) {
-        setMediaFileUploadDataInJS(MEDIA_UPLOAD_STATE_SUCCEEDED, mediaId, mediaUrl, 1, mediaServerId);
+    public void onMediaFileUploadSucceeded(int mediaId, String mediaUrl, int mediaServerId, WritableNativeMap metadata) {
+        setMediaFileUploadDataInJS(MEDIA_UPLOAD_STATE_SUCCEEDED, mediaId, mediaUrl, 1, mediaServerId, metadata);
     }
 
     @Override

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -33,6 +33,7 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.common.LifecycleState;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.shell.MainPackageConfig;
@@ -1058,8 +1059,9 @@ public class WPAndroidGlueCode {
         mDeferredEventEmitter.onMediaFileUploadFailed(mediaId);
     }
 
-    public void mediaFileUploadSucceeded(final int mediaId, final String mediaUrl, final int serverMediaId) {
-        mDeferredEventEmitter.onMediaFileUploadSucceeded(mediaId, mediaUrl, serverMediaId);
+    public void mediaFileUploadSucceeded(final int mediaId, final String mediaUrl, final int serverMediaId, final
+                                         WritableNativeMap metadata) {
+        mDeferredEventEmitter.onMediaFileUploadSucceeded(mediaId, mediaUrl, serverMediaId, metadata);
     }
 
     public void clearMediaFileURL(final int mediaId) {

--- a/packages/react-native-bridge/ios/Gutenberg.swift
+++ b/packages/react-native-bridge/ios/Gutenberg.swift
@@ -140,8 +140,8 @@ public class Gutenberg: UIResponder {
         bridgeModule.sendEvent(withName: event.rawValue, body: body)
     }
 
-    public func mediaUploadUpdate(id: Int32, state: MediaUploadState, progress: Float, url: URL?, serverID: Int32?) {
-        mediaUpdate(event: .mediaUpload, id: id, state: state, progress: progress, url: url, serverID: serverID)
+    public func mediaUploadUpdate(id: Int32, state: MediaUploadState, progress: Float, url: URL?, serverID: Int32?, metadata: [String: Any] = [:]) {
+        mediaUpdate(event: .mediaUpload, id: id, state: state, progress: progress, url: url, serverID: serverID, metadata: metadata)
     }
 
     public func updateMediaSaveStatus(id: Int32, state: MediaSaveState, progress: Float, url: URL?, serverID: Int32?) {
@@ -165,8 +165,8 @@ public class Gutenberg: UIResponder {
         ])
     }
 
-    private func mediaUpdate<State: MediaState>(event: RNReactNativeGutenbergBridge.EventName, id: Int32, state: State, progress: Float, url: URL?, serverID: Int32?)  {
-        var data: [String: Any] = ["mediaId": id, "state": state.rawValue, "progress": progress];
+    private func mediaUpdate<State: MediaState>(event: RNReactNativeGutenbergBridge.EventName, id: Int32, state: State, progress: Float, url: URL?, serverID: Int32?, metadata: [String: Any] = [:])  {
+        var data: [String: Any] = ["mediaId": id, "state": state.rawValue, "progress": progress, "metadata": metadata ];
         if let url = url {
             data["mediaUrl"] = url.absoluteString
         }

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,6 +10,7 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
+-   [*] Add metadata parameter to media upload events [#48103]  
 
 ## 1.89.0 
 * No User facing changes *

--- a/packages/react-native-editor/ios/GutenbergDemo/MediaUploadCoordinator.swift
+++ b/packages/react-native-editor/ios/GutenbergDemo/MediaUploadCoordinator.swift
@@ -70,7 +70,7 @@ class MediaUploadCoordinator: NSObject {
     if !successfullUpload {
       timer.invalidate()
       progress.setUserInfoObject("Network upload failed", forKey: .mediaError)
-      gutenberg.mediaUploadUpdate(id: mediaID, state: .failed, progress: 1, url: nil, serverID: nil)
+      gutenberg.mediaUploadUpdate(id: mediaID, state: .failed, progress: 1, url: nil, serverID: nil, metadata: ["demoApp" : true, "failReason" : "Network upload failed"])
       successfullUpload = true
       return
     }
@@ -80,7 +80,7 @@ class MediaUploadCoordinator: NSObject {
       gutenberg.mediaUploadUpdate(id: mediaID, state: .uploading, progress: Float(progress.fractionCompleted), url: nil, serverID: nil)
     } else if progress.fractionCompleted >= 1 {
       timer.invalidate()
-      gutenberg.mediaUploadUpdate(id: mediaID, state: .succeeded, progress: 1, url: mediaURL, serverID: mediaID)
+      gutenberg.mediaUploadUpdate(id: mediaID, state: .succeeded, progress: 1, url: mediaURL, serverID: mediaID, metadata: ["demoApp" : true])
       activeUploads[mediaID] = nil
     }
   }


### PR DESCRIPTION
**Related PRs:**
- [WordPress-Android](https://github.com/wordpress-mobile/WordPress-Android/pull/17961)
- [WordPress-Utils-Android](https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/121)
- [WordPress-iOS](https://github.com/wordpress-mobile/WordPress-iOS/pull/20144)
- [Gutenberg Mobile](https://github.com/wordpress-mobile/gutenberg-mobile/pull/5479)

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds a metadata parameter in the media upload events. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The first metadata that will be passed is the VideoPress GUID, which is needed to render the VideoPress block in the native version of the editor. Additionally, this will allow us to provide further information about media uploads.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The implementation differs between platforms:
- Android: A new parameter named `metadata` has been introduced in the `onMediaFileUploadSucceeded` event.
- iOS: A new parameter named `metadata` has been introduced in `mediaUpdate` event.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Apply the following patch:
```
diff --git forkSrcPrefix/packages/block-library/src/image/edit.native.js forkDstPrefix/packages/block-library/src/image/edit.native.js
index 3ffd377005af9227a030b24019d05b0d92b45ccd..6430d4457c47481eee6aa7510f58b969913fcde1 100644
--- forkSrcPrefix/packages/block-library/src/image/edit.native.js
+++ forkDstPrefix/packages/block-library/src/image/edit.native.js
@@ -365,6 +365,8 @@ export class ImageEdit extends Component {
 	finishMediaUploadWithSuccess( payload ) {
 		const { setAttributes } = this.props;
 
+		console.log( 'finishMediaUploadWithSuccess', payload );
+
 		setAttributes( { url: payload.mediaUrl, id: payload.mediaServerId } );
 		this.setState( { uploadStatus: UPLOAD_STATE_SUCCEEDED } );
 	}

```
1. Run the iOS demo app (on Android uploads are not working in the demo app).
2. Insert an Image block and upload an image from the device.
3. Once the upload finishes, observe a log entry with the name `finishMediaUploadWithSuccess` and that `metadata` property is shown (e.g. `"metadata": {"demoApp": true}`).

**NOTE:** This PR should be also tested using changes from https://github.com/wordpress-mobile/WordPress-Android/pull/17961 and https://github.com/wordpress-mobile/WordPress-iOS/pull/20144

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A