### PR TITLE
Fix Site Editor perf tests

### DIFF
--- a/packages/e2e-test-utils/src/site-editor.js
+++ b/packages/e2e-test-utils/src/site-editor.js
@@ -175,9 +175,4 @@ export async function enterEditMode() {
 		return;
 	}
 	await canvas().click( 'body' );
-
-	await page.waitForSelector(
-		'[role="region"][aria-label="Navigation sidebar"]',
-		{ hidden: true }
-	);
 }

--- a/packages/e2e-test-utils/src/site-editor.js
+++ b/packages/e2e-test-utils/src/site-editor.js
@@ -175,4 +175,9 @@ export async function enterEditMode() {
 		return;
 	}
 	await canvas().click( 'body' );
+
+	await page.waitForSelector(
+		'[role="region"][aria-label="Navigation sidebar"]',
+		{ hidden: true }
+	);
 }

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -90,6 +90,9 @@ describe( 'Site Editor Performance', () => {
 		await visitSiteEditor( {
 			postId: id,
 			postType: 'page',
+			// This shouldn't be necessary, but without it the tests fail.
+			// Could be related to having the necessary cookies in the browser.
+			// See https://github.com/WordPress/gutenberg/pull/48240/files#r1111760556
 			path: '/navigation/single',
 		} );
 	} );

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -90,6 +90,7 @@ describe( 'Site Editor Performance', () => {
 		await visitSiteEditor( {
 			postId: id,
 			postType: 'page',
+			path: '/navigation/single',
 		} );
 	} );
 

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -148,7 +148,7 @@ describe( 'Site Editor Performance', () => {
 			'[data-type="core/post-content"] [data-type="core/paragraph"]'
 		);
 		await enterEditMode();
-		await canvas().focus(
+		await canvas().click(
 			'[data-type="core/post-content"] [data-type="core/paragraph"]'
 		);
 		await insertBlock( 'Paragraph' );

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -90,7 +90,6 @@ describe( 'Site Editor Performance', () => {
 		await visitSiteEditor( {
 			postId: id,
 			postType: 'page',
-			path: '/navigation/single',
 		} );
 	} );
 

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -151,7 +151,7 @@ describe( 'Site Editor Performance', () => {
 			'[data-type="core/post-content"] [data-type="core/paragraph"]'
 		);
 		await enterEditMode();
-		await canvas().click(
+		await canvas().focus(
 			'[data-type="core/post-content"] [data-type="core/paragraph"]'
 		);
 		await insertBlock( 'Paragraph' );

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -59,7 +59,7 @@ describe( 'Site Editor Performance', () => {
 		);
 
 		await createNewPost( { postType: 'page' } );
-		await page.evaluate( async ( _html ) => {
+		await page.evaluate( ( _html ) => {
 			const { parse } = window.wp.blocks;
 			const { dispatch } = window.wp.data;
 			const blocks = parse( _html );
@@ -71,7 +71,7 @@ describe( 'Site Editor Performance', () => {
 				}
 			} );
 
-			await dispatch( 'core/block-editor' ).resetBlocks( blocks );
+			dispatch( 'core/block-editor' ).resetBlocks( blocks );
 		}, html );
 		await saveDraft();
 

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -59,7 +59,7 @@ describe( 'Site Editor Performance', () => {
 		);
 
 		await createNewPost( { postType: 'page' } );
-		await page.evaluate( ( _html ) => {
+		await page.evaluate( async ( _html ) => {
 			const { parse } = window.wp.blocks;
 			const { dispatch } = window.wp.data;
 			const blocks = parse( _html );
@@ -71,7 +71,7 @@ describe( 'Site Editor Performance', () => {
 				}
 			} );
 
-			dispatch( 'core/block-editor' ).resetBlocks( blocks );
+			await dispatch( 'core/block-editor' ).resetBlocks( blocks );
 		}, html );
 		await saveDraft();
 
@@ -90,6 +90,7 @@ describe( 'Site Editor Performance', () => {
 		await visitSiteEditor( {
 			postId: id,
 			postType: 'page',
+			path: '/navigation/single',
 		} );
 	} );
 
@@ -148,8 +149,7 @@ describe( 'Site Editor Performance', () => {
 		);
 		await enterEditMode();
 		await canvas().focus(
-			'[data-type="core/post-content"] [data-type="core/paragraph"]',
-			{ timeout: 240000 }
+			'[data-type="core/post-content"] [data-type="core/paragraph"]'
 		);
 		await insertBlock( 'Paragraph' );
 		let i = 200;

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -147,8 +147,9 @@ describe( 'Site Editor Performance', () => {
 			'[data-type="core/post-content"] [data-type="core/paragraph"]'
 		);
 		await enterEditMode();
-		await canvas().click(
-			'[data-type="core/post-content"] [data-type="core/paragraph"]'
+		await canvas().focus(
+			'[data-type="core/post-content"] [data-type="core/paragraph"]',
+			{ timeout: 240000 }
 		);
 		await insertBlock( 'Paragraph' );
 		let i = 200;


### PR DESCRIPTION
## What?

Isolating the solution from https://github.com/WordPress/gutenberg/pull/48208. See https://github.com/WordPress/gutenberg/pull/48208#issuecomment-1436030942.

## Why?

Site Editor performance tests are currently very flaky.

## How?

Focus on the paragraph instead of clicking it.