### PR TITLE
Block Editor: Improve empty `getBlockParents()` perf

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -510,6 +510,10 @@ export const getBlockParents = createSelector(
 			parents.push( current );
 		}
 
+		if ( ! parents.length ) {
+			return EMPTY_ARRAY;
+		}
+
 		return ascending ? parents : parents.reverse();
 	},
 	( state ) => [ state.blocks.parents ]


### PR DESCRIPTION
## What?
This PR improves the performance of the `getBlockParents()` selector, so it will always return the same empty array if no parents are returned. 

## Why?
I've noticed that when the List View is opened, and we're moving with the arrows up and down, extra re-renders are caused because `getBlockParents()` returns a different empty array every time.

## How?
We're simply returning the same empty array when the selector would return an empty array. 

## Testing Instructions
* Open the List view for a post with a few blocks.
* Click inside the editor with no block selected.
* Verify that navigating up and down with the arrows still works well.
* Verify checks are green.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None