### PR TITLE
Post Editor: Update postContentBlock check to see if the block is valid

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -280,7 +280,7 @@ export default function VisualEditor( { styles } ) {
 
 	// If there is a Post Content block we use its layout for the block list;
 	// if not, this must be a classic theme, in which case we use the fallback layout.
-	const blockListLayout = postContentBlock
+	const blockListLayout = postContentBlock?.isValid
 		? postContentLayout
 		: fallbackLayout;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes: https://github.com/WordPress/gutenberg/issues/48355

In the post editor's visual editor component, the post content block for the current template is fetched. There is a conditional that checks whether or not the post content block was found, however the fallback state of `postContentBlock` is an empty object, which means it's always truthy. If we update this to `postContentBlock?.isValid` which only exists when the value is a real parsed block, then this should fix up the failure state.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When logged in as a non-admin user that cannot edit templates (e.g. an Author role) then the edited template cannot be retrieved. In this state, we should use the fallback layout which allows for constrained layout and full/wide controls, however this wasn't happening.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Update the truthy check for the post content block to look for `isValid` so that an empty object doesn't accidentally return true

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Using a blocks-based theme like TT3 add a post or page — you should see that there are Full/Wide alignment controls available
2. Create a user with an Author role, and log in as this user
3. Go to add a post or page — with this PR applied you should have access to the Wide/Full alignment controls. Without this PR, it appears that those controls are not currently available.

## Screenshots or screencast <!-- if applicable -->

| Trunk (logged in as Author role) | This PR (logged in as Author role) |
| --- | --- |
| <img width="1274" alt="image" src="https://user-images.githubusercontent.com/14988353/221051586-7c26ee88-a441-4523-bfac-004b89098798.png"> | <img width="1275" alt="image" src="https://user-images.githubusercontent.com/14988353/221051453-c4a63f04-647f-4ec8-93e3-f4dc36407bd8.png"> |