### PR TITLE
Fix: OffCanvasEditor does not inserts submenu on collapsed items.

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/leaf-more-menu.js
+++ b/packages/block-editor/src/components/off-canvas-editor/leaf-more-menu.js
@@ -17,6 +17,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import { store as blockEditorStore } from '../../store';
 import BlockTitle from '../block-title';
+import { useListViewContext } from './context';
 
 const POPOVER_PROPS = {
 	className: 'block-editor-block-settings-menu__popover',
@@ -30,6 +31,7 @@ const BLOCKS_THAT_CAN_BE_CONVERTED_TO_SUBMENU = [
 ];
 
 function AddSubmenuItem( { block, onClose } ) {
+	const { expandedState, expand } = useListViewContext();
 	const { insertBlock, replaceBlock, replaceInnerBlocks } =
 		useDispatch( blockEditorStore );
 
@@ -73,6 +75,9 @@ function AddSubmenuItem( { block, onClose } ) {
 						[ newLink ],
 						updateSelectionOnInsert
 					);
+				}
+				if ( ! expandedState[ block.clientId ] ) {
+					expand( block.clientId );
 				}
 				onClose();
 			} }


### PR DESCRIPTION
Currently on the OffCanvasEditor if a menu item is collapsed and we press "Add submenu" nothing happens. This PR fixes the issue when inserting a submenu now the parent is automatically expanded and we see the UI to create the submenu as expected.

cc: @draganescu 