### PR TITLE
Fix i18n issues in the `block-editor` store

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1515,13 +1515,13 @@ export const __unstableSetEditorMode =
 		if ( mode === 'navigation' ) {
 			speak(
 				__(
-					'You are currently in navigation mode. Navigate blocks using the Tab key and Arrow keys. Use Left and Right Arrow keys to move between nesting levels. To exit navigation mode and edit the selected block, press Enter.'
+					'You are currently in navigation mode. Navigate blocks using the Tab key and Arrow keys. Use Left and Right Arrow keys to move between nesting levels. To exit navigation mode and edit the selected block, press the Enter key.'
 				)
 			);
 		} else if ( mode === 'edit' ) {
 			speak(
 				__(
-					'You are currently in edit mode. To return to the navigation mode, press Escape.'
+					'You are currently in edit mode. To return to the navigation mode, press the Escape key.'
 				)
 			);
 		} else if ( mode === 'zoom-out' ) {
@@ -1542,7 +1542,7 @@ export const setBlockMovingClientId =
 		if ( hasBlockMovingClientId ) {
 			speak(
 				__(
-					'Use the Tab key and Arrow keys to choose new block location. Use Left and Right Arrow keys to move between nesting levels. Once location is selected press Enter or Space to move the block.'
+					'Use the Tab key and Arrow keys to choose new block location. Use Left and Right Arrow keys to move between nesting levels. Once location is selected press the Enter or Space keys to move the block.'
 				)
 			);
 		}

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -133,9 +133,9 @@ export const SETTINGS_DEFAULTS = {
 
 	imageSizes: [
 		{ slug: 'thumbnail', name: __( 'Thumbnail' ) },
-		{ slug: 'medium', name: __( 'Medium' ) },
-		{ slug: 'large', name: __( 'Large' ) },
-		{ slug: 'full', name: __( 'Full Size' ) },
+		{ slug: 'medium', name: _x( 'Medium', 'image size' ) },
+		{ slug: 'large', name: _x( 'Large', 'image size' ) },
+		{ slug: 'full', name: _x( 'Full Size', 'image size' ) },
 	],
 
 	// Allow plugin to disable Image Editor if need be.


### PR DESCRIPTION
## What?
Fixes i18n issues in the `block-editor` store

## Why?

Strings in Gutenberg are inconsistent and are not always easy to translate. This PR is part of an audit to fix i18n issues.

* Use `_x` for translations that need additional context
* Improve wording

