### PR TITLE
Try reducing paragraph block rerendering

### DIFF
--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -350,7 +350,7 @@ export const withInspectorControls = createHigherOrderComponent(
  */
 export const withLayoutStyles = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
-		const { name, attributes, block } = props;
+		const { name, attributes } = props;
 		const hasLayoutBlockSupport = hasBlockSupport(
 			name,
 			layoutBlockSupportKey
@@ -372,7 +372,7 @@ export const withLayoutStyles = createHigherOrderComponent(
 				? { ...layout, type: 'constrained' }
 				: layout || defaultBlockLayout || {};
 		const layoutClasses = hasLayoutBlockSupport
-			? useLayoutClasses( block )
+			? useLayoutClasses( { name, attributes } )
 			: null;
 		// Higher specificity to override defaults from theme.json.
 		const selector = `.wp-container-${ id }.wp-container-${ id }`;

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -19,6 +19,7 @@ import {
 	RichText,
 	useBlockProps,
 	useSetting,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { formatLtr } from '@wordpress/icons';
@@ -27,6 +28,7 @@ import { formatLtr } from '@wordpress/icons';
  * Internal dependencies
  */
 import { useOnEnter } from './use-enter';
+import { useSelect } from '@wordpress/data';
 
 const name = 'core/paragraph';
 
@@ -49,6 +51,74 @@ function hasDropCapDisabled( align ) {
 	return align === ( isRTL() ? 'left' : 'right' ) || align === 'center';
 }
 
+// function useAttributes( name ) {
+// 	return useSelect(
+// 		( select ) => select( blockEditorStore ).getAttribute( name ),
+// 		[ name ]
+// 	);
+// }
+
+function BlockContent( {
+	attributes,
+	mergeBlocks,
+	onReplace,
+	onRemove,
+	setAttributes,
+	clientId,
+	blockProps,
+} ) {
+	const content = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getBlockAttributes( clientId ).content,
+		[ clientId ]
+	);
+	const { placeholder } = attributes;
+	return (
+		<RichText
+			identifier="content"
+			tagName="p"
+			{ ...blockProps }
+			value={ content }
+			onChange={ ( newContent ) =>
+				setAttributes( { content: newContent } )
+			}
+			onSplit={ ( value, isOriginal ) => {
+				let newAttributes;
+
+				if ( isOriginal || value ) {
+					newAttributes = {
+						...attributes,
+						content: value,
+					};
+				}
+
+				const block = createBlock( name, newAttributes );
+
+				if ( isOriginal ) {
+					block.clientId = clientId;
+				}
+
+				return block;
+			} }
+			onMerge={ mergeBlocks }
+			onReplace={ onReplace }
+			onRemove={ onRemove }
+			aria-label={
+				content
+					? __( 'Paragraph block' )
+					: __(
+							'Empty block; start writing or type forward slash to choose a block'
+					  )
+			}
+			data-empty={ content ? false : true }
+			placeholder={ placeholder || __( 'Type / to choose a block' ) }
+			data-custom-placeholder={ placeholder ? true : undefined }
+			__unstableEmbedURLOnPaste
+			__unstableAllowPrefixTransformations
+		/>
+	);
+}
+
 function ParagraphBlock( {
 	attributes,
 	mergeBlocks,
@@ -57,16 +127,8 @@ function ParagraphBlock( {
 	setAttributes,
 	clientId,
 } ) {
-	const { align, content, direction, dropCap, placeholder } = attributes;
+	const { align, direction, dropCap } = attributes;
 	const isDropCapFeatureEnabled = useSetting( 'typography.dropCap' );
-	const blockProps = useBlockProps( {
-		ref: useOnEnter( { clientId, content } ),
-		className: classnames( {
-			'has-drop-cap': hasDropCapDisabled( align ) ? false : dropCap,
-			[ `has-text-align-${ align }` ]: align,
-		} ),
-		style: { direction },
-	} );
 
 	let helpText;
 	if ( hasDropCapDisabled( align ) ) {
@@ -76,6 +138,15 @@ function ParagraphBlock( {
 	} else {
 		helpText = __( 'Toggle to show a large initial letter.' );
 	}
+
+	const blockProps = useBlockProps( {
+		ref: useOnEnter( { clientId } ),
+		className: classnames( {
+			'has-drop-cap': hasDropCapDisabled( align ) ? false : dropCap,
+			[ `has-text-align-${ align }` ]: align,
+		} ),
+		style: { direction },
+	} );
 
 	return (
 		<>
@@ -123,47 +194,14 @@ function ParagraphBlock( {
 					</ToolsPanelItem>
 				</InspectorControls>
 			) }
-			<RichText
-				identifier="content"
-				tagName="p"
-				{ ...blockProps }
-				value={ content }
-				onChange={ ( newContent ) =>
-					setAttributes( { content: newContent } )
-				}
-				onSplit={ ( value, isOriginal ) => {
-					let newAttributes;
-
-					if ( isOriginal || value ) {
-						newAttributes = {
-							...attributes,
-							content: value,
-						};
-					}
-
-					const block = createBlock( name, newAttributes );
-
-					if ( isOriginal ) {
-						block.clientId = clientId;
-					}
-
-					return block;
-				} }
-				onMerge={ mergeBlocks }
+			<BlockContent
+				attributes={ attributes }
+				mergeBlocks={ mergeBlocks }
 				onReplace={ onReplace }
 				onRemove={ onRemove }
-				aria-label={
-					content
-						? __( 'Paragraph block' )
-						: __(
-								'Empty block; start writing or type forward slash to choose a block'
-						  )
-				}
-				data-empty={ content ? false : true }
-				placeholder={ placeholder || __( 'Type / to choose a block' ) }
-				data-custom-placeholder={ placeholder ? true : undefined }
-				__unstableEmbedURLOnPaste
-				__unstableAllowPrefixTransformations
+				setAttributes={ setAttributes }
+				clientId={ clientId }
+				blockProps={ blockProps }
 			/>
 		</>
 	);

--- a/packages/block-library/src/paragraph/use-enter.js
+++ b/packages/block-library/src/paragraph/use-enter.js
@@ -23,6 +23,7 @@ export function useOnEnter( props ) {
 		getBlockName,
 		getBlock,
 		getNextBlockClientId,
+		getBlockAttributes,
 	} = useSelect( blockEditorStore );
 	const propsRef = useRef( props );
 	propsRef.current = props;
@@ -36,7 +37,8 @@ export function useOnEnter( props ) {
 				return;
 			}
 
-			const { content, clientId } = propsRef.current;
+			const { clientId } = propsRef.current;
+			const { content } = getBlockAttributes( clientId );
 
 			// The paragraph should be empty.
 			if ( content.length ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

The amount of time React spends rendering is significantly less. While I see an improvement in manual profiling, I don't see the same result in the performance tests and I'm not sure why.

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/4710635/221801016-31bd15e5-d001-4385-bd28-3299afea6c82.png)|![image](https://user-images.githubusercontent.com/4710635/221801044-086a7f67-47ac-4049-a429-9d276a8867e9.png)|

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
