### PR TITLE
Rich text: useAnchor: remove value dependency

### DIFF
--- a/packages/block-editor/src/components/rich-text/format-toolbar-container.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar-container.js
@@ -19,11 +19,7 @@ import FormatToolbar from './format-toolbar';
 import NavigableToolbar from '../navigable-toolbar';
 import { store as blockEditorStore } from '../../store';
 
-function InlineSelectionToolbar( {
-	value,
-	editableContentElement,
-	activeFormats,
-} ) {
+function InlineSelectionToolbar( { editableContentElement, activeFormats } ) {
 	const lastFormat = activeFormats[ activeFormats.length - 1 ];
 	const lastFormatType = lastFormat?.type;
 	const settings = useSelect(
@@ -32,7 +28,6 @@ function InlineSelectionToolbar( {
 	);
 	const popoverAnchor = useAnchor( {
 		editableContentElement,
-		value,
 		settings,
 	} );
 
@@ -85,7 +80,6 @@ const FormatToolbarContainer = ( {
 		return (
 			<InlineSelectionToolbar
 				editableContentElement={ editableContentElement }
-				value={ value }
 				activeFormats={ activeFormats }
 			/>
 		);

--- a/packages/components/src/autocomplete/autocompleter-ui.tsx
+++ b/packages/components/src/autocomplete/autocompleter-ui.tsx
@@ -42,13 +42,11 @@ export function getAutoCompleterUI( autocompleter: WPCompleter ) {
 		onSelect,
 		onReset,
 		reset,
-		value,
 		contentRef,
 	}: AutocompleterUIProps ) {
 		const [ items ] = useItems( filterValue );
 		const popoverAnchor = useAnchor( {
 			editableContentElement: contentRef.current,
-			value,
 		} );
 
 		const [ needsA11yCompat, setNeedsA11yCompat ] = useState( false );

--- a/packages/components/src/autocomplete/index.tsx
+++ b/packages/components/src/autocomplete/index.tsx
@@ -372,6 +372,7 @@ export function useAutocomplete( {
 				selectedIndex={ selectedIndex }
 				onChangeOptions={ onChangeOptions }
 				onSelect={ select }
+				value={ record }
 				contentRef={ contentRef }
 				reset={ reset }
 			/>

--- a/packages/components/src/autocomplete/index.tsx
+++ b/packages/components/src/autocomplete/index.tsx
@@ -372,7 +372,6 @@ export function useAutocomplete( {
 				selectedIndex={ selectedIndex }
 				onChangeOptions={ onChangeOptions }
 				onSelect={ select }
-				value={ record }
 				contentRef={ contentRef }
 				reset={ reset }
 			/>

--- a/packages/components/src/autocomplete/test/index.tsx
+++ b/packages/components/src/autocomplete/test/index.tsx
@@ -74,11 +74,6 @@ describe( 'AutocompleterUI', () => {
 							selectedIndex={ 0 }
 							onChangeOptions={ () => {} }
 							onSelect={ () => {} }
-							value={ {
-								text: 'This is the text that is being edited.',
-								start: 0,
-								end: 0,
-							} }
 							contentRef={ contentRef }
 							reset={ resetSpy }
 						/>

--- a/packages/components/src/autocomplete/types.ts
+++ b/packages/components/src/autocomplete/types.ts
@@ -141,6 +141,11 @@ export type AutocompleterUIProps = {
 	 * A function that defines the behavior of the completer when it is reset
 	 */
 	reset: ( event: Event ) => void;
+	// This is optional because it's still needed for mobile/native.
+	/**
+	 * The rich text value object the autocompleter is being applied to.
+	 */
+	value?: RichTextValue;
 	/**
 	 * A ref containing the editable element that will serve as the anchor for
 	 * `Autocomplete`'s `Popover`.

--- a/packages/components/src/autocomplete/types.ts
+++ b/packages/components/src/autocomplete/types.ts
@@ -142,10 +142,6 @@ export type AutocompleterUIProps = {
 	 */
 	reset: ( event: Event ) => void;
 	/**
-	 * The rich text value object the autocompleter is being applied to.
-	 */
-	value: RichTextValue;
-	/**
 	 * A ref containing the editable element that will serve as the anchor for
 	 * `Autocomplete`'s `Popover`.
 	 */

--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -45,7 +45,6 @@ function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 	const [ width, setWidth ] = useState( style?.replace( /\D/g, '' ) );
 	const popoverAnchor = useAnchor( {
 		editableContentElement: contentRef.current,
-		value,
 		settings: image,
 	} );
 

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -211,7 +211,6 @@ function InlineLinkUI( {
 
 	const popoverAnchor = useAnchor( {
 		editableContentElement: contentRef.current,
-		value,
 		settings,
 	} );
 

--- a/packages/format-library/src/text-color/inline.js
+++ b/packages/format-library/src/text-color/inline.js
@@ -147,7 +147,6 @@ export default function InlineColorUI( {
 	const popoverAnchor = useCachedTruthy(
 		useAnchor( {
 			editableContentElement: contentRef.current,
-			value,
 			settings,
 		} )
 	);

--- a/packages/rich-text/README.md
+++ b/packages/rich-text/README.md
@@ -485,7 +485,6 @@ _Parameters_
 
 -   _$1_ `Object`: Named parameters.
 -   _$1.editableContentElement_ `HTMLElement|null`: The element containing the editable content.
--   _$1.value_ `RichTextValue`: Value to check for selection.
 -   _$1.settings_ `RichTextFormatType`: The format type's settings.
 
 _Returns_

--- a/packages/rich-text/src/component/use-anchor.js
+++ b/packages/rich-text/src/component/use-anchor.js
@@ -22,12 +22,30 @@ function getFormatElement( range, editableContentElement, tagName, className ) {
 
 	// If the caret is right before the element, select the next element.
 	element = element.nextElementSibling || element;
-	element = element.parentElement;
+
+	if ( element.nodeType !== element.ELEMENT_NODE ) {
+		element = element.parentElement;
+	}
 
 	if ( ! element ) return;
 	if ( element === editableContentElement ) return;
+	if ( ! editableContentElement.contains( element ) ) return;
 
-	return element.closest( tagName + ( className ? '.' + className : '' ) );
+	const selector = tagName + ( className ? '.' + className : '' );
+
+	// .closest( selector ), but with a boundary. Check if the element matches
+	// the selector. If it doesn't match, try the parent element if it's not the
+	// editorable wrapper. We don't want to try to match ancestors of the
+	// editable wrapper, which is what .closest( selector ) would do. When the
+	// element is the editable wrapper (which is most likely the case because
+	// most text is unformatted), this never runs.
+	while ( element !== editableContentElement ) {
+		if ( element.matches( selector ) ) {
+			return element;
+		}
+
+		element = element.parentElement;
+	}
 }
 
 /**

--- a/packages/rich-text/src/component/use-anchor.js
+++ b/packages/rich-text/src/component/use-anchor.js
@@ -89,27 +89,27 @@ const virtualAnchorCache = new WeakMap();
  */
 export function useAnchor( { editableContentElement, settings = {} } ) {
 	const { tagName, className } = settings;
-	const {
-		ownerDocument: { defaultView },
-	} = editableContentElement;
+	const win = editableContentElement?.ownerDocument?.defaultView;
 
 	// Let the store be the selection and range, and the anchor be derived data.
 	// It's worth noting that the selection reference never changes.
-	const selection = defaultView.getSelection();
+	const selection = win?.getSelection();
 
 	// Only re-subscribe when the window changes.
 	const subscribe = useCallback(
 		( callback ) => {
-			defaultView.addEventListener( 'selectionchange', callback );
+			if ( ! win ) return;
+			win.addEventListener( 'selectionchange', callback );
 			return () => {
-				defaultView.removeEventListener( 'selectionchange', callback );
+				win.removeEventListener( 'selectionchange', callback );
 			};
 		},
-		[ defaultView ]
+		[ win ]
 	);
 
 	function getSnapshot() {
 		if ( ! editableContentElement ) return;
+		if ( ! selection ) return;
 		if ( ! selection.rangeCount ) return;
 
 		const range = selection.getRangeAt( 0 );

--- a/packages/rich-text/src/component/use-anchor.js
+++ b/packages/rich-text/src/component/use-anchor.js
@@ -35,10 +35,10 @@ function getFormatElement( range, editableContentElement, tagName, className ) {
 
 	// .closest( selector ), but with a boundary. Check if the element matches
 	// the selector. If it doesn't match, try the parent element if it's not the
-	// editorable wrapper. We don't want to try to match ancestors of the
-	// editable wrapper, which is what .closest( selector ) would do. When the
-	// element is the editable wrapper (which is most likely the case because
-	// most text is unformatted), this never runs.
+	// editable wrapper. We don't want to try to match ancestors of the editable
+	// wrapper, which is what .closest( selector ) would do. When the element is
+	// the editable wrapper (which is most likely the case because most text is
+	// unformatted), this never runs.
 	while ( element !== editableContentElement ) {
 		if ( element.matches( selector ) ) {
 			return element;
@@ -152,8 +152,8 @@ export function useAnchor( { editableContentElement, settings = {} } ) {
 			attach();
 		}
 
-		editableContentElement.addEventListener( 'focus', attach );
-		editableContentElement.addEventListener( 'blur', detach );
+		editableContentElement.addEventListener( 'focusin', attach );
+		editableContentElement.addEventListener( 'focusout', detach );
 
 		return detach;
 	}, [ editableContentElement, tagName, className ] );

--- a/packages/rich-text/src/component/use-anchor.js
+++ b/packages/rich-text/src/component/use-anchor.js
@@ -125,7 +125,7 @@ function getAnchor( editableContentElement, tagName, className ) {
  */
 export function useAnchor( { editableContentElement, settings = {} } ) {
 	const { tagName, className } = settings;
-	const [ anchor, setAnchor ] = useState(
+	const [ anchor, setAnchor ] = useState( () =>
 		getAnchor( editableContentElement, tagName, className )
 	);
 

--- a/packages/rich-text/src/component/use-anchor.js
+++ b/packages/rich-text/src/component/use-anchor.js
@@ -164,6 +164,7 @@ export function useAnchor( { editableContentElement, settings = {} } ) {
 	}, [ editableContentElement, tagName, className ] );
 
 	return useMemo( () => {
+		if ( ! anchor ) return;
 		return anchor.hasOwnProperty( 'ownerDocument' )
 			? anchor
 			: createVirtualAnchorElement( anchor, editableContentElement );

--- a/packages/rich-text/src/component/use-anchor.js
+++ b/packages/rich-text/src/component/use-anchor.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useEffect, useMemo } from '@wordpress/element';
+import { useState, useLayoutEffect, useMemo } from '@wordpress/element';
 
 /** @typedef {import('../register-format-type').RichTextFormatType} RichTextFormatType */
 /** @typedef {import('../create').RichTextValue} RichTextValue */
@@ -127,7 +127,7 @@ export function useAnchor( { editableContentElement, settings = {} } ) {
 		getAnchor( editableContentElement, tagName, className )
 	);
 
-	useEffect( () => {
+	useLayoutEffect( () => {
 		if ( ! editableContentElement ) return;
 
 		const { ownerDocument } = editableContentElement;
@@ -157,10 +157,22 @@ export function useAnchor( { editableContentElement, settings = {} } ) {
 			} );
 		}
 
-		ownerDocument.addEventListener( 'selectionchange', callback );
-		return () => {
+		function attach() {
+			ownerDocument.addEventListener( 'selectionchange', callback );
+		}
+
+		function detach() {
 			ownerDocument.removeEventListener( 'selectionchange', callback );
-		};
+		}
+
+		if ( editableContentElement === ownerDocument.activeElement ) {
+			attach();
+		}
+
+		editableContentElement.addEventListener( 'focus', attach );
+		editableContentElement.addEventListener( 'blur', detach );
+
+		return detach;
 	}, [ editableContentElement, tagName, className ] );
 
 	return useMemo( () => {

--- a/packages/rich-text/src/component/use-anchor.js
+++ b/packages/rich-text/src/component/use-anchor.js
@@ -1,21 +1,61 @@
 /**
  * WordPress dependencies
  */
-import { useMemo } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
-import { getActiveFormat } from '../get-active-format';
+import { useCallback, useSyncExternalStore } from '@wordpress/element';
 
 /** @typedef {import('../register-format-type').RichTextFormatType} RichTextFormatType */
 /** @typedef {import('../create').RichTextValue} RichTextValue */
+
+/**
+ * Given a range and a format tag name and class name, returns the closest
+ * format element.
+ *
+ * @param {Range}       range                  The Range to check.
+ * @param {HTMLElement} editableContentElement The editable wrapper.
+ * @param {string}      tagName                The tag name of the format element.
+ * @param {string}      className              The class name of the format element.
+ *
+ * @return {HTMLElement|undefined} The format element, if found.
+ */
+function getFormatElement( range, editableContentElement, tagName, className ) {
+	let element = range.startContainer;
+
+	// If the caret is right before the element, select the next element.
+	element = element.nextElementSibling || element;
+	element = element.parentElement;
+
+	if ( ! element ) return;
+	if ( element === editableContentElement ) return;
+
+	return element.closest( tagName + ( className ? '.' + className : '' ) );
+}
 
 /**
  * @typedef {Object} VirtualAnchorElement
  * @property {Function} getBoundingClientRect A function returning a DOMRect
  * @property {Document} ownerDocument         The element's ownerDocument
  */
+
+/**
+ * Creates a virtual anchor element for a range.
+ *
+ * @param {Range}       range                  The range to create a virtual anchor element for.
+ * @param {HTMLElement} editableContentElement The editable wrapper.
+ *
+ * @return {VirtualAnchorElement} The virtual anchor element.
+ */
+function createVirtualAnchorElement( range, editableContentElement ) {
+	return {
+		ownerDocument: range.startContainer.ownerDocument,
+		getBoundingClientRect() {
+			return editableContentElement.contains( range.startContainer )
+				? range.getBoundingClientRect()
+				: editableContentElement.getBoundingClientRect();
+		},
+	};
+}
+
+const virtualAnchorCache = new WeakMap();
 
 /**
  * This hook, to be used in a format type's Edit component, returns the active
@@ -26,59 +66,58 @@ import { getActiveFormat } from '../get-active-format';
  * @param {Object}             $1                        Named parameters.
  * @param {HTMLElement|null}   $1.editableContentElement The element containing
  *                                                       the editable content.
- * @param {RichTextValue}      $1.value                  Value to check for selection.
  * @param {RichTextFormatType} $1.settings               The format type's settings.
  * @return {Element|VirtualAnchorElement|undefined|null} The active element or selection range.
  */
-export function useAnchor( { editableContentElement, value, settings = {} } ) {
-	const { tagName, className, name } = settings;
-	const activeFormat = name ? getActiveFormat( value, name ) : undefined;
+export function useAnchor( { editableContentElement, settings = {} } ) {
+	const { tagName, className } = settings;
+	const {
+		ownerDocument: { defaultView },
+	} = editableContentElement;
 
-	return useMemo( () => {
+	// Let the store be the selection and range, and the anchor be derived data.
+	// It's worth noting that the selection reference never changes.
+	const selection = defaultView.getSelection();
+
+	// Only re-subscribe when the window changes.
+	const subscribe = useCallback(
+		( callback ) => {
+			defaultView.addEventListener( 'selectionchange', callback );
+			return () => {
+				defaultView.removeEventListener( 'selectionchange', callback );
+			};
+		},
+		[ defaultView ]
+	);
+
+	function getSnapshot() {
 		if ( ! editableContentElement ) return;
-		const {
-			ownerDocument: { defaultView },
-		} = editableContentElement;
-		const selection = defaultView.getSelection();
-
-		if ( ! selection.rangeCount ) {
-			return;
-		}
-
-		const selectionWithinEditableContentElement =
-			editableContentElement?.contains( selection?.anchorNode );
+		if ( ! selection.rangeCount ) return;
 
 		const range = selection.getRangeAt( 0 );
 
-		if ( ! activeFormat ) {
-			return {
-				ownerDocument: range.startContainer.ownerDocument,
-				getBoundingClientRect() {
-					return selectionWithinEditableContentElement
-						? range.getBoundingClientRect()
-						: editableContentElement.getBoundingClientRect();
-				},
-			};
-		}
+		if ( ! range || ! range.startContainer ) return;
 
-		let element = range.startContainer;
-
-		// If the caret is right before the element, select the next element.
-		element = element.nextElementSibling || element;
-
-		while ( element.nodeType !== element.ELEMENT_NODE ) {
-			element = element.parentNode;
-		}
-
-		return element.closest(
-			tagName + ( className ? '.' + className : '' )
+		const formatElement = getFormatElement(
+			range,
+			editableContentElement,
+			tagName,
+			className
 		);
-	}, [
-		editableContentElement,
-		activeFormat,
-		value.start,
-		value.end,
-		tagName,
-		className,
-	] );
+
+		if ( formatElement ) return formatElement;
+
+		// Ensure the same reference is returned between re-renderes. This is
+		// important for getSnapShot.
+		if ( ! virtualAnchorCache.has( range ) ) {
+			virtualAnchorCache.set(
+				range,
+				createVirtualAnchorElement( range, editableContentElement )
+			);
+		}
+
+		return virtualAnchorCache.get( range );
+	}
+
+	return useSyncExternalStore( subscribe, getSnapshot );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

`useAnchor` depends on `value`, which is actually only used to recalculate derived data from the DOM selection. Instead of using `value` to trigger recalculations, this PR adds a subscription to only selection changes.

## Why?

`useAnchor` currently depends on `value`, which blocks us from making further performance improvements, more specifically avoiding re-renders of RichText UI on typing. See https://github.com/WordPress/gutenberg/pull/48460#issuecomment-1448183197.

Additionally the API also becomes simpler to use.

## How?

Local state.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
