### PR TITLE
Add links to hook documentation in curation doc

### DIFF
--- a/docs/how-to-guides/curating-the-editor-experience.md
+++ b/docs/how-to-guides/curating-the-editor-experience.md
@@ -290,10 +290,10 @@ For instance, in the previous section, color and typography controls were disabl
 
 To provide more flexibility, WordPress 6.1 introduced server-side filters allowing you to customize theme.json data at four different data layers.
 
-- `wp_theme_json_data_default` - Hooks into the default data provided by WordPress
-- `wp_theme_json_data_blocks` - Hooks into the data provided by blocks.
-- `wp_theme_json_data_theme` - Hooks into the data provided by the current theme.
-- `wp_theme_json_data_user` - Hooks into the data provided by the user.
+- [`wp_theme_json_data_default`](https://developer.wordpress.org/reference/hooks/wp_theme_json_data_default/) - Hooks into the default data provided by WordPress
+- [`wp_theme_json_data_blocks`](https://developer.wordpress.org/reference/hooks/wp_theme_json_data_blocks/) - Hooks into the data provided by blocks.
+- [`wp_theme_json_data_theme`](https://developer.wordpress.org/reference/hooks/wp_theme_json_data_theme/) - Hooks into the data provided by the current theme.
+- [`wp_theme_json_data_user`](https://developer.wordpress.org/reference/hooks/wp_theme_json_data_user/) - Hooks into the data provided by the user.
 
 In the following example, the data from the current theme's theme.json file is updated using the `wp_theme_json_data_theme` filter. Color controls are restored if the current user is an Administrator.
 


### PR DESCRIPTION
## What?
The [Curate the Editing Experience](https://developer.wordpress.org/block-editor/how-to-guides/curating-the-editor-experience/) doc was recently updated in #48576. After the PR was merged, there was a [request](https://github.com/WordPress/gutenberg/pull/48576#discussion_r1119643943) to link the hooks to the proper documentation. This PR takes care of that.  