### PR TITLE
Fix: Excerpt limit is overruled (#48403)

### DIFF
--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -23,13 +23,21 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	* automatically generated and user-created excerpts.
 	* Because the excerpt_length filter only applies to auto generated excerpts,
 	* wp_trim_words is used instead.
+	* A high-priority filter is added here to ensure the excerpt returned by
+	* get_the_excerpt() is as long as the max length that can be applied in the
+	* block settings. The filter is removed after the excerpt is loaded.
 	*/
+	$filter_excerpt_length = function() {
+		return 100;
+	};
+	add_filter( 'excerpt_length', $filter_excerpt_length, PHP_INT_MAX );
 	$excerpt_length = $attributes['excerptLength'];
 	if ( isset( $excerpt_length ) ) {
 		$excerpt = wp_trim_words( get_the_excerpt(), $excerpt_length );
 	} else {
 		$excerpt = get_the_excerpt();
 	}
+	remove_filter( 'excerpt_length', $filter_excerpt_length, PHP_INT_MAX );
 	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . wp_kses_post( $attributes['moreText'] ) . '</a>' : '';
 	$filter_excerpt_more = function( $more ) use ( $more_text ) {
 		return empty( $more_text ) ? $more : '';

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -83,14 +83,9 @@ add_action( 'init', 'register_block_core_post_excerpt' );
  * the excerpt length block setting has no effect.
  * Returns 100 because 100 is the max length in the setting.
  */
-if ( is_admin() &&
-	defined( 'REST_REQUEST' ) &&
-	REST_REQUEST ) {
-	add_filter(
-		'excerpt_length',
-		function() {
-			return 100;
-		},
-		PHP_INT_MAX
-	);
-}
+add_filter( 'excerpt_length', function( $length ) {
+	if ( is_admin() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+		return 100;
+	}
+	return $length;
+}, PHP_INT_MAX );

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -83,9 +83,9 @@ add_action( 'init', 'register_block_core_post_excerpt' );
  * the excerpt length block setting has no effect.
  * Returns 100 because 100 is the max length in the setting.
  */
-if ( is_admin() ||
-	defined( 'REST_REQUEST' ) ||
-	'REST_REQUEST' ) {
+if ( is_admin() &&
+	defined( 'REST_REQUEST' ) &&
+	REST_REQUEST ) {
 	add_filter(
 		'excerpt_length',
 		function() {

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -83,9 +83,13 @@ add_action( 'init', 'register_block_core_post_excerpt' );
  * the excerpt length block setting has no effect.
  * Returns 100 because 100 is the max length in the setting.
  */
-add_filter( 'excerpt_length', function( $length ) {
-	if ( is_admin() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
-		return 100;
-	}
-	return $length;
-}, PHP_INT_MAX );
+add_filter(
+	'excerpt_length',
+	function( $length ) {
+		if ( is_admin() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+			return 100;
+		}
+		return $length;
+	},
+	PHP_INT_MAX
+);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
REST_REQUEST constant was mistakenly quoted, which caused the condition to always evaluate to true. And the conditional logic should be AND, not OR.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Issue #48403 describes the problem. Excerpt length is overridden always, rather than just in the editor as intended.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Fixes the conditional logic so implementations of excerpt_length filter hook will only be overridden in the block editor.

## Testing Instructions
1. Implement the following hook:
```php
add_filter( 'excerpt_length', function( $excerpt_length ) {
	return 1000;
}, 100 );
```
2. Add or edit a post in the block editor.
3. Use the post-excerpt block.

### Testing Instructions for Keyboard
n/a

## Screenshots or screencast
n.a
