### PR TITLE
Use Duotone presets in block duotone attributes

### DIFF
--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -448,7 +448,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	// 3. 'unset' (remove filter).
 	$duotone_attr = $block['attrs']['style']['color']['duotone'];
 
-	$is_duotone_colors_array = is_array( $duotone_attr ) && count( $duotone_attr ) === 2;
+	$is_duotone_colors_array = is_array( $duotone_attr );
 	$is_duotone_unset        = 'unset' === $duotone_attr;
 	$is_duotone_preset       = ! $is_duotone_colors_array && ! $is_duotone_unset;
 
@@ -465,7 +465,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 		// - an array of colors.
 
 		// Build a unique slug for the filter based on the array of colors.
-		$filter_key      = is_array( $duotone_attr ) ? implode( '-', $duotone_attr ) : $duotone_attr;
+		$filter_key      = $is_duotone_colors_array ? implode( '-', $duotone_attr ) : $duotone_attr;
 		$filter_preset   = array(
 			'slug' => wp_unique_id( sanitize_key( $filter_key . '-' ) ),
 		);

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -311,9 +311,6 @@ function gutenberg_get_duotone_filter_id( $preset ) {
  * @return string        Duotone CSS filter property url value.
  */
 function gutenberg_get_duotone_filter_property( $preset ) {
-	if ( isset( $preset['colors'] ) && 'unset' === $preset['colors'] ) {
-		return 'none';
-	}
 	$filter_id = gutenberg_get_duotone_filter_id( $preset );
 	return "url('#" . $filter_id . "')";
 }
@@ -446,15 +443,16 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	}
 
 	// Possible values for duotone attribute:
-	// 1. array('#000000', '#ffffff')
-	// 2. 'preset-slug'
-	// 3. 'unset' (remove filter)
+	// 1. array('#000000', '#ffffff').
+	// 2. 'preset-slug'.
+	// 3. 'unset' (remove filter).
 	$duotone_attr = $block['attrs']['style']['color']['duotone'];
 
 	$is_duotone_colors_array = is_array( $duotone_attr ) && count( $duotone_attr ) === 2;
 	$is_duotone_unset        = $duotone_attr === 'unset';
+	$is_duotone_preset       = ! $is_duotone_colors_array && ! $is_duotone_unset;
 
