### PR TITLE
Widget Importer: Don't render controls when there's nothing to import

### DIFF
--- a/packages/block-library/src/template-part/edit/import-controls.js
+++ b/packages/block-library/src/template-part/edit/import-controls.js
@@ -25,6 +25,11 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useCreateTemplatePartFromBlocks } from './utils/hooks';
 import { transformWidgetToBlock } from './utils/transformers';
 
+const SIDEBARS_QUERY = {
+	per_page: -1,
+	_fields: 'id,name,description,status,widgets',
+};
+
 export function TemplatePartImportControls( { area, setAttributes } ) {
 	const [ selectedSidebar, setSelectedSidebar ] = useState( '' );
 	const [ isBusy, setIsBusy ] = useState( false );
@@ -34,15 +39,9 @@ export function TemplatePartImportControls( { area, setAttributes } ) {
 		const { getSidebars, hasFinishedResolution } = select( coreStore );
 
 		return {
-			sidebars: getSidebars( {
-				per_page: -1,
-				_fields: 'id,name,description,status,widgets',
-			} ),
+			sidebars: getSidebars( SIDEBARS_QUERY ),
 			hasResolved: hasFinishedResolution( 'getSidebars', [
-				{
-					per_page: -1,
-					_fields: 'id,name,description,status,widgets',
-				},
+				SIDEBARS_QUERY,
 			] ),
 		};
 	}, [] );
@@ -77,10 +76,10 @@ export function TemplatePartImportControls( { area, setAttributes } ) {
 		];
 	}, [ sidebars ] );
 
-	// Only bailout from rendering after data is loaded, and there is nothing to import,
+	// Render an empty node while data is loading or when there is nothing to import;
 	// to avoid SlotFill re-positioning issue. See: https://github.com/WordPress/gutenberg/issues/15641.
-	if ( hasResolved && ! options.length ) {
-		return null;
+	if ( ! hasResolved || ( hasResolved && ! options.length ) ) {
+		return <Spacer marginBottom="0" />;
 	}
 
 	async function createFromWidgets( event ) {

--- a/packages/block-library/src/template-part/edit/import-controls.js
+++ b/packages/block-library/src/template-part/edit/import-controls.js
@@ -76,10 +76,14 @@ export function TemplatePartImportControls( { area, setAttributes } ) {
 		];
 	}, [ sidebars ] );
 
-	// Render an empty node while data is loading or when there is nothing to import;
-	// to avoid SlotFill re-positioning issue. See: https://github.com/WordPress/gutenberg/issues/15641.
-	if ( ! hasResolved || ( hasResolved && ! options.length ) ) {
+	// Render an empty node while data is loading to avoid SlotFill re-positioning bug.
+	// See: https://github.com/WordPress/gutenberg/issues/15641.
+	if ( ! hasResolved ) {
 		return <Spacer marginBottom="0" />;
+	}
+
+	if ( hasResolved && ! options.length ) {
+		return null;
 	}
 
 	async function createFromWidgets( event ) {


### PR DESCRIPTION
## What?
Fixes #47982.

PR updates the `TemplatePartImportControls` to not render controls when there's nothing to import.

## Testing Instructions
Make sure there're no "Widget Areas" to import. For example, running the following command should work for testing:

```
wp theme mod remove wp_classic_sidebars
```
1. Open a template in the Site Editor.
2. Add a new template part to the template.
3. Open Advanced controls of the Template Parts block.
4. Confirm empty controls for the Import setting are no longer displayed

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/221101102-caa63e76-2893-4671-9767-e1ec2397ac8d.mp4
