### PR TITLE
Open convert to links modal on select of a page item

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -860,6 +860,20 @@ _Returns_
 
 -   `string`: Client Id of moving block.
 
+### hasDraggedInnerBlock
+
+Returns true if one of the block's inner blocks is dragged.
+
+_Parameters_
+
+-   _state_ `Object`: Editor state.
+-   _clientId_ `string`: Block client ID.
+-   _deep_ `boolean`: Perform a deep check.
+
+_Returns_
+
+-   `boolean`: Whether the block has an inner block dragged
+
 ### hasInserterItems
 
 Determines whether there are items to show in the inserter.
@@ -909,7 +923,7 @@ _Parameters_
 
 _Returns_
 
--   `boolean`: Whether the block as an inner block selected
+-   `boolean`: Whether the block has an inner block selected
 
 ### isAncestorBeingDragged
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1199,7 +1199,7 @@ export function isBlockSelected( state, clientId ) {
  * @param {string}  clientId Block client ID.
  * @param {boolean} deep     Perform a deep check.
  *
- * @return {boolean} Whether the block as an inner block selected
+ * @return {boolean} Whether the block has an inner block selected
  */
 export function hasSelectedInnerBlock( state, clientId, deep = false ) {
 	return getBlockOrder( state, clientId ).some(
@@ -1207,6 +1207,23 @@ export function hasSelectedInnerBlock( state, clientId, deep = false ) {
 			isBlockSelected( state, innerClientId ) ||
 			isBlockMultiSelected( state, innerClientId ) ||
 			( deep && hasSelectedInnerBlock( state, innerClientId, deep ) )
+	);
+}
+
+/**
+ * Returns true if one of the block's inner blocks is dragged.
+ *
+ * @param {Object}  state    Editor state.
+ * @param {string}  clientId Block client ID.
+ * @param {boolean} deep     Perform a deep check.
+ *
+ * @return {boolean} Whether the block has an inner block dragged
+ */
+export function hasDraggedInnerBlock( state, clientId, deep = false ) {
+	return getBlockOrder( state, clientId ).some(
+		( innerClientId ) =>
+			isBlockBeingDragged( state, innerClientId ) ||
+			( deep && hasDraggedInnerBlock( state, innerClientId, deep ) )
 	);
 }
 

--- a/packages/block-library/src/page-list-item/edit.js
+++ b/packages/block-library/src/page-list-item/edit.js
@@ -5,7 +5,6 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useEffect } from '@wordpress/element';
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -35,12 +34,7 @@ function useFrontPageId() {
 	}, [] );
 }
 
-export default function PageListItemEdit( {
-	context,
-	attributes,
-	isSelected,
-	setAttributes,
-} ) {
+export default function PageListItemEdit( { context, attributes } ) {
 	const { id, label, link, hasChildren } = attributes;
 	const isNavigationChild = 'showSubmenuIcon' in context;
 	const frontPageId = useFrontPageId();
@@ -54,12 +48,6 @@ export default function PageListItemEdit( {
 	} );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps );
-
-	useEffect( () => {
-		if ( isSelected ) {
-			setAttributes( { isSelected: true } );
-		}
-	}, [ isSelected ] );
 
 	return (
 		<li

--- a/packages/block-library/src/page-list-item/edit.js
+++ b/packages/block-library/src/page-list-item/edit.js
@@ -2,10 +2,10 @@
  * External dependencies
  */
 import classnames from 'classnames';
-
 /**
  * WordPress dependencies
  */
+import { useEffect } from '@wordpress/element';
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -35,7 +35,12 @@ function useFrontPageId() {
 	}, [] );
 }
 
-export default function PageListItemEdit( { context, attributes } ) {
+export default function PageListItemEdit( {
+	context,
+	attributes,
+	isSelected,
+	setAttributes,
+} ) {
 	const { id, label, link, hasChildren } = attributes;
 	const isNavigationChild = 'showSubmenuIcon' in context;
 	const frontPageId = useFrontPageId();
@@ -49,6 +54,12 @@ export default function PageListItemEdit( { context, attributes } ) {
 	} );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps );
