### PR TITLE
withFallbackStyles: Convert to TypeScript

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `Guide`: Convert to TypeScript ([#47493](https://github.com/WordPress/gutenberg/pull/47493)).
 -   `PanelBody`: Convert to TypeScript ([#47702](https://github.com/WordPress/gutenberg/pull/47702)).
+-   `withFallbackStyles` HOC: Convert to TypeScript ([#48720](https://github.com/WordPress/gutenberg/pull/48720)).
 
 ## 23.5.0 (2023-03-01)
 

--- a/packages/components/src/higher-order/with-fallback-styles/index.tsx
+++ b/packages/components/src/higher-order/with-fallback-styles/index.tsx
@@ -9,11 +9,28 @@ import fastDeepEqual from 'fast-deep-equal/es6';
 import { Component } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
 
-export default ( mapNodeToProps ) =>
+type Props = {
+	node?: HTMLElement;
+	[ key: string ]: any;
+};
+
+type State = {
+	fallbackStyles?: { [ key: string ]: any };
+	grabStylesCompleted: boolean;
+};
+
+export default (
+	mapNodeToProps: (
+		node: HTMLElement,
+		props: Props
+	) => { [ key: string ]: any }
+) =>
 	createHigherOrderComponent( ( WrappedComponent ) => {
-		return class extends Component {
-			constructor() {
-				super( ...arguments );
+		return class extends Component< Props, State > {
+			nodeRef?: HTMLElement;
+
+			constructor( props: Props ) {
+				super( props );
 				this.nodeRef = this.props.node;
 				this.state = {
 					fallbackStyles: undefined,
@@ -23,7 +40,7 @@ export default ( mapNodeToProps ) =>
 				this.bindRef = this.bindRef.bind( this );
 			}
 
-			bindRef( node ) {
+			bindRef( node: HTMLDivElement ) {
 				if ( ! node ) {
 					return;
 				}

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -50,7 +50,6 @@
 		"src/duotone-picker",
 		"src/gradient-picker",
 		"src/higher-order/navigate-regions",
-		"src/higher-order/with-fallback-styles",
 		"src/higher-order/with-filters",
 		"src/higher-order/with-focus-return",
 		"src/higher-order/with-notices",


### PR DESCRIPTION
Part of #35744

## What?

Convert the `withFallbackStyles` HOC to TypeScript.

## Why?

It isn't really necessary that these HOCs are typed at this point, but just converting them because they are pretty simple. We can `ts-nocheck` any of the ones that are not worthwhile.

## Testing Instructions

✅ Static checks pass.
