### PR TITLE
Remove TemplateAreas from template details

### DIFF
--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -18,7 +18,6 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import isTemplateRevertable from '../../utils/is-template-revertable';
 import { store as editSiteStore } from '../../store';
-import TemplateAreas from './template-areas';
 import EditTemplateTitle from './edit-template-title';
 import { useLink } from '../routes/link';
 import TemplatePartAreaSelector from './template-part-area-selector';
@@ -88,8 +87,6 @@ export default function TemplateDetails( { template, onClose } ) {
 					<TemplatePartAreaSelector id={ template.id } />
 				</div>
 			) }
-
-			<TemplateAreas closeTemplateDetailsDropdown={ onClose } />
 
 			{ isTemplateRevertable( template ) && (
 				<MenuGroup className="edit-site-template-details__group edit-site-template-details__revert">


### PR DESCRIPTION
## What?
Closes #48487, removing a redundant UI for template part areas — the List View is more relevant and helpful. 

## How?
Removing `TemplateAreas` from `TemplateDetails`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the Site Editor.
2. Click on the Template Details popover.
3. See changes: no "Areas" section rendered. 

## Screenshots
<img width="1180" alt="CleanShot 2023-02-27 at 09 10 24" src="https://user-images.githubusercontent.com/1813435/221586881-c8702ec4-b3b0-4f00-8931-a328a10ba86b.png">
