### PR TITLE
Fix `e2e-test-utils-playwright`'s jsdoc and types

### DIFF
--- a/packages/e2e-test-utils-playwright/src/admin/get-page-error.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/get-page-error.ts
@@ -7,8 +7,6 @@ import type { Admin } from './';
  * Regular expression matching a displayed PHP error within a markup string.
  *
  * @see https://github.com/php/php-src/blob/598175e/main/main.c#L1257-L1297
- *
- * @type {RegExp}
  */
 const REGEXP_PHP_ERROR =
 	/(<b>)?(Fatal error|Recoverable fatal error|Warning|Parse error|Notice|Strict Standards|Deprecated|Unknown error)(<\/b>)?: (.*?) in (.*?) on line (<b>)?\d+(<\/b>)?/;
@@ -21,10 +19,8 @@ const REGEXP_PHP_ERROR =
  *
  * @see http://php.net/manual/en/function.error-reporting.php
  *
- * @param {Admin} this
- *
- * @return {Promise<?string>} Promise resolving to a string or null, depending
- *                            whether a page error is present.
+ * @param this
+ * @return Promise resolving to a string or null, depending whether a page error is present.
  */
 export async function getPageError( this: Admin ) {
 	const content = await this.page.content();

--- a/packages/e2e-test-utils-playwright/src/admin/index.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/index.ts
@@ -30,8 +30,12 @@ export class Admin {
 		this.pageUtils = pageUtils;
 	}
 
-	createNewPost = createNewPost.bind( this );
-	getPageError = getPageError.bind( this );
-	visitAdminPage = visitAdminPage.bind( this );
-	visitSiteEditor = visitSiteEditor.bind( this );
+	/** @borrows createNewPost as this.createNewPost */
+	createNewPost: typeof createNewPost = createNewPost.bind( this );
+	/** @borrows getPageError as this.getPageError */
+	getPageError: typeof getPageError = getPageError.bind( this );
+	/** @borrows visitAdminPage as this.visitAdminPage */
+	visitAdminPage: typeof visitAdminPage = visitAdminPage.bind( this );
+	/** @borrows visitSiteEditor as this.visitSiteEditor */
+	visitSiteEditor: typeof visitSiteEditor = visitSiteEditor.bind( this );
 }

