### PR TITLE
Site Editor: Move "Add Template"'s descriptions to tooltips

### DIFF
--- a/packages/components/src/tooltip/index.js
+++ b/packages/components/src/tooltip/index.js
@@ -1,6 +1,11 @@
 // @ts-nocheck
 
 /**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -66,6 +71,8 @@ const addPopoverToGrandchildren = ( {
 	position,
 	shortcut,
 	text,
+	className,
+	...props
 } ) =>
 	concatChildren(
 		grandchildren,
@@ -73,12 +80,13 @@ const addPopoverToGrandchildren = ( {
 			<Popover
 				focusOnMount={ false }
 				position={ position }
-				className="components-tooltip"
+				className={ classNames( 'components-tooltip', className ) }
 				aria-hidden="true"
 				animate={ false }
 				offset={ offset }
 				anchor={ anchor }
 				shift
+				{ ...props }
 			>
 				{ text }
 				<Shortcut
@@ -113,6 +121,7 @@ function Tooltip( props ) {
 		text,
 		shortcut,
 		delay = TOOLTIP_DELAY,
+		...popoverProps
 	} = props;
 	/**
 	 * Whether a mouse is currently pressed, used in determining whether
@@ -270,6 +279,7 @@ function Tooltip( props ) {
 	const childrenWithPopover = addPopoverToGrandchildren( {
 		grandchildren,
 		...popoverData,
+		...popoverProps,
 	} );
 
 	return getElementWithPopover( {

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -6,6 +6,7 @@ import {
 	MenuGroup,
 	MenuItem,
 	Tooltip,
+	VisuallyHidden,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
@@ -164,6 +165,11 @@ export default function NewTemplate( {
 	if ( ! missingTemplates.length ) {
 		return null;
 	}
+
+	const customTemplateDescription = __(
+		'Custom templates can be applied to any post or page.'
+	);
+
 	return (
 		<>
 			<DropdownMenu
@@ -210,6 +216,11 @@ export default function NewTemplate( {
 											}
 										>
 											{ title }
+											{ /* TODO: This probably won't be needed if the <Tooltip> component is accessible.
+											 * @see https://github.com/WordPress/gutenberg/issues/48222 */ }
+											<VisuallyHidden>
+												{ description }
+											</VisuallyHidden>
 										</MenuItem>
 									</Tooltip>
 								);
