### PR TITLE
Fix i18n issues in the `list-view` component.

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -117,12 +117,12 @@ function ListViewBlock( {
 		blockAriaLabel = isLocked
 			? sprintf(
 					// translators: %s: The title of the block. This string indicates a link to select the locked block.
-					__( '%s link (locked)' ),
+					__( '"%s" link (locked)' ),
 					blockInformation.title
 			  )
 			: sprintf(
 					// translators: %s: The title of the block. This string indicates a link to select the block.
-					__( '%s link' ),
+					__( '"%s" link' ),
 					blockInformation.title
 			  );
 	}
@@ -130,7 +130,7 @@ function ListViewBlock( {
 	const settingsAriaLabel = blockInformation
 		? sprintf(
 				// translators: %s: The title of the block.
-				__( 'Options for %s block' ),
+				__( 'Options for "%s" block' ),
 				blockInformation.title
 		  )
 		: __( 'Options' );

--- a/packages/block-editor/src/components/list-view/use-block-selection.js
+++ b/packages/block-editor/src/components/list-view/use-block-selection.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { speak } from '@wordpress/a11y';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { UP, DOWN, HOME, END } from '@wordpress/keycodes';
@@ -132,14 +132,18 @@ export default function useBlockSelection() {
 				if ( title ) {
 					label = sprintf(
 						/* translators: %s: block name */
-						__( '%s deselected.' ),
+						__( '"%s" block deselected.' ),
 						title
 					);
 				}
 			} else if ( selectionDiff.length > 1 ) {
 				label = sprintf(
-					/* translators: %s: number of deselected blocks */
-					__( '%s blocks deselected.' ),
+					/* translators: %d: number of deselected blocks */
+					_n(
+						'%d block deselected.',
+						'%d blocks deselected.',
+						selectionDiff.length
+					),
 					selectionDiff.length
 				);
 			}

--- a/packages/block-editor/src/components/list-view/utils.js
+++ b/packages/block-editor/src/components/list-view/utils.js
@@ -6,7 +6,7 @@ import { __, sprintf } from '@wordpress/i18n';
 export const getBlockPositionDescription = ( position, siblingCount, level ) =>
 	sprintf(
 		/* translators: 1: The numerical position of the block. 2: The total number of blocks. 3. The level of nesting for the block. */
-		__( 'Block %1$d of %2$d, Level %3$d' ),
+		__( 'Block %1$d of %2$d, level %3$d' ),
 		position,
 		siblingCount,
 		level

--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -26,7 +26,7 @@ test.describe( 'Columns', () => {
 		// block column add
 		await page
 			.locator(
-				'role=treegrid[name="Block navigation structure"i] >> role=gridcell[name="Column link"i]'
+				'role=treegrid[name="Block navigation structure"i] >> role=gridcell[name=""Column" link"i]' // eslint-disable-line prettier/prettier
 			)
 			.first()
 			.click();


### PR DESCRIPTION
## What?
Fixes i18n issues in the `list-view` component.

## Why?

Strings in Gutenberg are inconsistent and are not always easy to translate. This PR is part of an audit to fix i18n issues.

* Fixes string capitalization
* Adds quotes around block-names to avoid issues with 3rd-party blocks which may have inconsistent naming conventions
* Use `_n` for translations depending on a number

This PR is a result of a Yoast Hackathon event on Feb.16 2023.
Props @carolinan @afercia @SergeyBiryukov @aristath