-	if ( ! $is_duotone_colors_array && ! $is_duotone_unset ) {
+	if ( $is_duotone_preset ) {
 		// If we have a preset slug we need to fetch the details for that preset.
 		$filter_preset   = array(
 			'slug' => $duotone_attr,
@@ -464,10 +462,9 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 		// If we have an array of colors not a preset slug.
 		$filter_key      = is_array( $duotone_attr ) ? implode( '-', $duotone_attr ) : $duotone_attr;
 		$filter_preset   = array(
-			'slug'   => wp_unique_id( sanitize_key( $filter_key . '-' ) ),
-			'colors' => $duotone_attr,
+			'slug' => wp_unique_id( sanitize_key( $filter_key . '-' ) ),
 		);
-		$filter_property = gutenberg_get_duotone_filter_property( $filter_preset );
+		$filter_property = $is_duotone_unset ? 'none' : gutenberg_get_duotone_filter_property( $filter_preset );
 	}
 
 	$filter_id = gutenberg_get_duotone_filter_id( $filter_preset );

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -453,22 +453,33 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	$is_duotone_preset       = ! $is_duotone_colors_array && ! $is_duotone_unset;
 
 	if ( $is_duotone_preset ) {
-		// If we have a preset slug we need to fetch the details for that preset.
 		$filter_preset   = array(
 			'slug' => $duotone_attr,
 		);
+
+		// Utilise existing CSS custom property.
 		$filter_property = "var(--wp--preset--duotone--$duotone_attr)";
 	} else {
-		// If we have an array of colors not a preset slug.
+		// Handle when Duotone is either:
+		// - "unset"
+		// - an array of colors.
+
+		// Build a unique slug for the filter based on the array of colors.
 		$filter_key      = is_array( $duotone_attr ) ? implode( '-', $duotone_attr ) : $duotone_attr;
 		$filter_preset   = array(
 			'slug' => wp_unique_id( sanitize_key( $filter_key . '-' ) ),
 		);
+
+		// Build a customised CSS filter property for unique slug.
 		$filter_property = $is_duotone_unset ? 'none' : gutenberg_get_duotone_filter_property( $filter_preset );
 	}
 
+	// - Applied as a class attribute to the block wrapper.
+	// - Used as a selector to apply the filter to the block.
 	$filter_id = gutenberg_get_duotone_filter_id( $filter_preset );
 
+	// Build the CSS selectors to which the filter will be applied.
+	// Todo - encapsulate this in a function.
 	$scope     = '.' . $filter_id;
 	$selectors = explode( ',', $duotone_support );
 	$scoped    = array();

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -445,14 +445,29 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$colors          = $block['attrs']['style']['color']['duotone'];
-	$filter_key      = is_array( $colors ) ? implode( '-', $colors ) : $colors;
-	$filter_preset   = array(
-		'slug'   => wp_unique_id( sanitize_key( $filter_key . '-' ) ),
-		'colors' => $colors,
-	);
-	$filter_property = gutenberg_get_duotone_filter_property( $filter_preset );
-	$filter_id       = gutenberg_get_duotone_filter_id( $filter_preset );
+	// Possible values for duotone attribute:
+	// 1. array('#000000', '#ffffff')
+	// 2. 'preset-slug'
+	// 3. 'unset' (remove filter)
+	$duotone_attr = $block['attrs']['style']['color']['duotone'];
+
+	if ( ! is_array( $duotone_attr ) && $duotone_attr !== 'unset' ) {
+		// If we have a preset slug we need to fetch the details for that preset.
+		$filter_preset   = array(
+			'slug' => $duotone_attr,
+		);
+		$filter_property = "var(--wp--preset--duotone--$duotone_attr)";
+	} else {
+		// If we have an array of colors not a preset slug.
+		$filter_key      = is_array( $duotone_attr ) ? implode( '-', $duotone_attr ) : $duotone_attr;
+		$filter_preset   = array(
+			'slug'   => wp_unique_id( sanitize_key( $filter_key . '-' ) ),
+			'colors' => $duotone_attr,
+		);
+		$filter_property = gutenberg_get_duotone_filter_property( $filter_preset );
+	}
+
+	$filter_id = gutenberg_get_duotone_filter_id( $filter_preset );
 
 	$scope     = '.' . $filter_id;
 	$selectors = explode( ',', $duotone_support );
@@ -483,7 +498,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 		)
 	);
 
