### PR TITLE
Fix typo in template parts description

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/index.js
@@ -19,7 +19,7 @@ const config = {
 	wp_template_part: {
 		title: __( 'All template parts' ),
 		description: __(
-			'Create new template parts, or reset any customisations made to the template parts supplied by your theme." seems good.'
+			'Create new template parts, or reset any customisations made to the template parts supplied by your theme.'
 		),
 	},
 };


### PR DESCRIPTION
Follow up of: https://github.com/WordPress/gutenberg/pull/48739