### PR TITLE
Editor: Provide static native editor help article slugs

### DIFF
--- a/packages/editor/src/components/editor-help/index.native.js
+++ b/packages/editor/src/components/editor-help/index.native.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { paramCase } from 'change-case';
 import { SafeAreaView, ScrollView, StyleSheet, View } from 'react-native';
 import { TransitionPresets } from '@react-navigation/stack';
 
@@ -40,34 +39,35 @@ import HelpSectionTitle from './help-section-title';
 const HELP_TOPICS = [
 	{
 		label: __( 'What is a block?' ),
+		slug: 'what-is-a-block',
 		icon: helpFilled,
 		view: <IntroToBlocks />,
 	},
 	{
 		label: __( 'Add blocks' ),
+		slug: 'add-blocks',
 		icon: plusCircleFilled,
 		view: <AddBlocks />,
 	},
-	{ label: __( 'Move blocks' ), icon: moveBlocksIcon, view: <MoveBlocks /> },
-	{ label: __( 'Remove blocks' ), icon: trash, view: <RemoveBlocks /> },
+	{
+		label: __( 'Move blocks' ),
+		slug: 'move-blocks',
+		icon: moveBlocksIcon,
+		view: <MoveBlocks />,
+	},
+	{
+		label: __( 'Remove blocks' ),
+		slug: 'remove-blocks',
+		icon: trash,
+		view: <RemoveBlocks />,
+	},
 	{
 		label: __( 'Customize blocks' ),
+		slug: 'customize-blocks',
 		icon: cog,
 		view: <CustomizeBlocks />,
 	},
 ];
-
-const kebabCaseSettings = {
-	splitRegexp: [
-		/([\p{Ll}\p{Lo}\p{N}])([\p{Lu}\p{Lt}])/gu, // One lowercase or digit, followed by one uppercase.
-		/([\p{Lu}\p{Lt}])([\p{Lu}\p{Lt}][\p{Ll}\p{Lo}])/gu, // One uppercase followed by one uppercase and one lowercase.
-	],
-	stripRegexp: /(\p{C}|\p{P}|\p{S})+/giu, // Anything that's not a punctuation, symbol or control/format character.
-};
-
-function kebabCase( string ) {
-	return paramCase( string, kebabCaseSettings );
-}
 
 function EditorHelpTopics( { close, isVisible, onClose, showSupport } ) {
 	const { postType } = useSelect( ( select ) => ( {
@@ -153,24 +153,20 @@ function EditorHelpTopics( { close, isVisible, onClose, showSupport } ) {
 												{ /* Print out help topics. */ }
 												{ HELP_TOPICS.map(
 													(
-														{ label, icon },
+														{ label, icon, slug },
 														index
 													) => {
-														const labelSlug =
-															kebabCase( label );
 														const isLastItem =
 															index ===
 															HELP_TOPICS.length -
 																1;
 														return (
 															<HelpTopicRow
-																key={
-																	labelSlug
-																}
+																key={ slug }
 																label={ label }
 																icon={ icon }
 																screenName={
-																	labelSlug
+																	slug
 																}
 																isLastItem={
 																	isLastItem
@@ -189,12 +185,11 @@ function EditorHelpTopics( { close, isVisible, onClose, showSupport } ) {
 						</View>
 					</BottomSheet.NavigationScreen>
 					{ /* Print out help detail screens. */ }
-					{ HELP_TOPICS.map( ( { view, label } ) => {
-						const labelSlug = kebabCase( label );
+					{ HELP_TOPICS.map( ( { view, label, slug } ) => {
 						return (
 							<HelpDetailNavigationScreen
-								key={ labelSlug }
-								name={ labelSlug }
+								key={ slug }
+								name={ slug }
 								content={ view }
 								label={ label }
 								options={ {


### PR DESCRIPTION
## What?
This PR simplifies the way we work with help article slugs in `EditorHelp`. Particularly, we use static slugs instead of having to generate them automatically and deal with added i18n complexity. 

This PR is a follow-up to #48776.

## Why?
See https://github.com/WordPress/gutenberg/pull/48776#discussion_r1126528742 for rationale

## How?
We're declaring help article slugs statically and getting rid of the additional complexity.

## Testing Instructions
* Head to #33240 for testing instructions.
* Verify all checks are green.
