### PR TITLE
Don't add Post Content layout styles to title in the post editor.

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -376,15 +376,11 @@ export default function VisualEditor( { styles } ) {
 						{ ! isTemplateMode && (
 							<div
 								className={ classnames(
-									// This wrapper div should have the same
-									// classes as the block list beneath.
-									'is-root-container',
-									'block-editor-block-list__layout',
 									'edit-post-visual-editor__post-title-wrapper',
 									{
 										'is-focus-mode': isFocusMode,
 									},
-									blockListLayoutClass
+									'is-layout-flow'
 								) }
 								contentEditable={ false }
 							>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #48579.

If Post Content block has custom layout settings (e.g. if it's justified right and/or has a narrow content width) the post title in the post editor shouldn't get those styles, as they don't necessarily reflect the layout of the Post Title block in the template.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Edit the post template and set a custom layout on the Post Content block; save and go back to the post editor.
2. Post title should't reflect the post content styles; they should be applied to the post content only.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="1010" alt="Screenshot 2023-03-02 at 4 10 42 pm" src="https://user-images.githubusercontent.com/8096000/222336861-46926e5a-4f86-4c58-8c2e-ff3aa327327d.png">

