### PR TITLE
Rich text: fix range equality checks for Safari

### DIFF
--- a/packages/rich-text/src/component/use-selection-change-compat.js
+++ b/packages/rich-text/src/component/use-selection-change-compat.js
@@ -7,6 +7,7 @@ import { useRefEffect } from '@wordpress/compose';
  * Internal dependencies
  */
 import { isRangeEqual } from '../is-range-equal';
+
 /**
  * Sometimes some browsers are not firing a `selectionchange` event when
  * changing the selection by mouse or keyboard. This hook makes sure that, if we

--- a/packages/rich-text/src/component/use-selection-change-compat.js
+++ b/packages/rich-text/src/component/use-selection-change-compat.js
@@ -4,6 +4,10 @@
 import { useRefEffect } from '@wordpress/compose';
 
 /**
+ * Internal dependencies
+ */
+import { isRangeEqual } from '../is-range-equal';
+/**
  * Sometimes some browsers are not firing a `selectionchange` event when
  * changing the selection by mouse or keyboard. This hook makes sure that, if we
  * detect no `selectionchange` or `input` event between the up and down events,
@@ -38,7 +42,7 @@ export function useSelectionChangeCompat() {
 
 			function onUp() {
 				onCancel();
-				if ( range === getRange() ) return;
+				if ( isRangeEqual( range, getRange() ) ) return;
 				ownerDocument.dispatchEvent( new Event( 'selectionchange' ) );
 			}
 

--- a/packages/rich-text/src/is-range-equal.js
+++ b/packages/rich-text/src/is-range-equal.js
@@ -1,0 +1,19 @@
+/**
+ * Returns true if two ranges are equal, or false otherwise. Ranges are
+ * considered equal if their start and end occur in the same container and
+ * offset.
+ *
+ * @param {Range|null} a First range object to test.
+ * @param {Range|null} b First range object to test.
+ *
+ * @return {boolean} Whether the two ranges are equal.
+ */
+export function isRangeEqual( a, b ) {
+	return (
+		a === b ||
+		( a.startContainer === b.startContainer &&
+			a.startOffset === b.startOffset &&
+			a.endContainer === b.endContainer &&
+			a.endOffset === b.endOffset )
+	);
+}

--- a/packages/rich-text/src/is-range-equal.js
+++ b/packages/rich-text/src/is-range-equal.js
@@ -11,7 +11,9 @@
 export function isRangeEqual( a, b ) {
 	return (
 		a === b ||
-		( a.startContainer === b.startContainer &&
+		( a &&
+			b &&
+			a.startContainer === b.startContainer &&
 			a.startOffset === b.startOffset &&
 			a.endContainer === b.endContainer &&
 			a.endOffset === b.endOffset )

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -4,6 +4,7 @@
 
 import { toTree } from './to-tree';
 import { createElement } from './create-element';
+import { isRangeEqual } from './is-range-equal';
 
 /** @typedef {import('./create').RichTextValue} RichTextValue */
 
@@ -252,25 +253,6 @@ export function applyValue( future, current ) {
 	while ( current.childNodes[ i ] ) {
 		current.removeChild( current.childNodes[ i ] );
 	}
-}
-
-/**
- * Returns true if two ranges are equal, or false otherwise. Ranges are
- * considered equal if their start and end occur in the same container and
- * offset.
- *
- * @param {Range} a First range object to test.
- * @param {Range} b First range object to test.
- *
- * @return {boolean} Whether the two ranges are equal.
- */
-function isRangeEqual( a, b ) {
-	return (
-		a.startContainer === b.startContainer &&
-		a.startOffset === b.startOffset &&
-		a.endContainer === b.endContainer &&
-		a.endOffset === b.endOffset
-	);
 }
 
 export function applySelection( { startPath, endPath }, current ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

In Safari, `window.getSelection().getRangeAt(0) === window.getSelection().getRangeAt(0)` never holds true, so we must check if every property of the range is equal instead.

While in this case it's not very harmful, it's good to prevent unnecessary `selectionchange` dispatches for performance reasons and extract this utility function for other use cases.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
