### PR TITLE
Lodash: Remove some `_.get()` from editor

### DIFF
--- a/packages/editor/src/components/page-attributes/check.js
+++ b/packages/editor/src/components/page-attributes/check.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
@@ -21,14 +16,9 @@ export function PageAttributesCheck( { children } ) {
 
 		return getPostType( getEditedPostAttribute( 'type' ) );
 	}, [] );
-	const supportsPageAttributes = get(
-		postType,
-		[ 'supports', 'page-attributes' ],
-		false
-	);
 
 	// Only render fields if post type supports page attributes or available templates exist.
-	if ( ! supportsPageAttributes ) {
+	if ( ! postType?.supports?.[ 'page-attributes' ] ) {
 		return null;
 	}
 

--- a/packages/editor/src/components/post-author/check.js
+++ b/packages/editor/src/components/post-author/check.js
@@ -16,7 +16,8 @@ export default function PostAuthorCheck( { children } ) {
 		const post = select( editorStore ).getCurrentPost();
 		const authors = select( coreStore ).getUsers( AUTHORS_QUERY );
 		return {
-			hasAssignAuthorAction: post._links?.[ 'wp:action-assign-author' ],
+			hasAssignAuthorAction:
+				post._links?.[ 'wp:action-assign-author' ] ?? false,
 			hasAuthors: authors?.length >= 1,
 		};
 	}, [] );

--- a/packages/editor/src/components/post-author/check.js
+++ b/packages/editor/src/components/post-author/check.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
@@ -21,11 +16,7 @@ export default function PostAuthorCheck( { children } ) {
 		const post = select( editorStore ).getCurrentPost();
 		const authors = select( coreStore ).getUsers( AUTHORS_QUERY );
 		return {
-			hasAssignAuthorAction: get(
-				post,
-				[ '_links', 'wp:action-assign-author' ],
-				false
-			),
+			hasAssignAuthorAction: post._links?.[ 'wp:action-assign-author' ],
 			hasAuthors: authors?.length >= 1,
 		};
 	}, [] );

