### PR TITLE
[Editor]: Handle `title` display and selection in `outline`

### DIFF
--- a/packages/editor/src/components/document-outline/index.js
+++ b/packages/editor/src/components/document-outline/index.js
@@ -76,7 +76,11 @@ export const DocumentOutline = ( {
 	let prevHeadingLevel = 1;
 
 	// Not great but it's the simplest way to locate the title right now.
-	const titleNode = document.querySelector( '.editor-post-title__input' );
+	const titleNode =
+		document.querySelector( '.editor-post-title__input' ) ||
+		window.frames[ 'editor-canvas' ]?.document.querySelector(
+			'.editor-post-title__input'
+		);
 	const hasTitle = isTitleSupported && title && titleNode;
 	const countByLevel = headings.reduce(
 		( acc, heading ) => ( {
@@ -94,7 +98,10 @@ export const DocumentOutline = ( {
 					<DocumentOutlineItem
 						level={ __( 'Title' ) }
 						isValid
-						onSelect={ onSelect }
+						onSelect={ () => {
+							titleNode.focus();
+							onSelect?.();
+						} }
 						href={ `#${ titleNode.id }` }
 						isDisabled={ hasOutlineItemsDisabled }
 					>

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -25,7 +25,7 @@ import {
 	toHTMLString,
 	insert,
 } from '@wordpress/rich-text';
-import { useMergeRefs } from '@wordpress/compose';
+import { useMergeRefs, useInstanceId } from '@wordpress/compose';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 
 /**
@@ -40,6 +40,7 @@ import { store as editorStore } from '../../store';
 const REGEXP_NEWLINES = /[\r\n]+/g;
 
 function PostTitle( _, forwardedRef ) {
+	const postTitleId = useInstanceId( PostTitle, 'post-title' );
 	const ref = useRef();
 	const [ isSelected, setIsSelected ] = useState( false );
 	const { editPost } = useDispatch( editorStore );
@@ -226,6 +227,7 @@ function PostTitle( _, forwardedRef ) {
 	return (
 		<PostTypeSupportCheck supportKeys="title">
 			<h1
+				id={ postTitleId }
 				ref={ useMergeRefs( [ richTextRef, ref ] ) }
 				contentEditable
 				className={ className }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/47624

If the editor content is an iframe, the title area will not be displayed. And if the post editor is not iframed, the title is not selected when we click it.


## Testing Instructions
1. In `outline` click the title and should be selected
