### PR TITLE
Reusable Blocks: Use React 18 rendering for import dropdown

### DIFF
--- a/packages/list-reusable-blocks/src/index.js
+++ b/packages/list-reusable-blocks/src/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { render } from '@wordpress/element';
+import { createRoot } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -45,5 +45,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	const container = document.createElement( 'div' );
 	container.className = 'list-reusable-blocks__container';
 	button.parentNode.insertBefore( container, button );
-	render( <ImportDropdown onUpload={ showNotice } />, container );
+	createRoot( container ).render(
+		<ImportDropdown onUpload={ showNotice } />
+	);
 } );


### PR DESCRIPTION
## What?
This PR updates reusable blocks to use the React 18 rendering for the import from JSON form.

## Why?
We already use React 18 concurrent rendering everywhere. This will also remove the following warning from the console:

![Screenshot 2023-02-20 at 13 58 46](https://user-images.githubusercontent.com/8436925/220100283-47e40938-6e47-4386-91fb-cc944783a86e.png)

## How?
We're updating to use the new `createRoot().render()` API instead of the legacy `render()`.

## Testing Instructions
* Go to `/wp-admin/edit.php?post_type=wp_block`
* Click the "Import from JSON" button.
* Verify importing still works well.
* Verify you no longer see the warning in the console.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None