+
+	useEffect( () => {
+		if ( isSelected ) {
+			setAttributes( { isSelected: true } );
+		}
+	}, [ isSelected ] );
 
 	return (
 		<li

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -113,29 +113,6 @@ function BlockContent( {
 	}
 }
 
-function ConvertToLinks( { onClick, disabled } ) {
-	const [ isOpen, setOpen ] = useState( false );
-	const openModal = () => setOpen( true );
-	const closeModal = () => setOpen( false );
-
-	return (
-		<>
-			<BlockControls group="other">
-				<ToolbarButton title={ __( 'Edit' ) } onClick={ openModal }>
-					{ __( 'Edit' ) }
-				</ToolbarButton>
-			</BlockControls>
-			{ isOpen && (
-				<ConvertToLinksModal
-					onClick={ onClick }
-					onClose={ closeModal }
-					disabled={ disabled }
-				/>
-			) }
-		</>
-	);
-}
-
 export default function PageListEdit( {
 	context,
 	clientId,
@@ -143,6 +120,9 @@ export default function PageListEdit( {
 	setAttributes,
 } ) {
 	const { parentPageID } = attributes;
+	const [ isOpen, setOpen ] = useState( false );
+	const openModal = () => setOpen( true );
+	const closeModal = () => setOpen( false );
 
 	const { records: pages, hasResolved: hasResolvedPages } = useEntityRecords(
 		'postType',
@@ -269,7 +249,11 @@ export default function PageListEdit( {
 		__unstableDisableDropZone: true,
 		templateLock: 'all',
 		onInput: NOOP,
-		onChange: NOOP,
+		onChange: () => {
+			if ( hasResolvedPages ) {
+				openModal();
+			}
+		},
 		value: blockList,
 	} );
 
@@ -325,10 +309,23 @@ export default function PageListEdit( {
 				) }
 			</InspectorControls>
 			{ allowConvertToLinks && (
-				<ConvertToLinks
-					disabled={ ! hasResolvedPages }
-					onClick={ convertToNavigationLinks }
-				/>
+				<>
+					<BlockControls group="other">
+						<ToolbarButton
+							title={ __( 'Edit' ) }
+							onClick={ openModal }
+						>
+							{ __( 'Edit' ) }
+						</ToolbarButton>
+					</BlockControls>
+					{ isOpen && (
+						<ConvertToLinksModal
+							onClick={ convertToNavigationLinks }
+							onClose={ closeModal }
+							disabled={ ! hasResolvedPages }
+						/>
+					) }
+				</>
 			) }
 			<BlockContent
 				blockProps={ blockProps }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
When users interact with the Page List Items in the Navigation List View, we should invoke the "convert to links" modal, to make it clear that these items can't be edited.

Questions
1. Should we also display the modal if I interact with these blocks in the canvas?
2. Should we even show the modal, or should we just do the conversion silently?

cc @SaxonF @richtabor 

Fixes https://github.com/WordPress/gutenberg/issues/47064

## Why?
To make it clear that these items can't be edited, and allow users to do so.

## How?
By using the onChange prop of `innerBlocks` in the page list template and simulating a change via `setAttributtes`. A cleaner way may exist.

## Testing Instructions
1. Edit a navigation block which has a page list inside it.
2. Click on/select one of the pages in the page list block.
3. Confirm that you see the convert to links modal.
4. Try to drag one of the pages in the navigation block's inspector tree
5. Confirm that you see the convert to links modal.
6. Also test that the page list block can still invoke the modal using the edit button in the toolbar, and the inspector controls.

### Testing Instructions for Keyboard
As above.

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/107534/222785015-58eebf49-1d61-43f9-a400-9b15d4139572.mp4


