### PR TITLE
Change the social links block icon

### DIFF
--- a/packages/block-library/src/social-links/index.js
+++ b/packages/block-library/src/social-links/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { share as icon } from '@wordpress/icons';
+import { people as icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
## What?
This PR addresses the 'Social Links Block needs different icons' issue #26780.

The currently used "sharing" icon is confusing - Social Links Block contains _links to social profiles_, not _sharing buttons_.

## How?
I've switched the icon to the "people" icon proposed by @mapk, as I thought it would be the best option. That provides a clear distinction between social media profile links and sharing links block.

## Testing Instructions
Steps to reproduce the behavior:
1. Edit the post.
2. Add a Social Links Block.

## Screenshot
<img width="686" alt="Zrzut ekranu 2023-02-26 o 19 55 28" src="https://user-images.githubusercontent.com/115597522/221432626-55b5dd29-eef4-454f-bbe6-1e119632fad7.png">

cc @bph @jasmussen @noisysocks @adamziel 