### PR TITLE
Site editor: Add hover animation to site editor canvas

### DIFF
--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -44,7 +44,8 @@ function EditorCanvas( { enableResizing, settings, children, ...props } ) {
 						// Forming a "block formatting context" to prevent margin collapsing.
 						// @see https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
 						`.is-root-container { display: flow-root; }
-							body { position: relative; }`
+							body { position: relative;
+							${ canvasMode === 'view' ? 'cursor: pointer;' : '' }}}`
 					}</style>
 					{ enableResizing && (
 						<style>

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -280,15 +280,13 @@ export default function Layout() {
 									whileHover={
 										canvasMode === 'view'
 											? {
-													top: '8px',
-													bottom: '8px',
-													left: '-8px',
+													scale: 1.01,
 													transition: {
 														duration:
 															disableMotion ||
 															isResizing
 																? 0
-																: ANIMATION_DURATION,
+																: 0.2,
 													},
 											  }
 											: {}

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -277,6 +277,22 @@ export default function Layout() {
 							{ canvasResizer }
 							{ !! canvasSize.width && (
 								<motion.div
+									whileHover={
+										canvasMode === 'view'
+											? {
+													top: '8px',
+													bottom: '8px',
+													left: '-8px',
+													transition: {
+														duration:
+															disableMotion ||
+															isResizing
+																? 0
+																: ANIMATION_DURATION,
+													},
+											  }
+											: {}
+									}
 									initial={ false }
 									layout="position"
 									className="edit-site-layout__canvas"

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -278,7 +278,7 @@ export default function Layout() {
 							{ !! canvasSize.width && (
 								<motion.div
 									whileHover={
-										canvasMode === 'view'
+										isEditorPage && canvasMode === 'view'
 											? {
 													scale: 1.01,
 													transition: {


### PR DESCRIPTION
## What?
Adds a hover animation to the editor canvas when in browse/view mode

## Why?
Fixes: #47656

## How?
User framer motions `whileHover` prop with a small `scale`. Also adds the hand pointer when the editor is in view mode.

## Testing Instructions
Open the site editor
Check that mouse over the editor canvas causes it to scale up slightly
Check that on mouse out it scales down again
Check that the hand pointer only shows when mousing over the canvas in view mode and not when the editor is opened

## Screenshots or screencast 

https://user-images.githubusercontent.com/3629020/222314312-2ca0af64-2127-493a-8d5b-7578e533372d.mp4

