### PR TITLE
Allow duotone presets to be stored in the "duotone" block attribute

### DIFF
--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -463,7 +463,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 		// Build a customized CSS filter property for unique slug.
 		$filter_property = gutenberg_get_duotone_filter_property( $filter_data );
 	} elseif ( $has_preset_duotone ) {
-		// Handle preset values for duotone iff the preset is set and there is no custom duotone.
+		// Handle preset values for duotone if the preset is set and there is no custom duotone.
 
 		// 1. Slug of an existing Duotone preset - e.g. 'green-blue'.
 		$duotone_attr = $block['attrs']['duotone'];

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -480,14 +480,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	$filter_id = gutenberg_get_duotone_filter_id( $filter_data );
 
 	// Build the CSS selectors to which the filter will be applied.
-	// Todo - encapsulate this in a function.
-	$scope     = '.' . $filter_id;
-	$selectors = explode( ',', $duotone_support );
-	$scoped    = array();
-	foreach ( $selectors as $sel ) {
-		$scoped[] = $scope . ' ' . trim( $sel );
-	}
-	$selector = implode( ', ', $scoped );
+	$selector = WP_Theme_JSON_Gutenberg::scope_selector( $scope, $duotone_support );
 
 	// Calling gutenberg_style_engine_get_stylesheet_from_css_rules ensures that
 	// the styles are rendered in an inline for block supports because we're

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -451,13 +451,13 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 
 		// 1. Array of colors - e.g. array('#000000', '#ffffff').
 		// 2. The string 'unset' - indicates explicitly "override the theme duotone with `filter: none !important`".
-		$custom_duotone = $block['attrs']['style']['color']['duotone'];
+		$duotone_attr = $block['attrs']['style']['color']['duotone'];
 
 		// Build a unique slug for the filter based on the array of colors.
-		$filter_key  = is_array( $custom_duotone ) ? implode( '-', $custom_duotone ) : $custom_duotone;
+		$filter_key  = is_array( $duotone_attr ) ? implode( '-', $duotone_attr ) : $duotone_attr;
 		$filter_data = array(
 			'slug'   => wp_unique_id( sanitize_key( $filter_key . '-' ) ),
-			'colors' => $custom_duotone, // required for building the SVG with gutenberg_get_duotone_filter_svg.
+			'colors' => $duotone_attr, // required for building the SVG with gutenberg_get_duotone_filter_svg.
 		);
 
 		// Build a customized CSS filter property for unique slug.
@@ -466,13 +466,13 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 		// Handle preset values for duotone iff the preset is set and there is no custom duotone.
 
 		// 1. Slug of an existing Duotone preset - e.g. 'green-blue'.
-		$preset_duotone = $block['attrs']['duotone'];
+		$duotone_attr = $block['attrs']['duotone'];
 		$filter_data    = array(
-			'slug' => $preset_duotone,
+			'slug' => $duotone_attr,
 		);
 
 		// Utilize existing CSS custom property.
-		$filter_property = "var(--wp--preset--duotone--$preset_duotone)";
+		$filter_property = "var(--wp--preset--duotone--$duotone_attr)";
 	}
 
 	// - Applied as a class attribute to the block wrapper.
@@ -504,7 +504,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	);
 
 	// Only custom duotone filters with values need to be rendered here.
