### PR TITLE
Navigation: Don't create duplicate wp_navigation CPTs when updating inner blocks

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -282,7 +282,8 @@ function Navigation( {
 			ref ||
 			! hasResolvedNavigationMenus ||
 			isConvertingClassicMenu ||
-			fallbackNavigationMenus?.length > 0
+			fallbackNavigationMenus?.length > 0 ||
+			hasUnsavedBlocks
 		) {
 			return;
 		}
@@ -323,13 +324,14 @@ function Navigation( {
 			if ( getBlockType( 'core/page-list' ) ) {
 				defaultBlocks = [ createBlock( 'core/page-list' ) ];
 			}
+
 			createNavigationMenu(
 				'Navigation', // TODO - use the template slug in future
 				defaultBlocks,
 				'publish'
 			);
 		}
-	}, [ hasResolvedNavigationMenus ] );
+	}, [ hasResolvedNavigationMenus, hasUnsavedBlocks ] );
 
 	const navRef = useRef();
 

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -277,6 +277,17 @@ function Navigation( {
 		hasUncontrolledInnerBlocks,
 	] );
 
+	const isEntityAvailable =
+		! isNavigationMenuMissing && isNavigationMenuResolved;
+
+	// If the block has inner blocks, but no menu id, then these blocks are either:
+	// - inserted via a pattern.
+	// - inserted directly via Code View (or otherwise).
+	// - from an older version of navigation block added before the block used a wp_navigation entity.
+	// Consider this state as 'unsaved' and offer an uncontrolled version of inner blocks,
+	// that automatically saves the menu as an entity when changes are made to the inner blocks.
+	const hasUnsavedBlocks = hasUncontrolledInnerBlocks && ! isEntityAvailable;
+
 	useEffect( () => {
 		if (
 			ref ||
@@ -350,9 +361,6 @@ function Navigation( {
 		hasResolvedNavigationMenus &&
 		classicMenus?.length === 0 &&
 		! hasUncontrolledInnerBlocks;
-
-	const isEntityAvailable =
-		! isNavigationMenuMissing && isNavigationMenuResolved;
 
 	// "loading" state:
 	// - there is a menu creation process in progress.
@@ -727,14 +735,6 @@ function Navigation( {
 			</InspectorControls>
 		</>
 	);
-
-	// If the block has inner blocks, but no menu id, then these blocks are either:
-	// - inserted via a pattern.
-	// - inserted directly via Code View (or otherwise).
-	// - from an older version of navigation block added before the block used a wp_navigation entity.
-	// Consider this state as 'unsaved' and offer an uncontrolled version of inner blocks,
-	// that automatically saves the menu as an entity when changes are made to the inner blocks.
-	const hasUnsavedBlocks = hasUncontrolledInnerBlocks && ! isEntityAvailable;
 
 	const isManageMenusButtonDisabled =
 		! hasManagePermissions || ! hasResolvedNavigationMenus;

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -275,6 +275,7 @@ function Navigation( {
 		isCreatingNavigationMenu,
 		fallbackNavigationMenus,
 		hasUncontrolledInnerBlocks,
+		createNavigationMenuIsSuccess,
 	] );
 
 	const isEntityAvailable =

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -119,6 +119,11 @@ export default function UnsavedInnerBlocks( {
 
 	const { hasResolvedNavigationMenus } = useNavigationMenu();
 
+	// We need to use a ref to track whether the effect has been called.
+	// Otherwise the effect will be called when blocks changes, which
+	// happens faster than the state of navigation menu creation is updated.
+	const createNavigationEffectCalled = useRef( false );
+
 	// Automatically save the uncontrolled blocks.
 	useEffect( () => {
 		// The block will be disabled when used in a BlockPreview.
@@ -139,11 +144,14 @@ export default function UnsavedInnerBlocks( {
 			! hasResolvedDraftNavigationMenus ||
 			! hasResolvedNavigationMenus ||
 			! hasSelection ||
-			! innerBlocksAreDirty
+			! innerBlocksAreDirty ||
+			createNavigationEffectCalled.current
 		) {
 			return;
 		}
 
+		// Setting this to true so that this effect is only called once.
+		createNavigationEffectCalled.current = true;
 		createNavigationMenu( null, blocks );
 	}, [
 		blocks,
@@ -154,6 +162,7 @@ export default function UnsavedInnerBlocks( {
 		hasResolvedNavigationMenus,
 		innerBlocksAreDirty,
 		hasSelection,
+		createNavigationEffectCalled,
 	] );
 
 	const Wrapper = isSaving ? Disabled : 'div';

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -446,8 +446,8 @@ function block_core_navigation_get_default_pages_fallback() {
 	$wp_insert_post_result = wp_insert_post(
 		array(
 			'post_content' => $default_blocks,
-			'post_title'   => 'Navigation', // TODO - use the template slug in future.
-			'post_name'    => 'Navigation', // TODO - use the template slug in future.
+			'post_title'   => 'Navigation PHP', // TODO - use the template slug in future.
+			'post_name'    => 'Navigation PHP', // TODO - use the template slug in future.
 			'post_status'  => 'publish',
 			'post_type'    => 'wp_navigation',
 		),


### PR DESCRIPTION
## What?
When creating a navigation menu from the state of navigation when it has uncontrolled inner blocks, we are currently creating two wp_navigation CPTs. This is because `blocks` gets modified by the Navigation Link block edit component, triggering the `useEffect` twice.

To avoid this I tried using the status of the `useCreateNavigationMenu` hook, but the problem with this approach is that state is set asynchronously, whereas the changes to `blocks` happens immediately, so the useEffect is still called twice.

To get around this I have tried using a ref which stores the state of the useEffect allowing us to ensure that it is only called once. This feels like a bit of a work around, but I couldn't think of a better option, except removing `blocks` from the dependencies (https://github.com/WordPress/gutenberg/pull/48220).

## Testing Instructions
1. Add a navigation block to a theme, and update the template to supply inner blocks:
<!-- wp:site-logo /-->
<!-- wp:page-list /-->
<!-- /wp:navigation -->
2. Delete all wp_navigation menus from wp-admin/edit.php?post_type=wp_navigation&paged=1
3. Reload the site editor with this template loaded
4. Check that no wp_navigation menus are created (as per https://github.com/WordPress/gutenberg/pull/48585)
5. Now open the inspector controls for the navigation block.
6. Add a block to the navgtion
7. Check that only one wp_navigation CPT is created

