### PR TITLE
Site editor: go direct to edit from manage all templates list

### DIFF
--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -89,6 +89,8 @@ export default function Table( { templateType } ) {
 									params={ {
 										postId: template.id,
 										postType: template.type,
+										canvas: 'edit',
+										fromTemplateList: true,
 									} }
 								>
 									{ decodeEntities(

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -90,7 +90,6 @@ export default function Table( { templateType } ) {
 										postId: template.id,
 										postType: template.type,
 										canvas: 'edit',
-										fromTemplateList: true,
 									} }
 								>
 									{ decodeEntities(

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { forwardRef } from '@wordpress/element';
+import { getQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -24,10 +25,13 @@ import { forwardRef } from '@wordpress/element';
 import { store as editSiteStore } from '../../store';
 import SiteIcon from '../site-icon';
 import { unlock } from '../../private-apis';
+import { useHistory } from '../routes';
 
 const HUB_ANIMATION_DURATION = 0.3;
 
 const SiteHub = forwardRef( ( props, ref ) => {
+	const history = useHistory();
+	const { fromTemplateList } = getQueryArgs( window.location.href );
 	const { canvasMode, dashboardLink } = useSelect( ( select ) => {
 		select( editSiteStore ).getEditedPostType();
 		const { getCanvasMode, getSettings } = unlock(
@@ -52,6 +56,14 @@ const SiteHub = forwardRef( ( props, ref ) => {
 				label: __( 'Open Navigation Sidebar' ),
 				onClick: () => {
 					clearSelectedBlock();
+					if ( fromTemplateList ) {
+						history.push( {
+							path: '/wp_template/all',
+							postType: 'wp_template',
+							postId: undefined,
+							fromTemplateList: undefined,
+						} );
+					}
 					setCanvasMode( 'view' );
 				},
 		  };

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -17,7 +17,6 @@ import { __ } from '@wordpress/i18n';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { forwardRef } from '@wordpress/element';
-import { getQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -25,13 +24,10 @@ import { getQueryArgs } from '@wordpress/url';
 import { store as editSiteStore } from '../../store';
 import SiteIcon from '../site-icon';
 import { unlock } from '../../private-apis';
-import { useHistory } from '../routes';
 
 const HUB_ANIMATION_DURATION = 0.3;
 
 const SiteHub = forwardRef( ( props, ref ) => {
-	const history = useHistory();
-	const { fromTemplateList } = getQueryArgs( window.location.href );
 	const { canvasMode, dashboardLink } = useSelect( ( select ) => {
 		select( editSiteStore ).getEditedPostType();
 		const { getCanvasMode, getSettings } = unlock(
@@ -56,14 +52,6 @@ const SiteHub = forwardRef( ( props, ref ) => {
 				label: __( 'Open Navigation Sidebar' ),
 				onClick: () => {
 					clearSelectedBlock();
-					if ( fromTemplateList ) {
-						history.push( {
-							path: '/wp_template/all',
-							postType: 'wp_template',
-							postId: undefined,
-							fromTemplateList: undefined,
-						} );
-					}
 					setCanvasMode( 'view' );
 				},
 		  };


### PR DESCRIPTION
## What?
If clicking on a template in the manage all templates list go direct to the editor rather than  the interim view canvas for the template.

## Why?
The interim view step is currently redundant as offers no additional functionality.
Fixes: #48702

## How?

- Replaces `canvas=view` with `canvas=edit` in the link params
- Adds a `fromTemplateList` param so the back link can be correctly generated in the editor


## Testing Instructions

- Open the site editor and go to the 'Manage all templates' page.
- Click on  a template in the list and check that it goes direct to the editor
- Click on the WordPress icon and check it returns to the 'Manage all templates' page
- Check that the back button works to return from the editor to the 'Manage all templates' page (currently broken)

## Screenshots or screencast <!-- if applicable -->

Before:

https://user-images.githubusercontent.com/3629020/223001747-c99592e7-b9d1-4aa0-8850-f5c0365b9f33.mov

After:

https://user-images.githubusercontent.com/3629020/223001791-05f0d66c-09ec-4722-8c5e-5cd978c352c7.mov



