### PR TITLE
components/utils/font: refactor away from lodash `.get`

### DIFF
--- a/packages/components/src/utils/font.js
+++ b/packages/components/src/utils/font.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import FONT from './font-values';
@@ -14,5 +9,5 @@ import FONT from './font-values';
  * @return {string} Font rule value
  */
 export function font( value ) {
-	return get( FONT, value, '' );
+	return FONT[ value ] ?? '';
 }


### PR DESCRIPTION
## What?

This PR removes Lodash's `_.get()` from the `font` helper utility in the components package.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using nullish coalescing instead. 

## Testing Instructions

* Test this by starting storybook on this branch (`npm run storybook:dev`) and inspect all the stories of the `InputControl` component. Make sure it looks exactly the same as here: [InputControl](https://wordpress.github.io/gutenberg/?path=/story/components-experimental-inputcontrol--default) (Storybook).