### PR TITLE
Pin `floating-ui/react-dom` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17444,7 +17444,7 @@
 				"@emotion/serialize": "^1.0.2",
 				"@emotion/styled": "^11.6.0",
 				"@emotion/utils": "^1.0.0",
-				"@floating-ui/react-dom": "^1.0.0",
+				"@floating-ui/react-dom": "1.0.0",
 				"@use-gesture/react": "^10.2.6",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/compose": "file:packages/compose",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -36,7 +36,7 @@
 		"@emotion/serialize": "^1.0.2",
 		"@emotion/styled": "^11.6.0",
 		"@emotion/utils": "^1.0.0",
-		"@floating-ui/react-dom": "^1.0.0",
+		"@floating-ui/react-dom": "1.0.0",
 		"@use-gesture/react": "^10.2.6",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/compose": "file:../compose",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/48059
Fixes: https://github.com/WordPress/gutenberg/issues/48398
Similar to: https://github.com/WordPress/gutenberg/pull/48237
<!-- In a few words, what is the PR actually doing? -->

## Why?
Core resolves different version `1.3.0` and it seems something has changed that causes these problems.

Ideally we should update the version in GB and resolve the issues, but beta 4 is in a few days. So I think this `hotfix` for core it's an acceptable temporary solution.

## Testing Instructions
1. Everything should work as before in GB.

We'll need to do a packages update for 6.2 to verify it resolves the issues.
