### PR TITLE
Widget Editor: Fix a problem with 'Move to Widget Area' button not working

### DIFF
--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -395,7 +395,7 @@ export const moveBlockToWidgetArea =
 	async ( { dispatch, select, registry } ) => {
 		const sourceRootClientId = registry
 			.select( blockEditorStore )
-			.getBlockRootClientId( [ clientId ] );
+			.getBlockRootClientId( clientId );
 
 		// Search the top level blocks (widget areas) for the one with the matching
 		// id attribute. Makes the assumption that all top-level blocks are widget


### PR DESCRIPTION
Fixes #48113

## What?

This PR fixes a problem with 'Move to Widget Area' button not working in the widget editor.

## Why?

I have discovered that the root client ID (`sourceRootClientId`) for the widget area from which I'm moving is `null`. In #30826, when this feature was implemented, [`yield` was used](https://github.com/WordPress/gutenberg/pull/30826/files#diff-bf9863e9cdc2891132a3751d051b5171d1ec7d4856491870f1f941e756fedcfcR332-R336) to get the route ID of the source of the move. Perhaps the parentheses were not removed when they were refactored into the `registry`. The second argument of the current `getBlockRootClientId` [accepts only a single clientId](https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/data/data-core-block-editor.md#getblockrootclientid).

## Screenshots or screencast <!-- if applicable -->

Make sure that moving blocks between widgets works correctly.

https://user-images.githubusercontent.com/54422211/219954861-b20eec87-5b39-49dc-825e-e286a881ce48.mp4


