### PR TITLE
Renames parent selection boolean param and improves docs

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1382,7 +1382,7 @@ the set of specified client IDs are to be removed.
 _Parameters_
 
 -   _clientIds_ `string|string[]`: Client IDs of blocks to remove.
--   _selectPrevious_ `boolean`: True if the previous block or the immediate parent, if no previous block exists, should be selected when a block is removed.
+-   _selectPrevious_ `boolean`: True if the previous block or the immediate parent (if no previous block exists) should be selected when a block is removed.
 
 ### replaceBlock
 

--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1382,7 +1382,7 @@ the set of specified client IDs are to be removed.
 _Parameters_
 
 -   _clientIds_ `string|string[]`: Client IDs of blocks to remove.
--   _selectPrevious_ `boolean`: True if the previous block should be selected when a block is removed.
+-   _selectPrevious_ `boolean`: True if the previous block or the immediate parent, if no previous block exists, should be selected when a block is removed.
 
 ### replaceBlock
 
@@ -1502,7 +1502,7 @@ should be selected.
 _Parameters_
 
 -   _clientId_ `string`: Block client ID.
--   _orFirstParent_ `boolean`: If true, select the first parent if there is no previous block.
+-   _fallbackToParent_ `boolean`: If true, select the first parent if there is no previous block.
 
 ### setBlockMovingClientId
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1183,8 +1183,8 @@ export const mergeBlocks =
  *
  * @param {string|string[]} clientIds      Client IDs of blocks to remove.
  * @param {boolean}         selectPrevious True if the previous block
- *                                         or the immediate parent,
- *                                         if no previous block exists,
+ *                                         or the immediate parent
+ *                                         (if no previous block exists)
  *                                         should be selected
  *                                         when a block is removed.
  */

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -235,17 +235,17 @@ export function selectBlock( clientId, initialPosition = 0 ) {
  * clientId (or optionally, its first parent from bottom to top)
  * should be selected.
  *
- * @param {string}  clientId      Block client ID.
- * @param {boolean} orFirstParent If true, select the first parent if there is no previous block.
+ * @param {string}  clientId         Block client ID.
+ * @param {boolean} fallbackToParent If true, select the first parent if there is no previous block.
  */
 export const selectPreviousBlock =
-	( clientId, orFirstParent = false ) =>
+	( clientId, fallbackToParent = false ) =>
 	( { select, dispatch } ) => {
 		const previousBlockClientId =
 			select.getPreviousBlockClientId( clientId );
 		if ( previousBlockClientId ) {
 			dispatch.selectBlock( previousBlockClientId, -1 );
-		} else if ( orFirstParent ) {
+		} else if ( fallbackToParent ) {
 			const firstParentClientId = select.getBlockRootClientId( clientId );
 			if ( firstParentClientId ) {
 				dispatch.selectBlock( firstParentClientId, -1 );
@@ -1182,8 +1182,11 @@ export const mergeBlocks =
  * the set of specified client IDs are to be removed.
  *
  * @param {string|string[]} clientIds      Client IDs of blocks to remove.
- * @param {boolean}         selectPrevious True if the previous block should be
- *                                         selected when a block is removed.
+ * @param {boolean}         selectPrevious True if the previous block
+ *                                         or the immediate parent,
+ *                                         if no previous block exists,
+ *                                         should be selected
+ *                                         when a block is removed.
  */
 export const removeBlocks =
 	( clientIds, selectPrevious = true ) =>
@@ -1204,8 +1207,7 @@ export const removeBlocks =
 		}
 
 		if ( selectPrevious ) {
-			const shouldSelectParent = true;
-			dispatch.selectPreviousBlock( clientIds[ 0 ], shouldSelectParent );
+			dispatch.selectPreviousBlock( clientIds[ 0 ], selectPrevious );
 		}
 
 		dispatch( { type: 'REMOVE_BLOCKS', clientIds } );


### PR DESCRIPTION
This is a small code quality and documentation PR to improve how #48204 gets merged to core.


Co-authored-by: Nik Tsekouras <16275880+ntsekouras@users.noreply.github.com>
Co-authored-by: George Mamadashvili <240569+Mamaduka@users.noreply.github.com>

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?


Rename the param to optionally select parent block of the `selectPreviousBlock` action to `fallbackToParent`
Make docs more explicit.
Remove one useless variable.

All tests should pass.
