### PR TITLE
Lodash: Remove `_.get()` for post type usages

### DIFF
--- a/packages/edit-post/src/components/device-preview/index.js
+++ b/packages/edit-post/src/components/device-preview/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { Icon, MenuGroup } from '@wordpress/components';
@@ -35,7 +30,7 @@ export default function DevicePreview() {
 			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
 			isSaving: select( editPostStore ).isSavingMetaBoxes(),
 			isPostSaveable: select( editorStore ).isEditedPostSaveable(),
-			isViewable: get( postType, [ 'viewable' ], false ),
+			isViewable: postType?.viewable,
 			deviceType:
 				select( editPostStore ).__experimentalGetPreviewDeviceType(),
 		};

--- a/packages/edit-post/src/components/device-preview/index.js
+++ b/packages/edit-post/src/components/device-preview/index.js
@@ -30,7 +30,7 @@ export default function DevicePreview() {
 			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
 			isSaving: select( editPostStore ).isSavingMetaBoxes(),
 			isPostSaveable: select( editorStore ).isEditedPostSaveable(),
-			isViewable: postType?.viewable,
+			isViewable: postType?.viewable ?? false,
 			deviceType:
 				select( editPostStore ).__experimentalGetPreviewDeviceType(),
 		};

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -99,11 +98,7 @@ function FullscreenModeClose( { showTooltip, icon, href } ) {
 						post_type: postType.slug,
 					} )
 				}
-				label={ get(
-					postType,
-					[ 'labels', 'view_items' ],
-					__( 'Back' )
-				) }
+				label={ postType?.labels?.view_items ?? __( 'Back' ) }
 				showTooltip={ showTooltip }
 			>
 				{ buttonIcon }

