### PR TITLE
Navigation: Don't create a fallback navigation menu if there are inner blocks

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -282,7 +282,8 @@ function Navigation( {
 			ref ||
 			! hasResolvedNavigationMenus ||
 			isConvertingClassicMenu ||
-			fallbackNavigationMenus?.length > 0
+			fallbackNavigationMenus?.length > 0 ||
+			hasUnsavedBlocks
 		) {
 			return;
 		}
@@ -323,13 +324,14 @@ function Navigation( {
 			if ( getBlockType( 'core/page-list' ) ) {
 				defaultBlocks = [ createBlock( 'core/page-list' ) ];
 			}
+
 			createNavigationMenu(
 				'Navigation', // TODO - use the template slug in future
 				defaultBlocks,
 				'publish'
 			);
 		}
-	}, [ hasResolvedNavigationMenus ] );
+	}, [ hasResolvedNavigationMenus, hasUnsavedBlocks ] );
 
 	const navRef = useRef();
 

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -277,6 +277,17 @@ function Navigation( {
 		hasUncontrolledInnerBlocks,
 	] );
 
+	const isEntityAvailable =
+		! isNavigationMenuMissing && isNavigationMenuResolved;
+
+	// If the block has inner blocks, but no menu id, then these blocks are either:
+	// - inserted via a pattern.
+	// - inserted directly via Code View (or otherwise).
+	// - from an older version of navigation block added before the block used a wp_navigation entity.
+	// Consider this state as 'unsaved' and offer an uncontrolled version of inner blocks,
+	// that automatically saves the menu as an entity when changes are made to the inner blocks.
+	const hasUnsavedBlocks = hasUncontrolledInnerBlocks && ! isEntityAvailable;
+
 	useEffect( () => {
 		if (
 			ref ||
@@ -350,9 +361,6 @@ function Navigation( {
 		hasResolvedNavigationMenus &&
 		classicMenus?.length === 0 &&
 		! hasUncontrolledInnerBlocks;
-
-	const isEntityAvailable =
-		! isNavigationMenuMissing && isNavigationMenuResolved;
 
 	// "loading" state:
 	// - there is a menu creation process in progress.
@@ -727,14 +735,6 @@ function Navigation( {
 			</InspectorControls>
 		</>
 	);
-
-	// If the block has inner blocks, but no menu id, then these blocks are either:
-	// - inserted via a pattern.
-	// - inserted directly via Code View (or otherwise).
-	// - from an older version of navigation block added before the block used a wp_navigation entity.
-	// Consider this state as 'unsaved' and offer an uncontrolled version of inner blocks,
-	// that automatically saves the menu as an entity when changes are made to the inner blocks.
-	const hasUnsavedBlocks = hasUncontrolledInnerBlocks && ! isEntityAvailable;
 
 	const isManageMenusButtonDisabled =
 		! hasManagePermissions || ! hasResolvedNavigationMenus;


### PR DESCRIPTION
## What?
If a navigation block contains inner blocks then we shouldn't create a fallback for it.

## Why?
This behaviour is a regression.

## How?
We check the state of `hasUnsavedBlocks` before running the code that creates the fallback.

## Testing Instructions
1. Add a navigation block to a theme, and update the template to supply inner blocks:

```

<!-- wp:navigation {"overlayBackgroundColor":"secondary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} -->
<!-- wp:site-logo /-->
<!-- wp:page-list /-->
<!-- /wp:navigation -->

```
3. Delete all wp_navigation menus from wp-admin/edit.php?post_type=wp_navigation&paged=1
4. Reload the site editor with this template loaded
5. Check that no wp_navigation menus are created

### Testing Instructions for Keyboard
As above
