### PR TITLE
Fix i18n issues in the `media-placeholder` component.

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.native.js
+++ b/packages/block-editor/src/components/media-placeholder/index.native.js
@@ -90,13 +90,13 @@ function MediaPlaceholder( props ) {
 	let instructions = labels.instructions;
 	if ( instructions === undefined ) {
 		if ( isImage ) {
-			instructions = __( 'ADD IMAGE' );
+			instructions = __( 'Add image' );
 		} else if ( isVideo ) {
-			instructions = __( 'ADD VIDEO' );
+			instructions = __( 'Add video' );
 		} else if ( isAudio ) {
-			instructions = __( 'ADD AUDIO' );
+			instructions = __( 'Add audio' );
 		} else {
-			instructions = __( 'ADD IMAGE OR VIDEO' );
+			instructions = __( 'Add image or video' );
 		}
 	}
 
@@ -176,7 +176,7 @@ function MediaPlaceholder( props ) {
 						<TouchableWithoutFeedback
 							accessibilityLabel={ sprintf(
 								/* translators: accessibility text for the media block empty state. %s: media type */
-								__( '%s block. Empty' ),
+								__( '"%s" block. Empty' ),
 								placeholderTitle
 							) }
 							accessibilityRole={ 'button' }

--- a/packages/block-library/src/audio/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/audio/test/__snapshots__/edit.native.js.snap
@@ -362,7 +362,7 @@ exports[`Audio block renders placeholder without crashing 1`] = `
   >
     <View
       accessibilityHint="Double tap to select an audio file"
-      accessibilityLabel="Audio block. Empty"
+      accessibilityLabel="\"Audio\" block. Empty"
       accessibilityRole="button"
       accessible={true}
       focusable={true}

--- a/packages/block-library/src/cover/test/edit.native.js
+++ b/packages/block-library/src/cover/test/edit.native.js
@@ -334,7 +334,7 @@ describe( 'color settings', () => {
 			initialHtml: COVER_BLOCK_PLACEHOLDER_HTML,
 		} );
 
-		const block = await screen.findByLabelText( 'Cover block. Empty' );
+		const block = await screen.findByLabelText( '"Cover" block. Empty' );
 		expect( block ).toBeDefined();
 
 		// Select a color from the placeholder palette.
@@ -425,7 +425,7 @@ describe( 'color settings', () => {
 			initialHtml: COVER_BLOCK_PLACEHOLDER_HTML,
 		} );
 
-		const block = await screen.findByLabelText( 'Cover block. Empty' );
+		const block = await screen.findByLabelText( '"Cover" block. Empty' );
 		expect( block ).toBeDefined();
 
 		// Select a color from the placeholder palette.

--- a/packages/block-library/src/file/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/file/test/__snapshots__/edit.native.js.snap
@@ -432,7 +432,7 @@ exports[`File block renders placeholder without crashing 1`] = `
 >
   <View
     accessibilityHint="Double tap to select"
-    accessibilityLabel="File block. Empty"
+    accessibilityLabel="\"File\" block. Empty"
     accessibilityRole="button"
     accessible={true}
     focusable={true}

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -681,7 +681,7 @@ class EditorPage {
 		const accessibilityId = await block.getAttribute(
 			this.accessibilityIdKey
 		);
-		const blockLocator = `//*[@${ this.accessibilityIdXPathAttrib }="${ accessibilityId }"]//XCUIElementTypeButton[@name="Image block. Empty"]`;
+		const blockLocator = `//*[@${ this.accessibilityIdXPathAttrib }="${ accessibilityId }"]//XCUIElementTypeButton[@name="\"Image\" block. Empty"]`;
 		const imageBlockInnerElement = await this.driver.elementByXPath(
 			blockLocator
 		);


### PR DESCRIPTION
## What?
Fixes i18n issues in the `media-placeholder` component.

## Why?

Strings in Gutenberg are inconsistent and are not always easy to translate. This PR is part of an audit to fix i18n issues.

* Fix strings capitalization
* Fix inconsistencies with quotes around block-names to avoid issues with 3rd-party blocks which may have inconsistent naming conventions

This PR is a result of a Yoast Hackathon event on Feb.16 2023.
Props @carolinan @afercia @SergeyBiryukov @aristath