### PR TITLE
PageAttributesCheck: Return boolean value directly from the selector

### DIFF
--- a/packages/editor/src/components/page-attributes/check.js
+++ b/packages/editor/src/components/page-attributes/check.js
@@ -10,15 +10,16 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '../../store';
 
 export function PageAttributesCheck( { children } ) {
-	const postType = useSelect( ( select ) => {
+	const supportsPageAttributes = useSelect( ( select ) => {
 		const { getEditedPostAttribute } = select( editorStore );
 		const { getPostType } = select( coreStore );
+		const postType = getPostType( getEditedPostAttribute( 'type' ) );
 
-		return getPostType( getEditedPostAttribute( 'type' ) );
+		return !! postType?.supports?.[ 'page-attributes' ];
 	}, [] );
 
 	// Only render fields if post type supports page attributes or available templates exist.
-	if ( ! postType?.supports?.[ 'page-attributes' ] ) {
+	if ( ! supportsPageAttributes ) {
 		return null;
 	}
 


### PR DESCRIPTION
## What?
PR updates the selector in the `PageAttributesCheck` component to return the `boolean` we use for a check instead of a post-type object.

## Why?
While it's less likely that post-type objects will be updated in the store, the component only needs to check one supports flag. It's also a good practice to return primitive values when we can.

## Testing Instructions
1. Open a Page.
2. Confim Page Attributes panel is displayed as before.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-02-23 at 07 26 41](https://user-images.githubusercontent.com/240569/220815079-73c2f67d-df6e-44e5-8c97-1818bf58553f.png)
