### PR TITLE
[Mobile] - E2E tests - Add new helpers

### DIFF
--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -103,7 +103,7 @@ export default function ButtonsEdit( {
 
 			const insertedBlock = createBlock( 'core/button' );
 
-			insertBlock( insertedBlock, index, clientId );
+			insertBlock( insertedBlock, index, clientId, false );
 			selectBlock( insertedBlock.clientId );
 		}, 200 ),
 		[]

--- a/packages/edit-post/src/components/header/header-toolbar/index.native.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.native.js
@@ -99,8 +99,13 @@ function HeaderToolbar( {
 		? wasNoContentSelected.current
 		: noContentSelected;
 
+	/* translators: accessibility text for the editor toolbar */
+	const toolbarAriaLabel = __( 'Document tools' );
+
 	return (
 		<View
+			testID={ toolbarAriaLabel }
+			accessibilityLabel={ toolbarAriaLabel }
 			style={ [
 				getStylesFromColorScheme(
 					styles[ 'header-toolbar__container' ],

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -380,6 +380,11 @@ const selectTextFromTextInput = async ( driver, element ) => {
 		await longPressMiddleOfElement( driver, element, 0 );
 	} else {
 		await doubleTap( driver, element );
+		await driver.waitForElementByXPath(
+			'//XCUIElementTypeMenuItem[@name="Copy"]',
+			wd.asserters.isDisplayed,
+			4000
+		);
 	}
 };
 

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -375,7 +375,7 @@ const tapPasteAboveElement = async ( driver, element ) => {
 	}
 };
 
-const selectTextFromTextInput = async ( driver, element ) => {
+const selectTextFromElement = async ( driver, element ) => {
 	if ( isAndroid() ) {
 		await longPressMiddleOfElement( driver, element, 0 );
 	} else {
@@ -697,7 +697,7 @@ module.exports = {
 	longPressMiddleOfElement,
 	setClipboard,
 	setupDriver,
-	selectTextFromTextInput,
+	selectTextFromElement,
 	stopDriver,
 	swipeDown,
 	swipeFromTo,

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -375,6 +375,14 @@ const tapPasteAboveElement = async ( driver, element ) => {
 	}
 };
 
+const selectTextFromTextInput = async ( driver, element ) => {
+	if ( isAndroid() ) {
+		await longPressMiddleOfElement( driver, element, 0 );
+	} else {
+		await doubleTap( driver, element );
+	}
+};
+
 // Starts from the middle of the screen or the element(if specified)
 // and swipes upwards.
 const swipeUp = async (
@@ -684,6 +692,7 @@ module.exports = {
 	longPressMiddleOfElement,
 	setClipboard,
 	setupDriver,
+	selectTextFromTextInput,
 	stopDriver,
 	swipeDown,
 	swipeFromTo,

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -882,6 +882,29 @@ class EditorPage {
 		return await waitForVisible( this.driver, blockLocator );
 	}
 
+	// =========================
+	// Button Block functions
+	// =========================
+
+	async getButtonBlockTextInputAtPosition( blockName, position = 1 ) {
+		// iOS needs a click to get the text element
+		if ( ! isAndroid() ) {
+			const textBlockLocator = `(//XCUIElementTypeButton[contains(@name, "Button Block. Row ${ position }")])`;
+
+			const textBlock = await waitForVisible(
+				this.driver,
+				textBlockLocator
+			);
+			await textBlock.click();
+		}
+
+		const blockLocator = isAndroid()
+			? `//android.view.ViewGroup[@content-desc="Button Block. Row ${ position }"]/android.view.ViewGroup[2]/android.view.ViewGroup/android.view.ViewGroup/android.widget.EditText`
+			: `//XCUIElementTypeButton[contains(@name, "Button Block. Row ${ position }")]//XCUIElementTypeTextView`;
+
+		return await waitForVisible( this.driver, blockLocator );
+	}
+
 	async waitForElementToBeDisplayedById( id, timeout = 2000 ) {
 		return await this.driver.waitForElementByAccessibilityId(
 			id,
@@ -919,6 +942,8 @@ const blockNames = {
 	verse: 'Verse',
 	shortcode: 'Shortcode',
 	group: 'Group',
+	buttons: 'Buttons',
+	button: 'Button',
 };
 
 module.exports = { initializeEditorPage, blockNames };

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -381,6 +381,10 @@ class EditorPage {
 	// Block toolbar functions
 	// =========================
 
+	async getToolbar() {
+		return await this.driver.elementsByAccessibilityId( 'Document tools' );
+	}
+
 	async addNewBlock( blockName, relativePosition ) {
 		const addButton = await this.getAddBlockButton();
 

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -575,6 +575,28 @@ class EditorPage {
 	}
 
 	// =========================
+	// Formatting toolbar functions
+	// =========================
+
+	async toggleFormatting( formatting ) {
+		const identifier = isAndroid()
+			? `//android.widget.Button[@content-desc="${ formatting }"]/android.view.ViewGroup`
+			: `//XCUIElementTypeButton[@name="${ formatting }"]`;
+		const toggleElement = await this.waitForElementToBeDisplayedByXPath(
+			identifier
+		);
+		return await toggleElement.click();
+	}
+
+	async openLinkToSettings() {
+		const element = await this.waitForElementToBeDisplayedById(
+			'Link to, Search or type URL'
+		);
+
+		await element.click();
+	}
+
+	// =========================
 	// Paragraph Block functions
 	// =========================
 
@@ -886,23 +908,21 @@ class EditorPage {
 	// Button Block functions
 	// =========================
 
-	async getButtonBlockTextInputAtPosition( blockName, position = 1 ) {
-		// iOS needs a click to get the text element
-		if ( ! isAndroid() ) {
-			const textBlockLocator = `(//XCUIElementTypeButton[contains(@name, "Button Block. Row ${ position }")])`;
-
-			const textBlock = await waitForVisible(
-				this.driver,
-				textBlockLocator
-			);
-			await textBlock.click();
-		}
-
+	async getButtonBlockTextInputAtPosition( position = 1 ) {
 		const blockLocator = isAndroid()
 			? `//android.view.ViewGroup[@content-desc="Button Block. Row ${ position }"]/android.view.ViewGroup[2]/android.view.ViewGroup/android.view.ViewGroup/android.widget.EditText`
 			: `//XCUIElementTypeButton[contains(@name, "Button Block. Row ${ position }")]//XCUIElementTypeTextView`;
 
-		return await waitForVisible( this.driver, blockLocator );
+		return await this.waitForElementToBeDisplayedByXPath( blockLocator );
+	}
+
+	async addButtonWithInlineAppender( position = 1 ) {
+		const appenderButton = isAndroid()
+			? await this.waitForElementToBeDisplayedByXPath(
+					`//android.view.ViewGroup[@content-desc="block-list"]/android.view.ViewGroup[${ position }]/android.widget.Button`
+			  )
+			: await this.waitForElementToBeDisplayedById( 'appender-button' );
+		await appenderButton.click();
 	}
 
 	async waitForElementToBeDisplayedById( id, timeout = 2000 ) {

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -315,8 +315,20 @@ class EditorPage {
 		const { addButtonLocation } = this.initialValues;
 		const addButton = await this.getAddBlockButton();
 		const location = await addButton.getLocation();
+		let YLocation = addButtonLocation?.y;
+		const currentOrientation = await this.driver.getOrientation();
+		const isLandscape = currentOrientation === 'LANDSCAPE';
 
-		if ( location.y < addButtonLocation?.y ) {
+		if ( isLandscape ) {
+			const windowSize = await this.driver.getWindowSize();
+			const safeAreaOffset = 32;
+			YLocation = Math.floor(
+				( windowSize.height * YLocation ) / windowSize.width -
+					safeAreaOffset
+			);
+		}
+
+		if ( location.y < YLocation ) {
 			await this.waitForKeyboardToBeHidden();
 		}
 	}


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/5501

## What?
This PR adds new helpers for E2E tests and it also fixes an issue where sometimes the formatting tools don't show up correctly when focusing `Button` blocks.

## Why?
To simplify and avoid duplicating code some helpers were needed.

## How?
It adds the following helpers:

- `toggleFormatting` -> To be able to toggle text formatting e.g. `Bold`, `Link`.
- `getButtonBlockTextInputAtPosition` -> To get a TextInput element within a Button block.
- `addButtonWithInlineAppender` -> To be able to add new Button blocks within a Buttons block using the in-line appender.
- `selectTextFromTextInput` -> Util to select a text within TextInput.

It also updates `waitForKeyboardToBeHidden` to take into account when the device is in Lanscape mode for iOS.

## Testing Instructions
CI checks should pass on both Gutenberg and Gutenberg Mobile.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A