### PR TITLE
Prefer committer over author date for perf results timestamp

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -94,22 +94,13 @@ jobs:
               run: |
                   ./bin/plugin/cli.js perf $(echo $BRANCHES | tr ',' ' ') --tests-branch $GITHUB_SHA --wp-version "$WP_VERSION"
 
-            - name: Get commit timestamp
-              uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # v6.4.0
-              if: github.event_name == 'push'
-              id: commit-timestamp
-              with:
-                  github-token: ${{secrets.GITHUB_TOKEN}}
-                  script: |
-                      const commit_details = await github.rest.git.getCommit({owner: context.repo.owner, repo: context.repo.repo, commit_sha: context.sha});
-                      return parseInt((new Date( commit_details.data.author.date ).getTime() / 1000).toFixed(0))
-
             - name: Publish performance results
               if: github.event_name == 'push'
               env:
-                  COMMITTED_AT: ${{ steps.commit-timestamp.outputs.result }}
                   CODEHEALTH_PROJECT_TOKEN: ${{ secrets.CODEHEALTH_PROJECT_TOKEN }}
-              run: ./bin/log-performance-results.js $CODEHEALTH_PROJECT_TOKEN trunk $GITHUB_SHA debd225d007f4e441ceec80fbd6fa96653f94737 $COMMITTED_AT
+              run: |
+                  COMMITTED_AT=$(git show -s $GITHUB_SHA --format="%ct")
+                  ./bin/log-performance-results.js $CODEHEALTH_PROJECT_TOKEN trunk $GITHUB_SHA debd225d007f4e441ceec80fbd6fa96653f94737 $COMMITTED_AT
 
             - name: Archive debug artifacts (screenshots, HTML snapshots)
               uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2


### PR DESCRIPTION
## What?
Related: https://github.com/WordPress/gutenberg/pull/48243#discussion_r1122270698

Prefer the [commiter date](https://git-scm.com/docs/pretty-formats#Documentation/pretty-formats.txt-emctem) over the [author date](https://git-scm.com/docs/pretty-formats#Documentation/pretty-formats.txt-ematem) for logging performance tests results.

## Why?
There's a mismatch between `COMMITTED_AT` and `commit_details.data.author.data` whereby the author can choose a time for the commit, but the actual time of the commit is different. From [the docs](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-github-profile/managing-contribution-settings-on-your-profile/troubleshooting-commits-on-your-timeline#:~:text=In%20Git%2C%20the%20author%20date%20is%20when%20someone%20first%20creates%20a%20commit%20with%20git%20commit.%20The%20commit%20date%20is%20identical%20to%20the%20author%20date%20unless%20someone%20changes%20the%20commit%20date%20by%20using%20git%20commit%20%2D%2Damend%2C%20a%20force%20push%2C%20a%20rebase%2C%20or%20other%20Git%20commands.): 

>In Git, the author date is when someone first creates a commit with git commit. The commit date is identical to the author date unless someone changes the commit date by using git commit --amend, a force push, a rebase, or other Git commands.

## How?
Get the committer timestamp directly via git instead of [fetching](https://github.com/octokit/plugin-rest-endpoint-methods.js/blob/8efdcf24713ab34d5353b5763ac81814b25b7e55/src/generated/endpoints.ts#L723) via the script action as suggested by @dmsnell [here](https://github.com/WordPress/gutenberg/pull/48243#discussion_r1122270698).