### PR TITLE
Site Editor: polish add template modal style

### DIFF
--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
@@ -11,6 +11,7 @@ import {
 	SearchControl,
 	TextHighlight,
 	__experimentalText as Text,
+	__experimentalVStack as VStack,
 	__unstableComposite as Composite,
 	__unstableUseCompositeState as useCompositeState,
 	__unstableCompositeItem as CompositeItem,
@@ -158,9 +159,12 @@ function SuggestionList( { entityForSuggestions, onSelect } ) {
 				</Composite>
 			) }
 			{ debouncedSearch && ! suggestions?.length && (
-				<p className="edit-site-custom-template-modal__no-results">
+				<Text
+					as="p"
+					className="edit-site-custom-template-modal__no-results"
+				>
 					{ labels.not_found }
-				</p>
+				</Text>
 			) }
 		</>
 	);
@@ -188,12 +192,12 @@ function AddCustomTemplateModal( {
 		>
 			{ isCreatingTemplate && <TemplateActionsLoadingScreen /> }
 			{ ! showSearchEntities && (
-				<>
-					<p>
+				<VStack spacing={ 4 }>
+					<Text as="p">
 						{ __(
 							'Select whether to create a single template for all items or a specific one.'
 						) }
-					</p>
+					</Text>
 					<Flex
 						className={ `${ baseCssClass }__contents` }
 						gap="4"
@@ -245,20 +249,20 @@ function AddCustomTemplateModal( {
 							</Text>
 						</FlexItem>
 					</Flex>
-				</>
+				</VStack>
 			) }
 			{ showSearchEntities && (
-				<>
-					<p>
+				<VStack spacing={ 4 }>
+					<Text as="p">
 						{ __(
 							'This template will be used only for the specific item chosen.'
 						) }
-					</p>
+					</Text>
 					<SuggestionList
 						entityForSuggestions={ entityForSuggestions }
 						onSelect={ onSelect }
 					/>
-				</>
+				</VStack>
 			) }
 		</Modal>
 	);

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -69,8 +69,6 @@
 }
 
 .edit-site-custom-template-modal__suggestions_list {
-	margin-top: $grid-unit-20;
-
 	@include break-small() {
 		height: 232px;
 		overflow: scroll;
@@ -130,10 +128,7 @@
 	border: 1px solid $gray-400;
 	border-radius: $radius-block-ui;
 	padding: $grid-unit-20;
-	margin-bottom: 0;
-	margin-top: $grid-unit-20;
 }
-
 
 .edit-site-custom-generic-template__modal {
 	.components-base-control {


### PR DESCRIPTION
Fixes #48414

## What?
This PR removes the unexpected space above content in modal content for adding custom templates.

## Why?
This is because the WP-Admin style is applied to the `p` element.

![admin-style](https://user-images.githubusercontent.com/54422211/221361244-cd040153-52dc-4592-b78f-df618fb8b8f2.png)

## How?

I used the `Text` component to reset the paragraph margin. Additionally, since the bottom margin is also reset, I used the `VStack` component to provide the space. [This approach is also used in the `ConfirmDialog` component](https://github.com/WordPress/gutenberg/blob/d75741c93e63206da652f61f2a7ea285edfbed14/packages/components/src/confirm-dialog/component.tsx#L95-L111).

## Screenshots or screencast

The scrollbar seen in the screenshot is probably a Windows-specific problem. This issue will be fixed by #48442.

### Add page template

| Before | After |
| --- | --- |
| ![page-before](https://user-images.githubusercontent.com/54422211/221360140-777abe19-d5d9-42ec-9c3e-f62b385180a5.png) | ![page-after](https://user-images.githubusercontent.com/54422211/221360145-f486b2ee-c725-41c2-b410-07f27ce5bcc1.png) |

### Add page template with search control

There must be at least 10 pages in order to show the search control.

| Before | After |
| --- | --- |
| ![page-with-search-before](https://user-images.githubusercontent.com/54422211/221360159-18c69ec4-cf36-4be4-83f6-ab2fc5d631cf.png) | ![page-with-search-after](https://user-images.githubusercontent.com/54422211/221360182-6728e954-ca77-4562-a463-20ad65be2e65.png) |

### Add page template with search control (no results)

The border around the "No pages found." text seems unnatural, but if anyone agrees, I would like to add this PR to address it.

| Before | After |
| --- | --- |
| ![page-no-result-before](https://user-images.githubusercontent.com/54422211/221360205-9a2c0577-34fa-4b72-b8d9-de2f15af87c9.png) | ![page-no-result-after](https://user-images.githubusercontent.com/54422211/221360218-589dad21-17ec-4725-bce4-24a49ea3a622.png) |

### Add author template

| Before | After |
| --- | --- |
| ![author-before](https://user-images.githubusercontent.com/54422211/221360230-a7f2afed-da51-4fdb-97ff-4a83c0eebf76.png) | ![author-after](https://user-images.githubusercontent.com/54422211/221360234-20a7781b-ddce-4835-a121-7da5ac6f4105.png) |