### PR TITLE
Add component level tests to withDuotoneControls HOC

### DIFF
--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -187,7 +187,7 @@ function addDuotoneAttributes( settings ) {
  *
  * @return {Function} Wrapped component.
  */
-const withDuotoneControls = createHigherOrderComponent(
+export const withDuotoneControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const hasDuotoneSupport = hasBlockSupport(
 			props.name,

--- a/packages/block-editor/src/hooks/test/duotone.js
+++ b/packages/block-editor/src/hooks/test/duotone.js
@@ -200,6 +200,52 @@ describe( 'withDuotoneControls', () => {
 		} );
 		expect( presetOption ).toBeInTheDocument();
 	} );
+
+	it( 'should not show a selected Duotone preset in the panel when the block attribute contains a custom duotone', async () => {
+		const user = userEvent.setup();
+		const blockWithDuotoneProps = {
+			...blockProps,
+			attributes: {
+				style: {
+					color: {
+						duotone: [ 'rgb(0, 0, 0)', 'rgb(255, 255, 255)' ],
+					},
+				},
+			},
+		};
+
+		render(
+			<BlockEditorProvider settings={ blockEditorSettings } value={ [] }>
+				<SlotFillProvider>
+					<BlockEdit { ...blockWithDuotoneProps }>
+						<WithDuotoneControls />
+					</BlockEdit>
+					<BlockControls.Slot group="block" />
+				</SlotFillProvider>
+			</BlockEditorProvider>
+		);
+
+		const duotoneToggleButton = screen.getByRole( 'button', {
+			name: 'Apply duotone filter',
+		} );
+
+		await user.click( duotoneToggleButton );
+
+		const unsetOption = screen.queryByRole( 'button', {
+			name: 'Unset',
+			pressed: false, // the unset option should not be pressed.
+		} );
+		expect( unsetOption ).toBeInTheDocument();
+
+		duotonePresets?.forEach( ( preset ) => {
+			// check in document
+			const presetOption = screen.queryByRole( 'button', {
+				name: `Duotone: ${ preset.name }`,
+				pressed: false, // no preset should be pressed.
+			} );
+			expect( presetOption ).toBeInTheDocument();
+		} );
+	} );
 } );
 
 describe( 'Duotone utilities', () => {

--- a/packages/block-editor/src/hooks/test/duotone.js
+++ b/packages/block-editor/src/hooks/test/duotone.js
@@ -38,7 +38,7 @@ describe( 'withDuotoneControls', () => {
 		},
 	};
 
-	const componentProps = {
+	const blockProps = {
 		name: blockName,
 		attributes: {},
 		isSelected: true,
@@ -95,12 +95,42 @@ describe( 'withDuotoneControls', () => {
 		unregisterBlockType( blockName );
 	} );
 
+	it( 'should not show Duotone panel in toolbar for blocks that do not support Duotone', () => {
+		// A Block with no duotone support.
+		registerBlockType( 'test/no-duotone-support-block', {
+			...blockSettings,
+			name: 'Block with no duotone support',
+			supports: {}, // no duotone support.
+		} );
+
+		const blockNoDuotoneProps = {
+			...blockProps,
+			name: 'test/no-duotone-support-block',
+		};
+
+		render(
+			<BlockEditorProvider settings={ blockEditorSettings } value={ [] }>
+				<SlotFillProvider>
+					<BlockEdit { ...blockNoDuotoneProps }>
+						<EnhancedComponent />
+					</BlockEdit>
+					<BlockControls.Slot group="block" />
+				</SlotFillProvider>
+			</BlockEditorProvider>
+		);
+
+		const duotoneToggleButton = screen.queryByRole( 'button', {
+			name: 'Apply duotone filter',
+		} );
+		expect( duotoneToggleButton ).not.toBeInTheDocument();
+	} );
+
 	it( 'should show Duotone panel with presets in toolbar for blocks that support Duotone', async () => {
 		const user = userEvent.setup();
 		render(
 			<BlockEditorProvider settings={ blockEditorSettings } value={ [] }>
 				<SlotFillProvider>
-					<BlockEdit { ...componentProps }>
+					<BlockEdit { ...blockProps }>
 						<EnhancedComponent />
 					</BlockEdit>
 					<BlockControls.Slot group="block" />

--- a/packages/block-editor/src/hooks/test/duotone.js
+++ b/packages/block-editor/src/hooks/test/duotone.js
@@ -96,7 +96,7 @@ describe( 'withDuotoneControls', () => {
 			<BlockEditorProvider settings={ settings } value={ [] }>
 				<SlotFillProvider>
 					<BlockEdit { ...componentProps }>
-						<EnhancedComponent { ...componentProps } />
+						<EnhancedComponent />
 					</BlockEdit>
 					<BlockControls.Slot group="block" />
 				</SlotFillProvider>

--- a/packages/block-editor/src/hooks/test/duotone.js
+++ b/packages/block-editor/src/hooks/test/duotone.js
@@ -1,10 +1,113 @@
 /**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
+import { SlotFillProvider } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
+import BlockEditorProvider from '../../components/provider';
+import BlockControls from '../../components/block-controls';
+// eslint-disable-next-line no-unused-vars
+import BlockEdit from '../../components/block-edit';
 import {
+	withDuotoneControls,
 	getColorsFromDuotonePreset,
 	getDuotonePresetFromColors,
 } from '../duotone';
+
+describe( 'withDuotoneControls', () => {
+	const blockName = 'core/test-block';
+
+	const blockSettings = {
+		save: () => {},
+		category: 'media',
+		title: 'Block Title',
+		edit: ( { children } ) => <>{ children }</>,
+		supports: {
+			color: {
+				__experimentalDuotone: 'img',
+			},
+		},
+	};
+
+	const componentProps = {
+		name: blockName,
+		attributes: {},
+		isSelected: true,
+	};
+
+	const settings = {
+		__experimentalFeatures: {
+			color: {
+				palette: {
+					default: [
+						{
+							name: 'Pale pink',
+							slug: 'pale-pink',
+							color: '#f78da7',
+						},
+						{
+							name: 'Vivid green cyan',
+							slug: 'vivid-green-cyan',
+							color: '#00d084',
+						},
+					],
+				},
+				defaultDuotone: true,
+				duotone: {
+					default: [
+						{
+							name: 'Black and white',
+							slug: 'black-and-white',
+							colors: [ '#000000', '#FFFFFF' ],
+						},
+						{
+							name: 'Pale pink and green',
+							slug: 'palepink-green',
+							colors: [ '#f78da7', '#00d084' ],
+						},
+					],
+				},
+			},
+		},
+	};
+
+	beforeEach( () => {
+		registerBlockType( blockName, blockSettings );
+	} );
+
+	afterEach( () => {
+		unregisterBlockType( blockName );
+	} );
+
+	it( 'should show Duotone control in toolbar', () => {
+		const EnhancedComponent = withDuotoneControls( ( { wrapperProps } ) => (
+			<div { ...wrapperProps } />
+		) );
+
+		render(
+			<BlockEditorProvider settings={ settings } value={ [] }>
+				<SlotFillProvider>
+					<EnhancedComponent { ...componentProps } />
+					<BlockControls.Slot group="block" />
+				</SlotFillProvider>
+			</BlockEditorProvider>
+		);
+
+		expect(
+			screen.getByRole( 'button', {
+				name: 'Apply duotone filter"',
+			} )
+		).toBeInTheDocument();
+	} );
+} );
 
 describe( 'Duotone utilities', () => {
 	const duotonePalette = [

--- a/packages/block-editor/src/hooks/test/duotone.js
+++ b/packages/block-editor/src/hooks/test/duotone.js
@@ -95,7 +95,9 @@ describe( 'withDuotoneControls', () => {
 		render(
 			<BlockEditorProvider settings={ settings } value={ [] }>
 				<SlotFillProvider>
-					<EnhancedComponent { ...componentProps } />
+					<BlockEdit { ...componentProps }>
+						<EnhancedComponent { ...componentProps } />
+					</BlockEdit>
 					<BlockControls.Slot group="block" />
 				</SlotFillProvider>
 			</BlockEditorProvider>
@@ -103,7 +105,7 @@ describe( 'withDuotoneControls', () => {
 
 		expect(
 			screen.getByRole( 'button', {
-				name: 'Apply duotone filter"',
+				name: 'Apply duotone filter',
 			} )
 		).toBeInTheDocument();
 	} );

--- a/packages/block-editor/src/hooks/test/duotone.js
+++ b/packages/block-editor/src/hooks/test/duotone.js
@@ -83,7 +83,7 @@ describe( 'withDuotoneControls', () => {
 	const duotonePresets =
 		blockEditorSettings.__experimentalFeatures.color.duotone.default;
 
-	const EnhancedComponent = withDuotoneControls( ( { wrapperProps } ) => (
+	const WithDuotoneControls = withDuotoneControls( ( { wrapperProps } ) => (
 		<div { ...wrapperProps } />
 	) );
 
@@ -112,7 +112,7 @@ describe( 'withDuotoneControls', () => {
 			<BlockEditorProvider settings={ blockEditorSettings } value={ [] }>
 				<SlotFillProvider>
 					<BlockEdit { ...blockNoDuotoneProps }>
-						<EnhancedComponent />
+						<WithDuotoneControls />
 					</BlockEdit>
 					<BlockControls.Slot group="block" />
 				</SlotFillProvider>
@@ -131,7 +131,7 @@ describe( 'withDuotoneControls', () => {
 			<BlockEditorProvider settings={ blockEditorSettings } value={ [] }>
 				<SlotFillProvider>
 					<BlockEdit { ...blockProps }>
-						<EnhancedComponent />
+						<WithDuotoneControls />
 					</BlockEdit>
 					<BlockControls.Slot group="block" />
 				</SlotFillProvider>
@@ -161,6 +161,44 @@ describe( 'withDuotoneControls', () => {
 			} );
 			expect( presetOption ).toBeInTheDocument();
 		} );
+	} );
+
+	it( 'should select the duotone preset in the panel when the block attribute contains a duotone preset', async () => {
+		const user = userEvent.setup();
+		const duotonePreset = duotonePresets[ 0 ];
+		const blockWithDuotoneProps = {
+			...blockProps,
+			attributes: {
+				style: {
+					color: {
+						duotone: duotonePreset.slug,
+					},
+				},
+			},
+		};
+
+		render(
+			<BlockEditorProvider settings={ blockEditorSettings } value={ [] }>
+				<SlotFillProvider>
+					<BlockEdit { ...blockWithDuotoneProps }>
+						<WithDuotoneControls />
+					</BlockEdit>
+					<BlockControls.Slot group="block" />
+				</SlotFillProvider>
+			</BlockEditorProvider>
+		);
+
+		const duotoneToggleButton = screen.getByRole( 'button', {
+			name: 'Apply duotone filter',
+		} );
+
+		await user.click( duotoneToggleButton );
+
+		const presetOption = screen.queryByRole( 'button', {
+			name: `Duotone: ${ duotonePreset.name }`,
+			pressed: true, // the selected preset should be pressed.
+		} );
+		expect( presetOption ).toBeInTheDocument();
 	} );
 } );
 

--- a/packages/components/src/duotone-picker/duotone-picker.js
+++ b/packages/components/src/duotone-picker/duotone-picker.js
@@ -42,6 +42,7 @@ function DuotonePicker( {
 			key="unset"
 			value="unset"
 			isSelected={ isUnset }
+			aria-label={ __( 'Unset' ) }
 			tooltipText={ __( 'Unset' ) }
 			className="components-duotone-picker__color-indicator"
 			onClick={ () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds component level tests to verify high level functionality of `withDuotoneControls` HOC.

Closes https://github.com/WordPress/gutenberg/issues/48347

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Need for greater confidence in functionality of Duotone UI extension, particular that it only renders for blocks which exhibit the correct block supports.

Note: more complex assertions will require e2e tests. 



## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Tests 

- whether Duotone controls are rendered when blocks support Duotone
- that Duotone controls are _not_ rendered when blocks do _not_ support Duotone.
- verifies basics of controls selecting correct preset based on `attributes.style.color.duotone`.



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Run

```
npm run test:unit packages/block-editor/src/hooks/test/duotone.js
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
