### PR TITLE
Fixed incorrect type annotations in @wordpress/data, part 2

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -508,10 +508,6 @@ import { store as myCustomStore } from 'my-custom-store';
 dispatch( myCustomStore ).setPrice( 'hammer', 9.75 );
 ```
 
-_Type_
-
--   `(storeNameOrDescriptor: StoreDescriptor|string) => Object`
-
 _Parameters_
 
 -   _storeNameOrDescriptor_ `StoreDescriptor|string`: The store descriptor. The legacy calling convention of passing the store name is also supported.
@@ -658,10 +654,6 @@ import { store as myCustomStore } from 'my-custom-store';
 
 select( myCustomStore ).getPrice( 'hammer' );
 ```
-
-_Type_
-
--   `(storeNameOrDescriptor: StoreDescriptor|string) => Object`
 
 _Parameters_
 

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -25,8 +25,9 @@ const renderQueue = createQueue();
  */
 /**
  * @typedef {import('../../types').ReduxStoreConfig<State,Actions,Selectors>} ReduxStoreConfig
- * @template State,Selectors
+ * @template State
  * @template {Record<string,import('../../types').ActionCreator>} Actions
+ * @template Selectors
  */
 /** @typedef {import('../../types').MapSelect} MapSelect */
 /**

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -98,8 +98,6 @@ export const combineReducers = turboCombineReducers;
  * ```
  *
  * @return {Object} Object containing the store's selectors.
- *
- * @type {(storeNameOrDescriptor: StoreDescriptor|string) => Object}
  */
 export function select( storeNameOrDescriptor ) {
 	return defaultRegistry.select( storeNameOrDescriptor );
@@ -158,8 +156,6 @@ export const suspendSelect = defaultRegistry.suspendSelect;
  * dispatch( myCustomStore ).setPrice( 'hammer', 9.75 );
  * ```
  * @return {Object} Object containing the action creators.
- *
- * @type {(storeNameOrDescriptor: StoreDescriptor|string) => Object}
  */
 export function dispatch( storeNameOrDescriptor ) {
 	return defaultRegistry.dispatch( storeNameOrDescriptor );

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -101,7 +101,9 @@ export const combineReducers = turboCombineReducers;
  *
  * @type {(storeNameOrDescriptor: StoreDescriptor|string) => Object}
  */
-export const select = defaultRegistry.select;
+export function select( storeNameOrDescriptor ) {
+	return defaultRegistry.select( storeNameOrDescriptor );
+}
 
 /**
  * Given a store descriptor, returns an object containing the store's selectors pre-bound to state
@@ -159,7 +161,9 @@ export const suspendSelect = defaultRegistry.suspendSelect;
  *
  * @type {(storeNameOrDescriptor: StoreDescriptor|string) => Object}
  */
-export const dispatch = defaultRegistry.dispatch;
+export function dispatch( storeNameOrDescriptor ) {
+	return defaultRegistry.dispatch( storeNameOrDescriptor );
+}
 
 /**
  * Given a listener function, the function will be called any time the state value

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -30,8 +30,9 @@ import * as metadataActions from './metadata/actions';
  */
 /**
  * @typedef {import('../types').ReduxStoreConfig<State,Actions,Selectors>} ReduxStoreConfig
- * @template State,Selectors
+ * @template State
  * @template {Record<string,import('../../types').ActionCreator>} Actions
+ * @template Selectors
  */
 
 const trimUndefinedValues = ( array ) => {
@@ -117,8 +118,9 @@ function createResolversCache() {
  * } );
  * ```
  *
- * @template State,Selectors
+ * @template State
  * @template {Record<string,import('../../types').ActionCreator>} Actions
+ * @template Selectors
  * @param {string}                                    key     Unique namespace identifier.
  * @param {ReduxStoreConfig<State,Actions,Selectors>} options Registered store options, with properties
  *                                                            describing reducer, actions, selectors,


### PR DESCRIPTION
## What?
This PR modifies several type annotations in the data package so that they don't throw errors when used in a TS codebase. The errors are mainly due to types being exported as `const`s instead of `function`s, preventing successful declaration merging.

This PR is a continuation of #46881 and fixes #46626. Fixes https://github.com/WordPress/gutenberg/issues/48133.

## How?
I have changed the definitions for `select` and `dispatch` to be functions - I don't know any better approach, if the output types are declared as `export const`, declaration merging doesn't properly kick in.

## Testing Instructions
1. Check out https://github.com/marekdedic/DefinitelyTyped/tree/wordpress__rich-text-upstream-data
2. Delete the types/wordpress__data directory to force use of types in @wordpress/data
3. Run npm test wordpress__rich-text
4. You should see no error with this PR, as opposed to trunk
