### PR TITLE
Fix i18n issues in the `font-family` component.

### DIFF
--- a/packages/block-editor/src/components/font-family/index.js
+++ b/packages/block-editor/src/components/font-family/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { SelectControl } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -25,7 +25,7 @@ export default function FontFamilyControl( {
 	}
 
 	const options = [
-		{ value: '', label: __( 'Default' ) },
+		{ value: '', label: _x( 'Default', 'font family' ) },
 		...fontFamilies.map( ( { fontFamily, name } ) => {
 			return {
 				value: fontFamily,


### PR DESCRIPTION
## What?
Fixes i18n issues in the `font-family` component.

## Why?

Strings in Gutenberg are inconsistent and are not always easy to translate. This PR is part of an audit to fix i18n issues.

* Use `_x` for translations that need additional context

This PR is a result of a Yoast Hackathon event on Feb.16 2023.
Props @carolinan @afercia @SergeyBiryukov @aristath