### PR TITLE
`WP_Theme_JSON`: sync indirect properties changes from core

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3008,18 +3008,9 @@ class WP_Theme_JSON_Gutenberg {
 			}
 		}
 
-		foreach ( static::INDIRECT_PROPERTIES_METADATA as $property => $paths ) {
-			foreach ( $paths as $path ) {
-				$value = _wp_array_get( $input, $path, array() );
-				if (
-					isset( $value ) &&
-					! is_array( $value ) &&
-					static::is_safe_css_declaration( $property, $value )
-				) {
-					_wp_array_set( $output, $path, $value );
-				}
-			}
-		}
+		// Ensure indirect properties not included in any `PRESETS_METADATA` value are allowed.
+		static::remove_indirect_properties( $input, $output );
+
 		return $output;
 	}
 
@@ -3051,18 +3042,7 @@ class WP_Theme_JSON_Gutenberg {
 		}
 
 		// Ensure indirect properties not handled by `compute_style_properties` are allowed.
-		foreach ( static::INDIRECT_PROPERTIES_METADATA as $property => $paths ) {
-			foreach ( $paths as $path ) {
-				$value = _wp_array_get( $input, $path, array() );
-				if (
-					isset( $value ) &&
-					! is_array( $value ) &&
-					static::is_safe_css_declaration( $property, $value )
-				) {
-					_wp_array_set( $output, $path, $value );
-				}
-			}
-		}
+		static::remove_indirect_properties( $input, $output );
 
 		return $output;
 	}
@@ -3080,6 +3060,29 @@ class WP_Theme_JSON_Gutenberg {
 		$style_to_validate = $property_name . ': ' . $property_value;
 		$filtered          = esc_html( safecss_filter_attr( $style_to_validate ) );
 		return ! empty( trim( $filtered ) );
+	}
+
+	/**
+	 * Removes indirect properties from the given input node and
+	 * sets in the given output node.
+	 *
+	 * @since 6.2.0
+	 *
+	 * @param array $input  Node to process.
+	 * @param array $output The processed node. Passed by reference.
+	 */
+	private static function remove_indirect_properties( $input, &$output ) {
+		foreach ( static::INDIRECT_PROPERTIES_METADATA as $property => $paths ) {
+			foreach ( $paths as $path ) {
+				$value = _wp_array_get( $input, $path );
+				if (
+					is_string( $value ) &&
+					static::is_safe_css_declaration( $property, $value )
+				) {
+					_wp_array_set( $output, $path, $value );
+				}
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
## What?

This PR syncs the Gutenberg class with the corresponding WordPress core changes.

## Why?

By being in sync, future backport processes will be much easier.

Context:

- Original PR in Gutenberg https://github.com/WordPress/gutenberg/pull/46388
- PR as backported to core https://github.com/WordPress/wordpress-develop/pull/3742

## How?

Copy the code from core to Gutenberg.

