### PR TITLE
Site editor: specify focus state color for template navigation button

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -33,6 +33,7 @@
 	color: $gray-200;
 
 	&:hover,
+	&:focus,
 	&:not([aria-disabled="true"]):active {
 		color: $white;
 	}


### PR DESCRIPTION
Related to: #47851

## What?
This PR sets the focus state color of template navigation back icon.

## Why?

This style is overridden by WP Admin-style, but it should be displayed in white like the rest of the state.

![focus-style](https://user-images.githubusercontent.com/54422211/219413487-b4b7d487-631f-4893-bc57-7417f5929efb.png)

## Screenshot

### Before

https://user-images.githubusercontent.com/54422211/219413671-b2f869bb-68f9-4837-b0e4-798249350d8f.mp4

### After

https://user-images.githubusercontent.com/54422211/219413740-a955e6af-3eb3-43f3-b1d4-9445f271b669.mp4


