### PR TITLE
[post-excerpt][15.2.3] Fix the "is rest api?" condition in the `post-excerpt` PHP package entry point

### DIFF
--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -84,8 +84,7 @@ add_action( 'init', 'register_block_core_post_excerpt' );
  * Returns 100 because 100 is the max length in the setting.
  */
 if ( is_admin() ||
-	defined( 'REST_REQUEST' ) ||
-	'REST_REQUEST' ) {
+	defined( 'REST_REQUEST' ) && REST_REQUEST ) {
 	add_filter(
 		'excerpt_length',
 		function() {


### PR DESCRIPTION
## What?

Fixes a faulty condition in the `post-excerpt` package entry point PHP. 

## Why?

The condition was wrong, it should check if the current user is admin or the current request is an API request, the API part was faulty and hence not evaluating to true when it should have, causing some tests to fail (and possibly other bugs).

## How?

Change the condition expression from  `is_admin() || defined('REST_REQUEST') || 'REST_REQUEST'` to `is_admin() || defined('REST_REQUEST') && REST_REQUEST`. The expression after the first `or` should check if the `REST_REQUEST` constant is defined and short-circuit if it doesn't, and if it is, then return its truth value. That effectively evaluates to true if the current request is an API request. That's what this fix does.

