### PR TITLE
Fix duplication of block classname in feature selectors for style variations.

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2336,11 +2336,13 @@ class WP_Theme_JSON_Gutenberg {
 						if ( empty( $style_variation_node[ $feature_name ] ) ) {
 							continue;
 						}
+						// If feature selector includes block classname, remove it but leave the whitespace in.
+						$shortened_feature_selector = str_replace( $block_metadata['selector'] . ' ', ' ', $feature_selector );
 						// Prepend the variation selector to the feature selector.
-						$split_feature_selectors    = explode( ',', $feature_selector );
+						$split_feature_selectors    = explode( ',', $shortened_feature_selector );
 						$feature_selectors          = array_map(
 							static function( $split_feature_selector ) use ( $clean_style_variation_selector ) {
-								return $clean_style_variation_selector . trim( $split_feature_selector );
+								return $clean_style_variation_selector . $split_feature_selector;
 							},
 							$split_feature_selectors
 						);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #48441.

When block style variations target feature selectors, the block classname is duplicated in the concatenated selector. This increases selector specificity beyond what's necessary for this feature to work. 

The block style variation classname should still be duplicated in the front end output, just not the block classname.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In global styles, under the block section, go to the Image block and edit its "Rounded" style variation. Save.
2. Add an Image block to a post and pick "Rounded" as its style. Save and view in the front end. 
3. Inspect the Image styles and see that they are applied correctly, and that the block classname is no longer duplicated in the selector.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