--- a/packages/edit-post/src/components/sidebar/featured-image/index.js
+++ b/packages/edit-post/src/components/sidebar/featured-image/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -35,11 +30,9 @@ function FeaturedImage( { isEnabled, isOpened, postType, onTogglePanel } ) {
 	return (
 		<PostFeaturedImageCheck>
 			<PanelBody
-				title={ get(
-					postType,
-					[ 'labels', 'featured_image' ],
-					__( 'Featured image' )
-				) }
+				title={
+					postType?.labels?.featured_image ?? __( 'Featured image' )
+				}
 				opened={ isOpened }
 				onToggle={ onTogglePanel }
 			>

--- a/packages/edit-post/src/components/sidebar/page-attributes/index.js
+++ b/packages/edit-post/src/components/sidebar/page-attributes/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -52,11 +47,9 @@ export function PageAttributes() {
 	return (
 		<PageAttributesCheck>
 			<PanelBody
-				title={ get(
-					postType,
-					[ 'labels', 'attributes' ],
-					__( 'Page attributes' )
-				) }
+				title={
+					postType?.labels?.attributes ?? __( 'Page attributes' )
+				}
 				opened={ isOpened }
 				onToggle={ onTogglePanel }
 			>

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -70,7 +70,7 @@ export function PageAttributesParent() {
 				}
 
 				return {
-					postIsHierarchical,
+					isHierarchical: postIsHierarchical,
 					parentPostId: pageId,
 					parentPost: pageId
 						? getEntityRecord( 'postType', postTypeSlug, pageId )

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -43,46 +43,47 @@ export const getItemPriority = ( name, searchValue ) => {
 export function PageAttributesParent() {
 	const { editPost } = useDispatch( editorStore );
 	const [ fieldValue, setFieldValue ] = useState( false );
-	const { parentPost, parentPostId, items, postType } = useSelect(
-		( select ) => {
-			const { getPostType, getEntityRecords, getEntityRecord } =
-				select( coreStore );
-			const { getCurrentPostId, getEditedPostAttribute } =
-				select( editorStore );
-			const postTypeSlug = getEditedPostAttribute( 'type' );
-			const pageId = getEditedPostAttribute( 'parent' );
-			const pType = getPostType( postTypeSlug );
-			const postId = getCurrentPostId();
-			const isHierarchical = pType?.hierarchical;
-			const query = {
-				per_page: 100,
-				exclude: postId,
-				parent_exclude: postId,
-				orderby: 'menu_order',
-				order: 'asc',
-				_fields: 'id,title,parent',
-			};
+	const { isHierarchical, parentPost, parentPostId, items, postType } =
+		useSelect(
+			( select ) => {
+				const { getPostType, getEntityRecords, getEntityRecord } =
+					select( coreStore );
+				const { getCurrentPostId, getEditedPostAttribute } =
+					select( editorStore );
+				const postTypeSlug = getEditedPostAttribute( 'type' );
+				const pageId = getEditedPostAttribute( 'parent' );
+				const pType = getPostType( postTypeSlug );
+				const postId = getCurrentPostId();
+				const postIsHierarchical = pType?.hierarchical ?? false;
+				const query = {
+					per_page: 100,
+					exclude: postId,
+					parent_exclude: postId,
+					orderby: 'menu_order',
+					order: 'asc',
+					_fields: 'id,title,parent',
+				};
 
-			// Perform a search when the field is changed.
-			if ( !! fieldValue ) {
-				query.search = fieldValue;
-			}
+				// Perform a search when the field is changed.
+				if ( !! fieldValue ) {
+					query.search = fieldValue;
+				}
 
-			return {
-				parentPostId: pageId,
-				parentPost: pageId
-					? getEntityRecord( 'postType', postTypeSlug, pageId )
-					: null,
-				items: isHierarchical
-					? getEntityRecords( 'postType', postTypeSlug, query )
-					: [],
-				postType: pType,
-			};
-		},
-		[ fieldValue ]
-	);
+				return {
+					postIsHierarchical,
+					parentPostId: pageId,
+					parentPost: pageId
+						? getEntityRecord( 'postType', postTypeSlug, pageId )
+						: null,
+					items: postIsHierarchical
+						? getEntityRecords( 'postType', postTypeSlug, query )
+						: [],
+					postType: pType,
+				};
+			},
+			[ fieldValue ]
+		);
 
-	const isHierarchical = postType?.hierarchical;
 	const parentPageLabel = postType?.labels?.parent_item_colon;
 	const pageItems = items || [];
 

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
 import removeAccents from 'remove-accents';
 
 /**
@@ -54,7 +53,7 @@ export function PageAttributesParent() {
 			const pageId = getEditedPostAttribute( 'parent' );
 			const pType = getPostType( postTypeSlug );
 			const postId = getCurrentPostId();
-			const isHierarchical = get( pType, [ 'hierarchical' ], false );
+			const isHierarchical = pType?.hierarchical;
 			const query = {
 				per_page: 100,
 				exclude: postId,
@@ -83,8 +82,8 @@ export function PageAttributesParent() {
 		[ fieldValue ]
 	);
 
-	const isHierarchical = get( postType, [ 'hierarchical' ], false );
-	const parentPageLabel = get( postType, [ 'labels', 'parent_item_colon' ] );
+	const isHierarchical = postType?.hierarchical;
+	const parentPageLabel = postType?.labels?.parent_item_colon;
 	const pageItems = items || [];
 
 	const parentOptions = useMemo( () => {

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -100,7 +100,6 @@ function PostFeaturedImage( {
 	const mediaUpload = useSelect( ( select ) => {
 		return select( blockEditorStore ).getSettings().mediaUpload;
 	}, [] );
-	const postLabel = postType?.labels ?? {};
 	const { mediaWidth, mediaHeight, mediaSourceUrl } = getMediaDetails(
 		media,
 		currentPostId
@@ -154,7 +153,7 @@ function PostFeaturedImage( {
 				<MediaUploadCheck fallback={ instructions }>
 					<MediaUpload
 						title={
-							postLabel.featured_image ||
+							postType?.labels?.featured_image ||
 							DEFAULT_FEATURE_IMAGE_LABEL
 						}
 						onSelect={ onUpdateImage }
@@ -196,7 +195,8 @@ function PostFeaturedImage( {
 									{ isLoading && <Spinner /> }
 									{ ! featuredImageId &&
 										! isLoading &&
-										( postLabel.set_featured_image ||
+										( postType?.labels
+											?.set_featured_image ||
 											DEFAULT_SET_FEATURE_IMAGE_LABEL ) }
 								</Button>
 								<DropZone onFilesDrop={ onDropFiles } />
@@ -210,7 +210,7 @@ function PostFeaturedImage( {
 						{ media && (
 							<MediaUpload
 								title={
-									postLabel.featured_image ||
+									postType?.labels?.featured_image ||
 									DEFAULT_FEATURE_IMAGE_LABEL
 								}
 								onSelect={ onUpdateImage }
@@ -232,7 +232,7 @@ function PostFeaturedImage( {
 							variant="link"
 							isDestructive
 						>
-							{ postLabel.remove_featured_image ||
+							{ postType?.labels?.remove_featured_image ||
 								DEFAULT_REMOVE_FEATURE_IMAGE_LABEL }
 						</Button>
 					</MediaUploadCheck>

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
@@ -105,7 +100,7 @@ function PostFeaturedImage( {
 	const mediaUpload = useSelect( ( select ) => {
 		return select( blockEditorStore ).getSettings().mediaUpload;
 	}, [] );
-	const postLabel = get( postType, [ 'labels' ], {} );
+	const postLabel = postType?.labels ?? {};
 	const { mediaWidth, mediaHeight, mediaSourceUrl } = getMediaDetails(
 		media,
 		currentPostId

--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
@@ -164,7 +159,7 @@ export default function PostLockedModal() {
 		_wpnonce: postLockUtils.nonce,
 	} );
 	const allPostsUrl = addQueryArgs( 'edit.php', {
-		post_type: get( postType, [ 'slug' ] ),
+		post_type: postType?.slug,
 	} );
 	const allPostsLabel = __( 'Exit editor' );
 	return (

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -256,7 +255,7 @@ export default compose( [
 				forcePreviewLink !== undefined ? forcePreviewLink : previewLink,
 			isSaveable: isEditedPostSaveable(),
 			isAutosaveable: forceIsAutosaveable || isEditedPostAutosaveable(),
-			isViewable: get( postType, [ 'viewable' ], false ),
+			isViewable: postType?.viewable,
 			isDraft:
 				[ 'draft', 'auto-draft' ].indexOf(
 					getEditedPostAttribute( 'status' )

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -255,7 +255,7 @@ export default compose( [
 				forcePreviewLink !== undefined ? forcePreviewLink : previewLink,
 			isSaveable: isEditedPostSaveable(),
 			isAutosaveable: forceIsAutosaveable || isEditedPostAutosaveable(),
-			isViewable: postType?.viewable,
+			isViewable: postType?.viewable ?? false,
 			isDraft:
 				[ 'draft', 'auto-draft' ].indexOf(
 					getEditedPostAttribute( 'status' )

--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { PanelBody, Button, TextControl } from '@wordpress/components';
@@ -90,9 +85,9 @@ class PostPublishPanelPostpublish extends Component {
 
 	render() {
 		const { children, isScheduled, post, postType } = this.props;
-		const postLabel = get( postType, [ 'labels', 'singular_name' ] );
-		const viewPostLabel = get( postType, [ 'labels', 'view_item' ] );
-		const addNewPostLabel = get( postType, [ 'labels', 'add_new_item' ] );
+		const postLabel = postType?.labels?.singular_name;
+		const viewPostLabel = postType?.labels?.view_item;
+		const addNewPostLabel = postType?.labels?.add_new_item;
 		const link =
 			post.status === 'future' ? getFuturePostUrl( post ) : post.link;
 		const addLink = addQueryArgs( 'post-new.php', {

--- a/packages/editor/src/store/utils/notice-builder.js
+++ b/packages/editor/src/store/utils/notice-builder.js
@@ -33,7 +33,7 @@ export function getNotificationArgumentsForSaveSuccess( data ) {
 	const willPublish = publishStatus.includes( post.status );
 
 	let noticeMessage;
-	let shouldShowLink = postType?.viewable;
+	let shouldShowLink = postType?.viewable ?? false;
 	let isDraft;
 
 	// Always should a notice, which will be spoken for accessibility.

--- a/packages/editor/src/store/utils/notice-builder.js
+++ b/packages/editor/src/store/utils/notice-builder.js
@@ -9,11 +9,6 @@ import { __ } from '@wordpress/i18n';
 import { SAVE_POST_NOTICE_ID, TRASH_POST_NOTICE_ID } from '../constants';
 
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Builds the arguments for a success notification dispatch.
  *
  * @param {Object} data Incoming data to build the arguments from.
@@ -24,7 +19,7 @@ import { get } from 'lodash';
 export function getNotificationArgumentsForSaveSuccess( data ) {
 	const { previousPost, post, postType } = data;
 	// Autosaves are neither shown a notice nor redirected.
-	if ( get( data.options, [ 'isAutosave' ] ) ) {
+	if ( data.options?.isAutosave ) {
 		return [];
 	}
 
@@ -38,7 +33,7 @@ export function getNotificationArgumentsForSaveSuccess( data ) {
 	const willPublish = publishStatus.includes( post.status );
 
 	let noticeMessage;
-	let shouldShowLink = get( postType, [ 'viewable' ], false );
+	let shouldShowLink = postType?.viewable;
 	let isDraft;
 
 	// Always should a notice, which will be spoken for accessibility.


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.get()` from a few use cases that work with the result of `getPostType()` selector. Most of the usages affected here are similar and that makes it easier to review as a group.

This PR compliments #48104.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using direct access with optional chaining and nullish coalescing as an alternative.

## Testing Instructions

* Verify you're still able to preview a post on desktop and mobile and that the dropdown for that works well.
* Verify toggling fullscreen mode on and off still works well in the post editor.
* Verify the title of the Featured Image box and the "Set featured image" text when no image has been chosen in the sidebar of the post editor still appears properly while editing a post.
* Verify the title of the Page Attributes box in the sidebar of the post editor still appears properly while editing a page.
* Verify that you're still able to set the page parent for hierarchical post types (page) and the labels there look well.
* Verify that post locks still work well (while someone else is editing a certain post) and the "Exit editor" link works well and redirects you to the list of all posts (of the post type you're currently editing).
* Verify that post types that are not viewable still can't pre previewed.
* Verify that the post-publish panel still looks good.
* Verify that the post-save success notice still looks good.
* Verify checks are green - some of the changes are covered by tests.