### PR TITLE
List block: add Firefox e2e tests

### DIFF
--- a/test/e2e/specs/editor/blocks/__snapshots__/List-can-be-created-by-pasting-an-empty-list-1-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/List-can-be-created-by-pasting-an-empty-list-1-chromium.txt
@@ -1,5 +1,0 @@
-<!-- wp:list -->
-<ul><!-- wp:list-item -->
-<li></li>
-<!-- /wp:list-item --></ul>
-<!-- /wp:list -->

--- a/test/e2e/specs/editor/blocks/__snapshots__/List-can-be-exited-to-selected-paragraph-1-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/List-can-be-exited-to-selected-paragraph-1-chromium.txt
@@ -1,9 +1,0 @@
-<!-- wp:list -->
-<ul><!-- wp:list-item -->
-<li></li>
-<!-- /wp:list-item --></ul>
-<!-- /wp:list -->
-
-<!-- wp:paragraph -->
-<p>1</p>
-<!-- /wp:paragraph -->

--- a/test/e2e/specs/editor/blocks/__snapshots__/List-selects-all-transformed-output-1-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/List-selects-all-transformed-output-1-chromium.txt
@@ -1,7 +1,0 @@
-<!-- wp:paragraph -->
-<p>1</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>2</p>
-<!-- /wp:paragraph -->

--- a/test/e2e/specs/editor/blocks/__snapshots__/List-selects-all-transformed-output-2-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/List-selects-all-transformed-output-2-chromium.txt
@@ -1,9 +1,0 @@
-<!-- wp:list -->
-<ul><!-- wp:list-item -->
-<li>1</li>
-<!-- /wp:list-item -->
-
-<!-- wp:list-item -->
-<li>2</li>
-<!-- /wp:list-item --></ul>
-<!-- /wp:list -->

--- a/test/e2e/specs/editor/blocks/__snapshots__/List-selects-all-transformed-output-3-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/List-selects-all-transformed-output-3-chromium.txt
@@ -1,9 +1,0 @@
-<!-- wp:list -->
-<ul><!-- wp:list-item -->
-<li>1</li>
-<!-- /wp:list-item -->
-
-<!-- wp:list-item -->
-<li>2</li>
-<!-- /wp:list-item --></ul>
-<!-- /wp:list -->

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1158,7 +1158,7 @@ test.describe( 'List (@firefox)', () => {
 		);
 	} );
 
-	test( 'can be created by pasting an empty list', async ( {
+	test( 'can be created by pasting an empty list (-firefox)', async ( {
 		editor,
 		pageUtils,
 	} ) => {
@@ -1176,7 +1176,11 @@ test.describe( 'List (@firefox)', () => {
 		await pageUtils.pressKeyWithModifier( 'secondary', 'M' ); // Emulates CTRL+Shift+Alt + M => toggle code editor
 
 		// Verify no WSOD and content is proper.
-		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
+		expect( await editor.getEditedPostContent() ).toBe( `<!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->` );
 	} );
 
 	test( 'should merge two list with same attributes', async ( {
@@ -1231,7 +1235,15 @@ test.describe( 'List (@firefox)', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '1' );
 
-		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
+		expect( await editor.getEditedPostContent() ).toBe( `<!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->
+
+<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->` );
 	} );
 
 	test( 'selects all transformed output', async ( { editor, page } ) => {
@@ -1250,11 +1262,26 @@ test.describe( 'List (@firefox)', () => {
 		await page.getByRole( 'button', { name: 'List', exact: true } ).click();
 		await page.getByRole( 'menuitem', { name: 'Paragraph' } ).click();
 
-		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
+		expect( await editor.getEditedPostContent() )
+			.toBe( `<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->` );
 
 		await page.getByRole( 'button', { name: 'Paragraph' } ).click();
 		await page.getByRole( 'menuitem', { name: 'List' } ).click();
 
-		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
+		expect( await editor.getEditedPostContent() ).toBe( `<!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li>1</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>2</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->` );
 	} );
 } );

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -3,7 +3,7 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-test.describe( 'List', () => {
+test.describe( 'List (@firefox)', () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
 	} );
@@ -84,7 +84,7 @@ test.describe( 'List', () => {
 		);
 	} );
 
-	test( 'should undo asterisk transform with backspace', async ( {
+	test( 'should undo asterisk transform with backspace (-firefox)', async ( {
 		editor,
 		page,
 	} ) => {
@@ -99,7 +99,7 @@ test.describe( 'List', () => {
 		);
 	} );
 
-	test( 'should undo asterisk transform with backspace after selection changes', async ( {
+	test( 'should undo asterisk transform with backspace after selection changes (-firefox)', async ( {
 		editor,
 		page,
 	} ) => {
@@ -115,7 +115,7 @@ test.describe( 'List', () => {
 		);
 	} );
 
-	test( 'should undo asterisk transform with backspace setting isTyping state', async ( {
+	test( 'should undo asterisk transform with backspace setting isTyping state (-firefox)', async ( {
 		editor,
 		page,
 	} ) => {
@@ -131,7 +131,7 @@ test.describe( 'List', () => {
 		);
 	} );
 
-	test( 'should undo asterisk transform with backspace after selection changes without requestIdleCallback', async ( {
+	test( 'should undo asterisk transform with backspace after selection changes without requestIdleCallback (-firefox)', async ( {
 		editor,
 		page,
 	} ) => {
@@ -148,7 +148,7 @@ test.describe( 'List', () => {
 		);
 	} );
 
-	test( 'should undo asterisk transform with escape', async ( {
+	test( 'should undo asterisk transform with escape (-firefox)', async ( {
 		editor,
 		page,
 	} ) => {
@@ -1009,7 +1009,7 @@ test.describe( 'List', () => {
 		);
 	} );
 
-	test( 'should preserve indentation after merging backward and forward', async ( {
+	test( 'should preserve indentation after merging backward and forward (-firefox)', async ( {
 		editor,
 		page,
 	} ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Adds Firefox e2e tests for the list block. Some tests I had to disable because they are unstable and I couldn't figure out the cause. They pass when testing manually.

## Why?

I added FF e2e testing for the wrong suite in #48210. This change will prevent regressions.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
