### PR TITLE
Fix snapshots for Spacer mobile unit tests

### DIFF
--- a/packages/block-library/src/spacer/test/__snapshots__/index.native.js.snap
+++ b/packages/block-library/src/spacer/test/__snapshots__/index.native.js.snap
@@ -19,14 +19,14 @@ exports[`Spacer block inserts block 1`] = `
 `;
 
 exports[`Spacer block inserts block with spacingSizes preset 1`] = `
-"<!-- wp:spacer {\\"height\\":\\"70px\\"} -->
-<div style=\\"height:70px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+"<!-- wp:spacer {"height":"70px"} -->
+<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->"
 `;
 
 exports[`Spacer block inserts block with spacingSizes preset without matching global styles values 1`] = `
-"<!-- wp:spacer {\\"height\\":\\"120px\\"} -->
-<div style=\\"height:120px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+"<!-- wp:spacer {"height":"120px"} -->
+<div style="height:120px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->"
 `;
 


### PR DESCRIPTION
Fixes regression introduced by #48366, where I updated snapshot format. After I created the PR and before I merged it, @geriux merged #47258 which adds two new snapshots for the Spacer block, in the old format. This PR puts everything back in order.