### PR TITLE
Layout hook: improve BlockListBlock filter

### DIFF
--- a/packages/block-editor/src/components/use-setting/index.js
+++ b/packages/block-editor/src/components/use-setting/index.js
@@ -115,6 +115,8 @@ export default function useSetting( path ) {
 
 	return useSelect(
 		( select ) => {
+			if ( ! path ) return;
+
 			if ( blockedPaths.includes( path ) ) {
 				// eslint-disable-next-line no-console
 				console.warn(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Avoids a bunch of computation for every block. While we have to call `useLayoutClasses` for every block, which calls `useSelect` and `useSetting`, we can return early within those hooks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
