### PR TITLE
Classic Block: replace the deprecated `isPrimary` prop with `variant`

### DIFF
--- a/packages/block-library/src/freeform/modal.js
+++ b/packages/block-library/src/freeform/modal.js
@@ -88,7 +88,7 @@ export default function ModalEdit( props ) {
 								{ __( 'Cancel' ) }
 							</Button>
 							<Button
-								isPrimary
+								variant="primary"
 								onClick={ () => {
 									setAttributes( {
 										content:


### PR DESCRIPTION
## What?
This PR replaces the deprecated `isPrimary` prop with `variant="primary"` in the button component of the Classic block.

There is no impact on functionality or layout.
