### PR TITLE
Ensure aspect ratio is applied when Post Featured Image block is linked

### DIFF
--- a/packages/block-library/src/post-featured-image/style.scss
+++ b/packages/block-library/src/post-featured-image/style.scss
@@ -3,6 +3,7 @@
 	margin-right: 0;
 	a {
 		display: block;
+		height: 100%;
 	}
 	img {
 		max-width: 100%;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #48494 by adding height: 100% to the <a> element within the Post Featured Image block. 

## Why?
Without the height applied, the aspect ratio control does not function if the block has `isLink` set to `true`. 

## How?
Minor SCSS change, applying `height: 100%` to the `a`. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Add a Post Featured Image block to any page or post (or within the Query Loop block).
2. Toggle on the "Link to..." control.
3. Add an aspect ratio, from the "Styles" tab of the block.
4. See the aspect ratio applied properly within the editor.
5. Preview the page.
6. See the aspect ratio applied properly on the front-end.
7. Also test that the Post Featured Image block renders properly with link + without aspect ratio.

## Screenshots or screencast <!-- if applicable -->
<img width="1254" alt="CleanShot 2023-02-27 at 10 15 02" src="https://user-images.githubusercontent.com/1813435/221602668-90badf32-89bb-4219-b1b8-6d3da08236bb.png">
<img width="1253" alt="CleanShot 2023-02-27 at 10 15 10" src="https://user-images.githubusercontent.com/1813435/221602645-67c2b4b9-6efc-40cd-97e2-6e9c3656c5f7.png">
