### PR TITLE
[Block Library - Post Terms]: Add transforms for variations

### DIFF
--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -87,6 +87,7 @@ function register_block_core_post_terms() {
 				'term' => $taxonomy->name,
 			),
 			'isActive'    => array( 'term' ),
+			'scope'       => array( 'inserter', 'transform' ),
 		);
 		// Set the category variation as the default one.
 		if ( 'category' === $taxonomy->name ) {

--- a/packages/block-library/src/post-terms/use-post-terms.js
+++ b/packages/block-library/src/post-terms/use-post-terms.js
@@ -36,6 +36,6 @@ export default function usePostTerms( { postId, term } ) {
 				hasPostTerms: !! terms?.length,
 			};
 		},
-		[ postId, term?.visibility?.publicly_queryable ]
+		[ postId, term?.visibility?.publicly_queryable, slug ]
 	);
 }


### PR DESCRIPTION


## What?
Post Terms variations are created dynamically based on the registered public(and with REST support) taxonomies. This PR enables these variations to be easily switched through the transform variations UI in block inspector controls. 

## Testing Instructions
1. In a Query Loop or in a post type add a `post terms` block variation - a basic example would be to insert `Categories` variation through the inserter.
2. Open the block inspector controls and verify that you can transform it to another variation.

### Notes
The transform variation UI shows icons if all variation have an icon and all icons are unique. If this is not true, it renders a dropdown list.


#### Unique icons

https://user-images.githubusercontent.com/16275880/220692029-d62a7dfe-ce55-4564-8831-36982237c9e7.mov




#### Dropdown

https://user-images.githubusercontent.com/16275880/220691783-cd35f5f4-5ffe-4a5d-8999-1068820ea44e.mov


