### PR TITLE
Only add layout classes to inner wrapper if block is a container.

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -302,23 +302,6 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 }
 
 /**
- * Gets classname from last tag in a string of HTML.
- *
- * @param string $html markup to be processed.
- * @return string String of inner wrapper classnames.
- */
-function gutenberg_get_classnames_from_last_tag( $html ) {
-	$tags            = new WP_HTML_Tag_Processor( $html );
-	$last_classnames = '';
-
-	while ( $tags->next_tag() ) {
-		$last_classnames = $tags->get_attribute( 'class' );
-	}
-
-	return (string) $last_classnames;
-}
-
-/**
  * Renders the layout config to the block wrapper.
  *
  * @param  string $block_content Rendered block content.
@@ -502,7 +485,17 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	* The first chunk of innerContent contains the block markup up until the inner blocks start.
 	* We want to target the opening tag of the inner blocks wrapper, which is the last tag in that chunk.
 	*/
-	$inner_content_classnames = isset( $block['innerContent'][0] ) && 'string' === gettype( $block['innerContent'][0] ) ? gutenberg_get_classnames_from_last_tag( $block['innerContent'][0] ) : '';
+	$inner_content_classnames = '';
+
+	if ( isset( $block['innerContent'][0] ) && 'string' === gettype( $block['innerContent'][0] ) && count( $block['innerContent'] ) > 1 ) {
+		$tags            = new WP_HTML_Tag_Processor( $block['innerContent'][0] );
+		$last_classnames = '';
+		while ( $tags->next_tag() ) {
+			$last_classnames = $tags->get_attribute( 'class' );
+		}
+
+		$inner_content_classnames = (string) $last_classnames;
+	}
 
 	$content = $content_with_outer_classnames ? new WP_HTML_Tag_Processor( $content_with_outer_classnames ) : new WP_HTML_Tag_Processor( $block_content );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #48606. While working on this change I noticed the updates to this logic from the [Core backport code review](https://github.com/WordPress/wordpress-develop/pull/3976) hadn't been copied over yet, and as they are fairly minor and touch the same part of the code I'm also including them here.

The actual fix is just updating the `isset( $block['innerContent'][0] ) && 'string' === gettype( $block['innerContent'][0]` condition to `isset( $block['innerContent'][0] ) && 'string' === gettype( $block['innerContent'][0] ) && count($block['innerContent']) > 1 `

because if the number of items in `$block['innerContent']` is less than or equal to 1, then either the block isn't a container for inner blocks, or it's a dynamic block such as Post Content or Navigation, in which case the logic to add classnames to the inner wrapper would have to be added in the block's custom PHP anyway.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add layout-enabled blocks to a template: Query, Post Content, Social Icons, Buttons, Gallery, Navigation, Group, Columns, Comments Pagination;
2. Check that their layout classnames still render correctly in the expected wrapper;
3. Generate some posts via CLI using the deprecated Gallery block markup as outlined in #48606;
4. Check that those posts don't have layout classes in unexpected places on the front end.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
