### PR TITLE
Fix: Show creation popover on empty page links in the navigation sidebar.

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
@@ -68,7 +68,7 @@ export default function NavigationMenuContent( { rootClientId, onSelect } ) {
 					showAppender={ false }
 				/>
 			) }
-			<div style={ { display: 'none' } }>
+			<div style={ { visibility: 'hidden' } }>
 				<BlockTools>
 					<BlockList />
 				</BlockTools>


### PR DESCRIPTION
This PR fixes the navigation sidebar and shows the page/custom link creation popover when the user clicks on an empty custom/page link block on the navigation sidebar.

## Testing

Add a page link block on the navigation sidebar.
Leave it empty and close the popover.
Click on the block and verify the popover appears again.
Repeat the steps for the custom link case.
