### PR TITLE
Fix: Browse mode descriptions margin.

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -1,6 +1,5 @@
 .edit-site-sidebar-navigation-screen__description {
-	margin-top: 0;
-	margin-bottom: $grid-unit-40;
+	margin: 0 0 $grid-unit-40 $grid-unit-20;
 }
 
 .edit-site-sidebar-navigation-screen-navigation-menus__placeholder {

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -21,6 +21,8 @@
 	.components-external-link__icon {
 		margin-left: $grid-unit-05;
 	}
+	margin-left: $grid-unit-20;
+	display: inline-block;
 }
 
 .edit-site-sidebar-navigation-screen__title-icon {


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/48739.
Fixes the margins of the descriptions.

<img width="379" alt="Screenshot 2023-03-06 at 12 12 28" src="https://user-images.githubusercontent.com/11271197/223107176-325b2ec5-9cfa-4182-8872-fd4884db2f25.png">

cc: @jasmussen @jameskoster 
