### PR TITLE
Fix typo: use WP_Theme_JSON_Gutenberg instead of WP_Theme_JSON class name

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -571,7 +571,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			_deprecated_argument( __FUNCTION__, '5.9.0' );
 		}
 
-		$result = new WP_Theme_JSON();
+		$result = new WP_Theme_JSON_Gutenberg();
 		$result->merge( static::get_core_data() );
 		if ( 'default' === $origin ) {
 			$result->set_spacing_sizes();


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/48644

## What

This fixes a typo in the class name.

## Why 

Gutenberg code should use the `WP_Theme_JSON_Gutenberg` class instead of the `WP_Theme_JSON` class defined by core.

## Testing

No need.
