### PR TITLE
Update snapshot format to Jest 29 default

### DIFF
--- a/bin/plugin/commands/test/__snapshots__/changelog.js.snap
+++ b/bin/plugin/commands/test/__snapshots__/changelog.js.snap
@@ -41,7 +41,7 @@ exports[`getChangelog verify that the changelog is properly formatted 1`] = `
 - Correct \`function_exists()\` check typo introduced in #33331. ([33513](https://github.com/WordPress/gutenberg/pull/33513))
 - ESLint Plugin: Include .jsx extenstion when linting import statements. ([33746](https://github.com/WordPress/gutenberg/pull/33746))
 - Fix block appender position in classic themes. ([33895](https://github.com/WordPress/gutenberg/pull/33895))
-- Fix misspelling of \\"queries\\" in filter documentation. ([33799](https://github.com/WordPress/gutenberg/pull/33799))
+- Fix misspelling of "queries" in filter documentation. ([33799](https://github.com/WordPress/gutenberg/pull/33799))
 - Fix positioning discrepancy with draggable chip. ([33893](https://github.com/WordPress/gutenberg/pull/33893))
 - Navigation Editor: Avoid React warning when creating a new menu. ([33843](https://github.com/WordPress/gutenberg/pull/33843))
 

--- a/packages/block-editor/src/components/block-draggable/test/__snapshots__/index.native.js.snap
+++ b/packages/block-editor/src/components/block-draggable/test/__snapshots__/index.native.js.snap
@@ -5,28 +5,28 @@ exports[`BlockDraggable moves blocks: Initial order 1`] = `
 <p>This is a paragraph.</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:image {\\"sizeSlug\\":\\"large\\"} -->
-<figure class=\\"wp-block-image size-large\\"><img src=\\"https://cldup.com/cXyG__fTLN.jpg\\" alt=\\"\\"/></figure>
+<!-- wp:image {"sizeSlug":"large"} -->
+<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
 <!-- /wp:image -->
 
 <!-- wp:spacer -->
