### PR TITLE
react-native-editor: move parser tests to a test directory

### DIFF
--- a/packages/react-native-editor/src/test/block-parser-code.test.js
+++ b/packages/react-native-editor/src/test/block-parser-code.test.js
@@ -1,9 +1,4 @@
 /**
- * Internal dependencies
- */
-import '../globals';
-
-/**
  * WordPress dependencies
  */
 import { registerCoreBlocks } from '@wordpress/block-library';

--- a/packages/react-native-editor/src/test/block-parser-more.test.js
+++ b/packages/react-native-editor/src/test/block-parser-more.test.js
@@ -1,9 +1,4 @@
 /**
- * Internal dependencies
- */
-import '../globals';
-
-/**
  * WordPress dependencies
  */
 import { registerCoreBlocks } from '@wordpress/block-library';

--- a/packages/react-native-editor/src/test/block-parser-paragraph.test.js
+++ b/packages/react-native-editor/src/test/block-parser-paragraph.test.js
@@ -1,9 +1,4 @@
 /**
- * Internal dependencies
- */
-import '../globals';
-
-/**
  * WordPress dependencies
  */
 import { registerCoreBlocks } from '@wordpress/block-library';

--- a/test/native/jest.config.js
+++ b/test/native/jest.config.js
@@ -31,12 +31,7 @@ module.exports = {
 		'**/test/!(helper)*.native.[jt]s?(x)',
 		'<rootDir>/packages/react-native-*/**/?(*.)+(spec|test).[jt]s?(x)',
 	],
-	testPathIgnorePatterns: [
-		'/node_modules/',
-		'/__device-tests__/',
-		'<rootDir>/.*/build/',
-		'<rootDir>/.*/build-module/',
-	],
+	testPathIgnorePatterns: [ '/node_modules/', '/__device-tests__/' ],
 	testURL: 'http://localhost/',
 	// Add the `Libraries/Utilities` subfolder to the module directories, otherwise haste/jest doesn't find Platform.js on Travis,
 	// and add it first so https://github.com/facebook/react-native/blob/v0.60.0/Libraries/react-native/react-native-implementation.js#L324-L326 doesn't pick up the Platform npm module.


### PR DESCRIPTION
Spinoff from the Jest upgrade in #47388 which moves some tests to a `test` subdirectory. The result is that these test files are excluded from the build and are not transpiled and copied into `./build` and `./build-module`.

I also removed `../globals` imports from the test files because these imports are already done by the tested modules.

Now when the test files are excluded from the build, we no longer need to add the build directories to `testPathIgnorePatterns`. These exclusions are difficult to implement once you change the `rootDir` and want to include `..` in the paths. Paths in regular expressions are not resolved, the expression including `..` is matched against the real filename, and never matches anything.