### PR TITLE
Prevent distracting focused back button on site editor load

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -32,7 +32,18 @@
 .edit-site-sidebar-navigation-screen__back {
 	color: $gray-200;
 
+	// Focus (resets default button focus and use focus-visible).
+	&:focus:not(:disabled) {
+		box-shadow: none;
+		outline: none;
+	}
+	&:focus-visible:not(:disabled) {
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
+		outline: 3px solid transparent;
+	}
+
 	&:hover,
+	&:focus-visible,
 	&:focus,
 	&:not([aria-disabled="true"]):active {
 		color: $white;

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { memo } from '@wordpress/element';
+import { memo, useRef } from '@wordpress/element';
 import {
 	__experimentalNavigatorProvider as NavigatorProvider,
 	__experimentalNavigatorScreen as NavigatorScreen,
@@ -13,11 +13,14 @@ import {
 import SidebarNavigationScreenMain from '../sidebar-navigation-screen-main';
 import SidebarNavigationScreenTemplates from '../sidebar-navigation-screen-templates';
 import SidebarNavigationScreenTemplate from '../sidebar-navigation-screen-template';
-import useSyncPathWithURL from '../sync-state-with-url/use-sync-path-with-url';
+import useSyncPathWithURL, {
+	getPathFromURL,
+} from '../sync-state-with-url/use-sync-path-with-url';
 import SidebarNavigationScreenNavigationMenus from '../sidebar-navigation-screen-navigation-menus';
 import SidebarNavigationScreenTemplatesBrowse from '../sidebar-navigation-screen-templates-browse';
 import SaveButton from '../save-button';
 import SidebarNavigationScreenNavigationItem from '../sidebar-navigation-screen-navigation-item';
+import { useLocation } from '../routes';
 
 function SidebarScreens() {
 	useSyncPathWithURL();
@@ -47,11 +50,14 @@ function SidebarScreens() {
 }
 
 function Sidebar() {
+	const { params: urlParams } = useLocation();
+	const initialPath = useRef( getPathFromURL( urlParams ) );
+
 	return (
 		<>
 			<NavigatorProvider
 				className="edit-site-sidebar__content"
-				initialPath="/"
+				initialPath={ initialPath.current }
 			>
 				<SidebarScreens />
 			</NavigatorProvider>


### PR DESCRIPTION
When loading the site editor in trunk, the "back button" is focused initially because the "initial path" of the sidebar is incorrect causing the "Navigator" component to "focus" the screen. 

Also, when navigating between screens, the focus style is a bit distracting. 

This PR fixes both of these issues by computing the right initial path and by using focus-visible instead of focus.

