### PR TITLE
Create a fallback navigation menu as one time operation on install and Theme switch

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -41,7 +41,6 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
-import { createBlock, getBlockType } from '@wordpress/blocks';
 import { close, Icon } from '@wordpress/icons';
 
 /**
@@ -307,71 +306,6 @@ function Navigation( {
 	// Consider this state as 'unsaved' and offer an uncontrolled version of inner blocks,
 	// that automatically saves the menu as an entity when changes are made to the inner blocks.
 	const hasUnsavedBlocks = hasUncontrolledInnerBlocks && ! isEntityAvailable;
-
-	useEffect( () => {
-		if (
-			ref ||
-			! hasResolvedNavigationMenus ||
-			isConvertingClassicMenu ||
-			fallbackNavigationMenus?.length > 0 ||
-			hasUnsavedBlocks
-		) {
-			return;
-		}
-
-		// If there's non fallback navigation menus and
-		// a classic menu with a `primary` location or slug,
-		// then create a new navigation menu based on it.
-		// Otherwise, use the most recently created classic menu.
-		if ( classicMenus?.length ) {
-			const primaryMenus = classicMenus.filter(
-				( classicMenu ) =>
-					classicMenu.locations.includes( 'primary' ) ||
-					classicMenu.slug === 'primary'
-			);
-
-			if ( primaryMenus.length ) {
-				convertClassicMenu(
-					primaryMenus[ 0 ].id,
-					primaryMenus[ 0 ].name,
-					'publish'
-				);
-			} else {
-				classicMenus.sort( ( a, b ) => {
-					return b.id - a.id;
-				} );
-				convertClassicMenu(
-					classicMenus[ 0 ].id,
-					classicMenus[ 0 ].name,
-					'publish'
-				);
-			}
-		} else {
-			// If there are no fallback navigation menus and no classic menus,
-			// then create a new navigation menu.
-
-			// Check that we have a page-list block type.
-			let defaultBlocks = [];
-			if ( getBlockType( 'core/page-list' ) ) {
-				defaultBlocks = [ createBlock( 'core/page-list' ) ];
-			}
-
-			createNavigationMenu(
-				'Navigation', // TODO - use the template slug in future
-				defaultBlocks,
-				'publish'
-			);
-		}
-	}, [
-		hasResolvedNavigationMenus,
-		hasUnsavedBlocks,
-		classicMenus,
-		convertClassicMenu,
-		createNavigationMenu,
-		fallbackNavigationMenus?.length,
-		isConvertingClassicMenu,
-		ref,
-	] );
 
 	const navRef = useRef();
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -436,11 +436,12 @@ function block_core_navigation_block_contains_core_navigation( $inner_blocks ) {
 }
 
 /**
- * Create and returns a navigation menu containing a page-list as a fallback.
+ * Create and returns a navigation menu containing default fallback content.
+ * (ideally a page-list).
  *
  * @return array the newly created navigation menu.
  */
