### PR TITLE
Import Classic Menu using the menu name as the block menu title

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -348,7 +348,7 @@ function block_core_navigation_maybe_use_classic_menu_fallback() {
 	$wp_insert_post_result = wp_insert_post(
 		array(
 			'post_content' => $classic_nav_menu_blocks,
-			'post_title'   => $classic_nav_menu->slug,
+			'post_title'   => $classic_nav_menu->name,
 			'post_name'    => $classic_nav_menu->slug,
 			'post_status'  => 'publish',
 			'post_type'    => 'wp_navigation',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes Classic Menu import in the Nav block to use the menu's name rather than it's slug for the Navigation menu's title.

Spun out of https://github.com/WordPress/gutenberg/pull/48625/ just in case that one doesn't land.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Using the slug for a title is sub optimal. We should prefer the menu's name as it maps better to the post title.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Using the classic menu `name` attribute rather than `slug` when create the Navigation menu post (`wp_navigation`).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Delete all Navigation Menus at `http://localhost:8888/wp-admin/edit.php?post_type=wp_navigation`
- Switch to Classic Theme.
- Create Menu with a name you can remember.
- Switch to Block Theme (do not visit editor!)
- Go to front of site (this should import the Classic Menu).
- Go to `http://localhost:8888/wp-admin/edit.php?post_type=wp_navigation`. 
- Check the title of the imported Navigation menu matches with that of the Classic Menu

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
