### PR TITLE
Playwright Utils: Fix the 'publishPost' address locator

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/publish-post.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/publish-post.ts
@@ -28,9 +28,10 @@ export async function publishPost( this: Editor ) {
 		'role=region[name="Editor publish"i] >> role=button[name="Publish"i]'
 	);
 
-	const urlString = await this.page.inputValue(
-		'role=textbox[name="Post address"i]'
-	);
+	const urlString = await this.page
+		.getByRole( 'region', { name: 'Editor publish' } )
+		.getByRole( 'textbox', { name: /address/i } )
+		.inputValue();
 	const url = new URL( urlString );
 	const postId = url.searchParams.get( 'p' );
 

--- a/packages/e2e-test-utils-playwright/src/editor/publish-post.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/publish-post.ts
@@ -30,7 +30,7 @@ export async function publishPost( this: Editor ) {
 
 	const urlString = await this.page
 		.getByRole( 'region', { name: 'Editor publish' } )
-		.getByRole( 'textbox', { name: /address/i } )
+		.getByRole( 'textbox', { name: 'address' } )
 		.inputValue();
 	const url = new URL( urlString );
 	const postId = url.searchParams.get( 'p' );


### PR DESCRIPTION
## What?
PR fixes the locator for published post URL addresses.

## Why?
The input label changes based on the post type name, so if you publish a Page or CPT, the field label would be - "{CPTName} Address".

## How?
I've updated the locator to use RegExp.

## Testing Instructions
CI tests are passing.
