### PR TITLE
`QueryControls`: refactor away from `lodash.groupBy`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -25,6 +25,7 @@
 -   `ToolbarButton`: Convert to TypeScript ([#47750](https://github.com/WordPress/gutenberg/pull/47750)).
 -   `DimensionControl(Experimental)`: Convert to TypeScript ([#47351](https://github.com/WordPress/gutenberg/pull/47351)).
 -   `PaletteEdit`: Convert to TypeScript ([#47764](https://github.com/WordPress/gutenberg/pull/47764)).
+-   `QueryControls`: Refactor away from Lodash (`.groupBy`) ([#48779](https://github.com/WordPress/gutenberg/pull/48779)).
 
 ## 23.5.0 (2023-03-01)
 

--- a/packages/components/src/query-controls/terms.ts
+++ b/packages/components/src/query-controls/terms.ts
@@ -8,7 +8,7 @@ import type {
 	TermsByParent,
 } from './types';
 
-const ensureParents = (
+const ensureParentsAreDefined = (
 	terms: TermWithParentAndChildren[]
 ): terms is ( TermWithParentAndChildren & { parent: number } )[] => {
 	return terms.every( ( term ) => term.parent !== null );
@@ -29,7 +29,11 @@ export function buildTermsTree( flatTerms: readonly ( Author | Category )[] ) {
 			id: String( term.id ),
 		} ) );
 
-	if ( ! ensureParents( flatTermsWithParentAndChildren ) ) {
+	// We use a custom type guard here to ensure that the parent property is
+	// defined on all terms. The type of the `parent` property is `number | null`
+	// and we need to ensure that it is `number`. This is because we use the
+	// `parent` property as a key in the `termsByParent` object.
+	if ( ! ensureParentsAreDefined( flatTermsWithParentAndChildren ) ) {
 		return flatTermsWithParentAndChildren;
 	}
 

--- a/packages/components/src/query-controls/terms.ts
+++ b/packages/components/src/query-controls/terms.ts
@@ -22,14 +22,12 @@ const ensureParents = (
  */
 export function buildTermsTree( flatTerms: readonly ( Author | Category )[] ) {
 	const flatTermsWithParentAndChildren: TermWithParentAndChildren[] =
-		flatTerms.map( ( term ) => {
-			return {
-				children: [],
-				parent: null,
-				...term,
-				id: String( term.id ),
-			};
-		} );
+		flatTerms.map( ( term ) => ( {
+			children: [],
+			parent: null,
+			...term,
+			id: String( term.id ),
+		} ) );
 
 	if ( ! ensureParents( flatTermsWithParentAndChildren ) ) {
 		return flatTermsWithParentAndChildren;
@@ -37,7 +35,7 @@ export function buildTermsTree( flatTerms: readonly ( Author | Category )[] ) {
 
 	const termsByParent = flatTermsWithParentAndChildren.reduce(
 		( acc: TermsByParent, term ) => {
-			const parent = term.parent.toString();
+			const { parent } = term;
 			if ( ! acc[ parent ] ) {
 				acc[ parent ] = [];
 			}


### PR DESCRIPTION
## What?

This PR removes Lodash's `_.groupBy()` from the `buildTermsTree` function used in `QueryControls`

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

Replaces `_.groupBy` with a native `.reduce` function.

## Testing Instructions

1. Verify unit tests still pass
2. Verify stories for `QueryControls` still work as expected