### PR TITLE
Fix perf regression in duotone hooks

### DIFF
--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -309,20 +309,18 @@ const withDuotoneStyles = createHigherOrderComponent(
 		);
 
 		const id = `wp-duotone-flibble-${ useInstanceId( BlockListBlock ) }`;
-		const className = classnames( props?.className, id );
+		const className = duotoneSupport
+			? classnames( props?.className, id )
+			: props?.className;
 		const duotoneStyle = props?.attributes?.style?.color?.duotone;
 
-		// CAUTION: code added before the early return will be executed
+		// CAUTION: code added before this line will be executed
 		// for all blocks, not just those that support duotone. Code added
 		// above this line should be carefully evaluated for its impact on
 		// performance.
-		if ( ! duotoneSupport ) {
-			return <BlockListBlock { ...props } />;
-		}
-
 		return (
 			<>
-				{ duotoneStyle && (
+				{ duotoneSupport && duotoneStyle && (
 					<BlockDuotoneStyles
 						name={ props?.name }
 						duotoneStyle={ duotoneStyle }

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -202,12 +202,18 @@ const withDuotoneControls = createHigherOrderComponent(
 			[ props.clientId ]
 		);
 
+		// CAUTION: code added before the early return will be executed
+		// for all blocks, not just those that support duotone. Code added
+		// above this line should be carefully evaluated for its impact on
+		// performance.
+		if ( ! hasDuotoneSupport || isContentLocked ) {
+			return <BlockEdit { ...props } />;
+		}
+
 		return (
 			<>
+				<DuotonePanel { ...props } />
 				<BlockEdit { ...props } />
-				{ hasDuotoneSupport && ! isContentLocked && (
-					<DuotonePanel { ...props } />
-				) }
 			</>
 		);
 	},

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -202,17 +202,15 @@ const withDuotoneControls = createHigherOrderComponent(
 			[ props.clientId ]
 		);
 
-		// CAUTION: code added before the early return will be executed
+		// CAUTION: code added before this line will be executed
 		// for all blocks, not just those that support duotone. Code added
 		// above this line should be carefully evaluated for its impact on
 		// performance.
-		if ( ! hasDuotoneSupport ) {
-			return <BlockEdit { ...props } />;
-		}
-
 		return (
 			<>
-				{ ! isContentLocked && <DuotonePanel { ...props } /> }
+				{ hasDuotoneSupport && ! isContentLocked && (
+					<DuotonePanel { ...props } />
+				) }
 				<BlockEdit { ...props } />
 			</>
 		);

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -206,13 +206,13 @@ const withDuotoneControls = createHigherOrderComponent(
 		// for all blocks, not just those that support duotone. Code added
 		// above this line should be carefully evaluated for its impact on
 		// performance.
-		if ( ! hasDuotoneSupport || isContentLocked ) {
+		if ( ! hasDuotoneSupport ) {
 			return <BlockEdit { ...props } />;
 		}
 
 		return (
 			<>
-				<DuotonePanel { ...props } />
+				{ ! isContentLocked && <DuotonePanel { ...props } /> }
 				<BlockEdit { ...props } />
 			</>
 		);

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -316,17 +316,19 @@ const withDuotoneStyles = createHigherOrderComponent(
 		// for all blocks, not just those that support duotone. Code added
 		// above this line should be carefully evaluated for its impact on
 		// performance.
-		if ( ! duotoneSupport || ! duotoneStyle ) {
+		if ( ! duotoneSupport ) {
 			return <BlockListBlock { ...props } />;
 		}
 
 		return (
 			<>
-				<BlockDuotoneStyles
-					name={ props?.name }
-					duotoneStyle={ duotoneStyle }
-					id={ id }
-				/>
+				{ duotoneStyle && (
+					<BlockDuotoneStyles
+						name={ props?.name }
+						duotoneStyle={ duotoneStyle }
+						id={ id }
+					/>
+				) }
 				<BlockListBlock { ...props } className={ className } />
 			</>
 		);

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -306,7 +306,7 @@ const withDuotoneStyles = createHigherOrderComponent(
 			'color.__experimentalDuotone'
 		);
 
-		const id = `wp-duotone-flibble-${ useInstanceId( BlockListBlock ) }`;
+		const id = `wp-duotone-${ useInstanceId( BlockListBlock ) }`;
 		const className = duotoneSupport
 			? classnames( props?.className, id )
 			: props?.className;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes a performance regression likely introduced by https://github.com/WordPress/gutenberg/pull/48318.

See https://github.com/WordPress/gutenberg/pull/48318/#issuecomment-1443250045.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The refactor in https://github.com/WordPress/gutenberg/pull/48318 caused some hooks to be executed for _all_ blocks and not just those which support duotone. This has a big impact on performance, especially as some of those hooks were doing potentially expensive lookups in settings.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Established a component guard pattern where by:

- as many hooks as possible are moved into a wrapping component
- an early exit condition is added to hook handlers which returns the default component if the block does not support Duotone~ improved conditions are added to the JSX to avoid Duotone related components being rendered if te block does not support Duotone - the following hooks are guarded:
    - `editor.BlockEdit`
    - `editor.BlockListBlock`
- cautionary comments are added to the ~early `return`s~ JSX conditionals to help encourage developers to consider the perf impact of future changes. Ideally this wouldn't be necessary but given that the code is not well covered with tests (and developers are human) it's probably our best bet of avoiding this happening again.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

The goal is that Duotone support _in the Editor_ on blocks behaves _exactly_ as per `trunk` (but just with better performance).

Manual testing should involve:

- checking that Duotone can be:
    - set
    - unset
    - cleared
- checking that the above still works if you have multiple blocks on the canvas
- check that if a block is content-locked then Duotone panel does not show. (tip: wrap a couple of Images in a Group and then apply the following attribute to the underlying Group block markup `"templateLock": "contentOnly"`).

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
