### PR TITLE
Fixes i18n issues in the `default-style-picker` component.

### DIFF
--- a/packages/block-editor/src/components/default-style-picker/index.js
+++ b/packages/block-editor/src/components/default-style-picker/index.js
@@ -61,7 +61,7 @@ export default function DefaultStylePicker( { blockName } ) {
 					__nextHasNoMarginBottom
 					options={ selectOptions }
 					value={ preferredStyle || '' }
-					label={ __( 'Default Style' ) }
+					label={ __( 'Default style' ) }
 					onChange={ selectOnChange }
 				/>
 			</div>


### PR DESCRIPTION
## What?
Fixes i18n issues in the `default-style-picker` component.

## Why?

Strings in Gutenberg are inconsistent and are not always easy to translate. This PR is part of an audit to fix i18n issues.

* Fix strings capitalization

This PR is a result of a Yoast Hackathon event on Feb.16 2023.
Props @carolinan @afercia @SergeyBiryukov @aristath