### PR TITLE
Navigation Block: Fix big spinner

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -894,7 +894,9 @@ function Navigation( {
 
 				{ isLoading && (
 					<TagName { ...blockProps }>
-						<Spinner className="wp-block-navigation__loading-indicator" />
+						<div className="wp-block-navigation__loading-indicator-container">
+							<Spinner className="wp-block-navigation__loading-indicator" />
+						</div>
 					</TagName>
 				) }
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -39,9 +39,8 @@
 }
 
 // Only show the flyout on hover if the parent menu item is selected.
-.wp-block-navigation:not(.is-selected):not(.has-child-selected)
-.has-child:hover {
-	> .wp-block-navigation__submenu-container {
+.wp-block-navigation:not(.is-selected):not(.has-child-selected) .has-child:hover {
+	>.wp-block-navigation__submenu-container {
 		opacity: 0;
 		visibility: hidden;
 	}
@@ -49,9 +48,10 @@
 
 // Styles for submenu flyout.
 .has-child {
+
 	&.is-selected,
 	&.has-child-selected {
-		> .wp-block-navigation__submenu-container {
+		>.wp-block-navigation__submenu-container {
 			display: flex;
 			opacity: 1;
 			visibility: visible;
@@ -62,22 +62,21 @@
 // Show a submenu when generally dragging (is-dragging-components-draggable) if that
 // submenu has children (has-child) and is being dragged within (is-dragging-within).
 .is-dragging-components-draggable .has-child.is-dragging-within {
-	> .wp-block-navigation__submenu-container {
+	>.wp-block-navigation__submenu-container {
 		opacity: 1;
 		visibility: visible;
 	}
 }
 
 // IE fix for submenu visibility on parent focus.
-.is-editing > .wp-block-navigation__container {
+.is-editing>.wp-block-navigation__container {
 	visibility: visible;
 	opacity: 1;
 	display: flex;
 	flex-direction: column;
 }
 
-.is-dragging-components-draggable
-.wp-block-navigation-link > .wp-block-navigation__container {
+.is-dragging-components-draggable .wp-block-navigation-link>.wp-block-navigation__container {
 	// Set opacity to 1 to still be able to show the draggable chip.
 	opacity: 1;
 	visibility: hidden;
@@ -89,7 +88,7 @@
 }
 
 // Show even when a child is selected. This is an edgecase just for navigation submenus.
-.is-editing > .wp-block-navigation__submenu-container > .block-list-appender {
+.is-editing>.wp-block-navigation__submenu-container>.block-list-appender {
 	display: block;
 	position: static;
 	width: 100%;
@@ -117,6 +116,7 @@
  */
 
 $colors-selector-size: 22px;
+
 .block-library-colors-selector {
 	width: auto;
 
@@ -151,18 +151,19 @@ $colors-selector-size: 22px;
 		min-width: $colors-selector-size;
 		height: $colors-selector-size;
 		min-height: $colors-selector-size;
-		line-height: ( $colors-selector-size - 2 );
+		line-height: ($colors-selector-size - 2);
 		padding: 2px;
 
-		> svg {
+		>svg {
 			// Override `min-width: $button-size-small` on toolbar-group/style.scss
 			min-width: auto !important;
 		}
 
 		// Styling icon color.
 		&.has-text-color {
-			> svg,
-			> svg path {
+
+			>svg,
+			>svg path {
 				color: inherit;
 			}
 		}
@@ -171,6 +172,7 @@ $colors-selector-size: 22px;
 
 // Colors Selector Popover.
 $color-control-label-height: 20px;
+
 .block-library-colors-selector__popover {
 	.color-palette-controller-container {
 		padding: 16px;
@@ -195,7 +197,7 @@ $color-control-label-height: 20px;
 // This should be a temporary fix, to be replaced by improvements to
 // the sibling inserter. Or by the dropdown appender that is used in Group, instead of the "Button block appender".
 // See https://github.com/WordPress/gutenberg/issues/37572.
-.wp-block-navigation .wp-block + .block-list-appender .block-editor-button-block-appender {
+.wp-block-navigation .wp-block+.block-list-appender .block-editor-button-block-appender {
 	background-color: $gray-900;
 	color: $white;
 
@@ -222,13 +224,16 @@ $color-control-label-height: 20px;
 	0% {
 		opacity: 1;
 	}
+
 	50% {
 		opacity: 0.5;
 	}
+
 	100% {
 		opacity: 1;
 	}
 }
+
 // Unstyle some inherited placeholder component styles.
 .components-placeholder.wp-block-navigation-placeholder {
 	outline: none;
@@ -271,6 +276,7 @@ $color-control-label-height: 20px;
 	// against any background color.
 	color: currentColor;
 	background: transparent;
+
 	&::before {
 		content: "";
 		display: block;
@@ -287,7 +293,7 @@ $color-control-label-height: 20px;
 		border-radius: inherit;
 	}
 
-	> svg {
+	>svg {
 		fill: currentColor;
 	}
 }
@@ -338,8 +344,9 @@ $color-control-label-height: 20px;
 	// Hide the navigation indicator when in small contexts.
 	.is-small &,
 	.is-medium & {
+
 		.wp-block-navigation-placeholder__actions__indicator,
-		.wp-block-navigation-placeholder__actions__indicator + hr {
+		.wp-block-navigation-placeholder__actions__indicator+hr {
 			display: none;
 		}
 	}
@@ -395,7 +402,7 @@ $color-control-label-height: 20px;
 
 	// Margins.
 	.components-dropdown,
-	> .components-button {
+	>.components-button {
 		margin-right: 0;
 	}
 
@@ -427,6 +434,7 @@ $color-control-label-height: 20px;
 		}
 	}
 }
+
 // Emulate the fullscreen editing inside the editor.
 // Most of this can be removed when the iframe lands.
 
@@ -434,8 +442,7 @@ $color-control-label-height: 20px;
 .wp-block-navigation__responsive-container.is-menu-open {
 	position: fixed;
 	top:
-		$admin-bar-height-big + $header-height + $block-toolbar-height +
-		$border-width;
+		$admin-bar-height-big + $header-height + $block-toolbar-height + $border-width;
 
 	@include break-medium() {
 		top: $admin-bar-height + $header-height + $border-width;
@@ -445,6 +452,7 @@ $color-control-label-height: 20px;
 	@include break-medium() {
 		left: $admin-sidebar-width-collapsed;
 	}
+
 	@include break-large() {
 		left: $admin-sidebar-width;
 	}
@@ -453,16 +461,14 @@ $color-control-label-height: 20px;
 .has-fixed-toolbar .wp-block-navigation__responsive-container.is-menu-open {
 	@include break-medium() {
 		top:
-			$admin-bar-height + $header-height + $block-toolbar-height +
-			$border-width;
+			$admin-bar-height + $header-height + $block-toolbar-height + $border-width;
 	}
 }
 
 .is-mobile-preview .wp-block-navigation__responsive-container.is-menu-open,
 .is-tablet-preview .wp-block-navigation__responsive-container.is-menu-open {
 	top:
-		$admin-bar-height + $header-height + $block-toolbar-height +
-		$border-width;
+		$admin-bar-height + $header-height + $block-toolbar-height + $border-width;
 }
 
 .is-sidebar-opened .wp-block-navigation__responsive-container.is-menu-open {
@@ -474,8 +480,7 @@ $color-control-label-height: 20px;
 	.wp-block-navigation__responsive-container.is-menu-open {
 		left: 0; // Unset the value from non fullscreen mode.
 		top:
-			$admin-bar-height-big + $header-height + $block-toolbar-height +
-			$border-width;
+			$admin-bar-height-big + $header-height + $block-toolbar-height + $border-width;
 
 		@include break-medium() {
 			top: $header-height + $border-width;
@@ -495,8 +500,7 @@ $color-control-label-height: 20px;
 }
 
 // The iframe makes these rules a lot simpler.
-body.editor-styles-wrapper
-.wp-block-navigation__responsive-container.is-menu-open {
+body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-open {
 	top: 0;
 	right: 0;
 	bottom: 0;
@@ -536,6 +540,7 @@ body.editor-styles-wrapper
 .components-heading.wp-block-navigation-off-canvas-editor__title {
 	margin: 0;
 }
+
 .wp-block-navigation-off-canvas-editor__header {
 	margin-bottom: $grid-unit-10;
 }
@@ -552,6 +557,7 @@ body.editor-styles-wrapper
 	0% {
 		opacity: 0;
 	}
+
 	100% {
 		opacity: 1;
 	}
@@ -559,8 +565,8 @@ body.editor-styles-wrapper
 
 // Space spinner to give it breathing
 // room when block is selected and has focus outline.
-.wp-block-navigation .components-spinner {
-	margin: $grid-unit-10 $grid-unit-15;
+.wp-block-navigation__loading-indicator-container {
+	padding: $grid-unit-10 $grid-unit-15;
 }
 
 .wp-block-navigation .wp-block-navigation__uncontrolled-inner-blocks-loading-indicator {
@@ -571,6 +577,7 @@ body.editor-styles-wrapper
 	0% {
 		opacity: 1;
 	}
+
 	100% {
 		opacity: 0.5;
 	}
@@ -614,7 +621,7 @@ body.editor-styles-wrapper
 
 // Temp - hide adjacent <hr>s when Nav Menu Selector is empty.
 // TODO - extract state to common hook or parent component to avoid render of <hr>.
-.wp-block-navigation-placeholder__actions hr + hr {
+.wp-block-navigation-placeholder__actions hr+hr {
 	display: none;
 }
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -40,7 +40,7 @@
 
 // Only show the flyout on hover if the parent menu item is selected.
 .wp-block-navigation:not(.is-selected):not(.has-child-selected) .has-child:hover {
-	>.wp-block-navigation__submenu-container {
+	> .wp-block-navigation__submenu-container {
 		opacity: 0;
 		visibility: hidden;
 	}
@@ -51,7 +51,7 @@
 
 	&.is-selected,
 	&.has-child-selected {
-		>.wp-block-navigation__submenu-container {
+		> .wp-block-navigation__submenu-container {
 			display: flex;
 			opacity: 1;
 			visibility: visible;
@@ -62,21 +62,21 @@
 // Show a submenu when generally dragging (is-dragging-components-draggable) if that
 // submenu has children (has-child) and is being dragged within (is-dragging-within).
 .is-dragging-components-draggable .has-child.is-dragging-within {
-	>.wp-block-navigation__submenu-container {
+	> .wp-block-navigation__submenu-container {
 		opacity: 1;
 		visibility: visible;
 	}
 }
 
 // IE fix for submenu visibility on parent focus.
-.is-editing>.wp-block-navigation__container {
+.is-editing > .wp-block-navigation__container {
 	visibility: visible;
 	opacity: 1;
 	display: flex;
 	flex-direction: column;
 }
 
-.is-dragging-components-draggable .wp-block-navigation-link>.wp-block-navigation__container {
+.is-dragging-components-draggable .wp-block-navigation-link > .wp-block-navigation__container {
 	// Set opacity to 1 to still be able to show the draggable chip.
 	opacity: 1;
 	visibility: hidden;
@@ -88,7 +88,7 @@
 }
 
 // Show even when a child is selected. This is an edgecase just for navigation submenus.
-.is-editing>.wp-block-navigation__submenu-container>.block-list-appender {
+.is-editing > .wp-block-navigation__submenu-container > .block-list-appender {
 	display: block;
 	position: static;
 	width: 100%;
@@ -154,7 +154,7 @@ $colors-selector-size: 22px;
 		line-height: ($colors-selector-size - 2);
 		padding: 2px;
 
-		>svg {
+		> svg {
 			// Override `min-width: $button-size-small` on toolbar-group/style.scss
 			min-width: auto !important;
 		}
@@ -162,8 +162,8 @@ $colors-selector-size: 22px;
 		// Styling icon color.
 		&.has-text-color {
 
-			>svg,
-			>svg path {
+			> svg,
+			> svg path {
 				color: inherit;
 			}
 		}
@@ -197,7 +197,7 @@ $color-control-label-height: 20px;
 // This should be a temporary fix, to be replaced by improvements to
 // the sibling inserter. Or by the dropdown appender that is used in Group, instead of the "Button block appender".
 // See https://github.com/WordPress/gutenberg/issues/37572.
-.wp-block-navigation .wp-block+.block-list-appender .block-editor-button-block-appender {
+.wp-block-navigation .wp-block + .block-list-appender .block-editor-button-block-appender {
 	background-color: $gray-900;
 	color: $white;
 
@@ -293,7 +293,7 @@ $color-control-label-height: 20px;
 		border-radius: inherit;
 	}
 
-	>svg {
+	> svg {
 		fill: currentColor;
 	}
 }
@@ -346,7 +346,7 @@ $color-control-label-height: 20px;
 	.is-medium & {
 
 		.wp-block-navigation-placeholder__actions__indicator,
-		.wp-block-navigation-placeholder__actions__indicator+hr {
+		.wp-block-navigation-placeholder__actions__indicator + hr {
 			display: none;
 		}
 	}
@@ -402,7 +402,7 @@ $color-control-label-height: 20px;
 
 	// Margins.
 	.components-dropdown,
-	>.components-button {
+	> .components-button {
 		margin-right: 0;
 	}
 
@@ -441,8 +441,7 @@ $color-control-label-height: 20px;
 // When not fullscreen.
 .wp-block-navigation__responsive-container.is-menu-open {
 	position: fixed;
-	top:
-		$admin-bar-height-big + $header-height + $block-toolbar-height + $border-width;
+	top: $admin-bar-height-big + $header-height + $block-toolbar-height + $border-width;
 
 	@include break-medium() {
 		top: $admin-bar-height + $header-height + $border-width;
@@ -460,15 +459,13 @@ $color-control-label-height: 20px;
 
 .has-fixed-toolbar .wp-block-navigation__responsive-container.is-menu-open {
 	@include break-medium() {
-		top:
-			$admin-bar-height + $header-height + $block-toolbar-height + $border-width;
+		top: $admin-bar-height + $header-height + $block-toolbar-height + $border-width;
 	}
 }
 
 .is-mobile-preview .wp-block-navigation__responsive-container.is-menu-open,
 .is-tablet-preview .wp-block-navigation__responsive-container.is-menu-open {
-	top:
-		$admin-bar-height + $header-height + $block-toolbar-height + $border-width;
+	top: $admin-bar-height + $header-height + $block-toolbar-height + $border-width;
 }
 
 .is-sidebar-opened .wp-block-navigation__responsive-container.is-menu-open {
@@ -479,8 +476,7 @@ $color-control-label-height: 20px;
 .is-fullscreen-mode {
 	.wp-block-navigation__responsive-container.is-menu-open {
 		left: 0; // Unset the value from non fullscreen mode.
-		top:
-			$admin-bar-height-big + $header-height + $block-toolbar-height + $border-width;
+		top: $admin-bar-height-big + $header-height + $block-toolbar-height + $border-width;
 
 		@include break-medium() {
 			top: $header-height + $border-width;
@@ -621,7 +617,7 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 
 // Temp - hide adjacent <hr>s when Nav Menu Selector is empty.
 // TODO - extract state to common hook or parent component to avoid render of <hr>.
-.wp-block-navigation-placeholder__actions hr+hr {
+.wp-block-navigation-placeholder__actions hr + hr {
 	display: none;
 }
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -560,7 +560,7 @@ body.editor-styles-wrapper
 // Space spinner to give it breathing
 // room when block is selected and has focus outline.
 .wp-block-navigation .components-spinner {
-	padding: $grid-unit-10 $grid-unit-15;
+	margin: $grid-unit-10 $grid-unit-15;
 }
 
 .wp-block-navigation .wp-block-navigation__uncontrolled-inner-blocks-loading-indicator {

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -53,7 +53,9 @@ function BlockContent( {
 	if ( ! hasResolvedPages ) {
 		return (
 			<div { ...blockProps }>
-				<Spinner />
+				<div className="wp-block-page-list__loading-indicator-container">
+					<Spinner className="wp-block-page-list__loading-indicator" />
+				</div>
 			</div>
 		);
 	}

--- a/packages/block-library/src/page-list/editor.scss
+++ b/packages/block-library/src/page-list/editor.scss
@@ -61,3 +61,9 @@
 .wp-block-page-list .components-notice {
 	margin-left: 0;
 }
+
+// Space spinner to give it breathing
+// room when block is selected and has focus outline.
+.wp-block-page-list__loading-indicator-container {
+	padding: $grid-unit-10 $grid-unit-15;
+}


### PR DESCRIPTION
Fixes #47696

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adding padding to the spinner component output causes the SVG to render at the incorrect size on some themes.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Change the padding to margin in this instance to fix the issue but retain the spacing that is desired.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Install and activate the blockbase theme
2. Insert a navigation block
3. Confirm the spinner that shows briefly on first insertion is small an appropriately sized.

## Screenshots or screencast <!-- if applicable -->

**Before**
![2023-02-22 12 20 18](https://user-images.githubusercontent.com/1464705/220750060-becd3397-3dc8-4b09-a7cb-bb0ddd42086c.gif)

**After**
![2023-02-22 12 17 51](https://user-images.githubusercontent.com/1464705/220749970-d992df49-c0af-46ac-9557-6596b2acc06e.gif)


