### PR TITLE
[RNMobile] Allow wildcard block transformations for container blocks

### DIFF
--- a/packages/block-library/src/paragraph/test/__snapshots__/transforms.native.js.snap
+++ b/packages/block-library/src/paragraph/test/__snapshots__/transforms.native.js.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Paragraph block transforms to Columns block 1`] = `
+"<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
+<div class="wp-block-column" style="flex-basis:100%"><!-- wp:paragraph -->
+<p>Example text</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->"
+`;
+
+exports[`Paragraph block transforms to Group block 1`] = `
+"<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>Example text</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->"
+`;
+
+exports[`Paragraph block transforms to Heading block 1`] = `
+"<!-- wp:heading -->
+<h2 class="wp-block-heading">Example text</h2>
+<!-- /wp:heading -->"
+`;
+
+exports[`Paragraph block transforms to List block 1`] = `
+"<!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li>Example text</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->"
+`;
+
+exports[`Paragraph block transforms to Preformatted block 1`] = `
+"<!-- wp:preformatted -->
+<pre class="wp-block-preformatted">Example text</pre>
+<!-- /wp:preformatted -->"
+`;
+
+exports[`Paragraph block transforms to Pullquote block 1`] = `
+"<!-- wp:pullquote -->
+<figure class="wp-block-pullquote"><blockquote><p>Example text</p></blockquote></figure>
+<!-- /wp:pullquote -->"
+`;
+
+exports[`Paragraph block transforms to Quote block 1`] = `
+"<!-- wp:quote -->
+<blockquote class="wp-block-quote"><!-- wp:paragraph -->
+<p>Example text</p>
+<!-- /wp:paragraph --></blockquote>
+<!-- /wp:quote -->"
+`;
+
+exports[`Paragraph block transforms to Verse block 1`] = `
+"<!-- wp:verse -->
+<pre class="wp-block-verse">Example text</pre>
+<!-- /wp:verse -->"
+`;

--- a/packages/block-library/src/paragraph/test/transforms.native.js
+++ b/packages/block-library/src/paragraph/test/transforms.native.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import {
+	fireEvent,
+	getBlock,
+	getEditorHtml,
+	initializeEditor,
+	openBlockActionsMenu,
+	setupCoreBlocks,
+	triggerBlockListLayout,
+} from 'test/helpers';
+
+const block = 'Paragraph';
+const initialHtml = `
+<!-- wp:paragraph -->
+<p>Example text</p>
+<!-- /wp:paragraph -->`;
+
+// NOTE: Paragraph block can be transformed to Buttons block in web,
+// however this transform is not supported in the native version.
+const transformsWithInnerBlocks = [ 'List', 'Quote', 'Columns', 'Group' ];
+const blockTransforms = [
+	'Heading',
+	'Preformatted',
+	'Pullquote',
+	'Verse',
+	...transformsWithInnerBlocks,
+];
+
+setupCoreBlocks();
+
+describe( `${ block } block transforms`, () => {
+	test.each( blockTransforms )(
+		'to %s block',
+		async ( blockTransformation ) => {
+			const screen = await initializeEditor( { initialHtml } );
+			const { getByText } = screen;
+			fireEvent.press( getBlock( screen, block ) );
+
+			await openBlockActionsMenu( screen );
+			fireEvent.press( getByText( 'Transform block…' ) );
+			fireEvent.press( getByText( blockTransformation ) );
+
+			const newBlock = getBlock( screen, blockTransformation );
+			if ( transformsWithInnerBlocks.includes( blockTransformation ) )
+				await triggerBlockListLayout( newBlock );
+
+			expect( newBlock ).toBeVisible();
+			expect( getEditorHtml() ).toMatchSnapshot();
+		}
+	);
+} );

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -211,14 +211,6 @@ const isPossibleTransformForSource = ( transform, direction, blocks ) => {
 		return false;
 	}
 
-	if (
-		transform.usingMobileTransformations &&
-		isWildcardBlockTransform( transform ) &&
-		! isContainerGroupBlock( sourceBlock.name )
-	) {
-		return false;
-	}
-
 	return true;
 };
 

--- a/test/native/integration-test-helpers/README.md
+++ b/test/native/integration-test-helpers/README.md
@@ -30,6 +30,10 @@ Gets an inner block from another block.
 
 Initialize an editor for test assertions.
 
+### [`openBlockActionsMenu`](https://github.com/WordPress/gutenberg/blob/HEAD/test/native/integration-test-helpers/open-block-actions-menu.js)
+
+Opens the block's actions menu of the current selected block.
+
 ### [`openBlockSettings`](https://github.com/WordPress/gutenberg/blob/HEAD/test/native/integration-test-helpers/open-block-settings.js)
 
 Opens the block settings of the current selected block.

--- a/test/native/integration-test-helpers/index.js
+++ b/test/native/integration-test-helpers/index.js
@@ -8,6 +8,7 @@ export { getBlock } from './get-block';
 export { getEditorHtml } from './get-editor-html';
 export { getInnerBlock } from './get-inner-block';
 export { initializeEditor } from './initialize-editor';
+export { openBlockActionsMenu } from './open-block-actions-menu';
 export { openBlockSettings } from './open-block-settings';
 export { changeAndSelectTextOfRichText } from './rich-text-change-and-select-text';
 export { changeTextOfRichText } from './rich-text-change-text';

--- a/test/native/integration-test-helpers/open-block-actions-menu.js
+++ b/test/native/integration-test-helpers/open-block-actions-menu.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { fireEvent } from '@testing-library/react-native';
+
+/**
+ * Internal dependencies
+ */
+import { waitForModalVisible } from './wait-for-modal-visible';
+
+/**
+ * Opens the block's actions menu of the current selected block.
+ *
+ * @param {import('@testing-library/react-native').RenderAPI} screen The Testing Library screen.
+ */
+export const openBlockActionsMenu = async ( screen ) => {
+	const { getByLabelText, getByTestId } = screen;
+	fireEvent.press( getByLabelText( 'Open Block Actions Menu' ) );
+	return waitForModalVisible( getByTestId( 'block-actions-menu' ) );
+};

--- a/test/native/integration-test-helpers/trigger-block-list-layout.js
+++ b/test/native/integration-test-helpers/trigger-block-list-layout.js
@@ -15,14 +15,20 @@ import { waitForStoreResolvers } from './wait-for-store-resolvers';
  * case any of the inner elements use selectors that are associated with store
  * resolvers.
  *
- * @param {import('react-test-renderer').ReactTestInstance} block           Block test instance to trigger layout event.
- * @param {Object}                                          [options]       Configuration options for the event.
- * @param {number}                                          [options.width] Width value to be passed to the event.
+ * @param {import('react-test-renderer').ReactTestInstance} block                    Block test instance to trigger layout event.
+ * @param {Object}                                          [options]                Configuration options for the event.
+ * @param {number}                                          [options.width]          Width value to be passed to the event.
+ * @param {number}                                          [options.blockListIndex] Block list index, for cases when there is more than one, like in inner blocks.
  */
-export const triggerBlockListLayout = async ( block, { width = 320 } = {} ) =>
+export const triggerBlockListLayout = async (
+	block,
+	{ width = 320, blockListIndex = 0 } = {}
+) =>
 	waitForStoreResolvers( () =>
 		fireEvent(
-			within( block ).getByTestId( 'block-list-wrapper' ),
+			within( block ).getAllByTestId( 'block-list-wrapper' )[
+				blockListIndex
+			],
 			'layout',
 			{
 				nativeEvent: {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Allow wildcard block transformations for container blocks in the native version of the editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fix https://github.com/WordPress/gutenberg/issues/44452.

One of the Paragraph blocks' transformations is to the Quote block. The v2 of the Quote block, which was released some time ago, allows inner blocks which makes it a container block. This change made the native version of the editor remove the Quote block transformation option based on the following code:

https://github.com/WordPress/gutenberg/blob/d1ab8ce383cceae975ea1948e273fcc423183204/packages/blocks/src/api/factory.js#L214-L220

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Disable the restriction that disallows wildcard block transformations for container blocks. It's not clear why we introduced this restriction when [native block transformations were added](https://github.com/WordPress/gutenberg/pull/28453), however, per the tests I've made seems the issues we might have by that time can no longer be reproduced.

This change will also allow new transformations for most of the blocks we support in the native version. In the following list, I outline the new transformations:
- Quote _**(available in text blocks)**_
- Columns _**(available in all blocks)**_
- Group _**(available in all blocks)**_
 
**NOTE:** As mentioned above, this PR will allow new transformations so I'll create another PR adding unit tests to cover the different transformations of all blocks.

**UPDATE:** Here are the follow-up PRs:
- [[RNMobile] Add block transforms integration tests for **Text blocks**](https://github.com/WordPress/gutenberg/pull/48823#top)
- [[RNMobile] Add block transforms integration tests for **Media blocks**](https://github.com/WordPress/gutenberg/pull/48825#top)
- [[RNMobile] Add block transforms integration tests for **Container blocks**](https://github.com/WordPress/gutenberg/pull/48883#top)
- [[RNMobile] Add block transforms integration tests for **Other blocks**](https://github.com/WordPress/gutenberg/pull/48889#top)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Add a Paragraph block.
1. Type some text.
1. Tap on the "..." button to open the block settings.
1. Tap on "Transform block..." option.
1. Observe that the option for Quote is displayed.
2. Tap on "Quote" option.
3. Observe that a Quote block is created with the content of the Paragraph block.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A