### PR TITLE
Plugin: Only apply the viewScript compat to core blocks 

### DIFF
--- a/lib/compat/wordpress-6.1/blocks.php
+++ b/lib/compat/wordpress-6.1/blocks.php
@@ -124,6 +124,10 @@ function gutenberg_block_type_metadata_multiple_view_scripts( $metadata ) {
 		return $metadata;
 	}
 
+	if ( ! isset( $metadata['file'] ) || ! str_starts_with( $metadata['file'], wp_normalize_path( gutenberg_dir_path() ) ) ) {
+		return $metadata;
+	}
+	
 	// Register all viewScript items.
 	foreach ( $metadata['viewScript'] as $view_script ) {
 		$item_metadata               = $metadata;

--- a/lib/compat/wordpress-6.1/blocks.php
+++ b/lib/compat/wordpress-6.1/blocks.php
@@ -126,7 +126,7 @@ function gutenberg_block_type_metadata_multiple_view_scripts( $metadata ) {
 	) {
 		return $metadata;
 	}
-	
+
 	// Register all viewScript items.
 	foreach ( $metadata['viewScript'] as $view_script ) {
 		$item_metadata               = $metadata;

--- a/lib/compat/wordpress-6.1/blocks.php
+++ b/lib/compat/wordpress-6.1/blocks.php
@@ -118,13 +118,12 @@ add_filter( 'block_type_metadata_settings', 'gutenberg_block_type_metadata_view_
  * @return array
  */
 function gutenberg_block_type_metadata_multiple_view_scripts( $metadata ) {
-
-	// Early return if viewScript is empty, or not an array.
-	if ( ! isset( $metadata['viewScript'] ) || ! is_array( $metadata['viewScript'] ) ) {
-		return $metadata;
-	}
-
-	if ( ! isset( $metadata['file'] ) || ! str_starts_with( $metadata['file'], wp_normalize_path( gutenberg_dir_path() ) ) ) {
+	if (
+		! isset( $metadata['viewScript'] ) ||
+		! is_array( $metadata['viewScript'] ) ||
+		! isset( $metadata['file'] ) ||
+		! str_starts_with( $metadata['file'], wp_normalize_path( gutenberg_dir_path() ) )
+	) {
 		return $metadata;
 	}
 	


### PR DESCRIPTION
See #45870

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR limits the functionality in `gutenberg_block_type_metadata_multiple_view_scripts()` to gutenberg-provided blocks only.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is done as `gutenberg_block_type_metadata_multiple_view_scripts()` relies upon `gutenberg_block_type_metadata_view_script()` which only operates on files present within Gutenberg.

As noted within #45870  this causes WordPress 6.1 + Gutenberg plugin to be unable to use a block which has multiple items in the `viewScript` property.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The exclusion logic from `gutenberg_block_type_metadata_view_script()` is copied to `gutenberg_block_type_metadata_multiple_view_scripts()`.

This ensures that any `viewScript`s that are from plugin-provided blocks fall through to the Core support.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a block with `viewScript: [ "file:./index.js", "registered-script-handle", "script-handle-two" ]` 
2. View the front-end page source with that block present. All three handles should be present.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
