### PR TITLE
Block editor: create automatic change higher order reducer

### DIFF
--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -175,13 +175,16 @@ test.describe( 'List (@firefox)', () => {
 		await expect.poll( editor.getEditedPostContent ).toBe( '' );
 	} );
 
-	test( 'should not undo asterisk transform with backspace after selection change (-firefox)', async ( {
+	test( 'should not undo asterisk transform with backspace after selection change', async ( {
 		editor,
 		page,
 	} ) => {
 		await page.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '* ' );
 		await expect( page.locator( '[data-type="core/list"]' ) ).toBeVisible();
+		// Wait until the automatic change is marked as "final", which is done
+		// with an idle callback, see __unstableMarkAutomaticChange.
+		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
 		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'ArrowDown' );
 		await page.keyboard.press( 'Backspace' );

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -175,7 +175,7 @@ test.describe( 'List (@firefox)', () => {
 		await expect.poll( editor.getEditedPostContent ).toBe( '' );
 	} );
 
-	test( 'should not undo asterisk transform with backspace after selection change', async ( {
+	test( 'should not undo asterisk transform with backspace after selection change (-firefox)', async ( {
 		editor,
 		page,
 	} ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Creates an automatic change higher order reducer so we can reset `automaticChangeStatus` if blocks or selection changes.

## Why?

The current implementation is very fragile: if you add an action to the store, it will automatically reset the `automaticChangeStatus` when dispatched.

## How?

Higher order reducer

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
