### PR TITLE
Fixes extra UI in navigation block inspector

### DIFF
--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -89,9 +89,7 @@ const MenuInspectorControls = ( props ) => {
 
 	return (
 		<InspectorControls group="list">
-			<PanelBody
-				title={ process.env.IS_GUTENBERG_PLUGIN ? null : __( 'Menu' ) }
-			>
+			<PanelBody title={ null }>
 				<HStack className="wp-block-navigation-off-canvas-editor__header">
 					<Heading
 						className="wp-block-navigation-off-canvas-editor__title"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #48671

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because we don't want a double heading in a panel.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Fixes a left over plugin check that was setting a unneeded title on the panel of the navigation block's inspector tree view.

## Testing Instructions

1. On this PR
2. In a block theme
3. Open a template part with a navigation 
4. Select the navigation 
5. Notice in the inspector there is only one Menu heading on top of the tree representation

## Screenshots or screencast <!-- if applicable -->

N/A
