### PR TITLE
Global Styles: Fix typo in valid settings for fluid typography

### DIFF
--- a/packages/block-editor/src/components/global-styles/hooks.js
+++ b/packages/block-editor/src/components/global-styles/hooks.js
@@ -55,7 +55,7 @@ const VALID_SETTINGS = [
 	'spacing.margin',
 	'spacing.padding',
 	'spacing.units',
-	'typography.fuild',
+	'typography.fluid',
 	'typography.customFontSize',
 	'typography.dropCap',
 	'typography.fontFamilies',


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/47356
- https://github.com/WordPress/gutenberg/pull/48070#issuecomment-1449060823

## What?

Fixes typo introduced in https://github.com/WordPress/gutenberg/pull/47356.

## Why?

Typo prevents `typography.fluid` from being a valid setting.

## How?

`fuild` --> `fluid`

## Testing Instructions

1. Confirm that `typography.fluid` is the correct setting path
