### PR TITLE
Duotone: Use CSS variables instead of slugs in block attributes

### DIFF
--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -311,6 +311,9 @@ function gutenberg_get_duotone_filter_id( $preset ) {
  * @return string        Duotone CSS filter property url value.
  */
 function gutenberg_get_duotone_filter_property( $preset ) {
+	if ( isset( $preset['colors'] ) && 'unset' === $preset['colors'] ) {
+		return 'none';
+	}
 	$filter_id = gutenberg_get_duotone_filter_id( $preset );
 	return "url('#" . $filter_id . "')";
 }
@@ -473,7 +476,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 		);
 
 		// Build a customised CSS filter property for unique slug.
-		$filter_property = $is_duotone_unset ? 'none' : gutenberg_get_duotone_filter_property( $filter_preset );
+		$filter_property = gutenberg_get_duotone_filter_property( $filter_preset );
 	}
 
 	// - Applied as a class attribute to the block wrapper.

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -450,15 +450,16 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 
 	$is_duotone_colors_array = is_array( $duotone_attr );
 	$is_duotone_unset        = 'unset' === $duotone_attr;
-	$is_duotone_preset       = ! $is_duotone_colors_array && ! $is_duotone_unset;
+	$is_duotone_preset       = ! $is_duotone_colors_array && strpos( $duotone_attr, 'var:preset|duotone|' ) === 0;
 
 	if ( $is_duotone_preset ) {
+		$slug = str_replace( 'var:preset|duotone|', '', $duotone_attr );
 		$filter_preset = array(
-			'slug' => $duotone_attr,
+			'slug' => $slug,
 		);
 
 		// Utilise existing CSS custom property.
-		$filter_property = "var(--wp--preset--duotone--$duotone_attr)";
+		$filter_property = "var(--wp--preset--duotone--$slug)";
 	} else {
 		// Handle when Duotone is either:
 		// - "unset"

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -452,7 +452,6 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	$duotone_attr = $block['attrs']['style']['color']['duotone'];
 
 	$is_duotone_colors_array = is_array( $duotone_attr );
-	$is_duotone_unset        = 'unset' === $duotone_attr;
 	$is_duotone_preset       = ! $is_duotone_colors_array && strpos( $duotone_attr, 'var:preset|duotone|' ) === 0;
 
 	if ( $is_duotone_preset ) {

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -453,7 +453,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	$is_duotone_preset       = ! $is_duotone_colors_array && strpos( $duotone_attr, 'var:preset|duotone|' ) === 0;
 
 	if ( $is_duotone_preset ) {
-		$slug = str_replace( 'var:preset|duotone|', '', $duotone_attr );
+		$slug          = str_replace( 'var:preset|duotone|', '', $duotone_attr );
 		$filter_preset = array(
 			'slug' => $slug,
 		);

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -80,7 +80,7 @@ export function getColorsFromDuotonePreset( duotone, duotonePalette ) {
 		return;
 	}
 	const preset = duotonePalette?.find( ( { slug } ) => {
-		return duotone === 'var:preset|duotone|' + slug;
+		return duotone === `var:preset|duotone|${ slug }`;
 	} );
 
 	return preset ? preset.colors : undefined;
@@ -97,7 +97,7 @@ export function getDuotonePresetFromColors( colors, duotonePalette ) {
 		);
 	} );
 
-	return preset ? 'var:preset|duotone|' + preset.slug : undefined;
+	return preset ? `var:preset|duotone|${ preset.slug }` : undefined;
 }
 
 function DuotonePanel( { attributes, setAttributes } ) {

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -80,7 +80,7 @@ export function getColorsFromDuotonePreset( duotone, duotonePalette ) {
 		return;
 	}
 	const preset = duotonePalette?.find( ( { slug } ) => {
-		return slug === duotone;
+		return duotone === 'var:preset|duotone|' + slug;
 	} );
 
 	return preset ? preset.colors : undefined;
@@ -97,7 +97,7 @@ export function getDuotonePresetFromColors( colors, duotonePalette ) {
 		);
 	} );
 
-	return preset ? preset.slug : undefined;
+	return preset ? 'var:preset|duotone|' + preset.slug : undefined;
 }
 
 function DuotonePanel( { attributes, setAttributes } ) {

--- a/packages/block-editor/src/hooks/test/duotone.js
+++ b/packages/block-editor/src/hooks/test/duotone.js
@@ -37,14 +37,17 @@ describe( 'Duotone utilities', () => {
 
 		it( 'should return undefined if a non-existent preset is provided', () => {
 			expect(
-				getColorsFromDuotonePreset( 'does-not-exist', duotonePalette )
+				getColorsFromDuotonePreset(
+					`var:preset|duotone|does-not-exist`,
+					duotonePalette
+				)
 			).toBeUndefined();
 		} );
 
 		it( 'should return the colors from the preset if found', () => {
 			expect(
 				getColorsFromDuotonePreset(
-					duotonePalette[ 2 ].slug,
+					`var:preset|duotone|${ duotonePalette[ 2 ].slug }`,
 					duotonePalette
 				)
 			).toEqual( duotonePalette[ 2 ].colors );
@@ -93,7 +96,7 @@ describe( 'Duotone utilities', () => {
 					duotonePalette[ 2 ].colors,
 					duotonePalette
 				)
-			).toEqual( duotonePalette[ 2 ].slug );
+			).toEqual( `var:preset|duotone|${ duotonePalette[ 2 ].slug }` );
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
If we save Duotone preset slugs in the style attribute, we should use the standard `var:preset|duotone|*` syntax for consistency with other styles.

## Why?
Fixes an issue introduced in #48318

Resolves https://github.com/WordPress/gutenberg/issues/48371

## How?
Just prepend the slug with `var:preset|duotone` and then remove it again.

## Testing Instructions
1. Add an image to a post
2. Apply a Duotone that uses a preset filter
3. Check that the image uses that filter in the editor and the frontend.

### Testing Instructions for Keyboard
Check that the image has a `filter` CSS applied to it and there is an SVG that has a filter with the same id as as the one referenced in the CSS for the image.
