### PR TITLE
Proactively update versions in WordPress ahead of 6.2

### DIFF
--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -6,6 +6,7 @@ If anything looks incorrect here, please bring it up in #core-editor in [WordPre
 
 | Gutenberg Versions | WordPress Version |
 | ------------------ | ----------------- |
+| 14.2-15.1          | 6.2               |
 | 13.1-14.1          | 6.1.1             |
 | 13.1-14.1          | 6.1               |
 | 12.0-13.0          | 6.0.3             |


### PR DESCRIPTION
Just a quick update to the versions in WordPress doc as this is around the time folks start digging for this info. 