### PR TITLE
Layout hook: improve BlockEdit filter

### DIFF
--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -326,18 +326,14 @@ export function addAttribute( settings ) {
  * @return {Function} Wrapped component.
  */
 export const withInspectorControls = createHigherOrderComponent(
-	( BlockEdit ) => ( props ) => {
-		const { name: blockName } = props;
-		const supportLayout = hasBlockSupport(
-			blockName,
-			layoutBlockSupportKey
-		);
-
-		return [
-			supportLayout && <LayoutPanel key="layout" { ...props } />,
+	( BlockEdit ) => ( props ) =>
+		[
+			props.isSelected &&
+				hasBlockSupport( props.name, layoutBlockSupportKey ) && (
+					<LayoutPanel key="layout" { ...props } />
+				),
 			<BlockEdit key="edit" { ...props } />,
-		];
-	},
+		],
 	'withInspectorControls'
 );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Split out from https://github.com/WordPress/gutenberg/pull/48420.

Only add the controls (and run related checks) which the block is selected and supports layout.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
