### PR TITLE
Style Book: Add extra margin to support displaying box shadow

### DIFF
--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -207,8 +207,8 @@ const Example = memo( ( { title, blocks, isSelected, onClick } ) => (
 				additionalStyles={ [
 					{
 						css:
-							'.wp-block:first-child { margin-top: 0; }' +
-							'.wp-block:last-child { margin-bottom: 0; }',
+							'.is-root-container > .wp-block:first-child { margin-top: 16px; }' +
+							'.is-root-container > .wp-block:last-child { margin-bottom: 16px; }',
 					},
 				] }
 			/>

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -207,8 +207,9 @@ const Example = memo( ( { title, blocks, isSelected, onClick } ) => (
 				additionalStyles={ [
 					{
 						css:
-							'.is-root-container > .wp-block:first-child { margin-top: 16px; }' +
-							'.is-root-container > .wp-block:last-child { margin-bottom: 16px; }',
+							'.is-root-container { margin: 16px; }' +
+							'.is-root-container > .wp-block:first-child { margin-top: 0; }' +
+							'.is-root-container > .wp-block:last-child { margin-bottom: 0; }',
 					},
 				] }
 			/>

--- a/packages/edit-site/src/components/style-book/style.scss
+++ b/packages/edit-site/src/components/style-book/style.scss
@@ -78,4 +78,5 @@
 
 .edit-site-style-book__example-preview {
 	width: 100%;
+	margin-left: -16px;
 }

--- a/packages/edit-site/src/components/style-book/style.scss
+++ b/packages/edit-site/src/components/style-book/style.scss
@@ -46,9 +46,11 @@
 	cursor: pointer;
 	display: flex;
 	flex-direction: column;
-	gap: $grid-unit-50;
-	margin-bottom: $grid-unit-50;
-	padding: $grid-unit-20;
+	column-gap: $grid-unit-50;
+	row-gap: $grid-unit-20;
+	margin-bottom: $grid-unit-40;
+	padding-left: $grid-unit-20;
+	padding-right: $grid-unit-20;
 	width: 100%;
 
 	&.is-selected {
@@ -66,6 +68,7 @@
 	margin: 0;
 	text-align: left;
 	text-transform: uppercase;
+	padding-top: $grid-unit-20;
 
 	.edit-site-style-book.is-wide & {
 		text-align: right;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes: https://github.com/WordPress/gutenberg/issues/48392

This PR updates the styling rules for the Style Book so that there's a little more breathing room within the preview to account for the most common box shadow values. This helps prevents the Style Book from cutting off the shadows in the previews.

Note that this is a naive approach that just adds a little spacing. I also hacked away at an attempt to see if we can extract the shadow values to determine the exact amount of margin to add, but this turned out to be quite complex — we would need to both parse the shadow value, and also iterate over all blocks within the preview to see if it contains any blocks that have a shadow. Otherwise, Button within a Buttons block preview will not trigger additional margins to be added. I'm happy to continue exploring this in a follow-up if folks think the "proper" approach is worth it.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As reported in #48392 box shadow values fall outside of the content area of the block preview within the Style Book and were being cut off. This PR seeks to remedy this.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add `16px` top and bottom margin to the preview in the Style Book
* Add `16px` top padding to the block title text so that it still lines up with the preview
* Reduce spacing between each example to account for the additional margin

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open up global styles, and go to the Button block and add a Shadow (as in #48392)
2. Open up the Style Book
3. Play around with setting different shadows and see that the shadows can be seen in the Style Book now. A caveat: the large and soft shadows are still being cut off. So a question for the reviewer — is this PR good enough of an improvement for now?

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="1260" alt="image" src="https://user-images.githubusercontent.com/14988353/221485000-e549bc90-8988-43a6-9067-53b128d60290.png"> | <img width="1262" alt="image" src="https://user-images.githubusercontent.com/14988353/221484920-a46b10ff-34b4-4762-8b1f-dec084deb4e9.png"> |