### PR TITLE
Style Book: Focus the Style Book when opened, and enable ESCAPE key to close

### DIFF
--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -24,8 +24,14 @@ import {
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { closeSmall } from '@wordpress/icons';
-import { useResizeObserver } from '@wordpress/compose';
+import {
+	useResizeObserver,
+	useFocusOnMount,
+	useFocusReturn,
+	useMergeRefs,
+} from '@wordpress/compose';
 import { useMemo, memo } from '@wordpress/element';
+import { ESCAPE } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -90,6 +96,9 @@ function getExamples() {
 
 function StyleBook( { isSelected, onSelect, onClose } ) {
 	const [ resizeObserver, sizes ] = useResizeObserver();
+	const focusOnMountRef = useFocusOnMount( 'firstElement' );
+	const sectionFocusReturnRef = useFocusReturn();
+
 	const [ textColor ] = useGlobalStyle( 'color.text' );
 	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
 	const examples = useMemo( getExamples, [] );
@@ -108,8 +117,17 @@ function StyleBook( { isSelected, onSelect, onClose } ) {
 				} ) ),
 		[ examples ]
 	);
+
+	function closeOnEscape( event ) {
+		if ( event.keyCode === ESCAPE && ! event.defaultPrevented ) {
+			event.preventDefault();
+			onClose();
+		}
+	}
+
 	return (
 		<StyleBookFill>
+			{ /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */ }
 			<section
 				className={ classnames( 'edit-site-style-book', {
 					'is-wide': sizes.width > 600,
@@ -119,6 +137,11 @@ function StyleBook( { isSelected, onSelect, onClose } ) {
 					background: backgroundColor,
 				} }
 				aria-label={ __( 'Style Book' ) }
+				onKeyDown={ closeOnEscape }
+				ref={ useMergeRefs( [
+					sectionFocusReturnRef,
+					focusOnMountRef,
+				] ) }
 			>
 				{ resizeObserver }
 				<Button
@@ -126,6 +149,7 @@ function StyleBook( { isSelected, onSelect, onClose } ) {
 					icon={ closeSmall }
 					label={ __( 'Close Style Book' ) }
 					onClick={ onClose }
+					showTooltip={ false }
 				/>
 				<TabPanel
 					className="edit-site-style-book__tab-panel"

--- a/test/e2e/specs/site-editor/style-book.spec.js
+++ b/test/e2e/specs/site-editor/style-book.spec.js
@@ -120,26 +120,31 @@ test.describe( 'Style Book', () => {
 	test( 'should disappear when closed via click event or Escape key', async ( {
 		page,
 	} ) => {
+		const styleBookRegion = page.getByRole( 'region', {
+			name: 'Style Book',
+		} );
+
 		// Close Style Book via click event.
-		await page.click(
-			'role=region[name="Style Book"i] >> role=button[name="Close Style Book"i]'
-		);
+		await styleBookRegion
+			.getByRole( 'button', { name: 'Close Style Book' } )
+			.click();
+
 		await expect(
-			page.locator( 'role=region[name="Style Book"i]' ),
+			styleBookRegion,
 			'should close when close button is clicked'
 		).not.toBeVisible();
 
 		// Open Style Book again.
-		await page.click( 'role=button[name="Style Book"i]' );
+		await page.getByRole( 'button', { name: 'Style Book' } ).click();
 		await expect(
-			page.locator( 'role=region[name="Style Book"i]' ),
+			styleBookRegion,
 			'style book should be visible'
 		).toBeVisible();
 
 		// Close Style Book via Escape key.
 		await page.keyboard.press( 'Escape' );
 		await expect(
-			page.locator( 'role=region[name="Style Book"i]' ),
+			styleBookRegion,
 			'should close when Escape key is pressed'
 		).not.toBeVisible();
 	} );

--- a/test/e2e/specs/site-editor/style-book.spec.js
+++ b/test/e2e/specs/site-editor/style-book.spec.js
@@ -126,6 +126,14 @@ test.describe( 'Style Book', () => {
 			page.locator( 'role=region[name="Style Book"i]' )
 		).not.toBeVisible();
 	} );
+
+	test( 'should close when Escape key is pressed', async ( { page } ) => {
+		await page.keyboard.press( 'Escape' );
+
+		await expect(
+			page.locator( 'role=region[name="Style Book"i]' )
+		).not.toBeVisible();
+	} );
 } );
 
 class StyleBook {

--- a/test/e2e/specs/site-editor/style-book.spec.js
+++ b/test/e2e/specs/site-editor/style-book.spec.js
@@ -117,21 +117,30 @@ test.describe( 'Style Book', () => {
 		).toBeVisible();
 	} );
 
-	test( 'should disappear when closed', async ( { page } ) => {
+	test( 'should disappear when closed via click event or Escape key', async ( {
+		page,
+	} ) => {
+		// Close Style Book via click event.
 		await page.click(
 			'role=region[name="Style Book"i] >> role=button[name="Close Style Book"i]'
 		);
-
 		await expect(
-			page.locator( 'role=region[name="Style Book"i]' )
+			page.locator( 'role=region[name="Style Book"i]' ),
+			'should close when close button is clicked'
 		).not.toBeVisible();
-	} );
 
-	test( 'should close when Escape key is pressed', async ( { page } ) => {
-		await page.keyboard.press( 'Escape' );
-
+		// Open Style Book again.
+		await page.click( 'role=button[name="Style Book"i]' );
 		await expect(
-			page.locator( 'role=region[name="Style Book"i]' )
+			page.locator( 'role=region[name="Style Book"i]' ),
+			'style book should be visible'
+		).toBeVisible();
+
+		// Close Style Book via Escape key.
+		await page.keyboard.press( 'Escape' );
+		await expect(
+			page.locator( 'role=region[name="Style Book"i]' ),
+			'should close when Escape key is pressed'
 		).not.toBeVisible();
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR addresses part of https://github.com/WordPress/gutenberg/issues/48054 by attempting to improve the keyboard navigation for opening and closing the Style Book. It does not address the problems of returning to the Style Book from other parts of global styles.

The features in this PR are:

* When opening the Style Book, shift focus to be within the Style Book, with focus set on the close button.
* When focus is anywhere within the Style Book, allow the ESCAPE key to close the Style Book.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

#48054 flagged a number of keyboard navigation challenges with the Style Book. This PR seeks to improve the keyboard navigation incrementally by focusing on one particular area — opening and closing the Style Book via keyboard.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Use the `useFocusOnMount` and `useFocusReturn` hooks to allow focusing to the first tabbable element when the Style Book is mounted, and to return focus to the button in the sidebar once the Style Book is closed. This follows the same logic as used by the List View sidebar.
* Add support for the Escape key to close out the Style Book, when the focus is within the Style Book. Pressing Escape outside of the Style Book should have no effect, as the Escape key is used elsewhere within the editor. This also follows the logic used by the List View sidebar.
* Hide the tooltip for the close button in the Style Book — without this, the tooltip for closing the Style Book appeared to be too prominent when the Style Book is initially opened and focused. I noticed that many other modals in Gutenberg also don't show the tooltip for the close button. I'm not sure if that's the right way to go about it, though, so happy for feedback on this.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In global styles click the Style Book icon in the top right hand corner. Notice that the close button within the Style Book should now be focused.
2. Press the Escape key, and the Style Book should close.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

1. Open global styles and click on the Styles header. Press Tab once to focus the Style Book icon.
2. Press Enter to open the Style Book, and notice that focus should have moved to the close button within the Style Book.
3. Press Enter again, and the Style Book should be closed.
4. Open the Style Book again, and tab around (i.e. press Tab once to get to the Tab Panel, or twice to get to the list of blocks).
5. While still focused within the Style Book, press Escape to close the Style Book.

## Screenshots or screencast <!-- if applicable -->

The below screengrab demonstrates the following:

* Pressing Enter on the Style Book icon, then the focus is shifted to the close button within the Style Book. Pressing Enter again returns the focus to the Style Book icon in the sidebar.
* After opening the Style Book again, the user can tab around within the Style Book, and then press Escape to close the Style book.

https://user-images.githubusercontent.com/14988353/219525610-e8a6e10c-df74-4046-b246-89b6a7844bd5.mp4


