### PR TITLE
Fix i18n issues in the `block-patterns-list` component.

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -122,7 +122,7 @@ function BlockPatternList( {
 	onHover,
 	onClickPattern,
 	orientation,
-	label = __( 'Block Patterns' ),
+	label = __( 'Block patterns' ),
 	showTitlesAsTooltip,
 } ) {
 	const composite = useCompositeState( { orientation } );


### PR DESCRIPTION
## What?
Fixes i18n issues in the `block-patterns-list` component.

## Why?

Strings in Gutenberg are inconsistent and are not always easy to translate. This PR is part of an audit to fix i18n issues.

* Fix strings capitalization

This PR is a result of a Yoast Hackathon event on Feb.16 2023.
Props @carolinan @afercia @SergeyBiryukov @aristath