### PR TITLE
Switch react-autosize-textarea to react-textarea-autosize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16599,8 +16599,8 @@
 				"fast-deep-equal": "^3.1.3",
 				"inherits": "^2.0.3",
 				"lodash": "^4.17.21",
-				"react-autosize-textarea": "^7.1.0",
 				"react-easy-crop": "^4.5.1",
+				"react-textarea-autosize": "^8.4.0",
 				"rememo": "^4.0.0",
 				"remove-accents": "^0.4.2",
 				"traverse": "^0.6.6"
@@ -17097,7 +17097,7 @@
 				"history": "^5.1.0",
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
-				"react-autosize-textarea": "^7.1.0",
+				"react-textarea-autosize": "^8.4.0",
 				"rememo": "^4.0.0"
 			},
 			"dependencies": {
@@ -17177,7 +17177,7 @@
 				"escape-html": "^1.0.3",
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
-				"react-autosize-textarea": "^7.1.0",
+				"react-textarea-autosize": "^8.4.0",
 				"rememo": "^4.0.0",
 				"remove-accents": "^0.4.2"
 			},
@@ -26363,11 +26363,6 @@
 				}
 			}
 		},
-		"autosize": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.2.tgz",
-			"integrity": "sha512-jnSyH2d+qdfPGpWlcuhGiHmqBJ6g3X+8T+iRwFrHPLVcdoGJE/x6Qicm6aDHfTsbgZKxyV8UU/YB2p4cjKDRRA=="
-		},
 		"available-typed-arrays": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -28798,11 +28793,6 @@
 			"resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.16.tgz",
 			"integrity": "sha512-a85LHKY81oQnikatZYA90pufpZ6sQx++BoCxOEMsjpZx+ZnaKGQnCyCehTRr/1p9GBIAHTjcU9k71kSYWloLiQ=="
 		},
-		"computed-style": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/computed-style/-/computed-style-0.1.4.tgz",
-			"integrity": "sha1-fzRP2FhLLkJb7cpKGvwOMAuwXXQ="
-		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -30095,7 +30085,7 @@
 		"css.escape": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-			"integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+			"integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
 			"dev": true
 		},
 		"cssesc": {
@@ -39772,14 +39762,6 @@
 			"integrity": "sha512-EHKqr/+ZvdKCifpNrJCKxBTgk5XupZA3y/aCPY9mxfgBzmgh93Mt/WqjjQ38oMxXuvDokaKiM3lAgvSH2sjtHg==",
 			"dev": true
 		},
-		"line-height": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/line-height/-/line-height-0.3.1.tgz",
-			"integrity": "sha1-SxIF7d4YKHKl76PI9iCzGHqcVMk=",
-			"requires": {
-				"computed-style": "~0.1.3"
-			}
-		},
 		"lines-and-columns": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -40649,7 +40631,7 @@
 		"lz-string": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-			"integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+			"integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
 			"dev": true
 		},
 		"macos-release": {
@@ -48208,16 +48190,6 @@
 				"loose-envify": "^1.1.0"
 			}
 		},
-		"react-autosize-textarea": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-7.1.0.tgz",
-			"integrity": "sha512-BHpjCDkuOlllZn3nLazY2F8oYO1tS2jHnWhcjTWQdcKiiMU6gHLNt/fzmqMSyerR0eTdKtfSIqtSeTtghNwS+g==",
-			"requires": {
-				"autosize": "^4.0.2",
-				"line-height": "^0.3.1",
-				"prop-types": "^15.5.6"
-			}
-		},
 		"react-colorful": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.3.1.tgz",
@@ -49213,6 +49185,16 @@
 					"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
 					"dev": true
 				}
+			}
+		},
+		"react-textarea-autosize": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.0.tgz",
+			"integrity": "sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==",
+			"requires": {
+				"@babel/runtime": "^7.10.2",
+				"use-composed-ref": "^1.3.0",
+				"use-latest": "^1.2.1"
 			}
 		},
 		"read": {
@@ -55670,6 +55652,24 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+		},
+		"use-composed-ref": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
+			"integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ=="
+		},
+		"use-isomorphic-layout-effect": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+			"integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA=="
+		},
+		"use-latest": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
+			"integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
+			"requires": {
+				"use-isomorphic-layout-effect": "^1.1.1"
+			}
 		},
 		"use-lilius": {
 			"version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16600,7 +16600,7 @@
 				"inherits": "^2.0.3",
 				"lodash": "^4.17.21",
 				"react-easy-crop": "^4.5.1",
-				"react-textarea-autosize": "^8.4.0",
+				"react-textarea-autosize": "^8.4.1",
 				"rememo": "^4.0.0",
 				"remove-accents": "^0.4.2",
 				"traverse": "^0.6.6"
@@ -17097,7 +17097,7 @@
 				"history": "^5.1.0",
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
-				"react-textarea-autosize": "^8.4.0",
+				"react-textarea-autosize": "^8.4.1",
 				"rememo": "^4.0.0"
 			},
 			"dependencies": {
@@ -17177,7 +17177,7 @@
 				"escape-html": "^1.0.3",
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
-				"react-textarea-autosize": "^8.4.0",
+				"react-textarea-autosize": "^8.4.1",
 				"rememo": "^4.0.0",
 				"remove-accents": "^0.4.2"
 			},
