### PR TITLE
Add test for useConstrainedTabbing

### DIFF
--- a/packages/compose/src/hooks/use-constrained-tabbing/index.js
+++ b/packages/compose/src/hooks/use-constrained-tabbing/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { TAB } from '@wordpress/keycodes';
 import { focus } from '@wordpress/dom';
 
 /**
@@ -33,9 +32,9 @@ import useRefEffect from '../use-ref-effect';
 function useConstrainedTabbing() {
 	return useRefEffect( ( /** @type {HTMLElement} */ node ) => {
 		function onKeyDown( /** @type {KeyboardEvent} */ event ) {
-			const { keyCode, shiftKey, target } = event;
+			const { code, shiftKey, target } = event;
 
-			if ( keyCode !== TAB ) {
+			if ( code !== 'Tab' ) {
 				return;
 			}
 

--- a/packages/compose/src/hooks/use-constrained-tabbing/test/index.js
+++ b/packages/compose/src/hooks/use-constrained-tabbing/test/index.js
@@ -1,0 +1,88 @@
+/**
+ * External dependencies
+ */
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import useConstrainedTabbing from '../';
+
+describe( 'useConstrainedTabbing', () => {
+	function ConstrainedTabbingComponent() {
+		const constrainedTabbingRef = useConstrainedTabbing();
+		return (
+			<div ref={ constrainedTabbingRef } data-testid="test-component">
+				<button type="button">Button 1</button>
+				<div data-testid="test-component" tabIndex={ -1 } />
+				<button type="button">Button 2</button>
+				<button
+					type="button"
+					onClick={ () => {
+						const placeholder =
+							screen.getByTestId( 'test-component' );
+						placeholder.focus();
+					} }
+				>
+					Button 3
+				</button>
+			</div>
+		);
+	}
+
+	it( 'should constrain tabbing when tabbing forwards', async () => {
+		const user = userEvent.setup( { delay: 100 } );
+
+		render(
+			<div>
+				<button type="button">Focusable element before</button>
+				<ConstrainedTabbingComponent />
+				<button type="button">Focusable element after</button>
+			</div>
+		);
+
+		const focusableBefore = screen.getByRole( 'button', {
+			name: 'Focusable element before',
+		} );
+		const button1 = screen.getByRole( 'button', {
+			name: 'Button 1',
+		} );
+		const button2 = screen.getByRole( 'button', {
+			name: 'Button 2',
+		} );
+		const button3 = screen.getByRole( 'button', {
+			name: 'Button 3',
+		} );
+
+		await user.keyboard( '{Tab}' );
+		expect( focusableBefore ).toHaveFocus();
+
+		await user.keyboard( '{Tab}' );
+		expect( button1 ).toHaveFocus();
+
+		await user.keyboard( '{Tab}' );
+		expect( button2 ).toHaveFocus();
+
+		await user.keyboard( '{Tab}' );
+		expect( button3 ).toHaveFocus();
+
+		// Looks like the React Testing Library didn't implement event.keycode.
+		// Also, we can't use user.Tab() and the like, as the trap element is
+		// injected in the DOM while the Tab key is being pressed.
+		fireEvent.keyDown( button3, { code: 'Tab' } );
+
+		const component = screen.getByTestId( 'test-component' );
+		// eslint-disable-next-line testing-library/no-node-access
+		const trap = component.firstChild;
+
+		await waitFor( () =>
+			expect( trap.outerHTML ).toEqual( '<div tabindex="-1"></div>' )
+		);
+
+		expect( trap ).toHaveFocus();
+
+		// At this point, the trap element should be blurred.
+		// Then, the focused element should be Button 1.
+	} );
+} );

--- a/packages/compose/src/hooks/use-constrained-tabbing/test/index.js
+++ b/packages/compose/src/hooks/use-constrained-tabbing/test/index.js
@@ -15,13 +15,14 @@ describe( 'useConstrainedTabbing', () => {
 		return (
 			<div ref={ constrainedTabbingRef } data-testid="test-component">
 				<button type="button">Button 1</button>
-				<div data-testid="test-component" tabIndex={ -1 } />
+				<div data-testid="test-focusable-element" tabIndex={ -1 } />
 				<button type="button">Button 2</button>
 				<button
 					type="button"
 					onClick={ () => {
-						const placeholder =
-							screen.getByTestId( 'test-component' );
+						const placeholder = screen.getByTestId(
+							'test-focusable-element'
+						);
 						placeholder.focus();
 					} }
 				>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/47427

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR seeks to add tests for `useConstrainedTabbing`.

For now, it's a draft as I'm unclear how to solve some issues. I'd greatly appreciate any jelp and feedback. Cc @ellatrix 

- Looks like the React testing Library didn't implement `event.keycode` so I had to change the hook to use `event.code`.
- I'm not sure how to assert that after the `trap` element is focused and then blurred, the actual focus goes to the first tabbable element within the node.
- The plan is: first complete the test above.
- Then, add a test to check the behavior is correct when tabbing backwards.
- Finally, add a test to cover the specific use case from #34681.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Right now, there's no unit tests for `useConstrainedTabbing`. Such an important component should have at least some basic tests.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add tests.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Run the test: `npm run test:unit -- --testPathPattern packages/compose/src/hooks/use-constrained-tabbing/test/index.js`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
