### PR TITLE
Backport #47828 as fix for unwanted Link UI popup in Navigation sidebar

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/block-contents.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-contents.js
@@ -73,7 +73,7 @@ const ListViewBlockContents = forwardRef(
 			setInsertedBlockAttributes,
 		} = useInsertedBlock( lastInsertedBlockClientId );
 
-		const hasExistingLinkValue = insertedBlockAttributes?.id;
+		const hasExistingLinkValue = insertedBlockAttributes?.url;
 
 		useEffect( () => {
 			if (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Backports changes from https://github.com/WordPress/gutenberg/pull/47828 to WP 6.2.

Fixes a bug whereby adding a Custom Link to the Nav block list view would result in the Link UI always appearing when the panel is re-rendered.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The reason why the bug occurred can be read about in https://github.com/WordPress/gutenberg/pull/47828. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Essentially the Link UI was shown on a condition relating to whether the link had an `id` whereas is should have been looking for a `url` to determine whether or not to display the Link UI.

Because Custom Link's do not have an `id` the Link UI always appeared even if a `url` was configured. By checking against `url` we account for Custom Link and avoid the UI appearing all the time.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

#### On current `wp/6.2` branch

- Site Editor
- Go to Nav block
- Open Nav block list view in Inspector Controls.
- Add a Custom Link and fill out a manual _URL_ only (e.g. `www.wordpress.org`).
- Click away from Nav block.
- Re select the Nav block and open block list view.
- See Link UI appear automatically.

#### This branch

- Repeat steps above but this time see that no UI is shown when list view is re-mounted.
- Also check that you can add other types of links and other behavuiour seems ok.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

#### Before


https://user-images.githubusercontent.com/444434/222403957-98ef9e24-0112-4b44-8599-3360fbc5718f.mp4

#### After


https://user-images.githubusercontent.com/444434/222404328-b7da2827-fbd1-4696-81f3-7e1d029dd6f5.mp4