--- a/packages/editor/src/components/post-pending-status/check.js
+++ b/packages/editor/src/components/post-pending-status/check.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { compose } from '@wordpress/compose';
@@ -31,11 +26,7 @@ export default compose(
 		const { isCurrentPostPublished, getCurrentPostType, getCurrentPost } =
 			select( editorStore );
 		return {
-			hasPublishAction: get(
-				getCurrentPost(),
-				[ '_links', 'wp:action-publish' ],
-				false
-			),
+			hasPublishAction: getCurrentPost()._links?.[ 'wp:action-publish' ],
 			isPublished: isCurrentPostPublished(),
 			postType: getCurrentPostType(),
 		};

--- a/packages/editor/src/components/post-pending-status/check.js
+++ b/packages/editor/src/components/post-pending-status/check.js
@@ -26,7 +26,8 @@ export default compose(
 		const { isCurrentPostPublished, getCurrentPostType, getCurrentPost } =
 			select( editorStore );
 		return {
-			hasPublishAction: getCurrentPost()._links?.[ 'wp:action-publish' ],
+			hasPublishAction:
+				getCurrentPost()._links?.[ 'wp:action-publish' ] ?? false,
 			isPublished: isCurrentPostPublished(),
 			postType: getCurrentPostType(),
 		};

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -242,11 +241,7 @@ export default compose( [
 			isPostSavingLocked: isPostSavingLocked(),
 			isPublishable: isEditedPostPublishable(),
 			isPublished: isCurrentPostPublished(),
-			hasPublishAction: get(
-				getCurrentPost(),
-				[ '_links', 'wp:action-publish' ],
-				false
-			),
+			hasPublishAction: getCurrentPost()._links?.[ 'wp:action-publish' ],
 			postType: getCurrentPostType(),
 			postId: getCurrentPostId(),
 			hasNonPostEntityChanges: hasNonPostEntityChanges(),

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -241,7 +241,8 @@ export default compose( [
 			isPostSavingLocked: isPostSavingLocked(),
 			isPublishable: isEditedPostPublishable(),
 			isPublished: isCurrentPostPublished(),
-			hasPublishAction: getCurrentPost()._links?.[ 'wp:action-publish' ],
+			hasPublishAction:
+				getCurrentPost()._links?.[ 'wp:action-publish' ] ?? false,
 			postType: getCurrentPostType(),
 			postId: getCurrentPostId(),
 			hasNonPostEntityChanges: hasNonPostEntityChanges(),

--- a/packages/editor/src/components/post-publish-button/label.js
+++ b/packages/editor/src/components/post-publish-button/label.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -64,11 +59,7 @@ export default compose( [
 			isBeingScheduled: isEditedPostBeingScheduled(),
 			isSaving: forceIsSaving || isSavingPost(),
 			isPublishing: isPublishingPost(),
-			hasPublishAction: get(
-				getCurrentPost(),
-				[ '_links', 'wp:action-publish' ],
-				false
-			),
+			hasPublishAction: getCurrentPost()._links?.[ 'wp:action-publish' ],
 			postType: getCurrentPostType(),
 			isAutosaving: isAutosavingPost(),
 		};

--- a/packages/editor/src/components/post-publish-button/label.js
+++ b/packages/editor/src/components/post-publish-button/label.js
@@ -59,7 +59,8 @@ export default compose( [
 			isBeingScheduled: isEditedPostBeingScheduled(),
 			isSaving: forceIsSaving || isSavingPost(),
 			isPublishing: isPublishingPost(),
-			hasPublishAction: getCurrentPost()._links?.[ 'wp:action-publish' ],
+			hasPublishAction:
+				getCurrentPost()._links?.[ 'wp:action-publish' ] ?? false,
 			postType: getCurrentPostType(),
 			isAutosaving: isAutosavingPost(),
 		};

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -153,12 +148,8 @@ export default compose( [
 		const postType = getPostType( getEditedPostAttribute( 'type' ) );
 
 		return {
-			hasPublishAction: get(
-				getCurrentPost(),
-				[ '_links', 'wp:action-publish' ],
-				false
-			),
-			isPostTypeViewable: get( postType, [ 'viewable' ], false ),
+			hasPublishAction: getCurrentPost()._links?.[ 'wp:action-publish' ],
+			isPostTypeViewable: postType?.viewable,
 			isBeingScheduled: isEditedPostBeingScheduled(),
 			isDirty: isEditedPostDirty(),
 			isPublished: isCurrentPostPublished(),

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -148,7 +148,8 @@ export default compose( [
 		const postType = getPostType( getEditedPostAttribute( 'type' ) );
 
 		return {
-			hasPublishAction: getCurrentPost()._links?.[ 'wp:action-publish' ],
+			hasPublishAction:
+				getCurrentPost()._links?.[ 'wp:action-publish' ] ?? false,
 			isPostTypeViewable: postType?.viewable,
 			isBeingScheduled: isEditedPostBeingScheduled(),
 			isDirty: isEditedPostDirty(),

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -37,7 +37,8 @@ function PostPublishPanelPrepublish( { children } ) {
 			getEntityRecord( 'root', '__unstableBase', undefined ) || {};
 
 		return {
-			hasPublishAction: getCurrentPost()._links?.[ 'wp:action-publish' ],
+			hasPublishAction:
+				getCurrentPost()._links?.[ 'wp:action-publish' ] ?? false,
 			isBeingScheduled: isEditedPostBeingScheduled(),
 			isRequestingSiteIcon: isResolving( 'getEntityRecord', [
 				'root',

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -42,11 +37,7 @@ function PostPublishPanelPrepublish( { children } ) {
 			getEntityRecord( 'root', '__unstableBase', undefined ) || {};
 
 		return {
-			hasPublishAction: get(
-				getCurrentPost(),
-				[ '_links', 'wp:action-publish' ],
-				false
-			),
+			hasPublishAction: getCurrentPost()._links?.[ 'wp:action-publish' ],
 			isBeingScheduled: isEditedPostBeingScheduled(),
 			isRequestingSiteIcon: isResolving( 'getEntityRecord', [
 				'root',

--- a/packages/editor/src/components/post-schedule/check.js
+++ b/packages/editor/src/components/post-schedule/check.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { compose } from '@wordpress/compose';
@@ -26,11 +21,7 @@ export default compose( [
 	withSelect( ( select ) => {
 		const { getCurrentPost, getCurrentPostType } = select( editorStore );
 		return {
-			hasPublishAction: get(
-				getCurrentPost(),
-				[ '_links', 'wp:action-publish' ],
-				false
-			),
+			hasPublishAction: getCurrentPost()._links?.[ 'wp:action-publish' ],
 			postType: getCurrentPostType(),
 		};
 	} ),

--- a/packages/editor/src/components/post-schedule/check.js
+++ b/packages/editor/src/components/post-schedule/check.js
@@ -21,7 +21,8 @@ export default compose( [
 	withSelect( ( select ) => {
 		const { getCurrentPost, getCurrentPostType } = select( editorStore );
 		return {
-			hasPublishAction: getCurrentPost()._links?.[ 'wp:action-publish' ],
+			hasPublishAction:
+				getCurrentPost()._links?.[ 'wp:action-publish' ] ?? false,
 			postType: getCurrentPostType(),
 		};
 	} ),

--- a/packages/editor/src/components/post-sticky/check.js
+++ b/packages/editor/src/components/post-sticky/check.js
@@ -21,7 +21,7 @@ export default compose( [
 	withSelect( ( select ) => {
 		const post = select( editorStore ).getCurrentPost();
 		return {
-			hasStickyAction: post._links?.[ 'wp:action-sticky' ],
+			hasStickyAction: post._links?.[ 'wp:action-sticky' ] ?? false,
 			postType: select( editorStore ).getCurrentPostType(),
 		};
 	} ),

--- a/packages/editor/src/components/post-sticky/check.js
+++ b/packages/editor/src/components/post-sticky/check.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { compose } from '@wordpress/compose';
@@ -26,11 +21,7 @@ export default compose( [
 	withSelect( ( select ) => {
 		const post = select( editorStore ).getCurrentPost();
 		return {
-			hasStickyAction: get(
-				post,
-				[ '_links', 'wp:action-sticky' ],
-				false
-			),
+			hasStickyAction: post._links?.[ 'wp:action-sticky' ],
 			postType: select( editorStore ).getCurrentPostType(),
 		};
 	} ),

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -105,10 +105,14 @@ export function FlatTermSelector( { slug } ) {
 
 			return {
 				hasCreateAction: _taxonomy
-					? post._links?.[ 'wp:action-create-' + _taxonomy.rest_base ]
+					? post._links?.[
+							'wp:action-create-' + _taxonomy.rest_base
+					  ] ?? false
 					: false,
 				hasAssignAction: _taxonomy
-					? post._links?.[ 'wp:action-assign-' + _taxonomy.rest_base ]
+					? post._links?.[
+							'wp:action-assign-' + _taxonomy.rest_base
+					  ] ?? false
 					: false,
 				taxonomy: _taxonomy,
 				termIds: _termIds,

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
 import escapeHtml from 'escape-html';
 
 /**
@@ -106,24 +105,10 @@ export function FlatTermSelector( { slug } ) {
 
 			return {
 				hasCreateAction: _taxonomy
-					? get(
-							post,
-							[
-								'_links',
-								'wp:action-create-' + _taxonomy.rest_base,
-							],
-							false
-					  )
+					? post._links?.[ 'wp:action-create-' + _taxonomy.rest_base ]
 					: false,
 				hasAssignAction: _taxonomy
-					? get(
-							post,
-							[
-								'_links',
-								'wp:action-assign-' + _taxonomy.rest_base,
-							],
-							false
-					  )
+					? post._links?.[ 'wp:action-assign-' + _taxonomy.rest_base ]
 					: false,
 				taxonomy: _taxonomy,
 				termIds: _termIds,
@@ -239,30 +224,23 @@ export function FlatTermSelector( { slug } ) {
 		}
 
 		const newTermIds = [ ...termIds, newTerm.id ];
+		const defaultName = slug === 'post_tag' ? __( 'Tag' ) : __( 'Term' );
 		const termAddedMessage = sprintf(
 			/* translators: %s: term name. */
 			_x( '%s added', 'term' ),
-			get(
-				taxonomy,
-				[ 'labels', 'singular_name' ],
-				slug === 'post_tag' ? __( 'Tag' ) : __( 'Term' )
-			)
+			taxonomy?.labels?.singular_name ?? defaultName
 		);
 
 		speak( termAddedMessage, 'assertive' );
 		onUpdateTerms( newTermIds );
 	}
 
-	const newTermLabel = get(
-		taxonomy,
-		[ 'labels', 'add_new_item' ],
-		slug === 'post_tag' ? __( 'Add new tag' ) : __( 'Add new Term' )
-	);
-	const singularName = get(
-		taxonomy,
-		[ 'labels', 'singular_name' ],
-		slug === 'post_tag' ? __( 'Tag' ) : __( 'Term' )
-	);
+	const newTermLabel =
+		taxonomy?.labels?.add_new_item ??
+		( slug === 'post_tag' ? __( 'Add new tag' ) : __( 'Add new Term' ) );
+	const singularName =
+		taxonomy?.labels?.singular_name ??
+		( slug === 'post_tag' ? __( 'Tag' ) : __( 'Term' ) );
 	const termAddedLabel = sprintf(
 		/* translators: %s: term name. */
 		_x( '%s added', 'term' ),

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __, _n, _x, sprintf } from '@wordpress/i18n';
@@ -180,27 +175,14 @@ export function HierarchicalTermSelector( { slug } ) {
 			const { getTaxonomy, getEntityRecords, isResolving } =
 				select( coreStore );
 			const _taxonomy = getTaxonomy( slug );
+			const post = getCurrentPost();
 
 			return {
 				hasCreateAction: _taxonomy
-					? get(
-							getCurrentPost(),
-							[
-								'_links',
-								'wp:action-create-' + _taxonomy.rest_base,
-							],
-							false
-					  )
+					? post._links?.[ 'wp:action-create-' + _taxonomy.rest_base ]
 					: false,
 				hasAssignAction: _taxonomy
-					? get(
-							getCurrentPost(),
-							[
-								'_links',
-								'wp:action-assign-' + _taxonomy.rest_base,
-							],
-							false
-					  )
+					? post._links?.[ 'wp:action-assign-' + _taxonomy.rest_base ]
 					: false,
 				terms: _taxonomy
 					? getEditedPostAttribute( _taxonomy.rest_base )
@@ -308,14 +290,12 @@ export function HierarchicalTermSelector( { slug } ) {
 			parent: formParent ? formParent : undefined,
 		} );
 
+		const defaultName =
+			slug === 'category' ? __( 'Category' ) : __( 'Term' );
 		const termAddedMessage = sprintf(
 			/* translators: %s: taxonomy name */
 			_x( '%s added', 'term' ),
-			get(
-				taxonomy,
-				[ 'labels', 'singular_name' ],
-				slug === 'category' ? __( 'Category' ) : __( 'Term' )
-			)
+			taxonomy?.labels?.singular_name ?? defaultName
 		);
 		speak( termAddedMessage, 'assertive' );
 		setAdding( false );
@@ -383,11 +363,9 @@ export function HierarchicalTermSelector( { slug } ) {
 		fallbackIsCategory,
 		fallbackIsNotCategory
 	) =>
-		get(
-			taxonomy,
-			[ 'labels', labelProperty ],
-			slug === 'category' ? fallbackIsCategory : fallbackIsNotCategory
-		);
+		taxonomy?.labels?.[ labelProperty ] ??
+		( slug === 'category' ? fallbackIsCategory : fallbackIsNotCategory );
+
 	const newTermButtonLabel = labelWithFallback(
 		'add_new_item',
 		__( 'Add new category' ),
@@ -405,12 +383,8 @@ export function HierarchicalTermSelector( { slug } ) {
 	);
 	const noParentOption = `— ${ parentSelectLabel } —`;
 	const newTermSubmitLabel = newTermButtonLabel;
-	const filterLabel = get(
-		taxonomy,
-		[ 'labels', 'search_items' ],
-		__( 'Search Terms' )
-	);
-	const groupLabel = get( taxonomy, [ 'name' ], __( 'Terms' ) );
+	const filterLabel = taxonomy?.labels?.search_items ?? __( 'Search Terms' );
+	const groupLabel = taxonomy?.name ?? __( 'Terms' );
 	const showFilter = availableTerms.length >= MIN_TERMS_COUNT_FOR_FILTER;
 
 	return (

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -179,10 +179,14 @@ export function HierarchicalTermSelector( { slug } ) {
 
 			return {
 				hasCreateAction: _taxonomy
-					? post._links?.[ 'wp:action-create-' + _taxonomy.rest_base ]
+					? post._links?.[
+							'wp:action-create-' + _taxonomy.rest_base
+					  ] ?? false
 					: false,
 				hasAssignAction: _taxonomy
-					? post._links?.[ 'wp:action-assign-' + _taxonomy.rest_base ]
+					? post._links?.[
+							'wp:action-assign-' + _taxonomy.rest_base
+					  ] ?? false
 					: false,
 				terms: _taxonomy
 					? getEditedPostAttribute( _taxonomy.rest_base )

--- a/packages/editor/src/components/post-visibility/check.js
+++ b/packages/editor/src/components/post-visibility/check.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { compose } from '@wordpress/compose';
@@ -23,11 +18,7 @@ export default compose( [
 	withSelect( ( select ) => {
 		const { getCurrentPost, getCurrentPostType } = select( editorStore );
 		return {
-			hasPublishAction: get(
-				getCurrentPost(),
-				[ '_links', 'wp:action-publish' ],
-				false
-			),
+			hasPublishAction: getCurrentPost()._links?.[ 'wp:action-publish' ],
 			postType: getCurrentPostType(),
 		};
 	} ),

--- a/packages/editor/src/components/post-visibility/check.js
+++ b/packages/editor/src/components/post-visibility/check.js
@@ -18,7 +18,8 @@ export default compose( [
 	withSelect( ( select ) => {
 		const { getCurrentPost, getCurrentPostType } = select( editorStore );
 		return {
-			hasPublishAction: getCurrentPost()._links?.[ 'wp:action-publish' ],
+			hasPublishAction:
+				getCurrentPost()._links?.[ 'wp:action-publish' ] ?? false,
 			postType: getCurrentPostType(),
 		};
 	} ),


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.get()` from a bunch of `@wordpress/editor` components. Most of the usages affected here are similar and that makes it easier to review as a group.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using direct access with optional chaining and nullish coalescing as an alternative.

## Testing Instructions

* Verify the "Page attributes" box appears in the sidebar when editing a page, but not when editing a post.
* Verify the "Author" setting appears in the sidebar for posts and pages.
* Verify that as an Admin, Editor or Author user, you can publish or schedule posts.
* Verify that as a Contributor user, you can't publish or schedule posts.
* Verify that as an Editor you can set a post to be sticky. 
* Verify that as an Author, you can't set a post to be sticky. 
* Verify that as an Author, you can't create new categories or tags.
* Verify that as an Editor, you can create new categories or tags.
* Verify that as an Admin, Editor or Author user, you can change the visibility of posts.
* Verify that as a Contributor user, you can't change the visibility of posts.
* Verify checks are green - changes are covered by tests.