### PR TITLE
Improve Nav block loading UX by preloading Navigation menu requests

### DIFF
--- a/lib/compat/wordpress-6.3/navigation-block-preloading.php
+++ b/lib/compat/wordpress-6.3/navigation-block-preloading.php
@@ -9,7 +9,7 @@
 /**
  * Preloads requests needed for Navigation posts
  *
- * @param array                   $preload_paths    Preload paths to be filtered.
+ * @param array $preload_paths    Preload paths to be filtered.
  * @return array
  */
 function gutenberg_preload_navigation_permissions( $preload_paths ) {

--- a/lib/compat/wordpress-6.3/navigation-block-preloading.php
+++ b/lib/compat/wordpress-6.3/navigation-block-preloading.php
@@ -9,7 +9,8 @@
 /**
  * Preloads requests needed for Navigation posts
  *
- * @param array $preload_paths    Preload paths to be filtered.
+ * @param array                   $preload_paths    Preload paths to be filtered.
+ * @param WP_Block_Editor_Context $context          The current block editor context.
  * @return array
  */
 function gutenberg_preload_navigation_posts( $preload_paths, $context ) {

--- a/lib/compat/wordpress-6.3/navigation-block-preloading.php
+++ b/lib/compat/wordpress-6.3/navigation-block-preloading.php
@@ -32,7 +32,7 @@ function gutenberg_preload_navigation_posts( $preload_paths, $context ) {
 		add_query_arg(
 			array(
 				'context'   => 'edit',
-				'per_page'  => '100',
+				'per_page'  => 100,
 				'_locale'   => 'user',
 				// array indices are required to avoid query being encoded and not matching in cache.
 				'status[0]' => 'publish',
@@ -48,7 +48,7 @@ function gutenberg_preload_navigation_posts( $preload_paths, $context ) {
 		add_query_arg(
 			array(
 				'context'  => 'edit',
-				'per_page' => '1',
+				'per_page' => 1,
 				'status'   => 'publish',
 				'order'    => 'desc',
 				'orderby'  => 'date',
@@ -57,7 +57,6 @@ function gutenberg_preload_navigation_posts( $preload_paths, $context ) {
 		),
 		'GET',
 	);
-
 
 	return $preload_paths;
 }

--- a/lib/compat/wordpress-6.3/navigation-block-preloading.php
+++ b/lib/compat/wordpress-6.3/navigation-block-preloading.php
@@ -50,12 +50,27 @@ function gutenberg_preload_navigation_posts( $preload_paths, $context ) {
 				'context'  => 'edit',
 				'per_page' => '100',
 				'status'   => 'publish',
-				'_locale'  => 'user',
 			),
 			$navigation_rest_route
 		),
 		'GET',
 	);
+
+	// Preload request for Browse Mode sidebar.
+	$preload_paths[] = array(
+		add_query_arg(
+			array(
+				'context'  => 'edit',
+				'per_page' => '1',
+				'status'   => 'publish',
+				'order'    => 'desc',
+				'orderby'  => 'date',
+			),
+			$navigation_rest_route
+		),
+		'GET',
+	);
+
 
 	return $preload_paths;
 }

--- a/lib/compat/wordpress-6.3/navigation-block-preloading.php
+++ b/lib/compat/wordpress-6.3/navigation-block-preloading.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Adds the preload paths registered in Core (`edit-form-blocks.php`).
+ *
+ * @param array                   $preload_paths    Preload paths to be filtered.
+ * @param WP_Block_Editor_Context $context The current block editor context.
+ * @return array
+ */
+function gutenberg_preload_navigation_permissions( $preload_paths, $context ) {
+
+    $preload_paths[] = array( rest_get_route_for_post_type_items( 'wp_navigation' ), 'OPTIONS' );
+
+	$preload_paths[] = rest_get_route_for_post_type_items( 'wp_navigation' );
+	// add /wp/v2/navigation?context=edit&per_page=-1&status%5B0%5D=publish&status%5B1%5D=draft to preload paths array
+	$preload_paths[] = array(
+		rest_get_route_for_post_type_items(
+			'wp_navigation',
+		),
+		array(
+			'context'  => 'edit',
+			'per_page' => '-1',
+			'status'   => array( 'publish, draft' ),
+		),
+
+	);
+
+	// add /wp/v2/navigation?_locale=user&context=edit&per_page=100&status%5B0%5D=publish&status%5B1%5D=draft to preload paths array
+	$preload_paths[] = array(
+		rest_get_route_for_post_type_items(
+			'wp_navigation',
+		),
+		array(
+			'_locale'  => 'user',
+			'context'  => 'edit',
+			'per_page' => '100',
+			'status'   => array( 'publish, draft' ),
+		),
+
+	);
+
+	echo '<pre>';
+	var_dump( $preload_paths );
+	echo '</pre>';
+
+	return $preload_paths;
+}
+add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_preload_navigation_permissions', 10, 2 );

--- a/lib/compat/wordpress-6.3/navigation-block-preloading.php
+++ b/lib/compat/wordpress-6.3/navigation-block-preloading.php
@@ -1,13 +1,18 @@
 <?php
+/**
+ * Patches resources loaded by the block editor page
+ * to include Navigation posts.
+ *
+ * @package gutenberg
+ */
 
 /**
- * Adds the preload paths registered in Core (`edit-form-blocks.php`).
+ * Preloads requests needed for Navigation posts
  *
  * @param array                   $preload_paths    Preload paths to be filtered.
- * @param WP_Block_Editor_Context $context The current block editor context.
  * @return array
  */
-function gutenberg_preload_navigation_permissions( $preload_paths, $context ) {
+function gutenberg_preload_navigation_permissions( $preload_paths ) {
 
 	$navigation_rest_route = rest_get_route_for_post_type_items(
 		'wp_navigation'

--- a/lib/compat/wordpress-6.3/navigation-block-preloading.php
+++ b/lib/compat/wordpress-6.3/navigation-block-preloading.php
@@ -9,39 +9,18 @@
  */
 function gutenberg_preload_navigation_permissions( $preload_paths, $context ) {
 
-    $preload_paths[] = array( rest_get_route_for_post_type_items( 'wp_navigation' ), 'OPTIONS' );
-
-	$preload_paths[] = rest_get_route_for_post_type_items( 'wp_navigation' );
-	// add /wp/v2/navigation?context=edit&per_page=-1&status%5B0%5D=publish&status%5B1%5D=draft to preload paths array
-	$preload_paths[] = array(
-		rest_get_route_for_post_type_items(
-			'wp_navigation',
-		),
-		array(
-			'context'  => 'edit',
-			'per_page' => '-1',
-			'status'   => array( 'publish, draft' ),
-		),
-
+	$navigation_rest_route = rest_get_route_for_post_type_items(
+		'wp_navigation'
 	);
 
-	// add /wp/v2/navigation?_locale=user&context=edit&per_page=100&status%5B0%5D=publish&status%5B1%5D=draft to preload paths array
+	// Preload the OPTIONS request for all Navigation posts request.
+	$preload_paths[] = array( $navigation_rest_route, 'OPTIONS' );
+
+	// Preload the GET request for all Navigation posts request.
 	$preload_paths[] = array(
-		rest_get_route_for_post_type_items(
-			'wp_navigation',
-		),
-		array(
-			'_locale'  => 'user',
-			'context'  => 'edit',
-			'per_page' => '100',
-			'status'   => array( 'publish, draft' ),
-		),
-
+		$navigation_rest_route . '?context=edit&per_page=100&status[0]=publish&status[1]=draft&_locale=user',
+		'GET',
 	);
-
-	echo '<pre>';
-	var_dump( $preload_paths );
-	echo '</pre>';
 
 	return $preload_paths;
 }

--- a/lib/compat/wordpress-6.3/navigation-block-preloading.php
+++ b/lib/compat/wordpress-6.3/navigation-block-preloading.php
@@ -12,7 +12,12 @@
  * @param array $preload_paths    Preload paths to be filtered.
  * @return array
  */
-function gutenberg_preload_navigation_posts( $preload_paths ) {
+function gutenberg_preload_navigation_posts( $preload_paths, $context ) {
+
+	// Limit to the Site Editor.
+	if ( ! empty( $context->name ) && 'core/edit-site' !== $context->name ) {
+		return $preload_paths;
+	}
 
 	$navigation_rest_route = rest_get_route_for_post_type_items(
 		'wp_navigation'

--- a/lib/compat/wordpress-6.3/navigation-block-preloading.php
+++ b/lib/compat/wordpress-6.3/navigation-block-preloading.php
@@ -27,7 +27,7 @@ function gutenberg_preload_navigation_posts( $preload_paths, $context ) {
 	// Preload the OPTIONS request for all Navigation posts request.
 	$preload_paths[] = array( $navigation_rest_route, 'OPTIONS' );
 
-	// Preload the GET request for all 'published' or 'draft' Navigation posts.
+	// Preload the GET request for ALL 'published' or 'draft' Navigation posts.
 	$preload_paths[] = array(
 		add_query_arg(
 			array(
@@ -43,20 +43,7 @@ function gutenberg_preload_navigation_posts( $preload_paths, $context ) {
 		'GET',
 	);
 
-	// Preload the GET request for 'published' Navigation posts only.
-	$preload_paths[] = array(
-		add_query_arg(
-			array(
-				'context'  => 'edit',
-				'per_page' => '100',
-				'status'   => 'publish',
-			),
-			$navigation_rest_route
-		),
-		'GET',
-	);
-
-	// Preload request for Browse Mode sidebar.
+	// Preload request for Browse Mode sidebar "Navigation" section.
 	$preload_paths[] = array(
 		add_query_arg(
 			array(

--- a/lib/compat/wordpress-6.3/navigation-block-preloading.php
+++ b/lib/compat/wordpress-6.3/navigation-block-preloading.php
@@ -12,7 +12,7 @@
  * @param array $preload_paths    Preload paths to be filtered.
  * @return array
  */
-function gutenberg_preload_navigation_permissions( $preload_paths ) {
+function gutenberg_preload_navigation_posts( $preload_paths ) {
 
 	$navigation_rest_route = rest_get_route_for_post_type_items(
 		'wp_navigation'
@@ -53,4 +53,4 @@ function gutenberg_preload_navigation_permissions( $preload_paths ) {
 
 	return $preload_paths;
 }
-add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_preload_navigation_permissions', 10, 2 );
+add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_preload_navigation_posts', 10, 2 );

--- a/lib/compat/wordpress-6.3/navigation-block-preloading.php
+++ b/lib/compat/wordpress-6.3/navigation-block-preloading.php
@@ -22,9 +22,10 @@ function gutenberg_preload_navigation_permissions( $preload_paths, $context ) {
 			array(
 				'context'   => 'edit',
 				'per_page'  => '100',
+				'_locale'   => 'user',
+				// array indices are required to avoid query being encoded and not matching in cache.
 				'status[0]' => 'publish',
 				'status[1]' => 'draft',
-				'_locale'   => 'user',
 			),
 			$navigation_rest_route
 		),

--- a/lib/compat/wordpress-6.3/navigation-block-preloading.php
+++ b/lib/compat/wordpress-6.3/navigation-block-preloading.php
@@ -16,9 +16,32 @@ function gutenberg_preload_navigation_permissions( $preload_paths, $context ) {
 	// Preload the OPTIONS request for all Navigation posts request.
 	$preload_paths[] = array( $navigation_rest_route, 'OPTIONS' );
 
-	// Preload the GET request for all Navigation posts request.
+	// Preload the GET request for all 'published' or 'draft' Navigation posts.
 	$preload_paths[] = array(
-		$navigation_rest_route . '?context=edit&per_page=100&status[0]=publish&status[1]=draft&_locale=user',
+		add_query_arg(
+			array(
+				'context'   => 'edit',
+				'per_page'  => '100',
+				'status[0]' => 'publish',
+				'status[1]' => 'draft',
+				'_locale'   => 'user',
+			),
+			$navigation_rest_route
+		),
+		'GET',
+	);
+
+	// Preload the GET request for 'published' Navigation posts only.
+	$preload_paths[] = array(
+		add_query_arg(
+			array(
+				'context'  => 'edit',
+				'per_page' => '100',
+				'status'   => 'publish',
+				'_locale'  => 'user',
+			),
+			$navigation_rest_route
+		),
 		'GET',
 	);
 

--- a/lib/load.php
+++ b/lib/load.php
@@ -49,6 +49,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require_once __DIR__ . '/compat/wordpress-6.3/class-gutenberg-rest-global-styles-controller-6-3.php';
 	require_once __DIR__ . '/compat/wordpress-6.3/rest-api.php';
 	require_once __DIR__ . '/compat/wordpress-6.3/theme-previews.php';
+	require_once __DIR__ . '/compat/wordpress-6.3/navigation-block-preloading.php';
 
 	// Experimental.
 	if ( ! class_exists( 'WP_Rest_Customizer_Nonces' ) ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Preloads Navigation entities in the Site Editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We have lots of requests going out async for Navigation entities. This causes the block (and resultingly the editor) to feel very sluggish as these requests can take a while to resolve on slower connections.

The waterfall is:

- request for _all_ Navigation menus (needed ~to find a fallback~ for other things).
- request for individual Navigation menu (by ID).

These also have `OPTIONS` requests which take time to resolve. By preloading these requests we improve the perceived performance in the editor as the requests are not dispatched.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Preload the requests that cause network waterfalls for Navigation posts. 

We can't preload the _individual_ Nav block, but we _can_ preload a list of all the Nav blocks and OPTIONS requests as well.

In the **future**, once we reference Navigation posts by `slug` then it will be possible to preload the Nav with the `header` slug which will allow us to have the primary Navigation menu available in editor fetch cache on editor being loaded.

## ⚠️ Potential Considerations

- may increase TTFB
- not all sites will use a Navigation block (i'd argue that 80% will).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

⚠️ Some of the perceived performance may be difficult to perceive on fast environments. You may need to throttle your network speed in Chrome dev tools.

#### On trunk

- Activate TT3 Theme.
- Ensure you have at least one Navigation menu at `http://localhost:8888/wp-admin/edit.php?post_type=wp_navigation`
- Open the Site Editor
- See header template part load and once resolved, see a long _additional_ loading state for the Navigation block itself.
 
#### On this branch

Do the same as the above but this time notice that once the template part is loaded there is almost no (or a reduced) loading state for the Nav block _at all_. The menu is almost instantly available. 

Observe the network tab (filtered by "navigation") and notice that only a single requests is dispatched for `OPTIONS` for the single Navigation by ID. This is actually a request to get _permissions_ on that Navigation. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->



### Editor loading UX

#### Before

Notice how once the template part resolves the Navigation block shows its own loading state for quite a while before resolving to the menu:

https://user-images.githubusercontent.com/444434/223682332-fa69f99c-23b0-423c-9bb6-099d1820d38e.mp4



#### After

Notice how once the template part resolves the menu is almost instantly available in the Navigation block:

https://user-images.githubusercontent.com/444434/223682302-658f3931-5be4-43ed-af19-0d63c3d16863.mp4




### Network timings

#### Before

Notice the request for the single Navigation menu is not dispatched until the requests for all Navigation Menus are resolved.

<img width="1507" alt="Screen Shot 2023-03-08 at 09 53 39" src="https://user-images.githubusercontent.com/444434/223681154-9649b807-fdbd-42e9-8f75-d78cc7663ca2.png">

#### After

Now only a single OPTIONS request for the single Navigation Menu.

<img width="755" alt="Screen Shot 2023-03-08 at 09 54 14" src="https://user-images.githubusercontent.com/444434/223681165-009dc1bc-5d64-4c3e-87fa-89fe7f963396.png">



