### PR TITLE
LinkControl: Remove HTML from suggestion title before passing it to TextHighlight component

### DIFF
--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -18,6 +18,7 @@ import {
 	category,
 	file,
 } from '@wordpress/icons';
+import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 
 const ICONS_MAP = {
 	post: postList,
@@ -72,7 +73,8 @@ export const LinkControlSearchItem = ( {
 			<span className="block-editor-link-control__search-item-header">
 				<span className="block-editor-link-control__search-item-title">
 					<TextHighlight
-						text={ suggestion.title }
+						// we are stripping HTML here because the title may include markup which can cause issues with TextHighlight
+						text={ stripHTML( suggestion.title ) }
 						highlight={ searchTerm }
 					/>
 				</span>

--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -73,7 +73,7 @@ export const LinkControlSearchItem = ( {
 			<span className="block-editor-link-control__search-item-header">
 				<span className="block-editor-link-control__search-item-title">
 					<TextHighlight
-						// we are stripping HTML here because the title may include markup which can cause issues with TextHighlight
+						// The component expects a plain text string.
 						text={ stripHTML( suggestion.title ) }
 						highlight={ searchTerm }
 					/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

strip html tags from suggestion.title before passing it to `TextHighlight` component

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

An alternate approach to #48674 to close #48672

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

wrapping the `suggestion.title` in a `stripHTML` function call

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Create a new page with the page where the page title contains a `mark` element with any tag in it. For example: `<mark style="">test</mark> page`
2. Publish that page
3. Create another new page
4. Insert the Button block
5. Add a link to the button and try searching for the page you just created

Before this patch this caused the block to error.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

_Not applicable_
