### PR TITLE
Clarify backport status of `appearance-tools` theme support

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -319,10 +319,15 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			// Classic themes without a theme.json don't support global duotone.
 			$theme_support_data['settings']['color']['defaultDuotone'] = false;
 
+			// BEGIN EXPERIMENTAL.
 			// Allow themes to enable appearance tools via theme_support.
+			// This feature was backported for WordPress 6.2 as of https://core.trac.wordpress.org/ticket/56487
+			// and then reverted as of https://core.trac.wordpress.org/ticket/57649
+			// Not to backport until the issues are resolved.
 			if ( current_theme_supports( 'appearance-tools' ) ) {
 				$theme_support_data['settings']['appearanceTools'] = true;
 			}
+			// END EXPERIMENTAL.
 		}
 		$with_theme_supports = new WP_Theme_JSON_Gutenberg( $theme_support_data );
 		$with_theme_supports->merge( static::$theme );


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/43337

## What?

This PR clarifies the status of the `appearance-tools` theme support by adding a comment and marking the code as experimental, so it's not backported unintentionally.

## Why?

The feature missed the 6.1 cycle and was backported in the 6.2 cycle as of https://core.trac.wordpress.org/ticket/56487 However, it had to be reverted as of https://core.trac.wordpress.org/ticket/57649 due to some issues.

## How?

Add a comment for people not to backport, following existing practices.

## Testing Instructions

Nothing to test. This only adds a comment.
