### PR TITLE
 Fix for `WP_Theme_JSON_Resolver_Gutenberg::get_merged_data`

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -571,7 +571,8 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			_deprecated_argument( __FUNCTION__, '5.9.0' );
 		}
 
-		$result = static::get_core_data();
+		$result = new WP_Theme_JSON();
+		$result->merge( static::get_core_data() );
 		if ( 'default' === $origin ) {
 			$result->set_spacing_sizes();
 			return $result;


### PR DESCRIPTION
Related trac ticket https://core.trac.wordpress.org/ticket/57824
Reverts https://github.com/WordPress/wordpress-develop/pull/3441
Backport PR https://github.com/WordPress/wordpress-develop/pull/4145

## What

This PR fixes a bug by which the reset function of the global styles sidebar wouldn't work as expected in the site editor.

## How to reproduce

Take the following steps:

- Using TwentyTwentyTwo and any WordPress version after [rev54517](https://github.com/WordPress/wordpress-develop/pull/3441), for example, WordPress 6.2 beta 3.
- Go to the site editor.
- Open the global styles sidebar and set the padding values to something else (222px, for example).
- Save the changes and reload the editor.
- Open the global styles sidebar and try resetting the padding values (for example, by using the "Reset to defaults" option displayed under the three dot menu of the global styles sidebar).
- The expected result is that the values would be reset. However, they are not.

Note that if this is saved and then site editor reloaded, the proper data is shown.

## How this PR fixes the issue

By reverting https://github.com/WordPress/wordpress-develop/pull/3441 which was the one that introduced the issue.

That PR changed the `get_merged_data` code to (pseudo-code):

```php
function get_merged_data( $origin ) {
    $result = static::get_core_data();

    if ( 'block' === $origin ) { $result->merge( static::get_block_data() ); }
    if ( 'theme' === $origin ) { $result->merge( static::get_theme_data() ); }
    if ( 'custom' === $origin ) { $result->merge( static::get_custom_data() ); }

    return $result;
}
```

However, by doing so, the base object (`$result`) is modifying the `$core` object directly, and `$core` ends up storing the consolidated values instead of only the ones coming from the `theme.json` provided by core.

This is problematic because `$core` data is cached. Take, for example, the following scenario:

```php
$data = get_merged_data( 'custom' );
$data = get_merged_data( 'theme' );
```

The expected output for `$data` is that it should not have data coming from the 'custom' origin, however, it does.

The fix is reverting the change and use an empty object as base (pseudo-code):

```php
function get_merged_data( $origin ) {
    $result = new WP_Theme_JSON();

    $result->merge( static::get_core_data() );
    if ( 'block' === $origin ) { $result->merge( static::get_block_data() ); }
    if ( 'theme' === $origin ) { $result->merge( static::get_theme_data() ); }
    if ( 'custom' === $origin ) { $result->merge( static::get_custom_data() ); }

    return $result;
}
```

## Performance

_(The performance data is taken from core, not Gutenberg. Left here as a section for visibility)._

This is a bug that needs to be fixed. I thought about running some performance analysis anyway, given the intent of the PR this reverts was improving performance. Given the improvements introduced in 6.2, reverting the PR doesn't affect performance.

Using XDebug (only for completeness, we should not use data extracted from a xdebug profiler to make perf decisions, as there's a cost to observability):

| Method                                    | WordPress 6.2 rev55436     | This PR (based off trunk@55436)          |
| ----------------------------------------- | ---------------- | ----------------- |
| `WP_Theme_JSON_Resolver::get_merged_data` | 23ms (6 calls)   | 24ms (6 calls)  |
| `WP_Theme_JSON->merge`                    | 3.5ms (24ms) | 5.8ms (30 calls) |

Using production code (see [raw data](https://docs.google.com/spreadsheets/d/14kxomBT3PurwJk_-4vKr1CLZJZm9BL8tMIhn0Ks4Baw/edit#gid=0)): the variance is sub-millisecond, so it may be attributed to the measuring conditions.

![image](https://user-images.githubusercontent.com/583546/221940283-0cbbfeb0-d12a-4b4c-ad1b-85b3c752ec69.png)

