### PR TITLE
Fix: Incorrect selector generated by `append_to_selector` method

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -797,7 +797,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @return string The new selector.
 	 */
 	protected static function append_to_selector( $selector, $to_append, $position = 'right' ) {
-		if ( ! str_contains( ',', $selector ) ) {
+		if ( ! str_contains( $selector, ',' ) ) {
 			return 'right' === $position ? $selector . $to_append : $to_append . $selector;
 		}
 		$new_selectors = array();


### PR DESCRIPTION
Fixes: #48393
Fixes: #48706 

Related to: #47833

## What?
This PR fixes the problem that the `append_to_selector()` method of the `WP_Theme_JSON_Gutenberg` class does not generate the correct selector.

## Why?
In #47833, a process has been added to check if the selector contains a comma to avoid unwanted `implide`/`explode`. However, the parameters of the [str_contains](https://www.php.net/manual/en/function.str-contains.php) function to check for it appears to be reversed.

## Testing Instructions

Confirm that the correct selector is generated in the two issues that this PR fixes.

### Testing for #48393 (Button Block: Style for pseudo-elements has priority)

The pseudo-element selector should be correctly generated and the background color of the button should change to the expected color.

#### Before

![before_button](https://user-images.githubusercontent.com/54422211/222961989-28e377f8-1a96-4c1b-8b87-f645d9b6ccbc.png)

#### After

![after_button](https://user-images.githubusercontent.com/54422211/222961995-4deff26c-1331-4053-b171-ada0e1cc0900.png)

### Testing for #48706 (Heading in selectors aren't set correctly at the block level)

- Enable EmptyTheme and overwrite `theme.json` with the code described in [this comment](https://github.com/WordPress/gutenberg/issues/48706#issuecomment-1455014587).
- Insert a group block in the post.
- Confirm that the global inline style is outputting the correct selector.

### Before

![before_group](https://user-images.githubusercontent.com/54422211/222962423-1d0d0813-0dd8-4c40-81b9-7717d567cf7d.png)

### After

![after_group](https://user-images.githubusercontent.com/54422211/222962425-36288305-b9c8-4ba2-aed8-700f8a9c58d0.png)



