### PR TITLE
[WIP] Negative Margins / Position: Try layering approach with z-index values

### DIFF
--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -152,6 +152,7 @@ export function MarginEdit( props ) {
 						splitOnAxis={ splitOnAxis }
 						onMouseOver={ onMouseOver }
 						onMouseOut={ onMouseOut }
+						inputProps={ { min: -Infinity } }
 					/>
 				) }
 				{ spacingSizes?.length > 0 && (
@@ -165,6 +166,7 @@ export function MarginEdit( props ) {
 						splitOnAxis={ false }
 						onMouseOver={ onMouseOver }
 						onMouseOut={ onMouseOut }
+						minimumCustomValue={ -Infinity }
 					/>
 				) }
 			</>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

🚧 🚧 🚧 🚧 WIP: This is an early exploratory PR and is likely to change quite a lot! 🚧 🚧 🚧 🚧

This PR explores adding in support for negative margins at the block level, alongside the ability to set a block to a particular layer (really just a z-index value for now).

If the general direction of this PR winds up appearing to be viable, then I think rather than using explicit z-index values, it would probably be better to use a named preset, and have it be mapped to z-index values in `theme.json` or something like that.

For now, the purpose of this PR is to highlight the importance of some level of control over `z-index` and positioning when enabling negative margins.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Negative margins is a desired feature as raised in https://github.com/WordPress/gutenberg/issues/32644 — however, in order for users to be able to create their desired layout, it appears that some level of control over `z-index` (and therefore implicitly setting a block to `position: relative`) will be required. Otherwise, via a default `z-index`, which block sits on top will be unpredictable.

For example, have a Group block directly before a Cover block, and set its bottom margin to a negative value. In this case, the user might expect the Group block to sit above the Cover block. However, by default, it will sit underneath. In the below screengrab, observe being able to set the Group block above the Cover block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* (Experimental — this would require further design work) Add a select dropdown under Position to change the layer (z-index) value of a Group block
* In the Position CSS output, add support for outputting z-index values — use an implicit `position: relative` when a z-index value is set, so that it will have an effect
* Allow the Margin controls to support negative margin values

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In a post or page, add a Group block and image block within it
2. After the Group block, add a Cover block
3. In the Group block, set the bottom margin to a custom negative value (e.g. `-8em`)
4. See that the Group block is underneath the Cover block
5. In the Group block's Position panel, select "Top"
6. Save the post — the Group should sit above the Cover in the editor and on the site frontend

## Screenshots or screencast <!-- if applicable -->

| Group with negative bottom margin without setting `z-index` | Group with negative bottom margin with setting `z-index` |
|  --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/220015060-49b13f36-213e-405b-801e-d4142fe0b886.png) | ![image](https://user-images.githubusercontent.com/14988353/220015082-9b6628d9-a93e-4ceb-ac14-de04b63db0aa.png) |

The below screengrab demonstrates setting a Group block to a bottom margin of `-8em`, and then setting the position layer to `Top` (which currently sets a hard-coded value of `5`).

https://user-images.githubusercontent.com/14988353/220016572-1169eef6-467d-40e0-8cb4-dfcc4c9080ca.mp4

## To-do / to explore next

* [ ] Can z-index direct values be replaced by presets?
* [ ] If using presets, what is a good set of default preset z-index values (keeping in mind that sticky/fixed currently uses a value of `10`)
* [ ] What would make for a good UI for adjusting the layer / positioning
* [ ] If we were to add in "Send to front" or "Send to back" options/actions somewhere, what real values would that translate to?
