### PR TITLE
Fix block selection when transforming via replace

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1309,7 +1309,10 @@ function selectionHelper( state = {}, action ) {
 
 			return {};
 		case 'REPLACE_BLOCKS': {
-			if ( action.clientIds.indexOf( state.clientId ) === -1 ) {
+			if (
+				state.clientId &&
+				action.clientIds.indexOf( state.clientId ) === -1
+			) {
 				return state;
 			}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In the Navigation Submenu block we have an effect that transforms the submenu into a link when it's last Navigation Link child is removed. This results in a focus loss, with focus moved to the body of the `iframe` where the editor lives.

This is surprising because transforming via replace happens two steps:
1. remove the last block which triggers the transformation
2. replace the parent with it’s transformation

So in step 2 we have a focus target - the block that replaces the original one.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Focus loss is one of the worst bugs in terms of using the UI via assistive technology.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

When step (1) ends the state of selection is empty! We just removed a block and _we don't have any heuristics in place_ to solve for this. This should be it's own issue - try to remove an image in a group, focus loss.

When step (2) happens the `selectionHelper` reducer in the `block-editor` store wrongly returns the empty selection state from (1),  when instead we should select the block we just added via replacement in the canvas. This patch does not return that, instead it allows the heurstics in the `REPLACE_BLOCKS` branch of `selectionHelper` to continue and select the block we just added via replacement.

## Testing Instructions

1. Add a navigation block
2. Add a link
3. Add a submenu item via the block toolbar add submenu button
4. Add a link
5. Remove the link
6. Check the submenu parent is selected in the canvas
7. In the console check the curent active element is the selected block via
```
const ifrm = document.getElementsByTagName('iframe')[0];
```
and then
```
ifrm.contentWindow.document.activeElement
```
8 Check to not get `<body ...` but the tag of the submenu.
