### PR TITLE
Docs: Table of styles keys with since versions

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -606,6 +606,12 @@
 		"parent": "theme-json-reference"
 	},
 	{
+		"title": "Available Styles Options",
+		"slug": "styles-versions",
+		"markdown_source": "../docs/reference-guides/theme-json-reference/styles-versions.md",
+		"parent": "theme-json-reference"
+	},
+	{
 		"title": "Component Reference",
 		"slug": "components",
 		"markdown_source": "../packages/components/README.md",

--- a/docs/reference-guides/theme-json-reference/styles-versions.md
+++ b/docs/reference-guides/theme-json-reference/styles-versions.md
@@ -1,0 +1,53 @@
+# Styles Keys with theme.json and Style editor versions
+
+| Key | theme.json Since| Style Editor Since |
+| --- | :---: | :---: |
+| `color.gradient` | 5.8 | ? |
+| `color.background` | 5.8 | ? |
+| `color.text` | 5.8 | ? |
+| `border.color` | 5.9 | ? |
+| `border.width` | 5.9 | ? |
+| `border.style` | 5.9 | ? |
+| `border.radius` | ? | ? |
+| `border.radius.topLeft` | ? | ? |
+| `border.radius.topRight` | ? | ? |
+| `border.radius.bottomLeft` | ? | ? |
+| `border.radius.bottomRight` | ? | ? |
+| `border.top.color` | 6.1 | ? |
+| `border.top.width` | 6.1 | ? |
+| `border.top.style` | 6.1 | ? |
+| `border.right.color` | 6.1 | ? |
+| `border.right.width` | 6.1 | ? |
+| `border.right.style` | 6.1 | ? |
+| `border.bottom.color` | 6.1 | ? |
+| `border.bottom.width` | 6.1 | ? |
+| `border.bottom.style` | 6.1 | ? |
+| `border.left.color` | 6.1 | ? |
+| `border.left.width` | 6.1 | ? |
+| `border.left.style` | 6.1 | ? |
+| `typography.fontFamily` | ? | ? |
+| `typography.fontSize` | ? | ? |
+| `typography.fontStyle` | ? | ? |
+| `typography.fontWeight` | ? | ? |
+| `typography.letterSpacing` | ? | ? |
+| `typography.lineHeight` | ? | ? |
+| `typography.textDecoration` | ? | ? |
+| `typography.textTransform`| ? | ? |
+| `spacing.padding` | ? | ? |
+| `spacing.padding.top` | ? | ? |
+| `spacing.padding.right` | ? | ? |
+| `spacing.padding.left` | ? | ? |
+| `spacing.padding.bottom` | ? | ? |
+| `spacing.padding` | ? | ? |
+| `spacing.margin.top` | ? | ? |
+| `spacing.margin.right` | ? | ? |
+| `spacing.margin.left` | ? | ? |
+| `spacing.margin.bottom` | ? | ? |
+| `spacing.blockGap` | ? | ? |
+| `dimensions.minHeight` | ? | ? |
+| `outline.color` | ? | ? |
+| `outline.offset` | ? | ? |
+| `outline.style` | ? | ? |
+| `outline.width` | ? | ? |
+| `filter.duotone` | ? | ? |
+| `shadow` | ? | ? |

--- a/docs/reference-guides/theme-json-reference/styles-versions.md
+++ b/docs/reference-guides/theme-json-reference/styles-versions.md
@@ -1,65 +1,55 @@
+New styles options are integrated into theme.json on a regular basis. Knowing the style options available through theme.json or the styles editor at any given time can be challenging. To clarify, the table below indicates the WordPress version when each theme.json styles option became available and when a corresponding control was added to the user interface to allow management of the style from the Styles editor.
+
 # Styles Keys
 
 | Key | theme.json Since| Style Editor Since |
 | --- | :---: | :---: |
-| `color.gradient`              | 5.8 | ? |
-| `color.background`            | 5.8 | ? |
-| `color.text`                  | 5.8 | ? |
-| `border.color`                | 5.9 | ? |
-| `border.width`                | 5.9 | ? |
-| `border.style`                | 5.9 | ? |
-| `border.radius`               | 5.8 | ? |
-| `border.radius.topLeft`       | 5.9 | ? |
-| `border.radius.topRight`      | 5.9 | ? |
-| `border.radius.bottomLeft`    | 5.9 | ? |
-| `border.radius.bottomRight`   | 5.9 | ? |
-| `border.top.color`            | 6.1 | ? |
-| `border.top.width`            | 6.1 | ? |
-| `border.top.style`            | 6.1 | ? |
-| `border.right.color`          | 6.1 | ? |
-| `border.right.width`          | 6.1 | ? |
-| `border.right.style`          | 6.1 | ? |
-| `border.bottom.color`         | 6.1 | ? |
-| `border.bottom.width`         | 6.1 | ? |
-| `border.bottom.style`         | 6.1 | ? |
-| `border.left.color`           | 6.1 | ? |
-| `border.left.width`           | 6.1 | ? |
-| `border.left.style`           | 6.1 | ? |
-| `typography.fontFamily`       | 5.9 | ? |
-| `typography.fontSize`         | 5.8 | ? |
-| `typography.fontStyle`        | 5.9 | ? |
-| `typography.fontWeight`       | 5.9 | ? |
-| `typography.letterSpacing`    | 5.9 | ? |
-| `typography.lineHeight`       | 5.8 | ? |
-| `typography.textDecoration`   | 5.9 | ? |
-| `typography.textTransform`    | 5.9 | ? |
-| `spacing.padding`             | 5.9 | ? |
-| `spacing.padding.top`         | 5.8 | ? |
-| `spacing.padding.right`       | 5.8 | ? |
-| `spacing.padding.left`        | 5.8 | ? |
-| `spacing.padding.bottom`      | 5.8 | ? |
-| `spacing.margin`              | 5.9 | ? |
-| `spacing.margin.top`          | 5.8 | ? |
-| `spacing.margin.right`        | 5.8 | ? |
-| `spacing.margin.left`         | 5.8 | ? |
-| `spacing.margin.bottom`       | 5.8 | ? |
-| `spacing.blockGap`            | 5.9 | ? |
-| `dimensions.minHeight`        | 6.2 | ? |
-| `outline.color`               | 6.2 | ? |
-| `outline.offset`              | 6.2 | ? |
-| `outline.style`               | 6.2 | ? |
-| `outline.width`               | 6.2 | ? |
-| `filter.duotone`              | 5.9 | ? |
-| `shadow`                      | 6.1 | ? |
-
-# Reference
-
-[5.8](https://github.com/WordPress/wordpress-develop/blob/95c643852001ba43f23dc5af5b6b3d1e02e9d9e4/src/wp-includes/class-wp-theme-json.php#L216)
-
-[5.9](https://github.com/WordPress/wordpress-develop/blob/88b0e2fe7f065118323cbe493b7c014a3786d90d/src/wp-includes/class-wp-theme-json.php#L173)
-
-[6.0](https://github.com/WordPress/wordpress-develop/blob/1e52ae5fed0cdb92f6d2f537c5cab14f34333e12/src/wp-includes/class-wp-theme-json.php#L181)
-
-[6.1](https://github.com/WordPress/wordpress-develop/blob/7c965e781f297e9f47f3abd3835c613eb41c0765/src/wp-includes/class-wp-theme-json.php#L197)
-
-[trunk](https://github.com/WordPress/wordpress-develop/blob/f01313a47489f1ba66bac01b7ab54fd2b01d00b4/src/wp-includes/class-wp-theme-json.php#L209)
+| `color.gradient`              | 5.8 | 5.9 |
+| `color.background`            | 5.8 | 5.9 |
+| `color.text`                  | 5.8 | 5.9 |
+| `border.color`                | 5.9 | 5.9 |
+| `border.width`                | 5.9 | 5.9 |
+| `border.style`                | 5.9 | 5.9 |
+| `border.radius`               | 5.8 | 5.9 |
+| `border.radius.topLeft`       | 5.9 | 5.9 |
+| `border.radius.topRight`      | 5.9 | 5.9 |
+| `border.radius.bottomLeft`    | 5.9 | 5.9 |
+| `border.radius.bottomRight`   | 5.9 | 5.9 |
+| `border.top.color`            | 6.1 | 6.1 |
+| `border.top.width`            | 6.1 | 6.1 |
+| `border.top.style`            | 6.1 | 6.1 |
+| `border.right.color`          | 6.1 | 6.1 |
+| `border.right.width`          | 6.1 | 6.1 |
+| `border.right.style`          | 6.1 | 6.1 |
+| `border.bottom.color`         | 6.1 | 6.1 |
+| `border.bottom.width`         | 6.1 | 6.1 |
+| `border.bottom.style`         | 6.1 | 6.1 |
+| `border.left.color`           | 6.1 | 6.1 |
+| `border.left.width`           | 6.1 | 6.1 |
+| `border.left.style`           | 6.1 | 6.1 |
+| `typography.fontFamily`       | 5.9 | 5.9 |
+| `typography.fontSize`         | 5.8 | 5.9 |
+| `typography.fontStyle`        | 5.9 | 5.9 |
+| `typography.fontWeight`       | 5.9 | 5.9 |
+| `typography.letterSpacing`    | 5.9 | 5.9 |
+| `typography.lineHeight`       | 5.8 | 5.9 |
+| `typography.textDecoration`   | 5.9 | 6.2 |
+| `typography.textTransform`    | 5.9 | 6.0 |
+| `spacing.padding`             | 5.9 | 5.9 |
+| `spacing.padding.top`         | 5.8 | 5.9 |
+| `spacing.padding.right`       | 5.8 | 5.9 |
+| `spacing.padding.left`        | 5.8 | 5.9 |
+| `spacing.padding.bottom`      | 5.8 | 5.9 |
+| `spacing.margin`              | 5.9 | 5.9 |
+| `spacing.margin.top`          | 5.8 | 5.9 |
+| `spacing.margin.right`        | 5.8 | 5.9 |
+| `spacing.margin.left`         | 5.8 | 5.9 |
+| `spacing.margin.bottom`       | 5.8 | 5.9 |
+| `spacing.blockGap`            | 5.9 | 5.9 |
+| `dimensions.minHeight`        | 6.2 | N/A |
+| `outline.color`               | 6.2 | N/A |
+| `outline.offset`              | 6.2 | N/A |
+| `outline.style`               | 6.2 | N/A |
+| `outline.width`               | 6.2 | N/A |
+| `filter.duotone`              | 5.9 | N/A |
+| `shadow`                      | 6.1 | 6.2 |

--- a/docs/reference-guides/theme-json-reference/styles-versions.md
+++ b/docs/reference-guides/theme-json-reference/styles-versions.md
@@ -1,6 +1,8 @@
+# Available Styles Options
+
 New styles options are integrated into theme.json on a regular basis. Knowing the style options available through theme.json or the styles editor at any given time can be challenging. To clarify, the table below indicates the WordPress version when each theme.json styles option became available and when a corresponding control was added to the user interface to allow management of the style from the Styles editor.
 
-# Styles Keys
+## Styles Keys
 
 | Key | theme.json Since| Style Editor Since |
 | --- | :---: | :---: |

--- a/docs/reference-guides/theme-json-reference/styles-versions.md
+++ b/docs/reference-guides/theme-json-reference/styles-versions.md
@@ -1,53 +1,65 @@
-# Styles Keys with theme.json and Style editor versions
+# Styles Keys
 
 | Key | theme.json Since| Style Editor Since |
 | --- | :---: | :---: |
-| `color.gradient` | 5.8 | ? |
-| `color.background` | 5.8 | ? |
-| `color.text` | 5.8 | ? |
-| `border.color` | 5.9 | ? |
-| `border.width` | 5.9 | ? |
-| `border.style` | 5.9 | ? |
-| `border.radius` | ? | ? |
-| `border.radius.topLeft` | ? | ? |
-| `border.radius.topRight` | ? | ? |
-| `border.radius.bottomLeft` | ? | ? |
-| `border.radius.bottomRight` | ? | ? |
-| `border.top.color` | 6.1 | ? |
-| `border.top.width` | 6.1 | ? |
-| `border.top.style` | 6.1 | ? |
-| `border.right.color` | 6.1 | ? |
-| `border.right.width` | 6.1 | ? |
-| `border.right.style` | 6.1 | ? |
-| `border.bottom.color` | 6.1 | ? |
-| `border.bottom.width` | 6.1 | ? |
-| `border.bottom.style` | 6.1 | ? |
-| `border.left.color` | 6.1 | ? |
-| `border.left.width` | 6.1 | ? |
-| `border.left.style` | 6.1 | ? |
-| `typography.fontFamily` | ? | ? |
-| `typography.fontSize` | ? | ? |
-| `typography.fontStyle` | ? | ? |
-| `typography.fontWeight` | ? | ? |
-| `typography.letterSpacing` | ? | ? |
-| `typography.lineHeight` | ? | ? |
-| `typography.textDecoration` | ? | ? |
-| `typography.textTransform`| ? | ? |
-| `spacing.padding` | ? | ? |
-| `spacing.padding.top` | ? | ? |
-| `spacing.padding.right` | ? | ? |
-| `spacing.padding.left` | ? | ? |
-| `spacing.padding.bottom` | ? | ? |
-| `spacing.padding` | ? | ? |
-| `spacing.margin.top` | ? | ? |
-| `spacing.margin.right` | ? | ? |
-| `spacing.margin.left` | ? | ? |
-| `spacing.margin.bottom` | ? | ? |
-| `spacing.blockGap` | ? | ? |
-| `dimensions.minHeight` | ? | ? |
-| `outline.color` | ? | ? |
-| `outline.offset` | ? | ? |
-| `outline.style` | ? | ? |
-| `outline.width` | ? | ? |
-| `filter.duotone` | ? | ? |
-| `shadow` | ? | ? |
+| `color.gradient`              | 5.8 | ? |
+| `color.background`            | 5.8 | ? |
+| `color.text`                  | 5.8 | ? |
+| `border.color`                | 5.9 | ? |
+| `border.width`                | 5.9 | ? |
+| `border.style`                | 5.9 | ? |
+| `border.radius`               | 5.8 | ? |
+| `border.radius.topLeft`       | 5.9 | ? |
+| `border.radius.topRight`      | 5.9 | ? |
+| `border.radius.bottomLeft`    | 5.9 | ? |
+| `border.radius.bottomRight`   | 5.9 | ? |
+| `border.top.color`            | 6.1 | ? |
+| `border.top.width`            | 6.1 | ? |
+| `border.top.style`            | 6.1 | ? |
+| `border.right.color`          | 6.1 | ? |
+| `border.right.width`          | 6.1 | ? |
+| `border.right.style`          | 6.1 | ? |
+| `border.bottom.color`         | 6.1 | ? |
+| `border.bottom.width`         | 6.1 | ? |
+| `border.bottom.style`         | 6.1 | ? |
+| `border.left.color`           | 6.1 | ? |
+| `border.left.width`           | 6.1 | ? |
+| `border.left.style`           | 6.1 | ? |
+| `typography.fontFamily`       | 5.9 | ? |
+| `typography.fontSize`         | 5.8 | ? |
+| `typography.fontStyle`        | 5.9 | ? |
+| `typography.fontWeight`       | 5.9 | ? |
+| `typography.letterSpacing`    | 5.9 | ? |
+| `typography.lineHeight`       | 5.8 | ? |
+| `typography.textDecoration`   | 5.9 | ? |
+| `typography.textTransform`    | 5.9 | ? |
+| `spacing.padding`             | 5.9 | ? |
+| `spacing.padding.top`         | 5.8 | ? |
+| `spacing.padding.right`       | 5.8 | ? |
+| `spacing.padding.left`        | 5.8 | ? |
+| `spacing.padding.bottom`      | 5.8 | ? |
+| `spacing.margin`              | 5.9 | ? |
+| `spacing.margin.top`          | 5.8 | ? |
+| `spacing.margin.right`        | 5.8 | ? |
+| `spacing.margin.left`         | 5.8 | ? |
+| `spacing.margin.bottom`       | 5.8 | ? |
+| `spacing.blockGap`            | 5.9 | ? |
+| `dimensions.minHeight`        | 6.2 | ? |
+| `outline.color`               | 6.2 | ? |
+| `outline.offset`              | 6.2 | ? |
+| `outline.style`               | 6.2 | ? |
+| `outline.width`               | 6.2 | ? |
+| `filter.duotone`              | 5.9 | ? |
+| `shadow`                      | 6.1 | ? |
+
+# Reference
+
+[5.8](https://github.com/WordPress/wordpress-develop/blob/95c643852001ba43f23dc5af5b6b3d1e02e9d9e4/src/wp-includes/class-wp-theme-json.php#L216)
+
+[5.9](https://github.com/WordPress/wordpress-develop/blob/88b0e2fe7f065118323cbe493b7c014a3786d90d/src/wp-includes/class-wp-theme-json.php#L173)
+
+[6.0](https://github.com/WordPress/wordpress-develop/blob/1e52ae5fed0cdb92f6d2f537c5cab14f34333e12/src/wp-includes/class-wp-theme-json.php#L181)
+
+[6.1](https://github.com/WordPress/wordpress-develop/blob/7c965e781f297e9f47f3abd3835c613eb41c0765/src/wp-includes/class-wp-theme-json.php#L197)
+
+[trunk](https://github.com/WordPress/wordpress-develop/blob/f01313a47489f1ba66bac01b7ab54fd2b01d00b4/src/wp-includes/class-wp-theme-json.php#L209)

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -247,6 +247,9 @@
 					},
 					{
 						"docs/reference-guides/theme-json-reference/theme-json-migrations.md": []
+					},
+					{
+						"docs/reference-guides/theme-json-reference/styles-versions.md": []
 					}
 				]
 			},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR is a first pass at expanding theme.json documentation with more granular information. Starting with a table of theme.json styles keys and the versions implemented in theme.json and the styles editor, respectively.

I'm not sure this is the best long-term approach to display this information, but working within the confines of what can be accomplished on the DevHub site.

Fixes #44340 

## ToDo

- [x] Add Introductory text
- [x] Add theme.json since versions
- [x] Add styles editor since versions
- [x] Maybe add `styles.` to the beginning of each key for the sake of being complete

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It can be difficult to know exactly what options are available in theme.json and, from those, which have a user interface implementation that can be used from the styles editor panel. 

This table will ideally also exist on the Theme Developer Handbook, covering only options that have been already made available in Core.

I've created this as a new page since the theme.json How-To page has become extremely long.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This table is a first attempt at making this information available in an easy-to-scan format. This is PR is not ready to publish but is being submitted for feedback about the overall format of the table..

## Testing Instructions

Confirm that the list of styles keys is complete and accurate and the Since columns contain accurate versions for WP Core inclusion or N/A if not yet available.
