### PR TITLE
Fix site editor switch mode message.

### DIFF
--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -526,7 +526,7 @@ export const switchEditorMode =
 
 		if ( mode === 'visual' ) {
 			speak( __( 'Visual editor selected' ), 'assertive' );
-		} else if ( mode === 'mosaic' ) {
-			speak( __( 'Mosaic view selected' ), 'assertive' );
+		} else if ( mode === 'text' ) {
+			speak( __( 'Code editor selected' ), 'assertive' );
 		}
 	};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
When switching the Site Editor mode from Visual editor to Code editor and vice-versa, an audible `speak` message is supposed to be provided for screen reader users:

https://github.com/WordPress/gutenberg/blob/11525f7c9ad1f0cb7f464d86cdc0b9e207bb3d45/packages/edit-site/src/store/actions.js#L527-L531

Turns out there's no 'mosaic' mode so when switching to 'Code' nothing is announced.

To. my understanding, a 'Mosaic View' was tried in https://github.com/WordPress/gutenberg/pull/33770 but the PR was closed and never merged. Nonetheless, the reference to a 'mosaic' mode was added in https://github.com/WordPress/gutenberg/pull/37765

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
A proper audible message should be provided when switching to Code mode.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Fixes the mode value used for a conditional and changes the related translatable string.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Go to the Site Editor.
- Switch the editor to 'Code' mode.
- Inspect the source in your browser dev tools and check the textual content of the element with ID `a11y-speak-assertive` is: `Code editor selected`.
- Switch the editor back to 'Visual' mode.
- Inspect the source in your browser dev tools and check the textual content of the element with ID `a11y-speak-assertive` is: `Visual editor selected`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
