### PR TITLE
VizReg e2e tests: programmatically test all combinations of a given list of props/values

### DIFF
--- a/packages/components/src/h-stack/stories/e2e/index.tsx
+++ b/packages/components/src/h-stack/stories/e2e/index.tsx
@@ -1,0 +1,112 @@
+/**
+ * External dependencies
+ */
+import type { ComponentStory, ComponentMeta } from '@storybook/react';
+
+/**
+ * Internal dependencies
+ */
+import { View } from '../../../view';
+import { HStack } from '../..';
+
+const E2E_CONTROLS_PROPS: {
+	name: keyof Omit< React.ComponentProps< typeof HStack >, 'children' >;
+	required: boolean;
+	values: Record< string, any >;
+}[] = [
+	{
+		name: 'alignment',
+		required: false,
+		values: {
+			top: 'top',
+			topLeft: 'topLeft',
+			topRight: 'topRight',
+			left: 'left',
+			center: 'center',
+			right: 'right',
+			bottom: 'bottom',
+			bottomLeft: 'bottomLeft',
+			bottomRight: 'bottomRight',
+			edge: 'edge',
+			stretch: 'stretch',
+		},
+	},
+	{
+		name: 'direction',
+		required: false,
+		values: {
+			row: 'row',
+			column: 'column',
+			// responsive: 'responsive',
+		},
+	},
+	// {
+	// 	name: 'expanded',
+	// 	required: false,
+	// 	values: {
+	// 		true: true,
+	// 		false: false,
+	// 	},
+	// },
+	// {
+	// 	name: 'isReversed',
+	// 	required: false,
+	// 	values: {
+	// 		true: true,
+	// 		false: false,
+	// 	},
+	// },
+	{
+		name: 'justify',
+		required: false,
+		values: {
+			spaceAround: 'space-around',
+			spaceBetween: 'space-between',
+			spaceEvenly: 'space-evenly',
+			stretch: 'stretch',
+			center: 'center',
+			end: 'end',
+			flexEnd: 'flex-end',
+			flexStart: 'flex-start',
+			start: 'start',
+		},
+	},
+	// {
+	// 	name: 'wrap',
+	// 	required: false,
+	// 	values: {
+	// 		true: true,
+	// 		false: false,
+	// 	},
+	// },
+];
+
+const meta: ComponentMeta< typeof HStack > = {
+	component: HStack,
+	title: 'Components (Experimental)/HStack',
+};
+export default meta;
+
+const Template: ComponentStory< typeof HStack > = ( props ) => {
+	return (
+		<HStack
+			style={ { background: '#eee', minHeight: '3rem' } }
+			{ ...props }
+		>
+			{ [ 'One', 'Two', 'Three', 'Four', 'Five' ].map( ( text ) => (
+				<View key={ text } style={ { background: '#b9f9ff' } }>
+					{ text }
+				</View>
+			) ) }
+		</HStack>
+	);
+};
+
+export const Default: ComponentStory< typeof HStack > = Template.bind( {} );
+Default.args = {
+	spacing: 3,
+	// The `customE2EControlsProps` is used by custom decorator
+	// used for Storybook-powered e2e tests
+	// @ts-expect-error
+	customE2EControlsProps: E2E_CONTROLS_PROPS,
+};

--- a/packages/components/src/h-stack/stories/e2e/index.tsx
+++ b/packages/components/src/h-stack/stories/e2e/index.tsx
@@ -37,25 +37,8 @@ const E2E_CONTROLS_PROPS: {
 		values: {
 			row: 'row',
 			column: 'column',
-			// responsive: 'responsive',
 		},
 	},
-	// {
-	// 	name: 'expanded',
-	// 	required: false,
-	// 	values: {
-	// 		true: true,
-	// 		false: false,
-	// 	},
-	// },
-	// {
-	// 	name: 'isReversed',
-	// 	required: false,
-	// 	values: {
-	// 		true: true,
-	// 		false: false,
-	// 	},
-	// },
 	{
 		name: 'justify',
 		required: false,
@@ -71,14 +54,6 @@ const E2E_CONTROLS_PROPS: {
 			start: 'start',
 		},
 	},
