### PR TITLE
Try: Sticky headers: Add "none" as a HTML tag option for template parts

### DIFF
--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -113,6 +113,7 @@ export function TemplatePartAdvancedControls( {
 					{ label: '<aside>', value: 'aside' },
 					{ label: '<footer>', value: 'footer' },
 					{ label: '<div>', value: 'div' },
+					{ label: 'None (front only)', value: 'none' },
 				] }
 				value={ tagName || '' }
 				onChange={ ( value ) => setAttributes( { tagName: value } ) }

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -91,7 +91,8 @@ export default function TemplatePartEdit( {
 	const blockProps = useBlockProps();
 	const isPlaceholder = ! slug;
 	const isEntityAvailable = ! isPlaceholder && ! isMissing && isResolved;
-	const TagName = tagName || areaObject.tagName;
+	const TagName =
+		tagName === 'none' ? areaObject.tagName : tagName || areaObject.tagName;
 
 	// The `isSelected` check ensures the `BlockSettingsMenuControls` fill
 	// doesn't render multiple times. The block controls has similar internal check.

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -166,7 +166,7 @@ function render_block_core_template_part( $attributes ) {
 		$html_tag = esc_attr( $attributes['tagName'] );
 	}
 
-	if ( $html_tag === 'none' ) {
+	if ( 'none' == $html_tag ) {
 		return str_replace( ']]>', ']]&gt;', $content );
 	} else {
 		$wrapper_attributes = get_block_wrapper_attributes();

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -166,7 +166,7 @@ function render_block_core_template_part( $attributes ) {
 		$html_tag = esc_attr( $attributes['tagName'] );
 	}
 
-	if ( 'none' == $html_tag ) {
+	if ( 'none' === $html_tag ) {
 		return str_replace( ']]>', ']]&gt;', $content );
 	} else {
 		$wrapper_attributes = get_block_wrapper_attributes();

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -165,9 +165,13 @@ function render_block_core_template_part( $attributes ) {
 	} else {
 		$html_tag = esc_attr( $attributes['tagName'] );
 	}
-	$wrapper_attributes = get_block_wrapper_attributes();
 
-	return "<$html_tag $wrapper_attributes>" . str_replace( ']]>', ']]&gt;', $content ) . "</$html_tag>";
+	if ( $html_tag === 'none' ) {
+		return str_replace( ']]>', ']]&gt;', $content );
+	} else {
+		$wrapper_attributes = get_block_wrapper_attributes();
+		return "<$html_tag $wrapper_attributes>" . str_replace( ']]>', ']]&gt;', $content ) . "</$html_tag>";
+	}
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This is a test to see if we can make it easier to add sticky headers by allowing template parts not to have a HTML tag on the front of the website.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It is tricky to update an existing site header to be sticky because sticky groups do not work when nested inside a template part (They are stickied but only inside the closest parent).

Today, to make a header sticky, you need to create a new group, make it sticky, and move the template part inside the group. Then repeat that for every template.

If the template part had no HTML tag, the group would no longer be nested, and it would stick correctly to the browser window.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By adding "None" as an option to the HTML tag selection in the Advanced panel in the block settings sidebar of the template part.
By not outputting the wrapping HTML tag and block wrapper attributes for template parts on the front of the website.

This works well **if** the site header follows a common pattern where a group is the first element inside the template part.
The caveat is that it only works for the front, the element in the editor must not be removed, so the front and editor do not match.

## Testing Instructions

1. Activate Twenty Twenty-Three.
2. Open the Site Editor, select and edit the header template part. 
3. Select the first group and set the Position option to Sticky.
4. **Optionally**, add a background color to the group to make the feature more visible when you scroll.
Save.
5. **Optionally**, set the HTML tag of the group to "Header".
6. Go back to the template list in the Site Editor and open the Home template.
7. Select the header template part. Open the Advanced panel and change the HTML tag to none. Save.
8. View the front of the website and test the sticky header.




## Screenshots or screencast <!-- if applicable -->
