### PR TITLE
Playwright: fix request utils for non Docker envs

### DIFF
--- a/packages/e2e-test-utils-playwright/src/request-utils/themes.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/themes.ts
@@ -4,7 +4,7 @@
 import type { RequestUtils } from './index';
 import { WP_BASE_URL } from '../config';
 
-const THEMES_URL = new URL( '/wp-admin/themes.php', WP_BASE_URL ).href;
+const THEMES_URL = new URL( 'wp-admin/themes.php', WP_BASE_URL ).href;
 
 async function activateTheme(
 	this: RequestUtils,
@@ -12,8 +12,9 @@ async function activateTheme(
 ): Promise< void > {
 	let response = await this.request.get( THEMES_URL );
 	const html = await response.text();
+	const optionalFolder = '([a-z0-9-]+%2F)?';
 	const matchGroup = html.match(
-		`action=activate&amp;stylesheet=${ encodeURIComponent(
+		`action=activate&amp;stylesheet=${ optionalFolder }${ encodeURIComponent(
 			themeSlug
 		) }&amp;_wpnonce=[a-z0-9]+`
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

For non Docker installs theme activation fails: the path assumes the base URL to be simply the host while WP could be installed in a directory. It also assumes the theme won't be located in a subdirectory.
Extracting this out of #47907 to isolate test failures.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

Use MAMP: https://github.com/WordPress/gutenberg/blob/9a4b95e37da8b4c4b271f510895690a4ea1fa780/docs/contributors/code/getting-started-with-code-contribution.md#using-local-or-mamp

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
