### PR TITLE
Fonts API: Add missing files to lib/load.php

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -111,8 +111,11 @@ require __DIR__ . '/experimental/kses.php';
 // Fonts API.
 require __DIR__ . '/experimental/fonts-api/class-wp-fonts-provider.php';
 require __DIR__ . '/experimental/fonts-api/deprecations/webfonts-deprecations.php';
+require __DIR__ . '/experimental/fonts-api/deprecations/class-wp-webfonts-utils.php';
 require __DIR__ . '/experimental/fonts-api/deprecations/class-wp-webfonts-provider.php';
+require __DIR__ . '/experimental/fonts-api/deprecations/class-wp-webfonts-provider-local.php';
 require __DIR__ . '/experimental/fonts-api/deprecations/class-wp-webfonts.php';
+require __DIR__ . '/experimental/fonts-api/deprecations/class-wp-web-fonts.php';
 require __DIR__ . '/experimental/fonts-api/class-wp-fonts-utils.php';
 require __DIR__ . '/experimental/fonts-api/register-fonts-from-theme-json.php';
 require __DIR__ . '/experimental/fonts-api/class-wp-fonts.php';

--- a/lib/load.php
+++ b/lib/load.php
@@ -109,18 +109,20 @@ require __DIR__ . '/experimental/navigation-theme-opt-in.php';
 require __DIR__ . '/experimental/kses.php';
 
 // Fonts API.
-require __DIR__ . '/experimental/fonts-api/class-wp-fonts-provider.php';
-require __DIR__ . '/experimental/fonts-api/deprecations/webfonts-deprecations.php';
-require __DIR__ . '/experimental/fonts-api/deprecations/class-wp-webfonts-utils.php';
-require __DIR__ . '/experimental/fonts-api/deprecations/class-wp-webfonts-provider.php';
-require __DIR__ . '/experimental/fonts-api/deprecations/class-wp-webfonts-provider-local.php';
-require __DIR__ . '/experimental/fonts-api/deprecations/class-wp-webfonts.php';
-require __DIR__ . '/experimental/fonts-api/deprecations/class-wp-web-fonts.php';
-require __DIR__ . '/experimental/fonts-api/class-wp-fonts-utils.php';
-require __DIR__ . '/experimental/fonts-api/register-fonts-from-theme-json.php';
-require __DIR__ . '/experimental/fonts-api/class-wp-fonts.php';
-require __DIR__ . '/experimental/fonts-api/class-wp-fonts-provider-local.php';
-require __DIR__ . '/experimental/fonts-api/fonts-api.php';
+if ( ! class_exists( 'WP_Fonts' ) ) {
+	require __DIR__ . '/experimental/fonts-api/class-wp-fonts-provider.php';
+	require __DIR__ . '/experimental/fonts-api/deprecations/webfonts-deprecations.php';
+	require __DIR__ . '/experimental/fonts-api/deprecations/class-wp-webfonts-utils.php';
+	require __DIR__ . '/experimental/fonts-api/deprecations/class-wp-webfonts-provider.php';
+	require __DIR__ . '/experimental/fonts-api/deprecations/class-wp-webfonts-provider-local.php';
+	require __DIR__ . '/experimental/fonts-api/deprecations/class-wp-webfonts.php';
+	require __DIR__ . '/experimental/fonts-api/deprecations/class-wp-web-fonts.php';
+	require __DIR__ . '/experimental/fonts-api/class-wp-fonts-utils.php';
+	require __DIR__ . '/experimental/fonts-api/register-fonts-from-theme-json.php';
+	require __DIR__ . '/experimental/fonts-api/class-wp-fonts.php';
+	require __DIR__ . '/experimental/fonts-api/class-wp-fonts-provider-local.php';
+	require __DIR__ . '/experimental/fonts-api/fonts-api.php';
+}
 
 // Plugin specific code.
 require __DIR__ . '/class-wp-theme-json-gutenberg.php';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Closed #48107.

## What?
Load all of the deprecated files into memory.

## Why?
To avoid fatal errors for sites that are actively using the non-deprecated architecture, i.e. before the API was renamed and redesigned.

## How?
Add each file in `lib/experimental/fonts-api/deprecations/` to the `lib/load.php` file.

## Testing Instructions

* Step 1: Activate the Twenty Twenty-Three theme.
* Step 2: Activate the Gutenberg plugin.
* Step 3: Upload this plugin file and then activate it.
[fonts-api-bc-tester.zip](https://github.com/WordPress/gutenberg/files/10747363/fonts-api-bc-tester.zip)

* Step 4: Reset the global styles to the default by:
   - Go to the Site Editor > Global Styles "Styles Beta" UI
   - Click on the 3 vertical dots
   - Select "Reset to defaults"
   - Click on the "Save" button

* Step 5: Select a Playflair Display font for the headings.  In the Google Styles UI
   * Select `Typography`.
   * Select `Headings`.
   * In `FONT` select `Playflair Display` (a Google Font).
   * In `APPEARANCE`, select `Bold Italic`. (Notice the heading should change)
   * Click on the "Save" button.
  
* Step 6: Examine the dynamically generated `@font-face` stylings in the admin area by:
   - Open Dev Tools in your favorite browser
   - Search for `wp-fonts-fonts-tester` (which is in the `<head>`)
   - Expand the `<style>` element to inspect the CSS
   - The CSS should be:
```html
<style id="wp-fonts-fonts-tester">
@font-face{font-family:"Playfair Display";font-style:normal;font-weight:100 900;font-display:fallback;src:local("Playfair Display"), url('/wp-content/plugins/fonts-api-bc-tester/fonts/PlayfairDisplay-VariableFont_wght.ttf') format('truetype');}@font-face{font-family:"Playfair Display";font-style:italic;font-weight:100 900;font-display:fallback;src:local("Playfair Display"), url('/wp-content/plugins/fonts-api-bc-tester/fonts/PlayfairDisplay-Italic-VariableFont_wght.ttf') format('truetype');}
</style>
```

* Step 7: Examine the front-end by:
   - Go to the front-end of the website
   - Open Dev Tools in your favorite browser
   - Search for `wp-fonts-fonts-tester` 
   - Expand the `<style>` element to inspect the CSS
   - The CSS should be the same as above.
  