### PR TITLE
Make sure the directly inserted block in the Nav block is a Page link

### DIFF
--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -29,6 +29,9 @@ const ALLOWED_BLOCKS = [
 
 const DEFAULT_BLOCK = {
 	name: 'core/navigation-link',
+	attributes: {
+		type: 'page',
+	},
 };
 
 export default function NavigationInnerBlocks( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Makes the directly inserted block in the Nav block a Page variation instead of a Custom Link.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because most of the time people just want to insert a link to a Page. Let's default to that.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update the `attributes` of the default block (which is the directly inserted one) to include a `type` attribute set to `page`. This will cause the variation to be active.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Have an empty Nav block (or one containing only links - if it contains other stuff it won't work and that is a feature not a bug).
- Click the + inserter in _the editor canvas_
- See Page variation auto-inserted

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/444434/222786334-b5b38b4b-26a8-4c2a-801b-623701063354.mp4