--- a/packages/e2e-test-utils-playwright/src/admin/visit-admin-page.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/visit-admin-page.ts
@@ -11,9 +11,9 @@ import type { Admin } from './';
 /**
  * Visits admin page and handle errors.
  *
- * @param {Admin}  this
- * @param {string} adminPath String to be serialized as pathname.
- * @param {string} query     String to be serialized as query portion of URL.
+ * @param this
+ * @param adminPath String to be serialized as pathname.
+ * @param query     String to be serialized as query portion of URL.
  */
 export async function visitAdminPage(
 	this: Admin,

--- a/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
@@ -20,9 +20,9 @@ const CANVAS_SELECTOR = 'iframe[title="Editor canvas"i]';
  *
  * By default, it also skips the welcome guide. The option can be disabled if need be.
  *
- * @param {Admin}                 this
- * @param {SiteEditorQueryParams} query            Query params to be serialized as query portion of URL.
- * @param {boolean}               skipWelcomeGuide Whether to skip the welcome guide as part of the navigation.
+ * @param this
+ * @param query            Query params to be serialized as query portion of URL.
+ * @param skipWelcomeGuide Whether to skip the welcome guide as part of the navigation.
  */
 export async function visitSiteEditor(
 	this: Admin,

--- a/packages/e2e-test-utils-playwright/src/editor/click-block-options-menu-item.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/click-block-options-menu-item.ts
@@ -6,8 +6,8 @@ import type { Editor } from './index';
 /**
  * Clicks a block toolbar button.
  *
- * @param {Editor} this
- * @param {string} label The text string of the button label.
+ * @param this
+ * @param label The text string of the button label.
  */
 export async function clickBlockOptionsMenuItem( this: Editor, label: string ) {
 	await this.clickBlockToolbarButton( 'Options' );

--- a/packages/e2e-test-utils-playwright/src/editor/click-block-toolbar-button.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/click-block-toolbar-button.ts
@@ -6,8 +6,8 @@ import type { Editor } from './index';
 /**
  * Clicks a block toolbar button.
  *
- * @param {Editor} this
- * @param {string} label The text string of the button label.
+ * @param this
+ * @param label The text string of the button label.
  */
 export async function clickBlockToolbarButton( this: Editor, label: string ) {
 	await this.showBlockToolbar();

--- a/packages/e2e-test-utils-playwright/src/editor/get-edited-post-content.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/get-edited-post-content.ts
@@ -6,9 +6,9 @@ import type { Editor } from './index';
 /**
  * Returns a promise which resolves with the edited post content (HTML string).
  *
- * @param {Editor} this
+ * @param this
  *
- * @return {Promise} Promise resolving with post content markup.
+ * @return Promise resolving with post content markup.
  */
 export async function getEditedPostContent( this: Editor ) {
 	return await this.page.evaluate( () =>

--- a/packages/e2e-test-utils-playwright/src/editor/index.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/index.ts
@@ -39,17 +39,35 @@ export class Editor {
 		return this.page.frame( 'editor-canvas' ) || this.page;
 	}
 
-	clickBlockOptionsMenuItem = clickBlockOptionsMenuItem.bind( this );
-	clickBlockToolbarButton = clickBlockToolbarButton.bind( this );
-	getBlocks = getBlocks.bind( this );
-	getEditedPostContent = getEditedPostContent.bind( this );
-	insertBlock = insertBlock.bind( this );
-	openDocumentSettingsSidebar = openDocumentSettingsSidebar.bind( this );
-	openPreviewPage = openPreviewPage.bind( this );
-	publishPost = publishPost.bind( this );
-	saveSiteEditorEntities = saveSiteEditorEntities.bind( this );
-	selectBlocks = selectBlocks.bind( this );
-	setContent = setContent.bind( this );
-	showBlockToolbar = showBlockToolbar.bind( this );
-	transformBlockTo = transformBlockTo.bind( this );
+	/** @borrows clickBlockOptionsMenuItem as this.clickBlockOptionsMenuItem */
+	clickBlockOptionsMenuItem: typeof clickBlockOptionsMenuItem =
+		clickBlockOptionsMenuItem.bind( this );
+	/** @borrows clickBlockToolbarButton as this.clickBlockToolbarButton */
+	clickBlockToolbarButton: typeof clickBlockToolbarButton =
+		clickBlockToolbarButton.bind( this );
+	/** @borrows getBlocks as this.getBlocks */
+	getBlocks: typeof getBlocks = getBlocks.bind( this );
+	/** @borrows getEditedPostContent as this.getEditedPostContent */
+	getEditedPostContent: typeof getEditedPostContent =
+		getEditedPostContent.bind( this );
+	/** @borrows insertBlock as this.insertBlock */
+	insertBlock: typeof insertBlock = insertBlock.bind( this );
+	/** @borrows openDocumentSettingsSidebar as this.openDocumentSettingsSidebar */
+	openDocumentSettingsSidebar: typeof openDocumentSettingsSidebar =
+		openDocumentSettingsSidebar.bind( this );
+	/** @borrows openPreviewPage as this.openPreviewPage */
+	openPreviewPage: typeof openPreviewPage = openPreviewPage.bind( this );
+	/** @borrows publishPost as this.publishPost */
+	publishPost: typeof publishPost = publishPost.bind( this );
+	/** @borrows saveSiteEditorEntities as this.saveSiteEditorEntities */
+	saveSiteEditorEntities: typeof saveSiteEditorEntities =
+		saveSiteEditorEntities.bind( this );
+	/** @borrows selectBlocks as this.selectBlocks */
+	selectBlocks: typeof selectBlocks = selectBlocks.bind( this );
+	/** @borrows setContent as this.setContent */
+	setContent: typeof setContent = setContent.bind( this );
+	/** @borrows showBlockToolbar as this.showBlockToolbar */
+	showBlockToolbar: typeof showBlockToolbar = showBlockToolbar.bind( this );
+	/** @borrows transformBlockTo as this.transformBlockTo */
+	transformBlockTo: typeof transformBlockTo = transformBlockTo.bind( this );
 }

--- a/packages/e2e-test-utils-playwright/src/editor/insert-block.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/insert-block.ts
@@ -12,8 +12,8 @@ interface BlockRepresentation {
 /**
  * Insert a block.
  *
- * @param {Editor}              this
- * @param {BlockRepresentation} blockRepresentation Inserted block representation.
+ * @param this
+ * @param blockRepresentation Inserted block representation.
  */
 async function insertBlock(
 	this: Editor,

--- a/packages/e2e-test-utils-playwright/src/editor/open-document-settings-sidebar.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/open-document-settings-sidebar.ts
@@ -7,7 +7,7 @@ import type { Editor } from './index';
  * Clicks on the button in the header which opens Document Settings sidebar when
  * it is closed.
  *
- * @param {Editor} this
+ * @param this
  */
 export async function openDocumentSettingsSidebar( this: Editor ) {
 	const toggleButton = this.page

--- a/packages/e2e-test-utils-playwright/src/editor/preview.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/preview.ts
@@ -11,9 +11,9 @@ import type { Editor } from './index';
 /**
  * Opens the preview page of an edited post.
  *
- * @param {Editor} this
+ * @param this
  *
- * @return {Promise<Page>} preview page.
+ * @return preview page.
  */
 export async function openPreviewPage( this: Editor ): Promise< Page > {
 	const editorTopBar = this.page.locator(

--- a/packages/e2e-test-utils-playwright/src/editor/publish-post.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/publish-post.ts
@@ -7,7 +7,7 @@ import type { Editor } from './index';
  * Publishes the post, resolving once the request is complete (once a notice
  * is displayed).
  *
- * @param {Editor} this
+ * @param this
  */
 export async function publishPost( this: Editor ) {
 	await this.page.click( 'role=button[name="Publish"i]' );

--- a/packages/e2e-test-utils-playwright/src/editor/show-block-toolbar.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/show-block-toolbar.ts
@@ -7,7 +7,7 @@ import type { Editor } from './index';
  * The block toolbar is not always visible while typing.
  * Call this function to reveal it.
  *
- * @param {Editor} this
+ * @param this
  */
 export async function showBlockToolbar( this: Editor ) {
 	// Move the mouse to disable the isTyping mode. We need at least three

--- a/packages/e2e-test-utils-playwright/src/editor/site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/site-editor.ts
@@ -6,7 +6,7 @@ import type { Editor } from './index';
 /**
  * Save entities in the site editor. Assumes the editor is in a dirty state.
  *
- * @param {Editor} this
+ * @param this
  */
 export async function saveSiteEditorEntities( this: Editor ) {
 	await this.page.click(

--- a/packages/e2e-test-utils-playwright/src/editor/transform-block-to.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/transform-block-to.ts
@@ -6,8 +6,8 @@ import type { Editor } from './index';
 /**
  * Clicks the default block appender.
  *
- * @param {Editor} this
- * @param {string} name Block name.
+ * @param this
+ * @param name Block name.
  */
 export async function transformBlockTo( this: Editor, name: string ) {
 	await this.page.evaluate(

--- a/packages/e2e-test-utils-playwright/src/page-utils/index.ts
+++ b/packages/e2e-test-utils-playwright/src/page-utils/index.ts
@@ -30,12 +30,20 @@ class PageUtils {
 		this.browser = this.context.browser()!;
 	}
 
-	dragFiles = dragFiles.bind( this );
-	isCurrentURL = isCurrentURL.bind( this );
-	pressKeyTimes = pressKeyTimes.bind( this );
-	pressKeyWithModifier = pressKeyWithModifier.bind( this );
-	setBrowserViewport = setBrowserViewport.bind( this );
-	setClipboardData = setClipboardData.bind( this );
+	/** @borrows dragFiles as this.dragFiles */
+	dragFiles: typeof dragFiles = dragFiles.bind( this );
+	/** @borrows isCurrentURL as this.isCurrentURL */
+	isCurrentURL: typeof isCurrentURL = isCurrentURL.bind( this );
+	/** @borrows pressKeyTimes as this.pressKeyTimes */
+	pressKeyTimes: typeof pressKeyTimes = pressKeyTimes.bind( this );
+	/** @borrows pressKeyWithModifier as this.pressKeyWithModifier */
+	pressKeyWithModifier: typeof pressKeyWithModifier =
+		pressKeyWithModifier.bind( this );
+	/** @borrows setBrowserViewport as this.setBrowserViewport */
+	setBrowserViewport: typeof setBrowserViewport =
+		setBrowserViewport.bind( this );
+	/** @borrows setClipboardData as this.setClipboardData */
+	setClipboardData: typeof setClipboardData = setClipboardData.bind( this );
 }
 
 export { PageUtils };

--- a/packages/e2e-test-utils-playwright/src/page-utils/is-current-url.ts
+++ b/packages/e2e-test-utils-playwright/src/page-utils/is-current-url.ts
@@ -7,10 +7,10 @@ import type { PageUtils } from './';
 /**
  * Checks if current path of the URL matches the provided path.
  *
- * @param {PageUtils} this
- * @param {string}    path String to be serialized as pathname.
+ * @param this
+ * @param path String to be serialized as pathname.
  *
- * @return {boolean} Boolean represents whether current URL is or not a WordPress path.
+ * @return Boolean represents whether current URL is or not a WordPress path.
  */
 export function isCurrentURL( this: PageUtils, path: string ) {
 	const currentURL = new URL( this.page.url() );

--- a/packages/e2e-test-utils-playwright/src/request-utils/comments.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/comments.ts
@@ -22,8 +22,8 @@ export interface User {
 /**
  * Create new comment using the REST API.
  *
- * @param {RequestUtils}         this
- * @param {CreateCommentPayload} payload
+ * @param this
+ * @param payload
  */
 export async function createComment(
 	this: RequestUtils,
@@ -48,7 +48,7 @@ export async function createComment(
 /**
  * Delete all comments using the REST API.
  *
- * @param {RequestUtils} this
+ * @param this
  */
 export async function deleteAllComments( this: RequestUtils ) {
 	// List all comments.

--- a/packages/e2e-test-utils-playwright/src/request-utils/index.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/index.ts
@@ -118,40 +118,76 @@ class RequestUtils {
 		this.baseURL = baseURL;
 	}
 
-	login = login.bind( this );
-	setupRest = setupRest.bind( this );
+	/** @borrows login as this.login */
+	login: typeof login = login.bind( this );
+	/** @borrows setupRest as this.setupRest */
+	setupRest: typeof setupRest = setupRest.bind( this );
 	// .bind() drops the generic types. Re-casting it to keep the type signature.
-	rest = rest.bind( this ) as typeof rest;
-	getMaxBatchSize = getMaxBatchSize.bind( this );
+	rest: typeof rest = rest.bind( this ) as typeof rest;
+	/** @borrows getMaxBatchSize as this.getMaxBatchSize */
+	getMaxBatchSize: typeof getMaxBatchSize = getMaxBatchSize.bind( this );
 	// .bind() drops the generic types. Re-casting it to keep the type signature.
-	batchRest = batchRest.bind( this ) as typeof batchRest;
-	getPluginsMap = getPluginsMap.bind( this );
-	activatePlugin = activatePlugin.bind( this );
-	deactivatePlugin = deactivatePlugin.bind( this );
-	activateTheme = activateTheme.bind( this );
-	deleteAllBlocks = deleteAllBlocks;
-	createPost = createPost.bind( this );
-	deleteAllPosts = deleteAllPosts.bind( this );
-	createClassicMenu = createClassicMenu.bind( this );
-	createNavigationMenu = createNavigationMenu.bind( this );
-	deleteAllMenus = deleteAllMenus.bind( this );
-	getNavigationMenus = getNavigationMenus.bind( this );
-	createComment = createComment.bind( this );
-	deleteAllComments = deleteAllComments.bind( this );
-	deleteAllWidgets = deleteAllWidgets.bind( this );
-	addWidgetBlock = addWidgetBlock.bind( this );
-	deleteAllTemplates = deleteAllTemplates.bind( this );
-	resetPreferences = resetPreferences.bind( this );
-	listMedia = listMedia.bind( this );
-	uploadMedia = uploadMedia.bind( this );
-	deleteMedia = deleteMedia.bind( this );
-	deleteAllMedia = deleteAllMedia.bind( this );
-	createUser = createUser.bind( this );
-	deleteAllUsers = deleteAllUsers.bind( this );
-	getSiteSettings = getSiteSettings.bind( this );
-	updateSiteSettings = updateSiteSettings.bind( this );
-	deleteAllPages = deleteAllPages.bind( this );
-	createPage = createPage.bind( this );
+	batchRest: typeof batchRest = batchRest.bind( this ) as typeof batchRest;
+	/** @borrows getPluginsMap as this.getPluginsMap */
+	getPluginsMap: typeof getPluginsMap = getPluginsMap.bind( this );
+	/** @borrows activatePlugin as this.activatePlugin */
+	activatePlugin: typeof activatePlugin = activatePlugin.bind( this );
+	/** @borrows deactivatePlugin as this.deactivatePlugin */
+	deactivatePlugin: typeof deactivatePlugin = deactivatePlugin.bind( this );
+	/** @borrows activateTheme as this.activateTheme */
+	activateTheme: typeof activateTheme = activateTheme.bind( this );
+	/** @borrows deleteAllBlocks as this.deleteAllBlocks */
+	deleteAllBlocks = deleteAllBlocks.bind( this );
+	/** @borrows createPost as this.createPost */
+	createPost: typeof createPost = createPost.bind( this );
+	/** @borrows deleteAllPosts as this.deleteAllPosts */
+	deleteAllPosts: typeof deleteAllPosts = deleteAllPosts.bind( this );
+	/** @borrows createClassicMenu as this.createClassicMenu */
+	createClassicMenu: typeof createClassicMenu =
+		createClassicMenu.bind( this );
+	/** @borrows createNavigationMenu as this.createNavigationMenu */
+	createNavigationMenu: typeof createNavigationMenu =
+		createNavigationMenu.bind( this );
+	/** @borrows deleteAllMenus as this.deleteAllMenus */
+	deleteAllMenus: typeof deleteAllMenus = deleteAllMenus.bind( this );
+	/** @borrows getNavigationMenus as this.getNavigationMenus */
+	getNavigationMenus: typeof getNavigationMenus =
+		getNavigationMenus.bind( this );
+	/** @borrows createComment as this.createComment */
+	createComment: typeof createComment = createComment.bind( this );
+	/** @borrows deleteAllComments as this.deleteAllComments */
+	deleteAllComments: typeof deleteAllComments =
+		deleteAllComments.bind( this );
+	/** @borrows deleteAllWidgets as this.deleteAllWidgets */
+	deleteAllWidgets: typeof deleteAllWidgets = deleteAllWidgets.bind( this );
+	/** @borrows addWidgetBlock as this.addWidgetBlock */
+	addWidgetBlock: typeof addWidgetBlock = addWidgetBlock.bind( this );
+	/** @borrows deleteAllTemplates as this.deleteAllTemplates */
+	deleteAllTemplates: typeof deleteAllTemplates =
+		deleteAllTemplates.bind( this );
+	/** @borrows resetPreferences as this.resetPreferences */
+	resetPreferences: typeof resetPreferences = resetPreferences.bind( this );
+	/** @borrows listMedia as this.listMedia */
+	listMedia: typeof listMedia = listMedia.bind( this );
+	/** @borrows uploadMedia as this.uploadMedia */
+	uploadMedia: typeof uploadMedia = uploadMedia.bind( this );
+	/** @borrows deleteMedia as this.deleteMedia */
+	deleteMedia: typeof deleteMedia = deleteMedia.bind( this );
+	/** @borrows deleteAllMedia as this.deleteAllMedia */
+	deleteAllMedia: typeof deleteAllMedia = deleteAllMedia.bind( this );
+	/** @borrows createUser as this.createUser */
+	createUser: typeof createUser = createUser.bind( this );
+	/** @borrows deleteAllUsers as this.deleteAllUsers */
+	deleteAllUsers: typeof deleteAllUsers = deleteAllUsers.bind( this );
+	/** @borrows getSiteSettings as this.getSiteSettings */
+	getSiteSettings: typeof getSiteSettings = getSiteSettings.bind( this );
+	/** @borrows updateSiteSettings as this.updateSiteSettings */
+	updateSiteSettings: typeof updateSiteSettings =
+		updateSiteSettings.bind( this );
+	/** @borrows deleteAllPages as this.deleteAllPages */
+	deleteAllPages: typeof deleteAllPages = deleteAllPages.bind( this );
+	/** @borrows createPage as this.createPage */
+	createPage: typeof createPage = createPage.bind( this );
 }
 
 export type { StorageState };

--- a/packages/e2e-test-utils-playwright/src/request-utils/menus.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/menus.ts
@@ -56,8 +56,8 @@ export async function createClassicMenu( this: RequestUtils, name: string ) {
 /**
  * Create a navigation menu
  *
- * @param  menuData navigation menu post data.
- * @return {string} Menu content.
+ * @param menuData navigation menu post data.
+ * @return Menu content.
  */
 export async function createNavigationMenu(
 	this: RequestUtils,

--- a/packages/e2e-test-utils-playwright/src/request-utils/pages.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/pages.ts
@@ -39,7 +39,7 @@ export async function deletePage( this: RequestUtils, id: number ) {
 /**
  * Delete all pages using REST API.
  *
- * @param {RequestUtils} this
+ * @param this
  */
 export async function deleteAllPages( this: RequestUtils ) {
 	// List all pages.

--- a/packages/e2e-test-utils-playwright/src/request-utils/plugins.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/plugins.ts
@@ -12,8 +12,8 @@ import type { RequestUtils } from './index';
  * Fetch the plugins from API and cache them in memory,
  * since they are unlikely to change during testing.
  *
- * @param {RequestUtils} this
- * @param {boolean?}     forceRefetch Force refetch the installed plugins to update the cache.
+ * @param this
+ * @param forceRefetch Force refetch the installed plugins to update the cache.
  */
 async function getPluginsMap( this: RequestUtils, forceRefetch = false ) {
 	if ( ! forceRefetch && this.pluginsMap ) {
@@ -35,8 +35,8 @@ async function getPluginsMap( this: RequestUtils, forceRefetch = false ) {
 /**
  * Activates an installed plugin.
  *
- * @param {this}   this RequestUtils.
- * @param {string} slug Plugin slug.
+ * @param this RequestUtils.
+ * @param slug Plugin slug.
  */
 async function activatePlugin( this: RequestUtils, slug: string ) {
 	const pluginsMap = await this.getPluginsMap();
@@ -56,8 +56,8 @@ async function activatePlugin( this: RequestUtils, slug: string ) {
 /**
  * Deactivates an active plugin.
  *
- * @param {this}   this RequestUtils.
- * @param {string} slug Plugin slug.
+ * @param this RequestUtils.
+ * @param slug Plugin slug.
  */
 async function deactivatePlugin( this: RequestUtils, slug: string ) {
 	const pluginsMap = await this.getPluginsMap();

--- a/packages/e2e-test-utils-playwright/src/request-utils/posts.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/posts.ts
@@ -20,7 +20,7 @@ export interface CreatePostPayload {
 /**
  * Delete all posts using REST API.
  *
- * @param {RequestUtils} this
+ * @param this
  */
 export async function deleteAllPosts( this: RequestUtils ) {
 	// List all posts.
@@ -53,8 +53,8 @@ export async function deleteAllPosts( this: RequestUtils ) {
 /**
  * Creates a new post using the REST API.
  *
- * @param {RequestUtils}      this
- * @param {CreatePostPayload} payload Post attributes.
+ * @param this
+ * @param payload Post attributes.
  */
 export async function createPost(
 	this: RequestUtils,

--- a/packages/e2e-test-utils-playwright/src/request-utils/preferences.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/preferences.ts
@@ -6,7 +6,7 @@ import type { RequestUtils } from './index';
 /**
  * Reset user preferences
  *
- * @param {this} this Request utils.
+ * @param this Request utils.
  */
 export async function resetPreferences( this: RequestUtils ) {
 	await this.rest( {

--- a/packages/e2e-test-utils-playwright/src/request-utils/rest.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/rest.ts
@@ -128,8 +128,8 @@ async function rest< RestResponse = any >(
 /**
  * Get the maximum batch size for the REST API.
  *
- * @param {RequestUtils} this
- * @param {boolean?}     forceRefetch Force revalidate the cached max batch size.
+ * @param this
+ * @param forceRefetch Force revalidate the cached max batch size.
  */
 async function getMaxBatchSize( this: RequestUtils, forceRefetch = false ) {
 	if ( ! forceRefetch && this.maxBatchSize ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What and why?
<!-- In a few words, what is the PR actually doing? -->
This PR does two things:
1. Fix jsdoc in `e2e-test-utils-playwright` when using from a fixture. Now it correctly shows the jsdoc when hovering over a method.
2. Remove jsdoc types in favor of typescript types. jsdoc types are never enforced and can be out-of-sync. It's preferred to refer to the TS types if possible.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Use the fancy `@borrows` jsdoc magic to _borrow_ jsdoc from a pure function to a class field. Due to some circular dependencies issue, we also have to manually type the class field with `: typeof methodName` to show the jsdoc.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
```sh
npm run build:packages
```
Hover over some util in the supported editors and see the jsdoc.

> **Note**:
> You have to call the function to be able to show the full jsdoc. That is, hovering over `editor.getBlocks` won't show the jsdoc, but hovering over `editor.getBlocks()` will show the jsdoc. This is probably a jsdoc or typescript bug.

## Screenshots or screencast <!-- if applicable -->
jsdoc in VSCode:

![image](https://user-images.githubusercontent.com/7753001/220238296-f2a2f29d-a085-48c2-b9b3-7131c2919cd7.png)
