### PR TITLE
useAsyncList: flush state updates when processing queue

### DIFF
--- a/packages/compose/src/hooks/use-async-list/index.ts
+++ b/packages/compose/src/hooks/use-async-list/index.ts
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useState } from '@wordpress/element';
+import { flushSync, useEffect, useState } from '@wordpress/element';
 import { createQueue } from '@wordpress/priority-queue';
 
 type AsyncListConfig = {
@@ -61,10 +61,12 @@ function useAsyncList< T >(
 			if ( list.length <= nextIndex ) {
 				return;
 			}
-			setCurrent( ( state ) => [
-				...state,
-				...list.slice( nextIndex, nextIndex + step ),
-			] );
+			flushSync( () => {
+				setCurrent( ( state ) => [
+					...state,
+					...list.slice( nextIndex, nextIndex + step ),
+				] );
+			} );
 			asyncQueue.add( {}, append( nextIndex + step ) );
 		};
 		asyncQueue.add( {}, append( firstItems.length ) );

--- a/packages/compose/src/hooks/use-async-list/index.ts
+++ b/packages/compose/src/hooks/use-async-list/index.ts
@@ -57,19 +57,16 @@ function useAsyncList< T >(
 		setCurrent( firstItems );
 
 		const asyncQueue = createQueue();
-		const append = ( nextIndex: number ) => () => {
-			if ( list.length <= nextIndex ) {
-				return;
-			}
-			flushSync( () => {
-				setCurrent( ( state ) => [
-					...state,
-					...list.slice( nextIndex, nextIndex + step ),
-				] );
+		for ( let i = firstItems.length; i < list.length; i += step ) {
+			asyncQueue.add( {}, () => {
+				flushSync( () => {
+					setCurrent( ( state ) => [
+						...state,
+						...list.slice( i, i + step ),
+					] );
+				} );
 			} );
-			asyncQueue.add( {}, append( nextIndex + step ) );
-		};
-		asyncQueue.add( {}, append( firstItems.length ) );
+		}
 
 		return () => asyncQueue.reset();
 	}, [ list ] );

--- a/packages/element/CHANGELOG.md
+++ b/packages/element/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Started exporting the `flushSync` function from `react-dom`
+
 ## 5.4.0 (2023-02-15)
 
 ## 5.3.0 (2023-02-01)

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -213,6 +213,14 @@ _Parameters_
 
 -   _component_ `import('./react').WPComponent`: Component's instance.
 
+### flushSync
+
+Forces React to flush any updates inside the provided callback synchronously.
+
+_Parameters_
+
+-   _callback_ `Function`: Callback to run synchronously.
+
 ### forwardRef
 
 Component enhancer used to enable passing a ref to its wrapped component.

--- a/packages/element/src/react-platform.js
+++ b/packages/element/src/react-platform.js
@@ -4,6 +4,7 @@
 import {
 	createPortal,
 	findDOMNode,
+	flushSync,
 	render,
 	hydrate,
 	unmountComponentAtNode,
@@ -27,6 +28,13 @@ export { createPortal };
  * @param {import('./react').WPComponent} component Component's instance.
  */
 export { findDOMNode };
+
+/**
+ * Forces React to flush any updates inside the provided callback synchronously.
+ *
+ * @param {Function} callback Callback to run synchronously.
+ */
+export { flushSync };
 
 /**
  * Renders a given element into the target DOM node.


### PR DESCRIPTION
Fixes `useAsyncList` in concurrent mode by using `ReactDOM.flushSync` to synchronously run all the renders and effects triggered by `setState`. Doing the work inside `requestIdleCallback` and consuming the `timeRemaining` provided by it.

Fixes the issues discussed in #48085. In that discussion, I was wrong about `flushSync` not being sync, and merely scheduling a microtask. It indeed is completely sync, doing all the rendering work and even effects synchronously. Very similar to `act()` in tests in this regard.

I'm wondering how this will work in React Native. `flushSync` is a `react-dom` API, not available in the `react-native` package.