### PR TITLE
Site Editor: Hide horizontal scrollbar when adding new page template

### DIFF
--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Hide horizontal scrollbar when adding new page template ([#48442](https://github.com/WordPress/gutenberg/pull/48442)).
+
 ## 5.4.0 (2023-02-15)
 
 ## 5.3.0 (2023-02-01)

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -73,7 +73,7 @@
 
 	@include break-small() {
 		height: 232px;
-		overflow: scroll;
+		overflow-y: auto;
 	}
 
 	&__list-item {


### PR DESCRIPTION
## What?

This PR fixes the display of an unintended horizontal scroll bar in the site editor when adding a new page template.

In my environment, this occurs on Windows OS and Chrome browser. It may be possible to reproduce this on Mac OS if you set scrollbar to always display.

## Screenshots or screencast <!-- if applicable -->

### Before

![before-few-page](https://user-images.githubusercontent.com/54422211/221353473-2c3a5fbe-0b4f-49ac-933c-675b14bba701.png)

![before-many-page](https://user-images.githubusercontent.com/54422211/221353480-b0c10d48-76d6-411e-afe2-fcb89e90f027.png)

### After

![after-few-page](https://user-images.githubusercontent.com/54422211/221353486-89194e0d-281a-4d8d-aae1-9ddeed773bfc.png)

![after-many-page](https://user-images.githubusercontent.com/54422211/221353491-7ebdb346-c904-4cb8-9fd6-596a319875f4.png)

