### PR TITLE
[Editor]: Select blocks in `outline` list

### DIFF
--- a/packages/editor/src/components/document-outline/index.js
+++ b/packages/editor/src/components/document-outline/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
-import { withSelect } from '@wordpress/data';
+import { withSelect, useDispatch } from '@wordpress/data';
 import { create, getTextContent } from '@wordpress/rich-text';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
@@ -68,7 +68,7 @@ export const DocumentOutline = ( {
 	hasOutlineItemsDisabled,
 } ) => {
 	const headings = computeOutlineHeadings( blocks );
-
+	const { selectBlock } = useDispatch( blockEditorStore );
 	if ( headings.length < 1 ) {
 		return null;
 	}
@@ -121,7 +121,10 @@ export const DocumentOutline = ( {
 							isValid={ isValid }
 							isDisabled={ hasOutlineItemsDisabled }
 							href={ `#block-${ item.clientId }` }
-							onSelect={ onSelect }
+							onSelect={ () => {
+								selectBlock( item.clientId );
+								onSelect?.();
+							} }
 						>
 							{ item.isEmpty
 								? emptyHeadingContent


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/47624

The heading links in the post outline no longer work. This is a problem when the post editor is iframed. This PR fixes that by also selecting the block.

The main issue has a few things to resolve regarding the Post Title. Right now it's not shown for iframed editor and the link is not working in non iframed editor.


## Testing Instructions
1. In iframed post editor(that means using a block theme without any metaboxes present) open the outline view
2. Observe that the blocks are selected and shown in the editor

#### Before

https://user-images.githubusercontent.com/16275880/219312485-7a8937e9-de64-4206-b42a-b5477c113881.mp4




#### After

https://user-images.githubusercontent.com/16275880/219312591-f17a52ed-69a2-45cf-a4db-360ede696c13.mp4

