### PR TITLE
Fix i18n issues in the `block-mobile-toolbar` component.

### DIFF
--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -206,8 +206,8 @@ const BlockActionsMenu = ( {
 					sprintf(
 						/* translators: %s: name of the reusable block */
 						_n(
-							'"%s" converted to regular block',
-							'"%s" converted to regular blocks',
+							'%s converted to regular block',
+							'%s converted to regular blocks',
 							innerBlockCount
 						),
 						reusableBlock?.title?.raw || blockTitle

--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -296,7 +296,7 @@ const BlockActionsMenu = ( {
 				leftAlign={ true }
 				getAnchor={ getAnchor }
 				// translators: %s: block title e.g: "Paragraph".
-				title={ sprintf( __( '"%s" block options' ), blockTitle ) }
+				title={ sprintf( __( '%s block options' ), blockTitle ) }
 			/>
 			<BlockTransformationsMenu
 				anchorNodeRef={ anchorNodeRef }

--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -206,8 +206,8 @@ const BlockActionsMenu = ( {
 					sprintf(
 						/* translators: %s: name of the reusable block */
 						_n(
-							'%s converted to regular block',
-							'%s converted to regular blocks',
+							'"%s" converted to regular block',
+							'"%s" converted to regular blocks',
 							innerBlockCount
 						),
 						reusableBlock?.title?.raw || blockTitle

--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -22,7 +22,7 @@ import {
 	isUnmodifiedDefaultBlock,
 	isReusableBlock,
 } from '@wordpress/blocks';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { withDispatch, withSelect, useSelect } from '@wordpress/data';
 import { withInstanceId, compose } from '@wordpress/compose';
 import { moreHorizontalMobile } from '@wordpress/icons';
@@ -130,7 +130,7 @@ const BlockActionsMenu = ( {
 		},
 		transformButton: {
 			id: 'transformButtonOption',
-			label: __( 'Transform block…' ),
+			label: __( 'Transform block' ),
 			value: 'transformButtonOption',
 			onSelect: () => {
 				if ( blockTransformationMenuPickerRef.current ) {
@@ -195,21 +195,21 @@ const BlockActionsMenu = ( {
 		},
 		convertToRegularBlocks: {
 			id: 'convertToRegularBlocksOption',
-			label:
-				innerBlockCount > 1
-					? __( 'Convert to regular blocks' )
-					: __( 'Convert to regular block' ),
+			label: _n(
+				'Convert to regular block',
+				'Convert to regular blocks',
+				innerBlockCount
+			),
 			value: 'convertToRegularBlocksOption',
 			onSelect: () => {
-				const successNotice =
-					innerBlockCount > 1
-						? /* translators: %s: name of the reusable block */
-						  __( '%s converted to regular blocks' )
-						: /* translators: %s: name of the reusable block */
-						  __( '%s converted to regular block' );
 				createSuccessNotice(
 					sprintf(
-						successNotice,
+						/* translators: %s: name of the reusable block */
+						_n(
+							'%s converted to regular block',
+							'%s converted to regular blocks',
+							innerBlockCount
+						),
 						reusableBlock?.title?.raw || blockTitle
 					)
 				);
@@ -237,7 +237,7 @@ const BlockActionsMenu = ( {
 	if ( ! options.length ) {
 		return (
 			<ToolbarButton
-				title={ __( 'Open Block Actions Menu' ) }
+				title={ __( 'Open block Actions menu' ) }
 				icon={ moreHorizontalMobile }
 				disabled={ true }
 			/>
@@ -278,7 +278,7 @@ const BlockActionsMenu = ( {
 	return (
 		<>
 			<ToolbarButton
-				title={ __( 'Open Block Actions Menu' ) }
+				title={ __( 'Open block Actions menu' ) }
 				onClick={ onPickerPresent }
 				icon={ moreHorizontalMobile }
 				extraProps={ {
@@ -296,7 +296,7 @@ const BlockActionsMenu = ( {
 				leftAlign={ true }
 				getAnchor={ getAnchor }
 				// translators: %s: block title e.g: "Paragraph".
-				title={ sprintf( __( '%s block options' ), blockTitle ) }
+				title={ sprintf( __( '"%s" block options' ), blockTitle ) }
 			/>
 			<BlockTransformationsMenu
 				anchorNodeRef={ anchorNodeRef }

--- a/packages/block-editor/src/components/block-mobile-toolbar/test/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/test/block-actions-menu.native.js
@@ -43,7 +43,7 @@ describe( 'Block Actions Menu', () => {
 		fireEvent.press( paragraphBlock );
 
 		// Open block actions menu
-		const blockActionsButton = getByLabelText( /Open Block Actions Menu/ );
+		const blockActionsButton = getByLabelText( /Open block Actions menu/ );
 		fireEvent.press( blockActionsButton );
 
 		// Get Picker title
@@ -86,7 +86,7 @@ describe( 'Block Actions Menu', () => {
 			fireEvent.press( spacerBlock );
 
 			// Open block actions menu
-			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
+			fireEvent.press( getByLabelText( /Open block Actions menu/ ) );
 
 			// Get block actions modal
 			let blockActionsMenu = await getByTestId( 'block-actions-menu' );
@@ -103,7 +103,7 @@ describe( 'Block Actions Menu', () => {
 			fireEvent.press( headingBlock );
 
 			// Open block actions menu
-			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
+			fireEvent.press( getByLabelText( /Open block Actions menu/ ) );
 
 			// Get block actions modal
 			blockActionsMenu = await getByTestId( 'block-actions-menu' );
@@ -145,7 +145,7 @@ describe( 'Block Actions Menu', () => {
 			fireEvent.press( paragraphBlock );
 
 			// Open block actions menu
-			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
+			fireEvent.press( getByLabelText( /Open block Actions menu/ ) );
 
 			// Get block actions modal
 			const blockActionsMenu = await getByTestId( 'block-actions-menu' );
@@ -194,7 +194,7 @@ describe( 'Block Actions Menu', () => {
 			fireEvent.press( headingBlock );
 
 			// Open block actions menu
-			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
+			fireEvent.press( getByLabelText( /Open block Actions menu/ ) );
 
 			// Get block actions modal
 			const blockActionsMenu = await getByTestId( 'block-actions-menu' );
@@ -243,7 +243,7 @@ describe( 'Block Actions Menu', () => {
 			fireEvent.press( headingBlock );
 
 			// Open block actions menu
-			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
+			fireEvent.press( getByLabelText( /Open block Actions menu/ ) );
 
 			// Tap on the Copy button
 			fireEvent.press( getByLabelText( /Copy block/ ) );
@@ -253,7 +253,7 @@ describe( 'Block Actions Menu', () => {
 			fireEvent.press( paragraphBlock );
 
 			// Open block actions menu
-			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
+			fireEvent.press( getByLabelText( /Open block Actions menu/ ) );
 
 			// Tap on the Paste block after button
 			fireEvent.press( getByLabelText( /Paste block after/ ) );
@@ -290,7 +290,7 @@ describe( 'Block Actions Menu', () => {
 			fireEvent.press( headingBlock );
 
 			// Open block actions menu
-			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
+			fireEvent.press( getByLabelText( /Open block Actions menu/ ) );
 
 			// Tap on the Copy button
 			fireEvent.press( getByLabelText( /Copy block/ ) );
@@ -300,7 +300,7 @@ describe( 'Block Actions Menu', () => {
 			fireEvent.press( paragraphBlock );
 
 			// Open block actions menu
-			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
+			fireEvent.press( getByLabelText( /Open block Actions menu/ ) );
 
 			// Tap on the Past block after button
 			fireEvent.press( getByLabelText( /Paste block after/ ) );
@@ -335,7 +335,7 @@ describe( 'Block Actions Menu', () => {
 			fireEvent.press( paragraphBlock );
 
 			// Open block actions menu
-			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
+			fireEvent.press( getByLabelText( /Open block Actions menu/ ) );
 
 			// Tap on the Cut button
 			fireEvent.press( getByLabelText( /Cut block/ ) );
@@ -346,7 +346,7 @@ describe( 'Block Actions Menu', () => {
 			fireEvent.press( headingBlock );
 
 			// Open block actions menu
-			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
+			fireEvent.press( getByLabelText( /Open block Actions menu/ ) );
 
 			// Tap on the Cut button
 			fireEvent.press( getByLabelText( /Paste block after/ ) );
@@ -383,7 +383,7 @@ describe( 'Block Actions Menu', () => {
 			fireEvent.press( spacerBlock );
 
 			// Open block actions menu
-			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
+			fireEvent.press( getByLabelText( /Open block Actions menu/ ) );
 
 			// Tap on the Duplicate button
 			fireEvent.press( getByLabelText( /Duplicate block/ ) );
@@ -418,7 +418,7 @@ describe( 'Block Actions Menu', () => {
 			fireEvent.press( paragraphBlock );
 
 			// Open block actions menu
-			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
+			fireEvent.press( getByLabelText( /Open block Actions menu/ ) );
 
 			// Tap on the Transform block button
 			fireEvent.press( getByLabelText( /Transform block/ ) );

--- a/packages/block-editor/src/components/block-mobile-toolbar/test/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/test/block-actions-menu.native.js
@@ -421,7 +421,7 @@ describe( 'Block Actions Menu', () => {
 			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
 
 			// Tap on the Transform block button
-			fireEvent.press( getByLabelText( /Transform block…/ ) );
+			fireEvent.press( getByLabelText( /Transform block/ ) );
 
 			// Get Picker title
 			const pickerHeader = getByRole( 'header' );

--- a/packages/block-library/src/buttons/test/edit.native.js
+++ b/packages/block-library/src/buttons/test/edit.native.js
@@ -228,7 +228,7 @@ describe( 'Buttons block', () => {
 
 				// Open block actions menu
 				const blockActionsButton = screen.getByLabelText(
-					/Open Block Actions Menu/
+					/Open block Actions menu/
 				);
 				fireEvent.press( blockActionsButton );
 

--- a/packages/block-library/src/columns/test/edit.native.js
+++ b/packages/block-library/src/columns/test/edit.native.js
@@ -175,7 +175,7 @@ describe( 'Columns block', () => {
 		fireEvent.press( firstColumnBlock );
 
 		// Open block actions menu
-		const blockActionsButton = getByLabelText( /Open Block Actions Menu/ );
+		const blockActionsButton = getByLabelText( /Open block Actions menu/ );
 		fireEvent.press( blockActionsButton );
 
 		// Delete block
@@ -200,7 +200,7 @@ describe( 'Columns block', () => {
 		fireEvent.press( firstColumnBlock );
 
 		// Open block actions menu
-		let blockActionsButton = getByLabelText( /Open Block Actions Menu/ );
+		let blockActionsButton = getByLabelText( /Open block Actions menu/ );
 		fireEvent.press( blockActionsButton );
 
 		// Delete block
@@ -212,7 +212,7 @@ describe( 'Columns block', () => {
 		fireEvent.press( lastColumnBlock );
 
 		// Open block actions menu
-		blockActionsButton = getByLabelText( /Open Block Actions Menu/ );
+		blockActionsButton = getByLabelText( /Open block Actions menu/ );
 		fireEvent.press( blockActionsButton );
 
 		// Delete block

--- a/packages/block-library/src/gallery/test/index.native.js
+++ b/packages/block-library/src/gallery/test/index.native.js
@@ -121,7 +121,7 @@ describe( 'Gallery block', () => {
 
 		// Observe that the block is selected, this is done by checking if the block settings
 		// button is visible
-		const blockActionsButton = getByLabelText( /Open Block Actions Menu/ );
+		const blockActionsButton = getByLabelText( /Open block Actions menu/ );
 		expect( blockActionsButton ).toBeVisible();
 	} );
 
@@ -537,7 +537,7 @@ describe( 'Gallery block', () => {
 		<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":${ media[ 0 ].localId }} -->
 		<figure class="wp-block-image"><img src="${ media[ 0 ].localUrl }" alt="" class="wp-image-${ media[ 0 ].localId }"/></figure>
 		<!-- /wp:image -->
-		
+
 		<!-- wp:image {"id":${ media[ 1 ].localId },"linkDestination":"attachment"} -->
 		<figure class="wp-block-image"><img src="${ media[ 1 ].localUrl }" alt="" class="wp-image-${ media[ 1 ].localId }"/></figure>
 		<!-- /wp:image --></figure>

--- a/packages/block-library/src/social-links/test/edit.native.js
+++ b/packages/block-library/src/social-links/test/edit.native.js
@@ -179,7 +179,7 @@ describe( 'Social links block', () => {
 		fireEvent.press( firstLinkBlock );
 
 		// Open block actions menu
-		const blockActionsButton = getByLabelText( /Open Block Actions Menu/ );
+		const blockActionsButton = getByLabelText( /Open block Actions menu/ );
 		fireEvent.press( blockActionsButton );
 
 		// Delete the social link

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -300,8 +300,8 @@ class EditorPage {
 
 	async removeBlock() {
 		const blockActionsButtonElement = isAndroid()
-			? 'Open Block Actions Menu, Double tap to open Bottom Sheet with available options'
-			: 'Open Block Actions Menu';
+			? 'Open block Actions menu, Double tap to open Bottom Sheet with available options'
+			: 'Open block Actions menu';
 		const blockActionsMenu = await this.waitForElementToBeDisplayedById(
 			blockActionsButtonElement
 		);
@@ -504,7 +504,7 @@ class EditorPage {
 		const buttonElementName = isAndroid()
 			? '//*'
 			: '//XCUIElementTypeButton';
-		const blockActionsMenuButtonIdentifier = `Open Block Actions Menu`;
+		const blockActionsMenuButtonIdentifier = `Open block Actions menu`;
 		const blockActionsMenuButtonLocator = `${ buttonElementName }[contains(@${ this.accessibilityIdXPathAttrib }, "${ blockActionsMenuButtonIdentifier }")]`;
 		const blockActionsMenuButton = await waitForVisible(
 			this.driver,


### PR DESCRIPTION
## What?
Fixes i18n issues in the `block-mobile-toolbar` component.

## Why?

Strings in Gutenberg are inconsistent and are not always easy to translate. This PR is part of an audit to fix i18n issues.

* Fixes string capitalization
* Adds quotes around block-names to avoid issues with 3rd-party blocks which may have inconsistent naming conventions
* Use `_n` for translations depending on a number

This PR is a result of a Yoast Hackathon event on Feb.16 2023.
Props @carolinan @afercia @SergeyBiryukov @aristath