### PR TITLE
Global Styles: Display preset names via the tooltip

### DIFF
--- a/packages/edit-site/src/components/global-styles/shadow-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadow-panel.js
@@ -146,9 +146,9 @@ function ShadowPopoverContainer( { shadow, onShadowChange } ) {
 function ShadowPresets( { presets, activeShadow, onSelect } ) {
 	return ! presets ? null : (
 		<Grid columns={ 6 } gap={ 0 } align="center" justify="center">
-			{ presets.map( ( { name, shadow }, i ) => (
+			{ presets.map( ( { name, slug, shadow } ) => (
 				<ShadowIndicator
-					key={ i }
+					key={ slug }
 					label={ name }
 					isActive={ shadow === activeShadow }
 					onSelect={ () =>

--- a/packages/edit-site/src/components/global-styles/shadow-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadow-panel.js
@@ -167,8 +167,9 @@ function ShadowIndicator( { label, isActive, onSelect, shadow } ) {
 			<Button
 				className="edit-site-global-styles__shadow-indicator"
 				onClick={ onSelect }
-				aria-label={ label }
+				label={ label }
 				style={ { boxShadow: shadow } }
+				showTooltip
 			>
 				{ isActive && <Icon icon={ check } /> }
 			</Button>


### PR DESCRIPTION
## What?
PR updates the `ShadowIndicator` component to display preset labels via tooltips.

## Why?
There was no visual indication of which preset the user is selecting without tooltips.

## Testing Instructions
1. Open the Site Editor.
2. Open Global Styles.
3. Navigate to Blocks > Button > Shadow
4. Hover or focus on the preset and confirm that label is displayed via the tooltip.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-02-22 at 12 50 23](https://user-images.githubusercontent.com/240569/220570195-1aa3ede1-d188-470c-bdfc-af6c3e0803ed.png)