### PR TITLE
Duotone: Use the style engine to generate CSS for Duotone

### DIFF
--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -464,13 +464,19 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 
 	// !important is needed because these styles render before global styles,
 	// and they should be overriding the duotone filters set by global styles.
-	$filter_style = SCRIPT_DEBUG
-		? $selector . " {\n\tfilter: " . $filter_property . " !important;\n}\n"
-		: $selector . '{filter:' . $filter_property . ' !important;}';
-
-	wp_register_style( $filter_id, false, array(), true, true );
-	wp_add_inline_style( $filter_id, $filter_style );
-	wp_enqueue_style( $filter_id );
+	$filter_style = gutenberg_style_engine_get_stylesheet_from_css_rules(
+		array(
+			array(
+				'selector' => $selector,
+				'declarations' => array(
+					'filter' => $filter_property . ' !important',
+				),
+			),
+		),
+		array(
+			'context' => 'block-supports'
+		)
+	);
 
 	if ( 'unset' !== $colors ) {
 		$filter_svg = gutenberg_get_duotone_filter_svg( $filter_preset );

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -462,13 +462,18 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	}
 	$selector = implode( ', ', $scoped );
 
-	// !important is needed because these styles render before global styles,
-	// and they should be overriding the duotone filters set by global styles.
+	// Calling gutenberg_style_engine_get_stylesheet_from_css_rules ensures that
+	// the styles are rendered in an inline for block supports because we're
+	// useing the `context` option to instruct it so.
 	gutenberg_style_engine_get_stylesheet_from_css_rules(
 		array(
 			array(
 				'selector'     => $selector,
 				'declarations' => array(
+					// !important is needed because these styles
+					// render before global styles,
+					// and they should be overriding the duotone
+					// filters set by global styles.
 					'filter' => $filter_property . ' !important',
 				),
 			),

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -464,7 +464,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 
 	// Calling gutenberg_style_engine_get_stylesheet_from_css_rules ensures that
 	// the styles are rendered in an inline for block supports because we're
-	// useing the `context` option to instruct it so.
+	// using the `context` option to instruct it so.
 	gutenberg_style_engine_get_stylesheet_from_css_rules(
 		array(
 			array(

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -464,17 +464,17 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 
 	// !important is needed because these styles render before global styles,
 	// and they should be overriding the duotone filters set by global styles.
-	$filter_style = gutenberg_style_engine_get_stylesheet_from_css_rules(
+	gutenberg_style_engine_get_stylesheet_from_css_rules(
 		array(
 			array(
-				'selector' => $selector,
+				'selector'     => $selector,
 				'declarations' => array(
 					'filter' => $filter_property . ' !important',
 				),
 			),
 		),
 		array(
-			'context' => 'block-supports'
+			'context' => 'block-supports',
 		)
 	);
 

--- a/lib/experimental/kses.php
+++ b/lib/experimental/kses.php
@@ -65,3 +65,22 @@ function gutenberg_override_core_kses_init_filters() {
 // The 'kses_init_filters' is usually initialized with default priority. Use higher priority to override.
 add_action( 'init', 'gutenberg_override_core_kses_init_filters', 20 );
 add_action( 'set_current_user', 'gutenberg_override_core_kses_init_filters' );
+
+/**
+ * See https://github.com/WordPress/wordpress-develop/pull/4108
+ *
+ * Mark CSS safe if it contains a "filter: url('#wp-duotone-...')" rule.
+ *
+ * This function should not be backported to core.
+ *
+ * @param bool   $allow_css Whether the CSS is allowed.
+ * @param string $css_test_string The CSS to test.
+ */
+function allow_filter_in_styles( $allow_css, $css_test_string ) {
+	if ( strpos( $css_test_string, "filter: url('#wp-duotone" ) !== false ) {
+		return true;
+	}
+	return $allow_css;
+}
+
+add_filter( 'safecss_filter_attr_allow_css', 'allow_filter_in_styles', 10, 2 );

--- a/lib/experimental/kses.php
+++ b/lib/experimental/kses.php
@@ -77,7 +77,10 @@ add_action( 'set_current_user', 'gutenberg_override_core_kses_init_filters' );
  * @param string $css_test_string The CSS to test.
  */
 function allow_filter_in_styles( $allow_css, $css_test_string ) {
-	if ( strpos( $css_test_string, "filter: url('#wp-duotone" ) !== false ) {
+	if ( preg_match(
+		"/^filter: url\('#wp-duotone-[-a-zA-Z0-9]+'\) \!important$/",
+		$css_test_string
+	) ) {
 		return true;
 	}
 	return $allow_css;


### PR DESCRIPTION
## What?
This changes the custom approach for block supports to use the style engine. This means that the CSS is output as part of the block supports CSS block rather than in its own inline style.

## Why?
It's better to use the same code to generate CSS as its more efficient. It also will be slightly more performant as the output on the client is a little smaller.
 
## How?
Using `gutenberg_style_engine_get_stylesheet_from_css_rules`

## Testing Instructions
1. Apply this core patch: https://github.com/WordPress/wordpress-develop/pull/4108
1. Add an image block to a post
2. Add a duotone filter to the image block
3. Open the post in the frontend and confirm that the image block has the correct filter applied.

### Testing Instructions for Keyboard
Check that the image has CSS applied to it in the form:
`filter: url('#wp-duotone-*') !important;`

## Note
Requires this core patch: https://github.com/WordPress/wordpress-develop/pull/4108. I don't see a way to get this fix in to Gutenberg before its in core...
