### PR TITLE
Update Welcome Guide article links to avoid redirect

### DIFF
--- a/packages/customize-widgets/src/components/welcome-guide/index.js
+++ b/packages/customize-widgets/src/components/welcome-guide/index.js
@@ -70,7 +70,7 @@ export default function WelcomeGuide( { sidebar } ) {
 				<br />
 				<ExternalLink
 					href={ __(
-						'https://wordpress.org/support/article/wordpress-editor/'
+						'https://wordpress.org/documentation/article/wordpress-block-editor/'
 					) }
 				>
 					{ __( "Here's a detailed guide." ) }

--- a/packages/edit-post/src/components/welcome-guide/default.js
+++ b/packages/edit-post/src/components/welcome-guide/default.js
@@ -110,7 +110,7 @@ export default function WelcomeGuideDefault() {
 								) }
 								<ExternalLink
 									href={ __(
-										'https://wordpress.org/support/article/wordpress-editor/'
+										'https://wordpress.org/documentation/article/wordpress-block-editor/'
 									) }
 								>
 									{ __( "Here's a detailed guide." ) }

--- a/packages/edit-site/src/components/welcome-guide/styles.js
+++ b/packages/edit-site/src/components/welcome-guide/styles.js
@@ -119,7 +119,7 @@ export default function WelcomeGuideStyles() {
 								) }
 								<ExternalLink
 									href={ __(
-										'https://wordpress.org/support/article/styles-overview/'
+										'https://wordpress.org/documentation/article/wordpress-block-editor/'
 									) }
 								>
 									{ __(

--- a/packages/edit-site/src/components/welcome-guide/styles.js
+++ b/packages/edit-site/src/components/welcome-guide/styles.js
@@ -119,7 +119,7 @@ export default function WelcomeGuideStyles() {
 								) }
 								<ExternalLink
 									href={ __(
-										'https://wordpress.org/documentation/article/wordpress-block-editor/'
+										'https://wordpress.org/support/article/styles-overview/'
 									) }
 								>
 									{ __(

--- a/packages/edit-widgets/src/components/welcome-guide/index.js
+++ b/packages/edit-widgets/src/components/welcome-guide/index.js
@@ -177,7 +177,7 @@ export default function WelcomeGuide() {
 								) }
 								<ExternalLink
 									href={ __(
-										'https://wordpress.org/support/article/wordpress-editor/'
+										'https://wordpress.org/documentation/article/wordpress-block-editor/'
 									) }
 								>
 									{ __( "Here's a detailed guide." ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In the Welcome Guide, the final step titled 'Learn how to use the block editor' links to a support article under 'Here's a detailed guide' which opens a new tab for the url: https://wordpress.org/support/article/wordpress-editor/.

This url has since been redirected, and the final url the user will visit will be: https://wordpress.org/documentation/article/wordpress-block-editor/

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

There is no valid reason to point to an old url for this support article. By doing so, it slows the help experience down as the user is redirected but more importantly could lead to a broken page if the redirect is removed in error at a later date.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
My PR removes the need for the redirection, by pointing the user directly to the correct help article.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
Visit the Welcome Guide modal
Follow the Welcome Guide steps until the 4th and final one. 
Hover over the link titled Here's a detailed guide and view the url.
Click the link and view the final url in the address bar.

Fixes #48583.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="1392" alt="redirection-welcome-guide" src="https://user-images.githubusercontent.com/38789408/221781668-b65929d7-db6b-4278-9f23-52483af67432.png">