### PR TITLE
Block alignment controls: don't remount the block when alignments change

### DIFF
--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -119,7 +119,7 @@ export function addAttribute( settings ) {
  */
 export const withToolbarControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
-		const blockEdit = <BlockEdit { ...props } />;
+		const blockEdit = <BlockEdit key="edit" { ...props } />;
 		const { name: blockName } = props;
 		// Compute the block valid alignments by taking into account,
 		// if the theme supports wide alignments or not and the layout's


### PR DESCRIPTION
While reviewing and testing the changes in #47978, I noticed that the block edit component, like `QueryEdit`, is mounted twice. There is initial mount, and then for some reason the component is unmounted and mounted again, resetting all local state. In particular, the `QueryPlaceholder` component has `isStartingBlank` state that is set to `true` in effect, and never set back to `false`, and yet I was getting the `false` state again.

I tracked this behavior down to the `withToolbarControls` HOC for block alignment options. It has rendering code like:
```js
const blockEdit = <BlockEdit />;
if ( ! hasValidAlignments ) {
  return blockEdit;
}

return (
  <>
    <BlockAlignmentControl />
    { blockEdit }
  </>
);
```
The `hasValidAlignments` value is initially `false`, and then, after the edited post template is finished fetching from a REST endpoint, it becomes `true`. Because the `<BlockEdit />` component get "re-parented", i.e., it's now in a different position in the tree, it's considered as different component and created from scratch.

This PR fixes that by adding `key="edit"`, which helps React to identify the component and keep it alive during the re-parenting. This `key="edit"` trick is already widely used in other `editor.BlockEdit` HOCs.

**How to test:**
Add debugging code to `QueryEdit`:
```js
useEffect( () => {
  console.log( 'edit mounting' );
  return () => console.log( 'edit unmounting' );
}, [] );
```
and load a post with a query block. Instead of:
```
edit mounting
edit unmounting
edit mounting
```
you should see just a single
```
edit mounting
```
