### PR TITLE
Prevent the saving button from showing when renaming templates

### DIFF
--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -51,9 +51,6 @@
 .edit-site-layout__content {
 	flex-grow: 1;
 	display: flex;
-
-	// Hide scrollbars during the edit/view animation.
-	overflow: hidden;
 }
 
 .edit-site-layout__sidebar {

--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -12,7 +12,7 @@ import { displayShortcut } from '@wordpress/keycodes';
  */
 import { store as editSiteStore } from '../../store';
 
-export default function SaveButton( { showTooltip = true } ) {
+export default function SaveButton() {
 	const { isDirty, isSaving, isSaveViewOpen } = useSelect( ( select ) => {
 		const { __experimentalGetDirtyEntityRecords, isSavingEntityRecord } =
 			select( coreStore );
@@ -52,7 +52,7 @@ export default function SaveButton( { showTooltip = true } ) {
 			 * of the button that we want to avoid. By setting `showTooltip`,
 			 & the tooltip is always rendered even when there's no keyboard shortcut.
 			 */
-			showTooltip={ showTooltip }
+			showTooltip
 		>
 			{ label }
 		</Button>

--- a/packages/edit-site/src/components/save-hub/index.js
+++ b/packages/edit-site/src/components/save-hub/index.js
@@ -1,0 +1,78 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import { sprintf, __, _n } from '@wordpress/i18n';
+import { store as coreStore } from '@wordpress/core-data';
+import { displayShortcut } from '@wordpress/keycodes';
+import { check } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../../store';
+
+export default function SaveButton() {
+	const { countUnsavedChanges, isDirty, isSaving, isSaveViewOpen } =
+		useSelect( ( select ) => {
+			const {
+				__experimentalGetDirtyEntityRecords,
+				isSavingEntityRecord,
+			} = select( coreStore );
+			const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
+			const { isSaveViewOpened } = select( editSiteStore );
+			return {
+				isDirty: dirtyEntityRecords.length > 0,
+				isSaving: dirtyEntityRecords.some( ( record ) =>
+					isSavingEntityRecord( record.kind, record.name, record.key )
+				),
+				isSaveViewOpen: isSaveViewOpened(),
+				countUnsavedChanges: dirtyEntityRecords.length,
+			};
+		}, [] );
+	const { setIsSaveViewOpened } = useDispatch( editSiteStore );
+
+	const disabled = ! isDirty || isSaving;
+
+	const label = disabled ? __( 'Saved' ) : __( 'Save' );
+
+	return (
+		<HStack className="edit-site-save-hub" alignment="right">
+			{ isDirty && (
+				<span>
+					{ sprintf(
+						// translators: %d: number of unsaved changes (number).
+						_n(
+							'%d unsaved change',
+							'%d unsaved changes',
+							countUnsavedChanges
+						),
+						countUnsavedChanges
+					) }
+				</span>
+			) }
+			<Button
+				className="edit-site-save-hub__button"
+				variant={ disabled ? undefined : 'primary' }
+				aria-disabled={ disabled }
+				aria-expanded={ isSaveViewOpen }
+				isBusy={ isSaving }
+				onClick={
+					disabled ? undefined : () => setIsSaveViewOpened( true )
+				}
+				label={ label }
+				/*
+				 * We want the tooltip to show the keyboard shortcut only when the
+				 * button does something, i.e. when it's not disabled.
+				 */
+				shortcut={
+					disabled ? undefined : displayShortcut.primary( 's' )
+				}
+				icon={ disabled ? check : undefined }
+			>
+				{ label }
+			</Button>
+		</HStack>
+	);
+}

--- a/packages/edit-site/src/components/save-hub/index.js
+++ b/packages/edit-site/src/components/save-hub/index.js
@@ -38,7 +38,7 @@ export default function SaveButton() {
 	const label = disabled ? __( 'Saved' ) : __( 'Save' );
 
 	return (
-		<HStack className="edit-site-save-hub" alignment="right">
+		<HStack className="edit-site-save-hub" alignment="right" spacing={ 4 }>
 			{ isDirty && (
 				<span>
 					{ sprintf(

--- a/packages/edit-site/src/components/save-hub/style.scss
+++ b/packages/edit-site/src/components/save-hub/style.scss
@@ -1,0 +1,15 @@
+.edit-site-save-hub {
+	color: $gray-600;
+}
+
+.edit-site-save-hub__button {
+	color: inherit;
+
+	&[aria-disabled="true"] {
+		opacity: 1;
+	}
+
+	&[aria-disabled="true"]:hover {
+		color: inherit;
+	}
+}

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -6,8 +6,6 @@ import {
 	__experimentalNavigatorProvider as NavigatorProvider,
 	__experimentalNavigatorScreen as NavigatorScreen,
 } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -20,7 +18,7 @@ import useSyncPathWithURL, {
 } from '../sync-state-with-url/use-sync-path-with-url';
 import SidebarNavigationScreenNavigationMenus from '../sidebar-navigation-screen-navigation-menus';
 import SidebarNavigationScreenTemplatesBrowse from '../sidebar-navigation-screen-templates-browse';
-import SaveButton from '../save-button';
+import SaveHub from '../save-hub';
 import SidebarNavigationScreenNavigationItem from '../sidebar-navigation-screen-navigation-item';
 import { useLocation } from '../routes';
 
@@ -54,15 +52,6 @@ function SidebarScreens() {
 function Sidebar() {
 	const { params: urlParams } = useLocation();
 	const initialPath = useRef( getPathFromURL( urlParams ) );
-	const { isDirty } = useSelect( ( select ) => {
-		const { __experimentalGetDirtyEntityRecords } = select( coreStore );
-		const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
-		// The currently selected entity to display.
-		// Typically template or template part in the site editor.
-		return {
-			isDirty: dirtyEntityRecords.length > 0,
-		};
-	}, [] );
 
 	return (
 		<>
@@ -72,11 +61,9 @@ function Sidebar() {
 			>
 				<SidebarScreens />
 			</NavigatorProvider>
-			{ isDirty && (
-				<div className="edit-site-sidebar__footer">
-					<SaveButton showTooltip={ false } />
-				</div>
-			) }
+			<div className="edit-site-sidebar__footer">
+				<SaveHub />
+			</div>
 		</>
 	);
 }

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -8,7 +8,6 @@ import {
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { usePrevious } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -55,23 +54,15 @@ function SidebarScreens() {
 function Sidebar() {
 	const { params: urlParams } = useLocation();
 	const initialPath = useRef( getPathFromURL( urlParams ) );
-	const { isDirty, isSaving } = useSelect( ( select ) => {
-		const { __experimentalGetDirtyEntityRecords, isSavingEntityRecord } =
-			select( coreStore );
+	const { isDirty } = useSelect( ( select ) => {
+		const { __experimentalGetDirtyEntityRecords } = select( coreStore );
 		const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
 		// The currently selected entity to display.
 		// Typically template or template part in the site editor.
 		return {
 			isDirty: dirtyEntityRecords.length > 0,
-			isSaving: dirtyEntityRecords.some( ( record ) =>
-				isSavingEntityRecord( record.kind, record.name, record.key )
-			),
 		};
 	}, [] );
-	// The wasDirty variable is used to prevent the save button from showing
-	// in the sidebar if the saving was triggered without edits.
-	// For instance: when renaming templates.
-	const wasDirty = usePrevious( isDirty );
 
 	return (
 		<>
@@ -81,7 +72,7 @@ function Sidebar() {
 			>
 				<SidebarScreens />
 			</NavigatorProvider>
-			{ ( ( isSaving && wasDirty ) || ( isDirty && ! isSaving ) ) && (
+			{ isDirty && (
 				<div className="edit-site-sidebar__footer">
 					<SaveButton showTooltip={ false } />
 				</div>

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -9,8 +9,6 @@
 	flex-shrink: 0;
 	margin: 0 $canvas-padding;
 	padding: $canvas-padding 0;
-	display: flex;
-	justify-content: flex-end;
 }
 
 .edit-site-sidebar__content.edit-site-sidebar__content {

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -20,6 +20,7 @@
 @import "./components/start-template-options/style.scss";
 @import "./components/keyboard-shortcut-help-modal/style.scss";
 @import "./components/layout/style.scss";
+@import "./components/save-hub/style.scss";
 @import "./components/save-panel/style.scss";
 @import "./components/sidebar/style.scss";
 @import "./components/sidebar-navigation-item/style.scss";


### PR DESCRIPTION
closes #48345 

## What?

This PR prevents the save button form showing in the site editor like confirmed in this issue #48345 but also prevents the "isSaving" button from showing when we trigger a direct save elsewhere (like when renaming templates).

## Why?

See reasoning here https://github.com/WordPress/gutenberg/issues/48345#issuecomment-1442190253

## Testing Instructions

1- Make an edit
2- Trigger a save from the sidebar of the site editor or using `ctrl + s`
3- The saving button is visible when the save is in progress.

1- Rename a template from the template list page
2- The saving button doesn't show up in the sidebar.
