### PR TITLE
Align hook: improve BlockEdit filter

### DIFF
--- a/packages/block-editor/src/components/block-controls/hook.js
+++ b/packages/block-editor/src/components/block-controls/hook.js
@@ -3,17 +3,15 @@
  */
 import groups from './groups';
 import { useBlockEditContext } from '../block-edit/context';
-import useDisplayBlockControls from '../use-display-block-controls';
 
 export default function useBlockControlsFill( group, shareWithChildBlocks ) {
-	const isDisplayed = useDisplayBlockControls();
-	const { shouldDisplayControls } = useBlockEditContext();
-	const isParentDisplayed = shareWithChildBlocks && shouldDisplayControls;
+	const { shouldDisplayControls, shouldDisplayControlsWithinChildren } =
+		useBlockEditContext();
 
-	if ( isDisplayed ) {
+	if ( shouldDisplayControls ) {
 		return groups[ group ]?.Fill;
 	}
-	if ( isParentDisplayed ) {
+	if ( shareWithChildBlocks && shouldDisplayControlsWithinChildren ) {
 		return groups.parent.Fill;
 	}
 	return null;

--- a/packages/block-editor/src/components/block-controls/hook.js
+++ b/packages/block-editor/src/components/block-controls/hook.js
@@ -1,37 +1,14 @@
 /**
- * WordPress dependencies
- */
-import { store as blocksStore } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
-
-/**
  * Internal dependencies
  */
 import groups from './groups';
-import { store as blockEditorStore } from '../../store';
 import { useBlockEditContext } from '../block-edit/context';
 import useDisplayBlockControls from '../use-display-block-controls';
 
 export default function useBlockControlsFill( group, shareWithChildBlocks ) {
 	const isDisplayed = useDisplayBlockControls();
-	const { clientId } = useBlockEditContext();
-	const isParentDisplayed = useSelect(
-		( select ) => {
-			const { getBlockName, hasSelectedInnerBlock } =
-				select( blockEditorStore );
-			const { hasBlockSupport } = select( blocksStore );
-			return (
-				shareWithChildBlocks &&
-				hasBlockSupport(
-					getBlockName( clientId ),
-					'__experimentalExposeControlsToChildren',
-					false
-				) &&
-				hasSelectedInnerBlock( clientId )
-			);
-		},
-		[ shareWithChildBlocks, clientId ]
-	);
+	const { shouldDisplayControls } = useBlockEditContext();
+	const isParentDisplayed = shareWithChildBlocks && shouldDisplayControls;
 
 	if ( isDisplayed ) {
 		return groups[ group ]?.Fill;

--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -47,7 +47,6 @@ export default function BlockEdit( props ) {
 				getBlockName,
 				isFirstMultiSelectedBlock,
 				getMultiSelectedBlockClientIds,
-				hasSelectedInnerBlock,
 			} = select( blockEditorStore );
 
 			if ( isFirstMultiSelectedBlock( clientId ) ) {
@@ -56,6 +55,14 @@ export default function BlockEdit( props ) {
 				);
 			}
 
+			return false;
+		},
+		[ clientId, isSelected, name ]
+	);
+	const shouldDisplayControlsWithinChildren = useSelect(
+		( select ) => {
+			const { getBlockName, hasSelectedInnerBlock } =
+				select( blockEditorStore );
 			return (
 				hasBlockSupport(
 					getBlockName( clientId ),
@@ -73,6 +80,7 @@ export default function BlockEdit( props ) {
 		layout: layoutSupport ? layout : null,
 		__unstableLayoutClassNames,
 		shouldDisplayControls,
+		shouldDisplayControlsWithinChildren,
 	};
 	return (
 		<BlockEditContextProvider

--- a/packages/block-editor/src/components/use-display-block-controls/index.js
+++ b/packages/block-editor/src/components/use-display-block-controls/index.js
@@ -1,36 +1,8 @@
 /**
- * WordPress dependencies
- */
-import { useSelect } from '@wordpress/data';
-
-/**
  * Internal dependencies
  */
 import { useBlockEditContext } from '../block-edit/context';
-import { store as blockEditorStore } from '../../store';
 
 export default function useDisplayBlockControls() {
-	const { isSelected, clientId, name } = useBlockEditContext();
-	return useSelect(
-		( select ) => {
-			if ( isSelected ) {
-				return true;
-			}
-
-			const {
-				getBlockName,
-				isFirstMultiSelectedBlock,
-				getMultiSelectedBlockClientIds,
-			} = select( blockEditorStore );
-
-			if ( isFirstMultiSelectedBlock( clientId ) ) {
-				return getMultiSelectedBlockClientIds().every(
-					( id ) => getBlockName( id ) === name
-				);
-			}
-
-			return false;
-		},
-		[ clientId, isSelected, name ]
-	);
+	return useBlockEditContext().shouldDisplayControls;
 }

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -21,6 +21,7 @@ import { useSelect } from '@wordpress/data';
 import { BlockControls, BlockAlignmentControl } from '../components';
 import useAvailableAlignments from '../components/block-alignment-control/use-available-alignments';
 import { store as blockEditorStore } from '../store';
+import { useBlockEditContext } from '../components/block-edit/context';
 
 /**
  * An array which includes all possible valid alignments,
@@ -170,7 +171,7 @@ export const withToolbarControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		return (
 			<>
-				{ props.isSelected &&
+				{ useBlockEditContext().shouldDisplayControls &&
 					!! getBlockSupport( props.name, 'align' ) && (
 						<AlignControls { ...props } />
 					) }

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -169,10 +169,13 @@ function AlignControls( props ) {
  */
 export const withToolbarControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
+		const { shouldDisplayControls, shouldDisplayControlsWithinChildren } =
+			useBlockEditContext();
 		return (
 			<>
-				{ useBlockEditContext().shouldDisplayControls &&
-					!! getBlockSupport( props.name, 'align' ) && (
+				{ ( shouldDisplayControls ||
+					shouldDisplayControlsWithinChildren ) &&
+					hasBlockSupport( props.name, 'align' ) && (
 						<AlignControls { ...props } />
 					) }
 				<BlockEdit { ...props } />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Split out from #48420.

Only add the controls (and run related checks) which the block is selected and supports alignment.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
