### PR TITLE
Lodash: Refactor away from `_.merge()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -106,6 +106,7 @@ const restrictedImports = [
 			'mapKeys',
 			'maxBy',
 			'memoize',
+			'merge',
 			'negate',
 			'noop',
 			'nth',

--- a/package-lock.json
+++ b/package-lock.json
@@ -17227,7 +17227,7 @@
 			"dev": true,
 			"requires": {
 				"gettext-parser": "^1.3.1",
-				"lodash": "^4.17.21"
+				"is-plain-object": "^5.0.0"
 			}
 		},
 		"@wordpress/babel-preset-default": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17226,8 +17226,17 @@
 			"version": "file:packages/babel-plugin-makepot",
 			"dev": true,
 			"requires": {
+				"deepmerge": "^4.3.0",
 				"gettext-parser": "^1.3.1",
 				"is-plain-object": "^5.0.0"
+			},
+			"dependencies": {
+				"deepmerge": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
+					"integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/babel-preset-default": {

--- a/packages/babel-plugin-makepot/CHANGELOG.md
+++ b/packages/babel-plugin-makepot/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Lodash: Refactor away from `_.merge()` ([#48239](https://github.com/WordPress/gutenberg/pull/48239)).
+
 ## 5.11.0 (2023-02-15)
 
 ## 5.10.0 (2023-02-01)

--- a/packages/babel-plugin-makepot/CHANGELOG.md
+++ b/packages/babel-plugin-makepot/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Internal
 
--   Lodash: Refactor away from `_.merge()` ([#48239](https://github.com/WordPress/gutenberg/pull/48239)).
+-   Lodash: Refactor away from `_.merge()` and remove Lodash dependency ([#48239](https://github.com/WordPress/gutenberg/pull/48239)).
 
 ## 5.11.0 (2023-02-15)
 

--- a/packages/babel-plugin-makepot/index.js
+++ b/packages/babel-plugin-makepot/index.js
@@ -32,8 +32,9 @@
  * External dependencies
  */
 
+const deepmerge = require( 'deepmerge' );
+const { isPlainObject } = require( 'is-plain-object' );
 const { po } = require( 'gettext-parser' );
-const { merge, isEmpty } = require( 'lodash' );
 const { relative, sep } = require( 'path' );
 const { writeFileSync } = require( 'fs' );
 
@@ -312,7 +313,10 @@ module.exports = () => {
 				},
 				exit( path, state ) {
 					const { filename } = this.file.opts;
-					if ( isEmpty( strings[ filename ] ) ) {
+					if (
+						! strings[ filename ] ||
+						! Object.values( strings[ filename ] ).length
+					) {
 						delete strings[ filename ];
 						return;
 					}
@@ -362,7 +366,13 @@ module.exports = () => {
 					}, {} );
 
 					// Merge translations from individual files into headers
-					const data = merge( {}, baseData, { translations } );
+					const data = deepmerge(
+						baseData,
+						{ translations },
+						{
+							isMergeableObject: isPlainObject,
+						}
+					);
 
 					// Ideally we could wait until Babel has finished parsing
 					// all files or at least asynchronously write, but the

--- a/packages/babel-plugin-makepot/package.json
+++ b/packages/babel-plugin-makepot/package.json
@@ -28,8 +28,9 @@
 	],
 	"main": "index.js",
 	"dependencies": {
+		"deepmerge": "^4.3.0",
 		"gettext-parser": "^1.3.1",
-		"lodash": "^4.17.21"
+		"is-plain-object": "^5.0.0"
 	},
 	"peerDependencies": {
 		"@babel/core": "^7.12.9"


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.merge()` from the `babel-plugin-makepot` package. It's the last usage, so we're also deprecating that method. Finally, we're removing a stray `_.isEmpty()` which is straightforward enough to remove.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `deepmerge` instead of `_.merge()`, which has been properly used as a substitute in other places of the codebase where we need deep merging of objects. We're using an additional bool check and `Object.values().length` to replace the `isEmpty()` over an object.

## Testing Instructions

* Start with a project that uses `babel-plugin-makepot` in its build pipeline. If you don't have one, you could start with the one mentioned at https://github.com/WordPress/gutenberg/issues/43793
* Apply the changes manually to the package in `node_modules`, similar to how we did in #43797.
* Verify babel builds correctly and generates a pot file.

cc @jeremyfelt who has historically been capable to test changes on this package - I'd really appreciate a review on this one. 🙌 