### PR TITLE
Remove broken site editor redirect

### DIFF
--- a/lib/compat/wordpress-6.2/site-editor.php
+++ b/lib/compat/wordpress-6.2/site-editor.php
@@ -22,24 +22,3 @@ function gutenberg_site_editor_unset_homepage_setting( $settings, $context ) {
 	return $settings;
 }
 add_filter( 'block_editor_settings_all', 'gutenberg_site_editor_unset_homepage_setting', 10, 2 );
-
-/**
- * Overrides the site editor initialization for WordPress 6.2 and cancels the redirection.
- * The logic of this function is not important, we just need to remove the redirection from core.
- *
- * @param string $location Location.
- *
- * @return string Updated location.
- */
-function gutenberg_prevent_site_editor_redirection( $location ) {
-	if ( strpos( $location, 'site-editor.php' ) !== false && strpos( $location, '?' ) !== false ) {
-		return add_query_arg(
-			array( 'postId' => 'none' ),
-			admin_url( 'site-editor.php' )
-		);
-	}
-
-	return $location;
-}
-
-add_filter( 'wp_redirect', 'gutenberg_prevent_site_editor_redirection', 1 );

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -31,13 +31,7 @@ export default function useInitEditedEntityFromURL() {
 		useDispatch( editSiteStore );
 
 	useEffect( () => {
-		if (
-			postType &&
-			postId &&
-			// This is just a special case to support old WP versions that perform redirects.
-			// This code should be removed when we minimum WP version becomes 6.2.
-			postId !== 'none'
-		) {
+		if ( postType && postId ) {
 			switch ( postType ) {
 				case 'wp_template':
 					setTemplate( postId );

--- a/packages/edit-site/src/components/sync-state-with-url/use-sync-path-with-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-sync-path-with-url.js
@@ -13,13 +13,7 @@ export function getPathFromURL( urlParams ) {
 	let path = urlParams?.path ?? '/';
 
 	// Compute the navigator path based on the URL params.
-	if (
-		urlParams?.postType &&
-		urlParams?.postId &&
-		// This is just a special case to support old WP versions that perform redirects.
-		// This code should be removed when we minimum WP version becomes 6.2.
-		urlParams?.postId !== 'none'
-	) {
+	if ( urlParams?.postType && urlParams?.postId ) {
 		switch ( urlParams.postType ) {
 			case 'wp_template':
 			case 'wp_template_part':


### PR DESCRIPTION
## What?

In previous WP versions, when you load the site editor, we used to fetch the home page and redirect to it (adding some params to the url), we don't rely on this behavior anymore and in order to "cancel" the redirect in Gutenberg we had a filter that was supposed to do that. The problem is that that filter doesn't work properly:

 - When we redirect to login (if we're logged out), the filter is triggered as well while it shouldn't be causing a 403.

I'm removing that redirect in this filter. The impact of this change is that in previous WP versions when you load the site editor, it won't load the site editor sidebar in the "root" screen, instead it will load the "home page" that is set as static and opens it in the site editor. I think this is not perfect but it's fine.

**Testing**

There shouldn't be any impact here unless you explicitly load an old WP version (6.1) in addition to the Gutenberg plugin.