@@ -30085,7 +30085,7 @@
 		"css.escape": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-			"integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+			"integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
 			"dev": true
 		},
 		"cssesc": {
@@ -40631,7 +40631,7 @@
 		"lz-string": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-			"integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
+			"integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
 			"dev": true
 		},
 		"macos-release": {

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -70,8 +70,8 @@
 		"fast-deep-equal": "^3.1.3",
 		"inherits": "^2.0.3",
 		"lodash": "^4.17.21",
-		"react-autosize-textarea": "^7.1.0",
 		"react-easy-crop": "^4.5.1",
+		"react-textarea-autosize": "^8.4.0",
 		"rememo": "^4.0.0",
 		"remove-accents": "^0.4.2",
 		"traverse": "^0.6.6"

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -71,7 +71,7 @@
 		"inherits": "^2.0.3",
 		"lodash": "^4.17.21",
 		"react-easy-crop": "^4.5.1",
-		"react-textarea-autosize": "^8.4.0",
+		"react-textarea-autosize": "^8.4.1",
 		"rememo": "^4.0.0",
 		"remove-accents": "^0.4.2",
 		"traverse": "^0.6.6"

--- a/packages/block-editor/src/components/block-list/block-html.js
+++ b/packages/block-editor/src/components/block-list/block-html.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import TextareaAutosize from 'react-autosize-textarea';
+import TextareaAutosize from 'react-textarea-autosize';
 
 /**
  * WordPress dependencies

--- a/packages/block-editor/src/components/plain-text/index.js
+++ b/packages/block-editor/src/components/plain-text/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import TextareaAutosize from 'react-autosize-textarea';
+import TextareaAutosize from 'react-textarea-autosize';
 import classnames from 'classnames';
 
 /**

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -63,7 +63,7 @@
 		"history": "^5.1.0",
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
-		"react-autosize-textarea": "^7.1.0",
+		"react-textarea-autosize": "^8.4.0",
 		"rememo": "^4.0.0"
 	},
 	"peerDependencies": {

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -63,7 +63,7 @@
 		"history": "^5.1.0",
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
-		"react-textarea-autosize": "^8.4.0",
+		"react-textarea-autosize": "^8.4.1",
 		"rememo": "^4.0.0"
 	},
 	"peerDependencies": {

--- a/packages/edit-site/src/components/code-editor/code-editor-text-area.js
+++ b/packages/edit-site/src/components/code-editor/code-editor-text-area.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import Textarea from 'react-autosize-textarea';
+import Textarea from 'react-textarea-autosize';
 
 /**
  * WordPress dependencies

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -64,7 +64,7 @@
 		"escape-html": "^1.0.3",
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
-		"react-autosize-textarea": "^7.1.0",
+		"react-textarea-autosize": "^8.4.0",
 		"rememo": "^4.0.0",
 		"remove-accents": "^0.4.2"
 	},

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -64,7 +64,7 @@
 		"escape-html": "^1.0.3",
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
-		"react-textarea-autosize": "^8.4.0",
+		"react-textarea-autosize": "^8.4.1",
 		"rememo": "^4.0.0",
 		"remove-accents": "^0.4.2"
 	},

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import Textarea from 'react-autosize-textarea';
+import Textarea from 'react-textarea-autosize';
 
 /**
  * WordPress dependencies

--- a/packages/editor/src/components/post-text-editor/test/index.js
+++ b/packages/editor/src/components/post-text-editor/test/index.js
@@ -16,7 +16,7 @@ import PostTextEditor from '../';
 
 // "Downgrade" ReactAutosizeTextarea to a regular textarea. Assumes aligned
 // props interface.
-jest.mock( 'react-autosize-textarea', () => ( props ) => (
+jest.mock( 'react-textarea-autosize', () => ( props ) => (
 	<textarea { ...props } />
 ) );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Solves at least part of #48009 

The package we use to auto-resize text areas in React doesn't support React 18 and hasn't been actively maintained for 3 years. Another package, react-textarea-autosize does support React 18, so this PR attempts to switch.

One issue I found so far is that the initial text height is incorrect in some situations. I could only verify this bug in **Firefox**, not Chrome or Safari.

1. Switch to code editor. Initial height will be **incorrect**.
2. Type something or open the dev tools and the height will be **correct**
3. Reload the page -- it'll stay in code editor, and the height will be **correct** this time.
4. Switch back to normal editor, and then back to code editor. Height will be **correct**.
5. Switch back to normal editor, and reload the page. Then open the code editor. Height will be **incorrect**

Not sure why, though. 🤔 Reported the bug here: https://github.com/Andarist/react-textarea-autosize/issues/366

## Why?
We want to upgrade to modern npm/node versions, which means resolving peer dependency errors. As a result, we need to use maintained packages which have peer dependencies on React 18 instead of older React versions.

## How?
Just switching the packages!

## Testing 
This seems to be mostly working, but I'm noticing that the text area does not re-size on initial load. It does resize after reloading the page, for some reason.

We need to test these components:
- [ ] The `BlockHTML` component in `block-editor` (used in the block list in "html" mode)
- [ ] The `PlainText` component in `block-editor`
- [ ] The `CodeEditorTextArea` component in `edit-site`
- [ ] The `PostTextEditor` component in `editor`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
