### PR TITLE
Performance: improve focus metric (diff between focus start and type start)

### DIFF
--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -27,9 +27,9 @@ import {
 	getTypingEventDurations,
 	getClickEventDurations,
 	getHoverEventDurations,
-	getSelectionEventDurations,
 	getLoadingDurations,
 	sum,
+	getDiffBetweenEventStarts,
 } from './utils';
 
 jest.setTimeout( 1000000 );
@@ -242,9 +242,13 @@ describe( 'Post Editor Performance', () => {
 			await page.keyboard.type( 'a' );
 			await page.tracing.stop();
 			traceResults = JSON.parse( readFile( traceFile ) );
-			const [ focusEvents, keyDownEvents ] =
-				getSelectionEventDurations( traceResults );
-			results.focus.push( keyDownEvents[ 0 ] - focusEvents[ 0 ] );
+			results.focus.push(
+				getDiffBetweenEventStarts(
+					traceResults,
+					'pointerdown',
+					'keydown'
+				)
+			);
 		}
 	} );
 

--- a/packages/e2e-tests/specs/performance/utils.js
+++ b/packages/e2e-tests/specs/performance/utils.js
@@ -15,34 +15,31 @@ export function deleteFile( filePath ) {
 	}
 }
 
-function isEvent( item ) {
+function isEvent( item, type ) {
 	return (
 		item.cat === 'devtools.timeline' &&
 		item.name === 'EventDispatch' &&
 		item.dur &&
 		item.args &&
-		item.args.data
+		item.args.data &&
+		item.args.data.type === type
 	);
 }
 
 function isKeyDownEvent( item ) {
-	return isEvent( item ) && item.args.data.type === 'keydown';
-}
-
-function isFocusEvent( item ) {
-	return isEvent( item ) && item.args.data.type === 'focus';
+	return isEvent( item, 'keydown' );
 }
 
 function isClickEvent( item ) {
-	return isEvent( item ) && item.args.data.type === 'click';
+	return isEvent( item, 'click' );
 }
 
 function isMouseOverEvent( item ) {
-	return isEvent( item ) && item.args.data.type === 'mouseover';
+	return isEvent( item, 'mouseover' );
 }
 
 function isMouseOutEvent( item ) {
-	return isEvent( item ) && item.args.data.type === 'mouseout';
+	return isEvent( item, 'mouseout' );
 }
 
 function getEventDurationsForType( trace, filterFunction ) {
@@ -61,11 +58,10 @@ export function getTypingEventDurations( trace ) {
 	return [ getEventStartForType( trace, isKeyDownEvent ) ];
 }
 
-export function getSelectionEventDurations( trace ) {
-	return [
-		getEventStartForType( trace, isFocusEvent ),
-		getEventStartForType( trace, isKeyDownEvent ),
-	];
+export function getDiffBetweenEventStarts( trace, aType, bType ) {
+	const aEvent = trace.traceEvents.find( ( item ) => isEvent( item, aType ) );
+	const bEvent = trace.traceEvents.find( ( item ) => isEvent( item, bType ) );
+	return ( bEvent.ts - aEvent.ts ) / 1000;
 }
 
 export function getClickEventDurations( trace ) {

--- a/packages/e2e-tests/specs/performance/utils.js
+++ b/packages/e2e-tests/specs/performance/utils.js
@@ -29,20 +29,8 @@ function isKeyDownEvent( item ) {
 	return isEvent( item ) && item.args.data.type === 'keydown';
 }
 
-function isKeyPressEvent( item ) {
-	return isEvent( item ) && item.args.data.type === 'keypress';
-}
-
-function isKeyUpEvent( item ) {
-	return isEvent( item ) && item.args.data.type === 'keyup';
-}
-
 function isFocusEvent( item ) {
 	return isEvent( item ) && item.args.data.type === 'focus';
-}
-
-function isFocusInEvent( item ) {
-	return isEvent( item ) && item.args.data.type === 'focusin';
 }
 
 function isClickEvent( item ) {
@@ -63,18 +51,20 @@ function getEventDurationsForType( trace, filterFunction ) {
 		.map( ( item ) => item.dur / 1000 );
 }
 
+function getEventStartForType( trace, filterFunction ) {
+	return trace.traceEvents
+		.filter( filterFunction )
+		.map( ( item ) => item.ts / 1000 );
+}
+
 export function getTypingEventDurations( trace ) {
-	return [
-		getEventDurationsForType( trace, isKeyDownEvent ),
-		getEventDurationsForType( trace, isKeyPressEvent ),
-		getEventDurationsForType( trace, isKeyUpEvent ),
-	];
+	return [ getEventStartForType( trace, isKeyDownEvent ) ];
 }
 
 export function getSelectionEventDurations( trace ) {
 	return [
-		getEventDurationsForType( trace, isFocusEvent ),
-		getEventDurationsForType( trace, isFocusInEvent ),
+		getEventStartForType( trace, isFocusEvent ),
+		getEventStartForType( trace, isKeyDownEvent ),
 	];
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Related: #48362. Calculates the time difference between the start of `pointerdown` and `keydown` when typing immediately after clicking on a block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This ensures all events are included that are blocking typing. This makes sure that if we simply move work from e.g. focus to (just an example) click, we don't see a performance improvement while the work is still blocking the next user interaction.

An alternative could be to get the time between the start of `pointerdown` and the end of the last relevant event, in this case `click`. We do risk excluding blocking work between that and the next user interaction though.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
