### PR TITLE
Fix i18n issues in the `block-editor` hooks.

### DIFF
--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -74,7 +74,7 @@ export const withInspectorControl = createHigherOrderComponent(
 						help={
 							<>
 								{ __(
-									'Enter a word or two — without spaces — to make a unique web address just for this block, called an “anchor.” Then, you’ll be able to link directly to this section of your page.'
+									'Enter a word or two (without spaces) to make a unique web address just for this block, called an “anchor”. Then, you will be able to link directly to this section of your page.'
 								) }
 
 								{ isWeb && (

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -16,7 +16,7 @@ import {
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { Platform } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -281,7 +281,7 @@ export function BorderPanel( props ) {
 			{ isRadiusSupported && (
 				<ToolsPanelItem
 					hasValue={ () => hasBorderRadiusValue( props ) }
-					label={ __( 'Radius' ) }
+					label={ _x( 'Radius', 'border radius' ) }
 					onDeselect={ () => resetBorderRadius( props ) }
 					isShownByDefault={ defaultBorderControls?.radius }
 					resetAllFilter={ ( newAttributes ) => ( {

--- a/packages/block-editor/src/hooks/child-layout.js
+++ b/packages/block-editor/src/hooks/child-layout.js
@@ -6,7 +6,7 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
 
 /**
@@ -88,17 +88,17 @@ export function ChildLayoutEdit( {
 				<ToggleGroupControlOption
 					key={ 'fit' }
 					value={ 'fit' }
-					label={ __( 'Fit' ) }
+					label={ _x( 'Fit', 'CSS flex size' ) }
 				/>
 				<ToggleGroupControlOption
 					key={ 'fill' }
 					value={ 'fill' }
-					label={ __( 'Fill' ) }
+					label={ _x( 'Fill', 'CSS flex size' ) }
 				/>
 				<ToggleGroupControlOption
 					key={ 'fixed' }
 					value={ 'fixed' }
-					label={ __( 'Fixed' ) }
+					label={ _x( 'Fixed', 'CSS flex size' ) }
 				/>
 			</ToggleGroupControl>
 			{ selfStretch === 'fixed' && (

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
 import {
 	BaseControl,
@@ -42,14 +42,14 @@ const OPTION_CLASSNAME =
 const DEFAULT_OPTION = {
 	key: 'default',
 	value: '',
-	name: __( 'Default' ),
+	name: _x( 'Default', 'CSS position' ),
 	className: OPTION_CLASSNAME,
 };
 
 const STICKY_OPTION = {
 	key: 'sticky',
 	value: 'sticky',
-	name: __( 'Sticky' ),
+	name: _x( 'Sticky', 'CSS position' ),
 	className: OPTION_CLASSNAME,
 	__experimentalHint: __(
 		'The block will stick to the top of the window instead of scrolling.'
@@ -59,7 +59,7 @@ const STICKY_OPTION = {
 const FIXED_OPTION = {
 	key: 'fixed',
 	value: 'fixed',
-	name: __( 'Fixed' ),
+	name: _x( 'Fixed', 'CSS position' ),
 	className: OPTION_CLASSNAME,
 	__experimentalHint: __(
 		'The block will not move when the page is scrolled.'


### PR DESCRIPTION

## What?
Fixes i18n issues in the `block-editor` hooks.

## Why?

Strings in Gutenberg are inconsistent and are not always easy to translate. This PR is part of an audit to fix i18n issues.

* Use `_x` for translations that need additional context
* Avoid contractions. This is already done in Core, Gutenberg should follow the same convention where appropriate
* Avoid the use of special characters in translations

This PR is a result of a Yoast Hackathon event on Feb.16 2023.
Props @carolinan @afercia @SergeyBiryukov @aristath