### PR TITLE
Fix i18n issues in the `link-control` component.

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -287,7 +287,7 @@ function LinkControl( {
 		>
 			{ isCreatingPage && (
 				<div className="block-editor-link-control__loading">
-					<Spinner /> { __( 'Creating' ) }…
+					<Spinner /> { __( 'Creating…' ) }
 				</div>
 			) }
 

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import {
 	Button,
 	ExternalLink,
@@ -59,7 +59,7 @@ export default function LinkPreview( {
 
 	return (
 		<div
-			aria-label={ __( 'Currently selected' ) }
+			aria-label={ _x( 'Currently selected', 'link' ) }
 			className={ classnames( 'block-editor-link-control__search-item', {
 				'is-current': true,
 				'is-rich': hasRichData,

--- a/packages/block-editor/src/components/link-control/search-create-button.js
+++ b/packages/block-editor/src/components/link-control/search-create-button.js
@@ -32,8 +32,8 @@ export const LinkControlSearchCreate = ( {
 		text = createInterpolateElement(
 			sprintf(
 				/* translators: %s: search term. */
-				__( 'Create: <mark>%s</mark>' ),
-				searchTerm
+				__( 'Create: %s' ),
+				'<mark>' + searchTerm + '</mark>'
 			),
 			{ mark: <mark /> }
 		);

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -131,7 +131,7 @@ const LinkControlSearchInput = forwardRef(
 					className={ inputClasses }
 					value={ value }
 					onChange={ onInputChange }
-					placeholder={ placeholder ?? __( 'Search or type url' ) }
+					placeholder={ placeholder ?? __( 'Search or type URL' ) }
 					__experimentalRenderSuggestions={
 						showSuggestions ? handleRenderSuggestions : null
 					}

--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -85,7 +85,7 @@ export const LinkControlSearchItem = ( {
 							safeDecodeURI( suggestion.url )
 						) ||
 							'' ) }
-					{ isURL && __( 'Press ENTER to add this link' ) }
+					{ isURL && __( 'Press the Enter key to add this link' ) }
 				</span>
 			</span>
 			{ shouldShowType && suggestion.type && (

--- a/packages/block-editor/src/components/link-control/settings-drawer.js
+++ b/packages/block-editor/src/components/link-control/settings-drawer.js
@@ -46,7 +46,7 @@ function LinkSettingsDrawer( {
 				aria-expanded={ settingsOpen }
 				onClick={ () => setSettingsOpen( ! settingsOpen ) }
 				icon={ settingsIcon }
-				label={ __( 'Toggle link settings' ) }
+				label={ __( 'Link settings' ) }
 				aria-controls={ settingsDrawerId }
 			/>
 			<MaybeAnimatePresence>

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -198,7 +198,7 @@ describe( 'Basic rendering', () => {
 			within( resultsList ).getAllByRole( 'option' );
 
 		expect( searchResultElements ).toHaveLength(
-			// The fauxEntitySuggestions length plus the 'Press ENTER to add this link' button.
+			// The fauxEntitySuggestions length plus the 'Press the Enter key to add this link' button.
 			fauxEntitySuggestions.length + 1
 		);
 
@@ -577,7 +577,7 @@ describe( 'Searching for a link', () => {
 			expect( lastSearchResultItem ).toHaveTextContent( searchTerm );
 			expect( lastSearchResultItem ).toHaveTextContent( 'URL' );
 			expect( lastSearchResultItem ).toHaveTextContent(
-				'Press ENTER to add this link'
+				'Press the Enter key to add this link'
 			);
 		}
 	);
@@ -632,7 +632,7 @@ describe( 'Manual link entry', () => {
 			expect( searchResultElements ).toHaveTextContent( searchTerm );
 			expect( searchResultElements ).toHaveTextContent( 'URL' );
 			expect( searchResultElements ).toHaveTextContent(
-				'Press ENTER to add this link'
+				'Press the Enter key to add this link'
 			);
 		}
 	);
@@ -890,7 +890,7 @@ describe( 'Manual link entry', () => {
 				expect( searchResultElements ).toHaveTextContent( searchTerm );
 				expect( searchResultElements ).toHaveTextContent( searchType );
 				expect( searchResultElements ).toHaveTextContent(
-					'Press ENTER to add this link'
+					'Press the Enter key to add this link'
 				);
 			}
 		);
@@ -1670,7 +1670,7 @@ describe( 'Addition Settings UI', () => {
 		render( <LinkControlConsumer /> );
 
 		const settingsToggle = screen.queryByRole( 'button', {
-			name: 'Toggle link settings',
+			name: 'Link settings',
 			ariaControls: 'link-settings-1',
 		} );
 
@@ -1690,7 +1690,7 @@ describe( 'Addition Settings UI', () => {
 		const user = userEvent.setup();
 
 		const settingsToggle = screen.queryByRole( 'button', {
-			name: 'Toggle link settings',
+			name: 'Link settings',
 			ariaControls: 'link-settings-1',
 		} );
 
@@ -2241,7 +2241,7 @@ describe( 'Controlling link title text', () => {
 
 async function toggleSettingsDrawer( user ) {
 	const settingsToggle = screen.queryByRole( 'button', {
-		name: 'Toggle link settings',
+		name: 'Link settings',
 	} );
 
 	await user.click( settingsToggle );


### PR DESCRIPTION
## What?
Fixes i18n issues in the `link-control` component.

## Why?

Strings in Gutenberg are inconsistent and are not always easy to translate. This PR is part of an audit to fix i18n issues.

* Fix strings capitalization
* Avoid the use of HTML in translation strings
* Use `_x` for translations that need additional context
* Improve wording
* Avoid using the word "toggle" in translatable strings


This PR is a result of a Yoast Hackathon event on Feb.16 2023.
Props @carolinan @afercia @SergeyBiryukov @aristath