@@ -218,9 +229,7 @@ export default function NewTemplate( {
 						<MenuGroup>
 							<Tooltip
 								position="top right"
-								text={ __(
-									'Custom templates can be applied to any post or page.'
-								) }
+								text={ customTemplateDescription }
 							>
 								<MenuItem
 									icon={ customGenericTemplateIcon }
@@ -232,6 +241,11 @@ export default function NewTemplate( {
 									}
 								>
 									{ __( 'Custom template' ) }
+									{ /* TODO: This probably won't be needed if the <Tooltip> component is accessible.
+									 * @see https://github.com/WordPress/gutenberg/issues/48222 */ }
+									<VisuallyHidden>
+										{ customTemplateDescription }
+									</VisuallyHidden>
 								</MenuItem>
 							</Tooltip>
 						</MenuGroup>

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -5,7 +5,7 @@ import {
 	DropdownMenu,
 	MenuGroup,
 	MenuItem,
-	NavigableMenu,
+	Tooltip,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
@@ -181,17 +181,21 @@ export default function NewTemplate( {
 						{ isCreatingTemplate && (
 							<TemplateActionsLoadingScreen />
 						) }
-						<NavigableMenu className="edit-site-new-template-dropdown__popover">
-							<MenuGroup label={ postType.labels.add_new_item }>
-								{ missingTemplates.map( ( template ) => {
-									const {
-										title,
-										description,
-										slug,
-										onClick,
-										icon,
-									} = template;
-									return (
+						<MenuGroup label={ postType.labels.add_new_item }>
+							{ missingTemplates.map( ( template ) => {
+								const {
+									title,
+									description,
+									slug,
+									onClick,
+									icon,
+								} = template;
+								return (
+									<Tooltip
+										key={ slug }
+										position="top right"
+										text={ description }
+									>
 										<MenuItem
 											icon={
 												icon ||
@@ -199,8 +203,6 @@ export default function NewTemplate( {
 												post
 											}
 											iconPosition="left"
-											info={ description }
-											key={ slug }
 											onClick={ () =>
 												onClick
 													? onClick( template )
@@ -209,17 +211,20 @@ export default function NewTemplate( {
 										>
 											{ title }
 										</MenuItem>
-									);
-								} ) }
-							</MenuGroup>
-							<MenuGroup>
+									</Tooltip>
+								);
+							} ) }
+						</MenuGroup>
+						<MenuGroup>
+							<Tooltip
+								position="top right"
+								text={ __(
+									'Custom templates can be applied to any post or page.'
+								) }
+							>
 								<MenuItem
 									icon={ customGenericTemplateIcon }
 									iconPosition="left"
-									info={ __(
-										'Custom templates can be applied to any post or page.'
-									) }
-									key="custom-template"
 									onClick={ () =>
 										setShowCustomGenericTemplateModal(
 											true
@@ -228,8 +233,8 @@ export default function NewTemplate( {
 								>
 									{ __( 'Custom template' ) }
 								</MenuItem>
-							</MenuGroup>
-						</NavigableMenu>
+							</Tooltip>
+						</MenuGroup>
 					</>
 				) }
 			</DropdownMenu>

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -187,68 +187,74 @@ export default function NewTemplate( {
 						{ isCreatingTemplate && (
 							<TemplateActionsLoadingScreen />
 						) }
-						<MenuGroup label={ postType.labels.add_new_item }>
-							{ missingTemplates.map( ( template ) => {
-								const {
-									title,
-									description,
-									slug,
-									onClick,
-									icon,
-								} = template;
-								return (
-									<Tooltip
-										key={ slug }
-										position="top right"
-										text={ description }
-									>
-										<MenuItem
-											icon={
-												icon ||
-												TEMPLATE_ICONS[ slug ] ||
-												post
-											}
-											iconPosition="left"
-											onClick={ () =>
-												onClick
-													? onClick( template )
-													: createTemplate( template )
-											}
+						<div className="edit-site-new-template-dropdown__menu-groups">
+							<MenuGroup label={ postType.labels.add_new_item }>
+								{ missingTemplates.map( ( template ) => {
+									const {
+										title,
+										description,
+										slug,
+										onClick,
+										icon,
+									} = template;
+									return (
+										<Tooltip
+											key={ slug }
+											position="top right"
+											text={ description }
+											className="edit-site-new-template-dropdown__menu-item-tooltip"
 										>
-											{ title }
-											{ /* TODO: This probably won't be needed if the <Tooltip> component is accessible.
-											 * @see https://github.com/WordPress/gutenberg/issues/48222 */ }
-											<VisuallyHidden>
-												{ description }
-											</VisuallyHidden>
-										</MenuItem>
-									</Tooltip>
-								);
-							} ) }
-						</MenuGroup>
-						<MenuGroup>
-							<Tooltip
-								position="top right"
-								text={ customTemplateDescription }
-							>
-								<MenuItem
-									icon={ customGenericTemplateIcon }
-									iconPosition="left"
-									onClick={ () =>
-										setShowCustomGenericTemplateModal(
-											true
-										)
-									}
+											<MenuItem
+												icon={
+													icon ||
+													TEMPLATE_ICONS[ slug ] ||
+													post
+												}
+												iconPosition="left"
+												onClick={ () =>
+													onClick
+														? onClick( template )
+														: createTemplate(
+																template
+														  )
+												}
+											>
+												{ title }
+												{ /* TODO: This probably won't be needed if the <Tooltip> component is accessible.
+												 * @see https://github.com/WordPress/gutenberg/issues/48222 */ }
+												<VisuallyHidden>
+													{ description }
+												</VisuallyHidden>
+											</MenuItem>
+										</Tooltip>
+									);
+								} ) }
+							</MenuGroup>
+							<MenuGroup>
+								<Tooltip
+									position="top right"
+									text={ customTemplateDescription }
+									className="edit-site-new-template-dropdown__menu-item-tooltip"
 								>
-									{ __( 'Custom template' ) }
-									{ /* TODO: This probably won't be needed if the <Tooltip> component is accessible.
-									 * @see https://github.com/WordPress/gutenberg/issues/48222 */ }
-									<VisuallyHidden>
-										{ customTemplateDescription }
-									</VisuallyHidden>
-								</MenuItem>
-							</Tooltip>
-						</MenuGroup>
+									<MenuItem
+										icon={ customGenericTemplateIcon }
+										iconPosition="left"
+										onClick={ () =>
+											setShowCustomGenericTemplateModal(
+												true
+											)
+										}
+									>
+										{ __( 'Custom template' ) }
+										{ /* TODO: This probably won't be needed if the <Tooltip> component is accessible.
+										 * @see https://github.com/WordPress/gutenberg/issues/48222 */ }
+										<VisuallyHidden>
+											{ customTemplateDescription }
+										</VisuallyHidden>
+									</MenuItem>
+								</Tooltip>
+							</MenuGroup>
+						</div>
 					</>
 				) }
 			</DropdownMenu>

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -7,7 +7,7 @@
 
 	// The specificity is needed to override the default tooltip styles.
 	&__menu-item-tooltip.components-tooltip .components-popover__content {
-		max-width: 400px;
+		max-width: 320px;
 		padding: $grid-unit-10 $grid-unit-15;
 		border-radius: 2px;
 		white-space: pre-wrap;

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -1,6 +1,19 @@
 .edit-site-new-template-dropdown {
-	@include break-small() {
-		min-width: 300px;
+	.edit-site-new-template-dropdown__menu-groups {
+		@include break-small() {
+			min-width: 300px;
+		}
+	}
+
+	// The specificity is needed to override the default tooltip styles.
+	&__menu-item-tooltip.components-tooltip .components-popover__content {
+		max-width: 400px;
+		padding: $grid-unit-10 $grid-unit-15;
+		border-radius: 2px;
+		white-space: pre-wrap;
+		min-width: 0;
+		width: auto;
+		text-align: left;
 	}
 }
 

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -1,8 +1,6 @@
 .edit-site-new-template-dropdown {
-	.edit-site-new-template-dropdown__popover {
-		@include break-small() {
-			min-width: 300px;
-		}
+	@include break-small() {
+		min-width: 300px;
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Close https://github.com/WordPress/gutenberg/issues/48589. Move the descriptions inside the "Add template" popover to tooltips.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See https://github.com/WordPress/gutenberg/issues/48589. This is meant to be the first iteration for 6.2 until we find a better alternative.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Using `<Tooltip>` component to wrap the menu item. Note that this component currently is not accessible, ongoing work is tracked in https://github.com/WordPress/gutenberg/issues/48222. In the meantime, I'm using `<VisuallyHidden>` to keep it accessible as the original to screen readers in a less ideal way.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Go to the Site Editor
2. Navigate to the template section in the left sidebar
3. Click on the "+" icon in the templates section
4. Hover over the menu items in the "Add template" dropdown, and expect tooltips to be shown.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Visit the side editor at: `/wp-admin/site-editor.php?canvas=view&path=%2Fwp_template&postType=wp_template`
2. Press <kbd>Tab</kbd> three times to move focus to the "Add template" button
3. Hit <kbd>Enter</kbd> to open the add template dropdown
4. Press <kbd>Tab</kbd> to navigate through the dropdown menu, and expect the descriptions to be announced as before

## Screenshots or screencast <!-- if applicable -->
![image](https://user-images.githubusercontent.com/7753001/222651200-f2a14997-e3bc-4766-93de-d1e3a83789eb.png)

