### PR TITLE
Firefox: fix input rules (React async state issue)

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -280,6 +280,7 @@ function RichTextWrapper(
 
 	const {
 		value,
+		getValue,
 		onChange,
 		ref: richTextRef,
 	} = useRichText( {
@@ -400,7 +401,7 @@ function RichTextWrapper(
 					richTextRef,
 					useBeforeInputRules( { value, onChange } ),
 					useInputRules( {
-						value,
+						getValue,
 						onChange,
 						__unstableAllowPrefixTransformations,
 						formatTypes,

--- a/packages/block-editor/src/components/rich-text/use-input-rules.js
+++ b/packages/block-editor/src/components/rich-text/use-input-rules.js
@@ -49,12 +49,15 @@ export function useInputRules( props ) {
 	propsRef.current = props;
 	return useRefEffect( ( element ) => {
 		function inputRule() {
-			const { value, onReplace, selectionChange } = propsRef.current;
+			const { getValue, onReplace, selectionChange } = propsRef.current;
 
 			if ( ! onReplace ) {
 				return;
 			}
 
+			// We must use getValue() here because value may be update
+			// asynchronously.
+			const value = getValue();
 			const { start, text } = value;
 			const characterBefore = text.slice( start - 1, start );
 
@@ -91,7 +94,7 @@ export function useInputRules( props ) {
 		function onInput( event ) {
 			const { inputType, type } = event;
 			const {
-				value,
+				getValue,
 				onChange,
 				__unstableAllowPrefixTransformations,
 				formatTypes,
@@ -106,6 +109,7 @@ export function useInputRules( props ) {
 				inputRule();
 			}
 
+			const value = getValue();
 			const transformed = formatTypes.reduce(
 				( accumlator, { __unstableInputRule } ) => {
 					if ( __unstableInputRule ) {

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -247,32 +247,13 @@ export function useRichText( {
 	] );
 
 	return {
-		// Instead of exposing the record as ref, create getters for the
-		// properties so event handlers in useRichText implementations have
-		// access to the most recent value. For example when listening to input
-		// events, we internally update the state, but this state is not yet
-		// available to the input event handler because React may re-render
-		// asynchronously.
-		value: {
-			get text() {
-				return record.current.text;
-			},
-			get formats() {
-				return record.current.formats;
-			},
-			get replacements() {
-				return record.current.replacements;
-			},
-			get start() {
-				return record.current.start;
-			},
-			get end() {
-				return record.current.end;
-			},
-			get activeFormats() {
-				return record.current.activeFormats;
-			},
-		},
+		value: record.current,
+		// A function to get the most recent value so event handlers in
+		// useRichText implementations have access to it. For example when
+		// listening to input events, we internally update the state, but this
+		// state is not yet available to the input event handler because React
+		// may re-render asynchronously.
+		getValue: () => record.current,
 		onChange: handleChange,
 		ref: mergedRefs,
 	};

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -247,7 +247,32 @@ export function useRichText( {
 	] );
 
 	return {
-		value: record.current,
+		// Instead of exposing the record as ref, create getters for the
+		// properties so event handlers in useRichText implementations have
+		// access to the most recent value. For example when listening to input
+		// events, we internally update the state, but this state is not yet
+		// available to the input event handler because React may re-render
+		// asynchronously.
+		value: {
+			get text() {
+				return record.current.text;
+			},
+			get formats() {
+				return record.current.formats;
+			},
+			get replacements() {
+				return record.current.replacements;
+			},
+			get start() {
+				return record.current.start;
+			},
+			get end() {
+				return record.current.end;
+			},
+			get activeFormats() {
+				return record.current.activeFormats;
+			},
+		},
 		onChange: handleChange,
 		ref: mergedRefs,
 	};

--- a/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
+++ b/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
@@ -47,7 +47,7 @@ const userList = [
 		password: 'sm1lingsmyfavorite',
 	},
 ];
-test.describe( 'Autocomplete', () => {
+test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await Promise.all(
 			userList.map( ( user ) =>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Currently the `useRichText` hook outputs a rich text value which is normally immediately updated when the state changes on input. However, React may update the state async, which mean other `input` event handlers may be getting an old state.

One way to work around this would be returning a ref in the `useRichText` hook _alongside_ the normal value (because some components will still rely on a value change).

~~A better way to work around this is with with getters: replace all the rich text value properties with getters so it's guaranteed to get the latest value. Since having the latest value immediately available is only important for event handlers, we don't need to find a way for the re-rendering to be synchronous.~~

Edit: I switched to adding a `getValue` function to get the latest value between re-renders in event handlers.

## Why?

Fixes #48207.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
