### PR TITLE
Fix i18n issues in the `inserter` component.

### DIFF
--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -6,7 +6,7 @@ import { groupBy } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import { useMemo, useEffect } from '@wordpress/element';
 import { pipe, useAsyncList } from '@wordpress/compose';
 
@@ -137,13 +137,13 @@ export function BlockTypesTab( {
 				{ didRenderAllCategories && uncategorizedItems.length > 0 && (
 					<InserterPanel
 						className="block-editor-inserter__uncategorized-blocks-panel"
-						title={ __( 'Uncategorized' ) }
+						title={ _x( 'Uncategorized', 'block category' ) }
 					>
 						<BlockTypesList
 							items={ uncategorizedItems }
 							onSelect={ onSelectItem }
 							onHover={ onHover }
-							label={ __( 'Uncategorized' ) }
+							label={ _x( 'Uncategorized', 'block category' ) }
 						/>
 					</InserterPanel>
 				) }

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -403,7 +403,7 @@ export default compose( [
 
 				const message = sprintf(
 					// translators: %s: the name of the block that has been added
-					__( '%s block added' ),
+					__( '"%s" block added' ),
 					allowedBlockType.title
 				);
 				speak( message );

--- a/packages/block-editor/src/components/inserter/index.native.js
+++ b/packages/block-editor/src/components/inserter/index.native.js
@@ -96,31 +96,31 @@ export class Inserter extends Component {
 	getInsertionOptions() {
 		const addBeforeOption = {
 			value: 'before',
-			label: __( 'Add Block Before' ),
+			label: __( 'Add block before' ),
 			icon: plusCircle,
 		};
 
 		const replaceCurrentOption = {
 			value: 'replace',
-			label: __( 'Replace Current Block' ),
+			label: __( 'Replace current block' ),
 			icon: plusCircleFilled,
 		};
 
 		const addAfterOption = {
 			value: 'after',
-			label: __( 'Add Block After' ),
+			label: __( 'Add block after' ),
 			icon: plusCircle,
 		};
 
 		const addToBeginningOption = {
 			value: 'start',
-			label: __( 'Add To Beginning' ),
+			label: __( 'Add to beginning' ),
 			icon: insertBefore,
 		};
 
 		const addToEndOption = {
 			value: 'end',
-			label: __( 'Add To End' ),
+			label: __( 'Add to end' ),
 			icon: insertAfter,
 		};
 

--- a/packages/block-editor/src/components/inserter/media-tab/media-list.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-list.js
@@ -129,7 +129,7 @@ function MediaList( {
 	mediaList,
 	category,
 	onClick,
-	label = __( 'Media List' ),
+	label = __( 'Media list' ),
 } ) {
 	const composite = useCompositeState();
 	const onPreviewClick = useCallback(

--- a/packages/block-editor/src/components/inserter/preview-panel.js
+++ b/packages/block-editor/src/components/inserter/preview-panel.js
@@ -42,7 +42,7 @@ function InserterPreviewPanel( { item } ) {
 					</div>
 				) : (
 					<div className="block-editor-inserter__preview-content-missing">
-						{ __( 'No Preview Available.' ) }
+						{ __( 'No preview available.' ) }
 					</div>
 				) }
 			</div>

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -149,7 +149,7 @@ function InserterSearchResults( {
 	const patternsUI = !! filteredBlockPatterns.length && (
 		<InserterPanel
 			title={
-				<VisuallyHidden>{ __( 'Block Patterns' ) }</VisuallyHidden>
+				<VisuallyHidden>{ __( 'Block patterns' ) }</VisuallyHidden>
 			}
 		>
 			<div className="block-editor-inserter__quick-inserter-patterns">

--- a/packages/block-editor/src/components/inserter/tips.js
+++ b/packages/block-editor/src/components/inserter/tips.js
@@ -8,18 +8,21 @@ import { Tip } from '@wordpress/components';
 const globalTips = [
 	createInterpolateElement(
 		__(
+			// translators: Do not remove the <kbd> code.
 			'While writing, you can press <kbd>/</kbd> to quickly insert new blocks.'
 		),
 		{ kbd: <kbd /> }
 	),
 	createInterpolateElement(
 		__(
+			// translators: Do not remove the <kbd> code.
 			'Indent a list by pressing <kbd>space</kbd> at the beginning of a line.'
 		),
 		{ kbd: <kbd /> }
 	),
 	createInterpolateElement(
 		__(
+			// translators: Do not remove the <kbd> code.
 			'Outdent a list by pressing <kbd>backspace</kbd> at the beginning of a line.'
 		),
 		{ kbd: <kbd /> }


### PR DESCRIPTION
## What?
Fixes i18n issues in the `inserter` component.

## Why?

Strings in Gutenberg are inconsistent and are not always easy to translate. This PR is part of an audit to fix i18n issues.

* Fixes string capitalization
* Adds translator comments to make it clear to translators what the context is, and make their job easier.
* Fix inconsistencies with quotes around block-names to avoid issues with 3rd-party blocks which may have inconsistent naming conventions
* Use `_x` for translations that need additional context
* Improve wording


This PR is a result of a Yoast Hackathon event on Feb.16 2023.
Props @carolinan @afercia @SergeyBiryukov @aristath