### PR TITLE
Add border radius to off canvas navigation menu items

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -25,6 +25,7 @@
 .edit-site-sidebar-navigation-screen-navigation-menus__content {
 	.offcanvas-editor-list-view-leaf {
 		max-width: calc(100% - #{ $grid-unit-05 });
+		border-radius: $radius-block-ui;
 		&:hover,
 		&:focus,
 		&[aria-current] {


### PR DESCRIPTION
## What?
Adds a border radius to menu items in the off-canvas menu management interface. 

## Why?
To make this UI consistent with others throughout the Editor, e.g. List View and the Site Editor Navigation sidebar.

## How?
One line of css.

## Testing Instructions
1. Open the Navigation panel in the Site Editor.
2. Hover over an item.
3. Observe a 2px radius.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="233" alt="Screenshot 2023-03-06 at 16 25 14" src="https://user-images.githubusercontent.com/846565/223171538-ffe6b47c-d48e-4e13-84df-dddb4b825061.png"> | <img width="1035" alt="Screenshot 2023-03-06 at 16 27 01" src="https://user-images.githubusercontent.com/846565/223171607-b636f864-5d85-4255-82c8-e8c8ab9a34dd.png"> |


