### PR TITLE
Site Editor Sidebar: Add line-height for template/parts name and update width for edit button

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -45,7 +45,6 @@
 		white-space: nowrap;
 		background: $components-color-accent;
 		color: $components-color-accent-inverted;
-		min-width: auto;
 		text-decoration: none;
 		text-shadow: none;
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -45,6 +45,7 @@
 		white-space: nowrap;
 		background: $components-color-accent;
 		color: $components-color-accent-inverted;
+		min-width: auto;
 		text-decoration: none;
 		text-shadow: none;
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-item/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-item/index.js
@@ -45,6 +45,7 @@ export default function SidebarNavigationScreenNavigationItem() {
 			actions={
 				<Button
 					variant="primary"
+					className="edit-site-sidebar-navigation-screen__edit"
 					onClick={ () => setCanvasMode( 'edit' ) }
 				>
 					{ __( 'Edit' ) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
@@ -29,7 +29,7 @@ export default function SidebarNavigationScreenTemplate() {
 			actions={
 				<Button
 					variant="primary"
-					className="edit-site-sidebar-navigation-screen__button"
+					className="edit-site-sidebar-navigation-screen__edit"
 					onClick={ () => setCanvasMode( 'edit' ) }
 				>
 					{ __( 'Edit' ) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
@@ -29,6 +29,7 @@ export default function SidebarNavigationScreenTemplate() {
 			actions={
 				<Button
 					variant="primary"
+					className="edit-site-sidebar-navigation-screen__button"
 					onClick={ () => setCanvasMode( 'edit' ) }
 				>
 					{ __( 'Edit' ) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -30,7 +30,7 @@
 	margin: 0;
 }
 
-.edit-site-sidebar-navigation-screen__button {
+.edit-site-sidebar-navigation-screen__edit {
 	flex-shrink: 0;
 }
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -30,6 +30,10 @@
 	margin: 0;
 }
 
+.edit-site-sidebar-navigation-screen__button {
+	flex-shrink: 0;
+}
+
 .edit-site-sidebar-navigation-screen__back {
 	color: $gray-200;
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -23,6 +23,7 @@
 
 .edit-site-sidebar-navigation-screen__title {
 	font-size: calc(1.56 * 13px);
+	line-height: normal;
 	font-weight: 500;
 	flex-grow: 1;
 	color: $white;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
- Add `flex-shrink: 0` to the edit button so that it will not cut off even if the template/parts title is very big.
- Add `line-height: normal` to the template/parts name so that it will look better in the cases of big template/parts names. 

## Why?
Issue - https://github.com/WordPress/gutenberg/issues/48155

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Added some css that handles both edit button's width issue and the height of template/parts title.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Login to WordPress dashboard
2. Go to **Appearance** -> **Editor**
3. Click on **Templates** or **Template Parts**
4. Then click on plus(+) icon
5. Enter the name (should be big enough) and click create.
6. Then click on WordPress logo at the top left corner.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

| Before adding changes |
|--|
| <img width="1440" alt="Screenshot 2023-02-17 at 1 46 14 PM" src="https://user-images.githubusercontent.com/40795917/219594657-c2f6c45b-8f15-4a05-94ee-9251b9078b83.png"> |

| After adding changes |
|--|
| <img width="1440" alt="Screenshot 2023-02-17 at 1 46 37 PM" src="https://user-images.githubusercontent.com/40795917/219594681-845c3c32-d452-490f-9e05-605544497ca1.png"> |
