### PR TITLE
duotone.php code cleanup

### DIFF
--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -451,27 +451,35 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	// 3. A CSS string - e.g. 'unset' to remove globally applied duotone.
 	$duotone_attr = $block['attrs']['style']['color']['duotone'];
 
-	$is_custom = is_array( $duotone_attr );
 	$is_preset = is_string( $duotone_attr ) && strpos( $duotone_attr, 'var:preset|duotone|' ) === 0;
+	$is_css    = is_string( $duotone_attr ) && strpos( $duotone_attr, 'var:preset|duotone|' ) === -1;
+	$is_custom = is_array( $duotone_attr );
 
 	if ( $is_preset ) {
-		$slug          = str_replace( 'var:preset|duotone|', '', $duotone_attr );
+		// Extract the slug from the variable string.
+		$slug        = str_replace( 'var:preset|duotone|', '', $duotone_attr );
 		$filter_data = array(
 			'slug' => $slug,
 		);
 
 		// Utilize existing CSS custom property.
 		$filter_property = "var(--wp--preset--duotone--$slug)";
-	} else {
-		// Handle when Duotone is either:
-		// - a CSS string such as 'unset'.
-		// - an array of colors.
-
-		// Build a unique slug for the filter based on the array of colors.
-		$filter_key    = $is_custom ? implode( '-', $duotone_attr ) : $duotone_attr;
+	} else if ( $is_css ) {
+		// Build a unique slug for the filter based on the CSS value.
+		$slug        = wp_unique_id( sanitize_key( $duotone_attr . '-' ) );
 		$filter_data = array(
-			'slug'   => wp_unique_id( sanitize_key( $filter_key . '-' ) ),
-			'colors' => $duotone_attr, // required for building the SVG with gutenberg_get_duotone_filter_svg.
+			'slug'   => $slug,
+			'colors' => $duotone_attr,
+		);
+
+		// Pass through the CSS value.
+		$filter_property = $duotone_attr;
+	} else if ( $is_custom ) {
+		// Build a unique slug for the filter based on the array of colors.
+		$slug        = wp_unique_id( sanitize_key( implode( '-', $duotone_attr ) . '-' ) );
+		$filter_data = array(
+			'slug'   => $slug,
+			'colors' => $duotone_attr,
 		);
 
 		// Build a customized CSS filter property for unique slug.

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -456,7 +456,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 
 	if ( $is_duotone_preset ) {
 		$slug          = str_replace( 'var:preset|duotone|', '', $duotone_attr );
-		$filter_preset = array(
+		$filter_data = array(
 			'slug' => $slug,
 		);
 
@@ -469,18 +469,18 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 
 		// Build a unique slug for the filter based on the array of colors.
 		$filter_key    = $is_duotone_colors_array ? implode( '-', $duotone_attr ) : $duotone_attr;
-		$filter_preset = array(
+		$filter_data = array(
 			'slug'   => wp_unique_id( sanitize_key( $filter_key . '-' ) ),
 			'colors' => $duotone_attr, // required for building the SVG with gutenberg_get_duotone_filter_svg.
 		);
 
 		// Build a customised CSS filter property for unique slug.
-		$filter_property = gutenberg_get_duotone_filter_property( $filter_preset );
+		$filter_property = gutenberg_get_duotone_filter_property( $filter_data );
 	}
 
 	// - Applied as a class attribute to the block wrapper.
 	// - Used as a selector to apply the filter to the block.
-	$filter_id = gutenberg_get_duotone_filter_id( $filter_preset );
+	$filter_id = gutenberg_get_duotone_filter_id( $filter_data );
 
 	// Build the CSS selectors to which the filter will be applied.
 	// Todo - encapsulate this in a function.
@@ -516,7 +516,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	// For *non*-presets then generate an SVG for the filter.
 	// Note: duotone presets are already pre-generated so no need to do this again.
 	if ( $is_duotone_colors_array ) {
-		$filter_svg = gutenberg_get_duotone_filter_svg( $filter_preset );
+		$filter_svg = gutenberg_get_duotone_filter_svg( $filter_data );
 
 		add_action(
 			'wp_footer',

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -477,7 +477,9 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 			'colors' => $duotone_attr,
 		);
 		$filter_property = gutenberg_get_duotone_filter_property( $filter_data );
-		$filter_svg      = gutenberg_get_duotone_filter_svg( $filter_data );
+
+		// SVG will be output on the page later.
+		$filter_svg = gutenberg_get_duotone_filter_svg( $filter_data );
 	}
 
 	// - Applied as a class attribute to the block wrapper.

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -448,7 +448,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	// Possible values for duotone attribute:
 	// 1. Array of colors - e.g. array('#000000', '#ffffff').
 	// 2. Variable for an existing Duotone preset - e.g. 'var:preset|duotone|green-blue'.
-	// 3. The string 'unset' - indicates explicitly "no Duotone"..
+	// 3. A CSS string - e.g. 'unset' to remove globally applied duotone.
 	$duotone_attr = $block['attrs']['style']['color']['duotone'];
 
 	$is_duotone_colors_array = is_array( $duotone_attr );
@@ -464,7 +464,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 		$filter_property = "var(--wp--preset--duotone--$slug)";
 	} else {
 		// Handle when Duotone is either:
-		// - "unset"
+		// - a CSS string such as 'unset'.
 		// - an array of colors.
 
 		// Build a unique slug for the filter based on the array of colors.

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -311,8 +311,8 @@ function gutenberg_get_duotone_filter_id( $preset ) {
  * @return string        Duotone CSS filter property url value.
  */
 function gutenberg_get_duotone_filter_property( $preset ) {
-	if ( isset( $preset['colors'] ) && 'unset' === $preset['colors'] ) {
-		return 'none';
+	if ( isset( $preset['colors'] ) && is_string( $preset['colors'] ) ) {
+		return $preset['colors'];
 	}
 	$filter_id = gutenberg_get_duotone_filter_id( $preset );
 	return "url('#" . $filter_id . "')";

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -447,7 +447,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 
 	// Possible values for duotone attribute:
 	// 1. Array of colors - e.g. array('#000000', '#ffffff').
-	// 2. Slug of an existing Duotone preset - e.g. 'green-blue'.
+	// 2. Variable for an existing Duotone preset - e.g. 'var:preset|duotone|green-blue'.
 	// 3. The string 'unset' - indicates explicitly "no Duotone"..
 	$duotone_attr = $block['attrs']['style']['color']['duotone'];
 

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -451,8 +451,8 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	// 3. A CSS string - e.g. 'unset' to remove globally applied duotone.
 	$duotone_attr = $block['attrs']['style']['color']['duotone'];
 
-	$is_duotone_colors_array = is_array( $duotone_attr );
-	$is_duotone_preset       = is_string( $duotone_attr ) && strpos( $duotone_attr, 'var:preset|duotone|' ) === 0;
+	$is_duotone_custom_colors = is_array( $duotone_attr );
+	$is_duotone_preset        = is_string( $duotone_attr ) && strpos( $duotone_attr, 'var:preset|duotone|' ) === 0;
 
 	if ( $is_duotone_preset ) {
 		$slug          = str_replace( 'var:preset|duotone|', '', $duotone_attr );
@@ -468,7 +468,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 		// - an array of colors.
 
 		// Build a unique slug for the filter based on the array of colors.
-		$filter_key    = $is_duotone_colors_array ? implode( '-', $duotone_attr ) : $duotone_attr;
+		$filter_key    = $is_duotone_custom_colors ? implode( '-', $duotone_attr ) : $duotone_attr;
 		$filter_data = array(
 			'slug'   => wp_unique_id( sanitize_key( $filter_key . '-' ) ),
 			'colors' => $duotone_attr, // required for building the SVG with gutenberg_get_duotone_filter_svg.
@@ -508,7 +508,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 
 	// For *non*-presets then generate an SVG for the filter.
 	// Note: duotone presets are already pre-generated so no need to do this again.
-	if ( $is_duotone_colors_array ) {
+	if ( $is_duotone_custom_colors ) {
 		$filter_svg = gutenberg_get_duotone_filter_svg( $filter_data );
 
 		add_action(

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -469,7 +469,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 		$filter_property = $duotone_attr;
 	} else if ( $is_custom ) {
 		// Build a unique slug for the filter based on the array of colors.
-		$slug        = wp_unique_id( sanitize_key( implode( '-', $duotone_attr ) . '-' ) );
+		$slug = wp_unique_id( sanitize_key( implode( '-', $duotone_attr ) . '-' ) );
 
 		// Build a customized CSS filter property for unique slug.
 		$filter_data     = array(

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -483,14 +483,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	$filter_id = gutenberg_get_duotone_filter_id( $filter_data );
 
 	// Build the CSS selectors to which the filter will be applied.
-	// Todo - encapsulate this in a function.
-	$scope     = '.' . $filter_id;
-	$selectors = explode( ',', $duotone_support );
-	$scoped    = array();
-	foreach ( $selectors as $sel ) {
-		$scoped[] = $scope . ' ' . trim( $sel );
-	}
-	$selector = implode( ', ', $scoped );
+	$selector = WP_Theme_JSON_Gutenberg::scope_selector( '.' . $filter_id, $duotone_support );
 
 	// Calling gutenberg_style_engine_get_stylesheet_from_css_rules ensures that
 	// the styles are rendered in an inline for block supports because we're

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -451,10 +451,10 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	// 3. A CSS string - e.g. 'unset' to remove globally applied duotone.
 	$duotone_attr = $block['attrs']['style']['color']['duotone'];
 
-	$is_duotone_custom_colors = is_array( $duotone_attr );
-	$is_duotone_preset        = is_string( $duotone_attr ) && strpos( $duotone_attr, 'var:preset|duotone|' ) === 0;
+	$is_custom = is_array( $duotone_attr );
+	$is_preset = is_string( $duotone_attr ) && strpos( $duotone_attr, 'var:preset|duotone|' ) === 0;
 
-	if ( $is_duotone_preset ) {
+	if ( $is_preset ) {
 		$slug          = str_replace( 'var:preset|duotone|', '', $duotone_attr );
 		$filter_data = array(
 			'slug' => $slug,
@@ -468,7 +468,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 		// - an array of colors.
 
 		// Build a unique slug for the filter based on the array of colors.
-		$filter_key    = $is_duotone_custom_colors ? implode( '-', $duotone_attr ) : $duotone_attr;
+		$filter_key    = $is_custom ? implode( '-', $duotone_attr ) : $duotone_attr;
 		$filter_data = array(
 			'slug'   => wp_unique_id( sanitize_key( $filter_key . '-' ) ),
 			'colors' => $duotone_attr, // required for building the SVG with gutenberg_get_duotone_filter_svg.
@@ -508,7 +508,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 
 	// For *non*-presets then generate an SVG for the filter.
 	// Note: duotone presets are already pre-generated so no need to do this again.
-	if ( $is_duotone_custom_colors ) {
+	if ( $is_custom ) {
 		$filter_svg = gutenberg_get_duotone_filter_svg( $filter_data );
 
 		add_action(

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -452,7 +452,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	$duotone_attr = $block['attrs']['style']['color']['duotone'];
 
 	$is_duotone_colors_array = is_array( $duotone_attr );
-	$is_duotone_preset       = ! $is_duotone_colors_array && strpos( $duotone_attr, 'var:preset|duotone|' ) === 0;
+	$is_duotone_preset       = is_string( $duotone_attr ) && strpos( $duotone_attr, 'var:preset|duotone|' ) === 0;
 
 	if ( $is_duotone_preset ) {
 		$slug          = str_replace( 'var:preset|duotone|', '', $duotone_attr );

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -457,38 +457,32 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 
 	if ( $is_preset ) {
 		// Extract the slug from the variable string.
-		$slug        = str_replace( 'var:preset|duotone|', '', $duotone_attr );
-		$filter_data = array(
-			'slug' => $slug,
-		);
+		$slug = str_replace( 'var:preset|duotone|', '', $duotone_attr );
 
 		// Utilize existing CSS custom property.
 		$filter_property = "var(--wp--preset--duotone--$slug)";
 	} else if ( $is_css ) {
 		// Build a unique slug for the filter based on the CSS value.
-		$slug        = wp_unique_id( sanitize_key( $duotone_attr . '-' ) );
-		$filter_data = array(
-			'slug'   => $slug,
-			'colors' => $duotone_attr,
-		);
+		$slug = wp_unique_id( sanitize_key( $duotone_attr . '-' ) );
 
 		// Pass through the CSS value.
 		$filter_property = $duotone_attr;
 	} else if ( $is_custom ) {
 		// Build a unique slug for the filter based on the array of colors.
 		$slug        = wp_unique_id( sanitize_key( implode( '-', $duotone_attr ) . '-' ) );
-		$filter_data = array(
+
+		// Build a customized CSS filter property for unique slug.
+		$filter_data     = array(
 			'slug'   => $slug,
 			'colors' => $duotone_attr,
 		);
-
-		// Build a customized CSS filter property for unique slug.
 		$filter_property = gutenberg_get_duotone_filter_property( $filter_data );
+		$filter_svg      = gutenberg_get_duotone_filter_svg( $filter_data );
 	}
 
 	// - Applied as a class attribute to the block wrapper.
 	// - Used as a selector to apply the filter to the block.
-	$filter_id = gutenberg_get_duotone_filter_id( $filter_data );
+	$filter_id = gutenberg_get_duotone_filter_id( array( 'slug' => $slug ) );
 
 	// Build the CSS selectors to which the filter will be applied.
 	$selector = WP_Theme_JSON_Gutenberg::scope_selector( '.' . $filter_id, $duotone_support );
@@ -514,11 +508,8 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 		)
 	);
 
-	// For *non*-presets then generate an SVG for the filter.
-	// Note: duotone presets are already pre-generated so no need to do this again.
-	if ( $is_custom ) {
-		$filter_svg = gutenberg_get_duotone_filter_svg( $filter_data );
-
+	// If we needed to generate an SVG, output it on the page.
+	if ( isset( $filter_svg ) ) {
 		add_action(
 			'wp_footer',
 			static function () use ( $filter_svg, $selector ) {

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -455,11 +455,12 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	$is_css    = is_string( $duotone_attr ) && strpos( $duotone_attr, 'var:preset|duotone|' ) === -1;
 	$is_custom = is_array( $duotone_attr );
 
+	// Generate the pieces needed for rendering a duotone to the page.
 	if ( $is_preset ) {
-		// Extract the slug from the variable string.
+		// Extract the slug from the preset variable string.
 		$slug = str_replace( 'var:preset|duotone|', '', $duotone_attr );
 
-		// Utilize existing CSS custom property.
+		// Utilize existing preset CSS custom property.
 		$filter_property = "var(--wp--preset--duotone--$slug)";
 	} else if ( $is_css ) {
 		// Build a unique slug for the filter based on the CSS value.
@@ -471,11 +472,14 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 		// Build a unique slug for the filter based on the array of colors.
 		$slug = wp_unique_id( sanitize_key( implode( '-', $duotone_attr ) . '-' ) );
 
-		// Build a customized CSS filter property for unique slug.
-		$filter_data     = array(
+		// This has the same shape as a preset, so it can be used in place of a
+		// preset when getting the filter property and SVG filter.
+		$filter_data = array(
 			'slug'   => $slug,
 			'colors' => $duotone_attr,
 		);
+
+		// Build a customized CSS filter property for unique slug.
 		$filter_property = gutenberg_get_duotone_filter_property( $filter_data );
 
 		// SVG will be output on the page later.

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -452,7 +452,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	$duotone_attr = $block['attrs']['style']['color']['duotone'];
 
 	$is_preset = is_string( $duotone_attr ) && strpos( $duotone_attr, 'var:preset|duotone|' ) === 0;
-	$is_css    = is_string( $duotone_attr ) && strpos( $duotone_attr, 'var:preset|duotone|' ) === -1;
+	$is_css    = is_string( $duotone_attr ) && strpos( $duotone_attr, 'var:preset|duotone|' ) === false;
 	$is_custom = is_array( $duotone_attr );
 
 	// Generate the pieces needed for rendering a duotone to the page.

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -462,13 +462,13 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 
 		// Utilize existing preset CSS custom property.
 		$filter_property = "var(--wp--preset--duotone--$slug)";
-	} else if ( $is_css ) {
+	} elseif ( $is_css ) {
 		// Build a unique slug for the filter based on the CSS value.
 		$slug = wp_unique_id( sanitize_key( $duotone_attr . '-' ) );
 
 		// Pass through the CSS value.
 		$filter_property = $duotone_attr;
-	} else if ( $is_custom ) {
+	} elseif ( $is_custom ) {
 		// Build a unique slug for the filter based on the array of colors.
 		$slug = wp_unique_id( sanitize_key( implode( '-', $duotone_attr ) . '-' ) );
 

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -460,7 +460,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 			'slug' => $slug,
 		);
 
-		// Utilise existing CSS custom property.
+		// Utilize existing CSS custom property.
 		$filter_property = "var(--wp--preset--duotone--$slug)";
 	} else {
 		// Handle when Duotone is either:
@@ -474,7 +474,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 			'colors' => $duotone_attr, // required for building the SVG with gutenberg_get_duotone_filter_svg.
 		);
 
-		// Build a customised CSS filter property for unique slug.
+		// Build a customized CSS filter property for unique slug.
 		$filter_property = gutenberg_get_duotone_filter_property( $filter_data );
 	}
 

--- a/phpunit/block-supports/duotone-test.php
+++ b/phpunit/block-supports/duotone-test.php
@@ -25,7 +25,7 @@ class WP_Block_Supports_Duotone_Test extends WP_UnitTestCase {
 	}
 
 	public function test_gutenberg_render_duotone_support_css() {
-		$block = array(
+		$block         = array(
 			'blockName' => 'core/image',
 			'attrs'     => array( 'style' => array( 'color' => array( 'duotone' => 'unset' ) ) ),
 		);
@@ -35,7 +35,7 @@ class WP_Block_Supports_Duotone_Test extends WP_UnitTestCase {
 	}
 
 	public function test_gutenberg_render_duotone_support_custom() {
-		$block = array(
+		$block         = array(
 			'blockName' => 'core/image',
 			'attrs'     => array( 'style' => array( 'color' => array( 'duotone' => array( '#FFFFFF', '#000000' ) ) ) ),
 		);

--- a/phpunit/block-supports/duotone-test.php
+++ b/phpunit/block-supports/duotone-test.php
@@ -7,15 +7,8 @@
  */
 
 class WP_Block_Supports_Duotone_Test extends WP_UnitTestCase {
-	public function tear_down() {
-		wp_clean_themes_cache();
-		unset( $GLOBALS['wp_themes'] );
-		WP_Style_Engine_CSS_Rules_Store_Gutenberg::remove_all_stores();
-		parent::tear_down();
-	}
-
 	public function test_gutenberg_render_duotone_support_preset() {
-		$block = array(
+		$block         = array(
 			'blockName' => 'core/image',
 			'attrs'     => array( 'style' => array( 'color' => array( 'duotone' => 'var:preset|duotone|slug' ) ) ),
 		);

--- a/phpunit/block-supports/duotone-test.php
+++ b/phpunit/block-supports/duotone-test.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Test the block duotone support.
+ *
+ * @package Gutenberg
+ */
+
+class WP_Block_Supports_Duotone_Test extends WP_UnitTestCase {
+	public function tear_down() {
+		wp_clean_themes_cache();
+		unset( $GLOBALS['wp_themes'] );
+		WP_Style_Engine_CSS_Rules_Store_Gutenberg::remove_all_stores();
+		parent::tear_down();
+	}
+
+	public function test_gutenberg_render_duotone_support_preset() {
+		$block = array(
+			'blockName' => 'core/image',
+			'attrs'     => array( 'style' => array( 'color' => array( 'duotone' => 'var:preset|duotone|slug' ) ) ),
+		);
+		$block_content = '<figure class="wp-block-image size-full"><img src="/my-image.jpg" /></figure>';
+		$expected      = '<figure class="wp-duotone-slug wp-block-image size-full"><img src="/my-image.jpg" /></figure>';
+		$this->assertSame( $expected, gutenberg_render_duotone_support( $block_content, $block ) );
+	}
+
+	public function test_gutenberg_render_duotone_support_css() {
+		$block = array(
+			'blockName' => 'core/image',
+			'attrs'     => array( 'style' => array( 'color' => array( 'duotone' => 'unset' ) ) ),
+		);
+		$block_content = '<figure class="wp-block-image size-full"><img src="/my-image.jpg" /></figure>';
+		$expected      = '/<figure class="wp-duotone-unset-\d+ wp-block-image size-full"><img src="\\/my-image.jpg" \\/><\\/figure>/';
+		$this->assertMatchesRegularExpression( $expected, gutenberg_render_duotone_support( $block_content, $block ) );
+	}
+
+	public function test_gutenberg_render_duotone_support_custom() {
+		$block = array(
+			'blockName' => 'core/image',
+			'attrs'     => array( 'style' => array( 'color' => array( 'duotone' => array( '#FFFFFF', '#000000' ) ) ) ),
+		);
+		$block_content = '<figure class="wp-block-image size-full"><img src="/my-image.jpg" /></figure>';
+		$expected      = '/<figure class="wp-duotone-ffffff-000000-\d+ wp-block-image size-full"><img src="\\/my-image.jpg" \\/><\\/figure>/';
+		$this->assertMatchesRegularExpression( $expected, gutenberg_render_duotone_support( $block_content, $block ) );
+	}
+
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Just a bit of cleanup in duotone.php.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I hope the code is easier to understand.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Use `WP_Theme_JSON_Gutenberg::scope_selector` to scope the selector.
- Treat non-variable strings as plain CSS.
- Update comments.
- Update variable names.
- Restructure duotone generation into custom preset, CSS, and custom code branches.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Duotone rendering should work as before except unset filters will use `unset` instead of `none`.

`none` is equivalent to `unset` for non-inherited CSS properties, like `filter`, with an initial value of `none`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

N/A
