### PR TITLE
Add login/out to menu

### DIFF
--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -24,6 +24,7 @@ const ALLOWED_BLOCKS = [
 	'core/home-link',
 	'core/site-title',
 	'core/site-logo',
+	'core/loginout',
 	'core/navigation-submenu',
 ];
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds login/out block to navigation #48704 

## Why?
It's common to add login to menu

## How?
Add core/loginout block to allowed blocks in navigation
