### PR TITLE
i18n of created Navigation menu title

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -446,8 +446,8 @@ function block_core_navigation_get_default_pages_fallback() {
 	$wp_insert_post_result = wp_insert_post(
 		array(
 			'post_content' => $default_blocks,
-			'post_title'   => 'Navigation', // TODO - use the template slug in future.
-			'post_name'    => 'Navigation', // TODO - use the template slug in future.
+			'post_title'   => _x( 'Navigation', 'Title of a Navigation menu' ),
+			'post_name'    => 'navigation',
 			'post_status'  => 'publish',
 			'post_type'    => 'wp_navigation',
 		),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Makes the post title of the Navigation menu translated.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Strings should be translatable. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Uses `_x()` to ensure context is provided.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Delete all `wp_navigation` (http://localhost:8888/wp-admin/edit.php?post_type=wp_navigation) _and_ Classic Menus.
- Switch to block theme and DO NOT visit the editor
- Go to front of site.
- View Nav Menus at http://localhost:8888/wp-admin/edit.php?post_type=wp_navigatio
- See the menu created with title `Navigation`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
