### PR TITLE
Site Editor: Add "Added by" description to template part navigation sidebar

### DIFF
--- a/packages/edit-site/src/components/list/added-by.js
+++ b/packages/edit-site/src/components/list/added-by.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * External dependencies
  */
@@ -24,9 +25,11 @@ import { _x } from '@wordpress/i18n';
 const TEMPLATE_POST_TYPE_NAMES = [ 'wp_template', 'wp_template_part' ];
 
 /**
+ * @typedef {'theme'|'plugin'|'site'|'user'} AddedByType
  *
  * @typedef AddedByData
  * @type {Object}
+ * @property {AddedByType}  type         The type of the data.
  * @property {JSX.Element}  icon         The icon to display.
  * @property {string}       [imageUrl]   The optional image URL to display.
  * @property {string}       [text]       The text to display.
@@ -68,6 +71,7 @@ export function useAddedBy( postType, postId ) {
 							) ) )
 				) {
 					return {
+						type: 'theme',
 						icon: themeIcon,
 						text:
 							getTheme( template.theme )?.name?.rendered ||
@@ -79,6 +83,7 @@ export function useAddedBy( postType, postId ) {
 				// Added by plugin.
 				if ( template.has_theme_file && template.origin === 'plugin' ) {
 					return {
+						type: 'plugin',
 						icon: pluginIcon,
 						text:
 							getPlugin( template.theme )?.name || template.theme,
@@ -100,6 +105,7 @@ export function useAddedBy( postType, postId ) {
 						'__unstableBase'
 					);
 					return {
+						type: 'site',
 						icon: globeIcon,
 						imageUrl: siteData?.site_logo
 							? getMedia( siteData.site_logo )?.source_url
@@ -113,6 +119,7 @@ export function useAddedBy( postType, postId ) {
 			// Added by user.
 			const user = getUser( template.author );
 			return {
+				type: 'user',
 				icon: authorIcon,
 				imageUrl: user?.avatar_urls?.[ 48 ],
 				text: user?.nickname,

--- a/packages/edit-site/src/components/list/added-by.js
+++ b/packages/edit-site/src/components/list/added-by.js
@@ -18,25 +18,41 @@ import {
 } from '@wordpress/icons';
 import { _x } from '@wordpress/i18n';
 
+/** @typedef {'wp_template'|'wp_template_part'} TemplateType */
+
+/** @type {TemplateType} */
 const TEMPLATE_POST_TYPE_NAMES = [ 'wp_template', 'wp_template_part' ];
 
 /**
  *
  * @typedef AddedByData
  * @type {Object}
- * @property {JSX.Element} icon         The icon to display.
- * @property {string}      [imageUrl]   The optional image URL to display.
- * @property {string}      [text]       The text to display.
- * @property {boolean}     isCustomized Whether the template has been customized.
+ * @property {JSX.Element}  icon         The icon to display.
+ * @property {string}       [imageUrl]   The optional image URL to display.
+ * @property {string}       [text]       The text to display.
+ * @property {boolean}      isCustomized Whether the template has been customized.
  *
- * @param    {Object}      template     The template object.
+ * @param    {TemplateType} postType     The template post type.
+ * @param    {number}       postId       The template post id.
  * @return {AddedByData} The added by object or null.
  */
