### PR TITLE
[Block Library]: Update the relationship of `No results` block  to `ancestor`

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -724,7 +724,7 @@ Contains the block elements used to render content when no query results are fou
 
 -	**Name:** core/query-no-results
 -	**Category:** theme
--	**Parent:** core/query
+-	**Ancestor:** core/query
 -	**Supports:** align, color (background, gradients, link, text), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 
 ## Pagination

--- a/packages/block-library/src/query-no-results/block.json
+++ b/packages/block-library/src/query-no-results/block.json
@@ -5,7 +5,7 @@
 	"title": "No results",
 	"category": "theme",
 	"description": "Contains the block elements used to render content when no query results are found.",
-	"parent": [ "core/query" ],
+	"ancestor": [ "core/query" ],
 	"textdomain": "default",
 	"usesContext": [ "queryId", "query" ],
 	"example": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR just add a bit more flexibility to the insertion of `No results` inside a Query Loop block. Previously you could insert them through the inserter only if they were direct parents of Query Loop, but now they can be inserted in nested blocks(ex Group), as long as they have Query Loop as an ancestor. 

Similar with: https://github.com/WordPress/gutenberg/pull/67657 and https://github.com/WordPress/gutenberg/pull/58602

## Testing Instructions
1. Inside a Query Loop block add a `Group` and then insert through the inserter `No results` block.
2. The above block cannot be inserted through the inserter if it doesn't have a Query Loop ancestor.
3. No regressions are introduced and everything else should work as before.
