### PR TITLE
Format library: improve unknown format performance

### DIFF
--- a/packages/format-library/src/unknown/index.js
+++ b/packages/format-library/src/unknown/index.js
@@ -2,12 +2,23 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { removeFormat, slice } from '@wordpress/rich-text';
+import { removeFormat, slice, isCollapsed } from '@wordpress/rich-text';
 import { RichTextToolbarButton } from '@wordpress/block-editor';
 import { help } from '@wordpress/icons';
 
 const name = 'core/unknown';
 const title = __( 'Clear Unknown Formatting' );
+
+function selectionContainsUnknownFormats( value ) {
+	if ( isCollapsed( value ) ) {
+		return false;
+	}
+
+	const selectedValue = slice( value );
+	return selectedValue.formats.some( ( formats ) => {
+		return formats.some( ( format ) => format.type === name );
+	} );
+}
 
 export const unknown = {
 	name,
@@ -15,18 +26,13 @@ export const unknown = {
 	tagName: '*',
 	className: null,
 	edit( { isActive, value, onChange, onFocus } ) {
+		if ( ! isActive && ! selectionContainsUnknownFormats( value ) ) {
+			return null;
+		}
+
 		function onClick() {
 			onChange( removeFormat( value, name ) );
 			onFocus();
-		}
-
-		const selectedValue = slice( value );
-		const hasUnknownFormats = selectedValue.formats.some( ( formats ) => {
-			return formats.some( ( format ) => format.type === name );
-		} );
-
-		if ( ! isActive && ! hasUnknownFormats ) {
-			return null;
 		}
 
 		return (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Not expecting a huge difference here, but on every keystroke we're slicing the rich text value based on the selection. We should return early if the selection is collapsed and not bother slicing and looping over the formats.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
