### PR TITLE
Experiment: disable per-block stylesheet to measure the impact on TTFB and LCP

### DIFF
--- a/lib/compat/wordpress-6.2/default-filters.php
+++ b/lib/compat/wordpress-6.2/default-filters.php
@@ -23,3 +23,5 @@
  */
 add_action( 'start_previewing_theme', '_gutenberg_clean_theme_json_caches' );
 add_action( 'switch_theme', '_gutenberg_clean_theme_json_caches' );
+
+add_filter( 'should_load_separate_core_block_assets', '__return_false', 9999 );


### PR DESCRIPTION
**THIS PR IS AN EXPERIMENT. NOT TO MERGE.**

## What?

This PR disables per-block stylesheet, making all core block styles be enqueued as part of the block-library stylesheet instead.

## Why?

I'd like to see whether it impacts front-end metrics (TTFB and LCP) in our CI environment.

## How?

**The implementation is a hack, it's not to be shipped.**

This disables the `should_load_separate_core_block_assets` filter.

## Testing Instructions

Using TT3, go to the front-end and verify that the block-library stylesheet is present and that there is no per-block stylesheets.

