### PR TITLE
Duotone: add block controls on the inspector

### DIFF
--- a/packages/block-editor/src/components/duotone-control/index.js
+++ b/packages/block-editor/src/components/duotone-control/index.js
@@ -16,6 +16,7 @@ import { Icon, filter } from '@wordpress/icons';
 function DuotoneControl( {
 	colorPalette,
 	duotonePalette,
+	duotonePaletteByOrigin,
 	disableCustomColors,
 	disableCustomDuotone,
 	value,
@@ -67,6 +68,7 @@ function DuotoneControl( {
 					<DuotonePicker
 						colorPalette={ colorPalette }
 						duotonePalette={ duotonePalette }
+						duotonePaletteByOrigin={ duotonePaletteByOrigin }
 						disableCustomColors={ disableCustomColors }
 						disableCustomDuotone={ disableCustomDuotone }
 						value={ value }

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -32,6 +32,7 @@ const StylesTab = ( { blockName, clientId, hasBlockStyles } ) => {
 				label={ __( 'Color' ) }
 				className="color-block-support-panel__inner-wrapper"
 			/>
+			<InspectorControls.Slot group="filter" label={ __( 'Filter' ) } />
 			<InspectorControls.Slot
 				group="typography"
 				label={ __( 'Typography' ) }

--- a/packages/block-editor/src/components/inspector-controls/groups.js
+++ b/packages/block-editor/src/components/inspector-controls/groups.js
@@ -7,6 +7,7 @@ const InspectorControlsDefault = createSlotFill( 'InspectorControls' );
 const InspectorControlsAdvanced = createSlotFill( 'InspectorAdvancedControls' );
 const InspectorControlsBorder = createSlotFill( 'InspectorControlsBorder' );
 const InspectorControlsColor = createSlotFill( 'InspectorControlsColor' );
+const InspectorControlsFilter = createSlotFill( 'InspectorControlsFilter' );
 const InspectorControlsDimensions = createSlotFill(
 	'InspectorControlsDimensions'
 );
@@ -22,6 +23,7 @@ const groups = {
 	advanced: InspectorControlsAdvanced,
 	border: InspectorControlsBorder,
 	color: InspectorControlsColor,
+	filter: InspectorControlsFilter,
 	dimensions: InspectorControlsDimensions,
 	list: InspectorControlsListView,
 	settings: InspectorControlsDefault, // Alias for default.

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -23,6 +23,7 @@ import { useSelect } from '@wordpress/data';
  */
 import {
 	BlockControls,
+	InspectorControls,
 	__experimentalDuotoneControl as DuotoneControl,
 	useSetting,
 } from '../components';
@@ -132,30 +133,59 @@ function DuotonePanel( { attributes, setAttributes } ) {
 		: duotoneStyle;
 
 	return (
-		<BlockControls group="block" __experimentalShareWithChildBlocks>
-			<DuotoneControl
-				duotonePalette={ duotonePalette }
-				colorPalette={ colorPalette }
-				disableCustomDuotone={ disableCustomDuotone }
-				disableCustomColors={ disableCustomColors }
-				value={ duotonePresetOrColors }
-				onChange={ ( newDuotone ) => {
-					const maybePreset = getDuotonePresetFromColors(
-						newDuotone,
-						duotonePalette
-					);
+		<>
+			<InspectorControls
+				group="filter"
+				__experimentalShareWithChildBlocks
+			>
+				<DuotoneControl
+					duotonePalette={ duotonePalette }
+					colorPalette={ colorPalette }
+					disableCustomDuotone={ disableCustomDuotone }
+					disableCustomColors={ disableCustomColors }
+					value={ duotonePresetOrColors }
+					onChange={ ( newDuotone ) => {
+						const maybePreset = getDuotonePresetFromColors(
+							newDuotone,
+							duotonePalette
+						);
 
-					const newStyle = {
-						...style,
-						color: {
-							...style?.color,
-							duotone: maybePreset ?? newDuotone, // use preset or fallback to custom colors.
-						},
-					};
-					setAttributes( { style: newStyle } );
-				} }
-			/>
-		</BlockControls>
+						const newStyle = {
+							...style,
+							color: {
+								...style?.color,
+								duotone: maybePreset ?? newDuotone, // use preset or fallback to custom colors.
+							},
+						};
+						setAttributes( { style: newStyle } );
+					} }
+				/>
+			</InspectorControls>
+			<BlockControls group="block" __experimentalShareWithChildBlocks>
+				<DuotoneControl
+					duotonePalette={ duotonePalette }
+					colorPalette={ colorPalette }
+					disableCustomDuotone={ disableCustomDuotone }
+					disableCustomColors={ disableCustomColors }
+					value={ duotonePresetOrColors }
+					onChange={ ( newDuotone ) => {
+						const maybePreset = getDuotonePresetFromColors(
+							newDuotone,
+							duotonePalette
+						);
+
+						const newStyle = {
+							...style,
+							color: {
+								...style?.color,
+								duotone: maybePreset ?? newDuotone, // use preset or fallback to custom colors.
+							},
+						};
+						setAttributes( { style: newStyle } );
+					} }
+				/>
+			</BlockControls>
+		</>
 	);
 }
 

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -93,11 +93,20 @@ function useGroupedPresets( { presetSetting, defaultSetting } ) {
 		useSetting( `${ presetSetting }.default` ) || EMPTY_ARRAY;
 
 	return useMemo( () => {
-		return {
-			user: userPresets,
-			theme: themePresets,
-			default: disableDefault ? EMPTY_ARRAY : defaultPresets,
-		};
+		return [
+			{
+				name: 'User',
+				palettes: userPresets,
+			},
+			{
+				name: 'Theme',
+				palettes: themePresets,
+			},
+			{
+				name: 'Default',
+				palettes: disableDefault ? EMPTY_ARRAY : defaultPresets,
+			},
+		];
 	}, [ disableDefault, userPresets, themePresets, defaultPresets ] );
 }
 
@@ -162,7 +171,7 @@ function DuotonePanel( { attributes, setAttributes } ) {
 				__experimentalShareWithChildBlocks
 			>
 				<DuotoneControl
-					duotonePalette={ duotonePalette }
+					duotonePaletteByOrigin={ duotonePaletteByOrigin }
 					colorPalette={ colorPalette }
 					disableCustomDuotone={ disableCustomDuotone }
 					disableCustomColors={ disableCustomColors }
@@ -186,7 +195,7 @@ function DuotonePanel( { attributes, setAttributes } ) {
 			</InspectorControls>
 			<BlockControls group="block" __experimentalShareWithChildBlocks>
 				<DuotoneControl
-					duotonePaletteByOrigin={ duotonePaletteByOrigin }
+					duotonePalette={ duotonePalette }
 					colorPalette={ colorPalette }
 					disableCustomDuotone={ true }
 					disableCustomColors={ true }

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -72,6 +72,7 @@ function useMultiOriginPresets( { presetSetting, defaultSetting } ) {
 		useSetting( `${ presetSetting }.theme` ) || EMPTY_ARRAY;
 	const defaultPresets =
 		useSetting( `${ presetSetting }.default` ) || EMPTY_ARRAY;
+
 	return useMemo(
 		() => [
 			...userPresets,
@@ -80,6 +81,24 @@ function useMultiOriginPresets( { presetSetting, defaultSetting } ) {
 		],
 		[ disableDefault, userPresets, themePresets, defaultPresets ]
 	);
+}
+
+function useGroupedPresets( { presetSetting, defaultSetting } ) {
+	const disableDefault = ! useSetting( defaultSetting );
+	const userPresets =
+		useSetting( `${ presetSetting }.custom` ) || EMPTY_ARRAY;
+	const themePresets =
+		useSetting( `${ presetSetting }.theme` ) || EMPTY_ARRAY;
+	const defaultPresets =
+		useSetting( `${ presetSetting }.default` ) || EMPTY_ARRAY;
+
+	return useMemo( () => {
+		return {
+			user: userPresets,
+			theme: themePresets,
+			default: disableDefault ? EMPTY_ARRAY : defaultPresets,
+		};
+	}, [ disableDefault, userPresets, themePresets, defaultPresets ] );
 }
 
 export function getColorsFromDuotonePreset( duotone, duotonePalette ) {
@@ -112,6 +131,10 @@ function DuotonePanel( { attributes, setAttributes } ) {
 	const duotoneStyle = style?.color?.duotone;
 
 	const duotonePalette = useMultiOriginPresets( {
+		presetSetting: 'color.duotone',
+		defaultSetting: 'color.defaultDuotone',
+	} );
+	const duotonePaletteByOrigin = useGroupedPresets( {
 		presetSetting: 'color.duotone',
 		defaultSetting: 'color.defaultDuotone',
 	} );
@@ -163,7 +186,7 @@ function DuotonePanel( { attributes, setAttributes } ) {
 			</InspectorControls>
 			<BlockControls group="block" __experimentalShareWithChildBlocks>
 				<DuotoneControl
-					duotonePalette={ duotonePalette }
+					duotonePaletteByOrigin={ duotonePaletteByOrigin }
 					colorPalette={ colorPalette }
 					disableCustomDuotone={ true }
 					disableCustomColors={ true }

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -165,8 +165,8 @@ function DuotonePanel( { attributes, setAttributes } ) {
 				<DuotoneControl
 					duotonePalette={ duotonePalette }
 					colorPalette={ colorPalette }
-					disableCustomDuotone={ disableCustomDuotone }
-					disableCustomColors={ disableCustomColors }
+					disableCustomDuotone={ true }
+					disableCustomColors={ true }
 					value={ duotonePresetOrColors }
 					onChange={ ( newDuotone ) => {
 						const maybePreset = getDuotonePresetFromColors(

--- a/packages/components/src/duotone-picker/duotone-picker.tsx
+++ b/packages/components/src/duotone-picker/duotone-picker.tsx
@@ -12,7 +12,7 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-//import { ColorHeading } from '../color-palette/styles';
+import { ColorHeading } from '../color-palette/styles';
 import ColorListPicker from './color-list-picker';
 import CircularOptionPicker from '../circular-option-picker';
 import { VStack } from '../v-stack';
@@ -20,23 +20,15 @@ import { VStack } from '../v-stack';
 import CustomDuotoneBar from './custom-duotone-bar';
 import { getDefaultColors, getGradientFromCSSColors } from './utils';
 import { Spacer } from '../spacer';
-import type { DuotonePickerProps, SinglePaletteProps } from './types';
+import type {
+	DuotonePickerProps,
+	SinglePaletteProps,
+	MultiplePalettesProps,
+	paletteOptionsProps,
+} from './types';
 
-function SinglePalette( {
-	defaultDark,
-	defaultLight,
-	clearable,
-	unsetable,
-	colorPalette,
-	duotonePalette,
-	disableCustomColors,
-	disableCustomDuotone,
-	value,
-	unsetOption,
-	onChange,
-}: SinglePaletteProps ) {
-	const colorValue = value && value !== 'unset' ? value : undefined;
-	const options = duotonePalette.map( ( { colors, slug, name } ) => {
+function paletteOptions( { palette, value, onChange }: paletteOptionsProps ) {
+	return palette.map( ( { colors, slug, name } ) => {
 		const style = {
 			background: getGradientFromCSSColors( colors, '135deg' ),
 			color: 'transparent',
@@ -70,6 +62,27 @@ function SinglePalette( {
 				} }
 			/>
 		);
+	} );
+}
+
+function SinglePalette( {
+	defaultDark,
+	defaultLight,
+	clearable,
+	unsetable,
+	colorPalette,
+	duotonePalette,
+	disableCustomColors,
+	disableCustomDuotone,
+	value,
+	unsetOption,
+	onChange,
+}: SinglePaletteProps ) {
+	const colorValue = value && value !== 'unset' ? value : undefined;
+	const options = paletteOptions( {
+		palette: duotonePalette,
+		value,
+		onChange,
 	} );
 
 	return (
@@ -121,6 +134,60 @@ function SinglePalette( {
 				</VStack>
 			</Spacer>
 		</CircularOptionPicker>
+	);
+}
+
+function MultiplePalettes( {
+	defaultDark,
+	defaultLight,
+	unsetable,
+	colorPalette,
+	duotonePaletteByOrigin,
+	disableCustomColors,
+	disableCustomDuotone,
+	value,
+	unsetOption,
+	onChange,
+}: MultiplePalettesProps ) {
+	if ( ! duotonePaletteByOrigin ) {
+		return null;
+	}
+
+	const paletteProps = {
+		defaultDark,
+		defaultLight,
+		clearable: false,
+		unsetable,
+		colorPalette,
+		disableCustomColors,
+		disableCustomDuotone,
+		value,
+		unsetOption,
+		onChange,
+	};
+
+	return (
+		<>
+			{ duotonePaletteByOrigin
+				.filter( ( { palettes } ) => palettes.length > 0 )
+				.map( ( { name, palettes }, index, array ) => {
+					if ( index > 0 ) {
+						paletteProps.unsetable = false;
+					}
+					if ( index === array.length - 1 ) {
+						paletteProps.clearable = true;
+					}
+					return (
+						<VStack spacing={ 2 } key={ index }>
+							<ColorHeading level={ 3 }>{ name }</ColorHeading>
+							<SinglePalette
+								{ ...paletteProps }
+								duotonePalette={ palettes }
+							/>
+						</VStack>
+					);
+				} ) }
+		</>
 	);
 }
 
@@ -191,10 +258,8 @@ function DuotonePicker( {
 	const paletteCommonProps = {
 		defaultDark,
 		defaultLight,
-		clearable,
 		unsetable,
 		colorPalette,
-		duotonePalette,
 		disableCustomColors,
 		disableCustomDuotone,
 		value,
@@ -205,13 +270,16 @@ function DuotonePicker( {
 	return (
 		<>
 			{ duotonePaletteByOrigin ? (
-				<SinglePalette
-					{ ...paletteCommonProps }
-					duotonePalette={ duotonePaletteByOrigin.theme }
-				/>
+				<>
+					<MultiplePalettes
+						{ ...paletteCommonProps }
+						duotonePaletteByOrigin={ duotonePaletteByOrigin }
+					/>
+				</>
 			) : (
 				<SinglePalette
 					{ ...paletteCommonProps }
+					clearable={ clearable }
 					duotonePalette={ duotonePalette }
 				/>
 			) }

--- a/packages/components/src/duotone-picker/duotone-picker.tsx
+++ b/packages/components/src/duotone-picker/duotone-picker.tsx
@@ -12,6 +12,7 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+//import { ColorHeading } from '../color-palette/styles';
 import ColorListPicker from './color-list-picker';
 import CircularOptionPicker from '../circular-option-picker';
 import { VStack } from '../v-stack';
@@ -19,71 +20,22 @@ import { VStack } from '../v-stack';
 import CustomDuotoneBar from './custom-duotone-bar';
 import { getDefaultColors, getGradientFromCSSColors } from './utils';
 import { Spacer } from '../spacer';
-import type { DuotonePickerProps } from './types';
+import type { DuotonePickerProps, SinglePaletteProps } from './types';
 
-/**
- * ```jsx
- * import { DuotonePicker, DuotoneSwatch } from '@wordpress/components';
- * import { useState } from '@wordpress/element';
- *
- * const DUOTONE_PALETTE = [
- * 	{ colors: [ '#8c00b7', '#fcff41' ], name: 'Purple and yellow', slug: 'purple-yellow' },
- * 	{ colors: [ '#000097', '#ff4747' ], name: 'Blue and red', slug: 'blue-red' },
- * ];
- *
- * const COLOR_PALETTE = [
- * 	{ color: '#ff4747', name: 'Red', slug: 'red' },
- * 	{ color: '#fcff41', name: 'Yellow', slug: 'yellow' },
- * 	{ color: '#000097', name: 'Blue', slug: 'blue' },
- * 	{ color: '#8c00b7', name: 'Purple', slug: 'purple' },
- * ];
- *
- * const Example = () => {
- * 	const [ duotone, setDuotone ] = useState( [ '#000000', '#ffffff' ] );
- * 	return (
- * 		<>
- * 			<DuotonePicker
- * 				duotonePalette={ DUOTONE_PALETTE }
- * 				colorPalette={ COLOR_PALETTE }
- * 				value={ duotone }
- * 				onChange={ setDuotone }
- * 			/>
- * 			<DuotoneSwatch values={ duotone } />
- * 		</>
- * 	);
- * };
- * ```
- */
-function DuotonePicker( {
-	clearable = true,
-	unsetable = true,
+function SinglePalette( {
+	defaultDark,
+	defaultLight,
+	clearable,
+	unsetable,
 	colorPalette,
 	duotonePalette,
 	disableCustomColors,
 	disableCustomDuotone,
 	value,
+	unsetOption,
 	onChange,
-}: DuotonePickerProps ) {
-	const [ defaultDark, defaultLight ] = useMemo(
-		() => getDefaultColors( colorPalette ),
-		[ colorPalette ]
-	);
-
-	const isUnset = value === 'unset';
-
-	const unsetOption = (
-		<CircularOptionPicker.Option
-			key="unset"
-			value="unset"
-			isSelected={ isUnset }
-			tooltipText={ __( 'Unset' ) }
-			className="components-duotone-picker__color-indicator"
-			onClick={ () => {
-				onChange( isUnset ? undefined : 'unset' );
-			} }
-		/>
-	);
-
+}: SinglePaletteProps ) {
+	const colorValue = value && value !== 'unset' ? value : undefined;
 	const options = duotonePalette.map( ( { colors, slug, name } ) => {
 		const style = {
 			background: getGradientFromCSSColors( colors, '135deg' ),
@@ -137,7 +89,7 @@ function DuotonePicker( {
 				<VStack spacing={ 3 }>
 					{ ! disableCustomColors && ! disableCustomDuotone && (
 						<CustomDuotoneBar
-							value={ isUnset ? undefined : value }
+							value={ colorValue }
 							onChange={ onChange }
 						/>
 					) }
@@ -145,7 +97,7 @@ function DuotonePicker( {
 						<ColorListPicker
 							labels={ [ __( 'Shadows' ), __( 'Highlights' ) ] }
 							colors={ colorPalette }
-							value={ isUnset ? undefined : value }
+							value={ colorValue }
 							disableCustomColors={ disableCustomColors }
 							enableAlpha
 							onChange={ ( newColors ) => {
@@ -169,6 +121,101 @@ function DuotonePicker( {
 				</VStack>
 			</Spacer>
 		</CircularOptionPicker>
+	);
+}
+
+/**
+ * ```jsx
+ * import { DuotonePicker, DuotoneSwatch } from '@wordpress/components';
+ * import { useState } from '@wordpress/element';
+ *
+ * const DUOTONE_PALETTE = [
+ * 	{ colors: [ '#8c00b7', '#fcff41' ], name: 'Purple and yellow', slug: 'purple-yellow' },
+ * 	{ colors: [ '#000097', '#ff4747' ], name: 'Blue and red', slug: 'blue-red' },
+ * ];
+ *
+ * const COLOR_PALETTE = [
+ * 	{ color: '#ff4747', name: 'Red', slug: 'red' },
+ * 	{ color: '#fcff41', name: 'Yellow', slug: 'yellow' },
+ * 	{ color: '#000097', name: 'Blue', slug: 'blue' },
+ * 	{ color: '#8c00b7', name: 'Purple', slug: 'purple' },
+ * ];
+ *
+ * const Example = () => {
+ * 	const [ duotone, setDuotone ] = useState( [ '#000000', '#ffffff' ] );
+ * 	return (
+ * 		<>
+ * 			<DuotonePicker
+ * 				duotonePalette={ DUOTONE_PALETTE }
+ * 				colorPalette={ COLOR_PALETTE }
+ * 				value={ duotone }
+ * 				onChange={ setDuotone }
+ * 			/>
+ * 			<DuotoneSwatch values={ duotone } />
+ * 		</>
+ * 	);
+ * };
+ * ```
+ */
+function DuotonePicker( {
+	clearable = true,
+	unsetable = true,
+	colorPalette,
+	duotonePalette,
+	duotonePaletteByOrigin,
+	disableCustomColors,
+	disableCustomDuotone,
+	value,
+	onChange,
+}: DuotonePickerProps ) {
+	const [ defaultDark, defaultLight ] = useMemo(
+		() => getDefaultColors( colorPalette ),
+		[ colorPalette ]
+	);
+
+	const isUnset = value === 'unset';
+
+	const unsetOption = (
+		<CircularOptionPicker.Option
+			key="unset"
+			value="unset"
+			isSelected={ isUnset }
+			tooltipText={ __( 'Unset' ) }
+			className="components-duotone-picker__color-indicator"
+			onClick={ () => {
+				onChange( isUnset ? undefined : 'unset' );
+			} }
+		/>
+	);
+
+	const paletteCommonProps = {
+		defaultDark,
+		defaultLight,
+		clearable,
+		unsetable,
+		colorPalette,
+		duotonePalette,
+		disableCustomColors,
+		disableCustomDuotone,
+		value,
+		unsetOption,
+		onChange,
+	};
+
+	return (
+		<>
+			{ duotonePaletteByOrigin ? (
+				<SinglePalette
+					{ ...paletteCommonProps }
+					duotonePalette={ duotonePaletteByOrigin.theme }
+				/>
+			) : (
+				<SinglePalette
+					{ ...paletteCommonProps }
+					duotonePalette={ duotonePalette }
+				/>
+			) }
+		</>
 	);
 }
 

--- a/packages/components/src/duotone-picker/types.ts
+++ b/packages/components/src/duotone-picker/types.ts
@@ -20,6 +20,10 @@ export type DuotonePickerProps = {
 	 */
 	duotonePalette: DuotoneColor[];
 	/**
+	 * Array of duotone presets of the form `{ colors: [ '#000000', '#ffffff' ], name: 'Grayscale', slug: 'grayscale' } grouped by origin`.
+	 */
+	duotonePaletteByOrigin?: duotonePaletteByOrigin;
+	/**
 	 * Whether custom colors should be disabled.
 	 *
 	 * @default false
@@ -47,6 +51,12 @@ type Color = {
 	slug: string;
 };
 
+type duotonePaletteByOrigin = {
+	theme: DuotoneColor[];
+	user: DuotoneColor[];
+	default: DuotoneColor[];
+};
+
 type DuotoneColor = {
 	colors: string[];
 	name: string;
@@ -58,4 +68,10 @@ export type DuotoneSwatchProps = {
 	 * An array of colors to show or `null` to show the placeholder swatch icon.
 	 */
 	values?: string[] | null;
+};
+
+export type SinglePaletteProps = DuotonePickerProps & {
+	defaultDark: string;
+	defaultLight: string;
+	unsetOption: any;
 };

--- a/packages/components/src/duotone-picker/types.ts
+++ b/packages/components/src/duotone-picker/types.ts
@@ -51,11 +51,10 @@ type Color = {
 	slug: string;
 };
 
-type duotonePaletteByOrigin = {
-	theme: DuotoneColor[];
-	user: DuotoneColor[];
-	default: DuotoneColor[];
-};
+type duotonePaletteByOrigin = Array< {
+	name: string;
+	palettes: DuotoneColor[];
+} >;
 
 type DuotoneColor = {
 	colors: string[];
@@ -70,8 +69,35 @@ export type DuotoneSwatchProps = {
 	values?: string[] | null;
 };
 
-export type SinglePaletteProps = DuotonePickerProps & {
+export type SinglePaletteProps = {
 	defaultDark: string;
 	defaultLight: string;
-	unsetOption: any;
+	unsetable?: boolean;
+	colorPalette: Color[];
+	disableCustomColors?: boolean;
+	disableCustomDuotone?: boolean;
+	value?: string[] | 'unset';
+	unsetOption: React.ReactElement;
+	onChange: ( value: DuotonePickerProps[ 'value' ] | undefined ) => void;
+	clearable?: boolean;
+	duotonePalette: DuotoneColor[];
+};
+
+export type MultiplePalettesProps = {
+	defaultDark: string;
+	defaultLight: string;
+	unsetable?: boolean;
+	colorPalette: Color[];
+	disableCustomColors?: boolean;
+	disableCustomDuotone?: boolean;
+	value?: string[] | 'unset';
+	unsetOption: React.ReactElement;
+	onChange: ( value: DuotonePickerProps[ 'value' ] | undefined ) => void;
+	duotonePaletteByOrigin: duotonePaletteByOrigin;
+};
+
+export type paletteOptionsProps = {
+	palette: DuotoneColor[];
+	value?: string[] | 'unset';
+	onChange: ( value: DuotonePickerProps[ 'value' ] | undefined ) => void;
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This is a WIP and it's not ready for review.

This PR aims to simplify the Duotone picker that shows on the block Toolbar and have the full controls appear on the Inspector controls. The option to create a custom duotone will be exclusive to the inspector to free space on the toolbar popover as discussed in https://github.com/WordPress/gutenberg/issues/39452

Part of https://github.com/WordPress/gutenberg/issues/39452

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
