### PR TITLE
Mobile - Fix parsing of css units for null matched values

### DIFF
--- a/packages/block-editor/src/utils/parse-css-unit-to-px.js
+++ b/packages/block-editor/src/utils/parse-css-unit-to-px.js
@@ -124,19 +124,24 @@ function evalMathExpression( cssUnit ) {
 	// The following regex matches numbers that have a following unit
 	// E.g. 5.25rem, 1vw
 	const cssUnitsBits = cssUnit.match( /\d+\.?\d*[a-zA-Z]+|\.\d+[a-zA-Z]+/g );
-	for ( const unit of cssUnitsBits ) {
-		// Standardize the unit to px and extract the value.
-		const parsedUnit = parseUnit( getPxFromCssUnit( unit ) );
-		if ( ! parseFloat( parsedUnit.value ) ) {
-			errorFound = true;
-			// End early since we are dealing with a null value.
-			break;
+	if ( cssUnitsBits ) {
+		for ( const unit of cssUnitsBits ) {
+			// Standardize the unit to px and extract the value.
+			const parsedUnit = parseUnit( getPxFromCssUnit( unit ) );
+			if ( ! parseFloat( parsedUnit.value ) ) {
+				errorFound = true;
+				// End early since we are dealing with a null value.
+				break;
+			}
+			cssUnit = cssUnit.replace( unit, parsedUnit.value );
 		}
-		cssUnit = cssUnit.replace( unit, parsedUnit.value );
+	} else {
+		errorFound = true;
 	}
 
 	// For mixed math expressions wrapped within CSS expressions
-	if ( ! errorFound && cssUnit.match( /(max|min|clamp)/g ) ) {
+	const expressionsMatches = cssUnit.match( /(max|min|clamp)/g );
+	if ( ! errorFound && expressionsMatches ) {
 		const values = cssUnit.split( ',' );
 		for ( const currentValue of values ) {
 			// Check for nested calc() and remove them to calculate the value.

--- a/packages/block-editor/src/utils/test/parse-css-unit-to-px.js
+++ b/packages/block-editor/src/utils/test/parse-css-unit-to-px.js
@@ -128,6 +128,7 @@ describe( 'getPxFromCssUnit', () => {
 				'clamp(2.625rem, calc(2.625rem + ((1vw - 0.48rem) * 8.4135)), 3.25rem)',
 				'42px',
 			],
+			[ 'var:preset|font-size|medium', null ],
 		];
 
 		test.each( testData )( 'getPxFromCssUnit( %s )', ( unit, expected ) => {


### PR DESCRIPTION
**Related PRS:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/5516

## What?
Follow-up of https://github.com/WordPress/gutenberg/pull/47258

## Why?
There is a case for a theme that has `var:preset|font-size|medium` values and it was crashing the editor as the `match` value was `null`. This fix will also prevent other values that can't be parsed from going through the rest of the code.
## How?
Checking if the matched value is not null before continuing parsing the value.

## Testing Instructions

**Precondition**: A site using a block-based theme like `Bitácora`

- Open the editor with metro running using the main parent apps.
- **Expect** the editor to not crash: you can add blocks, and type in some text.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
Before | After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/222138085-a9cb4f13-f385-41f9-b15f-04d5a9a26e9d.png" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/222138048-6a4782ca-4bcb-4808-9eec-f774d237fc41.png" width="200" /></kbd>