### PR TITLE
FormTokenField: Hide suggestions list on blur event if input value is invalid

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   `FontSizePicker`: Allow custom units for custom font size control ([#48468](https://github.com/WordPress/gutenberg/pull/48468)).
+-   `FormTokenField`: Hide suggestions list on blur event if the input value is invalid ([#48785](https://github.com/WordPress/gutenberg/pull/48785)).
 
 ### Bug Fix
 

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -153,7 +153,10 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 	}
 
 	function onBlur() {
-		if ( inputHasValidValue() ) {
+		if (
+			inputHasValidValue() &&
+			__experimentalValidateInput( incompleteTokenValue )
+		) {
 			setIsActive( false );
 		} else {
 			// Reset to initial state

--- a/packages/components/src/form-token-field/stories/index.tsx
+++ b/packages/components/src/form-token-field/stories/index.tsx
@@ -124,6 +124,11 @@ WithCustomRenderItem.args = {
 	),
 };
 
+/**
+ * Only values for which the `__experimentalValidateInput` function returns
+ * `true` will be tokenized. (This is still an experimental feature and is
+ * subject to change.)
+ */
 export const WithValidatedInput: ComponentStory< typeof FormTokenField > =
 	DefaultTemplate.bind( {} );
 WithValidatedInput.args = {

--- a/packages/components/src/form-token-field/stories/index.tsx
+++ b/packages/components/src/form-token-field/stories/index.tsx
@@ -123,3 +123,11 @@ WithCustomRenderItem.args = {
 		<div>{ `${ item } — a nice place to visit` }</div>
 	),
 };
+
+export const WithValidatedInput: ComponentStory< typeof FormTokenField > =
+	DefaultTemplate.bind( {} );
+WithValidatedInput.args = {
+	...Default.args,
+	__experimentalValidateInput: ( input: string ) =>
+		continents.includes( input ),
+};

--- a/packages/components/src/form-token-field/test/index.tsx
+++ b/packages/components/src/form-token-field/test/index.tsx
@@ -950,7 +950,7 @@ describe( 'FormTokenField', () => {
 			expect( onChangeSpy ).not.toHaveBeenCalled();
 		} );
 
-		it( 'should hide the suggestion list on blur and empty input', async () => {
+		it( 'should hide the suggestion list on an empty input', async () => {
 			const user = userEvent.setup();
 
 			const suggestions = [ 'One', 'Two', 'Three' ];
@@ -968,8 +968,6 @@ describe( 'FormTokenField', () => {
 			expect( screen.getByRole( 'listbox' ) ).toBeVisible();
 
 			await user.clear( input );
-			// Clicking document.body to trigger a blur event on the input.
-			await user.click( document.body );
 
 			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
 		} );

--- a/packages/components/src/form-token-field/test/index.tsx
+++ b/packages/components/src/form-token-field/test/index.tsx
@@ -950,6 +950,88 @@ describe( 'FormTokenField', () => {
 			expect( onChangeSpy ).not.toHaveBeenCalled();
 		} );
 
+		it( 'should hide the suggestion list on blur and empty input', async () => {
+			const user = userEvent.setup();
+
+			const suggestions = [ 'One', 'Two', 'Three' ];
+
+			render( <FormTokenFieldWithState suggestions={ suggestions } /> );
+
+			const input = screen.getByRole( 'combobox' );
+
+			await user.type( input, 'on' );
+
+			expectVisibleSuggestionsToBe( screen.getByRole( 'listbox' ), [
+				'One',
+			] );
+
+			expect( screen.getByRole( 'listbox' ) ).toBeVisible();
+
+			await user.clear( input );
+			// Clicking document.body to trigger a blur event on the input.
+			await user.click( document.body );
+
+			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'should hide the suggestion list on blur and invalid input', async () => {
+			const user = userEvent.setup();
+
+			const suggestions = [ 'One', 'Two', 'Three' ];
+
+			render(
+				<FormTokenFieldWithState
+					suggestions={ suggestions }
+					__experimentalValidateInput={ ( token ) =>
+						suggestions.includes( token )
+					}
+				/>
+			);
+
+			const input = screen.getByRole( 'combobox' );
+
+			await user.type( input, 'on' );
+
+			expectVisibleSuggestionsToBe( screen.getByRole( 'listbox' ), [
+				'One',
+			] );
+
+			expect( screen.getByRole( 'listbox' ) ).toBeVisible();
+
+			await user.click( document.body );
+
+			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'should not hide the suggestion list on blur and valid input', async () => {
+			const user = userEvent.setup();
+
+			const suggestions = [ 'One', 'Two', 'Three' ];
+
+			render(
+				<FormTokenFieldWithState
+					suggestions={ suggestions }
+					__experimentalValidateInput={ ( token ) =>
+						suggestions.includes( token )
+					}
+				/>
+			);
+
+			const input = screen.getByRole( 'combobox' );
+
+			await user.type( input, 'One' );
+
+			expectVisibleSuggestionsToBe( screen.getByRole( 'listbox' ), [
+				'One',
+			] );
+
+			expect( screen.getByRole( 'listbox' ) ).toBeVisible();
+
+			await user.click( document.body );
+
+			expect( screen.getByRole( 'listbox' ) ).toBeVisible();
+		} );
+
 		it( 'matches the search text with the suggestions in a case-insensitive way', async () => {
 			const user = userEvent.setup();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Currently, if FormTokenField loses focus the suggestions list is still rendered unless the input value is empty. The PR forces input clearing and suggestion list closing on blur event even if the input is not empty but invalid based on the `__experimentalValidateInput` property.

## Why?
In my opinion, the change allows for improving UX because it is not clear why the need suggestions list is still opened after blurring (i.e. the user finished interaction) if there is no valid information.

## How?
`inputHasValidValue` is a bit misleading now because we have `__experimentalValidateInput`. Basically, the first one uses `saveTransform` under the hood which is useful during suggestion searching and matching, and saving, the second one validates the token immediately before persisting.
IMO `inputHasValidValue() && __experimentalValidateInput( incompleteTokenValue )` is the right condition to detect if the input is "valid" (makes sense) after blurring.

## Testing Instructions
Changes could be reproduced if the FormTokenField component uses `__experimentalValidateInput` property. In this case, if the input value doesn't pass the validation suggestion list gets hidden after the field loses focus.

### Testing Instructions for Keyboard
The change works if you switch to the next active element with the `Tab` button.

## Screencast

### Before
[before.webm](https://user-images.githubusercontent.com/3157352/224801768-88f23a10-8637-497a-95ed-4ffee2ffec6f.webm)


### After
[after.webm](https://user-images.githubusercontent.com/3157352/224801795-56a1e363-2e5b-4051-b4cc-cb0ca685bd05.webm)


