### PR TITLE
Components: remove lodash from `context/getStyledClassName`:

### DIFF
--- a/packages/components/src/ui/context/get-styled-class-name-from-key.ts
+++ b/packages/components/src/ui/context/get-styled-class-name-from-key.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { kebabCase } from 'lodash';
+import { paramCase as kebabCase } from 'change-case';
 import memoize from 'memize';
 
 /**


### PR DESCRIPTION
## What?

This PR removes Lodash's `_.kebabCase()` from the `getStyledClassName` function used in ui/context. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

Replaces `_.kebabCase` with `paramCase` from the `change-case` package (already used in the components package).

## Testing Instructions

1. Verify unit tests still pass; this change should be covered there
2. Start storybook locally and verify the story for the `ContextSystemProvider` works and looks as expected (compare with trunk here: [ContextSystemProvider](https://wordpress.github.io/gutenberg/?path=/story/components-experimental-contextsystemprovider--default))