### PR TITLE
[Page list Block] Show untitled pages on page list on the editor

### DIFF
--- a/packages/block-library/src/page-list-item/edit.js
+++ b/packages/block-library/src/page-list-item/edit.js
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -39,6 +40,9 @@ export default function PageListItemEdit( { context, attributes } ) {
 	const isNavigationChild = 'showSubmenuIcon' in context;
 	const frontPageId = useFrontPageId();
 
+	const pageLabel =
+		label !== '' ? decodeEntities( label ) : __( '(No title)' );
+
 	const innerBlocksColors = getColors( context, true );
 
 	const navigationChildBlockProps =
@@ -67,7 +71,7 @@ export default function PageListItemEdit( { context, attributes } ) {
 						className="wp-block-navigation-item__content wp-block-navigation-submenu__toggle"
 						aria-expanded="false"
 					>
-						{ decodeEntities( label ) }
+						{ pageLabel }
 					</button>
 					<span className="wp-block-page-list__submenu-icon wp-block-navigation__submenu-icon">
 						<ItemSubmenuIcon />
@@ -80,7 +84,7 @@ export default function PageListItemEdit( { context, attributes } ) {
 					} ) }
 					href={ link }
 				>
-					{ decodeEntities( label ) }
+					{ pageLabel }
 				</a>
 			) }
 			{ hasChildren && (

--- a/packages/block-library/src/page-list-item/edit.js
+++ b/packages/block-library/src/page-list-item/edit.js
@@ -5,7 +5,6 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -40,9 +39,6 @@ export default function PageListItemEdit( { context, attributes } ) {
 	const isNavigationChild = 'showSubmenuIcon' in context;
 	const frontPageId = useFrontPageId();
 
-	const pageLabel =
-		label !== '' ? decodeEntities( label ) : __( '(No title)' );
-
 	const innerBlocksColors = getColors( context, true );
 
 	const navigationChildBlockProps =
@@ -71,7 +67,7 @@ export default function PageListItemEdit( { context, attributes } ) {
 						className="wp-block-navigation-item__content wp-block-navigation-submenu__toggle"
 						aria-expanded="false"
 					>
-						{ pageLabel }
+						{ decodeEntities( label ) }
 					</button>
 					<span className="wp-block-page-list__submenu-icon wp-block-navigation__submenu-icon">
 						<ItemSubmenuIcon />
@@ -84,7 +80,7 @@ export default function PageListItemEdit( { context, attributes } ) {
 					} ) }
 					href={ link }
 				>
-					{ pageLabel }
+					{ decodeEntities( label ) }
 				</a>
 			) }
 			{ hasChildren && (

--- a/packages/block-library/src/page-list-item/edit.js
+++ b/packages/block-library/src/page-list-item/edit.js
@@ -35,7 +35,7 @@ function useFrontPageId() {
 }
 
 export default function PageListItemEdit( { context, attributes } ) {
-	const { id, label, link, hasChildren } = attributes;
+	const { id, label, link, hasChildren, title } = attributes;
 	const isNavigationChild = 'showSubmenuIcon' in context;
 	const frontPageId = useFrontPageId();
 
@@ -80,7 +80,7 @@ export default function PageListItemEdit( { context, attributes } ) {
 					} ) }
 					href={ link }
 				>
-					{ decodeEntities( label ) }
+					{ decodeEntities( title ) }
 				</a>
 			) }
 			{ hasChildren && (

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -200,7 +200,10 @@ export default function PageListEdit( {
 			const hasChildren = pagesByParentId.has( page.id );
 			const pageProps = {
 				id: page.id,
-				label: page.title?.rendered,
+				label:
+					page.title?.rendered !== ''
+						? page.title?.rendered
+						: __( '(No title)' ),
 				title: page.title?.rendered,
 				link: page.url,
 				hasChildren,

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -202,7 +202,7 @@ export default function PageListEdit( {
 				id: page.id,
 				label:
 					// translators: displayed when a page has an empty title.
-					page.title?.rendered !== ''
+					page.title?.rendered?.trim() !== ''
 						? page.title?.rendered
 						: __( '(No title)' ),
 				title: page.title?.rendered,

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -201,6 +201,7 @@ export default function PageListEdit( {
 			const pageProps = {
 				id: page.id,
 				label:
+					// translators: displayed when a page has an empty title.
 					page.title?.rendered !== ''
 						? page.title?.rendered
 						: __( '(No title)' ),

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -204,7 +204,7 @@ export default function PageListEdit( {
 					// translators: displayed when a page has an empty title.
 					page.title?.rendered?.trim() !== ''
 						? page.title?.rendered
-						: __( '(No title)' ),
+						: __( '(no title)' ),
 				title: page.title?.rendered,
 				link: page.url,
 				hasChildren,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR adds a `(No title)` label for page list items that are untitled, so they are visible to the user and don't create confusing spaces due to padding on empty tags. This change is also done for the editor, the frontend won't show any text for these pages.

Closes https://github.com/WordPress/gutenberg/issues/48226

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's hard for the user to know they have an untitled page on their menu unless they are looking at the list view, this makes it more apparent and it's in line with how untitled pages are displayed on wp-admin.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
We change the label for the items that have an empty string as content.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Create an untitled page
2. Insert a navigation block
3. Add a page list inside if it doesn't have it
4. Check the contents, you should see (No title) for the untitled page in the editor and it should be empty on the frontend.

## Screenshots or screencast <!-- if applicable -->

Frontend:

<img width="1354" alt="Screenshot 2023-03-06 at 12 04 08" src="https://user-images.githubusercontent.com/3593343/223094405-dec4246b-ba06-4b70-834e-808aa236eb7b.png">

Editor:

<img width="1293" alt="Screenshot 2023-03-06 at 12 04 23" src="https://user-images.githubusercontent.com/3593343/223094399-8fa0b108-b685-4a86-b363-d6ca4797cf6a.png">


