### PR TITLE
ResponsiveWrapper: use aspect-ratio CSS prop and support SVG elements

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Enhancements
 -   `FontSizePicker`: Allow custom units for custom font size control ([#48468](https://github.com/WordPress/gutenberg/pull/48468)).
 
+### Bug Fix
+
+-  `ResponsiveWrapper`: use `aspect-ratio` CSS prop, add support for `SVG` elements ([#48573](https://github.com/WordPress/gutenberg/pull/48573).
+
 ### Internal
 
 -   `Guide`: Convert to TypeScript ([#47493](https://github.com/WordPress/gutenberg/pull/47493)).
@@ -17,7 +21,7 @@
 
 ### Enhancements
 
--   `ToolsPanel`: Separate reset all filter registration from items registration and support global resets ([#48123](https://github.com/WordPress/gutenberg/pull/48123#pullrequestreview-1308386926)).
+-  `ToolsPanel`: Separate reset all filter registration from items registration and support global resets ([#48123](https://github.com/WordPress/gutenberg/pull/48123)).
 
 ### Internal
 

--- a/packages/components/src/responsive-wrapper/README.md
+++ b/packages/components/src/responsive-wrapper/README.md
@@ -36,10 +36,10 @@ If true, the wrapper will be `span` instead of `div`.
 
 The intrinsic height of the element to wrap. Will be used to determine the aspect ratio.
 
--   Required: Yes
+-   Required: No
 
 ### `naturalWidth`: `number`
 
 The intrinsic width of the element to wrap. Will be used to determine the aspect ratio.
 
--   Required: Yes
+-   Required: No

--- a/packages/components/src/responsive-wrapper/README.md
+++ b/packages/components/src/responsive-wrapper/README.md
@@ -17,6 +17,12 @@ const MyResponsiveWrapper = () => (
 );
 ```
 
+### Usage with `SVG` elements
+
+When passing an `SVG` element as the `<ResponsiveWrapper />`'s child, make sure that it has the `viewbox` and the `preserveAspectRatio` set.
+
+When dealing with SVGs, it may not be possible to derive its `naturalWidth` and `naturalHeight` and therefore passing them as propertied to `<ResponsiveWrapper />`. In this case, the SVG simply keeps scaling up to fill its container, unless the `height` and `width` attributes are specified.
+
 ## Props
 
 ### `children`: `React.ReactElement`

--- a/packages/components/src/responsive-wrapper/index.tsx
+++ b/packages/components/src/responsive-wrapper/index.tsx
@@ -7,7 +7,6 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { cloneElement, Children } from '@wordpress/element';
-import { useResizeObserver } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -36,28 +35,30 @@ function ResponsiveWrapper( {
 	children,
 	isInline = false,
 }: ResponsiveWrapperProps ) {
-	const [ containerResizeListener, { width: containerWidth } ] =
-		useResizeObserver();
 	if ( Children.count( children ) !== 1 ) {
 		return null;
 	}
-	const imageStyle = {
-		paddingBottom:
-			naturalWidth < ( containerWidth ?? 0 )
-				? naturalHeight
-				: ( naturalHeight / naturalWidth ) * 100 + '%',
-	};
+
 	const TagName = isInline ? 'span' : 'div';
+	let aspectRatio;
+	if ( naturalWidth && naturalHeight ) {
+		aspectRatio = `${ naturalWidth } / ${ naturalHeight }`;
+	}
+
 	return (
 		<TagName className="components-responsive-wrapper">
-			{ containerResizeListener }
-			<TagName style={ imageStyle } />
-			{ cloneElement( children, {
-				className: classnames(
-					'components-responsive-wrapper__content',
-					children.props.className
-				),
-			} ) }
+			<div>
+				{ cloneElement( children, {
+					className: classnames(
+						'components-responsive-wrapper__content',
+						children.props.className
+					),
+					style: {
+						...children.props.style,
+						aspectRatio,
+					},
+				} ) }
+			</div>
 		</TagName>
 	);
 }

--- a/packages/components/src/responsive-wrapper/stories/index.tsx
+++ b/packages/components/src/responsive-wrapper/stories/index.tsx
@@ -38,10 +38,13 @@ Default.args = {
 };
 
 /**
- * Since SVG images don't have the equivalent of a natural width and height,
- * it is possible that the `naturalWidth` and `naturalHeight` properties are not
- * specified. In this case, the SVG simply keeps scaling up to fill its
- * container, unless the `height` and `width` attributes are specified.
+ * When passing an `SVG` element as the `<ResponsiveWrapper />`'s child, make
+ * sure that it has the `viewbox` and the `preserveAspectRatio` set.
+ *
+ * When dealing with SVGs, it may not be possible to derive its `naturalWidth`
+ * and `naturalHeight` and therefore passing them as propertied to
+ * `<ResponsiveWrapper />`. In this case, the SVG simply keeps scaling up to fill
+ * its container, unless the `height` and `width` attributes are specified.
  */
 export const WithSVG: ComponentStory< typeof ResponsiveWrapper > =
 	Template.bind( {} );

--- a/packages/components/src/responsive-wrapper/stories/index.tsx
+++ b/packages/components/src/responsive-wrapper/stories/index.tsx
@@ -36,3 +36,41 @@ Default.args = {
 		/>
 	),
 };
+
+/**
+ * Since SVG images don't have the equivalent of a natural width and height,
+ * it is possible that the `naturalWidth` and `naturalHeight` properties are not
+ * specified. In this case, the SVG simply keeps scaling up to fill its
+ * container, unless the `height` and `width` attributes are specified.
+ */
+export const WithSVG: ComponentStory< typeof ResponsiveWrapper > =
+	Template.bind( {} );
+WithSVG.args = {
+	children: (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 280 640"
+			preserveAspectRatio="xMinYMin meet"
+			width="280px"
+			height="640px"
+		>
+			<rect
+				x="0"
+				y="0"
+				width="280"
+				height="640"
+				style={ { fill: 'blue' } }
+			/>
+			<g>
+				<circle style={ { fill: 'red' } } cx="140" cy="160" r="60" />
+				<circle style={ { fill: 'yellow' } } cx="140" cy="320" r="60" />
+				<circle
+					style={ { fill: '#40CC40' } }
+					cx="140"
+					cy="480"
+					r="60"
+				/>
+			</g>
+		</svg>
+	),
+};

--- a/packages/components/src/responsive-wrapper/style.scss
+++ b/packages/components/src/responsive-wrapper/style.scss
@@ -1,19 +1,13 @@
 .components-responsive-wrapper {
 	position: relative;
 	max-width: 100%;
-	&,
-	& > span {
-		display: block;
-	}
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .components-responsive-wrapper__content {
-	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
+	display: block;
+	max-width: 100%;
 	width: 100%;
-	height: 100%;
-	margin: auto;
 }

--- a/packages/components/src/responsive-wrapper/types.ts
+++ b/packages/components/src/responsive-wrapper/types.ts
@@ -2,11 +2,11 @@ export type ResponsiveWrapperProps = {
 	/**
 	 * The intrinsic width of the element to wrap. Will be used to determine the aspect ratio.
 	 */
-	naturalWidth: number;
+	naturalWidth?: number;
 	/**
 	 * The intrinsic height of the element to wrap. Will be used to determine the aspect ratio.
 	 */
-	naturalHeight: number;
+	naturalHeight?: number;
 	/**
 	 * The element to wrap.
 	 */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Alternative approach to #48307
Fixes #48184, #5477

For more context: #20892

Instead of using `useResizeObserver`, use the CSS `aspect-ratio` prop and the `width` and `max-width` properties to style the child element of the `ResponsiveWrapper` component

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This approach has a few advantages over the current approach in `trunk`:

- it supports sizing `SVG` elements, even when `naturalWidth` and `naturalHeight` props are not passed
- it fixes a bug where an `img` tag would grow without respecting its aspect ratio when the browser's viewport would be greater than the image width
- it's more performant, since it relies on the native browser calculations instead of the `useResizeObserver` hook

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
