### PR TITLE
Fix the site editor home page loading when installed in a subdirectory

### DIFF
--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -13,7 +13,7 @@ import { store as editSiteStore } from '../../store';
 
 export default function useInitEditedEntityFromURL() {
 	const { params: { postId, postType } = {} } = useLocation();
-	const { isRequestingSite, homepageId } = useSelect( ( select ) => {
+	const { isRequestingSite, homepageId, url } = useSelect( ( select ) => {
 		const { getSite } = select( coreDataStore );
 		const siteData = getSite();
 
@@ -23,6 +23,7 @@ export default function useInitEditedEntityFromURL() {
 				siteData?.show_on_front === 'page'
 					? siteData.page_on_front
 					: null,
+			url: siteData?.url,
 		};
 	}, [] );
 
@@ -60,10 +61,11 @@ export default function useInitEditedEntityFromURL() {
 			} );
 		} else if ( ! isRequestingSite ) {
 			setPage( {
-				path: '/',
+				path: url,
 			} );
 		}
 	}, [
+		url,
 		postId,
 		postType,
 		homepageId,


### PR DESCRIPTION
closes #48292 

## What?

When WP is installed in a subdirectory, the site editor would show a loader indefinitely. This PR fixes that.

## How?

The URL of the home page is not always `/`. This PR uses the `getSite` selector to grab the url of the frontend and retrieve the template based on that URL.

## Testing Instructions

1- Have a WP install in a subdirectory
2- Load the site editor
3- The front page should load properly.