### PR TITLE
Fix apiFetch error response not being parsed when using `fetchAllMiddleware`

### DIFF
--- a/packages/api-fetch/src/middlewares/fetch-all-middleware.js
+++ b/packages/api-fetch/src/middlewares/fetch-all-middleware.js
@@ -7,6 +7,7 @@ import { addQueryArgs } from '@wordpress/url';
  * Internal dependencies
  */
 import apiFetch from '..';
+import { parseAndThrowError } from '../utils/response';
 
 /**
  * Apply query arguments to both URL and Path, whichever is present.
@@ -91,7 +92,7 @@ const fetchAllMiddleware = async ( options, next ) => {
 		} ),
 		// Ensure headers are returned for page 1.
 		parse: false,
-	} );
+	} ).catch( parseAndThrowError );
 
 	const results = await parseResponse( response );
 
@@ -117,7 +118,7 @@ const fetchAllMiddleware = async ( options, next ) => {
 			url: nextPage,
 			// Ensure we still get headers so we can identify the next page.
 			parse: false,
-		} );
+		} ).catch( parseAndThrowError );
 		const nextResults = await parseResponse( nextResponse );
 		mergedResults = mergedResults.concat( nextResults );
 		nextPage = getNextPageUrl( nextResponse );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

It fixes an issue with the `apiFetch`, which is not parsing the response error when using the `fetchAllMiddleware`.

Notice that it's not ready to be merged because it could cause backward compatibility problems. I didn't have any good idea so far to keep it working with existing implementations parsing the error manually for this case. Any ideas?

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When using the `apiFetch`, we need to parse the error JSON manually if we have a `per_page=-1` in the path. See the problem with more details by running:

```js
apiFetch( { path: '/wp/v2/anything?per_page=-1' } )
	.then( console.log )
	.catch( ( err ) => {
		console.log(
			'See that the error is not parsed when using per_page=-1',
			err
		);
	} );

apiFetch( { path: '/wp/v2/anything?per_page=-1' } )
	.then( console.log )
	.catch( ( err ) => err.json() )
	.then( ( err ) => {
		console.log(
			'See that the error is parsed when we do it manually',
			err
		);
	} );

apiFetch( { path: '/wp/v2/anything' } )
	.then( console.log )
	.catch( ( err ) => {
		console.log(
			'See that the error is parsed when not using the per_page=-1',
			err
		);
	} );
```

By default, it shouldn't be needed, because the `parse` option is `true` and should parse the JSON for us.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

It was skipping the parse in case of error because it's forcing `parse: false` and parsing it later only in case of success. It fixes it by catching the error and parsing it too through the `parseAndThrowError`. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Use the following snippet, and make sure the error is parsed.

```js
apiFetch( { path: '/wp/v2/anything?per_page=-1' } )
	.then( console.log )
	.catch( console.log );
```