### PR TITLE
Fix: Content only CPT template locking.

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2761,7 +2761,10 @@ export const __unstableGetContentLockingParent = createSelector(
 		let result;
 		while ( state.blocks.parents.has( current ) ) {
 			current = state.blocks.parents.get( current );
-			if ( getTemplateLock( state, current ) === 'contentOnly' ) {
+			if (
+				current &&
+				getTemplateLock( state, current ) === 'contentOnly'
+			) {
 				result = current;
 			}
 		}


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/48293

This PR fixes regression with CPT template locking which according to git bisect happened in https://github.com/WordPress/gutenberg/pull/46225.


cc: @ntsekouras, @t-hamano, @kevin940726

## Testing

Register the following CPT provided by @BennyVL: 
```
<?php
function register_books_post_type() {
  $labels = array(
    'name' => __( 'Books', 'text-domain' ),
    'singular_name' => __( 'Book', 'text-domain' ),
    'menu_name' => __( 'Books', 'text-domain' ),
  );

  $args = array(
    'labels' => $labels,
    'public' => true,
    'publicly_queryable' => true,
    'show_ui' => true,
    'show_in_menu' => true,
    'show_in_rest' => true,
    'query_var' => true,
    'rewrite' => array( 'slug' => 'books' ),
    'capability_type' => 'post',
    'has_archive' => true,
    'hierarchical' => false,
    'menu_position' => null,
    'supports' => array( 'title', 'editor', 'thumbnail' ),
    'template' => array(
      array(
        'core/group',
        array(),
        array(
          array(
            'core/paragraph',
            array(
              'placeholder' => 'Book Description - Paragraph 1',
              'content' => 'This is the first paragraph of the book description. 1',
            )
          ),
          array(
            'core/paragraph',
            array(
              'placeholder' => 'Book Description - Paragraph 2',
              'content' => 'This is the second paragraph of the book description.',
            )
          ),
        )
      ),
    ),
    'template_lock' => 'contentOnly',
  );

  register_post_type( 'books', $args );
}

add_action( 'init', 'register_books_post_type' );
```
Create a new book and verify it is possible to select the content of paragraphs and change the content. On trunk it is not.