-function block_core_navigation_get_default_pages_fallback() {
+function block_core_navigation_get_default_fallback() {
 	$registry = WP_Block_Type_Registry::get_instance();
 
 	// If `core/page-list` is not registered then use empty blocks.
@@ -486,7 +487,7 @@ function block_core_navigation_create_fallback() {
 
 	// If there are no navigation posts then default to a list of Pages.
 	if ( ! $navigation_post ) {
-		$navigation_post = block_core_navigation_get_default_pages_fallback();
+		$navigation_post = block_core_navigation_get_default_fallback();
 	}
 
 	return $navigation_post;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -484,6 +484,8 @@ function block_core_navigation_create_fallback() {
 	if ( ! $navigation_post ) {
 		$navigation_post = block_core_navigation_get_default_pages_fallback();
 	}
+
+	return $navigation_post;
 }
 
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -433,7 +433,7 @@ function block_core_navigation_block_contains_core_navigation( $inner_blocks ) {
 
 /**
  * Create and returns a navigation menu containing default fallback content.
- * (ideally a page-list).
+ * (a page-list if registered).
  *
  * @return array the newly created navigation menu.
  */

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -476,8 +476,9 @@ function block_core_navigation_get_default_fallback() {
  *
  * @return void
  */
-function block_core_navigation_create_fallback() {
+function block_core_navigation_create_and_get_fallback() {
 	$should_skip = apply_filters( 'block_core_navigation_skip_fallback', false );
+
 	if ( $should_skip ) {
 		return;
 	}
@@ -487,23 +488,29 @@ function block_core_navigation_create_fallback() {
 		return;
 	}
 
-	// Get the most recently published Navigation post.
-	$navigation_post = block_core_navigation_get_most_recently_published_navigation();
+	// Get the most recently published Navigation menu.
+	$navigation_menu = block_core_navigation_get_most_recently_published_navigation();
 
-	// If there are no navigation posts then try to find a classic menu
-	// and convert it into a block based navigation menu.
-	if ( ! $navigation_post ) {
-		$navigation_post = block_core_navigation_maybe_use_classic_menu_fallback();
+	if ( $navigation_menu ) {
+		return $navigation_menu;
+	}
+
+	// If there are no Navigation menus then try to find a Classic menu
+	// and convert it into a Navigation menu.
+
+	$navigation_menu = block_core_navigation_maybe_use_classic_menu_fallback();
+
+	if ( $navigation_menu ) {
+		return $navigation_menu;
 	}
 
 	// If there are no navigation posts then default to a list of Pages.
-	if ( ! $navigation_post ) {
-		$navigation_post = block_core_navigation_get_default_fallback();
-	}
+	return block_core_navigation_get_default_fallback();
+
 }
 // Run on switching Theme and when installing WP for the first time.
-add_action( 'switch_theme', 'block_core_navigation_create_fallback' );
-add_action( 'wp_install', 'block_core_navigation_create_fallback' );
+add_action( 'switch_theme', 'block_core_navigation_create_and_get_fallback' );
+add_action( 'wp_install', 'block_core_navigation_create_and_get_fallback' );
 
 
 /**

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -472,6 +472,11 @@ function block_core_navigation_create_fallback() {
 		return;
 	}
 
+	// Don't create a fallback if the theme is not a block theme.
+	if ( ! wp_is_block_theme() ) {
+		return;
+	}
+
 	// Get the most recently published Navigation post.
 	$navigation_post = block_core_navigation_get_most_recently_published_navigation();
 
@@ -488,6 +493,9 @@ function block_core_navigation_create_fallback() {
 
 	return $navigation_post;
 }
+// Run on switching Theme and when installing WP for the first time.
+add_action( 'switch_theme', 'block_core_navigation_create_fallback' );
+add_action( 'wp_install', 'block_core_navigation_create_fallback' );
 
 
 /**
@@ -572,8 +580,6 @@ function block_core_navigation_from_block_get_post_ids( $block ) {
  * @return string Returns the post content with the legacy widget added.
  */
 function render_block_core_navigation( $attributes, $content, $block ) {
-	// First things first, let's create the fallback.
-	block_core_navigation_create_fallback();
 
 	static $seen_menu_names = array();
 
@@ -920,5 +926,5 @@ function block_core_navigation_typographic_presets_backcompatibility( $parsed_bl
 
 add_filter( 'render_block_data', 'block_core_navigation_typographic_presets_backcompatibility' );
 
-// We apply this action on render_block_data, so that we generate a navigation in the dashboard.
-add_action( 'render_block_data', 'block_core_navigation_create_fallback' );
+
+

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -344,6 +344,7 @@ function block_core_navigation_maybe_use_classic_menu_fallback() {
 		return;
 	}
 
+
 	// Create a new navigation menu from the classic menu.
 	$wp_insert_post_result = wp_insert_post(
 		array(
@@ -355,6 +356,9 @@ function block_core_navigation_maybe_use_classic_menu_fallback() {
 		),
 		true // So that we can check whether the result is an error.
 	);
+
+
+
 
 	if ( is_wp_error( $wp_insert_post_result ) ) {
 		return;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -464,7 +464,17 @@ function block_core_navigation_get_default_fallback() {
 }
 
 /**
- * Creates the appropriate fallback to be used on the front of the site.
+ * Creates an appropriate fallback Navigation Menu (`wp_navigation` Post)
+ * to be used by the Navigation block.
+ *
+ * Behaviour:
+ * 1. If there is a Navigation menu already then use it.
+ * 2. If there is a Classic menu then convert it to a Navigation menu.
+ * 3. If there is no Navigation menu and no Classic menu then create a default menu.
+ *
+ * The fallback menu is only created if the theme is a block theme.
+ *
+ * @return void
  */
 function block_core_navigation_create_fallback() {
 	$should_skip = apply_filters( 'block_core_navigation_skip_fallback', false );
@@ -490,8 +500,6 @@ function block_core_navigation_create_fallback() {
 	if ( ! $navigation_post ) {
 		$navigation_post = block_core_navigation_get_default_fallback();
 	}
-
-	return $navigation_post;
 }
 // Run on switching Theme and when installing WP for the first time.
 add_action( 'switch_theme', 'block_core_navigation_create_fallback' );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -344,7 +344,6 @@ function block_core_navigation_maybe_use_classic_menu_fallback() {
 		return;
 	}
 
-
 	// Create a new navigation menu from the classic menu.
 	$wp_insert_post_result = wp_insert_post(
 		array(
@@ -356,9 +355,6 @@ function block_core_navigation_maybe_use_classic_menu_fallback() {
 		),
 		true // So that we can check whether the result is an error.
 	);
-
-
-
 
 	if ( is_wp_error( $wp_insert_post_result ) ) {
 		return;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -325,9 +325,10 @@ function block_core_navigation_get_classic_menu_fallback_blocks( $classic_nav_me
 }
 
 /**
- * If there's a the classic menu then use it as a fallback.
+ * Checks for a Classic Menu and attempts to convert into a block-based
+ * Navigation menu.
  *
- * @return array the normalized parsed blocks.
+ * @return int|WP_Error The Navigation menu post ID on success. A WP_Error on failure.
  */
 function block_core_navigation_create_classic_menu_fallback() {
 	// See if we have a Classic menu.
@@ -360,9 +361,7 @@ function block_core_navigation_create_classic_menu_fallback() {
 		$return_errors // So that we can check whether the result is an error.
 	);
 
-
 	return $wp_insert_post_result;
-
 }
 
 /**
@@ -433,10 +432,10 @@ function block_core_navigation_block_contains_core_navigation( $inner_blocks ) {
 }
 
 /**
- * Create and returns a navigation menu containing default fallback content.
+ * Creates a navigation menu containing default fallback content.
  * (a page-list if registered).
  *
- * @return array the newly created navigation menu.
+ * @return int|WP_Error The post ID on success. A WP_Error on failure.
  */
 function block_core_navigation_create_default_fallback() {
 	$registry = WP_Block_Type_Registry::get_instance();
@@ -485,19 +484,19 @@ function block_core_navigation_create_fallback() {
 	}
 
 	// Get the most recently published Navigation menu.
-	$navigation_menu = block_core_navigation_get_most_recently_published_navigation();
+	$existing_navigation_menu = block_core_navigation_get_most_recently_published_navigation();
 
 	// If there is already a Navigation menu then exit.
-	if ( $navigation_menu ) {
+	if ( $existing_navigation_menu ) {
 		return;
 	}
 
 	// If there are no Navigation menus then try to find a Classic menu
 	// and attempt to convert it into a Navigation menu.
-	$navigation_menu = block_core_navigation_create_classic_menu_fallback();
+	$converted_classic_menu_id = block_core_navigation_create_classic_menu_fallback();
 
 	// If the conversion + creation was successful then exit.
-	if ( ! is_wp_error( $navigation_menu ) ) {
+	if ( ! is_wp_error( $converted_classic_menu_id ) ) {
 		return;
 	}
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -463,15 +463,14 @@ function block_core_navigation_get_default_pages_fallback() {
 }
 
 /**
- * Retrieves the appropriate fallback to be used on the front of the
- * site when there is no menu assigned to the Nav block.
- *
- * This aims to mirror how the fallback mechanic for wp_nav_menu works.
- * See https://developer.wordpress.org/reference/functions/wp_nav_menu/#more-information.
- *
- * @return array the array of blocks to be used as a fallback.
+ * Creates the appropriate fallback to be used on the front of the site.
  */
-function block_core_navigation_get_fallback_blocks() {
+function block_core_navigation_create_fallback() {
+	$should_skip = apply_filters( 'block_core_navigation_skip_fallback', false );
+	if ( $should_skip ) {
+		return;
+	}
+
 	// Get the most recently published Navigation post.
 	$navigation_post = block_core_navigation_get_most_recently_published_navigation();
 
@@ -485,6 +484,21 @@ function block_core_navigation_get_fallback_blocks() {
 	if ( ! $navigation_post ) {
 		$navigation_post = block_core_navigation_get_default_pages_fallback();
 	}
+}
+
+
+/**
+ * Retrieves the appropriate fallback to be used on the front of the
+ * site when there is no menu assigned to the Nav block.
+ *
+ * This aims to mirror how the fallback mechanic for wp_nav_menu works.
+ * See https://developer.wordpress.org/reference/functions/wp_nav_menu/#more-information.
+ *
+ * @return array the array of blocks to be used as a fallback.
+ */
+function block_core_navigation_get_fallback_blocks() {
+	// Get the most recently published Navigation post.
+	$navigation_post = block_core_navigation_get_most_recently_published_navigation();
 
 	// Use the first non-empty Navigation as fallback, there should always be one.
 	if ( $navigation_post ) {
@@ -899,3 +913,7 @@ function block_core_navigation_typographic_presets_backcompatibility( $parsed_bl
 }
 
 add_filter( 'render_block_data', 'block_core_navigation_typographic_presets_backcompatibility' );
+
+// We have to aply this action on both init and admin init, as the code loads after init when in wp-admin.
+add_action( 'init', 'block_core_navigation_create_fallback' );
+add_action( 'admin_init', 'block_core_navigation_create_fallback' );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -572,6 +572,9 @@ function block_core_navigation_from_block_get_post_ids( $block ) {
  * @return string Returns the post content with the legacy widget added.
  */
 function render_block_core_navigation( $attributes, $content, $block ) {
+	// First things first, let's create the fallback.
+	block_core_navigation_create_fallback();
+
 	static $seen_menu_names = array();
 
 	// Flag used to indicate whether the rendered output is considered to be
@@ -917,6 +920,5 @@ function block_core_navigation_typographic_presets_backcompatibility( $parsed_bl
 
 add_filter( 'render_block_data', 'block_core_navigation_typographic_presets_backcompatibility' );
 
-// We have to aply this action on both init and admin init, as the code loads after init when in wp-admin.
-add_action( 'init', 'block_core_navigation_create_fallback' );
-add_action( 'admin_init', 'block_core_navigation_create_fallback' );
+// We apply this action on render_block_data, so that we generate a navigation in the dashboard.
+add_action( 'render_block_data', 'block_core_navigation_create_fallback' );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -580,7 +580,6 @@ function block_core_navigation_from_block_get_post_ids( $block ) {
  * @return string Returns the post content with the legacy widget added.
  */
 function render_block_core_navigation( $attributes, $content, $block ) {
-
 	static $seen_menu_names = array();
 
 	// Flag used to indicate whether the rendered output is considered to be
@@ -925,6 +924,3 @@ function block_core_navigation_typographic_presets_backcompatibility( $parsed_bl
 }
 
 add_filter( 'render_block_data', 'block_core_navigation_typographic_presets_backcompatibility' );
-
-
-

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -476,7 +476,7 @@ function block_core_navigation_get_default_fallback() {
  *
  * @return void
  */
-function block_core_navigation_create_and_get_fallback() {
+function block_core_navigation_create_fallback() {
 	$should_skip = apply_filters( 'block_core_navigation_skip_fallback', false );
 
 	if ( $should_skip ) {
@@ -492,7 +492,7 @@ function block_core_navigation_create_and_get_fallback() {
 	$navigation_menu = block_core_navigation_get_most_recently_published_navigation();
 
 	if ( $navigation_menu ) {
-		return $navigation_menu;
+		return;
 	}
 
 	// If there are no Navigation menus then try to find a Classic menu
@@ -501,16 +501,15 @@ function block_core_navigation_create_and_get_fallback() {
 	$navigation_menu = block_core_navigation_maybe_use_classic_menu_fallback();
 
 	if ( $navigation_menu ) {
-		return $navigation_menu;
+		return;
 	}
 
 	// If there are no navigation posts then default to a list of Pages.
-	return block_core_navigation_get_default_fallback();
-
+	block_core_navigation_get_default_fallback();
 }
 // Run on switching Theme and when installing WP for the first time.
-add_action( 'switch_theme', 'block_core_navigation_create_and_get_fallback' );
-add_action( 'wp_install', 'block_core_navigation_create_and_get_fallback' );
+add_action( 'switch_theme', 'block_core_navigation_create_fallback' );
+add_action( 'wp_install', 'block_core_navigation_create_fallback' );
 
 
 /**

--- a/phpunit/class-block-library-navigation-fallbacks-test.php
+++ b/phpunit/class-block-library-navigation-fallbacks-test.php
@@ -231,7 +231,7 @@ class Block_Library_Navigation_Fallbacks_Test extends WP_UnitTestCase {
 	public function test_should_skip_if_filter_returns_truthy() {
 		add_filter( 'block_core_navigation_skip_fallback', '__return_true' );
 
-		$actual = gutenberg_block_core_navigation_create_fallback();
+		gutenberg_block_core_navigation_create_fallback();
 
 		$navs_in_db = $this->get_navigations_in_database();
 		$this->assertCount( 0, $navs_in_db, 'No Navigation Menus should have been created.' );

--- a/phpunit/class-block-library-navigation-fallbacks-test.php
+++ b/phpunit/class-block-library-navigation-fallbacks-test.php
@@ -12,7 +12,7 @@ class Block_Library_Navigation_Fallbacks_Test extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 		// Navigation menu will be created on Theme switch. Therefore in order to test
-		// the behaviour of `gutenberg_block_core_navigation_create_and_get_fallback`
+		// the behaviour of `gutenberg_block_core_navigation_create_fallback`
 		// the auto-creation of a fallback must be disabled for this initial
 		// theme switch.
 		add_filter( 'block_core_navigation_skip_fallback', '__return_true' );
@@ -131,7 +131,9 @@ class Block_Library_Navigation_Fallbacks_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$fallback = gutenberg_block_core_navigation_create_and_get_fallback();
+		gutenberg_block_core_navigation_create_fallback();
+
+		$fallback = $this->get_navigations_in_database()[0];
 
 		$this->assertEquals( $fallback->post_title, $most_recently_published_nav->post_title, 'The title of the fallback Navigation Menu should match the title of the most recently published Navigation Menu.' );
 		$this->assertEquals( $fallback->post_type, $most_recently_published_nav->post_type, 'The post type of the fallback Navigation Menu should match the post type of the most recently published Navigation Menu.' );
@@ -159,7 +161,9 @@ class Block_Library_Navigation_Fallbacks_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$fallback = gutenberg_block_core_navigation_create_and_get_fallback();
+		gutenberg_block_core_navigation_create_fallback();
+
+		$fallback = $this->get_navigations_in_database()[0];
 
 		$this->assertEquals( 'Existing Classic Menu', $fallback->post_title, 'The title of the fallback Navigation Menu should match the name of the Classic menu.' );
 
@@ -183,7 +187,9 @@ class Block_Library_Navigation_Fallbacks_Test extends WP_UnitTestCase {
 	 * @covers ::block_core_navigation_create_fallback
 	 */
 	public function test_creates_fallback_navigation_with_page_list_by_default() {
-		$fallback = gutenberg_block_core_navigation_create_and_get_fallback();
+		gutenberg_block_core_navigation_create_fallback();
+
+		$fallback = $this->get_navigations_in_database()[0];
 
 		$this->assertEquals( 'wp_navigation', $fallback->post_type, 'The fallback Navigation Menu should be of the expected Post type.' );
 		$this->assertEquals( 'Navigation', $fallback->post_title, 'The fallback Navigation Menu should be have the expected title.' );
@@ -211,7 +217,9 @@ class Block_Library_Navigation_Fallbacks_Test extends WP_UnitTestCase {
 		// Also create a Classic Menu - this should be ignored.
 		$menu_id = wp_create_nav_menu( 'Existing Classic Menu' );
 
-		$fallback = gutenberg_block_core_navigation_create_and_get_fallback();
+		gutenberg_block_core_navigation_create_fallback();
+
+		$fallback = $this->get_navigations_in_database()[0];
 
 		$this->assertEquals( $fallback->post_title, $navigation_post->post_title, 'The title of the fallback Navigation Menu should match that of the existing Navigation Menu.' );
 		$this->assertEquals( $fallback->post_type, $navigation_post->post_type, 'The post type of the fallback Navigation Menu should match that of the existing Navigation Menu.' );
@@ -231,7 +239,7 @@ class Block_Library_Navigation_Fallbacks_Test extends WP_UnitTestCase {
 	public function test_should_skip_if_filter_returns_truthy() {
 		add_filter( 'block_core_navigation_skip_fallback', '__return_true' );
 
-		gutenberg_block_core_navigation_create_and_get_fallback();
+		gutenberg_block_core_navigation_create_fallback();
 
 		$navs_in_db = $this->get_navigations_in_database();
 		$this->assertCount( 0, $navs_in_db, 'No Navigation Menus should have been created.' );

--- a/phpunit/class-block-library-navigation-fallbacks-test.php
+++ b/phpunit/class-block-library-navigation-fallbacks-test.php
@@ -246,8 +246,7 @@ class Block_Library_Navigation_Fallbacks_Test extends WP_UnitTestCase {
 	public function test_should_get_fallback_blocks_when_no_navigations_exist() {
 		$fallback_blocks = gutenberg_block_core_navigation_get_fallback_blocks();
 
-		$this->assertIsArray( $fallback_blocks, 'Fallback blocks should be an array.' );
-		$this->assertEmpty( $fallback_blocks, 'Fallback blocks should be empty.' );
+		$this->assertSame( array(), $fallback_blocks, 'Fallback blocks should be an empty array.' );
 	}
 
 	/**

--- a/phpunit/class-block-library-navigation-fallbacks-test.php
+++ b/phpunit/class-block-library-navigation-fallbacks-test.php
@@ -4,9 +4,10 @@
  *
  * @package    Gutenberg
  * @subpackage block-library
+ * @group     Navigation block
  */
 
-class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
+class Block_Library_Navigation_Fallbacks_Test extends WP_UnitTestCase {
 
 	public function set_up() {
 		parent::set_up();

--- a/phpunit/class-block-library-navigation-fallbacks-test.php
+++ b/phpunit/class-block-library-navigation-fallbacks-test.php
@@ -12,7 +12,7 @@ class Block_Library_Navigation_Fallbacks_Test extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 		// Navigation menu will be created on Theme switch. Therefore in order to test
-		// the behaviour of `gutenberg_block_core_navigation_create_fallback`
+		// the behaviour of `gutenberg_block_core_navigation_create_and_get_fallback`
 		// the auto-creation of a fallback must be disabled for this initial
 		// theme switch.
 		add_filter( 'block_core_navigation_skip_fallback', '__return_true' );
@@ -131,7 +131,7 @@ class Block_Library_Navigation_Fallbacks_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$fallback = gutenberg_block_core_navigation_create_fallback();
+		$fallback = gutenberg_block_core_navigation_create_and_get_fallback();
 
 		$this->assertEquals( $fallback->post_title, $most_recently_published_nav->post_title, 'The title of the fallback Navigation Menu should match the title of the most recently published Navigation Menu.' );
 		$this->assertEquals( $fallback->post_type, $most_recently_published_nav->post_type, 'The post type of the fallback Navigation Menu should match the post type of the most recently published Navigation Menu.' );
@@ -159,7 +159,7 @@ class Block_Library_Navigation_Fallbacks_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$fallback = gutenberg_block_core_navigation_create_fallback();
+		$fallback = gutenberg_block_core_navigation_create_and_get_fallback();
 
 		$this->assertEquals( 'Existing Classic Menu', $fallback->post_title, 'The title of the fallback Navigation Menu should match the name of the Classic menu.' );
 
@@ -183,7 +183,7 @@ class Block_Library_Navigation_Fallbacks_Test extends WP_UnitTestCase {
 	 * @covers ::block_core_navigation_create_fallback
 	 */
 	public function test_creates_fallback_navigation_with_page_list_by_default() {
-		$fallback = gutenberg_block_core_navigation_create_fallback();
+		$fallback = gutenberg_block_core_navigation_create_and_get_fallback();
 
 		$this->assertEquals( 'wp_navigation', $fallback->post_type, 'The fallback Navigation Menu should be of the expected Post type.' );
 		$this->assertEquals( 'Navigation', $fallback->post_title, 'The fallback Navigation Menu should be have the expected title.' );
@@ -211,7 +211,7 @@ class Block_Library_Navigation_Fallbacks_Test extends WP_UnitTestCase {
 		// Also create a Classic Menu - this should be ignored.
 		$menu_id = wp_create_nav_menu( 'Existing Classic Menu' );
 
-		$fallback = gutenberg_block_core_navigation_create_fallback();
+		$fallback = gutenberg_block_core_navigation_create_and_get_fallback();
 
 		$this->assertEquals( $fallback->post_title, $navigation_post->post_title, 'The title of the fallback Navigation Menu should match that of the existing Navigation Menu.' );
 		$this->assertEquals( $fallback->post_type, $navigation_post->post_type, 'The post type of the fallback Navigation Menu should match that of the existing Navigation Menu.' );
@@ -231,7 +231,7 @@ class Block_Library_Navigation_Fallbacks_Test extends WP_UnitTestCase {
 	public function test_should_skip_if_filter_returns_truthy() {
 		add_filter( 'block_core_navigation_skip_fallback', '__return_true' );
 
-		gutenberg_block_core_navigation_create_fallback();
+		gutenberg_block_core_navigation_create_and_get_fallback();
 
 		$navs_in_db = $this->get_navigations_in_database();
 		$this->assertCount( 0, $navs_in_db, 'No Navigation Menus should have been created.' );

--- a/phpunit/navigation-block-fallback-test.php
+++ b/phpunit/navigation-block-fallback-test.php
@@ -36,6 +36,9 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		// Remove any existing disabling filters.
 		remove_filter( 'block_core_navigation_skip_fallback', '__return_true' );
 
+		$navs_in_db = $this->get_navigations_in_database();
+		$this->assertCount( 0, $navs_in_db );
+
 		// Should trigger creation of Navigation Menu if one does not already exist.
 		switch_theme( 'emptytheme' );
 
@@ -45,6 +48,7 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 
 	public function test_should_not_auto_create_navigation_menu_on_theme_switch_if_one_already_exists() {
 
+		// Pre-add a Navigation Menu to simulate when a user already has a menu.
 		self::factory()->post->create_and_get(
 			array(
 				'post_type'    => 'wp_navigation',

--- a/phpunit/navigation-block-fallback-test.php
+++ b/phpunit/navigation-block-fallback-test.php
@@ -9,7 +9,13 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 
 	public function set_up() {
 		parent::set_up();
+		// Navigation menu will be created on Theme switch. Therefore in order to test
+		// the behaviour of `gutenberg_block_core_navigation_create_fallback`
+		// the auto-creation of a fallback must be disabled for this initial
+		// theme switch.
+		add_filter( 'block_core_navigation_skip_fallback', '__return_true' );
 		switch_theme( 'emptytheme' );
+		remove_filter( 'block_core_navigation_skip_fallback', '__return_true' );
 	}
 
 	public function get_navigations_in_database() {

--- a/phpunit/navigation-block-fallback-test.php
+++ b/phpunit/navigation-block-fallback-test.php
@@ -44,7 +44,7 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		$this->mock_wp_install();
 
 		$navs_in_db = $this->get_navigations_in_database();
-		$this->assertCount( 1, $navs_in_db );
+		$this->assertCount( 1, $navs_in_db, 'No Navigation Menu was found.' );
 	}
 
 	public function test_should_auto_create_navigation_menu_on_theme_switch() {
@@ -52,7 +52,7 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		remove_filter( 'block_core_navigation_skip_fallback', '__return_true' );
 
 		$navs_in_db = $this->get_navigations_in_database();
-		$this->assertCount( 0, $navs_in_db, 'Navigation Menu should not exist before running the tests.' );
+		$this->assertCount( 0, $navs_in_db, 'Navigation Menu should not exist before switching Theme.' );
 
 		// Should trigger creation of Navigation Menu if one does not already exist.
 		switch_theme( 'emptytheme' );
@@ -64,13 +64,13 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 	public function test_should_not_auto_create_navigation_menu_on_theme_switch_to_classic_theme() {
 
 		$navs_in_db = $this->get_navigations_in_database();
-		$this->assertCount( 0, $navs_in_db );
+		$this->assertCount( 0, $navs_in_db, 'Navigation Menu should not exist before switching Theme.' );
 
 		// Should trigger creation of Navigation Menu if one does not already exist.
 		switch_theme( 'twentytwenty' );
 
 		$navs_in_db = $this->get_navigations_in_database();
-		$this->assertCount( 0, $navs_in_db );
+		$this->assertCount( 0, $navs_in_db, 'A Navigation Menu should not exist.' );
 	}
 
 	public function test_should_not_auto_create_navigation_menu_on_theme_switch_if_one_already_exists() {
@@ -93,10 +93,10 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		$navs_in_db = $this->get_navigations_in_database();
 
 		// There should still only be one Navigation Menu.
-		$this->assertCount( 1, $navs_in_db );
+		$this->assertCount( 1, $navs_in_db, 'A single Navigation Menu should exist.' );
 
 		// The existing Navigation Menu should be unchanged.
-		$this->assertEquals( 'Existing Navigation Menu', $navs_in_db[0]->post_title );
+		$this->assertEquals( 'Existing Navigation Menu', $navs_in_db[0]->post_title, 'The title of the Navigation Menu should match the existing Navigation Menu' );
 	}
 
 	public function test_gets_fallback_navigation_with_existing_navigation_menu_if_found() {
@@ -119,13 +119,13 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 
 		$fallback = gutenberg_block_core_navigation_create_fallback();
 
-		$this->assertEquals( $fallback->post_title, $most_recently_published_nav->post_title );
-		$this->assertEquals( $fallback->post_type, $most_recently_published_nav->post_type );
-		$this->assertEquals( $fallback->post_content, $most_recently_published_nav->post_content );
-		$this->assertEquals( $fallback->post_status, $most_recently_published_nav->post_status );
+		$this->assertEquals( $fallback->post_title, $most_recently_published_nav->post_title, 'The title of the fallback Navigation Menu should match the title of the most recently published Navigation Menu.' );
+		$this->assertEquals( $fallback->post_type, $most_recently_published_nav->post_type, 'The post type of the fallback Navigation Menu should match the post type of the most recently published Navigation Menu.' );
+		$this->assertEquals( $fallback->post_content, $most_recently_published_nav->post_content, 'The contents of the fallback Navigation Menu should match the contents of the most recently published Navigation Menu.' );
+		$this->assertEquals( $fallback->post_status, $most_recently_published_nav->post_status, 'The status of the fallback Navigation Menu should match the status of the most recently published Navigation Menu.' );
 
 		$navs_in_db = $this->get_navigations_in_database();
-		$this->assertCount( 2, $navs_in_db );
+		$this->assertCount( 2, $navs_in_db, '2 Navigation Menus should exist.' );
 	}
 
 	public function test_gets_fallback_navigation_with_existing_classic_menu_if_found() {
@@ -144,21 +144,19 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 
 		$fallback = gutenberg_block_core_navigation_create_fallback();
 
-		$this->assertEquals( 'Existing Classic Menu', $fallback->post_title );
-		$this->assertEquals( 'wp_navigation', $fallback->post_type );
-		$this->assertEquals( 'publish', $fallback->post_status );
+		$this->assertEquals( 'Existing Classic Menu', $fallback->post_title, 'The title of the fallback Navigation Menu should match the name of the Classic menu.' );
 
 		// Assert that the fallback contains a navigation-link block.
-		$this->assertStringContainsString( '<!-- wp:navigation-link', $fallback->post_content );
+		$this->assertStringContainsString( '<!-- wp:navigation-link', $fallback->post_content, 'The fallback Navigation Menu should contain a `core/navigation-link` block.' );
 
 		// Assert that fallback post_content contains the expected menu item title.
-		$this->assertStringContainsString( '"label":"Classic Menu Item 1"', $fallback->post_content );
+		$this->assertStringContainsString( '"label":"Classic Menu Item 1"', $fallback->post_content, 'The fallback Navigation Menu should contain menu item with a label matching the title of the menu item from the Classic Menu.' );
 
 		// Assert that fallback post_content contains the expected menu item url.
-		$this->assertStringContainsString( '"url":"/classic-menu-item-1"', $fallback->post_content );
+		$this->assertStringContainsString( '"url":"/classic-menu-item-1"', $fallback->post_content, 'The fallback Navigation Menu should contain menu item with a url matching the slug of the menu item from the Classic Menu.' );
 
 		$navs_in_db = $this->get_navigations_in_database();
-		$this->assertCount( 1, $navs_in_db );
+		$this->assertCount( 1, $navs_in_db, 'A single Navigation Menu should exist.' );
 
 		// Cleanup.
 		wp_delete_nav_menu( $menu_id );
@@ -167,13 +165,13 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 	public function test_creates_fallback_navigation_with_page_list_by_default() {
 		$fallback = gutenberg_block_core_navigation_create_fallback();
 
-		$this->assertEquals( 'wp_navigation', $fallback->post_type );
-		$this->assertEquals( 'Navigation', $fallback->post_title );
-		$this->assertEquals( '<!-- wp:page-list /-->', $fallback->post_content );
-		$this->assertEquals( 'publish', $fallback->post_status );
+		$this->assertEquals( 'wp_navigation', $fallback->post_type, 'The fallback Navigation Menu should be of the expected Post type.' );
+		$this->assertEquals( 'Navigation', $fallback->post_title, 'The fallback Navigation Menu should be have the expected title.' );
+		$this->assertEquals( '<!-- wp:page-list /-->', $fallback->post_content, 'The fallback Navigation Menu should contain a Page List block.' );
+		$this->assertEquals( 'publish', $fallback->post_status, 'The fallback Navigation Menu should be published.' );
 
 		$navs_in_db = $this->get_navigations_in_database();
-		$this->assertCount( 1, $navs_in_db );
+		$this->assertCount( 1, $navs_in_db, 'A single Navigation Menu should exist.' );
 	}
 
 	public function test_creates_fallback_from_existing_navigation_menu_even_if_classic_menu_exists() {
@@ -192,13 +190,13 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 
 		$fallback = gutenberg_block_core_navigation_create_fallback();
 
-		$this->assertEquals( $fallback->post_title, $navigation_post->post_title );
-		$this->assertEquals( $fallback->post_type, $navigation_post->post_type );
-		$this->assertEquals( $fallback->post_content, $navigation_post->post_content );
-		$this->assertEquals( $fallback->post_status, $navigation_post->post_status );
+		$this->assertEquals( $fallback->post_title, $navigation_post->post_title, 'The title of the fallback Navigation Menu should match that of the existing Navigation Menu.' );
+		$this->assertEquals( $fallback->post_type, $navigation_post->post_type, 'The post type of the fallback Navigation Menu should match that of the existing Navigation Menu.' );
+		$this->assertEquals( $fallback->post_content, $navigation_post->post_content, 'The contents of the fallback Navigation Menu should match that of the existing Navigation Menu.' );
+		$this->assertEquals( $fallback->post_status, $navigation_post->post_status, 'The status of the fallback Navigation Menu should match that of the existing Navigation Menu.' );
 
 		$navs_in_db = $this->get_navigations_in_database();
-		$this->assertCount( 1, $navs_in_db );
+		$this->assertCount( 1, $navs_in_db, 'A single Navigation Menu should exist.' );
 
 		// Cleanup.
 		wp_delete_nav_menu( $menu_id );
@@ -209,11 +207,8 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 
 		$actual = gutenberg_block_core_navigation_create_fallback();
 
-		// Assert no fallback is created.
-		$this->assertEquals( $actual, null );
-
 		$navs_in_db = $this->get_navigations_in_database();
-		$this->assertCount( 0, $navs_in_db );
+		$this->assertCount( 0, $navs_in_db, 'No Navigation Menus should have been created.' );
 
 		remove_filter( 'block_core_navigation_skip_fallback', '__return_true' );
 	}
@@ -221,8 +216,8 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 	public function test_should_return_empty_fallback_blocks_when_no_navigations_exist() {
 		$fallback_blocks = gutenberg_block_core_navigation_get_fallback_blocks();
 
-		$this->assertIsArray( $fallback_blocks );
-		$this->assertEmpty( $fallback_blocks );
+		$this->assertIsArray( $fallback_blocks, 'Fallback blocks should be an array.' );
+		$this->assertEmpty( $fallback_blocks, 'Fallback blocks should be empty.' );
 	}
 
 	public function test_should_return_blocks_from_most_recently_created_navigation() {
@@ -250,9 +245,9 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		$block = $fallback_blocks[0];
 
 		// Check blocks match most recently Navigation Post data.
-		$this->assertEquals( $block['blockName'], 'core/navigation-link' );
-		$this->assertEquals( $block['attrs']['label'], 'Hello world' );
-		$this->assertEquals( $block['attrs']['url'], '/hello-world' );
+		$this->assertEquals( $block['blockName'], 'core/navigation-link', '1st fallback block should match expected type.' );
+		$this->assertEquals( $block['attrs']['label'], 'Hello world', '1st fallback block\'s label should match.' );
+		$this->assertEquals( $block['attrs']['url'], '/hello-world', '1st fallback block\'s url should match.' );
 
 	}
 
@@ -268,8 +263,8 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 
 		$fallback_blocks = gutenberg_block_core_navigation_get_fallback_blocks();
 
-		$this->assertIsArray( $fallback_blocks );
-		$this->assertEmpty( $fallback_blocks );
+		$this->assertIsArray( $fallback_blocks, 'Fallback blocks should be an array.' );
+		$this->assertEmpty( $fallback_blocks, 'Fallback blocks should be empty.' );
 	}
 
 	public function test_should_filter_out_empty_blocks_from_fallbacks() {
@@ -288,8 +283,8 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		$first_block = $fallback_blocks[0];
 
 		// There should only be a single page list block and no "null" blocks.
-		$this->assertCount( 1, $fallback_blocks );
-		$this->assertEquals( $first_block['blockName'], 'core/page-list' );
+		$this->assertCount( 1, $fallback_blocks, 'Fallback blocks should contain a single block.' );
+		$this->assertEquals( $first_block['blockName'], 'core/page-list', 'Fallback block should be a page list.' );
 
 		// Check that no "empty" blocks exist with a blockName of 'null'.
 		// If the block parser encounters whitespace it will return a block with a blockName of null.
@@ -300,7 +295,7 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 				return null === $block['blockName'];
 			}
 		);
-		$this->assertEmpty( $null_blocks );
+		$this->assertEmpty( $null_blocks, 'Fallback blocks should not contain any null blocks.' );
 	}
 
 	public function test_should_return_filtered_blocks_fallback_is_filtered() {
@@ -324,7 +319,7 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		$block = $fallback_blocks[0];
 
 		// Check blocks match most recently Navigation Post data.
-		$this->assertEquals( $block['blockName'], 'core/site-logo' );
+		$this->assertEquals( $block['blockName'], 'core/site-logo', '1st fallback block should match expected type.' );
 
 		remove_filter( 'block_core_navigation_render_fallback', 'use_site_logo' );
 	}

--- a/phpunit/navigation-block-fallback-test.php
+++ b/phpunit/navigation-block-fallback-test.php
@@ -28,7 +28,7 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 
 	public function test_gets_fallback_navigation_with_existing_navigation_menu_if_found() {
 
-		$navigation_post_1 = self::factory()->post->create_and_get(
+		self::factory()->post->create_and_get(
 			array(
 				'post_type'    => 'wp_navigation',
 				'post_title'   => 'Existing Navigation Menu 1',
@@ -36,15 +36,13 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 			)
 		);
 
-		$navigation_post_2 = self::factory()->post->create_and_get(
+		$most_recently_published_nav = self::factory()->post->create_and_get(
 			array(
 				'post_type'    => 'wp_navigation',
 				'post_title'   => 'Existing Navigation Menu 2',
 				'post_content' => '<!-- wp:navigation-link {"label":"Hello world","type":"post","id":1,"url":"/hello-world","kind":"post-type"} /-->',
 			)
 		);
-
-		$most_recently_published_nav = $navigation_post_2;
 
 		$fallback = gutenberg_block_core_navigation_create_fallback();
 
@@ -107,7 +105,7 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 
 	public function test_creates_fallback_from_existing_navigation_menu_even_if_classic_menu_exists() {
 
-		// Create a Navigation Post
+		// Create a Navigation Post.
 		$navigation_post = self::factory()->post->create_and_get(
 			array(
 				'post_type'    => 'wp_navigation',
@@ -156,7 +154,7 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 
 	public function test_should_return_blocks_from_most_recently_created_navigation() {
 
-		$navigation_post_1 = self::factory()->post->create_and_get(
+		self::factory()->post->create_and_get(
 			array(
 				'post_type'    => 'wp_navigation',
 				'post_title'   => 'Existing Navigation Menu 1',
@@ -164,15 +162,13 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 			)
 		);
 
-		$navigation_post_2 = self::factory()->post->create_and_get(
+		$most_recently_published_nav = self::factory()->post->create_and_get(
 			array(
 				'post_type'    => 'wp_navigation',
 				'post_title'   => 'Existing Navigation Menu 2',
 				'post_content' => '<!-- wp:navigation-link {"label":"Hello world","type":"post","id":1,"url":"/hello-world","kind":"post-type"} /-->',
 			)
 		);
-
-		$most_recently_published_nav = $navigation_post_2;
 
 		$fallback_blocks = gutenberg_block_core_navigation_get_fallback_blocks();
 
@@ -187,7 +183,7 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 
 	public function test_should_return_empty_array_if_most_recently_created_navigation_is_empty() {
 
-		$navigation_post_2 = self::factory()->post->create_and_get(
+		self::factory()->post->create_and_get(
 			array(
 				'post_type'    => 'wp_navigation',
 				'post_title'   => 'Existing Navigation Menu',
@@ -239,7 +235,7 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 
 		add_filter( 'block_core_navigation_render_fallback', 'use_site_logo' );
 
-		$navigation_post_2 = self::factory()->post->create_and_get(
+		self::factory()->post->create_and_get(
 			array(
 				'post_type'    => 'wp_navigation',
 				'post_title'   => 'Existing Navigation Menu',

--- a/phpunit/navigation-block-fallback-test.php
+++ b/phpunit/navigation-block-fallback-test.php
@@ -40,7 +40,7 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 			array(
 				'post_type'    => 'wp_navigation',
 				'post_title'   => 'Existing Navigation Menu 2',
-				'post_content' => '<!-- wp:page-list /-->',
+				'post_content' => '<!-- wp:navigation-link {"label":"Hello world","type":"post","id":1,"url":"/hello-world","kind":"post-type"} /-->',
 			)
 		);
 

--- a/phpunit/navigation-block-fallback-test.php
+++ b/phpunit/navigation-block-fallback-test.php
@@ -58,6 +58,18 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		$this->assertCount( 1, $navs_in_db );
 	}
 
+	public function test_should_not_auto_create_navigation_menu_on_theme_switch_to_classic_theme() {
+
+		$navs_in_db = $this->get_navigations_in_database();
+		$this->assertCount( 0, $navs_in_db );
+
+		// Should trigger creation of Navigation Menu if one does not already exist.
+		switch_theme( 'twentytwenty' );
+
+		$navs_in_db = $this->get_navigations_in_database();
+		$this->assertCount( 0, $navs_in_db );
+	}
+
 	public function test_should_not_auto_create_navigation_menu_on_theme_switch_if_one_already_exists() {
 
 		// Pre-add a Navigation Menu to simulate when a user already has a menu.

--- a/phpunit/navigation-block-fallback-test.php
+++ b/phpunit/navigation-block-fallback-test.php
@@ -6,6 +6,15 @@
  */
 
 class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
+
+	/**
+	 * @var WP_Post
+	 */
+	protected static $navigation_post;
+
+
+
+
 	public function set_up() {
 		parent::set_up();
 		switch_theme( 'emptytheme' );
@@ -16,10 +25,12 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 	}
 
 	public static function wpTearDownAfterClass() {
-
+		if ( ! empty( self::$post_with_comments_disabled->ID ) ) {
+			wp_delete_post( self::$navigation_post->ID, true );
+		}
 	}
 
-	public function test_creates_fallback_with_page_list_by_default() {
+	public function test_creates_fallback_navigation_with_page_list_by_default() {
 		$fallback = gutenberg_block_core_navigation_create_fallback();
 
 		$this->assertEquals( $fallback->post_type, 'wp_navigation' );
@@ -28,11 +39,63 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		$this->assertEquals( $fallback->post_status, 'publish' );
 	}
 
-	public function test_skip_if_filter_returns_truthy() {
+	public function test_gets_fallback_navigation_with_existing_navigation_menu_if_found() {
+
+		self::$navigation_post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'wp_navigation',
+				'post_title'   => 'Existing Navigation Menu',
+				'post_content' => '<!-- wp:page-list /-->',
+			)
+		);
+
+		$fallback = gutenberg_block_core_navigation_create_fallback();
+
+		$this->assertEquals( $fallback->post_title, self::$navigation_post->post_title );
+		$this->assertEquals( $fallback->post_type, self::$navigation_post->post_type );
+		$this->assertEquals( $fallback->post_content, self::$navigation_post->post_content );
+		$this->assertEquals( $fallback->post_status, self::$navigation_post->post_status );
+	}
+
+	public function test_gets_fallback_navigation_with_existing_classic_menu_if_found() {
+
+		$menu_id = wp_create_nav_menu( 'Existing Classic Menu' );
+
+		wp_update_nav_menu_item(
+			$menu_id,
+			0,
+			array(
+				'menu-item-title'  => 'Classic Menu Item 1',
+				'menu-item-url'    => '/classic-menu-item-1',
+				'menu-item-status' => 'publish',
+			)
+		);
+
+		$fallback = gutenberg_block_core_navigation_create_fallback();
+
+		$this->assertEquals( 'Existing Classic Menu', $fallback->post_title, );
+		$this->assertEquals( 'wp_navigation', $fallback->post_type, );
+		$this->assertEquals( 'publish', $fallback->post_status );
+
+		// Assert that the fallback contains a navigation-link block.
+		$this->assertStringContainsString( '<!-- wp:navigation-link', $fallback->post_content );
+
+		// Assert that fallback post_content contains the expected menu item title.
+		$this->assertStringContainsString( '"label":"Classic Menu Item 1"', $fallback->post_content );
+
+		// Assert that fallback post_content contains the expected menu item url.
+		$this->assertStringContainsString( '"url":"/classic-menu-item-1"', $fallback->post_content );
+
+		// Cleanup.
+		wp_delete_nav_menu( $menu_id );
+	}
+
+	public function test_should_skip_if_filter_returns_truthy() {
 		add_filter( 'block_core_navigation_skip_fallback', '__return_true' );
 
 		$actual = gutenberg_block_core_navigation_create_fallback();
 
+		// Asserr no fallback is created.
 		$this->assertEquals( $actual, null );
 
 		remove_filter( 'block_core_navigation_skip_fallback', '__return_true' );

--- a/phpunit/navigation-block-fallback-test.php
+++ b/phpunit/navigation-block-fallback-test.php
@@ -23,7 +23,7 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 			)
 		);
 
-		return $navs_in_db->posts ?? array();
+		return $navs_in_db->posts ? $navs_in_db->posts : array();
 	}
 
 	public function test_gets_fallback_navigation_with_existing_navigation_menu_if_found() {
@@ -71,7 +71,7 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 
 		$fallback = gutenberg_block_core_navigation_create_fallback();
 
-		$this->assertEquals( 'Existing Classic Menu', $fallback->post_title, );
+		$this->assertEquals( 'Existing Classic Menu', $fallback->post_title );
 		$this->assertEquals( 'wp_navigation', $fallback->post_type );
 		$this->assertEquals( 'publish', $fallback->post_status );
 

--- a/phpunit/navigation-block-fallback-test.php
+++ b/phpunit/navigation-block-fallback-test.php
@@ -201,6 +201,36 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		$this->assertEmpty( $fallback_blocks );
 	}
 
+	public function test_should_filter_out_empty_blocks_from_fallbacks() {
+
+		$navigation_post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'wp_navigation',
+				'post_title'   => 'Existing Navigation Menu',
+				'post_content' => '    <!-- wp:page-list /-->         ',
+			)
+		);
+
+		$fallback_blocks = gutenberg_block_core_navigation_get_fallback_blocks();
+
+		$first_block = $fallback_blocks[0];
+
+		// There should only be a single page list block and no "null" blocks.
+		$this->assertCount( 1, $fallback_blocks );
+		$this->assertEquals( $first_block['blockName'], 'core/page-list' );
+
+		// Check that no "empty" blocks exist with a blockName of 'null'.
+		// If the block parser encounters whitespace it will return a block with a blockName of null.
+		// This is an intentional feature, but is undesirable for our fallbacks.
+		$null_blocks = array_filter(
+			$fallback_blocks,
+			function( $block ) {
+				return $block['blockName'] === null;
+			}
+		);
+		$this->assertEmpty( $null_blocks );
+	}
+
 	public function test_should_return_filtered_blocks_fallback_is_filtered() {
 
 		function use_site_logo() {

--- a/phpunit/navigation-block-fallback-test.php
+++ b/phpunit/navigation-block-fallback-test.php
@@ -74,7 +74,7 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		$fallback = gutenberg_block_core_navigation_create_fallback();
 
 		$this->assertEquals( 'Existing Classic Menu', $fallback->post_title, );
-		$this->assertEquals( 'wp_navigation', $fallback->post_type, );
+		$this->assertEquals( 'wp_navigation', $fallback->post_type );
 		$this->assertEquals( 'publish', $fallback->post_status );
 
 		// Assert that the fallback contains a navigation-link block.

--- a/phpunit/navigation-block-fallback-test.php
+++ b/phpunit/navigation-block-fallback-test.php
@@ -37,6 +37,9 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		do_action( 'wp_install', $user );
 	}
 
+	/**
+	 * @covers ::block_core_navigation_get_default_fallback
+	 */
 	public function test_should_auto_create_navigation_menu_on_wp_install() {
 		$this->mock_wp_install();
 
@@ -49,13 +52,13 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		remove_filter( 'block_core_navigation_skip_fallback', '__return_true' );
 
 		$navs_in_db = $this->get_navigations_in_database();
-		$this->assertCount( 0, $navs_in_db );
+		$this->assertCount( 0, $navs_in_db, 'Navigation Menu should not exist before running the tests.' );
 
 		// Should trigger creation of Navigation Menu if one does not already exist.
 		switch_theme( 'emptytheme' );
 
 		$navs_in_db = $this->get_navigations_in_database();
-		$this->assertCount( 1, $navs_in_db );
+		$this->assertCount( 1, $navs_in_db, 'No Navigation Menu was found.' );
 	}
 
 	public function test_should_not_auto_create_navigation_menu_on_theme_switch_to_classic_theme() {

--- a/phpunit/navigation-block-fallback-test.php
+++ b/phpunit/navigation-block-fallback-test.php
@@ -105,6 +105,34 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		$this->assertCount( 1, $navs_in_db );
 	}
 
+	public function test_creates_fallback_from_existing_navigation_menu_even_if_classic_menu_exists() {
+
+		// Create a Navigation Post
+		$navigation_post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'wp_navigation',
+				'post_title'   => 'Existing Navigation Menu',
+				'post_content' => '<!-- wp:page-list /-->',
+			)
+		);
+
+		// Also create a Classic Menu - this should be ignored.
+		$menu_id = wp_create_nav_menu( 'Existing Classic Menu' );
+
+		$fallback = gutenberg_block_core_navigation_create_fallback();
+
+		$this->assertEquals( $fallback->post_title, $navigation_post->post_title );
+		$this->assertEquals( $fallback->post_type, $navigation_post->post_type );
+		$this->assertEquals( $fallback->post_content, $navigation_post->post_content );
+		$this->assertEquals( $fallback->post_status, $navigation_post->post_status );
+
+		$navs_in_db = $this->get_navigations_in_database();
+		$this->assertCount( 1, $navs_in_db );
+
+		// Cleanup.
+		wp_delete_nav_menu( $menu_id );
+	}
+
 	public function test_should_skip_if_filter_returns_truthy() {
 		add_filter( 'block_core_navigation_skip_fallback', '__return_true' );
 

--- a/phpunit/navigation-block-fallback-test.php
+++ b/phpunit/navigation-block-fallback-test.php
@@ -30,14 +30,7 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		}
 	}
 
-	public function test_creates_fallback_navigation_with_page_list_by_default() {
-		$fallback = gutenberg_block_core_navigation_create_fallback();
 
-		$this->assertEquals( $fallback->post_type, 'wp_navigation' );
-		$this->assertEquals( $fallback->post_title, 'Navigation' );
-		$this->assertEquals( $fallback->post_content, '<!-- wp:page-list /-->' );
-		$this->assertEquals( $fallback->post_status, 'publish' );
-	}
 
 	public function test_gets_fallback_navigation_with_existing_navigation_menu_if_found() {
 
@@ -88,6 +81,15 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 
 		// Cleanup.
 		wp_delete_nav_menu( $menu_id );
+	}
+
+	public function test_creates_fallback_navigation_with_page_list_by_default() {
+		$fallback = gutenberg_block_core_navigation_create_fallback();
+
+		$this->assertEquals( 'wp_navigation', $fallback->post_type );
+		$this->assertEquals( 'Navigation', $fallback->post_title, );
+		$this->assertEquals( '<!-- wp:page-list /-->', $fallback->post_content );
+		$this->assertEquals( 'publish', $fallback->post_status );
 	}
 
 	public function test_should_skip_if_filter_returns_truthy() {

--- a/phpunit/navigation-block-fallback-test.php
+++ b/phpunit/navigation-block-fallback-test.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Tests Fallback Behavior for Navigation block
+ *
+ * @package WordPress
+ */
+
+class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
+	public function set_up() {
+		parent::set_up();
+		switch_theme( 'emptytheme' );
+	}
+
+	public static function wpSetUpBeforeClass() {
+
+	}
+
+	public static function wpTearDownAfterClass() {
+
+	}
+
+	public function test_creates_fallback_with_page_list_by_default() {
+		$fallback = gutenberg_block_core_navigation_create_fallback();
+
+		$this->assertEquals( $fallback->post_type, 'wp_navigation' );
+		$this->assertEquals( $fallback->post_title, 'Navigation' );
+		$this->assertEquals( $fallback->post_content, '<!-- wp:page-list /-->' );
+		$this->assertEquals( $fallback->post_status, 'publish' );
+	}
+
+	public function test_skip_if_filter_returns_truthy() {
+		add_filter( 'block_core_navigation_skip_fallback', '__return_true' );
+
+		$actual = gutenberg_block_core_navigation_create_fallback();
+
+		$this->assertEquals( $actual, null );
+
+		remove_filter( 'block_core_navigation_skip_fallback', '__return_true' );
+	}
+}
+
+

--- a/phpunit/navigation-block-fallback-test.php
+++ b/phpunit/navigation-block-fallback-test.php
@@ -2,7 +2,8 @@
 /**
  * Tests Fallback Behavior for Navigation block
  *
- * @package WordPress
+ * @package    Gutenberg
+ * @subpackage block-library
  */
 
 class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {

--- a/phpunit/navigation-block-fallback-test.php
+++ b/phpunit/navigation-block-fallback-test.php
@@ -32,6 +32,18 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		return $navs_in_db->posts ? $navs_in_db->posts : array();
 	}
 
+	private function mock_wp_install() {
+		$user = get_current_user();
+		do_action( 'wp_install', $user );
+	}
+
+	public function test_should_auto_create_navigation_menu_on_wp_install() {
+		$this->mock_wp_install();
+
+		$navs_in_db = $this->get_navigations_in_database();
+		$this->assertCount( 1, $navs_in_db );
+	}
+
 	public function test_should_auto_create_navigation_menu_on_theme_switch() {
 		// Remove any existing disabling filters.
 		remove_filter( 'block_core_navigation_skip_fallback', '__return_true' );

--- a/phpunit/navigation-block-fallback-test.php
+++ b/phpunit/navigation-block-fallback-test.php
@@ -95,7 +95,7 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		$fallback = gutenberg_block_core_navigation_create_fallback();
 
 		$this->assertEquals( 'wp_navigation', $fallback->post_type );
-		$this->assertEquals( 'Navigation', $fallback->post_title, );
+		$this->assertEquals( 'Navigation', $fallback->post_title );
 		$this->assertEquals( '<!-- wp:page-list /-->', $fallback->post_content );
 		$this->assertEquals( 'publish', $fallback->post_status );
 
@@ -154,6 +154,7 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 
 	public function test_should_return_blocks_from_most_recently_created_navigation() {
 
+		// Create a fallback navigation.
 		self::factory()->post->create_and_get(
 			array(
 				'post_type'    => 'wp_navigation',
@@ -162,7 +163,8 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 			)
 		);
 
-		$most_recently_published_nav = self::factory()->post->create_and_get(
+		// Create another fallback navigation.
+		self::factory()->post->create_and_get(
 			array(
 				'post_type'    => 'wp_navigation',
 				'post_title'   => 'Existing Navigation Menu 2',
@@ -199,7 +201,8 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 
 	public function test_should_filter_out_empty_blocks_from_fallbacks() {
 
-		$navigation_post = self::factory()->post->create_and_get(
+		// Create a fallback navigation.
+		self::factory()->post->create_and_get(
 			array(
 				'post_type'    => 'wp_navigation',
 				'post_title'   => 'Existing Navigation Menu',
@@ -221,7 +224,7 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		$null_blocks = array_filter(
 			$fallback_blocks,
 			function( $block ) {
-				return $block['blockName'] === null;
+				return null === $block['blockName'];
 			}
 		);
 		$this->assertEmpty( $null_blocks );

--- a/phpunit/navigation-block-fallback-test.php
+++ b/phpunit/navigation-block-fallback-test.php
@@ -38,7 +38,7 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::block_core_navigation_get_default_fallback
+	 * @covers ::block_core_navigation_create_fallback
 	 */
 	public function test_should_auto_create_navigation_menu_on_wp_install() {
 		$this->mock_wp_install();
@@ -47,6 +47,9 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		$this->assertCount( 1, $navs_in_db, 'No Navigation Menu was found.' );
 	}
 
+	/**
+	 * @covers ::block_core_navigation_create_fallback
+	 */
 	public function test_should_auto_create_navigation_menu_on_theme_switch() {
 		// Remove any existing disabling filters.
 		remove_filter( 'block_core_navigation_skip_fallback', '__return_true' );
@@ -61,6 +64,9 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		$this->assertCount( 1, $navs_in_db, 'No Navigation Menu was found.' );
 	}
 
+	/**
+	 * @covers ::block_core_navigation_create_fallback
+	 */
 	public function test_should_not_auto_create_navigation_menu_on_theme_switch_to_classic_theme() {
 
 		$navs_in_db = $this->get_navigations_in_database();
@@ -73,6 +79,9 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		$this->assertCount( 0, $navs_in_db, 'A Navigation Menu should not exist.' );
 	}
 
+	/**
+	 * @covers ::block_core_navigation_create_fallback
+	 */
 	public function test_should_not_auto_create_navigation_menu_on_theme_switch_if_one_already_exists() {
 
 		// Pre-add a Navigation Menu to simulate when a user already has a menu.
@@ -99,7 +108,10 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		$this->assertEquals( 'Existing Navigation Menu', $navs_in_db[0]->post_title, 'The title of the Navigation Menu should match the existing Navigation Menu' );
 	}
 
-	public function test_gets_fallback_navigation_with_existing_navigation_menu_if_found() {
+	/**
+	 * @covers ::block_core_navigation_create_fallback
+	 */
+	public function test_creates_fallback_navigation_with_existing_navigation_menu_if_found() {
 
 		self::factory()->post->create_and_get(
 			array(
@@ -128,7 +140,10 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		$this->assertCount( 2, $navs_in_db, '2 Navigation Menus should exist.' );
 	}
 
-	public function test_gets_fallback_navigation_with_existing_classic_menu_if_found() {
+	/**
+	 * @covers ::block_core_navigation_create_fallback
+	 */
+	public function test_creates_fallback_navigation_with_existing_classic_menu_if_found() {
 
 		$menu_id = wp_create_nav_menu( 'Existing Classic Menu' );
 
@@ -162,6 +177,9 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		wp_delete_nav_menu( $menu_id );
 	}
 
+	/**
+	 * @covers ::block_core_navigation_create_fallback
+	 */
 	public function test_creates_fallback_navigation_with_page_list_by_default() {
 		$fallback = gutenberg_block_core_navigation_create_fallback();
 
@@ -174,6 +192,9 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		$this->assertCount( 1, $navs_in_db, 'A single Navigation Menu should exist.' );
 	}
 
+	/**
+	 * @covers ::block_core_navigation_create_fallback
+	 */
 	public function test_creates_fallback_from_existing_navigation_menu_even_if_classic_menu_exists() {
 
 		// Create a Navigation Post.
@@ -202,6 +223,9 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		wp_delete_nav_menu( $menu_id );
 	}
 
+	/**
+	 * @covers ::block_core_navigation_create_fallback
+	 */
 	public function test_should_skip_if_filter_returns_truthy() {
 		add_filter( 'block_core_navigation_skip_fallback', '__return_true' );
 
@@ -213,14 +237,21 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		remove_filter( 'block_core_navigation_skip_fallback', '__return_true' );
 	}
 
-	public function test_should_return_empty_fallback_blocks_when_no_navigations_exist() {
+
+	/**
+	 * @covers ::gutenberg_block_core_navigation_get_fallback_blocks
+	 */
+	public function test_should_get_fallback_blocks_when_no_navigations_exist() {
 		$fallback_blocks = gutenberg_block_core_navigation_get_fallback_blocks();
 
 		$this->assertIsArray( $fallback_blocks, 'Fallback blocks should be an array.' );
 		$this->assertEmpty( $fallback_blocks, 'Fallback blocks should be empty.' );
 	}
 
-	public function test_should_return_blocks_from_most_recently_created_navigation() {
+	/**
+	 * @covers ::gutenberg_block_core_navigation_get_fallback_blocks
+	 */
+	public function test_should_get_blocks_from_most_recently_created_navigation() {
 
 		// Create a fallback navigation.
 		self::factory()->post->create_and_get(
@@ -251,7 +282,10 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 
 	}
 
-	public function test_should_return_empty_array_if_most_recently_created_navigation_is_empty() {
+	/**
+	 * @covers ::gutenberg_block_core_navigation_get_fallback_blocks
+	 */
+	public function test_should_get_empty_array_if_most_recently_created_navigation_is_empty() {
 
 		self::factory()->post->create_and_get(
 			array(
@@ -267,6 +301,9 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		$this->assertEmpty( $fallback_blocks, 'Fallback blocks should be empty.' );
 	}
 
+	/**
+	 * @covers ::gutenberg_block_core_navigation_get_fallback_blocks
+	 */
 	public function test_should_filter_out_empty_blocks_from_fallbacks() {
 
 		// Create a fallback navigation.
@@ -298,7 +335,10 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 		$this->assertEmpty( $null_blocks, 'Fallback blocks should not contain any null blocks.' );
 	}
 
-	public function test_should_return_filtered_blocks_fallback_is_filtered() {
+	/**
+	 * @covers ::gutenberg_block_core_navigation_get_fallback_blocks
+	 */
+	public function test_should_get_filtered_blocks_if_fallback_is_filtered() {
 
 		function use_site_logo() {
 			return parse_blocks( '<!-- wp:site-logo /-->' );
@@ -323,8 +363,6 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 
 		remove_filter( 'block_core_navigation_render_fallback', 'use_site_logo' );
 	}
-
-
 }
 
 

--- a/phpunit/navigation-block-fallback-test.php
+++ b/phpunit/navigation-block-fallback-test.php
@@ -7,34 +7,14 @@
 
 class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 
-	/**
-	 * @var WP_Post
-	 */
-	protected static $navigation_post;
-
-
-
-
 	public function set_up() {
 		parent::set_up();
 		switch_theme( 'emptytheme' );
 	}
 
-	public static function wpSetUpBeforeClass() {
-
-	}
-
-	public static function wpTearDownAfterClass() {
-		if ( ! empty( self::$post_with_comments_disabled->ID ) ) {
-			wp_delete_post( self::$navigation_post->ID, true );
-		}
-	}
-
-
-
 	public function test_gets_fallback_navigation_with_existing_navigation_menu_if_found() {
 
-		self::$navigation_post = self::factory()->post->create_and_get(
+		$navigation_post = self::factory()->post->create_and_get(
 			array(
 				'post_type'    => 'wp_navigation',
 				'post_title'   => 'Existing Navigation Menu',
@@ -44,10 +24,10 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 
 		$fallback = gutenberg_block_core_navigation_create_fallback();
 
-		$this->assertEquals( $fallback->post_title, self::$navigation_post->post_title );
-		$this->assertEquals( $fallback->post_type, self::$navigation_post->post_type );
-		$this->assertEquals( $fallback->post_content, self::$navigation_post->post_content );
-		$this->assertEquals( $fallback->post_status, self::$navigation_post->post_status );
+		$this->assertEquals( $fallback->post_title, $navigation_post->post_title );
+		$this->assertEquals( $fallback->post_type, $navigation_post->post_type );
+		$this->assertEquals( $fallback->post_content, $navigation_post->post_content );
+		$this->assertEquals( $fallback->post_status, $navigation_post->post_status );
 	}
 
 	public function test_gets_fallback_navigation_with_existing_classic_menu_if_found() {
@@ -97,7 +77,7 @@ class Tests_Block_Navigation_Fallbacks extends WP_UnitTestCase {
 
 		$actual = gutenberg_block_core_navigation_create_fallback();
 
-		// Asserr no fallback is created.
+		// Assert no fallback is created.
 		$this->assertEquals( $actual, null );
 
 		remove_filter( 'block_core_navigation_skip_fallback', '__return_true' );


### PR DESCRIPTION
## What?

Improves Nav block fallback performance and UX by **auto-creating a Navigation Post** (`wp_navigation`). This is done on:

- `switch_theme`
- `wp_install`

Removes redundant code from editor and front of site.

## Why?

#### TL;DR
Creating Navigation menus in the client side is very susceptible to bugs - when we fire multiple requests to create navigation menus we can't know if others are still pending. To reduce the complexity of this we should just always ensure that a navigation menu CPT exists.

#### Longer

For a long while contributors working on the Nav block have been implementing various mechanics to handle the fallbacks for the Nav block.

As a re-fresher:

- uses most recently created Navigation menu `wp_navigation` if found.
- fallback to converting most recent Classic Menu (or primary) to Navigation menu (if found)
- fallback to creating a Navigation menu containing default content (a Page List).

Handling the asynchronicity of this in a single block is somewhat feasible (indeed we've been doing this for a while). 

However....doing it across potentially multiple blocks on a given page is _extremely_ complex, susceptible to race conditions and generally very difficult to test. This is compounded by the fact that the same logic has to be _repeated_ for the dynamic block rendering on the PHP side introducing yet another surface area for bugs and regressions.

In addition, there has been a drive to reduce the friction introduced by "loading" UX. This was apparent due to network when transitioning from a "placeholder" block (one that isn't saved to a `wp_navigation`) and a synced block (one whose contents is saved to a `wp_navigation` post). To work around this functionality was introduced to auto-create a Nav menu if one didn't exist. 

These two elements combined have introduced some nasty bugs into the Nav block. Perhaps the most obvious is multiple menus being created when mulitple empty Nav blocks are on a given page (if you think this will never happen think again because simply opening the Patterns inserter and viewing the `Header` patterns causes this to occur).

We can mimic this behaviour by checking out `trunk`, clearing all Navigation Menus and Classic Menus and inserting multiple empty Nav block's into a post:

```
<!-- wp:navigation /--><!-- wp:navigation /--><!-- wp:navigation /--><!-- wp:navigation /--><!-- wp:navigation /--><!-- wp:navigation /-->
```

The result is 5 `wp_navigation` posts get created when we only wanted a single fallback to be auto-created.

This PR attempts to resolve this problem by pre-creating a Navigation post on `render_block_data` (if one doesn't exist). This mechanic:

- obeys all fallback rules
- reduces complexity in editor client side code.
- unifies fallback logic between editor and front of site code
- is easily tested
- ensures an improved UX

## How?
Add an action on `switch_theme` and `wp_install` to create a fallback navigation menu if one does not exist and if the active Theme is a block theme.

Also adds a new filter called `block_core_navigation_skip_fallback` which allows developers to skip the creation of a navigation if they want to.

## Testing Instructions

#### Automated Testing
Run

```
npm run test:unit:php -- --filter Block_Library_Navigation_Fallbacks_Test
```

#### Manual Testing
1. Delete all your navigation menus (from `wp-admin/edit.php?post_type=wp_navigation`)
2. Switch to a Classic Theme.
3. Check there are no Navigation Menus (in `wp-admin/edit.php?post_type=wp_navigation`)
4. Switch to a Block Theme.
5. Check a default Navigation Menu has been created (in `wp-admin/edit.php?post_type=wp_navigation`).
7. Load the frontend of a site that uses the navigation block and notice that your fallback menu is there.
8. Load the editor of a site that uses the navigation block and notice that your fallback menu is there.
9. Add this code to your site:
`add_filter( 'block_core_navigation_skip_fallback', '__return_true' );`
10. Delete all wp_navigation menus.
11. Check that no more are created.
12. Add this code to your site:
```
add_filter( 'block_core_navigation_render_fallback', function() {
	return parse_blocks( '<!-- wp:site-logo /-->' );
} );
```
13. Check that you see a site logo in your navigation menu


Co-authored-by: Andrei Draganescu <107534+draganescu@users.noreply.github.com>
Co-authored-by: Dave Smith <444434+getdave@users.noreply.github.com>