### PR TITLE
Lodash: Remove from integration tests

### DIFF
--- a/test/integration/full-content/full-content.test.js
+++ b/test/integration/full-content/full-content.test.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import glob from 'fast-glob';
-import { get } from 'lodash';
 import { format } from 'util';
 
 /**
@@ -252,11 +251,8 @@ describe( 'full post content fixture', () => {
 								JSON.parse( jsonFixtureContent );
 							// The name of the first block that this fixture file
 							// contains (if any).
-							const firstBlock = get(
-								parserOutput,
-								[ '0', 'name' ],
-								null
-							);
+							const firstBlock =
+								parserOutput?.[ '0' ]?.name ?? null;
 							return {
 								filename: htmlFixtureFileName,
 								parserOutput,


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.get()` from the integration tests.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using direct access with optional chaining and nullish coalescing as an alternative.

## Testing Instructions

* Verify checks are still green and tests still pass.