### PR TITLE
Tag Processor: Make `$html` field `protected`

### DIFF
--- a/lib/compat/wordpress-6.2/html-api/class-wp-html-tag-processor.php
+++ b/lib/compat/wordpress-6.2/html-api/class-wp-html-tag-processor.php
@@ -274,7 +274,7 @@ class WP_HTML_Tag_Processor {
 	 * @since 6.2.0
 	 * @var string
 	 */
-	private $html;
+	protected $html;
 
 	/**
 	 * The last query passed to next_tag().


### PR DESCRIPTION
## What?
In the 6.2 compat layer, make `WP_HTML_Tag_Processor`'s `$html` member `protected` to support subclassing.

## Why?
For parity with Code in WP 6.2, authored by @dmsnell in https://github.com/WordPress/wordpress-develop/pull/4112 and committed by @gziolo in [r55402](https://core.trac.wordpress.org/changeset/55402).