### PR TITLE
Prevent text decoration from showing up in all blocks

### DIFF
--- a/packages/block-editor/src/components/global-styles/hooks.js
+++ b/packages/block-editor/src/components/global-styles/hooks.js
@@ -252,6 +252,7 @@ export function overrideSettingsWithSupports( settings, supports ) {
 		'fontWeight',
 		'letterSpacing',
 		'textTransform',
+		'textDecoration',
 	].forEach( ( key ) => {
 		if ( ! supports.includes( key ) ) {
 			updatedSettings.typography = {


### PR DESCRIPTION
closes #48111

## What?
In a small refactoring done in #47908 I've made a small mistake where I forgot to handle the textDecoration block support flag which caused the panel to appear for all blocks. This PR fixes it.

## Testing Instructions

1- Select a template part block
2- The text decoration control shouldn't show up in the sidebar.

