### PR TITLE
Update assertion Autocomplete E2E tests

### DIFF
--- a/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
+++ b/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
@@ -118,10 +118,8 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 			// Ensure `aria-owns` is part of the same document and ensure the
 			// selected option is equal to the active descendant.
 			await expect(
-				await editor.canvas
-					.locator( `#${ ariaOwns } [aria-selected="true"]` )
-					.getAttribute( 'id' )
-			).toBe( ariaActiveDescendant );
+				editor.canvas.locator( `#${ ariaOwns } [aria-selected="true"]` )
+			).toHaveAttribute( 'id', ariaActiveDescendant );
 			await page.keyboard.press( 'Enter' );
 			await page.keyboard.type( '.' );
 


### PR DESCRIPTION
## What?
PR updates assertion in Autocomplete E2E tests to fix the following ESLint warning - `Unexpected `await` of a non-Promise (non-"Thenable") value.`.

## Why?
The `expect().toBe()` doesn't return Promise, and we can use `toHaveAttribute` directly for this assertion.

## Testing Instructions
CI checks are green.
