### PR TITLE
Fix i18n issues in the `font-sizes` component's documentation examples

### DIFF
--- a/packages/block-editor/src/components/font-sizes/README.MD
+++ b/packages/block-editor/src/components/font-sizes/README.MD
@@ -10,19 +10,19 @@ There is an equivalent component exposed under @wordpress/components. The differ
 ```jsx
 import { FontSizePicker } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 
 ...
 const MyFontSizePicker = () => {
 	const [ fontSize, setFontSize ] = useState( 16 );
 	const fontSizes = [
 		{
-			name: __( 'Small' ),
+			name: _x( 'Small', 'font size' ),
 			slug: 'small',
 			size: 12,
 		},
 		{
-			name: __( 'Big' ),
+			name: _x( 'Big', 'font size' ),
 			slug: 'big',
 			size: 26,
 		},


### PR DESCRIPTION
## What?
Fixes i18n issues in the `font-sizes` component's documentation examples

## Why?

Strings in Gutenberg are inconsistent and are not always easy to translate. This PR is part of an audit to fix i18n issues.
This particular file edited here is the documentation, so the changes suggested in this PR aim to educate and urge users to use the correct context for their translations when that is necessary.

* Use `_x` for translations that need additional context

This PR is a result of a Yoast Hackathon event on Feb.16 2023.
Props @carolinan @afercia @SergeyBiryukov @aristath