### PR TITLE
TextHighlight : strip html from text

### DIFF
--- a/packages/components/src/text-highlight/index.tsx
+++ b/packages/components/src/text-highlight/index.tsx
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { createInterpolateElement } from '@wordpress/element';
+import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 
 /**
  * Internal dependencies
@@ -27,9 +28,10 @@ import type { TextHighlightProps } from './types';
 export const TextHighlight = ( props: TextHighlightProps ) => {
 	const { text = '', highlight = '' } = props;
 	const trimmedHighlightText = highlight.trim();
+	const plainText = stripHTML( text );
 
 	if ( ! trimmedHighlightText ) {
-		return <>{ text }</>;
+		return <>{ plainText }</>;
 	}
 
 	const regex = new RegExp(
@@ -37,9 +39,12 @@ export const TextHighlight = ( props: TextHighlightProps ) => {
 		'gi'
 	);
 
-	return createInterpolateElement( text.replace( regex, '<mark>$&</mark>' ), {
-		mark: <mark />,
-	} );
+	return createInterpolateElement(
+		plainText.replace( regex, '<mark>$&</mark>' ),
+		{
+			mark: <mark />,
+		}
+	);
 };
 
 export default TextHighlight;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

strip html from text passed to `TextHighlight` component


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Closing #48672

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Instead of trying to run the interpolation on the text as passed into the component, the text first gets stripped of any html that may be within it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Create a new page with the page where the page title contains a `mark` element with any tag in it. For example: `<mark style="">test</mark> page`
2. Publish that page
3. Create another new page
4. Insert the Button block
5. Add a link to the button and try searching for the page you just created

Before this patch this caused the block to error.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

_Not applicable_
