### PR TITLE
Update missing translation from label

### DIFF
--- a/packages/block-library/src/columns/edit.native.js
+++ b/packages/block-library/src/columns/edit.native.js
@@ -198,7 +198,7 @@ function ColumnsEditContainer( {
 			return (
 				<UnitControl
 					label={ label }
-					settingLabel="Width"
+					settingLabel={ __( 'Width' ) }
 					key={ `${ column.clientId }-${
 						getWidths( innerWidths ).length
 					}` }

--- a/packages/block-library/src/comments/edit/placeholder.js
+++ b/packages/block-library/src/comments/edit/placeholder.js
@@ -94,7 +94,9 @@ export default function PostCommentsPlaceholder( { postType, postId } ) {
 							<a
 								className="comment-reply-link"
 								href="#top"
-								aria-label="Reply to A WordPress Commenter"
+								aria-label={ __(
+									'Reply to A WordPress Commenter'
+								) }
 							>
 								{ __( 'Reply' ) }
 							</a>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Found the following files missing translations function on the aria-label & settingsLabel attribute

- packages/block-library/src/columns/edit.native.js
- packages/block-library/src/comments/edit/placeholder.js

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I think we should change  codes to like this
`settingLabel={ __( 'Width' ) }`

`aria-label={ __( 'Reply to A WordPress Commenter' ) }`


## Screenshots or screencast <!-- if applicable -->

<img width="1492" alt="Screenshot 2023-03-06 at 12 54 24 AM" src="https://user-images.githubusercontent.com/60743337/222980667-489f995a-06a2-478c-b488-14f5caa8b1b5.png">
