### PR TITLE
i18n: Fix node version compatible

### DIFF
--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -19,7 +19,7 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=14.0.0"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of [Upgrade node and npm to latest LTS versions](https://github.com/WordPress/gutenberg/issues/34801).

Fix node version compatible with null coalescing operator.

- The null coalescing operator support is available from node 14 only.

Reference:

https://node.green/#ES2020-features--nullish-coalescing-operator-----

Resolves:

https://github.com/WordPress/gutenberg/pull/45414/files

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Resolves syntax error unexpected token in older node version.

## Screenshots or screencast <!-- if applicable -->
![null-coalescing](https://user-images.githubusercontent.com/4319097/220962946-af45e068-0ab4-4a8c-81c5-ce709e4a5865.png)


