### PR TITLE
[WIP] Post Template: Try adding flex layout and block spacing support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -572,7 +572,7 @@ Contains the block elements used to render a post, like the title, date, feature
 
 -	**Name:** core/post-template
 -	**Category:** theme
--	**Supports:** align, anchor, color (background, gradients, link, text), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** align, anchor, color (background, gradients, link, text), spacing (blockGap), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** 
 
 ## Post Terms

--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -21,7 +21,7 @@
 		"align": true,
 		"anchor": true,
 		"__experimentalLayout": {
-			"allowEditing": false
+			"allowSwitching": true
 		},
 		"color": {
 			"gradients": true,
@@ -30,6 +30,9 @@
 				"background": true,
 				"text": true
 			}
+		},
+		"spacing": {
+			"blockGap": true
 		},
 		"typography": {
 			"fontSize": true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

🚧 🚧 🚧 🚧 This is an experimental WIP PR and currently does not work! 🚧 🚧 🚧 🚧 

This PR seeks to explore some of the issues that will need to be resolved in order to support block spacing in the post template block. The longer-term goal is to come up with a fix for https://github.com/WordPress/gutenberg/issues/44557

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The Post Template block is a very useful and frequently used block for laying out a list of posts, and it'll likely be very beneficial to have more control over how it's displayed, along with its positioning and spacing.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Try opting the Post Template block into flex layout and opt-in to block spacing

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

TBC

## Tasks

* [ ] The Query Loop block currently passes down the ad-hoc layout type. Can we get the local layout type of the Post Template block to override this, and as a result, workaround some of the backcompat issues with introducing flex layout here?
* [ ] How can we allow switching between Flex and Flow/Constrained in an intuitive way? The layout switcher component at the moment isn't very user friendly
* [ ] How do we deal with the default `1.25em` gap value, and allow themes / editors to override this value without breaking anything?
* [ ] How do we add in vertical alignment controls with a safe default?

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

It's pretty broken, but it's a start:

![image](https://user-images.githubusercontent.com/14988353/220829295-23022cbe-523a-4ddc-902f-d20eea866486.png)
