### PR TITLE
Fix i18n issues in the `off-canvas-editor` component.

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/appender.js
+++ b/packages/block-editor/src/components/off-canvas-editor/appender.js
@@ -68,7 +68,7 @@ export const Appender = forwardRef(
 		const descriptionId = `off-canvas-editor-appender__${ instanceId }`;
 		const description = sprintf(
 			/* translators: 1: The name of the block. 2: The numerical position of the block. 3: The level of nesting for the block. */
-			__( 'Append to %1$s block at position %2$d, Level %3$d' ),
+			__( 'Append to "%1$s" block at position %2$d, level %3$d' ),
 			blockTitle,
 			blockCount + 1,
 			nestingLevel

--- a/packages/block-editor/src/components/off-canvas-editor/block-select-button.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-select-button.js
@@ -65,7 +65,7 @@ function ListViewBlockSelectButton(
 	const editAriaLabel = blockInformation
 		? sprintf(
 				// translators: %s: The title of the block.
-				__( 'Edit %s block' ),
+				__( 'Edit "%s" block' ),
 				blockInformation.title
 		  )
 		: __( 'Edit' );

--- a/packages/block-editor/src/components/off-canvas-editor/block.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block.js
@@ -166,12 +166,12 @@ function ListViewBlock( {
 		blockAriaLabel = isLocked
 			? sprintf(
 					// translators: %s: The title of the block. This string indicates a link to select the locked block.
-					__( '%s link (locked)' ),
+					__( '"%s" link (locked)' ),
 					blockInformation.title
 			  )
 			: sprintf(
 					// translators: %s: The title of the block. This string indicates a link to select the block.
-					__( '%s link' ),
+					__( '"%s" link' ),
 					blockInformation.title
 			  );
 	}
@@ -179,7 +179,7 @@ function ListViewBlock( {
 	const settingsAriaLabel = blockInformation
 		? sprintf(
 				// translators: %s: The title of the block.
-				__( 'Options for %s block' ),
+				__( 'Options for "%s" block' ),
 				blockInformation.title
 		  )
 		: __( 'Options' );

--- a/packages/block-editor/src/components/off-canvas-editor/leaf-more-menu.js
+++ b/packages/block-editor/src/components/off-canvas-editor/leaf-more-menu.js
@@ -90,7 +90,7 @@ export default function LeafMoreMenu( props ) {
 
 	const removeLabel = sprintf(
 		/* translators: %s: block name */
-		__( 'Remove %s' ),
+		__( 'Remove "%s"' ),
 		BlockTitle( { clientId, maximumLength: 25 } )
 	);
 

--- a/packages/block-editor/src/components/off-canvas-editor/use-block-selection.js
+++ b/packages/block-editor/src/components/off-canvas-editor/use-block-selection.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { speak } from '@wordpress/a11y';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { UP, DOWN, HOME, END } from '@wordpress/keycodes';
@@ -132,14 +132,18 @@ export default function useBlockSelection() {
 				if ( title ) {
 					label = sprintf(
 						/* translators: %s: block name */
-						__( '%s deselected.' ),
+						__( '"%s" block deselected.' ),
 						title
 					);
 				}
 			} else if ( selectionDiff.length > 1 ) {
 				label = sprintf(
-					/* translators: %s: number of deselected blocks */
-					__( '%s blocks deselected.' ),
+					/* translators: %d: number of deselected blocks */
+					_n(
+						'%d block deselected.',
+						'%d blocks deselected.',
+						selectionDiff.length
+					),
 					selectionDiff.length
 				);
 			}

--- a/packages/block-editor/src/components/off-canvas-editor/utils.js
+++ b/packages/block-editor/src/components/off-canvas-editor/utils.js
@@ -6,7 +6,7 @@ import { __, sprintf } from '@wordpress/i18n';
 export const getBlockPositionDescription = ( position, siblingCount, level ) =>
 	sprintf(
 		/* translators: 1: The numerical position of the block. 2: The total number of blocks. 3. The level of nesting for the block. */
-		__( 'Block %1$d of %2$d, Level %3$d' ),
+		__( 'Block %1$d of %2$d, level %3$d' ),
 		position,
 		siblingCount,
 		level


### PR DESCRIPTION
## What?
Fixes i18n issues in the `off-canvas-editor` component.

## Why?

Strings in Gutenberg are inconsistent and are not always easy to translate. This PR is part of an audit to fix i18n issues.

* Fix strings capitalization
* Fix inconsistencies with quotes around block-names to avoid issues with 3rd-party blocks which may have inconsistent naming conventions
* Use `_n` for translations depending on a number

This PR is a result of a Yoast Hackathon event on Feb.16 2023.
Props @carolinan @afercia @SergeyBiryukov @aristath