-	// {
-	// 	name: 'wrap',
-	// 	required: false,
-	// 	values: {
-	// 		true: true,
-	// 		false: false,
-	// 	},
-	// },
 ];
 
 const meta: ComponentMeta< typeof HStack > = {

--- a/packages/components/src/h-stack/stories/e2e/index.tsx
+++ b/packages/components/src/h-stack/stories/e2e/index.tsx
@@ -9,53 +9,6 @@ import type { ComponentStory, ComponentMeta } from '@storybook/react';
 import { View } from '../../../view';
 import { HStack } from '../..';
 
-const E2E_CONTROLS_PROPS: {
-	name: keyof Omit< React.ComponentProps< typeof HStack >, 'children' >;
-	required: boolean;
-	values: Record< string, any >;
-}[] = [
-	{
-		name: 'alignment',
-		required: false,
-		values: {
-			top: 'top',
-			topLeft: 'topLeft',
-			topRight: 'topRight',
-			left: 'left',
-			center: 'center',
-			right: 'right',
-			bottom: 'bottom',
-			bottomLeft: 'bottomLeft',
-			bottomRight: 'bottomRight',
-			edge: 'edge',
-			stretch: 'stretch',
-		},
-	},
-	{
-		name: 'direction',
-		required: false,
-		values: {
-			row: 'row',
-			column: 'column',
-		},
-	},
-	{
-		name: 'justify',
-		required: false,
-		values: {
-			spaceAround: 'space-around',
-			spaceBetween: 'space-between',
-			spaceEvenly: 'space-evenly',
-			stretch: 'stretch',
-			center: 'center',
-			end: 'end',
-			flexEnd: 'flex-end',
-			flexStart: 'flex-start',
-			start: 'start',
-		},
-	},
-];
-
 const meta: ComponentMeta< typeof HStack > = {
 	component: HStack,
 	title: 'Components (Experimental)/HStack',
@@ -80,8 +33,4 @@ const Template: ComponentStory< typeof HStack > = ( props ) => {
 export const Default: ComponentStory< typeof HStack > = Template.bind( {} );
 Default.args = {
 	spacing: 3,
-	// The `customE2EControlsProps` is used by custom decorator
-	// used for Storybook-powered e2e tests
-	// @ts-expect-error
-	customE2EControlsProps: E2E_CONTROLS_PROPS,
 };

--- a/packages/components/src/v-stack/stories/e2e/index.tsx
+++ b/packages/components/src/v-stack/stories/e2e/index.tsx
@@ -9,53 +9,6 @@ import type { ComponentStory, ComponentMeta } from '@storybook/react';
 import { View } from '../../../view';
 import { VStack } from '../..';
 
-const E2E_CONTROLS_PROPS: {
-	name: keyof Omit< React.ComponentProps< typeof VStack >, 'children' >;
-	required: boolean;
-	values: Record< string, any >;
-}[] = [
-	{
-		name: 'alignment',
-		required: false,
-		values: {
-			top: 'top',
-			topLeft: 'topLeft',
-			topRight: 'topRight',
-			left: 'left',
-			center: 'center',
-			right: 'right',
-			bottom: 'bottom',
-			bottomLeft: 'bottomLeft',
-			bottomRight: 'bottomRight',
-			edge: 'edge',
-			stretch: 'stretch',
-		},
-	},
-	{
-		name: 'direction',
-		required: false,
-		values: {
-			row: 'row',
-			column: 'column',
-		},
-	},
-	{
-		name: 'justify',
-		required: false,
-		values: {
-			spaceAround: 'space-around',
-			spaceBetween: 'space-between',
-			spaceEvenly: 'space-evenly',
-			stretch: 'stretch',
-			center: 'center',
-			end: 'end',
-			flexEnd: 'flex-end',
-			flexStart: 'flex-start',
-			start: 'start',
-		},
-	},
-];
-
 const meta: ComponentMeta< typeof VStack > = {
 	component: VStack,
 	title: 'Components (Experimental)/VStack',
@@ -80,8 +33,4 @@ const Template: ComponentStory< typeof VStack > = ( props ) => {
 export const Default: ComponentStory< typeof VStack > = Template.bind( {} );
 Default.args = {
 	spacing: 3,
-	// The `customE2EControlsProps` is used by custom decorator
-	// used for Storybook-powered e2e tests
-	// @ts-expect-error
-	customE2EControlsProps: E2E_CONTROLS_PROPS,
 };

--- a/packages/components/src/v-stack/stories/e2e/index.tsx
+++ b/packages/components/src/v-stack/stories/e2e/index.tsx
@@ -1,0 +1,112 @@
+/**
+ * External dependencies
+ */
+import type { ComponentStory, ComponentMeta } from '@storybook/react';
+
+/**
+ * Internal dependencies
+ */
+import { View } from '../../../view';
+import { VStack } from '../..';
+
+const E2E_CONTROLS_PROPS: {
+	name: keyof Omit< React.ComponentProps< typeof VStack >, 'children' >;
+	required: boolean;
+	values: Record< string, any >;
+}[] = [
+	{
+		name: 'alignment',
+		required: false,
+		values: {
+			top: 'top',
+			topLeft: 'topLeft',
+			topRight: 'topRight',
+			left: 'left',
+			center: 'center',
+			right: 'right',
+			bottom: 'bottom',
+			bottomLeft: 'bottomLeft',
+			bottomRight: 'bottomRight',
+			edge: 'edge',
+			stretch: 'stretch',
+		},
+	},
+	{
+		name: 'direction',
+		required: false,
+		values: {
+			row: 'row',
+			column: 'column',
+			// responsive: 'responsive',
+		},
+	},
+	// {
+	// 	name: 'expanded',
+	// 	required: false,
+	// 	values: {
+	// 		true: true,
+	// 		false: false,
+	// 	},
+	// },
+	// {
+	// 	name: 'isReversed',
+	// 	required: false,
+	// 	values: {
+	// 		true: true,
+	// 		false: false,
+	// 	},
+	// },
+	{
+		name: 'justify',
+		required: false,
+		values: {
+			spaceAround: 'space-around',
+			spaceBetween: 'space-between',
+			spaceEvenly: 'space-evenly',
+			stretch: 'stretch',
+			center: 'center',
+			end: 'end',
+			flexEnd: 'flex-end',
+			flexStart: 'flex-start',
+			start: 'start',
+		},
+	},
+	// {
+	// 	name: 'wrap',
+	// 	required: false,
+	// 	values: {
+	// 		true: true,
+	// 		false: false,
+	// 	},
+	// },
+];
+
+const meta: ComponentMeta< typeof VStack > = {
+	component: VStack,
+	title: 'Components (Experimental)/VStack',
+};
+export default meta;
+
+const Template: ComponentStory< typeof VStack > = ( props ) => {
+	return (
+		<VStack
+			{ ...props }
+			style={ { background: '#eee', minHeight: '3rem' } }
+		>
+			{ [ 'One', 'Two', 'Three', 'Four', 'Five' ].map( ( text ) => (
+				<View key={ text } style={ { background: '#b9f9ff' } }>
+					{ text }
+				</View>
+			) ) }
+		</VStack>
+	);
+};
+
+export const Default: ComponentStory< typeof VStack > = Template.bind( {} );
+Default.args = {
+	spacing: 3,
+	// The `customE2EControlsProps` is used by custom decorator
+	// used for Storybook-powered e2e tests
+	// @ts-expect-error
+	customE2EControlsProps: E2E_CONTROLS_PROPS,
+};

--- a/packages/components/src/v-stack/stories/e2e/index.tsx
+++ b/packages/components/src/v-stack/stories/e2e/index.tsx
@@ -37,25 +37,8 @@ const E2E_CONTROLS_PROPS: {
 		values: {
 			row: 'row',
 			column: 'column',
-			// responsive: 'responsive',
 		},
 	},
-	// {
-	// 	name: 'expanded',
-	// 	required: false,
-	// 	values: {
-	// 		true: true,
-	// 		false: false,
-	// 	},
-	// },
-	// {
-	// 	name: 'isReversed',
-	// 	required: false,
-	// 	values: {
-	// 		true: true,
-	// 		false: false,
-	// 	},
-	// },
 	{
 		name: 'justify',
 		required: false,
@@ -71,14 +54,6 @@ const E2E_CONTROLS_PROPS: {
 			start: 'start',
 		},
 	},
-	// {
-	// 	name: 'wrap',
-	// 	required: false,
-	// 	values: {
-	// 		true: true,
-	// 		false: false,
-	// 	},
-	// },
 ];
 
 const meta: ComponentMeta< typeof VStack > = {

--- a/test/storybook-playwright/playwright.config.ts
+++ b/test/storybook-playwright/playwright.config.ts
@@ -8,6 +8,7 @@ const config: PlaywrightTestConfig = {
 	reporter: [
 		[ 'html', { open: 'on-failure', outputFolder: 'test-results/report' } ],
 	],
+	fullyParallel: true,
 };
 
 export default config;

--- a/test/storybook-playwright/specs/hstack.spec.ts
+++ b/test/storybook-playwright/specs/hstack.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test, Page } from '@playwright/test';
+import { test } from '@playwright/test';
 
 /**
  * Internal dependencies

--- a/test/storybook-playwright/specs/hstack.spec.ts
+++ b/test/storybook-playwright/specs/hstack.spec.ts
@@ -1,29 +1,55 @@
 /**
  * External dependencies
  */
-import { test } from '@playwright/test';
+import { test, Page } from '@playwright/test';
 
 /**
  * Internal dependencies
  */
 import {
 	gotoStoryId,
-	testAllSnapshotsCombinationsWithE2EControls,
+	getAllPropsPermutations,
+	testSnapshotForPropsConfig,
 } from '../utils';
+
+const PROP_VALUES_TO_TEST = [
+	{
+		propName: 'alignment',
+		valuesToTest: [
+			undefined,
+			'top',
+			'topLeft',
+			'topRight',
+			'left',
+			'center',
+			'right',
+			'bottom',
+			'bottomLeft',
+			'bottomRight',
+			'edge',
+			'stretch',
+		],
+	},
+	{
+		propName: 'direction',
+		valuesToTest: [ undefined, 'row', 'column' ],
+	},
+];
 
 test.describe( 'HStack', () => {
 	test.beforeEach( async ( { page } ) => {
 		await gotoStoryId( page, 'components-experimental-hstack--default', {
-			decorators: { marginChecker: 'show' },
+			decorators: { marginChecker: 'show', customE2EControls: 'show' },
 		} );
 	} );
 
-	test( 'should render', async ( { page } ) => {
-		// This test is going to run slow. Triple the default timeout.
-		test.slow();
+	getAllPropsPermutations( PROP_VALUES_TO_TEST ).forEach( ( propsConfig ) => {
+		test( `should render with ${ JSON.stringify( propsConfig ) }`, async ( {
+			page,
+		} ) => {
+			await page.waitForSelector( '.components-h-stack' );
 
-		await page.waitForSelector( '.components-h-stack' );
-
-		await testAllSnapshotsCombinationsWithE2EControls( page );
+			await testSnapshotForPropsConfig( page, propsConfig );
+		} );
 	} );
 } );

--- a/test/storybook-playwright/specs/hstack.spec.ts
+++ b/test/storybook-playwright/specs/hstack.spec.ts
@@ -19,7 +19,7 @@ test.describe( 'HStack', () => {
 	} );
 
 	test( 'should render', async ( { page } ) => {
-		// This test is going to run slow. Tripe the default timeout.
+		// This test is going to run slow. Triple the default timeout.
 		test.slow();
 
 		await page.waitForSelector( '.components-h-stack' );

--- a/test/storybook-playwright/specs/hstack.spec.ts
+++ b/test/storybook-playwright/specs/hstack.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { test } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import {
+	gotoStoryId,
+	testAllSnapshotsCombinationsWithE2EControls,
+} from '../utils';
+
+test.describe( 'HStack', () => {
+	test.beforeEach( async ( { page } ) => {
+		await gotoStoryId( page, 'components-experimental-hstack--default', {
+			decorators: { marginChecker: 'show' },
+		} );
+	} );
+
+	test( 'should render', async ( { page } ) => {
+		// This test is going to run slow. Tripe the default timeout.
+		test.slow();
+
+		await page.waitForSelector( '.components-h-stack' );
+
+		await testAllSnapshotsCombinationsWithE2EControls( page );
+	} );
+} );

--- a/test/storybook-playwright/specs/hstack.spec.ts
+++ b/test/storybook-playwright/specs/hstack.spec.ts
@@ -36,7 +36,7 @@ const PROP_VALUES_TO_TEST = [
 	},
 ];
 
-test.describe( 'HStack', () => {
+test.describe.parallel( 'HStack', () => {
 	test.beforeEach( async ( { page } ) => {
 		await gotoStoryId( page, 'components-experimental-hstack--default', {
 			decorators: { marginChecker: 'show', customE2EControls: 'show' },

--- a/test/storybook-playwright/specs/hstack.spec.ts
+++ b/test/storybook-playwright/specs/hstack.spec.ts
@@ -36,7 +36,7 @@ const PROP_VALUES_TO_TEST = [
 	},
 ];
 
-test.describe.parallel( 'HStack', () => {
+test.describe( 'HStack', () => {
 	test.beforeEach( async ( { page } ) => {
 		await gotoStoryId( page, 'components-experimental-hstack--default', {
 			decorators: { marginChecker: 'show', customE2EControls: 'show' },

--- a/test/storybook-playwright/specs/vstack.spec.ts
+++ b/test/storybook-playwright/specs/vstack.spec.ts
@@ -1,29 +1,55 @@
 /**
  * External dependencies
  */
-import { test } from '@playwright/test';
+import { test, Page } from '@playwright/test';
 
 /**
  * Internal dependencies
  */
 import {
 	gotoStoryId,
-	testAllSnapshotsCombinationsWithE2EControls,
+	getAllPropsPermutations,
+	testSnapshotForPropsConfig,
 } from '../utils';
+
+const PROP_VALUES_TO_TEST = [
+	{
+		propName: 'alignment',
+		valuesToTest: [
+			undefined,
+			'top',
+			'topLeft',
+			'topRight',
+			'left',
+			'center',
+			'right',
+			'bottom',
+			'bottomLeft',
+			'bottomRight',
+			'edge',
+			'stretch',
+		],
+	},
+	{
+		propName: 'direction',
+		valuesToTest: [ undefined, 'row', 'column' ],
+	},
+];
 
 test.describe( 'VStack', () => {
 	test.beforeEach( async ( { page } ) => {
 		await gotoStoryId( page, 'components-experimental-vstack--default', {
-			decorators: { marginChecker: 'show' },
+			decorators: { marginChecker: 'show', customE2EControls: 'show' },
 		} );
 	} );
 
-	test( 'should render', async ( { page } ) => {
-		// This test is going to run slow. Triple the default timeout.
-		test.slow();
+	getAllPropsPermutations( PROP_VALUES_TO_TEST ).forEach( ( propsConfig ) => {
+		test( `should render with ${ JSON.stringify( propsConfig ) }`, async ( {
+			page,
+		} ) => {
+			await page.waitForSelector( '.components-v-stack' );
 
-		await page.waitForSelector( '.components-v-stack' );
-
-		await testAllSnapshotsCombinationsWithE2EControls( page );
+			await testSnapshotForPropsConfig( page, propsConfig );
+		} );
 	} );
 } );

--- a/test/storybook-playwright/specs/vstack.spec.ts
+++ b/test/storybook-playwright/specs/vstack.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test, Page } from '@playwright/test';
+import { test } from '@playwright/test';
 
 /**
  * Internal dependencies

--- a/test/storybook-playwright/specs/vstack.spec.ts
+++ b/test/storybook-playwright/specs/vstack.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { test } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import {
+	gotoStoryId,
+	testAllSnapshotsCombinationsWithE2EControls,
+} from '../utils';
+
+test.describe( 'VStack', () => {
+	test.beforeEach( async ( { page } ) => {
+		await gotoStoryId( page, 'components-experimental-vstack--default', {
+			decorators: { marginChecker: 'show' },
+		} );
+	} );
+
+	test( 'should render', async ( { page } ) => {
+		// This test is going to run slow. Tripe the default timeout.
+		test.slow();
+
+		await page.waitForSelector( '.components-v-stack' );
+
+		await testAllSnapshotsCombinationsWithE2EControls( page );
+	} );
+} );

--- a/test/storybook-playwright/specs/vstack.spec.ts
+++ b/test/storybook-playwright/specs/vstack.spec.ts
@@ -19,7 +19,7 @@ test.describe( 'VStack', () => {
 	} );
 
 	test( 'should render', async ( { page } ) => {
-		// This test is going to run slow. Tripe the default timeout.
+		// This test is going to run slow. Triple the default timeout.
 		test.slow();
 
 		await page.waitForSelector( '.components-v-stack' );

--- a/test/storybook-playwright/specs/vstack.spec.ts
+++ b/test/storybook-playwright/specs/vstack.spec.ts
@@ -36,7 +36,7 @@ const PROP_VALUES_TO_TEST = [
 	},
 ];
 
-test.describe( 'VStack', () => {
+test.describe.parallel( 'VStack', () => {
 	test.beforeEach( async ( { page } ) => {
 		await gotoStoryId( page, 'components-experimental-vstack--default', {
 			decorators: { marginChecker: 'show', customE2EControls: 'show' },

--- a/test/storybook-playwright/specs/vstack.spec.ts
+++ b/test/storybook-playwright/specs/vstack.spec.ts
@@ -36,7 +36,7 @@ const PROP_VALUES_TO_TEST = [
 	},
 ];
 
-test.describe.parallel( 'VStack', () => {
+test.describe( 'VStack', () => {
 	test.beforeEach( async ( { page } ) => {
 		await gotoStoryId( page, 'components-experimental-vstack--default', {
 			decorators: { marginChecker: 'show', customE2EControls: 'show' },

--- a/test/storybook-playwright/storybook/decorators/with-custom-controls.js
+++ b/test/storybook-playwright/storybook/decorators/with-custom-controls.js
@@ -1,0 +1,116 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+/**
+ * WordPress dependencies
+ */
+import { useId, useState } from '@wordpress/element';
+
+const StyledButton = styled.button`
+	font-family: monospace;
+	&[aria-pressed='true'] {
+		outline: 1px solid red;
+	}
+`;
+
+/**
+ * @template T
+ * @typedef {Object} PropSelectorProps
+ * @property {string}                         propName        the name of the property
+ * @property {{label: string, value: T}[]}    propValues      the list of values to provide controls for
+ * @property {T | undefined}                  selectedValue   the currently selected value for this prop
+ * @property {(value: T | undefined) => void} onValueSelected the callback fired when a value gets selected
+ * @property {boolean=}                       required        Used to show (or hide) an "unset" control
+ */
+
+/**
+ * @template TValue
+ * @param {PropSelectorProps<TValue>} props
+ * @return {JSX.Element} The controls used in the e2e test
+ */
+const PropSelector = ( {
+	propName,
+	propValues,
+	selectedValue,
+	onValueSelected,
+	required = false,
+} ) => {
+	const titleId = useId();
+
+	const selectValue = ( newValue ) => {
+		onValueSelected( newValue );
+	};
+
+	return (
+		<div role="group" aria-labelledby={ titleId }>
+			<h2 id={ titleId }>{ propName } prop controls</h2>
+			{ ! required && (
+				<StyledButton
+					onClick={ () => selectValue( undefined ) }
+					aria-pressed={ selectedValue === undefined }
+				>
+					Unset
+				</StyledButton>
+			) }
+			{ propValues.map( ( { label, value } ) => (
+				<StyledButton
+					key={ label }
+					onClick={ () => selectValue( value ) }
+					aria-pressed={ selectedValue === value }
+				>
+					{ label }
+				</StyledButton>
+			) ) }
+		</div>
+	);
+};
+
+export const WithCustomControls = ( Story, context ) => {
+	const [ partialProps, setPartialProps ] = useState( {} );
+
+	if ( ! context.args.customE2EControlsProps ) {
+		return <Story { ...context } />;
+	}
+
+	const contextWithControlledProps = {
+		...context,
+		// override args with the ones set by custom controls
+		args: { ...context.args, ...partialProps },
+	};
+
+	const { customE2EControlsProps, ...propsToShow } =
+		contextWithControlledProps.args;
+
+	return (
+		<>
+			<Story { ...contextWithControlledProps } />
+
+			<p>Props:</p>
+			<pre>{ JSON.stringify( propsToShow, undefined, 4 ) }</pre>
+
+			{ context.args.customE2EControlsProps.map(
+				( { name, required, values } ) => (
+					<PropSelector
+						key={ name }
+						propName={ name }
+						required={ required }
+						propValues={ Object.entries( values ).map(
+							( [ label, value ] ) => ( { label, value } )
+						) }
+						onValueSelected={ ( newValue ) =>
+							setPartialProps( ( oldProps ) => ( {
+								...oldProps,
+								[ name ]: newValue,
+							} ) )
+						}
+						selectedValue={
+							contextWithControlledProps.args[ name ]
+						}
+					/>
+				)
+			) }
+		</>
+	);
+};

--- a/test/storybook-playwright/storybook/decorators/with-custom-controls.js
+++ b/test/storybook-playwright/storybook/decorators/with-custom-controls.js
@@ -1,76 +1,13 @@
 /**
- * External dependencies
- */
-import styled from '@emotion/styled';
-
-/**
  * WordPress dependencies
  */
 import { useId, useState } from '@wordpress/element';
 
-const StyledButton = styled.button`
-	font-family: monospace;
-	&[aria-pressed='true'] {
-		outline: 1px solid red;
-	}
-`;
-
-/**
- * @template T
- * @typedef {Object} PropSelectorProps
- * @property {string}                         propName        the name of the property
- * @property {{label: string, value: T}[]}    propValues      the list of values to provide controls for
- * @property {T | undefined}                  selectedValue   the currently selected value for this prop
- * @property {(value: T | undefined) => void} onValueSelected the callback fired when a value gets selected
- * @property {boolean=}                       required        Used to show (or hide) an "unset" control
- */
-
-/**
- * @template TValue
- * @param {PropSelectorProps<TValue>} props
- * @return {JSX.Element} The controls used in the e2e test
- */
-const PropSelector = ( {
-	propName,
-	propValues,
-	selectedValue,
-	onValueSelected,
-	required = false,
-} ) => {
-	const titleId = useId();
-
-	const selectValue = ( newValue ) => {
-		onValueSelected( newValue );
-	};
-
-	return (
-		<div role="group" aria-labelledby={ titleId }>
-			<h2 id={ titleId }>{ propName } prop controls</h2>
-			{ ! required && (
-				<StyledButton
-					onClick={ () => selectValue( undefined ) }
-					aria-pressed={ selectedValue === undefined }
-				>
-					Unset
-				</StyledButton>
-			) }
-			{ propValues.map( ( { label, value } ) => (
-				<StyledButton
-					key={ label }
-					onClick={ () => selectValue( value ) }
-					aria-pressed={ selectedValue === value }
-				>
-					{ label }
-				</StyledButton>
-			) ) }
-		</div>
-	);
-};
-
 export const WithCustomControls = ( Story, context ) => {
+	const textareaId = useId();
 	const [ partialProps, setPartialProps ] = useState( {} );
 
-	if ( ! context.args.customE2EControlsProps ) {
+	if ( context.globals.customE2EControls === 'hide' ) {
 		return <Story { ...context } />;
 	}
 
@@ -80,37 +17,42 @@ export const WithCustomControls = ( Story, context ) => {
 		args: { ...context.args, ...partialProps },
 	};
 
-	const { customE2EControlsProps, ...propsToShow } =
-		contextWithControlledProps.args;
-
 	return (
 		<>
 			<Story { ...contextWithControlledProps } />
 
 			<p>Props:</p>
-			<pre>{ JSON.stringify( propsToShow, undefined, 4 ) }</pre>
+			<pre>
+				{ JSON.stringify(
+					contextWithControlledProps.args,
+					undefined,
+					4
+				) }
+			</pre>
 
-			{ context.args.customE2EControlsProps.map(
-				( { name, required, values } ) => (
-					<PropSelector
-						key={ name }
-						propName={ name }
-						required={ required }
-						propValues={ Object.entries( values ).map(
-							( [ label, value ] ) => ( { label, value } )
-						) }
-						onValueSelected={ ( newValue ) =>
-							setPartialProps( ( oldProps ) => ( {
-								...oldProps,
-								[ name ]: newValue,
-							} ) )
-						}
-						selectedValue={
-							contextWithControlledProps.args[ name ]
-						}
-					/>
-				)
-			) }
+			<hr />
+
+			<form
+				name="e2e-controls-form"
+				onSubmit={ ( event ) => {
+					event.preventDefault();
+
+					const propsRawText = event.target.elements.props.value;
+
+					const propsParsed = JSON.parse( propsRawText );
+
+					setPartialProps( ( oldProps ) => ( {
+						...oldProps,
+						...propsParsed,
+					} ) );
+				} }
+			>
+				<p>
+					<label htmlFor={ textareaId }>Raw props</label>
+					<textarea name="props" id={ textareaId } />
+				</p>
+				<button type="submit">Set props</button>
+			</form>
 		</>
 	);
 };

--- a/test/storybook-playwright/storybook/preview.js
+++ b/test/storybook-playwright/storybook/preview.js
@@ -5,7 +5,22 @@
 import * as basePreviewConfig from '../../../storybook/preview';
 import { WithCustomControls } from './decorators/with-custom-controls';
 
-export const globalTypes = { ...basePreviewConfig.globalTypes };
+export const globalTypes = {
+	...basePreviewConfig.globalTypes,
+	customE2EControls: {
+		name: 'Custom E2E Controls',
+		description:
+			'Shows custom UI used by e2e tests for setting props programmatically',
+		defaultValue: 'hide',
+		toolbar: {
+			icon: 'edit',
+			items: [
+				{ value: 'hide', title: 'Hide' },
+				{ value: 'show', title: 'Show' },
+			],
+		},
+	},
+};
 export const decorators = [
 	...basePreviewConfig.decorators,
 	WithCustomControls,

--- a/test/storybook-playwright/storybook/preview.js
+++ b/test/storybook-playwright/storybook/preview.js
@@ -1,1 +1,13 @@
-export * from '../../../storybook/preview';
+/**
+ * Internal dependencies
+ */
+
+import * as basePreviewConfig from '../../../storybook/preview';
+import { WithCustomControls } from './decorators/with-custom-controls';
+
+export const globalTypes = { ...basePreviewConfig.globalTypes };
+export const decorators = [
+	...basePreviewConfig.decorators,
+	WithCustomControls,
+];
+export const parameters = { ...basePreviewConfig.parameters };

--- a/test/storybook-playwright/utils.ts
+++ b/test/storybook-playwright/utils.ts
@@ -42,8 +42,7 @@ export const gotoStoryId = (
 };
 
 /**
- * Parses the Story, looking for e2e tests-specific controls, and generates
- * all possible permutations of those controls.
+ * Generate all possible permutations of those controls.
  *
  * @param propsConfig
  */

--- a/test/storybook-playwright/utils.ts
+++ b/test/storybook-playwright/utils.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 const STORYBOOK_PORT = '50241';
 
@@ -37,4 +38,87 @@ export const gotoStoryId = (
 		`http://localhost:${ STORYBOOK_PORT }/iframe.html?${ params.toString() }`,
 		{ waitUntil: 'load' }
 	);
+};
+
+/**
+ * Parses the Story, looking for e2e tests-specific controls, and generates
+ * snapshots for all possible combinations of these controls.
+ *
+ * @param page
+ */
+export const testAllSnapshotsCombinationsWithE2EControls = async (
+	page: Page
+) => {
+	type PropsObject = { name: string; values: string[] };
+
+	// Collect all available configurations.
+	const allProps: PropsObject[] = [];
+
+	// Scan all `role=group` elements containing text "prop controls"
+	for ( const group of await page
+		.getByRole( 'group' )
+		.filter( { hasText: 'prop controls' } )
+		.all() ) {
+		// Get the text content
+		const title = await group.textContent();
+		if ( title === null ) {
+			continue;
+		}
+
+		// Use a RegExp to extract the prop name —
+		// it's expected to be the first word, before "prop controls"
+		const results = /(?<propName>^\w+) prop controls/g.exec( title );
+		if ( results === null || ! results.groups?.propName ) {
+			continue;
+		}
+
+		const propObject: PropsObject = {
+			name: results.groups?.propName,
+			values: [],
+		};
+
+		// Once the prop name is extracted, scan all buttons inside the group,
+		// and extract the label.
+		for ( const button of await group.getByRole( 'button' ).all() ) {
+			const buttonLabel = await button.textContent();
+			if ( buttonLabel !== null ) {
+				propObject.values.push( buttonLabel );
+			}
+		}
+		allProps.push( propObject );
+	}
+
+	// Test all possible configurations
+	const iterateOverNextPropValues = async (
+		remainingProps: PropsObject[]
+	) => {
+		const [ propObject, ...restProps ] = remainingProps;
+
+		// Test all values for the given prop.
+		for ( const value of propObject.values ) {
+			// Find the button corresponding to the current value
+			const button = await page
+				.getByRole( 'group' )
+				.filter( {
+					hasText: `${ propObject.name } prop controls`,
+				} )
+				.getByRole( 'button', { name: value, exact: true } );
+
+			// Click the button. This will set the corresponding prop in the story.
+			await button.click();
+
+			if ( restProps.length === 0 ) {
+				// If we exhausted all of the props to set for this specific combination,
+				// it's time to take a screenshot of this specific combination of props.
+				expect( await page.screenshot() ).toMatchSnapshot();
+			} else {
+				// IF there are more props to iterate through, let's do that through
+				// recursively calling this function.
+				await iterateOverNextPropValues( restProps );
+			}
+		}
+	};
+
+	// Start!
+	await iterateOverNextPropValues( allProps );
 };

--- a/test/storybook-playwright/utils.ts
+++ b/test/storybook-playwright/utils.ts
@@ -10,6 +10,7 @@ type Decorators = {
 	css?: 'none' | 'basic' | 'wordpress';
 	direction?: 'ltr' | 'rtl';
 	marginChecker?: 'show' | 'hide';
+	customE2EControls?: 'show' | 'hide';
 };
 type Options = { decorators?: Decorators };
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR adds utils for testing all combinations of a a given set of props during visual regression testing.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is a way to speed up the creation of VizReg tests, useful for programmatically testing a component in series of configurations that depend on the props passed.

I initially considered using the storybook controls add-on and pass the prop values via URL params, but I found two issues with this approach:

1. object values are not handled
2. there seems to be a bug where URL params are ignored when rendering the story's iframe (ie. not rendering the Storybook shell)

That's why I decided to implement a "custom" way to set props directly from e2e tests.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Added a custom Storybook decorator which adds a little `<textarea />` to the page where it's possible to input a JSON object with the prop values that needs to be tested. Submitting the form will apply those prop values to the component being tested via Story args.
- Added custom Playwright utilities:
  - To generate all possible permutations of a given set of props and values to test
  - To interact with the custom form described above, to input the desired prop config to test
- Added test stories for `VStack` and `HStack` components (in preparation to #47914)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

#### Generate the snapshots

1. Clean up npm dependencies: `npm run distclean && npm ci`
2. Install playwright: `npx playwright install`
3. In two separate terminal windows:
  - Run Storybook for e2e tests: `npm run storybook:e2e:dev `
  - Once Storybook has loaded successfully, run Playwright tests: `npm run test:e2e:storybook -- --update-snapshots`

#### Test VizReg with on `HStack` and `VStack`

1. Make sure that the tests run correctly, and that snapshots are generated successfully.

<details>
<summary>Make an amend to `VStack` or `HStack` that would cause a change in how the component visually render, for examplem(click to expand)</summary>

```diff
diff --git a/packages/components/src/h-stack/utils.ts b/packages/components/src/h-stack/utils.ts
index 3abddd0309..efa8180033 100644
--- a/packages/components/src/h-stack/utils.ts
+++ b/packages/components/src/h-stack/utils.ts
@@ -11,7 +11,7 @@ import { isValueDefined } from '../utils/values';
 
 const H_ALIGNMENTS: Alignments = {
 	bottom: { align: 'flex-end', justify: 'center' },
-	bottomLeft: { align: 'flex-start', justify: 'flex-end' },
+	bottomLeft: { justify: 'center', align: 'center' },
 	bottomRight: { align: 'flex-end', justify: 'flex-end' },
 	center: { align: 'center', justify: 'center' },
 	edge: { align: 'center', justify: 'space-between' },
```
</details>

2. Make sure that snapshots failed and the visual diff matches the expectations