### PR TITLE
List Item: Avoid an error when the 'onReplace' prop is undefined

### DIFF
--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -88,9 +88,16 @@ export default function ListItemEdit( {
 					placeholder={ placeholder || __( 'List' ) }
 					onSplit={ onSplit }
 					onMerge={ onMerge }
-					onReplace={ ( blocks, ...args ) => {
-						onReplace( convertToListItems( blocks ), ...args );
-					} }
+					onReplace={
+						onReplace
+							? ( blocks, ...args ) => {
+									onReplace(
+										convertToListItems( blocks ),
+										...args
+									);
+							  }
+							: undefined
+					}
 				/>
 				{ innerBlocksProps.children }
 			</li>


### PR DESCRIPTION
## What?
Fixes #48324.

PR adds a check to avoid an error when the `onReplace` prop is `undefined`. Updated behavior matches the Paragraph block - where pressing enter doesn't create a new block.

## Why?
The `onReplace` method can be undefined based on the block's or its parent's lock state.

## Testing Instructions
1. Open a Post or Page.
2. Insert example markup
3. Pressing enter inside the List Item should trigger an error.

### Example markup

```
<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>These paragraphs and the list block is part of a group which has a templateLock of 'contentOnly'.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>If you try to add an extra list item this will fail and an error is shown in the console.</p>
<!-- /wp:paragraph -->

<!-- wp:list -->
<ul><!-- wp:list-item -->
<li>One</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>Two</li>
<!-- /wp:list-item --></ul>
<!-- /wp:list --></div>
<!-- /wp:group -->
```

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/222163781-d69a163e-19e9-4c84-94a0-6f782e608c1b.mp4