### PR TITLE
Remove border from quick inserter child elements

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -35,6 +35,7 @@ $block-inserter-tabs-height: 44px;
 	.components-popover__content {
 		border: none;
 		outline: none;
+		box-shadow: $shadow-popover;
 
 		.block-editor-inserter__quick-inserter > * {
 			border-left: $border-width solid $gray-400;

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -43,10 +43,12 @@ $block-inserter-tabs-height: 44px;
 
 			&:first-child {
 				border-top: $border-width solid $gray-400;
+				border-radius: $radius-block-ui $radius-block-ui 0 0;
 			}
 
 			&:last-child {
 				border-bottom: $border-width solid $gray-400;
+				border-radius: 0 0 $radius-block-ui $radius-block-ui;
 			}
 
 			&.components-button {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -37,6 +37,17 @@ $block-inserter-tabs-height: 44px;
 		outline: none;
 
 		.block-editor-inserter__quick-inserter > * {
+			border-left: $border-width solid $gray-400;
+			border-right: $border-width solid $gray-400;
+
+			&:first-child {
+				border-top: $border-width solid $gray-400;
+			}
+
+			&:last-child {
+				border-bottom: $border-width solid $gray-400;
+			}
+
 			&.components-button {
 				border: $border-width solid $gray-900;
 			}

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -37,17 +37,6 @@ $block-inserter-tabs-height: 44px;
 		outline: none;
 
 		.block-editor-inserter__quick-inserter > * {
-			border-left: $border-width solid $gray-400;
-			border-right: $border-width solid $gray-400;
-
-			&:first-child {
-				border-top: $border-width solid $gray-400;
-			}
-
-			&:last-child {
-				border-bottom: $border-width solid $gray-400;
-			}
-
 			&.components-button {
 				border: $border-width solid $gray-900;
 			}


### PR DESCRIPTION
## What?
Fixes the 'double-border' on quick inserter child elements.

Also fixes a small radius quirk.

## Why?
Currently we're applying two borders, one via the `border` property, and one via `box-shadow`. The result is a UI that feels inconsistent with the rest of the Editor.

## How?
Removes some CSS. ~I removed the border instead of the shadow as that style was local to the quick inserter, while the shadow is applied to all popovers.~ I revised this to leave the border on the quick inserter children, and remove the one added by the shadow. The benefit to this approach is that the dark grey button at the bottom is not wrapped in an awkward light grey border.

## Testing Instructions
1. Open the editor
2. Open a quick inserter popover
3. Observe a 1px outline, not a 2px outline

## Screenshots or screencast <!-- if applicable -->

| Border before | Border after |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/846565/223151218-62b28697-378d-4c29-8713-6c3a9e7af9f0.png" width="400"> | <img width="404" alt="Screenshot 2023-03-06 at 16 07 07" src="https://user-images.githubusercontent.com/846565/223167674-95a8ae35-1f04-4343-8034-94ff1dd17059.png"> |

| Radius before | Radius after |
| --- | --- |
| <img width="153" alt="Screenshot 2023-03-06 at 16 11 45" src="https://user-images.githubusercontent.com/846565/223167527-bcc58206-9d98-4061-b148-9a209710dcd3.png"> | <img width="135" alt="Screenshot 2023-03-06 at 16 11 49" src="https://user-images.githubusercontent.com/846565/223167562-2b6629c5-6056-49b4-94c5-790de1266c6b.png"> |


