### PR TITLE
Rich text: avoid createRecord for delete handler

### DIFF
--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -228,7 +228,7 @@ export function useRichText( {
 		useSelectObject(),
 		useFormatBoundaries( { record, applyRecord } ),
 		useDelete( {
-			createRecord,
+			record,
 			handleChange,
 			multilineTag,
 		} ),

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -39,25 +39,6 @@ export function useRichText( {
 	const [ , forceRender ] = useReducer( () => ( {} ) );
 	const ref = useRef();
 
-	function createRecord() {
-		const {
-			ownerDocument: { defaultView },
-		} = ref.current;
-		const selection = defaultView.getSelection();
-		const range =
-			selection.rangeCount > 0 ? selection.getRangeAt( 0 ) : null;
-
-		return create( {
-			element: ref.current,
-			range,
-			multilineTag,
-			multilineWrapperTags:
-				multilineTag === 'li' ? [ 'ul', 'ol' ] : undefined,
-			__unstableIsEditableTree: true,
-			preserveWhiteSpace,
-		} );
-	}
-
 	function applyRecord( newRecord, { domOnly } = {} ) {
 		apply( {
 			value: newRecord,
@@ -235,10 +216,11 @@ export function useRichText( {
 		useInputAndSelection( {
 			record,
 			applyRecord,
-			createRecord,
 			handleChange,
 			isSelected,
 			onSelectionChange,
+			multilineTag,
+			preserveWhiteSpace,
 		} ),
 		useRefEffect( () => {
 			applyFromProps();

--- a/packages/rich-text/src/component/use-delete.js
+++ b/packages/rich-text/src/component/use-delete.js
@@ -18,8 +18,7 @@ export function useDelete( props ) {
 	return useRefEffect( ( element ) => {
 		function onKeyDown( event ) {
 			const { keyCode } = event;
-			const { createRecord, handleChange, multilineTag } =
-				propsRef.current;
+			const { record, handleChange, multilineTag } = propsRef.current;
 
 			if ( event.defaultPrevented ) {
 				return;
@@ -29,13 +28,12 @@ export function useDelete( props ) {
 				return;
 			}
 
-			const currentValue = createRecord();
-			const { start, end, text } = currentValue;
+			const { start, end, text } = record;
 			const isReverse = keyCode === BACKSPACE;
 
 			// Always handle full content deletion ourselves.
 			if ( start === 0 && end !== 0 && end === text.length ) {
-				handleChange( remove( currentValue ) );
+				handleChange( remove( record ) );
 				event.preventDefault();
 				return;
 			}
@@ -46,13 +44,13 @@ export function useDelete( props ) {
 				// Check to see if we should remove the first item if empty.
 				if (
 					isReverse &&
-					currentValue.start === 0 &&
-					currentValue.end === 0 &&
-					isEmptyLine( currentValue )
+					record.start === 0 &&
+					record.end === 0 &&
+					isEmptyLine( record )
 				) {
-					newValue = removeLineSeparator( currentValue, ! isReverse );
+					newValue = removeLineSeparator( record, ! isReverse );
 				} else {
-					newValue = removeLineSeparator( currentValue, isReverse );
+					newValue = removeLineSeparator( record, isReverse );
 				}
 
 				if ( newValue ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Not sure why this is using createRecord while all the other hooks are using the already computed record.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
