### PR TITLE
[Mobile] - E2E helpers - Update dismissKeyboard helper

### DIFF
--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-@canary.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-@canary.test.js
@@ -60,10 +60,6 @@ describe( 'Gutenberg Editor tests for Block insertion', () => {
 		await editorPage.sendTextToParagraphBlock( 1, testData.longText );
 		// Should have 3 paragraph blocks at this point.
 
-		if ( isAndroid() ) {
-			await editorPage.dismissKeyboard();
-		}
-
 		const titleElement = await editorPage.getTitleElement( {
 			autoscroll: true,
 		} );

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -28,7 +28,24 @@ const {
 const initializeEditorPage = async () => {
 	const driver = await setupDriver();
 	await isEditorVisible( driver );
-	return new EditorPage( driver );
+	const initialValues = await setupInitialValues( driver );
+	return new EditorPage( driver, initialValues );
+};
+
+const ADD_BLOCK_ID = isAndroid()
+	? 'Add block, Double tap to add a block'
+	: 'Add block';
+
+// Stores initial values from the editor for different helpers.
+const setupInitialValues = async ( driver ) => {
+	const initialValues = {};
+	const addButton = await driver.elementsByAccessibilityId( ADD_BLOCK_ID );
+
+	if ( addButton.length !== 0 ) {
+		initialValues.addButtonLocation = await addButton[ 0 ].getLocation();
+	}
+
+	return initialValues;
 };
 
 class EditorPage {
@@ -39,10 +56,11 @@ class EditorPage {
 	verseBlockName = 'Verse';
 	orderedListButtonName = 'Ordered';
 
-	constructor( driver ) {
+	constructor( driver, initialValues ) {
 		this.driver = driver;
 		this.accessibilityIdKey = 'name';
 		this.accessibilityIdXPathAttrib = 'name';
+		this.initialValues = initialValues;
 
 		if ( isAndroid() ) {
 			this.accessibilityIdXPathAttrib = 'content-desc';
@@ -52,6 +70,13 @@ class EditorPage {
 
 	async getBlockList() {
 		return await this.driver.hasElementByAccessibilityId( 'block-list' );
+	}
+
+	async getAddBlockButton( options = { timeout: 3000 } ) {
+		return await this.waitForElementToBeDisplayedById(
+			ADD_BLOCK_ID,
+			options.timeout
+		);
 	}
 
 	// ===============================
@@ -180,12 +205,11 @@ class EditorPage {
 			titleElement
 		);
 
-		if (
-			( elements.length === 0 || ! elements[ 0 ].isDisplayed() ) &&
-			options.autoscroll
-		) {
-			await swipeDown( this.driver );
-			return this.getTitleElement( options );
+		if ( elements.length === 0 || ! elements[ 0 ].isDisplayed() ) {
+			if ( options.autoscroll ) {
+				await swipeDown( this.driver );
+			}
+			return await this.getTitleElement( options );
 		}
 		return elements[ 0 ];
 	}
@@ -261,18 +285,40 @@ class EditorPage {
 	}
 
 	async dismissKeyboard() {
+		const orientation = await this.driver.getOrientation();
 		const keyboardShown = await this.driver.isKeyboardShown();
 		if ( ! keyboardShown ) {
 			return;
 		}
-		if ( isAndroid() ) {
+
+		// On Android with the landspace orientation set, we use the
+		// driver functionality to hide the keyboard.
+		if ( isAndroid() && orientation === 'LANDSCAPE' ) {
 			return await this.driver.hideDeviceKeyboard();
 		}
 
-		await clickIfClickable(
-			this.driver,
-			'//XCUIElementTypeButton[@name="Hide keyboard"]'
-		);
+		const hideKeyboardButton = isAndroid()
+			? await this.waitForElementToBeDisplayedById(
+					'Hide keyboard, Tap to hide the keyboard'
+			  )
+			: await this.waitForElementToBeDisplayedByXPath(
+					'//XCUIElementTypeButton[@name="Hide keyboard"]'
+			  );
+
+		await hideKeyboardButton.click();
+		await this.waitForKeyboardToBeHidden();
+	}
+
+	// Takes the add block button as reference for the keyboard to be
+	// fully hidden.
+	async waitForKeyboardToBeHidden() {
+		const { addButtonLocation } = this.initialValues;
+		const addButton = await this.getAddBlockButton();
+		const location = await addButton.getLocation();
+
+		if ( location.y < addButtonLocation?.y ) {
+			await this.waitForKeyboardToBeHidden();
+		}
 	}
 
 	async dismissAndroidClipboardSmartSuggestion() {
@@ -324,13 +370,7 @@ class EditorPage {
 	// =========================
 
 	async addNewBlock( blockName, relativePosition ) {
-		const addBlockElement = isAndroid()
-			? 'Add block, Double tap to add a block'
-			: 'Add block';
-		const addButton = await this.waitForElementToBeDisplayedById(
-			addBlockElement,
-			3000
-		);
+		const addButton = await this.getAddBlockButton();
 
 		if ( relativePosition === 'before' ) {
 			// On Android it doesn't get the right size of the button
@@ -843,13 +883,19 @@ class EditorPage {
 	}
 
 	async waitForElementToBeDisplayedById( id, timeout = 2000 ) {
-		await this.driver.waitForElementByAccessibilityId(
+		return await this.driver.waitForElementByAccessibilityId(
 			id,
 			wd.asserters.isDisplayed,
 			timeout
 		);
+	}
 
-		return await this.driver.elementByAccessibilityId( id );
+	async waitForElementToBeDisplayedByXPath( id, timeout = 2000 ) {
+		return await this.driver.waitForElementByXPath(
+			id,
+			wd.asserters.isDisplayed,
+			timeout
+		);
 	}
 }
 

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -25,16 +25,16 @@ const {
 	clickIfClickable,
 } = require( '../helpers/utils' );
 
+const ADD_BLOCK_ID = isAndroid()
+	? 'Add block, Double tap to add a block'
+	: 'Add block';
+
 const initializeEditorPage = async () => {
 	const driver = await setupDriver();
 	await isEditorVisible( driver );
 	const initialValues = await setupInitialValues( driver );
 	return new EditorPage( driver, initialValues );
 };
-
-const ADD_BLOCK_ID = isAndroid()
-	? 'Add block, Double tap to add a block'
-	: 'Add block';
 
 // Stores initial values from the editor for different helpers.
 const setupInitialValues = async ( driver ) => {


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/5505

## What?
This PR updates some existing E2E helpers and it adds new ones.

## Why?
To address an issue with a recently added visual test that fails in `trunk` in the Gutenberg Mobile repo.

## How?
It introduces `setupInitialValues` which for now will store the initial location of the `Add block` button (when the editor loads). This will be used to detect if the keyboard was fully dismissed and the button is back to the initial position. Relying on `sleep` values is unreliable on CI so I think this approach might be more stable. 

Updates `dismissKeyboard` to take into account the location of the `Add block` button by calling the new `waitForKeyboardToBeHidden` helper.

It adds `waitForElementToBeDisplayedByXPath` to wait for elements to be visible by XPaths.

## Testing Instructions
CI checks should pass on both Gutenberg and Gutenberg mobile.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A