### PR TITLE
Docs: Add position: sticky to the Opt-in into UI controls appearanceTools section

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -321,6 +321,7 @@ There's one special setting property, `appearanceTools`, which is a boolean and 
 - border: color, radius, style, width
 - color: link
 - dimensions: minHeight
+- position: sticky
 - spacing: blockGap, margin, padding
 - typography: lineHeight
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add `sticky: position` to the section of the global settings and styles page describing `appearanceTools`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When I updated the documentation to include references to position settings in #48057, I missed updating this particular page.

Kudos @bph for highlighting this missing line of documentation!

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add a single line to the section on `appearanceTools` to mention sticky position.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Proofread to make sure there isn't a typo 😄