### PR TITLE
Fix wrong inserter suggestions for Nav block list view/browse mode inserter

### DIFF
--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -150,6 +150,7 @@ class Inserter extends Component {
 			prioritizePatterns,
 			onSelectOrClose,
 			selectBlockOnInsert,
+			__unstableForceBlockInserterItems: forceBlockInserterItems,
 		} = this.props;
 
 		if ( isQuick ) {
@@ -173,6 +174,7 @@ class Inserter extends Component {
 					isAppender={ isAppender }
 					prioritizePatterns={ prioritizePatterns }
 					selectBlockOnInsert={ selectBlockOnInsert }
+					forceBlockInserterItems={ forceBlockInserterItems }
 				/>
 			);
 		}

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -32,6 +32,7 @@ export default function QuickInserter( {
 	isAppender,
 	prioritizePatterns,
 	selectBlockOnInsert,
+	forceBlockInserterItems,
 } ) {
 	const [ filterValue, setFilterValue ] = useState( '' );
 	const [ destinationRootClientId, onInsertBlocks ] = useInsertionPoint( {
@@ -124,6 +125,7 @@ export default function QuickInserter( {
 					isDraggable={ false }
 					prioritizePatterns={ prioritizePatterns }
 					selectBlockOnInsert={ selectBlockOnInsert }
+					forceBlockInserterItems={ forceBlockInserterItems }
 				/>
 			</div>
 

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -88,8 +88,26 @@ function InserterSearchResults( {
 		if ( maxBlockTypesToShow === 0 ) {
 			return [];
 		}
+
+		const forceBlockSearchResults = [
+			'core/navigation-link/page',
+			'core/navigation-link',
+		]?.reverse(); // force first item to be the one that is shown first
+
+		const comparator = forceBlockSearchResults?.length
+			? ( resultItem ) => {
+					if ( forceBlockSearchResults.includes( resultItem.id ) ) {
+						return (
+							10000 +
+							forceBlockSearchResults.indexOf( resultItem.id )
+						);
+					}
+					return resultItem.frecency;
+			  }
+			: 'frecency';
+
 		const results = searchBlockItems(
-			orderBy( blockTypes, 'frecency', 'desc' ),
+			orderBy( blockTypes, comparator, 'desc' ),
 			blockTypeCategories,
 			blockTypeCollections,
 			filterValue

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -46,6 +46,7 @@ function InserterSearchResults( {
 	shouldFocusBlock = true,
 	prioritizePatterns,
 	selectBlockOnInsert,
+	forceBlockInserterItems,
 } ) {
 	const debouncedSpeak = useDebounce( speak, 500 );
 
@@ -89,17 +90,30 @@ function InserterSearchResults( {
 			return [];
 		}
 
-		const forceBlockSearchResults = [
-			'core/navigation-link/page',
-			'core/navigation-link',
-		]?.reverse(); // force first item to be the one that is shown first
+		// Force first block to be the one that is shown first
+		const reversedforceBlockInserterItems =
+			forceBlockInserterItems?.reverse();
 
-		const comparator = forceBlockSearchResults?.length
+		/**
+		 * Allow for consumer to overide the default sorting of the block types.
+		 * This is useful for when you want to force a block(s) to be shown first.
+		 * The remaining blocks will obey the "frecency" sorting.
+		 *
+		 * @param {Object} resultItem a block type item result to be sorted.
+		 * @return {number} the sorting value.
+		 */
+		const comparatorField = reversedforceBlockInserterItems?.length
 			? ( resultItem ) => {
-					if ( forceBlockSearchResults.includes( resultItem.id ) ) {
+					if (
+						reversedforceBlockInserterItems.includes(
+							resultItem.id
+						)
+					) {
 						return (
 							10000 +
-							forceBlockSearchResults.indexOf( resultItem.id )
+							reversedforceBlockInserterItems.indexOf(
+								resultItem.id
+							)
 						);
 					}
 					return resultItem.frecency;
@@ -107,7 +121,7 @@ function InserterSearchResults( {
 			: 'frecency';
 
 		const results = searchBlockItems(
-			orderBy( blockTypes, comparator, 'desc' ),
+			orderBy( blockTypes, comparatorField, 'desc' ),
 			blockTypeCategories,
 			blockTypeCollections,
 			filterValue

--- a/packages/block-editor/src/components/off-canvas-editor/appender.js
+++ b/packages/block-editor/src/components/off-canvas-editor/appender.js
@@ -88,6 +88,10 @@ export const Appender = forwardRef(
 							setInsertedBlock( maybeInsertedBlock );
 						}
 					} }
+					__unstableForceBlockInserterItems={ [
+						'core/navigation-link/page',
+						'core/navigation-link',
+					] }
 				/>
 				<div
 					className="offcanvas-editor-appender__description"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Forces `Page link` and `Custom link` to always display 1st and 2nd in the inserter search results when adding a new item to a Navigation in either:

- Browse mode sidebar
- Nav block list view

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The current ordering model is based on frequency (frequency + recency) which can lead to unusal results depending on what you've been doing elsewhere in the editor.

For Nav we always want to prioritise adding Page links and Custom links. Therefore we need to prioritise those in the inserter search results.

After that we can allow the standard frecency model to take care fo the remaining order.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds a prop that allows defining a set of blocks that you _always_ want to appear in the results. This is marked as `__unstable` because it's an internal API and not intended for use by 3rd party contributors as it's open to abuse.

By passing in names of block types these will be prioritised in the search results in the order in which they are defined in the array. This is achieved by way of customising the comparator function of the search results logic.

I couldn't see a way to achieve this using the existing frecency but as this is `__unstable` we can revise in future if required. 


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### On trunk

- Open Browse mode or Nav block list view
- Click the appender to bring up the block quick inserter
- Add a block that is not `Page` or `Custom link` (e.g. `Social Icons).
- Do this repeatedly several times in rapid succession.
- Notice that eventually that block will be placed at the top of the list of inserter items.
- Notice that `Page` or `Custom link` are not prioritised.

### On this branch

- Repeat steps above 
- Notice that `Page` or `Custom link` _are_ prioritised as the 1st and 2nd items in the results.
- This shoulld be the same no matter how many times you add other blocks.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="1214" alt="Screen Shot 2023-03-03 at 12 50 01" src="https://user-images.githubusercontent.com/444434/222724593-1bdf2b7b-7514-4e98-9e28-0e4e55962b6d.png">



https://user-images.githubusercontent.com/444434/222724666-2fd8c5b4-9f4b-49a1-b3e8-91efd8359bab.mp4

