### PR TITLE
Revert Link control UX changes for WP 6.2

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -274,7 +274,6 @@ function LinkControl( {
 	// See https://github.com/WordPress/gutenberg/pull/33849/#issuecomment-932194927.
 	const showTextControl = hasLinkValue && hasTextControl;
 
-	const isEditing = ( isEditingLink || ! value ) && ! isCreatingPage;
 	return (
 		<div
 			tabIndex={ -1 }
@@ -287,7 +286,7 @@ function LinkControl( {
 				</div>
 			) }
 
-			{ isEditing && (
+			{ ( isEditingLink || ! value ) && ! isCreatingPage && (
 				<>
 					<div
 						className={ classnames( {
@@ -336,6 +335,19 @@ function LinkControl( {
 							{ errorMessage }
 						</Notice>
 					) }
+					<div className="block-editor-link-control__search-actions">
+						<Button
+							variant="primary"
+							onClick={ handleSubmit }
+							className="xblock-editor-link-control__search-submit"
+							disabled={ currentInputIsEmpty } // Disallow submitting empty values.
+						>
+							{ __( 'Apply' ) }
+						</Button>
+						<Button variant="tertiary" onClick={ handleCancel }>
+							{ __( 'Cancel' ) }
+						</Button>
+					</div>
 				</>
 			) }
 
@@ -350,34 +362,15 @@ function LinkControl( {
 				/>
 			) }
 
-			<div className="block-editor-link-control__drawer">
-				{ showSettingsDrawer && (
-					<div className="block-editor-link-control__tools">
-						<LinkControlSettingsDrawer
-							value={ value }
-							settings={ settings }
-							onChange={ onChange }
-						/>
-					</div>
-				) }
-
-				{ isEditing && (
-					<div className="block-editor-link-control__search-actions">
-						<Button
-							variant="primary"
-							onClick={ handleSubmit }
-							className="xblock-editor-link-control__search-submit"
-							disabled={ currentInputIsEmpty } // Disallow submitting empty values.
-						>
-							{ __( 'Apply' ) }
-						</Button>
-						<Button variant="tertiary" onClick={ handleCancel }>
-							{ __( 'Cancel' ) }
-						</Button>
-					</div>
-				) }
-			</div>
-
+			{ showSettingsDrawer && (
+				<div className="block-editor-link-control__tools">
+					<LinkControlSettingsDrawer
+						value={ value }
+						settings={ settings }
+						onChange={ onChange }
+					/>
+				</div>
+			) }
 			{ renderControlBottom && renderControlBottom() }
 		</div>
 	);

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -6,13 +6,8 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	Button,
-	ButtonGroup,
-	Spinner,
-	Notice,
-	TextControl,
-} from '@wordpress/components';
+import { Button, Spinner, Notice, TextControl } from '@wordpress/components';
+import { keyboardReturn } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { useRef, useState, useEffect } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
@@ -118,7 +113,6 @@ function LinkControl( {
 	settings = DEFAULT_LINK_SETTINGS,
 	onChange = noop,
 	onRemove,
-	onCancel,
 	noDirectEntry = false,
 	showSuggestions = true,
 	showInitialSuggestions,
@@ -196,8 +190,6 @@ function LinkControl( {
 		isEndingEditWithFocus.current = false;
 	}, [ isEditingLink, isCreatingPage ] );
 
-	const hasLinkValue = value?.url?.trim()?.length > 0;
-
 	/**
 	 * Cancels editing state and marks that focus may need to be restored after
 	 * the next render, if focus was within the wrapper when editing finished.
@@ -243,29 +235,6 @@ function LinkControl( {
 		}
 	};
 
-	const resetInternalValues = () => {
-		setInternalUrlInputValue( value?.url );
-		setInternalTextInputValue( value?.title );
-	};
-
-	const handleCancel = ( event ) => {
-		event.preventDefault();
-		event.stopPropagation();
-
-		// Ensure that any unsubmitted input changes are reset.
-		resetInternalValues();
-
-		if ( hasLinkValue ) {
-			// If there is a link then exist editing mode and show preview.
-			stopEditing();
-		} else {
-			// If there is no link value, then remove the link entirely.
-			onRemove?.();
-		}
-
-		onCancel?.();
-	};
-
 	const currentUrlInputValue = propInputValue || internalUrlInputValue;
 
 	const currentInputIsEmpty = ! currentUrlInputValue?.trim()?.length;
@@ -278,7 +247,7 @@ function LinkControl( {
 	// Only show text control once a URL value has been committed
 	// and it isn't just empty whitespace.
 	// See https://github.com/WordPress/gutenberg/pull/33849/#issuecomment-932194927.
-	const showTextControl = hasLinkValue && hasTextControl;
+	const showTextControl = value?.url?.trim()?.length > 0 && hasTextControl;
 
 	return (
 		<div
@@ -330,7 +299,17 @@ function LinkControl( {
 								createSuggestionButtonText
 							}
 							useLabel={ showTextControl }
-						/>
+						>
+							<div className="block-editor-link-control__search-actions">
+								<Button
+									onClick={ handleSubmit }
+									label={ __( 'Submit' ) }
+									icon={ keyboardReturn }
+									className="block-editor-link-control__search-submit"
+									disabled={ currentInputIsEmpty } // Disallow submitting empty values.
+								/>
+							</div>
+						</LinkControlSearchInput>
 					</div>
 					{ errorMessage && (
 						<Notice
@@ -341,19 +320,6 @@ function LinkControl( {
 							{ errorMessage }
 						</Notice>
 					) }
-					<ButtonGroup className="block-editor-link-control__search-actions">
-						<Button
-							variant="primary"
-							onClick={ handleSubmit }
-							className="xblock-editor-link-control__search-submit"
-							disabled={ currentInputIsEmpty } // Disallow submitting empty values.
-						>
-							{ __( 'Apply' ) }
-						</Button>
-						<Button variant="tertiary" onClick={ handleCancel }>
-							{ __( 'Cancel' ) }
-						</Button>
-					</ButtonGroup>
 				</>
 			) }
 

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -6,7 +6,13 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Button, Spinner, Notice, TextControl } from '@wordpress/components';
+import {
+	Button,
+	ButtonGroup,
+	Spinner,
+	Notice,
+	TextControl,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useRef, useState, useEffect } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
@@ -335,7 +341,7 @@ function LinkControl( {
 							{ errorMessage }
 						</Notice>
 					) }
-					<div className="block-editor-link-control__search-actions">
+					<ButtonGroup className="block-editor-link-control__search-actions">
 						<Button
 							variant="primary"
 							onClick={ handleSubmit }
@@ -347,7 +353,7 @@ function LinkControl( {
 						<Button variant="tertiary" onClick={ handleCancel }>
 							{ __( 'Cancel' ) }
 						</Button>
-					</div>
+					</ButtonGroup>
 				</>
 			) }
 

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -64,6 +64,7 @@ $preview-image-height: 140px;
 		width: calc(100% - #{$grid-unit-20 * 2});
 		display: block;
 		padding: 11px $grid-unit-20;
+		padding-right: ( $button-size * $block-editor-link-control-number-of-actions ); // width of reset and submit buttons
 		margin: 0;
 		position: relative;
 		border: 1px solid $gray-300;
@@ -76,11 +77,20 @@ $preview-image-height: 140px;
 }
 
 .block-editor-link-control__search-actions {
-	display: flex;
-	flex-direction: row-reverse; // put "Cancel" on the left but retain DOM order.
-	justify-content: flex-start;
-	margin: $grid-unit-20; // allow margin collapse for vertical spacing.
-	gap: $grid-unit-10;
+	position: absolute;
+	/*
+	 * Actions must be positioned on top of URLInput, since the input will grow
+	 * when suggestions are rendered.
+	 *
+	 * Compensate for:
+	 *  - Border (1px)
+	 *  - Vertically, for the difference in height between the input (40px) and
+	 *    the icon buttons.
+	 *  - Horizontally, pad to the minimum of: default input padding, or the
+	 *    equivalent of the vertical padding.
+	 */
+	top: 1px + ( ( 40px - $button-size ) * 0.5 );
+	right: $grid-unit-20 + 1px + min($grid-unit-10, ( 40px - $button-size ) * 0.5);
 }
 
 .components-button .block-editor-link-control__search-submit .has-icon {
@@ -469,8 +479,14 @@ $preview-image-height: 140px;
 		position: absolute;
 		left: auto;
 		bottom: auto;
+		/*
+		 * Position spinner to the left of the actions.
+		 *
+		 * Compensate for:
+		 *  - Input padding right ($button-size)
+		 */
 		top: calc(50% - #{$spinner-size} / 2);
-		right: $grid-unit-20;
+		right: $button-size;
 	}
 }
 

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -79,6 +79,7 @@ $preview-image-height: 140px;
 	display: flex;
 	flex-direction: row-reverse; // put "Cancel" on the left but retain DOM order.
 	justify-content: flex-start;
+	margin: $grid-unit-20; // allow margin collapse for vertical spacing.
 	gap: $grid-unit-10;
 }
 
@@ -426,10 +427,9 @@ $preview-image-height: 140px;
 	padding: 10px;
 }
 
-.block-editor-link-control__drawer {
+.block-editor-link-control__tools {
 	display: flex;
 	align-items: center;
-	justify-content: space-between;
 	border-top: $border-width solid $gray-300;
 	margin: 0;
 	padding: $grid-unit-20;

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -537,7 +537,7 @@ describe( 'Manual link entry', () => {
 				} );
 
 				let submitButton = screen.getByRole( 'button', {
-					name: 'Apply',
+					name: 'Submit',
 				} );
 
 				expect( submitButton ).toBeDisabled();
@@ -555,7 +555,7 @@ describe( 'Manual link entry', () => {
 				await user.keyboard( '[Enter]' );
 
 				submitButton = screen.getByRole( 'button', {
-					name: 'Apply',
+					name: 'Submit',
 				} );
 
 				// Verify the UI hasn't allowed submission.
@@ -578,7 +578,7 @@ describe( 'Manual link entry', () => {
 				} );
 
 				let submitButton = screen.queryByRole( 'button', {
-					name: 'Apply',
+					name: 'Submit',
 				} );
 
 				expect( submitButton ).toBeDisabled();
@@ -597,7 +597,7 @@ describe( 'Manual link entry', () => {
 				await user.click( submitButton );
 
 				submitButton = screen.queryByRole( 'button', {
-					name: 'Apply',
+					name: 'Submit',
 				} );
 
 				// Verify the UI hasn't allowed submission.
@@ -606,135 +606,6 @@ describe( 'Manual link entry', () => {
 				expect( submitButton ).toBeVisible();
 			}
 		);
-	} );
-
-	describe( 'Handling cancellation', () => {
-		it( 'should allow cancellation of the link creation process and reset any entered values', async () => {
-			const user = userEvent.setup();
-			const mockOnRemove = jest.fn();
-			const mockOnCancel = jest.fn();
-
-			render( <LinkControl onRemove={ mockOnRemove } /> );
-
-			// Search Input UI.
-			const searchInput = screen.getByRole( 'combobox', {
-				name: 'URL',
-			} );
-
-			const cancelButton = screen.queryByRole( 'button', {
-				name: 'Cancel',
-			} );
-
-			expect( cancelButton ).toBeEnabled();
-			expect( cancelButton ).toBeVisible();
-
-			// Simulate adding a link for a term.
-			await user.type( searchInput, 'https://www.wordpress.org' );
-
-			// Attempt to submit the empty search value in the input.
-			await user.click( cancelButton );
-
-			// Verify the consumer can handle the cancellation.
-			expect( mockOnRemove ).toHaveBeenCalled();
-
-			// Ensure optional callback is not called.
-			expect( mockOnCancel ).not.toHaveBeenCalled();
-
-			expect( searchInput ).toHaveValue( '' );
-		} );
-
-		it( 'should allow cancellation of the link editing process and reset any entered values', async () => {
-			const user = userEvent.setup();
-			const initialLink = fauxEntitySuggestions[ 0 ];
-
-			const LinkControlConsumer = () => {
-				const [ link, setLink ] = useState( initialLink );
-
-				return (
-					<LinkControl
-						value={ link }
-						onChange={ ( suggestion ) => {
-							setLink( suggestion );
-						} }
-						hasTextControl
-					/>
-				);
-			};
-
-			render( <LinkControlConsumer /> );
-
-			let linkPreview = screen.getByLabelText( 'Currently selected' );
-
-			expect( linkPreview ).toBeInTheDocument();
-
-			// Click the "Edit" button to trigger into the editing mode.
-			let editButton = screen.queryByRole( 'button', {
-				name: 'Edit',
-			} );
-
-			await user.click( editButton );
-
-			let searchInput = screen.getByRole( 'combobox', {
-				name: 'URL',
-			} );
-
-			let textInput = screen.getByRole( 'textbox', {
-				name: 'Text',
-			} );
-
-			// Make a change to the search input.
-			await user.type( searchInput, 'This URL value was changed!' );
-
-			// Make a change to the text input.
-			await user.type( textInput, 'This text value was changed!' );
-
-			const cancelButton = screen.queryByRole( 'button', {
-				name: 'Cancel',
-			} );
-
-			// Cancel the editing process.
-			await user.click( cancelButton );
-
-			linkPreview = screen.getByLabelText( 'Currently selected' );
-
-			expect( linkPreview ).toBeInTheDocument();
-
-			// Re-query the edit button as it's been replaced.
-			editButton = screen.queryByRole( 'button', {
-				name: 'Edit',
-			} );
-
-			await user.click( editButton );
-
-			// Re-query the inputs as they have been replaced.
-			searchInput = screen.getByRole( 'combobox', {
-				name: 'URL',
-			} );
-
-			textInput = screen.getByRole( 'textbox', {
-				name: 'Text',
-			} );
-
-			// Expect to see the original link values and **not** the changed values.
-			expect( searchInput ).toHaveValue( initialLink.url );
-			expect( textInput ).toHaveValue( initialLink.text );
-		} );
-
-		it( 'should call onCancel callback when cancelling if provided', async () => {
-			const user = userEvent.setup();
-			const mockOnCancel = jest.fn();
-
-			render( <LinkControl onCancel={ mockOnCancel } /> );
-
-			const cancelButton = screen.queryByRole( 'button', {
-				name: 'Cancel',
-			} );
-
-			await user.click( cancelButton );
-
-			// Verify the consumer can handle the cancellation.
-			expect( mockOnCancel ).toHaveBeenCalled();
-		} );
 	} );
 
 	describe( 'Alternative link protocols and formats', () => {
@@ -1988,7 +1859,7 @@ describe( 'Controlling link title text', () => {
 		expect( textInput ).toHaveValue( textValue );
 
 		const submitButton = screen.queryByRole( 'button', {
-			name: 'Apply',
+			name: 'Submit',
 		} );
 
 		await user.click( submitButton );

--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -137,7 +137,7 @@ describe( 'General media replace flow', () => {
 
 		await user.click(
 			screen.getByRole( 'button', {
-				name: 'Apply',
+				name: 'Submit',
 			} )
 		);
 

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -315,17 +315,12 @@ export default function NavigationLinkEdit( {
 	 */
 	function removeLink() {
 		// Reset all attributes that comprise the link.
-		// It is critical that all attributes are reset
-		// to their default values otherwise this may
-		// in advertently trigger side effects because
-		// the values will have "changed".
 		setAttributes( {
-			url: undefined,
-			label: undefined,
-			id: undefined,
-			kind: undefined,
-			type: undefined,
-			opensInNewTab: false,
+			url: '',
+			label: '',
+			id: '',
+			kind: '',
+			type: '',
 		} );
 
 		// Close the link editing UI.

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/links.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/links.test.js.snap
@@ -68,6 +68,6 @@ exports[`Links should contain a label when it should open in a new tab 1`] = `
 
 exports[`Links should contain a label when it should open in a new tab 2`] = `
 "<!-- wp:paragraph -->
-<p>This is <a href=\\"http://wordpress.org\\" target=\\"_blank\\" rel=\\"noreferrer noopener\\">WordPress</a></p>
+<p>This is <a href=\\"http://wordpress.org\\">WordPress</a></p>
 <!-- /wp:paragraph -->"
 `;

--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -121,6 +121,8 @@ describe( 'Links', () => {
 
 		// Navigate to and toggle the "Open in new tab" checkbox.
 		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Space' );
 
 		// Toggle should still have focus and be checked.
@@ -133,7 +135,8 @@ describe( 'Links', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 
 		// Tab back to the Submit and apply the link.
-		await page.keyboard.press( 'Tab' );
+		await pressKeyWithModifier( 'shift', 'Tab' );
+		await pressKeyWithModifier( 'shift', 'Tab' );
 		await page.keyboard.press( 'Enter' );
 
 		// The link should have been inserted.
@@ -526,6 +529,8 @@ describe( 'Links', () => {
 
 		// Navigate to and toggle the "Open in new tab" checkbox.
 		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Space' );
 
 		// Confirm that focus was not prematurely returned to the paragraph on
@@ -534,8 +539,7 @@ describe( 'Links', () => {
 
 		// Close dialog. Expect that "Open in new tab" would have been applied
 		// immediately.
-
-		await pressKeyWithModifier( 'shift', 'Tab' );
+		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Enter' );
 
 		// Wait for Gutenberg to finish the job.

--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -122,7 +122,6 @@ describe( 'Links', () => {
 		// Navigate to and toggle the "Open in new tab" checkbox.
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Space' );
 
 		// Toggle should still have focus and be checked.
@@ -135,7 +134,6 @@ describe( 'Links', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 
 		// Tab back to the Submit and apply the link.
-		await pressKeyWithModifier( 'shift', 'Tab' );
 		await pressKeyWithModifier( 'shift', 'Tab' );
 		await page.keyboard.press( 'Enter' );
 
@@ -530,7 +528,6 @@ describe( 'Links', () => {
 		// Navigate to and toggle the "Open in new tab" checkbox.
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Space' );
 
 		// Confirm that focus was not prematurely returned to the paragraph on
@@ -766,7 +763,6 @@ describe( 'Links', () => {
 			await waitForURLFieldAutoFocus();
 
 			// Move focus back to RichText for the underlying link.
-			await page.keyboard.press( 'Tab' );
 			await page.keyboard.press( 'Tab' );
 			await page.keyboard.press( 'Tab' );
 			await page.keyboard.press( 'Tab' );

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -498,7 +498,7 @@ test.describe( 'Image', () => {
 			await page.click( 'role=button[name="Edit"i]' );
 			// Replace the url.
 			await page.fill( 'role=combobox[name="URL"i]', imageUrl );
-			await page.click( 'role=button[name="Apply"i]' );
+			await page.click( 'role=button[name="Submit"i]' );
 
 			const regex = new RegExp(
 				`<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Some UX/UI changes to Link Control were accidentally included in 6.2 (see https://github.com/WordPress/gutenberg/issues/48356 for details). These must now be removed from 6.2 but kept in Gutenberg `trunk`.

Closes https://github.com/WordPress/gutenberg/issues/48356

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See https://github.com/WordPress/gutenberg/issues/48356

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

`git revert HASH` on all the PRs introduced into Link Control in Gutenberg 15.1.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Check out PR
- Add a Link to some text
- Check the UI looks as it did in WP 6.1 ("one" not "two").
- Check the UI does not look like it does in 6.2 (i.e. Apply/Cancel buttons .etc).
- Check all functionality still works.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/444434/220899883-30141aed-ef6a-47bd-8cf5-40c6da78331e.mp4


