### PR TITLE
`PaletteEdit`: refactor away from `lodash.kebabCase`

### DIFF
--- a/packages/components/src/palette-edit/index.js
+++ b/packages/components/src/palette-edit/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { kebabCase } from 'lodash';
+import { paramCase as kebabCase } from 'change-case';
 
 /**
  * WordPress dependencies


### PR DESCRIPTION
## What?

This PR removes Lodash's `_.kebabCase()` from the `PaletteEdit` component 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

Replaces `_.kebabCase` with `paramCase` from the `change-case` package (already used in the components package).

## Testing Instructions

1. Open the Global Styles sidebar and choose _Colors_, next choose _Palette_ and add a new custom color & name it (use spaces). Make sure that doesn't work without errrors.
2. Next it's probably easiest to use React Devtools to inspect the attribute was formatted correctly. Search for a component named `<PaletteEditListView />`, inspect the `elements` prop and verify the `slug` attribute looks as expected (param-cased depending on what name you chose).