### PR TITLE
Navigation: Don't create duplicate navigation menus

### DIFF
--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -146,7 +146,6 @@ export default function UnsavedInnerBlocks( {
 
 		createNavigationMenu( null, blocks );
 	}, [
-		blocks,
 		createNavigationMenu,
 		isDisabled,
 		isSaving,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is just a quick fix for an issue where duplicate navigation menus are created from the fallback. Ideally we should be providing `blocks` as a dependency to this `useEffect` but at the moment this causes a duplicate navigation menu to be created because blocks get mutated by this `useEffect`:

https://github.com/WordPress/gutenberg/blob/7d8c488d572addeb993957652868e80284c44569/packages/block-library/src/navigation-link/edit.js#L234

I am proposing in https://github.com/WordPress/gutenberg/pull/48219 that we remove this `useEffect` but that PR might take some time to get right, so in the meantime I suggest we just remove the `blocks` dependency.

## Testing Instructions
1. Remove all wp_navigation menus
2. Add a navigation block
3. It should contain a page list fallback
4. Add a block to the fallback
5. A new navigation should be created
6. Check in wp_admin that you have only one. (If you do this in trunk you'll see two)

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
