### PR TITLE
Rich text: only consider a format active if active at every selected index

### DIFF
--- a/packages/block-editor/src/components/rich-text/format-edit.js
+++ b/packages/block-editor/src/components/rich-text/format-edit.js
@@ -1,11 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	getActiveFormat,
-	getActiveObject,
-	isCollapsed,
-} from '@wordpress/rich-text';
+import { getActiveFormat, getActiveObject } from '@wordpress/rich-text';
 
 export default function FormatEdit( {
 	formatTypes,
@@ -22,36 +18,10 @@ export default function FormatEdit( {
 		}
 
 		const activeFormat = getActiveFormat( value, name );
-		let isActive = activeFormat !== undefined;
+		const isActive = activeFormat !== undefined;
 		const activeObject = getActiveObject( value );
 		const isObjectActive =
 			activeObject !== undefined && activeObject.type === name;
-
-		// Edge case: un-collapsed link formats.
-		// If there is a missing link format at either end of the selection
-		// then we shouldn't show the Edit UI because the selection has exceeded
-		// the bounds of the link format.
-		// Also if the format objects don't match then we're dealing with two separate
-		// links so we should not allow the link to be modified over the top.
-		if ( name === 'core/link' && ! isCollapsed( value ) ) {
-			const formats = value.formats;
-
-			const linkFormatAtStart = formats[ value.start ]?.find(
-				( { type } ) => type === 'core/link'
-			);
-
-			const linkFormatAtEnd = formats[ value.end - 1 ]?.find(
-				( { type } ) => type === 'core/link'
-			);
-
-			if (
-				! linkFormatAtStart ||
-				! linkFormatAtEnd ||
-				linkFormatAtStart !== linkFormatAtEnd
-			) {
-				isActive = false;
-			}
-		}
 
 		return (
 			<Edit

--- a/packages/rich-text/src/get-active-format.js
+++ b/packages/rich-text/src/get-active-format.js
@@ -19,7 +19,7 @@ import { getActiveFormats } from './get-active-formats';
  *                                    type, or undefined.
  */
 export function getActiveFormat( value, formatType ) {
-	return getActiveFormats( value )?.find(
+	return getActiveFormats( value ).find(
 		( { type } ) => type === formatType
 	);
 }

--- a/packages/rich-text/src/get-active-formats.js
+++ b/packages/rich-text/src/get-active-formats.js
@@ -48,7 +48,8 @@ export function getActiveFormats( value, EMPTY_ACTIVE_FORMATS = [] ) {
 
 	const selectedValue = slice( value );
 
-	const _activeFormats = selectedValue.formats[ 0 ];
+	// Clone the formats so we're not mutating the live value.
+	const _activeFormats = [ ...selectedValue.formats[ 0 ] ];
 	let i = selectedValue.formats.length;
 
 	// For performance reasons, start from the end where it's much quicker to

--- a/packages/rich-text/src/get-active-formats.js
+++ b/packages/rich-text/src/get-active-formats.js
@@ -5,7 +5,6 @@
  * Internal dependencies
  */
 import { isFormatEqual } from './is-format-equal';
-import { slice } from './slice';
 
 /**
  * Gets the all format objects at the start of the selection.
@@ -46,16 +45,16 @@ export function getActiveFormats( value, EMPTY_ACTIVE_FORMATS = [] ) {
 		return EMPTY_ACTIVE_FORMATS;
 	}
 
-	const selectedValue = slice( value );
+	const selectedFormats = formats.slice( start, end );
 
 	// Clone the formats so we're not mutating the live value.
-	const _activeFormats = [ ...selectedValue.formats[ 0 ] ];
-	let i = selectedValue.formats.length;
+	const _activeFormats = [ ...selectedFormats[ 0 ] ];
+	let i = selectedFormats.length;
 
 	// For performance reasons, start from the end where it's much quicker to
 	// realise that there are no active formats.
 	while ( i-- ) {
-		const formatsAtIndex = selectedValue.formats[ i ];
+		const formatsAtIndex = selectedFormats[ i ];
 
 		// If we run into any index without formats, we're sure that there's no
 		// active formats.

--- a/packages/rich-text/src/get-active-formats.js
+++ b/packages/rich-text/src/get-active-formats.js
@@ -59,7 +59,7 @@ export function getActiveFormats( value, EMPTY_ACTIVE_FORMATS = [] ) {
 			return EMPTY_ACTIVE_FORMATS;
 		}
 
-		// Only keep an acive format if it's active for every single index.
+		// Only keep an active format if it's active for every single index.
 		_activeFormats = _activeFormats.filter(
 			( format, index ) => format === formatsAtIndex[ index ]
 		);

--- a/packages/rich-text/src/get-active-formats.js
+++ b/packages/rich-text/src/get-active-formats.js
@@ -2,6 +2,11 @@
 /** @typedef {import('./create').RichTextFormatList} RichTextFormatList */
 
 /**
+ * Internal dependencies
+ */
+import { slice } from './slice';
+
+/**
  * Gets the all format objects at the start of the selection.
  *
  * @param {RichTextValue} value                Value to inspect.
@@ -10,10 +15,8 @@
  *
  * @return {RichTextFormatList} Active format objects.
  */
-export function getActiveFormats(
-	{ formats, start, end, activeFormats },
-	EMPTY_ACTIVE_FORMATS = []
-) {
+export function getActiveFormats( value, EMPTY_ACTIVE_FORMATS = [] ) {
+	const { formats, start, end, activeFormats } = value;
 	if ( start === undefined ) {
 		return EMPTY_ACTIVE_FORMATS;
 	}
@@ -37,5 +40,30 @@ export function getActiveFormats(
 		return formatsAfter;
 	}
 
-	return formats[ start ] || EMPTY_ACTIVE_FORMATS;
+	// If there's no formats at the start index, there are not active formats.
+	if ( ! formats[ start ] ) {
+		return EMPTY_ACTIVE_FORMATS;
+	}
+
+	const selectedValue = slice( value );
+
+	let _activeFormats = selectedValue.formats[ 0 ];
+	let i = selectedValue.formats.length;
+
+	while ( i-- ) {
+		const formatsAtIndex = selectedValue.formats[ i ];
+
+		// If we run into any index without formats, we're sure that there's no
+		// active formats.
+		if ( ! formatsAtIndex ) {
+			return EMPTY_ACTIVE_FORMATS;
+		}
+
+		// Only keep an acive format if it's active for every single index.
+		_activeFormats = _activeFormats.filter(
+			( format, index ) => format === formatsAtIndex[ index ]
+		);
+	}
+
+	return _activeFormats || EMPTY_ACTIVE_FORMATS;
 }

--- a/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
+++ b/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
@@ -61,9 +61,7 @@ exports[`recordToDom should create a value with image object and formatting 1`] 
 
 exports[`recordToDom should create a value with image object and text after 1`] = `
 <body>
-  <em
-    data-rich-text-format-boundary="true"
-  >
+  <em>
     
     <img
       src=""

--- a/packages/rich-text/src/test/get-active-format.js
+++ b/packages/rich-text/src/test/get-active-format.js
@@ -20,7 +20,6 @@ describe( 'getActiveFormat', () => {
 	it( 'should return format when active over whole selection', () => {
 		const record = {
 			formats: [ [ em ], [ strong ], , ],
-			replacements: [ , , , ],
 			text: 'one',
 			start: 0,
 			end: 1,
@@ -32,7 +31,6 @@ describe( 'getActiveFormat', () => {
 	it( 'should return not return format when not active over whole selection', () => {
 		const record = {
 			formats: [ [ em ], [ strong ], , ],
-			replacements: [ , , , ],
 			text: 'one',
 			start: 0,
 			end: 2,

--- a/packages/rich-text/src/test/get-active-format.js
+++ b/packages/rich-text/src/test/get-active-format.js
@@ -17,15 +17,28 @@ describe( 'getActiveFormat', () => {
 		expect( getActiveFormat( record, 'em' ) ).toBe( undefined );
 	} );
 
-	it( 'should return format at first character for uncollapsed selection', () => {
+	it( 'should return format when active over whole selection', () => {
 		const record = {
 			formats: [ [ em ], [ strong ], , ],
+			replacements: [ , , , ],
+			text: 'one',
+			start: 0,
+			end: 1,
+		};
+
+		expect( getActiveFormat( record, 'em' ) ).toBe( em );
+	} );
+
+	it( 'should return not return format when not active over whole selection', () => {
+		const record = {
+			formats: [ [ em ], [ strong ], , ],
+			replacements: [ , , , ],
 			text: 'one',
 			start: 0,
 			end: 2,
 		};
 
-		expect( getActiveFormat( record, 'em' ) ).toBe( em );
+		expect( getActiveFormat( record, 'em' ) ).toBe( undefined );
 	} );
 
 	it( 'should return undefined if at the boundary before', () => {

--- a/packages/rich-text/src/test/toggle-format.js
+++ b/packages/rich-text/src/test/toggle-format.js
@@ -20,9 +20,12 @@ describe( 'toggleFormat', () => {
 				,
 				,
 				,
-				[ strong ],
-				[ strong, em ],
-				[ strong, em ],
+				// In reality, formats at a different index are never the same
+				// value. Only formats that create the same tag are the same
+				// value.
+				[ { type: 'strong' } ],
+				[ em, strong ],
+				[ em, strong ],
 				[ em ],
 				,
 				,

--- a/packages/rich-text/src/test/toggle-format.js
+++ b/packages/rich-text/src/test/toggle-format.js
@@ -34,14 +34,12 @@ describe( 'toggleFormat', () => {
 				,
 				,
 			],
-			replacements: [ , , , , , , , , , , , , , ],
 			text: 'one two three',
 			start: 3,
 			end: 6,
 		};
 		const expected = {
 			formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
-			replacements: [ , , , , , , , , , , , , , ],
 			activeFormats: [],
 			text: 'one two three',
 			start: 3,

--- a/packages/rich-text/src/test/toggle-format.js
+++ b/packages/rich-text/src/test/toggle-format.js
@@ -14,15 +14,15 @@ describe( 'toggleFormat', () => {
 	const strong = { type: 'strong' };
 	const em = { type: 'em' };
 
-	it( 'should remove format if it exists at start of selection', () => {
+	it( 'should remove format if it is active', () => {
 		const record = {
 			formats: [
 				,
 				,
 				,
 				[ strong ],
-				[ em, strong ],
-				[ em ],
+				[ strong, em ],
+				[ strong, em ],
 				[ em ],
 				,
 				,
@@ -31,12 +31,14 @@ describe( 'toggleFormat', () => {
 				,
 				,
 			],
+			replacements: [ , , , , , , , , , , , , , ],
 			text: 'one two three',
 			start: 3,
 			end: 6,
 		};
 		const expected = {
 			formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
+			replacements: [ , , , , , , , , , , , , , ],
 			activeFormats: [],
 			text: 'one two three',
 			start: 3,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently we consider all formats at the start index as active formats. It seems to make more sense to check if it's active at every selected index, which is why an exception was made for link. This PR changes it for all other formats.

The current behaviour we have was taken directly from TinyMCE and CKEditor, while this new behaviour is what Google Docs does.

## Why?

To remove inconsistencies and exceptions for the link format.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

* Make some word bold. Select the word. Bold should be active. Move the start and/or end of the selection outside the bold. Bold should not be active.
* Make another word bold. Select between the two words. Bold should not be active because non formatted text is selected.

Generally make sure formatting works as expected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
