### PR TITLE
Style Book: Attempt to add margin offset for shadow values

### DIFF
--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -207,8 +207,8 @@ const Example = memo( ( { title, blocks, isSelected, onClick } ) => (
 				additionalStyles={ [
 					{
 						css:
-							'.wp-block:first-child { margin-top: 0; }' +
-							'.wp-block:last-child { margin-bottom: 0; }',
+							'.is-root-container > .wp-block:first-child { margin-top: 16px; }' +
+							'.is-root-container > .wp-block:last-child { margin-bottom: 16px; }',
 					},
 				] }
 			/>

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -37,7 +37,7 @@ import { ESCAPE } from '@wordpress/keycodes';
  * Internal dependencies
  */
 import { unlock } from '../../private-apis';
-import { getMarginBoxValuesFromCSSShadowValue } from './utils';
+import { getMarginBoxValuesFromShadowValue } from './utils';
 
 const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
@@ -200,10 +200,7 @@ function useShadowValueFromInnerBlocks( block ) {
 		block?.innerBlocks?.[ ( block?.innerBlocks?.length || 1 ) - 1 ]?.name
 	);
 
-	const results = [ firstInnerBlockShadow, lastInnerBlockShadow ].filter(
-		Boolean
-	);
-	return results[ 0 ];
+	return firstInnerBlockShadow || lastInnerBlockShadow;
 }
 
 const Example = memo( ( { name, title, blocks, isSelected, onClick } ) => {
@@ -213,9 +210,11 @@ const Example = memo( ( { name, title, blocks, isSelected, onClick } ) => {
 	const innerShadow = useShadowValueFromInnerBlocks( blocks );
 	const foundShadow = shadow || innerShadow;
 
+	// If a shadow is found for either the block or its first/last inner block,
+	// add a margin to the preview that is big enough to accommodate the shadow.
 	if ( foundShadow ) {
 		const marginBoxValues =
-			getMarginBoxValuesFromCSSShadowValue( foundShadow );
+			getMarginBoxValuesFromShadowValue( foundShadow );
 
 		[ 'left', 'top', 'right', 'bottom' ].forEach( ( side ) => {
 			if ( marginBoxValues[ side ] ) {
@@ -224,8 +223,10 @@ const Example = memo( ( { name, title, blocks, isSelected, onClick } ) => {
 		} );
 	}
 
-	cssRules += `.is-root-container > .wp-block { margin-top: 0 }`;
-	cssRules += `.is-root-container > .wp-block { margin-bottom: 0 }`;
+	// Ensure that margin is not applied to the first and last blocks within the preview.
+	// This prevents block-level margin styles from unexpectedly affecting the preview.
+	cssRules += `.is-root-container > .wp-block:first-child { margin-top: 0 }`;
+	cssRules += `.is-root-container > .wp-block:last-child { margin-bottom: 0 }`;
 
 	return (
 		<button

--- a/packages/edit-site/src/components/style-book/style.scss
+++ b/packages/edit-site/src/components/style-book/style.scss
@@ -46,11 +46,9 @@
 	cursor: pointer;
 	display: flex;
 	flex-direction: column;
-	column-gap: $grid-unit-50;
-	row-gap: $grid-unit-20;
-	margin-bottom: $grid-unit-40;
-	padding-left: $grid-unit-20;
-	padding-right: $grid-unit-20;
+	gap: $grid-unit-50;
+	margin-bottom: $grid-unit-50;
+	padding: $grid-unit-20;
 	width: 100%;
 
 	&.is-selected {
@@ -68,7 +66,6 @@
 	margin: 0;
 	text-align: left;
 	text-transform: uppercase;
-	padding-top: $grid-unit-20;
 
 	.edit-site-style-book.is-wide & {
 		text-align: right;

--- a/packages/edit-site/src/components/style-book/style.scss
+++ b/packages/edit-site/src/components/style-book/style.scss
@@ -46,9 +46,11 @@
 	cursor: pointer;
 	display: flex;
 	flex-direction: column;
-	gap: $grid-unit-50;
-	margin-bottom: $grid-unit-50;
-	padding: $grid-unit-20;
+	column-gap: $grid-unit-50;
+	row-gap: $grid-unit-20;
+	margin-bottom: $grid-unit-40;
+	padding-left: $grid-unit-20;
+	padding-right: $grid-unit-20;
 	width: 100%;
 
 	&.is-selected {
@@ -66,6 +68,7 @@
 	margin: 0;
 	text-align: left;
 	text-transform: uppercase;
+	padding-top: $grid-unit-20;
 
 	.edit-site-style-book.is-wide & {
 		text-align: right;

--- a/packages/edit-site/src/components/style-book/test/utils.js
+++ b/packages/edit-site/src/components/style-book/test/utils.js
@@ -1,0 +1,83 @@
+/**
+ * Internal dependencies
+ */
+import { getMarginBoxValuesFromShadowValue } from '../utils';
+
+describe( 'getMarginBoxValuesFromShadowValue()', () => {
+	describe( 'should parse CSS box-shadow value and return matching margin offset values', () => {
+		const testData = [
+			[
+				'6px 6px 9px rgba(0, 0, 0, 0.2)',
+				{
+					top: '3px', // bottom offset of 6px minus 9px blur radius = give 3px breathing room.
+					right: '15px', // right offset of 6px plus 9px blur radius = give 15px breathing room.
+					bottom: '15px',
+					left: '3px',
+				},
+			],
+			[
+				'12px 12px 50px rgba(0, 0, 0, 0.4)',
+				{
+					top: '38px', // bottom offset of 12px minus 50px blur radius = give 38px breathing room.
+					right: '62px', // right offset of 12px plus 50px blur radius = give 62px breathing room.
+					bottom: '62px',
+					left: '38px',
+				},
+			],
+			[
+				'6px 6px 0px rgba(0, 0, 0, 0.2)',
+				{
+					top: '0px', // bottom offset of 6px minus 0px blur radius = give 0px breathing room.
+					right: '6px', // right offset of 6px plus 0px blur radius = give 6px breathing room.
+					bottom: '6px',
+					left: '0px',
+				},
+			],
+			[
+				'6px 6px 0px -3px rgba(255, 255, 255, 1), 6px 6px rgba(0, 0, 0, 1)',
+				{
+					top: '0px',
+					right: '6px',
+					bottom: '6px',
+					left: '0px',
+				},
+			],
+			[
+				'1em 2rem 16px rgba(0, 0, 0, 1)',
+				{
+					top: '0px',
+					right: '32px',
+					bottom: '48px',
+					left: '0px',
+				},
+			],
+			[
+				'1em 2rem 16px rgba(0, 0, 0, 1)',
+				{
+					top: '0px',
+					right: '32px',
+					bottom: '48px',
+					left: '0px',
+				},
+			],
+			[
+				'-8px -8px 16px #fff',
+				{
+					top: '24px',
+					right: '8px',
+					bottom: '8px',
+					left: '24px',
+				},
+			],
+		];
+
+		test.each( testData )(
+			'getMarginBoxValuesFromShadowValue( %s )',
+			( cssShadowValue, expected ) => {
+				expect(
+					getMarginBoxValuesFromShadowValue( cssShadowValue )
+				).toEqual( expected );
+			}
+		);
+	} );
+} );

--- a/packages/edit-site/src/components/style-book/utils.js
+++ b/packages/edit-site/src/components/style-book/utils.js
@@ -35,7 +35,7 @@ export function getValueAsPx( rawValue ) {
 
 	const acceptableUnitsGroup = acceptableUnits?.join( '|' );
 	const regexUnits = new RegExp(
-		`^(\\d*\\.?\\d+)(${ acceptableUnitsGroup }){1,1}$`
+		`^(-?\\d*\\.?\\d+)(${ acceptableUnitsGroup }){1,1}$`
 	);
 
 	const matches = rawValue.match( regexUnits );
@@ -57,7 +57,7 @@ export function getValueAsPx( rawValue ) {
 	return returnValue;
 }
 
-export function getMarginBoxValuesFromCSSShadowValue( cssShadowValue ) {
+export function getMarginBoxValuesFromShadowValue( cssShadowValue ) {
 	// Strip all the values inside parentheses.
 	const filteredValue = cssShadowValue.replace( /\(.*?\)/g, '' );
 
@@ -82,6 +82,7 @@ export function getMarginBoxValuesFromCSSShadowValue( cssShadowValue ) {
 		// Split by space, and only extract the first three elements (x-offset, y-offset, blur-radius).
 		const shadowValueParts = shadowValue.trim().split( ' ' ).slice( 0, 3 );
 
+		// Only support simple `px`, `em`, and `rem` values.
 		if (
 			shadowValueParts.every( ( part ) =>
 				part.match( /([-0-9.]+)(px|em|rem)/ )
@@ -89,6 +90,7 @@ export function getMarginBoxValuesFromCSSShadowValue( cssShadowValue ) {
 		) {
 			const xOffset = getValueAsPx( shadowValueParts[ 0 ] ) || 0;
 			const yOffset = getValueAsPx( shadowValueParts[ 1 ] ) || 0;
+
 			const currentBlurRadius =
 				getValueAsPx( shadowValueParts[ 2 ] ) || 0;
 
@@ -96,20 +98,20 @@ export function getMarginBoxValuesFromCSSShadowValue( cssShadowValue ) {
 				blurRadius = currentBlurRadius;
 			}
 
-			if ( xOffset - blurRadius < marginLeft ) {
-				marginLeft = xOffset - blurRadius;
-			}
-
-			if ( yOffset - blurRadius < marginTop ) {
-				marginTop = xOffset - blurRadius;
-			}
-
-			if ( yOffset + blurRadius > marginBottom ) {
-				marginBottom = yOffset + blurRadius;
+			if ( -xOffset + blurRadius > marginLeft ) {
+				marginLeft = -xOffset + blurRadius;
 			}
 
 			if ( xOffset + blurRadius > marginRight ) {
 				marginRight = xOffset + blurRadius;
+			}
+
+			if ( -yOffset + blurRadius > marginTop ) {
+				marginTop = -yOffset + blurRadius;
+			}
+
+			if ( yOffset + blurRadius > marginBottom ) {
+				marginBottom = yOffset + blurRadius;
 			}
 
 			if (

--- a/packages/edit-site/src/components/style-book/utils.js
+++ b/packages/edit-site/src/components/style-book/utils.js
@@ -1,0 +1,136 @@
+/**
+ * Returns a value rounded to defined precision.
+ * Returns `undefined` if the value is not a valid finite number.
+ *
+ * @param {number} value  Raw value.
+ * @param {number} digits The number of digits to appear after the decimal point
+ *
+ * @return {number|undefined} Value rounded to standard precision.
+ */
+export function roundToPrecision( value, digits = 3 ) {
+	const base = Math.pow( 10, digits );
+	return Number.isFinite( value )
+		? parseFloat( Math.round( value * base ) / base )
+		: undefined;
+}
+
+/**
+ * Converts a value to a pixel value.
+ *
+ * @param {string|number} rawValue A raw CSS value to convert to `px`.
+ * @return {number} The value in pixels.
+ */
+export function getValueAsPx( rawValue ) {
+	if ( typeof rawValue !== 'string' && typeof rawValue !== 'number' ) {
+		return null;
+	}
+
+	// Converts numeric values to pixel values by default.
+	if ( isFinite( rawValue ) ) {
+		rawValue = `${ rawValue }px`;
+	}
+
+	const rootSizeValue = 16;
+	const acceptableUnits = [ 'rem', 'px', 'em' ];
+
+	const acceptableUnitsGroup = acceptableUnits?.join( '|' );
+	const regexUnits = new RegExp(
+		`^(\\d*\\.?\\d+)(${ acceptableUnitsGroup }){1,1}$`
+	);
+
+	const matches = rawValue.match( regexUnits );
+
+	// We need a number value and a unit.
+	if ( ! matches || matches.length < 3 ) {
+		return null;
+	}
+
+	let [ , value, unit ] = matches;
+
+	let returnValue = parseFloat( value );
+
+	if ( 'em' === unit || 'rem' === unit ) {
+		returnValue = returnValue * rootSizeValue;
+		unit = 'px';
+	}
+
+	return returnValue;
+}
+
+export function getMarginBoxValuesFromCSSShadowValue( cssShadowValue ) {
+	// Strip all the values inside parentheses.
+	const filteredValue = cssShadowValue.replace( /\(.*?\)/g, '' );
+
+	// Split by comma if multiple shadows are in use.
+	const shadowValues = filteredValue.split( ',' );
+
+	let marginLeft = 0;
+	let marginRight = 0;
+	let marginTop = 0;
+	let marginBottom = 0;
+	let blurRadius = 0;
+
+	const output = {
+		left: marginLeft,
+		right: marginRight,
+		top: marginTop,
+		bottom: marginBottom,
+	};
+
+	// Iterate over each shadow value.
+	shadowValues.forEach( ( shadowValue ) => {
+		// Split by space, and only extract the first three elements (x-offset, y-offset, blur-radius).
+		const shadowValueParts = shadowValue.trim().split( ' ' ).slice( 0, 3 );
+
+		if (
+			shadowValueParts.every( ( part ) =>
+				part.match( /([-0-9.]+)(px|em|rem)/ )
+			)
+		) {
+			const xOffset = getValueAsPx( shadowValueParts[ 0 ] ) || 0;
+			const yOffset = getValueAsPx( shadowValueParts[ 1 ] ) || 0;
+			const currentBlurRadius =
+				getValueAsPx( shadowValueParts[ 2 ] ) || 0;
+
+			if ( xOffset < marginLeft ) {
+				marginLeft = xOffset;
+			}
+			if ( xOffset > marginRight ) {
+				marginRight = xOffset;
+			}
+			if ( yOffset < marginTop ) {
+				marginTop = yOffset;
+			}
+			if ( yOffset > marginBottom ) {
+				marginBottom = yOffset;
+			}
+
+			if ( currentBlurRadius > blurRadius ) {
+				blurRadius = currentBlurRadius;
+			}
+
+			if (
+				marginLeft ||
+				marginRight ||
+				marginTop ||
+				marginBottom ||
+				blurRadius
+			) {
+				output.left = `calc(${ Math.abs(
+					marginLeft
+				) }px + ${ blurRadius }px)`;
+				output.right = `calc(${ Math.abs(
+					marginRight
+				) }px + ${ blurRadius }px)`;
+				output.top = `calc(${ Math.abs(
+					marginTop
+				) }px + ${ blurRadius }px)`;
+				output.bottom = `calc(${ Math.abs(
+					marginBottom
+				) }px + ${ blurRadius }px)`;
+			}
+		}
+	} );
+
+	return output;
+}

--- a/packages/edit-site/src/components/style-book/utils.js
+++ b/packages/edit-site/src/components/style-book/utils.js
@@ -92,21 +92,24 @@ export function getMarginBoxValuesFromCSSShadowValue( cssShadowValue ) {
 			const currentBlurRadius =
 				getValueAsPx( shadowValueParts[ 2 ] ) || 0;
 
-			if ( xOffset < marginLeft ) {
-				marginLeft = xOffset;
-			}
-			if ( xOffset > marginRight ) {
-				marginRight = xOffset;
-			}
-			if ( yOffset < marginTop ) {
-				marginTop = yOffset;
-			}
-			if ( yOffset > marginBottom ) {
-				marginBottom = yOffset;
-			}
-
 			if ( currentBlurRadius > blurRadius ) {
 				blurRadius = currentBlurRadius;
+			}
+
+			if ( xOffset - blurRadius < marginLeft ) {
+				marginLeft = xOffset - blurRadius;
+			}
+
+			if ( yOffset - blurRadius < marginTop ) {
+				marginTop = xOffset - blurRadius;
+			}
+
+			if ( yOffset + blurRadius > marginBottom ) {
+				marginBottom = yOffset + blurRadius;
+			}
+
+			if ( xOffset + blurRadius > marginRight ) {
+				marginRight = xOffset + blurRadius;
 			}
 
 			if (
@@ -116,18 +119,10 @@ export function getMarginBoxValuesFromCSSShadowValue( cssShadowValue ) {
 				marginBottom ||
 				blurRadius
 			) {
-				output.left = `calc(${ Math.abs(
-					marginLeft
-				) }px + ${ blurRadius }px)`;
-				output.right = `calc(${ Math.abs(
-					marginRight
-				) }px + ${ blurRadius }px)`;
-				output.top = `calc(${ Math.abs(
-					marginTop
-				) }px + ${ blurRadius }px)`;
-				output.bottom = `calc(${ Math.abs(
-					marginBottom
-				) }px + ${ blurRadius }px)`;
+				output.left = Math.abs( marginLeft ) + 'px';
+				output.right = Math.abs( marginRight ) + 'px';
+				output.top = Math.abs( marginTop ) + 'px';
+				output.bottom = Math.abs( marginBottom ) + 'px';
 			}
 		}
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes: #48392 (potentially)

This is an alternative PR to #48470 that seeks to fix the issue where shadows are cut off within the Style Book previews by parsing any shadow values set on the blocks within the preview, and adding a margin as an offset.

Where #48470 attempted to fix the issue by adding a small margin across the board, it had the limitation that larger shadows would still get cut-off. The trade-off of this PR is that while it attempts to extract the real shadow values and calculate a margin to accomodate, it's more complex, and potentially adds code that we might wish to avoid including.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As raised in reviews for https://github.com/WordPress/gutenberg/pull/48470, the approach there didn't resolve the issue for larger shadows. This PR seeks to explore whether or not it's worth it to try a more complex solution.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Iterate over the block and block(s) within the previews in the Style Book, and find the first block that has a shadow set.
* Parse the shadow value and use it to determine an offset margin to pass into the Style Book example preview for that block. For example, if a block has an offset of `8px` and a blur radius of `50px` then its right and bottom values should be `58px`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open up global styles, and go to the Button block and add a Shadow (as in Style Book: Box shadow is cut off  #48392)
2. Open up the Style Book
3. Play around with setting different shadows and see that the shadows can be seen in the Style Book now.

A question for the reviewer: is the approach in this PR appropriate, or too heavy-handed? Also, does the logic need tweaking?

## Screenshots or screencast <!-- if applicable -->

![2023-02-28 15 52 09](https://user-images.githubusercontent.com/14988353/221758973-ae673707-a125-4f96-b628-d0664e3dfe98.gif)