### PR TITLE
Skip redundant registration for Fonts API-registered fonts

### DIFF
--- a/lib/experimental/fonts-api/deprecations/class-wp-web-fonts.php
+++ b/lib/experimental/fonts-api/deprecations/class-wp-web-fonts.php
@@ -690,7 +690,7 @@ class WP_Web_Fonts extends WP_Webfonts {
 			}
 
 			$variation_obj        = $this->registered[ $variation_handle ];
-			$variation_properties = array( 'origin' => 'gutenberg_wp_webfonts_api' );
+			$variation_properties = array( 'origin' => 'gutenberg_wp_fonts_api' );
 			foreach ( $variation_obj->extra['font-properties'] as $property_name => $property_value ) {
 				$property_in_camelcase                          = lcfirst( str_replace( '-', '', ucwords( $property_name, '-' ) ) );
 				$variation_properties[ $property_in_camelcase ] = $property_value;

--- a/lib/experimental/fonts-api/register-fonts-from-theme-json.php
+++ b/lib/experimental/fonts-api/register-fonts-from-theme-json.php
@@ -59,8 +59,8 @@ if ( ! function_exists( 'gutenberg_register_fonts_from_theme_json' ) ) {
 				$font_family['fontFace'] = (array) $font_family['fontFace'];
 
 				foreach ( $font_family['fontFace'] as $font_face ) {
-					// Skip if the webfont was registered through the Webfonts API.
-					if ( isset( $font_face['origin'] ) && 'gutenberg_wp_webfonts_api' === $font_face['origin'] ) {
+					// Skip if the webfont was registered through the Fonts API.
+					if ( isset( $font_face['origin'] ) && 'gutenberg_wp_fonts_api' === $font_face['origin'] ) {
 						continue;
 					}
 

--- a/lib/experimental/fonts-api/register-fonts-from-theme-json.php
+++ b/lib/experimental/fonts-api/register-fonts-from-theme-json.php
@@ -59,7 +59,7 @@ if ( ! function_exists( 'gutenberg_register_fonts_from_theme_json' ) ) {
 				$font_family['fontFace'] = (array) $font_family['fontFace'];
 
 				foreach ( $font_family['fontFace'] as $font_face ) {
-					// Skip if the webfont was registered through the Fonts API.
+					// Skip if the font was registered through the Fonts API.
 					if ( isset( $font_face['origin'] ) && 'gutenberg_wp_fonts_api' === $font_face['origin'] ) {
 						continue;
 					}


### PR DESCRIPTION
## What?
This update synchronizes the origin name checked for fonts registered through the Fonts API. Those fonts are already registered, so can be skipped here.

## Why?
Addresses #48263, where all fonts registered through a plugin are rendered on the front end, regardless of whether they are in use by global, template, or per-page style settings.

## How?
Updates the origin name check to `gutenberg_wp_fonts_api`, to [match where it's being set originally](https://github.com/WordPress/gutenberg/blob/37bb7c59f032afd034c136db18456388bb45c1fe/lib/experimental/fonts-api/class-wp-fonts.php#L734).

## Testing Instructions
_If you have previously set custom fonts for global styles, templates/patterns through the editor, or on a per-post basis, please reset the typography to their defaults for the active template, otherwise test results may vary._

1. On your test site, activate the TT3 theme, as well as the Gutenberg plugin (from this branch).
2. Install and activate [this test plugin](https://github.com/ironprogrammer/webfonts-jetpack-test).
3. View the site frontend, and view source or inspect the elements/markup.
4. 👀 Near the end of the `<head>` element, there should be a `<style id="wp-fonts-local">` tag, but there should NOT be a `<style id="wp-fonts-jetpack-google-fonts">` tag.
5. In WP admin, create a new post, and add a heading.
6. Open the Settings sidebar, and under Typography enable Font Family. The added Font dropdown should list numerous fonts registered by the test plugin.
7. Set the heading's Font to one of the non-default font options (e.g. Arvo), and Publish or Update the post.
8. View the post on the site frontend, and view source or inspect the elements/markup.
9. 👀 Near the end of the `<head>` element, there should now be a `<style id="wp-fonts-jetpack-google-fonts">` tag, and the `@font-face` declarations should match the custom font selected above. For instance, for Arvo there should be 4 declarations.
10. In WP admin, navigate to _Appearance > Editor_, and click anywhere on the right side to go into edit mode.
11. Open the Styles panel, and select Typography.
12. Under Elements select Headings, and set the Font to something other than a default TT3 font or the one selected above (e.g. Space Mono), then Save the custom styles.
13. View the previous post on the site frontend, and view source or inspect the elements/markup.
14. 👀 The `<style id="wp-fonts-jetpack-google-fonts">` tag should include `@font-face` declarations for both the custom font selected on the post, as well as the font set in the global styles above. For instance, for Arvo there should be 4 declarations, and Space Mono should have 12.

### Expected Results
- ✅ With the test plugin activated, but no custom fonts assigned, unassigned fonts should not be output on the site frontend (i.e. no `<style id="wp-fonts-jetpack-google-fonts">` tag).
- ✅ With a custom font(s) assigned in a post, the `@font-face`(s) should render on the site frontend in the `<style id="wp-fonts-jetpack-google-fonts">` tag.
- ✅ With a custom font(s) assigned globally, the `@font-face`(s) should render on the site frontend's `<style id="wp-fonts-jetpack-google-fonts">` tag, in addition to other custom fonts per template or page.

Please note that logged deprecation notices for `wp_webfonts` and `wp_enqueue_webfont` are expected.

### Testing Instructions for Keyboard
n/a

## Screenshots or screencast
n/a

## Additional Note
[The test plugin provided for](https://github.com/mreishus/webfonts-jetpack-test) #48263 includes registration of fonts already present in TT3, and results in those fonts being doubly-rendered in the front end (first in `#wp-fonts-local`, and then `#wp-fonts-jetpack-google-fonts`). The [updated test plugin for this PR](https://github.com/ironprogrammer/webfonts-jetpack-test) mitigates that issue by removing those fonts, as that bug should be tracked down separately.
