### PR TITLE
[Block Library - Site Tagline]: Add example in block settings

### DIFF
--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -12,6 +12,7 @@
 			"type": "string"
 		}
 	},
+	"example": {},
 	"supports": {
 		"anchor": true,
 		"align": [ "wide", "full" ],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Just adds an example in Site Tagline's settings, so it can have a preview and be shown in Style book.