### PR TITLE
Change "Browse all templates" to "Manage all templates" in template details popover

### DIFF
--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -110,8 +110,8 @@ export default function TemplateDetails( { template, onClose } ) {
 				{ ...browseAllLinkProps }
 			>
 				{ template?.type === 'wp_template'
-					? __( 'Browse all templates' )
-					: __( 'Browse all template parts' ) }
+					? __( 'Manage all templates' )
+					: __( 'Manage all template parts' ) }
 			</Button>
 		</div>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Changes "Browse all templates" to "Manage all templates" in template details popover, to bring it in line with the same action within the templates and template parts control in the Site Editor. 

## Why?
Consistency is nice. 

## How?
Two minor string changes. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the Site Editor.
2. Click on the Template Details Popover. 
3. See "Manage all templates". 
4. Open a template part from the Site Editor navigation.
2. Click on the Template Details Popover from a template part.
3. See "Manage all template parts".

## Screenshots or screencast <!-- if applicable -->

<img width="445" alt="CleanShot 2023-02-27 at 10 32 52" src="https://user-images.githubusercontent.com/1813435/221607853-c0f18db1-5fa9-47c8-a33b-c687709fde34.png">

Matches the existing control in the Site Editor > Templates/Template Parts UI: 

![CleanShot 2023-02-27 at 10 33 00](https://user-images.githubusercontent.com/1813435/221607886-d42f9b77-d44c-49d8-bc4e-f5dc57025a9b.png)