-export function useAddedBy( template ) {
+export function useAddedBy( postType, postId ) {
 	return useSelect(
 		( select ) => {
-			const { getTheme, getPlugin, getEntityRecord, getMedia, getUser } =
-				select( coreStore );
+			const {
+				getTheme,
+				getPlugin,
+				getEntityRecord,
+				getMedia,
+				getUser,
+				getEditedEntityRecord,
+			} = select( coreStore );
+			const template = getEditedEntityRecord(
+				'postType',
+				postType,
+				postId
+			);
+
 			if ( TEMPLATE_POST_TYPE_NAMES.includes( template.type ) ) {
 				// Added by theme.
 				// Template originally provided by a theme, but customized by a user.
@@ -103,7 +119,7 @@ export function useAddedBy( template ) {
 				isCustomized: false,
 			};
 		},
-		[ template ]
+		[ postType, postId ]
 	);
 }
 
@@ -129,8 +145,16 @@ function AvatarImage( { imageUrl } ) {
 	);
 }
 
-export default function AddedBy( { template } ) {
-	const { text, icon, imageUrl, isCustomized } = useAddedBy( template );
+/**
+ * @param {Object}       props
+ * @param {TemplateType} props.postType The template post type.
+ * @param {number}       props.postId   The template post id.
+ */
+export default function AddedBy( { postType, postId } ) {
+	const { text, icon, imageUrl, isCustomized } = useAddedBy(
+		postType,
+		postId
+	);
 
 	return (
 		<HStack alignment="left">
@@ -145,7 +169,7 @@ export default function AddedBy( { template } ) {
 				{ text }
 				{ isCustomized && (
 					<span className="edit-site-list-added-by__customized-info">
-						{ template.type === 'wp_template'
+						{ postType === 'wp_template'
 							? _x( 'Customized', 'template' )
 							: _x( 'Customized', 'template part' ) }
 					</span>

--- a/packages/edit-site/src/components/list/added-by.js
+++ b/packages/edit-site/src/components/list/added-by.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
+import { Icon, __experimentalHStack as HStack } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
@@ -19,6 +19,94 @@ import {
 import { _x } from '@wordpress/i18n';
 
 const TEMPLATE_POST_TYPE_NAMES = [ 'wp_template', 'wp_template_part' ];
+
+/**
+ *
+ * @typedef AddedByData
+ * @type {Object}
+ * @property {JSX.Element} icon         The icon to display.
+ * @property {string}      [imageUrl]   The optional image URL to display.
+ * @property {string}      [text]       The text to display.
+ * @property {boolean}     isCustomized Whether the template has been customized.
+ *
+ * @param    {Object}      template     The template object.
+ * @return {AddedByData} The added by object or null.
+ */
+export function useAddedBy( template ) {
+	return useSelect(
+		( select ) => {
+			const { getTheme, getPlugin, getEntityRecord, getMedia, getUser } =
+				select( coreStore );
+			if ( TEMPLATE_POST_TYPE_NAMES.includes( template.type ) ) {
+				// Added by theme.
+				// Template originally provided by a theme, but customized by a user.
+				// Templates originally didn't have the 'origin' field so identify
+				// older customized templates by checking for no origin and a 'theme'
+				// or 'custom' source.
+				if (
+					template.has_theme_file &&
+					( template.origin === 'theme' ||
+						( ! template.origin &&
+							[ 'theme', 'custom' ].includes(
+								template.source
+							) ) )
+				) {
+					return {
+						icon: themeIcon,
+						text:
+							getTheme( template.theme )?.name?.rendered ||
+							template.theme,
+						isCustomized: template.source === 'custom',
+					};
+				}
+
+				// Added by plugin.
+				// Template originally provided by a plugin, but customized by a user.
+				if ( template.has_theme_file && template.origin === 'plugin' ) {
+					return {
+						icon: pluginIcon,
+						text:
+							getPlugin( template.theme )?.name || template.theme,
+						isCustomized: template.source === 'custom',
+					};
+				}
+
+				// Added by site.
+				// Template was created from scratch, but has no author. Author support
+				// was only added to templates in WordPress 5.9. Fallback to showing the
+				// site logo and title.
+				if (
+					! template.has_theme_file &&
+					template.source === 'custom' &&
+					! template.author
+				) {
+					const siteData = getEntityRecord(
+						'root',
+						'__unstableBase'
+					);
+					return {
+						icon: globeIcon,
+						imageUrl: siteData?.site_logo
+							? getMedia( siteData.site_logo )?.source_url
+							: undefined,
+						text: siteData?.name,
+						isCustomized: false,
+					};
+				}
+			}
+
+			// Added by user.
+			const user = getUser( template.author );
+			return {
+				icon: authorIcon,
+				imageUrl: user?.avatar_urls?.[ 48 ],
+				text: user?.nickname,
+				isCustomized: false,
+			};
+		},
+		[ template ]
+	);
+}
 
 function BaseAddedBy( { text, icon, imageUrl, isCustomized, templateType } ) {
 	const [ isImageLoaded, setIsImageLoaded ] = useState( false );
@@ -56,128 +144,16 @@ function BaseAddedBy( { text, icon, imageUrl, isCustomized, templateType } ) {
 	);
 }
 
-function AddedByTheme( { slug, isCustomized, templateType } ) {
-	const theme = useSelect(
-		( select ) => select( coreStore ).getTheme( slug ),
-		[ slug ]
-	);
+export default function AddedBy( { template } ) {
+	const addedBy = useAddedBy( template );
 
 	return (
 		<BaseAddedBy
-			icon={ themeIcon }
-			text={ theme?.name?.rendered || slug }
-			isCustomized={ isCustomized }
-			templateType={ templateType }
+			icon={ addedBy.icon }
+			imageUrl={ addedBy.imageUrl }
+			text={ addedBy.text }
+			isCustomized={ addedBy.isCustomized }
+			templateType={ template.type }
 		/>
-	);
-}
-
-function AddedByPlugin( { slug, isCustomized, templateType } ) {
-	const plugin = useSelect(
-		( select ) => select( coreStore ).getPlugin( slug ),
-		[ slug ]
-	);
-
-	return (
-		<BaseAddedBy
-			icon={ pluginIcon }
-			text={ plugin?.name || slug }
-			isCustomized={ isCustomized }
-			templateType={ templateType }
-		/>
-	);
-}
-
-function AddedByAuthor( { id, templateType } ) {
-	const user = useSelect(
-		( select ) => select( coreStore ).getUser( id ),
-		[ id ]
-	);
-
-	return (
-		<BaseAddedBy
-			icon={ authorIcon }
-			imageUrl={ user?.avatar_urls?.[ 48 ] }
-			text={ user?.nickname }
-			templateType={ templateType }
-		/>
-	);
-}
-
-function AddedBySite( { templateType } ) {
-	const { name, logoURL } = useSelect( ( select ) => {
-		const { getEntityRecord, getMedia } = select( coreStore );
-		const siteData = getEntityRecord( 'root', '__unstableBase' );
-
-		return {
-			name: siteData?.name,
-			logoURL: siteData?.site_logo
-				? getMedia( siteData.site_logo )?.source_url
-				: undefined,
-		};
-	}, [] );
-
-	return (
-		<BaseAddedBy
-			icon={ globeIcon }
-			imageUrl={ logoURL }
-			text={ name }
-			templateType={ templateType }
-		/>
-	);
-}
-
-export default function AddedBy( { templateType, template } ) {
-	if ( ! template ) {
-		return;
-	}
-
-	if ( TEMPLATE_POST_TYPE_NAMES.includes( templateType ) ) {
-		// Template originally provided by a theme, but customized by a user.
-		// Templates originally didn't have the 'origin' field so identify
-		// older customized templates by checking for no origin and a 'theme'
-		// or 'custom' source.
-		if (
-			template.has_theme_file &&
-			( template.origin === 'theme' ||
-				( ! template.origin &&
-					[ 'theme', 'custom' ].includes( template.source ) ) )
-		) {
-			return (
-				<AddedByTheme
-					slug={ template.theme }
-					isCustomized={ template.source === 'custom' }
-					templateType={ templateType }
-				/>
-			);
-		}
-
-		// Template originally provided by a plugin, but customized by a user.
-		if ( template.has_theme_file && template.origin === 'plugin' ) {
-			return (
-				<AddedByPlugin
-					slug={ template.theme }
-					isCustomized={ template.source === 'custom' }
-					templateType={ templateType }
-				/>
-			);
-		}
-
-		// Template was created from scratch, but has no author. Author support
-		// was only added to templates in WordPress 5.9. Fallback to showing the
-		// site logo and title.
-		if (
-			! template.has_theme_file &&
-			template.source === 'custom' &&
-			! template.author
-		) {
-			return <AddedBySite templateType={ templateType } />;
-		}
-	}
-
-	// Simply show the author for templates created from scratch that have an
-	// author or for any other post type.
-	return (
-		<AddedByAuthor id={ template.author } templateType={ templateType } />
 	);
 }

--- a/packages/edit-site/src/components/list/added-by.js
+++ b/packages/edit-site/src/components/list/added-by.js
@@ -61,7 +61,6 @@ export function useAddedBy( template ) {
 				}
 
 				// Added by plugin.
-				// Template originally provided by a plugin, but customized by a user.
 				if ( template.has_theme_file && template.origin === 'plugin' ) {
 					return {
 						icon: pluginIcon,
@@ -108,23 +107,35 @@ export function useAddedBy( template ) {
 	);
 }
 
-function BaseAddedBy( { text, icon, imageUrl, isCustomized, templateType } ) {
+/**
+ * @param {Object} props
+ * @param {string} props.imageUrl
+ */
+function AvatarImage( { imageUrl } ) {
 	const [ isImageLoaded, setIsImageLoaded ] = useState( false );
+
+	return (
+		<div
+			className={ classnames( 'edit-site-list-added-by__avatar', {
+				'is-loaded': isImageLoaded,
+			} ) }
+		>
+			<img
+				onLoad={ () => setIsImageLoaded( true ) }
+				alt=""
+				src={ imageUrl }
+			/>
+		</div>
+	);
+}
+
+export default function AddedBy( { template } ) {
+	const { text, icon, imageUrl, isCustomized } = useAddedBy( template );
 
 	return (
 		<HStack alignment="left">
 			{ imageUrl ? (
-				<div
-					className={ classnames( 'edit-site-list-added-by__avatar', {
-						'is-loaded': isImageLoaded,
-					} ) }
-				>
-					<img
-						onLoad={ () => setIsImageLoaded( true ) }
-						alt=""
-						src={ imageUrl }
-					/>
-				</div>
+				<AvatarImage imageUrl={ imageUrl } />
 			) : (
 				<div className="edit-site-list-added-by__icon">
 					<Icon icon={ icon } />
@@ -134,26 +145,12 @@ function BaseAddedBy( { text, icon, imageUrl, isCustomized, templateType } ) {
 				{ text }
 				{ isCustomized && (
 					<span className="edit-site-list-added-by__customized-info">
-						{ templateType === 'wp_template'
+						{ template.type === 'wp_template'
 							? _x( 'Customized', 'template' )
 							: _x( 'Customized', 'template part' ) }
 					</span>
 				) }
 			</span>
 		</HStack>
-	);
-}
-
-export default function AddedBy( { template } ) {
-	const addedBy = useAddedBy( template );
-
-	return (
-		<BaseAddedBy
-			icon={ addedBy.icon }
-			imageUrl={ addedBy.imageUrl }
-			text={ addedBy.text }
-			isCustomized={ addedBy.isCustomized }
-			templateType={ template.type }
-		/>
 	);
 }

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -102,7 +102,10 @@ export default function Table( { templateType } ) {
 
 						<td className="edit-site-list-table-column" role="cell">
 							{ template ? (
-								<AddedBy template={ template } />
+								<AddedBy
+									postType={ template.type }
+									postId={ template.id }
+								/>
 							) : null }
 						</td>
 						<td className="edit-site-list-table-column" role="cell">

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -101,10 +101,9 @@ export default function Table( { templateType } ) {
 						</td>
 
 						<td className="edit-site-list-table-column" role="cell">
-							<AddedBy
-								templateType={ templateType }
-								template={ template }
-							/>
+							{ template ? (
+								<AddedBy template={ template } />
+							) : null }
 						</td>
 						<td className="edit-site-list-table-column" role="cell">
 							<Actions template={ template } />

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
@@ -1,10 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __, sprintf, _x } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { pencil } from '@wordpress/icons';
-import { __experimentalUseNavigator as useNavigator } from '@wordpress/components';
+import {
+	__experimentalUseNavigator as useNavigator,
+	Icon,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -23,40 +26,55 @@ function useTemplateTitleAndDescription( postType, postId ) {
 	);
 	const addedBy = useAddedBy( postType, postId );
 	const title = getTitle();
-	let description = getDescription();
+	let descriptionText = getDescription();
 
-	if ( ! description && addedBy.text ) {
-		const authorText = addedBy.isCustomized
-			? sprintf(
-					/* translators: %s: The author. Could be either the theme's name, plugin's name, or user's name. */
-					__( '%s (customized)' ),
-					addedBy.text
-			  )
-			: addedBy.text;
-
+	if ( ! descriptionText && addedBy.text ) {
 		if ( record.type === 'wp_template' && record.is_custom ) {
-			description = sprintf(
-				/* translators: %s: The author. Could be either the theme's name, plugin's name, or user's name. */
-				__(
-					'This is a custom template that can be applied manually to any Post or Page, added by %s.'
-				),
-				authorText
+			descriptionText = __(
+				'This is a custom template that can be applied manually to any Post or Page.'
 			);
 		} else if ( record.type === 'wp_template_part' ) {
-			description = sprintf(
-				// translators: 1: template part title e.g: "Header". 2: The author. Could be either the theme's name, plugin's name, or user's name.
-				__( 'This is your %1$s template part, added by %2$s.' ),
-				getTitle(),
-				authorText
-			);
-		} else {
-			description = sprintf(
-				/* translators: %s: The author. Could be either the theme's name, plugin's name, or user's name. */
-				__( 'Added by %s.' ),
-				authorText
+			descriptionText = sprintf(
+				// translators: %s: template part title e.g: "Header".
+				__( 'This is your %s template part.' ),
+				getTitle()
 			);
 		}
 	}
+
+	const description = (
+		<>
+			{ descriptionText }
+
+			{ addedBy.text && (
+				<span className="edit-site-sidebar-navigation-screen-template__added-by-description">
+					<span className="edit-site-sidebar-navigation-screen-template__added-by-description-author">
+						<span className="edit-site-sidebar-navigation-screen-template__added-by-description-author-icon">
+							{ addedBy.imageUrl ? (
+								<img
+									src={ addedBy.imageUrl }
+									alt=""
+									width="24"
+									height="24"
+								/>
+							) : (
+								<Icon icon={ addedBy.icon } />
+							) }
+						</span>
+						{ addedBy.text }
+					</span>
+
+					{ addedBy.isCustomized && (
+						<span className="edit-site-sidebar-navigation-screen-template__added-by-description-customized">
+							{ postType === 'wp_template'
+								? _x( '(Customized)', 'template' )
+								: _x( '(Customized)', 'template part' ) }
+						</span>
+					) }
+				</span>
+			) }
+		</>
+	);
 
 	return { title, description };
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
@@ -2,12 +2,13 @@
  * WordPress dependencies
  */
 import { __, sprintf, _x } from '@wordpress/i18n';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { pencil } from '@wordpress/icons';
 import {
 	__experimentalUseNavigator as useNavigator,
 	Icon,
 } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -24,7 +25,13 @@ function useTemplateTitleAndDescription( postType, postId ) {
 		postType,
 		postId
 	);
+	const currentTheme = useSelect(
+		( select ) => select( coreStore ).getCurrentTheme(),
+		[]
+	);
 	const addedBy = useAddedBy( postType, postId );
+	const isAddedByActiveTheme =
+		addedBy.type === 'theme' && record.theme === currentTheme?.stylesheet;
 	const title = getTitle();
 	let descriptionText = getDescription();
 
@@ -46,7 +53,7 @@ function useTemplateTitleAndDescription( postType, postId ) {
 		<>
 			{ descriptionText }
 
-			{ addedBy.text && (
+			{ addedBy.text && ! isAddedByActiveTheme && (
 				<span className="edit-site-sidebar-navigation-screen-template__added-by-description">
 					<span className="edit-site-sidebar-navigation-screen-template__added-by-description-author">
 						<span className="edit-site-sidebar-navigation-screen-template__added-by-description-author-icon">

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
@@ -14,6 +14,19 @@ import useEditedEntityRecord from '../use-edited-entity-record';
 import { unlock } from '../../private-apis';
 import { store as editSiteStore } from '../../store';
 import SidebarButton from '../sidebar-button';
+import { useAddedBy } from '../list/added-by';
+
+function AddedByDescription( { template } ) {
+	const addedBy = useAddedBy( template );
+
+	if ( ! addedBy.text ) return null;
+
+	return sprintf(
+		/* translators: %s: The author. Could be either the theme's name, plugin's name, or user's name. */
+		__( 'Added by %s.' ),
+		addedBy.text
+	);
+}
 
 export default function SidebarNavigationScreenTemplate() {
 	const { params } = useNavigator();
@@ -48,7 +61,13 @@ export default function SidebarNavigationScreenTemplate() {
 					icon={ pencil }
 				/>
 			}
-			description={ description }
+			description={
+				description ? (
+					description
+				) : (
+					<AddedByDescription template={ record } />
+				)
+			}
 		/>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
@@ -21,11 +21,17 @@ function AddedByDescription( { template } ) {
 
 	if ( ! addedBy.text ) return null;
 
-	return sprintf(
-		/* translators: %s: The author. Could be either the theme's name, plugin's name, or user's name. */
-		__( 'Added by %s.' ),
-		addedBy.text
-	);
+	return addedBy.isCustomized
+		? sprintf(
+				/* translators: %s: The author. Could be either the theme's name, plugin's name, or user's name. */
+				__( 'Added by %s (customized).' ),
+				addedBy.text
+		  )
+		: sprintf(
+				/* translators: %s: The author. Could be either the theme's name, plugin's name, or user's name. */
+				__( 'Added by %s.' ),
+				addedBy.text
+		  );
 }
 
 export default function SidebarNavigationScreenTemplate() {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
@@ -17,7 +17,7 @@ import SidebarButton from '../sidebar-button';
 import { useAddedBy } from '../list/added-by';
 
 function TemplateDescription( { template, getTitle } ) {
-	const addedBy = useAddedBy( template );
+	const addedBy = useAddedBy( template.type, template.id );
 
 	// Still loading for the metadata.
 	if ( ! addedBy.text ) return null;

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
@@ -16,7 +16,7 @@ import { store as editSiteStore } from '../../store';
 import SidebarButton from '../sidebar-button';
 import { useAddedBy } from '../list/added-by';
 
-function AddedByDescription( { template } ) {
+function AddedByText( { template } ) {
 	const addedBy = useAddedBy( template );
 
 	if ( ! addedBy.text ) return null;
@@ -68,11 +68,7 @@ export default function SidebarNavigationScreenTemplate() {
 				/>
 			}
 			description={
-				description ? (
-					description
-				) : (
-					<AddedByDescription template={ record } />
-				)
+				description ? description : <AddedByText template={ record } />
 			}
 		/>
 	);

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
@@ -16,22 +16,26 @@ import { store as editSiteStore } from '../../store';
 import SidebarButton from '../sidebar-button';
 import { useAddedBy } from '../list/added-by';
 
-function AddedByText( { template } ) {
+function AddedByDescription( { template } ) {
 	const addedBy = useAddedBy( template );
 
 	if ( ! addedBy.text ) return null;
 
-	return addedBy.isCustomized
-		? sprintf(
-				/* translators: %s: The author. Could be either the theme's name, plugin's name, or user's name. */
-				__( 'Added by %s (customized).' ),
-				addedBy.text
-		  )
-		: sprintf(
-				/* translators: %s: The author. Could be either the theme's name, plugin's name, or user's name. */
-				__( 'Added by %s.' ),
-				addedBy.text
-		  );
+	return (
+		<p>
+			{ addedBy.isCustomized
+				? sprintf(
+						/* translators: %s: The author. Could be either the theme's name, plugin's name, or user's name. */
+						__( 'Added by %s (customized).' ),
+						addedBy.text
+				  )
+				: sprintf(
+						/* translators: %s: The author. Could be either the theme's name, plugin's name, or user's name. */
+						__( 'Added by %s.' ),
+						addedBy.text
+				  ) }
+		</p>
+	);
 }
 
 export default function SidebarNavigationScreenTemplate() {
@@ -67,9 +71,8 @@ export default function SidebarNavigationScreenTemplate() {
 					icon={ pencil }
 				/>
 			}
-			description={
-				description ? description : <AddedByText template={ record } />
-			}
+			description={ description }
+			content={ <AddedByDescription template={ record } /> }
 		/>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/style.scss
@@ -8,10 +8,18 @@
 		display: inline-flex;
 		align-items: center;
 
+		img {
+			border-radius: $grid-unit-15;
+		}
+
+		svg {
+			fill: $gray-600;
+		}
+
 		&-icon {
 			width: 24px;
 			height: 24px;
-			margin-right: $grid-unit-05;
+			margin-right: $grid-unit-10;
 		}
 	}
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/style.scss
@@ -1,0 +1,17 @@
+.edit-site-sidebar-navigation-screen-template__added-by-description {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-top: $grid-unit-30;
+
+	&-author {
+		display: inline-flex;
+		align-items: center;
+
+		&-icon {
+			width: 24px;
+			height: 24px;
+			margin-right: $grid-unit-05;
+		}
+	}
+}

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -25,6 +25,7 @@
 @import "./components/sidebar-button/style.scss";
 @import "./components/sidebar-navigation-item/style.scss";
 @import "./components/sidebar-navigation-screen/style.scss";
+@import "./components/sidebar-navigation-screen-template/style.scss";
 @import "./components/sidebar-navigation-screen-templates/style.scss";
 @import "./components/site-hub/style.scss";
 @import "./components/sidebar-navigation-screen-navigation-menus/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Close https://github.com/WordPress/gutenberg/issues/48483. Add "Added by" description to the template part navigation sidebar.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See https://github.com/WordPress/gutenberg/issues/48483.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
In order to reuse the logic in `<AddedBy>`, I extract them into a hook `useAddedBy`, and use that in the sidebar. Open to ideas to make it more simple and more elegant!

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Go to Site Editor
2. Click "Template parts" in the sidebar.
3. Click on any template part, and expect to see the "Added by" description.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Go to the Site Editor with template parts: `/wp-admin/site-editor.php?canvas=view&postType=wp_template_part&path=%2Fwp_template_part`
2. Press <kbd>Tab</kbd> four times to navigate to the template parts list
3. Enter either of the template part, expect the screen readers to announce the "Added by" description in the sidebar.

## Screenshots or screencast <!-- if applicable -->
![image](https://user-images.githubusercontent.com/7753001/222747958-4abd8ccd-671b-4faf-8071-23dae78012c4.png)

![image](https://user-images.githubusercontent.com/7753001/222748011-f658796c-52be-4af9-a796-cc7a029acc4d.png)

