### PR TITLE
Post Editor: Apply busy status to the publish button in progress and unify button width

### DIFF
--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -194,7 +194,6 @@ export class PostPublishButton extends Component {
 
 		const componentProps = isToggle ? toggleProps : buttonProps;
 		const componentChildren = isToggle ? toggleChildren : buttonChildren;
-
 		return (
 			<>
 				<Button

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -168,7 +168,7 @@ export class PostPublishButton extends Component {
 		const buttonProps = {
 			'aria-disabled': isButtonDisabled,
 			className: 'editor-post-publish-button',
-			isBusy: ! isAutoSaving && isSaving && isPublished,
+			isBusy: ! isAutoSaving && isSaving,
 			variant: 'primary',
 			onClick: this.createOnClick( onClickButton ),
 		};
@@ -194,6 +194,7 @@ export class PostPublishButton extends Component {
 
 		const componentProps = isToggle ? toggleProps : buttonProps;
 		const componentChildren = isToggle ? toggleChildren : buttonChildren;
+
 		return (
 			<>
 				<Button

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -62,7 +62,7 @@
 
 .editor-post-publish-panel__header-publish-button,
 .editor-post-publish-panel__header-cancel-button {
-	flex-grow: 1;
+	flex: 1;
 
 	@include break-mobile() {
 		max-width: $admin-sidebar-width;


### PR DESCRIPTION
## What?
This PR applies a busy status to the Publish button when the publication process is in progress.

## Why?
If the button text is in progress, I think it should indicate busy status.

## Screenshots or screencast <!-- if applicable -->

### Before

![publishing-post-before](https://user-images.githubusercontent.com/54422211/221357757-abfcf463-59a8-4cb7-bd72-d2f4dbd886f6.png)

### After

![publishing-after](https://user-images.githubusercontent.com/54422211/221357769-b90ae6c6-36a5-499e-8680-ae293999debf.png)

---

When the status is as follows, the status of the button remains the same as before.

### Updating draft post

![saving-draft-post-after](https://user-images.githubusercontent.com/54422211/221357781-b638a280-d190-4faf-afdc-a7d221983601.png)

### Swithing to draft post

![switching-to-draft-after](https://user-images.githubusercontent.com/54422211/221357793-cff94ebf-f624-4e6a-beb6-cac199729d38.png)

### Updating published post

![updating-published-post-after](https://user-images.githubusercontent.com/54422211/221357798-2c97ad14-1d70-40c4-ac43-d3cbd7ed2a3f.png)
