### PR TITLE
Site Tagline: Add example so that it will display in style book

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -744,7 +744,7 @@ Describe in a few words what the site is about. The tagline can be used in searc
 -	**Name:** core/site-tagline
 -	**Category:** theme
 -	**Supports:** align (full, wide), anchor, color (background, gradients, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** textAlign
+-	**Attributes:** placeholder, textAlign
 
 ## Site Title
 

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -8,6 +8,9 @@
 	"keywords": [ "description" ],
 	"textdomain": "default",
 	"attributes": {
+		"placeholder": {
+			"type": "string"
+		},
 		"textAlign": {
 			"type": "string"
 		}

--- a/packages/block-library/src/site-tagline/edit.js
+++ b/packages/block-library/src/site-tagline/edit.js
@@ -22,7 +22,7 @@ export default function SiteTaglineEdit( {
 	setAttributes,
 	insertBlocksAfter,
 } ) {
-	const { textAlign } = attributes;
+	const { placeholder, textAlign } = attributes;
 	const { canUserEdit, tagline } = useSelect( ( select ) => {
 		const { canUser, getEntityRecord, getEditedEntityRecord } =
 			select( coreStore );
@@ -57,7 +57,7 @@ export default function SiteTaglineEdit( {
 			allowedFormats={ [] }
 			onChange={ setTagline }
 			aria-label={ __( 'Site tagline text' ) }
-			placeholder={ __( 'Write site tagline…' ) }
+			placeholder={ placeholder || __( 'Write site tagline…' ) }
 			tagName="p"
 			value={ tagline }
 			disableLineBreaks

--- a/packages/block-library/src/site-tagline/index.js
+++ b/packages/block-library/src/site-tagline/index.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import initBlock from '../utils/init-block';
@@ -13,7 +18,11 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
-	example: {},
+	example: {
+		attributes: {
+			placeholder: __( 'A site tagline.' ),
+		},
+	},
 	deprecated,
 };
 

--- a/packages/block-library/src/site-tagline/index.js
+++ b/packages/block-library/src/site-tagline/index.js
@@ -13,6 +13,7 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
+	example: {},
 	deprecated,
 };
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add an empty to the Site Tagline block so that it will be displayed in the Style Book in global styles. Also adds a `placeholder` attribute so that if the site does not currently have a tagline set, the preview does not say "Write a site tagline..."

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Without an `example` object set, the block will not be previewed in the Style Book. Much like the Site Title or other theme blocks, it's important that it can be seen / previewed within the Style Book when users are making changes to global styles.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add an `example` object to the Site Tagline block (using the same approach as the Site Title block). This causes an example of the block to be displayed in the inserter and in the Style Book. No parameters need to be provided in the example as the block will render the current site's tagline, however a `placeholder` attribute has been included so that on sites with no tagline set, the preview will not say "Write a site tagline..."

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In a site with a tagline open up global styles and click the Eye icon to open the style book.
2. Click on the Theme tab.
3. See that the Site Tagline block should now be listed. If you change the Site Tagline's global styles, they should be reflected in the Style Book.
4. If you clear out the Site Tagline from within the block (either in the site template or in a post) and then revisit the Style Book, it should display the placeholder text "A site tagline." instead of "Write a site tagline..."

## Screenshots or screencast <!-- if applicable -->

| Before (Site tagline does not show in Style Book) | After (Site tagline shows in Style Book) |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/220521907-4ac7527d-01a6-42b5-be96-5af5d0cc4685.png) | ![image](https://user-images.githubusercontent.com/14988353/220521940-b6df89c3-63ed-4ff1-b3c0-e66ac6009c1a.png) |
