### PR TITLE
Navigation block e2e tests: default to my most recently created menu

### DIFF
--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -165,7 +165,7 @@ test.describe(
 			// Check the block in the canvas.
 			await expect(
 				editor.canvas.locator(
-					`role=textbox[name="Navigation link text"i] >> text="My site link"`
+					`role=textbox[name="Navigation link text"i] >> text="Menu 2 Link"`
 				)
 			).toBeVisible();
 
@@ -173,7 +173,7 @@ test.describe(
 			await page.goto( '/' );
 			await expect(
 				page.locator(
-					`role=navigation >> role=link[name="My site link"i]`
+					`role=navigation >> role=link[name="Menu 2 Link"i]`
 				)
 			).toBeVisible();
 		} );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -144,6 +144,10 @@ test.describe(
 					'<!-- wp:navigation-link {"label":"Menu 1 Link","type":"custom","url":"http://localhost:8889/#menu-1-link","kind":"custom","isTopLevelLink":true} /-->',
 			} );
 
+			//FIXME this is needed because if the two menus are created at the same time, the API will return them in the wrong order.
+			//https://core.trac.wordpress.org/ticket/57914
+			await editor.page.waitForTimeout( 1000 );
+
 			const latestMenu = await requestUtils.createNavigationMenu( {
 				title: 'Test Menu 2',
 				content:

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -138,12 +138,14 @@ test.describe(
 			requestUtils,
 		} ) => {
 			await admin.createNewPost();
-
 			await requestUtils.createNavigationMenu( {
 				title: 'Test Menu 1',
 				content:
 					'<!-- wp:navigation-link {"label":"WordPress","type":"custom","url":"http://www.wordpress.org/","kind":"custom","isTopLevelLink":true} /-->',
 			} );
+
+			// The two menus are created with the same timestamp, so we need to wait a bit to ensure the second one is created after the first one.
+			await editor.page.waitForTimeout( 2000 );
 
 			const latestMenu = await requestUtils.createNavigationMenu( {
 				title: 'Test Menu 2',
@@ -152,13 +154,6 @@ test.describe(
 			} );
 
 			await editor.insertBlock( { name: 'core/navigation' } );
-
-			// Check the block in the canvas.
-			await expect(
-				editor.canvas.locator(
-					`role=textbox[name="Navigation link text"i] >> text="My site link"`
-				)
-			).toBeVisible();
 
 			// Check the markup of the block is correct.
 			await editor.publishPost();
@@ -169,6 +164,13 @@ test.describe(
 				},
 			] );
 			await page.locator( 'role=button[name="Close panel"i]' ).click();
+
+			// Check the block in the canvas.
+			await expect(
+				editor.canvas.locator(
+					`role=textbox[name="Navigation link text"i] >> text="My site link"`
+				)
+			).toBeVisible();
 
 			// Check the block in the frontend.
 			await page.goto( '/' );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -141,16 +141,13 @@ test.describe(
 			await requestUtils.createNavigationMenu( {
 				title: 'Test Menu 1',
 				content:
-					'<!-- wp:navigation-link {"label":"WordPress","type":"custom","url":"http://www.wordpress.org/","kind":"custom","isTopLevelLink":true} /-->',
+					'<!-- wp:navigation-link {"label":"Menu 1 Link","type":"custom","url":"http://localhost:8889/#menu-1-link","kind":"custom","isTopLevelLink":true} /-->',
 			} );
-
-			// The two menus are created with the same timestamp, so we need to wait a bit to ensure the second one is created after the first one.
-			await editor.page.waitForTimeout( 2000 );
 
 			const latestMenu = await requestUtils.createNavigationMenu( {
 				title: 'Test Menu 2',
 				content:
-					'<!-- wp:navigation-link {"label":"My site link","type":"custom","url":"http://localhost:8889/#my-site-link","kind":"custom","isTopLevelLink":true} /-->',
+					'<!-- wp:navigation-link {"label":"Menu 2 Link","type":"custom","url":"http://localhost:8889/#menu-2-link","kind":"custom","isTopLevelLink":true} /-->',
 			} );
 
 			await editor.insertBlock( { name: 'core/navigation' } );


### PR DESCRIPTION
## What?

This is part of the effort to re work all the navigation block e2e tests and migration to playwright. This is one of the user stories described in https://github.com/WordPress/gutenberg/issues/45199

This test checks that when only two navigation menus, inserting a Navigation block will default correctly to using the most recently created one.

## Testing Instructions

Run `npm run test:e2e:playwright -- editor/blocks/navigation.spec.js`