### PR TITLE
Navigation: Don't save the level of the link in an attribute

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -225,15 +225,6 @@ export default function NavigationLinkEdit( {
 		[ clientId ]
 	);
 
-	useEffect( () => {
-		// This side-effect should not create an undo level as those should
-		// only be created via user interactions. Mark this change as
-		// not persistent to avoid undo level creation.
-		// See https://github.com/WordPress/gutenberg/issues/34564.
-		__unstableMarkNextChangeAsNotPersistent();
-		setAttributes( { isTopLevelLink } );
-	}, [ isTopLevelLink ] );
-
 	/**
 	 * Transform to submenu block.
 	 */

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -6,75 +6,6 @@
  */
 
 /**
- * Build an array with CSS classes and inline styles defining the colors
- * which will be applied to the navigation markup in the front-end.
- *
- * @param  array $context    Navigation block context.
- * @param  array $attributes Block attributes.
- * @return array Colors CSS classes and inline styles.
- */
-function block_core_navigation_link_build_css_colors( $context, $attributes ) {
-	$colors = array(
-		'css_classes'   => array(),
-		'inline_styles' => '',
-	);
-
-	// Text color.
-	$named_text_color  = null;
-	$custom_text_color = null;
-
-	if ( $is_sub_menu && array_key_exists( 'customOverlayTextColor', $context ) ) {
-		$custom_text_color = $context['customOverlayTextColor'];
-	} elseif ( $is_sub_menu && array_key_exists( 'overlayTextColor', $context ) ) {
-		$named_text_color = $context['overlayTextColor'];
-	} elseif ( array_key_exists( 'customTextColor', $context ) ) {
-		$custom_text_color = $context['customTextColor'];
-	} elseif ( array_key_exists( 'textColor', $context ) ) {
-		$named_text_color = $context['textColor'];
-	} elseif ( isset( $context['style']['color']['text'] ) ) {
-		$custom_text_color = $context['style']['color']['text'];
-	}
-
-	// If has text color.
-	if ( ! is_null( $named_text_color ) ) {
-		// Add the color class.
-		array_push( $colors['css_classes'], 'has-text-color', sprintf( 'has-%s-color', $named_text_color ) );
-	} elseif ( ! is_null( $custom_text_color ) ) {
-		// Add the custom color inline style.
-		$colors['css_classes'][]  = 'has-text-color';
-		$colors['inline_styles'] .= sprintf( 'color: %s;', $custom_text_color );
-	}
-
-	// Background color.
-	$named_background_color  = null;
-	$custom_background_color = null;
-
-	if ( $is_sub_menu && array_key_exists( 'customOverlayBackgroundColor', $context ) ) {
-		$custom_background_color = $context['customOverlayBackgroundColor'];
-	} elseif ( $is_sub_menu && array_key_exists( 'overlayBackgroundColor', $context ) ) {
-		$named_background_color = $context['overlayBackgroundColor'];
-	} elseif ( array_key_exists( 'customBackgroundColor', $context ) ) {
-		$custom_background_color = $context['customBackgroundColor'];
-	} elseif ( array_key_exists( 'backgroundColor', $context ) ) {
-		$named_background_color = $context['backgroundColor'];
-	} elseif ( isset( $context['style']['color']['background'] ) ) {
-		$custom_background_color = $context['style']['color']['background'];
-	}
-
-	// If has background color.
-	if ( ! is_null( $named_background_color ) ) {
-		// Add the background-color class.
-		array_push( $colors['css_classes'], 'has-background', sprintf( 'has-%s-background-color', $named_background_color ) );
-	} elseif ( ! is_null( $custom_background_color ) ) {
-		// Add the custom background-color inline style.
-		$colors['css_classes'][]  = 'has-background';
-		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $custom_background_color );
-	}
-
-	return $colors;
-}
-
-/**
  * Build an array with CSS classes and inline styles defining the font sizes
  * which will be applied to the navigation markup in the front-end.
  *
@@ -172,7 +103,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$colors          = block_core_navigation_link_build_css_colors( $block->context, $attributes );
+	$colors          = block_core_navigation_submenu_build_css_colors( $block->context, $attributes );
 	$font_sizes      = block_core_navigation_link_build_css_font_sizes( $block->context );
 	$classes         = array_merge(
 		$colors['css_classes'],

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -19,8 +19,6 @@ function block_core_navigation_link_build_css_colors( $context, $attributes ) {
 		'inline_styles' => '',
 	);
 
-	$is_sub_menu = false; //isset( $attributes['isTopLevelLink'] ) ? ( ! $attributes['isTopLevelLink'] ) : false;
-
 	// Text color.
 	$named_text_color  = null;
 	$custom_text_color = null;

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -6,6 +6,77 @@
  */
 
 /**
+ * Build an array with CSS classes and inline styles defining the colors
+ * which will be applied to the navigation markup in the front-end.
+ *
+ * @param  array $context    Navigation block context.
+ * @param  array $attributes Block attributes.
+ * @return array Colors CSS classes and inline styles.
+ */
+function block_core_navigation_link_build_css_colors( $context, $attributes ) {
+	$colors = array(
+		'css_classes'   => array(),
+		'inline_styles' => '',
+	);
+
+	$is_sub_menu = isset( $attributes['isTopLevelLink'] ) ? ( ! $attributes['isTopLevelLink'] ) : false;
+
+	// Text color.
+	$named_text_color  = null;
+	$custom_text_color = null;
+
+	if ( $is_sub_menu && array_key_exists( 'customOverlayTextColor', $context ) ) {
+		$custom_text_color = $context['customOverlayTextColor'];
+	} elseif ( $is_sub_menu && array_key_exists( 'overlayTextColor', $context ) ) {
+		$named_text_color = $context['overlayTextColor'];
+	} elseif ( array_key_exists( 'customTextColor', $context ) ) {
+		$custom_text_color = $context['customTextColor'];
+	} elseif ( array_key_exists( 'textColor', $context ) ) {
+		$named_text_color = $context['textColor'];
+	} elseif ( isset( $context['style']['color']['text'] ) ) {
+		$custom_text_color = $context['style']['color']['text'];
+	}
+
+	// If has text color.
+	if ( ! is_null( $named_text_color ) ) {
+		// Add the color class.
+		array_push( $colors['css_classes'], 'has-text-color', sprintf( 'has-%s-color', $named_text_color ) );
+	} elseif ( ! is_null( $custom_text_color ) ) {
+		// Add the custom color inline style.
+		$colors['css_classes'][]  = 'has-text-color';
+		$colors['inline_styles'] .= sprintf( 'color: %s;', $custom_text_color );
+	}
+
+	// Background color.
+	$named_background_color  = null;
+	$custom_background_color = null;
+
+	if ( $is_sub_menu && array_key_exists( 'customOverlayBackgroundColor', $context ) ) {
+		$custom_background_color = $context['customOverlayBackgroundColor'];
+	} elseif ( $is_sub_menu && array_key_exists( 'overlayBackgroundColor', $context ) ) {
+		$named_background_color = $context['overlayBackgroundColor'];
+	} elseif ( array_key_exists( 'customBackgroundColor', $context ) ) {
+		$custom_background_color = $context['customBackgroundColor'];
+	} elseif ( array_key_exists( 'backgroundColor', $context ) ) {
+		$named_background_color = $context['backgroundColor'];
+	} elseif ( isset( $context['style']['color']['background'] ) ) {
+		$custom_background_color = $context['style']['color']['background'];
+	}
+
+	// If has background color.
+	if ( ! is_null( $named_background_color ) ) {
+		// Add the background-color class.
+		array_push( $colors['css_classes'], 'has-background', sprintf( 'has-%s-background-color', $named_background_color ) );
+	} elseif ( ! is_null( $custom_background_color ) ) {
+		// Add the custom background-color inline style.
+		$colors['css_classes'][]  = 'has-background';
+		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $custom_background_color );
+	}
+
+	return $colors;
+}
+
+/**
  * Build an array with CSS classes and inline styles defining the font sizes
  * which will be applied to the navigation markup in the front-end.
  *
@@ -103,7 +174,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$colors          = block_core_navigation_submenu_build_css_colors( $block->context, $attributes );
+	$colors          = block_core_navigation_link_build_css_colors( $block->context, $attributes );
 	$font_sizes      = block_core_navigation_link_build_css_font_sizes( $block->context );
 	$classes         = array_merge(
 		$colors['css_classes'],

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -9,17 +9,16 @@
  * Build an array with CSS classes and inline styles defining the colors
  * which will be applied to the navigation markup in the front-end.
  *
- * @param  array $context    Navigation block context.
- * @param  array $attributes Block attributes.
+ * @param  array $context     Navigation block context.
+ * @param  array $attributes  Block attributes.
+ * @param  bool	 $is_sub_menu Whether the link is part of a sub-menu.
  * @return array Colors CSS classes and inline styles.
  */
