### PR TITLE
SpacingSizesControl: Fix white dot on thumb

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   `SpacingSizesControl`: fix white dot on thumb ([#48574](https://github.com/WordPress/gutenberg/pull/48574)).
+
 ## 11.4.0 (2023-02-15)
 
 ### Bug Fix

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -126,7 +126,7 @@
 		}
 	}
 
-	[class*="ThumbWrapper-thumbColor"] {
+	.components-range-control__thumb-wrapper {
 		z-index: 3;
 	}
 

--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -269,7 +269,11 @@ function UnforwardedRangeControl< IconProps = unknown >(
 						style={ { width: fillValueOffset } }
 						trackColor={ trackColor }
 					/>
-					<ThumbWrapper style={ offsetStyle } disabled={ disabled }>
+					<ThumbWrapper
+						className="components-range-control__thumb-wrapper"
+						style={ offsetStyle }
+						disabled={ disabled }
+					>
 						<Thumb
 							aria-hidden={ true }
 							isFocused={ isThumbFocused }


### PR DESCRIPTION
## What?
This PR fixes the white dot that appears on the handle in the `SpacingSizesControl` component.

![pr](https://user-images.githubusercontent.com/54422211/221727363-07e0bbcf-988f-42a3-a4a8-78e50a5df784.png)

## Why?
The following style is applied to this handle in order to place it in front of the track separator:

https://github.com/WordPress/gutenberg/blob/3faa015215d6a1dcca0416e7a80a82e23f67ca4d/packages/block-editor/src/components/spacing-sizes-control/style.scss#L129-L131

This style is applied when the Gutenberg project is running in **dev** mode. This is because when in dev mode, the class name will be generated automatically by the [autoLabel](https://emotion.sh/docs/@emotion/babel-plugin#autolabel) option of `@emotion/babel-plugin`. However, when bundled with the WordPress core or when the Gutenberg plugin is built, this class name is not generated and the style is not hit.

## How?
I applied the class name explicitly so that it would not depend on the built environment. Ideally, In [the babel configuration file](https://github.com/WordPress/gutenberg/blob/3faa015215d6a1dcca0416e7a80a82e23f67ca4d/babel.config.js#L6), I think it would be better to explicitly set the autoLabel option to `never` instead of the default `dev-only`.

## Testing Instructions

- Check out this branch and **build** the project.
- Insert a block that supports `spacing`.
- Move the slider of the margin or padding control and confirm that no white dots appear on the handles.

## Screenshots

### Before

![before](https://user-images.githubusercontent.com/54422211/221728742-9b7d868c-9e18-49d4-b265-bb17c4a043a2.png)

### After

![after](https://user-images.githubusercontent.com/54422211/221728768-9fc517d9-5e9f-4293-9638-2478b9cc3b0d.png)


