### PR TITLE
Add typescript-eslint rules with type informations to e2e tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -388,7 +388,14 @@ module.exports = {
 				'test/e2e/**/*.[tj]s',
 				'packages/e2e-test-utils-playwright/**/*.[tj]s',
 			],
-			extends: [ 'plugin:eslint-plugin-playwright/playwright-test' ],
+			extends: [
+				'plugin:eslint-plugin-playwright/playwright-test',
+				'plugin:@typescript-eslint/base',
+			],
+			parserOptions: {
+				tsconfigRootDir: __dirname,
+				project: [ './test/e2e/tsconfig.json' ],
+			},
 			rules: {
 				'@wordpress/no-global-active-element': 'off',
 				'@wordpress/no-global-get-selection': 'off',
@@ -411,6 +418,9 @@ module.exports = {
 						message: 'Prefer page.locator instead.',
 					},
 				],
+				'@typescript-eslint/await-thenable': 'error',
+				'@typescript-eslint/no-floating-promises': 'error',
+				'@typescript-eslint/no-misused-promises': 'error',
 			},
 		},
 		{

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -394,7 +394,10 @@ module.exports = {
 			],
 			parserOptions: {
 				tsconfigRootDir: __dirname,
-				project: [ './test/e2e/tsconfig.json' ],
+				project: [
+					'./test/e2e/tsconfig.json',
+					'./packages/e2e-test-utils-playwright/tsconfig.json',
+				],
 			},
 			rules: {
 				'@wordpress/no-global-active-element': 'off',

--- a/test/e2e/specs/editor/blocks/classic.spec.js
+++ b/test/e2e/specs/editor/blocks/classic.spec.js
@@ -110,8 +110,8 @@ test.describe( 'Classic', () => {
 	} ) => {
 		// Based on docs routing diables caching.
 		// See: https://playwright.dev/docs/api/class-page#page-route
-		await page.route( '**', ( route ) => {
-			route.continue();
+		await page.route( '**', async ( route ) => {
+			await route.continue();
 		} );
 
 		await editor.insertBlock( { name: 'core/freeform' } );

--- a/test/e2e/specs/editor/blocks/code.spec.js
+++ b/test/e2e/specs/editor/blocks/code.spec.js
@@ -38,7 +38,7 @@ test.describe( 'Code', () => {
 		await editor.insertBlock( { name: 'core/code' } );
 
 		// Test to see if HTML and white space is kept.
-		await pageUtils.setClipboardData( { plainText: '<img />\n\t<br>' } );
+		pageUtils.setClipboardData( { plainText: '<img />\n\t<br>' } );
 
 		await pageUtils.pressKeyWithModifier( 'primary', 'v' );
 

--- a/test/e2e/specs/editor/blocks/gallery.spec.js
+++ b/test/e2e/specs/editor/blocks/gallery.spec.js
@@ -47,7 +47,7 @@ test.describe( 'Gallery', () => {
 	} ) => {
 		await admin.createNewPost();
 
-		await pageUtils.setClipboardData( {
+		pageUtils.setClipboardData( {
 			plainText: `[gallery ids="${ uploadedMedia.id }"]`,
 		} );
 

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -220,7 +220,7 @@ test.describe( 'Image', () => {
 		// Add caption and navigate to inline toolbar.
 		await editor.clickBlockToolbarButton( 'Add caption' );
 		await pageUtils.pressKeyWithModifier( 'shift', 'Tab' );
-		await expect(
+		expect(
 			await page.evaluate( () =>
 				document.activeElement.getAttribute( 'aria-label' )
 			)
@@ -234,7 +234,7 @@ test.describe( 'Image', () => {
 		await page.keyboard.press( 'ArrowLeft' );
 		// Italic to bold.
 		await page.keyboard.press( 'ArrowLeft' );
-		await expect(
+		expect(
 			await page.evaluate( () =>
 				document.activeElement.getAttribute( 'aria-label' )
 			)

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1166,7 +1166,7 @@ test.describe( 'List', () => {
 		await pageUtils.pressKeyWithModifier( 'secondary', 'M' ); // Emulates CTRL+Shift+Alt + M => toggle code editor
 
 		// Paste empty list block
-		await pageUtils.setClipboardData( {
+		pageUtils.setClipboardData( {
 			plainText:
 				'<!-- wp:list -->\n<ul><li></li></ul>\n<!-- /wp:list -->',
 		} );

--- a/test/e2e/specs/editor/plugins/nonce.spec.js
+++ b/test/e2e/specs/editor/plugins/nonce.spec.js
@@ -44,11 +44,11 @@ test.describe( 'Nonce', () => {
 					url.href.startsWith(
 						requestUtils.storageState.rootURL.slice( 0, -1 )
 					),
-				( route ) => {
+				async ( route ) => {
 					if ( refreshed ) {
-						route.continue();
+						await route.continue();
 					} else {
-						route.fulfill( {
+						await route.fulfill( {
 							status: 403,
 							contentType: 'application/json; charset=UTF-8',
 							body: JSON.stringify( {
@@ -63,7 +63,7 @@ test.describe( 'Nonce', () => {
 		}
 
 		const saveDraftResponses = [];
-		page.on( 'response', async ( response ) => {
+		page.on( 'response', ( response ) => {
 			const request = response.request();
 			if (
 				request.method() === 'POST' &&

--- a/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
+++ b/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
@@ -214,10 +214,9 @@ test.describe( 'Autocomplete', () => {
 			await expect(
 				page.locator( `role=option[name="${ testData.optionText }"i]` )
 			).toBeVisible();
-			await page;
-			page.locator(
-				`role=option[name="${ testData.optionText }"i]`
-			).click();
+			await page
+				.locator( `role=option[name="${ testData.optionText }"i]` )
+				.click();
 
 			await expect
 				.poll( editor.getEditedPostContent )

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -407,7 +407,7 @@ test.describe( 'Copy/cut/paste', () => {
 		// back to default browser behaviour, allowing the browser to insert
 		// unfiltered HTML. When we swap out the post title in the post editor
 		// with the proper block, this test can be removed.
-		await pageUtils.setClipboardData( {
+		pageUtils.setClipboardData( {
 			html: '<span style="border: 1px solid black">Hello World</span>',
 		} );
 		await pageUtils.pressKeyWithModifier( 'primary', 'v' );
@@ -423,7 +423,7 @@ test.describe( 'Copy/cut/paste', () => {
 	} ) => {
 		await page.keyboard.type( 'ab' );
 		await page.keyboard.press( 'ArrowLeft' );
-		await pageUtils.setClipboardData( {
+		pageUtils.setClipboardData( {
 			html: '<span style="border: 1px solid black">x</span>',
 		} );
 		await pageUtils.pressKeyWithModifier( 'primary', 'v' );
@@ -439,7 +439,7 @@ test.describe( 'Copy/cut/paste', () => {
 		pageUtils,
 		editor,
 	} ) => {
-		await pageUtils.setClipboardData( {
+		pageUtils.setClipboardData( {
 			html: '<pre>x</pre>',
 		} );
 		await editor.insertBlock( { name: 'core/list' } );

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -328,7 +328,7 @@ test.describe( 'insert media from inserter', () => {
 		);
 	} );
 	test.afterAll( async ( { requestUtils } ) => {
-		Promise.all( [
+		await Promise.all( [
 			requestUtils.deleteAllMedia(),
 			requestUtils.deleteAllPosts(),
 		] );

--- a/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
+++ b/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
@@ -196,7 +196,7 @@ class ToolbarRovingTabindexUtils {
 				document.activeElement.getAttribute( 'aria-label' )
 			);
 		}
-		await expect( ariaLabel ).toBe( label );
+		expect( ariaLabel ).toBe( label );
 	}
 
 	async wrapCurrentBlockWithGroup( currentBlockTitle ) {

--- a/test/e2e/specs/site-editor/title.spec.js
+++ b/test/e2e/specs/site-editor/title.spec.js
@@ -23,7 +23,7 @@ test.describe( 'Site editor title', () => {
 			postType: 'wp_template',
 		} );
 		await editor.canvas.click( 'body' );
-		const title = await page.locator(
+		const title = page.locator(
 			'role=region[name="Editor top bar"i] >> role=heading[level=1]'
 		);
 
@@ -41,7 +41,7 @@ test.describe( 'Site editor title', () => {
 			postType: 'wp_template_part',
 		} );
 		await editor.canvas.click( 'body' );
-		const title = await page.locator(
+		const title = page.locator(
 			'role=region[name="Editor top bar"i] >> role=heading[level=1]'
 		);
 
@@ -60,14 +60,14 @@ test.describe( 'Site editor title', () => {
 		await editor.canvas.click( 'body' );
 		// Select the header template part via list view.
 		await page.click( 'role=button[name="List View"i]' );
-		const listView = await page.locator(
+		const listView = page.locator(
 			'role=treegrid[name="Block navigation structure"i]'
 		);
 		await listView.locator( 'role=gridcell >> text="header"' ).click();
 		await page.click( 'role=button[name="Close List View Sidebar"i]' );
 
 		// Evaluate the document settings secondary title.
-		const secondaryTitle = await page.locator(
+		const secondaryTitle = page.locator(
 			'.edit-site-document-actions__secondary-item'
 		);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Enable the following three rules to Playwright e2e tests:

1. [`@typescript-eslint/await-thenable`](https://typescript-eslint.io/rules/await-thenable)
2. [`@typescript-eslint/no-floating-promises`](https://typescript-eslint.io/rules/no-floating-promises)
3. [`@typescript-eslint/no-misused-promises`](https://typescript-eslint.io/rules/no-misused-promises)

And also fixes the reported errors.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Playwright is well-typed, we can enable some additional eslint rules to help us catch some bugs.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I originally tried enabling the rule for the whole project, but it's taking too long to process the monorepo. I think it's related to this documented [known issue](https://typescript-eslint.io/linting/typed-linting/monorepos#important-note-regarding-large--10-multi-package-monorepos) on the website.

I also tried extending `plugin:@typescript-eslint/recommended-requiring-type-checking`, but some rules don't work great with pure js files.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
```sh
npm run lint:js
# or
npm run lint:js -- test/e2e
```

CI should pass.

## Screenshots

![image](https://user-images.githubusercontent.com/7753001/220245120-03608c54-8465-463b-bf2f-fa84b8dab0da.png)
