### PR TITLE
WP_HTML_Tag_Processor: Support tag closer bookmarks

### DIFF
--- a/lib/compat/wordpress-6.2/html-api/class-wp-html-tag-processor.php
+++ b/lib/compat/wordpress-6.2/html-api/class-wp-html-tag-processor.php
@@ -722,7 +722,7 @@ class WP_HTML_Tag_Processor {
 		}
 
 		$this->bookmarks[ $name ] = new WP_HTML_Span(
-			$this->tag_name_starts_at - 1,
+			$this->tag_name_starts_at - ( $this->is_closing_tag ? 2 : 1 ),
 			$this->tag_ends_at
 		);
 
@@ -1504,7 +1504,7 @@ class WP_HTML_Tag_Processor {
 		$this->bytes_already_parsed = $this->bookmarks[ $bookmark_name ]->start;
 		$this->bytes_already_copied = $this->bytes_already_parsed;
 		$this->output_buffer        = substr( $this->html, 0, $this->bytes_already_copied );
-		return $this->next_tag();
+		return $this->next_tag( array( 'tag_closers' => 'visit' ) );
 	}
 
 	/**


### PR DESCRIPTION
## What?
In the 6.2 compat layer, support bookmarks pointing to closing tags.

## Why?
For parity with Core in WP 6.2, authored by @adamziel in https://github.com/WordPress/wordpress-develop/pull/4115 and committed by @hellofromtonya in [r55407](https://core.trac.wordpress.org/changeset/55407).

Note that these changes have already been backported to GB's 6.**3** compat layer by @dmsnell in #48378. However, since the change will be in WP 6.2, we also have to apply it to GB's 6.2 compat layer.