### PR TITLE
Duotone: Output duotone presets per block

### DIFF
--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -614,7 +614,7 @@ add_action(
 	}
 );
 
-function gutenberg_render_duotone_svgs( $block_content, $block ) {
+function gutenberg_save_duotone_preset_svgs( $block_content, $block ) {
 	// Get the per block settings from the theme.json.
 	$tree = WP_Theme_JSON_Resolver::get_merged_data();
 	$block_nodes = $tree->get_styles_block_nodes();
@@ -645,4 +645,4 @@ function gutenberg_render_duotone_svgs( $block_content, $block ) {
 	// Don't change the block content.
 	return $block_content;
 }
-add_action( 'render_block', 'gutenberg_render_duotone_svgs', 10, 2 );
+add_action( 'render_block', 'gutenberg_save_duotone_preset_svgs', 10, 2 );

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -633,16 +633,27 @@ function gutenberg_save_duotone_preset_svgs( $block_content, $block ) {
 	};
 	if ( $block_metadata ) {
 		$theme_json = $tree->get_raw_data();
-		$styles     = _wp_array_get( $theme_json, $block_metadata['path'], array() );
-		$duotone_filter = _wp_array_get( $styles, array( 'filter', 'duotone' ), array() );
-		if ( $duotone_filter ) {
-			preg_match('/var\(--wp--preset--duotone--(.*)\)/', $duotone_filter, $matches );
+		// Define the path to the duotone filter.
+		$duotone_filter_path = array_merge( $block_metadata['path'],  array( 'filter', 'duotone' ) );
+		$duotone_filter = _wp_array_get( $theme_json, $duotone_filter_path, array() );
+		$duotone_slug = gutenberg_get_duotone_slug_from_preset_css_variable( $duotone_filter );
+		if ( $duotone_slug ) {
 			// Save the preset slug to be used later.
-			WP_Duotone::$duotone_presets[ $matches[1] ] = true;
+			WP_Duotone::$duotone_presets[ $duotone_slug ] = true;
 		}
 	}
 
 	// Don't change the block content.
 	return $block_content;
+}
+
+function gutenberg_get_duotone_slug_from_preset_css_variable( $css_variable ) {
+	if ( ! empty( $css_variable ) ) {
+		// Get the preset slug from the filter.
+		preg_match('/var\(--wp--preset--duotone--(.*)\)/', $css_variable, $matches );
+		if ( $matches[1] ) {
+			return $matches[1];
+		}
+	}
 }
 add_action( 'render_block', 'gutenberg_save_duotone_preset_svgs', 10, 2 );

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -304,6 +304,12 @@ function gutenberg_get_duotone_filter_id( $preset ) {
 	return 'wp-duotone-' . $preset['slug'];
 }
 
+function gutenberg_get_duotone_preset_value( $preset ) {
+	if( array_key_exists( $preset['slug'], WP_Duotone::$duotone_presets ) ) {
+		return gutenberg_get_duotone_filter_property( $preset );
+	}
+}
+
 /**
  * Returns the CSS filter property url to reference the rendered SVG.
  *
@@ -311,10 +317,8 @@ function gutenberg_get_duotone_filter_id( $preset ) {
  * @return string        Duotone CSS filter property url value.
  */
 function gutenberg_get_duotone_filter_property( $preset ) {
-	if( array_key_exists( $preset['slug'], WP_Duotone::$duotone_presets ) ) {
-		$filter_id = gutenberg_get_duotone_filter_id( $preset );
-		return "url('#" . $filter_id . "')";
-	}
+	$filter_id = gutenberg_get_duotone_filter_id( $preset );
+	return "url('#" . $filter_id . "')";
 }
 
 /**

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -311,8 +311,10 @@ function gutenberg_get_duotone_filter_id( $preset ) {
  * @return string        Duotone CSS filter property url value.
  */
 function gutenberg_get_duotone_filter_property( $preset ) {
-	$filter_id = gutenberg_get_duotone_filter_id( $preset );
-	return "url('#" . $filter_id . "')";
+	if( array_key_exists( $preset['slug'], WP_Duotone::$duotone_presets ) ) {
+		$filter_id = gutenberg_get_duotone_filter_id( $preset );
+		return "url('#" . $filter_id . "')";
+	}
 }
 
 /**
@@ -626,6 +628,7 @@ function gutenberg_save_duotone_preset_svgs( $block_content, $block ) {
 		if ( empty( $node['duotone'] ) ) {
 			continue;
 		}
+		// TODO: Why do some nodes not have a name?
 		if( ! empty( $node['name'] ) && $node['name'] === $block['blockName'] ) {
 			$block_metadata = $node;
 			break;

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -663,4 +663,4 @@ function gutenberg_get_duotone_slug_from_preset_css_variable( $css_variable ) {
 		}
 	}
 }
-add_action( 'render_block', 'gutenberg_save_duotone_preset_svgs', 10, 2 );
+add_filter( 'render_block', 'gutenberg_save_duotone_preset_svgs', 10, 2 );

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -628,8 +628,8 @@ function gutenberg_save_duotone_preset_svgs( $block_content, $block ) {
 		if ( empty( $node['duotone'] ) ) {
 			continue;
 		}
-		// TODO: Why do some nodes not have a name?
-		if( ! empty( $node['name'] ) && $node['name'] === $block['blockName'] ) {
+
+		if( $node['name'] === $block['blockName'] ) {
 			$block_metadata = $node;
 			break;
 		}

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -548,7 +548,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 				}
 			}
 		);
-	} else {
+	} else if ( ! $is_duotone_unset ) {
 		WP_Duotone::$duotone_presets[] = $filter_preset['slug'];
 	}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1634,12 +1634,12 @@ class WP_Theme_JSON_Gutenberg {
 				) {
 					$value_func = $preset_metadata['value_func'];
 					$value      = call_user_func( $value_func, $preset );
-				} else {
-					// If we don't have a value, then don't add it to the result.
-					continue;
 				}
 
-				$result[ $slug ] = $value;
+				// If we don't have a value, then don't add it to the result.
+				if ( ! empty( $value) ) {
+					$result[ $slug ] = $value;
+				}
 			}
 		}
 		return $result;

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3460,4 +3460,39 @@ class WP_Theme_JSON_Gutenberg {
 
 		_wp_array_set( $this->theme_json, array( 'settings', 'spacing', 'spacingSizes', 'default' ), $spacing_sizes );
 	}
+
+	/**
+	 * Returns the CSS variable for a preset.
+	 *
+	 * @since 6.3.0
+	 *
+	 * @param array  $path Path to the preset.
+	 * @param string $slug Slug of the preset.
+	 * @return string CSS variable.
+	 */
+	public static function get_preset_css_var( $path, $slug ) {
+		$duotone_preset_metadata = static::get_preset_metadata_from_path( $path );
+		return static::replace_slug_in_string( $duotone_preset_metadata['css_vars'], $slug );
+	}
+
+	/**
+	 * Returns the metadata for a preset.
+	 *
+	 * @since 6.3.0
+	 *
+	 * @param array $path Path to the preset.
+	 * @return array Preset metadata.
+	 */
+	static function get_preset_metadata_from_path( $path ) {
+		$preset_metadata = array_filter(
+			static::PRESETS_METADATA,
+			function( $preset ) use ( &$path ) {
+				if ( $preset['path'] === $path ) {
+					return $preset;
+				}
+			}
+		);
+
+		return reset( $preset_metadata );
+	}
 }

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -152,7 +152,7 @@ class WP_Theme_JSON_Gutenberg {
 			'path'              => array( 'color', 'duotone' ),
 			'prevent_override'  => array( 'color', 'defaultDuotone' ),
 			'use_default_names' => false,
-			'value_func'        => 'gutenberg_get_duotone_filter_property',
+			'value_func'        => 'gutenberg_get_duotone_preset_value',
 			'css_vars'          => '--wp--preset--duotone--$slug',
 			'classes'           => array(),
 			'properties'        => array( 'filter' ),

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -121,6 +121,29 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 	}
 
 	/*
+	 * For the remaining types (presets, styles), we do consider origins:
+	 *
+	 * - themes without theme.json: only the classes for the presets defined by core
+	 * - themes with theme.json: the presets and styles classes, both from core and the theme
+	 */
+
+	// We need to do this first for duotone.
+	$styles_rest = '';
+	if ( ! empty( $types ) ) {
+		/*
+		 * We only use the default, theme, and custom origins.
+		 * This is because styles for blocks origin are added
+		 * at a later phase (render cycle) so we only render the ones in use.
+		 * @see wp_add_global_styles_for_blocks
+		 */
+		$origins = array( 'default', 'theme', 'custom' );
+		if ( ! $supports_theme_json ) {
+			$origins = array( 'default' );
+		}
+		$styles_rest = $tree->get_stylesheet( $types, $origins );
+	}
+
+	/*
 	 * If variables are part of the stylesheet,
 	 * we add them.
 	 *
@@ -141,26 +164,6 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 		$types            = array_diff( $types, array( 'variables' ) );
 	}
 
-	/*
-	 * For the remaining types (presets, styles), we do consider origins:
-	 *
-	 * - themes without theme.json: only the classes for the presets defined by core
-	 * - themes with theme.json: the presets and styles classes, both from core and the theme
-	 */
-	$styles_rest = '';
-	if ( ! empty( $types ) ) {
-		/*
-		 * We only use the default, theme, and custom origins.
-		 * This is because styles for blocks origin are added
-		 * at a later phase (render cycle) so we only render the ones in use.
-		 * @see wp_add_global_styles_for_blocks
-		 */
-		$origins = array( 'default', 'theme', 'custom' );
-		if ( ! $supports_theme_json ) {
-			$origins = array( 'default' );
-		}
-		$styles_rest = $tree->get_stylesheet( $types, $origins );
-	}
 	$stylesheet = $styles_variables . $styles_rest;
 	if ( $can_use_cached ) {
 		wp_cache_set( $cache_key, $stylesheet, $cache_group );

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -121,29 +121,6 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 	}
 
 	/*
-	 * For the remaining types (presets, styles), we do consider origins:
-	 *
-	 * - themes without theme.json: only the classes for the presets defined by core
-	 * - themes with theme.json: the presets and styles classes, both from core and the theme
-	 */
-
-	// We need to do this first for duotone.
-	$styles_rest = '';
-	if ( ! empty( $types ) ) {
-		/*
-		 * We only use the default, theme, and custom origins.
-		 * This is because styles for blocks origin are added
-		 * at a later phase (render cycle) so we only render the ones in use.
-		 * @see wp_add_global_styles_for_blocks
-		 */
-		$origins = array( 'default', 'theme', 'custom' );
-		if ( ! $supports_theme_json ) {
-			$origins = array( 'default' );
-		}
-		$styles_rest = $tree->get_stylesheet( $types, $origins );
-	}
-
-	/*
 	 * If variables are part of the stylesheet,
 	 * we add them.
 	 *
@@ -163,6 +140,28 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 		$styles_variables = $tree->get_stylesheet( array( 'variables' ), $origins );
 		$types            = array_diff( $types, array( 'variables' ) );
 	}
+
+	/*
+	 * For the remaining types (presets, styles), we do consider origins:
+	 *
+	 * - themes without theme.json: only the classes for the presets defined by core
+	 * - themes with theme.json: the presets and styles classes, both from core and the theme
+	 */
+	$styles_rest = '';
+	if ( ! empty( $types ) ) {
+		/*
+		 * We only use the default, theme, and custom origins.
+		 * This is because styles for blocks origin are added
+		 * at a later phase (render cycle) so we only render the ones in use.
+		 * @see wp_add_global_styles_for_blocks
+		 */
+		$origins = array( 'default', 'theme', 'custom' );
+		if ( ! $supports_theme_json ) {
+			$origins = array( 'default' );
+		}
+		$styles_rest = $tree->get_stylesheet( $types, $origins );
+	}
+
 
 	$stylesheet = $styles_variables . $styles_rest;
 	if ( $can_use_cached ) {

--- a/lib/compat/wordpress-6.2/script-loader.php
+++ b/lib/compat/wordpress-6.2/script-loader.php
@@ -191,3 +191,6 @@ function gutenberg_enqueue_global_styles_custom_css() {
 	}
 }
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_global_styles_custom_css' );
+
+remove_action( 'wp_body_open', 'wp_global_styles_render_svg_filters' );
+remove_action( 'in_admin_header', 'wp_global_styles_render_svg_filters' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is another angle on https://github.com/WordPress/gutenberg/pull/48291.

If we remove the code that outputs the presets, how can we still use presets? This PR suggests saving the presets to an array and then outputting them in the footer. We do this for both block supports, and filters that are defined in the theme.json.

## Why?
Outputting unused presets creates extra output that we don't need.

## How?
1. Create a new array called $duotone_presets.
2. When we render a block we check if the block has a duotone filter applied - if it does we save it to the new array.
3. We also check if the block has any filter settings in the theme.json - if it does then we also save this setting to the new array.
4. We then run an action on wp_footer which outputs all the used preset duotones.

## Testing Instructions
1. Switch to a theme that has a duotone setting in its theme.json. (eg. Skatepark)
2. Check that the images all have a duotone applied in the front end.
3. Add an image to a post and select a preset duotone filter that is different to the main one for the theme.
4. Check that this image also has a preset duotone filter applied in the frontend.
5. Check that only the used SVGs are output in the frontend

## Notes
Still to do:
- [ ] Find a way to cache the theme json settings so we dont recalculate on every render
- [ ] Combine the two wp_footer actions into one but saving custom duotones in the WP_Duotone class.