### PR TITLE
Fixes i18n issues in the `date-format-picker` component.

### DIFF
--- a/packages/block-editor/src/components/date-format-picker/index.js
+++ b/packages/block-editor/src/components/date-format-picker/index.js
@@ -99,7 +99,7 @@ function NonDefaultControls( { format, onChange } ) {
 	);
 	const customOption = {
 		key: 'custom',
-		name: __( 'Custom' ),
+		name: __( 'Custom format' ),
 		className:
 			'block-editor-date-format-picker__custom-format-select-control__custom-option',
 		__experimentalHint: __( 'Enter your own date format' ),
@@ -137,6 +137,7 @@ function NonDefaultControls( { format, onChange } ) {
 					label={ __( 'Custom format' ) }
 					hideLabelFromVision
 					help={ createInterpolateElement(
+						// translators: <Link> creates a link to the WordPress.org documentation on date and time formatting.
 						__(
 							'Enter a date or time <Link>format string</Link>.'
 						),


### PR DESCRIPTION
## What?
Fixes i18n issues in the `date-format-picker` component.

## Why?

Strings in Gutenberg are inconsistent and are not always easy to translate. This PR is part of an audit to fix i18n issues.

* Adds translator comments to make it clear to translators what the context is, and make their job easier.
* Improve wording

This PR is a result of a Yoast Hackathon event on Feb.16 2023.
Props @carolinan @afercia @SergeyBiryukov @aristath