### PR TITLE
Fix: Inserter does not appear on sidebar navigation.

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/branch.js
+++ b/packages/block-editor/src/components/off-canvas-editor/branch.js
@@ -116,8 +116,8 @@ function ListViewBranch( props ) {
 		return null;
 	}
 
-	// Only show the appender at the first level and if there is a parent block.
-	const showAppender = level === 1 && parentId;
+	// Only show the appender at the first level.
+	const showAppender = level === 1;
 
 	const filteredBlocks = blocks.filter( Boolean );
 	const blockCount = filteredBlocks.length;


### PR DESCRIPTION
This ParentId check was recently added by me at https://github.com/WordPress/gutenberg/pull/48049/.
It was done assuming we would also merge the change to reuse the canvas block editor on the sidebar navigation given that we followed another path this condition needs to be removed.

## Testing
Verify the inserter appears on the sidebar navigation.