### PR TITLE
Fix i18n issues in the `block-compare` component.

### DIFF
--- a/packages/block-editor/src/components/block-compare/index.js
+++ b/packages/block-editor/src/components/block-compare/index.js
@@ -61,7 +61,10 @@ function BlockCompare( {
 	return (
 		<div className="block-editor-block-compare__wrapper">
 			<BlockView
-				title={ __( 'Current' ) }
+				title={
+					/* translators: Current block HTML before conversion, for comparisons. */
+					__( 'Current' )
+				}
 				className="block-editor-block-compare__current"
 				action={ onKeep }
 				actionText={ __( 'Convert to HTML' ) }
@@ -70,7 +73,7 @@ function BlockCompare( {
 			/>
 
 			<BlockView
-				title={ __( 'After Conversion' ) }
+				title={ __( 'After conversion' ) }
 				className="block-editor-block-compare__converted"
 				action={ onConvert }
 				actionText={ convertButtonText }


### PR DESCRIPTION
## What?
Fixes i18n issues in the `block-compare` component.

## Why?
Strings in Gutenberg are inconsistent and are not always easy to translate. This PR is part of an audit to fix i18n issues.

* Fixes string capitalization
* Adds translator comments to make it clear to translators what the context is, and make their job easier.

This PR is a result of a Yoast Hackathon event on Feb.16 2023.
Props @carolinan @afercia @SergeyBiryukov @aristath 