### PR TITLE
Fix block style preview flickering when a 'style' is focused

### DIFF
--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -99,7 +99,11 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 				} ) }
 			</div>
 			{ hoveredStyle && ! isMobileViewport && (
-				<Popover placement="left-start" offset={ 20 }>
+				<Popover
+					placement="left-start"
+					offset={ 20 }
+					focusOnMount={ false }
+				>
 					<div
 						className="block-editor-block-styles__preview-panel"
 						onMouseLeave={ () => styleItemHandler( null ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/48320

In [this PR](https://github.com/WordPress/gutenberg/pull/44825/) the implementation changed to use `Popover`. When we focused a button in styles through keyboard, it would move the focus to the Popover, therefore triggering the `onBlur` callback. This would result in the disappearance of the style preview.

This PR fixes that, by not moving the focus to the Popover.

## Testing Instructions
1. Select a block with styles variations like "Image"
2. Navigate to block styles through the keyboard
3. Observe that when a 'style' is focused the preview is shown and when we navigate away, the preview is not rendered
4. Hovering in/out of a 'style' should be the same as before.

### Before


https://user-images.githubusercontent.com/16275880/221201937-67462d95-720d-4550-bfbc-81c01a016490.mov



### After
https://user-images.githubusercontent.com/16275880/221201561-08d09719-42aa-482d-86a5-9cce4df9573a.mov

