### PR TITLE
Global Styles: Add ContrastChecker to the Background, Text, Links, and Colors screens

### DIFF
--- a/packages/block-editor/src/components/contrast-checker/index.js
+++ b/packages/block-editor/src/components/contrast-checker/index.js
@@ -43,14 +43,14 @@ function getContrastMessage( backgroundIsDarker, suggestions, colorItem ) {
 			? sprintf(
 					// translators: %s is a type of text color, e.g., "text color" or "link color".
 					__(
-						'This color combination may be hard for people to read. Try using a darker %s.'
+						'This color combination may be hard for people to read. Try using a brighter %s.'
 					),
 					colorItem.description
 			  )
 			: sprintf(
 					// translators: %s is a type of text color, e.g., "text color" or "link color".
 					__(
-						'This color combination may be hard for people to read. Try using a brighter %s.'
+						'This color combination may be hard for people to read. Try using a darker %s.'
 					),
 					colorItem.description
 			  );

--- a/packages/edit-site/src/components/global-styles/color-utils.js
+++ b/packages/edit-site/src/components/global-styles/color-utils.js
@@ -1,7 +1,15 @@
 /**
+ * WordPress dependencies
+ */
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+
+/**
  * Internal dependencies
  */
 import { useSupportedStyles } from './hooks';
+import { unlock } from '../../private-apis';
+
+const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 export function useHasColorPanel( name ) {
 	const supports = useSupportedStyles( name );
@@ -11,4 +19,30 @@ export function useHasColorPanel( name ) {
 		supports.includes( 'background' ) ||
 		supports.includes( 'linkColor' )
 	);
+}
+
+/**
+ * Gets color values for use in the `ContrastChecker` component.
+ *
+ * @param {string} name      The block name, or undefined for the root.
+ * @param {string} variation The variation name, or empty string when no variation is in use.
+ * @return {Object} The colors to use in the contrast checker.
+ */
+export function useContrastCheckerColors( name, variation = '' ) {
+	const prefix = variation ? `variations.${ variation }.` : '';
+	const [ backgroundColor ] = useGlobalStyle(
+		prefix + 'color.background',
+		name
+	);
+	const [ textColor ] = useGlobalStyle( prefix + 'color.text', name );
+	const [ linkColor ] = useGlobalStyle(
+		prefix + 'elements.link.color.text',
+		name
+	);
+
+	return {
+		textColor,
+		backgroundColor,
+		linkColor,
+	};
 }

--- a/packages/edit-site/src/components/global-styles/screen-background-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-background-color.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import {
 	__experimentalColorGradientControl as ColorGradientControl,
+	ContrastChecker,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 
@@ -21,6 +22,7 @@ import {
 	useColorsPerOrigin,
 	useGradientsPerOrigin,
 } from './hooks';
+import { useContrastCheckerColors } from './color-utils';
 import { unlock } from '../../private-apis';
 
 const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorPrivateApis );
@@ -65,6 +67,11 @@ function ScreenBackgroundColor( { name, variation = '' } ) {
 		prefix + 'color.gradient',
 		name,
 		'user'
+	);
+
+	const { textColor, linkColor } = useContrastCheckerColors(
+		name,
+		variation
 	);
 
 	if ( ! hasBackgroundColor && ! hasGradientColor ) {
@@ -125,6 +132,13 @@ function ScreenBackgroundColor( { name, variation = '' } ) {
 				headingLevel={ 3 }
 				{ ...controlProps }
 			/>
+			{ name === undefined && (
+				<ContrastChecker
+					backgroundColor={ backgroundColor }
+					textColor={ textColor }
+					linkColor={ linkColor }
+				/>
+			) }
 		</>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/screen-background-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-background-color.js
@@ -137,6 +137,11 @@ function ScreenBackgroundColor( { name, variation = '' } ) {
 					backgroundColor={ backgroundColor }
 					textColor={ textColor }
 					linkColor={ linkColor }
+					suggestions={ {
+						backgroundColor: true,
+						textColor: false,
+						linkColor: false,
+					} }
 				/>
 			) }
 		</>

--- a/packages/edit-site/src/components/global-styles/screen-colors.js
+++ b/packages/edit-site/src/components/global-styles/screen-colors.js
@@ -10,10 +10,7 @@ import {
 	FlexItem,
 	ColorIndicator,
 } from '@wordpress/components';
-import {
-	ContrastChecker,
-	privateApis as blockEditorPrivateApis,
-} from '@wordpress/block-editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -26,7 +23,6 @@ import Subtitle from './subtitle';
 import ColorIndicatorWrapper from './color-indicator-wrapper';
 import BlockPreviewPanel from './block-preview-panel';
 import { getVariationClassName } from './utils';
-import { useContrastCheckerColors } from './color-utils';
 import { unlock } from '../../private-apis';
 
 const { useGlobalStyle } = unlock( blockEditorPrivateApis );
@@ -221,11 +217,6 @@ function ScreenColors( { name, variation = '' } ) {
 		name === undefined ? '' : '/blocks/' + encodeURIComponent( name );
 	const variationClassName = getVariationClassName( variation );
 
-	const { backgroundColor, textColor, linkColor } = useContrastCheckerColors(
-		name,
-		variation
-	);
-
 	return (
 		<>
 			<ScreenHeader
@@ -273,13 +264,6 @@ function ScreenColors( { name, variation = '' } ) {
 					</VStack>
 				</VStack>
 			</div>
-			{ name === undefined && (
-				<ContrastChecker
-					backgroundColor={ backgroundColor }
-					textColor={ textColor }
-					linkColor={ linkColor }
-				/>
-			) }
 		</>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/screen-colors.js
+++ b/packages/edit-site/src/components/global-styles/screen-colors.js
@@ -10,7 +10,10 @@ import {
 	FlexItem,
 	ColorIndicator,
 } from '@wordpress/components';
-import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import {
+	ContrastChecker,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -23,6 +26,7 @@ import Subtitle from './subtitle';
 import ColorIndicatorWrapper from './color-indicator-wrapper';
 import BlockPreviewPanel from './block-preview-panel';
 import { getVariationClassName } from './utils';
+import { useContrastCheckerColors } from './color-utils';
 import { unlock } from '../../private-apis';
 
 const { useGlobalStyle } = unlock( blockEditorPrivateApis );
@@ -217,6 +221,11 @@ function ScreenColors( { name, variation = '' } ) {
 		name === undefined ? '' : '/blocks/' + encodeURIComponent( name );
 	const variationClassName = getVariationClassName( variation );
 
+	const { backgroundColor, textColor, linkColor } = useContrastCheckerColors(
+		name,
+		variation
+	);
+
 	return (
 		<>
 			<ScreenHeader
@@ -264,6 +273,13 @@ function ScreenColors( { name, variation = '' } ) {
 					</VStack>
 				</VStack>
 			</div>
+			{ name === undefined && (
+				<ContrastChecker
+					backgroundColor={ backgroundColor }
+					textColor={ textColor }
+					linkColor={ linkColor }
+				/>
+			) }
 		</>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/screen-link-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-link-color.js
@@ -129,6 +129,11 @@ function ScreenLinkColor( { name, variation = '' } ) {
 					backgroundColor={ backgroundColor }
 					textColor={ textColor }
 					linkColor={ linkColor }
+					suggestions={ {
+						backgroundColor: false,
+						textColor: false,
+						linkColor: true,
+					} }
 				/>
 			) }
 		</>

--- a/packages/edit-site/src/components/global-styles/screen-link-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-link-color.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import {
+	ContrastChecker,
 	__experimentalColorGradientControl as ColorGradientControl,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
@@ -13,6 +14,7 @@ import { TabPanel } from '@wordpress/components';
  */
 import ScreenHeader from './header';
 import { useSupportedStyles, useColorsPerOrigin } from './hooks';
+import { useContrastCheckerColors } from './color-utils';
 import { unlock } from '../../private-apis';
 
 const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorPrivateApis );
@@ -63,6 +65,11 @@ function ScreenLinkColor( { name, variation = '' } ) {
 			)[ 0 ],
 		},
 	};
+
+	const { backgroundColor, linkColor, textColor } = useContrastCheckerColors(
+		name,
+		variation
+	);
 
 	if ( ! hasLinkColor ) {
 		return null;
@@ -117,6 +124,13 @@ function ScreenLinkColor( { name, variation = '' } ) {
 					);
 				} }
 			</TabPanel>
+			{ name === undefined && (
+				<ContrastChecker
+					backgroundColor={ backgroundColor }
+					textColor={ textColor }
+					linkColor={ linkColor }
+				/>
+			) }
 		</>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/screen-text-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-text-color.js
@@ -67,6 +67,11 @@ function ScreenTextColor( { name, variation = '' } ) {
 					backgroundColor={ backgroundColor }
 					textColor={ color }
 					linkColor={ linkColor }
+					suggestions={ {
+						backgroundColor: false,
+						textColor: true,
+						linkColor: false,
+					} }
 				/>
 			) }
 		</>

--- a/packages/edit-site/src/components/global-styles/screen-text-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-text-color.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import {
+	ContrastChecker,
 	__experimentalColorGradientControl as ColorGradientControl,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
@@ -12,6 +13,7 @@ import {
  */
 import ScreenHeader from './header';
 import { useSupportedStyles, useColorsPerOrigin } from './hooks';
+import { useContrastCheckerColors } from './color-utils';
 import { unlock } from '../../private-apis';
 
 const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorPrivateApis );
@@ -30,6 +32,11 @@ function ScreenTextColor( { name, variation = '' } ) {
 
 	const [ color, setColor ] = useGlobalStyle( prefix + 'color.text', name );
 	const [ userColor ] = useGlobalStyle( prefix + 'color.text', name, 'user' );
+
+	const { backgroundColor, linkColor } = useContrastCheckerColors(
+		name,
+		variation
+	);
 
 	if ( ! hasTextColor ) {
 		return null;
@@ -55,6 +62,13 @@ function ScreenTextColor( { name, variation = '' } ) {
 				clearable={ color === userColor }
 				headingLevel={ 3 }
 			/>
+			{ name === undefined && (
+				<ContrastChecker
+					backgroundColor={ backgroundColor }
+					textColor={ color }
+					linkColor={ linkColor }
+				/>
+			) }
 		</>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -201,6 +201,15 @@
 .edit-site-global-styles-sidebar__navigator-screen {
 	display: flex;
 	flex-direction: column;
+
+	// Ensure color contrast checker has consistent spacing across navigation screens.
+	.block-editor-contrast-checker {
+		margin-left: $grid-unit-20;
+		margin-right: $grid-unit-20;
+		.components-notice__content {
+			margin-right: 0;
+		}
+	}
 }
 
 .edit-site-global-styles__shadow-panel {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of addressing #48055

This PR introduces the `ContrastChecker` component to the Colors, Background color, Text color, and Links color screens in global styles — but only for the root global styles (e.g. not global styles set at the block level). This is for simplicity sake for now, as I imagine it could be tricky to reliably do contrast checking at the block level where we might not absolutely know what colors are being displayed in that context.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As reported in #48055, while there is currently a contrast warning when adjusting colors for an individual block in the post editor, when adjusting global styles and previewing how it looks across a site (particularly while using the Style Book), there currently isn't that kind of feedback.

The proposal here is to add it in for some places where it will hopefully be useful, and where it can be added (fairly) reliable. In this case, that's at the root level of global styles, for the colors, background color, link colors, and text colors screens.

Note: Heading and Buttons are not included yet — it could be interesting to look at seeing if we can have the `ContrastChecker` component accept arbitrary other color values / labels to use in a follow-up PR.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add a `useContrastCheckerColors` hook to the `color-utils.js` file in global styles, to group together common logic for retrieving the global styles values for background color, text color, and link color.
* In the parent Colors screen, the Text color screen, the Background color screen, and the Link colors screen, display the ContrastChecker component if the screen is viewing the respective root global styles values. Note: for the Link colors screen, it only uses the default link color and not the hover color for the contrast checker values.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open global styles and go to the Colors screen and adjust the root global styles colors for background color so that it is fairly close to the Text color. You should see the contrast warning.
2. Adjust the text color so that there is high contrast, and the warning should disappear.
3. Adjust the link color so that there is low contrast between link and background color. The warning should appear again.
4. Contrast warnings should not appear if you adjust block-level color values in global styles.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

| Colors screen | Background color screen | Text color screen | Link color screen |
| --- | --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/219274123-039151e2-9f40-4384-9686-8c15a6ceb181.png) | ![image](https://user-images.githubusercontent.com/14988353/219274219-378796ba-69b0-4116-833e-b7e34b098f7f.png) | ![image](https://user-images.githubusercontent.com/14988353/219274287-6fdd3421-8fb1-44b7-b11c-b95972f868c1.png) | ![image](https://user-images.githubusercontent.com/14988353/219274512-51d8cb13-c078-4c91-854e-a66cb8c8b5f8.png) |

## Screengrab

The below screengrab demonstrates the visibility of the contrast checker while the Style Book is open. The hope is that for users playing around with their site-wide color settings, that the introduced contrast checker will provide a useful warning.

https://user-images.githubusercontent.com/14988353/219275092-fd7bca57-5bb2-4fa6-a126-84b0ecd37a72.mp4