### PR TITLE
Fix i18n issues in the `block-switcher` component.

### DIFF
--- a/packages/block-editor/src/components/block-mobile-toolbar/test/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/test/block-actions-menu.native.js
@@ -426,7 +426,7 @@ describe( 'Block Actions Menu', () => {
 			// Get Picker title
 			const pickerHeader = getByRole( 'header' );
 			const headerTitle = within( pickerHeader ).getByText(
-				/Transform Paragraph to/
+				/Transform "Paragraph" to/
 			);
 			expect( headerTitle ).toBeVisible();
 

--- a/packages/block-editor/src/components/block-switcher/block-transformations-menu.native.js
+++ b/packages/block-editor/src/components/block-switcher/block-transformations-menu.native.js
@@ -66,7 +66,7 @@ const BlockTransformationsMenu = ( {
 		);
 		const successNotice = sprintf(
 			/* translators: 1: From block title, e.g. Paragraph. 2: To block title, e.g. Header. */
-			__( '%1$s transformed to %2$s' ),
+			__( '"%1$s" transformed to "%2$s"' ),
 			blockTitle,
 			selectedItem.label
 		);
@@ -82,7 +82,7 @@ const BlockTransformationsMenu = ( {
 			leftAlign={ true }
 			getAnchor={ getAnchor }
 			// translators: %s: block title e.g: "Paragraph".
-			title={ sprintf( __( 'Transform %s to' ), blockTitle ) }
+			title={ sprintf( __( 'Transform "%s" to' ), blockTitle ) }
 		/>
 	);
 };


### PR DESCRIPTION
## What?
Fixes i18n issues in the `block-switcher` component.

## Why?

Strings in Gutenberg are inconsistent and are not always easy to translate. This PR is part of an audit to fix i18n issues.

* Fix inconsistencies with quotes around block-names to avoid issues with 3rd-party blocks which may have inconsistent naming conventions


This PR is a result of a Yoast Hackathon event on Feb.16 2023.
Props @carolinan @afercia @SergeyBiryukov @aristath