### PR TITLE
`WP_Theme_JSON_Gutenberg`: update comments to be aligned with core, so backports are easier

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2358,6 +2358,7 @@ class WP_Theme_JSON_Gutenberg {
 						} else {
 							$style_variation_declarations[ $combined_feature_selectors ] = $new_feature_declarations;
 						}
+
 						/*
 						 * Remove the feature from the variation's node now the
 						 * styles will be included under the feature level selector.
@@ -2369,6 +2370,7 @@ class WP_Theme_JSON_Gutenberg {
 				$style_variation_declarations[ $style_variation_selector ] = static::compute_style_properties( $style_variation_node, $settings, null, $this->theme_json );
 			}
 		}
+
 		/*
 		 * Get a reference to element name from path.
 		 * $block_metadata['path'] = array( 'styles','elements','link' );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1700,10 +1700,12 @@ class WP_Theme_JSON_Gutenberg {
 	 * for the presets and adds them to the $declarations array
 	 * following the format:
 	 *
-	 *     array(
-	 *       'name'  => 'property_name',
-	 *       'value' => 'property_value,
-	 *     )
+	 * ```php
+	 * array(
+	 *   'name'  => 'property_name',
+	 *   'value' => 'property_value,
+	 * )
+	 * ```
 	 *
 	 * @since 5.8.0
 	 * @since 5.9.0 Added the `$origins` parameter.
@@ -1732,10 +1734,12 @@ class WP_Theme_JSON_Gutenberg {
 	 * for the custom values and adds them to the $declarations
 	 * array following the format:
 	 *
-	 *     array(
-	 *       'name'  => 'property_name',
-	 *       'value' => 'property_value,
-	 *     )
+	 * ```php
+	 * array(
+	 *   'name'  => 'property_name',
+	 *   'value' => 'property_value,
+	 * )
+	 * ```
 	 *
 	 * @since 5.8.0
 	 *
@@ -1819,10 +1823,12 @@ class WP_Theme_JSON_Gutenberg {
 	 * Given a styles array, it extracts the style properties
 	 * and adds them to the $declarations array following the format:
 	 *
-	 *     array(
-	 *       'name'  => 'property_name',
-	 *       'value' => 'property_value,
-	 *     )
+	 * ```php
+	 * array(
+	 *   'name'  => 'property_name',
+	 *   'value' => 'property_value,
+	 * )
+	 * ```
 	 *
 	 * @since 5.8.0
 	 * @since 5.9.0 Added the `$settings` and `$properties` parameters.


### PR DESCRIPTION
## What?

This PR updates the comments in the `WP_Theme_JSON_Gutenberg` class to be aligned with those of the corresponding core class.

## Why?

This way the backports are easier. This is also a preparation for other PRs that update other parts of the class.

## How?

Update the comments as per core's standards.

## Testing Instructions

No manual testing is necessary.