-	if ( 'unset' !== $colors ) {
+	if ( is_array( $duotone_attr ) ) {
 		$filter_svg = gutenberg_get_duotone_filter_svg( $filter_preset );
 		add_action(
 			'wp_footer',

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -451,7 +451,10 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	// 3. 'unset' (remove filter)
 	$duotone_attr = $block['attrs']['style']['color']['duotone'];
 
-	if ( ! is_array( $duotone_attr ) && $duotone_attr !== 'unset' ) {
+	$is_duotone_colors_array = is_array( $duotone_attr ) && count( $duotone_attr ) === 2;
+	$is_duotone_unset        = $duotone_attr === 'unset';
+
+	if ( ! $is_duotone_colors_array && ! $is_duotone_unset ) {
 		// If we have a preset slug we need to fetch the details for that preset.
 		$filter_preset   = array(
 			'slug' => $duotone_attr,
@@ -498,7 +501,9 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 		)
 	);
 
-	if ( is_array( $duotone_attr ) ) {
+	// For *non*-presets then generate an SVG for the filter.
+	// Note: duotone presets are already pre-generated so no need to do this again.
+	if ( $is_duotone_colors_array ) {
 		$filter_svg = gutenberg_get_duotone_filter_svg( $filter_preset );
 		add_action(
 			'wp_footer',

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -443,9 +443,9 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	}
 
 	// Possible values for duotone attribute:
-	// 1. array('#000000', '#ffffff').
-	// 2. 'preset-slug'.
-	// 3. 'unset' (remove filter).
+	// 1. Array of colors - e.g. array('#000000', '#ffffff').
+	// 2. Slug of an existing Duotone preset - e.g. 'green-blue'.
+	// 3. The string 'unset' - indicates explicitly "no Duotone"..
 	$duotone_attr = $block['attrs']['style']['color']['duotone'];
 
 	$is_duotone_colors_array = is_array( $duotone_attr );
@@ -453,7 +453,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	$is_duotone_preset       = ! $is_duotone_colors_array && ! $is_duotone_unset;
 
 	if ( $is_duotone_preset ) {
-		$filter_preset   = array(
+		$filter_preset = array(
 			'slug' => $duotone_attr,
 		);
 
@@ -465,8 +465,8 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 		// - an array of colors.
 
 		// Build a unique slug for the filter based on the array of colors.
-		$filter_key      = $is_duotone_colors_array ? implode( '-', $duotone_attr ) : $duotone_attr;
-		$filter_preset   = array(
+		$filter_key    = $is_duotone_colors_array ? implode( '-', $duotone_attr ) : $duotone_attr;
+		$filter_preset = array(
 			'slug' => wp_unique_id( sanitize_key( $filter_key . '-' ) ),
 		);
 

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -449,7 +449,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	$duotone_attr = $block['attrs']['style']['color']['duotone'];
 
 	$is_duotone_colors_array = is_array( $duotone_attr ) && count( $duotone_attr ) === 2;
-	$is_duotone_unset        = $duotone_attr === 'unset';
+	$is_duotone_unset        = 'unset' === $duotone_attr;
 	$is_duotone_preset       = ! $is_duotone_colors_array && ! $is_duotone_unset;
 
 	if ( $is_duotone_preset ) {

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -467,7 +467,8 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 		// Build a unique slug for the filter based on the array of colors.
 		$filter_key    = $is_duotone_colors_array ? implode( '-', $duotone_attr ) : $duotone_attr;
 		$filter_preset = array(
-			'slug' => wp_unique_id( sanitize_key( $filter_key . '-' ) ),
+			'slug'   => wp_unique_id( sanitize_key( $filter_key . '-' ) ),
+			'colors' => $duotone_attr, // required for building the SVG with gutenberg_get_duotone_filter_svg.
 		);
 
 		// Build a customised CSS filter property for unique slug.
@@ -513,6 +514,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	// Note: duotone presets are already pre-generated so no need to do this again.
 	if ( $is_duotone_colors_array ) {
 		$filter_svg = gutenberg_get_duotone_filter_svg( $filter_preset );
+
 		add_action(
 			'wp_footer',
 			static function () use ( $filter_svg, $selector ) {

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -134,14 +134,16 @@ function DuotonePanel( { attributes, setAttributes } ) {
 				disableCustomColors={ disableCustomColors }
 				value={ duotonePresetOrColors }
 				onChange={ ( newDuotone ) => {
+					const maybePreset = getDuotonePresetFromColors(
+						newDuotone,
+						duotonePalette
+					);
+
 					const newStyle = {
 						...style,
 						color: {
 							...style?.color,
-							duotone: getDuotonePresetFromColors(
-								newDuotone,
-								duotonePalette
-							),
+							duotone: maybePreset ?? newDuotone, // use preset or fallback to custom colors.
 						},
 					};
 					setAttributes( { style: newStyle } );

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -75,9 +75,29 @@ function useMultiOriginPresets( { presetSetting, defaultSetting } ) {
 	);
 }
 
+function getColorsFromDuotonePreset( duotone, duotonePalette ) {
+	if ( ! duotone ) {
+		return;
+	}
+	const preset = duotonePalette.find( ( { slug } ) => {
+		return slug === duotone;
+	} );
+
+	return preset ? preset.colors : duotone;
+}
+
+function getDuotonePresetFromColors( colors, duotonePalette ) {
+	const preset = duotonePalette.find( ( duotonePreset ) => {
+		return duotonePreset?.colors?.every(
+			( val, index ) => val === colors[ index ]
+		);
+	} );
+
+	return preset ? preset.slug : colors;
+}
+
 function DuotonePanel( { attributes, setAttributes } ) {
 	const style = attributes?.style;
-	let duotone = style?.color?.duotone;
 
 	const duotonePalette = useMultiOriginPresets( {
 		presetSetting: 'color.duotone',
@@ -96,16 +116,10 @@ function DuotonePanel( { attributes, setAttributes } ) {
 		return null;
 	}
 
-	if ( ! Array.isArray( duotone ) ) {
-		// find the duotone preset with the slug duotone
-		// if found, return duotone.colors
-		// if not found, return false
-		const preset = duotonePalette.find( ( duotonePreset ) => {
-			return duotonePreset.slug === duotone;
-		} );
-
-		duotone = preset?.colors;
-	}
+	const duotone = getColorsFromDuotonePreset(
+		style?.color?.duotone,
+		duotonePalette
+	);
 
 	return (
 		<BlockControls group="block" __experimentalShareWithChildBlocks>
@@ -116,21 +130,14 @@ function DuotonePanel( { attributes, setAttributes } ) {
 				disableCustomColors={ disableCustomColors }
 				value={ duotone }
 				onChange={ ( newDuotone ) => {
-					// See if there is a duotone preset with the same colors
-					// as the new duotone colors.
-					const preset = duotonePalette.find( ( duotonePreset ) => {
-						return duotonePreset?.colors?.every(
-							( val, index ) => val === newDuotone[ index ]
-						);
-					} );
-
 					const newStyle = {
 						...style,
 						color: {
 							...style?.color,
-							// If there is a preset, store the preset slug,
-							// otherwise store the colors array.
-							duotone: preset ? preset.slug : newDuotone,
+							duotone: getDuotonePresetFromColors(
+								newDuotone,
+								duotonePalette
+							),
 						},
 					};
 					setAttributes( { style: newStyle } );

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -87,17 +87,17 @@ export function getColorsFromDuotonePreset( duotone, duotonePalette ) {
 }
 
 export function getDuotonePresetFromColors( colors, duotonePalette ) {
-	if ( ! colors ) {
+	if ( ! colors || ! Array.isArray( colors ) ) {
 		return;
 	}
 
-	const preset = duotonePalette.find( ( duotonePreset ) => {
+	const preset = duotonePalette?.find( ( duotonePreset ) => {
 		return duotonePreset?.colors?.every(
 			( val, index ) => val === colors[ index ]
 		);
 	} );
 
-	return preset ? preset.slug : colors;
+	return preset ? preset.slug : undefined;
 }
 
 function DuotonePanel( { attributes, setAttributes } ) {

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -257,6 +257,8 @@ const withDuotoneStyles = createHigherOrderComponent(
 			defaultSetting: 'color.defaultDuotone',
 		} );
 
+		const id = `wp-duotone-${ useInstanceId( BlockListBlock ) }`;
+
 		let colors = props?.attributes?.style?.color?.duotone;
 
 		if ( ! Array.isArray( colors ) ) {
@@ -270,8 +272,6 @@ const withDuotoneStyles = createHigherOrderComponent(
 		if ( ! duotoneSupport || ! colors ) {
 			return <BlockListBlock { ...props } />;
 		}
-
-		const id = `wp-duotone-${ useInstanceId( BlockListBlock ) }`;
 
 		// Extra .editor-styles-wrapper specificity is needed in the editor
 		// since we're not using inline styles to apply the filter. We need to

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -87,6 +87,10 @@ function getColorsFromDuotonePreset( duotone, duotonePalette ) {
 }
 
 function getDuotonePresetFromColors( colors, duotonePalette ) {
+	if ( ! colors ) {
+		return;
+	}
+
 	const preset = duotonePalette.find( ( duotonePreset ) => {
 		return duotonePreset?.colors?.every(
 			( val, index ) => val === colors[ index ]

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -75,18 +75,18 @@ function useMultiOriginPresets( { presetSetting, defaultSetting } ) {
 	);
 }
 
-function getColorsFromDuotonePreset( duotone, duotonePalette ) {
+export function getColorsFromDuotonePreset( duotone, duotonePalette ) {
 	if ( ! duotone ) {
 		return;
 	}
-	const preset = duotonePalette.find( ( { slug } ) => {
+	const preset = duotonePalette?.find( ( { slug } ) => {
 		return slug === duotone;
 	} );
 
-	return preset ? preset.colors : duotone;
+	return preset ? preset.colors : undefined;
 }
 
-function getDuotonePresetFromColors( colors, duotonePalette ) {
+export function getDuotonePresetFromColors( colors, duotonePalette ) {
 	if ( ! colors ) {
 		return;
 	}
@@ -102,6 +102,7 @@ function getDuotonePresetFromColors( colors, duotonePalette ) {
 
 function DuotonePanel( { attributes, setAttributes } ) {
 	const style = attributes?.style;
+	const duotoneStyle = style?.color?.duotone;
 
 	const duotonePalette = useMultiOriginPresets( {
 		presetSetting: 'color.duotone',
@@ -120,10 +121,9 @@ function DuotonePanel( { attributes, setAttributes } ) {
 		return null;
 	}
 
-	const duotone = getColorsFromDuotonePreset(
-		style?.color?.duotone,
-		duotonePalette
-	);
+	const duotonePresetOrColors = ! Array.isArray( duotoneStyle )
+		? getColorsFromDuotonePreset( duotoneStyle, duotonePalette )
+		: duotoneStyle;
 
 	return (
 		<BlockControls group="block" __experimentalShareWithChildBlocks>
@@ -132,7 +132,7 @@ function DuotonePanel( { attributes, setAttributes } ) {
 				colorPalette={ colorPalette }
 				disableCustomDuotone={ disableCustomDuotone }
 				disableCustomColors={ disableCustomColors }
-				value={ duotone }
+				value={ duotonePresetOrColors }
 				onChange={ ( newDuotone ) => {
 					const newStyle = {
 						...style,

--- a/packages/block-editor/src/hooks/test/duotone.js
+++ b/packages/block-editor/src/hooks/test/duotone.js
@@ -1,9 +1,12 @@
 /**
  * Internal dependencies
  */
-import { getColorsFromDuotonePreset } from '../duotone';
+import {
+	getColorsFromDuotonePreset,
+	getDuotonePresetFromColors,
+} from '../duotone';
 
-describe( 'getColorsFromDuotonePreset', () => {
+describe( 'Duotone utilities', () => {
 	const duotonePalette = [
 		{
 			name: 'Dark grayscale',
@@ -21,25 +24,76 @@ describe( 'getColorsFromDuotonePreset', () => {
 			slug: 'purple-yellow',
 		},
 	];
-	it( 'should return undefined if no arguments are provided', () => {
-		expect( getColorsFromDuotonePreset() ).toBeUndefined();
+	describe( 'getColorsFromDuotonePreset', () => {
+		it( 'should return undefined if no arguments are provided', () => {
+			expect( getColorsFromDuotonePreset() ).toBeUndefined();
+		} );
+
+		it( 'should return undefined if no duotone preset is provided', () => {
+			expect(
+				getColorsFromDuotonePreset( undefined, duotonePalette )
+			).toBeUndefined();
+		} );
+
+		it( 'should return undefined if a non-existent preset is provided', () => {
+			expect(
+				getColorsFromDuotonePreset( 'does-not-exist', duotonePalette )
+			).toBeUndefined();
+		} );
+
+		it( 'should return the colors from the preset if found', () => {
+			expect(
+				getColorsFromDuotonePreset(
+					duotonePalette[ 2 ].slug,
+					duotonePalette
+				)
+			).toEqual( duotonePalette[ 2 ].colors );
+		} );
 	} );
 
-	it( 'should return undefined if no duotone preset is provided', () => {
-		expect(
-			getColorsFromDuotonePreset( undefined, duotonePalette )
-		).toBeUndefined();
-	} );
+	describe( 'getDuotonePresetFromColors', () => {
+		it( 'should return undefined if no arguments are provided', () => {
+			expect( getDuotonePresetFromColors() ).toBeUndefined();
+		} );
 
-	it( 'should return undefined if a non-existent preset is provided', () => {
-		expect(
-			getColorsFromDuotonePreset( 'does-not-exist', duotonePalette )
-		).toBeUndefined();
-	} );
+		it( 'should return undefined if no colors are provided', () => {
+			expect(
+				getDuotonePresetFromColors( undefined, duotonePalette )
+			).toBeUndefined();
+		} );
 
-	it( 'should return the colors from the preset if found', () => {
-		expect(
-			getColorsFromDuotonePreset( 'purple-yellow', duotonePalette )
-		).toEqual( [ '#8c00b7', '#fcff41' ] );
+		it( 'should return undefined if provided colors is not of valid type', () => {
+			const notAnArrayOfColorStrings = 'purple-yellow';
+			expect(
+				getDuotonePresetFromColors(
+					notAnArrayOfColorStrings,
+					duotonePalette
+				)
+			).toBeUndefined();
+		} );
+
+		it( 'should return undefined if no duotone palette is provided', () => {
+			expect(
+				getDuotonePresetFromColors( [ '#8c00b7', '#fcff41' ] )
+			).toBeUndefined();
+		} );
+
+		it( 'should return undefined if the provided colors do not match any preset', () => {
+			expect(
+				getDuotonePresetFromColors(
+					[ '#000000', '#000000' ],
+					duotonePalette
+				)
+			).toBeUndefined();
+		} );
+
+		it( 'should return the slug of the preset if found', () => {
+			expect(
+				getDuotonePresetFromColors(
+					duotonePalette[ 2 ].colors,
+					duotonePalette
+				)
+			).toEqual( duotonePalette[ 2 ].slug );
+		} );
 	} );
 } );

--- a/packages/block-editor/src/hooks/test/duotone.js
+++ b/packages/block-editor/src/hooks/test/duotone.js
@@ -1,0 +1,39 @@
+/**
+ * Internal dependencies
+ */
+import { getColorsFromDuotonePreset } from '../duotone';
+
+describe( 'getColorsFromDuotonePreset', () => {
+	const duotonePalette = [
+		{
+			name: 'Dark grayscale',
+			colors: [ '#000000', '#7f7f7f' ],
+			slug: 'dark-grayscale',
+		},
+		{
+			name: 'Grayscale',
+			colors: [ '#000000', '#ffffff' ],
+			slug: 'grayscale',
+		},
+		{
+			name: 'Purple and yellow',
+			colors: [ '#8c00b7', '#fcff41' ],
+			slug: 'purple-yellow',
+		},
+	];
+	it( 'should return undefined if no arguments are provided', () => {
+		expect( getColorsFromDuotonePreset() ).toBeUndefined();
+	} );
+
+	it( 'should return undefined if no duotone preset is provided', () => {
+		expect(
+			getColorsFromDuotonePreset( undefined, duotonePalette )
+		).toBeUndefined();
+	} );
+
+	it( 'should return undefined if a non-existent preset is provided', () => {
+		expect(
+			getColorsFromDuotonePreset( 'does-not-exist', duotonePalette )
+		).toBeUndefined();
+	} );
+} );

--- a/packages/block-editor/src/hooks/test/duotone.js
+++ b/packages/block-editor/src/hooks/test/duotone.js
@@ -36,4 +36,10 @@ describe( 'getColorsFromDuotonePreset', () => {
 			getColorsFromDuotonePreset( 'does-not-exist', duotonePalette )
 		).toBeUndefined();
 	} );
+
+	it( 'should return the colors from the preset if found', () => {
+		expect(
+			getColorsFromDuotonePreset( 'purple-yellow', duotonePalette )
+		).toEqual( [ '#8c00b7', '#fcff41' ] );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Uses Duotone presets (where available) when storing duotone for a given block.

Part of https://github.com/WordPress/gutenberg/issues/46547

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently when setitng Duotone on a given block (e.g. `core/image`) the duotone is stored as an array of colors:

`['#000', '#fff']`

However this isn't useful if you switch Themes. Be storing slugs of Duotone presets we can take advantage of portability of color swatches across Themes.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR checks the selected Duotone swatches against known Duotone preset values and if one is found the slug of the matching Duotone is stored in the block attributes.

If no preset is found then an array of custom colors is stored as per `trunk`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
