### PR TITLE
[Query Loop] Fix top border in pattern selection modal

### DIFF
--- a/packages/block-library/src/query/editor.scss
+++ b/packages/block-library/src/query/editor.scss
@@ -42,6 +42,7 @@
 		position: sticky;
 		top: 0;
 		padding: $grid-unit-20 0;
+		margin-bottom: 2px;
 		z-index: z-index(".block-library-query-pattern__selection-search");
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/47909

Fix top border in pattern selection modal in Query Loop

#### Before
<img width="862" alt="Screenshot 2023-02-22 at 10 27 17 AM" src="https://user-images.githubusercontent.com/16275880/220565266-05053072-b884-4499-bf7e-cc0dfc854473.png">


#### After

<img width="862" alt="Screenshot 2023-02-22 at 10 29 28 AM" src="https://user-images.githubusercontent.com/16275880/220565283-0b12e3ab-8f65-4048-a290-15edd022d474.png">
