### PR TITLE
Post editor: iframe if all blocks are v3

### DIFF
--- a/docs/getting-started/create-block/block-anatomy.md
+++ b/docs/getting-started/create-block/block-anatomy.md
@@ -44,7 +44,7 @@ Most of the properties are set in the `src/block.json` file.
 ```json
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "create-block/gutenpride",
 	"version": "0.1.0",
 	"title": "Gutenpride",

--- a/docs/getting-started/create-block/wp-plugin.md
+++ b/docs/getting-started/create-block/wp-plugin.md
@@ -104,7 +104,7 @@ The `register_block_type` function registers the block we are going to create an
 ```json
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "create-block/gutenpride",
 	"version": "0.1.0",
 	"title": "Gutenpride",

--- a/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
+++ b/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
@@ -205,7 +205,7 @@ For example:
 
 ```json
 {
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "gutenberg-examples/example-02-stylesheets",
 	"title": "Example: Stylesheets",
 	"icon": "universal-access-alt",

--- a/docs/how-to-guides/block-tutorial/block-controls-toolbar-and-sidebar.md
+++ b/docs/how-to-guides/block-tutorial/block-controls-toolbar-and-sidebar.md
@@ -24,7 +24,7 @@ import {
 } from '@wordpress/block-editor';
 
 registerBlockType( 'gutenberg-examples/example-04-controls-esnext', {
-	apiVersion: 2,
+	apiVersion: 3,
 	title: 'Example: Controls (esnext)',
 	icon: 'universal-access-alt',
 	category: 'design',
@@ -208,7 +208,7 @@ import {
 } from '@wordpress/block-editor';
 
 registerBlockType( 'create-block/gutenpride', {
-	apiVersion: 2,
+	apiVersion: 3,
 	attributes: {
 		message: {
 			type: 'string',

--- a/docs/how-to-guides/block-tutorial/block-supports-in-dynamic-blocks.md
+++ b/docs/how-to-guides/block-tutorial/block-supports-in-dynamic-blocks.md
@@ -20,7 +20,7 @@ import {
 } from '@wordpress/block-editor';
 
 registerBlockType( 'gutenberg-examples/example-dynamic', {
-	apiVersion: 2,
+	apiVersion: 3,
 	title: 'Example: last post title',
 	icon: 'megaphone',
 	category: 'widgets',
@@ -119,7 +119,7 @@ function gutenberg_examples_dynamic() {
 	register_block_type(
 		'gutenberg-examples/example-dynamic',
 		array(
-			'api_version'       => 2,
+			'api_version'       => 3,
 			'category'          => 'widgets',
 			'attributes'        => array(
 				'bgColor'   => array( 'type' => 'string' ),
@@ -144,7 +144,7 @@ import { useSelect } from '@wordpress/data';
 import { useBlockProps } from '@wordpress/block-editor';
 
 registerBlockType( 'gutenberg-examples/example-dynamic-block-supports', {
-	apiVersion: 2,
+	apiVersion: 3,
 	title: 'Example: last post title(block supports)',
 	icon: 'megaphone',
 	category: 'widgets',
@@ -195,7 +195,7 @@ function gutenberg_examples_dynamic_block_supports() {
 	register_block_type(
 		'gutenberg-examples/example-dynamic-block-supports',
 		array(
-			'api_version'       => 2,
+			'api_version'       => 3,
 			'category'          => 'widgets',
 			'supports'          => array( 'color' => true ),
 			'render_callback'   => 'gutenberg_examples_dynamic_block_supports_render_callback',

--- a/docs/how-to-guides/block-tutorial/block-supports-in-static-blocks.md
+++ b/docs/how-to-guides/block-tutorial/block-supports-in-static-blocks.md
@@ -16,7 +16,7 @@ import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps, RichText } from '@wordpress/block-editor';
 
 registerBlockType( 'gutenberg-examples/example-03-editable-esnext', {
-	apiVersion: 2,
+	apiVersion: 3,
 	title: 'Example: Basic with block supports',
 	icon: 'universal-access-alt',
 	category: 'design',
@@ -73,7 +73,7 @@ registerBlockType( 'gutenberg-examples/example-03-editable-esnext', {
 	var useBlockProps = blockEditor.useBlockProps;
 
 	blocks.registerBlockType( 'gutenberg-examples/example-03-editable', {
-		apiVersion: 2,
+		apiVersion: 3,
 		title: 'Example: Basic with block supports',
 		icon: 'universal-access-alt',
 		category: 'design',
@@ -127,7 +127,7 @@ Now, let's alter the block.json file for that block, and add the supports key. (
 
 ```json
 {
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "gutenberg-examples/example-03-editable-esnext",
 	"title": "Example: Basic with block supports",
 	"icon": "universal-access-alt",

--- a/docs/how-to-guides/block-tutorial/creating-dynamic-blocks.md
+++ b/docs/how-to-guides/block-tutorial/creating-dynamic-blocks.md
@@ -26,7 +26,7 @@ import { useSelect } from '@wordpress/data';
 import { useBlockProps } from '@wordpress/block-editor';
 
 registerBlockType( 'gutenberg-examples/example-dynamic', {
-	apiVersion: 2,
+	apiVersion: 3,
 	title: 'Example: last post',
 	icon: 'megaphone',
 	category: 'widgets',
@@ -62,7 +62,7 @@ registerBlockType( 'gutenberg-examples/example-dynamic', {
 		useBlockProps = blockEditor.useBlockProps;
 
 	registerBlockType( 'gutenberg-examples/example-dynamic', {
-		apiVersion: 2,
+		apiVersion: 3,
 		title: 'Example: last post',
 		icon: 'megaphone',
 		category: 'widgets',
@@ -132,7 +132,7 @@ function gutenberg_examples_dynamic() {
 	);
 
 	register_block_type( 'gutenberg-examples/example-dynamic', array(
-		'api_version' => 2,
+		'api_version' => 3,
 		'editor_script' => 'gutenberg-examples-dynamic',
 		'render_callback' => 'gutenberg_examples_dynamic_render_callback'
 	) );
@@ -165,7 +165,7 @@ import ServerSideRender from '@wordpress/server-side-render';
 import { useBlockProps } from '@wordpress/block-editor';
 
 registerBlockType( 'gutenberg-examples/example-dynamic', {
-	apiVersion: 2,
+	apiVersion: 3,
 	title: 'Example: last post',
 	icon: 'megaphone',
 	category: 'widgets',
@@ -194,7 +194,7 @@ registerBlockType( 'gutenberg-examples/example-dynamic', {
 		useBlockProps = blockEditor.useBlockProps;
 
 	registerBlockType( 'gutenberg-examples/example-dynamic', {
-		apiVersion: 2,
+		apiVersion: 3,
 		title: 'Example: last post',
 		icon: 'megaphone',
 		category: 'widgets',

--- a/docs/how-to-guides/block-tutorial/introducing-attributes-and-editable-fields.md
+++ b/docs/how-to-guides/block-tutorial/introducing-attributes-and-editable-fields.md
@@ -60,7 +60,7 @@ import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps, RichText } from '@wordpress/block-editor';
 
 registerBlockType( 'gutenberg-examples/example-03-editable-esnext', {
-	apiVersion: 2,
+	apiVersion: 3,
 	title: 'Example: Editable (esnext)',
 	icon: 'universal-access-alt',
 	category: 'design',
@@ -117,7 +117,7 @@ registerBlockType( 'gutenberg-examples/example-03-editable-esnext', {
 	var useBlockProps = blockEditor.useBlockProps;
 
 	blocks.registerBlockType( 'gutenberg-examples/example-03-editable', {
-		apiVersion: 2,
+		apiVersion: 3,
 		title: 'Example: Editable',
 		icon: 'universal-access-alt',
 		category: 'design',

--- a/docs/how-to-guides/block-tutorial/writing-your-first-block-type.md
+++ b/docs/how-to-guides/block-tutorial/writing-your-first-block-type.md
@@ -43,7 +43,7 @@ Create a basic `block.json` file there:
 
 ```json
 {
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"title": "Example: Basic (ESNext)",
 	"name": "gutenberg-examples/example-01-basic-esnext",
 	"category": "layout",
@@ -56,7 +56,7 @@ Create a basic `block.json` file there:
 
 ```json
 {
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"title": "Example: Basic",
 	"name": "gutenberg-examples/example-01-basic",
 	"category": "layout",

--- a/docs/how-to-guides/internationalization.md
+++ b/docs/how-to-guides/internationalization.md
@@ -28,7 +28,7 @@ function myguten_block_init() {
     );
 
     register_block_type( 'myguten/simple', array(
-		'api_version' => 2,
+		'api_version' => 3,
         'editor_script' => 'myguten-script',
     ) );
 }
@@ -46,7 +46,7 @@ import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps } from '@wordpress/block-editor';
 
 registerBlockType( 'myguten/simple', {
-	apiVersion: 2,
+	apiVersion: 3,
 	title: __( 'Simple Block', 'myguten' ),
 	category: 'widgets',
 

--- a/docs/how-to-guides/metabox.md
+++ b/docs/how-to-guides/metabox.md
@@ -152,7 +152,7 @@ function myguten_render_paragraph( $block_attributes, $content ) {
 }
 
 register_block_type( 'core/paragraph', array(
-	'api_version' => 2,
+	'api_version' => 3,
 	'render_callback' => 'myguten_render_paragraph',
 ) );
 ```

--- a/docs/reference-guides/block-api/block-edit-save.md
+++ b/docs/reference-guides/block-api/block-edit-save.md
@@ -14,7 +14,7 @@ import { useBlockProps } from '@wordpress/block-editor';
 
 // ...
 const blockSettings = {
-	apiVersion: 2,
+	apiVersion: 3,
 
 	// ...
 
@@ -30,7 +30,7 @@ const blockSettings = {
 
 ```js
 var blockSettings = {
-	apiVersion: 2,
+	apiVersion: 3,
 
 	// ...
 
@@ -58,7 +58,7 @@ import { useBlockProps } from '@wordpress/block-editor';
 
 // ...
 const blockSettings = {
-	apiVersion: 2,
+	apiVersion: 3,
 
 	// ...
 
@@ -76,7 +76,7 @@ const blockSettings = {
 
 ```js
 var blockSettings = {
-	apiVersion: 2,
+	apiVersion: 3,
 
 	// ...
 

--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -7,7 +7,7 @@ Starting in WordPress 5.8 release, we recommend using the `block.json` metadata 
 ```json
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "my-plugin/notice",
 	"title": "Notice",
 	"category": "text",
@@ -150,10 +150,10 @@ This section describes all the properties that can be added to the `block.json` 
 -   Default: `1`
 
 ```json
-{ "apiVersion": 2 }
+{ "apiVersion": 3 }
 ```
 
-The version of the Block API used by the block. The most recent version is `2` and it was introduced in WordPress 5.6.
+The version of the Block API used by the block. The most recent version is `3` and it was introduced in WordPress 6.3.
 
 See the [the API versions documentation](/docs/reference-guides/block-api/block-api-versions.md) for more details.
 

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -77,6 +77,7 @@ function gutenberg_reregister_core_block_types() {
 				'navigation-link.php'              => 'core/navigation-link',
 				'navigation-submenu.php'           => 'core/navigation-submenu',
 				'page-list.php'                    => 'core/page-list',
+				'page-list-item.php'               => 'core/page-list-item',
 				'pattern.php'                      => 'core/pattern',
 				'post-author.php'                  => 'core/post-author',
 				'post-author-name.php'             => 'core/post-author-name',

--- a/lib/compat/wordpress-6.3/script-loader.php
+++ b/lib/compat/wordpress-6.3/script-loader.php
@@ -42,8 +42,12 @@ function _gutenberg_get_iframed_editor_assets() {
 	$wp_styles->registered  = $current_wp_styles->registered;
 	$wp_scripts->registered = $current_wp_scripts->registered;
 
-	// We do not need reset styles for the iframed editor.
-	$wp_styles->done = array( 'wp-reset-editor-styles' );
+	// We generally do not need reset styles for the iframed editor.
+	// However, if it's a classic theme, margins will be added to every block,
+	// which is reset specifically for list items, so classic themes rely on
+	// these reset styles.
+	$wp_styles->done =
+		wp_theme_has_theme_json() ? array( 'wp-reset-editor-styles' ) : array();
 
 	wp_enqueue_script( 'wp-polyfill' );
 	// Enqueue the `editorStyle` handles for all core block, and dependencies.

--- a/packages/block-editor/src/components/block-edit/test/edit.js
+++ b/packages/block-editor/src/components/block-edit/test/edit.js
@@ -107,7 +107,7 @@ describe( 'Edit', () => {
 		it( 'should assign context', () => {
 			const edit = ( { context } ) => context.value;
 			registerBlockType( 'core/test-block', {
-				apiVersion: 2,
+				apiVersion: 3,
 				category: 'text',
 				title: 'block title',
 				usesContext: [ 'value' ],

--- a/packages/block-editor/src/components/iframe/use-compatibility-styles.js
+++ b/packages/block-editor/src/components/iframe/use-compatibility-styles.js
@@ -38,12 +38,6 @@ export function useCompatibilityStyles() {
 					return accumulator;
 				}
 
-				// Generally, ignore inline styles. We add inline styles belonging to a
-				// stylesheet later, which may or may not match the selectors.
-				if ( ownerNode.tagName !== 'LINK' ) {
-					return accumulator;
-				}
-
 				// Don't try to add the reset styles, which were removed as a dependency
 				// from `edit-blocks` for the iframe since we don't need to reset admin
 				// styles.
@@ -80,16 +74,17 @@ export function useCompatibilityStyles() {
 					// See: https://github.com/WordPress/gutenberg/pull/37466.
 					accumulator.push( ownerNode.cloneNode( true ) );
 
+					const isInline = ownerNode.tagName === 'STYLE';
+
 					// Add inline styles belonging to the stylesheet.
 					const inlineCssId = ownerNode.id.replace(
-						'-css',
-						'-inline-css'
+						isInline ? '-inline-css' : '-css',
+						isInline ? '-css' : '-inline-css'
 					);
-					const inlineCssElement =
-						document.getElementById( inlineCssId );
+					const otherElement = document.getElementById( inlineCssId );
 
-					if ( inlineCssElement ) {
-						accumulator.push( inlineCssElement.cloneNode( true ) );
+					if ( otherElement ) {
+						accumulator.push( otherElement.cloneNode( true ) );
 					}
 				}
 

--- a/packages/block-editor/src/components/iframe/use-compatibility-styles.js
+++ b/packages/block-editor/src/components/iframe/use-compatibility-styles.js
@@ -70,10 +70,6 @@ export function useCompatibilityStyles() {
 				}
 
 				if ( matchFromRules( cssRules ) ) {
-					// Display warning once we have a way to add style dependencies to the editor.
-					// See: https://github.com/WordPress/gutenberg/pull/37466.
-					accumulator.push( ownerNode.cloneNode( true ) );
-
 					const isInline = ownerNode.tagName === 'STYLE';
 
 					// Add inline styles belonging to the stylesheet.
@@ -83,7 +79,15 @@ export function useCompatibilityStyles() {
 					);
 					const otherElement = document.getElementById( inlineCssId );
 
-					if ( otherElement ) {
+					// If the matched stylesheet is inline, add the main
+					// stylesheet before the inline style element.
+					if ( otherElement && isInline ) {
+						accumulator.push( otherElement.cloneNode( true ) );
+					}
+
+					accumulator.push( ownerNode.cloneNode( true ) );
+
+					if ( otherElement && ! isInline ) {
 						accumulator.push( otherElement.cloneNode( true ) );
 					}
 				}

--- a/packages/block-editor/src/components/inspector-controls/README.md
+++ b/packages/block-editor/src/components/inspector-controls/README.md
@@ -23,7 +23,7 @@ import {
 } from '@wordpress/block-editor';
 
 registerBlockType( 'my-plugin/inspector-controls-example', {
-	apiVersion: 2,
+	apiVersion: 3,
 
 	title: 'Inspector controls example',
 

--- a/packages/block-library/src/archives/block.json
+++ b/packages/block-library/src/archives/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/archives",
 	"title": "Archives",
 	"category": "widgets",

--- a/packages/block-library/src/audio/block.json
+++ b/packages/block-library/src/audio/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/audio",
 	"title": "Audio",
 	"category": "media",

--- a/packages/block-library/src/avatar/block.json
+++ b/packages/block-library/src/avatar/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/avatar",
 	"title": "Avatar",
 	"category": "theme",

--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/block",
 	"title": "Reusable block",
 	"category": "reusable",

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/button",
 	"title": "Button",
 	"category": "design",

--- a/packages/block-library/src/buttons/block.json
+++ b/packages/block-library/src/buttons/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/buttons",
 	"title": "Buttons",
 	"category": "design",

--- a/packages/block-library/src/calendar/block.json
+++ b/packages/block-library/src/calendar/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/calendar",
 	"title": "Calendar",
 	"category": "widgets",

--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/categories",
 	"title": "Categories List",
 	"category": "widgets",

--- a/packages/block-library/src/code/block.json
+++ b/packages/block-library/src/code/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/code",
 	"title": "Code",
 	"category": "text",

--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/column",
 	"title": "Column",
 	"category": "design",

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/columns",
 	"title": "Columns",
 	"category": "design",

--- a/packages/block-library/src/comment-author-avatar/block.json
+++ b/packages/block-library/src/comment-author-avatar/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"__experimental": "fse",
 	"name": "core/comment-author-avatar",
 	"title": "Comment Author Avatar (deprecated)",

--- a/packages/block-library/src/comment-author-name/block.json
+++ b/packages/block-library/src/comment-author-name/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/comment-author-name",
 	"title": "Comment Author Name",
 	"category": "theme",

--- a/packages/block-library/src/comment-content/block.json
+++ b/packages/block-library/src/comment-content/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/comment-content",
 	"title": "Comment Content",
 	"category": "theme",

--- a/packages/block-library/src/comment-date/block.json
+++ b/packages/block-library/src/comment-date/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/comment-date",
 	"title": "Comment Date",
 	"category": "theme",

--- a/packages/block-library/src/comment-edit-link/block.json
+++ b/packages/block-library/src/comment-edit-link/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/comment-edit-link",
 	"title": "Comment Edit Link",
 	"category": "theme",

--- a/packages/block-library/src/comment-reply-link/block.json
+++ b/packages/block-library/src/comment-reply-link/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/comment-reply-link",
 	"title": "Comment Reply Link",
 	"category": "theme",

--- a/packages/block-library/src/comment-template/block.json
+++ b/packages/block-library/src/comment-template/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/comment-template",
 	"title": "Comment Template",
 	"category": "design",

--- a/packages/block-library/src/comments-pagination-next/block.json
+++ b/packages/block-library/src/comments-pagination-next/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/comments-pagination-next",
 	"title": "Comments Next Page",
 	"category": "theme",

--- a/packages/block-library/src/comments-pagination-numbers/block.json
+++ b/packages/block-library/src/comments-pagination-numbers/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/comments-pagination-numbers",
 	"title": "Comments Page Numbers",
 	"category": "theme",

--- a/packages/block-library/src/comments-pagination-previous/block.json
+++ b/packages/block-library/src/comments-pagination-previous/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/comments-pagination-previous",
 	"title": "Comments Previous Page",
 	"category": "theme",

--- a/packages/block-library/src/comments-pagination/block.json
+++ b/packages/block-library/src/comments-pagination/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/comments-pagination",
 	"title": "Comments Pagination",
 	"category": "theme",

--- a/packages/block-library/src/comments-title/block.json
+++ b/packages/block-library/src/comments-title/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/comments-title",
 	"title": "Comments Title",
 	"category": "theme",

--- a/packages/block-library/src/comments/block.json
+++ b/packages/block-library/src/comments/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/comments",
 	"title": "Comments",
 	"category": "theme",

--- a/packages/block-library/src/comments/deprecated.js
+++ b/packages/block-library/src/comments/deprecated.js
@@ -12,7 +12,7 @@ const v1 = {
 			default: 'div',
 		},
 	},
-	apiVersion: 2,
+	apiVersion: 3,
 	supports: {
 		align: [ 'wide', 'full' ],
 		html: false,

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/cover",
 	"title": "Cover",
 	"category": "media",

--- a/packages/block-library/src/details/block.json
+++ b/packages/block-library/src/details/block.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
+	"__experimental": true,
 	"name": "core/details",
 	"title": "Details",
 	"category": "text",

--- a/packages/block-library/src/details/block.json
+++ b/packages/block-library/src/details/block.json
@@ -1,7 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
-	"__experimental": true,
 	"name": "core/details",
 	"title": "Details",
 	"category": "text",

--- a/packages/block-library/src/embed/block.json
+++ b/packages/block-library/src/embed/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/embed",
 	"title": "Embed",
 	"category": "embed",

--- a/packages/block-library/src/file/block.json
+++ b/packages/block-library/src/file/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/file",
 	"title": "File",
 	"category": "media",

--- a/packages/block-library/src/freeform/block.json
+++ b/packages/block-library/src/freeform/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/freeform",
 	"title": "Classic",
 	"category": "text",

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/gallery",
 	"title": "Gallery",
 	"category": "media",

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/group",
 	"title": "Group",
 	"category": "design",

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/heading",
 	"title": "Heading",
 	"category": "text",

--- a/packages/block-library/src/home-link/block.json
+++ b/packages/block-library/src/home-link/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/home-link",
 	"category": "design",
 	"parent": [ "core/navigation" ],

--- a/packages/block-library/src/html/block.json
+++ b/packages/block-library/src/html/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/html",
 	"title": "Custom HTML",
 	"category": "widgets",

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/image",
 	"title": "Image",
 	"category": "media",

--- a/packages/block-library/src/latest-comments/block.json
+++ b/packages/block-library/src/latest-comments/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/latest-comments",
 	"title": "Latest Comments",
 	"category": "widgets",

--- a/packages/block-library/src/latest-posts/block.json
+++ b/packages/block-library/src/latest-posts/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/latest-posts",
 	"title": "Latest Posts",
 	"category": "widgets",

--- a/packages/block-library/src/list-item/block.json
+++ b/packages/block-library/src/list-item/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/list-item",
 	"title": "List item",
 	"category": "text",

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/list",
 	"title": "List",
 	"category": "text",

--- a/packages/block-library/src/loginout/block.json
+++ b/packages/block-library/src/loginout/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/loginout",
 	"title": "Login/out",
 	"category": "theme",

--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/media-text",
 	"title": "Media & Text",
 	"category": "media",

--- a/packages/block-library/src/missing/block.json
+++ b/packages/block-library/src/missing/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/missing",
 	"title": "Unsupported",
 	"category": "text",

--- a/packages/block-library/src/more/block.json
+++ b/packages/block-library/src/more/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/more",
 	"title": "More",
 	"category": "design",

--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/navigation-link",
 	"title": "Custom Link",
 	"category": "design",

--- a/packages/block-library/src/navigation-submenu/block.json
+++ b/packages/block-library/src/navigation-submenu/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/navigation-submenu",
 	"title": "Submenu",
 	"category": "design",

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/navigation",
 	"title": "Navigation",
 	"category": "theme",

--- a/packages/block-library/src/nextpage/block.json
+++ b/packages/block-library/src/nextpage/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/nextpage",
 	"title": "Page Break",
 	"category": "design",

--- a/packages/block-library/src/page-list-item/block.json
+++ b/packages/block-library/src/page-list-item/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/page-list-item",
 	"title": "Page List Item",
 	"category": "widgets",

--- a/packages/block-library/src/page-list-item/index.php
+++ b/packages/block-library/src/page-list-item/index.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Server-side rendering of the `core/page-list-item` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Registers the `core/page-list-item` block on server.
+ */
+function register_block_core_page_list_item() {
+	register_block_type_from_metadata( __DIR__ . '/page-list-item' );
+}
+add_action( 'init', 'register_block_core_page_list_item' );

--- a/packages/block-library/src/page-list/block.json
+++ b/packages/block-library/src/page-list/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/page-list",
 	"title": "Page List",
 	"category": "widgets",

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/paragraph",
 	"title": "Paragraph",
 	"category": "text",

--- a/packages/block-library/src/pattern/block.json
+++ b/packages/block-library/src/pattern/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/pattern",
 	"title": "Pattern",
 	"category": "theme",

--- a/packages/block-library/src/post-author-biography/block.json
+++ b/packages/block-library/src/post-author-biography/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/post-author-biography",
 	"title": "Post Author Biography",
 	"category": "theme",

--- a/packages/block-library/src/post-author-name/block.json
+++ b/packages/block-library/src/post-author-name/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/post-author-name",
 	"title": "Post Author Name",
 	"category": "theme",

--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/post-author",
 	"title": "Post Author",
 	"category": "theme",

--- a/packages/block-library/src/post-comment/block.json
+++ b/packages/block-library/src/post-comment/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"__experimental": "fse",
 	"name": "core/post-comment",
 	"title": "Post Comment (deprecated)",

--- a/packages/block-library/src/post-comments-count/block.json
+++ b/packages/block-library/src/post-comments-count/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"__experimental": "fse",
 	"name": "core/post-comments-count",
 	"title": "Post Comments Count",

--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/post-comments-form",
 	"title": "Post Comments Form",
 	"category": "theme",

--- a/packages/block-library/src/post-comments-link/block.json
+++ b/packages/block-library/src/post-comments-link/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"__experimental": "fse",
 	"name": "core/post-comments-link",
 	"title": "Post Comments Link",

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/post-content",
 	"title": "Post Content",
 	"category": "theme",

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/post-date",
 	"title": "Post Date",
 	"category": "theme",

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/post-excerpt",
 	"title": "Post Excerpt",
 	"category": "theme",

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/post-featured-image",
 	"title": "Post Featured Image",
 	"category": "theme",

--- a/packages/block-library/src/post-navigation-link/block.json
+++ b/packages/block-library/src/post-navigation-link/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/post-navigation-link",
 	"title": "Post Navigation Link",
 	"category": "theme",

--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/post-template",
 	"title": "Post Template",
 	"category": "theme",

--- a/packages/block-library/src/post-terms/block.json
+++ b/packages/block-library/src/post-terms/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/post-terms",
 	"title": "Post Terms",
 	"category": "theme",

--- a/packages/block-library/src/post-time-to-read/block.json
+++ b/packages/block-library/src/post-time-to-read/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"__experimental": true,
 	"name": "core/post-time-to-read",
 	"title": "Time To Read",

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/post-title",
 	"title": "Post Title",
 	"category": "theme",

--- a/packages/block-library/src/preformatted/block.json
+++ b/packages/block-library/src/preformatted/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/preformatted",
 	"title": "Preformatted",
 	"category": "text",

--- a/packages/block-library/src/pullquote/block.json
+++ b/packages/block-library/src/pullquote/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/pullquote",
 	"title": "Pullquote",
 	"category": "text",

--- a/packages/block-library/src/query-no-results/block.json
+++ b/packages/block-library/src/query-no-results/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/query-no-results",
 	"title": "No results",
 	"category": "theme",

--- a/packages/block-library/src/query-pagination-next/block.json
+++ b/packages/block-library/src/query-pagination-next/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/query-pagination-next",
 	"title": "Next Page",
 	"category": "theme",

--- a/packages/block-library/src/query-pagination-numbers/block.json
+++ b/packages/block-library/src/query-pagination-numbers/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/query-pagination-numbers",
 	"title": "Page Numbers",
 	"category": "theme",

--- a/packages/block-library/src/query-pagination-previous/block.json
+++ b/packages/block-library/src/query-pagination-previous/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/query-pagination-previous",
 	"title": "Previous Page",
 	"category": "theme",

--- a/packages/block-library/src/query-pagination/block.json
+++ b/packages/block-library/src/query-pagination/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/query-pagination",
 	"title": "Pagination",
 	"category": "theme",

--- a/packages/block-library/src/query-title/block.json
+++ b/packages/block-library/src/query-title/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/query-title",
 	"title": "Query Title",
 	"category": "theme",

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/query",
 	"title": "Query Loop",
 	"category": "theme",

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/quote",
 	"title": "Quote",
 	"category": "text",

--- a/packages/block-library/src/read-more/block.json
+++ b/packages/block-library/src/read-more/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/read-more",
 	"title": "Read More",
 	"category": "theme",

--- a/packages/block-library/src/rss/block.json
+++ b/packages/block-library/src/rss/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/rss",
 	"title": "RSS",
 	"category": "widgets",

--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/search",
 	"title": "Search",
 	"category": "widgets",

--- a/packages/block-library/src/separator/block.json
+++ b/packages/block-library/src/separator/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/separator",
 	"title": "Separator",
 	"category": "design",

--- a/packages/block-library/src/shortcode/block.json
+++ b/packages/block-library/src/shortcode/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/shortcode",
 	"title": "Shortcode",
 	"category": "widgets",

--- a/packages/block-library/src/site-logo/block.json
+++ b/packages/block-library/src/site-logo/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/site-logo",
 	"title": "Site Logo",
 	"category": "theme",

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/site-tagline",
 	"title": "Site Tagline",
 	"category": "theme",

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/site-title",
 	"title": "Site Title",
 	"category": "theme",

--- a/packages/block-library/src/social-link/block.json
+++ b/packages/block-library/src/social-link/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/social-link",
 	"title": "Social Icon",
 	"category": "widgets",

--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/social-links",
 	"title": "Social Icons",
 	"category": "widgets",

--- a/packages/block-library/src/spacer/block.json
+++ b/packages/block-library/src/spacer/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/spacer",
 	"title": "Spacer",
 	"category": "design",

--- a/packages/block-library/src/table-of-contents/block.json
+++ b/packages/block-library/src/table-of-contents/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"__experimental": true,
 	"name": "core/table-of-contents",
 	"title": "Table of Contents",

--- a/packages/block-library/src/table/block.json
+++ b/packages/block-library/src/table/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/table",
 	"title": "Table",
 	"category": "text",

--- a/packages/block-library/src/tag-cloud/block.json
+++ b/packages/block-library/src/tag-cloud/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/tag-cloud",
 	"title": "Tag Cloud",
 	"category": "widgets",

--- a/packages/block-library/src/template-part/block.json
+++ b/packages/block-library/src/template-part/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/template-part",
 	"title": "Template Part",
 	"category": "theme",

--- a/packages/block-library/src/term-description/block.json
+++ b/packages/block-library/src/term-description/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/term-description",
 	"title": "Term Description",
 	"category": "theme",

--- a/packages/block-library/src/text-columns/block.json
+++ b/packages/block-library/src/text-columns/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/text-columns",
 	"title": "Text Columns (deprecated)",
 	"icon": "columns",

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/verse",
 	"title": "Verse",
 	"category": "text",

--- a/packages/block-library/src/video/block.json
+++ b/packages/block-library/src/video/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/video",
 	"title": "Video",
 	"category": "media",

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -362,7 +362,7 @@ describe( 'blocks', () => {
 			const blockName = 'core/test-block-with-incompatible-keys';
 			unstable__bootstrapServerSideBlockDefinitions( {
 				[ blockName ]: {
-					api_version: 2,
+					api_version: 3,
 					provides_context: {
 						fontSize: 'fontSize',
 					},
@@ -375,7 +375,7 @@ describe( 'blocks', () => {
 			};
 			registerBlockType( blockName, blockType );
 			expect( getBlockType( blockName ) ).toEqual( {
-				apiVersion: 2,
+				apiVersion: 3,
 				name: blockName,
 				save: expect.any( Function ),
 				title: 'block title',
@@ -403,7 +403,7 @@ describe( 'blocks', () => {
 			} );
 			unstable__bootstrapServerSideBlockDefinitions( {
 				[ blockName ]: {
-					apiVersion: 2,
+					apiVersion: 3,
 					category: 'ignored',
 				},
 			} );
@@ -413,7 +413,7 @@ describe( 'blocks', () => {
 			};
 			registerBlockType( blockName, blockType );
 			expect( getBlockType( blockName ) ).toEqual( {
-				apiVersion: 2,
+				apiVersion: 3,
 				name: blockName,
 				save: expect.any( Function ),
 				title: 'block title',

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -220,7 +220,7 @@ const getPluginTemplate = async ( templateName ) => {
 const getDefaultValues = ( pluginTemplate, variant ) => {
 	return {
 		$schema: 'https://schemas.wp.org/trunk/block.json',
-		apiVersion: 2,
+		apiVersion: 3,
 		namespace: 'create-block',
 		category: 'widgets',
 		author: 'The WordPress Contributors',

--- a/packages/e2e-test-utils-playwright/src/page-utils/drag-files.ts
+++ b/packages/e2e-test-utils-playwright/src/page-utils/drag-files.ts
@@ -9,7 +9,7 @@ import { getType } from 'mime';
  * Internal dependencies
  */
 import type { PageUtils } from './index';
-import type { Locator } from '@playwright/test';
+import type { ElementHandle, Locator } from '@playwright/test';
 
 type FileObject = {
 	name: string;
@@ -141,21 +141,25 @@ async function dragFiles(
 
 		/**
 		 * Drop the files at the current position.
+		 *
+		 * @param locator
 		 */
-		drop: async () => {
-			const topMostElement = await this.page.evaluateHandle(
-				( { x, y } ) => {
-					return document.elementFromPoint( x, y );
-				},
-				position
-			);
-			const elementHandle = topMostElement.asElement();
+		drop: async ( locator: Locator | ElementHandle | null ) => {
+			if ( ! locator ) {
+				const topMostElement = await this.page.evaluateHandle(
+					( { x, y } ) => {
+						return document.elementFromPoint( x, y );
+					},
+					position
+				);
+				locator = topMostElement.asElement();
+			}
 
-			if ( ! elementHandle ) {
+			if ( ! locator ) {
 				throw new Error( 'Element not found.' );
 			}
 
-			await elementHandle.dispatchEvent( 'drop', { dataTransfer } );
+			await locator.dispatchEvent( 'drop', { dataTransfer } );
 
 			await cdpSession.detach();
 		},

--- a/packages/e2e-test-utils-playwright/src/page-utils/press-keys.ts
+++ b/packages/e2e-test-utils-playwright/src/page-utils/press-keys.ts
@@ -49,6 +49,9 @@ export function setClipboardData(
 async function emulateClipboard( page: Page, type: 'copy' | 'cut' | 'paste' ) {
 	clipboardDataHolder = await page.evaluate(
 		( [ _type, _clipboardData ] ) => {
+			const canvasDoc =
+				// @ts-ignore
+				document.activeElement?.contentDocument ?? document;
 			const clipboardDataTransfer = new DataTransfer();
 
 			if ( _type === 'paste' ) {
@@ -61,7 +64,7 @@ async function emulateClipboard( page: Page, type: 'copy' | 'cut' | 'paste' ) {
 					_clipboardData.html
 				);
 			} else {
-				const selection = window.getSelection()!;
+				const selection = canvasDoc.defaultView.getSelection()!;
 				const plainText = selection.toString();
 				let html = plainText;
 				if ( selection.rangeCount ) {
@@ -70,7 +73,8 @@ async function emulateClipboard( page: Page, type: 'copy' | 'cut' | 'paste' ) {
 					html = Array.from( fragment.childNodes )
 						.map(
 							( node ) =>
-								( node as Element ).outerHTML ?? node.nodeValue
+								( node as Element ).outerHTML ??
+								( node as Element ).nodeValue
 						)
 						.join( '' );
 				}
@@ -78,7 +82,7 @@ async function emulateClipboard( page: Page, type: 'copy' | 'cut' | 'paste' ) {
 				clipboardDataTransfer.setData( 'text/html', html );
 			}
 
-			document.activeElement?.dispatchEvent(
+			canvasDoc.activeElement?.dispatchEvent(
 				new ClipboardEvent( _type, {
 					bubbles: true,
 					cancelable: true,

--- a/packages/e2e-test-utils/src/click-block-appender.js
+++ b/packages/e2e-test-utils/src/click-block-appender.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import { canvas } from './canvas';
+
+/**
  * Clicks the default block appender.
  */
 export async function clickBlockAppender() {
@@ -6,7 +11,7 @@ export async function clickBlockAppender() {
 	await page.evaluate( () =>
 		window.wp.data.dispatch( 'core/block-editor' ).clearSelectedBlock()
 	);
-	const appender = await page.waitForSelector(
+	const appender = await canvas().waitForSelector(
 		'.block-editor-default-block-appender__content'
 	);
 	await appender.click();

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -261,7 +261,7 @@ export async function insertFromGlobalInserter( category, searchTerm ) {
 
 	// Extra wait for the reusable block to be ready.
 	if ( category === 'Reusable' ) {
-		await page.waitForSelector(
+		await canvas().waitForSelector(
 			'.block-library-block__reusable-block-container'
 		);
 	}

--- a/packages/e2e-test-utils/src/press-key-with-modifier.js
+++ b/packages/e2e-test-utils/src/press-key-with-modifier.js
@@ -24,8 +24,9 @@ import { modifiers, SHIFT, ALT, CTRL } from '@wordpress/keycodes';
 async function emulateSelectAll() {
 	await page.evaluate( () => {
 		const isMac = /Mac|iPod|iPhone|iPad/.test( window.navigator.platform );
+		const canvasDoc = document.activeElement.contentDocument ?? document;
 
-		document.activeElement.dispatchEvent(
+		canvasDoc.activeElement.dispatchEvent(
 			new KeyboardEvent( 'keydown', {
 				bubbles: true,
 				cancelable: true,
@@ -58,14 +59,14 @@ async function emulateSelectAll() {
 		} );
 
 		const wasPrevented =
-			! document.activeElement.dispatchEvent( preventableEvent ) ||
+			! canvasDoc.activeElement.dispatchEvent( preventableEvent ) ||
 			preventableEvent.defaultPrevented;
 
 		if ( ! wasPrevented ) {
-			document.execCommand( 'selectall', false, null );
+			canvasDoc.execCommand( 'selectall', false, null );
 		}
 
-		document.activeElement.dispatchEvent(
+		canvasDoc.activeElement.dispatchEvent(
 			new KeyboardEvent( 'keyup', {
 				bubbles: true,
 				cancelable: true,
@@ -103,10 +104,12 @@ export async function setClipboardData( { plainText = '', html = '' } ) {
 
 async function emulateClipboard( type ) {
 	await page.evaluate( ( _type ) => {
+		const canvasDoc = document.activeElement.contentDocument ?? document;
+
 		if ( _type !== 'paste' ) {
 			window._clipboardData = new DataTransfer();
 
-			const selection = window.getSelection();
+			const selection = canvasDoc.defaultView.getSelection();
 			const plainText = selection.toString();
 			let html = plainText;
 
@@ -123,7 +126,7 @@ async function emulateClipboard( type ) {
 			window._clipboardData.setData( 'text/html', html );
 		}
 
-		document.activeElement.dispatchEvent(
+		canvasDoc.activeElement.dispatchEvent(
 			new ClipboardEvent( _type, {
 				bubbles: true,
 				cancelable: true,

--- a/packages/e2e-tests/plugins/iframed-block/block.json
+++ b/packages/e2e-tests/plugins/iframed-block/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/iframed-block",
 	"title": "Iframed Block",
 	"category": "text",

--- a/packages/e2e-tests/plugins/iframed-inline-styles/block.json
+++ b/packages/e2e-tests/plugins/iframed-inline-styles/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/iframed-inline-styles",
 	"title": "Iframed Inline Styles",
 	"category": "text",

--- a/packages/e2e-tests/plugins/iframed-inline-styles/editor.js
+++ b/packages/e2e-tests/plugins/iframed-inline-styles/editor.js
@@ -4,7 +4,7 @@
 	const { useBlockProps } = blockEditor;
 
 	registerBlockType( 'test/iframed-inline-styles', {
-		apiVersion: 2,
+		apiVersion: 3,
 		edit: function Edit() {
 			return el( 'div', useBlockProps(), 'Edit' );
 		},

--- a/packages/e2e-tests/plugins/iframed-masonry-block/block.json
+++ b/packages/e2e-tests/plugins/iframed-masonry-block/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/iframed-masonry-block",
 	"title": "Iframed Masonry Block",
 	"category": "text",

--- a/packages/e2e-tests/plugins/iframed-masonry-block/editor.js
+++ b/packages/e2e-tests/plugins/iframed-masonry-block/editor.js
@@ -31,7 +31,7 @@
 	];
 
 	registerBlockType( 'test/iframed-masonry-block', {
-		apiVersion: 2,
+		apiVersion: 3,
 		edit: function Edit() {
 			const ref = useRefEffect( ( node ) => {
 				const { ownerDocument } = node;

--- a/packages/e2e-tests/plugins/iframed-multiple-stylesheets/block.json
+++ b/packages/e2e-tests/plugins/iframed-multiple-stylesheets/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/iframed-multiple-stylesheets",
 	"title": "Iframed Multiple Stylesheets",
 	"category": "text",

--- a/packages/e2e-tests/plugins/iframed-multiple-stylesheets/editor.js
+++ b/packages/e2e-tests/plugins/iframed-multiple-stylesheets/editor.js
@@ -4,7 +4,7 @@
 	const { useBlockProps } = blockEditor;
 
 	registerBlockType( 'test/iframed-multiple-stylesheets', {
-		apiVersion: 2,
+		apiVersion: 3,
 		edit: function Edit() {
 			return el( 'div', useBlockProps(), 'Edit' );
 		},

--- a/packages/e2e-tests/specs/editor/blocks/post-title.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/post-title.test.js
@@ -5,6 +5,7 @@ import {
 	createNewPost,
 	insertBlock,
 	saveDraft,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Post Title block', () => {
@@ -17,8 +18,8 @@ describe( 'Post Title block', () => {
 		await insertBlock( 'Post Title' );
 		const editablePostTitleSelector =
 			'.wp-block-post-title[contenteditable="true"]';
-		await page.waitForSelector( editablePostTitleSelector );
-		await page.focus( editablePostTitleSelector );
+		await canvas().waitForSelector( editablePostTitleSelector );
+		await canvas().focus( editablePostTitleSelector );
 
 		// Create a second list item.
 		await page.keyboard.type( 'Just tweaking the post title' );
@@ -26,7 +27,7 @@ describe( 'Post Title block', () => {
 		await saveDraft();
 		await page.reload();
 		await page.waitForSelector( '.edit-post-layout' );
-		const title = await page.$eval(
+		const title = await canvas().$eval(
 			'.editor-post-title__input',
 			( element ) => element.textContent
 		);

--- a/packages/e2e-tests/specs/editor/blocks/site-title.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/site-title.test.js
@@ -9,6 +9,7 @@ import {
 	pressKeyWithModifier,
 	setOption,
 	openDocumentSettingsSidebar,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 const saveEntities = async () => {
@@ -45,8 +46,8 @@ describe( 'Site Title block', () => {
 		await insertBlock( 'Site Title' );
 		const editableSiteTitleSelector =
 			'[aria-label="Block: Site Title"] a[contenteditable="true"]';
-		await page.waitForSelector( editableSiteTitleSelector );
-		await page.focus( editableSiteTitleSelector );
+		await canvas().waitForSelector( editableSiteTitleSelector );
+		await canvas().focus( editableSiteTitleSelector );
 		await pressKeyWithModifier( 'primary', 'a' );
 
 		await page.keyboard.type( 'New Site Title' );

--- a/packages/e2e-tests/specs/editor/plugins/annotations.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/annotations.test.js
@@ -29,6 +29,13 @@ describe( 'Annotations', () => {
 
 	beforeEach( async () => {
 		await createNewPost();
+		// To do: run with iframe.
+		await page.evaluate( () => {
+			window.wp.blocks.registerBlockType( 'test/v2', {
+				apiVersion: '2',
+				title: 'test',
+			} );
+		} );
 	} );
 
 	/**

--- a/packages/e2e-tests/specs/editor/plugins/annotations.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/annotations.test.js
@@ -8,6 +8,7 @@ import {
 	clickOnMoreMenuItem,
 	createNewPost,
 	deactivatePlugin,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 const clickOnBlockSettingsMenuItem = async ( buttonLabel ) => {
@@ -51,7 +52,7 @@ describe( 'Annotations', () => {
 			await page.$x( "//button[contains(text(), 'Add annotation')]" )
 		 )[ 0 ];
 		await addAnnotationButton.click();
-		await page.evaluate( () =>
+		await canvas().evaluate( () =>
 			document.querySelector( '.wp-block-paragraph' ).focus()
 		);
 	}
@@ -67,7 +68,7 @@ describe( 'Annotations', () => {
 			await page.$x( "//button[contains(text(), 'Remove annotations')]" )
 		 )[ 0 ];
 		await addAnnotationButton.click();
-		await page.evaluate( () =>
+		await canvas().evaluate( () =>
 			document.querySelector( '[contenteditable]' ).focus()
 		);
 	}
@@ -78,11 +79,11 @@ describe( 'Annotations', () => {
 	 * @return {Promise<string>} The annotated text.
 	 */
 	async function getAnnotatedText() {
-		const annotations = await page.$$( ANNOTATIONS_SELECTOR );
+		const annotations = await canvas().$$( ANNOTATIONS_SELECTOR );
 
 		const annotation = annotations[ 0 ];
 
-		return await page.evaluate( ( el ) => el.innerText, annotation );
+		return await canvas().evaluate( ( el ) => el.innerText, annotation );
 	}
 
 	/**
@@ -91,7 +92,7 @@ describe( 'Annotations', () => {
 	 * @return {Promise<string>} Inner HTML.
 	 */
 	async function getRichTextInnerHTML() {
-		const htmlContent = await page.$$( '.wp-block-paragraph' );
+		const htmlContent = await canvas().$$( '.wp-block-paragraph' );
 		return await page.evaluate( ( el ) => {
 			return el.innerHTML;
 		}, htmlContent[ 0 ] );
@@ -102,12 +103,12 @@ describe( 'Annotations', () => {
 
 		await clickOnMoreMenuItem( 'Annotations' );
 
-		let annotations = await page.$$( ANNOTATIONS_SELECTOR );
+		let annotations = await canvas().$$( ANNOTATIONS_SELECTOR );
 		expect( annotations ).toHaveLength( 0 );
 
 		await annotateFirstBlock( 9, 13 );
 
-		annotations = await page.$$( ANNOTATIONS_SELECTOR );
+		annotations = await canvas().$$( ANNOTATIONS_SELECTOR );
 		expect( annotations ).toHaveLength( 1 );
 
 		const text = await getAnnotatedText();
@@ -115,7 +116,7 @@ describe( 'Annotations', () => {
 
 		await clickOnBlockSettingsMenuItem( 'Edit as HTML' );
 
-		const htmlContent = await page.$$(
+		const htmlContent = await canvas().$$(
 			'.block-editor-block-list__block-html-textarea'
 		);
 		const html = await page.evaluate( ( el ) => {
@@ -136,7 +137,7 @@ describe( 'Annotations', () => {
 		await page.keyboard.type( 'D' );
 
 		await removeAnnotations();
-		const htmlContent = await page.$$( '.wp-block-paragraph' );
+		const htmlContent = await canvas().$$( '.wp-block-paragraph' );
 		const html = await page.evaluate( ( el ) => {
 			return el.innerHTML;
 		}, htmlContent[ 0 ] );

--- a/packages/e2e-tests/specs/editor/plugins/block-variations.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-variations.test.js
@@ -11,6 +11,7 @@ import {
 	openDocumentSettingsSidebar,
 	togglePreferencesOption,
 	toggleMoreMenu,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Block variations', () => {
@@ -45,7 +46,7 @@ describe( 'Block variations', () => {
 		await insertBlock( 'Large Quote' );
 
 		expect(
-			await page.$(
+			await canvas().$(
 				'.wp-block[data-type="core/quote"] blockquote.is-style-large'
 			)
 		).toBeDefined();
@@ -58,7 +59,7 @@ describe( 'Block variations', () => {
 		await page.keyboard.press( 'Enter' );
 
 		expect(
-			await page.$(
+			await canvas().$(
 				'.wp-block[data-type="core/quote"] blockquote.is-style-large'
 			)
 		).toBeDefined();
@@ -75,7 +76,7 @@ describe( 'Block variations', () => {
 	test( 'Insert the Success Message block variation', async () => {
 		await insertBlock( 'Success Message' );
 
-		const successMessageBlock = await page.$(
+		const successMessageBlock = await canvas().$(
 			'.wp-block[data-type="core/paragraph"]'
 		);
 		expect( successMessageBlock ).toBeDefined();
@@ -86,12 +87,12 @@ describe( 'Block variations', () => {
 	test( 'Pick the additional variation in the inserted Columns block', async () => {
 		await insertBlock( 'Columns' );
 
-		const fourColumnsVariation = await page.waitForSelector(
+		const fourColumnsVariation = await canvas().waitForSelector(
 			'.wp-block[data-type="core/columns"] .block-editor-block-variation-picker__variation[aria-label="Four columns"]'
 		);
 		await fourColumnsVariation.click();
 		expect(
-			await page.$$(
+			await canvas().$$(
 				'.wp-block[data-type="core/columns"] .wp-block[data-type="core/column"]'
 			)
 		).toHaveLength( 4 );

--- a/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
@@ -12,6 +12,7 @@ import {
 	pressKeyTimes,
 	pressKeyWithModifier,
 	setPostContent,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'cpt locking', () => {
@@ -35,7 +36,7 @@ describe( 'cpt locking', () => {
 	};
 
 	const shouldNotAllowBlocksToBeRemoved = async () => {
-		await page.type(
+		await canvas().type(
 			'.block-editor-rich-text__editable[data-type="core/paragraph"]',
 			'p1'
 		);
@@ -46,12 +47,12 @@ describe( 'cpt locking', () => {
 	};
 
 	const shouldAllowBlocksToBeMoved = async () => {
-		await page.click(
+		await canvas().click(
 			'div > .block-editor-rich-text__editable[data-type="core/paragraph"]'
 		);
 		expect( await page.$( 'button[aria-label="Move up"]' ) ).not.toBeNull();
 		await page.click( 'button[aria-label="Move up"]' );
-		await page.type(
+		await canvas().type(
 			'div > .block-editor-rich-text__editable[data-type="core/paragraph"]',
 			'p1'
 		);
@@ -71,14 +72,14 @@ describe( 'cpt locking', () => {
 		);
 
 		it( 'should not allow blocks to be moved', async () => {
-			await page.click(
+			await canvas().click(
 				'.block-editor-rich-text__editable[data-type="core/paragraph"]'
 			);
 			expect( await page.$( 'button[aria-label="Move up"]' ) ).toBeNull();
 		} );
 
 		it( 'should not error when deleting the cotents of a paragraph', async () => {
-			await page.click(
+			await canvas().click(
 				'.block-editor-block-list__block[data-type="core/paragraph"]'
 			);
 			const textToType = 'Paragraph';
@@ -88,7 +89,7 @@ describe( 'cpt locking', () => {
 		} );
 
 		it( 'should insert line breaks when using enter and shift-enter', async () => {
-			await page.click(
+			await canvas().click(
 				'.block-editor-block-list__block[data-type="core/paragraph"]'
 			);
 			await page.keyboard.type( 'First line' );
@@ -118,12 +119,14 @@ describe( 'cpt locking', () => {
 		} );
 
 		it( 'should not allow blocks to be inserted in inner blocks', async () => {
-			await page.click( 'button[aria-label="Two columns; equal split"]' );
+			await canvas().click(
+				'button[aria-label="Two columns; equal split"]'
+			);
 			await page.evaluate(
 				() => new Promise( window.requestIdleCallback )
 			);
 			expect(
-				await page.$(
+				await canvas().$(
 					'.wp-block-column .block-editor-button-block-appender'
 				)
 			).toBeNull();
@@ -173,7 +176,7 @@ describe( 'cpt locking', () => {
 		} );
 
 		it( 'should allow blocks to be removed', async () => {
-			await page.type(
+			await canvas().type(
 				'.block-editor-rich-text__editable[data-type="core/paragraph"]',
 				'p1'
 			);
@@ -193,7 +196,7 @@ describe( 'cpt locking', () => {
 		} );
 
 		it( 'should allow blocks to be removed', async () => {
-			await page.type(
+			await canvas().type(
 				'div > .block-editor-rich-text__editable[data-type="core/paragraph"]',
 				'p1'
 			);
@@ -219,7 +222,7 @@ describe( 'cpt locking', () => {
 		);
 
 		it( 'should not allow blocks to be moved', async () => {
-			await page.click(
+			await canvas().click(
 				'.block-editor-rich-text__editable[data-type="core/paragraph"]'
 			);
 			expect( await page.$( 'button[aria-label="Move up"]' ) ).toBeNull();
@@ -239,7 +242,7 @@ describe( 'cpt locking', () => {
 		);
 
 		it( 'should not allow blocks to be moved', async () => {
-			await page.click(
+			await canvas().click(
 				'.block-editor-rich-text__editable[data-type="core/paragraph"]'
 			);
 			expect( await page.$( 'button[aria-label="Move up"]' ) ).toBeNull();

--- a/packages/e2e-tests/specs/editor/plugins/iframed-inline-styles.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/iframed-inline-styles.test.js
@@ -35,8 +35,10 @@ describe( 'iframed inline styles', () => {
 		await insertBlock( 'Iframed Inline Styles' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
-		expect( await getComputedStyle( page, 'padding' ) ).toBe( '20px' );
-		expect( await getComputedStyle( page, 'border-width' ) ).toBe( '2px' );
+		expect( await getComputedStyle( canvas(), 'padding' ) ).toBe( '20px' );
+		expect( await getComputedStyle( canvas(), 'border-width' ) ).toBe(
+			'2px'
+		);
 
 		await createNewTemplate( 'Iframed Test' );
 

--- a/packages/e2e-tests/specs/editor/plugins/iframed-masonry-block.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/iframed-masonry-block.test.js
@@ -39,7 +39,7 @@ describe( 'iframed masonry block', () => {
 		await insertBlock( 'Iframed Masonry Block' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
-		expect( await didMasonryLoadCorrectly( page ) ).toBe( true );
+		expect( await didMasonryLoadCorrectly( canvas() ) ).toBe( true );
 
 		await createNewTemplate( 'Iframed Test' );
 		await canvas().waitForSelector( '.grid-item[style]' );

--- a/packages/e2e-tests/specs/editor/plugins/iframed-multiple-block-stylesheets.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/iframed-multiple-block-stylesheets.test.js
@@ -35,7 +35,7 @@ describe( 'iframed multiple block stylesheets', () => {
 	it( 'should load multiple block stylesheets in iframe', async () => {
 		await insertBlock( 'Iframed Multiple Stylesheets' );
 
-		await page.waitForSelector(
+		await canvas().waitForSelector(
 			'.wp-block-test-iframed-multiple-stylesheets'
 		);
 		await createNewTemplate( 'Iframed Test' );

--- a/packages/e2e-tests/specs/editor/plugins/inner-blocks-allowed-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/inner-blocks-allowed-blocks.test.js
@@ -10,6 +10,7 @@ import {
 	openGlobalBlockInserter,
 	closeGlobalBlockInserter,
 	clickBlockToolbarButton,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Allowed Blocks Setting on InnerBlocks', () => {
@@ -32,8 +33,8 @@ describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 		const childParagraphSelector = `${ parentBlockSelector } ${ paragraphSelector }`;
 		await insertBlock( 'Allowed Blocks Unset' );
 		await closeGlobalBlockInserter();
-		await page.waitForSelector( childParagraphSelector );
-		await page.click( childParagraphSelector );
+		await canvas().waitForSelector( childParagraphSelector );
+		await canvas().click( childParagraphSelector );
 		await openGlobalBlockInserter();
 		await expect(
 			(
@@ -47,8 +48,8 @@ describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 		const childParagraphSelector = `${ parentBlockSelector } ${ paragraphSelector }`;
 		await insertBlock( 'Allowed Blocks Set' );
 		await closeGlobalBlockInserter();
-		await page.waitForSelector( childParagraphSelector );
-		await page.click( childParagraphSelector );
+		await canvas().waitForSelector( childParagraphSelector );
+		await canvas().click( childParagraphSelector );
 		await openGlobalBlockInserter();
 		const allowedBlocks = await getAllBlockInserterItemTitles();
 		expect( allowedBlocks.sort() ).toEqual( [
@@ -66,8 +67,8 @@ describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 		const parentBlockSelector = '[data-type="test/allowed-blocks-dynamic"]';
 		const blockAppender = '.block-list-appender button';
 		const appenderSelector = `${ parentBlockSelector } ${ blockAppender }`;
-		await page.waitForSelector( appenderSelector );
-		await page.click( appenderSelector );
+		await canvas().waitForSelector( appenderSelector );
+		await canvas().click( appenderSelector );
 		expect( await getAllBlockInserterItemTitles() ).toEqual( [
 			'Image',
 			'List',

--- a/packages/e2e-tests/specs/editor/plugins/inner-blocks-prioritized-inserter-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/inner-blocks-prioritized-inserter-blocks.test.js
@@ -8,6 +8,7 @@ import {
 	getAllBlockInserterItemTitles,
 	insertBlock,
 	closeGlobalBlockInserter,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 const QUICK_INSERTER_RESULTS_SELECTOR =
@@ -108,7 +109,7 @@ describe( 'Prioritized Inserter Blocks Setting on InnerBlocks', () => {
 	describe( 'Slash inserter', () => {
 		it( 'uses the priority ordering if prioritzed blocks setting is set', async () => {
 			await insertBlock( 'Prioritized Inserter Blocks Set' );
-			await page.click( '[data-type="core/image"]' );
+			await canvas().click( '[data-type="core/image"]' );
 			await page.keyboard.press( 'Enter' );
 			await page.keyboard.type( '/' );
 			// Wait for the results to display.

--- a/packages/e2e-tests/specs/editor/various/adding-inline-tokens.test.js
+++ b/packages/e2e-tests/specs/editor/various/adding-inline-tokens.test.js
@@ -68,7 +68,6 @@ describe( 'adding inline tokens', () => {
 			'.block-editor-format-toolbar__image-popover'
 		);
 		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Tab' );
 		await page.keyboard.type( '20' );
 		await page.keyboard.press( 'Enter' );
 

--- a/packages/e2e-tests/specs/editor/various/autosave.test.js
+++ b/packages/e2e-tests/specs/editor/various/autosave.test.js
@@ -9,6 +9,7 @@ import {
 	publishPost,
 	saveDraft,
 	toggleOfflineMode,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 // Constant to override editor preference
@@ -258,7 +259,7 @@ describe( 'autosave', () => {
 		await page.keyboard.type( 'before publish' );
 		await publishPost();
 
-		await page.click( '[data-type="core/paragraph"]' );
+		await canvas().click( '[data-type="core/paragraph"]' );
 		await page.keyboard.type( ' after publish' );
 
 		// Trigger remote autosave.

--- a/packages/e2e-tests/specs/editor/various/block-editor-keyboard-shortcuts.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-editor-keyboard-shortcuts.test.js
@@ -9,6 +9,7 @@ import {
 	clickBlockToolbarButton,
 	clickMenuItem,
 	clickOnCloseModalButton,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 const createTestParagraphBlocks = async () => {
@@ -51,7 +52,7 @@ describe( 'block editor keyboard shortcuts', () => {
 				await createTestParagraphBlocks();
 				expect( await getEditedPostContent() ).toMatchSnapshot();
 				await pressKeyWithModifier( 'shift', 'ArrowUp' );
-				await page.waitForSelector(
+				await canvas().waitForSelector(
 					'[aria-label="Multiple selected blocks"]'
 				);
 				await moveUp();
@@ -63,7 +64,7 @@ describe( 'block editor keyboard shortcuts', () => {
 				expect( await getEditedPostContent() ).toMatchSnapshot();
 				await page.keyboard.press( 'ArrowUp' );
 				await pressKeyWithModifier( 'shift', 'ArrowUp' );
-				await page.waitForSelector(
+				await canvas().waitForSelector(
 					'[aria-label="Multiple selected blocks"]'
 				);
 				await moveDown();

--- a/packages/e2e-tests/specs/editor/various/block-grouping.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-grouping.test.js
@@ -14,6 +14,7 @@ import {
 	activatePlugin,
 	deactivatePlugin,
 	createReusableBlock,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 async function insertBlocksOfSameType() {
@@ -115,8 +116,8 @@ describe( 'Block Grouping', () => {
 			const getParagraphText = async () => {
 				const paragraphInReusableSelector =
 					'.block-editor-block-list__block[data-type="core/block"] p';
-				await page.waitForSelector( paragraphInReusableSelector );
-				return page.$eval(
+				await canvas().waitForSelector( paragraphInReusableSelector );
+				return canvas().$eval(
 					paragraphInReusableSelector,
 					( element ) => element.innerText
 				);
@@ -128,14 +129,14 @@ describe( 'Block Grouping', () => {
 			await clickBlockToolbarButton( 'Options' );
 			await clickMenuItem( 'Group' );
 
-			let group = await page.$$( '[data-type="core/group"]' );
+			let group = await canvas().$$( '[data-type="core/group"]' );
 			expect( group ).toHaveLength( 1 );
 			// Make sure the paragraph in reusable block exists.
 			expect( await getParagraphText() ).toMatch( paragraphText );
 
 			await clickBlockToolbarButton( 'Options' );
 			await clickMenuItem( 'Ungroup' );
-			group = await page.$$( '[data-type="core/group"]' );
+			group = await canvas().$$( '[data-type="core/group"]' );
 			expect( group ).toHaveLength( 0 );
 			// Make sure the paragraph in reusable block exists.
 			expect( await getParagraphText() ).toEqual( paragraphText );

--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -10,6 +10,7 @@ import {
 	openDocumentSettingsSidebar,
 	getListViewBlocks,
 	switchBlockInspectorTab,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 async function openListViewSidebar() {
@@ -53,7 +54,7 @@ describe( 'Navigating the block hierarchy', () => {
 
 	it( 'should navigate using the list view sidebar', async () => {
 		await insertBlock( 'Columns' );
-		await page.click( '[aria-label="Two columns; equal split"]' );
+		await canvas().click( '[aria-label="Two columns; equal split"]' );
 
 		// Add a paragraph in the first column.
 		await page.keyboard.press( 'ArrowDown' ); // Navigate to inserter.
@@ -114,7 +115,7 @@ describe( 'Navigating the block hierarchy', () => {
 	it( 'should navigate block hierarchy using only the keyboard', async () => {
 		await insertBlock( 'Columns' );
 		await openDocumentSettingsSidebar();
-		await page.click( '[aria-label="Two columns; equal split"]' );
+		await canvas().click( '[aria-label="Two columns; equal split"]' );
 
 		// Add a paragraph in the first column.
 		await page.keyboard.press( 'ArrowDown' ); // Navigate to inserter.
@@ -143,11 +144,13 @@ describe( 'Navigating the block hierarchy', () => {
 		await pressKeyWithModifier( 'ctrlShift', '`' );
 		await pressKeyTimes( 'Tab', 3 );
 		await pressKeyTimes( 'ArrowDown', 4 );
-		await page.waitForSelector(
+		await canvas().waitForSelector(
 			'.is-highlighted[aria-label="Block: Column (3 of 3)"]'
 		);
 		await page.keyboard.press( 'Enter' );
-		await page.waitForSelector( '.is-selected[data-type="core/column"]' );
+		await canvas().waitForSelector(
+			'.is-selected[data-type="core/column"]'
+		);
 
 		// Insert text in the last column block.
 		await page.keyboard.press( 'ArrowDown' ); // Navigate to inserter.
@@ -190,12 +193,12 @@ describe( 'Navigating the block hierarchy', () => {
 		// Insert a group block.
 		await insertBlock( 'Group' );
 		// Select the default, selected Group layout from the variation picker.
-		await page.click(
+		await canvas().click(
 			'button[aria-label="Group: Gather blocks in a container."]'
 		);
 		// Insert some random blocks.
 		// The last block shouldn't be a textual block.
-		await page.click( '.block-list-appender .block-editor-inserter' );
+		await canvas().click( '.block-list-appender .block-editor-inserter' );
 		const paragraphMenuItem = (
 			await page.$x( `//button//span[contains(text(), 'Paragraph')]` )
 		 )[ 0 ];
@@ -207,7 +210,7 @@ describe( 'Navigating the block hierarchy', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 
 		// Unselect the blocks.
-		await page.click( '.editor-post-title' );
+		await canvas().click( '.editor-post-title' );
 
 		// Try selecting the group block using the Outline.
 		await page.click(
@@ -217,7 +220,7 @@ describe( 'Navigating the block hierarchy', () => {
 		await groupMenuItem.click();
 
 		// The group block's wrapper should be selected.
-		const isGroupBlockSelected = await page.evaluate(
+		const isGroupBlockSelected = await canvas().evaluate(
 			() =>
 				document.activeElement.getAttribute( 'data-type' ) ===
 				'core/group'

--- a/packages/e2e-tests/specs/editor/various/change-detection.test.js
+++ b/packages/e2e-tests/specs/editor/various/change-detection.test.js
@@ -11,6 +11,7 @@ import {
 	openDocumentSettingsSidebar,
 	isCurrentURL,
 	openTypographyToolsPanelMenu,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Change detection', () => {
@@ -78,7 +79,7 @@ describe( 'Change detection', () => {
 	} );
 
 	it( 'Should autosave post', async () => {
-		await page.type( '.editor-post-title__input', 'Hello World' );
+		await canvas().type( '.editor-post-title__input', 'Hello World' );
 
 		// Force autosave to occur immediately.
 		await Promise.all( [
@@ -94,7 +95,7 @@ describe( 'Change detection', () => {
 	} );
 
 	it( 'Should prompt to confirm unsaved changes for autosaved draft for non-content fields', async () => {
-		await page.type( '.editor-post-title__input', 'Hello World' );
+		await canvas().type( '.editor-post-title__input', 'Hello World' );
 
 		// Toggle post as needing review (not persisted for autosave).
 		await ensureSidebarOpened();
@@ -117,7 +118,7 @@ describe( 'Change detection', () => {
 	} );
 
 	it( 'Should prompt to confirm unsaved changes for autosaved published post', async () => {
-		await page.type( '.editor-post-title__input', 'Hello World' );
+		await canvas().type( '.editor-post-title__input', 'Hello World' );
 
 		await publishPost();
 
@@ -130,7 +131,7 @@ describe( 'Change detection', () => {
 		] );
 
 		// Should be dirty after autosave change of published post.
-		await page.type( '.editor-post-title__input', '!' );
+		await canvas().type( '.editor-post-title__input', '!' );
 
 		await Promise.all( [
 			page.waitForSelector(
@@ -162,7 +163,7 @@ describe( 'Change detection', () => {
 	} );
 
 	it( 'Should prompt if property changed without save', async () => {
-		await page.type( '.editor-post-title__input', 'Hello World' );
+		await canvas().type( '.editor-post-title__input', 'Hello World' );
 
 		await assertIsDirty( true );
 	} );
@@ -175,7 +176,7 @@ describe( 'Change detection', () => {
 	} );
 
 	it( 'Should not prompt if changes saved', async () => {
-		await page.type( '.editor-post-title__input', 'Hello World' );
+		await canvas().type( '.editor-post-title__input', 'Hello World' );
 
 		await saveDraft();
 
@@ -192,7 +193,7 @@ describe( 'Change detection', () => {
 	} );
 
 	it( 'Should not save if all changes saved', async () => {
-		await page.type( '.editor-post-title__input', 'Hello World' );
+		await canvas().type( '.editor-post-title__input', 'Hello World' );
 
 		await saveDraft();
 
@@ -205,7 +206,7 @@ describe( 'Change detection', () => {
 	} );
 
 	it( 'Should prompt if save failed', async () => {
-		await page.type( '.editor-post-title__input', 'Hello World' );
+		await canvas().type( '.editor-post-title__input', 'Hello World' );
 
 		await page.setOfflineMode( true );
 
@@ -231,7 +232,7 @@ describe( 'Change detection', () => {
 	} );
 
 	it( 'Should prompt if changes and save is in-flight', async () => {
-		await page.type( '.editor-post-title__input', 'Hello World' );
+		await canvas().type( '.editor-post-title__input', 'Hello World' );
 
 		// Hold the posts request so we don't deal with race conditions of the
 		// save completing early. Other requests should be allowed to continue,
@@ -247,7 +248,7 @@ describe( 'Change detection', () => {
 	} );
 
 	it( 'Should prompt if changes made while save is in-flight', async () => {
-		await page.type( '.editor-post-title__input', 'Hello World' );
+		await canvas().type( '.editor-post-title__input', 'Hello World' );
 
 		// Hold the posts request so we don't deal with race conditions of the
 		// save completing early. Other requests should be allowed to continue,
@@ -257,7 +258,7 @@ describe( 'Change detection', () => {
 		// Keyboard shortcut Ctrl+S save.
 		await pressKeyWithModifier( 'primary', 'S' );
 
-		await page.type( '.editor-post-title__input', '!' );
+		await canvas().type( '.editor-post-title__input', '!' );
 		await page.waitForSelector( '.editor-post-save-draft' );
 
 		await releaseSaveIntercept();
@@ -266,7 +267,7 @@ describe( 'Change detection', () => {
 	} );
 
 	it( 'Should prompt if property changes made while save is in-flight, and save completes', async () => {
-		await page.type( '.editor-post-title__input', 'Hello World' );
+		await canvas().type( '.editor-post-title__input', 'Hello World' );
 
 		// Hold the posts request so we don't deal with race conditions of the
 		// save completing early.
@@ -282,7 +283,7 @@ describe( 'Change detection', () => {
 		);
 
 		// Dirty post while save is in-flight.
-		await page.type( '.editor-post-title__input', '!' );
+		await canvas().type( '.editor-post-title__input', '!' );
 
 		// Allow save to complete. Disabling interception flushes pending.
 		await Promise.all( [ savedPromise, releaseSaveIntercept() ] );
@@ -291,7 +292,7 @@ describe( 'Change detection', () => {
 	} );
 
 	it( 'Should prompt if block revision is made while save is in-flight, and save completes', async () => {
-		await page.type( '.editor-post-title__input', 'Hello World' );
+		await canvas().type( '.editor-post-title__input', 'Hello World' );
 
 		// Hold the posts request so we don't deal with race conditions of the
 		// save completing early.
@@ -324,7 +325,7 @@ describe( 'Change detection', () => {
 		await saveDraft();
 
 		// Verify that the title is empty.
-		const title = await page.$eval(
+		const title = await canvas().$eval(
 			'.editor-post-title__input',
 			// Trim padding non-breaking space.
 			( element ) => element.textContent.trim()
@@ -337,7 +338,7 @@ describe( 'Change detection', () => {
 
 	it( 'should not prompt to confirm unsaved changes when trashing an existing post', async () => {
 		// Enter title.
-		await page.type( '.editor-post-title__input', 'Hello World' );
+		await canvas().type( '.editor-post-title__input', 'Hello World' );
 
 		// Save.
 		await saveDraft();
@@ -381,7 +382,7 @@ describe( 'Change detection', () => {
 		] );
 
 		// Change the paragraph's `drop cap`.
-		await page.click( '[data-type="core/paragraph"]' );
+		await canvas().click( '[data-type="core/paragraph"]' );
 
 		await openTypographyToolsPanelMenu();
 		await page.click( 'button[aria-label="Show Drop cap"]' );
@@ -390,7 +391,7 @@ describe( 'Change detection', () => {
 			"//label[contains(text(), 'Drop cap')]"
 		);
 		await dropCapToggle.click();
-		await page.click( '[data-type="core/paragraph"]' );
+		await canvas().click( '[data-type="core/paragraph"]' );
 
 		// Check that the post is dirty.
 		await page.waitForSelector( '.editor-post-save-draft' );
@@ -402,7 +403,7 @@ describe( 'Change detection', () => {
 		] );
 
 		// Change the paragraph's `drop cap` again.
-		await page.click( '[data-type="core/paragraph"]' );
+		await canvas().click( '[data-type="core/paragraph"]' );
 		await dropCapToggle.click();
 
 		// Check that the post is dirty.

--- a/packages/e2e-tests/specs/editor/various/editor-modes.test.js
+++ b/packages/e2e-tests/specs/editor/various/editor-modes.test.js
@@ -11,6 +11,7 @@ import {
 	pressKeyTimes,
 	pressKeyWithModifier,
 	openTypographyToolsPanelMenu,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Editing modes (visual/HTML)', () => {
@@ -22,7 +23,7 @@ describe( 'Editing modes (visual/HTML)', () => {
 
 	it( 'should switch between visual and HTML modes', async () => {
 		// This block should be in "visual" mode by default.
-		let visualBlock = await page.$$( '[data-block].rich-text' );
+		let visualBlock = await canvas().$$( '[data-block].rich-text' );
 		expect( visualBlock ).toHaveLength( 1 );
 
 		// Change editing mode from "Visual" to "HTML".
@@ -30,7 +31,7 @@ describe( 'Editing modes (visual/HTML)', () => {
 		await clickMenuItem( 'Edit as HTML' );
 
 		// Wait for the block to be converted to HTML editing mode.
-		const htmlBlock = await page.$$(
+		const htmlBlock = await canvas().$$(
 			'[data-block] .block-editor-block-list__block-html-textarea'
 		);
 		expect( htmlBlock ).toHaveLength( 1 );
@@ -40,7 +41,7 @@ describe( 'Editing modes (visual/HTML)', () => {
 		await clickMenuItem( 'Edit visually' );
 
 		// This block should be in "visual" mode by default.
-		visualBlock = await page.$$( '[data-block].rich-text' );
+		visualBlock = await canvas().$$( '[data-block].rich-text' );
 		expect( visualBlock ).toHaveLength( 1 );
 	} );
 
@@ -67,7 +68,7 @@ describe( 'Editing modes (visual/HTML)', () => {
 		await clickMenuItem( 'Edit as HTML' );
 
 		// Make sure the paragraph content is rendered as expected.
-		let htmlBlockContent = await page.$eval(
+		let htmlBlockContent = await canvas().$eval(
 			'.block-editor-block-list__layout .block-editor-block-list__block .block-editor-block-list__block-html-textarea',
 			( node ) => node.textContent
 		);
@@ -83,7 +84,7 @@ describe( 'Editing modes (visual/HTML)', () => {
 		await dropCapToggle.click();
 
 		// Make sure the HTML content updated.
-		htmlBlockContent = await page.$eval(
+		htmlBlockContent = await canvas().$eval(
 			'.block-editor-block-list__layout .block-editor-block-list__block .block-editor-block-list__block-html-textarea',
 			( node ) => node.textContent
 		);
@@ -138,7 +139,7 @@ describe( 'Editing modes (visual/HTML)', () => {
 		const editPosition = textContent.indexOf( 'Hello' );
 
 		// Replace the word 'Hello' with 'Hi'.
-		await page.click( '.editor-post-title__input' );
+		await canvas().click( '.editor-post-title__input' );
 		await page.keyboard.press( 'Tab' );
 		await pressKeyTimes( 'ArrowRight', editPosition );
 		await pressKeyTimes( 'Delete', 5 );

--- a/packages/e2e-tests/specs/editor/various/embedding.test.js
+++ b/packages/e2e-tests/specs/editor/various/embedding.test.js
@@ -3,7 +3,6 @@
  */
 import {
 	clickBlockAppender,
-	clickButton,
 	createEmbeddingMatcher,
 	createJSONResponse,
 	createNewPost,
@@ -12,6 +11,7 @@ import {
 	insertBlock,
 	publishPost,
 	setUpResponseMocking,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 const MOCK_EMBED_WORDPRESS_SUCCESS_RESPONSE = {
@@ -178,24 +178,24 @@ describe( 'Embedding content', () => {
 	it( 'should render embeds in the correct state', async () => {
 		// Valid embed. Should render valid figure element.
 		await insertEmbed( 'https://twitter.com/notnownikki' );
-		await page.waitForSelector( 'figure.wp-block-embed' );
+		await canvas().waitForSelector( 'figure.wp-block-embed' );
 
 		// Valid provider; invalid content. Should render failed, edit state.
 		await insertEmbed( 'https://twitter.com/wooyaygutenberg123454312' );
-		await page.waitForSelector(
+		await canvas().waitForSelector(
 			'input[value="https://twitter.com/wooyaygutenberg123454312"]'
 		);
 
 		// WordPress invalid content. Should render failed, edit state.
 		await insertEmbed( 'https://wordpress.org/gutenberg/handbook/' );
-		await page.waitForSelector(
+		await canvas().waitForSelector(
 			'input[value="https://wordpress.org/gutenberg/handbook/"]'
 		);
 
 		// Provider whose oembed API has gone wrong. Should render failed, edit
 		// state.
 		await insertEmbed( 'https://twitter.com/thatbunty' );
-		await page.waitForSelector(
+		await canvas().waitForSelector(
 			'input[value="https://twitter.com/thatbunty"]'
 		);
 
@@ -204,18 +204,18 @@ describe( 'Embedding content', () => {
 		await insertEmbed(
 			'https://wordpress.org/gutenberg/handbook/block-api/attributes/'
 		);
-		await page.waitForSelector( 'figure.wp-block-embed' );
+		await canvas().waitForSelector( 'figure.wp-block-embed' );
 
 		// Video content. Should render valid figure element, and include the
 		// aspect ratio class.
 		await insertEmbed( 'https://www.youtube.com/watch?v=lXMskKTw3Bc' );
-		await page.waitForSelector(
+		await canvas().waitForSelector(
 			'figure.wp-block-embed.is-type-video.wp-embed-aspect-16-9'
 		);
 
 		// Photo content. Should render valid figure element.
 		await insertEmbed( 'https://cloudup.com/cQFlxqtY4ob' );
-		await page.waitForSelector(
+		await canvas().waitForSelector(
 			'iframe[title="Embedded content from cloudup"'
 		);
 
@@ -230,18 +230,21 @@ describe( 'Embedding content', () => {
 		// has styles applied which depend on resize observer, wait for the
 		// expected size class to settle before clicking, since otherwise a race
 		// condition could occur on the placeholder layout vs. click intent.
-		await page.waitForSelector(
+		await canvas().waitForSelector(
 			'.components-placeholder.is-large .components-placeholder__error'
 		);
 
-		await clickButton( 'Convert to link' );
+		const button = await canvas().waitForXPath(
+			`//button[contains(text(), 'Convert to link')]`
+		);
+		await button.click();
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
 	it( 'should retry embeds that could not be embedded with trailing slashes, without the trailing slashes', async () => {
 		await insertEmbed( 'https://twitter.com/notnownikki/' );
 		// The twitter block should appear correctly.
-		await page.waitForSelector( 'figure.wp-block-embed' );
+		await canvas().waitForSelector( 'figure.wp-block-embed' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
@@ -253,7 +256,7 @@ describe( 'Embedding content', () => {
 		// has styles applied which depend on resize observer, wait for the
 		// expected size class to settle before clicking, since otherwise a race
 		// condition could occur on the placeholder layout vs. click intent.
-		await page.waitForSelector(
+		await canvas().waitForSelector(
 			'.components-placeholder.is-large .components-placeholder__error'
 		);
 
@@ -268,8 +271,11 @@ describe( 'Embedding content', () => {
 				),
 			},
 		] );
-		await clickButton( 'Try again' );
-		await page.waitForSelector( 'figure.wp-block-embed' );
+		const button = await canvas().waitForXPath(
+			`//button[contains(text(), 'Try again')]`
+		);
+		await button.click();
+		await canvas().waitForSelector( 'figure.wp-block-embed' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
@@ -292,6 +298,6 @@ describe( 'Embedding content', () => {
 		await insertEmbed( postUrl );
 
 		// Check the block has become a WordPress block.
-		await page.waitForSelector( 'figure.wp-block-embed' );
+		await canvas().waitForSelector( 'figure.wp-block-embed' );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js
@@ -11,6 +11,7 @@ import {
 	searchForBlock,
 	setBrowserViewport,
 	pressKeyWithModifier,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 /** @typedef {import('puppeteer-core').ElementHandle} ElementHandle */
@@ -165,7 +166,7 @@ describe( 'Inserting blocks', () => {
 		await page.keyboard.press( 'Enter' );
 
 		expect(
-			await page.waitForSelector( '[data-type="core/tag-cloud"]' )
+			await canvas().waitForSelector( '[data-type="core/tag-cloud"]' )
 		).not.toBeNull();
 	} );
 
@@ -175,7 +176,7 @@ describe( 'Inserting blocks', () => {
 		await page.keyboard.type( '1.1' );
 
 		// After inserting the Buttons block the inner button block should be selected.
-		const selectedButtonBlocks = await page.$$(
+		const selectedButtonBlocks = await canvas().$$(
 			'.wp-block-button.is-selected'
 		);
 		expect( selectedButtonBlocks.length ).toBe( 1 );
@@ -185,7 +186,7 @@ describe( 'Inserting blocks', () => {
 			window.wp.data.dispatch( 'core/block-editor' ).clearSelectedBlock()
 		);
 		// Specifically click the root container appender.
-		await page.click(
+		await canvas().click(
 			'.block-editor-block-list__layout.is-root-container > .block-list-appender .block-editor-inserter__toggle'
 		);
 
@@ -222,7 +223,7 @@ describe( 'Inserting blocks', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 
 		// Using the between inserter.
-		const insertionPoint = await page.$( '[data-type="core/heading"]' );
+		const insertionPoint = await canvas().$( '[data-type="core/heading"]' );
 		const rect = await insertionPoint.boundingBox();
 		await page.mouse.move( rect.x + rect.width / 2, rect.y - 10, {
 			steps: 10,
@@ -247,7 +248,7 @@ describe( 'Inserting blocks', () => {
 		await insertBlock( 'Paragraph' );
 		await page.keyboard.type( 'First paragraph' );
 		await insertBlock( 'Image' );
-		const paragraphBlock = await page.$(
+		const paragraphBlock = await canvas().$(
 			'p[aria-label="Paragraph block"]'
 		);
 		paragraphBlock.click();
@@ -278,14 +279,16 @@ describe( 'Inserting blocks', () => {
 	it( 'inserts a block in proper place after having clicked `Browse All` from block appender', async () => {
 		await insertBlock( 'Group' );
 		// Select the default, selected Group layout from the variation picker.
-		await page.click(
+		await canvas().click(
 			'button[aria-label="Group: Gather blocks in a container."]'
 		);
 		await insertBlock( 'Paragraph' );
 		await page.keyboard.type( 'Paragraph after group' );
 		// Click the Group first to make the appender inside it clickable.
-		await page.click( '[data-type="core/group"]' );
-		await page.click( '[data-type="core/group"] [aria-label="Add block"]' );
+		await canvas().click( '[data-type="core/group"]' );
+		await canvas().click(
+			'[data-type="core/group"] [aria-label="Add block"]'
+		);
 		const browseAll = await page.waitForXPath(
 			'//button[text()="Browse all"]'
 		);
@@ -300,14 +303,16 @@ describe( 'Inserting blocks', () => {
 			'.block-editor-inserter__search input,.block-editor-inserter__search-input,input.block-editor-inserter__search';
 		await insertBlock( 'Group' );
 		// Select the default, selected Group layout from the variation picker.
-		await page.click(
+		await canvas().click(
 			'button[aria-label="Group: Gather blocks in a container."]'
 		);
 		await insertBlock( 'Paragraph' );
 		await page.keyboard.type( 'Text' );
 		// Click the Group first to make the appender inside it clickable.
-		await page.click( '[data-type="core/group"]' );
-		await page.click( '[data-type="core/group"] [aria-label="Add block"]' );
+		await canvas().click( '[data-type="core/group"]' );
+		await canvas().click(
+			'[data-type="core/group"] [aria-label="Add block"]'
+		);
 		await page.waitForSelector( INSERTER_SEARCH_SELECTOR );
 		await page.focus( INSERTER_SEARCH_SELECTOR );
 		await pressKeyWithModifier( 'primary', 'a' );
@@ -337,7 +342,7 @@ describe( 'Inserting blocks', () => {
 		expect( inserterPanels.length ).toBe( 0 );
 
 		// The editable 'Read More' text should be focused.
-		const isFocusInBlock = await page.evaluate( () =>
+		const isFocusInBlock = await canvas().evaluate( () =>
 			document
 				.querySelector( '[data-type="core/more"]' )
 				.contains( document.activeElement )
@@ -366,14 +371,14 @@ describe( 'Inserting blocks', () => {
 		async ( viewport ) => {
 			await setBrowserViewport( viewport );
 
-			await page.type(
+			await canvas().type(
 				'.block-editor-default-block-appender__content',
 				'Testing inserted block focus'
 			);
 
 			await insertBlock( 'Image' );
 
-			await page.waitForSelector( 'figure[data-type="core/image"]' );
+			await canvas().waitForSelector( 'figure[data-type="core/image"]' );
 
 			const selectedBlock = await page.evaluate( () => {
 				return wp.data.select( 'core/block-editor' ).getSelectedBlock();

--- a/packages/e2e-tests/specs/editor/various/invalid-block.test.js
+++ b/packages/e2e-tests/specs/editor/various/invalid-block.test.js
@@ -7,6 +7,7 @@ import {
 	clickBlockAppender,
 	clickBlockToolbarButton,
 	setPostContent,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'invalid blocks', () => {
@@ -25,7 +26,7 @@ describe( 'invalid blocks', () => {
 		await clickMenuItem( 'Edit as HTML' );
 
 		// Focus on the textarea and enter an invalid paragraph
-		await page.click(
+		await canvas().click(
 			'.block-editor-block-list__layout .block-editor-block-list__block .block-editor-block-list__block-html-textarea'
 		);
 		await page.keyboard.type( '<p>invalid paragraph' );
@@ -34,7 +35,7 @@ describe( 'invalid blocks', () => {
 		await page.click( '.editor-post-save-draft' );
 
 		// Click on the 'three-dots' menu toggle.
-		await page.click(
+		await canvas().click(
 			'.block-editor-warning__actions button[aria-label="More options"]'
 		);
 

--- a/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
@@ -8,13 +8,16 @@ import {
 	clickBlockAppender,
 	getEditedPostContent,
 	showBlockToolbar,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 async function getActiveLabel() {
 	return await page.evaluate( () => {
+		const { activeElement } =
+			document.activeElement.contentDocument ?? document;
 		return (
-			document.activeElement.getAttribute( 'aria-label' ) ||
-			document.activeElement.innerHTML
+			activeElement.getAttribute( 'aria-label' ) ||
+			activeElement.innerHTML
 		);
 	} );
 }
@@ -34,7 +37,11 @@ const tabThroughParagraphBlock = async ( paragraphText ) => {
 	await page.keyboard.press( 'Tab' );
 	await expect( await getActiveLabel() ).toBe( 'Paragraph block' );
 	await expect(
-		await page.evaluate( () => document.activeElement.innerHTML )
+		await page.evaluate( () => {
+			const { activeElement } =
+				document.activeElement.contentDocument ?? document;
+			return activeElement.innerHTML;
+		} )
 	).toBe( paragraphText );
 
 	await page.keyboard.press( 'Tab' );
@@ -113,16 +120,12 @@ describe( 'Order of block keyboard navigation', () => {
 		}
 
 		// Clear the selected block.
-		const paragraph = await page.$( '[data-type="core/paragraph"]' );
+		const paragraph = await canvas().$( '[data-type="core/paragraph"]' );
 		const box = await paragraph.boundingBox();
 		await page.mouse.click( box.x - 1, box.y );
 
 		await page.keyboard.press( 'Tab' );
-		await expect(
-			await page.evaluate( () => {
-				return document.activeElement.getAttribute( 'aria-label' );
-			} )
-		).toBe( 'Add title' );
+		await expect( await getActiveLabel() ).toBe( 'Add title' );
 
 		await page.keyboard.press( 'Tab' );
 		await expect( await getActiveLabel() ).toBe(
@@ -148,7 +151,7 @@ describe( 'Order of block keyboard navigation', () => {
 		}
 
 		// Clear the selected block.
-		const paragraph = await page.$( '[data-type="core/paragraph"]' );
+		const paragraph = await canvas().$( '[data-type="core/paragraph"]' );
 		const box = await paragraph.boundingBox();
 		await page.mouse.click( box.x - 1, box.y );
 
@@ -176,11 +179,7 @@ describe( 'Order of block keyboard navigation', () => {
 		);
 
 		await pressKeyWithModifier( 'shift', 'Tab' );
-		await expect(
-			await page.evaluate( () => {
-				return document.activeElement.getAttribute( 'aria-label' );
-			} )
-		).toBe( 'Add title' );
+		await expect( await getActiveLabel() ).toBe( 'Add title' );
 	} );
 
 	it( 'should navigate correctly with multi selection', async () => {
@@ -217,7 +216,7 @@ describe( 'Order of block keyboard navigation', () => {
 		await insertBlock( 'Image' );
 
 		// Make sure the upload button has focus.
-		const uploadButton = await page.waitForXPath(
+		const uploadButton = await canvas().waitForXPath(
 			'//button[contains( text(), "Upload" ) ]'
 		);
 		await expect( uploadButton ).toHaveFocus();
@@ -231,7 +230,7 @@ describe( 'Order of block keyboard navigation', () => {
 		// Insert a group block.
 		await insertBlock( 'Group' );
 		// Select the default, selected Group layout from the variation picker.
-		await page.click(
+		await canvas().click(
 			'button[aria-label="Group: Gather blocks in a container."]'
 		);
 		// If active label matches, that means focus did not change from group block wrapper.

--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -9,6 +9,7 @@ import {
 	pressKeyWithModifier,
 	showBlockToolbar,
 	pressKeyTimes,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Links', () => {
@@ -57,7 +58,7 @@ describe( 'Links', () => {
 
 		await page.keyboard.press( 'Enter' );
 
-		const actualText = await page.evaluate(
+		const actualText = await canvas().evaluate(
 			() =>
 				document.querySelector( '.block-editor-rich-text__editable a' )
 					.textContent
@@ -172,7 +173,7 @@ describe( 'Links', () => {
 		await page.keyboard.type( 'https://wordpress.org/gutenberg' );
 
 		// Click somewhere else - it doesn't really matter where.
-		await page.click( '.editor-post-title' );
+		await canvas().click( '.editor-post-title' );
 	} );
 
 	const createAndReselectLink = async () => {
@@ -311,7 +312,7 @@ describe( 'Links', () => {
 
 	const createPostWithTitle = async ( titleText ) => {
 		await createNewPost();
-		await page.type( '.editor-post-title__input', titleText );
+		await canvas().type( '.editor-post-title__input', titleText );
 		await page.click( '.editor-post-publish-panel__toggle' );
 
 		// Disable reason: Wait for the animation to complete, since otherwise the
@@ -630,7 +631,7 @@ describe( 'Links', () => {
 			await page.keyboard.press( 'Enter' );
 
 			// Check the created link reflects the link text.
-			const actualLinkText = await page.evaluate(
+			const actualLinkText = await canvas().evaluate(
 				() =>
 					document.querySelector(
 						'.block-editor-rich-text__editable a'
@@ -880,7 +881,7 @@ describe( 'Links', () => {
 
 			await page.keyboard.press( 'Enter' );
 
-			const richTextText = await page.evaluate(
+			const richTextText = await canvas().evaluate(
 				() =>
 					document.querySelector(
 						'.block-editor-rich-text__editable'
@@ -889,7 +890,7 @@ describe( 'Links', () => {
 			// Check that the correct (i.e. last) instance of "a" was replaced with "z".
 			expect( richTextText ).toBe( 'a b c z' );
 
-			const richTextLink = await page.evaluate(
+			const richTextLink = await canvas().evaluate(
 				() =>
 					document.querySelector(
 						'.block-editor-rich-text__editable a'

--- a/packages/e2e-tests/specs/editor/various/navigable-toolbar.test.js
+++ b/packages/e2e-tests/specs/editor/various/navigable-toolbar.test.js
@@ -20,9 +20,10 @@ describe( 'Block Toolbar', () => {
 		it( 'should not scroll page', async () => {
 			while (
 				await page.evaluate( () => {
-					const scrollable = wp.dom.getScrollContainer(
-						document.activeElement
-					);
+					const { activeElement } =
+						document.activeElement?.contentDocument ?? document;
+					const scrollable =
+						wp.dom.getScrollContainer( activeElement );
 					return ! scrollable || scrollable.scrollTop === 0;
 				} )
 			) {
@@ -31,21 +32,20 @@ describe( 'Block Toolbar', () => {
 
 			await page.keyboard.type( 'a' );
 
-			const scrollTopBefore = await page.evaluate(
-				() =>
-					wp.dom.getScrollContainer( document.activeElement )
-						.scrollTop
-			);
+			const scrollTopBefore = await page.evaluate( () => {
+				const { activeElement } =
+					document.activeElement?.contentDocument ?? document;
+				window.scrollContainer =
+					wp.dom.getScrollContainer( activeElement );
+				return window.scrollContainer.scrollTop;
+			} );
 
 			await pressKeyWithModifier( 'alt', 'F10' );
 			expect( await isInBlockToolbar() ).toBe( true );
 
-			const scrollTopAfter = await page.evaluate(
-				() =>
-					wp.dom.getScrollContainer( document.activeElement )
-						.scrollTop
-			);
-
+			const scrollTopAfter = await page.evaluate( () => {
+				return window.scrollContainer.scrollTop;
+			} );
 			expect( scrollTopBefore ).toBe( scrollTopAfter );
 		} );
 

--- a/packages/e2e-tests/specs/editor/various/nux.test.js
+++ b/packages/e2e-tests/specs/editor/various/nux.test.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { createNewPost, clickOnMoreMenuItem } from '@wordpress/e2e-test-utils';
+import {
+	createNewPost,
+	clickOnMoreMenuItem,
+	canvas,
+} from '@wordpress/e2e-test-utils';
 
 describe( 'New User Experience (NUX)', () => {
 	it( 'should show the guide to first-time users', async () => {
@@ -128,7 +132,7 @@ describe( 'New User Experience (NUX)', () => {
 		await page.click( '[role="dialog"] button[aria-label="Close"]' );
 
 		// Focus should be in post title field.
-		const postTitle = await page.waitForSelector(
+		const postTitle = await canvas().waitForSelector(
 			'h1[aria-label="Add title"'
 		);
 		await expect( postTitle ).toHaveFocus();

--- a/packages/e2e-tests/specs/editor/various/publish-button.test.js
+++ b/packages/e2e-tests/specs/editor/various/publish-button.test.js
@@ -6,6 +6,7 @@ import {
 	disablePrePublishChecks,
 	enablePrePublishChecks,
 	createNewPost,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'PostPublishButton', () => {
@@ -32,7 +33,7 @@ describe( 'PostPublishButton', () => {
 	} );
 
 	it( 'should be disabled when post is being saved', async () => {
-		await page.type( '.editor-post-title__input', 'E2E Test Post' ); // Make it saveable.
+		await canvas().type( '.editor-post-title__input', 'E2E Test Post' ); // Make it saveable.
 		expect(
 			await page.$( '.editor-post-publish-button[aria-disabled="true"]' )
 		).toBeNull();
@@ -44,7 +45,7 @@ describe( 'PostPublishButton', () => {
 	} );
 
 	it( 'should be disabled when metabox is being saved', async () => {
-		await page.type( '.editor-post-title__input', 'E2E Test Post' ); // Make it saveable.
+		await canvas().type( '.editor-post-title__input', 'E2E Test Post' ); // Make it saveable.
 		expect(
 			await page.$( '.editor-post-publish-button[aria-disabled="true"]' )
 		).toBeNull();

--- a/packages/e2e-tests/specs/editor/various/publish-panel.test.js
+++ b/packages/e2e-tests/specs/editor/various/publish-panel.test.js
@@ -9,6 +9,7 @@ import {
 	openPublishPanel,
 	pressKeyWithModifier,
 	publishPost,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'PostPublishPanel', () => {
@@ -28,7 +29,7 @@ describe( 'PostPublishPanel', () => {
 	} );
 
 	it( 'PrePublish: publish button should have the focus', async () => {
-		await page.type( '.editor-post-title__input', 'E2E Test Post' );
+		await canvas().type( '.editor-post-title__input', 'E2E Test Post' );
 		await openPublishPanel();
 
 		const focusedElementClassList = await page.$eval(
@@ -44,7 +45,7 @@ describe( 'PostPublishPanel', () => {
 
 	it( 'PostPublish: post link should have the focus', async () => {
 		const postTitle = 'E2E Test Post';
-		await page.type( '.editor-post-title__input', postTitle );
+		await canvas().type( '.editor-post-title__input', postTitle );
 		await publishPost();
 
 		const focusedElementTag = await page.$eval(
@@ -64,7 +65,7 @@ describe( 'PostPublishPanel', () => {
 	} );
 
 	it( 'should retain focus within the panel', async () => {
-		await page.type( '.editor-post-title__input', 'E2E Test Post' );
+		await canvas().type( '.editor-post-title__input', 'E2E Test Post' );
 		await openPublishPanel();
 		await pressKeyWithModifier( 'shift', 'Tab' );
 

--- a/packages/e2e-tests/specs/editor/various/publishing.test.js
+++ b/packages/e2e-tests/specs/editor/various/publishing.test.js
@@ -11,6 +11,7 @@ import {
 	setBrowserViewport,
 	openPublishPanel,
 	pressKeyWithModifier,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Publishing', () => {
@@ -22,7 +23,7 @@ describe( 'Publishing', () => {
 			} );
 
 			it( `disables the publish button when a ${ postType } is locked`, async () => {
-				await page.type(
+				await canvas().type(
 					'.editor-post-title__input',
 					'E2E Test Post lock check publish button'
 				);
@@ -42,7 +43,7 @@ describe( 'Publishing', () => {
 			} );
 
 			it( `disables the save shortcut when a ${ postType } is locked`, async () => {
-				await page.type(
+				await canvas().type(
 					'.editor-post-title__input',
 					'E2E Test Post check save shortcut'
 				);
@@ -79,7 +80,7 @@ describe( 'Publishing', () => {
 		} );
 
 		it( `should publish the ${ postType } and close the panel once we start editing again.`, async () => {
-			await page.type( '.editor-post-title__input', 'E2E Test Post' );
+			await canvas().type( '.editor-post-title__input', 'E2E Test Post' );
 
 			await publishPost();
 
@@ -89,7 +90,7 @@ describe( 'Publishing', () => {
 			).not.toBeNull();
 
 			// Start editing again.
-			await page.type( '.editor-post-title__input', ' (Updated)' );
+			await canvas().type( '.editor-post-title__input', ' (Updated)' );
 
 			// The post-publishing panel is not visible anymore.
 			expect( await page.$( '.editor-post-publish-panel' ) ).toBeNull();
@@ -117,7 +118,10 @@ describe( 'Publishing', () => {
 			} );
 
 			it( `should publish the ${ postType } without opening the post-publish sidebar.`, async () => {
-				await page.type( '.editor-post-title__input', 'E2E Test Post' );
+				await canvas().type(
+					'.editor-post-title__input',
+					'E2E Test Post'
+				);
 
 				// The "Publish" button should be shown instead of the "Publish..." toggle.
 				expect(

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -236,6 +236,7 @@ describe( 'Reusable blocks', () => {
 		await editButton.click();
 
 		await page.waitForNavigation();
+		await page.waitForSelector( 'iframe[name="editor-canvas"]' );
 
 		// Click the block to give it focus.
 		const blockSelector = 'p[data-title="Paragraph"]';
@@ -296,6 +297,7 @@ describe( 'Reusable blocks', () => {
 		await insertReusableBlock( 'Duplicated reusable block' );
 		await saveDraft();
 		await page.reload();
+		await page.waitForSelector( 'iframe[name="editor-canvas"]' );
 
 		// Wait for the paragraph to be loaded.
 		await canvas().waitForSelector(
@@ -359,6 +361,7 @@ describe( 'Reusable blocks', () => {
 		insertBlock( 'Quote' );
 		await saveDraft();
 		await page.reload();
+		await page.waitForSelector( 'iframe[name="editor-canvas"]' );
 
 		// The quote block should have a visible preview in the sidebar for this test to be valid.
 		const quoteBlock = await canvas().waitForSelector(

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -16,6 +16,7 @@ import {
 	saveDraft,
 	createReusableBlock,
 	publishPost,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 const reusableBlockNameInputSelector =
@@ -83,7 +84,7 @@ describe( 'Reusable blocks', () => {
 		await page.keyboard.type( 'Surprised greeting block' );
 
 		// Quickly focus the paragraph block.
-		await page.click(
+		await canvas().click(
 			'.block-editor-block-list__block[data-type="core/block"] p'
 		);
 		await page.keyboard.press( 'Escape' ); // Enter navigation mode.
@@ -96,7 +97,7 @@ describe( 'Reusable blocks', () => {
 		await saveAllButDontPublish();
 
 		// Check that its content is up to date.
-		const text = await page.$eval(
+		const text = await canvas().$eval(
 			'.block-editor-block-list__block[data-type="core/block"] p',
 			( element ) => element.innerText
 		);
@@ -111,13 +112,13 @@ describe( 'Reusable blocks', () => {
 		await clickBlockToolbarButton( 'Convert to regular block' );
 
 		// Check that we have a paragraph block on the page.
-		const paragraphBlock = await page.$(
+		const paragraphBlock = await canvas().$(
 			'.block-editor-block-list__block[data-type="core/paragraph"]'
 		);
 		expect( paragraphBlock ).not.toBeNull();
 
 		// Check that its content is up to date.
-		const paragraphContent = await page.$eval(
+		const paragraphContent = await canvas().$eval(
 			'.block-editor-block-list__block[data-type="core/paragraph"]',
 			( element ) => element.innerText
 		);
@@ -132,7 +133,7 @@ describe( 'Reusable blocks', () => {
 		);
 
 		// Make sure the reusable block has loaded properly before attempting to publish the post.
-		await page.waitForSelector( 'p[aria-label="Paragraph block"]' );
+		await canvas().waitForSelector( 'p[aria-label="Paragraph block"]' );
 
 		await publishPost();
 
@@ -142,8 +143,8 @@ describe( 'Reusable blocks', () => {
 		await page.waitForSelector( closePublishPanelSelector );
 		await page.click( closePublishPanelSelector );
 
-		await page.waitForSelector( 'p[aria-label="Paragraph block"]' );
-		await page.focus( 'p[aria-label="Paragraph block"]' );
+		await canvas().waitForSelector( 'p[aria-label="Paragraph block"]' );
+		await canvas().focus( 'p[aria-label="Paragraph block"]' );
 
 		// Change the block's content.
 		await page.keyboard.type( 'Einen ' );
@@ -152,7 +153,7 @@ describe( 'Reusable blocks', () => {
 		await saveAll();
 
 		// Check that its content is up to date.
-		const paragraphContent = await page.$eval(
+		const paragraphContent = await canvas().$eval(
 			'p[aria-label="Paragraph block"]',
 			( element ) => element.innerText
 		);
@@ -238,8 +239,8 @@ describe( 'Reusable blocks', () => {
 
 		// Click the block to give it focus.
 		const blockSelector = 'p[data-title="Paragraph"]';
-		await page.waitForSelector( blockSelector );
-		await page.click( blockSelector );
+		await canvas().waitForSelector( blockSelector );
+		await canvas().click( blockSelector );
 
 		// Delete the block, leaving the reusable block empty.
 		await clickBlockToolbarButton( 'Options' );
@@ -277,7 +278,7 @@ describe( 'Reusable blocks', () => {
 			] );
 		} );
 
-		await page.waitForXPath(
+		await canvas().waitForXPath(
 			'//*[contains(@class, "block-editor-warning")]/*[text()="Block has been deleted or is unavailable."]'
 		);
 
@@ -297,13 +298,13 @@ describe( 'Reusable blocks', () => {
 		await page.reload();
 
 		// Wait for the paragraph to be loaded.
-		await page.waitForSelector(
+		await canvas().waitForSelector(
 			'.block-editor-block-list__block[data-type="core/paragraph"]'
 		);
 		// The first click selects the reusable block wrapper.
 		// The second click selects the actual paragraph block.
-		await page.click( '.wp-block-block' );
-		await page.focus(
+		await canvas().click( '.wp-block-block' );
+		await canvas().focus(
 			'.block-editor-block-list__block[data-type="core/paragraph"]'
 		);
 		await pressKeyWithModifier( 'primary', 'a' );
@@ -333,8 +334,8 @@ describe( 'Reusable blocks', () => {
 
 		// Make an edit to the reusable block and assert that there's only a
 		// paragraph in a reusable block.
-		await page.waitForSelector( 'p[aria-label="Paragraph block"]' );
-		await page.click( 'p[aria-label="Paragraph block"]' );
+		await canvas().waitForSelector( 'p[aria-label="Paragraph block"]' );
+		await canvas().click( 'p[aria-label="Paragraph block"]' );
 		await page.keyboard.type( '2' );
 		const selector =
 			'//div[@aria-label="Block: Reusable block"]//p[@aria-label="Paragraph block"][.="12"]';
@@ -360,7 +361,7 @@ describe( 'Reusable blocks', () => {
 		await page.reload();
 
 		// The quote block should have a visible preview in the sidebar for this test to be valid.
-		const quoteBlock = await page.waitForSelector(
+		const quoteBlock = await canvas().waitForSelector(
 			'.block-editor-block-list__block[aria-label="Block: Quote"]'
 		);
 		// Select the quote block.
@@ -379,7 +380,7 @@ describe( 'Reusable blocks', () => {
 		await nameInput.click();
 		await page.keyboard.type( 'Block with styles' );
 		await page.keyboard.press( 'Enter' );
-		const reusableBlock = await page.waitForSelector(
+		const reusableBlock = await canvas().waitForSelector(
 			'.block-editor-block-list__block[aria-label="Block: Reusable block"]'
 		);
 		expect( reusableBlock ).toBeTruthy();

--- a/packages/e2e-tests/specs/editor/various/rich-text.test.js
+++ b/packages/e2e-tests/specs/editor/various/rich-text.test.js
@@ -9,6 +9,7 @@ import {
 	pressKeyWithModifier,
 	showBlockToolbar,
 	clickBlockToolbarButton,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'RichText', () => {
@@ -74,7 +75,7 @@ describe( 'RichText', () => {
 		await pressKeyWithModifier( 'shift', 'ArrowLeft' );
 		await pressKeyWithModifier( 'primary', 'b' );
 
-		const count = await page.evaluate(
+		const count = await canvas().evaluate(
 			() =>
 				document.querySelectorAll( '*[data-rich-text-format-boundary]' )
 					.length
@@ -173,7 +174,7 @@ describe( 'RichText', () => {
 		await pressKeyWithModifier( 'primary', 'b' );
 		await page.keyboard.type( '3' );
 
-		await page.evaluate( () => {
+		await canvas().evaluate( () => {
 			let called;
 			const { body } = document;
 			const config = {
@@ -233,7 +234,7 @@ describe( 'RichText', () => {
 
 		await page.keyboard.type( '4' );
 
-		await page.evaluate( () => {
+		await canvas().evaluate( () => {
 			// The selection change event should be called once. If there's only
 			// one item in `window.unsubscribes`, it means that only one
 			// function is present to disconnect the `mutationObserver`.
@@ -274,7 +275,7 @@ describe( 'RichText', () => {
 		await page.keyboard.press( 'Enter' );
 
 		// Wait for rich text editor to load.
-		await page.waitForSelector( '.block-editor-rich-text__editable' );
+		await canvas().waitForSelector( '.block-editor-rich-text__editable' );
 
 		await pressKeyWithModifier( 'primary', 'b' );
 		await page.keyboard.type( '12' );
@@ -305,7 +306,7 @@ describe( 'RichText', () => {
 		await page.keyboard.type( '1' );
 		// Simulate moving focus to a different app, then moving focus back,
 		// without selection being changed.
-		await page.evaluate( () => {
+		await canvas().evaluate( () => {
 			const activeElement = document.activeElement;
 			activeElement.blur();
 			activeElement.focus();
@@ -515,7 +516,7 @@ describe( 'RichText', () => {
 		// text in the DOM directly, setting selection in the right place, and
 		// firing `compositionend`.
 		// See https://github.com/puppeteer/puppeteer/issues/4981.
-		await page.evaluate( async () => {
+		await canvas().evaluate( async () => {
 			document.activeElement.textContent = '`a`';
 			const selection = window.getSelection();
 			// The `selectionchange` and `compositionend` events should run in separate event

--- a/packages/e2e-tests/specs/editor/various/sidebar-permalink.test.js
+++ b/packages/e2e-tests/specs/editor/various/sidebar-permalink.test.js
@@ -6,6 +6,7 @@ import {
 	createNewPost,
 	deactivatePlugin,
 	publishPost,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 const urlButtonSelector = '*[aria-label^="Change URL"]';
@@ -28,7 +29,7 @@ describe( 'Sidebar Permalink', () => {
 		await page.keyboard.type( 'aaaaa' );
 		await publishPost();
 		// Start editing again.
-		await page.type( '.editor-post-title__input', ' (Updated)' );
+		await canvas().type( '.editor-post-title__input', ' (Updated)' );
 		expect( await page.$( urlButtonSelector ) ).toBeNull();
 	} );
 
@@ -37,7 +38,7 @@ describe( 'Sidebar Permalink', () => {
 		await page.keyboard.type( 'aaaaa' );
 		await publishPost();
 		// Start editing again.
-		await page.type( '.editor-post-title__input', ' (Updated)' );
+		await canvas().type( '.editor-post-title__input', ' (Updated)' );
 		expect( await page.$( urlButtonSelector ) ).toBeNull();
 	} );
 
@@ -46,7 +47,7 @@ describe( 'Sidebar Permalink', () => {
 		await page.keyboard.type( 'aaaaa' );
 		await publishPost();
 		// Start editing again.
-		await page.type( '.editor-post-title__input', ' (Updated)' );
+		await canvas( 0 ).type( '.editor-post-title__input', ' (Updated)' );
 		expect( await page.$( urlButtonSelector ) ).not.toBeNull();
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/taxonomies.test.js
+++ b/packages/e2e-tests/specs/editor/various/taxonomies.test.js
@@ -6,6 +6,7 @@ import {
 	findSidebarPanelWithTitle,
 	openDocumentSettingsSidebar,
 	publishPost,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 /**
@@ -113,7 +114,7 @@ describe( 'Taxonomies', () => {
 		expect( selectedCategories[ 0 ] ).toEqual( 'z rand category 1' );
 
 		// Type something in the title so we can publish the post.
-		await page.type( '.editor-post-title__input', 'Hello World' );
+		await canvas().type( '.editor-post-title__input', 'Hello World' );
 
 		// Publish the post.
 		await publishPost();
@@ -171,7 +172,7 @@ describe( 'Taxonomies', () => {
 		expect( tags[ 0 ] ).toEqual( tagName );
 
 		// Type something in the title so we can publish the post.
-		await page.type( '.editor-post-title__input', 'Hello World' );
+		await canvas().type( '.editor-post-title__input', 'Hello World' );
 
 		// Publish the post.
 		await publishPost();
@@ -230,7 +231,7 @@ describe( 'Taxonomies', () => {
 		expect( tags[ 0 ] ).toEqual( tagName );
 
 		// Type something in the title so we can publish the post.
-		await page.type( '.editor-post-title__input', 'Hello World' );
+		await canvas().type( '.editor-post-title__input', 'Hello World' );
 
 		// Publish the post.
 		await publishPost();

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -112,7 +112,7 @@ export default function VisualEditor( { styles } ) {
 		wrapperBlockName,
 		wrapperUniqueId,
 		isBlockBasedTheme,
-		blockTypes,
+		hasV3BlocksOnly,
 	} = useSelect( ( select ) => {
 		const {
 			isFeatureActive,
@@ -153,12 +153,11 @@ export default function VisualEditor( { styles } ) {
 			wrapperBlockName: _wrapperBlockName,
 			wrapperUniqueId: getCurrentPostId(),
 			isBlockBasedTheme: editorSettings.__unstableIsBlockBasedTheme,
-			blockTypes: getBlockTypes(),
+			hasV3BlocksOnly: getBlockTypes().every( ( type ) => {
+				return type.apiVersion >= 3;
+			} ),
 		};
 	}, [] );
-	const hasV3BlocksOnly = blockTypes.every( ( type ) => {
-		return type.apiVersion >= 3;
-	} );
 	const { isCleanNewPost } = useSelect( editorStore );
 	const hasMetaBoxes = useSelect(
 		( select ) => select( editPostStore ).hasMetaBoxes(),

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -74,7 +74,8 @@ function PostTitle( _, forwardedRef ) {
 			return;
 		}
 
-		const { ownerDocument } = ref.current;
+		const ownerDocument =
+			ref.current.ownerDocument.defaultView.top.document;
 		const { activeElement, body } = ownerDocument;
 
 		// Only autofocus the title when the post is entirely empty. This should

--- a/packages/server-side-render/README.md
+++ b/packages/server-side-render/README.md
@@ -170,7 +170,7 @@ If you pass `attributes` to `ServerSideRender`, the block must also be registere
 register_block_type(
 	'core/archives',
 	array(
-		'api_version' => 2,
+		'api_version' => 3,
 		'attributes'      => array(
 			'showPostCounts'    => array(
 				'type'      => 'boolean',

--- a/packages/widgets/src/blocks/legacy-widget/block.json
+++ b/packages/widgets/src/blocks/legacy-widget/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/legacy-widget",
 	"title": "Legacy Widget",
 	"category": "widgets",

--- a/packages/widgets/src/blocks/widget-group/block.json
+++ b/packages/widgets/src/blocks/widget-group/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/widget-group",
 	"category": "widgets",
 	"attributes": {

--- a/phpunit/block-supports/border-test.php
+++ b/phpunit/block-supports/border-test.php
@@ -36,7 +36,7 @@ class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 		register_block_type(
 			$this->test_block_name,
 			array(
-				'api_version' => 2,
+				'api_version' => 3,
 				'attributes'  => array(
 					'borderColor' => array(
 						'type' => 'string',

--- a/phpunit/block-supports/colors-test.php
+++ b/phpunit/block-supports/colors-test.php
@@ -28,7 +28,7 @@ class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {
 		register_block_type(
 			$this->test_block_name,
 			array(
-				'api_version' => 2,
+				'api_version' => 3,
 				'attributes'  => array(
 					'textColor'       => array(
 						'type' => 'string',
@@ -69,7 +69,7 @@ class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {
 		register_block_type(
 			$this->test_block_name,
 			array(
-				'api_version' => 2,
+				'api_version' => 3,
 				'attributes'  => array(
 					'style' => array(
 						'type' => 'object',
@@ -107,7 +107,7 @@ class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {
 		register_block_type(
 			$this->test_block_name,
 			array(
-				'api_version' => 2,
+				'api_version' => 3,
 				'attributes'  => array(
 					'style' => array(
 						'type' => 'object',

--- a/phpunit/block-supports/dimensions-test.php
+++ b/phpunit/block-supports/dimensions-test.php
@@ -28,7 +28,7 @@ class WP_Block_Supports_Dimensions_Test extends WP_UnitTestCase {
 		register_block_type(
 			$this->test_block_name,
 			array(
-				'api_version' => 2,
+				'api_version' => 3,
 				'attributes'  => array(
 					'style' => array(
 						'type' => 'object',
@@ -64,7 +64,7 @@ class WP_Block_Supports_Dimensions_Test extends WP_UnitTestCase {
 		register_block_type(
 			$this->test_block_name,
 			array(
-				'api_version' => 2,
+				'api_version' => 3,
 				'attributes'  => array(
 					'style' => array(
 						'type' => 'object',
@@ -99,7 +99,7 @@ class WP_Block_Supports_Dimensions_Test extends WP_UnitTestCase {
 		register_block_type(
 			$this->test_block_name,
 			array(
-				'api_version' => 2,
+				'api_version' => 3,
 				'attributes'  => array(
 					'style' => array(
 						'type' => 'object',

--- a/phpunit/block-supports/position-test.php
+++ b/phpunit/block-supports/position-test.php
@@ -78,7 +78,7 @@ class WP_Block_Supports_Position_Test extends WP_UnitTestCase {
 		register_block_type(
 			$this->test_block_name,
 			array(
-				'api_version' => 2,
+				'api_version' => 3,
 				'attributes'  => array(
 					'style' => array(
 						'type' => 'object',

--- a/phpunit/block-supports/spacing-test.php
+++ b/phpunit/block-supports/spacing-test.php
@@ -28,7 +28,7 @@ class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
 		register_block_type(
 			$this->test_block_name,
 			array(
-				'api_version' => 2,
+				'api_version' => 3,
 				'attributes'  => array(
 					'style' => array(
 						'type' => 'object',
@@ -73,7 +73,7 @@ class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
 		register_block_type(
 			$this->test_block_name,
 			array(
-				'api_version' => 2,
+				'api_version' => 3,
 				'attributes'  => array(
 					'style' => array(
 						'type' => 'object',
@@ -117,7 +117,7 @@ class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
 		register_block_type(
 			$this->test_block_name,
 			array(
-				'api_version' => 2,
+				'api_version' => 3,
 				'attributes'  => array(
 					'style' => array(
 						'type' => 'object',

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -78,7 +78,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 		register_block_type(
 			$this->test_block_name,
 			array(
-				'api_version' => 2,
+				'api_version' => 3,
 				'attributes'  => array(
 					'fontSize' => array(
 						'type' => 'string',
@@ -112,7 +112,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 		register_block_type(
 			$this->test_block_name,
 			array(
-				'api_version' => 2,
+				'api_version' => 3,
 				'attributes'  => array(
 					'style' => array(
 						'type' => 'object',
@@ -145,7 +145,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 		register_block_type(
 			$this->test_block_name,
 			array(
-				'api_version' => 2,
+				'api_version' => 3,
 				'attributes'  => array(
 					'style' => array(
 						'type' => 'object',
@@ -191,7 +191,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 		register_block_type(
 			$this->test_block_name,
 			array(
-				'api_version' => 2,
+				'api_version' => 3,
 				'attributes'  => array(
 					'style' => array(
 						'type' => 'object',
@@ -227,7 +227,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 		register_block_type(
 			$this->test_block_name,
 			array(
-				'api_version' => 2,
+				'api_version' => 3,
 				'attributes'  => array(
 					'style' => array(
 						'type' => 'object',
@@ -260,7 +260,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 		register_block_type(
 			$this->test_block_name,
 			array(
-				'api_version' => 2,
+				'api_version' => 3,
 				'attributes'  => array(
 					'style' => array(
 						'type' => 'object',
@@ -625,7 +625,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 		register_block_type(
 			$this->test_block_name,
 			array(
-				'api_version' => 2,
+				'api_version' => 3,
 				'attributes'  => array(
 					'style' => array(
 						'type' => 'object',

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -105,7 +105,7 @@ function gutenberg_register_test_block_for_feature_selectors() {
 	WP_Block_Type_Registry::get_instance()->register(
 		'test/test',
 		array(
-			'api_version' => 2,
+			'api_version' => 3,
 			'attributes'  => array(
 				'textColor' => array(
 					'type' => 'string',

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -396,7 +396,7 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		register_block_type(
 			'my/block-with-styles',
 			array(
-				'api_version' => 2,
+				'api_version' => 3,
 				'attributes'  => array(
 					'borderColor' => array(
 						'type' => 'string',

--- a/phpunit/fixtures/block.json
+++ b/phpunit/fixtures/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "my-plugin/notice",
 	"title": "Notice",
 	"category": "common",

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -17,9 +17,9 @@
 		},
 		"apiVersion": {
 			"type": "integer",
-			"description": "The version of the Block API used by the block. The most recent version is 2 and it was introduced in WordPress 5.6.\n\n See the API versions documentation at https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/ for more details.",
+			"description": "The version of the Block API used by the block. The most recent version is 3 and it was introduced in WordPress 6.3.\n\n See the API versions documentation at https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/ for more details.",
 			"default": 1,
-			"enum": [ 1, 2 ]
+			"enum": [ 1, 2, 3 ]
 		},
 		"name": {
 			"type": "string",

--- a/test/e2e/specs/editor/blocks/avatar.spec.js
+++ b/test/e2e/specs/editor/blocks/avatar.spec.js
@@ -37,7 +37,7 @@ test.describe( 'Avatar', () => {
 
 		const username = 'Gravatar Gravatar';
 
-		const avatarBlock = page.locator(
+		const avatarBlock = editor.canvas.locator(
 			'role=document[name="Block: Avatar"i]'
 		);
 

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -27,7 +27,7 @@ test.describe( 'Buttons', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '/buttons' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'Content' );
@@ -56,7 +56,7 @@ test.describe( 'Buttons', () => {
 		).toBeFocused();
 		await page.keyboard.press( 'Escape' );
 		await expect(
-			page.locator( 'role=textbox[name="Button text"i]' )
+			editor.canvas.locator( 'role=textbox[name="Button text"i]' )
 		).toBeFocused();
 		await page.keyboard.type( 'WordPress' );
 
@@ -91,7 +91,7 @@ test.describe( 'Buttons', () => {
 
 		// Focus should move from the link control to the button block's text.
 		await expect(
-			page.locator( 'role=textbox[name="Button text"i]' )
+			editor.canvas.locator( 'role=textbox[name="Button text"i]' )
 		).toBeFocused();
 
 		// The link control should still be visible when a URL is set.

--- a/test/e2e/specs/editor/blocks/classic.spec.js
+++ b/test/e2e/specs/editor/blocks/classic.spec.js
@@ -29,10 +29,12 @@ test.describe( 'Classic', () => {
 	test( 'should be inserted', async ( { editor, page, pageUtils } ) => {
 		await editor.insertBlock( { name: 'core/freeform' } );
 		// Ensure there is focus.
-		await page.click( '.mce-content-body' );
+		await page.waitForSelector( '.mce-tinymce iframe' );
+		await page.click( '.mce-tinymce iframe' );
 		await page.keyboard.type( 'test' );
 		// Move focus away.
 		await pageUtils.pressKeys( 'shift+Tab' );
+		await page.keyboard.press( 'Enter' );
 
 		await expect.poll( editor.getEditedPostContent ).toBe( 'test' );
 	} );
@@ -45,7 +47,8 @@ test.describe( 'Classic', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/freeform' } );
 		// Ensure there is focus.
-		await page.click( '.mce-content-body' );
+		await page.waitForSelector( '.mce-tinymce iframe' );
+		await page.click( '.mce-tinymce iframe' );
 		await page.keyboard.type( 'test' );
 
 		await page.getByRole( 'button', { name: /Add Media/i } ).click();
@@ -74,12 +77,13 @@ test.describe( 'Classic', () => {
 		await page.click( 'role=button[name="Insert gallery"i]' );
 
 		await pageUtils.pressKeys( 'shift+Tab' );
+		await page.keyboard.press( 'Enter' );
 		await expect
 			.poll( editor.getEditedPostContent )
 			.toMatch( /\[gallery ids=\"\d+\"\]/ );
 
 		await editor.clickBlockToolbarButton( 'Convert to blocks' );
-		const galleryBlock = page.locator(
+		const galleryBlock = editor.canvas.locator(
 			'role=document[name="Block: Gallery"i]'
 		);
 		await expect( galleryBlock ).toBeVisible();
@@ -87,7 +91,7 @@ test.describe( 'Classic', () => {
 		// Check that you can undo back to a Classic block gallery in one step.
 		await pageUtils.pressKeys( 'primary+z' );
 		await expect(
-			page.locator( 'role=document[name="Block: Classic"i]' )
+			editor.canvas.locator( 'role=document[name="Block: Classic"i]' )
 		).toBeVisible();
 		await expect
 			.poll( editor.getEditedPostContent )
@@ -112,10 +116,12 @@ test.describe( 'Classic', () => {
 
 		await editor.insertBlock( { name: 'core/freeform' } );
 		// Ensure there is focus.
-		await page.click( '.mce-content-body' );
+		await page.waitForSelector( '.mce-tinymce iframe' );
+		await page.click( '.mce-tinymce iframe' );
 		await page.keyboard.type( 'test' );
 		// Move focus away.
 		await pageUtils.pressKeys( 'shift+Tab' );
+		await page.keyboard.press( 'Enter' );
 
 		await page.click( 'role=button[name="Save draft"i]' );
 
@@ -131,7 +137,7 @@ test.describe( 'Classic', () => {
 			errors.push( exception );
 		} );
 
-		const classicBlock = page.locator(
+		const classicBlock = editor.canvas.locator(
 			'role=document[name="Block: Classic"i]'
 		);
 

--- a/test/e2e/specs/editor/blocks/classic.spec.js
+++ b/test/e2e/specs/editor/blocks/classic.spec.js
@@ -133,6 +133,14 @@ test.describe( 'Classic', () => {
 		await page.reload();
 		await page.unroute( '**' );
 
+		// To do: run with iframe.
+		await page.evaluate( () => {
+			window.wp.blocks.registerBlockType( 'test/v2', {
+				apiVersion: '2',
+				title: 'test',
+			} );
+		} );
+
 		const errors = [];
 		page.on( 'pageerror', ( exception ) => {
 			errors.push( exception );

--- a/test/e2e/specs/editor/blocks/code.spec.js
+++ b/test/e2e/specs/editor/blocks/code.spec.js
@@ -12,7 +12,7 @@ test.describe( 'Code', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '```' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '<?php' );

--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -18,7 +18,9 @@ test.describe( 'Columns', () => {
 	} ) => {
 		// Open Columns
 		await editor.insertBlock( { name: 'core/columns' } );
-		await page.locator( '[aria-label="Two columns; equal split"]' ).click();
+		await editor.canvas
+			.locator( '[aria-label="Two columns; equal split"]' )
+			.click();
 
 		// Open List view toggle
 		await page.locator( 'role=button[name="Document Overview"i]' ).click();
@@ -51,13 +53,15 @@ test.describe( 'Columns', () => {
 	} ) => {
 		// Open Columns
 		await editor.insertBlock( { name: 'core/columns' } );
-		await page
+		await editor.canvas
 			.locator( '[aria-label="Three columns; equal split"]' )
 			.click();
 
 		// Lock last column block
 		await editor.selectBlocks(
-			page.locator( 'role=document[name="Block: Column (3 of 3)"i]' )
+			editor.canvas.locator(
+				'role=document[name="Block: Column (3 of 3)"i]'
+			)
 		);
 		await editor.clickBlockToolbarButton( 'Options' );
 		await page.click( 'role=menuitem[name="Lock"i]' );
@@ -66,7 +70,7 @@ test.describe( 'Columns', () => {
 
 		// Select columns block
 		await editor.selectBlocks(
-			page.locator( 'role=document[name="Block: Columns"i]' )
+			editor.canvas.locator( 'role=document[name="Block: Columns"i]' )
 		);
 		await editor.openDocumentSettingsSidebar();
 

--- a/test/e2e/specs/editor/blocks/comments.spec.js
+++ b/test/e2e/specs/editor/blocks/comments.spec.js
@@ -169,7 +169,7 @@ test.describe( 'Comments', () => {
 			'role=button[name="Switch to editable mode"i]'
 		);
 
-		const commentTemplate = block.locator(
+		const commentTemplate = editor.canvas.locator(
 			'role=document[name="Block: Comment Template"i]'
 		);
 		await expect( block ).toHaveClass( /has-vivid-purple-color/ );

--- a/test/e2e/specs/editor/blocks/cover.spec.js
+++ b/test/e2e/specs/editor/blocks/cover.spec.js
@@ -25,12 +25,11 @@ test.describe( 'Cover', () => {
 	} );
 
 	test( 'can set overlay color using color picker on block placeholder', async ( {
-		page,
 		editor,
 		coverBlockUtils,
 	} ) => {
 		await editor.insertBlock( { name: 'core/cover' } );
-		const coverBlock = page.getByRole( 'document', {
+		const coverBlock = editor.canvas.getByRole( 'document', {
 			name: 'Block: Cover',
 		} );
 
@@ -56,12 +55,11 @@ test.describe( 'Cover', () => {
 	} );
 
 	test( 'can set background image using image upload on block placeholder', async ( {
-		page,
 		editor,
 		coverBlockUtils,
 	} ) => {
 		await editor.insertBlock( { name: 'core/cover' } );
-		const coverBlock = page.getByRole( 'document', {
+		const coverBlock = editor.canvas.getByRole( 'document', {
 			name: 'Block: Cover',
 		} );
 
@@ -80,12 +78,11 @@ test.describe( 'Cover', () => {
 	} );
 
 	test( 'dims background image down by 50% by default', async ( {
-		page,
 		editor,
 		coverBlockUtils,
 	} ) => {
 		await editor.insertBlock( { name: 'core/cover' } );
-		const coverBlock = page.getByRole( 'document', {
+		const coverBlock = editor.canvas.getByRole( 'document', {
 			name: 'Block: Cover',
 		} );
 
@@ -104,11 +101,11 @@ test.describe( 'Cover', () => {
 		expect( backgroundDimOpacity ).toBe( '0.5' );
 	} );
 
-	test( 'can have the title edited', async ( { page, editor } ) => {
+	test( 'can have the title edited', async ( { editor } ) => {
 		const titleText = 'foo';
 
 		await editor.insertBlock( { name: 'core/cover' } );
-		const coverBlock = page.getByRole( 'document', {
+		const coverBlock = editor.canvas.getByRole( 'document', {
 			name: 'Block: Cover',
 		} );
 
@@ -134,7 +131,7 @@ test.describe( 'Cover', () => {
 
 	test( 'can be resized using drag & drop', async ( { page, editor } ) => {
 		await editor.insertBlock( { name: 'core/cover' } );
-		const coverBlock = page.getByRole( 'document', {
+		const coverBlock = editor.canvas.getByRole( 'document', {
 			name: 'Block: Cover',
 		} );
 		await coverBlock
@@ -205,13 +202,12 @@ test.describe( 'Cover', () => {
 	} );
 
 	test( 'dims the background image down by 50% when transformed from the Image block', async ( {
-		page,
 		editor,
 		coverBlockUtils,
 	} ) => {
 		await editor.insertBlock( { name: 'core/image' } );
 
-		const imageBlock = page.getByRole( 'document', {
+		const imageBlock = editor.canvas.getByRole( 'document', {
 			name: 'Block: Image',
 		} );
 
@@ -220,14 +216,14 @@ test.describe( 'Cover', () => {
 		);
 
 		await expect(
-			page
+			editor.canvas
 				.getByRole( 'document', { name: 'Block: Image' } )
 				.locator( 'img' )
 		).toBeVisible();
 
 		await editor.transformBlockTo( 'core/cover' );
 
-		const coverBlock = page.getByRole( 'document', {
+		const coverBlock = editor.canvas.getByRole( 'document', {
 			name: 'Block: Cover',
 		} );
 

--- a/test/e2e/specs/editor/blocks/gallery.spec.js
+++ b/test/e2e/specs/editor/blocks/gallery.spec.js
@@ -51,10 +51,10 @@ test.describe( 'Gallery', () => {
 			plainText: `[gallery ids="${ uploadedMedia.id }"]`,
 		} );
 
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await pageUtils.pressKeys( 'primary+v' );
 
-		const img = page.locator(
+		const img = editor.canvas.locator(
 			'role=document[name="Block: Image"i] >> role=img'
 		);
 
@@ -87,12 +87,11 @@ test.describe( 'Gallery', () => {
 	test( 'can be created using uploaded images', async ( {
 		admin,
 		editor,
-		page,
 		galleryBlockUtils,
 	} ) => {
 		await admin.createNewPost();
 		await editor.insertBlock( { name: 'core/gallery' } );
-		const galleryBlock = page.locator(
+		const galleryBlock = editor.canvas.locator(
 			'role=document[name="Block: Gallery"i]'
 		);
 		await expect( galleryBlock ).toBeVisible();
@@ -132,7 +131,9 @@ test.describe( 'Gallery', () => {
 			],
 		} );
 
-		const gallery = page.locator( 'role=document[name="Block: Gallery"i]' );
+		const gallery = editor.canvas.locator(
+			'role=document[name="Block: Gallery"i]'
+		);
 
 		await expect( gallery ).toBeVisible();
 		await editor.selectBlocks( gallery );
@@ -173,7 +174,7 @@ test.describe( 'Gallery', () => {
 			],
 		} );
 
-		const galleryImage = page.locator(
+		const galleryImage = editor.canvas.locator(
 			'role=document[name="Block: Gallery"i] >> role=document[name="Block: Image"i]'
 		);
 		const imageCaption = galleryImage.locator(
@@ -203,7 +204,7 @@ test.describe( 'Gallery', () => {
 	} ) => {
 		await admin.createNewPost();
 		await editor.insertBlock( { name: 'core/gallery' } );
-		await page.click( 'role=button[name="Media Library"i]' );
+		await editor.canvas.click( 'role=button[name="Media Library"i]' );
 
 		const mediaLibrary = page.locator(
 			'role=dialog[name="Create gallery"i]'

--- a/test/e2e/specs/editor/blocks/group.spec.js
+++ b/test/e2e/specs/editor/blocks/group.spec.js
@@ -29,7 +29,7 @@ test.describe( 'Group', () => {
 		);
 
 		// Select the default, selected Group layout from the variation picker.
-		await page.click(
+		await editor.canvas.click(
 			'role=button[name="Group: Gather blocks in a container."i]'
 		);
 
@@ -40,7 +40,7 @@ test.describe( 'Group', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '/group' );
 		await expect(
 			page.locator( 'role=option[name="Group"i][selected]' )
@@ -48,7 +48,7 @@ test.describe( 'Group', () => {
 		await page.keyboard.press( 'Enter' );
 
 		// Select the default, selected Group layout from the variation picker.
-		await page.click(
+		await editor.canvas.click(
 			'role=button[name="Group: Gather blocks in a container."i]'
 		);
 
@@ -60,10 +60,10 @@ test.describe( 'Group', () => {
 		page,
 	} ) => {
 		await editor.insertBlock( { name: 'core/group' } );
-		await page.click(
+		await editor.canvas.click(
 			'button[aria-label="Group: Gather blocks in a container."]'
 		);
-		await page.click( 'role=button[name="Add block"i]' );
+		await editor.canvas.click( 'role=button[name="Add block"i]' );
 		await page.click(
 			'role=listbox[name="Blocks"i] >> role=option[name="Paragraph"i]'
 		);

--- a/test/e2e/specs/editor/blocks/heading.spec.js
+++ b/test/e2e/specs/editor/blocks/heading.spec.js
@@ -12,7 +12,7 @@ test.describe( 'Heading', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '### 3' );
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
@@ -27,7 +27,7 @@ test.describe( 'Heading', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '4' );
 		await page.keyboard.press( 'ArrowLeft' );
 		await page.keyboard.type( '#### ' );
@@ -44,7 +44,7 @@ test.describe( 'Heading', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '## 1. H' );
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
@@ -59,7 +59,7 @@ test.describe( 'Heading', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '## `code`' );
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
@@ -115,7 +115,7 @@ test.describe( 'Heading', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '### Heading' );
 		await editor.openDocumentSettingsSidebar();
 
@@ -147,7 +147,7 @@ test.describe( 'Heading', () => {
 	} );
 
 	test( 'should correctly apply named colors', async ( { editor, page } ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '## Heading' );
 		await editor.openDocumentSettingsSidebar();
 
@@ -185,7 +185,7 @@ test.describe( 'Heading', () => {
 		page,
 		pageUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '## Heading' );
 
 		// Change text alignment
@@ -216,7 +216,7 @@ test.describe( 'Heading', () => {
 		page,
 		pageUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'Paragraph' );
 
 		// Change text alignment
@@ -247,7 +247,7 @@ test.describe( 'Heading', () => {
 		page,
 		pageUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '## Heading' );
 
 		// Change text alignment

--- a/test/e2e/specs/editor/blocks/html.spec.js
+++ b/test/e2e/specs/editor/blocks/html.spec.js
@@ -10,7 +10,7 @@ test.describe( 'HTML block', () => {
 
 	test( 'can be created by typing "/html"', async ( { editor, page } ) => {
 		// Create a Custom HTML block with the slash shortcut.
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '/html' );
 		await expect(
 			page.locator( 'role=option[name="Custom HTML"i][selected]' )
@@ -33,7 +33,7 @@ test.describe( 'HTML block', () => {
 
 	test( 'should not encode <', async ( { editor, page } ) => {
 		// Create a Custom HTML block with the slash shortcut.
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '/html' );
 		await expect(
 			page.locator( 'role=option[name="Custom HTML"i][selected]' )
@@ -42,8 +42,9 @@ test.describe( 'HTML block', () => {
 		await page.keyboard.type( '1 < 2' );
 		await editor.publishPost();
 		await page.reload();
+		await page.waitForSelector( '[name="editor-canvas"]' );
 		await expect(
-			page.locator( '[data-type="core/html"] textarea' )
+			editor.canvas.locator( '[data-type="core/html"] textarea' )
 		).toBeVisible();
 	} );
 } );

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -548,6 +548,13 @@ test.describe( 'Image', () => {
 		page,
 		editor,
 	} ) => {
+		// To do: run with iframe.
+		await page.evaluate( () => {
+			window.wp.blocks.registerBlockType( 'test/v2', {
+				apiVersion: '2',
+				title: 'test',
+			} );
+		} );
 		await editor.insertBlock( { name: 'core/image' } );
 		const imageBlock = editor.canvas.getByRole( 'document', {
 			name: 'Block: Image',
@@ -761,7 +768,7 @@ test.describe( 'Image - interactivity', () => {
 		await admin.createNewPost();
 		await editor.insertBlock( { name: 'core/image' } );
 
-		const imageBlock = page.locator(
+		const imageBlock = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'
 		);
 		await expect( imageBlock ).toBeVisible();

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -32,10 +32,10 @@ test.describe( 'Image', () => {
 		await requestUtils.deleteAllMedia();
 	} );
 
-	test( 'can be inserted', async ( { editor, page, imageBlockUtils } ) => {
+	test( 'can be inserted', async ( { editor, imageBlockUtils } ) => {
 		await editor.insertBlock( { name: 'core/image' } );
 
-		const imageBlock = page.locator(
+		const imageBlock = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'
 		);
 		await expect( imageBlock ).toBeVisible();
@@ -63,7 +63,7 @@ test.describe( 'Image', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/image' } );
 
-		const imageBlock = page.locator(
+		const imageBlock = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'
 		);
 		const image = imageBlock.locator( 'role=img' );
@@ -134,7 +134,7 @@ test.describe( 'Image', () => {
 		{
 			// Focus outside the block to avoid the image caption being selected
 			// It can happen on CI specially.
-			await page.click( 'role=textbox[name="Add title"i]' );
+			await editor.canvas.click( 'role=textbox[name="Add title"i]' );
 			await image.click();
 			await page.keyboard.press( 'Backspace' );
 
@@ -149,7 +149,7 @@ test.describe( 'Image', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/image' } );
 
-		const imageBlock = page.locator(
+		const imageBlock = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'
 		);
 		const image = imageBlock.locator( 'role=img' );
@@ -165,7 +165,9 @@ test.describe( 'Image', () => {
 		await page.keyboard.type( '2' );
 
 		expect(
-			await page.evaluate( () => document.activeElement.innerHTML )
+			await editor.canvas.evaluate(
+				() => document.activeElement.innerHTML
+			)
 		).toBe( '12' );
 	} );
 
@@ -176,7 +178,7 @@ test.describe( 'Image', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/image' } );
 
-		const imageBlock = page.locator(
+		const imageBlock = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'
 		);
 		const image = imageBlock.locator( 'role=img' );
@@ -193,7 +195,9 @@ test.describe( 'Image', () => {
 		await page.keyboard.press( 'Enter' );
 
 		expect(
-			await page.evaluate( () => document.activeElement.innerHTML )
+			await editor.canvas.evaluate(
+				() => document.activeElement.innerHTML
+			)
 		).toBe( '1<br data-rich-text-line-break="true">2' );
 	} );
 
@@ -205,7 +209,7 @@ test.describe( 'Image', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/image' } );
 
-		const imageBlock = page.locator(
+		const imageBlock = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'
 		);
 		const image = imageBlock.locator( 'role=img' );
@@ -245,7 +249,9 @@ test.describe( 'Image', () => {
 		await page.keyboard.press( 'ArrowRight' );
 
 		expect(
-			await page.evaluate( () => document.activeElement.innerHTML )
+			await editor.canvas.evaluate(
+				() => document.activeElement.innerHTML
+			)
 		).toBe( '<strong>a</strong>' );
 	} );
 
@@ -256,7 +262,7 @@ test.describe( 'Image', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/image' } );
 
-		const imageBlock = page.locator(
+		const imageBlock = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'
 		);
 		const image = imageBlock.locator( 'role=img' );
@@ -300,7 +306,7 @@ test.describe( 'Image', () => {
 		// Insert the block, upload a file and crop.
 		await editor.insertBlock( { name: 'core/image' } );
 
-		const imageBlock = page.locator(
+		const imageBlock = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'
 		);
 		const image = imageBlock.locator( 'role=img' );
@@ -366,7 +372,7 @@ test.describe( 'Image', () => {
 		// Insert the block, upload a file and crop.
 		await editor.insertBlock( { name: 'core/image' } );
 
-		const imageBlock = page.locator(
+		const imageBlock = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'
 		);
 		const image = imageBlock.locator( 'role=img' );
@@ -423,7 +429,7 @@ test.describe( 'Image', () => {
 		// Insert the block, upload a file and crop.
 		await editor.insertBlock( { name: 'core/image' } );
 
-		const imageBlock = page.locator(
+		const imageBlock = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'
 		);
 		const image = imageBlock.locator( 'role=img' );
@@ -459,7 +465,7 @@ test.describe( 'Image', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/image' } );
 
-		const imageBlock = page.locator(
+		const imageBlock = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'
 		);
 		const image = imageBlock.locator( 'role=img' );
@@ -513,13 +519,12 @@ test.describe( 'Image', () => {
 
 	test( 'should undo without broken temporary state', async ( {
 		editor,
-		page,
 		pageUtils,
 		imageBlockUtils,
 	} ) => {
 		await editor.insertBlock( { name: 'core/image' } );
 
-		const imageBlock = page.locator(
+		const imageBlock = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'
 		);
 		const image = imageBlock.locator( 'role=img' );
@@ -529,7 +534,7 @@ test.describe( 'Image', () => {
 		);
 
 		await expect( image ).toHaveAttribute( 'src', new RegExp( filename ) );
-		await page.focus( '.wp-block-image' );
+		await editor.canvas.focus( '.wp-block-image' );
 		await pageUtils.pressKeys( 'primary+z' );
 
 		// Expect an empty image block (placeholder) rather than one with a
@@ -544,7 +549,7 @@ test.describe( 'Image', () => {
 		editor,
 	} ) => {
 		await editor.insertBlock( { name: 'core/image' } );
-		const imageBlock = page.getByRole( 'document', {
+		const imageBlock = editor.canvas.getByRole( 'document', {
 			name: 'Block: Image',
 		} );
 		const blockLibrary = page.getByRole( 'region', {
@@ -637,7 +642,7 @@ test.describe( 'Image', () => {
 		editor,
 	} ) => {
 		await editor.insertBlock( { name: 'core/image' } );
-		const imageBlock = page.getByRole( 'document', {
+		const imageBlock = editor.canvas.getByRole( 'document', {
 			name: 'Block: Image',
 		} );
 
@@ -698,7 +703,7 @@ test.describe( 'Image', () => {
 		page,
 	} ) => {
 		await editor.insertBlock( { name: 'core/image' } );
-		const imageBlock = page.locator(
+		const imageBlock = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'
 		);
 		await expect( imageBlock ).toBeVisible();

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -735,6 +735,13 @@ test.describe( 'List (@firefox)', () => {
 	} );
 
 	test( 'should indent and outdent level 2', async ( { editor, page } ) => {
+		// To do: run with iframe.
+		await page.evaluate( () => {
+			window.wp.blocks.registerBlockType( 'test/v2', {
+				apiVersion: '2',
+				title: 'test',
+			} );
+		} );
 		await editor.insertBlock( { name: 'core/list' } );
 		await page.keyboard.type( 'a' );
 		await page.keyboard.press( 'Enter' );

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -13,7 +13,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		// Create a block with some text that will trigger a list creation.
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '* A list item' );
 
 		// Create a second list item.
@@ -38,7 +38,7 @@ test.describe( 'List (@firefox)', () => {
 		pageUtils,
 	} ) => {
 		// Create a list with the slash block shortcut.
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'test' );
 		await pageUtils.pressKeys( 'ArrowLeft', { times: 4 } );
 		await page.keyboard.type( '* ' );
@@ -56,7 +56,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		// Create a block with some text that will trigger a list creation.
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '1) A list item' );
 
 		await expect.poll( editor.getEditedPostContent ).toBe(
@@ -73,7 +73,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 		pageUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '1. ' );
 		await pageUtils.pressKeys( 'primary+z' );
 
@@ -88,7 +88,7 @@ test.describe( 'List (@firefox)', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '* ' );
 		await page.keyboard.press( 'Backspace' );
 
@@ -103,9 +103,11 @@ test.describe( 'List (@firefox)', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '* ' );
-		await expect( page.locator( '[data-type="core/list"]' ) ).toBeVisible();
+		await expect(
+			editor.canvas.locator( '[data-type="core/list"]' )
+		).toBeVisible();
 		await page.keyboard.press( 'Backspace' );
 
 		await expect.poll( editor.getEditedPostContent ).toBe(
@@ -119,7 +121,7 @@ test.describe( 'List (@firefox)', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '* ' );
 		await editor.showBlockToolbar();
 		await page.keyboard.press( 'Backspace' );
@@ -135,10 +137,12 @@ test.describe( 'List (@firefox)', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.evaluate( () => delete window.requestIdleCallback );
 		await page.keyboard.type( '* ' );
-		await expect( page.locator( '[data-type="core/list"]' ) ).toBeVisible();
+		await expect(
+			editor.canvas.locator( '[data-type="core/list"]' )
+		).toBeVisible();
 		await page.keyboard.press( 'Backspace' );
 
 		await expect.poll( editor.getEditedPostContent ).toBe(
@@ -152,7 +156,7 @@ test.describe( 'List (@firefox)', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '* ' );
 		await page.keyboard.press( 'Escape' );
 
@@ -167,7 +171,7 @@ test.describe( 'List (@firefox)', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '* a' );
 		await page.keyboard.press( 'Backspace' );
 		await page.keyboard.press( 'Backspace' );
@@ -179,9 +183,11 @@ test.describe( 'List (@firefox)', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '* ' );
-		await expect( page.locator( '[data-type="core/list"]' ) ).toBeVisible();
+		await expect(
+			editor.canvas.locator( '[data-type="core/list"]' )
+		).toBeVisible();
 		// Wait until the automatic change is marked as "final", which is done
 		// with an idle callback, see __unstableMarkAutomaticChange.
 		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
@@ -194,7 +200,7 @@ test.describe( 'List (@firefox)', () => {
 
 	test( 'can be created by typing "/list"', async ( { editor, page } ) => {
 		// Create a list with the slash block shortcut.
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '/list' );
 		await expect(
 			page.locator( 'role=option[name="List"i][selected]' )
@@ -215,7 +221,7 @@ test.describe( 'List (@firefox)', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'test' );
 		await editor.transformBlockTo( 'core/list' );
 
@@ -232,12 +238,12 @@ test.describe( 'List (@firefox)', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'one' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'two' );
 		await page.keyboard.down( 'Shift' );
-		await page.click( '[data-type="core/paragraph"] >> nth=0' );
+		await editor.canvas.click( '[data-type="core/paragraph"] >> nth=0' );
 		await page.keyboard.up( 'Shift' );
 		await editor.transformBlockTo( 'core/list' );
 
@@ -259,7 +265,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 		pageUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'one' );
 		await pageUtils.pressKeys( 'shift+Enter' );
 		await page.keyboard.type( 'two' );
@@ -283,14 +289,14 @@ test.describe( 'List (@firefox)', () => {
 		page,
 		pageUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'one' );
 		await pageUtils.pressKeys( 'shift+Enter' );
 		await page.keyboard.type( '...' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'two' );
 		await page.keyboard.down( 'Shift' );
-		await page.click( '[data-type="core/paragraph"] >> nth=0' );
+		await editor.canvas.click( '[data-type="core/paragraph"] >> nth=0' );
 		await page.keyboard.up( 'Shift' );
 		await editor.transformBlockTo( 'core/list' );
 
@@ -555,7 +561,7 @@ test.describe( 'List (@firefox)', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '1. one' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'two' );
@@ -897,7 +903,7 @@ test.describe( 'List (@firefox)', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 
 		await page.keyboard.type( '* 1' ); // Should be at level 0.
 		await page.keyboard.press( 'Enter' );
@@ -1011,7 +1017,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 		pageUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '* 1' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( ' a' );
@@ -1042,7 +1048,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 		pageUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 
 		await page.keyboard.type( '* 1' );
 		await page.keyboard.press( 'Enter' );
@@ -1065,7 +1071,7 @@ test.describe( 'List (@firefox)', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 
 		// Tests the shortcut with a non breaking space.
 		await page.keyboard.type( '*\u00a0' );
@@ -1081,7 +1087,7 @@ test.describe( 'List (@firefox)', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 
 		// Tests the shortcut with a non breaking space.
 		await page.keyboard.type( '* 1' );
@@ -1145,7 +1151,7 @@ test.describe( 'List (@firefox)', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '* 1' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '2' );
@@ -1170,7 +1176,7 @@ test.describe( 'List (@firefox)', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '* 1' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '2' );
@@ -1200,7 +1206,7 @@ test.describe( 'List (@firefox)', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '1. a' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'b' );
@@ -1255,7 +1261,7 @@ test.describe( 'List (@firefox)', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '* a' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'b' );
@@ -1298,7 +1304,7 @@ test.describe( 'List (@firefox)', () => {
 	} );
 
 	test( 'can be exited to selected paragraph', async ( { editor, page } ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '* ' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '1' );
@@ -1324,7 +1330,7 @@ test.describe( 'List (@firefox)', () => {
 		} );
 
 		await editor.selectBlocks(
-			page.locator( 'role=document[name="Block: List"i]' )
+			editor.canvas.locator( 'role=document[name="Block: List"i]' )
 		);
 
 		await page.getByRole( 'button', { name: 'List', exact: true } ).click();

--- a/test/e2e/specs/editor/blocks/paragraph.spec.js
+++ b/test/e2e/specs/editor/blocks/paragraph.spec.js
@@ -28,7 +28,7 @@ test.describe( 'Paragraph', () => {
 		} );
 		await page.keyboard.type( '1' );
 
-		const firstBlockTagName = await page.evaluate( () => {
+		const firstBlockTagName = await editor.canvas.evaluate( () => {
 			return document.querySelector( '[data-block]' ).tagName;
 		} );
 
@@ -59,7 +59,6 @@ test.describe( 'Paragraph', () => {
 
 		test( 'should allow dropping an image on an empty paragraph block', async ( {
 			editor,
-			page,
 			pageUtils,
 			draggingUtils,
 		} ) => {
@@ -76,14 +75,18 @@ test.describe( 'Paragraph', () => {
 				testImagePath
 			);
 
-			await dragOver( '[data-type="core/paragraph"]' );
+			await dragOver(
+				editor.canvas.locator( '[data-type="core/paragraph"]' )
+			);
 
 			await expect( draggingUtils.dropZone ).toBeVisible();
 			await expect( draggingUtils.insertionIndicator ).not.toBeVisible();
 
-			await drop();
+			await drop(
+				editor.canvas.locator( '[data-type="core/paragraph"]' )
+			);
 
-			const imageBlock = page.locator(
+			const imageBlock = editor.canvas.locator(
 				'role=document[name="Block: Image"i]'
 			);
 			await expect( imageBlock ).toBeVisible();
@@ -103,7 +106,7 @@ test.describe( 'Paragraph', () => {
 				attributes: { content: 'My Heading' },
 			} );
 			await editor.insertBlock( { name: 'core/paragraph' } );
-			await page.focus( 'text=My Heading' );
+			await editor.canvas.focus( 'text=My Heading' );
 			await editor.showBlockToolbar();
 
 			const dragHandle = page.locator(
@@ -112,7 +115,7 @@ test.describe( 'Paragraph', () => {
 			await dragHandle.hover();
 			await page.mouse.down();
 
-			const emptyParagraph = page.locator(
+			const emptyParagraph = editor.canvas.locator(
 				'[data-type="core/paragraph"][data-empty="true"]'
 			);
 			const boundingBox = await emptyParagraph.boundingBox();
@@ -140,7 +143,7 @@ test.describe( 'Paragraph', () => {
 				'<h2 class="wp-block-heading">My Heading</h2>'
 			);
 
-			const emptyParagraph = page.locator(
+			const emptyParagraph = editor.canvas.locator(
 				'[data-type="core/paragraph"][data-empty="true"]'
 			);
 			const boundingBox = await emptyParagraph.boundingBox();
@@ -160,7 +163,6 @@ test.describe( 'Paragraph', () => {
 		test.describe( 'Dragging positions', () => {
 			test( 'Only the first block is an empty paragraph block', async ( {
 				editor,
-				page,
 				draggingUtils,
 			} ) => {
 				await editor.setContent( `
@@ -173,10 +175,10 @@ test.describe( 'Paragraph', () => {
 					<!-- /wp:heading -->
 				` );
 
-				const emptyParagraph = page.locator(
+				const emptyParagraph = editor.canvas.locator(
 					'[data-type="core/paragraph"]'
 				);
-				const heading = page.locator( 'text=Heading' );
+				const heading = editor.canvas.locator( 'text=Heading' );
 
 				await draggingUtils.simulateDraggingHTML(
 					'<h2>Draggable</h2>'
@@ -271,7 +273,6 @@ test.describe( 'Paragraph', () => {
 
 			test( 'Only the second block is an empty paragraph block', async ( {
 				editor,
-				page,
 				draggingUtils,
 			} ) => {
 				await editor.setContent( `
@@ -284,10 +285,10 @@ test.describe( 'Paragraph', () => {
 					<!-- /wp:paragraph -->
 				` );
 
-				const emptyParagraph = page.locator(
+				const emptyParagraph = editor.canvas.locator(
 					'[data-type="core/paragraph"]'
 				);
-				const heading = page.locator( 'text=Heading' );
+				const heading = editor.canvas.locator( 'text=Heading' );
 
 				await draggingUtils.simulateDraggingHTML(
 					'<h2>Draggable</h2>'
@@ -382,7 +383,6 @@ test.describe( 'Paragraph', () => {
 
 			test( 'Both blocks are empty paragraph blocks', async ( {
 				editor,
-				page,
 				draggingUtils,
 			} ) => {
 				await editor.setContent( `
@@ -395,10 +395,10 @@ test.describe( 'Paragraph', () => {
 					<!-- /wp:paragraph -->
 				` );
 
-				const firstEmptyParagraph = page
+				const firstEmptyParagraph = editor.canvas
 					.locator( '[data-type="core/paragraph"]' )
 					.first();
-				const secondEmptyParagraph = page
+				const secondEmptyParagraph = editor.canvas
 					.locator( '[data-type="core/paragraph"]' )
 					.nth( 1 );
 

--- a/test/e2e/specs/editor/blocks/paragraph.spec.js
+++ b/test/e2e/specs/editor/blocks/paragraph.spec.js
@@ -61,7 +61,14 @@ test.describe( 'Paragraph', () => {
 			editor,
 			pageUtils,
 			draggingUtils,
+			page,
 		} ) => {
+			await page.evaluate( () => {
+				window.wp.blocks.registerBlockType( 'test/v2', {
+					apiVersion: '2',
+					title: 'test',
+				} );
+			} );
 			await editor.insertBlock( { name: 'core/paragraph' } );
 
 			const testImageName = '10x10_e2e_test_image_z9T8jK.png';

--- a/test/e2e/specs/editor/blocks/pullquote.spec.js
+++ b/test/e2e/specs/editor/blocks/pullquote.spec.js
@@ -12,7 +12,7 @@ test.describe( 'Quote', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 
 		await page.keyboard.type( 'test' );
 		await editor.transformBlockTo( 'core/quote' );

--- a/test/e2e/specs/editor/blocks/quote.spec.js
+++ b/test/e2e/specs/editor/blocks/quote.spec.js
@@ -33,7 +33,7 @@ test.describe( 'Quote', () => {
 		page,
 	} ) => {
 		// Create a block with some text that will trigger a paragraph creation.
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '> A quote' );
 		// Create a second paragraph.
 		await page.keyboard.press( 'Enter' );
@@ -56,7 +56,7 @@ test.describe( 'Quote', () => {
 		page,
 		pageUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'test' );
 		await pageUtils.pressKeys( 'ArrowLeft', { times: 'test'.length } );
 		await page.keyboard.type( '> ' );
@@ -71,7 +71,7 @@ test.describe( 'Quote', () => {
 
 	test( 'can be created by typing "/quote"', async ( { editor, page } ) => {
 		// Create a list with the slash block shortcut.
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '/quote' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'I’m a quote' );
@@ -88,7 +88,7 @@ test.describe( 'Quote', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'test' );
 		await editor.transformBlockTo( 'core/quote' );
 		expect( await editor.getEditedPostContent() ).toBe(
@@ -104,12 +104,12 @@ test.describe( 'Quote', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'one' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'two' );
 		await page.keyboard.down( 'Shift' );
-		await page.click(
+		await editor.canvas.click(
 			'role=document[name="Paragraph block"i] >> text=one'
 		);
 		await page.keyboard.up( 'Shift' );

--- a/test/e2e/specs/editor/blocks/separator.spec.js
+++ b/test/e2e/specs/editor/blocks/separator.spec.js
@@ -12,7 +12,7 @@ test.describe( 'Separator', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '---' );
 		await page.keyboard.press( 'Enter' );
 

--- a/test/e2e/specs/editor/blocks/spacer.spec.js
+++ b/test/e2e/specs/editor/blocks/spacer.spec.js
@@ -10,7 +10,7 @@ test.describe( 'Spacer', () => {
 
 	test( 'can be created by typing "/spacer"', async ( { editor, page } ) => {
 		// Create a spacer with the slash block shortcut.
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '/spacer' );
 		await page.keyboard.press( 'Enter' );
 
@@ -22,11 +22,11 @@ test.describe( 'Spacer', () => {
 		editor,
 	} ) => {
 		// Create a spacer with the slash block shortcut.
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '/spacer' );
 		await page.keyboard.press( 'Enter' );
 
-		const resizableHandle = page.locator(
+		const resizableHandle = editor.canvas.locator(
 			// Use class name selector until we have `data-testid` for the resize handles.
 			'role=document[name="Block: Spacer"i] >> css=.components-resizable-box__handle'
 		);
@@ -39,7 +39,7 @@ test.describe( 'Spacer', () => {
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 
 		await expect(
-			page.locator( 'role=document[name="Block: Spacer"i]' )
+			editor.canvas.locator( 'role=document[name="Block: Spacer"i]' )
 		).toBeFocused();
 	} );
 } );

--- a/test/e2e/specs/editor/blocks/table.spec.js
+++ b/test/e2e/specs/editor/blocks/table.spec.js
@@ -15,7 +15,7 @@ test.describe( 'Table', () => {
 		await editor.insertBlock( { name: 'core/table' } );
 
 		// Check for existence of the column count field.
-		const columnCountInput = page.locator(
+		const columnCountInput = editor.canvas.locator(
 			'role=spinbutton[name="Column count"i]'
 		);
 		await expect( columnCountInput ).toBeVisible();
@@ -27,7 +27,7 @@ test.describe( 'Table', () => {
 		await page.keyboard.type( '5' );
 
 		// Check for existence of the row count field.
-		const rowCountInput = page.locator(
+		const rowCountInput = editor.canvas.locator(
 			'role=spinbutton[name="Row count"i]'
 		);
 		await expect( rowCountInput ).toBeVisible();
@@ -39,7 +39,7 @@ test.describe( 'Table', () => {
 		await page.keyboard.type( '10' );
 
 		// Create the table.
-		await page.click( 'role=button[name="Create Table"i]' );
+		await editor.canvas.click( 'role=button[name="Create Table"i]' );
 
 		// Expect the post content to have a correctly sized table.
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
@@ -49,10 +49,12 @@ test.describe( 'Table', () => {
 		await editor.insertBlock( { name: 'core/table' } );
 
 		// Create the table.
-		await page.click( 'role=button[name="Create Table"i]' );
+		await editor.canvas.click( 'role=button[name="Create Table"i]' );
 
 		// Click the first cell and add some text.
-		await page.click( 'role=textbox[name="Body cell text"i] >> nth=0' );
+		await editor.canvas.click(
+			'role=textbox[name="Body cell text"i] >> nth=0'
+		);
 		await page.keyboard.type( 'This' );
 
 		// Navigate to the next cell and add some text.
@@ -90,7 +92,7 @@ test.describe( 'Table', () => {
 		await expect( footerSwitch ).toBeHidden();
 
 		// // Create the table.
-		await page.click( 'role=button[name="Create Table"i]' );
+		await editor.canvas.click( 'role=button[name="Create Table"i]' );
 
 		// Expect the header and footer switches to be present now that the table has been created.
 		await page.click(
@@ -103,17 +105,17 @@ test.describe( 'Table', () => {
 		await headerSwitch.check();
 		await footerSwitch.check();
 
-		await page.click(
+		await editor.canvas.click(
 			'role=rowgroup >> nth=0 >> role=textbox[name="Header cell text"i] >> nth=0'
 		);
 		await page.keyboard.type( 'header' );
 
-		await page.click(
+		await editor.canvas.click(
 			'role=rowgroup >> nth=1 >> role=textbox[name="Body cell text"i] >> nth=0'
 		);
 		await page.keyboard.type( 'body' );
 
-		await page.click(
+		await editor.canvas.click(
 			'role=rowgroup >> nth=2 >> role=textbox[name="Footer cell text"i] >> nth=0'
 		);
 		await page.keyboard.type( 'footer' );
@@ -137,7 +139,7 @@ test.describe( 'Table', () => {
 		await editor.openDocumentSettingsSidebar();
 
 		// Create the table.
-		await page.click( 'role=button[name="Create Table"i]' );
+		await editor.canvas.click( 'role=button[name="Create Table"i]' );
 
 		// Toggle on the switches and add some content.
 		await page.click(
@@ -145,7 +147,9 @@ test.describe( 'Table', () => {
 		);
 		await page.locator( 'role=checkbox[name="Header section"i]' ).check();
 		await page.locator( 'role=checkbox[name="Footer section"i]' ).check();
-		await page.click( 'role=textbox[name="Body cell text"i] >> nth=0' );
+		await editor.canvas.click(
+			'role=textbox[name="Body cell text"i] >> nth=0'
+		);
 
 		// Add a column.
 		await editor.clickBlockToolbarButton( 'Edit table' );
@@ -154,7 +158,9 @@ test.describe( 'Table', () => {
 		// Expect the table to have 3 columns across the header, body and footer.
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 
-		await page.click( 'role=textbox[name="Body cell text"i] >> nth=0' );
+		await editor.canvas.click(
+			'role=textbox[name="Body cell text"i] >> nth=0'
+		);
 
 		// Delete a column.
 		await editor.clickBlockToolbarButton( 'Edit table' );
@@ -167,15 +173,17 @@ test.describe( 'Table', () => {
 	test( 'allows columns to be aligned', async ( { editor, page } ) => {
 		await editor.insertBlock( { name: 'core/table' } );
 
-		await page.click( 'role=spinbutton[name="Column count"i]' );
+		await editor.canvas.click( 'role=spinbutton[name="Column count"i]' );
 		await page.keyboard.press( 'Backspace' );
 		await page.keyboard.type( '4' );
 
 		// Create the table.
-		await page.click( 'role=button[name="Create Table"i]' );
+		await editor.canvas.click( 'role=button[name="Create Table"i]' );
 
 		// Click the first cell and add some text. Don't align.
-		const cells = page.locator( 'role=textbox[name="Body cell text"i]' );
+		const cells = editor.canvas.locator(
+			'role=textbox[name="Body cell text"i]'
+		);
 		await cells.nth( 0 ).click();
 		await page.keyboard.type( 'None' );
 
@@ -210,7 +218,7 @@ test.describe( 'Table', () => {
 		await editor.openDocumentSettingsSidebar();
 
 		// Create the table.
-		await page.click( 'role=button[name="Create Table"i]' );
+		await editor.canvas.click( 'role=button[name="Create Table"i]' );
 
 		// Enable fixed width as it exacerbates the amount of empty space around the RichText.
 		await page.click(
@@ -221,11 +229,13 @@ test.describe( 'Table', () => {
 			.check();
 
 		// Add multiple new lines to the first cell to make it taller.
-		await page.click( 'role=textbox[name="Body cell text"i] >> nth=0' );
+		await editor.canvas.click(
+			'role=textbox[name="Body cell text"i] >> nth=0'
+		);
 		await page.keyboard.type( '\n\n\n\n' );
 
 		// Get the bounding client rect for the second cell.
-		const { x: secondCellX, y: secondCellY } = await page
+		const { x: secondCellX, y: secondCellY } = await editor.canvas
 			.locator( 'role=textbox[name="Body cell text"] >> nth=1' )
 			.boundingBox();
 
@@ -241,10 +251,12 @@ test.describe( 'Table', () => {
 		await editor.insertBlock( { name: 'core/table' } );
 
 		// Create the table.
-		await page.click( 'role=button[name="Create Table"i]' );
+		await editor.canvas.click( 'role=button[name="Create Table"i]' );
 
 		// Click the first cell and add some text.
-		await page.click( 'role=document[name="Block: Table"i] >> figcaption' );
+		await editor.canvas.click(
+			'role=document[name="Block: Table"i] >> figcaption'
+		);
 		await page.keyboard.type( 'Caption!' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
@@ -252,7 +264,7 @@ test.describe( 'Table', () => {
 	test( 'up and down arrow navigation', async ( { editor, page } ) => {
 		await editor.insertBlock( { name: 'core/table' } );
 		// Create the table.
-		await page.click( 'role=button[name="Create Table"i]' );
+		await editor.canvas.click( 'role=button[name="Create Table"i]' );
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'ArrowDown' );
 		await page.keyboard.type( '2' );
@@ -263,19 +275,18 @@ test.describe( 'Table', () => {
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
 
-	test( 'should not have focus loss after creation', async ( {
-		editor,
-		page,
-	} ) => {
+	test( 'should not have focus loss after creation', async ( { editor } ) => {
 		// Insert table block.
 		await editor.insertBlock( { name: 'core/table' } );
 
 		// Create the table.
-		await page.click( 'role=button[name="Create Table"i]' );
+		await editor.canvas.click( 'role=button[name="Create Table"i]' );
 
 		// Focus should be in first td.
 		await expect(
-			page.locator( 'role=textbox[name="Body cell text"i] >> nth=0' )
+			editor.canvas.locator(
+				'role=textbox[name="Body cell text"i] >> nth=0'
+			)
 		).toBeFocused();
 	} );
 } );

--- a/test/e2e/specs/editor/plugins/custom-post-types.spec.js
+++ b/test/e2e/specs/editor/plugins/custom-post-types.spec.js
@@ -20,7 +20,7 @@ test.describe( 'Test Custom Post Types', () => {
 		page,
 	} ) => {
 		await admin.createNewPost( { postType: 'hierar-no-title' } );
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'Parent Post' );
 		await editor.publishPost();
 
@@ -53,7 +53,7 @@ test.describe( 'Test Custom Post Types', () => {
 		await page.getByRole( 'listbox' ).getByRole( 'option' ).first().click();
 		const parentPage = await parentPageLocator.inputValue();
 
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'Child Post' );
 		await editor.publishPost();
 		await page.reload();
@@ -68,7 +68,7 @@ test.describe( 'Test Custom Post Types', () => {
 		page,
 	} ) => {
 		await admin.createNewPost( { postType: 'leg_block_in_tpl' } );
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'Hello there' );
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [

--- a/test/e2e/specs/editor/plugins/format-api.spec.js
+++ b/test/e2e/specs/editor/plugins/format-api.spec.js
@@ -21,7 +21,7 @@ test.describe( 'Using Format API', () => {
 		page,
 		pageUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'First paragraph' );
 		await pageUtils.pressKeys( 'shiftAlt+ArrowLeft' );
 		await editor.clickBlockToolbarButton( 'More' );

--- a/test/e2e/specs/editor/plugins/hooks-api.spec.js
+++ b/test/e2e/specs/editor/plugins/hooks-api.spec.js
@@ -19,8 +19,9 @@ test.describe( 'Using Hooks API', () => {
 
 	test( 'Should contain a reset block button on the sidebar', async ( {
 		page,
+		editor,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'First paragraph' );
 		await page.click(
 			`role=region[name="Editor settings"i] >> role=tab[name="Settings"i]`
@@ -34,10 +35,10 @@ test.describe( 'Using Hooks API', () => {
 		editor,
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'First paragraph' );
 
-		const paragraphBlock = page.locator(
+		const paragraphBlock = editor.canvas.locator(
 			'role=document[name="Paragraph block"i]'
 		);
 		await expect( paragraphBlock ).toHaveText( 'First paragraph' );

--- a/test/e2e/specs/editor/plugins/iframed-block.spec.js
+++ b/test/e2e/specs/editor/plugins/iframed-block.spec.js
@@ -18,7 +18,9 @@ test.describe( 'Iframed block', () => {
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 
 		await expect(
-			page.locator( 'role=document[name="Block: Iframed Block"i]' )
+			editor.canvas.locator(
+				'role=document[name="Block: Iframed Block"i]'
+			)
 		).toContainText( 'Iframed Block (set with jQuery)' );
 
 		// open page from sidebar settings

--- a/test/e2e/specs/editor/plugins/image-size.spec.js
+++ b/test/e2e/specs/editor/plugins/image-size.spec.js
@@ -52,7 +52,7 @@ test.describe( 'changing image size', () => {
 
 		// Verify that the custom size was applied to the image.
 		await expect(
-			page.locator( `role=img[name="${ filename }"]` )
+			editor.canvas.locator( `role=img[name="${ filename }"]` )
 		).toHaveCSS( 'width', '499px' );
 		await expect(
 			page.locator( 'role=spinbutton[name="Width"i]' )

--- a/test/e2e/specs/editor/plugins/post-type-templates.spec.js
+++ b/test/e2e/specs/editor/plugins/post-type-templates.spec.js
@@ -35,7 +35,7 @@ test.describe( 'Post type templates', () => {
 
 			// Remove a block from the template to verify that it's not
 			// re-added after saving and reloading the editor.
-			await page.focus( 'role=textbox[name="Add title"i]' );
+			await editor.canvas.focus( 'role=textbox[name="Add title"i]' );
 			await page.keyboard.press( 'ArrowDown' );
 			await page.keyboard.press( 'Backspace' );
 			await page.click( 'role=button[name="Save draft"i]' );
@@ -64,7 +64,7 @@ test.describe( 'Post type templates', () => {
 		} ) => {
 			// Remove all blocks from the template to verify that they're not
 			// re-added after saving and reloading the editor.
-			await page.fill(
+			await editor.canvas.fill(
 				'role=textbox[name="Add title"i]',
 				'My Empty Book'
 			);
@@ -125,11 +125,11 @@ test.describe( 'Post type templates', () => {
 
 			// Remove the default block template to verify that it's not
 			// re-added after saving and reloading the editor.
-			await page.fill(
+			await editor.canvas.fill(
 				'role=textbox[name="Add title"i]',
 				'My Image Format'
 			);
-			await page.focus( 'role=document[name="Block: Image"i]' );
+			await editor.canvas.focus( 'role=document[name="Block: Image"i]' );
 			await page.keyboard.press( 'Backspace' );
 			await page.click( 'role=button[name="Save draft"i]' );
 			await expect(

--- a/test/e2e/specs/editor/plugins/wp-editor-meta-box.spec.js
+++ b/test/e2e/specs/editor/plugins/wp-editor-meta-box.spec.js
@@ -20,7 +20,10 @@ test.describe( 'WP Editor Meta Boxes', () => {
 		await admin.createNewPost();
 
 		// Add title to enable valid non-empty post save.
-		await page.type( 'role=textbox[name="Add title"i]', 'Hello Meta' );
+		await editor.canvas.type(
+			'role=textbox[name="Add title"i]',
+			'Hello Meta'
+		);
 
 		// Type something.
 		await page.click( 'role=button[name="Text"i]' );

--- a/test/e2e/specs/editor/various/a11y.spec.js
+++ b/test/e2e/specs/editor/various/a11y.spec.js
@@ -22,7 +22,13 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 		pageUtils,
 		editor,
 	} ) => {
-		await page.waitForSelector( 'iframe[name="editor-canvas"]' );
+		// To do: run with iframe.
+		await page.evaluate( () => {
+			window.wp.blocks.registerBlockType( 'test/v2', {
+				apiVersion: '2',
+				title: 'test',
+			} );
+		} );
 		// On a new post, initial focus is set on the Post title.
 		await expect(
 			editor.canvas.locator( 'role=textbox[name=/Add title/i]' )

--- a/test/e2e/specs/editor/various/a11y.spec.js
+++ b/test/e2e/specs/editor/various/a11y.spec.js
@@ -55,6 +55,13 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 		page,
 		pageUtils,
 	} ) => {
+		// To do: run with iframe.
+		await page.evaluate( () => {
+			window.wp.blocks.registerBlockType( 'test/v2', {
+				apiVersion: '2',
+				title: 'test',
+			} );
+		} );
 		// Open keyboard shortcuts modal.
 		await pageUtils.pressKeys( 'access+h' );
 

--- a/test/e2e/specs/editor/various/a11y.spec.js
+++ b/test/e2e/specs/editor/various/a11y.spec.js
@@ -20,10 +20,12 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 	test( 'navigating through the Editor regions four times should land on the Editor top bar region', async ( {
 		page,
 		pageUtils,
+		editor,
 	} ) => {
+		await page.waitForSelector( 'iframe[name="editor-canvas"]' );
 		// On a new post, initial focus is set on the Post title.
 		await expect(
-			page.locator( 'role=textbox[name=/Add title/i]' )
+			editor.canvas.locator( 'role=textbox[name=/Add title/i]' )
 		).toBeFocused();
 		// Navigate to the 'Editor settings' region.
 		await pageUtils.pressKeys( 'ctrl+`' );

--- a/test/e2e/specs/editor/various/block-deletion.spec.js
+++ b/test/e2e/specs/editor/various/block-deletion.spec.js
@@ -37,7 +37,7 @@ test.describe( 'Block deletion', () => {
 
 		// Remove the current paragraph via the Block Toolbar options menu.
 		await editor.showBlockToolbar();
-		await editor.canvas
+		await page
 			.getByRole( 'toolbar', { name: 'Block tools' } )
 			.getByRole( 'button', { name: 'Options' } )
 			.click();
@@ -84,7 +84,7 @@ test.describe( 'Block deletion', () => {
 
 		// Remove the current paragraph via the Block Toolbar options menu.
 		await editor.showBlockToolbar();
-		await editor.canvas
+		await page
 			.getByRole( 'toolbar', { name: 'Block tools' } )
 			.getByRole( 'button', { name: 'Options' } )
 			.click();
@@ -313,7 +313,7 @@ test.describe( 'Block deletion', () => {
 
 		// Remove that paragraph via its options menu.
 		await editor.showBlockToolbar();
-		await editor.canvas
+		await page
 			.getByRole( 'toolbar', { name: 'Block tools' } )
 			.getByRole( 'button', { name: 'Options' } )
 			.click();

--- a/test/e2e/specs/editor/various/block-mover.spec.js
+++ b/test/e2e/specs/editor/various/block-mover.spec.js
@@ -23,7 +23,7 @@ test.describe( 'block mover', () => {
 		} );
 
 		// Select a block so the block mover is rendered.
-		await page.focus( 'text=First Paragraph' );
+		await editor.canvas.focus( 'text=First Paragraph' );
 		await editor.showBlockToolbar();
 
 		const moveDownButton = page.locator(
@@ -47,7 +47,7 @@ test.describe( 'block mover', () => {
 			attributes: { content: 'First Paragraph' },
 		} );
 		// Select a block so the block mover has the possibility of being rendered.
-		await page.focus( 'text=First Paragraph' );
+		await editor.canvas.focus( 'text=First Paragraph' );
 		await editor.showBlockToolbar();
 
 		// Ensure no block mover exists when only one block exists on the page.

--- a/test/e2e/specs/editor/various/compatibility-classic-editor.spec.js
+++ b/test/e2e/specs/editor/various/compatibility-classic-editor.spec.js
@@ -17,7 +17,7 @@ test.describe( 'Compatibility with classic editor', () => {
 		editor,
 	} ) => {
 		await editor.insertBlock( { name: 'core/html' } );
-		await page.focus( 'role=textbox[name="HTML"i]' );
+		await editor.canvas.focus( 'role=textbox[name="HTML"i]' );
 		await page.keyboard.type( '<a>' );
 		await page.keyboard.type( 'Random Link' );
 		await page.keyboard.type( '</a> ' );

--- a/test/e2e/specs/editor/various/content-only-lock.spec.js
+++ b/test/e2e/specs/editor/various/content-only-lock.spec.js
@@ -24,7 +24,7 @@ test.describe( 'Content-only lock', () => {
         <!-- /wp:group -->` );
 		await pageUtils.pressKeys( 'secondary+M' );
 
-		await page.click( 'role=document[name="Paragraph block"i]' );
+		await editor.canvas.click( 'role=document[name="Paragraph block"i]' );
 		await page.keyboard.type( ' World' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );

--- a/test/e2e/specs/editor/various/content-only-lock.spec.js
+++ b/test/e2e/specs/editor/various/content-only-lock.spec.js
@@ -23,7 +23,7 @@ test.describe( 'Content-only lock', () => {
         <!-- /wp:paragraph --></div>
         <!-- /wp:group -->` );
 		await pageUtils.pressKeys( 'secondary+M' );
-
+		await page.waitForSelector( 'iframe[name="editor-canvas"]' );
 		await editor.canvas.click( 'role=document[name="Paragraph block"i]' );
 		await page.keyboard.type( ' World' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -13,7 +13,7 @@ test.describe( 'Copy/cut/paste', () => {
 		page,
 		pageUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'Copy - collapsed selection' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '2' );
@@ -31,7 +31,7 @@ test.describe( 'Copy/cut/paste', () => {
 		page,
 		pageUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'Cut - collapsed selection' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '2' );
@@ -59,7 +59,7 @@ test.describe( 'Copy/cut/paste', () => {
 		await page.evaluate( () => {
 			window.wp.data.dispatch( 'core/block-editor' ).clearSelectedBlock();
 		} );
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await pageUtils.pressKeys( 'primary+v' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
@@ -78,7 +78,7 @@ test.describe( 'Copy/cut/paste', () => {
 		await page.evaluate( () => {
 			window.wp.data.dispatch( 'core/block-editor' ).clearSelectedBlock();
 		} );
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await pageUtils.pressKeys( 'primary+v' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
@@ -88,7 +88,7 @@ test.describe( 'Copy/cut/paste', () => {
 		page,
 		pageUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 
 		await page.keyboard.type( 'First block' );
 		await page.keyboard.press( 'Enter' );
@@ -240,7 +240,7 @@ test.describe( 'Copy/cut/paste', () => {
 		page,
 		pageUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'A block' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'B block' );
@@ -252,7 +252,7 @@ test.describe( 'Copy/cut/paste', () => {
 		await pageUtils.pressKeys( 'primary+ArrowLeft' );
 		// Sometimes the caret has not moved to the correct position before pressing Enter.
 		// @see https://github.com/WordPress/gutenberg/issues/40303#issuecomment-1109434887
-		await page.waitForFunction(
+		await editor.canvas.waitForFunction(
 			() => window.getSelection().type === 'Caret'
 		);
 		// Create a new block at the top of the document to paste there.
@@ -267,7 +267,7 @@ test.describe( 'Copy/cut/paste', () => {
 		page,
 		pageUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'A block' );
 		await editor.insertBlock( { name: 'core/spacer' } );
 		await page.keyboard.press( 'Enter' );
@@ -280,7 +280,7 @@ test.describe( 'Copy/cut/paste', () => {
 		await pageUtils.pressKeys( 'primary+ArrowLeft' );
 		// Sometimes the caret has not moved to the correct position before pressing Enter.
 		// @see https://github.com/WordPress/gutenberg/issues/40303#issuecomment-1109434887
-		await page.waitForFunction(
+		await editor.canvas.waitForFunction(
 			() => window.getSelection().type === 'Caret'
 		);
 		// Create a new block at the top of the document to paste there.
@@ -295,7 +295,7 @@ test.describe( 'Copy/cut/paste', () => {
 		page,
 		pageUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'A block' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'B block' );
@@ -307,7 +307,7 @@ test.describe( 'Copy/cut/paste', () => {
 		await pageUtils.pressKeys( 'primary+ArrowLeft' );
 		// Sometimes the caret has not moved to the correct position before pressing Enter.
 		// @see https://github.com/WordPress/gutenberg/issues/40303#issuecomment-1109434887
-		await page.waitForFunction(
+		await editor.canvas.waitForFunction(
 			() => window.getSelection().type === 'Caret'
 		);
 		// Create a new block at the top of the document to paste there.
@@ -322,7 +322,7 @@ test.describe( 'Copy/cut/paste', () => {
 		page,
 		pageUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'A block' );
 		await editor.insertBlock( { name: 'core/spacer' } );
 		await page.keyboard.press( 'Enter' );
@@ -335,7 +335,7 @@ test.describe( 'Copy/cut/paste', () => {
 		await pageUtils.pressKeys( 'primary+ArrowLeft' );
 		// Sometimes the caret has not moved to the correct position before pressing Enter.
 		// @see https://github.com/WordPress/gutenberg/issues/40303#issuecomment-1109434887
-		await page.waitForFunction(
+		await editor.canvas.waitForFunction(
 			() => window.getSelection().type === 'Caret'
 		);
 		// Create a new block at the top of the document to paste there.
@@ -362,7 +362,7 @@ test.describe( 'Copy/cut/paste', () => {
 		await pageUtils.pressKeys( 'primary+ArrowLeft' );
 		// Sometimes the caret has not moved to the correct position before pressing Enter.
 		// @see https://github.com/WordPress/gutenberg/issues/40303#issuecomment-1109434887
-		await page.waitForFunction(
+		await editor.canvas.waitForFunction(
 			() => window.getSelection().type === 'Caret'
 		);
 		// Create a new block at the top of the document to paste there.
@@ -389,7 +389,7 @@ test.describe( 'Copy/cut/paste', () => {
 		await pageUtils.pressKeys( 'primary+ArrowLeft' );
 		// Sometimes the caret has not moved to the correct position before pressing Enter.
 		// @see https://github.com/WordPress/gutenberg/issues/40303#issuecomment-1109434887
-		await page.waitForFunction(
+		await editor.canvas.waitForFunction(
 			() => window.getSelection().type === 'Caret'
 		);
 		// Create a new code block to paste there.
@@ -399,8 +399,8 @@ test.describe( 'Copy/cut/paste', () => {
 	} );
 
 	test( 'should paste single line in post title', async ( {
-		page,
 		pageUtils,
+		editor,
 	} ) => {
 		// This test checks whether we are correctly handling single line
 		// pasting in the post title. Previously we were accidentally falling
@@ -413,13 +413,16 @@ test.describe( 'Copy/cut/paste', () => {
 		await pageUtils.pressKeys( 'primary+v' );
 		// Expect the span to be filtered out.
 		expect(
-			await page.evaluate( () => document.activeElement.innerHTML )
+			await editor.canvas.evaluate(
+				() => document.activeElement.innerHTML
+			)
 		).toMatchSnapshot();
 	} );
 
 	test( 'should paste single line in post title with existing content', async ( {
 		page,
 		pageUtils,
+		editor,
 	} ) => {
 		await page.keyboard.type( 'ab' );
 		await page.keyboard.press( 'ArrowLeft' );
@@ -430,7 +433,9 @@ test.describe( 'Copy/cut/paste', () => {
 		// Ensure the selection is correct.
 		await page.keyboard.type( 'y' );
 		expect(
-			await page.evaluate( () => document.activeElement.innerHTML )
+			await editor.canvas.evaluate(
+				() => document.activeElement.innerHTML
+			)
 		).toBe( 'axyb' );
 	} );
 

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -31,6 +31,13 @@ test.describe( 'Copy/cut/paste', () => {
 		page,
 		pageUtils,
 	} ) => {
+		// To do: run with iframe.
+		await page.evaluate( () => {
+			window.wp.blocks.registerBlockType( 'test/v2', {
+				apiVersion: '2',
+				title: 'test',
+			} );
+		} );
 		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'Cut - collapsed selection' );
 		await page.keyboard.press( 'Enter' );

--- a/test/e2e/specs/editor/various/draggable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/draggable-blocks.spec.js
@@ -42,7 +42,9 @@ test.describe( 'Draggable block', () => {
 <p>2</p>
 <!-- /wp:paragraph -->` );
 
-		await page.focus( 'role=document[name="Paragraph block"i] >> text=2' );
+		await editor.canvas.focus(
+			'role=document[name="Paragraph block"i] >> text=2'
+		);
 		await editor.showBlockToolbar();
 
 		const dragHandle = page.locator(
@@ -54,7 +56,7 @@ test.describe( 'Draggable block', () => {
 		await page.mouse.down();
 
 		// Move to and hover on the upper half of the paragraph block to trigger the indicator.
-		const firstParagraph = page.locator(
+		const firstParagraph = editor.canvas.locator(
 			'role=document[name="Paragraph block"i] >> text=1'
 		);
 		const firstParagraphBound = await firstParagraph.boundingBox();
@@ -112,7 +114,9 @@ test.describe( 'Draggable block', () => {
 <p>2</p>
 <!-- /wp:paragraph -->` );
 
-		await page.focus( 'role=document[name="Paragraph block"i] >> text=1' );
+		await editor.canvas.focus(
+			'role=document[name="Paragraph block"i] >> text=1'
+		);
 		await editor.showBlockToolbar();
 
 		const dragHandle = page.locator(
@@ -124,7 +128,7 @@ test.describe( 'Draggable block', () => {
 		await page.mouse.down();
 
 		// Move to and hover on the bottom half of the paragraph block to trigger the indicator.
-		const secondParagraph = page.locator(
+		const secondParagraph = editor.canvas.locator(
 			'role=document[name="Paragraph block"i] >> text=2'
 		);
 		const secondParagraphBound = await secondParagraph.boundingBox();
@@ -193,7 +197,9 @@ test.describe( 'Draggable block', () => {
 			],
 		} );
 
-		await page.focus( 'role=document[name="Paragraph block"i] >> text=2' );
+		await editor.canvas.focus(
+			'role=document[name="Paragraph block"i] >> text=2'
+		);
 		await editor.showBlockToolbar();
 
 		const dragHandle = page.locator(
@@ -205,7 +211,7 @@ test.describe( 'Draggable block', () => {
 		await page.mouse.down();
 
 		// Move to and hover on the left half of the paragraph block to trigger the indicator.
-		const firstParagraph = page.locator(
+		const firstParagraph = editor.canvas.locator(
 			'role=document[name="Paragraph block"i] >> text=1'
 		);
 		const firstParagraphBound = await firstParagraph.boundingBox();
@@ -272,7 +278,9 @@ test.describe( 'Draggable block', () => {
 			],
 		} );
 
-		await page.focus( 'role=document[name="Paragraph block"i] >> text=1' );
+		await editor.canvas.focus(
+			'role=document[name="Paragraph block"i] >> text=1'
+		);
 		await editor.showBlockToolbar();
 
 		const dragHandle = page.locator(
@@ -284,7 +292,7 @@ test.describe( 'Draggable block', () => {
 		await page.mouse.down();
 
 		// Move to and hover on the right half of the paragraph block to trigger the indicator.
-		const secondParagraph = page.locator(
+		const secondParagraph = editor.canvas.locator(
 			'role=document[name="Paragraph block"i] >> text=2'
 		);
 		const secondParagraphBound = await secondParagraph.boundingBox();

--- a/test/e2e/specs/editor/various/draggable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/draggable-blocks.spec.js
@@ -342,6 +342,13 @@ test.describe( 'Draggable block', () => {
 		editor,
 		pageUtils,
 	} ) => {
+		// To do: run with iframe.
+		await page.evaluate( () => {
+			window.wp.blocks.registerBlockType( 'test/v2', {
+				apiVersion: '2',
+				title: 'test',
+			} );
+		} );
 		// Insert a row.
 		await editor.insertBlock( {
 			name: 'core/group',

--- a/test/e2e/specs/editor/various/font-size-picker.spec.js
+++ b/test/e2e/specs/editor/various/font-size-picker.spec.js
@@ -24,7 +24,9 @@ test.describe( 'Font Size Picker', () => {
 			page,
 		} ) => {
 			await editor.openDocumentSettingsSidebar();
-			await page.click( 'role=button[name="Add default block"i]' );
+			await editor.canvas.click(
+				'role=button[name="Add default block"i]'
+			);
 			await page.keyboard.type( 'Paragraph to be made "small"' );
 			await page.click(
 				'role=region[name="Editor settings"i] >> role=button[name="Set custom size"i]'
@@ -45,7 +47,9 @@ test.describe( 'Font Size Picker', () => {
 			pageUtils,
 		} ) => {
 			await editor.openDocumentSettingsSidebar();
-			await page.click( 'role=button[name="Add default block"i]' );
+			await editor.canvas.click(
+				'role=button[name="Add default block"i]'
+			);
 			await page.keyboard.type( 'Paragraph reset - custom size' );
 			await page.click(
 				'role=region[name="Editor settings"i] >> role=button[name="Set custom size"i]'
@@ -135,7 +139,9 @@ test.describe( 'Font Size Picker', () => {
 			pageUtils,
 		} ) => {
 			await editor.openDocumentSettingsSidebar();
-			await page.click( 'role=button[name="Add default block"i]' );
+			await editor.canvas.click(
+				'role=button[name="Add default block"i]'
+			);
 			await page.keyboard.type( 'Paragraph to be made "large"' );
 			await page.click(
 				'role=group[name="Font size"i] >> role=button[name="Font size"i]'
@@ -155,7 +161,9 @@ test.describe( 'Font Size Picker', () => {
 			pageUtils,
 		} ) => {
 			await editor.openDocumentSettingsSidebar();
-			await page.click( 'role=button[name="Add default block"i]' );
+			await editor.canvas.click(
+				'role=button[name="Add default block"i]'
+			);
 			await page.keyboard.type(
 				'Paragraph with font size reset using tools panel menu'
 			);
@@ -186,7 +194,9 @@ test.describe( 'Font Size Picker', () => {
 			pageUtils,
 		} ) => {
 			await editor.openDocumentSettingsSidebar();
-			await page.click( 'role=button[name="Add default block"i]' );
+			await editor.canvas.click(
+				'role=button[name="Add default block"i]'
+			);
 			await page.keyboard.type(
 				'Paragraph with font size reset using input field'
 			);
@@ -221,7 +231,9 @@ test.describe( 'Font Size Picker', () => {
 			page,
 		} ) => {
 			await editor.openDocumentSettingsSidebar();
-			await page.click( 'role=button[name="Add default block"i]' );
+			await editor.canvas.click(
+				'role=button[name="Add default block"i]'
+			);
 			await page.keyboard.type( 'Paragraph to be made "large"' );
 			await page.click(
 				'role=radiogroup[name="Font size"i] >> role=radio[name="Large"i]'
@@ -238,7 +250,9 @@ test.describe( 'Font Size Picker', () => {
 			page,
 		} ) => {
 			await editor.openDocumentSettingsSidebar();
-			await page.click( 'role=button[name="Add default block"i]' );
+			await editor.canvas.click(
+				'role=button[name="Add default block"i]'
+			);
 			await page.keyboard.type(
 				'Paragraph with font size reset using tools panel menu'
 			);
@@ -267,7 +281,9 @@ test.describe( 'Font Size Picker', () => {
 			pageUtils,
 		} ) => {
 			await editor.openDocumentSettingsSidebar();
-			await page.click( 'role=button[name="Add default block"i]' );
+			await editor.canvas.click(
+				'role=button[name="Add default block"i]'
+			);
 			await page.keyboard.type(
 				'Paragraph with font size reset using input field'
 			);

--- a/test/e2e/specs/editor/various/inner-blocks-templates.spec.js
+++ b/test/e2e/specs/editor/various/inner-blocks-templates.spec.js
@@ -28,7 +28,7 @@ test.describe( 'Inner blocks templates', () => {
 			name: 'test/test-inner-blocks-async-template',
 		} );
 
-		const blockWithTemplateContent = page.locator(
+		const blockWithTemplateContent = editor.canvas.locator(
 			'role=document[name="Block: Test Inner Blocks Async Template"i] >> text=OneTwo'
 		);
 

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -39,7 +39,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			name: 'core/paragraph',
 			attributes: { content: 'Dummy text' },
 		} );
-		const paragraphBlock = page.locator(
+		const paragraphBlock = editor.canvas.locator(
 			'[data-type="core/paragraph"] >> text=Dummy text'
 		);
 
@@ -116,7 +116,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 
 		const beforeContent = await editor.getEditedPostContent();
 
-		const paragraphBlock = page.locator(
+		const paragraphBlock = editor.canvas.locator(
 			'[data-type="core/paragraph"] >> text=Dummy text'
 		);
 
@@ -176,7 +176,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			attributes: { content: 'Dummy text' },
 		} );
 
-		const paragraphBlock = page.locator(
+		const paragraphBlock = editor.canvas.locator(
 			'[data-type="core/paragraph"] >> text=Dummy text'
 		);
 
@@ -244,7 +244,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 
 		const beforeContent = await editor.getEditedPostContent();
 
-		const paragraphBlock = page.locator(
+		const paragraphBlock = editor.canvas.locator(
 			'[data-type="core/paragraph"] >> text=Dummy text'
 		);
 

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -15,8 +15,16 @@ test.use( {
 } );
 
 test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
-	test.beforeEach( async ( { admin } ) => {
+	test.beforeEach( async ( { admin, page } ) => {
 		await admin.createNewPost();
+		// To do: some drag an drop tests are failing, so run them without
+		// iframe for now.
+		await page.evaluate( () => {
+			window.wp.blocks.registerBlockType( 'test/v2', {
+				apiVersion: '2',
+				title: 'test',
+			} );
+		} );
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {

--- a/test/e2e/specs/editor/various/keep-styles-on-block-transforms.spec.js
+++ b/test/e2e/specs/editor/various/keep-styles-on-block-transforms.spec.js
@@ -12,7 +12,7 @@ test.describe( 'Keep styles on block transforms', () => {
 		page,
 		editor,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '## Heading' );
 		await editor.openDocumentSettingsSidebar();
 		await page.click( 'role=button[name="Color Text styles"i]' );
@@ -38,7 +38,7 @@ test.describe( 'Keep styles on block transforms', () => {
 		editor,
 	} ) => {
 		// Create a paragraph block with some content.
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'Line 1 to be made large' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'Line 2 to be made large' );
@@ -71,7 +71,7 @@ test.describe( 'Keep styles on block transforms', () => {
 		editor,
 	} ) => {
 		// Create a paragraph block with some content.
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'Line 1 to be made large' );
 		await page.click( 'role=radio[name="Large"i]' );
 		await editor.showBlockToolbar();

--- a/test/e2e/specs/editor/various/keep-styles-on-block-transforms.spec.js
+++ b/test/e2e/specs/editor/various/keep-styles-on-block-transforms.spec.js
@@ -37,6 +37,13 @@ test.describe( 'Keep styles on block transforms', () => {
 		pageUtils,
 		editor,
 	} ) => {
+		// To do: run with iframe.
+		await page.evaluate( () => {
+			window.wp.blocks.registerBlockType( 'test/v2', {
+				apiVersion: '2',
+				title: 'test',
+			} );
+		} );
 		// Create a paragraph block with some content.
 		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'Line 1 to be made large' );

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -261,6 +261,13 @@ test.describe( 'List View', () => {
 		page,
 		pageUtils,
 	} ) => {
+		// To do: run with iframe.
+		await page.evaluate( () => {
+			window.wp.blocks.registerBlockType( 'test/v2', {
+				apiVersion: '2',
+				title: 'test',
+			} );
+		} );
 		await editor.insertBlock( { name: 'core/image' } );
 		await editor.insertBlock( {
 			name: 'core/paragraph',

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -336,7 +336,7 @@ test.describe( 'List View', () => {
 		await pageUtils.pressKeys( 'shift+Tab' );
 		await pageUtils.pressKeys( 'shift+Tab' );
 		await expect(
-			editor.canvas
+			page
 				.getByRole( 'region', { name: 'Document Overview' } )
 				.getByRole( 'button', {
 					name: 'Close',
@@ -354,7 +354,7 @@ test.describe( 'List View', () => {
 		// tab receives similar focus events based on the shortcut.
 		await pageUtils.pressKeys( 'shift+Tab' );
 		await page.keyboard.press( 'ArrowRight' );
-		const outlineButton = editor.canvas.getByRole( 'tab', {
+		const outlineButton = page.getByRole( 'tab', {
 			name: 'Outline',
 		} );
 		await expect( outlineButton ).toBeFocused();

--- a/test/e2e/specs/editor/various/mentions.spec.js
+++ b/test/e2e/specs/editor/various/mentions.spec.js
@@ -23,7 +23,7 @@ test.describe( 'autocomplete mentions', () => {
 	} );
 
 	test( 'should insert mention', async ( { page, editor } ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'I am @ad' );
 		await expect(
 			page.locator( 'role=listbox >> role=option[name=/admin/i]' )
@@ -42,7 +42,7 @@ test.describe( 'autocomplete mentions', () => {
 		editor,
 		pageUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'Stuck in the middle with you' );
 		await pageUtils.pressKeys( 'ArrowLeft', { times: 'you'.length } );
 		await page.keyboard.type( '@j' );
@@ -62,7 +62,7 @@ test.describe( 'autocomplete mentions', () => {
 		page,
 		editor,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'I am @j' );
 		await expect(
 			page.locator( 'role=listbox >> role=option[name=/testuser/i]' )

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -304,6 +304,7 @@ test.describe( 'Multi-block selection', () => {
 				.filter( { hasText: 'Draft saved' } )
 		).toBeVisible();
 		await page.reload();
+		await page.waitForSelector( 'iframe[name="editor-canvas"]' );
 
 		await editor.canvas
 			.getByRole( 'document', { name: 'Paragraph block' } )
@@ -867,7 +868,6 @@ test.describe( 'Multi-block selection', () => {
 	} );
 
 	test( 'should select title if the cursor is on title', async ( {
-		page,
 		editor,
 		pageUtils,
 		multiBlockSelectionUtils,
@@ -890,7 +890,7 @@ test.describe( 'Multi-block selection', () => {
 			.toEqual( [] );
 		await expect
 			.poll( () =>
-				page.evaluate( () => window.getSelection().toString() )
+				editor.canvas.evaluate( () => window.getSelection().toString() )
 			)
 			.toBe( 'Post title' );
 	} );

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -318,7 +318,13 @@ test.describe( 'Multi-block selection', () => {
 				.filter( { hasText: 'Draft saved' } )
 		).toBeVisible();
 		await page.reload();
-		await page.waitForSelector( 'iframe[name="editor-canvas"]' );
+		// To do: run with iframe.
+		await page.evaluate( () => {
+			window.wp.blocks.registerBlockType( 'test/v2', {
+				apiVersion: '2',
+				title: 'test',
+			} );
+		} );
 
 		await editor.canvas
 			.getByRole( 'document', { name: 'Paragraph block' } )
@@ -1156,6 +1162,13 @@ test.describe( 'Multi-block selection', () => {
 		page,
 		editor,
 	} ) => {
+		// To do: run with iframe.
+		await page.evaluate( () => {
+			window.wp.blocks.registerBlockType( 'test/v2', {
+				apiVersion: '2',
+				title: 'test',
+			} );
+		} );
 		await editor.insertBlock( {
 			name: 'core/paragraph',
 			attributes: { content: '<strong>1</strong>[' },

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -247,6 +247,13 @@ test.describe( 'Multi-block selection', () => {
 		editor,
 		multiBlockSelectionUtils,
 	} ) => {
+		// To do: run with iframe.
+		await page.evaluate( () => {
+			window.wp.blocks.registerBlockType( 'test/v2', {
+				apiVersion: '2',
+				title: 'test',
+			} );
+		} );
 		await editor.canvas
 			.getByRole( 'button', { name: 'Add default block' } )
 			.click();
@@ -292,6 +299,13 @@ test.describe( 'Multi-block selection', () => {
 		editor,
 		pageUtils,
 	} ) => {
+		// To do: run with iframe.
+		await page.evaluate( () => {
+			window.wp.blocks.registerBlockType( 'test/v2', {
+				apiVersion: '2',
+				title: 'test',
+			} );
+		} );
 		await editor.insertBlock( {
 			name: 'core/paragraph',
 			attributes: { content: 'test' },

--- a/test/e2e/specs/editor/various/new-post-default-content.spec.js
+++ b/test/e2e/specs/editor/various/new-post-default-content.spec.js
@@ -27,7 +27,7 @@ test.describe( 'new editor filtered state', () => {
 
 		// Assert they match what the plugin set.
 		await expect(
-			page.locator( 'role=textbox[name="Add title"i]' )
+			editor.canvas.locator( 'role=textbox[name="Add title"i]' )
 		).toHaveText( 'My default title' );
 		await expect
 			.poll( editor.getEditedPostContent )

--- a/test/e2e/specs/editor/various/new-post.spec.js
+++ b/test/e2e/specs/editor/various/new-post.spec.js
@@ -26,7 +26,9 @@ test.describe( 'new editor state', () => {
 		await expect( page ).toHaveURL( /post-new.php/ );
 
 		// Should display the blank title.
-		const title = page.locator( 'role=textbox[name="Add title"i]' );
+		const title = editor.canvas.locator(
+			'role=textbox[name="Add title"i]'
+		);
 		await expect( title ).toBeEditable();
 		await expect( title ).toHaveText( '' );
 
@@ -55,23 +57,24 @@ test.describe( 'new editor state', () => {
 
 	test( 'should focus the title if the title is empty', async ( {
 		admin,
-		page,
+		editor,
 	} ) => {
 		await admin.createNewPost();
 
 		await expect(
-			page.locator( 'role=textbox[name="Add title"i]' )
+			editor.canvas.locator( 'role=textbox[name="Add title"i]' )
 		).toBeFocused();
 	} );
 
 	test( 'should not focus the title if the title exists', async ( {
 		admin,
 		page,
+		editor,
 	} ) => {
 		await admin.createNewPost();
 
 		// Enter a title for this post.
-		await page.type(
+		await editor.canvas.type(
 			'role=textbox[name="Add title"i]',
 			'Here is the title'
 		);

--- a/test/e2e/specs/editor/various/post-visibility.spec.js
+++ b/test/e2e/specs/editor/various/post-visibility.spec.js
@@ -78,7 +78,7 @@ test.describe( 'Post visibility', () => {
 		await admin.createNewPost();
 
 		// Enter a title for this post.
-		await page.type( 'role=textbox[name="Add title"i]', 'Title' );
+		await editor.canvas.type( 'role=textbox[name="Add title"i]', 'Title' );
 
 		await editor.openDocumentSettingsSidebar();
 

--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -27,7 +27,7 @@ test.describe( 'Preview', () => {
 			editorPage.locator( 'role=button[name="Preview"i]' )
 		).toBeDisabled();
 
-		await editorPage.type(
+		await editor.canvas.type(
 			'role=textbox[name="Add title"i]',
 			'Hello World'
 		);
@@ -48,7 +48,7 @@ test.describe( 'Preview', () => {
 
 		// Return to editor to change title.
 		await editorPage.bringToFront();
-		await editorPage.type( 'role=textbox[name="Add title"i]', '!' );
+		await editor.canvas.type( 'role=textbox[name="Add title"i]', '!' );
 		await previewUtils.waitForPreviewNavigation( previewPage );
 
 		// Title in preview should match updated input.
@@ -70,7 +70,7 @@ test.describe( 'Preview', () => {
 
 		// Return to editor to change title.
 		await editorPage.bringToFront();
-		await editorPage.fill(
+		await editor.canvas.fill(
 			'role=textbox[name="Add title"i]',
 			'Hello World! And more.'
 		);
@@ -107,7 +107,7 @@ test.describe( 'Preview', () => {
 		const editorPage = page;
 
 		// Type aaaaa in the title field.
-		await editorPage.type( 'role=textbox[name="Add title"]', 'aaaaa' );
+		await editor.canvas.type( 'role=textbox[name="Add title"]', 'aaaaa' );
 		await editorPage.keyboard.press( 'Tab' );
 
 		// Save the post as a draft.
@@ -127,7 +127,7 @@ test.describe( 'Preview', () => {
 		await editorPage.bringToFront();
 
 		// Append bbbbb to the title, and tab away from the title so blur event is triggered.
-		await editorPage.fill(
+		await editor.canvas.fill(
 			'role=textbox[name="Add title"i]',
 			'aaaaabbbbb'
 		);
@@ -155,7 +155,7 @@ test.describe( 'Preview', () => {
 		const editorPage = page;
 
 		// Type Lorem in the title field.
-		await editorPage.type( 'role=textbox[name="Add title"i]', 'Lorem' );
+		await editor.canvas.type( 'role=textbox[name="Add title"i]', 'Lorem' );
 
 		// Open the preview page.
 		const previewPage = await editor.openPreviewPage( editorPage );
@@ -172,7 +172,7 @@ test.describe( 'Preview', () => {
 		await page.click( 'role=button[name="Close panel"i]' );
 
 		// Change the title and preview again.
-		await editorPage.type( 'role=textbox[name="Add title"i]', ' Ipsum' );
+		await editor.canvas.type( 'role=textbox[name="Add title"i]', ' Ipsum' );
 		await previewUtils.waitForPreviewNavigation( previewPage );
 
 		// Title in preview should match updated input.
@@ -191,7 +191,7 @@ test.describe( 'Preview', () => {
 		).toBeVisible();
 
 		// Change the title.
-		await editorPage.type( 'role=textbox[name="Add title"i]', ' Draft' );
+		await editor.canvas.type( 'role=textbox[name="Add title"i]', ' Draft' );
 
 		// Open the preview page.
 		await previewUtils.waitForPreviewNavigation( previewPage );
@@ -222,7 +222,10 @@ test.describe( 'Preview with Custom Fields enabled', () => {
 		const editorPage = page;
 
 		// Add an initial title and content.
-		await editorPage.type( 'role=textbox[name="Add title"i]', 'title 1' );
+		await editor.canvas.type(
+			'role=textbox[name="Add title"i]',
+			'title 1'
+		);
 		await editor.insertBlock( {
 			name: 'core/paragraph',
 			attributes: { content: 'content 1' },
@@ -246,8 +249,11 @@ test.describe( 'Preview with Custom Fields enabled', () => {
 
 		// Return to editor and modify the title and content.
 		await editorPage.bringToFront();
-		await editorPage.fill( 'role=textbox[name="Add title"i]', 'title 2' );
-		await editorPage.fill(
+		await editor.canvas.fill(
+			'role=textbox[name="Add title"i]',
+			'title 2'
+		);
+		await editor.canvas.fill(
 			'role=document >> text="content 1"',
 			'content 2'
 		);

--- a/test/e2e/specs/editor/various/rtl.spec.js
+++ b/test/e2e/specs/editor/various/rtl.spec.js
@@ -150,7 +150,7 @@ test.describe( 'RTL', () => {
 		page,
 		pageUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await pageUtils.pressKeys( 'primary+b' );
 		await page.keyboard.type( ARABIC_ONE );
 		await pageUtils.pressKeys( 'primary+b' );

--- a/test/e2e/specs/editor/various/splitting-merging.spec.js
+++ b/test/e2e/specs/editor/various/splitting-merging.spec.js
@@ -306,11 +306,11 @@ test.describe( 'splitting and merging blocks', () => {
 
 		// There is a default block and post title:
 		await expect(
-			page.locator( 'role=document[name=/Empty block/i]' )
+			editor.canvas.locator( 'role=document[name=/Empty block/i]' )
 		).toBeVisible();
 
 		await expect(
-			page.locator( 'role=textbox[name="Add title"i]' )
+			editor.canvas.locator( 'role=textbox[name="Add title"i]' )
 		).toBeVisible();
 
 		// But the effective saved content is still empty:
@@ -318,7 +318,7 @@ test.describe( 'splitting and merging blocks', () => {
 
 		// And focus is retained:
 		await expect(
-			page.locator( 'role=document[name=/Empty block/i]' )
+			editor.canvas.locator( 'role=document[name=/Empty block/i]' )
 		).toBeFocused();
 	} );
 

--- a/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
+++ b/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
@@ -104,7 +104,7 @@ test.describe( 'Toolbar roving tabindex', () => {
 		// Move focus to the first toolbar item.
 		await page.keyboard.press( 'Home' );
 		await ToolbarRovingTabindexUtils.expectLabelToHaveFocus( 'Table' );
-		await page.click( `role=button[name="Create Table"i]` );
+		await editor.canvas.click( `role=button[name="Create Table"i]` );
 		await pageUtils.pressKeys( 'Tab' );
 		await ToolbarRovingTabindexUtils.testBlockToolbarKeyboardNavigation(
 			'Body cell text',
@@ -188,15 +188,19 @@ class ToolbarRovingTabindexUtils {
 	}
 
 	async expectLabelToHaveFocus( label ) {
-		let ariaLabel = await this.page.evaluate( () =>
-			document.activeElement.getAttribute( 'aria-label' )
-		);
+		let ariaLabel = await this.page.evaluate( () => {
+			const { activeElement } =
+				document.activeElement.contentDocument ?? document;
+			return activeElement.getAttribute( 'aria-label' );
+		} );
 		// If the labels don't match, try pressing Up Arrow to focus the block wrapper in non-content editable block.
 		if ( ariaLabel !== label ) {
 			await this.page.keyboard.press( 'ArrowUp' );
-			ariaLabel = await this.page.evaluate( () =>
-				document.activeElement.getAttribute( 'aria-label' )
-			);
+			ariaLabel = await this.page.evaluate( () => {
+				const { activeElement } =
+					document.activeElement.contentDocument ?? document;
+				return activeElement.getAttribute( 'aria-label' );
+			} );
 		}
 		expect( ariaLabel ).toBe( label );
 	}

--- a/test/e2e/specs/editor/various/undo.spec.js
+++ b/test/e2e/specs/editor/various/undo.spec.js
@@ -174,7 +174,7 @@ test.describe( 'undo', () => {
 		await pageUtils.pressKeys( 'primary+a' );
 		await pageUtils.pressKeys( 'primary+b' );
 		await pageUtils.pressKeys( 'primary+z' );
-		const activeElementLocator = page.locator( ':focus' );
+		const activeElementLocator = editor.canvas.locator( ':focus' );
 		await expect( activeElementLocator ).toHaveText( 'test' );
 	} );
 
@@ -353,7 +353,7 @@ test.describe( 'undo', () => {
 		// regression present was accurate, it would produce the correct
 		// content. The issue had manifested in the form of what was shown to
 		// the user since the blocks state failed to sync to block editor.
-		const activeElementLocator = page.locator( ':focus' );
+		const activeElementLocator = editor.canvas.locator( ':focus' );
 		await expect( activeElementLocator ).toHaveText( 'original' );
 	} );
 
@@ -462,14 +462,19 @@ test.describe( 'undo', () => {
 	test( 'should be able to undo and redo property cross property changes', async ( {
 		page,
 		pageUtils,
+		editor,
 	} ) => {
-		await page.getByRole( 'textbox', { name: 'Add title' } ).type( 'a' ); // First step.
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.type( 'a' ); // First step.
 		await page.keyboard.press( 'Backspace' ); // Second step.
-		await page.getByRole( 'button', { name: 'Add default block' } ).click(); // third step.
+		await editor.canvas
+			.getByRole( 'button', { name: 'Add default block' } )
+			.click(); // third step.
 
 		// Title should be empty
 		await expect(
-			page.getByRole( 'textbox', { name: 'Add title' } )
+			editor.canvas.getByRole( 'textbox', { name: 'Add title' } )
 		).toHaveText( '' );
 
 		// First undo removes the block.
@@ -477,13 +482,13 @@ test.describe( 'undo', () => {
 		await pageUtils.pressKeys( 'primary+z' );
 		await pageUtils.pressKeys( 'primary+z' );
 		await expect(
-			page.getByRole( 'textbox', { name: 'Add title' } )
+			editor.canvas.getByRole( 'textbox', { name: 'Add title' } )
 		).toHaveText( 'a' );
 
 		// Redoing the "backspace" should clear the title again.
 		await pageUtils.pressKeys( 'primaryShift+z' );
 		await expect(
-			page.getByRole( 'textbox', { name: 'Add title' } )
+			editor.canvas.getByRole( 'textbox', { name: 'Add title' } )
 		).toHaveText( '' );
 	} );
 } );

--- a/test/e2e/specs/editor/various/undo.spec.js
+++ b/test/e2e/specs/editor/various/undo.spec.js
@@ -20,7 +20,7 @@ test.describe( 'undo', () => {
 		pageUtils,
 		undoUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'before pause' );
 		await editor.page.waitForTimeout( 1000 );
 		await page.keyboard.type( ' after pause' );
@@ -88,7 +88,7 @@ test.describe( 'undo', () => {
 		pageUtils,
 		undoUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 
 		await page.keyboard.type( 'before keyboard ' );
 		await pageUtils.pressKeys( 'primary+b' );
@@ -159,8 +159,8 @@ test.describe( 'undo', () => {
 		} );
 	} );
 
-	test( 'should undo bold', async ( { page, pageUtils } ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+	test( 'should undo bold', async ( { page, pageUtils, editor } ) => {
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'test' );
 		await page.click( 'role=button[name="Save draft"i]' );
 		await expect(
@@ -169,7 +169,8 @@ test.describe( 'undo', () => {
 			)
 		).toBeVisible();
 		await page.reload();
-		await page.click( '[data-type="core/paragraph"]' );
+		await page.waitForSelector( 'iframe[name="editor-canvas"]' );
+		await editor.canvas.click( '[data-type="core/paragraph"]' );
 		await pageUtils.pressKeys( 'primary+a' );
 		await pageUtils.pressKeys( 'primary+b' );
 		await pageUtils.pressKeys( 'primary+z' );
@@ -183,7 +184,7 @@ test.describe( 'undo', () => {
 		pageUtils,
 		undoUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 
 		const firstBlock = await editor.getEditedPostContent();
 
@@ -326,7 +327,7 @@ test.describe( 'undo', () => {
 		// See: https://github.com/WordPress/gutenberg/issues/14950
 
 		// Issue is demonstrated from an edited post: create, save, and reload.
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'original' );
 		await page.click( 'role=button[name="Save draft"i]' );
 		await expect(
@@ -335,10 +336,11 @@ test.describe( 'undo', () => {
 			)
 		).toBeVisible();
 		await page.reload();
+		await page.waitForSelector( 'iframe[name="editor-canvas"]' );
 
 		// Issue is demonstrated by forcing state merges (multiple inputs) on
 		// an existing text after a fresh reload.
-		await page.click( '[data-type="core/paragraph"] >> nth=0' );
+		await editor.canvas.click( '[data-type="core/paragraph"] >> nth=0' );
 		await page.keyboard.type( 'modified' );
 
 		// The issue is demonstrated after the one second delay to trigger the
@@ -360,7 +362,7 @@ test.describe( 'undo', () => {
 		page,
 		pageUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '1' );
 		await page.click( 'role=button[name="Save draft"i]' );
 		await expect(
@@ -378,7 +380,7 @@ test.describe( 'undo', () => {
 		page,
 		pageUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '1' );
 		await editor.publishPost();
 		await pageUtils.pressKeys( 'primary+z' );
@@ -391,7 +393,7 @@ test.describe( 'undo', () => {
 		page,
 		pageUtils,
 	} ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 
 		await page.keyboard.type( '1' );
 		await page.click( 'role=button[name="Save draft"i]' );
@@ -406,7 +408,7 @@ test.describe( 'undo', () => {
 		await expect(
 			page.locator( 'role=button[name="Undo"]' )
 		).toBeDisabled();
-		await page.click( '[data-type="core/paragraph"]' );
+		await editor.canvas.click( '[data-type="core/paragraph"]' );
 
 		await page.keyboard.type( '2' );
 
@@ -436,7 +438,7 @@ test.describe( 'undo', () => {
 		// block attribute as in the previous action and results in transient edits
 		// and skipping `undo` history steps.
 		const text = 'tonis';
-		await page.click( 'role=button[name="Add default block"i]' );
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( text );
 		await editor.publishPost();
 		await pageUtils.pressKeys( 'primary+z' );

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -4,8 +4,8 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.use( {
-	writingFlowUtils: async ( { page }, use ) => {
-		await use( new WritingFlowUtils( { page } ) );
+	writingFlowUtils: async ( { page, editor }, use ) => {
+		await use( new WritingFlowUtils( { page, editor } ) );
 	},
 } );
 
@@ -29,7 +29,7 @@ test.describe( 'Writing Flow', () => {
 		// See: https://github.com/WordPress/gutenberg/issues/18928
 		await writingFlowUtils.addDemoContent();
 
-		const activeElementLocator = page.locator( ':focus' );
+		const activeElementLocator = editor.canvas.locator( ':focus' );
 
 		// Arrow up into nested context focuses last text input.
 		await page.keyboard.press( 'ArrowUp' );
@@ -46,7 +46,7 @@ test.describe( 'Writing Flow', () => {
 			.poll( writingFlowUtils.getActiveBlockName )
 			.toBe( 'core/column' );
 		await page.keyboard.press( 'ArrowUp' );
-		const activeElementBlockType = await page.evaluate( () =>
+		const activeElementBlockType = await editor.canvas.evaluate( () =>
 			document.activeElement.getAttribute( 'data-type' )
 		);
 		expect( activeElementBlockType ).toBe( 'core/columns' );
@@ -317,25 +317,25 @@ test.describe( 'Writing Flow', () => {
 		await editor.insertBlock( { name: 'core/paragraph' } );
 		await page.keyboard.type( 'abc' ); // Need content to remove placeholder label.
 		await editor.selectBlocks(
-			page.locator( 'role=document[name="Block: Shortcode"i]' )
+			editor.canvas.locator( 'role=document[name="Block: Shortcode"i]' )
 		);
 
 		// Should remain in title upon ArrowRight:
 		await page.keyboard.press( 'ArrowRight' );
 		await expect(
-			page.locator( 'role=document[name="Block: Shortcode"i]' )
+			editor.canvas.locator( 'role=document[name="Block: Shortcode"i]' )
 		).toHaveClass( /is-selected/ );
 
 		// Should remain in title upon modifier + ArrowDown:
 		await pageUtils.pressKeys( 'primary+ArrowDown' );
 		await expect(
-			page.locator( 'role=document[name="Block: Shortcode"i]' )
+			editor.canvas.locator( 'role=document[name="Block: Shortcode"i]' )
 		).toHaveClass( /is-selected/ );
 
 		// Should navigate to the next block.
 		await page.keyboard.press( 'ArrowDown' );
 		await expect(
-			page.locator( 'role=document[name="Paragraph block"i]' )
+			editor.canvas.locator( 'role=document[name="Paragraph block"i]' )
 		).toHaveClass( /is-selected/ );
 	} );
 
@@ -447,12 +447,12 @@ test.describe( 'Writing Flow', () => {
 	} ) => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.press( 'Enter' );
-		await page.evaluate( () => {
+		await editor.canvas.evaluate( () => {
 			document.activeElement.style.paddingTop = '100px';
 		} );
 		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.type( '1' );
-		await page.evaluate( () => {
+		await editor.canvas.evaluate( () => {
 			document.activeElement.style.paddingBottom = '100px';
 		} );
 		await page.keyboard.press( 'ArrowDown' );
@@ -467,7 +467,7 @@ test.describe( 'Writing Flow', () => {
 	} ) => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.press( 'Enter' );
-		await page.evaluate( () => {
+		await editor.canvas.evaluate( () => {
 			document.activeElement.style.lineHeight = 'normal';
 		} );
 		await page.keyboard.press( 'ArrowUp' );
@@ -650,7 +650,7 @@ test.describe( 'Writing Flow', () => {
 	} ) => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.press( 'Enter' );
-		await page.evaluate( () => {
+		await editor.canvas.evaluate( () => {
 			document.activeElement.style.paddingLeft = '100px';
 		} );
 		await page.keyboard.press( 'Enter' );
@@ -696,7 +696,7 @@ test.describe( 'Writing Flow', () => {
 		await page.keyboard.type( '2' );
 		await page.keyboard.press( 'ArrowUp' );
 
-		const paragraphBlock = page
+		const paragraphBlock = editor.canvas
 			.locator( 'role=document[name="Paragraph block"i]' )
 			.first();
 		const paragraphRect = await paragraphBlock.boundingBox();
@@ -761,7 +761,7 @@ test.describe( 'Writing Flow', () => {
 <figure class="wp-block-image alignwide"><img alt=""/></figure>
 <!-- /wp:image -->` );
 
-		const paragraphBlock = page.locator(
+		const paragraphBlock = editor.canvas.locator(
 			'role=document[name="Paragraph block"i]'
 		);
 
@@ -784,7 +784,7 @@ test.describe( 'Writing Flow', () => {
 		await page.mouse.click( x, lowerInserterY );
 
 		await expect(
-			page.locator( 'role=document[name="Block: Image"i]' )
+			editor.canvas.locator( 'role=document[name="Block: Image"i]' )
 		).toHaveClass( /is-selected/ );
 	} );
 
@@ -802,7 +802,7 @@ test.describe( 'Writing Flow', () => {
 		// Create the table.
 		await page.keyboard.press( 'Space' );
 		await expect(
-			page.locator( 'role=document[name="Block: Table"i]' )
+			editor.canvas.locator( 'role=document[name="Block: Table"i]' )
 		).toBeVisible();
 		// Navigate to the second cell.
 		await page.keyboard.press( 'ArrowRight' );
@@ -867,7 +867,7 @@ test.describe( 'Writing Flow', () => {
 		await page.mouse.up();
 
 		await expect(
-			page.locator( 'role=document[name="Paragraph block"i]' )
+			editor.canvas.locator( 'role=document[name="Paragraph block"i]' )
 		).toHaveClass( /is-selected/ );
 	} );
 
@@ -901,12 +901,13 @@ test.describe( 'Writing Flow', () => {
 
 	test( 'should move to the start of the first line on ArrowUp', async ( {
 		page,
+		editor,
 	} ) => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'a' );
 
 		async function getHeight() {
-			return await page.evaluate(
+			return await editor.canvas.evaluate(
 				() => document.activeElement.offsetHeight
 			);
 		}
@@ -928,18 +929,19 @@ test.describe( 'Writing Flow', () => {
 
 		// Expect the "." to be added at the start of the paragraph
 		await expect(
-			page.locator( 'role=document[name="Paragraph block"i]' )
+			editor.canvas.locator( 'role=document[name="Paragraph block"i]' )
 		).toHaveText( /^\.a+$/ );
 	} );
 
 	test( 'should vertically move the caret from corner to corner', async ( {
 		page,
+		editor,
 	} ) => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'a' );
 
 		async function getHeight() {
-			return await page.evaluate(
+			return await editor.canvas.evaluate(
 				() => document.activeElement.offsetHeight
 			);
 		}
@@ -961,19 +963,20 @@ test.describe( 'Writing Flow', () => {
 
 		// Expect the "." to be added at the start of the paragraph
 		await expect(
-			page.locator( 'role=document[name="Paragraph block"i]' )
+			editor.canvas.locator( 'role=document[name="Paragraph block"i]' )
 		).toHaveText( /^a+\.a$/ );
 	} );
 
 	test( 'should vertically move the caret when pressing Alt', async ( {
 		page,
 		pageUtils,
+		editor,
 	} ) => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'a' );
 
 		async function getHeight() {
-			return await page.evaluate(
+			return await editor.canvas.evaluate(
 				() => document.activeElement.offsetHeight
 			);
 		}
@@ -995,14 +998,17 @@ test.describe( 'Writing Flow', () => {
 
 		// Expect the "." to be added at the start of the paragraph
 		await expect(
-			page.locator( 'role=document[name="Paragraph block"i] >> nth = 0' )
+			editor.canvas.locator(
+				'role=document[name="Paragraph block"i] >> nth = 0'
+			)
 		).toHaveText( /^.a+$/ );
 	} );
 } );
 
 class WritingFlowUtils {
-	constructor( { page } ) {
+	constructor( { page, editor } ) {
 		this.page = page;
+		this.editor = editor;
 
 		this.getActiveBlockName = this.getActiveBlockName.bind( this );
 	}
@@ -1021,19 +1027,19 @@ class WritingFlowUtils {
 		await this.page.keyboard.press( 'Enter' );
 		await this.page.keyboard.type( '/columns' );
 		await this.page.keyboard.press( 'Enter' );
-		await this.page.click(
+		await this.editor.canvas.click(
 			'role=button[name="Two columns; equal split"i]'
 		);
-		await this.page.click( 'role=button[name="Add block"i]' );
+		await this.editor.canvas.click( 'role=button[name="Add block"i]' );
 		await this.page.click(
 			'role=listbox[name="Blocks"i] >> role=option[name="Paragraph"i]'
 		);
 		await this.page.keyboard.type( '1st col' ); // If this text is too long, it may wrap to a new line and cause test failure. That's why we're using "1st" instead of "First" here.
 
-		await this.page.focus(
+		await this.editor.canvas.focus(
 			'role=document[name="Block: Column (2 of 2)"i]'
 		);
-		await this.page.click( 'role=button[name="Add block"i]' );
+		await this.editor.canvas.click( 'role=button[name="Add block"i]' );
 		await this.page.click(
 			'role=listbox[name="Blocks"i] >> role=option[name="Paragraph"i]'
 		);

--- a/test/e2e/specs/widgets/customizing-widgets.spec.js
+++ b/test/e2e/specs/widgets/customizing-widgets.spec.js
@@ -36,7 +36,11 @@ test.describe( 'Widgets Customizer', () => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
-	test( 'should add blocks', async ( { page, widgetsCustomizerPage } ) => {
+	test( 'should add blocks', async ( {
+		page,
+		widgetsCustomizerPage,
+		editor,
+	} ) => {
 		const previewFrame = widgetsCustomizerPage.previewFrame;
 
 		await widgetsCustomizerPage.visitCustomizerPage();
@@ -82,7 +86,7 @@ test.describe( 'Widgets Customizer', () => {
 
 		await page.click( 'role=option[name="Search"i]' );
 
-		await page.focus(
+		await editor.canvas.focus(
 			'role=document[name="Block: Search"i] >> role=textbox[name="Label text"i]'
 		);
 
@@ -229,6 +233,7 @@ test.describe( 'Widgets Customizer', () => {
 		page,
 		requestUtils,
 		widgetsCustomizerPage,
+		editor,
 	} ) => {
 		await requestUtils.addWidgetBlock(
 			`<!-- wp:paragraph -->\n<p>First Paragraph</p>\n<!-- /wp:paragraph -->`,
@@ -277,7 +282,7 @@ test.describe( 'Widgets Customizer', () => {
 		await headingWidget.click(); // noop click on the widget text to unfocus the editor and hide toolbar
 		await editHeadingWidget.click();
 
-		const headingBlock = page.locator(
+		const headingBlock = editor.canvas.locator(
 			'role=document[name="Block: Heading"i] >> text="First Heading"'
 		);
 		await expect( headingBlock ).toBeFocused();
@@ -583,12 +588,13 @@ test.describe( 'Widgets Customizer', () => {
 	test( 'preserves content in the Custom HTML block', async ( {
 		page,
 		widgetsCustomizerPage,
+		editor,
 	} ) => {
 		await widgetsCustomizerPage.visitCustomizerPage();
 		await widgetsCustomizerPage.expandWidgetArea( 'Footer #1' );
 
 		await widgetsCustomizerPage.addBlock( 'Custom HTML' );
-		const HTMLBlockTextarea = page.locator(
+		const HTMLBlockTextarea = editor.canvas.locator(
 			'role=document[name="Block: Custom HTML"i] >> role=textbox[name="HTML"i]'
 		);
 		await HTMLBlockTextarea.type( 'hello' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR reintroduces the iframe for the post editor, but only if all registered blocks are v3 or higher.

Previously: #48076,  #46212, #21102.
Fixes #33346, #6156, #21193.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
