### PR TITLE
Adds storybook links to components documentation

### DIFF
--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -6,9 +6,18 @@ Buttons let users take actions and make choices with a single click or tap.
 
 ## Table of contents
 
-1. [Design guidelines](#design-guidelines)
-2. [Development guidelines](#development-guidelines)
-3. [Related components](#related-components)
+1. [Storybook tool](#storybook-tool)
+2. [Design guidelines](#design-guidelines)
+3. [Development guidelines](#development-guidelines)
+4. [Related components](#related-components)
+
+## Storybook tool
+
+Try out the Button component interactively.
+
+The Gutenberg [Storybook tool](https://wordpress.github.io/gutenberg/) enables you to interactively set various options for individual components and then copy the code for use in your project.
+
+[View the Button component on Storybook](https://wordpress.github.io/gutenberg/?path=/story/components-button--default).
 
 ## Design guidelines
 

--- a/packages/components/src/card/card/README.md
+++ b/packages/components/src/card/card/README.md
@@ -2,6 +2,14 @@
 
 `Card` provides a flexible and extensible content container.
 
+## Storybook tool
+
+Try out the Card component interactively.
+
+The Gutenberg [Storybook tool](https://wordpress.github.io/gutenberg/) enables you to interactively set various options for individual components and then copy the code for use in your project.
+
+[View the Card component on Storybook](https://wordpress.github.io/gutenberg/?path=/story/components-card--default).
+
 ## Usage
 
 `Card` also provides a convenient set of [sub-components](#sub-components) such as `CardBody`, `CardHeader`, `CardFooter`, and more (see below).

--- a/packages/components/src/duotone-picker/README.md
+++ b/packages/components/src/duotone-picker/README.md
@@ -1,5 +1,13 @@
 # DuotonePicker & DuotoneSwatch
 
+## Storybook tool
+
+Try out the DuotonePicker component interactively.
+
+The Gutenberg [Storybook tool](https://wordpress.github.io/gutenberg/) enables you to interactively set various options for individual components and then copy the code for use in your project.
+
+[View the DuotonePicker component on Storybook](https://wordpress.github.io/gutenberg/?path=/story/components-duotonepicker--default).
+
 ## Usage
 
 ```jsx

--- a/packages/components/src/font-size-picker/README.md
+++ b/packages/components/src/font-size-picker/README.md
@@ -3,6 +3,14 @@
 FontSizePicker is a React component that renders a UI that allows users to select a font size.
 The component renders a user interface that allows the user to select predefined (common) font sizes and contains an option that allows users to select custom font sizes (by choosing the value) if that functionality is enabled.
 
+## Storybook tool
+
+Try out the FontSizePicker component interactively.
+
+The Gutenberg [Storybook tool](https://wordpress.github.io/gutenberg/) enables you to interactively set various options for individual components and then copy the code for use in your project.
+
+[View the FontSizePicker component on Storybook](https://wordpress.github.io/gutenberg/?path=/docs/components-fontsizepicker--default).
+
 ## Usage
 
 ```jsx

--- a/packages/components/src/range-control/README.md
+++ b/packages/components/src/range-control/README.md
@@ -8,9 +8,18 @@ A RangeControl for volume
 
 ## Table of contents
 
-1. [Design guidelines](#design-guidelines)
-2. [Development guidelines](#development-guidelines)
-3. [Related components](#related-components)
+1. [Storybook tool](#storybook-tool)
+2. [Design guidelines](#design-guidelines)
+3. [Development guidelines](#development-guidelines)
+4. [Related components](#related-components)
+
+## Storybook tool
+
+Try out the RangeControl component interactively.
+
+The Gutenberg [Storybook tool](https://wordpress.github.io/gutenberg/) enables you to interactively set various options for individual components and then copy the code for use in your project.
+
+[View the RangeControl component on Storybook](https://wordpress.github.io/gutenberg/?path=/story/components-rangecontrol--default).
 
 ## Design guidelines
 

--- a/packages/components/src/select-control/README.md
+++ b/packages/components/src/select-control/README.md
@@ -6,10 +6,18 @@ SelectControl allow users to select from a single or multiple option menu. It fu
 
 ## Table of contents
 
-1. [Design guidelines](#design-guidelines)
-2. [Development guidelines](#development-guidelines)
-3. [Related components](#related-components)
+1. [Storybook tool](#storybook-tool)
+2. [Design guidelines](#design-guidelines)
+3. [Development guidelines](#development-guidelines)
+4. [Related components](#related-components)
 
+## Storybook tool
+
+Try out the SelectControl component interactively.
+
+The Gutenberg [Storybook tool](https://wordpress.github.io/gutenberg/) enables you to interactively set various options for individual components and then copy the code for use in your project.
+
+[View the SelectControl component on Storybook](https://wordpress.github.io/gutenberg/?path=/story/components-selectcontrol--default).
 ## Design guidelines
 
 ### Usage


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
As proposed in #48100 this PR adds links to the corresponding [Storybook](https://wordpress.github.io/gutenberg/?path=/story/docs-introduction--page) page on the documentation pages for six components.

Why just six? This PR is to show the links in situ with a view to gathering feedback and suggestions for improvement. Once the final format has been decided on the concept can be extended to the remaining components.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Many developers are still unaware of the existence of, and usefulness of, the Storybook tool. While there are mentions of the Storybook tool in the handbook they are (a) few and far between, (b) not very prominent, and (c) generally merely made in passing.

Putting a link to the corresponding Storybook page in the documentation for each component will increase awareness of the tool among developers by placing it front and centre whenever they access the component reference docs, and provide them with easy access to try out the various options in Storybook and then copy the code into their project.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I added a "Storybook tool" section close to the top of each reference page for six selected components.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
n/a - it's just documentation - but you could test that the link on each page goes to the correct page in Storybook.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
