### PR TITLE
Fix i18n issues in the `text-decoration-control` component.

### DIFF
--- a/packages/block-editor/src/components/text-decoration-control/index.js
+++ b/packages/block-editor/src/components/text-decoration-control/index.js
@@ -8,11 +8,11 @@ import classnames from 'classnames';
  */
 import { BaseControl, Button } from '@wordpress/components';
 import { reset, formatStrikethrough, formatUnderline } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 const TEXT_DECORATIONS = [
 	{
-		name: __( 'None' ),
+		name: _x( 'None', 'text decoration' ),
 		value: 'none',
 		icon: reset,
 	},


### PR DESCRIPTION
## What?
Fixes i18n issues in the `text-decoration-control` component.

## Why?

Strings in Gutenberg are inconsistent and are not always easy to translate. This PR is part of an audit to fix i18n issues.

* Use `_x` for translations that need additional context

This PR is a result of a Yoast Hackathon event on Feb.16 2023.
Props @carolinan @afercia @SergeyBiryukov @aristath