### PR TITLE
Fix: Custom link UI does appears outside canvas on the sidebar navigation.

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/link-ui.js
+++ b/packages/block-editor/src/components/off-canvas-editor/link-ui.js
@@ -137,7 +137,6 @@ export function LinkUI( props ) {
 			placement="bottom"
 			onClose={ props.onClose }
 			anchor={ props.anchor }
-			__unstableSlotName={ '__unstable-block-tools-after' }
 			shift
 		>
 			<LinkControl

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -165,7 +165,6 @@ export function LinkUI( props ) {
 			placement="bottom"
 			onClose={ props.onClose }
 			anchor={ props.anchor }
-			__unstableSlotName={ '__unstable-block-tools-after' }
 			shift
 		>
 			<LinkControl

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -16,6 +16,8 @@ import { useHistory } from '../routes';
 import NavigationMenuContent from './navigation-menu-content';
 import SidebarButton from '../sidebar-button';
 import { NavigationMenuLoader } from './loader';
+import { unlock } from '../../private-apis';
+import { store as editSiteStore } from '../../store';
 
 const noop = () => {};
 const NAVIGATION_MENUS_QUERY = { per_page: -1, status: 'publish' };
@@ -41,8 +43,9 @@ function SidebarNavigationScreenWrapper( { children, actions } ) {
 
 export default function SidebarNavigationScreenNavigationMenus() {
 	const history = useHistory();
-	const { navigationMenus, hasResolvedNavigationMenus } = useSelect(
-		( select ) => {
+	const { navigationMenus, hasResolvedNavigationMenus, storedSettings } =
+		useSelect( ( select ) => {
+			const { getSettings } = unlock( select( editSiteStore ) );
 			const { getEntityRecords, hasFinishedResolution } =
 				select( coreStore );
 
@@ -52,15 +55,14 @@ export default function SidebarNavigationScreenNavigationMenus() {
 				NAVIGATION_MENUS_QUERY,
 			];
 			return {
+				storedSettings: getSettings( false ),
 				navigationMenus: getEntityRecords( ...navigationMenusQuery ),
 				hasResolvedNavigationMenus: hasFinishedResolution(
 					'getEntityRecords',
 					navigationMenusQuery
 				),
 			};
-		},
-		[]
-	);
+		}, [] );
 
 	// Sort navigation menus by date.
 	const orderedNavigationMenus = useMemo(
@@ -124,6 +126,7 @@ export default function SidebarNavigationScreenNavigationMenus() {
 
 	return (
 		<BlockEditorProvider
+			settings={ storedSettings }
 			value={ blocks }
 			onChange={ noop }
 			onInput={ noop }


### PR DESCRIPTION
On https://github.com/WordPress/gutenberg/pull/47930 which was merged last week, we added this unusable flag.
That change seems not to undo the remaining work.
This change makes the custom link popover not appear on the navigation sidebar. This PR reverts the change and makes the popover appear again.
@draganescu as a reviewer of https://github.com/WordPress/gutenberg/pull/47930 is this change safe?

## Screenshot 
<img width="400" alt="Screenshot 2023-03-03 at 12 17 05" src="https://user-images.githubusercontent.com/11271197/222722592-a9c1f744-4190-4dde-bd34-b4e1c131bca4.png">


# Testing 

Apply the following diff (because right now we have a bug that causes crashes when there are custom links being addressed by @draganescu and @scruffian):
```
diff --git a/packages/edit-site/src/components/block-editor/index.js b/packages/edit-site/src/components/block-editor/index.js
index ac6f762ded..518fe28625 100644
--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -201,11 +201,6 @@ export default function BlockEditor() {
                                                                        readonly={ canvasMode === 'view' }
                                                                >
                                                                        { resizeObserver }
-                                                                       <BlockList
-                                                                               className="edit-site-block-editor__block-list wp-site-blocks"
-                                                                               __experimentalLayout={ LAYOUT }
-                                                                               renderAppender={ showBlockAppender }
-                                                                       />
                                                                </EditorCanvas>
                                                        </ResizableEditor>
                                                </BlockTools
```
The diff removes the canvas so we can test a single block list.
Add a custom link and verify the popover appears as shown on the screenshot.
