### PR TITLE
Pin `valtio` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17475,7 +17475,7 @@
 				"remove-accents": "^0.4.2",
 				"use-lilius": "^2.0.1",
 				"uuid": "^8.3.0",
-				"valtio": "^1.7.0"
+				"valtio": "1.7.0"
 			},
 			"dependencies": {
 				"date-fns": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -76,7 +76,7 @@
 		"remove-accents": "^0.4.2",
 		"use-lilius": "^2.0.1",
 		"uuid": "^8.3.0",
-		"valtio": "^1.7.0"
+		"valtio": "1.7.0"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/47923

Let's pin valtio's version to see if it fixes the WP beta issues with the Popovers. It seems that the resolved version in GB for valtio is `1.7.0` but in core build is resolving to `1.10.2`. 

As @gziolo mentioned:

>There are two options at the moment:

>- we quickly pin valtio to 1.7.x and check if that helps
>- we upgrade to ^1.10.2 and make the code work with the changes applied

>Option 2 would be preferred if it doesn’t come with too many changes risky for the major WP release. It will be necessary anyway in trunk as it impacts 3rd party package usage.

Let's try option one for beta3.