### PR TITLE
[RNMobile] Update placeholder logic in two BottomSheet components

### DIFF
--- a/packages/components/src/mobile/bottom-sheet-text-control/README.md
+++ b/packages/components/src/mobile/bottom-sheet-text-control/README.md
@@ -71,7 +71,7 @@ The placeholder text that will display in the component's cell and subsheet when
 
 ### cellPlaceholder
 
-The placeholder text that will display in the component's cell when there is no set value. The cellPlaceholder will override the more generic placeholder prop when set, enabling the placeholders in the component's cell and subsheet to be different if desired.
+The placeholder text that will display in the component's cell when there is no set value. The `cellPlaceholder` will override the more generic placeholder prop when set, enabling the placeholders in the component's cell and subsheet to be different if desired.
 
 -   Type: `String`
 -   Required: No

--- a/packages/components/src/mobile/bottom-sheet-text-control/README.md
+++ b/packages/components/src/mobile/bottom-sheet-text-control/README.md
@@ -64,7 +64,14 @@ A function that receives the value that's input into the text editor.
 
 #### placeholder
 
-The placeholder text that will display in the component's subsheet, when its text editor is empty.
+The placeholder text that will display in the component's cell and subsheet when there is no set value.
+
+-   Type: `String`
+-   Required: No
+
+### cellPlaceholder
+
+The placeholder text that will display in the component's cell when there is no set value. The cellPlaceholder will override the more generic placeholder prop when set, enabling the placeholders in the component's cell and subsheet to be different if desired.
 
 -   Type: `String`
 -   Required: No

--- a/packages/components/src/mobile/bottom-sheet-text-control/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet-text-control/index.native.js
@@ -28,6 +28,7 @@ const BottomSheetTextControl = ( {
 	label,
 	icon,
 	footerNote,
+	cellPlaceholder,
 } ) => {
 	const [ showSubSheet, setShowSubSheet ] = useState( false );
 	const navigation = useNavigation();
@@ -57,10 +58,10 @@ const BottomSheetTextControl = ( {
 			navigationButton={
 				<BottomSheet.Cell
 					icon={ icon }
-					placeholder={ placeholder }
 					label={ label }
 					onPress={ openSubSheet }
 					value={ initialValue || '' }
+					placeholder={ cellPlaceholder || placeholder || '' }
 				>
 					<Icon icon={ chevronRight }></Icon>
 				</BottomSheet.Cell>

--- a/packages/components/src/mobile/bottom-sheet/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cell.native.js
@@ -234,7 +234,7 @@ class BottomSheetCell extends Component {
 			// we show the TextInput just when the user wants to edit the value,
 			// and the Text component to display it.
 			// We also show the TextInput to display placeholder.
-			const shouldShowPlaceholder = isValueEditable && value === '';
+			const shouldShowPlaceholder = isInteractive && value === '';
 			return this.state.isEditingValue || shouldShowPlaceholder ? (
 				<TextInput
 					ref={ ( c ) => ( this._valueTextInput = c ) }


### PR DESCRIPTION
* `gutenberg-mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5529

## What?

This PR updates the placeholder logic in two BottomSheet components:
* [The BottomSheetCell component](https://github.com/WordPress/gutenberg/blob/5176a3bb2cc7e8704538f1a18a532c6f98033c96/packages/components/src/mobile/bottom-sheet/cell.native.js) has been updated so that a placeholder is displayed in cases where it's both defined and the cell is interactive.
* [The BottomSheetTextControl component](https://github.com/WordPress/gutenberg/blob/5176a3bb2cc7e8704538f1a18a532c6f98033c96/packages/components/src/mobile/bottom-sheet-text-control/README.md) has been updated so that it's possible to set different placeholders for both its cell and text area sections.

## Why?

Previous to this PR, a placeholder would only be displayed if a BottomSheetCell was editable. However, there are cases where a BottomSheetCell is interactive and a placeholder could be useful. 

For example, [the BottomSheetTextControl component](https://github.com/WordPress/gutenberg/blob/5176a3bb2cc7e8704538f1a18a532c6f98033c96/packages/components/src/mobile/bottom-sheet-text-control/index.native.js) includes a BottomSheetCell that is interactive and opens up an editable subsheet when tapped. Although the BottomSheetCell isn't editable in this case, there is still a value linked to it and a placeholder could be useful. The screenshots section below shows this in action.

There are also use cases for having different placeholders in the BottomSheetTextControl's cell and text area sections, which this PR makes possible.

## How?

* The cell component's `shouldShowPlaceholder` conditional has been updated to check for `isInteractive` rather than `isValueEditable`. More details in [this comment](https://github.com/WordPress/gutenberg/pull/48737/files#r1124773023).
* In addition, a `cellPlaceholder` prop has been added to make it possible to set a separate cell placeholder in the BottomSheetTextControl.

## Testing Instructions

* Navigate to the post editor in the Android or iOS app.
* Add an image block and add an image to it. The image should not have existing alt text, if it does then simply remove it for the purpose of testing.
* Tap the block's cog icon to open up its settings.
* Verify that the empty alt text field in the settings panel shows an "add alt text" placeholder.
* Look through other uses of `BottomSheet.Cell` in the codebase to verify that there are no cases where a placeholder is both set _and_ the component is interactive.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/2998162/222776037-1ff217fe-d7d8-4448-945d-102a89b8c117.png" width="100%"> | <img src="https://user-images.githubusercontent.com/2998162/222775716-c1691f0d-80fd-413e-94be-5ea57c835493.png" width="100%"> |
