### PR TITLE
Lodash: Refactor away from `_.kebabCase()` in `EditorHelpTopics`

### DIFF
--- a/packages/editor/src/components/editor-help/index.native.js
+++ b/packages/editor/src/components/editor-help/index.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { kebabCase } from 'lodash';
+import { paramCase as kebabCase } from 'change-case';
 import { SafeAreaView, ScrollView, StyleSheet, View } from 'react-native';
 import { TransitionPresets } from '@react-navigation/stack';
 

--- a/packages/editor/src/components/editor-help/index.native.js
+++ b/packages/editor/src/components/editor-help/index.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { kebabCase } from 'lodash';
+import { paramCase } from 'change-case';
 import { SafeAreaView, ScrollView, StyleSheet, View } from 'react-native';
 import { TransitionPresets } from '@react-navigation/stack';
 
@@ -64,6 +64,10 @@ const kebabCaseSettings = {
 	],
 	stripRegexp: /(\p{C}|\p{P}|\p{S})+/giu, // Anything that's not a punctuation, symbol or control/format character.
 };
+
+function kebabCase( string ) {
+	return paramCase( string, kebabCaseSettings );
+}
 
 function EditorHelpTopics( { close, isVisible, onClose, showSupport } ) {
 	const { postType } = useSelect( ( select ) => ( {
@@ -153,10 +157,7 @@ function EditorHelpTopics( { close, isVisible, onClose, showSupport } ) {
 														index
 													) => {
 														const labelSlug =
-															kebabCase(
-																label,
-																kebabCaseSettings
-															);
+															kebabCase( label );
 														const isLastItem =
 															index ===
 															HELP_TOPICS.length -
@@ -189,7 +190,7 @@ function EditorHelpTopics( { close, isVisible, onClose, showSupport } ) {
 					</BottomSheet.NavigationScreen>
 					{ /* Print out help detail screens. */ }
 					{ HELP_TOPICS.map( ( { view, label } ) => {
-						const labelSlug = kebabCase( label, kebabCaseSettings );
+						const labelSlug = kebabCase( label );
 						return (
 							<HelpDetailNavigationScreen
 								key={ labelSlug }

--- a/packages/editor/src/components/editor-help/index.native.js
+++ b/packages/editor/src/components/editor-help/index.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { paramCase as kebabCase } from 'change-case';
+import { kebabCase } from 'lodash';
 import { SafeAreaView, ScrollView, StyleSheet, View } from 'react-native';
 import { TransitionPresets } from '@react-navigation/stack';
 
@@ -56,6 +56,14 @@ const HELP_TOPICS = [
 		view: <CustomizeBlocks />,
 	},
 ];
+
+const kebabCaseSettings = {
+	splitRegexp: [
+		/([\p{Ll}\p{Lo}\p{N}])([\p{Lu}\p{Lt}])/gu, // One lowercase or digit, followed by one uppercase.
+		/([\p{Lu}\p{Lt}])([\p{Lu}\p{Lt}][\p{Ll}\p{Lo}])/gu, // One uppercase followed by one uppercase and one lowercase.
+	],
+	stripRegexp: /(\p{C}|\p{P}|\p{S})+/giu, // Anything that's not a punctuation, symbol or control/format character.
+};
 
 function EditorHelpTopics( { close, isVisible, onClose, showSupport } ) {
 	const { postType } = useSelect( ( select ) => ( {
@@ -145,7 +153,10 @@ function EditorHelpTopics( { close, isVisible, onClose, showSupport } ) {
 														index
 													) => {
 														const labelSlug =
-															kebabCase( label );
+															kebabCase(
+																label,
+																kebabCaseSettings
+															);
 														const isLastItem =
 															index ===
 															HELP_TOPICS.length -
@@ -178,7 +189,7 @@ function EditorHelpTopics( { close, isVisible, onClose, showSupport } ) {
 					</BottomSheet.NavigationScreen>
 					{ /* Print out help detail screens. */ }
 					{ HELP_TOPICS.map( ( { view, label } ) => {
-						const labelSlug = kebabCase( label );
+						const labelSlug = kebabCase( label, kebabCaseSettings );
 						return (
 							<HelpDetailNavigationScreen
 								key={ labelSlug }


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.kebabCase()` from the `EditorHelpTopics` component. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `paramCase` from the `change-case` package, which we've been using as an all-around replacement.

This is a straightforward change since it works with predictable values (values that are already declared as localized sentence strings above in the same file).

## Testing Instructions

* Head to #33240 for testing instructions.
* Verify all checks are green.