### PR TITLE
Fix i18n issues in the `color-style-selector` component.

### DIFF
--- a/packages/block-editor/src/components/color-style-selector/index.js
+++ b/packages/block-editor/src/components/color-style-selector/index.js
@@ -63,7 +63,7 @@ const renderToggleComponent =
 			<ToolbarGroup>
 				<ToolbarButton
 					className="components-toolbar__control block-library-colors-selector__toggle"
-					label={ __( 'Open Colors Selector' ) }
+					label={ __( 'Open colors selector' ) }
 					onClick={ onToggle }
 					onKeyDown={ openOnArrowDown }
 					icon={


### PR DESCRIPTION
## What?
Fixes i18n issues in the `color-style-selector` component.

## Why?

Strings in Gutenberg are inconsistent and are not always easy to translate. This PR is part of an audit to fix i18n issues.

* Fix strings capitalization

This PR is a result of a Yoast Hackathon event on Feb.16 2023.
Props @carolinan @afercia @SergeyBiryukov @aristath