### PR TITLE
Fix PostContent initial render by waiting for the canEdit request

### DIFF
--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -58,8 +58,12 @@ function EditableContent( { context = {} } ) {
 
 function Content( props ) {
 	const { context: { queryId, postType, postId } = {} } = props;
-	const isDescendentOfQueryLoop = Number.isFinite( queryId );
 	const userCanEdit = useCanEditEntity( 'postType', postType, postId );
+	if ( userCanEdit === undefined ) {
+		return null;
+	}
+
+	const isDescendentOfQueryLoop = Number.isFinite( queryId );
 	const isEditable = userCanEdit && ! isDescendentOfQueryLoop;
 
 	return isEditable ? (


### PR DESCRIPTION
## What?
Fix `PostContent` block initial render by waiting until the `useCanEditEntity` request is resolved.

Related: https://github.com/WordPress/gutenberg/pull/48138#discussion_r1121720078

## Why?
Depending on the [returned value from the useCanEditEntity hook](https://github.com/WordPress/gutenberg/blob/ce49c68c128616b51df78f7443114fe6b6ddd972/packages/block-library/src/post-content/edit.js#L62-L73), the `PostContent` block renders either in the read-only or editable mode. The problem is that the `canEdit` value [can initially be `undefined`](https://github.com/WordPress/gutenberg/blob/8dee3e6764da100b20ad9abd41af5df086b5f42f/docs/reference-guides/data/data-core.md#L30-L48), so the content is rendered in the read-only mode by default. Once the value becomes defined (boolean), it either stays in the read-only mode or switches to the editable mode, which causes the whole body to rerender.

The following videos show the difference before and after the fix:

| Before | After |
| ------------- | ------------- |
| <video src="https://user-images.githubusercontent.com/1451471/222155102-5844bff7-c4e4-4a5e-a4fa-8f4180e0b32c.mov"> | <video src="https://user-images.githubusercontent.com/1451471/222155065-7cbe8128-0326-43c7-a5ac-9c4ae384ab44.mov"> |

This behavior has also been a [source of flakiness in our Site Editor performance tests](https://github.com/WordPress/gutenberg/pull/48138#discussion_r1113032311) as the initially rendered canvas nodes are detached once the `canEdit` state is established. 


## How?
Wait until the `useCanEditEntity` hook (via the `canUserEditEntityRecord` request) returns a boolean value, and then render the content. This approach should be correct according to the documentation (see the last line):

https://github.com/WordPress/gutenberg/blob/8dee3e6764da100b20ad9abd41af5df086b5f42f/docs/reference-guides/data/data-core.md#L30-L48
