### PR TITLE
Fix i18n issues in the `block-list` component.

### DIFF
--- a/docs/reference-guides/block-api/block-edit-save.md
+++ b/docs/reference-guides/block-api/block-edit-save.md
@@ -517,13 +517,13 @@ If a block is detected to be invalid, the user will be prompted to choose how to
 
 ![Invalid block prompt](https://user-images.githubusercontent.com/7753001/88754471-4cf7e900-d191-11ea-9123-3cee20719d10.png)
 
-Clicking **Attempt Block Recovery** button will attempt recovery action as much as possible.
+Clicking **Attempt block recovery** button will attempt recovery action as much as possible.
 
 Clicking the "3-dot" menu on the side of the block displays three options:
 
 -   **Resolve**: Open Resolve Block dialog box with two buttons:
     -   **Convert to HTML**: Protects the original markup from the saved post content and convert the block from its original type to the HTML block type, enabling the user to modify the HTML markup directly.
-    -   **Convert to Blocks**: Protects the original markup from the saved post content and convert the block from its original type to the validated block type.
+    -   **Convert to blocks**: Protects the original markup from the saved post content and convert the block from its original type to the validated block type.
 -   **Convert to HTML**: Protects the original markup from the saved post content and convert the block from its original type to the HTML block type, enabling the user to modify the HTML markup directly.
 -   **Convert to Classic Block**: Protects the original markup from the saved post content as correct. Since the block will be converted from its original type to the Classic block type, it will no longer be possible to edit the content using controls available for the original block type.
 

--- a/docs/reference-guides/block-api/block-transforms.md
+++ b/docs/reference-guides/block-api/block-transforms.md
@@ -188,7 +188,7 @@ transforms: {
 
 ### Raw
 
-This type of transformations support the _from_ direction, allowing blocks to be created from raw HTML nodes. They're applied when the user executes the "Convert to Blocks" action from within the block setting UI menu, as well as when some content is pasted or dropped into the editor.
+This type of transformations support the _from_ direction, allowing blocks to be created from raw HTML nodes. They're applied when the user executes the "Convert to blocks" action from within the block setting UI menu, as well as when some content is pasted or dropped into the editor.
 
 A transformation of type `raw` is an object that takes the following parameters:
 

--- a/packages/block-editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/block-editor/src/components/block-list/block-invalid-warning.js
@@ -58,7 +58,7 @@ export function BlockInvalidWarning( {
 						onClick={ attemptBlockRecovery }
 						variant="primary"
 					>
-						{ __( 'Attempt Block Recovery' ) }
+						{ __( 'Attempt block recovery' ) }
 					</Button>,
 				] }
 				secondaryActions={ hiddenActions }
@@ -69,7 +69,7 @@ export function BlockInvalidWarning( {
 				<Modal
 					title={
 						// translators: Dialog title to fix block content
-						__( 'Resolve Block' )
+						__( 'Resolve block' )
 					}
 					onRequestClose={ onCompareClose }
 					className="block-editor-block-compare"
@@ -79,7 +79,7 @@ export function BlockInvalidWarning( {
 						onKeep={ convertToHTML }
 						onConvert={ convertToBlocks }
 						convertor={ blockToBlocks }
-						convertButtonText={ __( 'Convert to Blocks' ) }
+						convertButtonText={ __( 'Convert to blocks' ) }
 					/>
 				</Modal>
 			) }

--- a/packages/block-editor/src/components/block-list/block-invalid-warning.native.js
+++ b/packages/block-editor/src/components/block-list/block-invalid-warning.native.js
@@ -19,7 +19,7 @@ import { store as blockEditorStore } from '../../store';
 export default function BlockInvalidWarning( { blockTitle, icon, clientId } ) {
 	const accessibilityLabel = sprintf(
 		/* translators: accessibility text for blocks with invalid content. %d: localized block title */
-		__( '%s block. This block has invalid content' ),
+		__( '"%s" block. This block has invalid content' ),
 		blockTitle
 	);
 
@@ -51,8 +51,10 @@ export default function BlockInvalidWarning( { blockTitle, icon, clientId } ) {
 			<Warning
 				title={ blockTitle }
 				// eslint-disable-next-line @wordpress/i18n-no-collapsible-whitespace
-				message={ __(
-					'Problem displaying block. \nTap to attempt block recovery.'
+				message={ sprintf(
+					'%1$s \n%2$s',
+					__( 'Problem displaying block.' ),
+					__( 'Tap to attempt block recovery.' )
 				) }
 				icon={ icon }
 				accessibilityLabel={ accessibilityLabel }

--- a/packages/block-editor/src/components/block-list/block-invalid-warning.native.js
+++ b/packages/block-editor/src/components/block-list/block-invalid-warning.native.js
@@ -19,7 +19,7 @@ import { store as blockEditorStore } from '../../store';
 export default function BlockInvalidWarning( { blockTitle, icon, clientId } ) {
 	const accessibilityLabel = sprintf(
 		/* translators: accessibility text for blocks with invalid content. %d: localized block title */
-		__( '"%s" block. This block has invalid content' ),
+		__( '%s block. This block has invalid content' ),
 		blockTitle
 	);
 

--- a/packages/block-editor/src/components/block-list/insertion-point.native.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.native.js
@@ -27,7 +27,7 @@ const BlockInsertionPoint = ( { getStylesFromColorScheme } ) => {
 	return (
 		<View style={ styles.containerStyleAddHere }>
 			<View style={ lineStyle }></View>
-			<Text style={ labelStyle }>{ __( 'ADD BLOCK HERE' ) }</Text>
+			<Text style={ labelStyle }>{ __( 'Add block here' ) }</Text>
 			<View style={ lineStyle }></View>
 		</View>
 	);

--- a/packages/block-editor/src/components/block-settings-menu/block-convert-button.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-convert-button.js
@@ -9,6 +9,6 @@ export default function BlockConvertButton( { shouldRender, onClick, small } ) {
 		return null;
 	}
 
-	const label = __( 'Convert to Blocks' );
+	const label = __( 'Convert to blocks' );
 	return <MenuItem onClick={ onClick }>{ ! small && label }</MenuItem>;
 }

--- a/packages/block-library/src/buttons/test/edit.native.js
+++ b/packages/block-library/src/buttons/test/edit.native.js
@@ -182,7 +182,7 @@ describe( 'Buttons block', () => {
 
 			// Check the Add block here placeholder is not visible
 			const addBlockHerePlaceholders =
-				screen.queryAllByLabelText( 'ADD BLOCK HERE' );
+				screen.queryAllByLabelText( 'Add block here' );
 			expect( addBlockHerePlaceholders.length ).toBe( 0 );
 
 			// Add a new Button block

--- a/test/e2e/specs/editor/blocks/preformatted.spec.js
+++ b/test/e2e/specs/editor/blocks/preformatted.spec.js
@@ -16,7 +16,7 @@ test.describe( 'Preformatted', () => {
 
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 
-		await editor.clickBlockOptionsMenuItem( 'Convert to Blocks' );
+		await editor.clickBlockOptionsMenuItem( 'Convert to blocks' );
 		// Once it's edited, it should be saved as BR tags.
 		await page.keyboard.type( '0' );
 		await page.keyboard.press( 'Enter' );


### PR DESCRIPTION
## What?
Fixes i18n issues in the `block-list` component.

## Why?
Strings in Gutenberg are inconsistent and are not always easy to translate. This PR is part of an audit to fix i18n issues.

* Fixes string capitalization
* Adds translator comments to make it clear to translators what the context is, and make their job easier.
* Avoid the use of HTML in translation strings
 
This PR is a result of a Yoast Hackathon event on Feb.16 2023.
Props @carolinan @afercia @SergeyBiryukov @aristath 