### PR TITLE
Improve block filters

### DIFF
--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -212,8 +212,8 @@ export const withDataAlign = createHigherOrderComponent(
 
 		return (
 			<BlockListBlockWithAlign
-				{ ...props }
 				BlockListBlock={ BlockListBlock }
+				{ ...props }
 			/>
 		);
 	}

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -178,6 +178,23 @@ export const withToolbarControls = createHigherOrderComponent(
 	'withToolbarControls'
 );
 
+function BlockListBlockWithAlign( { BlockListBlock, ...props } ) {
+	const { name, attributes } = props;
+	const { align } = attributes;
+	const blockAllowedAlignments = getValidAlignments(
+		getBlockSupport( name, 'align' ),
+		hasBlockSupport( name, 'alignWide', true )
+	);
+	const validAlignments = useAvailableAlignments( blockAllowedAlignments );
+
+	let wrapperProps = props.wrapperProps;
+	if ( validAlignments.some( ( alignment ) => alignment.name === align ) ) {
+		wrapperProps = { ...wrapperProps, 'data-align': align };
+	}
+
+	return <BlockListBlock { ...props } wrapperProps={ wrapperProps } />;
+}
+
 /**
  * Override the default block element to add alignment wrapper props.
  *
@@ -187,30 +204,18 @@ export const withToolbarControls = createHigherOrderComponent(
  */
 export const withDataAlign = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
-		const { name, attributes } = props;
-		const { align } = attributes;
-		const blockAllowedAlignments = getValidAlignments(
-			getBlockSupport( name, 'align' ),
-			hasBlockSupport( name, 'alignWide', true )
-		);
-		const validAlignments = useAvailableAlignments(
-			blockAllowedAlignments
-		);
-
 		// If an alignment is not assigned, there's no need to go through the
 		// effort to validate or assign its value.
-		if ( align === undefined ) {
+		if ( props.attributes.align === undefined ) {
 			return <BlockListBlock { ...props } />;
 		}
 
-		let wrapperProps = props.wrapperProps;
-		if (
-			validAlignments.some( ( alignment ) => alignment.name === align )
-		) {
-			wrapperProps = { ...wrapperProps, 'data-align': align };
-		}
-
-		return <BlockListBlock { ...props } wrapperProps={ wrapperProps } />;
+		return (
+			<BlockListBlockWithAlign
+				{ ...props }
+				BlockListBlock={ BlockListBlock }
+			/>
+		);
 	}
 );
 

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -109,6 +109,55 @@ export function addAttribute( settings ) {
 	return settings;
 }
 
+function AlignControls( props ) {
+	const { name: blockName } = props;
+	// Compute the block valid alignments by taking into account,
+	// if the theme supports wide alignments or not and the layout's
+	// availble alignments. We do that for conditionally rendering
+	// Slot.
+	const blockAllowedAlignments = getValidAlignments(
+		getBlockSupport( blockName, 'align' ),
+		hasBlockSupport( blockName, 'alignWide', true )
+	);
+
+	const validAlignments = useAvailableAlignments(
+		blockAllowedAlignments
+	).map( ( { name } ) => name );
+	const isContentLocked = useSelect(
+		( select ) => {
+			return select( blockEditorStore ).__unstableGetContentLockingParent(
+				props.clientId
+			);
+		},
+		[ props.clientId ]
+	);
+
+	if ( ! validAlignments.length || isContentLocked ) {
+		return null;
+	}
+
+	const updateAlignment = ( nextAlign ) => {
+		if ( ! nextAlign ) {
+			const blockType = getBlockType( props.name );
+			const blockDefaultAlign = blockType?.attributes?.align?.default;
+			if ( blockDefaultAlign ) {
+				nextAlign = '';
+			}
+		}
+		props.setAttributes( { align: nextAlign } );
+	};
+
+	return (
+		<BlockControls group="block" __experimentalShareWithChildBlocks>
+			<BlockAlignmentControl
+				value={ props.attributes.align }
+				onChange={ updateAlignment }
+				controls={ validAlignments }
+			/>
+		</BlockControls>
+	);
+}
+
 /**
  * Override the default edit UI to include new toolbar controls for block
  * alignment, if block defines support.
@@ -119,53 +168,10 @@ export function addAttribute( settings ) {
  */
 export const withToolbarControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
