### PR TITLE
Fix i18n issues in the `inspector-controls-tabs` component.

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/advanced-controls-panel.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/advanced-controls-panel.js
@@ -5,7 +5,7 @@ import {
 	PanelBody,
 	__experimentalUseSlotFills as useSlotFills,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -26,7 +26,7 @@ const AdvancedControls = () => {
 	return (
 		<PanelBody
 			className="block-editor-block-inspector__advanced"
-			title={ __( 'Advanced' ) }
+			title={ _x( 'Advanced', 'settings' ) }
 			initialOpen={ false }
 		>
 			<InspectorControls.Slot group="advanced" />

--- a/packages/block-editor/src/components/inspector-controls-tabs/settings-tab-hint.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/settings-tab-hint.js
@@ -29,7 +29,7 @@ export default function InspectorControlsTabsHint() {
 		<div ref={ ref } className="block-editor-inspector-controls-tabs__hint">
 			<div className="block-editor-inspector-controls-tabs__hint-content">
 				{ __(
-					"Looking for other block settings? They've moved to the styles tab."
+					'Looking for other block settings? They have moved to the styles tab.'
 				) }
 			</div>
 			<Button


### PR DESCRIPTION
## What?
Fixes i18n issues in the `inspector-controls-tabs` component.

## Why?

Strings in Gutenberg are inconsistent and are not always easy to translate. This PR is part of an audit to fix i18n issues.

* Use `_x` for translations that need additional context
* Avoid contractions. This is already done in Core, Gutenberg should follow the same convention where appropriate

This PR is a result of a Yoast Hackathon event on Feb.16 2023.
Props @carolinan @afercia @SergeyBiryukov @aristath