-	if ( is_array( $custom_duotone ) ) {
+	if ( is_array( $duotone_attr ) ) {
 		$filter_svg = gutenberg_get_duotone_filter_svg( $filter_data );
 
 		add_action(

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -467,7 +467,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 
 		// 1. Slug of an existing Duotone preset - e.g. 'green-blue'.
 		$duotone_attr = $block['attrs']['duotone'];
-		$filter_data    = array(
+		$filter_data  = array(
 			'slug' => $duotone_attr,
 		);
 

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -450,7 +450,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 		// Handle custom values for duotone attribute.
 
 		// 1. Array of colors - e.g. array('#000000', '#ffffff').
-		// 2. The string 'unset' (only for backwards compatibility, see presets below).
+		// 2. The string 'unset' - indicates explicitly "override the theme duotone with `filter: none !important`".
 		$custom_duotone = $block['attrs']['style']['color']['duotone'];
 
 		// Build a unique slug for the filter based on the array of colors.
@@ -466,7 +466,6 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 		// Handle preset values for duotone iff the preset is set and there is no custom duotone.
 
 		// 1. Slug of an existing Duotone preset - e.g. 'green-blue'.
-		// 2. TODO: The string 'unset' - indicates explicitly "override the theme duotone with no filter".
 		$preset_duotone = $block['attrs']['duotone'];
 		$filter_data    = array(
 			'slug' => $preset_duotone,

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -480,6 +480,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	$filter_id = gutenberg_get_duotone_filter_id( $filter_data );
 
 	// Build the CSS selectors to which the filter will be applied.
+	$scope = '.' . $filter_id;
 	$selector = WP_Theme_JSON_Gutenberg::scope_selector( $scope, $duotone_support );
 
 	// Calling gutenberg_style_engine_get_stylesheet_from_css_rules ensures that

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -480,8 +480,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	$filter_id = gutenberg_get_duotone_filter_id( $filter_data );
 
 	// Build the CSS selectors to which the filter will be applied.
-	$scope = '.' . $filter_id;
-	$selector = WP_Theme_JSON_Gutenberg::scope_selector( $scope, $duotone_support );
+	$selector = WP_Theme_JSON_Gutenberg::scope_selector( '.' . $filter_id, $duotone_support );
 
 	// Calling gutenberg_style_engine_get_stylesheet_from_css_rules ensures that
 	// the styles are rendered in an inline for block supports because we're

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -290,17 +290,20 @@ const withDuotoneStyles = createHigherOrderComponent(
 
 		const id = `wp-duotone-${ useInstanceId( BlockListBlock ) }`;
 
-		let colors = props?.attributes?.style?.color?.duotone;
+		const duotoneColors = props?.attributes?.style?.color?.duotone;
+		const duotonePreset = props?.attributes?.duotone;
 
-		if ( ! Array.isArray( colors ) ) {
-			const duotone = duotonePalette.find( ( dt ) => dt.slug === colors );
+		// Default to custom colors.
+		let duotoneValue = duotoneColors;
 
-			if ( duotone ) {
-				colors = duotone.colors;
-			}
+		// If a duotone preset is set, get the colors from the palette.
+		if ( duotonePreset ) {
+			duotoneValue = // preset may not exist so conditionally set.
+				getColorsFromDuotonePreset( duotonePreset, duotonePalette ) ??
+				duotoneColors;
 		}
 
-		if ( ! duotoneSupport || ! colors ) {
+		if ( ! duotoneSupport || ! duotoneValue ) {
 			return <BlockListBlock { ...props } />;
 		}
 
@@ -323,7 +326,7 @@ const withDuotoneStyles = createHigherOrderComponent(
 						<InlineDuotone
 							selector={ selectorsGroup }
 							id={ id }
-							colors={ colors }
+							colors={ duotoneValue }
 						/>,
 						element
 					) }

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -175,6 +175,13 @@ function addDuotoneAttributes( settings ) {
 			},
 		} );
 	}
+	if ( ! settings.attributes.duotone ) {
+		Object.assign( settings.attributes, {
+			duotone: {
+				type: 'string',
+			},
+		} );
+	}
 
 	return settings;
 }

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -123,9 +123,15 @@ function DuotonePanel( { attributes, setAttributes } ) {
 		return null;
 	}
 
-	const duotonePresetOrColors = duotonePreset
-		? getColorsFromDuotonePreset( duotonePreset, duotonePalette )
-		: duotoneColors;
+	let duotonePresetOrColors;
+
+	if ( duotoneColors === 'unset' ) {
+		duotonePresetOrColors = 'unset';
+	} else {
+		duotonePresetOrColors = duotonePreset
+			? getColorsFromDuotonePreset( duotonePreset, duotonePalette )
+			: duotoneColors;
+	}
 
 	return (
 		<BlockControls group="block" __experimentalShareWithChildBlocks>
@@ -146,6 +152,13 @@ function DuotonePanel( { attributes, setAttributes } ) {
 					if ( maybePreset ) {
 						// Duotone presets are stored in a separate attribute.
 						newDuotoneAttributes.duotone = maybePreset;
+						newDuotoneAttributes.style = {
+							...style,
+							color: {
+								...style?.color,
+								duotone: '', // remove any custom colors
+							},
+						};
 
 						// Todo: should we store the custom colors **as well**
 						// in the style attribute as a fallback?
@@ -158,6 +171,8 @@ function DuotonePanel( { attributes, setAttributes } ) {
 								duotone: newDuotone, // custom colors
 							},
 						};
+						// Remove any presets.
+						newDuotoneAttributes.duotone = '';
 					}
 
 					setAttributes( newDuotoneAttributes );

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -102,12 +102,14 @@ export function getDuotonePresetFromColors( colors, duotonePalette ) {
 
 function DuotonePanel( { attributes, setAttributes } ) {
 	const style = attributes?.style;
-	const duotoneStyle = style?.color?.duotone;
+	const duotonePreset = attributes?.duotone;
+	const duotoneColors = style?.color?.duotone;
 
 	const duotonePalette = useMultiOriginPresets( {
 		presetSetting: 'color.duotone',
 		defaultSetting: 'color.defaultDuotone',
 	} );
+
 	const colorPalette = useMultiOriginPresets( {
 		presetSetting: 'color.palette',
 		defaultSetting: 'color.defaultPalette',
@@ -121,9 +123,9 @@ function DuotonePanel( { attributes, setAttributes } ) {
 		return null;
 	}
 
-	const duotonePresetOrColors = ! Array.isArray( duotoneStyle )
-		? getColorsFromDuotonePreset( duotoneStyle, duotonePalette )
-		: duotoneStyle;
+	const duotonePresetOrColors = duotonePreset
+		? getColorsFromDuotonePreset( duotonePreset, duotonePalette )
+		: duotoneColors;
 
 	return (
 		<BlockControls group="block" __experimentalShareWithChildBlocks>
@@ -139,14 +141,26 @@ function DuotonePanel( { attributes, setAttributes } ) {
 						duotonePalette
 					);
 
-					const newStyle = {
-						...style,
-						color: {
-							...style?.color,
-							duotone: maybePreset ?? newDuotone, // use preset or fallback to custom colors.
-						},
-					};
-					setAttributes( { style: newStyle } );
+					const newDuotoneAttributes = {};
+
+					if ( maybePreset ) {
+						// Duotone presets are stored in a separate attribute.
+						newDuotoneAttributes.duotone = maybePreset;
+
+						// Todo: should we store the custom colors **as well**
+						// in the style attribute as a fallback?
+					} else {
+						// Custom duotone colors are stored in the style attribute.
+						newDuotoneAttributes.style = {
+							...style,
+							color: {
+								...style?.color,
+								duotone: newDuotone, // custom colors
+							},
+						};
+					}
+
+					setAttributes( newDuotoneAttributes );
 				} }
 			/>
 		</BlockControls>
@@ -175,6 +189,9 @@ function addDuotoneAttributes( settings ) {
 			},
 		} );
 	}
+
+	// Duotone presets are stored in a dedicated attribute.
+	// See https://github.com/WordPress/gutenberg/issues/48371.
 	if ( ! settings.attributes.duotone ) {
 		Object.assign( settings.attributes, {
 			duotone: {
@@ -265,6 +282,7 @@ const withDuotoneStyles = createHigherOrderComponent(
 			props.name,
 			'color.__experimentalDuotone'
 		);
+
 		const duotonePalette = useMultiOriginPresets( {
 			presetSetting: 'color.duotone',
 			defaultSetting: 'color.defaultDuotone',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #48371

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Co-authored-by: Dave Smith <444434+getdave@users.noreply.github.com>