### PR TITLE
Site Editor: Fix the 'Browse all' link in the template details modal

### DIFF
--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -31,10 +31,12 @@ export default function TemplateDetails( { template, onClose } ) {
 	);
 	const { revertTemplate } = useDispatch( editSiteStore );
 
+	// TODO: We should update this to filter by template part's areas as well.
 	const browseAllLinkProps = useLink( {
-		// TODO: We should update this to filter by template part's areas as well.
+		canvas: 'view',
 		postType: template.type,
 		postId: undefined,
+		path: '/' + template.type + '/all',
 	} );
 
 	const isTemplatePart = template.type === 'wp_template_part';


### PR DESCRIPTION
## What?
Fixes #48289.

PR fixes the "Browse" all link in the template details modal.

## Why?
The `useLink` hook now requires the `path` argument and canvas to be in the `view` mode.

A possible regression after #48063.

## Testing Instructions

1. Go to the Site Editor.
2. Click on the Template Details dropdown.
3. Click on the "Browse all templates" button.
4. Confirm that the "Manage all templates" page is rendered.
5. Repeat the steps with Template Parts

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-02-22 at 10 32 44](https://user-images.githubusercontent.com/240569/220541601-b58b6038-1bfd-46ff-9ecd-5e87e54af184.png)