-		const blockEdit = <BlockEdit key="edit" { ...props } />;
-		const { name: blockName } = props;
-		// Compute the block valid alignments by taking into account,
-		// if the theme supports wide alignments or not and the layout's
-		// availble alignments. We do that for conditionally rendering
-		// Slot.
-		const blockAllowedAlignments = getValidAlignments(
-			getBlockSupport( blockName, 'align' ),
-			hasBlockSupport( blockName, 'alignWide', true )
-		);
-
-		const validAlignments = useAvailableAlignments(
-			blockAllowedAlignments
-		).map( ( { name } ) => name );
-		const isContentLocked = useSelect(
-			( select ) => {
-				return select(
-					blockEditorStore
-				).__unstableGetContentLockingParent( props.clientId );
-			},
-			[ props.clientId ]
-		);
-		if ( ! validAlignments.length || isContentLocked ) {
-			return blockEdit;
-		}
-
-		const updateAlignment = ( nextAlign ) => {
-			if ( ! nextAlign ) {
-				const blockType = getBlockType( props.name );
-				const blockDefaultAlign = blockType?.attributes?.align?.default;
-				if ( blockDefaultAlign ) {
-					nextAlign = '';
-				}
-			}
-			props.setAttributes( { align: nextAlign } );
-		};
-
 		return (
 			<>
-				<BlockControls group="block" __experimentalShareWithChildBlocks>
-					<BlockAlignmentControl
-						value={ props.attributes.align }
-						onChange={ updateAlignment }
-						controls={ validAlignments }
-					/>
-				</BlockControls>
-				{ blockEdit }
+				{ props.isSelected && <AlignControls { ...props } /> }
+				<BlockEdit { ...props } />
 			</>
 		);
 	},

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -179,6 +179,27 @@ function addDuotoneAttributes( settings ) {
 	return settings;
 }
 
+function DuoToneControls( props ) {
+	const hasDuotoneSupport = hasBlockSupport(
+		props.name,
+		'color.__experimentalDuotone'
+	);
+	const isContentLocked = useSelect(
+		( select ) => {
+			return select( blockEditorStore ).__unstableGetContentLockingParent(
+				props.clientId
+			);
+		},
+		[ props.clientId ]
+	);
+
+	if ( ! hasDuotoneSupport || isContentLocked ) {
+		return null;
+	}
+
+	return <DuotonePanel { ...props } />;
+}
+
 /**
  * Override the default edit UI to include toolbar controls for duotone if the
  * block supports duotone.
@@ -189,28 +210,13 @@ function addDuotoneAttributes( settings ) {
  */
 const withDuotoneControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
-		const hasDuotoneSupport = hasBlockSupport(
-			props.name,
-			'color.__experimentalDuotone'
-		);
-		const isContentLocked = useSelect(
-			( select ) => {
-				return select(
-					blockEditorStore
-				).__unstableGetContentLockingParent( props.clientId );
-			},
-			[ props.clientId ]
-		);
-
 		// CAUTION: code added before this line will be executed
 		// for all blocks, not just those that support duotone. Code added
 		// above this line should be carefully evaluated for its impact on
 		// performance.
 		return (
 			<>
-				{ hasDuotoneSupport && ! isContentLocked && (
-					<DuotonePanel { ...props } />
-				) }
+				{ props.isSelected && <DuoToneControls { ...props } /> }
 				<BlockEdit { ...props } />
 			</>
 		);

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -328,13 +328,11 @@ export function addAttribute( settings ) {
 export const withInspectorControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const { name: blockName } = props;
-		const supportLayout = hasBlockSupport(
-			blockName,
-			layoutBlockSupportKey
-		);
-
 		return [
-			supportLayout && <LayoutPanel key="layout" { ...props } />,
+			props.isSelected &&
+				hasBlockSupport( blockName, layoutBlockSupportKey ) && (
+					<LayoutPanel key="layout" { ...props } />
+				),
 			<BlockEdit key="edit" { ...props } />,
 		];
 	},

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -326,7 +326,7 @@ export const withInspectorControls = createHigherOrderComponent(
 			positionSupport && ! useIsPositionDisabled( props );
 
 		return [
-			showPositionControls && (
+			props.isSelected && showPositionControls && (
 				<PositionPanel key="position" { ...props } />
 			),
 			<BlockEdit key="edit" { ...props } />,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Ok, there are a couple of problems with `trunk`.

* For the BlockEdit functions, some filters are not checking isSelected, so they are running for all blocks. Maybe we can early return in some instances even better.
* For BlockListBlock, in some cases we are returning early, but select or other hooks are still running for all blocks on every render. I think it's better to wrap these in a component and early return based on block support or the presence of an attribute.
* I'm also seeing the Rules of Hooks being broken in some of these HoCs because linting doesn't work, which is another good argument to create separate components. 


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
