### PR TITLE
check for all style classname and assign css using the class

### DIFF
--- a/packages/block-library/src/separator/save.js
+++ b/packages/block-library/src/separator/save.js
@@ -29,6 +29,12 @@ export default function separatorSave( { attributes } ) {
 			[ colorClass ]: colorClass,
 			'has-css-opacity': opacity === 'css',
 			'has-alpha-channel-opacity': opacity === 'alpha-channel',
+			'is-style-default':
+				( ! attributes.hasOwnProperty( 'className' ) ||
+					attributes.className === 'is-style-default' ) &&
+				'is-style-default',
+			'is-style-wide': attributes.className === 'is-style-wide',
+			'is-style-dots': attributes.className === 'is-style-dots',
 		},
 		colorProps.className
 	);

--- a/packages/block-library/src/separator/style.scss
+++ b/packages/block-library/src/separator/style.scss
@@ -7,6 +7,14 @@
 	border-left: none;
 	border-right: none;
 
+	&.is-style-default {
+		width: 200px;
+	}
+
+	&.is-style-wide {
+		width: 100%;
+	}
+
 	// Dots style
 	&.is-style-dots {
 		// Override any background themes often set on the hr tag for this style.


### PR DESCRIPTION
I have checked thoroughly and found that the issue is causing for separator on the Gutenberg side.
The classes are not assigning perfectly is causing the issue and there is no CSS for these classes. Please check now.

https://core.trac.wordpress.org/ticket/57667
