### PR TITLE
[Private APIs] Only prevent module re-registration if IS_WORDPRESS_CORE

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
 		"npm": ">=6.9.0 <7"
 	},
 	"config": {
-		"IS_GUTENBERG_PLUGIN": true,
-		"ALLOW_EXPERIMENT_REREGISTRATION": true
+		"IS_GUTENBERG_PLUGIN": true
 	},
 	"dependencies": {
 		"@wordpress/a11y": "file:packages/a11y",

--- a/packages/private-apis/src/implementation.js
+++ b/packages/private-apis/src/implementation.js
@@ -49,13 +49,13 @@ const requiredConsent =
 
 /** @type {boolean} */
 let allowReRegistration;
-// The safety measure is meant for WordPress core where ALLOW_EXPERIMENT_REREGISTRATION
-// is set to false.
+// The safety measure is meant for WordPress core where IS_WORDPRESS_CORE
+// is set to true.
 // For the general use-case, the re-registration should be allowed by default
 // Let's default to true, then. Try/catch will fall back to "true" even if the
 // environment variable is not explicitly defined.
 try {
-	allowReRegistration = process.env.ALLOW_EXPERIMENT_REREGISTRATION ?? true;
+	allowReRegistration = process.env.IS_WORDPRESS_CORE ? false : true;
 } catch ( error ) {
 	allowReRegistration = true;
 }

--- a/packages/private-apis/src/implementation.js
+++ b/packages/private-apis/src/implementation.js
@@ -49,12 +49,15 @@ const requiredConsent =
 
 /** @type {boolean} */
 let allowReRegistration;
-// Use try/catch to force "false" if the environment variable is not explicitly
-// set to true (e.g. when building WordPress core).
+// The safety measure is meant for WordPress core where ALLOW_EXPERIMENT_REREGISTRATION
+// is set to false.
+// For the general use-case, the re-registration should be allowed by default
+// Let's default to true, then. Try/catch will fall back to "true" even if the
+// environment variable is not explicitly defined.
 try {
-	allowReRegistration = process.env.ALLOW_EXPERIMENT_REREGISTRATION ?? false;
+	allowReRegistration = process.env.ALLOW_EXPERIMENT_REREGISTRATION ?? true;
 } catch ( error ) {
-	allowReRegistration = false;
+	allowReRegistration = true;
 }
 
 /**

--- a/storybook/main.js
+++ b/storybook/main.js
@@ -28,10 +28,4 @@ module.exports = {
 		emotionAlias: false,
 		storyStoreV7: true,
 	},
-	env: ( config ) => ( {
-		...config,
-		// Inject the `ALLOW_EXPERIMENT_REREGISTRATION` global, used by
-		// @wordpress/private-apis.
-		ALLOW_EXPERIMENT_REREGISTRATION: true,
-	} ),
 };

--- a/test/native/setup.js
+++ b/test/native/setup.js
@@ -8,14 +8,6 @@ import { Image, NativeModules as RNNativeModules } from 'react-native';
 // testing environment: https://github.com/facebook/react-native/blob/6c19dc3266b84f47a076b647a1c93b3c3b69d2c5/Libraries/Core/setUpNavigator.js#L17
 global.navigator = global.navigator ?? {};
 
-/**
- * Whether to allow the same experiment to be registered multiple times.
- * This is useful for development purposes, but should be set to false
- * during the unit tests to ensure the Gutenberg plugin can be cleanly
- * merged into WordPress core where this is false.
- */
-global.process.env.ALLOW_EXPERIMENT_REREGISTRATION = true;
-
 // Set up the app runtime globals for the test environment, which includes
 // modifying the above `global.navigator`
 require( '../../packages/react-native-editor/src/globals' );

--- a/test/unit/config/gutenberg-env.js
+++ b/test/unit/config/gutenberg-env.js
@@ -23,10 +23,10 @@ global.process.env = {
 	IS_GUTENBERG_PLUGIN:
 		String( process.env.npm_package_config_IS_GUTENBERG_PLUGIN ) === 'true',
 	/**
-	 * Whether to allow the same experiment to be registered multiple times.
-	 * This is useful for development purposes, but should be set to false
-	 * during the unit tests to ensure the Gutenberg plugin can be cleanly
-	 * merged into WordPress core where this is false.
+	 * Feature flag guarding features specific to WordPress core.
+	 * It's important to set it to "true" in the test environment
+	 * to ensure the Gutenberg plugin can be cleanly merged into
+	 * WordPress core.
 	 */
-	ALLOW_EXPERIMENT_REREGISTRATION: false,
+	IS_WORDPRESS_CORE: true,
 };

--- a/tools/webpack/shared.js
+++ b/tools/webpack/shared.js
@@ -66,9 +66,9 @@ const plugins = [
 		// Inject the `IS_GUTENBERG_PLUGIN` global, used for feature flagging.
 		'process.env.IS_GUTENBERG_PLUGIN':
 			process.env.npm_package_config_IS_GUTENBERG_PLUGIN,
-		// Inject the `ALLOW_EXPERIMENT_REREGISTRATION` global, used by @wordpress/private-apis.
-		'process.env.ALLOW_EXPERIMENT_REREGISTRATION':
-			process.env.npm_package_config_ALLOW_EXPERIMENT_REREGISTRATION,
+		// Inject the `IS_WORDPRESS_CORE` global, used for feature flagging.
+		'process.env.IS_WORDPRESS_CORE':
+			process.env.npm_package_config_IS_WORDPRESS_CORE,
 	} ),
 	mode === 'production' && new ReadableJsAssetsWebpackPlugin(),
 ];

