### PR TITLE
Tooltip: refine existing tests

### DIFF
--- a/packages/components/src/tooltip/test/index.js
+++ b/packages/components/src/tooltip/test/index.js
@@ -54,7 +54,7 @@ describe( 'Tooltip', () => {
 		expect( screen.queryByText( 'tooltip text' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'should render the tooltip when focusing the tooltip trigger via tab', async () => {
+	it( 'should render the tooltip when focusing the tooltip anchor via tab', async () => {
 		const user = userEvent.setup();
 
 		render(
@@ -81,7 +81,7 @@ describe( 'Tooltip', () => {
 		);
 	} );
 
-	it( 'should render the tooltip when the tooltip trigger is hovered', async () => {
+	it( 'should render the tooltip when the tooltip anchor is hovered', async () => {
 		const user = userEvent.setup();
 
 		render(
@@ -206,7 +206,7 @@ describe( 'Tooltip', () => {
 		expect( buttonRect ).toEqual( eventCatcherRect );
 	} );
 
-	it( 'should not show tooltip if the mouse leaves the tooltip trigger before set delay', async () => {
+	it( 'should not show tooltip if the mouse leaves the tooltip anchor before set delay', async () => {
 		const user = userEvent.setup();
 		const onMouseEnterMock = jest.fn();
 		const onMouseLeaveMock = jest.fn();
@@ -243,7 +243,7 @@ describe( 'Tooltip', () => {
 
 		expect( screen.queryByText( 'tooltip text' ) ).not.toBeInTheDocument();
 
-		// Hover the other button, meaning that the mouse will leave the tooltip trigger
+		// Hover the other button, meaning that the mouse will leave the tooltip anchor
 		await user.hover(
 			screen.getByRole( 'button', {
 				name: 'Hover me instead!',
@@ -260,7 +260,7 @@ describe( 'Tooltip', () => {
 			setTimeout( resolve, TOOLTIP_DELAY )
 		);
 
-		// Tooltip won't show, since the mouse has left the tooltip trigger
+		// Tooltip won't show, since the mouse has left the tooltip anchor
 		expect( screen.queryByText( 'tooltip text' ) ).not.toBeInTheDocument();
 	} );
 

--- a/packages/components/src/tooltip/test/index.js
+++ b/packages/components/src/tooltip/test/index.js
@@ -156,14 +156,16 @@ describe( 'Tooltip', () => {
 				screen.queryByText( 'tooltip text' )
 			).not.toBeInTheDocument();
 
-			const tooltip = await screen.findByText( 'tooltip text' );
-
-			expect( tooltip ).toBeVisible();
+			await waitFor( () =>
+				expect( screen.getByText( 'tooltip text' ) ).toBeVisible()
+			);
 
 			// Wait for the tooltip element to be positioned (aligned with the button)
 			await waitFor( () =>
 				expect(
-					getWrappingPopoverElement( tooltip )
+					getWrappingPopoverElement(
+						screen.getByText( 'tooltip text' )
+					)
 				).toBePositionedPopover()
 			);
 		} );

--- a/packages/components/src/tooltip/test/index.js
+++ b/packages/components/src/tooltip/test/index.js
@@ -59,7 +59,7 @@ describe( 'Tooltip', () => {
 			).not.toBeInTheDocument();
 		} );
 
-		it( 'should render the tooltip when focusing anchor via tab', async () => {
+		it( 'should render the tooltip when focusing the tooltip trigger via tab', async () => {
 			const user = userEvent.setup();
 
 			render(
@@ -88,7 +88,7 @@ describe( 'Tooltip', () => {
 			);
 		} );
 
-		it( 'should render the tooltip when anchor is hovered', async () => {
+		it( 'should render the tooltip when the tooltip trigger is hovered', async () => {
 			const user = userEvent.setup();
 
 			render(
@@ -227,7 +227,7 @@ describe( 'Tooltip', () => {
 			expect( buttonRect ).toEqual( eventCatcherRect );
 		} );
 
-		it( 'should not show tooltip if the mouse leaves the anchor before the tooltip has shown', async () => {
+		it( 'should not show tooltip if the mouse leaves the tooltip trigger before set delay', async () => {
 			const user = userEvent.setup();
 			const onMouseEnterMock = jest.fn();
 			const onMouseLeaveMock = jest.fn();
@@ -268,7 +268,7 @@ describe( 'Tooltip', () => {
 				screen.queryByText( 'tooltip text' )
 			).not.toBeInTheDocument();
 
-			// Hover the other button, meaning that the mouse will leave the tooltip anchor
+			// Hover the other button, meaning that the mouse will leave the tooltip trigger
 			await user.hover(
 				screen.getByRole( 'button', {
 					name: 'Hover me instead!',
@@ -287,7 +287,7 @@ describe( 'Tooltip', () => {
 				setTimeout( resolve, TOOLTIP_DELAY )
 			);
 
-			// Tooltip won't show, since the mouse has left the anchor
+			// Tooltip won't show, since the mouse has left the tooltip trigger
 			expect(
 				screen.queryByText( 'tooltip text' )
 			).not.toBeInTheDocument();

--- a/packages/components/src/tooltip/test/index.js
+++ b/packages/components/src/tooltip/test/index.js
@@ -1,19 +1,24 @@
 /**
  * External dependencies
  */
-import { render, screen, act, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
  */
 import Tooltip from '../';
+import Button from '../../button';
+
 /**
  * WordPress dependencies
  */
 import { TOOLTIP_DELAY } from '../index.js';
 
-jest.useFakeTimers();
+const props = {
+	text: 'tooltip text',
+	delay: TOOLTIP_DELAY,
+};
 
 function getWrappingPopoverElement( element ) {
 	return element.closest( '.components-popover' );
@@ -23,170 +28,135 @@ describe( 'Tooltip', () => {
 	describe( '#render()', () => {
 		it( 'should not render the tooltip if multiple children are passed', () => {
 			render(
-				<Tooltip text="Help text">
-					<button>Button 1</button>
-					<button>Button 2</button>
+				<Tooltip { ...props }>
+					<Button>Button 1</Button>
+					<Button>Button 2</Button>
 				</Tooltip>
 			);
 
-			const button = screen.getByText( 'Button 1' );
-			act( () => button.focus() );
-			expect( screen.queryByText( 'Help text' ) ).not.toBeInTheDocument();
+			expect(
+				screen.queryByText( 'tooltip text' )
+			).not.toBeInTheDocument();
 		} );
 
-		it( 'should render children', () => {
+		it( 'should not render the tooltip if there is no focus', () => {
 			render(
-				<Tooltip text="Help text">
-					<button>Hover Me!</button>
+				<Tooltip { ...props }>
+					<Button>Hover Me!</Button>
 				</Tooltip>
 			);
 
 			expect(
 				screen.getByRole( 'button', { name: 'Hover Me!' } )
 			).toBeVisible();
-			expect( screen.queryByText( 'Help text' ) ).not.toBeInTheDocument();
+			expect(
+				screen.queryByText( 'tooltip text' )
+			).not.toBeInTheDocument();
 		} );
 
-		it( 'should render children with additional tooltip when focused', async () => {
-			const mockOnFocus = jest.fn();
+		it( 'should render the tooltip when focusing anchor via tab', async () => {
+			const user = userEvent.setup();
 
 			render(
-				<Tooltip text="Help text">
-					<button onFocus={ mockOnFocus }>Hover Me!</button>
+				<Tooltip { ...props }>
+					<Button>Hover Me!</Button>
 				</Tooltip>
 			);
 
-			const button = screen.getByRole( 'button', { name: 'Hover Me!' } );
-			expect( button ).toBeVisible();
+			expect( document.body ).toHaveFocus();
 
-			// Before focus, the tooltip is not shown.
-			expect( screen.queryByText( 'Help text' ) ).not.toBeInTheDocument();
+			await user.tab();
 
-			act( () => button.focus() );
+			expect(
+				screen.getByRole( 'button', { name: /Hover me!/i } )
+			).toHaveFocus();
 
-			// Tooltip is shown after focusing the anchor.
-			const tooltip = screen.getByText( 'Help text' );
-			expect( tooltip ).toBeVisible();
-			expect( mockOnFocus ).toHaveBeenCalledWith(
-				expect.objectContaining( {
-					type: 'focus',
-				} )
+			await waitFor( () =>
+				expect( screen.getByText( 'tooltip text' ) ).toBeVisible()
 			);
 
 			// Wait for the tooltip element to be positioned (aligned with the button)
 			await waitFor( () =>
 				expect(
-					getWrappingPopoverElement( tooltip )
+					getWrappingPopoverElement(
+						screen.getByText( 'tooltip text' )
+					)
 				).toBePositionedPopover()
 			);
 		} );
 
-		it( 'should render children with additional tooltip when hovered', async () => {
-			const user = userEvent.setup( {
-				advanceTimers: jest.advanceTimersByTime,
-			} );
+		it( 'should render the tooltip when anchor is hovered', async () => {
+			const user = userEvent.setup();
 
 			render(
-				<Tooltip text="Help text">
-					<button>Hover Me!</button>
+				<Tooltip { ...props }>
+					<Button>Hover Me!</Button>
 				</Tooltip>
 			);
 
 			const button = screen.getByRole( 'button', { name: 'Hover Me!' } );
-			expect( button ).toBeVisible();
 
 			await user.hover( button );
 
-			// Tooltip hasn't appeared yet
-			expect( screen.queryByText( 'Help text' ) ).not.toBeInTheDocument();
-
-			act( () => jest.advanceTimersByTime( TOOLTIP_DELAY ) );
-
-			// Tooltip shows after the delay
-			const tooltip = screen.getByText( 'Help text' );
-			expect( tooltip ).toBeVisible();
+			await waitFor( () =>
+				expect( screen.getByText( 'tooltip text' ) ).toBeVisible()
+			);
 
 			// Wait for the tooltip element to be positioned (aligned with the button)
 			await waitFor( () =>
 				expect(
-					getWrappingPopoverElement( tooltip )
+					getWrappingPopoverElement(
+						screen.getByText( 'tooltip text' )
+					)
 				).toBePositionedPopover()
 			);
+
+			await user.unhover( button );
+
+			expect(
+				screen.queryByText( 'tooltip text' )
+			).not.toBeInTheDocument();
 		} );
 
 		it( 'should not show tooltip on focus as result of mouse click', async () => {
-			const user = userEvent.setup( {
-				advanceTimers: jest.advanceTimersByTime,
-			} );
-			const mockOnFocus = jest.fn();
+			const user = userEvent.setup();
 
 			render(
-				<Tooltip text="Help text">
-					<button onFocus={ mockOnFocus }>Hover Me!</button>
+				<Tooltip { ...props }>
+					<Button>Hover Me!</Button>
 				</Tooltip>
 			);
 
-			const button = screen.getByRole( 'button', { text: 'Hover Me!' } );
-			expect( button ).toBeVisible();
-
-			await user.click( button );
-
-			// Tooltip hasn't appeared yet
-			expect( screen.queryByText( 'Help text' ) ).not.toBeInTheDocument();
-
-			act( () => jest.advanceTimersByTime( TOOLTIP_DELAY ) );
-
-			// Tooltip still hasn't appeared yet, even though the component was focused
-			expect( screen.queryByText( 'Help text' ) ).not.toBeInTheDocument();
-			expect( mockOnFocus ).toHaveBeenCalledWith(
-				expect.objectContaining( {
-					type: 'focus',
-				} )
+			await user.click(
+				screen.getByRole( 'button', { text: 'Hover Me!' } )
 			);
+
+			expect(
+				screen.queryByText( 'tooltip text' )
+			).not.toBeInTheDocument();
 		} );
 
 		it( 'should respect custom delay prop when showing tooltip', async () => {
-			const user = userEvent.setup( {
-				advanceTimers: jest.advanceTimersByTime,
-			} );
-
-			const TEST_DELAY = TOOLTIP_DELAY * 2;
-			const mockOnMouseEnter = jest.fn();
-			const mockOnFocus = jest.fn();
+			const user = userEvent.setup( { delay: TOOLTIP_DELAY } );
+			const CUSTOM_DELAY = TOOLTIP_DELAY + 25;
 
 			render(
-				<Tooltip text="Help text" delay={ TEST_DELAY }>
-					<button
-						onMouseEnter={ mockOnMouseEnter }
-						onFocus={ mockOnFocus }
-					>
-						<span>Hover Me!</span>
-					</button>
+				<Tooltip { ...props } delay={ CUSTOM_DELAY }>
+					<Button>Hover Me!</Button>
 				</Tooltip>
 			);
 
 			const button = screen.getByRole( 'button', { name: 'Hover Me!' } );
-			expect( button ).toBeVisible();
 
 			await user.hover( button );
 
-			// Tooltip hasn't appeared yet
-			expect( mockOnMouseEnter ).toHaveBeenCalledTimes( 1 );
+			expect(
+				screen.queryByText( 'tooltip text' )
+			).not.toBeInTheDocument();
 
-			// Advance by the usual TOOLTIP_DELAY
-			act( () => jest.advanceTimersByTime( TOOLTIP_DELAY ) );
+			const tooltip = await screen.findByText( 'tooltip text' );
 
-			// Tooltip hasn't appeared yet after the usual delay
-			expect( screen.queryByText( 'Help text' ) ).not.toBeInTheDocument();
-
-			// Advance time again, so that we reach the full TEST_DELAY time
-			act( () => jest.advanceTimersByTime( TEST_DELAY - TOOLTIP_DELAY ) );
-
-			// Tooltip shows after TEST_DELAY time
-			const tooltip = screen.getByText( 'Help text' );
 			expect( tooltip ).toBeVisible();
-
-			expect( mockOnFocus ).not.toHaveBeenCalled();
 
 			// Wait for the tooltip element to be positioned (aligned with the button)
 			await waitFor( () =>
@@ -197,60 +167,44 @@ describe( 'Tooltip', () => {
 		} );
 
 		it( 'should show tooltip when an element is disabled', async () => {
-			const user = userEvent.setup( {
-				advanceTimers: jest.advanceTimersByTime,
-			} );
+			const user = userEvent.setup();
 
-			const { container } = render(
-				<Tooltip text="Show helpful text here">
-					<button disabled>Click me</button>
+			render(
+				<Tooltip { ...props }>
+					<Button disabled>Click me</Button>
 				</Tooltip>
 			);
 
-			const button = screen.getByRole( 'button', { name: 'Click me' } );
+			const button = screen.getByRole( 'button', { name: /Click me/i } );
+
 			expect( button ).toBeVisible();
 			expect( button ).toBeDisabled();
 
-			// Note: this is testing for implementation details,
-			// but couldn't find a better way.
-			const buttonRect = button.getBoundingClientRect();
-			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-			const eventCatcher = container.querySelector( '.event-catcher' );
-			const eventCatcherRect = eventCatcher.getBoundingClientRect();
-			expect( buttonRect ).toEqual( eventCatcherRect );
+			await user.hover( button );
 
-			await user.hover( eventCatcher );
-
-			// Tooltip hasn't appeared yet
-			expect(
-				screen.queryByText( 'Show helpful text here' )
-			).not.toBeInTheDocument();
-
-			act( () => jest.advanceTimersByTime( TOOLTIP_DELAY ) );
-
-			// Tooltip shows after the delay
-			const tooltip = screen.getByText( 'Show helpful text here' );
-			expect( tooltip ).toBeVisible();
+			await waitFor( () =>
+				expect( screen.getByText( 'tooltip text' ) ).toBeVisible()
+			);
 
 			// Wait for the tooltip element to be positioned (aligned with the button)
 			await waitFor( () =>
 				expect(
-					getWrappingPopoverElement( tooltip )
+					getWrappingPopoverElement(
+						screen.getByText( 'tooltip text' )
+					)
 				).toBePositionedPopover()
 			);
 		} );
 
 		it( 'should not emit events back to children when they are disabled', async () => {
-			const user = userEvent.setup( {
-				advanceTimers: jest.advanceTimersByTime,
-			} );
+			const user = userEvent.setup();
 
 			const onClickMock = jest.fn();
 			const { container } = render(
-				<Tooltip text="Show helpful text here">
-					<button disabled onClick={ onClickMock }>
+				<Tooltip { ...props }>
+					<Button disabled onClick={ onClickMock }>
 						Click me
-					</button>
+					</Button>
 				</Tooltip>
 			);
 
@@ -261,111 +215,131 @@ describe( 'Tooltip', () => {
 		} );
 
 		it( 'should not show tooltip if the mouse leaves the anchor before the tooltip has shown', async () => {
-			const user = userEvent.setup( {
-				advanceTimers: jest.advanceTimersByTime,
-			} );
-
-			const MOUSE_LEAVE_DELAY = TOOLTIP_DELAY - 200;
+			const user = userEvent.setup();
 			const onMouseEnterMock = jest.fn();
 			const onMouseLeaveMock = jest.fn();
+			const MOUSE_LEAVE_DELAY = TOOLTIP_DELAY - 200;
 
 			render(
 				<>
-					<Tooltip text="Help text">
-						<button
+					<Tooltip { ...props }>
+						<Button
 							onMouseEnter={ onMouseEnterMock }
 							onMouseLeave={ onMouseLeaveMock }
 						>
 							Hover Me!
-						</button>
+						</Button>
 					</Tooltip>
-					<button>Hover me instead!</button>
+					<Button>Hover me instead!</Button>
 				</>
 			);
 
-			const externalButton = screen.getByRole( 'button', {
-				name: 'Hover me instead!',
-			} );
-			const tooltipButton = screen.getByRole( 'button', {
-				name: 'Hover Me!',
-			} );
-
-			await user.hover( tooltipButton );
+			await user.hover(
+				screen.getByRole( 'button', {
+					name: 'Hover Me!',
+				} )
+			);
 
 			// Tooltip hasn't appeared yet
-			expect( screen.queryByText( 'Help text' ) ).not.toBeInTheDocument();
+			expect(
+				screen.queryByText( 'tooltip text' )
+			).not.toBeInTheDocument();
 			expect( onMouseEnterMock ).toHaveBeenCalledTimes( 1 );
 
 			// Advance time by MOUSE_LEAVE_DELAY time
-			act( () => jest.advanceTimersByTime( MOUSE_LEAVE_DELAY ) );
+			await waitFor(
+				() =>
+					expect(
+						screen.queryByText( 'tooltip text' )
+					).not.toBeInTheDocument(),
+				{ timeout: MOUSE_LEAVE_DELAY }
+			);
 
 			// Hover the other button, meaning that the mouse will leave the tooltip anchor
-			await user.hover( externalButton );
+			await user.hover(
+				screen.getByRole( 'button', {
+					name: 'Hover me instead!',
+				} )
+			);
 
 			// Tooltip still hasn't appeared yet
-			expect( screen.queryByText( 'Help text' ) ).not.toBeInTheDocument();
+			expect(
+				screen.queryByText( 'tooltip text' )
+			).not.toBeInTheDocument();
 			expect( onMouseEnterMock ).toHaveBeenCalledTimes( 1 );
 			expect( onMouseLeaveMock ).toHaveBeenCalledTimes( 1 );
 
 			// Advance time again, so that we reach the full TOOLTIP_DELAY time
-			act( () => jest.advanceTimersByTime( TOOLTIP_DELAY ) );
+			await waitFor(
+				() =>
+					expect(
+						screen.queryByText( 'tooltip text' )
+					).not.toBeInTheDocument(),
+				{ timeout: TOOLTIP_DELAY }
+			);
 
 			// Tooltip won't show, since the mouse has left the anchor
-			expect( screen.queryByText( 'Help text' ) ).not.toBeInTheDocument();
+			expect(
+				screen.queryByText( 'tooltip text' )
+			).not.toBeInTheDocument();
 		} );
 
 		it( 'should render the shortcut display text when a string is passed as the shortcut', async () => {
-			const user = userEvent.setup( {
-				advanceTimers: jest.advanceTimersByTime,
-			} );
+			const user = userEvent.setup();
 
 			render(
-				<Tooltip text="Help text" shortcut="shortcut text">
-					<button>Hover Me!</button>
+				<Tooltip { ...props } shortcut="shortcut text">
+					<Button>Hover Me!</Button>
 				</Tooltip>
 			);
 
-			const button = screen.getByRole( 'button', { name: 'Hover Me!' } );
-			await user.hover( button );
+			await user.hover(
+				screen.getByRole( 'button', { name: 'Hover Me!' } )
+			);
 
-			const tooltip = await screen.findByText( 'shortcut text' );
-			expect( tooltip ).toBeVisible();
+			await waitFor( () =>
+				expect( screen.getByText( 'shortcut text' ) ).toBeVisible()
+			);
 
 			// Wait for the tooltip element to be positioned (aligned with the button)
 			await waitFor( () =>
 				expect(
-					getWrappingPopoverElement( tooltip )
+					getWrappingPopoverElement(
+						screen.getByText( 'shortcut text' )
+					)
 				).toBePositionedPopover()
 			);
 		} );
 
 		it( 'should render the shortcut display text and aria-label when an object is passed as the shortcut with the correct properties', async () => {
-			const user = userEvent.setup( {
-				advanceTimers: jest.advanceTimersByTime,
-			} );
+			const user = userEvent.setup();
 
 			render(
 				<Tooltip
-					text="Help text"
+					{ ...props }
 					shortcut={ {
 						display: 'shortcut text',
 						ariaLabel: 'shortcut label',
 					} }
 				>
-					<button>Hover Me!</button>
+					<Button>Hover Me!</Button>
 				</Tooltip>
 			);
 
-			const button = screen.getByRole( 'button', { name: 'Hover Me!' } );
-			await user.hover( button );
+			await user.hover(
+				screen.getByRole( 'button', { name: 'Hover Me!' } )
+			);
 
-			const tooltip = await screen.findByLabelText( 'shortcut label' );
-			expect( tooltip ).toHaveTextContent( 'shortcut text' );
+			await waitFor( () =>
+				expect( screen.getByText( 'shortcut text' ) ).toBeVisible()
+			);
 
 			// Wait for the tooltip element to be positioned (aligned with the button)
 			await waitFor( () =>
 				expect(
-					getWrappingPopoverElement( tooltip )
+					getWrappingPopoverElement(
+						screen.getByText( 'shortcut text' )
+					)
 				).toBePositionedPopover()
 			);
 		} );

--- a/packages/components/src/tooltip/test/index.js
+++ b/packages/components/src/tooltip/test/index.js
@@ -14,6 +14,7 @@ import Button from '../../button';
  * WordPress dependencies
  */
 import { TOOLTIP_DELAY } from '../index.js';
+import { shortcutAriaLabel } from '@wordpress/keycodes';
 
 const props = {
 	text: 'tooltip text',
@@ -318,8 +319,8 @@ describe( 'Tooltip', () => {
 				<Tooltip
 					{ ...props }
 					shortcut={ {
-						display: 'shortcut text',
-						ariaLabel: 'shortcut label',
+						display: '⇧⌘,',
+						ariaLabel: shortcutAriaLabel.primaryShift( ',' ),
 					} }
 				>
 					<Button>Hover Me!</Button>
@@ -331,15 +332,18 @@ describe( 'Tooltip', () => {
 			);
 
 			await waitFor( () =>
-				expect( screen.getByText( 'shortcut text' ) ).toBeVisible()
+				expect( screen.getByText( '⇧⌘,' ) ).toBeVisible()
+			);
+
+			expect( screen.getByText( '⇧⌘,' ) ).toHaveAttribute(
+				'aria-label',
+				'Control + Shift + Comma'
 			);
 
 			// Wait for the tooltip element to be positioned (aligned with the button)
 			await waitFor( () =>
 				expect(
-					getWrappingPopoverElement(
-						screen.getByText( 'shortcut text' )
-					)
+					getWrappingPopoverElement( screen.getByText( '⇧⌘,' ) )
 				).toBePositionedPopover()
 			);
 		} );

--- a/packages/components/src/tooltip/test/index.js
+++ b/packages/components/src/tooltip/test/index.js
@@ -26,334 +26,298 @@ function getWrappingPopoverElement( element ) {
 }
 
 describe( 'Tooltip', () => {
-	describe( '#render()', () => {
-		it( 'should not render the tooltip if multiple children are passed', async () => {
-			const user = userEvent.setup();
+	it( 'should not render the tooltip if multiple children are passed', async () => {
+		const user = userEvent.setup();
 
-			render(
-				<Tooltip { ...props }>
-					<Button>Button 1</Button>
-					<Button>Button 2</Button>
-				</Tooltip>
-			);
+		render(
+			<Tooltip { ...props }>
+				<Button>Button 1</Button>
+				<Button>Button 2</Button>
+			</Tooltip>
+		);
 
-			await user.tab();
+		await user.tab();
 
+		expect( screen.queryByText( 'tooltip text' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should not render the tooltip if there is no focus', () => {
+		render(
+			<Tooltip { ...props }>
+				<Button>Hover Me!</Button>
+			</Tooltip>
+		);
+
+		expect(
+			screen.getByRole( 'button', { name: 'Hover Me!' } )
+		).toBeVisible();
+		expect( screen.queryByText( 'tooltip text' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should render the tooltip when focusing the tooltip trigger via tab', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<Tooltip { ...props }>
+				<Button>Hover Me!</Button>
+			</Tooltip>
+		);
+
+		await user.tab();
+
+		expect(
+			screen.getByRole( 'button', { name: /Hover me!/i } )
+		).toHaveFocus();
+
+		await waitFor( () =>
+			expect( screen.getByText( 'tooltip text' ) ).toBeVisible()
+		);
+
+		// Wait for the tooltip element to be positioned (aligned with the button)
+		await waitFor( () =>
 			expect(
-				screen.queryByText( 'tooltip text' )
-			).not.toBeInTheDocument();
-		} );
+				getWrappingPopoverElement( screen.getByText( 'tooltip text' ) )
+			).toBePositionedPopover()
+		);
+	} );
 
-		it( 'should not render the tooltip if there is no focus', () => {
-			render(
-				<Tooltip { ...props }>
-					<Button>Hover Me!</Button>
-				</Tooltip>
-			);
+	it( 'should render the tooltip when the tooltip trigger is hovered', async () => {
+		const user = userEvent.setup();
 
+		render(
+			<Tooltip { ...props }>
+				<Button>Hover Me!</Button>
+			</Tooltip>
+		);
+
+		const button = screen.getByRole( 'button', { name: 'Hover Me!' } );
+
+		await user.hover( button );
+
+		await waitFor( () =>
+			expect( screen.getByText( 'tooltip text' ) ).toBeVisible()
+		);
+
+		// Wait for the tooltip element to be positioned (aligned with the button)
+		await waitFor( () =>
 			expect(
-				screen.getByRole( 'button', { name: 'Hover Me!' } )
-			).toBeVisible();
+				getWrappingPopoverElement( screen.getByText( 'tooltip text' ) )
+			).toBePositionedPopover()
+		);
+
+		await user.unhover( button );
+
+		expect( screen.queryByText( 'tooltip text' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should not show tooltip on focus as result of mouse click', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<Tooltip { ...props }>
+				<Button>Hover Me!</Button>
+			</Tooltip>
+		);
+
+		await user.click( screen.getByRole( 'button', { text: 'Hover Me!' } ) );
+
+		expect( screen.queryByText( 'tooltip text' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should respect custom delay prop when showing tooltip', async () => {
+		const user = userEvent.setup( { delay: TOOLTIP_DELAY } );
+		const CUSTOM_DELAY = TOOLTIP_DELAY + 25;
+
+		render(
+			<Tooltip { ...props } delay={ CUSTOM_DELAY }>
+				<Button>Hover Me!</Button>
+			</Tooltip>
+		);
+
+		const button = screen.getByRole( 'button', { name: 'Hover Me!' } );
+
+		await user.hover( button );
+
+		expect( screen.queryByText( 'tooltip text' ) ).not.toBeInTheDocument();
+
+		await waitFor( () =>
+			expect( screen.getByText( 'tooltip text' ) ).toBeVisible()
+		);
+
+		// Wait for the tooltip element to be positioned (aligned with the button)
+		await waitFor( () =>
 			expect(
-				screen.queryByText( 'tooltip text' )
-			).not.toBeInTheDocument();
-		} );
+				getWrappingPopoverElement( screen.getByText( 'tooltip text' ) )
+			).toBePositionedPopover()
+		);
+	} );
 
-		it( 'should render the tooltip when focusing the tooltip trigger via tab', async () => {
-			const user = userEvent.setup();
+	it( 'should show tooltip when an element is disabled', async () => {
+		const user = userEvent.setup();
 
-			render(
-				<Tooltip { ...props }>
-					<Button>Hover Me!</Button>
-				</Tooltip>
-			);
+		render(
+			<Tooltip { ...props }>
+				<Button disabled>Click me</Button>
+			</Tooltip>
+		);
 
-			await user.tab();
+		const button = screen.getByRole( 'button', { name: /Click me/i } );
 
+		expect( button ).toBeVisible();
+		expect( button ).toBeDisabled();
+
+		await user.hover( button );
+
+		await waitFor( () =>
+			expect( screen.getByText( 'tooltip text' ) ).toBeVisible()
+		);
+
+		// Wait for the tooltip element to be positioned (aligned with the button)
+		await waitFor( () =>
 			expect(
-				screen.getByRole( 'button', { name: /Hover me!/i } )
-			).toHaveFocus();
+				getWrappingPopoverElement( screen.getByText( 'tooltip text' ) )
+			).toBePositionedPopover()
+		);
+	} );
 
-			await waitFor( () =>
-				expect( screen.getByText( 'tooltip text' ) ).toBeVisible()
-			);
+	it( 'should not emit events back to children when they are disabled', async () => {
+		const user = userEvent.setup();
+		const onClickMock = jest.fn();
 
-			// Wait for the tooltip element to be positioned (aligned with the button)
-			await waitFor( () =>
-				expect(
-					getWrappingPopoverElement(
-						screen.getByText( 'tooltip text' )
-					)
-				).toBePositionedPopover()
-			);
-		} );
+		const { container } = render(
+			<Tooltip { ...props }>
+				<Button disabled onClick={ onClickMock }>
+					Click me
+				</Button>
+			</Tooltip>
+		);
 
-		it( 'should render the tooltip when the tooltip trigger is hovered', async () => {
-			const user = userEvent.setup();
+		// Note: this is testing for implementation details,
+		// but couldn't find a better way.
+		const buttonRect = screen
+			.getByRole( 'button', { name: 'Click me' } )
+			.getBoundingClientRect();
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+		const eventCatcher = container.querySelector( '.event-catcher' );
+		await user.click( eventCatcher );
+		expect( onClickMock ).not.toHaveBeenCalled();
 
-			render(
+		const eventCatcherRect = eventCatcher.getBoundingClientRect();
+		expect( buttonRect ).toEqual( eventCatcherRect );
+	} );
+
+	it( 'should not show tooltip if the mouse leaves the tooltip trigger before set delay', async () => {
+		const user = userEvent.setup();
+		const onMouseEnterMock = jest.fn();
+		const onMouseLeaveMock = jest.fn();
+		const MOUSE_LEAVE_DELAY = TOOLTIP_DELAY - 200;
+
+		render(
+			<>
 				<Tooltip { ...props }>
-					<Button>Hover Me!</Button>
-				</Tooltip>
-			);
-
-			const button = screen.getByRole( 'button', { name: 'Hover Me!' } );
-
-			await user.hover( button );
-
-			await waitFor( () =>
-				expect( screen.getByText( 'tooltip text' ) ).toBeVisible()
-			);
-
-			// Wait for the tooltip element to be positioned (aligned with the button)
-			await waitFor( () =>
-				expect(
-					getWrappingPopoverElement(
-						screen.getByText( 'tooltip text' )
-					)
-				).toBePositionedPopover()
-			);
-
-			await user.unhover( button );
-
-			expect(
-				screen.queryByText( 'tooltip text' )
-			).not.toBeInTheDocument();
-		} );
-
-		it( 'should not show tooltip on focus as result of mouse click', async () => {
-			const user = userEvent.setup();
-
-			render(
-				<Tooltip { ...props }>
-					<Button>Hover Me!</Button>
-				</Tooltip>
-			);
-
-			await user.click(
-				screen.getByRole( 'button', { text: 'Hover Me!' } )
-			);
-
-			expect(
-				screen.queryByText( 'tooltip text' )
-			).not.toBeInTheDocument();
-		} );
-
-		it( 'should respect custom delay prop when showing tooltip', async () => {
-			const user = userEvent.setup( { delay: TOOLTIP_DELAY } );
-			const CUSTOM_DELAY = TOOLTIP_DELAY + 25;
-
-			render(
-				<Tooltip { ...props } delay={ CUSTOM_DELAY }>
-					<Button>Hover Me!</Button>
-				</Tooltip>
-			);
-
-			const button = screen.getByRole( 'button', { name: 'Hover Me!' } );
-
-			await user.hover( button );
-
-			expect(
-				screen.queryByText( 'tooltip text' )
-			).not.toBeInTheDocument();
-
-			await waitFor( () =>
-				expect( screen.getByText( 'tooltip text' ) ).toBeVisible()
-			);
-
-			// Wait for the tooltip element to be positioned (aligned with the button)
-			await waitFor( () =>
-				expect(
-					getWrappingPopoverElement(
-						screen.getByText( 'tooltip text' )
-					)
-				).toBePositionedPopover()
-			);
-		} );
-
-		it( 'should show tooltip when an element is disabled', async () => {
-			const user = userEvent.setup();
-
-			render(
-				<Tooltip { ...props }>
-					<Button disabled>Click me</Button>
-				</Tooltip>
-			);
-
-			const button = screen.getByRole( 'button', { name: /Click me/i } );
-
-			expect( button ).toBeVisible();
-			expect( button ).toBeDisabled();
-
-			await user.hover( button );
-
-			await waitFor( () =>
-				expect( screen.getByText( 'tooltip text' ) ).toBeVisible()
-			);
-
-			// Wait for the tooltip element to be positioned (aligned with the button)
-			await waitFor( () =>
-				expect(
-					getWrappingPopoverElement(
-						screen.getByText( 'tooltip text' )
-					)
-				).toBePositionedPopover()
-			);
-		} );
-
-		it( 'should not emit events back to children when they are disabled', async () => {
-			const user = userEvent.setup();
-			const onClickMock = jest.fn();
-
-			const { container } = render(
-				<Tooltip { ...props }>
-					<Button disabled onClick={ onClickMock }>
-						Click me
+					<Button
+						onMouseEnter={ onMouseEnterMock }
+						onMouseLeave={ onMouseLeaveMock }
+					>
+						Hover Me!
 					</Button>
 				</Tooltip>
-			);
+				<Button>Hover me instead!</Button>
+			</>
+		);
 
-			// Note: this is testing for implementation details,
-			// but couldn't find a better way.
-			const buttonRect = screen
-				.getByRole( 'button', { name: 'Click me' } )
-				.getBoundingClientRect();
-			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-			const eventCatcher = container.querySelector( '.event-catcher' );
-			await user.click( eventCatcher );
-			expect( onClickMock ).not.toHaveBeenCalled();
+		await user.hover(
+			screen.getByRole( 'button', {
+				name: 'Hover Me!',
+			} )
+		);
 
-			const eventCatcherRect = eventCatcher.getBoundingClientRect();
-			expect( buttonRect ).toEqual( eventCatcherRect );
-		} );
+		// Tooltip hasn't appeared yet
+		expect( screen.queryByText( 'tooltip text' ) ).not.toBeInTheDocument();
+		expect( onMouseEnterMock ).toHaveBeenCalledTimes( 1 );
 
-		it( 'should not show tooltip if the mouse leaves the tooltip trigger before set delay', async () => {
-			const user = userEvent.setup();
-			const onMouseEnterMock = jest.fn();
-			const onMouseLeaveMock = jest.fn();
-			const MOUSE_LEAVE_DELAY = TOOLTIP_DELAY - 200;
+		// Advance time by MOUSE_LEAVE_DELAY time
+		await new Promise( ( resolve ) =>
+			setTimeout( resolve, MOUSE_LEAVE_DELAY )
+		);
 
-			render(
-				<>
-					<Tooltip { ...props }>
-						<Button
-							onMouseEnter={ onMouseEnterMock }
-							onMouseLeave={ onMouseLeaveMock }
-						>
-							Hover Me!
-						</Button>
-					</Tooltip>
-					<Button>Hover me instead!</Button>
-				</>
-			);
+		expect( screen.queryByText( 'tooltip text' ) ).not.toBeInTheDocument();
 
-			await user.hover(
-				screen.getByRole( 'button', {
-					name: 'Hover Me!',
-				} )
-			);
+		// Hover the other button, meaning that the mouse will leave the tooltip trigger
+		await user.hover(
+			screen.getByRole( 'button', {
+				name: 'Hover me instead!',
+			} )
+		);
 
-			// Tooltip hasn't appeared yet
+		// Tooltip still hasn't appeared yet
+		expect( screen.queryByText( 'tooltip text' ) ).not.toBeInTheDocument();
+		expect( onMouseEnterMock ).toHaveBeenCalledTimes( 1 );
+		expect( onMouseLeaveMock ).toHaveBeenCalledTimes( 1 );
+
+		// Advance time again, so that we reach the full TOOLTIP_DELAY time
+		await new Promise( ( resolve ) =>
+			setTimeout( resolve, TOOLTIP_DELAY )
+		);
+
+		// Tooltip won't show, since the mouse has left the tooltip trigger
+		expect( screen.queryByText( 'tooltip text' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should render the shortcut display text when a string is passed as the shortcut', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<Tooltip { ...props } shortcut="shortcut text">
+				<Button>Hover Me!</Button>
+			</Tooltip>
+		);
+
+		await user.hover( screen.getByRole( 'button', { name: 'Hover Me!' } ) );
+
+		await waitFor( () =>
+			expect( screen.getByText( 'shortcut text' ) ).toBeVisible()
+		);
+
+		// Wait for the tooltip element to be positioned (aligned with the button)
+		await waitFor( () =>
 			expect(
-				screen.queryByText( 'tooltip text' )
-			).not.toBeInTheDocument();
-			expect( onMouseEnterMock ).toHaveBeenCalledTimes( 1 );
+				getWrappingPopoverElement( screen.getByText( 'shortcut text' ) )
+			).toBePositionedPopover()
+		);
+	} );
 
-			// Advance time by MOUSE_LEAVE_DELAY time
-			await new Promise( ( resolve ) =>
-				setTimeout( resolve, MOUSE_LEAVE_DELAY )
-			);
+	it( 'should render the shortcut display text and aria-label when an object is passed as the shortcut with the correct properties', async () => {
+		const user = userEvent.setup();
 
+		render(
+			<Tooltip
+				{ ...props }
+				shortcut={ {
+					display: '⇧⌘,',
+					ariaLabel: shortcutAriaLabel.primaryShift( ',' ),
+				} }
+			>
+				<Button>Hover Me!</Button>
+			</Tooltip>
+		);
+
+		await user.hover( screen.getByRole( 'button', { name: 'Hover Me!' } ) );
+
+		await waitFor( () =>
+			expect( screen.getByText( '⇧⌘,' ) ).toBeVisible()
+		);
+
+		expect( screen.getByText( '⇧⌘,' ) ).toHaveAttribute(
+			'aria-label',
+			'Control + Shift + Comma'
+		);
+
+		// Wait for the tooltip element to be positioned (aligned with the button)
+		await waitFor( () =>
 			expect(
-				screen.queryByText( 'tooltip text' )
-			).not.toBeInTheDocument();
-
-			// Hover the other button, meaning that the mouse will leave the tooltip trigger
-			await user.hover(
-				screen.getByRole( 'button', {
-					name: 'Hover me instead!',
-				} )
-			);
-
-			// Tooltip still hasn't appeared yet
-			expect(
-				screen.queryByText( 'tooltip text' )
-			).not.toBeInTheDocument();
-			expect( onMouseEnterMock ).toHaveBeenCalledTimes( 1 );
-			expect( onMouseLeaveMock ).toHaveBeenCalledTimes( 1 );
-
-			// Advance time again, so that we reach the full TOOLTIP_DELAY time
-			await new Promise( ( resolve ) =>
-				setTimeout( resolve, TOOLTIP_DELAY )
-			);
-
-			// Tooltip won't show, since the mouse has left the tooltip trigger
-			expect(
-				screen.queryByText( 'tooltip text' )
-			).not.toBeInTheDocument();
-		} );
-
-		it( 'should render the shortcut display text when a string is passed as the shortcut', async () => {
-			const user = userEvent.setup();
-
-			render(
-				<Tooltip { ...props } shortcut="shortcut text">
-					<Button>Hover Me!</Button>
-				</Tooltip>
-			);
-
-			await user.hover(
-				screen.getByRole( 'button', { name: 'Hover Me!' } )
-			);
-
-			await waitFor( () =>
-				expect( screen.getByText( 'shortcut text' ) ).toBeVisible()
-			);
-
-			// Wait for the tooltip element to be positioned (aligned with the button)
-			await waitFor( () =>
-				expect(
-					getWrappingPopoverElement(
-						screen.getByText( 'shortcut text' )
-					)
-				).toBePositionedPopover()
-			);
-		} );
-
-		it( 'should render the shortcut display text and aria-label when an object is passed as the shortcut with the correct properties', async () => {
-			const user = userEvent.setup();
-
-			render(
-				<Tooltip
-					{ ...props }
-					shortcut={ {
-						display: '⇧⌘,',
-						ariaLabel: shortcutAriaLabel.primaryShift( ',' ),
-					} }
-				>
-					<Button>Hover Me!</Button>
-				</Tooltip>
-			);
-
-			await user.hover(
-				screen.getByRole( 'button', { name: 'Hover Me!' } )
-			);
-
-			await waitFor( () =>
-				expect( screen.getByText( '⇧⌘,' ) ).toBeVisible()
-			);
-
-			expect( screen.getByText( '⇧⌘,' ) ).toHaveAttribute(
-				'aria-label',
-				'Control + Shift + Comma'
-			);
-
-			// Wait for the tooltip element to be positioned (aligned with the button)
-			await waitFor( () =>
-				expect(
-					getWrappingPopoverElement( screen.getByText( '⇧⌘,' ) )
-				).toBePositionedPopover()
-			);
-		} );
+				getWrappingPopoverElement( screen.getByText( '⇧⌘,' ) )
+			).toBePositionedPopover()
+		);
 	} );
 } );

--- a/packages/components/src/tooltip/test/index.js
+++ b/packages/components/src/tooltip/test/index.js
@@ -9,11 +9,11 @@ import userEvent from '@testing-library/user-event';
  */
 import Tooltip from '../';
 import Button from '../../button';
+import { TOOLTIP_DELAY } from '../index.js';
 
 /**
  * WordPress dependencies
  */
-import { TOOLTIP_DELAY } from '../index.js';
 import { shortcutAriaLabel } from '@wordpress/keycodes';
 
 const props = {

--- a/packages/components/src/tooltip/test/index.js
+++ b/packages/components/src/tooltip/test/index.js
@@ -26,13 +26,17 @@ function getWrappingPopoverElement( element ) {
 
 describe( 'Tooltip', () => {
 	describe( '#render()', () => {
-		it( 'should not render the tooltip if multiple children are passed', () => {
+		it( 'should not render the tooltip if multiple children are passed', async () => {
+			const user = userEvent.setup();
+
 			render(
 				<Tooltip { ...props }>
 					<Button>Button 1</Button>
 					<Button>Button 2</Button>
 				</Tooltip>
 			);
+
+			await user.tab();
 
 			expect(
 				screen.queryByText( 'tooltip text' )
@@ -62,8 +66,6 @@ describe( 'Tooltip', () => {
 					<Button>Hover Me!</Button>
 				</Tooltip>
 			);
-
-			expect( document.body ).toHaveFocus();
 
 			await user.tab();
 

--- a/packages/components/src/tooltip/test/index.js
+++ b/packages/components/src/tooltip/test/index.js
@@ -251,13 +251,13 @@ describe( 'Tooltip', () => {
 			expect( onMouseEnterMock ).toHaveBeenCalledTimes( 1 );
 
 			// Advance time by MOUSE_LEAVE_DELAY time
-			await waitFor(
-				() =>
-					expect(
-						screen.queryByText( 'tooltip text' )
-					).not.toBeInTheDocument(),
-				{ timeout: MOUSE_LEAVE_DELAY }
+			await new Promise( ( resolve ) =>
+				setTimeout( resolve, MOUSE_LEAVE_DELAY )
 			);
+
+			expect(
+				screen.queryByText( 'tooltip text' )
+			).not.toBeInTheDocument();
 
 			// Hover the other button, meaning that the mouse will leave the tooltip anchor
 			await user.hover(
@@ -274,12 +274,8 @@ describe( 'Tooltip', () => {
 			expect( onMouseLeaveMock ).toHaveBeenCalledTimes( 1 );
 
 			// Advance time again, so that we reach the full TOOLTIP_DELAY time
-			await waitFor(
-				() =>
-					expect(
-						screen.queryByText( 'tooltip text' )
-					).not.toBeInTheDocument(),
-				{ timeout: TOOLTIP_DELAY }
+			await new Promise( ( resolve ) =>
+				setTimeout( resolve, TOOLTIP_DELAY )
 			);
 
 			// Tooltip won't show, since the mouse has left the anchor

--- a/packages/components/src/tooltip/test/index.js
+++ b/packages/components/src/tooltip/test/index.js
@@ -203,8 +203,8 @@ describe( 'Tooltip', () => {
 
 		it( 'should not emit events back to children when they are disabled', async () => {
 			const user = userEvent.setup();
-
 			const onClickMock = jest.fn();
+
 			const { container } = render(
 				<Tooltip { ...props }>
 					<Button disabled onClick={ onClickMock }>
@@ -213,10 +213,18 @@ describe( 'Tooltip', () => {
 				</Tooltip>
 			);
 
+			// Note: this is testing for implementation details,
+			// but couldn't find a better way.
+			const buttonRect = screen
+				.getByRole( 'button', { name: 'Click me' } )
+				.getBoundingClientRect();
 			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 			const eventCatcher = container.querySelector( '.event-catcher' );
 			await user.click( eventCatcher );
 			expect( onClickMock ).not.toHaveBeenCalled();
+
+			const eventCatcherRect = eventCatcher.getBoundingClientRect();
+			expect( buttonRect ).toEqual( eventCatcherRect );
 		} );
 
 		it( 'should not show tooltip if the mouse leaves the anchor before the tooltip has shown', async () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Refining the existing tooltip tests (and likely adding a few more but this is still a WIP)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In preparation for a new tooltip component #48222, I wanted to refine and improve the existing tests for the legacy tooltip. As well as add any additional tests that are missing / would be beneficial. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- By replacing `focus()` with `userEvent.tab()`to closer mimic user behaviour 
- Removing `act()` and fake timers 
- Replacing the button with our Button component (initially done because of [this issue](https://github.com/WordPress/gutenberg/issues/43129) but it looks like it might be related to the Icon / possibly other components. Still needs to be researched further)
- Refining the shortcut test to include what the prop is for

## Testing Instructions

Run `npm run test:unit packages/components/src/tooltip/test/index.js` and ensure tests are passing 