### PR TITLE
Fix Flaky Test: default to the only existing classic menu if there are no block menus

### DIFF
--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -117,18 +117,20 @@ test.describe(
 				},
 			] );
 
+			// Snackbar notification should appear
+			await expect(
+				page.getByRole( 'button', {
+					name: 'Dismiss this notice',
+					text: 'Navigation Menu successfully created.',
+				} )
+			).toBeVisible();
+
 			// Check the block in the canvas.
 			await expect(
 				editor.canvas.locator(
 					`role=textbox[name="Navigation link text"i] >> text="Custom link"`
 				)
-			).toBeVisible( {
-				// Wait for the Nav block API request to resolve.
-				// Note: avoid waiting on network requests as these are not perceivable
-				// to the user.
-				// See: https://github.com/WordPress/gutenberg/pull/45070#issuecomment-1373712007.
-				timeout: 10000,
-			} );
+			).toBeVisible();
 
 			// Check the block in the frontend.
 			await page.goto( '/' );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -122,7 +122,13 @@ test.describe(
 				editor.canvas.locator(
 					`role=textbox[name="Navigation link text"i] >> text="Custom link"`
 				)
-			).toBeVisible();
+			).toBeVisible( {
+				// Wait for the Nav block API request to resolve.
+				// Note: avoid waiting on network requests as these are not perceivable
+				// to the user.
+				// See: https://github.com/WordPress/gutenberg/pull/45070#issuecomment-1373712007.
+				timeout: 10000,
+			} );
 
 			// Check the block in the frontend.
 			await page.goto( '/' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Tries to fix https://github.com/WordPress/gutenberg/issues/48033

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
