### PR TITLE
Only register anchor attribute for dynamic blocks with render callback.

### DIFF
--- a/lib/block-supports/anchor.php
+++ b/lib/block-supports/anchor.php
@@ -11,6 +11,10 @@
  * @param WP_Block_Type $block_type Block Type.
  */
 function gutenberg_register_anchor_support( $block_type ) {
+	if ( ! $block_type->render_callback ) {
+		return;
+	}
+
 	$has_anchor_support = _wp_array_get( $block_type->supports, array( 'anchor' ), true );
 	if ( ! $has_anchor_support ) {
 		return;

--- a/lib/block-supports/anchor.php
+++ b/lib/block-supports/anchor.php
@@ -11,7 +11,7 @@
  * @param WP_Block_Type $block_type Block Type.
  */
 function gutenberg_register_anchor_support( $block_type ) {
-	if ( ! $block_type->render_callback ) {
+	if ( ! $block_type->is_dynamic() ) {
 		return;
 	}
 


### PR DESCRIPTION
## What?
The anchor attribute should only be registered for the dynamic blocks. Otherwise static blocks will get this attribute which will break this blocks.

## Why?
Fixes #48232
