### PR TITLE
Custom Classname block support: Update code comments to remove reference to anchor id

### DIFF
--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -18,8 +18,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 import { InspectorControls } from '../components';
 
 /**
- * Filters registered block settings, extending attributes with anchor using ID
- * of the first node.
+ * Filters registered block settings, extending attributes to include `className`.
  *
  * @param {Object} settings Original block settings.
  *
@@ -42,6 +41,7 @@ export function addAttribute( settings ) {
 /**
  * Override the default edit UI to include a new block inspector control for
  * assigning the custom class name, if block supports custom class name.
+ * The control is displayed within the Advanced panel in the block inspector.
  *
  * @param {WPComponent} BlockEdit Original component.
  *
@@ -89,8 +89,8 @@ export const withInspectorControl = createHigherOrderComponent(
 );
 
 /**
- * Override props assigned to save component to inject anchor ID, if block
- * supports anchor. This is only applied if the block's save result is an
+ * Override props assigned to save component to inject the className, if block
+ * supports customClassName. This is only applied if the block's save result is an
  * element and not a markup string.
  *
  * @param {Object} extraProps Additional props applied to save element.

--- a/packages/block-editor/src/hooks/custom-class-name.native.js
+++ b/packages/block-editor/src/hooks/custom-class-name.native.js
@@ -10,8 +10,7 @@ import { addFilter } from '@wordpress/hooks';
 import { hasBlockSupport } from '@wordpress/blocks';
 
 /**
- * Filters registered block settings, extending attributes with anchor using ID
- * of the first node.
+ * Filters registered block settings, extending attributes to include `className`.
  *
  * @param {Object} settings Original block settings.
  *
@@ -32,8 +31,8 @@ export function addAttribute( settings ) {
 }
 
 /**
- * Override props assigned to save component to inject anchor ID, if block
- * supports anchor. This is only applied if the block's save result is an
+ * Override props assigned to save component to inject the className, if block
+ * supports customClassName. This is only applied if the block's save result is an
  * element and not a markup string.
  *
  * @param {Object} extraProps Additional props applied to save element.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Update code comments for the custom classname blocks support (the custom classname field under the Advanced panel in the block inspector) to remove references to anchor id. It looks like this was a copy+paste from the anchor id block support many years ago.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While reviewing https://github.com/WordPress/gutenberg/pull/48404, I gave this block support a read and was confused for a second about the reference to anchor ids — I figured it'd be good to update the comments a tiny bit to help prevent anyone else from being confused for a second 😄

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update the code comments.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Double check if the comments read okay / if I've made any spelling errors.