### PR TITLE
Lodash: Remove from e2e-tests package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17721,7 +17721,6 @@
 				"filenamify": "^4.2.0",
 				"jest-message-util": "^27.4.2",
 				"jest-snapshot": "^27.4.5",
-				"lodash": "^4.17.21",
 				"puppeteer-testing-library": "^0.5.0",
 				"uuid": "^8.3.0"
 			}

--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
 import { toMatchInlineSnapshot, toMatchSnapshot } from 'jest-snapshot';
 
 /**
@@ -172,11 +171,7 @@ function observeConsoleLogging() {
 		// correctly. Instead, the logic here synchronously inspects the
 		// internal object shape of the JSHandle to find the error text. If it
 		// cannot be found, the default text value is used instead.
-		text = get(
-			message.args(),
-			[ 0, '_remoteObject', 'description' ],
-			text
-		);
+		text = message.args()[ 0 ]?._remoteObject?.description ?? text;
 
 		// Disable reason: We intentionally bubble up the console message
 		// which, unless the test explicitly anticipates the logging via

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -33,7 +33,6 @@
 		"filenamify": "^4.2.0",
 		"jest-message-util": "^27.4.2",
 		"jest-snapshot": "^27.4.5",
-		"lodash": "^4.17.21",
 		"puppeteer-testing-library": "^0.5.0",
 		"uuid": "^8.3.0"
 	},

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -24,7 +24,6 @@ import {
  */
 // eslint-disable-next-line no-restricted-imports
 import { find, findAll } from 'puppeteer-testing-library';
-import { groupBy, mapValues } from 'lodash';
 
 describe( 'Widgets screen', () => {
 	beforeEach( async () => {
@@ -945,13 +944,20 @@ async function saveWidgets() {
 async function getSerializedWidgetAreas() {
 	const widgets = await rest( { path: '/wp/v2/widgets' } );
 
-	const serializedWidgetAreas = mapValues(
-		groupBy( widgets, 'sidebar' ),
-		( sidebarWidgets ) =>
-			sidebarWidgets
-				.map( ( widget ) => widget.rendered )
-				.filter( Boolean )
-				.join( '\n' )
+	const serializedWidgetAreas = widgets.reduce(
+		( acc, { sidebar, rendered } ) => {
+			const currentWidgets = acc[ sidebar ] || '';
+			let newWidgets = Boolean( rendered ) ? rendered : '';
+			if ( currentWidgets.length && newWidgets.length ) {
+				newWidgets = '\n' + newWidgets;
+			}
+
+			return {
+				...acc,
+				[ sidebar ]: currentWidgets + newWidgets,
+			};
+		},
+		{}
 	);
 
 	return serializedWidgetAreas;


### PR DESCRIPTION
## What?
This PR removes Lodash's from the `@wordpress/e2e-tests` package.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using vanilla JS for all manipulations.

## Testing Instructions

* Verify all checks are green. The changes affect existing e2e tests, so if they're green, we're good.