--- a/typings/gutenberg-env/index.d.ts
+++ b/typings/gutenberg-env/index.d.ts
@@ -1,6 +1,7 @@
 interface Environment {
 	NODE_ENV: unknown;
 	IS_GUTENBERG_PLUGIN?: boolean;
+	IS_WORDPRESS_CORE?: boolean;
 	ALLOW_EXPERIMENT_REREGISTRATION?: boolean;
 }
 interface Process {

--- a/typings/gutenberg-env/index.d.ts
+++ b/typings/gutenberg-env/index.d.ts
@@ -2,7 +2,6 @@ interface Environment {
 	NODE_ENV: unknown;
 	IS_GUTENBERG_PLUGIN?: boolean;
 	IS_WORDPRESS_CORE?: boolean;
-	ALLOW_EXPERIMENT_REREGISTRATION?: boolean;
 }
 interface Process {
 	env: Environment;


### PR DESCRIPTION
## Description

Gutenberg introduced a system of sharing private APIs in WordPress/gutenberg#46131. One of the safeguards is a check preventing the same module from opting-in twice so that contributors cannot easily gain access by pretending to be a core module.

That safeguard is only meant for WordPress core and not for the released @wordpress packages. However, right now it is opt-out and must be explicitly disabled by developers wanting to install the @wordpress packages. Let's make it opt-out instead.

In other words:

* If we’re in WP core – prevent opting-in to private API with the same package name twice
* If we’re not in WP core – don’t prevent it 

Or:

* Before the PR, double opt-in safeguard is enabled by default
* After the PR, double opt-in safeguard is disabled by default AND WordPress core [explicitly enables it](https://github.com/WordPress/wordpress-develop/pull/4121)

The corresponding PR in `wordpress-develop` repo makes WordPress explicitly set the `IS_WORDPRESS_CORE` to true:

https://github.com/WordPress/wordpress-develop/pull/4121

## Test plan

1. Apply this PR
2. Update `packages/data/src/js/private-apis.js` to the code snippet below
3. Load the post editor and confirm it doesn't blow up
4. Unapply this PR
5. Confirm the post editor blows up

```js
export const { lock, unlock } =
	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
		'@wordpress/data'
	);

__dangerousOptInToUnstableAPIsOnlyForCoreModules(
	'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
	'@wordpress/data'
);
```