### PR TITLE
Focus 1st parent block on block remove, if no previous block is available

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1496,7 +1496,8 @@ _Parameters_
 ### selectPreviousBlock
 
 Yields action objects used in signalling that the block preceding the given
-clientId or it's first parent from bottom to top should be selected.
+clientId (or optionally, its first parent from bottom to top)
+should be selected.
 
 _Parameters_
 

--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1493,7 +1493,7 @@ _Parameters_
 
 -   _clientId_ `string`: Block client ID.
 
-### selectPreviousBlockOrFirstParent
+### selectPreviousBlock
 
 Yields action objects used in signalling that the block preceding the given
 clientId or it's first parent from bottom to top should be selected.
@@ -1501,6 +1501,7 @@ clientId or it's first parent from bottom to top should be selected.
 _Parameters_
 
 -   _clientId_ `string`: Block client ID.
+-   _orFirstParent_ `boolean`: If true, select the first parent if there is no previous block.
 
 ### setBlockMovingClientId
 

--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1493,10 +1493,10 @@ _Parameters_
 
 -   _clientId_ `string`: Block client ID.
 
-### selectPreviousBlock
+### selectPreviousBlockOrFirstParent
 
 Yields action objects used in signalling that the block preceding the given
-clientId should be selected.
+clientId or it's first parent from bottom to top should be selected.
 
 _Parameters_
 

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -147,7 +147,9 @@ export function BlockSettingsDropdown( {
 		__experimentalSelectBlock
 			? () => {
 					const blockToSelect =
-						previousBlockClientId || nextBlockClientId;
+						previousBlockClientId ||
+						nextBlockClientId ||
+						firstParentClientId;
 
 					if (
 						blockToSelect &&
@@ -166,6 +168,7 @@ export function BlockSettingsDropdown( {
 			__experimentalSelectBlock,
 			previousBlockClientId,
 			nextBlockClientId,
+			firstParentClientId,
 			selectedBlockClientIds,
 		]
 	);

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -234,16 +234,17 @@ export function selectBlock( clientId, initialPosition = 0 ) {
  * Yields action objects used in signalling that the block preceding the given
  * clientId or it's first parent from bottom to top should be selected.
  *
- * @param {string} clientId Block client ID.
+ * @param {string}  clientId      Block client ID.
+ * @param {boolean} orFirstParent If true, select the first parent if there is no previous block.
  */
-export const selectPreviousBlockOrFirstParent =
-	( clientId ) =>
+export const selectPreviousBlock =
+	( clientId, orFirstParent = false ) =>
 	( { select, dispatch } ) => {
 		const previousBlockClientId =
 			select.getPreviousBlockClientId( clientId );
 		if ( previousBlockClientId ) {
 			dispatch.selectBlock( previousBlockClientId, -1 );
-		} else {
+		} else if ( orFirstParent ) {
 			const firstParentClientId = select.getBlockRootClientId( clientId );
 			if ( firstParentClientId ) {
 				dispatch.selectBlock( firstParentClientId, -1 );
@@ -1202,7 +1203,7 @@ export const removeBlocks =
 		}
 
 		if ( selectPrevious ) {
-			dispatch.selectPreviousBlockOrFirstParent( clientIds[ 0 ] );
+			dispatch.selectPreviousBlock( clientIds[ 0 ], true );
 		}
 
 		dispatch( { type: 'REMOVE_BLOCKS', clientIds } );

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -232,17 +232,22 @@ export function selectBlock( clientId, initialPosition = 0 ) {
 
 /**
  * Yields action objects used in signalling that the block preceding the given
- * clientId should be selected.
+ * clientId or it's first parent from bottom to top should be selected.
  *
  * @param {string} clientId Block client ID.
  */
-export const selectPreviousBlock =
+export const selectPreviousBlockOrFirstParent =
 	( clientId ) =>
 	( { select, dispatch } ) => {
 		const previousBlockClientId =
 			select.getPreviousBlockClientId( clientId );
 		if ( previousBlockClientId ) {
 			dispatch.selectBlock( previousBlockClientId, -1 );
+		} else {
+			const firstParentClientId = select.getBlockRootClientId( clientId );
+			if ( firstParentClientId ) {
+				dispatch.selectBlock( firstParentClientId, -1 );
+			}
 		}
 	};
 
@@ -1197,7 +1202,7 @@ export const removeBlocks =
 		}
 
 		if ( selectPrevious ) {
-			dispatch.selectPreviousBlock( clientIds[ 0 ] );
+			dispatch.selectPreviousBlockOrFirstParent( clientIds[ 0 ] );
 		}
 
 		dispatch( { type: 'REMOVE_BLOCKS', clientIds } );

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -232,7 +232,8 @@ export function selectBlock( clientId, initialPosition = 0 ) {
 
 /**
  * Yields action objects used in signalling that the block preceding the given
- * clientId or it's first parent from bottom to top should be selected.
+ * clientId (or optionally, its first parent from bottom to top)
+ * should be selected.
  *
  * @param {string}  clientId      Block client ID.
  * @param {boolean} orFirstParent If true, select the first parent if there is no previous block.
@@ -1203,7 +1204,8 @@ export const removeBlocks =
 		}
 
 		if ( selectPrevious ) {
-			dispatch.selectPreviousBlock( clientIds[ 0 ], true );
+			const shouldSelectParent = true;
+			dispatch.selectPreviousBlock( clientIds[ 0 ], shouldSelectParent );
 		}
 
 		dispatch( { type: 'REMOVE_BLOCKS', clientIds } );

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -619,14 +619,14 @@ describe( 'actions', () => {
 				canRemoveBlocks: () => true,
 			};
 			const dispatch = Object.assign( jest.fn(), {
-				selectPreviousBlockOrFirstParent: jest.fn(),
+				selectPreviousBlock: jest.fn(),
 			} );
 
 			removeBlocks( clientIds )( { select, dispatch } );
 
-			expect(
-				dispatch.selectPreviousBlockOrFirstParent
-			).toHaveBeenCalledWith( clientId );
+			expect( dispatch.selectPreviousBlock ).toHaveBeenCalledWith(
+				clientId
+			);
 
 			expect( dispatch ).toHaveBeenCalledWith( {
 				type: 'REMOVE_BLOCKS',
@@ -728,14 +728,14 @@ describe( 'actions', () => {
 				canRemoveBlocks: () => true,
 			};
 			const dispatch = Object.assign( jest.fn(), {
-				selectPreviousBlockOrFirstParent: jest.fn(),
+				selectPreviousBlock: jest.fn(),
 			} );
 
 			removeBlock( clientId )( { select, dispatch } );
 
-			expect(
-				dispatch.selectPreviousBlockOrFirstParent
-			).toHaveBeenCalledWith( clientId );
+			expect( dispatch.selectPreviousBlock ).toHaveBeenCalledWith(
+				clientId
+			);
 
 			expect( dispatch ).toHaveBeenCalledWith( {
 				type: 'REMOVE_BLOCKS',
@@ -751,14 +751,12 @@ describe( 'actions', () => {
 				canRemoveBlocks: () => true,
 			};
 			const dispatch = Object.assign( jest.fn(), {
-				selectPreviousBlockOrFirstParent: jest.fn(),
+				selectPreviousBlock: jest.fn(),
 			} );
 
 			removeBlocks( [ clientId ], false )( { select, dispatch } );
 
-			expect(
-				dispatch.selectPreviousBlockOrFirstParent
-			).not.toHaveBeenCalled();
+			expect( dispatch.selectPreviousBlock ).not.toHaveBeenCalled();
 
 			expect( dispatch ).toHaveBeenCalledWith( {
 				type: 'REMOVE_BLOCKS',

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -625,7 +625,8 @@ describe( 'actions', () => {
 			removeBlocks( clientIds )( { select, dispatch } );
 
 			expect( dispatch.selectPreviousBlock ).toHaveBeenCalledWith(
-				clientId
+				clientId,
+				true
 			);
 
 			expect( dispatch ).toHaveBeenCalledWith( {
@@ -734,7 +735,8 @@ describe( 'actions', () => {
 			removeBlock( clientId )( { select, dispatch } );
 
 			expect( dispatch.selectPreviousBlock ).toHaveBeenCalledWith(
-				clientId
+				clientId,
+				true
 			);
 
 			expect( dispatch ).toHaveBeenCalledWith( {

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -619,14 +619,14 @@ describe( 'actions', () => {
 				canRemoveBlocks: () => true,
 			};
 			const dispatch = Object.assign( jest.fn(), {
-				selectPreviousBlock: jest.fn(),
+				selectPreviousBlockOrFirstParent: jest.fn(),
 			} );
 
 			removeBlocks( clientIds )( { select, dispatch } );
 
-			expect( dispatch.selectPreviousBlock ).toHaveBeenCalledWith(
-				clientId
-			);
+			expect(
+				dispatch.selectPreviousBlockOrFirstParent
+			).toHaveBeenCalledWith( clientId );
 
 			expect( dispatch ).toHaveBeenCalledWith( {
 				type: 'REMOVE_BLOCKS',
@@ -728,14 +728,14 @@ describe( 'actions', () => {
 				canRemoveBlocks: () => true,
 			};
 			const dispatch = Object.assign( jest.fn(), {
-				selectPreviousBlock: jest.fn(),
+				selectPreviousBlockOrFirstParent: jest.fn(),
 			} );
 
 			removeBlock( clientId )( { select, dispatch } );
 
-			expect( dispatch.selectPreviousBlock ).toHaveBeenCalledWith(
-				clientId
-			);
+			expect(
+				dispatch.selectPreviousBlockOrFirstParent
+			).toHaveBeenCalledWith( clientId );
 
 			expect( dispatch ).toHaveBeenCalledWith( {
 				type: 'REMOVE_BLOCKS',
@@ -751,12 +751,14 @@ describe( 'actions', () => {
 				canRemoveBlocks: () => true,
 			};
 			const dispatch = Object.assign( jest.fn(), {
-				selectPreviousBlock: jest.fn(),
+				selectPreviousBlockOrFirstParent: jest.fn(),
 			} );
 
 			removeBlocks( [ clientId ], false )( { select, dispatch } );
 
-			expect( dispatch.selectPreviousBlock ).not.toHaveBeenCalled();
+			expect(
+				dispatch.selectPreviousBlockOrFirstParent
+			).not.toHaveBeenCalled();
 
 			expect( dispatch ).toHaveBeenCalledWith( {
 				type: 'REMOVE_BLOCKS',

--- a/packages/block-library/src/list-item/hooks/use-outdent-list-item.js
+++ b/packages/block-library/src/list-item/hooks/use-outdent-list-item.js
@@ -112,7 +112,7 @@ export default function useOutdentListItem( clientId ) {
 					getBlockIndex( parentListItemId ) + 1
 				);
 				if ( ! getBlockOrder( parentListId ).length ) {
-					removeBlock( parentListId );
+					removeBlock( parentListId, false );
 				}
 			} );
 		}, [] ),

--- a/packages/block-library/src/list-item/hooks/use-outdent-list-item.js
+++ b/packages/block-library/src/list-item/hooks/use-outdent-list-item.js
@@ -112,7 +112,8 @@ export default function useOutdentListItem( clientId ) {
 					getBlockIndex( parentListItemId ) + 1
 				);
 				if ( ! getBlockOrder( parentListId ).length ) {
-					removeBlock( parentListId, false );
+					const shouldSelectParent = false;
+					removeBlock( parentListId, shouldSelectParent );
 				}
 			} );
 		}, [] ),

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -425,6 +425,8 @@ describe( 'Widgets screen', () => {
 				if ( existingMarqueeWidgets ) {
 					await existingMarqueeWidgets.focus();
 					await pressKeyWithModifier( 'access', 'z' );
+					await closedPanelBody.focus();
+					await closedPanelBody.click();
 				}
 			}
 		}

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -384,6 +384,11 @@ describe( 'Widgets screen', () => {
 
 	describe( 'Function widgets', () => {
 		async function addMarquee( nbExpectedMarquees ) {
+			const [ firstWidgetArea ] = await findAll( {
+				role: 'document',
+				name: 'Block: Widget Area',
+			} );
+			await firstWidgetArea.focus();
 			const marqueeBlock = await getBlockInGlobalInserter(
 				'Marquee Greeting'
 			);

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -425,8 +425,6 @@ describe( 'Widgets screen', () => {
 				if ( existingMarqueeWidgets ) {
 					await existingMarqueeWidgets.focus();
 					await pressKeyWithModifier( 'access', 'z' );
-					await closedPanelBody.focus();
-					await closedPanelBody.click();
 				}
 			}
 		}

--- a/test/e2e/specs/editor/various/block-deletion.spec.js
+++ b/test/e2e/specs/editor/various/block-deletion.spec.js
@@ -62,6 +62,53 @@ test.describe( 'Block deletion', () => {
 		] );
 	} );
 
+	// this test should be moved to a new testing story about focus management.
+	test( 'deleting a block focuses the parent block', async ( {
+		editor,
+		page,
+	} ) => {
+		// Add a group with a paragraph in it.
+		await editor.insertBlock( {
+			name: 'core/group',
+			innerBlocks: [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Paragraph child of group' },
+				},
+			],
+		} );
+
+		// Select the paragraph.
+		const paragraph = editor.canvas.getByRole( 'document', {
+			name: 'Paragraph block',
+		} );
+		await editor.selectBlocks( paragraph );
+
+		// Remove the current paragraph via the Block Toolbar options menu.
+		await editor.showBlockToolbar();
+		await editor.canvas
+			.getByRole( 'toolbar', { name: 'Block tools' } )
+			.getByRole( 'button', { name: 'Options' } )
+			.click();
+		await page
+			.getByRole( 'menuitem', { name: 'Remove Paragraph' } )
+			.click();
+
+		// Ensure the paragraph was removed.
+		await expect
+			.poll( editor.getBlocks )
+			.toMatchObject( [ { name: 'core/group', attributes: {} } ] );
+
+		// Ensure the group block is focused.
+		await expect(
+			editor.canvas
+				.getByRole( 'document', {
+					name: 'Block: Group',
+				} )
+				.last()
+		).toBeFocused();
+	} );
+
 	test( 'deleting the last block via the keyboard shortcut', async ( {
 		editor,
 		page,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #48017 

Trying to fix a focus loss issue with the navigation block (see  #48105) I found that at all times when we remove the last child of a block we end up with focus loss - focus moves to the `body` of the editor's `iframe`.

This PR fixes this and also the original issue.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Focus loss is one of the worst bugs in terms of using the UI via assistive technology. We already handle this by:

- selecting the previous block in a list when a block is removed
- ensuring there is always a default block in the document to be selected

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR selects the 1st parent if the current block to be removed has no previous block to be selected. It also solves the same for the list view and the experimental off canvas editor component by updating the focus management logic in:

- the `selectPreviousBlock` action of the block editor store, making it into `selectPreviousBlockOrFirstParent`
- the `updateSelectionAfterRemove` callback of the `BlockSettingsDropdown` component

## Testing Instructions

In a post, a template or a template part:

- add a group block
- add an image in the group block
- save reload
- remove the image
- **notice the parent group block is selected**
- refresh
- remove the image via the list view
- **notice the parent group block is selected**

## To do

- [ ] add this case to the tests that test the focus management in a block editor