-<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:gallery {\\"linkTo\\":\\"none\\"} -->
-<figure class=\\"wp-block-gallery has-nested-images columns-default is-cropped\\"><!-- wp:image {\\"sizeSlug\\":\\"large\\",\\"linkDestination\\":\\"none\\"} -->
-<figure class=\\"wp-block-image size-large\\"><img src=\\"https://cldup.com/cXyG__fTLN.jpg\\" alt=\\"\\"/></figure>
+<!-- wp:gallery {"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {\\"sizeSlug\\":\\"large\\",\\"linkDestination\\":\\"none\\"} -->
-<figure class=\\"wp-block-image size-large\\"><img src=\\"https://cldup.com/cXyG__fTLN.jpg\\" alt=\\"\\"/></figure>
+<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
 
 exports[`BlockDraggable moves blocks: Paragraph block moved from first to second position 1`] = `
-"<!-- wp:image {\\"sizeSlug\\":\\"large\\"} -->
-<figure class=\\"wp-block-image size-large\\"><img src=\\"https://cldup.com/cXyG__fTLN.jpg\\" alt=\\"\\"/></figure>
+"<!-- wp:image {"sizeSlug":"large"} -->
+<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph -->
@@ -34,40 +34,40 @@ exports[`BlockDraggable moves blocks: Paragraph block moved from first to second
 <!-- /wp:paragraph -->
 
 <!-- wp:spacer -->
-<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:gallery {\\"linkTo\\":\\"none\\"} -->
-<figure class=\\"wp-block-gallery has-nested-images columns-default is-cropped\\"><!-- wp:image {\\"sizeSlug\\":\\"large\\",\\"linkDestination\\":\\"none\\"} -->
-<figure class=\\"wp-block-image size-large\\"><img src=\\"https://cldup.com/cXyG__fTLN.jpg\\" alt=\\"\\"/></figure>
+<!-- wp:gallery {"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {\\"sizeSlug\\":\\"large\\",\\"linkDestination\\":\\"none\\"} -->
-<figure class=\\"wp-block-image size-large\\"><img src=\\"https://cldup.com/cXyG__fTLN.jpg\\" alt=\\"\\"/></figure>
+<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
 
 exports[`BlockDraggable moves blocks: Spacer block moved from third to first position 1`] = `
 "<!-- wp:spacer -->
-<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:image {\\"sizeSlug\\":\\"large\\"} -->
-<figure class=\\"wp-block-image size-large\\"><img src=\\"https://cldup.com/cXyG__fTLN.jpg\\" alt=\\"\\"/></figure>
+<!-- wp:image {"sizeSlug":"large"} -->
+<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph -->
 <p>This is a paragraph.</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:gallery {\\"linkTo\\":\\"none\\"} -->
-<figure class=\\"wp-block-gallery has-nested-images columns-default is-cropped\\"><!-- wp:image {\\"sizeSlug\\":\\"large\\",\\"linkDestination\\":\\"none\\"} -->
-<figure class=\\"wp-block-image size-large\\"><img src=\\"https://cldup.com/cXyG__fTLN.jpg\\" alt=\\"\\"/></figure>
+<!-- wp:gallery {"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {\\"sizeSlug\\":\\"large\\",\\"linkDestination\\":\\"none\\"} -->
-<figure class=\\"wp-block-image size-large\\"><img src=\\"https://cldup.com/cXyG__fTLN.jpg\\" alt=\\"\\"/></figure>
+<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;

--- a/packages/block-editor/src/components/block-mobile-toolbar/test/__snapshots__/block-actions-menu.native.js.snap
+++ b/packages/block-editor/src/components/block-mobile-toolbar/test/__snapshots__/block-actions-menu.native.js.snap
@@ -6,25 +6,25 @@ exports[`Block Actions Menu block options copies and pastes a block 1`] = `
 <!-- /wp:paragraph -->
 
 <!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\"></h2>
+<h2 class="wp-block-heading"></h2>
 <!-- /wp:heading -->
 
 <!-- wp:spacer -->
-<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
 <!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\"></h2>
+<h2 class="wp-block-heading"></h2>
 <!-- /wp:heading -->"
 `;
 
 exports[`Block Actions Menu block options cuts and pastes a block 1`] = `
 "<!-- wp:spacer -->
-<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
 <!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\"></h2>
+<h2 class="wp-block-heading"></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -38,15 +38,15 @@ exports[`Block Actions Menu block options does not replace a non empty Paragraph
 <!-- /wp:paragraph -->
 
 <!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\"></h2>
+<h2 class="wp-block-heading"></h2>
 <!-- /wp:heading -->
 
 <!-- wp:spacer -->
-<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
 <!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\"></h2>
+<h2 class="wp-block-heading"></h2>
 <!-- /wp:heading -->"
 `;
 
@@ -56,29 +56,29 @@ exports[`Block Actions Menu block options duplicates a block 1`] = `
 <!-- /wp:paragraph -->
 
 <!-- wp:spacer -->
-<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
 <!-- wp:spacer -->
-<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
 <!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\"></h2>
+<h2 class="wp-block-heading"></h2>
 <!-- /wp:heading -->"
 `;
 
 exports[`Block Actions Menu block options transforms a Paragraph block into a Pullquote block 1`] = `
 "<!-- wp:pullquote -->
-<figure class=\\"wp-block-pullquote\\"><blockquote><p>Hello!</p></blockquote></figure>
+<figure class="wp-block-pullquote"><blockquote><p>Hello!</p></blockquote></figure>
 <!-- /wp:pullquote -->
 
 <!-- wp:spacer -->
-<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
 <!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\"></h2>
+<h2 class="wp-block-heading"></h2>
 <!-- /wp:heading -->"
 `;
 
@@ -88,11 +88,11 @@ exports[`Block Actions Menu moving blocks disables the Move Down button for the 
 <!-- /wp:paragraph -->
 
 <!-- wp:spacer -->
-<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
 <!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\"></h2>
+<h2 class="wp-block-heading"></h2>
 <!-- /wp:heading -->"
 `;
 
@@ -102,17 +102,17 @@ exports[`Block Actions Menu moving blocks disables the Move Up button for the fi
 <!-- /wp:paragraph -->
 
 <!-- wp:spacer -->
-<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
 <!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\"></h2>
+<h2 class="wp-block-heading"></h2>
 <!-- /wp:heading -->"
 `;
 
 exports[`Block Actions Menu moving blocks moves blocks up and down 1`] = `
 "<!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\"></h2>
+<h2 class="wp-block-heading"></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -120,6 +120,6 @@ exports[`Block Actions Menu moving blocks moves blocks up and down 1`] = `
 <!-- /wp:paragraph -->
 
 <!-- wp:spacer -->
-<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->"
 `;

--- a/packages/block-editor/src/components/block-mover/test/__snapshots__/index.native.js.snap
+++ b/packages/block-editor/src/components/block-mover/test/__snapshots__/index.native.js.snap
@@ -6,11 +6,11 @@ exports[`Block Mover Picker moving blocks disables the Move Down button for the 
 <!-- /wp:paragraph -->
 
 <!-- wp:spacer -->
-<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
 <!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\"></h2>
+<h2 class="wp-block-heading"></h2>
 <!-- /wp:heading -->"
 `;
 
@@ -20,17 +20,17 @@ exports[`Block Mover Picker moving blocks disables the Move Up button for the fi
 <!-- /wp:paragraph -->
 
 <!-- wp:spacer -->
-<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
 <!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\"></h2>
+<h2 class="wp-block-heading"></h2>
 <!-- /wp:heading -->"
 `;
 
 exports[`Block Mover Picker moving blocks moves blocks up and down 1`] = `
 "<!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\"></h2>
+<h2 class="wp-block-heading"></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -38,19 +38,19 @@ exports[`Block Mover Picker moving blocks moves blocks up and down 1`] = `
 <!-- /wp:paragraph -->
 
 <!-- wp:spacer -->
-<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->"
 `;
 
 exports[`Block Mover Picker should match snapshot 1`] = `
-Array [
+[
   <View>
     <View
       accessibilityHint="Double tap to move the block to the left"
       accessibilityLabel="Move block left from position 2 to position 1"
       accessibilityRole="button"
       accessibilityState={
-        Object {
+        {
           "disabled": false,
         }
       }
@@ -65,7 +65,7 @@ Array [
       onResponderTerminationRequest={[Function]}
       onStartShouldSetResponder={[Function]}
       style={
-        Object {
+        {
           "alignItems": "center",
           "flex": 1,
           "justifyContent": "center",
@@ -81,7 +81,7 @@ Array [
         onGestureHandlerEvent={[Function]}
         onGestureHandlerStateChange={[Function]}
         style={
-          Object {
+          {
             "alignItems": "center",
             "aspectRatio": 1,
             "flex": 1,
@@ -93,7 +93,7 @@ Array [
       >
         <View
           style={
-            Object {
+            {
               "flexDirection": "row",
             }
           }
@@ -109,7 +109,7 @@ Array [
       accessibilityLabel="Move block right"
       accessibilityRole="button"
       accessibilityState={
-        Object {
+        {
           "disabled": true,
         }
       }
@@ -124,7 +124,7 @@ Array [
       onResponderTerminationRequest={[Function]}
       onStartShouldSetResponder={[Function]}
       style={
-        Object {
+        {
           "alignItems": "center",
           "flex": 1,
           "justifyContent": "center",
@@ -140,7 +140,7 @@ Array [
         onGestureHandlerEvent={[Function]}
         onGestureHandlerStateChange={[Function]}
         style={
-          Object {
+          {
             "alignItems": "center",
             "aspectRatio": 1,
             "flex": 1,
@@ -152,7 +152,7 @@ Array [
       >
         <View
           style={
-            Object {
+            {
               "flexDirection": "row",
             }
           }

--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -158,7 +158,7 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
+                  aria-label="Custom color picker. The currently selected color is called "red" and has a value of "f00"."
                   class="components-flex components-color-palette__custom-color emotion-10 emotion-5"
                   data-wp-c16t="true"
                   data-wp-component="Flex"

--- a/packages/block-editor/src/components/inner-blocks/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/inner-blocks/test/__snapshots__/index.js.snap
@@ -9,7 +9,7 @@ exports[`InnerBlocks should force serialize for invalid block with inner blocks 
 `;
 
 exports[`InnerBlocks should return element as string, with inner blocks 1`] = `
-"<div>Bananas<!-- wp:fruit {\\"fruit\\":\\"Apples\\"} -->
+"<div>Bananas<!-- wp:fruit {"fruit":"Apples"} -->
 <div>Apples</div>
 <!-- /wp:fruit --></div>"
 `;

--- a/packages/block-editor/src/components/inserter/test/__snapshots__/index.native.js.snap
+++ b/packages/block-editor/src/components/inserter/test/__snapshots__/index.native.js.snap
@@ -2,21 +2,21 @@
 
 exports[`Inserter can add blocks adds new block at the end of post 1`] = `
 "<!-- wp:spacer -->
-<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
 <!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\"></h2>
+<h2 class="wp-block-heading"></h2>
 <!-- /wp:heading -->"
 `;
 
 exports[`Inserter can add blocks after another block 1`] = `
 "<!-- wp:spacer -->
-<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
 <!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\"></h2>
+<h2 class="wp-block-heading"></h2>
 <!-- /wp:heading -->
 
 <!-- wp:more -->
@@ -30,7 +30,7 @@ exports[`Inserter can add blocks after another block 1`] = `
 
 exports[`Inserter can add blocks before another block 1`] = `
 "<!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\"></h2>
+<h2 class="wp-block-heading"></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -40,11 +40,11 @@ exports[`Inserter can add blocks before another block 1`] = `
 
 exports[`Inserter can add blocks creates a new Paragraph block tapping on the empty area below the last block 1`] = `
 "<!-- wp:spacer -->
-<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
 <!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\"></h2>
+<h2 class="wp-block-heading"></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -54,7 +54,7 @@ exports[`Inserter can add blocks creates a new Paragraph block tapping on the em
 
 exports[`Inserter can add blocks inserts between 2 existing blocks 1`] = `
 "<!-- wp:spacer -->
-<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
 <!-- wp:more -->
@@ -62,17 +62,17 @@ exports[`Inserter can add blocks inserts between 2 existing blocks 1`] = `
 <!-- /wp:more -->
 
 <!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\"></h2>
+<h2 class="wp-block-heading"></h2>
 <!-- /wp:heading -->"
 `;
 
 exports[`Inserter can add blocks inserts block at the end of post when no block is selected 1`] = `
 "<!-- wp:spacer -->
-<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
 <!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\"></h2>
+<h2 class="wp-block-heading"></h2>
 <!-- /wp:heading -->
 
 <!-- wp:more -->
@@ -86,11 +86,11 @@ exports[`Inserter can add blocks to the beginning 1`] = `
 <!-- /wp:more -->
 
 <!-- wp:spacer -->
-<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
 <!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\"></h2>
+<h2 class="wp-block-heading"></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -100,11 +100,11 @@ exports[`Inserter can add blocks to the beginning 1`] = `
 
 exports[`Inserter can add blocks to the end 1`] = `
 "<!-- wp:spacer -->
-<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
 <!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\"></h2>
+<h2 class="wp-block-heading"></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->

--- a/packages/block-editor/src/hooks/test/__snapshots__/align.native.js.snap
+++ b/packages/block-editor/src/hooks/test/__snapshots__/align.native.js.snap
@@ -1,73 +1,73 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Align options for group block sets Full width option 1`] = `
-"<!-- wp:group {\\"align\\":\\"full\\",\\"layout\\":{\\"type\\":\\"constrained\\"}} -->
-<div class=\\"wp-block-group alignfull\\"></div>
+"<!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull"></div>
 <!-- /wp:group -->"
 `;
 
 exports[`Align options for group block sets None option 1`] = `
-"<!-- wp:group {\\"layout\\":{\\"type\\":\\"constrained\\"}} -->
-<div class=\\"wp-block-group\\"></div>
+"<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"></div>
 <!-- /wp:group -->"
 `;
 
 exports[`Align options for group block sets Wide width option 1`] = `
-"<!-- wp:group {\\"align\\":\\"wide\\",\\"layout\\":{\\"type\\":\\"constrained\\"}} -->
-<div class=\\"wp-block-group alignwide\\"></div>
+"<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide"></div>
 <!-- /wp:group -->"
 `;
 
 exports[`Align options for media block sets Align center option 1`] = `
-"<!-- wp:image {\\"align\\":\\"center\\",\\"id\\":1,\\"sizeSlug\\":\\"large\\",\\"linkDestination\\":\\"none\\"} -->
-<figure class=\\"wp-block-image aligncenter size-large\\"><img src=\\"https://test-site.files.wordpress.com/local-image-1.jpeg\\" alt=\\"\\" class=\\"wp-image-1\\"/></figure>
+"<!-- wp:image {"align":"center","id":1,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-large"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-1"/></figure>
 <!-- /wp:image -->"
 `;
 
 exports[`Align options for media block sets Align left option 1`] = `
-"<!-- wp:image {\\"align\\":\\"left\\",\\"id\\":1,\\"sizeSlug\\":\\"large\\",\\"linkDestination\\":\\"none\\"} -->
-<figure class=\\"wp-block-image alignleft size-large\\"><img src=\\"https://test-site.files.wordpress.com/local-image-1.jpeg\\" alt=\\"\\" class=\\"wp-image-1\\"/></figure>
+"<!-- wp:image {"align":"left","id":1,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image alignleft size-large"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-1"/></figure>
 <!-- /wp:image -->"
 `;
 
 exports[`Align options for media block sets Align right option 1`] = `
-"<!-- wp:image {\\"align\\":\\"right\\",\\"id\\":1,\\"sizeSlug\\":\\"large\\",\\"linkDestination\\":\\"none\\"} -->
-<figure class=\\"wp-block-image alignright size-large\\"><img src=\\"https://test-site.files.wordpress.com/local-image-1.jpeg\\" alt=\\"\\" class=\\"wp-image-1\\"/></figure>
+"<!-- wp:image {"align":"right","id":1,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image alignright size-large"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-1"/></figure>
 <!-- /wp:image -->"
 `;
 
 exports[`Align options for media block sets Full width option 1`] = `
-"<!-- wp:image {\\"align\\":\\"full\\",\\"id\\":1,\\"sizeSlug\\":\\"large\\",\\"linkDestination\\":\\"none\\"} -->
-<figure class=\\"wp-block-image alignfull size-large\\"><img src=\\"https://test-site.files.wordpress.com/local-image-1.jpeg\\" alt=\\"\\" class=\\"wp-image-1\\"/></figure>
+"<!-- wp:image {"align":"full","id":1,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image alignfull size-large"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-1"/></figure>
 <!-- /wp:image -->"
 `;
 
 exports[`Align options for media block sets None option 1`] = `
-"<!-- wp:image {\\"id\\":1,\\"sizeSlug\\":\\"large\\",\\"linkDestination\\":\\"none\\"} -->
-<figure class=\\"wp-block-image size-large\\"><img src=\\"https://test-site.files.wordpress.com/local-image-1.jpeg\\" alt=\\"\\" class=\\"wp-image-1\\"/></figure>
+"<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-1"/></figure>
 <!-- /wp:image -->"
 `;
 
 exports[`Align options for media block sets Wide width option 1`] = `
-"<!-- wp:image {\\"align\\":\\"wide\\",\\"id\\":1,\\"sizeSlug\\":\\"large\\",\\"linkDestination\\":\\"none\\"} -->
-<figure class=\\"wp-block-image alignwide size-large\\"><img src=\\"https://test-site.files.wordpress.com/local-image-1.jpeg\\" alt=\\"\\" class=\\"wp-image-1\\"/></figure>
+"<!-- wp:image {"align":"wide","id":1,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image alignwide size-large"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-1"/></figure>
 <!-- /wp:image -->"
 `;
 
 exports[`Align options for text block sets Align text center option 1`] = `
-"<!-- wp:paragraph {\\"align\\":\\"center\\"} -->
-<p class=\\"has-text-align-center\\"></p>
+"<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"></p>
 <!-- /wp:paragraph -->"
 `;
 
 exports[`Align options for text block sets Align text left option 1`] = `
-"<!-- wp:paragraph {\\"align\\":\\"left\\"} -->
-<p class=\\"has-text-align-left\\"></p>
+"<!-- wp:paragraph {"align":"left"} -->
+<p class="has-text-align-left"></p>
 <!-- /wp:paragraph -->"
 `;
 
 exports[`Align options for text block sets Align text right option 1`] = `
-"<!-- wp:paragraph {\\"align\\":\\"right\\"} -->
-<p class=\\"has-text-align-right\\"></p>
+"<!-- wp:paragraph {"align":"right"} -->
+<p class="has-text-align-right"></p>
 <!-- /wp:paragraph -->"
 `;

--- a/packages/block-library/src/audio/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/audio/test/__snapshots__/edit.native.js.snap
@@ -3,7 +3,7 @@
 exports[`Audio block renders audio block error state without crashing 1`] = `
 <View
   accessibilityState={
-    Object {
+    {
       "disabled": true,
     }
   }
@@ -20,7 +20,7 @@ exports[`Audio block renders audio block error state without crashing 1`] = `
   <View
     pointerEvents="box-none"
     style={
-      Array [
+      [
         undefined,
         undefined,
       ]
@@ -28,7 +28,7 @@ exports[`Audio block renders audio block error state without crashing 1`] = `
   >
     <View
       style={
-        Array [
+        [
           undefined,
           undefined,
           undefined,
@@ -37,7 +37,7 @@ exports[`Audio block renders audio block error state without crashing 1`] = `
     />
     <View
       accessibilityState={
-        Object {
+        {
           "disabled": true,
         }
       }
@@ -51,7 +51,7 @@ exports[`Audio block renders audio block error state without crashing 1`] = `
       onResponderTerminationRequest={[Function]}
       onStartShouldSetResponder={[Function]}
       style={
-        Object {
+        {
           "height": 44,
         }
       }
@@ -60,7 +60,7 @@ exports[`Audio block renders audio block error state without crashing 1`] = `
         Svg
       </View>
       <View
-        style={Object {}}
+        style={{}}
       >
         <Text>
           59IrU0WJtq
@@ -68,7 +68,7 @@ exports[`Audio block renders audio block error state without crashing 1`] = `
         <View>
           Svg
           <Text
-            style={Object {}}
+            style={{}}
           >
             Failed to insert audio file. Please tap for options.
           </Text>
@@ -78,8 +78,8 @@ exports[`Audio block renders audio block error state without crashing 1`] = `
   </View>
   <View
     style={
-      Array [
-        Object {
+      [
+        {
           "height": 44,
         },
         false,
@@ -91,7 +91,7 @@ exports[`Audio block renders audio block error state without crashing 1`] = `
       accessibilityRole="button"
       accessible={true}
       style={
-        Object {
+        {
           "display": "none",
           "flex": 1,
         }
@@ -99,7 +99,7 @@ exports[`Audio block renders audio block error state without crashing 1`] = `
     >
       <View
         style={
-          Array [
+          [
             undefined,
             undefined,
           ]
@@ -107,9 +107,9 @@ exports[`Audio block renders audio block error state without crashing 1`] = `
       >
         <RCTAztecView
           accessible={true}
-          activeFormats={Array []}
+          activeFormats={[]}
           blockType={
-            Object {
+            {
               "tag": "p",
             }
           }
@@ -140,14 +140,14 @@ exports[`Audio block renders audio block error state without crashing 1`] = `
           placeholder="Add caption"
           placeholderTextColor="gray"
           style={
-            Object {
+            {
               "backgroundColor": undefined,
               "maxWidth": undefined,
               "minHeight": 0,
             }
           }
           text={
-            Object {
+            {
               "eventCount": undefined,
               "linkTextColor": undefined,
               "selection": null,
@@ -156,7 +156,7 @@ exports[`Audio block renders audio block error state without crashing 1`] = `
             }
           }
           textAlign="center"
-          triggerKeyCodes={Array []}
+          triggerKeyCodes={[]}
         />
       </View>
     </View>
@@ -167,7 +167,7 @@ exports[`Audio block renders audio block error state without crashing 1`] = `
 exports[`Audio block renders audio file without crashing 1`] = `
 <View
   accessibilityState={
-    Object {
+    {
       "disabled": true,
     }
   }
@@ -184,7 +184,7 @@ exports[`Audio block renders audio file without crashing 1`] = `
   <View
     pointerEvents="box-none"
     style={
-      Array [
+      [
         undefined,
         undefined,
       ]
@@ -192,7 +192,7 @@ exports[`Audio block renders audio file without crashing 1`] = `
   >
     <View
       style={
-        Array [
+        [
           undefined,
           undefined,
           undefined,
@@ -201,7 +201,7 @@ exports[`Audio block renders audio file without crashing 1`] = `
     />
     <View
       accessibilityState={
-        Object {
+        {
           "disabled": true,
         }
       }
@@ -215,7 +215,7 @@ exports[`Audio block renders audio file without crashing 1`] = `
       onResponderTerminationRequest={[Function]}
       onStartShouldSetResponder={[Function]}
       style={
-        Object {
+        {
           "height": 44,
         }
       }
@@ -224,14 +224,14 @@ exports[`Audio block renders audio file without crashing 1`] = `
         Svg
       </View>
       <View
-        style={Object {}}
+        style={{}}
       >
         <Text>
           59IrU0WJtq
         </Text>
         <View>
           <Text
-            style={Object {}}
+            style={{}}
           >
             MP3 audio file
           </Text>
@@ -253,7 +253,7 @@ exports[`Audio block renders audio file without crashing 1`] = `
       >
         <Text
           style={
-            Object {
+            {
               "color": "white",
             }
           }
@@ -265,8 +265,8 @@ exports[`Audio block renders audio file without crashing 1`] = `
   </View>
   <View
     style={
-      Array [
-        Object {
+      [
+        {
           "height": 44,
         },
         false,
@@ -278,7 +278,7 @@ exports[`Audio block renders audio file without crashing 1`] = `
       accessibilityRole="button"
       accessible={true}
       style={
-        Object {
+        {
           "display": "none",
           "flex": 1,
         }
@@ -286,7 +286,7 @@ exports[`Audio block renders audio file without crashing 1`] = `
     >
       <View
         style={
-          Array [
+          [
             undefined,
             undefined,
           ]
@@ -294,9 +294,9 @@ exports[`Audio block renders audio file without crashing 1`] = `
       >
         <RCTAztecView
           accessible={true}
-          activeFormats={Array []}
+          activeFormats={[]}
           blockType={
-            Object {
+            {
               "tag": "p",
             }
           }
@@ -327,14 +327,14 @@ exports[`Audio block renders audio file without crashing 1`] = `
           placeholder="Add caption"
           placeholderTextColor="gray"
           style={
-            Object {
+            {
               "backgroundColor": undefined,
               "maxWidth": undefined,
               "minHeight": 0,
             }
           }
           text={
-            Object {
+            {
               "eventCount": undefined,
               "linkTextColor": undefined,
               "selection": null,
@@ -343,7 +343,7 @@ exports[`Audio block renders audio file without crashing 1`] = `
             }
           }
           textAlign="center"
-          triggerKeyCodes={Array []}
+          triggerKeyCodes={[]}
         />
       </View>
     </View>
@@ -355,7 +355,7 @@ exports[`Audio block renders placeholder without crashing 1`] = `
 <View>
   <View
     style={
-      Object {
+      {
         "flex": 1,
       }
     }
@@ -374,8 +374,8 @@ exports[`Audio block renders placeholder without crashing 1`] = `
       onResponderTerminationRequest={[Function]}
       onStartShouldSetResponder={[Function]}
       style={
-        Array [
-          Array [
+        [
+          [
             undefined,
             undefined,
             undefined,
@@ -386,13 +386,13 @@ exports[`Audio block renders placeholder without crashing 1`] = `
     >
       <View
         style={
-          Object {
+          {
             "fill": "gray",
           }
         }
       >
         <View
-          style={Object {}}
+          style={{}}
         >
           Svg
         </View>

--- a/packages/block-library/src/buttons/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/buttons/test/__snapshots__/edit.native.js.snap
@@ -1,26 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Buttons block justify content sets Justify items center option 1`] = `
-"<!-- wp:buttons {\\"layout\\":{\\"type\\":\\"flex\\",\\"justifyContent\\":\\"center\\"}} -->
-<div class=\\"wp-block-buttons\\"><!-- wp:button /--></div>
+"<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-buttons"><!-- wp:button /--></div>
 <!-- /wp:buttons -->"
 `;
 
 exports[`Buttons block justify content sets Justify items left option 1`] = `
-"<!-- wp:buttons {\\"layout\\":{\\"type\\":\\"flex\\",\\"justifyContent\\":\\"left\\"}} -->
-<div class=\\"wp-block-buttons\\"><!-- wp:button /--></div>
+"<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"left"}} -->
+<div class="wp-block-buttons"><!-- wp:button /--></div>
 <!-- /wp:buttons -->"
 `;
 
 exports[`Buttons block justify content sets Justify items right option 1`] = `
-"<!-- wp:buttons {\\"layout\\":{\\"type\\":\\"flex\\",\\"justifyContent\\":\\"right\\"}} -->
-<div class=\\"wp-block-buttons\\"><!-- wp:button /--></div>
+"<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"right"}} -->
+<div class="wp-block-buttons"><!-- wp:button /--></div>
 <!-- /wp:buttons -->"
 `;
 
 exports[`Buttons block when a button is shown adds another button using the inline appender 1`] = `
 "<!-- wp:buttons -->
-<div class=\\"wp-block-buttons\\"><!-- wp:button /-->
+<div class="wp-block-buttons"><!-- wp:button /-->
 
 <!-- wp:button /--></div>
 <!-- /wp:buttons -->
@@ -32,18 +32,18 @@ exports[`Buttons block when a button is shown adds another button using the inli
 
 exports[`Buttons block when a button is shown adds another button using the inserter 1`] = `
 "<!-- wp:buttons -->
-<div class=\\"wp-block-buttons\\"><!-- wp:button /-->
+<div class="wp-block-buttons"><!-- wp:button /-->
 
 <!-- wp:button -->
-<div class=\\"wp-block-button\\"><a class=\\"wp-block-button__link wp-element-button\\">Hello!</a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Hello!</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->"
 `;
 
 exports[`Buttons block when a button is shown adjusts the border radius 1`] = `
 "<!-- wp:buttons -->
-<div class=\\"wp-block-buttons\\"><!-- wp:button {\\"style\\":{\\"border\\":{\\"radius\\":\\"6px\\"}}} -->
-<div class=\\"wp-block-button\\"><a class=\\"wp-block-button__link wp-element-button\\" href=\\"\\" style=\\"border-radius:6px\\">Hello</a></div>
+<div class="wp-block-buttons"><!-- wp:button {"style":{"border":{"radius":"6px"}}} -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="" style="border-radius:6px">Hello</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->"
 `;

--- a/packages/block-library/src/code/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/code/test/__snapshots__/edit.native.js.snap
@@ -2,12 +2,12 @@
 
 exports[`Code renders given text without crashing 1`] = `
 "<!-- wp:code -->
-<pre class=\\"wp-block-code\\"><code>Sample text</code></pre>
+<pre class="wp-block-code"><code>Sample text</code></pre>
 <!-- /wp:code -->"
 `;
 
 exports[`Code renders without crashing 1`] = `
 "<!-- wp:code -->
-<pre class=\\"wp-block-code\\"><code></code></pre>
+<pre class="wp-block-code"><code></code></pre>
 <!-- /wp:code -->"
 `;

--- a/packages/block-library/src/columns/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/columns/test/__snapshots__/edit.native.js.snap
@@ -2,60 +2,60 @@
 
 exports[`Columns block adds a column block using the appender 1`] = `
 "<!-- wp:columns -->
-<div class=\\"wp-block-columns\\"><!-- wp:column -->
-<div class=\\"wp-block-column\\"></div>
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"></div>
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class=\\"wp-block-column\\"></div>
+<div class="wp-block-column"></div>
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class=\\"wp-block-column\\"></div>
+<div class="wp-block-column"></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->"
 `;
 
 exports[`Columns block changes the vertical alignment on individual Column 1`] = `
-"<!-- wp:columns {\\"verticalAlignment\\":\\"top\\"} -->
-<div class=\\"wp-block-columns are-vertically-aligned-top\\"><!-- wp:column {\\"verticalAlignment\\":\\"bottom\\"} -->
-<div class=\\"wp-block-column is-vertically-aligned-bottom\\"></div>
+"<!-- wp:columns {"verticalAlignment":"top"} -->
+<div class="wp-block-columns are-vertically-aligned-top"><!-- wp:column {"verticalAlignment":"bottom"} -->
+<div class="wp-block-column is-vertically-aligned-bottom"></div>
 <!-- /wp:column -->
 
-<!-- wp:column {\\"verticalAlignment\\":\\"top\\"} -->
-<div class=\\"wp-block-column is-vertically-aligned-top\\"></div>
+<!-- wp:column {"verticalAlignment":"top"} -->
+<div class="wp-block-column is-vertically-aligned-top"></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->"
 `;
 
 exports[`Columns block changes vertical alignment on Columns 1`] = `
-"<!-- wp:columns {\\"verticalAlignment\\":\\"top\\"} -->
-<div class=\\"wp-block-columns are-vertically-aligned-top\\"><!-- wp:column {\\"verticalAlignment\\":\\"top\\"} -->
-<div class=\\"wp-block-column is-vertically-aligned-top\\"></div>
+"<!-- wp:columns {"verticalAlignment":"top"} -->
+<div class="wp-block-columns are-vertically-aligned-top"><!-- wp:column {"verticalAlignment":"top"} -->
+<div class="wp-block-column is-vertically-aligned-top"></div>
 <!-- /wp:column -->
 
-<!-- wp:column {\\"verticalAlignment\\":\\"top\\"} -->
-<div class=\\"wp-block-column is-vertically-aligned-top\\"></div>
+<!-- wp:column {"verticalAlignment":"top"} -->
+<div class="wp-block-column is-vertically-aligned-top"></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->"
 `;
 
 exports[`Columns block inserts block 1`] = `
 "<!-- wp:columns -->
-<div class=\\"wp-block-columns\\"><!-- wp:column {\\"width\\":\\"50%\\"} -->
-<div class=\\"wp-block-column\\" style=\\"flex-basis:50%\\"></div>
+<div class="wp-block-columns"><!-- wp:column {"width":"50%"} -->
+<div class="wp-block-column" style="flex-basis:50%"></div>
 <!-- /wp:column -->
 
-<!-- wp:column {\\"width\\":\\"50%\\"} -->
-<div class=\\"wp-block-column\\" style=\\"flex-basis:50%\\"></div>
+<!-- wp:column {"width":"50%"} -->
+<div class="wp-block-column" style="flex-basis:50%"></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->"
 `;
 
 exports[`Columns block removes column with the remove button 1`] = `
 "<!-- wp:columns -->
-<div class=\\"wp-block-columns\\"><!-- wp:column -->
-<div class=\\"wp-block-column\\"></div>
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->"
 `;
@@ -67,153 +67,153 @@ exports[`Columns block removes the only one left Column with the remove button 1
 `;
 
 exports[`Columns block sets current vertical alignment on new Columns 1`] = `
-"<!-- wp:columns {\\"verticalAlignment\\":\\"top\\"} -->
-<div class=\\"wp-block-columns are-vertically-aligned-top\\"><!-- wp:column {\\"verticalAlignment\\":\\"top\\"} -->
-<div class=\\"wp-block-column is-vertically-aligned-top\\"></div>
+"<!-- wp:columns {"verticalAlignment":"top"} -->
+<div class="wp-block-columns are-vertically-aligned-top"><!-- wp:column {"verticalAlignment":"top"} -->
+<div class="wp-block-column is-vertically-aligned-top"></div>
 <!-- /wp:column -->
 
-<!-- wp:column {\\"verticalAlignment\\":\\"top\\"} -->
-<div class=\\"wp-block-column is-vertically-aligned-top\\"></div>
+<!-- wp:column {"verticalAlignment":"top"} -->
+<div class="wp-block-column is-vertically-aligned-top"></div>
 <!-- /wp:column -->
 
-<!-- wp:column {\\"verticalAlignment\\":\\"top\\"} -->
-<div class=\\"wp-block-column is-vertically-aligned-top\\"></div>
+<!-- wp:column {"verticalAlignment":"top"} -->
+<div class="wp-block-column is-vertically-aligned-top"></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->"
 `;
 
 exports[`Columns block when using columns percentage mechanism sets custom values correctly 1`] = `
 "<!-- wp:columns -->
-<div class=\\"wp-block-columns\\"><!-- wp:column {\\"width\\":\\"90%\\"} -->
-<div class=\\"wp-block-column\\" style=\\"flex-basis:90%\\"></div>
+<div class="wp-block-columns"><!-- wp:column {"width":"90%"} -->
+<div class="wp-block-column" style="flex-basis:90%"></div>
 <!-- /wp:column -->
 
-<!-- wp:column {\\"width\\":\\"55.5%\\"} -->
-<div class=\\"wp-block-column\\" style=\\"flex-basis:55.5%\\"></div>
+<!-- wp:column {"width":"55.5%"} -->
+<div class="wp-block-column" style="flex-basis:55.5%"></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->"
 `;
 
 exports[`Columns block when using columns percentage mechanism updates the slider's input value 1`] = `
 "<!-- wp:columns -->
-<div class=\\"wp-block-columns\\"><!-- wp:column {\\"width\\":\\"55.6%\\"} -->
-<div class=\\"wp-block-column\\" style=\\"flex-basis:55.6%\\"></div>
+<div class="wp-block-columns"><!-- wp:column {"width":"55.6%"} -->
+<div class="wp-block-column" style="flex-basis:55.6%"></div>
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class=\\"wp-block-column\\"></div>
+<div class="wp-block-column"></div>
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class=\\"wp-block-column\\"></div>
+<div class="wp-block-column"></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->"
 `;
 
 exports[`Columns block when using the columns layout picker sets the predefined percentages for 25 / 50 / 25 block 1`] = `
 "<!-- wp:columns -->
-<div class=\\"wp-block-columns\\"><!-- wp:column {\\"width\\":\\"25%\\"} -->
-<div class=\\"wp-block-column\\" style=\\"flex-basis:25%\\"></div>
+<div class="wp-block-columns"><!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"></div>
 <!-- /wp:column -->
 
-<!-- wp:column {\\"width\\":\\"50%\\"} -->
-<div class=\\"wp-block-column\\" style=\\"flex-basis:50%\\"></div>
+<!-- wp:column {"width":"50%"} -->
+<div class="wp-block-column" style="flex-basis:50%"></div>
 <!-- /wp:column -->
 
-<!-- wp:column {\\"width\\":\\"25%\\"} -->
-<div class=\\"wp-block-column\\" style=\\"flex-basis:25%\\"></div>
+<!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->"
 `;
 
 exports[`Columns block when using the columns layout picker sets the predefined percentages for 33 / 33 / 33 block 1`] = `
 "<!-- wp:columns -->
-<div class=\\"wp-block-columns\\"><!-- wp:column -->
-<div class=\\"wp-block-column\\"></div>
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"></div>
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class=\\"wp-block-column\\"></div>
+<div class="wp-block-column"></div>
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class=\\"wp-block-column\\"></div>
+<div class="wp-block-column"></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->"
 `;
 
 exports[`Columns block when using the columns layout picker sets the predefined percentages for 33 / 66 block 1`] = `
 "<!-- wp:columns -->
-<div class=\\"wp-block-columns\\"><!-- wp:column {\\"width\\":\\"33.33%\\"} -->
-<div class=\\"wp-block-column\\" style=\\"flex-basis:33.33%\\"></div>
+<div class="wp-block-columns"><!-- wp:column {"width":"33.33%"} -->
+<div class="wp-block-column" style="flex-basis:33.33%"></div>
 <!-- /wp:column -->
 
-<!-- wp:column {\\"width\\":\\"66.66%\\"} -->
-<div class=\\"wp-block-column\\" style=\\"flex-basis:66.66%\\"></div>
+<!-- wp:column {"width":"66.66%"} -->
+<div class="wp-block-column" style="flex-basis:66.66%"></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->"
 `;
 
 exports[`Columns block when using the columns layout picker sets the predefined percentages for 50 / 50 block 1`] = `
 "<!-- wp:columns -->
-<div class=\\"wp-block-columns\\"><!-- wp:column -->
-<div class=\\"wp-block-column\\"></div>
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"></div>
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class=\\"wp-block-column\\"></div>
+<div class="wp-block-column"></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->"
 `;
 
 exports[`Columns block when using the columns layout picker sets the predefined percentages for 66 / 33 block 1`] = `
 "<!-- wp:columns -->
-<div class=\\"wp-block-columns\\"><!-- wp:column {\\"width\\":\\"66.66%\\"} -->
-<div class=\\"wp-block-column\\" style=\\"flex-basis:66.66%\\"></div>
+<div class="wp-block-columns"><!-- wp:column {"width":"66.66%"} -->
+<div class="wp-block-column" style="flex-basis:66.66%"></div>
 <!-- /wp:column -->
 
-<!-- wp:column {\\"width\\":\\"33.33%\\"} -->
-<div class=\\"wp-block-column\\" style=\\"flex-basis:33.33%\\"></div>
+<!-- wp:column {"width":"33.33%"} -->
+<div class="wp-block-column" style="flex-basis:33.33%"></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->"
 `;
 
 exports[`Columns block when using the columns layout picker sets the predefined percentages for 100 block 1`] = `
 "<!-- wp:columns -->
-<div class=\\"wp-block-columns\\"><!-- wp:column -->
-<div class=\\"wp-block-column\\"></div>
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->"
 `;
 
 exports[`Columns block when using the number of columns setting adds a column block when incrementing the value 1`] = `
 "<!-- wp:columns -->
-<div class=\\"wp-block-columns\\"><!-- wp:column -->
-<div class=\\"wp-block-column\\"></div>
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"></div>
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class=\\"wp-block-column\\"></div>
+<div class="wp-block-column"></div>
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class=\\"wp-block-column\\"></div>
+<div class="wp-block-column"></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->"
 `;
 
 exports[`Columns block when using the number of columns setting reaches the minimum limit of number of column blocks 1`] = `
 "<!-- wp:columns -->
-<div class=\\"wp-block-columns\\"><!-- wp:column -->
-<div class=\\"wp-block-column\\"></div>
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->"
 `;
 
 exports[`Columns block when using the number of columns setting removes a column block when decrementing the value 1`] = `
 "<!-- wp:columns -->
-<div class=\\"wp-block-columns\\"><!-- wp:column -->
-<div class=\\"wp-block-column\\"></div>
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->"
 `;

--- a/packages/block-library/src/cover/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/cover/test/__snapshots__/edit.native.js.snap
@@ -1,97 +1,97 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`color settings clears the selected overlay color and mantains the inner blocks 1`] = `
-"<!-- wp:cover {\\"isDark\\":false} -->
-<div class=\\"wp-block-cover is-light\\"><span aria-hidden=\\"true\\" class=\\"wp-block-cover__background has-background-dim-100 has-background-dim\\"></span><div class=\\"wp-block-cover__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"center\\",\\"placeholder\\":\\"Write title…\\"} -->
-<p class=\\"has-text-align-center\\"></p>
+"<!-- wp:cover {"isDark":false} -->
+<div class="wp-block-cover is-light"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…"} -->
+<p class="has-text-align-center"></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->"
 `;
 
 exports[`color settings sets a color for the overlay background when the placeholder is visible 1`] = `
-"<!-- wp:cover {\\"overlayColor\\":\\"vivid-red\\"} -->
-<div class=\\"wp-block-cover\\"><span aria-hidden=\\"true\\" class=\\"wp-block-cover__background has-vivid-red-background-color has-background-dim-100 has-background-dim\\"></span><div class=\\"wp-block-cover__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"center\\",\\"placeholder\\":\\"Write title…\\"} -->
-<p class=\\"has-text-align-center\\"></p>
+"<!-- wp:cover {"overlayColor":"vivid-red"} -->
+<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-vivid-red-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…"} -->
+<p class="has-text-align-center"></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->"
 `;
 
 exports[`color settings sets a gradient overlay background when a solid background was already selected 1`] = `
-"<!-- wp:cover {\\"gradient\\":\\"light-green-cyan-to-vivid-green-cyan\\",\\"isDark\\":false} -->
-<div class=\\"wp-block-cover is-light\\"><span aria-hidden=\\"true\\" class=\\"wp-block-cover__background has-background-dim-100 has-background-dim has-background-gradient has-light-green-cyan-to-vivid-green-cyan-gradient-background\\"></span><div class=\\"wp-block-cover__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"center\\",\\"placeholder\\":\\"Write title…\\"} -->
-<p class=\\"has-text-align-center\\"></p>
+"<!-- wp:cover {"gradient":"light-green-cyan-to-vivid-green-cyan","isDark":false} -->
+<div class="wp-block-cover is-light"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim has-background-gradient has-light-green-cyan-to-vivid-green-cyan-gradient-background"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…"} -->
+<p class="has-text-align-center"></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->"
 `;
 
 exports[`color settings toggles between solid colors and gradients 1`] = `
-"<!-- wp:cover {\\"gradient\\":\\"light-green-cyan-to-vivid-green-cyan\\",\\"isDark\\":false} -->
-<div class=\\"wp-block-cover is-light\\"><span aria-hidden=\\"true\\" class=\\"wp-block-cover__background has-background-dim-100 has-background-dim has-background-gradient has-light-green-cyan-to-vivid-green-cyan-gradient-background\\"></span><div class=\\"wp-block-cover__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"center\\",\\"placeholder\\":\\"Write title…\\"} -->
-<p class=\\"has-text-align-center\\"></p>
+"<!-- wp:cover {"gradient":"light-green-cyan-to-vivid-green-cyan","isDark":false} -->
+<div class="wp-block-cover is-light"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim has-background-gradient has-light-green-cyan-to-vivid-green-cyan-gradient-background"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…"} -->
+<p class="has-text-align-center"></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->"
 `;
 
 exports[`minimum height settings changes the height value between units 1`] = `
-"<!-- wp:cover {\\"url\\":\\"https://cldup.com/cXyG__fTLN.jpg\\",\\"id\\":10710,\\"dimRatio\\":50,\\"overlayColor\\":\\"foreground\\",\\"minHeight\\":50,\\"minHeightUnit\\":\\"px\\",\\"isDark\\":false} -->
-<div class=\\"wp-block-cover is-light\\" style=\\"min-height:50px\\"><span aria-hidden=\\"true\\" class=\\"wp-block-cover__background has-foreground-background-color has-background-dim\\"></span><img class=\\"wp-block-cover__image-background wp-image-10710\\" alt=\\"\\" src=\\"https://cldup.com/cXyG__fTLN.jpg\\" data-object-fit=\\"cover\\"/><div class=\\"wp-block-cover__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"center\\",\\"placeholder\\":\\"Write title…\\",\\"fontSize\\":\\"large\\"} -->
-<p class=\\"has-text-align-center has-large-font-size\\"></p>
+"<!-- wp:cover {"url":"https://cldup.com/cXyG__fTLN.jpg","id":10710,"dimRatio":50,"overlayColor":"foreground","minHeight":50,"minHeightUnit":"px","isDark":false} -->
+<div class="wp-block-cover is-light" style="min-height:50px"><span aria-hidden="true" class="wp-block-cover__background has-foreground-background-color has-background-dim"></span><img class="wp-block-cover__image-background wp-image-10710" alt="" src="https://cldup.com/cXyG__fTLN.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+<p class="has-text-align-center has-large-font-size"></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->"
 `;
 
 exports[`minimum height settings changes the height value to 20(vw) 1`] = `
-"<!-- wp:cover {\\"url\\":\\"https://cldup.com/cXyG__fTLN.jpg\\",\\"id\\":10710,\\"dimRatio\\":50,\\"overlayColor\\":\\"foreground\\",\\"minHeight\\":20,\\"minHeightUnit\\":\\"vw\\",\\"isDark\\":false} -->
-<div class=\\"wp-block-cover is-light\\" style=\\"min-height:20vw\\"><span aria-hidden=\\"true\\" class=\\"wp-block-cover__background has-foreground-background-color has-background-dim\\"></span><img class=\\"wp-block-cover__image-background wp-image-10710\\" alt=\\"\\" src=\\"https://cldup.com/cXyG__fTLN.jpg\\" data-object-fit=\\"cover\\"/><div class=\\"wp-block-cover__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"center\\",\\"placeholder\\":\\"Write title…\\",\\"fontSize\\":\\"large\\"} -->
-<p class=\\"has-text-align-center has-large-font-size\\"></p>
+"<!-- wp:cover {"url":"https://cldup.com/cXyG__fTLN.jpg","id":10710,"dimRatio":50,"overlayColor":"foreground","minHeight":20,"minHeightUnit":"vw","isDark":false} -->
+<div class="wp-block-cover is-light" style="min-height:20vw"><span aria-hidden="true" class="wp-block-cover__background has-foreground-background-color has-background-dim"></span><img class="wp-block-cover__image-background wp-image-10710" alt="" src="https://cldup.com/cXyG__fTLN.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+<p class="has-text-align-center has-large-font-size"></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->"
 `;
 
 exports[`minimum height settings disables the decrease button when reaching the minimum value for Pixels (px) 1`] = `
-"<!-- wp:cover {\\"url\\":\\"https://cldup.com/cXyG__fTLN.jpg\\",\\"id\\":10710,\\"dimRatio\\":50,\\"overlayColor\\":\\"foreground\\",\\"minHeight\\":50,\\"minHeightUnit\\":\\"px\\",\\"isDark\\":false} -->
-<div class=\\"wp-block-cover is-light\\" style=\\"min-height:50px\\"><span aria-hidden=\\"true\\" class=\\"wp-block-cover__background has-foreground-background-color has-background-dim\\"></span><img class=\\"wp-block-cover__image-background wp-image-10710\\" alt=\\"\\" src=\\"https://cldup.com/cXyG__fTLN.jpg\\" data-object-fit=\\"cover\\"/><div class=\\"wp-block-cover__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"center\\",\\"placeholder\\":\\"Write title…\\",\\"fontSize\\":\\"large\\"} -->
-<p class=\\"has-text-align-center has-large-font-size\\"></p>
+"<!-- wp:cover {"url":"https://cldup.com/cXyG__fTLN.jpg","id":10710,"dimRatio":50,"overlayColor":"foreground","minHeight":50,"minHeightUnit":"px","isDark":false} -->
+<div class="wp-block-cover is-light" style="min-height:50px"><span aria-hidden="true" class="wp-block-cover__background has-foreground-background-color has-background-dim"></span><img class="wp-block-cover__image-background wp-image-10710" alt="" src="https://cldup.com/cXyG__fTLN.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+<p class="has-text-align-center has-large-font-size"></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->"
 `;
 
 exports[`minimum height settings disables the decrease button when reaching the minimum value for Relative to parent font size (em) 1`] = `
-"<!-- wp:cover {\\"url\\":\\"https://cldup.com/cXyG__fTLN.jpg\\",\\"id\\":10710,\\"dimRatio\\":50,\\"overlayColor\\":\\"foreground\\",\\"minHeight\\":1,\\"minHeightUnit\\":\\"em\\",\\"isDark\\":false} -->
-<div class=\\"wp-block-cover is-light\\" style=\\"min-height:1em\\"><span aria-hidden=\\"true\\" class=\\"wp-block-cover__background has-foreground-background-color has-background-dim\\"></span><img class=\\"wp-block-cover__image-background wp-image-10710\\" alt=\\"\\" src=\\"https://cldup.com/cXyG__fTLN.jpg\\" data-object-fit=\\"cover\\"/><div class=\\"wp-block-cover__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"center\\",\\"placeholder\\":\\"Write title…\\",\\"fontSize\\":\\"large\\"} -->
-<p class=\\"has-text-align-center has-large-font-size\\"></p>
+"<!-- wp:cover {"url":"https://cldup.com/cXyG__fTLN.jpg","id":10710,"dimRatio":50,"overlayColor":"foreground","minHeight":1,"minHeightUnit":"em","isDark":false} -->
+<div class="wp-block-cover is-light" style="min-height:1em"><span aria-hidden="true" class="wp-block-cover__background has-foreground-background-color has-background-dim"></span><img class="wp-block-cover__image-background wp-image-10710" alt="" src="https://cldup.com/cXyG__fTLN.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+<p class="has-text-align-center has-large-font-size"></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->"
 `;
 
 exports[`minimum height settings disables the decrease button when reaching the minimum value for Relative to root font size (rem) 1`] = `
-"<!-- wp:cover {\\"url\\":\\"https://cldup.com/cXyG__fTLN.jpg\\",\\"id\\":10710,\\"dimRatio\\":50,\\"overlayColor\\":\\"foreground\\",\\"minHeight\\":1,\\"minHeightUnit\\":\\"rem\\",\\"isDark\\":false} -->
-<div class=\\"wp-block-cover is-light\\" style=\\"min-height:1rem\\"><span aria-hidden=\\"true\\" class=\\"wp-block-cover__background has-foreground-background-color has-background-dim\\"></span><img class=\\"wp-block-cover__image-background wp-image-10710\\" alt=\\"\\" src=\\"https://cldup.com/cXyG__fTLN.jpg\\" data-object-fit=\\"cover\\"/><div class=\\"wp-block-cover__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"center\\",\\"placeholder\\":\\"Write title…\\",\\"fontSize\\":\\"large\\"} -->
-<p class=\\"has-text-align-center has-large-font-size\\"></p>
+"<!-- wp:cover {"url":"https://cldup.com/cXyG__fTLN.jpg","id":10710,"dimRatio":50,"overlayColor":"foreground","minHeight":1,"minHeightUnit":"rem","isDark":false} -->
+<div class="wp-block-cover is-light" style="min-height:1rem"><span aria-hidden="true" class="wp-block-cover__background has-foreground-background-color has-background-dim"></span><img class="wp-block-cover__image-background wp-image-10710" alt="" src="https://cldup.com/cXyG__fTLN.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+<p class="has-text-align-center has-large-font-size"></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->"
 `;
 
 exports[`minimum height settings disables the decrease button when reaching the minimum value for Viewport height (vh) 1`] = `
-"<!-- wp:cover {\\"url\\":\\"https://cldup.com/cXyG__fTLN.jpg\\",\\"id\\":10710,\\"dimRatio\\":50,\\"overlayColor\\":\\"foreground\\",\\"minHeight\\":1,\\"minHeightUnit\\":\\"vh\\",\\"isDark\\":false} -->
-<div class=\\"wp-block-cover is-light\\" style=\\"min-height:1vh\\"><span aria-hidden=\\"true\\" class=\\"wp-block-cover__background has-foreground-background-color has-background-dim\\"></span><img class=\\"wp-block-cover__image-background wp-image-10710\\" alt=\\"\\" src=\\"https://cldup.com/cXyG__fTLN.jpg\\" data-object-fit=\\"cover\\"/><div class=\\"wp-block-cover__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"center\\",\\"placeholder\\":\\"Write title…\\",\\"fontSize\\":\\"large\\"} -->
-<p class=\\"has-text-align-center has-large-font-size\\"></p>
+"<!-- wp:cover {"url":"https://cldup.com/cXyG__fTLN.jpg","id":10710,"dimRatio":50,"overlayColor":"foreground","minHeight":1,"minHeightUnit":"vh","isDark":false} -->
+<div class="wp-block-cover is-light" style="min-height:1vh"><span aria-hidden="true" class="wp-block-cover__background has-foreground-background-color has-background-dim"></span><img class="wp-block-cover__image-background wp-image-10710" alt="" src="https://cldup.com/cXyG__fTLN.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+<p class="has-text-align-center has-large-font-size"></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->"
 `;
 
 exports[`minimum height settings disables the decrease button when reaching the minimum value for Viewport width (vw) 1`] = `
-"<!-- wp:cover {\\"url\\":\\"https://cldup.com/cXyG__fTLN.jpg\\",\\"id\\":10710,\\"dimRatio\\":50,\\"overlayColor\\":\\"foreground\\",\\"minHeight\\":1,\\"minHeightUnit\\":\\"vw\\",\\"isDark\\":false} -->
-<div class=\\"wp-block-cover is-light\\" style=\\"min-height:1vw\\"><span aria-hidden=\\"true\\" class=\\"wp-block-cover__background has-foreground-background-color has-background-dim\\"></span><img class=\\"wp-block-cover__image-background wp-image-10710\\" alt=\\"\\" src=\\"https://cldup.com/cXyG__fTLN.jpg\\" data-object-fit=\\"cover\\"/><div class=\\"wp-block-cover__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"center\\",\\"placeholder\\":\\"Write title…\\",\\"fontSize\\":\\"large\\"} -->
-<p class=\\"has-text-align-center has-large-font-size\\"></p>
+"<!-- wp:cover {"url":"https://cldup.com/cXyG__fTLN.jpg","id":10710,"dimRatio":50,"overlayColor":"foreground","minHeight":1,"minHeightUnit":"vw","isDark":false} -->
+<div class="wp-block-cover is-light" style="min-height:1vw"><span aria-hidden="true" class="wp-block-cover__background has-foreground-background-color has-background-dim"></span><img class="wp-block-cover__image-background wp-image-10710" alt="" src="https://cldup.com/cXyG__fTLN.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+<p class="has-text-align-center has-large-font-size"></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->"
 `;
 
 exports[`when an image is attached updates background opacity 1`] = `
-"<!-- wp:cover {\\"url\\":\\"https://cldup.com/cXyG__fTLN.jpg\\",\\"id\\":10710,\\"dimRatio\\":15,\\"overlayColor\\":\\"foreground\\",\\"isDark\\":false} -->
-<div class=\\"wp-block-cover is-light\\"><span aria-hidden=\\"true\\" class=\\"wp-block-cover__background has-foreground-background-color has-background-dim-20 has-background-dim\\"></span><img class=\\"wp-block-cover__image-background wp-image-10710\\" alt=\\"\\" src=\\"https://cldup.com/cXyG__fTLN.jpg\\" data-object-fit=\\"cover\\"/><div class=\\"wp-block-cover__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"center\\",\\"placeholder\\":\\"Write title…\\",\\"fontSize\\":\\"large\\"} -->
-<p class=\\"has-text-align-center has-large-font-size\\"></p>
+"<!-- wp:cover {"url":"https://cldup.com/cXyG__fTLN.jpg","id":10710,"dimRatio":15,"overlayColor":"foreground","isDark":false} -->
+<div class="wp-block-cover is-light"><span aria-hidden="true" class="wp-block-cover__background has-foreground-background-color has-background-dim-20 has-background-dim"></span><img class="wp-block-cover__image-background wp-image-10710" alt="" src="https://cldup.com/cXyG__fTLN.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+<p class="has-text-align-center has-large-font-size"></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->"
 `;

--- a/packages/block-library/src/embed/test/__snapshots__/index.native.js.snap
+++ b/packages/block-library/src/embed/test/__snapshots__/index.native.js.snap
@@ -1,56 +1,56 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Embed block alignment options sets Align center option 1`] = `
-"<!-- wp:embed {\\"url\\":\\"https://twitter.com/notnownikki\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\",\\"responsive\\":true,\\"align\\":\\"center\\"} -->
-<figure class=\\"wp-block-embed aligncenter is-type-rich is-provider-twitter wp-block-embed-twitter\\"><div class=\\"wp-block-embed__wrapper\\">
+"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","responsive":true,"align":"center"} -->
+<figure class="wp-block-embed aligncenter is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/notnownikki
 </div></figure>
 <!-- /wp:embed -->"
 `;
 
 exports[`Embed block alignment options sets Align left option 1`] = `
-"<!-- wp:embed {\\"url\\":\\"https://twitter.com/notnownikki\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\",\\"responsive\\":true,\\"align\\":\\"left\\"} -->
-<figure class=\\"wp-block-embed alignleft is-type-rich is-provider-twitter wp-block-embed-twitter\\"><div class=\\"wp-block-embed__wrapper\\">
+"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","responsive":true,"align":"left"} -->
+<figure class="wp-block-embed alignleft is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/notnownikki
 </div></figure>
 <!-- /wp:embed -->"
 `;
 
 exports[`Embed block alignment options sets Align right option 1`] = `
-"<!-- wp:embed {\\"url\\":\\"https://twitter.com/notnownikki\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\",\\"responsive\\":true,\\"align\\":\\"right\\"} -->
-<figure class=\\"wp-block-embed alignright is-type-rich is-provider-twitter wp-block-embed-twitter\\"><div class=\\"wp-block-embed__wrapper\\">
+"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","responsive":true,"align":"right"} -->
+<figure class="wp-block-embed alignright is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/notnownikki
 </div></figure>
 <!-- /wp:embed -->"
 `;
 
 exports[`Embed block alignment options sets Full width option 1`] = `
-"<!-- wp:embed {\\"url\\":\\"https://twitter.com/notnownikki\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\",\\"responsive\\":true,\\"align\\":\\"full\\"} -->
-<figure class=\\"wp-block-embed alignfull is-type-rich is-provider-twitter wp-block-embed-twitter\\"><div class=\\"wp-block-embed__wrapper\\">
+"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","responsive":true,"align":"full"} -->
+<figure class="wp-block-embed alignfull is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/notnownikki
 </div></figure>
 <!-- /wp:embed -->"
 `;
 
 exports[`Embed block alignment options sets Wide width option 1`] = `
-"<!-- wp:embed {\\"url\\":\\"https://twitter.com/notnownikki\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\",\\"responsive\\":true,\\"align\\":\\"wide\\"} -->
-<figure class=\\"wp-block-embed alignwide is-type-rich is-provider-twitter wp-block-embed-twitter\\"><div class=\\"wp-block-embed__wrapper\\">
+"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","responsive":true,"align":"wide"} -->
+<figure class="wp-block-embed alignwide is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/notnownikki
 </div></figure>
 <!-- /wp:embed -->"
 `;
 
 exports[`Embed block block settings toggles resize for smaller devices media settings 1`] = `
-"<!-- wp:embed {\\"url\\":\\"https://twitter.com/notnownikki\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\",\\"allowResponsive\\":false,\\"responsive\\":true} -->
-<figure class=\\"wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter\\"><div class=\\"wp-block-embed__wrapper\\">
+"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","allowResponsive":false,"responsive":true} -->
+<figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/notnownikki
 </div></figure>
 <!-- /wp:embed -->"
 `;
 
 exports[`Embed block create by pasting URL creates embed block when pasting URL in paragraph block 1`] = `
-"<!-- wp:embed {\\"url\\":\\"https://www.youtube.com/watch?v=lXMskKTw3Bc\\",\\"type\\":\\"video\\",\\"providerNameSlug\\":\\"youtube\\",\\"responsive\\":true,\\"className\\":\\"wp-embed-aspect-16-9 wp-has-aspect-ratio\\"} -->
-<figure class=\\"wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio\\"><div class=\\"wp-block-embed__wrapper\\">
+"<!-- wp:embed {"url":"https://www.youtube.com/watch?v=lXMskKTw3Bc","type":"video","providerNameSlug":"youtube","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
 https://www.youtube.com/watch?v=lXMskKTw3Bc
 </div></figure>
 <!-- /wp:embed -->"
@@ -58,75 +58,75 @@ https://www.youtube.com/watch?v=lXMskKTw3Bc
 
 exports[`Embed block create by pasting URL creates link when pasting URL in paragraph block 1`] = `
 "<!-- wp:paragraph -->
-<p><a href=\\"https://www.youtube.com/watch?v=lXMskKTw3Bc\\">https://www.youtube.com/watch?v=lXMskKTw3Bc</a></p>
+<p><a href="https://www.youtube.com/watch?v=lXMskKTw3Bc">https://www.youtube.com/watch?v=lXMskKTw3Bc</a></p>
 <!-- /wp:paragraph -->"
 `;
 
 exports[`Embed block displays cannot embed on the placeholder if preview data is null 1`] = `
-"<!-- wp:embed {\\"url\\":\\"https://twitter.com/testing\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\",\\"responsive\\":true} -->
-<figure class=\\"wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter\\"><div class=\\"wp-block-embed__wrapper\\">
+"<!-- wp:embed {"url":"https://twitter.com/testing","type":"rich","providerNameSlug":"twitter","responsive":true} -->
+<figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/testing
 </div></figure>
 <!-- /wp:embed -->"
 `;
 
 exports[`Embed block edit URL edits URL when edited after setting a bad URL of a provider 1`] = `
-"<!-- wp:embed {\\"url\\":\\"https://twitter.com/notnownikki\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\",\\"responsive\\":true} -->
-<figure class=\\"wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter\\"><div class=\\"wp-block-embed__wrapper\\">
+"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","responsive":true} -->
+<figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/notnownikki
 </div></figure>
 <!-- /wp:embed -->"
 `;
 
 exports[`Embed block edit URL keeps the previous URL if an invalid URL is set 1`] = `
-"<!-- wp:embed {\\"url\\":\\"https://twitter.com/notnownikki\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\",\\"responsive\\":true} -->
-<figure class=\\"wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter\\"><div class=\\"wp-block-embed__wrapper\\">
+"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","responsive":true} -->
+<figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/notnownikki
 </div></figure>
 <!-- /wp:embed -->"
 `;
 
 exports[`Embed block edit URL keeps the previous URL if no URL is set 1`] = `
-"<!-- wp:embed {\\"url\\":\\"https://twitter.com/notnownikki\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\",\\"responsive\\":true} -->
-<figure class=\\"wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter\\"><div class=\\"wp-block-embed__wrapper\\">
+"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","responsive":true} -->
+<figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/notnownikki
 </div></figure>
 <!-- /wp:embed -->"
 `;
 
 exports[`Embed block edit URL replaces URL 1`] = `
-"<!-- wp:embed {\\"url\\":\\"https://www.youtube.com/watch?v=lXMskKTw3Bc\\",\\"type\\":\\"video\\",\\"providerNameSlug\\":\\"youtube\\",\\"responsive\\":true,\\"className\\":\\"wp-embed-aspect-16-9 wp-has-aspect-ratio\\"} -->
-<figure class=\\"wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio\\"><div class=\\"wp-block-embed__wrapper\\">
+"<!-- wp:embed {"url":"https://www.youtube.com/watch?v=lXMskKTw3Bc","type":"video","providerNameSlug":"youtube","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
 https://www.youtube.com/watch?v=lXMskKTw3Bc
 </div></figure>
 <!-- /wp:embed -->"
 `;
 
-exports[`Embed block edit URL sets empty state when setting an empty URL 1`] = `"<!-- wp:embed {\\"url\\":\\"\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\",\\"responsive\\":true} /-->"`;
+exports[`Embed block edit URL sets empty state when setting an empty URL 1`] = `"<!-- wp:embed {"url":"","type":"rich","providerNameSlug":"twitter","responsive":true} /-->"`;
 
 exports[`Embed block insert via slash inserter insert generic embed block 1`] = `"<!-- wp:embed /-->"`;
 
-exports[`Embed block insert via slash inserter inserts Twitter embed block 1`] = `"<!-- wp:embed {\\"providerNameSlug\\":\\"twitter\\",\\"responsive\\":true} /-->"`;
+exports[`Embed block insert via slash inserter inserts Twitter embed block 1`] = `"<!-- wp:embed {"providerNameSlug":"twitter","responsive":true} /-->"`;
 
-exports[`Embed block insert via slash inserter inserts Vimeo embed block 1`] = `"<!-- wp:embed {\\"providerNameSlug\\":\\"vimeo\\",\\"responsive\\":true} /-->"`;
+exports[`Embed block insert via slash inserter inserts Vimeo embed block 1`] = `"<!-- wp:embed {"providerNameSlug":"vimeo","responsive":true} /-->"`;
 
-exports[`Embed block insert via slash inserter inserts WordPress embed block 1`] = `"<!-- wp:embed {\\"providerNameSlug\\":\\"wordpress\\"} /-->"`;
+exports[`Embed block insert via slash inserter inserts WordPress embed block 1`] = `"<!-- wp:embed {"providerNameSlug":"wordpress"} /-->"`;
 
-exports[`Embed block insert via slash inserter inserts YouTube embed block 1`] = `"<!-- wp:embed {\\"providerNameSlug\\":\\"youtube\\",\\"responsive\\":true} /-->"`;
+exports[`Embed block insert via slash inserter inserts YouTube embed block 1`] = `"<!-- wp:embed {"providerNameSlug":"youtube","responsive":true} /-->"`;
 
-exports[`Embed block insertion inserts Twitter embed block 1`] = `"<!-- wp:embed {\\"providerNameSlug\\":\\"twitter\\",\\"responsive\\":true} /-->"`;
+exports[`Embed block insertion inserts Twitter embed block 1`] = `"<!-- wp:embed {"providerNameSlug":"twitter","responsive":true} /-->"`;
 
-exports[`Embed block insertion inserts Vimeo embed block 1`] = `"<!-- wp:embed {\\"providerNameSlug\\":\\"vimeo\\",\\"responsive\\":true} /-->"`;
+exports[`Embed block insertion inserts Vimeo embed block 1`] = `"<!-- wp:embed {"providerNameSlug":"vimeo","responsive":true} /-->"`;
 
-exports[`Embed block insertion inserts WordPress embed block 1`] = `"<!-- wp:embed {\\"providerNameSlug\\":\\"wordpress\\"} /-->"`;
+exports[`Embed block insertion inserts WordPress embed block 1`] = `"<!-- wp:embed {"providerNameSlug":"wordpress"} /-->"`;
 
-exports[`Embed block insertion inserts YouTube embed block 1`] = `"<!-- wp:embed {\\"providerNameSlug\\":\\"youtube\\",\\"responsive\\":true} /-->"`;
+exports[`Embed block insertion inserts YouTube embed block 1`] = `"<!-- wp:embed {"providerNameSlug":"youtube","responsive":true} /-->"`;
 
 exports[`Embed block insertion inserts generic embed block 1`] = `"<!-- wp:embed /-->"`;
 
 exports[`Embed block retry allows editing link if request failed 1`] = `
-"<!-- wp:embed {\\"url\\":\\"https://twitter.com/notnownikki\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\"} -->
-<figure class=\\"wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter\\"><div class=\\"wp-block-embed__wrapper\\">
+"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter"} -->
+<figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/notnownikki
 </div></figure>
 <!-- /wp:embed -->"
@@ -134,58 +134,58 @@ https://twitter.com/notnownikki
 
 exports[`Embed block retry converts to link if preview request failed 1`] = `
 "<!-- wp:paragraph -->
-<p><a href=\\"https://twitter.com/notnownikki\\">https://twitter.com/notnownikki</a></p>
+<p><a href="https://twitter.com/notnownikki">https://twitter.com/notnownikki</a></p>
 <!-- /wp:paragraph -->"
 `;
 
 exports[`Embed block retry retries loading the preview if initial request failed 1`] = `
-"<!-- wp:embed {\\"url\\":\\"https://twitter.com/notnownikki\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\",\\"responsive\\":true} -->
-<figure class=\\"wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter\\"><div class=\\"wp-block-embed__wrapper\\">
+"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","responsive":true} -->
+<figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/notnownikki
 </div></figure>
 <!-- /wp:embed -->"
 `;
 
 exports[`Embed block set URL upon block insertion auto-pastes the URL from clipboard 1`] = `
-"<!-- wp:embed {\\"url\\":\\"https://twitter.com/notnownikki\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\",\\"responsive\\":true} -->
-<figure class=\\"wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter\\"><div class=\\"wp-block-embed__wrapper\\">
+"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","responsive":true} -->
+<figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/notnownikki
 </div></figure>
 <!-- /wp:embed -->"
 `;
 
 exports[`Embed block set URL upon block insertion sets a valid URL when dismissing edit URL modal 1`] = `
-"<!-- wp:embed {\\"url\\":\\"https://twitter.com/notnownikki\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\",\\"responsive\\":true} -->
-<figure class=\\"wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter\\"><div class=\\"wp-block-embed__wrapper\\">
+"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","responsive":true} -->
+<figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/notnownikki
 </div></figure>
 <!-- /wp:embed -->"
 `;
 
-exports[`Embed block set URL upon block insertion sets empty URL when dismissing edit URL modal 1`] = `"<!-- wp:embed {\\"url\\":\\"\\"} /-->"`;
+exports[`Embed block set URL upon block insertion sets empty URL when dismissing edit URL modal 1`] = `"<!-- wp:embed {"url":""} /-->"`;
 
 exports[`Embed block set URL when empty block auto-pastes the URL from clipboard 1`] = `
-"<!-- wp:embed {\\"url\\":\\"https://twitter.com/notnownikki\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\",\\"responsive\\":true} -->
-<figure class=\\"wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter\\"><div class=\\"wp-block-embed__wrapper\\">
+"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","responsive":true} -->
+<figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/notnownikki
 </div></figure>
 <!-- /wp:embed -->"
 `;
 
 exports[`Embed block set URL when empty block sets a valid URL when dismissing edit URL modal 1`] = `
-"<!-- wp:embed {\\"url\\":\\"https://twitter.com/notnownikki\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\",\\"responsive\\":true} -->
-<figure class=\\"wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter\\"><div class=\\"wp-block-embed__wrapper\\">
+"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","responsive":true} -->
+<figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/notnownikki
 </div></figure>
 <!-- /wp:embed -->"
 `;
 
-exports[`Embed block set URL when empty block sets empty URL when dismissing edit URL modal 1`] = `"<!-- wp:embed {\\"url\\":\\"\\"} /-->"`;
+exports[`Embed block set URL when empty block sets empty URL when dismissing edit URL modal 1`] = `"<!-- wp:embed {"url":""} /-->"`;
 
 exports[`Embed block sets block caption 1`] = `
-"<!-- wp:embed {\\"url\\":\\"https://twitter.com/notnownikki\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\",\\"responsive\\":true} -->
-<figure class=\\"wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter\\"><div class=\\"wp-block-embed__wrapper\\">
+"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","responsive":true} -->
+<figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/notnownikki
-</div><figcaption class=\\"wp-element-caption\\">Caption</figcaption></figure>
+</div><figcaption class="wp-element-caption">Caption</figcaption></figure>
 <!-- /wp:embed -->"
 `;

--- a/packages/block-library/src/file/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/file/test/__snapshots__/edit.native.js.snap
@@ -4,7 +4,7 @@ exports[`File block renders file error state without crashing 1`] = `
 <View
   pointerEvents="box-none"
   style={
-    Array [
+    [
       undefined,
       undefined,
     ]
@@ -12,7 +12,7 @@ exports[`File block renders file error state without crashing 1`] = `
 >
   <View
     style={
-      Array [
+      [
         undefined,
         undefined,
         undefined,
@@ -21,7 +21,7 @@ exports[`File block renders file error state without crashing 1`] = `
   />
   <View
     accessibilityState={
-      Object {
+      {
         "disabled": false,
       }
     }
@@ -40,21 +40,21 @@ exports[`File block renders file error state without crashing 1`] = `
     <Text
       onTextLayout={[Function]}
       style={
-        Object {
+        {
           "color": "gray",
         }
       }
     />
     <View
       style={
-        Object {
+        {
           "height": 44,
         }
       }
     >
       <View
         style={
-          Array [
+          [
             undefined,
             undefined,
           ]
@@ -62,9 +62,9 @@ exports[`File block renders file error state without crashing 1`] = `
       >
         <RCTAztecView
           accessible={true}
-          activeFormats={Array []}
+          activeFormats={[]}
           blockType={
-            Object {
+            {
               "tag": "p",
             }
           }
@@ -95,14 +95,14 @@ exports[`File block renders file error state without crashing 1`] = `
           placeholder="File name"
           placeholderTextColor="gray"
           style={
-            Object {
+            {
               "backgroundColor": undefined,
               "maxWidth": undefined,
               "minHeight": 0,
             }
           }
           text={
-            Object {
+            {
               "eventCount": undefined,
               "linkTextColor": undefined,
               "selection": null,
@@ -111,7 +111,7 @@ exports[`File block renders file error state without crashing 1`] = `
             }
           }
           textAlign="left"
-          triggerKeyCodes={Array []}
+          triggerKeyCodes={[]}
         />
       </View>
       <View>
@@ -122,8 +122,8 @@ exports[`File block renders file error state without crashing 1`] = `
           onChange={[Function]}
           scrollEnabled={false}
           style={
-            Array [
-              Object {
+            [
+              {
                 "fontFamily": "serif",
               },
               undefined,
@@ -135,15 +135,15 @@ exports[`File block renders file error state without crashing 1`] = `
     </View>
     <View
       style={
-        Array [
-          Array [
-            Object {
+        [
+          [
+            {
               "paddingLeft": 10,
               "paddingRight": 10,
             },
             undefined,
           ],
-          Object {
+          {
             "alignSelf": "flex-start",
           },
         ]
@@ -151,7 +151,7 @@ exports[`File block renders file error state without crashing 1`] = `
     >
       <View
         style={
-          Array [
+          [
             undefined,
             undefined,
           ]
@@ -159,9 +159,9 @@ exports[`File block renders file error state without crashing 1`] = `
       >
         <RCTAztecView
           accessible={true}
-          activeFormats={Array []}
+          activeFormats={[]}
           blockType={
-            Object {
+            {
               "tag": "p",
             }
           }
@@ -195,7 +195,7 @@ exports[`File block renders file error state without crashing 1`] = `
           placeholderTextColor="white"
           selectionColor="white"
           style={
-            Object {
+            {
               "backgroundColor": undefined,
               "color": "white",
               "maxWidth": 80,
@@ -203,7 +203,7 @@ exports[`File block renders file error state without crashing 1`] = `
             }
           }
           text={
-            Object {
+            {
               "eventCount": undefined,
               "linkTextColor": undefined,
               "selection": null,
@@ -212,7 +212,7 @@ exports[`File block renders file error state without crashing 1`] = `
             }
           }
           textAlign="center"
-          triggerKeyCodes={Array []}
+          triggerKeyCodes={[]}
         />
       </View>
     </View>
@@ -224,7 +224,7 @@ exports[`File block renders file without crashing 1`] = `
 <View
   pointerEvents="box-none"
   style={
-    Array [
+    [
       undefined,
       undefined,
     ]
@@ -232,7 +232,7 @@ exports[`File block renders file without crashing 1`] = `
 >
   <View
     style={
-      Array [
+      [
         undefined,
         undefined,
         undefined,
@@ -241,7 +241,7 @@ exports[`File block renders file without crashing 1`] = `
   />
   <View
     accessibilityState={
-      Object {
+      {
         "disabled": false,
       }
     }
@@ -260,21 +260,21 @@ exports[`File block renders file without crashing 1`] = `
     <Text
       onTextLayout={[Function]}
       style={
-        Object {
+        {
           "color": "gray",
         }
       }
     />
     <View
       style={
-        Object {
+        {
           "height": 44,
         }
       }
     >
       <View
         style={
-          Array [
+          [
             undefined,
             undefined,
           ]
@@ -282,9 +282,9 @@ exports[`File block renders file without crashing 1`] = `
       >
         <RCTAztecView
           accessible={true}
-          activeFormats={Array []}
+          activeFormats={[]}
           blockType={
-            Object {
+            {
               "tag": "p",
             }
           }
@@ -315,14 +315,14 @@ exports[`File block renders file without crashing 1`] = `
           placeholder="File name"
           placeholderTextColor="gray"
           style={
-            Object {
+            {
               "backgroundColor": undefined,
               "maxWidth": undefined,
               "minHeight": 0,
             }
           }
           text={
-            Object {
+            {
               "eventCount": undefined,
               "linkTextColor": undefined,
               "selection": null,
@@ -331,21 +331,21 @@ exports[`File block renders file without crashing 1`] = `
             }
           }
           textAlign="left"
-          triggerKeyCodes={Array []}
+          triggerKeyCodes={[]}
         />
       </View>
     </View>
     <View
       style={
-        Array [
-          Array [
-            Object {
+        [
+          [
+            {
               "paddingLeft": 10,
               "paddingRight": 10,
             },
             false,
           ],
-          Object {
+          {
             "alignSelf": "flex-start",
           },
         ]
@@ -353,7 +353,7 @@ exports[`File block renders file without crashing 1`] = `
     >
       <View
         style={
-          Array [
+          [
             undefined,
             undefined,
           ]
@@ -361,9 +361,9 @@ exports[`File block renders file without crashing 1`] = `
       >
         <RCTAztecView
           accessible={true}
-          activeFormats={Array []}
+          activeFormats={[]}
           blockType={
-            Object {
+            {
               "tag": "p",
             }
           }
@@ -397,7 +397,7 @@ exports[`File block renders file without crashing 1`] = `
           placeholderTextColor="white"
           selectionColor="white"
           style={
-            Object {
+            {
               "backgroundColor": undefined,
               "color": "white",
               "maxWidth": 80,
@@ -405,7 +405,7 @@ exports[`File block renders file without crashing 1`] = `
             }
           }
           text={
-            Object {
+            {
               "eventCount": undefined,
               "linkTextColor": undefined,
               "selection": null,
@@ -414,7 +414,7 @@ exports[`File block renders file without crashing 1`] = `
             }
           }
           textAlign="center"
-          triggerKeyCodes={Array []}
+          triggerKeyCodes={[]}
         />
       </View>
     </View>
@@ -425,7 +425,7 @@ exports[`File block renders file without crashing 1`] = `
 exports[`File block renders placeholder without crashing 1`] = `
 <View
   style={
-    Object {
+    {
       "flex": 1,
     }
   }
@@ -444,8 +444,8 @@ exports[`File block renders placeholder without crashing 1`] = `
     onResponderTerminationRequest={[Function]}
     onStartShouldSetResponder={[Function]}
     style={
-      Array [
-        Array [
+      [
+        [
           undefined,
           undefined,
           undefined,
@@ -456,13 +456,13 @@ exports[`File block renders placeholder without crashing 1`] = `
   >
     <View
       style={
-        Object {
+        {
           "fill": "gray",
         }
       }
     >
       <View
-        style={Object {}}
+        style={{}}
       >
         Svg
       </View>

--- a/packages/block-library/src/gallery/test/__snapshots__/index.native.js.snap
+++ b/packages/block-library/src/gallery/test/__snapshots__/index.native.js.snap
@@ -1,171 +1,171 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Gallery block Columns setting decrements columns 1`] = `
-"<!-- wp:gallery {\\"columns\\":2,\\"linkTo\\":\\"none\\"} -->
-<figure class=\\"wp-block-gallery has-nested-images columns-2 is-cropped\\"><!-- wp:image {\\"id\\":2000} -->
-<figure class=\\"wp-block-image\\"><img src=\\"https://test-site.files.wordpress.com/local-image-1.jpeg\\" alt=\\"\\" class=\\"wp-image-2000\\"/></figure>
+"<!-- wp:gallery {"columns":2,"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-2 is-cropped"><!-- wp:image {"id":2000} -->
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {\\"id\\":2001} -->
-<figure class=\\"wp-block-image\\"><img src=\\"https://test-site.files.wordpress.com/local-image-2.jpeg\\" alt=\\"\\" class=\\"wp-image-2001\\"/></figure>
+<!-- wp:image {"id":2001} -->
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-2.jpeg" alt="" class="wp-image-2001"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {\\"id\\":2002} -->
-<figure class=\\"wp-block-image\\"><img src=\\"https://test-site.files.wordpress.com/local-image-3.jpeg\\" alt=\\"\\" class=\\"wp-image-2002\\"/></figure>
+<!-- wp:image {"id":2002} -->
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-3.jpeg" alt="" class="wp-image-2002"/></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
 
 exports[`Gallery block Columns setting does not increment due to maximum value 1`] = `
-"<!-- wp:gallery {\\"linkTo\\":\\"none\\"} -->
-<figure class=\\"wp-block-gallery has-nested-images columns-default is-cropped\\"><!-- wp:image {\\"id\\":2000} -->
-<figure class=\\"wp-block-image\\"><img src=\\"https://test-site.files.wordpress.com/local-image-1.jpeg\\" alt=\\"\\" class=\\"wp-image-2000\\"/></figure>
+"<!-- wp:gallery {"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":2000} -->
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {\\"id\\":2001} -->
-<figure class=\\"wp-block-image\\"><img src=\\"https://test-site.files.wordpress.com/local-image-2.jpeg\\" alt=\\"\\" class=\\"wp-image-2001\\"/></figure>
+<!-- wp:image {"id":2001} -->
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-2.jpeg" alt="" class="wp-image-2001"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {\\"id\\":2002} -->
-<figure class=\\"wp-block-image\\"><img src=\\"https://test-site.files.wordpress.com/local-image-3.jpeg\\" alt=\\"\\" class=\\"wp-image-2002\\"/></figure>
+<!-- wp:image {"id":2002} -->
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-3.jpeg" alt="" class="wp-image-2002"/></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
 
 exports[`Gallery block cancels uploads 1`] = `
-"<!-- wp:gallery {\\"linkTo\\":\\"none\\"} -->
-<figure class=\\"wp-block-gallery has-nested-images columns-default is-cropped\\"><!-- wp:image {\\"id\\":null} -->
-<figure class=\\"wp-block-image\\"><img alt=\\"\\"/></figure>
+"<!-- wp:gallery {"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":null} -->
+<figure class="wp-block-image"><img alt=""/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {\\"id\\":null} -->
-<figure class=\\"wp-block-image\\"><img alt=\\"\\"/></figure>
+<!-- wp:image {"id":null} -->
+<figure class="wp-block-image"><img alt=""/></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
 
 exports[`Gallery block disables crop images setting 1`] = `
-"<!-- wp:gallery {\\"imageCrop\\":false,\\"linkTo\\":\\"none\\"} -->
-<figure class=\\"wp-block-gallery has-nested-images columns-default\\"><!-- wp:image {\\"id\\":2000} -->
-<figure class=\\"wp-block-image\\"><img src=\\"https://test-site.files.wordpress.com/local-image-1.jpeg\\" alt=\\"\\" class=\\"wp-image-2000\\"/></figure>
+"<!-- wp:gallery {"imageCrop":false,"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-default"><!-- wp:image {"id":2000} -->
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
 
 exports[`Gallery block finishes pending uploads upon opening the editor 1`] = `
-"<!-- wp:gallery {\\"linkTo\\":\\"none\\"} -->
-<figure class=\\"wp-block-gallery has-nested-images columns-default is-cropped\\"><!-- wp:image {\\"id\\":2000} -->
-<figure class=\\"wp-block-image\\"><img src=\\"https://test-site.files.wordpress.com/local-image-1.jpeg\\" alt=\\"\\" class=\\"wp-image-2000\\"/></figure>
+"<!-- wp:gallery {"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":2000} -->
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {\\"id\\":2001} -->
-<figure class=\\"wp-block-image\\"><img src=\\"https://test-site.files.wordpress.com/local-image-2.jpeg\\" alt=\\"\\" class=\\"wp-image-2001\\"/></figure>
+<!-- wp:image {"id":2001} -->
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-2.jpeg" alt="" class="wp-image-2001"/></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
 
 exports[`Gallery block handles failed uploads 1`] = `
-"<!-- wp:gallery {\\"linkTo\\":\\"none\\"} -->
-<figure class=\\"wp-block-gallery has-nested-images columns-default is-cropped\\"><!-- wp:image {\\"id\\":1} -->
-<figure class=\\"wp-block-image\\"><img src=\\"file:///local-image-1.jpeg\\" alt=\\"\\" class=\\"wp-image-1\\"/></figure>
+"<!-- wp:gallery {"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":1} -->
+<figure class="wp-block-image"><img src="file:///local-image-1.jpeg" alt="" class="wp-image-1"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {\\"id\\":2} -->
-<figure class=\\"wp-block-image\\"><img src=\\"file:///local-image-2.jpeg\\" alt=\\"\\" class=\\"wp-image-2\\"/></figure>
+<!-- wp:image {"id":2} -->
+<figure class="wp-block-image"><img src="file:///local-image-2.jpeg" alt="" class="wp-image-2"/></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
 
 exports[`Gallery block inserts block 1`] = `
-"<!-- wp:gallery {\\"linkTo\\":\\"none\\"} -->
-<figure class=\\"wp-block-gallery has-nested-images columns-default is-cropped\\"></figure>
+"<!-- wp:gallery {"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"></figure>
 <!-- /wp:gallery -->"
 `;
 
 exports[`Gallery block overrides "Link to" setting of gallery items 1`] = `
-"<!-- wp:gallery {\\"linkTo\\":\\"media\\"} -->
-<figure class=\\"wp-block-gallery has-nested-images columns-default is-cropped\\"><!-- wp:image {\\"id\\":1,\\"linkDestination\\":\\"media\\"} -->
-<figure class=\\"wp-block-image\\"><img src=\\"file:///local-image-1.jpeg\\" alt=\\"\\" class=\\"wp-image-1\\"/></figure>
+"<!-- wp:gallery {"linkTo":"media"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":1,"linkDestination":"media"} -->
+<figure class="wp-block-image"><img src="file:///local-image-1.jpeg" alt="" class="wp-image-1"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {\\"id\\":2,\\"linkDestination\\":\\"media\\"} -->
-<figure class=\\"wp-block-image\\"><img src=\\"file:///local-image-2.jpeg\\" alt=\\"\\" class=\\"wp-image-2\\"/></figure>
+<!-- wp:image {"id":2,"linkDestination":"media"} -->
+<figure class="wp-block-image"><img src="file:///local-image-2.jpeg" alt="" class="wp-image-2"/></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
 
 exports[`Gallery block rearranges gallery items 1`] = `
-"<!-- wp:gallery {\\"linkTo\\":\\"none\\"} -->
-<figure class=\\"wp-block-gallery has-nested-images columns-default is-cropped\\"><!-- wp:image {\\"id\\":2002} -->
-<figure class=\\"wp-block-image\\"><img src=\\"https://test-site.files.wordpress.com/local-image-3.jpeg\\" alt=\\"\\" class=\\"wp-image-2002\\"/></figure>
+"<!-- wp:gallery {"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":2002} -->
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-3.jpeg" alt="" class="wp-image-2002"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {\\"id\\":2000} -->
-<figure class=\\"wp-block-image\\"><img src=\\"https://test-site.files.wordpress.com/local-image-1.jpeg\\" alt=\\"\\" class=\\"wp-image-2000\\"/></figure>
+<!-- wp:image {"id":2000} -->
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {\\"id\\":2001} -->
-<figure class=\\"wp-block-image\\"><img src=\\"https://test-site.files.wordpress.com/local-image-2.jpeg\\" alt=\\"\\" class=\\"wp-image-2001\\"/></figure>
+<!-- wp:image {"id":2001} -->
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-2.jpeg" alt="" class="wp-image-2001"/></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
 
 exports[`Gallery block sets caption to gallery 1`] = `
-"<!-- wp:gallery {\\"linkTo\\":\\"none\\"} -->
-<figure class=\\"wp-block-gallery has-nested-images columns-default is-cropped\\"><!-- wp:image {\\"id\\":2000} -->
-<figure class=\\"wp-block-image\\"><img src=\\"https://test-site.files.wordpress.com/local-image-1.jpeg\\" alt=\\"\\" class=\\"wp-image-2000\\"/></figure>
-<!-- /wp:image --><figcaption class=\\"blocks-gallery-caption wp-element-caption\\"><strong>Bold</strong> <em>italic</em> <s>strikethrough</s> gallery caption</figcaption></figure>
+"<!-- wp:gallery {"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":2000} -->
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/></figure>
+<!-- /wp:image --><figcaption class="blocks-gallery-caption wp-element-caption"><strong>Bold</strong> <em>italic</em> <s>strikethrough</s> gallery caption</figcaption></figure>
 <!-- /wp:gallery -->"
 `;
 
 exports[`Gallery block sets caption to gallery items 1`] = `
-"<!-- wp:gallery {\\"linkTo\\":\\"none\\"} -->
-<figure class=\\"wp-block-gallery has-nested-images columns-default is-cropped\\"><!-- wp:image {\\"id\\":2000} -->
-<figure class=\\"wp-block-image\\"><img src=\\"https://test-site.files.wordpress.com/local-image-1.jpeg\\" alt=\\"\\" class=\\"wp-image-2000\\"/><figcaption class=\\"wp-element-caption\\"><strong>Bold</strong> <em>italic</em> <s>strikethrough</s> image caption</figcaption></figure>
+"<!-- wp:gallery {"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":2000} -->
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/><figcaption class="wp-element-caption"><strong>Bold</strong> <em>italic</em> <s>strikethrough</s> image caption</figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
 
 exports[`Gallery block successfully uploads items 1`] = `
-"<!-- wp:gallery {\\"linkTo\\":\\"none\\"} -->
-<figure class=\\"wp-block-gallery has-nested-images columns-default is-cropped\\"><!-- wp:image {\\"id\\":2000} -->
-<figure class=\\"wp-block-image\\"><img src=\\"https://test-site.files.wordpress.com/local-image-1.jpeg\\" alt=\\"\\" class=\\"wp-image-2000\\"/></figure>
+"<!-- wp:gallery {"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":2000} -->
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {\\"id\\":2001} -->
-<figure class=\\"wp-block-image\\"><img src=\\"https://test-site.files.wordpress.com/local-image-2.jpeg\\" alt=\\"\\" class=\\"wp-image-2001\\"/></figure>
+<!-- wp:image {"id":2001} -->
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-2.jpeg" alt="" class="wp-image-2001"/></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
 
 exports[`Gallery block takes a photo 1`] = `
-"<!-- wp:gallery {\\"linkTo\\":\\"none\\"} -->
-<figure class=\\"wp-block-gallery has-nested-images columns-default is-cropped\\"><!-- wp:image {\\"id\\":2000} -->
-<figure class=\\"wp-block-image\\"><img src=\\"https://test-site.files.wordpress.com/local-image-1.jpeg\\" alt=\\"\\" class=\\"wp-image-2000\\"/></figure>
+"<!-- wp:gallery {"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":2000} -->
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
 
 exports[`Gallery block uploads from free photo library 1`] = `
-"<!-- wp:gallery {\\"linkTo\\":\\"none\\"} -->
-<figure class=\\"wp-block-gallery has-nested-images columns-default is-cropped\\"><!-- wp:image {\\"id\\":2000} -->
-<figure class=\\"wp-block-image\\"><img src=\\"https://test-site.files.wordpress.com/local-image-1.jpeg\\" alt=\\"\\" class=\\"wp-image-2000\\"/></figure>
+"<!-- wp:gallery {"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":2000} -->
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {\\"id\\":2001} -->
-<figure class=\\"wp-block-image\\"><img src=\\"https://test-site.files.wordpress.com/local-image-2.jpeg\\" alt=\\"\\" class=\\"wp-image-2001\\"/></figure>
+<!-- wp:image {"id":2001} -->
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-2.jpeg" alt="" class="wp-image-2001"/></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
 
 exports[`Gallery block uploads from other apps 1`] = `
-"<!-- wp:gallery {\\"linkTo\\":\\"none\\"} -->
-<figure class=\\"wp-block-gallery has-nested-images columns-default is-cropped\\"><!-- wp:image {\\"id\\":2000} -->
-<figure class=\\"wp-block-image\\"><img src=\\"https://test-site.files.wordpress.com/local-image-1.jpeg\\" alt=\\"\\" class=\\"wp-image-2000\\"/></figure>
+"<!-- wp:gallery {"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":2000} -->
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {\\"id\\":2001} -->
-<figure class=\\"wp-block-image\\"><img src=\\"https://test-site.files.wordpress.com/local-image-2.jpeg\\" alt=\\"\\" class=\\"wp-image-2001\\"/></figure>
+<!-- wp:image {"id":2001} -->
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-2.jpeg" alt="" class="wp-image-2001"/></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;

--- a/packages/block-library/src/group/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/group/test/__snapshots__/edit.native.js.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Group block inserts block and adds a Heading block as an inner block 1`] = `
-"<!-- wp:group {\\"layout\\":{\\"type\\":\\"constrained\\"}} -->
-<div class=\\"wp-block-group\\"><!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\"></h2>
+"<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:heading -->
+<h2 class="wp-block-heading"></h2>
 <!-- /wp:heading --></div>
 <!-- /wp:group -->"
 `;
 
 exports[`Group block ungroups inner blocks 1`] = `
 "<!-- wp:image -->
-<figure class=\\"wp-block-image\\"><img alt=\\"\\"/></figure>
+<figure class="wp-block-image"><img alt=""/></figure>
 <!-- /wp:image -->
 
 <!-- wp:spacer -->
-<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->"
 `;

--- a/packages/block-library/src/heading/test/__snapshots__/index.native.js.snap
+++ b/packages/block-library/src/heading/test/__snapshots__/index.native.js.snap
@@ -2,6 +2,6 @@
 
 exports[`Heading block inserts block 1`] = `
 "<!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\"></h2>
+<h2 class="wp-block-heading"></h2>
 <!-- /wp:heading -->"
 `;

--- a/packages/block-library/src/list/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/list/test/__snapshots__/edit.native.js.snap
@@ -21,7 +21,7 @@ exports[`List block changes the indentation level 1`] = `
 `;
 
 exports[`List block changes to ordered list 1`] = `
-"<!-- wp:list {\\"ordered\\":true} -->
+"<!-- wp:list {"ordered":true} -->
 <ol><!-- wp:list-item -->
 <li>Item 1</li>
 <!-- /wp:list-item -->
@@ -37,7 +37,7 @@ exports[`List block changes to ordered list 1`] = `
 `;
 
 exports[`List block changes to reverse ordered list 1`] = `
-"<!-- wp:list {\\"ordered\\":true,\\"reversed\\":true} -->
+"<!-- wp:list {"ordered":true,"reversed":true} -->
 <ol reversed><!-- wp:list-item -->
 <li>Item 1</li>
 <!-- /wp:list-item -->
@@ -73,8 +73,8 @@ exports[`List block removes the indentation level 1`] = `
 `;
 
 exports[`List block sets a start value to an ordered list 1`] = `
-"<!-- wp:list {\\"ordered\\":true,\\"start\\":25} -->
-<ol start=\\"25\\"><!-- wp:list-item -->
+"<!-- wp:list {"ordered":true,"start":25} -->
+<ol start="25"><!-- wp:list-item -->
 <li>Item 1</li>
 <!-- /wp:list-item -->
 

--- a/packages/block-library/src/missing/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/missing/test/__snapshots__/edit.native.js.snap
@@ -6,7 +6,7 @@ exports[`Missing block renders without crashing 1`] = `
   accessibilityLabel="Help button"
   accessibilityRole="button"
   accessibilityState={
-    Object {
+    {
       "disabled": true,
     }
   }

--- a/packages/block-library/src/navigation-link/test/__snapshots__/hooks.js.snap
+++ b/packages/block-library/src/navigation-link/test/__snapshots__/hooks.js.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`hooks enhanceNavigationLinkVariations enhances variations with icon and isActive functions 1`] = `
-Object {
+{
   "extraProp": "extraProp",
   "name": "core/navigation-link",
-  "variations": Array [
-    Object {
-      "attributes": Object {},
+  "variations": [
+    {
+      "attributes": {},
       "description": "A link to a custom URL.",
       "icon": <SVG
         viewBox="0 0 24 24"
@@ -20,8 +20,8 @@ Object {
       "name": "link",
       "title": "Custom Link",
     },
-    Object {
-      "attributes": Object {
+    {
+      "attributes": {
         "type": "post",
       },
       "description": "A link to a post.",
@@ -37,8 +37,8 @@ Object {
       "name": "post",
       "title": "Post Link",
     },
-    Object {
-      "attributes": Object {
+    {
+      "attributes": {
         "type": "page",
       },
       "description": "A link to a page.",
@@ -54,8 +54,8 @@ Object {
       "name": "page",
       "title": "Page Link",
     },
-    Object {
-      "attributes": Object {
+    {
+      "attributes": {
         "type": "category",
       },
       "description": "A link to a category.",
@@ -73,8 +73,8 @@ Object {
       "name": "category",
       "title": "Category Link",
     },
-    Object {
-      "attributes": Object {
+    {
+      "attributes": {
         "type": "tag",
       },
       "description": "A link to a tag.",

--- a/packages/block-library/src/preformatted/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/preformatted/test/__snapshots__/edit.native.js.snap
@@ -3,7 +3,7 @@
 exports[`core/more/edit/native should match snapshot when content is empty 1`] = `
 <View
   style={
-    Array [
+    [
       undefined,
       undefined,
       undefined,
@@ -12,7 +12,7 @@ exports[`core/more/edit/native should match snapshot when content is empty 1`] =
 >
   <View
     style={
-      Array [
+      [
         undefined,
         undefined,
       ]
@@ -20,9 +20,9 @@ exports[`core/more/edit/native should match snapshot when content is empty 1`] =
   >
     <TextInput
       accessibilityLabel="Text input. Empty"
-      activeFormats={Array []}
+      activeFormats={[]}
       blockType={
-        Object {
+        {
           "tag": "pre",
         }
       }
@@ -39,7 +39,7 @@ exports[`core/more/edit/native should match snapshot when content is empty 1`] =
       onSelectionChange={[Function]}
       placeholder="Write preformatted text…"
       placeholderTextColor="gray"
-      triggerKeyCodes={Array []}
+      triggerKeyCodes={[]}
       value=""
     />
   </View>
@@ -49,7 +49,7 @@ exports[`core/more/edit/native should match snapshot when content is empty 1`] =
 exports[`core/more/edit/native should match snapshot when content is not empty 1`] = `
 <View
   style={
-    Array [
+    [
       undefined,
       undefined,
       undefined,
@@ -58,7 +58,7 @@ exports[`core/more/edit/native should match snapshot when content is not empty 1
 >
   <View
     style={
-      Array [
+      [
         undefined,
         undefined,
       ]
@@ -66,9 +66,9 @@ exports[`core/more/edit/native should match snapshot when content is not empty 1
   >
     <TextInput
       accessibilityLabel="Text input. <pre>Hello World!</pre>"
-      activeFormats={Array []}
+      activeFormats={[]}
       blockType={
-        Object {
+        {
           "tag": "pre",
         }
       }
@@ -85,7 +85,7 @@ exports[`core/more/edit/native should match snapshot when content is not empty 1
       onSelectionChange={[Function]}
       placeholder="Write preformatted text…"
       placeholderTextColor="gray"
-      triggerKeyCodes={Array []}
+      triggerKeyCodes={[]}
       value="<pre>Hello World!</pre>"
     />
   </View>

--- a/packages/block-library/src/search/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/search/test/__snapshots__/edit.native.js.snap
@@ -13,7 +13,7 @@ exports[`Search Block renders block with button inside option 1`] = `
   >
     <View
       style={
-        Array [
+        [
           undefined,
           undefined,
         ]
@@ -21,9 +21,9 @@ exports[`Search Block renders block with button inside option 1`] = `
     >
       <RCTAztecView
         accessible={true}
-        activeFormats={Array []}
+        activeFormats={[]}
         blockType={
-          Object {
+          {
             "tag": "p",
           }
         }
@@ -53,14 +53,14 @@ exports[`Search Block renders block with button inside option 1`] = `
         placeholder="Add label…"
         placeholderTextColor="gray"
         style={
-          Object {
+          {
             "backgroundColor": undefined,
             "maxWidth": undefined,
             "minHeight": 0,
           }
         }
         text={
-          Object {
+          {
             "eventCount": undefined,
             "linkTextColor": undefined,
             "selection": null,
@@ -68,13 +68,13 @@ exports[`Search Block renders block with button inside option 1`] = `
             "text": "<p>Search</p>",
           }
         }
-        triggerKeyCodes={Array []}
+        triggerKeyCodes={[]}
       />
     </View>
   </View>
   <View
     style={
-      Array [
+      [
         undefined,
         undefined,
         false,
@@ -99,8 +99,8 @@ exports[`Search Block renders block with button inside option 1`] = `
         placeholder="Optional placeholder…"
         scrollEnabled={false}
         style={
-          Array [
-            Array [
+          [
+            [
               false,
               undefined,
               undefined,
@@ -112,7 +112,7 @@ exports[`Search Block renders block with button inside option 1`] = `
     </View>
     <View
       style={
-        Array [
+        [
           undefined,
           false,
           undefined,
@@ -128,7 +128,7 @@ exports[`Search Block renders block with button inside option 1`] = `
       >
         <View
           style={
-            Array [
+            [
               undefined,
               undefined,
             ]
@@ -136,9 +136,9 @@ exports[`Search Block renders block with button inside option 1`] = `
         >
           <RCTAztecView
             accessible={true}
-            activeFormats={Array []}
+            activeFormats={[]}
             blockType={
-              Object {
+              {
                 "tag": "p",
               }
             }
@@ -169,14 +169,14 @@ exports[`Search Block renders block with button inside option 1`] = `
             placeholder=""
             placeholderTextColor="gray"
             style={
-              Object {
+              {
                 "backgroundColor": undefined,
                 "maxWidth": NaN,
                 "minHeight": 0,
               }
             }
             text={
-              Object {
+              {
                 "eventCount": undefined,
                 "linkTextColor": undefined,
                 "selection": null,
@@ -185,7 +185,7 @@ exports[`Search Block renders block with button inside option 1`] = `
               }
             }
             textAlign="center"
-            triggerKeyCodes={Array []}
+            triggerKeyCodes={[]}
           />
         </View>
       </View>
@@ -207,7 +207,7 @@ exports[`Search Block renders block with icon button option matches snapshot 1`]
   >
     <View
       style={
-        Array [
+        [
           undefined,
           undefined,
         ]
@@ -215,9 +215,9 @@ exports[`Search Block renders block with icon button option matches snapshot 1`]
     >
       <RCTAztecView
         accessible={true}
-        activeFormats={Array []}
+        activeFormats={[]}
         blockType={
-          Object {
+          {
             "tag": "p",
           }
         }
@@ -247,14 +247,14 @@ exports[`Search Block renders block with icon button option matches snapshot 1`]
         placeholder="Add label…"
         placeholderTextColor="gray"
         style={
-          Object {
+          {
             "backgroundColor": undefined,
             "maxWidth": undefined,
             "minHeight": 0,
           }
         }
         text={
-          Object {
+          {
             "eventCount": undefined,
             "linkTextColor": undefined,
             "selection": null,
@@ -262,13 +262,13 @@ exports[`Search Block renders block with icon button option matches snapshot 1`]
             "text": "<p>Search</p>",
           }
         }
-        triggerKeyCodes={Array []}
+        triggerKeyCodes={[]}
       />
     </View>
   </View>
   <View
     style={
-      Array [
+      [
         undefined,
         false,
         false,
@@ -293,8 +293,8 @@ exports[`Search Block renders block with icon button option matches snapshot 1`]
         placeholder="Optional placeholder…"
         scrollEnabled={false}
         style={
-          Array [
-            Array [
+          [
+            [
               undefined,
               undefined,
               undefined,
@@ -306,7 +306,7 @@ exports[`Search Block renders block with icon button option matches snapshot 1`]
     </View>
     <View
       style={
-        Array [
+        [
           undefined,
           false,
           undefined,
@@ -328,7 +328,7 @@ exports[`Search Block renders block with label hidden matches snapshot 1`] = `
 >
   <View
     style={
-      Array [
+      [
         undefined,
         false,
         false,
@@ -353,8 +353,8 @@ exports[`Search Block renders block with label hidden matches snapshot 1`] = `
         placeholder="Optional placeholder…"
         scrollEnabled={false}
         style={
-          Array [
-            Array [
+          [
+            [
               undefined,
               undefined,
               undefined,
@@ -366,7 +366,7 @@ exports[`Search Block renders block with label hidden matches snapshot 1`] = `
     </View>
     <View
       style={
-        Array [
+        [
           undefined,
           false,
           undefined,
@@ -382,7 +382,7 @@ exports[`Search Block renders block with label hidden matches snapshot 1`] = `
       >
         <View
           style={
-            Array [
+            [
               undefined,
               undefined,
             ]
@@ -390,9 +390,9 @@ exports[`Search Block renders block with label hidden matches snapshot 1`] = `
         >
           <RCTAztecView
             accessible={true}
-            activeFormats={Array []}
+            activeFormats={[]}
             blockType={
-              Object {
+              {
                 "tag": "p",
               }
             }
@@ -423,14 +423,14 @@ exports[`Search Block renders block with label hidden matches snapshot 1`] = `
             placeholder=""
             placeholderTextColor="gray"
             style={
-              Object {
+              {
                 "backgroundColor": undefined,
                 "maxWidth": NaN,
                 "minHeight": 0,
               }
             }
             text={
-              Object {
+              {
                 "eventCount": undefined,
                 "linkTextColor": undefined,
                 "selection": null,
@@ -439,7 +439,7 @@ exports[`Search Block renders block with label hidden matches snapshot 1`] = `
               }
             }
             textAlign="center"
-            triggerKeyCodes={Array []}
+            triggerKeyCodes={[]}
           />
         </View>
       </View>
@@ -461,7 +461,7 @@ exports[`Search Block renders with default configuration matches snapshot 1`] = 
   >
     <View
       style={
-        Array [
+        [
           undefined,
           undefined,
         ]
@@ -469,9 +469,9 @@ exports[`Search Block renders with default configuration matches snapshot 1`] = 
     >
       <RCTAztecView
         accessible={true}
-        activeFormats={Array []}
+        activeFormats={[]}
         blockType={
-          Object {
+          {
             "tag": "p",
           }
         }
@@ -501,14 +501,14 @@ exports[`Search Block renders with default configuration matches snapshot 1`] = 
         placeholder="Add label…"
         placeholderTextColor="gray"
         style={
-          Object {
+          {
             "backgroundColor": undefined,
             "maxWidth": undefined,
             "minHeight": 0,
           }
         }
         text={
-          Object {
+          {
             "eventCount": undefined,
             "linkTextColor": undefined,
             "selection": null,
@@ -516,13 +516,13 @@ exports[`Search Block renders with default configuration matches snapshot 1`] = 
             "text": "<p>Search</p>",
           }
         }
-        triggerKeyCodes={Array []}
+        triggerKeyCodes={[]}
       />
     </View>
   </View>
   <View
     style={
-      Array [
+      [
         undefined,
         false,
         false,
@@ -547,8 +547,8 @@ exports[`Search Block renders with default configuration matches snapshot 1`] = 
         placeholder="Optional placeholder…"
         scrollEnabled={false}
         style={
-          Array [
-            Array [
+          [
+            [
               undefined,
               undefined,
               undefined,
@@ -560,7 +560,7 @@ exports[`Search Block renders with default configuration matches snapshot 1`] = 
     </View>
     <View
       style={
-        Array [
+        [
           undefined,
           false,
           undefined,
@@ -576,7 +576,7 @@ exports[`Search Block renders with default configuration matches snapshot 1`] = 
       >
         <View
           style={
-            Array [
+            [
               undefined,
               undefined,
             ]
@@ -584,9 +584,9 @@ exports[`Search Block renders with default configuration matches snapshot 1`] = 
         >
           <RCTAztecView
             accessible={true}
-            activeFormats={Array []}
+            activeFormats={[]}
             blockType={
-              Object {
+              {
                 "tag": "p",
               }
             }
@@ -617,14 +617,14 @@ exports[`Search Block renders with default configuration matches snapshot 1`] = 
             placeholder=""
             placeholderTextColor="gray"
             style={
-              Object {
+              {
                 "backgroundColor": undefined,
                 "maxWidth": NaN,
                 "minHeight": 0,
               }
             }
             text={
-              Object {
+              {
                 "eventCount": undefined,
                 "linkTextColor": undefined,
                 "selection": null,
@@ -633,7 +633,7 @@ exports[`Search Block renders with default configuration matches snapshot 1`] = 
               }
             }
             textAlign="center"
-            triggerKeyCodes={Array []}
+            triggerKeyCodes={[]}
           />
         </View>
       </View>
@@ -655,7 +655,7 @@ exports[`Search Block renders with no-button option matches snapshot 1`] = `
   >
     <View
       style={
-        Array [
+        [
           undefined,
           undefined,
         ]
@@ -663,9 +663,9 @@ exports[`Search Block renders with no-button option matches snapshot 1`] = `
     >
       <RCTAztecView
         accessible={true}
-        activeFormats={Array []}
+        activeFormats={[]}
         blockType={
-          Object {
+          {
             "tag": "p",
           }
         }
@@ -695,14 +695,14 @@ exports[`Search Block renders with no-button option matches snapshot 1`] = `
         placeholder="Add label…"
         placeholderTextColor="gray"
         style={
-          Object {
+          {
             "backgroundColor": undefined,
             "maxWidth": undefined,
             "minHeight": 0,
           }
         }
         text={
-          Object {
+          {
             "eventCount": undefined,
             "linkTextColor": undefined,
             "selection": null,
@@ -710,7 +710,7 @@ exports[`Search Block renders with no-button option matches snapshot 1`] = `
             "text": "<p>Search</p>",
           }
         }
-        triggerKeyCodes={Array []}
+        triggerKeyCodes={[]}
       />
     </View>
   </View>
@@ -732,8 +732,8 @@ exports[`Search Block renders with no-button option matches snapshot 1`] = `
       placeholder="Optional placeholder…"
       scrollEnabled={false}
       style={
-        Array [
-          Array [
+        [
+          [
             undefined,
             undefined,
             undefined,

--- a/packages/block-library/src/separator/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/separator/test/__snapshots__/edit.native.js.snap
@@ -2,6 +2,6 @@
 
 exports[`Separator block inserts block 1`] = `
 "<!-- wp:separator -->
-<hr class=\\"wp-block-separator has-alpha-channel-opacity\\"/>
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
 <!-- /wp:separator -->"
 `;

--- a/packages/block-library/src/social-links/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/social-links/test/__snapshots__/edit.native.js.snap
@@ -2,25 +2,25 @@
 
 exports[`Social links block inserts block with the default icons and the WordPress link set as active 1`] = `
 "<!-- wp:social-links -->
-<ul class=\\"wp-block-social-links\\"><!-- wp:social-link {\\"url\\":\\"https://wordpress.org\\",\\"service\\":\\"wordpress\\"} /-->
+<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->
 
-<!-- wp:social-link {\\"service\\":\\"facebook\\"} /-->
+<!-- wp:social-link {"service":"facebook"} /-->
 
-<!-- wp:social-link {\\"service\\":\\"twitter\\"} /-->
+<!-- wp:social-link {"service":"twitter"} /-->
 
-<!-- wp:social-link {\\"service\\":\\"instagram\\"} /--></ul>
+<!-- wp:social-link {"service":"instagram"} /--></ul>
 <!-- /wp:social-links -->"
 `;
 
 exports[`Social links block shows active links correctly when not selected 1`] = `
 "<!-- wp:social-links -->
-<ul class=\\"wp-block-social-links\\"><!-- wp:social-link {\\"url\\":\\"https://wordpress.org\\",\\"service\\":\\"wordpress\\"} /-->
+<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->
 
-<!-- wp:social-link {\\"service\\":\\"facebook\\"} /-->
+<!-- wp:social-link {"service":"facebook"} /-->
 
-<!-- wp:social-link {\\"service\\":\\"twitter\\"} /-->
+<!-- wp:social-link {"service":"twitter"} /-->
 
-<!-- wp:social-link {\\"service\\":\\"instagram\\"} /--></ul>
+<!-- wp:social-link {"service":"instagram"} /--></ul>
 <!-- /wp:social-links -->
 
 <!-- wp:paragraph -->
@@ -30,11 +30,11 @@ exports[`Social links block shows active links correctly when not selected 1`] =
 
 exports[`Social links block shows the ghost placeholder when no icon is active 1`] = `
 "<!-- wp:social-links -->
-<ul class=\\"wp-block-social-links\\"><!-- wp:social-link {\\"service\\":\\"facebook\\"} /-->
+<ul class="wp-block-social-links"><!-- wp:social-link {"service":"facebook"} /-->
 
-<!-- wp:social-link {\\"service\\":\\"twitter\\"} /-->
+<!-- wp:social-link {"service":"twitter"} /-->
 
-<!-- wp:social-link {\\"service\\":\\"instagram\\"} /--></ul>
+<!-- wp:social-link {"service":"instagram"} /--></ul>
 <!-- /wp:social-links -->
 
 <!-- wp:paragraph -->
@@ -44,14 +44,14 @@ exports[`Social links block shows the ghost placeholder when no icon is active 1
 
 exports[`Social links block shows the social links bottom sheet when tapping on the inline appender 1`] = `
 "<!-- wp:social-links -->
-<ul class=\\"wp-block-social-links\\"><!-- wp:social-link {\\"url\\":\\"https://wordpress.org\\",\\"service\\":\\"wordpress\\"} /-->
+<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->
 
-<!-- wp:social-link {\\"service\\":\\"facebook\\"} /-->
+<!-- wp:social-link {"service":"facebook"} /-->
 
-<!-- wp:social-link {\\"service\\":\\"twitter\\"} /-->
+<!-- wp:social-link {"service":"twitter"} /-->
 
-<!-- wp:social-link {\\"service\\":\\"instagram\\"} /-->
+<!-- wp:social-link {"service":"instagram"} /-->
 
-<!-- wp:social-link-amazon {\\"url\\":\\"\\"} /--></ul>
+<!-- wp:social-link-amazon {"url":""} /--></ul>
 <!-- /wp:social-links -->"
 `;

--- a/packages/block-library/src/spacer/test/__snapshots__/index.native.js.snap
+++ b/packages/block-library/src/spacer/test/__snapshots__/index.native.js.snap
@@ -1,31 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Spacer block decrements height 1`] = `
-"<!-- wp:spacer {\\"height\\":\\"99px\\"} -->
-<div style=\\"height:99px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+"<!-- wp:spacer {"height":"99px"} -->
+<div style="height:99px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->"
 `;
 
 exports[`Spacer block increments height 1`] = `
-"<!-- wp:spacer {\\"height\\":\\"101px\\"} -->
-<div style=\\"height:101px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+"<!-- wp:spacer {"height":"101px"} -->
+<div style="height:101px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->"
 `;
 
 exports[`Spacer block inserts block 1`] = `
 "<!-- wp:spacer -->
-<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->"
 `;
 
 exports[`Spacer block updates height to 25vh 1`] = `
-"<!-- wp:spacer {\\"height\\":\\"25vh\\"} -->
-<div style=\\"height:25vh\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+"<!-- wp:spacer {"height":"25vh"} -->
+<div style="height:25vh" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->"
 `;
 
 exports[`Spacer block updates height to 50px 1`] = `
-"<!-- wp:spacer {\\"height\\":\\"50px\\"} -->
-<div style=\\"height:50px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+"<!-- wp:spacer {"height":"50px"} -->
+<div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->"
 `;

--- a/packages/block-library/src/verse/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/verse/test/__snapshots__/edit.native.js.snap
@@ -2,12 +2,12 @@
 
 exports[`Verse block inserts block 1`] = `
 "<!-- wp:verse -->
-<pre class=\\"wp-block-verse\\"></pre>
+<pre class="wp-block-verse"></pre>
 <!-- /wp:verse -->"
 `;
 
 exports[`Verse block renders block text set as initial content 1`] = `
 "<!-- wp:verse -->
-<pre class=\\"wp-block-verse\\">Sample text</pre>
+<pre class="wp-block-verse">Sample text</pre>
 <!-- /wp:verse -->"
 `;

--- a/packages/components/src/color-palette/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.tsx.snap
@@ -179,7 +179,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
       <button
         aria-expanded="false"
         aria-haspopup="true"
-        aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
+        aria-label="Custom color picker. The currently selected color is called "red" and has a value of "f00"."
         class="components-flex components-color-palette__custom-color emotion-2 emotion-1"
         data-wp-c16t="true"
         data-wp-component="Flex"

--- a/packages/components/src/tree-grid/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/tree-grid/test/__snapshots__/index.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TreeGrid simple rendering renders a table, tbody and any child elements 1`] = `"<div role=\\"application\\"><table role=\\"treegrid\\"><tbody><tr role=\\"row\\" aria-level=\\"1\\" aria-posinset=\\"1\\" aria-setsize=\\"1\\"><td role=\\"gridcell\\">Test</td></tr></tbody></table></div>"`;
+exports[`TreeGrid simple rendering renders a table, tbody and any child elements 1`] = `"<div role="application"><table role="treegrid"><tbody><tr role="row" aria-level="1" aria-posinset="1" aria-setsize="1"><td role="gridcell">Test</td></tr></tbody></table></div>"`;

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -6,23 +6,23 @@ exports[`DependencyExtractionWebpackPlugin Webpack \`combine-assets\` should pro
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`combine-assets\` should produce expected output: External modules should match snapshot 1`] = `
-Array [
-  Object {
+[
+  {
     "externalType": "window",
     "request": "lodash",
     "userRequest": "lodash",
   },
-  Object {
+  {
     "externalType": "window",
-    "request": Array [
+    "request": [
       "wp",
       "blob",
     ],
     "userRequest": "@wordpress/blob",
   },
-  Object {
+  {
     "externalType": "window",
-    "request": Array [
+    "request": [
       "wp",
       "tokenList",
     ],
@@ -37,10 +37,10 @@ exports[`DependencyExtractionWebpackPlugin Webpack \`dynamic-import\` should pro
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`dynamic-import\` should produce expected output: External modules should match snapshot 1`] = `
-Array [
-  Object {
+[
+  {
     "externalType": "window",
-    "request": Array [
+    "request": [
       "wp",
       "blob",
     ],
@@ -55,15 +55,15 @@ exports[`DependencyExtractionWebpackPlugin Webpack \`function-output-filename\` 
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`function-output-filename\` should produce expected output: External modules should match snapshot 1`] = `
-Array [
-  Object {
+[
+  {
     "externalType": "window",
     "request": "lodash",
     "userRequest": "lodash",
   },
-  Object {
+  {
     "externalType": "window",
-    "request": Array [
+    "request": [
       "wp",
       "blob",
     ],
@@ -78,15 +78,15 @@ exports[`DependencyExtractionWebpackPlugin Webpack \`has-extension-suffix\` shou
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`has-extension-suffix\` should produce expected output: External modules should match snapshot 1`] = `
-Array [
-  Object {
+[
+  {
     "externalType": "window",
     "request": "lodash",
     "userRequest": "lodash",
   },
-  Object {
+  {
     "externalType": "window",
-    "request": Array [
+    "request": [
       "wp",
       "blob",
     ],
@@ -100,14 +100,14 @@ exports[`DependencyExtractionWebpackPlugin Webpack \`no-default\` should produce
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin Webpack \`no-default\` should produce expected output: External modules should match snapshot 1`] = `Array []`;
+exports[`DependencyExtractionWebpackPlugin Webpack \`no-default\` should produce expected output: External modules should match snapshot 1`] = `[]`;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`no-deps\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array(), 'version' => '091ffcd70d94dd16e773');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin Webpack \`no-deps\` should produce expected output: External modules should match snapshot 1`] = `Array []`;
+exports[`DependencyExtractionWebpackPlugin Webpack \`no-deps\` should produce expected output: External modules should match snapshot 1`] = `[]`;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`option-function-output-filename\` should produce expected output: Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '4c78134607e6ed966df3');
@@ -115,15 +115,15 @@ exports[`DependencyExtractionWebpackPlugin Webpack \`option-function-output-file
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`option-function-output-filename\` should produce expected output: External modules should match snapshot 1`] = `
-Array [
-  Object {
+[
+  {
     "externalType": "window",
     "request": "lodash",
     "userRequest": "lodash",
   },
-  Object {
+  {
     "externalType": "window",
-    "request": Array [
+    "request": [
       "wp",
       "blob",
     ],
@@ -138,15 +138,15 @@ exports[`DependencyExtractionWebpackPlugin Webpack \`option-output-filename\` sh
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`option-output-filename\` should produce expected output: External modules should match snapshot 1`] = `
-Array [
-  Object {
+[
+  {
     "externalType": "window",
     "request": "lodash",
     "userRequest": "lodash",
   },
-  Object {
+  {
     "externalType": "window",
-    "request": Array [
+    "request": [
       "wp",
       "blob",
     ],
@@ -155,11 +155,11 @@ Array [
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin Webpack \`output-format-json\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{\\"dependencies\\":[\\"lodash\\"],\\"version\\":\\"a8f35bfc9f46482cc48a\\"}"`;
+exports[`DependencyExtractionWebpackPlugin Webpack \`output-format-json\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":["lodash"],"version":"a8f35bfc9f46482cc48a"}"`;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`output-format-json\` should produce expected output: External modules should match snapshot 1`] = `
-Array [
-  Object {
+[
+  {
     "externalType": "window",
     "request": "lodash",
     "userRequest": "lodash",
@@ -173,31 +173,31 @@ exports[`DependencyExtractionWebpackPlugin Webpack \`overrides\` should produce 
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`overrides\` should produce expected output: External modules should match snapshot 1`] = `
-Array [
-  Object {
+[
+  {
     "externalType": "window",
     "request": "rxjs",
     "userRequest": "rxjs",
   },
-  Object {
+  {
     "externalType": "window",
-    "request": Array [
+    "request": [
       "rxjs",
       "operators",
     ],
     "userRequest": "rxjs/operators",
   },
-  Object {
+  {
     "externalType": "window",
-    "request": Array [
+    "request": [
       "wp",
       "blob",
     ],
     "userRequest": "@wordpress/blob",
   },
-  Object {
+  {
     "externalType": "window",
-    "request": Array [
+    "request": [
       "wp",
       "url",
     ],
@@ -222,15 +222,15 @@ exports[`DependencyExtractionWebpackPlugin Webpack \`runtime-chunk-single\` shou
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`runtime-chunk-single\` should produce expected output: External modules should match snapshot 1`] = `
-Array [
-  Object {
+[
+  {
     "externalType": "window",
     "request": "lodash",
     "userRequest": "lodash",
   },
-  Object {
+  {
     "externalType": "window",
-    "request": Array [
+    "request": [
       "wp",
       "blob",
     ],
@@ -245,15 +245,15 @@ exports[`DependencyExtractionWebpackPlugin Webpack \`style-imports\` should prod
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`style-imports\` should produce expected output: External modules should match snapshot 1`] = `
-Array [
-  Object {
+[
+  {
     "externalType": "window",
     "request": "lodash",
     "userRequest": "lodash",
   },
-  Object {
+  {
     "externalType": "window",
-    "request": Array [
+    "request": [
       "wp",
       "blob",
     ],
@@ -268,15 +268,15 @@ exports[`DependencyExtractionWebpackPlugin Webpack \`wordpress\` should produce 
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`wordpress\` should produce expected output: External modules should match snapshot 1`] = `
-Array [
-  Object {
+[
+  {
     "externalType": "window",
     "request": "lodash",
     "userRequest": "lodash",
   },
-  Object {
+  {
     "externalType": "window",
-    "request": Array [
+    "request": [
       "wp",
       "blob",
     ],
@@ -291,15 +291,15 @@ exports[`DependencyExtractionWebpackPlugin Webpack \`wordpress-require\` should 
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`wordpress-require\` should produce expected output: External modules should match snapshot 1`] = `
-Array [
-  Object {
+[
+  {
     "externalType": "window",
     "request": "lodash",
     "userRequest": "lodash",
   },
-  Object {
+  {
     "externalType": "window",
-    "request": Array [
+    "request": [
       "wp",
       "blob",
     ],

--- a/packages/env/lib/config/test/__snapshots__/config.js.snap
+++ b/packages/env/lib/config/test/__snapshots__/config.js.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`readConfig config file should match snapshot 1`] = `
-Object {
+{
   "configDirectoryPath": ".",
   "detectedLocalConfig": true,
-  "env": Object {
-    "development": Object {
-      "config": Object {
+  "env": {
+    "development": {
+      "config": {
         "SCRIPT_DEBUG": true,
         "TEST": 100,
         "TEST_VAL1": 1,
@@ -21,14 +21,14 @@ Object {
         "WP_TESTS_EMAIL": "admin@example.org",
         "WP_TESTS_TITLE": "Test Blog",
       },
-      "mappings": Object {},
+      "mappings": {},
       "phpVersion": null,
-      "pluginSources": Array [],
+      "pluginSources": [],
       "port": 2000,
-      "themeSources": Array [],
+      "themeSources": [],
     },
-    "tests": Object {
-      "config": Object {
+    "tests": {
+      "config": {
         "SCRIPT_DEBUG": false,
         "TEST": 200,
         "TEST_VAL1": 1,
@@ -43,11 +43,11 @@ Object {
         "WP_TESTS_EMAIL": "admin@example.org",
         "WP_TESTS_TITLE": "Test Blog",
       },
-      "mappings": Object {},
+      "mappings": {},
       "phpVersion": null,
-      "pluginSources": Array [],
+      "pluginSources": [],
       "port": 1000,
-      "themeSources": Array [],
+      "themeSources": [],
     },
   },
   "name": ".",
@@ -55,7 +55,7 @@ Object {
 `;
 
 exports[`readConfig wp config values should use default config values 1`] = `
-Object {
+{
   "SCRIPT_DEBUG": false,
   "WP_DEBUG": false,
   "WP_ENVIRONMENT_TYPE": "local",
@@ -69,7 +69,7 @@ Object {
 `;
 
 exports[`readConfig wp config values should use default config values 2`] = `
-Object {
+{
   "SCRIPT_DEBUG": true,
   "WP_DEBUG": true,
   "WP_ENVIRONMENT_TYPE": "local",

--- a/packages/format-library/src/text-color/test/__snapshots__/index.native.js.snap
+++ b/packages/format-library/src/text-color/test/__snapshots__/index.native.js.snap
@@ -2,28 +2,28 @@
 
 exports[`Text color allows toggling the highlight color feature to selected text 1`] = `
 "<!-- wp:paragraph -->
-<p><mark style=\\"background-color:rgba(0, 0, 0, 0);color:#f78da7\\" class=\\"has-inline-color has-pale-pink-color\\">Hello this is a test</mark></p>
+<p><mark style="background-color:rgba(0, 0, 0, 0);color:#f78da7" class="has-inline-color has-pale-pink-color">Hello this is a test</mark></p>
 <!-- /wp:paragraph -->"
 `;
 
 exports[`Text color allows toggling the highlight color feature to type new text 1`] = `
 "<!-- wp:paragraph -->
-<p><mark style=\\"background-color:rgba(0, 0, 0, 0);color:#f78da7\\" class=\\"has-inline-color has-pale-pink-color\\"></mark></p>
+<p><mark style="background-color:rgba(0, 0, 0, 0);color:#f78da7" class="has-inline-color has-pale-pink-color"></mark></p>
 <!-- /wp:paragraph -->"
 `;
 
 exports[`Text color creates a paragraph block with the text color format 1`] = `
 "<!-- wp:paragraph -->
-<p>Hello <mark style=\\"background-color:rgba(0,0,0,0);color:#cf2e2e\\" class=\\"has-inline-color has-vivid-red-color\\">this is a test</mark></p>
+<p>Hello <mark style="background-color:rgba(0,0,0,0);color:#cf2e2e" class="has-inline-color has-vivid-red-color">this is a test</mark></p>
 <!-- /wp:paragraph -->"
 `;
 
 exports[`Text color supports old text color format using "span" tag 1`] = `
 "<!-- wp:paragraph -->
-<p>this <span class=\\"has-inline-color has-green-color\\">is</span> <span class=\\"has-inline-color has-red-color\\">test</span></p>
+<p>this <span class="has-inline-color has-green-color">is</span> <span class="has-inline-color has-red-color">test</span></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><span style=\\"color:#08a5e9\\" class=\\"has-inline-color\\">this is a test</span></p>
+<p><span style="color:#08a5e9" class="has-inline-color">this is a test</span></p>
 <!-- /wp:paragraph -->"
 `;

--- a/packages/preferences-persistence/src/migrations/legacy-local-storage-data/test/index.js
+++ b/packages/preferences-persistence/src/migrations/legacy-local-storage-data/test/index.js
@@ -137,49 +137,49 @@ const alreadyConvertedData = {
 describe( 'convertLegacyData', () => {
 	it( 'converts to the expected format', () => {
 		expect( convertLegacyData( legacyData ) ).toMatchInlineSnapshot( `
-		Object {
-		  "core/customize-widgets": Object {
+		{
+		  "core/customize-widgets": {
 		    "fixedToolbar": true,
 		    "keepCaretInsideBlock": true,
 		    "welcomeGuide": false,
 		  },
-		  "core/edit-post": Object {
+		  "core/edit-post": {
 		    "complementaryArea": "edit-post/document",
 		    "editorMode": "text",
 		    "fixedToolbar": true,
-		    "hiddenBlockTypes": Array [
+		    "hiddenBlockTypes": [
 		      "core/heading",
 		      "core/list",
 		    ],
-		    "inactivePanels": Array [
+		    "inactivePanels": [
 		      "post-excerpt",
 		    ],
-		    "openPanels": Array [
+		    "openPanels": [
 		      "post-status",
 		      "taxonomy-panel-category",
 		    ],
-		    "pinnedItems": Object {
+		    "pinnedItems": {
 		      "my-sidebar-plugin/title-sidebar": false,
 		    },
-		    "preferredStyleVariations": Object {
+		    "preferredStyleVariations": {
 		      "core/quote": "plain",
 		    },
 		    "welcomeGuide": false,
 		  },
-		  "core/edit-site": Object {
+		  "core/edit-site": {
 		    "complementaryArea": "edit-site/global-styles",
 		    "fixedToolbar": true,
 		    "focusMode": true,
 		    "welcomeGuide": false,
 		    "welcomeGuideStyles": false,
 		  },
-		  "core/edit-widgets": Object {
+		  "core/edit-widgets": {
 		    "complementaryArea": "edit-widgets/block-areas",
 		    "fixedToolbar": true,
 		    "keepCaretInsideBlock": true,
 		    "welcomeGuide": false,
 		  },
-		  "third-party-plugin": Object {
+		  "third-party-plugin": {
 		    "thirdPartyFeature": true,
 		  },
 		}
@@ -189,35 +189,35 @@ describe( 'convertLegacyData', () => {
 	it( 'retains already converted data', () => {
 		expect( convertLegacyData( alreadyConvertedData ) )
 			.toMatchInlineSnapshot( `
-		Object {
-		  "core/edit-post": Object {
+		{
+		  "core/edit-post": {
 		    "complementaryArea": "edit-post/block",
 		    "editorMode": "visual",
 		    "fixedToolbar": true,
 		    "fullscreenMode": false,
-		    "hiddenBlockTypes": Array [
+		    "hiddenBlockTypes": [
 		      "core/audio",
 		      "core/cover",
 		    ],
-		    "inactivePanels": Array [],
-		    "openPanels": Array [
+		    "inactivePanels": [],
+		    "openPanels": [
 		      "post-status",
 		    ],
-		    "pinnedItems": Object {
+		    "pinnedItems": {
 		      "my-sidebar-plugin/title-sidebar": false,
 		    },
-		    "preferredStyleVariations": Object {
+		    "preferredStyleVariations": {
 		      "core/quote": "large",
 		    },
 		    "welcomeGuide": false,
 		  },
-		  "core/edit-site": Object {
+		  "core/edit-site": {
 		    "complementaryArea": "edit-site/global-styles",
 		    "fixedToolbar": true,
 		    "welcomeGuide": false,
 		    "welcomeGuideStyles": false,
 		  },
-		  "core/edit-widgets": Object {
+		  "core/edit-widgets": {
 		    "complementaryArea": "edit-widgets/block-areas",
 		    "fixedToolbar": true,
 		    "showBlockBreadcrumbs": false,

--- a/packages/preferences-persistence/src/migrations/preferences-package-data/test/index.js
+++ b/packages/preferences-persistence/src/migrations/preferences-package-data/test/index.js
@@ -41,38 +41,38 @@ describe( 'convertPreferencesPackageData', () => {
 	it( 'converts data to the expected format', () => {
 		expect( convertPreferencesPackageData( input ) )
 			.toMatchInlineSnapshot( `
-		Object {
-		  "core/customize-widgets": Object {
+		{
+		  "core/customize-widgets": {
 		    "fixedToolbar": true,
 		    "welcomeGuide": false,
 		  },
-		  "core/edit-post": Object {
+		  "core/edit-post": {
 		    "editorMode": "visual",
 		    "fixedToolbar": true,
 		    "fullscreenMode": false,
-		    "hiddenBlockTypes": Array [
+		    "hiddenBlockTypes": [
 		      "core/audio",
 		      "core/cover",
 		    ],
-		    "inactivePanels": Array [],
-		    "openPanels": Array [
+		    "inactivePanels": [],
+		    "openPanels": [
 		      "post-status",
 		    ],
-		    "pinnedItems": Object {
+		    "pinnedItems": {
 		      "my-sidebar-plugin/title-sidebar": false,
 		    },
-		    "preferredStyleVariations": Object {
+		    "preferredStyleVariations": {
 		      "core/quote": "large",
 		    },
 		    "welcomeGuide": false,
 		  },
-		  "core/edit-site": Object {
+		  "core/edit-site": {
 		    "fixedToolbar": true,
 		    "isComplementaryAreaVisible": true,
 		    "welcomeGuide": false,
 		    "welcomeGuideStyles": false,
 		  },
-		  "core/edit-widgets": Object {
+		  "core/edit-widgets": {
 		    "fixedToolbar": true,
 		    "isComplementaryAreaVisible": true,
 		    "showBlockBreadcrumbs": false,

--- a/packages/readable-js-assets-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/readable-js-assets-webpack-plugin/test/__snapshots__/build.js.snap
@@ -13,7 +13,7 @@ notMinified();
 ;"
 `;
 
-exports[`ReadableJsAssetsWebpackPlugin should produce the expected output: Asset file index.min.js should match snapshot 1`] = `"console.log(\\"hello\\");"`;
+exports[`ReadableJsAssetsWebpackPlugin should produce the expected output: Asset file index.min.js should match snapshot 1`] = `"console.log("hello");"`;
 
 exports[`ReadableJsAssetsWebpackPlugin should produce the expected output: Asset file view.js should match snapshot 1`] = `
 "/******/ (function() { // webpackBootstrap
@@ -28,4 +28,4 @@ notMinified();
 ;"
 `;
 
-exports[`ReadableJsAssetsWebpackPlugin should produce the expected output: Asset file view.min.js should match snapshot 1`] = `"console.log(\\"hello\\");"`;
+exports[`ReadableJsAssetsWebpackPlugin should produce the expected output: Asset file view.min.js should match snapshot 1`] = `"console.log("hello");"`;

--- a/packages/report-flaky-tests/src/__tests__/__snapshots__/markdown.test.ts.snap
+++ b/packages/report-flaky-tests/src/__tests__/__snapshots__/markdown.test.ts.snap
@@ -34,7 +34,7 @@ exports[`formatTestErrorMessage should format test error message for jest-circus
     expect(jest.fn()).not.toHaveErrored(expected)
 
     Expected mock function not to be called but it was called with:
-    [\\"TypeError: Cannot read properties of null (reading 'frameElement')
+    ["TypeError: Cannot read properties of null (reading 'frameElement')
 
       at Vo (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/block-editor/index.min.js?ver=dfd3a79ce1dc54c31b6ed591bcb0d55a:3:21925)
       at ft (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react-dom.min.js?ver=6.1-alpha-53362:1:43451)
@@ -45,7 +45,7 @@ exports[`formatTestErrorMessage should format test error message for jest-circus
       at Rr (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react-dom.min.js?ver=6.1-alpha-53362:1:77549)
       at Nr (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react-dom.min.js?ver=6.1-alpha-53362:1:74544)
       at ../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react-dom.min.js?ver=6.1-alpha-53362:1:30170
-      at unstable_runWithPriority (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react.min.js?ver=6.1-alpha-53362:1:7430)\\"]
+      at unstable_runWithPriority (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react.min.js?ver=6.1-alpha-53362:1:7430)"]
           at runMicrotasks (<anonymous>)
 
   ● Template Part › Template part block › Template part placeholder › Should insert new template part on creation
@@ -53,7 +53,7 @@ exports[`formatTestErrorMessage should format test error message for jest-circus
     expect(jest.fn()).not.toHaveErrored(expected)
 
     Expected mock function not to be called but it was called with:
-    [\\"TypeError: Cannot read properties of null (reading 'frameElement')
+    ["TypeError: Cannot read properties of null (reading 'frameElement')
 
       at Vo (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/block-editor/index.min.js?ver=dfd3a79ce1dc54c31b6ed591bcb0d55a:3:21925)
       at ft (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react-dom.min.js?ver=6.1-alpha-53362:1:43451)
@@ -64,13 +64,13 @@ exports[`formatTestErrorMessage should format test error message for jest-circus
       at Rr (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react-dom.min.js?ver=6.1-alpha-53362:1:77549)
       at Nr (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react-dom.min.js?ver=6.1-alpha-53362:1:74544)
       at ../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react-dom.min.js?ver=6.1-alpha-53362:1:30170
-      at unstable_runWithPriority (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react.min.js?ver=6.1-alpha-53362:1:7430)\\"]
+      at unstable_runWithPriority (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react.min.js?ver=6.1-alpha-53362:1:7430)"]
           at runMicrotasks (<anonymous>)
 "
 `;
 
 exports[`parseIssueBody should parse issue body 1`] = `
-"<!-- __META_DATA__:{\\"failedTimes\\":5,\\"totalCommits\\":95} -->
+"<!-- __META_DATA__:{"failedTimes":5,"totalCommits":95} -->
 **Flaky test detected. This is an auto-generated issue by GitHub Actions. Please do NOT edit this manually.**
 
 ## Test title
@@ -81,10 +81,10 @@ Test title
 
 ## Errors
 <!-- __TEST_RESULTS_LIST__ -->
-<!-- __TEST_RESULT__ --><time datetime=\\"2020-08-01T00:00:00.000Z\\"><code>[2020-08-01T00:00:00.000Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2282393879\\"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2020-08-01T00:00:00.000Z"><code>[2020-08-01T00:00:00.000Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2282393879"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
 <!-- __TEST_RESULT__ --><details>
 <summary>
-	<time datetime=\\"2020-05-10T00:00:00.000Z\\"><code>[2020-05-10T00:00:00.000Z]</code></time> Test passed after 2 failed attempts on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2297863316\\"><code>try/some-branch</code></a>.
+	<time datetime="2020-05-10T00:00:00.000Z"><code>[2020-05-10T00:00:00.000Z]</code></time> Test passed after 2 failed attempts on <a href="https://github.com/WordPress/gutenberg/actions/runs/2297863316"><code>try/some-branch</code></a>.
 </summary>
 
 \`\`\`

--- a/packages/report-flaky-tests/src/__tests__/__snapshots__/run.test.ts.snap
+++ b/packages/report-flaky-tests/src/__tests__/__snapshots__/run.test.ts.snap
@@ -14,7 +14,7 @@ Should insert new template part on creation
 <!-- __TEST_RESULTS_LIST__ -->
 <!-- __TEST_RESULT__ --><details>
 <summary>
-	<time datetime=\\"2020-05-10T00:00:00.000Z\\"><code>[2020-05-10T00:00:00.000Z]</code></time> Test passed after 2 failed attempts on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/100\\"><code>headBranch</code></a>.
+	<time datetime="2020-05-10T00:00:00.000Z"><code>[2020-05-10T00:00:00.000Z]</code></time> Test passed after 2 failed attempts on <a href="https://github.com/WordPress/gutenberg/actions/runs/100"><code>headBranch</code></a>.
 </summary>
 
 \`\`\`
@@ -23,7 +23,7 @@ Should insert new template part on creation
     expect(jest.fn()).not.toHaveErrored(expected)
 
     Expected mock function not to be called but it was called with:
-    [\\"TypeError: Cannot read properties of null (reading 'frameElement')
+    ["TypeError: Cannot read properties of null (reading 'frameElement')
 
       at Vo (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/block-editor/index.min.js?ver=dfd3a79ce1dc54c31b6ed591bcb0d55a:3:21925)
       at ft (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react-dom.min.js?ver=6.1-alpha-53362:1:43451)
@@ -34,7 +34,7 @@ Should insert new template part on creation
       at Rr (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react-dom.min.js?ver=6.1-alpha-53362:1:77549)
       at Nr (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react-dom.min.js?ver=6.1-alpha-53362:1:74544)
       at ../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react-dom.min.js?ver=6.1-alpha-53362:1:30170
-      at unstable_runWithPriority (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react.min.js?ver=6.1-alpha-53362:1:7430)\\"]
+      at unstable_runWithPriority (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react.min.js?ver=6.1-alpha-53362:1:7430)"]
           at runMicrotasks (<anonymous>)
 
   ● Template Part › Template part block › Template part placeholder › Should insert new template part on creation
@@ -42,7 +42,7 @@ Should insert new template part on creation
     expect(jest.fn()).not.toHaveErrored(expected)
 
     Expected mock function not to be called but it was called with:
-    [\\"TypeError: Cannot read properties of null (reading 'frameElement')
+    ["TypeError: Cannot read properties of null (reading 'frameElement')
 
       at Vo (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/block-editor/index.min.js?ver=dfd3a79ce1dc54c31b6ed591bcb0d55a:3:21925)
       at ft (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react-dom.min.js?ver=6.1-alpha-53362:1:43451)
@@ -53,7 +53,7 @@ Should insert new template part on creation
       at Rr (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react-dom.min.js?ver=6.1-alpha-53362:1:77549)
       at Nr (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react-dom.min.js?ver=6.1-alpha-53362:1:74544)
       at ../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react-dom.min.js?ver=6.1-alpha-53362:1:30170
-      at unstable_runWithPriority (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react.min.js?ver=6.1-alpha-53362:1:7430)\\"]
+      at unstable_runWithPriority (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react.min.js?ver=6.1-alpha-53362:1:7430)"]
           at runMicrotasks (<anonymous>)
 
 \`\`\`
@@ -63,7 +63,7 @@ Should insert new template part on creation
 `;
 
 exports[`Report flaky tests should report flaky tests to issue on pull request: Updated existing flaky issue 1`] = `
-"<!-- __META_DATA__:{\\"failedTimes\\":58,\\"totalCommits\\":134,\\"baseCommit\\":\\"32bb60d08b75486341d8a63b9e786152889aa02d\\"} -->
+"<!-- __META_DATA__:{"failedTimes":58,"totalCommits":134,"baseCommit":"32bb60d08b75486341d8a63b9e786152889aa02d"} -->
 **Flaky test detected. This is an auto-generated issue by GitHub Actions. Please do NOT edit this manually.**
 
 ## Test title
@@ -74,81 +74,81 @@ should copy only partial selection of text blocks
 
 ## Errors
 <!-- __TEST_RESULTS_LIST__ -->
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-13T10:32:59.201Z\\"><code>[2022-04-13T10:32:59.201Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2160552635\\"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-13T10:32:59.201Z"><code>[2022-04-13T10:32:59.201Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2160552635"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T09:51:38.785Z\\"><code>[2022-04-18T09:51:38.785Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2183265588\\"><code>update/post-featured-image-component</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T09:51:38.785Z"><code>[2022-04-18T09:51:38.785Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2183265588"><code>update/post-featured-image-component</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T10:53:30.411Z\\"><code>[2022-04-18T10:53:30.411Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2183485173\\"><code>add/wp-env/wp-env-core-env</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T10:53:30.411Z"><code>[2022-04-18T10:53:30.411Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2183485173"><code>add/wp-env/wp-env-core-env</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T12:20:51.800Z\\"><code>[2022-04-18T12:20:51.800Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2183790777\\"><code>fix/e2e-test</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T12:20:51.800Z"><code>[2022-04-18T12:20:51.800Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2183790777"><code>fix/e2e-test</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T13:47:15.612Z\\"><code>[2022-04-18T13:47:15.612Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184126130\\"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T13:47:15.612Z"><code>[2022-04-18T13:47:15.612Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184126130"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T13:48:06.669Z\\"><code>[2022-04-18T13:48:06.669Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184130029\\"><code>fix/duotone-site-editor</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T13:48:06.669Z"><code>[2022-04-18T13:48:06.669Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184130029"><code>fix/duotone-site-editor</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T14:01:10.151Z\\"><code>[2022-04-18T14:01:10.151Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184182012\\"><code>fix/playwright-snapshots</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T14:01:10.151Z"><code>[2022-04-18T14:01:10.151Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184182012"><code>fix/playwright-snapshots</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T14:12:20.129Z\\"><code>[2022-04-18T14:12:20.129Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184226509\\"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T14:12:20.129Z"><code>[2022-04-18T14:12:20.129Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184226509"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T14:48:36.649Z\\"><code>[2022-04-18T14:48:36.649Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184377565\\"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T14:48:36.649Z"><code>[2022-04-18T14:48:36.649Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184377565"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T14:56:37.960Z\\"><code>[2022-04-18T14:56:37.960Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184418035\\"><code>rnmobile/feature/drag-and-drop</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T14:56:37.960Z"><code>[2022-04-18T14:56:37.960Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184418035"><code>rnmobile/feature/drag-and-drop</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T15:02:27.183Z\\"><code>[2022-04-18T15:02:27.183Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184449849\\"><code>rnmobile/feature/drag-and-drop-prevent-text-focus-on-long-press</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T15:02:27.183Z"><code>[2022-04-18T15:02:27.183Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184449849"><code>rnmobile/feature/drag-and-drop-prevent-text-focus-on-long-press</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T15:34:59.990Z\\"><code>[2022-04-18T15:34:59.990Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184593633\\"><code>add/section-concept</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T15:34:59.990Z"><code>[2022-04-18T15:34:59.990Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184593633"><code>add/section-concept</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T15:38:30.538Z\\"><code>[2022-04-18T15:38:30.538Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184609574\\"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T15:38:30.538Z"><code>[2022-04-18T15:38:30.538Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184609574"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T15:48:40.494Z\\"><code>[2022-04-18T15:48:40.494Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184652286\\"><code>rnmobile/feature/drag-and-drop-refactor-draggable</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T15:48:40.494Z"><code>[2022-04-18T15:48:40.494Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184652286"><code>rnmobile/feature/drag-and-drop-refactor-draggable</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T15:50:50.420Z\\"><code>[2022-04-18T15:50:50.420Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184658598\\"><code>rnmobile/feature/drag-and-drop-update-chip-animation</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T15:50:50.420Z"><code>[2022-04-18T15:50:50.420Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184658598"><code>rnmobile/feature/drag-and-drop-update-chip-animation</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T15:52:48.948Z\\"><code>[2022-04-18T15:52:48.948Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184662247\\"><code>fix/comment-reply-link-alignment</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T15:52:48.948Z"><code>[2022-04-18T15:52:48.948Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184662247"><code>fix/comment-reply-link-alignment</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T15:55:31.386Z\\"><code>[2022-04-18T15:55:31.386Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184668485\\"><code>rnmobile/feature/drag-and-drop-haptic-feedback</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T15:55:31.386Z"><code>[2022-04-18T15:55:31.386Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184668485"><code>rnmobile/feature/drag-and-drop-haptic-feedback</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T16:09:33.323Z\\"><code>[2022-04-18T16:09:33.323Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184728812\\"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T16:09:33.323Z"><code>[2022-04-18T16:09:33.323Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184728812"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T16:17:20.282Z\\"><code>[2022-04-18T16:17:20.282Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184756693\\"><code>fix/embed-block-preview-cut-off</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T16:17:20.282Z"><code>[2022-04-18T16:17:20.282Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184756693"><code>fix/embed-block-preview-cut-off</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T17:30:31.287Z\\"><code>[2022-04-18T17:30:31.287Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2185065551\\"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T17:30:31.287Z"><code>[2022-04-18T17:30:31.287Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2185065551"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T17:51:21.537Z\\"><code>[2022-04-18T17:51:21.537Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2185158655\\"><code>fix/copy-from-non-text-inputs</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T17:51:21.537Z"><code>[2022-04-18T17:51:21.537Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2185158655"><code>fix/copy-from-non-text-inputs</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T19:54:17.115Z\\"><code>[2022-04-18T19:54:17.115Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2185732975\\"><code>remove/block-styles-remove-role</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T19:54:17.115Z"><code>[2022-04-18T19:54:17.115Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2185732975"><code>remove/block-styles-remove-role</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T21:02:44.582Z\\"><code>[2022-04-18T21:02:44.582Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2186019382\\"><code>docgen/replace-fixtures-with-code</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T21:02:44.582Z"><code>[2022-04-18T21:02:44.582Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2186019382"><code>docgen/replace-fixtures-with-code</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T22:38:25.644Z\\"><code>[2022-04-18T22:38:25.644Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2186398254\\"><code>try/use-css-var-for-user-presets</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T22:38:25.644Z"><code>[2022-04-18T22:38:25.644Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2186398254"><code>try/use-css-var-for-user-presets</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-23T16:41:35.814Z\\"><code>[2022-04-23T16:41:35.814Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2212870284\\"><code>fix/flaky-test-reporter</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-23T16:41:35.814Z"><code>[2022-04-23T16:41:35.814Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2212870284"><code>fix/flaky-test-reporter</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-05-10T13:20:09.628Z\\"><code>[2022-05-10T13:20:09.628Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2300794825\\"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-05-10T13:20:09.628Z"><code>[2022-05-10T13:20:09.628Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2300794825"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-05-10T13:33:14.282Z\\"><code>[2022-05-10T13:33:14.282Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2300911722\\"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-05-10T13:33:14.282Z"><code>[2022-05-10T13:33:14.282Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2300911722"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-05-10T13:40:06.465Z\\"><code>[2022-05-10T13:40:06.465Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2300960655\\"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-05-10T13:40:06.465Z"><code>[2022-05-10T13:40:06.465Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2300960655"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-05-10T15:45:55.917Z\\"><code>[2022-05-10T15:45:55.917Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2301711710\\"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-05-10T15:45:55.917Z"><code>[2022-05-10T15:45:55.917Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2301711710"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-05-10T15:54:10.994Z\\"><code>[2022-05-10T15:54:10.994Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2301740850\\"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-05-10T15:54:10.994Z"><code>[2022-05-10T15:54:10.994Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2301740850"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-05-10T18:58:47.148Z\\"><code>[2022-05-10T18:58:47.148Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2302689513\\"><code>fix/input-field-reset-behavior-moar</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-05-10T18:58:47.148Z"><code>[2022-05-10T18:58:47.148Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2302689513"><code>fix/input-field-reset-behavior-moar</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-05-16T07:23:49.752Z\\"><code>[2022-05-16T07:23:49.752Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2330295878\\"><code>refactor/range-control-to-typescript</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-05-16T07:23:49.752Z"><code>[2022-05-16T07:23:49.752Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2330295878"><code>refactor/range-control-to-typescript</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-05-16T07:50:53.486Z\\"><code>[2022-05-16T07:50:53.486Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2330425165\\"><code>refactor/range-control-to-typescript</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-05-16T07:50:53.486Z"><code>[2022-05-16T07:50:53.486Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2330425165"><code>refactor/range-control-to-typescript</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-05-16T09:51:42.310Z\\"><code>[2022-05-16T09:51:42.310Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2331036710\\"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-05-16T09:51:42.310Z"><code>[2022-05-16T09:51:42.310Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2331036710"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-05-16T10:08:17.403Z\\"><code>[2022-05-16T10:08:17.403Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2331126515\\"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-05-16T10:08:17.403Z"><code>[2022-05-16T10:08:17.403Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2331126515"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-05-17T12:57:57.490Z\\"><code>[2022-05-17T12:57:57.490Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2338696807\\"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-05-17T12:57:57.490Z"><code>[2022-05-17T12:57:57.490Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2338696807"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
 <!-- __TEST_RESULT__ --><details>
 <summary>
-	<time datetime=\\"2020-05-10T00:00:00.000Z\\"><code>[2020-05-10T00:00:00.000Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/100\\"><code>headBranch</code></a>.
+	<time datetime="2020-05-10T00:00:00.000Z"><code>[2020-05-10T00:00:00.000Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/100"><code>headBranch</code></a>.
 </summary>
 
 \`\`\`
@@ -197,7 +197,7 @@ Should insert new template part on creation
 <!-- __TEST_RESULTS_LIST__ -->
 <!-- __TEST_RESULT__ --><details>
 <summary>
-	<time datetime=\\"2020-05-10T00:00:00.000Z\\"><code>[2020-05-10T00:00:00.000Z]</code></time> Test passed after 2 failed attempts on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/100\\"><code>trunk</code></a>.
+	<time datetime="2020-05-10T00:00:00.000Z"><code>[2020-05-10T00:00:00.000Z]</code></time> Test passed after 2 failed attempts on <a href="https://github.com/WordPress/gutenberg/actions/runs/100"><code>trunk</code></a>.
 </summary>
 
 \`\`\`
@@ -206,7 +206,7 @@ Should insert new template part on creation
     expect(jest.fn()).not.toHaveErrored(expected)
 
     Expected mock function not to be called but it was called with:
-    [\\"TypeError: Cannot read properties of null (reading 'frameElement')
+    ["TypeError: Cannot read properties of null (reading 'frameElement')
 
       at Vo (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/block-editor/index.min.js?ver=dfd3a79ce1dc54c31b6ed591bcb0d55a:3:21925)
       at ft (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react-dom.min.js?ver=6.1-alpha-53362:1:43451)
@@ -217,7 +217,7 @@ Should insert new template part on creation
       at Rr (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react-dom.min.js?ver=6.1-alpha-53362:1:77549)
       at Nr (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react-dom.min.js?ver=6.1-alpha-53362:1:74544)
       at ../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react-dom.min.js?ver=6.1-alpha-53362:1:30170
-      at unstable_runWithPriority (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react.min.js?ver=6.1-alpha-53362:1:7430)\\"]
+      at unstable_runWithPriority (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react.min.js?ver=6.1-alpha-53362:1:7430)"]
           at runMicrotasks (<anonymous>)
 
   ● Template Part › Template part block › Template part placeholder › Should insert new template part on creation
@@ -225,7 +225,7 @@ Should insert new template part on creation
     expect(jest.fn()).not.toHaveErrored(expected)
 
     Expected mock function not to be called but it was called with:
-    [\\"TypeError: Cannot read properties of null (reading 'frameElement')
+    ["TypeError: Cannot read properties of null (reading 'frameElement')
 
       at Vo (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/block-editor/index.min.js?ver=dfd3a79ce1dc54c31b6ed591bcb0d55a:3:21925)
       at ft (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react-dom.min.js?ver=6.1-alpha-53362:1:43451)
@@ -236,7 +236,7 @@ Should insert new template part on creation
       at Rr (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react-dom.min.js?ver=6.1-alpha-53362:1:77549)
       at Nr (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react-dom.min.js?ver=6.1-alpha-53362:1:74544)
       at ../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react-dom.min.js?ver=6.1-alpha-53362:1:30170
-      at unstable_runWithPriority (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react.min.js?ver=6.1-alpha-53362:1:7430)\\"]
+      at unstable_runWithPriority (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/vendors/react.min.js?ver=6.1-alpha-53362:1:7430)"]
           at runMicrotasks (<anonymous>)
 
 \`\`\`
@@ -246,7 +246,7 @@ Should insert new template part on creation
 `;
 
 exports[`Report flaky tests should report flaky tests to issue on push: Updated existing flaky issue 1`] = `
-"<!-- __META_DATA__:{\\"failedTimes\\":58,\\"totalCommits\\":134,\\"baseCommit\\":\\"32bb60d08b75486341d8a63b9e786152889aa02d\\"} -->
+"<!-- __META_DATA__:{"failedTimes":58,"totalCommits":134,"baseCommit":"32bb60d08b75486341d8a63b9e786152889aa02d"} -->
 **Flaky test detected. This is an auto-generated issue by GitHub Actions. Please do NOT edit this manually.**
 
 ## Test title
@@ -257,81 +257,81 @@ should copy only partial selection of text blocks
 
 ## Errors
 <!-- __TEST_RESULTS_LIST__ -->
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-13T10:32:59.201Z\\"><code>[2022-04-13T10:32:59.201Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2160552635\\"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-13T10:32:59.201Z"><code>[2022-04-13T10:32:59.201Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2160552635"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T09:51:38.785Z\\"><code>[2022-04-18T09:51:38.785Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2183265588\\"><code>update/post-featured-image-component</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T09:51:38.785Z"><code>[2022-04-18T09:51:38.785Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2183265588"><code>update/post-featured-image-component</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T10:53:30.411Z\\"><code>[2022-04-18T10:53:30.411Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2183485173\\"><code>add/wp-env/wp-env-core-env</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T10:53:30.411Z"><code>[2022-04-18T10:53:30.411Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2183485173"><code>add/wp-env/wp-env-core-env</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T12:20:51.800Z\\"><code>[2022-04-18T12:20:51.800Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2183790777\\"><code>fix/e2e-test</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T12:20:51.800Z"><code>[2022-04-18T12:20:51.800Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2183790777"><code>fix/e2e-test</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T13:47:15.612Z\\"><code>[2022-04-18T13:47:15.612Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184126130\\"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T13:47:15.612Z"><code>[2022-04-18T13:47:15.612Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184126130"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T13:48:06.669Z\\"><code>[2022-04-18T13:48:06.669Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184130029\\"><code>fix/duotone-site-editor</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T13:48:06.669Z"><code>[2022-04-18T13:48:06.669Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184130029"><code>fix/duotone-site-editor</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T14:01:10.151Z\\"><code>[2022-04-18T14:01:10.151Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184182012\\"><code>fix/playwright-snapshots</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T14:01:10.151Z"><code>[2022-04-18T14:01:10.151Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184182012"><code>fix/playwright-snapshots</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T14:12:20.129Z\\"><code>[2022-04-18T14:12:20.129Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184226509\\"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T14:12:20.129Z"><code>[2022-04-18T14:12:20.129Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184226509"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T14:48:36.649Z\\"><code>[2022-04-18T14:48:36.649Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184377565\\"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T14:48:36.649Z"><code>[2022-04-18T14:48:36.649Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184377565"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T14:56:37.960Z\\"><code>[2022-04-18T14:56:37.960Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184418035\\"><code>rnmobile/feature/drag-and-drop</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T14:56:37.960Z"><code>[2022-04-18T14:56:37.960Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184418035"><code>rnmobile/feature/drag-and-drop</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T15:02:27.183Z\\"><code>[2022-04-18T15:02:27.183Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184449849\\"><code>rnmobile/feature/drag-and-drop-prevent-text-focus-on-long-press</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T15:02:27.183Z"><code>[2022-04-18T15:02:27.183Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184449849"><code>rnmobile/feature/drag-and-drop-prevent-text-focus-on-long-press</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T15:34:59.990Z\\"><code>[2022-04-18T15:34:59.990Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184593633\\"><code>add/section-concept</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T15:34:59.990Z"><code>[2022-04-18T15:34:59.990Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184593633"><code>add/section-concept</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T15:38:30.538Z\\"><code>[2022-04-18T15:38:30.538Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184609574\\"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T15:38:30.538Z"><code>[2022-04-18T15:38:30.538Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184609574"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T15:48:40.494Z\\"><code>[2022-04-18T15:48:40.494Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184652286\\"><code>rnmobile/feature/drag-and-drop-refactor-draggable</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T15:48:40.494Z"><code>[2022-04-18T15:48:40.494Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184652286"><code>rnmobile/feature/drag-and-drop-refactor-draggable</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T15:50:50.420Z\\"><code>[2022-04-18T15:50:50.420Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184658598\\"><code>rnmobile/feature/drag-and-drop-update-chip-animation</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T15:50:50.420Z"><code>[2022-04-18T15:50:50.420Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184658598"><code>rnmobile/feature/drag-and-drop-update-chip-animation</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T15:52:48.948Z\\"><code>[2022-04-18T15:52:48.948Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184662247\\"><code>fix/comment-reply-link-alignment</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T15:52:48.948Z"><code>[2022-04-18T15:52:48.948Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184662247"><code>fix/comment-reply-link-alignment</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T15:55:31.386Z\\"><code>[2022-04-18T15:55:31.386Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184668485\\"><code>rnmobile/feature/drag-and-drop-haptic-feedback</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T15:55:31.386Z"><code>[2022-04-18T15:55:31.386Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184668485"><code>rnmobile/feature/drag-and-drop-haptic-feedback</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T16:09:33.323Z\\"><code>[2022-04-18T16:09:33.323Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184728812\\"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T16:09:33.323Z"><code>[2022-04-18T16:09:33.323Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184728812"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T16:17:20.282Z\\"><code>[2022-04-18T16:17:20.282Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2184756693\\"><code>fix/embed-block-preview-cut-off</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T16:17:20.282Z"><code>[2022-04-18T16:17:20.282Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2184756693"><code>fix/embed-block-preview-cut-off</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T17:30:31.287Z\\"><code>[2022-04-18T17:30:31.287Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2185065551\\"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T17:30:31.287Z"><code>[2022-04-18T17:30:31.287Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2185065551"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T17:51:21.537Z\\"><code>[2022-04-18T17:51:21.537Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2185158655\\"><code>fix/copy-from-non-text-inputs</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T17:51:21.537Z"><code>[2022-04-18T17:51:21.537Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2185158655"><code>fix/copy-from-non-text-inputs</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T19:54:17.115Z\\"><code>[2022-04-18T19:54:17.115Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2185732975\\"><code>remove/block-styles-remove-role</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T19:54:17.115Z"><code>[2022-04-18T19:54:17.115Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2185732975"><code>remove/block-styles-remove-role</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T21:02:44.582Z\\"><code>[2022-04-18T21:02:44.582Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2186019382\\"><code>docgen/replace-fixtures-with-code</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T21:02:44.582Z"><code>[2022-04-18T21:02:44.582Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2186019382"><code>docgen/replace-fixtures-with-code</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-18T22:38:25.644Z\\"><code>[2022-04-18T22:38:25.644Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2186398254\\"><code>try/use-css-var-for-user-presets</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-18T22:38:25.644Z"><code>[2022-04-18T22:38:25.644Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2186398254"><code>try/use-css-var-for-user-presets</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-04-23T16:41:35.814Z\\"><code>[2022-04-23T16:41:35.814Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2212870284\\"><code>fix/flaky-test-reporter</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-04-23T16:41:35.814Z"><code>[2022-04-23T16:41:35.814Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2212870284"><code>fix/flaky-test-reporter</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-05-10T13:20:09.628Z\\"><code>[2022-05-10T13:20:09.628Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2300794825\\"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-05-10T13:20:09.628Z"><code>[2022-05-10T13:20:09.628Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2300794825"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-05-10T13:33:14.282Z\\"><code>[2022-05-10T13:33:14.282Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2300911722\\"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-05-10T13:33:14.282Z"><code>[2022-05-10T13:33:14.282Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2300911722"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-05-10T13:40:06.465Z\\"><code>[2022-05-10T13:40:06.465Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2300960655\\"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-05-10T13:40:06.465Z"><code>[2022-05-10T13:40:06.465Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2300960655"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-05-10T15:45:55.917Z\\"><code>[2022-05-10T15:45:55.917Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2301711710\\"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-05-10T15:45:55.917Z"><code>[2022-05-10T15:45:55.917Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2301711710"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-05-10T15:54:10.994Z\\"><code>[2022-05-10T15:54:10.994Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2301740850\\"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-05-10T15:54:10.994Z"><code>[2022-05-10T15:54:10.994Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2301740850"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-05-10T18:58:47.148Z\\"><code>[2022-05-10T18:58:47.148Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2302689513\\"><code>fix/input-field-reset-behavior-moar</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-05-10T18:58:47.148Z"><code>[2022-05-10T18:58:47.148Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2302689513"><code>fix/input-field-reset-behavior-moar</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-05-16T07:23:49.752Z\\"><code>[2022-05-16T07:23:49.752Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2330295878\\"><code>refactor/range-control-to-typescript</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-05-16T07:23:49.752Z"><code>[2022-05-16T07:23:49.752Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2330295878"><code>refactor/range-control-to-typescript</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-05-16T07:50:53.486Z\\"><code>[2022-05-16T07:50:53.486Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2330425165\\"><code>refactor/range-control-to-typescript</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-05-16T07:50:53.486Z"><code>[2022-05-16T07:50:53.486Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2330425165"><code>refactor/range-control-to-typescript</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-05-16T09:51:42.310Z\\"><code>[2022-05-16T09:51:42.310Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2331036710\\"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-05-16T09:51:42.310Z"><code>[2022-05-16T09:51:42.310Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2331036710"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-05-16T10:08:17.403Z\\"><code>[2022-05-16T10:08:17.403Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2331126515\\"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-05-16T10:08:17.403Z"><code>[2022-05-16T10:08:17.403Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2331126515"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
-<!-- __TEST_RESULT__ --><time datetime=\\"2022-05-17T12:57:57.490Z\\"><code>[2022-05-17T12:57:57.490Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2338696807\\"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
+<!-- __TEST_RESULT__ --><time datetime="2022-05-17T12:57:57.490Z"><code>[2022-05-17T12:57:57.490Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2338696807"><code>wp/6.0</code></a>.<!-- /__TEST_RESULT__ -->
 <br/>
 <!-- __TEST_RESULT__ --><details>
 <summary>
-	<time datetime=\\"2020-05-10T00:00:00.000Z\\"><code>[2020-05-10T00:00:00.000Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/100\\"><code>trunk</code></a>.
+	<time datetime="2020-05-10T00:00:00.000Z"><code>[2020-05-10T00:00:00.000Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/100"><code>trunk</code></a>.
 </summary>
 
 \`\`\`

--- a/packages/report-flaky-tests/src/__tests__/markdown.test.ts
+++ b/packages/report-flaky-tests/src/__tests__/markdown.test.ts
@@ -53,7 +53,7 @@ describe( 'formatTestResults', () => {
 		} );
 
 		expect( formatted ).toMatchInlineSnapshot(
-			`"<!-- __TEST_RESULT__ --><time datetime=\\"2020-05-10T00:00:00.000Z\\"><code>[2020-05-10T00:00:00.000Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2282393879\\"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->"`
+			`"<!-- __TEST_RESULT__ --><time datetime="2020-05-10T00:00:00.000Z"><code>[2020-05-10T00:00:00.000Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2282393879"><code>trunk</code></a>.<!-- /__TEST_RESULT__ -->"`
 		);
 
 		expect( renderToDisplayText( formatted ) ).toMatchInlineSnapshot(
@@ -73,7 +73,7 @@ describe( 'formatTestResults', () => {
 		expect( formatted ).toMatchInlineSnapshot( `
 		"<!-- __TEST_RESULT__ --><details>
 		<summary>
-			<time datetime=\\"2020-05-10T00:00:00.000Z\\"><code>[2020-05-10T00:00:00.000Z]</code></time> Test passed after 1 failed attempt on <a href=\\"https://github.com/WordPress/gutenberg/actions/runs/2282393879\\"><code>trunk</code></a>.
+			<time datetime="2020-05-10T00:00:00.000Z"><code>[2020-05-10T00:00:00.000Z]</code></time> Test passed after 1 failed attempt on <a href="https://github.com/WordPress/gutenberg/actions/runs/2282393879"><code>trunk</code></a>.
 		</summary>
 
 		\`\`\`
@@ -101,7 +101,7 @@ describe( 'renderIssueBody', () => {
 		} );
 
 		expect( body ).toMatchInlineSnapshot( `
-		"<!-- __META_DATA__:{\\"failedTimes\\":5,\\"totalCommits\\":100} -->
+		"<!-- __META_DATA__:{"failedTimes":5,"totalCommits":100} -->
 		**Flaky test detected. This is an auto-generated issue by GitHub Actions. Please do NOT edit this manually.**
 
 		## Test title

--- a/packages/reusable-blocks/src/store/test/__snapshots__/actions.js.snap
+++ b/packages/reusable-blocks/src/store/test/__snapshots__/actions.js.snap
@@ -1,48 +1,48 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Actions __experimentalConvertBlockToStatic should convert a static reusable into a static block 1`] = `
-Array [
-  Object {
-    "attributes": Object {
+[
+  {
+    "attributes": {
       "name": "Big Bird",
     },
-    "innerBlocks": Array [
-      Object {
-        "attributes": Object {
+    "innerBlocks": [
+      {
+        "attributes": {
           "name": "Oscar the Grouch",
         },
-        "innerBlocks": Array [],
+        "innerBlocks": [],
         "isValid": true,
         "name": "core/test-block",
         "originalContent": "",
-        "validationIssues": Array [],
+        "validationIssues": [],
       },
-      Object {
-        "attributes": Object {
+      {
+        "attributes": {
           "name": "Cookie Monster",
         },
-        "innerBlocks": Array [],
+        "innerBlocks": [],
         "isValid": true,
         "name": "core/test-block",
         "originalContent": "",
-        "validationIssues": Array [],
+        "validationIssues": [],
       },
     ],
     "isValid": true,
     "name": "core/test-block",
     "originalContent": "",
-    "validationIssues": Array [],
+    "validationIssues": [],
   },
 ]
 `;
 
 exports[`Actions __experimentalConvertBlocksToReusable should convert a static block into a reusable block 1`] = `
-Array [
-  Object {
-    "attributes": Object {
+[
+  {
+    "attributes": {
       "ref": "new-id",
     },
-    "innerBlocks": Array [],
+    "innerBlocks": [],
     "isValid": true,
     "name": "core/block",
   },

--- a/packages/rich-text/src/test/__snapshots__/index.native.js.snap
+++ b/packages/rich-text/src/test/__snapshots__/index.native.js.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<RichText/> Font Size renders component with style and font size 1`] = `
-"<!-- wp:paragraph {\\"style\\":{\\"color\\":{\\"text\\":\\"#fcb900\\"},\\"typography\\":{\\"fontSize\\":35.56}}} -->
-<p class=\\"has-text-color\\" style=\\"color:#fcb900;font-size:35.56px\\">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet ut nibh vitae ornare. Sed auctor nec augue at blandit.</p>
+"<!-- wp:paragraph {"style":{"color":{"text":"#fcb900"},"typography":{"fontSize":35.56}}} -->
+<p class="has-text-color" style="color:#fcb900;font-size:35.56px">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet ut nibh vitae ornare. Sed auctor nec augue at blandit.</p>
 <!-- /wp:paragraph -->"
 `;
 
 exports[`<RichText/> Font Size should update the font size when style prop with font size property is provided 1`] = `
 <View
   style={
-    Array [
+    [
       undefined,
       undefined,
     ]
@@ -17,9 +17,9 @@ exports[`<RichText/> Font Size should update the font size when style prop with 
 >
   <TextInput
     accessibilityLabel="Text input. Empty"
-    activeFormats={Array []}
+    activeFormats={[]}
     blockType={
-      Object {
+      {
         "tag": "div",
       }
     }
@@ -36,7 +36,7 @@ exports[`<RichText/> Font Size should update the font size when style prop with 
     onPaste={[Function]}
     onSelectionChange={[Function]}
     placeholderTextColor="gray"
-    triggerKeyCodes={Array []}
+    triggerKeyCodes={[]}
     value=""
   />
 </View>
@@ -45,7 +45,7 @@ exports[`<RichText/> Font Size should update the font size when style prop with 
 exports[`<RichText/> Font Size should update the font size with decimals when style prop with font size property is provided 1`] = `
 <View
   style={
-    Array [
+    [
       undefined,
       undefined,
     ]
@@ -53,9 +53,9 @@ exports[`<RichText/> Font Size should update the font size with decimals when st
 >
   <TextInput
     accessibilityLabel="Text input. Empty"
-    activeFormats={Array []}
+    activeFormats={[]}
     blockType={
-      Object {
+      {
         "tag": "div",
       }
     }
@@ -72,7 +72,7 @@ exports[`<RichText/> Font Size should update the font size with decimals when st
     onPaste={[Function]}
     onSelectionChange={[Function]}
     placeholderTextColor="gray"
-    triggerKeyCodes={Array []}
+    triggerKeyCodes={[]}
     value=""
   />
 </View>

--- a/packages/stylelint-config/test/__snapshots__/commenting.js.snap
+++ b/packages/stylelint-config/test/__snapshots__/commenting.js.snap
@@ -1,22 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`flags warnings with invalid commenting css snapshot matches warnings 1`] = `
-Array [
-  Object {
+[
+  {
     "column": 1,
     "line": 9,
     "rule": "comment-empty-line-before",
     "severity": "error",
     "text": "Expected empty line before comment (comment-empty-line-before)",
   },
-  Object {
+  {
     "column": 1,
     "line": 18,
     "rule": "comment-empty-line-before",
     "severity": "error",
     "text": "Expected empty line before comment (comment-empty-line-before)",
   },
-  Object {
+  {
     "column": 131,
     "line": 24,
     "rule": "max-line-length",

--- a/packages/stylelint-config/test/__snapshots__/functions.js.snap
+++ b/packages/stylelint-config/test/__snapshots__/functions.js.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`flags warnings with invalid functions css snapshot matches warnings 1`] = `
-Array [
-  Object {
+[
+  {
     "column": 9,
     "line": 4,
     "rule": "function-name-case",
     "severity": "error",
-    "text": "Expected \\"Calc\\" to be \\"calc\\" (function-name-case)",
+    "text": "Expected "Calc" to be "calc" (function-name-case)",
   },
 ]
 `;

--- a/packages/stylelint-config/test/__snapshots__/index.js.snap
+++ b/packages/stylelint-config/test/__snapshots__/index.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`flags warnings with invalid css snapshot matches warnings 1`] = `
-Array [
-  Object {
+[
+  {
     "column": 7,
     "line": 2,
     "rule": "number-leading-zero",

--- a/packages/stylelint-config/test/__snapshots__/media-queries.js.snap
+++ b/packages/stylelint-config/test/__snapshots__/media-queries.js.snap
@@ -1,83 +1,83 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`flags warnings with invalid media queries css snapshot matches warnings 1`] = `
-Array [
-  Object {
+[
+  {
     "column": 1,
     "line": 31,
     "rule": "at-rule-no-unknown",
     "severity": "error",
-    "text": "Unexpected unknown at-rule \\"@mdia\\" (at-rule-no-unknown)",
+    "text": "Unexpected unknown at-rule "@mdia" (at-rule-no-unknown)",
   },
-  Object {
+  {
     "column": 26,
     "line": 1,
     "rule": "media-feature-colon-space-after",
     "severity": "error",
-    "text": "Expected single space after \\":\\" (media-feature-colon-space-after)",
+    "text": "Expected single space after ":" (media-feature-colon-space-after)",
   },
-  Object {
+  {
     "column": 27,
     "line": 6,
     "rule": "media-feature-colon-space-after",
     "severity": "error",
-    "text": "Expected single space after \\":\\" (media-feature-colon-space-after)",
+    "text": "Expected single space after ":" (media-feature-colon-space-after)",
   },
-  Object {
+  {
     "column": 27,
     "line": 6,
     "rule": "media-feature-colon-space-before",
     "severity": "error",
-    "text": "Unexpected whitespace before \\":\\" (media-feature-colon-space-before)",
+    "text": "Unexpected whitespace before ":" (media-feature-colon-space-before)",
   },
-  Object {
+  {
     "column": 17,
     "line": 11,
     "rule": "media-feature-name-no-unknown",
     "severity": "error",
-    "text": "Unexpected unknown media feature name \\"max-width 699px\\" (media-feature-name-no-unknown)",
+    "text": "Unexpected unknown media feature name "max-width 699px" (media-feature-name-no-unknown)",
   },
-  Object {
+  {
     "column": 28,
     "line": 16,
     "rule": "media-feature-range-operator-space-after",
     "severity": "error",
     "text": "Expected single space after range operator (media-feature-range-operator-space-after)",
   },
-  Object {
+  {
     "column": 29,
     "line": 21,
     "rule": "media-feature-range-operator-space-after",
     "severity": "error",
     "text": "Expected single space after range operator (media-feature-range-operator-space-after)",
   },
-  Object {
+  {
     "column": 25,
     "line": 16,
     "rule": "media-feature-range-operator-space-before",
     "severity": "error",
     "text": "Expected single space before range operator (media-feature-range-operator-space-before)",
   },
-  Object {
+  {
     "column": 25,
     "line": 26,
     "rule": "media-feature-range-operator-space-before",
     "severity": "error",
     "text": "Expected single space before range operator (media-feature-range-operator-space-before)",
   },
-  Object {
+  {
     "column": 27,
     "line": 36,
     "rule": "media-query-list-comma-space-before",
     "severity": "error",
-    "text": "Unexpected whitespace before \\",\\" (media-query-list-comma-space-before)",
+    "text": "Unexpected whitespace before "," (media-query-list-comma-space-before)",
   },
-  Object {
+  {
     "column": 27,
     "line": 40,
     "rule": "media-query-list-comma-space-before",
     "severity": "error",
-    "text": "Unexpected whitespace before \\",\\" (media-query-list-comma-space-before)",
+    "text": "Unexpected whitespace before "," (media-query-list-comma-space-before)",
   },
 ]
 `;

--- a/packages/stylelint-config/test/__snapshots__/properties.js.snap
+++ b/packages/stylelint-config/test/__snapshots__/properties.js.snap
@@ -1,55 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`flags warnings with invalid properties css snapshot matches warnings 1`] = `
-Array [
-  Object {
+[
+  {
     "column": 13,
     "line": 2,
     "rule": "color-hex-case",
     "severity": "error",
-    "text": "Expected \\"#FFFFFF\\" to be \\"#ffffff\\" (color-hex-case)",
+    "text": "Expected "#FFFFFF" to be "#ffffff" (color-hex-case)",
   },
-  Object {
+  {
     "column": 13,
     "line": 2,
     "rule": "color-hex-length",
     "severity": "error",
-    "text": "Expected \\"#FFFFFF\\" to be \\"#FFF\\" (color-hex-length)",
+    "text": "Expected "#FFFFFF" to be "#FFF" (color-hex-length)",
   },
-  Object {
+  {
     "column": 2,
     "line": 5,
     "rule": "declaration-block-no-shorthand-property-overrides",
     "severity": "error",
-    "text": "Unexpected shorthand \\"margin\\" after \\"margin-left\\" (declaration-block-no-shorthand-property-overrides)",
+    "text": "Unexpected shorthand "margin" after "margin-left" (declaration-block-no-shorthand-property-overrides)",
   },
-  Object {
+  {
     "column": 13,
     "line": 2,
     "rule": "declaration-colon-space-after",
     "severity": "error",
-    "text": "Expected single space after \\":\\" with a single-line declaration (declaration-colon-space-after)",
+    "text": "Expected single space after ":" with a single-line declaration (declaration-colon-space-after)",
   },
-  Object {
+  {
     "column": 2,
     "line": 6,
     "rule": "property-no-unknown",
     "severity": "error",
-    "text": "Unexpected unknown property \\"argin\\" (property-no-unknown)",
+    "text": "Unexpected unknown property "argin" (property-no-unknown)",
   },
-  Object {
+  {
     "column": 15,
     "line": 4,
     "rule": "unit-case",
     "severity": "error",
-    "text": "Expected \\"PX\\" to be \\"px\\" (unit-case)",
+    "text": "Expected "PX" to be "px" (unit-case)",
   },
-  Object {
+  {
     "column": 11,
     "line": 3,
     "rule": "value-keyword-case",
     "severity": "error",
-    "text": "Expected \\"BLOCK\\" to be \\"block\\" (value-keyword-case)",
+    "text": "Expected "BLOCK" to be "block" (value-keyword-case)",
   },
 ]
 `;

--- a/packages/stylelint-config/test/__snapshots__/scss.js.snap
+++ b/packages/stylelint-config/test/__snapshots__/scss.js.snap
@@ -1,57 +1,57 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`flags warnings with invalid scss snapshot matches warnings 1`] = `
-Array [
-  Object {
+[
+  {
     "column": 1,
     "line": 14,
     "rule": "scss/at-else-empty-line-before",
     "severity": "error",
     "text": "Unexpected empty line before @else (scss/at-else-empty-line-before)",
   },
-  Object {
+  {
     "column": 2,
     "line": 12,
     "rule": "scss/at-if-closing-brace-newline-after",
     "severity": "error",
-    "text": "Unexpected newline after \\"}\\" of @if statement (scss/at-if-closing-brace-newline-after)",
+    "text": "Unexpected newline after "}" of @if statement (scss/at-if-closing-brace-newline-after)",
   },
-  Object {
+  {
     "column": 2,
     "line": 12,
     "rule": "scss/at-if-closing-brace-space-after",
     "severity": "error",
-    "text": "Expected single space after \\"}\\" of @if statement (scss/at-if-closing-brace-space-after)",
+    "text": "Expected single space after "}" of @if statement (scss/at-if-closing-brace-space-after)",
   },
-  Object {
+  {
     "column": 1,
     "line": 1,
     "rule": "scss/at-rule-no-unknown",
     "severity": "error",
-    "text": "Unexpected unknown at-rule \\"@unknown\\" (scss/at-rule-no-unknown)",
+    "text": "Unexpected unknown at-rule "@unknown" (scss/at-rule-no-unknown)",
   },
-  Object {
+  {
     "column": 2,
     "line": 22,
     "rule": "at-rule-empty-line-before",
     "severity": "error",
     "text": "Unexpected empty line before at-rule (at-rule-empty-line-before)",
   },
-  Object {
+  {
     "column": 5,
     "line": 14,
     "rule": "block-opening-brace-space-before",
     "severity": "error",
-    "text": "Expected single space before \\"{\\" (block-opening-brace-space-before)",
+    "text": "Expected single space before "{" (block-opening-brace-space-before)",
   },
-  Object {
+  {
     "column": 15,
     "line": 28,
     "rule": "no-extra-semicolons",
     "severity": "error",
     "text": "Unexpected extra semicolon (no-extra-semicolons)",
   },
-  Object {
+  {
     "column": 7,
     "line": 31,
     "rule": "number-leading-zero",

--- a/packages/stylelint-config/test/__snapshots__/selectors-scss.js.snap
+++ b/packages/stylelint-config/test/__snapshots__/selectors-scss.js.snap
@@ -1,43 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`flags warnings with invalid selectors scss snapshot matches warnings 1`] = `
-Array [
-  Object {
+[
+  {
     "column": 2,
     "line": 3,
     "rule": "scss/selector-no-redundant-nesting-selector",
     "severity": "error",
     "text": "Unnecessary nesting selector (&) (scss/selector-no-redundant-nesting-selector)",
   },
-  Object {
+  {
     "column": 2,
     "line": 10,
     "rule": "scss/selector-no-redundant-nesting-selector",
     "severity": "error",
     "text": "Unnecessary nesting selector (&) (scss/selector-no-redundant-nesting-selector)",
   },
-  Object {
+  {
     "column": 2,
     "line": 17,
     "rule": "scss/selector-no-redundant-nesting-selector",
     "severity": "error",
     "text": "Unnecessary nesting selector (&) (scss/selector-no-redundant-nesting-selector)",
   },
-  Object {
+  {
     "column": 2,
     "line": 24,
     "rule": "scss/selector-no-redundant-nesting-selector",
     "severity": "error",
     "text": "Unnecessary nesting selector (&) (scss/selector-no-redundant-nesting-selector)",
   },
-  Object {
+  {
     "column": 2,
     "line": 31,
     "rule": "scss/selector-no-redundant-nesting-selector",
     "severity": "error",
     "text": "Unnecessary nesting selector (&) (scss/selector-no-redundant-nesting-selector)",
   },
-  Object {
+  {
     "column": 10,
     "line": 31,
     "rule": "selector-pseudo-element-colon-notation",

--- a/packages/stylelint-config/test/__snapshots__/selectors.js.snap
+++ b/packages/stylelint-config/test/__snapshots__/selectors.js.snap
@@ -1,57 +1,57 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`flags warnings with invalid selectors css snapshot matches warnings 1`] = `
-Array [
-  Object {
+[
+  {
     "column": 15,
     "line": 18,
     "rule": "declaration-property-unit-allowed-list",
     "severity": "error",
-    "text": "Unexpected unit \\"%\\" for property \\"line-height\\" (declaration-property-unit-allowed-list)",
+    "text": "Unexpected unit "%" for property "line-height" (declaration-property-unit-allowed-list)",
   },
-  Object {
+  {
     "column": 1,
     "line": 25,
     "rule": "selector-class-pattern",
     "severity": "error",
     "text": "Selector should use lowercase and separate words with hyphens (selector-class-pattern)",
   },
-  Object {
+  {
     "column": 1,
     "line": 1,
     "rule": "selector-id-pattern",
     "severity": "error",
     "text": "Selector should use lowercase and separate words with hyphens (selector-id-pattern)",
   },
-  Object {
+  {
     "column": 1,
     "line": 5,
     "rule": "selector-id-pattern",
     "severity": "error",
     "text": "Selector should use lowercase and separate words with hyphens (selector-id-pattern)",
   },
-  Object {
+  {
     "column": 4,
     "line": 9,
     "rule": "selector-id-pattern",
     "severity": "error",
     "text": "Selector should use lowercase and separate words with hyphens (selector-id-pattern)",
   },
-  Object {
+  {
     "column": 1,
     "line": 21,
     "rule": "selector-id-pattern",
     "severity": "error",
     "text": "Selector should use lowercase and separate words with hyphens (selector-id-pattern)",
   },
-  Object {
+  {
     "column": 10,
     "line": 29,
     "rule": "selector-pseudo-element-colon-notation",
     "severity": "error",
     "text": "Expected double colon pseudo-element notation (selector-pseudo-element-colon-notation)",
   },
-  Object {
+  {
     "column": 12,
     "line": 17,
     "rule": "string-quotes",

--- a/packages/stylelint-config/test/__snapshots__/structure.js.snap
+++ b/packages/stylelint-config/test/__snapshots__/structure.js.snap
@@ -1,57 +1,57 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`flags warnings with invalid structure css snapshot matches warnings 1`] = `
-Array [
-  Object {
+[
+  {
     "column": 45,
     "line": 7,
     "rule": "block-closing-brace-newline-before",
     "severity": "error",
-    "text": "Expected newline before \\"}\\" (block-closing-brace-newline-before)",
+    "text": "Expected newline before "}" (block-closing-brace-newline-before)",
   },
-  Object {
+  {
     "column": 14,
     "line": 7,
     "rule": "block-opening-brace-newline-after",
     "severity": "error",
-    "text": "Expected newline after \\"{\\" (block-opening-brace-newline-after)",
+    "text": "Expected newline after "{" (block-opening-brace-newline-after)",
   },
-  Object {
+  {
     "column": 32,
     "line": 7,
     "rule": "declaration-block-semicolon-newline-after",
     "severity": "error",
-    "text": "Expected newline after \\";\\" (declaration-block-semicolon-newline-after)",
+    "text": "Expected newline after ";" (declaration-block-semicolon-newline-after)",
   },
-  Object {
+  {
     "column": 12,
     "line": 1,
     "rule": "selector-list-comma-newline-after",
     "severity": "error",
-    "text": "Expected newline after \\",\\" (selector-list-comma-newline-after)",
+    "text": "Expected newline after "," (selector-list-comma-newline-after)",
   },
-  Object {
+  {
     "column": 25,
     "line": 1,
     "rule": "selector-list-comma-newline-after",
     "severity": "error",
-    "text": "Expected newline after \\",\\" (selector-list-comma-newline-after)",
+    "text": "Expected newline after "," (selector-list-comma-newline-after)",
   },
-  Object {
+  {
     "column": 3,
     "line": 4,
     "rule": "indentation",
     "severity": "error",
     "text": "Expected indentation of 0 tabs (indentation)",
   },
-  Object {
+  {
     "column": 3,
     "line": 2,
     "rule": "indentation",
     "severity": "error",
     "text": "Expected indentation of 1 tab (indentation)",
   },
-  Object {
+  {
     "column": 3,
     "line": 3,
     "rule": "indentation",

--- a/packages/stylelint-config/test/__snapshots__/values.js.snap
+++ b/packages/stylelint-config/test/__snapshots__/values.js.snap
@@ -1,69 +1,69 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`flags warnings with invalid values css snapshot matches warnings 1`] = `
-Array [
-  Object {
+[
+  {
     "column": 16,
     "line": 2,
     "rule": "declaration-block-trailing-semicolon",
     "severity": "error",
     "text": "Expected a trailing semicolon (declaration-block-trailing-semicolon)",
   },
-  Object {
+  {
     "column": 13,
     "line": 2,
     "rule": "declaration-colon-space-after",
     "severity": "error",
-    "text": "Expected single space after \\":\\" with a single-line declaration (declaration-colon-space-after)",
+    "text": "Expected single space after ":" with a single-line declaration (declaration-colon-space-after)",
   },
-  Object {
+  {
     "column": 15,
     "line": 12,
     "rule": "declaration-property-unit-allowed-list",
     "severity": "error",
-    "text": "Unexpected unit \\"em\\" for property \\"line-height\\" (declaration-property-unit-allowed-list)",
+    "text": "Unexpected unit "em" for property "line-height" (declaration-property-unit-allowed-list)",
   },
-  Object {
+  {
     "column": 15,
     "line": 10,
     "rule": "font-family-name-quotes",
     "severity": "error",
-    "text": "Expected quotes around \\"Times New Roman\\" (font-family-name-quotes)",
+    "text": "Expected quotes around "Times New Roman" (font-family-name-quotes)",
   },
-  Object {
+  {
     "column": 15,
     "line": 11,
     "rule": "font-weight-notation",
     "severity": "error",
     "text": "Expected numeric font-weight notation (font-weight-notation)",
   },
-  Object {
+  {
     "column": 11,
     "line": 6,
     "rule": "length-zero-no-unit",
     "severity": "error",
     "text": "Unexpected unit (length-zero-no-unit)",
   },
-  Object {
+  {
     "column": 15,
     "line": 6,
     "rule": "length-zero-no-unit",
     "severity": "error",
     "text": "Unexpected unit (length-zero-no-unit)",
   },
-  Object {
+  {
     "column": 24,
     "line": 6,
     "rule": "length-zero-no-unit",
     "severity": "error",
     "text": "Unexpected unit (length-zero-no-unit)",
   },
-  Object {
+  {
     "column": 1,
     "line": 15,
     "rule": "no-duplicate-selectors",
     "severity": "error",
-    "text": "Unexpected duplicate selector \\".selector\\", first used at line 1 (no-duplicate-selectors)",
+    "text": "Unexpected duplicate selector ".selector", first used at line 1 (no-duplicate-selectors)",
   },
 ]
 `;

--- a/test/integration/__snapshots__/blocks-raw-handling.test.js.snap
+++ b/test/integration/__snapshots__/blocks-raw-handling.test.js.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Blocks raw handling pasteHandler apple 1`] = `"<strong>This is a </strong>title<br><br><br><strong>This is a <em>heading</em></strong><br><br><br>This is a <strong>paragraph</strong> with a <a href=\\"https://w.org\\">link</a>.<br><br><br>A<br>Bulleted<br>Indented<br>List<br><br><br>One<br>Two<br>Three<br><br><br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III<br><br><br>An image:<br>"`;
+exports[`Blocks raw handling pasteHandler apple 1`] = `"<strong>This is a </strong>title<br><br><br><strong>This is a <em>heading</em></strong><br><br><br>This is a <strong>paragraph</strong> with a <a href="https://w.org">link</a>.<br><br><br>A<br>Bulleted<br>Indented<br>List<br><br><br>One<br>Two<br>Three<br><br><br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III<br><br><br>An image:<br>"`;
 
 exports[`Blocks raw handling pasteHandler classic 1`] = `"First paragraph<br><br>Second paragraph<br>Third paragraph<br>Fourth paragraph<br>Fifth paragraph<br>Sixth paragraph"`;
 
-exports[`Blocks raw handling pasteHandler evernote 1`] = `"This is a <em>paragraph</em>.<br><br><br>This is a <a href=\\"https://w.org\\">link</a>.<br><br><br>An<br>Unordered<br>Indented<br>List<br><br><br>One<br>Two<br>Indented<br>Three<br><br><br><br><br><br><br>One<br>Two<br>Three<br>Four<br>Five<br>Six<br><img src=\\"data:image/jpeg;base64,###\\">"`;
+exports[`Blocks raw handling pasteHandler evernote 1`] = `"This is a <em>paragraph</em>.<br><br><br>This is a <a href="https://w.org">link</a>.<br><br><br>An<br>Unordered<br>Indented<br>List<br><br><br>One<br>Two<br>Indented<br>Three<br><br><br><br><br><br><br>One<br>Two<br>Three<br>Four<br>Five<br>Six<br><img src="data:image/jpeg;base64,###">"`;
 
-exports[`Blocks raw handling pasteHandler google-docs 1`] = `"This is a <strong>title</strong><br><br>This is a <em>heading</em><br><br>Formatting test: <strong>bold</strong>, <em>italic</em>, <a href=\\"https://w.org/\\">link</a>, <s>strikethrough</s>, <sup>superscript</sup>, <sub>subscript</sub>, <strong><em>nested</em></strong>.<br><br>A<br>Bulleted<br>Indented<br>List<br><br>One<br>Two<br>Three<br><br><br><br><br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III<br><br><br><br><br><br>An image:<br><br><img src=\\"https://lh4.googleusercontent.com/ID\\" width=\\"544\\" height=\\"184\\"><br>"`;
+exports[`Blocks raw handling pasteHandler google-docs 1`] = `"This is a <strong>title</strong><br><br>This is a <em>heading</em><br><br>Formatting test: <strong>bold</strong>, <em>italic</em>, <a href="https://w.org/">link</a>, <s>strikethrough</s>, <sup>superscript</sup>, <sub>subscript</sub>, <strong><em>nested</em></strong>.<br><br>A<br>Bulleted<br>Indented<br>List<br><br>One<br>Two<br>Three<br><br><br><br><br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III<br><br><br><br><br><br>An image:<br><br><img src="https://lh4.googleusercontent.com/ID" width="544" height="184"><br>"`;
 
 exports[`Blocks raw handling pasteHandler google-docs-list-only 1`] = `"My first list item<br>A sub list item<br>A second sub list item<br>My second list item<br>My third list item"`;
 
@@ -18,27 +18,27 @@ exports[`Blocks raw handling pasteHandler google-docs-table-with-rowspan 1`] = `
 
 exports[`Blocks raw handling pasteHandler google-docs-table-with-comments 1`] = `"<br><br><br><br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III"`;
 
-exports[`Blocks raw handling pasteHandler google-docs-with-comments 1`] = `"This is a <strong>title</strong><br><br>This is a <em>heading</em><br><br>Formatting test: <strong>bold</strong>, <em>italic</em>, <a href=\\"https://w.org/\\">link</a>, <s>strikethrough</s>, <sup>superscript</sup>, <sub>subscript</sub>, <strong><em>nested</em></strong>.<br><br>A<br>Bulleted<br>Indented<br>List<br><br>One<br>Two<br>Three<br><br><br><br><br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III<br><br><br><br><br><br>An image:<br><br><img src=\\"https://lh4.googleusercontent.com/ID\\" width=\\"544\\" height=\\"184\\"><br><br>"`;
+exports[`Blocks raw handling pasteHandler google-docs-with-comments 1`] = `"This is a <strong>title</strong><br><br>This is a <em>heading</em><br><br>Formatting test: <strong>bold</strong>, <em>italic</em>, <a href="https://w.org/">link</a>, <s>strikethrough</s>, <sup>superscript</sup>, <sub>subscript</sub>, <strong><em>nested</em></strong>.<br><br>A<br>Bulleted<br>Indented<br>List<br><br>One<br>Two<br>Three<br><br><br><br><br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III<br><br><br><br><br><br>An image:<br><br><img src="https://lh4.googleusercontent.com/ID" width="544" height="184"><br><br>"`;
 
 exports[`Blocks raw handling pasteHandler gutenberg 1`] = `"Test"`;
 
 exports[`Blocks raw handling pasteHandler iframe-embed 1`] = `""`;
 
-exports[`Blocks raw handling pasteHandler markdown 1`] = `"This is a heading with <em>italic</em><br>This is a paragraph with a <a href=\\"https://w.org/\\">link</a>, <strong>bold</strong>, and <del>strikethrough</del>.<br>Preserve<br>line breaks please.<br>Lists<br>A<br>Bulleted Indented<br>List<br>One<br>Two<br>Three<br>Table<br>First Header<br>Second Header<br>Content from cell 1<br>Content from cell 2<br>Content in the first column<br>Content in the second column<br><br><br><br>Table with empty cells.<br>Quote<br>First<br>Second<br>Code<br>Inline <code>code</code> tags should work.<br><code>This is a code block.</code>"`;
+exports[`Blocks raw handling pasteHandler markdown 1`] = `"This is a heading with <em>italic</em><br>This is a paragraph with a <a href="https://w.org/">link</a>, <strong>bold</strong>, and <del>strikethrough</del>.<br>Preserve<br>line breaks please.<br>Lists<br>A<br>Bulleted Indented<br>List<br>One<br>Two<br>Three<br>Table<br>First Header<br>Second Header<br>Content from cell 1<br>Content from cell 2<br>Content in the first column<br>Content in the second column<br><br><br><br>Table with empty cells.<br>Quote<br>First<br>Second<br>Code<br>Inline <code>code</code> tags should work.<br><code>This is a code block.</code>"`;
 
-exports[`Blocks raw handling pasteHandler ms-word 1`] = `"This is a title<br>&nbsp;<br>This is a subtitle<br>&nbsp;<br>This is a heading level 1<br>&nbsp;<br>This is a heading level 2<br>&nbsp;<br>This is a <strong>paragraph</strong> with a <a href=\\"https://w.org/\\">link</a>.<br>&nbsp;<br>·&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; A<br>·&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Bulleted<br>o&nbsp;&nbsp; Indented<br>·&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; List<br>&nbsp;<br>1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; One<br>2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Two<br>3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Three<br>&nbsp;<br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III<br>&nbsp;<br>An image:<br>&nbsp;<br><img width=\\"451\\" height=\\"338\\" src=\\"file:LOW-RES.png\\"><br><a href=\\"#anchor\\">This is an anchor link</a> that leads to the next paragraph.<br><a id=\\"anchor\\">This is the paragraph with the anchor.</a><br><a href=\\"#nowhere\\">This is an anchor link</a> that leads nowhere.<br><a>This is a paragraph with an anchor with no link pointing to it.</a><br>This is a reference to a footnote<a href=\\"#_ftn1\\" id=\\"_ftnref1\\">[1]</a>.<br>This is a reference to an endnote<a href=\\"#_edn1\\" id=\\"_ednref1\\">[i]</a>.<br><br><br><a href=\\"#_ftnref1\\" id=\\"_ftn1\\">[1]</a> This is a footnote.<br><br><br><a href=\\"#_ednref1\\" id=\\"_edn1\\">[i]</a> This is an endnote."`;
+exports[`Blocks raw handling pasteHandler ms-word 1`] = `"This is a title<br>&nbsp;<br>This is a subtitle<br>&nbsp;<br>This is a heading level 1<br>&nbsp;<br>This is a heading level 2<br>&nbsp;<br>This is a <strong>paragraph</strong> with a <a href="https://w.org/">link</a>.<br>&nbsp;<br>·&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; A<br>·&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Bulleted<br>o&nbsp;&nbsp; Indented<br>·&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; List<br>&nbsp;<br>1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; One<br>2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Two<br>3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Three<br>&nbsp;<br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III<br>&nbsp;<br>An image:<br>&nbsp;<br><img width="451" height="338" src="file:LOW-RES.png"><br><a href="#anchor">This is an anchor link</a> that leads to the next paragraph.<br><a id="anchor">This is the paragraph with the anchor.</a><br><a href="#nowhere">This is an anchor link</a> that leads nowhere.<br><a>This is a paragraph with an anchor with no link pointing to it.</a><br>This is a reference to a footnote<a href="#_ftn1" id="_ftnref1">[1]</a>.<br>This is a reference to an endnote<a href="#_edn1" id="_ednref1">[i]</a>.<br><br><br><a href="#_ftnref1" id="_ftn1">[1]</a> This is a footnote.<br><br><br><a href="#_ednref1" id="_edn1">[i]</a> This is an endnote."`;
 
-exports[`Blocks raw handling pasteHandler ms-word-online 1`] = `"This is a <em>heading</em>&nbsp;<br>This is a <strong>paragraph </strong>with a <a href=\\"https://w.org/\\" target=\\"_blank\\" rel=\\"noreferrer noopener\\">link</a>.&nbsp;<br>A&nbsp;<br>Bulleted&nbsp;<br>Indented&nbsp;<br>List&nbsp;<br>&nbsp;<br>One&nbsp;<br>Two&nbsp;<br>Three&nbsp;<br><br>One&nbsp;<br>Two&nbsp;<br>Three&nbsp;<br>1&nbsp;<br>2&nbsp;<br>3&nbsp;<br>I&nbsp;<br>II&nbsp;<br>III&nbsp;<br>&nbsp;<br>An image:&nbsp;<br><img src=\\"data:image/jpeg;base64,###\\">&nbsp;"`;
+exports[`Blocks raw handling pasteHandler ms-word-online 1`] = `"This is a <em>heading</em>&nbsp;<br>This is a <strong>paragraph </strong>with a <a href="https://w.org/" target="_blank" rel="noreferrer noopener">link</a>.&nbsp;<br>A&nbsp;<br>Bulleted&nbsp;<br>Indented&nbsp;<br>List&nbsp;<br>&nbsp;<br>One&nbsp;<br>Two&nbsp;<br>Three&nbsp;<br><br>One&nbsp;<br>Two&nbsp;<br>Three&nbsp;<br>1&nbsp;<br>2&nbsp;<br>3&nbsp;<br>I&nbsp;<br>II&nbsp;<br>III&nbsp;<br>&nbsp;<br>An image:&nbsp;<br><img src="data:image/jpeg;base64,###">&nbsp;"`;
 
 exports[`Blocks raw handling pasteHandler ms-word-styled 1`] = `"<br><strong>Lorem ipsum dolor sit amet, consectetur adipiscing elit&nbsp;</strong><br><br><br>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque aliquet hendrerit auctor. Nam lobortis, est vel lacinia tincidunt, purus tellus vehicula ex, nec pharetra justo dui sed lorem. Nam congue laoreet massa, quis varius est tincidunt ut."`;
 
 exports[`Blocks raw handling pasteHandler nested-divs 1`] = `"First paragraph<br><br>Second paragraph<br>Third paragraph<br>Fourth paragraph<br>Fifth paragraph<br>Sixth paragraph"`;
 
-exports[`Blocks raw handling pasteHandler one-image 1`] = `"<img src=\\"http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif\\" alt=\\"\\" width=\\"300\\" height=\\"137\\">"`;
+exports[`Blocks raw handling pasteHandler one-image 1`] = `"<img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" width="300" height="137">"`;
 
 exports[`Blocks raw handling pasteHandler plain 1`] = `"test<br>test<br><br>test"`;
 
-exports[`Blocks raw handling pasteHandler shortcode-matching 1`] = `"[gallery ids=\\"40,41,42\\"]<br>[gallery ids=\\"1000\\"]<br>[gallery ids=\\"42\\"]"`;
+exports[`Blocks raw handling pasteHandler shortcode-matching 1`] = `"[gallery ids="40,41,42"]<br>[gallery ids="1000"]<br>[gallery ids="42"]"`;
 
 exports[`Blocks raw handling pasteHandler should remove extra blank lines 1`] = `
 "<!-- wp:paragraph -->
@@ -60,7 +60,7 @@ exports[`Blocks raw handling pasteHandler should strip some text-level elements 
 
 exports[`Blocks raw handling pasteHandler should strip windows data 1`] = `
 "<!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\">Heading Win</h2>
+<h2 class="wp-block-heading">Heading Win</h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -68,18 +68,18 @@ exports[`Blocks raw handling pasteHandler should strip windows data 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Blocks raw handling pasteHandler slack-paragraphs 1`] = `"test with&nbsp;<a target=\\"_blank\\" href=\\"http://w.org/\\" rel=\\"noreferrer noopener\\">link</a><br>a new linea new paragraph<br>another new lineanother paragraph"`;
+exports[`Blocks raw handling pasteHandler slack-paragraphs 1`] = `"test with&nbsp;<a target="_blank" href="http://w.org/" rel="noreferrer noopener">link</a><br>a new linea new paragraph<br>another new lineanother paragraph"`;
 
-exports[`Blocks raw handling pasteHandler slack-quote 1`] = `"Test with&nbsp;<a target=\\"_blank\\" href=\\"http://w.org/\\" rel=\\"noreferrer noopener\\">link</a>."`;
+exports[`Blocks raw handling pasteHandler slack-quote 1`] = `"Test with&nbsp;<a target="_blank" href="http://w.org/" rel="noreferrer noopener">link</a>."`;
 
-exports[`Blocks raw handling pasteHandler two-images 1`] = `"<img src=\\"http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif\\" alt=\\"\\" width=\\"300\\" height=\\"137\\"> <img src=\\"http://localhost/wp-content/uploads/2018/01/Dec-05-2017-17-52-09-9-300x248.gif\\" alt=\\"\\" width=\\"300\\" height=\\"248\\">"`;
+exports[`Blocks raw handling pasteHandler two-images 1`] = `"<img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" width="300" height="137"> <img src="http://localhost/wp-content/uploads/2018/01/Dec-05-2017-17-52-09-9-300x248.gif" alt="" width="300" height="248">"`;
 
-exports[`Blocks raw handling pasteHandler wordpress 1`] = `"Howdy<br>This is a paragraph.<br>More tag<br><br>Shortcode<br>[gallery ids=\\"1\\"]<br><img src=\\"block.png\\" alt=\\"\\"><br><img src=\\"aligned.png\\" alt=\\"\\"> test<br><img src=\\"not-aligned.png\\" alt=\\"\\"> test"`;
+exports[`Blocks raw handling pasteHandler wordpress 1`] = `"Howdy<br>This is a paragraph.<br>More tag<br><br>Shortcode<br>[gallery ids="1"]<br><img src="block.png" alt=""><br><img src="aligned.png" alt=""> test<br><img src="not-aligned.png" alt=""> test"`;
 
 exports[`Blocks raw handling should correctly handle quotes with mixed content 1`] = `
 "<!-- wp:quote -->
-<blockquote class=\\"wp-block-quote\\"><!-- wp:heading {\\"level\\":1} -->
-<h1 class=\\"wp-block-heading\\">chicken</h1>
+<blockquote class="wp-block-quote"><!-- wp:heading {"level":1} -->
+<h1 class="wp-block-heading">chicken</h1>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -90,11 +90,11 @@ exports[`Blocks raw handling should correctly handle quotes with mixed content 1
 
 exports[`rawHandler should convert HTML post to blocks with minimal content changes 1`] = `
 "<!-- wp:heading -->
-<h2 class=\\"wp-block-heading\\">Howdy</h2>
+<h2 class="wp-block-heading">Howdy</h2>
 <!-- /wp:heading -->
 
 <!-- wp:image -->
-<figure class=\\"wp-block-image\\"><img src=\\"https://w.org\\" alt=\\"\\"/></figure>
+<figure class="wp-block-image"><img src="https://w.org" alt=""/></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph -->
@@ -102,24 +102,24 @@ exports[`rawHandler should convert HTML post to blocks with minimal content chan
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Preserve <span style=\\"color:red\\">me</span>!</p>
+<p>Preserve <span style="color:red">me</span>!</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:heading {\\"level\\":3} -->
-<h3 class=\\"wp-block-heading\\">More tag</h3>
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">More tag</h3>
 <!-- /wp:heading -->
 
 <!-- wp:more -->
 <!--more-->
 <!-- /wp:more -->
 
-<!-- wp:heading {\\"level\\":3} -->
-<h3 class=\\"wp-block-heading\\">Shortcode</h3>
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Shortcode</h3>
 <!-- /wp:heading -->
 
-<!-- wp:gallery {\\"columns\\":3,\\"linkTo\\":\\"none\\"} -->
-<figure class=\\"wp-block-gallery has-nested-images columns-3 is-cropped\\"><!-- wp:image {\\"id\\":1} -->
-<figure class=\\"wp-block-image\\"><img alt=\\"\\" class=\\"wp-image-1\\"/></figure>
+<!-- wp:gallery {"columns":3,"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-3 is-cropped"><!-- wp:image {"id":1} -->
+<figure class="wp-block-image"><img alt="" class="wp-image-1"/></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->
 
@@ -132,21 +132,21 @@ exports[`rawHandler should convert HTML post to blocks with minimal content chan
 </dl>
 <!-- /wp:html -->
 
-<!-- wp:list {\\"ordered\\":true} -->
+<!-- wp:list {"ordered":true} -->
 <ol><!-- wp:list-item -->
 <li>Item</li>
 <!-- /wp:list-item --></ol>
 <!-- /wp:list -->
 
 <!-- wp:quote -->
-<blockquote class=\\"wp-block-quote\\"><!-- wp:paragraph -->
+<blockquote class="wp-block-quote"><!-- wp:paragraph -->
 <p>Text.</p>
 <!-- /wp:paragraph --></blockquote>
 <!-- /wp:quote -->
 
 <!-- wp:quote -->
-<blockquote class=\\"wp-block-quote\\"><!-- wp:heading {\\"level\\":1} -->
-<h1 class=\\"wp-block-heading\\">Heading</h1>
+<blockquote class="wp-block-quote"><!-- wp:heading {"level":1} -->
+<h1 class="wp-block-heading">Heading</h1>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -156,28 +156,28 @@ exports[`rawHandler should convert HTML post to blocks with minimal content chan
 `;
 
 exports[`rawHandler should convert a caption shortcode 1`] = `
-"<!-- wp:image {\\"align\\":\\"none\\",\\"id\\":122,\\"className\\":\\"size-medium wp-image-122\\"} -->
-<figure class=\\"wp-block-image alignnone size-medium wp-image-122\\"><img src=\\"image.png\\" alt=\\"\\" class=\\"wp-image-122\\"/><figcaption class=\\"wp-element-caption\\">test</figcaption></figure>
+"<!-- wp:image {"align":"none","id":122,"className":"size-medium wp-image-122"} -->
+<figure class="wp-block-image alignnone size-medium wp-image-122"><img src="image.png" alt="" class="wp-image-122"/><figcaption class="wp-element-caption">test</figcaption></figure>
 <!-- /wp:image -->"
 `;
 
 exports[`rawHandler should convert a caption shortcode with caption 1`] = `
-"<!-- wp:image {\\"align\\":\\"none\\",\\"id\\":122,\\"className\\":\\"size-medium wp-image-122\\"} -->
-<figure class=\\"wp-block-image alignnone size-medium wp-image-122\\"><img src=\\"image.png\\" alt=\\"\\" class=\\"wp-image-122\\"/><figcaption class=\\"wp-element-caption\\"><a href=\\"https://w.org\\">test</a></figcaption></figure>
+"<!-- wp:image {"align":"none","id":122,"className":"size-medium wp-image-122"} -->
+<figure class="wp-block-image alignnone size-medium wp-image-122"><img src="image.png" alt="" class="wp-image-122"/><figcaption class="wp-element-caption"><a href="https://w.org">test</a></figcaption></figure>
 <!-- /wp:image -->"
 `;
 
 exports[`rawHandler should convert a caption shortcode with link 1`] = `
-"<!-- wp:image {\\"align\\":\\"none\\",\\"id\\":754} -->
-<figure class=\\"wp-block-image alignnone\\"><a href=\\"http://build.wordpress-develop.test/wp-content/uploads/2011/07/100_5478.jpg\\"><img src=\\"http://build.wordpress-develop.test/wp-content/uploads/2011/07/100_5478.jpg?w=604\\" alt=\\"Bell on Wharf\\" class=\\"wp-image-754\\"/></a><figcaption class=\\"wp-element-caption\\">Bell on wharf in San Francisco</figcaption></figure>
+"<!-- wp:image {"align":"none","id":754} -->
+<figure class="wp-block-image alignnone"><a href="http://build.wordpress-develop.test/wp-content/uploads/2011/07/100_5478.jpg"><img src="http://build.wordpress-develop.test/wp-content/uploads/2011/07/100_5478.jpg?w=604" alt="Bell on Wharf" class="wp-image-754"/></a><figcaption class="wp-element-caption">Bell on wharf in San Francisco</figcaption></figure>
 <!-- /wp:image -->"
 `;
 
 exports[`rawHandler should convert a list with attributes 1`] = `
-"<!-- wp:list {\\"ordered\\":true,\\"type\\":\\"i\\",\\"start\\":2,\\"reversed\\":true} -->
-<ol type=\\"i\\" reversed start=\\"2\\"><!-- wp:list-item -->
-<li>1<!-- wp:list {\\"ordered\\":true,\\"type\\":\\"i\\",\\"start\\":2,\\"reversed\\":true} -->
-<ol type=\\"i\\" reversed start=\\"2\\"><!-- wp:list-item -->
+"<!-- wp:list {"ordered":true,"type":"i","start":2,"reversed":true} -->
+<ol type="i" reversed start="2"><!-- wp:list-item -->
+<li>1<!-- wp:list {"ordered":true,"type":"i","start":2,"reversed":true} -->
+<ol type="i" reversed start="2"><!-- wp:list-item -->
 <li>1</li>
 <!-- /wp:list-item --></ol>
 <!-- /wp:list --></li>
@@ -192,7 +192,7 @@ exports[`rawHandler should not strip any text-level elements 1`] = `
 `;
 
 exports[`rawHandler should preserve alignment 1`] = `
-"<!-- wp:paragraph {\\"align\\":\\"center\\"} -->
-<p class=\\"has-text-align-center\\">center</p>
+"<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">center</p>
 <!-- /wp:paragraph -->"
 `;

--- a/test/native/jest.config.js
+++ b/test/native/jest.config.js
@@ -68,5 +68,9 @@ module.exports = {
 		'node_modules/(?!(simple-html-tokenizer|(jest-)?react-native|@react-native|react-clone-referenced-element|@react-navigation))',
 	],
 	snapshotSerializers: [ '@emotion/jest/serializer' ],
+	snapshotFormat: {
+		escapeString: false,
+		printBasicPrototype: false,
+	},
 	reporters: [ 'default', 'jest-junit' ],
 };

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -40,6 +40,10 @@ module.exports = {
 		'@emotion/jest/serializer',
 		'snapshot-diff/serializer',
 	],
+	snapshotFormat: {
+		escapeString: false,
+		printBasicPrototype: false,
+	},
 	watchPlugins: [
 		'jest-watch-typeahead/filename',
 		'jest-watch-typeahead/testname',


### PR DESCRIPTION
Spinoff from #47388 which updates the snapshot format to Jest 29 default, with less escaping and more human readability.

After the v29 upgrade the `snapshotFormat` declarations won't be necessary -- the values that we're setting there will be the defaults.

