### PR TITLE
Add artifacts upload for the performance tests

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -60,6 +60,14 @@ jobs:
                   name: perf-test-results
                   path: ./__test-results/*.json
 
+            - name: Archive debug artifacts (screenshots, traces)
+              uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+              if: github.event_name == 'pull_request'
+              with:
+                  name: failures-artifacts
+                  path: ./__test-results/artifacts
+                  if-no-files-found: ignore
+
             - name: Compare performance with current WordPress Core and previous Gutenberg versions
               if: github.event_name == 'release'
               env:
@@ -85,14 +93,6 @@ jobs:
                   IFS=. read -ra WP_VERSION_ARRAY <<< "$WP_VERSION"
                   WP_MAJOR="${WP_VERSION_ARRAY[0]}.${WP_VERSION_ARRAY[1]}"
                   ./bin/plugin/cli.js perf $GITHUB_SHA debd225d007f4e441ceec80fbd6fa96653f94737 --tests-branch $GITHUB_SHA --wp-version "$WP_MAJOR"
-
-            - name: Archive debug artifacts (screenshots, traces)
-              uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-              if: always()
-              with:
-                  name: failures-artifacts
-                  path: ./__test-results/artifacts
-                  if-no-files-found: ignore
 
             - uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # v6.4.0
               if: github.event_name == 'push'

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -86,6 +86,14 @@ jobs:
                   WP_MAJOR="${WP_VERSION_ARRAY[0]}.${WP_VERSION_ARRAY[1]}"
                   ./bin/plugin/cli.js perf $GITHUB_SHA debd225d007f4e441ceec80fbd6fa96653f94737 --tests-branch $GITHUB_SHA --wp-version "$WP_MAJOR"
 
+            - name: Archive debug artifacts (screenshots, traces)
+              uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+              if: always()
+              with:
+                  name: perf-failures-artifacts
+                  path: ./__test-results/artifacts
+                  if-no-files-found: ignore
+
             - uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # v6.4.0
               if: github.event_name == 'push'
               id: commit-timestamp

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -90,7 +90,7 @@ jobs:
               uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
               if: always()
               with:
-                  name: perf-failures-artifacts
+                  name: failures-artifacts
                   path: ./__test-results/artifacts
                   if-no-files-found: ignore
 

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -60,14 +60,6 @@ jobs:
                   name: perf-test-results
                   path: ./__test-results/*.json
 
-            - name: Archive debug artifacts (screenshots, traces)
-              uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-              if: github.event_name == 'pull_request'
-              with:
-                  name: failures-artifacts
-                  path: ./__test-results/artifacts
-                  if-no-files-found: ignore
-
             - name: Compare performance with current WordPress Core and previous Gutenberg versions
               if: github.event_name == 'release'
               env:
@@ -117,3 +109,11 @@ jobs:
                   COMMITTED_AT: ${{ steps.commit-timestamp.outputs.result }}
                   CODEHEALTH_PROJECT_TOKEN: ${{ secrets.CODEHEALTH_PROJECT_TOKEN }}
               run: ./bin/log-performance-results.js $CODEHEALTH_PROJECT_TOKEN trunk $GITHUB_SHA debd225d007f4e441ceec80fbd6fa96653f94737 $COMMITTED_AT
+
+            - name: Archive debug artifacts (screenshots, HTML snapshots)
+              uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+              if: always()
+              with:
+                  name: failures-artifacts
+                  path: ./__test-results/artifacts
+                  if-no-files-found: ignore

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -86,15 +86,6 @@ jobs:
                   WP_MAJOR="${WP_VERSION_ARRAY[0]}.${WP_VERSION_ARRAY[1]}"
                   ./bin/plugin/cli.js perf $GITHUB_SHA debd225d007f4e441ceec80fbd6fa96653f94737 --tests-branch $GITHUB_SHA --wp-version "$WP_MAJOR"
 
-            - uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # v6.4.0
-              if: github.event_name == 'push'
-              id: commit-timestamp
-              with:
-                  github-token: ${{secrets.GITHUB_TOKEN}}
-                  script: |
-                      const commit_details = await github.rest.git.getCommit({owner: context.repo.owner, repo: context.repo.repo, commit_sha: context.sha});
-                      return parseInt((new Date( commit_details.data.author.date ).getTime() / 1000).toFixed(0))
-
             - name: Compare performance with custom branches
               if: github.event_name == 'workflow_dispatch'
               env:
@@ -102,6 +93,16 @@ jobs:
                   WP_VERSION: ${{ github.event.inputs.wpversion }}
               run: |
                   ./bin/plugin/cli.js perf $(echo $BRANCHES | tr ',' ' ') --tests-branch $GITHUB_SHA --wp-version "$WP_VERSION"
+
+            - name: Get commit timestamp
+              uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # v6.4.0
+              if: github.event_name == 'push'
+              id: commit-timestamp
+              with:
+                  github-token: ${{secrets.GITHUB_TOKEN}}
+                  script: |
+                      const commit_details = await github.rest.git.getCommit({owner: context.repo.owner, repo: context.repo.repo, commit_sha: context.sha});
+                      return parseInt((new Date( commit_details.data.author.date ).getTime() / 1000).toFixed(0))
 
             - name: Publish performance results
               if: github.event_name == 'push'

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -187,34 +187,33 @@ async function runTestSuite( testSuite, performanceTestDirectory, runKey ) {
 			`npm run test:performance -- packages/e2e-tests/specs/performance/${ testSuite }.test.js`,
 			performanceTestDirectory
 		);
-		const resultsFile = path.join(
-			performanceTestDirectory,
-			`packages/e2e-tests/specs/performance/${ testSuite }.test.results.json`
-		);
-		fs.mkdirSync( './__test-results', { recursive: true } );
-		fs.copyFileSync(
-			resultsFile,
-			`./__test-results/${ runKey }.results.json`
-		);
-		const rawResults = await readJSONFile(
-			path.join(
-				performanceTestDirectory,
-				`packages/e2e-tests/specs/performance/${ testSuite }.test.results.json`
-			)
-		);
-		return curateResults( testSuite, rawResults );
 	} catch ( error ) {
 		fs.mkdirSync( './__test-results/artifacts', { recursive: true } );
 		const artifactsFolder = path.join(
 			performanceTestDirectory,
-			'artifacts'
+			'artifacts/'
 		);
 		await runShellScript(
-			'cp -Rv ' + artifactsFolder + ' ' + './__test-results/artifacts'
+			'cp -Rv ' + artifactsFolder + ' ' + './__test-results/artifacts/'
 		);
 
 		throw error;
 	}
+
+	const resultsFile = path.join(
+		performanceTestDirectory,
+		`packages/e2e-tests/specs/performance/${ testSuite }.test.results.json`
+	);
+	fs.mkdirSync( './__test-results', { recursive: true } );
+	fs.copyFileSync( resultsFile, `./__test-results/${ runKey }.results.json` );
+	const rawResults = await readJSONFile(
+		path.join(
+			performanceTestDirectory,
+			`packages/e2e-tests/specs/performance/${ testSuite }.test.results.json`
+		)
+	);
+
+	return curateResults( testSuite, rawResults );
 }
 
 /**

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -386,10 +386,10 @@ async function runPerformanceTests( branches, options ) {
 	log( '\n>> Running the tests' );
 
 	const testSuites = [
-		// 'post-editor',
+		'post-editor',
 		'site-editor',
-		// 'front-end-classic-theme',
-		// 'front-end-block-theme',
+		'front-end-classic-theme',
+		'front-end-block-theme',
 	];
 
 	/** @type {Record<string,Record<string, WPPerformanceResults>>} */

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -182,23 +182,39 @@ function curateResults( testSuite, results ) {
  * @return {Promise<WPPerformanceResults>} Performance results for the branch.
  */
 async function runTestSuite( testSuite, performanceTestDirectory, runKey ) {
-	await runShellScript(
-		`npm run test:performance -- packages/e2e-tests/specs/performance/${ testSuite }.test.js`,
-		performanceTestDirectory
-	);
-	const resultsFile = path.join(
-		performanceTestDirectory,
-		`packages/e2e-tests/specs/performance/${ testSuite }.test.results.json`
-	);
-	fs.mkdirSync( './__test-results', { recursive: true } );
-	fs.copyFileSync( resultsFile, `./__test-results/${ runKey }.results.json` );
-	const rawResults = await readJSONFile(
-		path.join(
+	try {
+		await runShellScript(
+			`npm run test:performance -- packages/e2e-tests/specs/performance/${ testSuite }.test.js`,
+			performanceTestDirectory
+		);
+		const resultsFile = path.join(
 			performanceTestDirectory,
 			`packages/e2e-tests/specs/performance/${ testSuite }.test.results.json`
-		)
-	);
-	return curateResults( testSuite, rawResults );
+		);
+		fs.mkdirSync( './__test-results', { recursive: true } );
+		fs.copyFileSync(
+			resultsFile,
+			`./__test-results/${ runKey }.results.json`
+		);
+		const rawResults = await readJSONFile(
+			path.join(
+				performanceTestDirectory,
+				`packages/e2e-tests/specs/performance/${ testSuite }.test.results.json`
+			)
+		);
+		return curateResults( testSuite, rawResults );
+	} catch ( error ) {
+		fs.mkdirSync( './__test-results/artifacts', { recursive: true } );
+		const artifactsFolder = path.join(
+			performanceTestDirectory,
+			'artifacts'
+		);
+		await runShellScript(
+			'cp -Rv ' + artifactsFolder + ' ' + './__test-results/artifacts'
+		);
+
+		throw error;
+	}
 }
 
 /**
@@ -370,10 +386,10 @@ async function runPerformanceTests( branches, options ) {
 	log( '\n>> Running the tests' );
 
 	const testSuites = [
-		'post-editor',
+		// 'post-editor',
 		'site-editor',
-		'front-end-classic-theme',
-		'front-end-block-theme',
+		// 'front-end-classic-theme',
+		// 'front-end-block-theme',
 	];
 
 	/** @type {Record<string,Record<string, WPPerformanceResults>>} */

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -114,6 +114,7 @@ describe( 'Site Editor Performance', () => {
 			await page.waitForSelector( '.edit-site-visual-editor', {
 				timeout: 120000,
 			} );
+			expect( true ).toBe( false ); // TMP: Test the artifacts upload
 			await canvas().waitForSelector( '.wp-block', { timeout: 120000 } );
 
 			if ( i < samples ) {

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -114,7 +114,6 @@ describe( 'Site Editor Performance', () => {
 			await page.waitForSelector( '.edit-site-visual-editor', {
 				timeout: 120000,
 			} );
-			expect( true ).toBe( false ); // TMP: Test the artifacts upload
 			await canvas().waitForSelector( '.wp-block', { timeout: 120000 } );
 
 			if ( i < samples ) {


### PR DESCRIPTION
## What?

Upload artifacts for the performance tests.

## Why?

So that it's easier to debug them.

## How?

Add the same action as for E2E tests artifacts upload. 

## Testing Instructions

CI should upload perf test artifacts when it fails. [This commit](https://github.com/WordPress/gutenberg/pull/48243/commits/43acd1cc287d5d76ad259365cbc95754ed41863d) shows that it works as expected.
