### PR TITLE
Lodash: Refactor away from `edit-post` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17759,7 +17759,6 @@
 				"@wordpress/warning": "file:packages/warning",
 				"@wordpress/widgets": "file:packages/widgets",
 				"classnames": "^2.3.1",
-				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
 				"rememo": "^4.0.0"
 			},

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -56,7 +56,6 @@
 		"@wordpress/warning": "file:../warning",
 		"@wordpress/widgets": "file:../widgets",
 		"classnames": "^2.3.1",
-		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
 		"rememo": "^4.0.0"
 	},

--- a/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
+++ b/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useViewportMatch, compose } from '@wordpress/compose';
@@ -83,11 +78,10 @@ export function PostPublishButtonOrToggle( {
 
 export default compose(
 	withSelect( ( select ) => ( {
-		hasPublishAction: get(
-			select( editorStore ).getCurrentPost(),
-			[ '_links', 'wp:action-publish' ],
-			false
-		),
+		hasPublishAction:
+			select( editorStore ).getCurrentPost()?._links?.[
+				'wp:action-publish'
+			] ?? false,
 		isBeingScheduled: select( editorStore ).isEditedPostBeingScheduled(),
 		isPending: select( editorStore ).isCurrentPostPending(),
 		isPublished: select( editorStore ).isCurrentPostPublished(),

--- a/packages/edit-post/src/components/header/template-title/edit-template-title.js
+++ b/packages/edit-post/src/components/header/template-title/edit-template-title.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { mapValues } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -61,14 +56,15 @@ export default function EditTemplateTitle() {
 					setForceEmpty( false );
 
 					const settings = getEditorSettings();
-					const newAvailableTemplates = mapValues(
-						settings.availableTemplates,
-						( existingTitle, id ) => {
-							if ( id !== template.slug ) {
-								return existingTitle;
+					const newAvailableTemplates = Object.fromEntries(
+						Object.entries( settings.availableTemplates ?? {} ).map(
+							( [ id, existingTitle ] ) => {
+								if ( id !== template.slug ) {
+									return existingTitle;
+								}
+								return newTitle;
 							}
-							return newTitle;
-						}
+						)
 					);
 					updateEditorSettings( {
 						...settings,

--- a/packages/edit-post/src/components/header/tools-more-menu-group/index.js
+++ b/packages/edit-post/src/components/header/tools-more-menu-group/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isEmpty } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { createSlotFill, MenuGroup } from '@wordpress/components';
@@ -15,7 +10,7 @@ const { Fill: ToolsMoreMenuGroup, Slot } =
 ToolsMoreMenuGroup.Slot = ( { fillProps } ) => (
 	<Slot fillProps={ fillProps }>
 		{ ( fills ) =>
-			! isEmpty( fills ) && (
+			fills.length > 0 && (
 				<MenuGroup label={ __( 'Tools' ) }>{ fills }</MenuGroup>
 			)
 		}

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 
@@ -213,10 +208,7 @@ export default function EditPostPreferencesModal() {
 							<PostTaxonomies
 								taxonomyWrapper={ ( content, taxonomy ) => (
 									<EnablePanelOption
-										label={ get( taxonomy, [
-											'labels',
-											'menu_name',
-										] ) }
+										label={ taxonomy.labels.menu_name }
 										panelName={ `taxonomy-panel-${ taxonomy.slug }` }
 									/>
 								) }

--- a/packages/edit-post/src/components/sidebar/post-taxonomies/taxonomy-panel.js
+++ b/packages/edit-post/src/components/sidebar/post-taxonomies/taxonomy-panel.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { compose } from '@wordpress/compose';
@@ -26,7 +21,7 @@ function TaxonomyPanel( {
 		return null;
 	}
 
-	const taxonomyMenuName = get( taxonomy, [ 'labels', 'menu_name' ] );
+	const taxonomyMenuName = taxonomy?.labels?.menu_name;
 	if ( ! taxonomyMenuName ) {
 		return null;
 	}
@@ -44,7 +39,7 @@ function TaxonomyPanel( {
 
 export default compose(
 	withSelect( ( select, ownProps ) => {
-		const slug = get( ownProps.taxonomy, [ 'slug' ] );
+		const slug = ownProps.taxonomy?.slug;
 		const panelName = slug ? `taxonomy-panel-${ slug }` : '';
 		return {
 			panelName,


### PR DESCRIPTION
## What?
This PR removes the remaining Lodash from the `@wordpress/edit-post` package. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

Usages are straightforward. We're using direct access instead of `_.get()`, coupled with optional chaining where necessary. We're using `Object.fromEntries( Object.entries().map() )` instead of `_.mapValues()` and `Array.prototype.length` instead of `isEmpty()` since `fills` in the `Slot` callback are always provided as an array.

## Testing Instructions

* Verify post-publish button still works well (behavior is [thoroughly described here](https://github.com/WordPress/gutenberg/blob/2c5b5ea96408e44ff887d3c68992d086a99e14bc/packages/edit-post/src/components/header/post-publish-button-or-toggle.js#L31-L52)). 
* Verify that editing the title of a template in the post editor still works well.
* Verify the more menu in the post editor header still works well (it's the one that holds the "Manage Reusable blocks" item).
* Verify the preferences modal still works well, particularly in rendering the post-taxonomies panel (under Document Settings).
* Verify all checks are green.