### PR TITLE
 Theme JSON: Clarify status of fixed position opt-in in appearance tools

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -545,7 +545,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * Options that settings.appearanceTools enables.
 	 *
 	 * @since 6.0.0
-	 * @since 6.2.0 Added `position.fixed` and `position.sticky`.
+	 * @since 6.2.0 Added `dimensions.minHeight` and `position.sticky`.
 	 * @var array
 	 */
 	const APPEARANCE_TOOLS_OPT_INS = array(
@@ -555,7 +555,12 @@ class WP_Theme_JSON_Gutenberg {
 		array( 'border', 'width' ),
 		array( 'color', 'link' ),
 		array( 'dimensions', 'minHeight' ),
+		// BEGIN EXPERIMENTAL.
+		// Allow `position.fixed` to be opted-in by default.
+		// Sticky position support was backported to WordPress 6.2 in https://core.trac.wordpress.org/ticket/57618.
+		// While `fixed` was included as a valid setting, exposing it by default it still experimental.
 		array( 'position', 'fixed' ),
+		// END EXPERIMENTAL.
 		array( 'position', 'sticky' ),
 		array( 'spacing', 'blockGap' ),
 		array( 'spacing', 'margin' ),

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -558,7 +558,7 @@ class WP_Theme_JSON_Gutenberg {
 		// BEGIN EXPERIMENTAL.
 		// Allow `position.fixed` to be opted-in by default.
 		// Sticky position support was backported to WordPress 6.2 in https://core.trac.wordpress.org/ticket/57618.
-		// While `fixed` was included as a valid setting, exposing it by default it still experimental.
+		// While `fixed` was included as a valid setting, exposing it by default is still experimental.
 		array( 'position', 'fixed' ),
 		// END EXPERIMENTAL.
 		array( 'position', 'sticky' ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes: #48635

Add a comment to the Theme JSON class clarifying the current status of the `position.fixed` opt-in within appearance tools.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As raised in #48635, without a comment, it isn't clear why there's a discrepancy between the core code and the Gutenberg code for this particular opt-in.

As discussed in https://github.com/WordPress/gutenberg/issues/48635#issuecomment-1450970783 and https://github.com/WordPress/wordpress-develop/pull/3973#discussion_r1097984933, Gutenberg should be slightly more permissive than core here, so that it's easier to test subsequent explorations in adding `fixed` to the Group block, but this wasn't desired in core. In core, `fixed` is a valid setting, but it needs to be opted-in intentionally so that it isn't accidentally exposed anywhere.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add a comment to the Theme JSON class explaining the current status of the `position.fixed` opt-in. This uses the same `// BEGIN EXPERIMENTAL` and `// END EXPERIMENTAL` comments I've seen used elsewhere.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Proofread the comments.
2. (Optional) Load up the site editor or post editor with TT3 theme, and check that you can still access the Position panel and set Sticky (this just checks that I didn't add a typo or anything to break the PHP file)
