### PR TITLE
Site Editor: Add page details when viewing a specific page.

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-item/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-item/index.js
@@ -54,7 +54,10 @@ export default function SidebarNavigationScreenNavigationItem() {
 			content={
 				<>
 					{ post?.link ? (
-						<ExternalLink href={ post.link }>
+						<ExternalLink
+							className="edit-site-sidebar-navigation-screen__page-link"
+							href={ post.link }
+						>
 							{ post.link }
 						</ExternalLink>
 					) : null }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-item/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-item/index.js
@@ -3,7 +3,10 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { __experimentalUseNavigator as useNavigator } from '@wordpress/components';
+import {
+	__experimentalUseNavigator as useNavigator,
+	ExternalLink,
+} from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { pencil } from '@wordpress/icons';
@@ -50,9 +53,11 @@ export default function SidebarNavigationScreenNavigationItem() {
 			}
 			content={
 				<>
-					<a href={ post?.link } target="_blank" rel="noreferrer">
-						{ post?.link }
-					</a>
+					{ post?.link ? (
+						<ExternalLink href={ post.link }>
+							{ post.link }
+						</ExternalLink>
+					) : null }
 					{ post
 						? decodeEntities( post?.description?.rendered )
 						: null }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-item/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-item/index.js
@@ -49,7 +49,12 @@ export default function SidebarNavigationScreenNavigationItem() {
 				/>
 			}
 			content={
-				post ? decodeEntities( post?.description?.rendered ) : null
+				<>
+					<a href={ post?.link }>{ post?.link }</a>
+					{ post
+						? decodeEntities( post?.description?.rendered )
+						: null }
+				</>
 			}
 		/>
 	);

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-item/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-item/index.js
@@ -50,7 +50,9 @@ export default function SidebarNavigationScreenNavigationItem() {
 			}
 			content={
 				<>
-					<a href={ post?.link }>{ post?.link }</a>
+					<a href={ post?.link } target="_blank" rel="noreferrer">
+						{ post?.link }
+					</a>
 					{ post
 						? decodeEntities( post?.description?.rendered )
 						: null }

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -10,6 +10,19 @@
 	color: $gray-600;
 }
 
+.edit-site-sidebar-navigation-screen__page-link {
+	color: $gray-600;
+
+	&:hover,
+	&:focus {
+		color: $white;
+	}
+
+	.components-external-link__icon {
+		margin-left: $grid-unit-5;
+	}
+}
+
 .edit-site-sidebar-navigation-screen__title-icon {
 	position: sticky;
 	top: 0;

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -19,7 +19,7 @@
 	}
 
 	.components-external-link__icon {
-		margin-left: $grid-unit-5;
+		margin-left: $grid-unit-05;
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This adds the URL of the current page when previewing a page in the Site Editor.

Fixes https://github.com/WordPress/gutenberg/issues/48482#issuecomment-1450475528

## Why?
This gives additional context when editing a page and also makes it possible to preview the page.

## How?
Get the URL from the post data.

## Testing Instructions
1. In the Site Editor, navigate to a page using the Navigation section
2. Check that you see the page URL under the page name

## Screenshots or screencast <!-- if applicable -->
<img width="984" alt="Screenshot 2023-03-01 at 17 37 13" src="https://user-images.githubusercontent.com/275961/222218355-96df1ce1-2847-4ba7-ae18-7e4981bf3152.png">
