### PR TITLE
Lodash: Remove remaining `_.get()` from `editor`

### DIFF
--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { Button, PanelBody } from '@wordpress/components';
@@ -41,11 +36,8 @@ export default function PostFormatPanel() {
 	const { currentPostFormat, suggestion } = useSelect( ( select ) => {
 		const { getEditedPostAttribute, getSuggestedPostFormat } =
 			select( editorStore );
-		const supportedFormats = get(
-			select( coreStore ).getThemeSupports(),
-			[ 'formats' ],
-			[]
-		);
+		const supportedFormats =
+			select( coreStore ).getThemeSupports().formats ?? [];
 		return {
 			currentPostFormat: getEditedPostAttribute( 'format' ),
 			suggestion: getSuggestion(

--- a/packages/editor/src/components/post-taxonomies/most-used-terms.js
+++ b/packages/editor/src/components/post-taxonomies/most-used-terms.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { BaseControl, Button } from '@wordpress/components';
@@ -46,7 +41,6 @@ export default function MostUsedTerms( { onSelect, taxonomy } ) {
 	}
 
 	const terms = unescapeTerms( _terms );
-	const label = get( taxonomy, [ 'labels', 'most_used' ] );
 
 	return (
 		<div className="editor-post-taxonomies__flat-term-most-used">
@@ -54,7 +48,7 @@ export default function MostUsedTerms( { onSelect, taxonomy } ) {
 				as="h3"
 				className="editor-post-taxonomies__flat-term-most-used-label"
 			>
-				{ label }
+				{ taxonomy.labels.most_used }
 			</BaseControl.VisualLabel>
 			{ /*
 			 * Disable reason: The `list` ARIA role is redundant but

--- a/packages/editor/src/components/theme-support-check/index.js
+++ b/packages/editor/src/components/theme-support-check/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { withSelect } from '@wordpress/data';
@@ -23,7 +18,7 @@ export function ThemeSupportCheck( {
 	const isSupported = (
 		Array.isArray( supportKeys ) ? supportKeys : [ supportKeys ]
 	 ).some( ( key ) => {
-		const supported = get( themeSupports, [ key ], false );
+		const supported = themeSupports[ key ] ?? false;
 		// 'post-thumbnails' can be boolean or an array of post types.
 		// In the latter case, we need to verify `postType` exists
 		// within `supported`. If `postType` isn't passed, then the check

--- a/packages/editor/src/components/theme-support-check/index.js
+++ b/packages/editor/src/components/theme-support-check/index.js
@@ -18,7 +18,7 @@ export function ThemeSupportCheck( {
 	const isSupported = (
 		Array.isArray( supportKeys ) ? supportKeys : [ supportKeys ]
 	 ).some( ( key ) => {
-		const supported = themeSupports[ key ] ?? false;
+		const supported = themeSupports?.[ key ] ?? false;
 		// 'post-thumbnails' can be boolean or an array of post types.
 		// In the latter case, we need to verify `postType` exists
 		// within `supported`. If `postType` isn't passed, then the check

--- a/packages/editor/src/components/theme-support-check/test/index.js
+++ b/packages/editor/src/components/theme-support-check/test/index.js
@@ -10,12 +10,7 @@ import { ThemeSupportCheck } from '../index';
 
 describe( 'ThemeSupportCheck', () => {
 	it( "should not render if there's no support check provided", () => {
-		const themeSupports = {};
-		render(
-			<ThemeSupportCheck themeSupports={ themeSupports }>
-				foobar
-			</ThemeSupportCheck>
-		);
+		render( <ThemeSupportCheck>foobar</ThemeSupportCheck> );
 		expect( screen.queryByText( 'foobar' ) ).not.toBeInTheDocument();
 	} );
 

--- a/packages/editor/src/components/theme-support-check/test/index.js
+++ b/packages/editor/src/components/theme-support-check/test/index.js
@@ -10,7 +10,12 @@ import { ThemeSupportCheck } from '../index';
 
 describe( 'ThemeSupportCheck', () => {
 	it( "should not render if there's no support check provided", () => {
-		render( <ThemeSupportCheck>foobar</ThemeSupportCheck> );
+		const themeSupports = {};
+		render(
+			<ThemeSupportCheck themeSupports={ themeSupports }>
+				foobar
+			</ThemeSupportCheck>
+		);
 		expect( screen.queryByText( 'foobar' ) ).not.toBeInTheDocument();
 	} );
 


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.get()` from the `@wordpress/editor` package. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using direct access with optional chaining and nullish coalescing as an alternative. 

## Testing Instructions
* Verify that the Post Format box in the sidebar still appears or doesn't appear based on whether your theme supports it.
* Verify that the "Most used" under Tags still works well. You need at least 3 tags that have posts for it to appear.
* Verify that the Featured Image box in the sidebar still appears or doesn't appear based on whether your theme supports it.
* Verify all checks are green.