### PR TITLE
Scripts: Fix `render.php` isn't copied in Windows OS

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Fix `render.php` isn't copied in Windows OS ([#48735](https://github.com/WordPress/gutenberg/pull/48735)).
+
 ## 25.5.0 (2023-03-01)
 
 ## 25.4.0 (2023-02-15)

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -353,7 +353,7 @@ function getRenderPropPaths() {
 				);
 				return false;
 			}
-			return filepath;
+			return filepath.replace( /\\/g, '/' );
 		}
 		return false;
 	} );


### PR DESCRIPTION
Fixes #48696

## What?
This PR fixes a problem in which the target file is not copied in Windows when the `render` property is defined in `block.json`.

## Why?

The process of finding the file path for `render.php` is done below:

https://github.com/WordPress/gutenberg/blob/0766b79ad07f668ce9a75ed805a75c8eb6a90fa8/packages/scripts/utils/config.js#L332-L359

In this process, on Windows, the `filepath` variable has a backslash as the path separator, as shown below:

```
D:\path\to\plugin\src\render.php
```

Then I discovered that the `renderPaths` variable created by the `map()` function has escaped backslashes as array values:

```
[ 'D:\\path\\to\\plugin\\src\\render.php' ]
```

The reason for this was that the string could not hold an unescaped backslash, so I suspected it to be automatically escaped in the `map()` function.

And the path separator characters do not match in the `filter` property of `CopyWebpackPlugin`.

https://github.com/WordPress/gutenberg/blob/0420e497eba652717349b2c11efa78b12a919488/packages/scripts/config/webpack.config.js#L277-L282

```
filepath:
D:/path/to/plugin/src/render.php

renderPaths:
[ 'D:\\path\\to\\plugin\\src\\render.php' ]
```
## How?
Replaced the path delimiter in the `filepath` variable with a forward slash. As a result, the array values in the `renderPaths` variable now also contain forward slashes, and the condition in the `filter` property works correctly.

## Testing Instructions

Check out this branch and create a dynamic block template in the project root.

```
npx @wordpress/create-block gutenpride --no-wp-scripts --variant=dynamic
cd gutenpride
```

Build the block.

```
../node_modules/.bin/wp-scripts build
```

Confirm that the `render.php` file has been copied to the `gutenpride/build/` directory.

Also, if multiple blocks are created in the `src` directory, make sure that `render.php` file is generated in each build directory.