### PR TITLE
Make the template customized info accessible.

### DIFF
--- a/packages/edit-site/src/components/list/style.scss
+++ b/packages/edit-site/src/components/list/style.scss
@@ -141,7 +141,6 @@
 .edit-site-list-added-by__icon {
 	display: flex;
 	flex-shrink: 0;
-	position: relative;
 	align-items: center;
 	justify-content: center;
 	width: $grid-unit-40;
@@ -151,18 +150,6 @@
 
 	svg {
 		fill: $white;
-	}
-
-	&.is-customized::after {
-		position: absolute;
-		content: "";
-		background: var(--wp-admin-theme-color);
-		height: $grid-unit-10;
-		width: $grid-unit-10;
-		outline: 2px solid $white;
-		border-radius: 100%;
-		top: -1px;
-		right: -1px;
 	}
 }
 
@@ -188,4 +175,9 @@
 			opacity: 1;
 		}
 	}
+}
+
+.edit-site-list-added-by__customized-info {
+	display: block;
+	color: $gray-700;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/42557

## What?
<!-- In a few words, what is the PR actually doing? -->
In the templates/parts list, customized templates/parts show a blue 'dot'. Hovering the dot shows a tooltip with text 'This template/part has been customized'. The blue dot is only viusal information, there's no other semantic information. The tooltip appears only on hover and it's not accessible for keyboard users.

This PR removes the dot and tooltip in favor of visible text, as agreed on https://github.com/WordPress/gutenberg/issues/42557#issuecomment-1428223177

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The current 'customized info' is not accessible.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Makes the info use visible text.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Customize a template and a template part by making a small change to them and save.
- Go to Templates > Manage all templates
- Check the template you customized has a visible text 'Customized' in the 'Added by' column.
- Go to Template Parts > Manage all template parts
- Check the template part you customized has a visible text 'Customized' in the 'Added by' column.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before:

<img width="1343" alt="Screenshot 2023-02-21 at 09 14 26" src="https://user-images.githubusercontent.com/1682452/220286736-b19d1818-34e2-423f-b157-516601d5a8a5.png">

After:

<img width="1333" alt="Screenshot 2023-02-16 at 17 35 44" src="https://user-images.githubusercontent.com/1682452/219595047-b677805b-b184-4c78-8fe9-78b5d3546800.png">


