### PR TITLE
Theme JSON: Don't output rules that 'unset' properties

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1488,6 +1488,9 @@ class WP_Theme_JSON_Gutenberg {
 		$declaration_block = array_reduce(
 			$declarations,
 			static function ( $carry, $element ) {
+				if ( 'unset' === $element['value'] ) {
+					return $carry;
+				}
 				return $carry .= $element['name'] . ': ' . $element['value'] . ';'; },
 			''
 		);


### PR DESCRIPTION
## What?
If a theme sets a Duotone filter, users might want to override this by setting the filter to "unset" (see https://github.com/WordPress/gutenberg/pull/48255). This is important to allow users to turn off duotone for specific blocks.

When unset is selected, this is saved to the database:

`{"styles":{"blocks":{"core\/image":{"filter":{"duotone":"unset"}}}},"isGlobalStylesUserThemeJSON":true,"version":2}`

Which generates the following CSS:

`.wp-block-image img, .wp-block-image .components-placeholder{filter: unset;}`

It would be better if we didn't generate any CSS for the block if the global styles changed to unset.

## Why?
Outputting redundant code is bad for performance.

## How?
If a declaration has a value of `unset` then don't output it. I'm not sure if this is the best place to achieve this. We can do something specific for Duotone in https://github.com/WordPress/gutenberg/pull/48255 but once Duotone is treated like all other styles then we won't be able to (which is the goal).

## Testing Instructions
1. Switch to a theme that has a default Duotone (TT3 style variations have them)
2. Open Global Styles and disable the Duotone for that block (see https://github.com/WordPress/gutenberg/pull/48255 for details)
3. Check that the block in the frontend doesn't have an filters applied in the CSS.

