### PR TITLE
Block Editor: Add 'Justify' option to alignment controls

### DIFF
--- a/packages/block-editor/src/components/alignment-control/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/alignment-control/test/__snapshots__/index.js.snap
@@ -164,6 +164,29 @@ exports[`AlignmentUI should match snapshot when controls are visible 1`] = `
         </svg>
       </button>
     </div>
+    <div>
+      <button
+        align="justify"
+        aria-label="Align text justify"
+        aria-pressed="false"
+        class="components-button components-toolbar__control has-icon"
+        data-toolbar-item="true"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="https://www.w3.org/2000/svg"
+        >
+          <path
+            d="M4 12.8h16v-1.5H4v1.5zm0 7h12.4v-1.5H4v1.5zM4 4.3v1.5h16V4.3H4z"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </div>
 `;

--- a/packages/block-editor/src/components/alignment-control/test/index.js
+++ b/packages/block-editor/src/components/alignment-control/test/index.js
@@ -74,7 +74,7 @@ describe( 'AlignmentUI', () => {
 			screen.getAllByRole( 'menuitemradio', {
 				name: /^Align text \w+$/,
 			} )
-		).toHaveLength( 3 );
+		).toHaveLength( 4 );
 
 		// Cancel running effects, like delayed dropdown menu popover positioning.
 		unmount();

--- a/packages/block-editor/src/components/alignment-control/ui.js
+++ b/packages/block-editor/src/components/alignment-control/ui.js
@@ -3,7 +3,12 @@
  */
 import { __, isRTL } from '@wordpress/i18n';
 import { ToolbarDropdownMenu, ToolbarGroup } from '@wordpress/components';
-import { alignLeft, alignRight, alignCenter } from '@wordpress/icons';
+import {
+	alignLeft,
+	alignRight,
+	alignCenter,
+	alignJustify,
+} from '@wordpress/icons';
 
 const DEFAULT_ALIGNMENT_CONTROLS = [
 	{
@@ -20,6 +25,11 @@ const DEFAULT_ALIGNMENT_CONTROLS = [
 		icon: alignRight,
 		title: __( 'Align text right' ),
 		align: 'right',
+	},
+	{
+		icon: alignJustify,
+		title: __( 'Align text justify' ),
+		align: 'justify',
 	},
 ];
 

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -46,6 +46,11 @@
 	text-align: right;
 }
 
+.has-text-align-justify {
+	/*rtl:ignore*/
+	text-align: justify;
+}
+
 // This tag marks the end of the styles that apply to editing canvas contents and need to be manipulated when we resize the editor.
 #end-resizable-editor-section {
 	display: none;


### PR DESCRIPTION
## What?

Adds a 'Align text justify' option to alignment controls:

<img width="763" alt="image" src="https://user-images.githubusercontent.com/36432/219483043-cb881685-975c-42a0-8812-37300a69261f.png">

## Why?

'Justify' as a text alignment option is a long-requested Gutenberg enhancement: https://github.com/WordPress/gutenberg/issues/8450

Many plugins have added 'Justify' on their own but it's much better for Gutenberg to simply support it.

Fixes https://github.com/WordPress/gutenberg/issues/27300
Fixes https://github.com/WordPress/gutenberg/issues/8450

## How?

This PR registers a new 'Align text justify' option alongside the existing alignment options.

## Testing Instructions

1. Add a new paragraph block to the block editor with some text.
2. Click on the 'Align text justify' option.
3. Verify the text appears justified.
4. Deselect the 'Align text justify' option.
5. Verify the text no longer appears justified.

### Testing Instructions for Keyboard

N/A