### PR TITLE
Try to fix a11y test flakiness

### DIFF
--- a/test/e2e/specs/editor/various/a11y.spec.js
+++ b/test/e2e/specs/editor/various/a11y.spec.js
@@ -174,8 +174,8 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 		// This is necessary for solving a flaky result where Playwright runs too fast
 		// before DOM catching up.
 		await expect( preferencesModalContent ).toHaveAttribute(
-			'aria-label',
-			'Scrollable section'
+			'tabindex',
+			'0'
 		);
 		await page.keyboard.press( 'Shift+Tab' );
 		await expect( closeButton ).toBeFocused();

--- a/test/e2e/specs/editor/various/a11y.spec.js
+++ b/test/e2e/specs/editor/various/a11y.spec.js
@@ -157,10 +157,6 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 			// in the UI. This isn't part of the user flow we want to test.
 			await tab.click();
 			await tab.focus();
-			// Perform actionability checks implicitly to wait for the modal content
-			// to be attached with certain attributes. This is necessary for solving
-			// a flaky result where Playwright runs too fast before DOM catching up.
-			await expect( preferencesModalContent ).toBeVisible();
 		}
 
 		// The General tab panel content is short and not scrollable.
@@ -174,12 +170,15 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 		// The Blocks tab panel content is long and scrollable.
 		// Check it's focusable.
 		await clickAndFocusTab( blocksTab );
-		await page.keyboard.press( 'Shift+Tab' );
-		await expect( closeButton ).toBeFocused();
+		// Explicitly wait for the modal content to be attached with certain attributes.
+		// This is necessary for solving a flaky result where Playwright runs too fast
+		// before DOM catching up.
 		await expect( preferencesModalContent ).toHaveAttribute(
 			'aria-label',
 			'Scrollable section'
 		);
+		await page.keyboard.press( 'Shift+Tab' );
+		await expect( closeButton ).toBeFocused();
 		await page.keyboard.press( 'Shift+Tab' );
 		await expect( preferencesModalContent ).toBeFocused();
 

--- a/test/e2e/specs/editor/various/a11y.spec.js
+++ b/test/e2e/specs/editor/various/a11y.spec.js
@@ -176,6 +176,10 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 		await clickAndFocusTab( blocksTab );
 		await page.keyboard.press( 'Shift+Tab' );
 		await expect( closeButton ).toBeFocused();
+		await expect( preferencesModalContent ).toHaveAttribute(
+			'aria-label',
+			'Scrollable section'
+		);
 		await page.keyboard.press( 'Shift+Tab' );
 		await expect( preferencesModalContent ).toBeFocused();
 

--- a/test/e2e/specs/editor/various/a11y.spec.js
+++ b/test/e2e/specs/editor/various/a11y.spec.js
@@ -157,6 +157,10 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 			// in the UI. This isn't part of the user flow we want to test.
 			await tab.click();
 			await tab.focus();
+			// Perform actionability checks implicitly to wait for the modal content
+			// to be attached with certain attributes. This is necessary for solving
+			// a flaky result where Playwright runs too fast before DOM catching up.
+			await expect( preferencesModalContent ).toBeVisible();
 		}
 
 		// The General tab panel content is short and not scrollable.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Close https://github.com/WordPress/gutenberg/issues/48067.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix the flakiness of the a11y test.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Playwright runs too fast before the modal can run some of the code for constrained tabbing. We explicitly wait for `aria-label` to be sure that `tabindex` has been updated. I'm not sure why it's only failing on Webkit though. This is not an ideal solution but I couldn't figure out a better one at the time. Let's merge this first to unblock other PRs, we can figure out a better solution in another PR.

I ran this locally 100 times and they all passed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
CI should pass.
