### PR TITLE
Fix i18n issues in the `spacing-sizes-control` component.

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/index.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { BaseControl } from '@wordpress/components';
 
 /**
@@ -23,7 +23,7 @@ import useSetting from '../use-setting';
 export default function SpacingSizesControl( {
 	inputProps,
 	onChange,
-	label = __( 'Spacing Control' ),
+	label = __( 'Spacing control' ),
 	values,
 	sides,
 	splitOnAxis = false,
@@ -39,7 +39,7 @@ export default function SpacingSizesControl( {
 
 	if ( spacingSizes.length > 8 ) {
 		spacingSizes.unshift( {
-			name: __( 'Default' ),
+			name: _x( 'Default', 'size' ),
 			slug: 'default',
 			size: undefined,
 		} );

--- a/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
@@ -18,7 +18,7 @@ import {
 	__experimentalUseCustomUnits as useCustomUnits,
 	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
 } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { settings } from '@wordpress/icons';
 
 /**
@@ -91,7 +91,7 @@ export default function SpacingInputControl( {
 				name: ! isMixed
 					? // translators: A custom measurement, eg. a number followed by a unit like 12px.
 					  sprintf( __( 'Custom (%s)' ), value )
-					: __( 'Mixed' ),
+					: _x( 'Mixed', 'CSS values' ),
 				slug: 'custom',
 				size: value,
 			},
@@ -146,11 +146,11 @@ export default function SpacingInputControl( {
 		onChange( [ next, selectedUnit ].join( '' ) );
 	};
 
-	const allPlaceholder = isMixed ? __( 'Mixed' ) : null;
+	const allPlaceholder = isMixed ? _x( 'Mixed', 'CSS values' ) : null;
 
 	const currentValueHint = ! isMixed
 		? customTooltipContent( currentValue )
-		: __( 'Mixed' );
+		: _x( 'Mixed', 'CSS values' );
 
 	const options = selectListSizes.map( ( size, index ) => ( {
 		key: index,
@@ -164,7 +164,7 @@ export default function SpacingInputControl( {
 
 	const ariaLabel = sprintf(
 		// translators: 1: The side of the block being modified (top, bottom, left, etc.). 2. Type of spacing being modified (Padding, margin, etc)
-		__( '%1$s %2$s' ),
+		_x( '%1$s %2$s', 'block side and spacing type' ),
 		LABELS[ side ],
 		type?.toLowerCase()
 	);

--- a/packages/block-editor/src/components/spacing-sizes-control/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/utils.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Checks is given value is a spacing preset.
@@ -137,7 +137,7 @@ export const LABELS = {
 	bottom: __( 'Bottom' ),
 	left: __( 'Left' ),
 	right: __( 'Right' ),
-	mixed: __( 'Mixed' ),
+	mixed: _x( 'Mixed', 'spacing sides' ),
 	vertical: __( 'Vertical' ),
 	horizontal: __( 'Horizontal' ),
 };


### PR DESCRIPTION
## What?
Fixes i18n issues in the `spacing-sizes-control` component.

## Why?

Strings in Gutenberg are inconsistent and are not always easy to translate. This PR is part of an audit to fix i18n issues.

* Fix strings capitalization
* Use `_x` for translations that need additional context

This PR is a result of a Yoast Hackathon event on Feb.16 2023.
Props @carolinan @afercia @SergeyBiryukov @aristath