### PR TITLE
Sort templates and template parts by slug

### DIFF
--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -46,6 +46,9 @@ export default function Table( { templateType } ) {
 		);
 	}
 
+	const sortedTemplates = [ ...templates ];
+	sortedTemplates.sort( ( a, b ) => a.slug.localeCompare( b.slug ) );
+
 	return (
 		// These explicit aria roles are needed for Safari.
 		// See https://developer.mozilla.org/en-US/docs/Web/CSS/display#tables
@@ -74,7 +77,7 @@ export default function Table( { templateType } ) {
 			</thead>
 
 			<tbody>
-				{ templates.map( ( template ) => (
+				{ sortedTemplates.map( ( template ) => (
 					<tr
 						key={ template.id }
 						className="edit-site-list-table-row"

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -66,6 +66,8 @@ export default function SidebarNavigationScreenTemplates() {
 			per_page: -1,
 		}
 	);
+	const sortedTemplates = templates ? [ ...templates ] : [];
+	sortedTemplates.sort( ( a, b ) => a.slug.localeCompare( b.slug ) );
 
 	const browseAllLink = useLink( {
 		path: '/' + postType + '/all',
@@ -98,7 +100,7 @@ export default function SidebarNavigationScreenTemplates() {
 									{ config[ postType ].labels.notFound }
 								</Item>
 							) }
-							{ ( templates ?? [] ).map( ( template ) => (
+							{ sortedTemplates.map( ( template ) => (
 								<TemplateItem
 									postType={ postType }
 									postId={ template.id }


### PR DESCRIPTION
closes #38378

## What?

The list of templates and template parts in the site editor is sorted randomly using the "last save date". This PR applies a more consistent sorting algorithm (sort by slug/name).

## How

The REST API for templates/template parts don't support sorting yet, I decided to not implement it there, that late in 6.2 cycle and just went with a JS sort since we already have all the templates locally.

## Testing Instructions

1- Open the site editor
2- Make edits to templates or template parts
3- The order in the sidebar should remain stable.
 