### PR TITLE
Navigation: Wrap the dependent functions in useCallback

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import {
+	useCallback,
 	useState,
 	useEffect,
 	useRef,
@@ -365,16 +366,16 @@ function Navigation( {
 	] = useState();
 	const [ detectedOverlayColor, setDetectedOverlayColor ] = useState();
 
-	const handleUpdateMenu = (
-		menuId,
-		options = { focusNavigationBlock: false }
-	) => {
-		const { focusNavigationBlock } = options;
-		setRef( menuId );
-		if ( focusNavigationBlock ) {
-			selectBlock( clientId );
-		}
-	};
+	const handleUpdateMenu = useCallback(
+		( menuId, options = { focusNavigationBlock: false } ) => {
+			const { focusNavigationBlock } = options;
+			setRef( menuId );
+			if ( focusNavigationBlock ) {
+				selectBlock( clientId );
+			}
+		},
+		[ selectBlock, clientId ]
+	);
 
 	const onSelectClassicMenu = async ( classicMenu ) => {
 		const navMenu = await convertClassicMenu(
@@ -421,9 +422,9 @@ function Navigation( {
 		createNavigationMenuPost,
 		createNavigationMenuIsError,
 		createNavigationMenuIsSuccess,
+		isCreatingNavigationMenu,
 		handleUpdateMenu,
 		hideNavigationMenuStatusNotice,
-		isCreatingNavigationMenu,
 		showNavigationMenuStatusNotice,
 	] );
 

--- a/packages/block-library/src/navigation/edit/use-navigation-notice.js
+++ b/packages/block-library/src/navigation/edit/use-navigation-notice.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useRef } from '@wordpress/element';
+import { useCallback, useRef } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { store as noticeStore } from '@wordpress/notices';
 
@@ -10,26 +10,29 @@ function useNavigationNotice( { name, message = '' } = {} ) {
 
 	const { createWarningNotice, removeNotice } = useDispatch( noticeStore );
 
-	const showNotice = ( customMsg ) => {
-		if ( noticeRef.current ) {
-			return;
-		}
+	const showNotice = useCallback(
+		( customMsg ) => {
+			if ( noticeRef.current ) {
+				return;
+			}
 
-		noticeRef.current = name;
+			noticeRef.current = name;
 
-		createWarningNotice( customMsg || message, {
-			id: noticeRef.current,
-			type: 'snackbar',
-		} );
-	};
+			createWarningNotice( customMsg || message, {
+				id: noticeRef.current,
+				type: 'snackbar',
+			} );
+		},
+		[ noticeRef, createWarningNotice ]
+	);
 
-	const hideNotice = () => {
+	const hideNotice = useCallback( () => {
 		if ( ! noticeRef.current ) {
 			return;
 		}
 		removeNotice( noticeRef.current );
 		noticeRef.current = null;
-	};
+	}, [ noticeRef, removeNotice ] );
 
 	return [ showNotice, hideNotice ];
 }


### PR DESCRIPTION
## What?
In https://github.com/WordPress/gutenberg/pull/48066/ we added all the necessary dependencies to the useEffects in the navigation block. Three of these dependencies (handleUpdateMenu, hideNavigationMenuStatusNotice, showNavigationMenuStatusNotice) were functions, which get redefined whenever the component renders. This means we got stuck in a loop where there useEffect would keep firing.

To avoid this we need to wrap these function in `useCallback` which will cache the function until the parameters change. I'm not sure if I have specified the correct dependencies for the `useCallback` functions I have added.

## Testing Instructions
1. Delete all wp_navigation menus
2. Open the site editor
3. Add the navigation block to a site (if it doesn't have one)
4. Open the inspector controls for the navigation block
5. Add a block using the block inserter
6. Now click on the Page List in the Navigation List View
7. Check that the Page List block becomes selected
