### PR TITLE
Add a manual performance job that we can trigger from Github UI

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -6,6 +6,15 @@ on:
         types: [published]
     push:
         branches: [trunk]
+    workflow_dispatch:
+        inputs:
+            branches:
+                description: 'branches or commits to compare (comma separated)'
+                required: true
+            wpversion:
+                description: 'The base WP version to use for the tests (latest or 6.0, 6.1...)'
+                required: false
+                default: 'latest'
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
@@ -85,6 +94,14 @@ jobs:
                   script: |
                       const commit_details = await github.rest.git.getCommit({owner: context.repo.owner, repo: context.repo.repo, commit_sha: context.sha});
                       return parseInt((new Date( commit_details.data.author.date ).getTime() / 1000).toFixed(0))
+
+            - name: Compare performance with custom branches
+              if: github.event_name == 'workflow_dispatch'
+              env:
+                  BRANCHES: ${{ github.event.inputs.branches }}
+                  WP_VERSION: ${{ github.event.inputs.wpversion }}
+              run: |
+                  ./bin/plugin/cli.js perf $(echo $BRANCHES | tr ',' ' ') --tests-branch $GITHUB_SHA --wp-version "$WP_VERSION"
 
             - name: Publish performance results
               if: github.event_name == 'push'


### PR DESCRIPTION
Running performance jobs locally is tedious. This PR allows us to run the job on demand from Github UI by:

 - going to the "actions" tab, 
 - selecting the "Performance Tests" job
 - Click "run  workflow"

The "workflow_dispatch" jobs can only be triggered if they're part of the default branch (trunk), meaning that we won't be able to test this PR properly unless we actually merge it.