### PR TITLE
Fix i18n issues in the `block-mover` component.

### DIFF
--- a/packages/block-editor/src/components/block-mover/mover-description.js
+++ b/packages/block-editor/src/components/block-mover/mover-description.js
@@ -59,7 +59,7 @@ export function getBlockMoverDescription(
 	if ( isFirst && isLast ) {
 		return sprintf(
 			// translators: %s: Type of block (i.e. Text, Image etc)
-			__( 'Block %s is the only block, and cannot be moved' ),
+			__( 'Block "%s" is the only block, and cannot be moved' ),
 			type
 		);
 	}
@@ -72,7 +72,7 @@ export function getBlockMoverDescription(
 			return sprintf(
 				// translators: 1: Type of block (i.e. Text, Image etc), 2: Position of selected block, 3: New position
 				__(
-					'Move %1$s block from position %2$d down to position %3$d'
+					'Move "%1$s" block from position %2$d down to position %3$d'
 				),
 				type,
 				position,
@@ -84,7 +84,7 @@ export function getBlockMoverDescription(
 			return sprintf(
 				// translators: 1: Type of block (i.e. Text, Image etc), 2: Position of selected block, 3: New position
 				__(
-					'Move %1$s block from position %2$d left to position %3$d'
+					'Move "%1$s" block from position %2$d left to position %3$d'
 				),
 				type,
 				position,
@@ -96,7 +96,7 @@ export function getBlockMoverDescription(
 			return sprintf(
 				// translators: 1: Type of block (i.e. Text, Image etc), 2: Position of selected block, 3: New position
 				__(
-					'Move %1$s block from position %2$d right to position %3$d'
+					'Move "%1$s" block from position %2$d right to position %3$d'
 				),
 				type,
 				position,
@@ -113,7 +113,7 @@ export function getBlockMoverDescription(
 			return sprintf(
 				// translators: 1: Type of block (i.e. Text, Image etc)
 				__(
-					'Block %1$s is at the end of the content and can’t be moved down'
+					'Block "%1$s" is at the end of the content and can’t be moved down'
 				),
 				type
 			);
@@ -123,7 +123,7 @@ export function getBlockMoverDescription(
 			return sprintf(
 				// translators: 1: Type of block (i.e. Text, Image etc)
 				__(
-					'Block %1$s is at the end of the content and can’t be moved left'
+					'Block "%1$s" is at the end of the content and can’t be moved left'
 				),
 				type
 			);
@@ -133,7 +133,7 @@ export function getBlockMoverDescription(
 			return sprintf(
 				// translators: 1: Type of block (i.e. Text, Image etc)
 				__(
-					'Block %1$s is at the end of the content and can’t be moved right'
+					'Block "%1$s" is at the end of the content and can’t be moved right'
 				),
 				type
 			);
@@ -147,7 +147,9 @@ export function getBlockMoverDescription(
 		if ( movementDirection === 'up' ) {
 			return sprintf(
 				// translators: 1: Type of block (i.e. Text, Image etc), 2: Position of selected block, 3: New position
-				__( 'Move %1$s block from position %2$d up to position %3$d' ),
+				__(
+					'Move "%1$s" block from position %2$d up to position %3$d'
+				),
 				type,
 				position,
 				position - 1
@@ -158,7 +160,7 @@ export function getBlockMoverDescription(
 			return sprintf(
 				// translators: 1: Type of block (i.e. Text, Image etc), 2: Position of selected block, 3: New position
 				__(
-					'Move %1$s block from position %2$d left to position %3$d'
+					'Move "%1$s" block from position %2$d left to position %3$d'
 				),
 				type,
 				position,
@@ -170,7 +172,7 @@ export function getBlockMoverDescription(
 			return sprintf(
 				// translators: 1: Type of block (i.e. Text, Image etc), 2: Position of selected block, 3: New position
 				__(
-					'Move %1$s block from position %2$d right to position %3$d'
+					'Move "%1$s" block from position %2$d right to position %3$d'
 				),
 				type,
 				position,
@@ -187,7 +189,7 @@ export function getBlockMoverDescription(
 			return sprintf(
 				// translators: 1: Type of block (i.e. Text, Image etc)
 				__(
-					'Block %1$s is at the beginning of the content and can’t be moved up'
+					'Block "%1$s" is at the beginning of the content and can’t be moved up'
 				),
 				type
 			);
@@ -197,7 +199,7 @@ export function getBlockMoverDescription(
 			return sprintf(
 				// translators: 1: Type of block (i.e. Text, Image etc)
 				__(
-					'Block %1$s is at the beginning of the content and can’t be moved left'
+					'Block "%1$s" is at the beginning of the content and can’t be moved left'
 				),
 				type
 			);
@@ -207,7 +209,7 @@ export function getBlockMoverDescription(
 			return sprintf(
 				// translators: 1: Type of block (i.e. Text, Image etc)
 				__(
-					'Block %1$s is at the beginning of the content and can’t be moved right'
+					'Block "%1$s" is at the beginning of the content and can’t be moved right'
 				),
 				type
 			);

--- a/packages/block-editor/src/components/block-mover/test/mover-description.js
+++ b/packages/block-editor/src/components/block-mover/test/mover-description.js
@@ -24,7 +24,7 @@ describe( 'block mover', () => {
 					negativeDirection
 				)
 			).toBe(
-				`Block ${ label } is at the beginning of the content and can’t be moved up`
+				`Block "${ label }" is at the beginning of the content and can’t be moved up`
 			);
 		} );
 
@@ -39,7 +39,7 @@ describe( 'block mover', () => {
 					positiveDirection
 				)
 			).toBe(
-				`Block ${ label } is at the end of the content and can’t be moved down`
+				`Block "${ label }" is at the end of the content and can’t be moved down`
 			);
 		} );
 
@@ -53,7 +53,9 @@ describe( 'block mover', () => {
 					false,
 					negativeDirection
 				)
-			).toBe( `Move ${ label } block from position 2 up to position 1` );
+			).toBe(
+				`Move "${ label }" block from position 2 up to position 1`
+			);
 		} );
 
 		it( 'generates a title for the second item moving down', () => {
@@ -67,7 +69,7 @@ describe( 'block mover', () => {
 					positiveDirection
 				)
 			).toBe(
-				`Move ${ label } block from position 2 down to position 3`
+				`Move "${ label }" block from position 2 down to position 3`
 			);
 		} );
 
@@ -81,7 +83,9 @@ describe( 'block mover', () => {
 					true,
 					positiveDirection
 				)
-			).toBe( `Block ${ label } is the only block, and cannot be moved` );
+			).toBe(
+				`Block "${ label }" is the only block, and cannot be moved`
+			);
 		} );
 
 		it( 'indicates that the block can be moved left when the orientation is horizontal and the direction is negative', () => {
@@ -96,7 +100,7 @@ describe( 'block mover', () => {
 					'horizontal'
 				)
 			).toBe(
-				`Move ${ label } block from position 2 left to position 1`
+				`Move "${ label }" block from position 2 left to position 1`
 			);
 		} );
 
@@ -112,7 +116,7 @@ describe( 'block mover', () => {
 					'horizontal'
 				)
 			).toBe(
-				`Move ${ label } block from position 2 right to position 3`
+				`Move "${ label }" block from position 2 right to position 3`
 			);
 		} );
 
@@ -128,7 +132,7 @@ describe( 'block mover', () => {
 					'horizontal'
 				)
 			).toBe(
-				`Block ${ label } is at the beginning of the content and can’t be moved left`
+				`Block "${ label }" is at the beginning of the content and can’t be moved left`
 			);
 		} );
 
@@ -144,7 +148,7 @@ describe( 'block mover', () => {
 					'horizontal'
 				)
 			).toBe(
-				`Block ${ label } is at the end of the content and can’t be moved right`
+				`Block "${ label }" is at the end of the content and can’t be moved right`
 			);
 		} );
 	} );


### PR DESCRIPTION

## What?
Fixes i18n issues in the `block-mover` component.

## Why?

Strings in Gutenberg are inconsistent and are not always easy to translate. This PR is part of an audit to fix i18n issues.

* Fix inconsistencies with quotes around block-names to avoid issues with 3rd-party blocks which may have inconsistent naming conventions

This PR is a result of a Yoast Hackathon event on Feb.16 2023.
Props @carolinan @afercia @SergeyBiryukov @aristath