### PR TITLE
Rich text: remove unnecessary handleSelectionChange call

### DIFF
--- a/packages/rich-text/src/component/use-input-and-selection.js
+++ b/packages/rich-text/src/component/use-input-and-selection.js
@@ -290,12 +290,6 @@ export function useInputAndSelection( props ) {
 				applyRecord( record.current );
 				onSelectionChange( record.current.start, record.current.end );
 			}
-
-			// Update selection as soon as possible, which is at the next animation
-			// frame. The event listener for selection changes may be added too late
-			// at this point, but this focus event is still too early to calculate
-			// the selection.
-			window.queueMicrotask( handleSelectionChange );
 		}
 
 		element.addEventListener( 'input', onInput );

--- a/packages/rich-text/src/component/use-input-and-selection.js
+++ b/packages/rich-text/src/component/use-input-and-selection.js
@@ -112,11 +112,10 @@ export function useInputAndSelection( props ) {
 		}
 
 		/**
-		 * Syncs the selection to local state. A callback for the `selectionchange`
-		 * native events, `keyup`, `mouseup` and `touchend` synthetic events, and
-		 * animation frames after the `focus` event.
+		 * Syncs the selection to local state. A callback for the
+		 * `selectionchange`, `keyup`, `mouseup` and `touchend` events.
 		 *
-		 * @param {Event|undefined} event
+		 * @param {Event} event
 		 */
 		function handleSelectionChange( event ) {
 			const {
@@ -179,7 +178,7 @@ export function useInputAndSelection( props ) {
 				return;
 			}
 
-			if ( event?.type !== 'selectionchange' && ! isSelected ) {
+			if ( event.type !== 'selectionchange' && ! isSelected ) {
 				return;
 			}
 

--- a/packages/rich-text/src/component/use-input-and-selection.js
+++ b/packages/rich-text/src/component/use-input-and-selection.js
@@ -64,7 +64,6 @@ export function useInputAndSelection( props ) {
 		const { defaultView } = ownerDocument;
 
 		let isComposing = false;
-		let rafId;
 
 		function onInput( event ) {
 			// Do not trigger a change if characters are being composed.
@@ -117,7 +116,7 @@ export function useInputAndSelection( props ) {
 		 * native events, `keyup`, `mouseup` and `touchend` synthetic events, and
 		 * animation frames after the `focus` event.
 		 *
-		 * @param {Event|DOMHighResTimeStamp} event
+		 * @param {Event|undefined} event
 		 */
 		function handleSelectionChange( event ) {
 			const {
@@ -180,7 +179,7 @@ export function useInputAndSelection( props ) {
 				return;
 			}
 
-			if ( event.type !== 'selectionchange' && ! isSelected ) {
+			if ( event?.type !== 'selectionchange' && ! isSelected ) {
 				return;
 			}
 
@@ -296,7 +295,7 @@ export function useInputAndSelection( props ) {
 			// frame. The event listener for selection changes may be added too late
 			// at this point, but this focus event is still too early to calculate
 			// the selection.
-			rafId = defaultView.requestAnimationFrame( handleSelectionChange );
+			window.queueMicrotask( handleSelectionChange );
 		}
 
 		element.addEventListener( 'input', onInput );
@@ -329,7 +328,6 @@ export function useInputAndSelection( props ) {
 				'selectionchange',
 				handleSelectionChange
 			);
-			defaultView.cancelAnimationFrame( rafId );
 		};
 	}, [] );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Setting selection after focus is no longer necessary. It's probably enough to handle it on keyup/mouseup.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
