### PR TITLE
Update stylelint to 15.1

### DIFF
--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -35,7 +35,7 @@
 		"stylelint-config-recommended-scss": "^5.0.2"
 	},
 	"peerDependencies": {
-		"stylelint": "^14.2"
+		"stylelint": "^15.1"
 	},
 	"npmpackagejsonlint": {
 		"extends": "@wordpress/npm-package-json-lint-config",


### PR DESCRIPTION
## What?
Updated stylelint to 15.1. Fixes #48142.

## Why?
Allows people to use the current version of stylelint alongside `@wordpress/stylelint-config`.