-function block_core_navigation_link_build_css_colors( $context, $attributes ) {
+function block_core_navigation_link_build_css_colors( $context, $attributes, $is_sub_menu = false ) {
 	$colors = array(
 		'css_classes'   => array(),
 		'inline_styles' => '',
 	);
-
-	$is_sub_menu = isset( $attributes['isTopLevelLink'] ) ? ( ! $attributes['isTopLevelLink'] ) : false;
 
 	// Text color.
 	$named_text_color  = null;

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -19,7 +19,7 @@ function block_core_navigation_link_build_css_colors( $context, $attributes ) {
 		'inline_styles' => '',
 	);
 
-	$is_sub_menu = isset( $attributes['isTopLevelLink'] ) ? ( ! $attributes['isTopLevelLink'] ) : false;
+	$is_sub_menu = false; //isset( $attributes['isTopLevelLink'] ) ? ( ! $attributes['isTopLevelLink'] ) : false;
 
 	// Text color.
 	$named_text_color  = null;

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -11,7 +11,7 @@
  *
  * @param  array $context     Navigation block context.
  * @param  array $attributes  Block attributes.
- * @param  bool	 $is_sub_menu Whether the link is part of a sub-menu.
+ * @param  bool  $is_sub_menu Whether the link is part of a sub-menu.
  * @return array Colors CSS classes and inline styles.
  */
 function block_core_navigation_link_build_css_colors( $context, $attributes, $is_sub_menu = false ) {

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -224,16 +224,6 @@ export default function NavigationSubmenuEdit( {
 		}
 	}, [] );
 
-	// Store the colors from context as attributes for rendering.
-	useEffect( () => {
-		// This side-effect should not create an undo level as those should
-		// only be created via user interactions. Mark this change as
-		// not persistent to avoid undo level creation.
-		// See https://github.com/WordPress/gutenberg/issues/34564.
-		__unstableMarkNextChangeAsNotPersistent();
-		setAttributes( { isTopLevelItem } );
-	}, [ isTopLevelItem ] );
-
 	/**
 	 * The hook shouldn't be necessary but due to a focus loss happening
 	 * when selecting a suggestion in the link popover, we force close on block unselection.

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -19,7 +19,7 @@ function block_core_navigation_submenu_build_css_colors( $context, $attributes )
 		'inline_styles' => '',
 	);
 
-	$is_sub_menu = isset( $attributes['isTopLevelItem'] ) ? ( ! $attributes['isTopLevelItem'] ) : false;
+	$is_sub_menu = false; //isset( $attributes['isTopLevelItem'] ) ? ( ! $attributes['isTopLevelItem'] ) : false;
 
 	// Text color.
 	$named_text_color  = null;
@@ -250,6 +250,19 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	}
 
 	if ( $has_submenu ) {
+
+		if ( array_key_exists( 'customOverlayTextColor', $block->context ) ) {
+			$custom_text_color = $block->context['customOverlayTextColor'];
+		} elseif ( array_key_exists( 'overlayTextColor', $block->context ) ) {
+			$named_text_color = $block->context['overlayTextColor'];
+		}
+
+		if ( array_key_exists( 'customOverlayBackgroundColor', $block->context ) ) {
+			$custom_background_color = $block->context['customOverlayBackgroundColor'];
+		} elseif ( array_key_exists( 'overlayBackgroundColor', $block->context ) ) {
+			$named_background_color = $block->context['overlayBackgroundColor'];
+		}
+
 		$inner_blocks_html = '';
 		foreach ( $block->inner_blocks as $inner_block ) {
 			$inner_blocks_html .= $inner_block->render();
@@ -264,7 +277,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		}
 
 		$html .= sprintf(
-			'<ul class="wp-block-navigation__submenu-container">%s</ul>',
+			'<ul class="wp-block-navigation__submenu-container has-background has-' . $named_background_color . '-background-color has-text-color has-' . $named_text_color . '-color">%s</ul>',
 			$inner_blocks_html
 		);
 	}

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -13,13 +13,11 @@
  * @param  array $attributes Block attributes.
  * @return array Colors CSS classes and inline styles.
  */
-function block_core_navigation_submenu_build_css_colors( $context, $attributes ) {
+function block_core_navigation_submenu_build_css_colors( $context, $attributes, $is_sub_menu = false ) {
 	$colors = array(
 		'css_classes'   => array(),
 		'inline_styles' => '',
 	);
-
-	$is_sub_menu = false; //isset( $attributes['isTopLevelItem'] ) ? ( ! $attributes['isTopLevelItem'] ) : false;
 
 	// Text color.
 	$named_text_color  = null;
@@ -250,18 +248,13 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	}
 
 	if ( $has_submenu ) {
-
-		if ( array_key_exists( 'customOverlayTextColor', $block->context ) ) {
-			$custom_text_color = $block->context['customOverlayTextColor'];
-		} elseif ( array_key_exists( 'overlayTextColor', $block->context ) ) {
-			$named_text_color = $block->context['overlayTextColor'];
-		}
-
-		if ( array_key_exists( 'customOverlayBackgroundColor', $block->context ) ) {
-			$custom_background_color = $block->context['customOverlayBackgroundColor'];
-		} elseif ( array_key_exists( 'overlayBackgroundColor', $block->context ) ) {
-			$named_background_color = $block->context['overlayBackgroundColor'];
-		}
+		$colors  = block_core_navigation_submenu_build_css_colors( $block->context, $attributes, true );
+		$classes = array_merge(
+			array( 'wp-block-navigation__submenu-container' ),
+			$colors['css_classes'],
+		);
+		$css_classes = trim( implode( ' ', $classes ) );
+		$style_attribute = $colors['inline_styles'];
 
 		$inner_blocks_html = '';
 		foreach ( $block->inner_blocks as $inner_block ) {
@@ -276,8 +269,16 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 			$html = $tag_processor->get_updated_html();
 		}
 
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'class' => $css_classes,
+				'style' => $style_attribute,
+			)
+		);
+
 		$html .= sprintf(
-			'<ul class="wp-block-navigation__submenu-container has-background has-' . $named_background_color . '-background-color has-text-color has-' . $named_text_color . '-color">%s</ul>',
+			'<ul %s>%s</ul>',
+			$wrapper_attributes,
 			$inner_blocks_html
 		);
 	}

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -9,8 +9,9 @@
  * Build an array with CSS classes and inline styles defining the colors
  * which will be applied to the navigation markup in the front-end.
  *
- * @param  array $context    Navigation block context.
- * @param  array $attributes Block attributes.
+ * @param  array $context     Navigation block context.
+ * @param  array $attributes  Block attributes.
+ * @param  bool  $is_sub_menu Whether the block is a sub-menu.
  * @return array Colors CSS classes and inline styles.
  */
 function block_core_navigation_submenu_build_css_colors( $context, $attributes, $is_sub_menu = false ) {

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -252,7 +252,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		$colors          = block_core_navigation_submenu_build_css_colors( $block->context, $attributes, true );
 		$classes         = array_merge(
 			array( 'wp-block-navigation__submenu-container' ),
-			$colors['css_classes'],
+			$colors['css_classes']
 		);
 		$css_classes     = trim( implode( ' ', $classes ) );
 		$style_attribute = $colors['inline_styles'];

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -279,7 +279,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 
 		$html .= sprintf(
 			'<ul %s>%s</ul>',
-			esc_attr( $wrapper_attributes ),
+			$wrapper_attributes,
 			$inner_blocks_html
 		);
 	}

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -249,12 +249,12 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	}
 
 	if ( $has_submenu ) {
-		$colors  = block_core_navigation_submenu_build_css_colors( $block->context, $attributes, true );
-		$classes = array_merge(
+		$colors          = block_core_navigation_submenu_build_css_colors( $block->context, $attributes, true );
+		$classes         = array_merge(
 			array( 'wp-block-navigation__submenu-container' ),
 			$colors['css_classes'],
 		);
-		$css_classes = trim( implode( ' ', $classes ) );
+		$css_classes     = trim( implode( ' ', $classes ) );
 		$style_attribute = $colors['inline_styles'];
 
 		$inner_blocks_html = '';

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -249,12 +249,13 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	}
 
 	if ( $has_submenu ) {
-		$colors          = block_core_navigation_submenu_build_css_colors( $block->context, $attributes, true );
-		$classes         = array_merge(
+		$colors      = block_core_navigation_submenu_build_css_colors( $block->context, $attributes, $has_submenu );
+		$classes     = array_merge(
 			array( 'wp-block-navigation__submenu-container' ),
 			$colors['css_classes']
 		);
-		$css_classes     = trim( implode( ' ', $classes ) );
+		$css_classes = trim( implode( ' ', $classes ) );
+
 		$style_attribute = $colors['inline_styles'];
 
 		$inner_blocks_html = '';
@@ -282,6 +283,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 			$wrapper_attributes,
 			$inner_blocks_html
 		);
+
 	}
 
 	$html .= '</li>';

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -278,7 +278,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 
 		$html .= sprintf(
 			'<ul %s>%s</ul>',
-			$wrapper_attributes,
+			esc_attr( $wrapper_attributes ),
 			$inner_blocks_html
 		);
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The useEffect that saves the `isTopLevelLink` and `isTopLevelItem` to an attribute causes ripples through the other useEffects in the navigation block, which means that we get unexpected bugs like those listed below.

I don't think we need this useEffect at all - we don't even need to know if this is a top level link. Instead we can output the colors on the navigation submenu wrapper element itself. 


Closes https://github.com/WordPress/gutenberg/issues/47829
Closes https://github.com/WordPress/gutenberg/issues/48594
Closes https://github.com/WordPress/gutenberg/issues/48668

## Why?
I think this is a simpler approach and avoids the needs for a useEffect and extra attributes. 

## Testing Instructions
- Set a submenu color on the navigation block
- Check that the color setting is applied only to the submenu, and not the top level links.
- Test this for both text color and background color
- Test setting custom colors and preset colors

### Testing Instructions for Keyboard
I suppose you'll have to inspect the code to ensure that the correct colors are applied.

## Screenshots or screencast <!-- if applicable -->
Here are some disgusting colors:
<img width="588" alt="Screenshot 2023-03-02 at 12 37 17" src="https://user-images.githubusercontent.com/275961/222430879-1c0c4585-fc95-4247-b1e7-e40ceeb34406.png">
