### PR TITLE
Track new front-end metric: LCP-TTFB

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -52,6 +52,7 @@ const config = require( '../config' );
  *
  * @property {number=} timeToFirstByte        Represents the time since the browser started the request until it received a response.
  * @property {number=} largestContentfulPaint Represents the time when the main content of the page has likely loaded.
+ * @property {number=} lcpMinusTtfb           Represents the difference between LCP and TTFB.
  * @property {number=} serverResponse         Represents the time the server takes to respond.
  * @property {number=} firstPaint             Represents the time when the user agent first rendered after navigation.
  * @property {number=} domContentLoaded       Represents the time immediately after the document's DOMContentLoaded event completes.
@@ -132,9 +133,12 @@ function curateResults( testSuite, results ) {
 		testSuite === 'front-end-classic-theme' ||
 		testSuite === 'front-end-block-theme'
 	) {
+		const timeToFirstByte = median( results.timeToFirstByte );
+		const largestContentfulPaint = median( results.largestContentfulPaint );
 		return {
-			timeToFirstByte: median( results.timeToFirstByte ),
-			largestContentfulPaint: median( results.largestContentfulPaint ),
+			timeToFirstByte,
+			largestContentfulPaint,
+			lcpMinusTtfb: largestContentfulPaint - timeToFirstByte,
 		};
 	}
 

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -50,37 +50,35 @@ const config = require( '../config' );
 /**
  * @typedef WPPerformanceResults
  *
- * @property {number=} timeToFirstByteMedian        Represents the time since the browser started the request until it received a response (median).
- * @property {number=} timeToFirstByteP75           Represents the time since the browser started the request until it received a response (75th percentile).
- * @property {number=} largestContentfulPaintMedian Represents the time when the main content of the page has likely loaded (median).
- * @property {number=} largestContentfulPaintP75    Represents the time when the main content of the page has likely loaded (75th percentile).
- * @property {number=} serverResponse               Represents the time the server takes to respond.
- * @property {number=} firstPaint                   Represents the time when the user agent first rendered after navigation.
- * @property {number=} domContentLoaded             Represents the time immediately after the document's DOMContentLoaded event completes.
- * @property {number=} loaded                       Represents the time when the load event of the current document is completed.
- * @property {number=} firstContentfulPaint         Represents the time when the browser first renders any text or media.
- * @property {number=} firstBlock                   Represents the time when Puppeteer first sees a block selector in the DOM.
- * @property {number=} type                         Average type time.
- * @property {number=} minType                      Minimum type time.
- * @property {number=} maxType                      Maximum type time.
- * @property {number=} typeContainer                Average type time within a container.
- * @property {number=} minTypeContainer             Minimum type time within a container.
- * @property {number=} maxTypeContainer             Maximum type time within a container.
- * @property {number=} focus                        Average block selection time.
- * @property {number=} minFocus                     Min block selection time.
- * @property {number=} maxFocus                     Max block selection time.
- * @property {number=} inserterOpen                 Average time to open global inserter.
- * @property {number=} minInserterOpen              Min time to open global inserter.
- * @property {number=} maxInserterOpen              Max time to open global inserter.
- * @property {number=} inserterSearch               Average time to open global inserter.
- * @property {number=} minInserterSearch            Min time to open global inserter.
- * @property {number=} maxInserterSearch            Max time to open global inserter.
- * @property {number=} inserterHover                Average time to move mouse between two block item in the inserter.
- * @property {number=} minInserterHover             Min time to move mouse between two block item in the inserter.
- * @property {number=} maxInserterHover             Max time to move mouse between two block item in the inserter.
- * @property {number=} listViewOpen                 Average time to open list view.
- * @property {number=} minListViewOpen              Min time to open list view.
- * @property {number=} maxListViewOpen              Max time to open list view.
+ * @property {number=} timeToFirstByte        Represents the time since the browser started the request until it received a response.
+ * @property {number=} largestContentfulPaint Represents the time when the main content of the page has likely loaded.
+ * @property {number=} serverResponse         Represents the time the server takes to respond.
+ * @property {number=} firstPaint             Represents the time when the user agent first rendered after navigation.
+ * @property {number=} domContentLoaded       Represents the time immediately after the document's DOMContentLoaded event completes.
+ * @property {number=} loaded                 Represents the time when the load event of the current document is completed.
+ * @property {number=} firstContentfulPaint   Represents the time when the browser first renders any text or media.
+ * @property {number=} firstBlock             Represents the time when Puppeteer first sees a block selector in the DOM.
+ * @property {number=} type                   Average type time.
+ * @property {number=} minType                Minimum type time.
+ * @property {number=} maxType                Maximum type time.
+ * @property {number=} typeContainer          Average type time within a container.
+ * @property {number=} minTypeContainer       Minimum type time within a container.
+ * @property {number=} maxTypeContainer       Maximum type time within a container.
+ * @property {number=} focus                  Average block selection time.
+ * @property {number=} minFocus               Min block selection time.
+ * @property {number=} maxFocus               Max block selection time.
+ * @property {number=} inserterOpen           Average time to open global inserter.
+ * @property {number=} minInserterOpen        Min time to open global inserter.
+ * @property {number=} maxInserterOpen        Max time to open global inserter.
+ * @property {number=} inserterSearch         Average time to open global inserter.
+ * @property {number=} minInserterSearch      Min time to open global inserter.
+ * @property {number=} maxInserterSearch      Max time to open global inserter.
+ * @property {number=} inserterHover          Average time to move mouse between two block item in the inserter.
+ * @property {number=} minInserterHover       Min time to move mouse between two block item in the inserter.
+ * @property {number=} maxInserterHover       Max time to move mouse between two block item in the inserter.
+ * @property {number=} listViewOpen           Average time to open list view.
+ * @property {number=} minListViewOpen        Min time to open list view.
+ * @property {number=} maxListViewOpen        Max time to open list view.
  */
 
 /**
@@ -110,19 +108,6 @@ function median( array ) {
 }
 
 /**
- * Computes the 75th percentile from an array of numbers.
- *
- * @param {number[]} array
- *
- * @return {number} 75th percentile of the given dataset.
- */
-function percentile75( array ) {
-	const ascending = array.sort( ( a, b ) => a - b );
-	const position = Math.floor( ( 75 / 100 ) * array.length );
-	return ascending[ position ];
-}
-
-/**
  * Rounds and format a time passed in milliseconds.
  *
  * @param {number} number
@@ -148,14 +133,8 @@ function curateResults( testSuite, results ) {
 		testSuite === 'front-end-block-theme'
 	) {
 		return {
-			timeToFirstByteMedian: median( results.timeToFirstByte ),
-			timeToFirstByteP75: percentile75( results.timeToFirstByte ),
-			largestContentfulPaintMedian: median(
-				results.largestContentfulPaint
-			),
-			largestContentfulPaintP75: percentile75(
-				results.largestContentfulPaint
-			),
+			timeToFirstByte: median( results.timeToFirstByte ),
+			largestContentfulPaint: median( results.largestContentfulPaint ),
 		};
 	}
 

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -32,6 +32,7 @@ const config = require( '../config' );
  *
  * @property {number[]} timeToFirstByte        Represents the time since the browser started the request until it received a response.
  * @property {number[]} largestContentfulPaint Represents the time when the main content of the page has likely loaded.
+ * @property {number[]} lcpMinusTtfb           Represents the difference between LCP and TTFB.
  * @property {number[]} serverResponse         Represents the time the server takes to respond.
  * @property {number[]} firstPaint             Represents the time when the user agent first rendered after navigation.
  * @property {number[]} domContentLoaded       Represents the time immediately after the document's DOMContentLoaded event completes.
@@ -133,12 +134,10 @@ function curateResults( testSuite, results ) {
 		testSuite === 'front-end-classic-theme' ||
 		testSuite === 'front-end-block-theme'
 	) {
-		const timeToFirstByte = median( results.timeToFirstByte );
-		const largestContentfulPaint = median( results.largestContentfulPaint );
 		return {
-			timeToFirstByte,
-			largestContentfulPaint,
-			lcpMinusTtfb: largestContentfulPaint - timeToFirstByte,
+			timeToFirstByte: median( results.timeToFirstByte ),
+			largestContentfulPaint: median( results.largestContentfulPaint ),
+			lcpMinusTtfb: median( results.lcpMinusTtfb ),
 		};
 	}
 

--- a/packages/e2e-tests/specs/performance/front-end-block-theme.test.js
+++ b/packages/e2e-tests/specs/performance/front-end-block-theme.test.js
@@ -13,7 +13,7 @@ describe( 'Front End Performance', () => {
 	const results = {
 		timeToFirstByte: [],
 		largestContentfulPaint: [],
-		lcpMinusTTFB: [],
+		lcpMinusTtfb: [],
 	};
 
 	beforeAll( async () => {
@@ -77,7 +77,7 @@ describe( 'Front End Performance', () => {
 
 			results.largestContentfulPaint.push( lcp );
 			results.timeToFirstByte.push( ttfb );
-			results.lcpMinusTTFB.push( lcp - ttfb );
+			results.lcpMinusTtfb.push( lcp - ttfb );
 		}
 	} );
 } );

--- a/packages/e2e-tests/specs/performance/front-end-block-theme.test.js
+++ b/packages/e2e-tests/specs/performance/front-end-block-theme.test.js
@@ -13,6 +13,7 @@ describe( 'Front End Performance', () => {
 	const results = {
 		timeToFirstByte: [],
 		largestContentfulPaint: [],
+		lcpMinusTTFB: [],
 	};
 
 	beforeAll( async () => {
@@ -29,24 +30,7 @@ describe( 'Front End Performance', () => {
 		);
 	} );
 
-	it( 'Time To First Byte (TTFB)', async () => {
-		// We derive the 75th percentile of the TTFB based on these results.
-		// By running it 16 times, the percentile value would be (75/100)*16=12,
-		// meaning that we discard the worst 4 values.
-		let i = 16;
-		while ( i-- ) {
-			await page.goto( createURL( '/' ) );
-			const navigationTimingJson = await page.evaluate( () =>
-				JSON.stringify( performance.getEntriesByType( 'navigation' ) )
-			);
-			const [ navigationTiming ] = JSON.parse( navigationTimingJson );
-			results.timeToFirstByte.push(
-				navigationTiming.responseStart - navigationTiming.startTime
-			);
-		}
-	} );
-
-	it( 'Largest Contentful Paint (LCP)', async () => {
+	it( 'Report TTFB, LCP, and LCP-TTFB', async () => {
 		// Based on https://addyosmani.com/blog/puppeteer-recipes/#performance-observer-lcp
 		function calcLCP() {
 			// By using -1 we know when it didn't record any event.
@@ -74,9 +58,6 @@ describe( 'Front End Performance', () => {
 			} );
 		}
 
-		// We derive the 75th percentile of the TTFB based on these results.
-		// By running it 16 times, the percentile value would be (75/100)*16=12,
-		// meaning that we discard the worst 4 values.
 		let i = 16;
 		while ( i-- ) {
 			await page.evaluateOnNewDocument( calcLCP );
@@ -85,10 +66,18 @@ describe( 'Front End Performance', () => {
 			// https://pptr.dev/api/puppeteer.page.goto#remarks
 			await page.goto( createURL( '/' ), { waitUntil: 'networkidle0' } );
 
-			const lcp = await page.evaluate(
-				() => window.largestContentfulPaint
-			);
+			const { lcp, ttfb } = await page.evaluate( () => {
+				const [ { responseStart, startTime } ] =
+					performance.getEntriesByType( 'navigation' );
+				return {
+					lcp: window.largestContentfulPaint,
+					ttfb: responseStart - startTime,
+				};
+			} );
+
 			results.largestContentfulPaint.push( lcp );
+			results.timeToFirstByte.push( ttfb );
+			results.lcpMinusTTFB.push( lcp - ttfb );
 		}
 	} );
 } );

--- a/packages/e2e-tests/specs/performance/front-end-classic-theme.test.js
+++ b/packages/e2e-tests/specs/performance/front-end-classic-theme.test.js
@@ -13,6 +13,7 @@ describe( 'Front End Performance', () => {
 	const results = {
 		timeToFirstByte: [],
 		largestContentfulPaint: [],
+		lcpMinusTTFB: [],
 	};
 
 	beforeAll( async () => {
@@ -28,24 +29,7 @@ describe( 'Front End Performance', () => {
 		);
 	} );
 
-	it( 'Time To First Byte (TTFB)', async () => {
-		// We derive the 75th percentile of the TTFB based on these results.
-		// By running it 16 times, the percentile value would be (75/100)*16=12,
-		// meaning that we discard the worst 4 values.
-		let i = 16;
-		while ( i-- ) {
-			await page.goto( createURL( '/' ) );
-			const navigationTimingJson = await page.evaluate( () =>
-				JSON.stringify( performance.getEntriesByType( 'navigation' ) )
-			);
-			const [ navigationTiming ] = JSON.parse( navigationTimingJson );
-			results.timeToFirstByte.push(
-				navigationTiming.responseStart - navigationTiming.startTime
-			);
-		}
-	} );
-
-	it( 'Largest Contentful Paint (LCP)', async () => {
+	it( 'Report TTFB, LCP, and LCP-TTFB', async () => {
 		// Based on https://addyosmani.com/blog/puppeteer-recipes/#performance-observer-lcp
 		function calcLCP() {
 			// By using -1 we know when it didn't record any event.
@@ -73,9 +57,6 @@ describe( 'Front End Performance', () => {
 			} );
 		}
 
-		// We derive the 75th percentile of the TTFB based on these results.
-		// By running it 16 times, the percentile value would be (75/100)*16=12,
-		// meaning that we discard the worst 4 values.
 		let i = 16;
 		while ( i-- ) {
 			await page.evaluateOnNewDocument( calcLCP );
@@ -84,10 +65,18 @@ describe( 'Front End Performance', () => {
 			// https://pptr.dev/api/puppeteer.page.goto#remarks
 			await page.goto( createURL( '/' ), { waitUntil: 'networkidle0' } );
 
-			const lcp = await page.evaluate(
-				() => window.largestContentfulPaint
-			);
+			const { lcp, ttfb } = await page.evaluate( () => {
+				const [ { responseStart, startTime } ] =
+					performance.getEntriesByType( 'navigation' );
+				return {
+					lcp: window.largestContentfulPaint,
+					ttfb: responseStart - startTime,
+				};
+			} );
+
 			results.largestContentfulPaint.push( lcp );
+			results.timeToFirstByte.push( ttfb );
+			results.lcpMinusTTFB.push( lcp - ttfb );
 		}
 	} );
 } );

--- a/packages/e2e-tests/specs/performance/front-end-classic-theme.test.js
+++ b/packages/e2e-tests/specs/performance/front-end-classic-theme.test.js
@@ -13,7 +13,7 @@ describe( 'Front End Performance', () => {
 	const results = {
 		timeToFirstByte: [],
 		largestContentfulPaint: [],
-		lcpMinusTTFB: [],
+		lcpMinusTtfb: [],
 	};
 
 	beforeAll( async () => {
@@ -76,7 +76,7 @@ describe( 'Front End Performance', () => {
 
 			results.largestContentfulPaint.push( lcp );
 			results.timeToFirstByte.push( ttfb );
-			results.lcpMinusTTFB.push( lcp - ttfb );
+			results.lcpMinusTtfb.push( lcp - ttfb );
 		}
 	} );
 } );


### PR DESCRIPTION
## What?

This PR does two things:

- removes the p75 data that was calculated for both TTFB and LCP
- adds a new metric to track in the front-end: LCP-TTFB

## Why?

The median has proven stable enough, so we don't need the percentile as well. We are only shipping the median to `codevitals.run` anyway.

The TTFB represents a big chunk of the LCP time (50% for classic, 80% for block themes). It influences LCP so much that we are unable to actually detect changes that affect the time it takes the client to render a page.

## How?

By subtracting TTFB (median) from LCP.

## Testing Instructions

Verify that the front-end metrics include LCP, TTFB, and LCP-TTFB.

![image](https://user-images.githubusercontent.com/583546/220585068-d3be8253-f57a-4453-b705-bc00908b2b5e.png)

