### PR TITLE
Block editor: new `editor.BlockControls` filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17338,7 +17338,8 @@
 				"react-easy-crop": "^4.5.1",
 				"rememo": "^4.0.0",
 				"remove-accents": "^0.4.2",
-				"traverse": "^0.6.6"
+				"traverse": "^0.6.6",
+				"uuid": "8.3.0"
 			}
 		},
 		"@wordpress/block-library": {

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -74,7 +74,8 @@
 		"react-easy-crop": "^4.5.1",
 		"rememo": "^4.0.0",
 		"remove-accents": "^0.4.2",
-		"traverse": "^0.6.6"
+		"traverse": "^0.6.6",
+		"uuid": "8.3.0"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",

--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -75,7 +75,7 @@ function BlockControlFilters( props ) {
 			removeAction( 'hookRemoved', namespace );
 			removeAction( 'hookAdded', namespace );
 		};
-	} );
+	}, [] );
 
 	if ( ! shouldDisplayControls ) {
 		return;

--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -30,7 +30,8 @@ import { store as blockEditorStore } from '../../store';
 export { useBlockEditContext };
 
 // Please do not export this at the package level until we have a stable API.
-export const blockControlsFilterName = uuid();
+// Hook names must start with a letter.
+export const blockControlsFilterName = 'a' + uuid();
 
 function BlockControlFilters( props ) {
 	const { name, isSelected, clientId } = props;

--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { v4 as uuid } from 'uuid';
+
+/**
  * WordPress dependencies
  */
 import { useMemo, useEffect, useReducer } from '@wordpress/element';
@@ -23,6 +28,9 @@ import { store as blockEditorStore } from '../../store';
  * @return {Object} Block edit context
  */
 export { useBlockEditContext };
+
+// Please do not export this at the package level until we have a stable API.
+export const blockControlsFilterName = uuid();
 
 function BlockControlFilters( props ) {
 	const { name, isSelected, clientId } = props;
@@ -56,14 +64,13 @@ function BlockControlFilters( props ) {
 		[ clientId, isSelected, name ]
 	);
 
-	const hookName = 'editor.BlockControls';
 	const [ , forceRender ] = useReducer( () => [] );
 
 	useEffect( () => {
 		const namespace = 'core/block-edit/block-controls';
 
 		function onHooksUpdated( updatedHookName ) {
-			if ( updatedHookName === hookName ) {
+			if ( updatedHookName === blockControlsFilterName ) {
 				forceRender();
 			}
 		}
@@ -81,16 +88,16 @@ function BlockControlFilters( props ) {
 		return;
 	}
 
-	const blockControlFilters = filters[ hookName ];
+	const blockControlFilters = filters[ blockControlsFilterName ];
 
 	if ( ! blockControlFilters ) {
 		return;
 	}
 
 	return blockControlFilters.handlers.map(
-		( { callback: Controls, namespace } ) => (
-			<Controls { ...props } key={ namespace } />
-		)
+		( { callback: Controls, namespace } ) => {
+			return <Controls { ...props } key={ namespace } />;
+		}
 	);
 }
 

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -113,64 +113,55 @@ export function addAttribute( settings ) {
  * Override the default edit UI to include new toolbar controls for block
  * alignment, if block defines support.
  *
- * @param {Function} BlockEdit Original component.
- *
- * @return {Function} Wrapped component.
+ * @param {Object} props
  */
-export const withToolbarControls = createHigherOrderComponent(
-	( BlockEdit ) => ( props ) => {
-		const blockEdit = <BlockEdit key="edit" { ...props } />;
-		const { name: blockName } = props;
-		// Compute the block valid alignments by taking into account,
-		// if the theme supports wide alignments or not and the layout's
-		// availble alignments. We do that for conditionally rendering
-		// Slot.
-		const blockAllowedAlignments = getValidAlignments(
-			getBlockSupport( blockName, 'align' ),
-			hasBlockSupport( blockName, 'alignWide', true )
-		);
+export const ToolbarControls = ( props ) => {
+	const { name: blockName } = props;
+	// Compute the block valid alignments by taking into account,
+	// if the theme supports wide alignments or not and the layout's
+	// availble alignments. We do that for conditionally rendering
+	// Slot.
+	const blockAllowedAlignments = getValidAlignments(
+		getBlockSupport( blockName, 'align' ),
+		hasBlockSupport( blockName, 'alignWide', true )
+	);
 
-		const validAlignments = useAvailableAlignments(
-			blockAllowedAlignments
-		).map( ( { name } ) => name );
-		const isContentLocked = useSelect(
-			( select ) => {
-				return select(
-					blockEditorStore
-				).__unstableGetContentLockingParent( props.clientId );
-			},
-			[ props.clientId ]
-		);
-		if ( ! validAlignments.length || isContentLocked ) {
-			return blockEdit;
-		}
+	const validAlignments = useAvailableAlignments(
+		blockAllowedAlignments
+	).map( ( { name } ) => name );
+	const isContentLocked = useSelect(
+		( select ) => {
+			return select( blockEditorStore ).__unstableGetContentLockingParent(
+				props.clientId
+			);
+		},
+		[ props.clientId ]
+	);
+	if ( ! validAlignments.length || isContentLocked ) {
+		return null;
+	}
 
-		const updateAlignment = ( nextAlign ) => {
-			if ( ! nextAlign ) {
-				const blockType = getBlockType( props.name );
-				const blockDefaultAlign = blockType?.attributes?.align?.default;
-				if ( blockDefaultAlign ) {
-					nextAlign = '';
-				}
+	const updateAlignment = ( nextAlign ) => {
+		if ( ! nextAlign ) {
+			const blockType = getBlockType( props.name );
+			const blockDefaultAlign = blockType?.attributes?.align?.default;
+			if ( blockDefaultAlign ) {
+				nextAlign = '';
 			}
-			props.setAttributes( { align: nextAlign } );
-		};
+		}
+		props.setAttributes( { align: nextAlign } );
+	};
 
-		return (
-			<>
-				<BlockControls group="block" __experimentalShareWithChildBlocks>
-					<BlockAlignmentControl
-						value={ props.attributes.align }
-						onChange={ updateAlignment }
-						controls={ validAlignments }
-					/>
-				</BlockControls>
-				{ blockEdit }
-			</>
-		);
-	},
-	'withToolbarControls'
-);
+	return (
+		<BlockControls group="block" __experimentalShareWithChildBlocks>
+			<BlockAlignmentControl
+				value={ props.attributes.align }
+				onChange={ updateAlignment }
+				controls={ validAlignments }
+			/>
+		</BlockControls>
+	);
+};
 
 /**
  * Override the default block element to add alignment wrapper props.
@@ -248,9 +239,9 @@ addFilter(
 	withDataAlign
 );
 addFilter(
-	'editor.BlockEdit',
+	'editor.BlockControls',
 	'core/editor/align/with-toolbar-controls',
-	withToolbarControls
+	ToolbarControls
 );
 addFilter(
 	'blocks.getSaveContent.extraProps',

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { createHigherOrderComponent } from '@wordpress/compose';
+import { createHigherOrderComponent, ifCondition } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
 import {
 	getBlockSupport,
@@ -241,7 +241,9 @@ addFilter(
 addFilter(
 	'editor.BlockControls',
 	'core/editor/align/with-toolbar-controls',
-	ToolbarControls
+	ifCondition( ( { name } ) => hasBlockSupport( name, 'align' ) )(
+		ToolbarControls
+	)
 );
 addFilter(
 	'blocks.getSaveContent.extraProps',

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -21,6 +21,7 @@ import { useSelect } from '@wordpress/data';
 import { BlockControls, BlockAlignmentControl } from '../components';
 import useAvailableAlignments from '../components/block-alignment-control/use-available-alignments';
 import { store as blockEditorStore } from '../store';
+import { blockControlsFilterName } from '../components/block-edit';
 
 /**
  * An array which includes all possible valid alignments,
@@ -239,7 +240,7 @@ addFilter(
 	withDataAlign
 );
 addFilter(
-	'editor.BlockControls',
+	blockControlsFilterName,
 	'core/editor/align/with-toolbar-controls',
 	ifCondition( ( { name } ) => hasBlockSupport( name, 'align' ) )(
 		ToolbarControls

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -6,6 +6,7 @@ import { PanelBody, TextControl, ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { hasBlockSupport } from '@wordpress/blocks';
 import { Platform } from '@wordpress/element';
+import { ifCondition } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -57,9 +58,7 @@ export function addAttribute( settings ) {
  * @param {Object} props
  */
 export const InspectorControl = ( props ) => {
-	const hasAnchor = hasBlockSupport( props.name, 'anchor' );
-
-	if ( ! hasAnchor || ! props.isSelected ) {
+	if ( ! props.isSelected ) {
 		return null;
 	}
 
@@ -146,7 +145,9 @@ addFilter( 'blocks.registerBlockType', 'core/anchor/attribute', addAttribute );
 addFilter(
 	'editor.BlockControls',
 	'core/editor/anchor/with-inspector-control',
-	InspectorControl
+	ifCondition( ( { name } ) => hasBlockSupport( name, 'anchor' ) )(
+		InspectorControl
+	)
 );
 addFilter(
 	'blocks.getSaveContent.extraProps',

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -12,6 +12,7 @@ import { ifCondition } from '@wordpress/compose';
  * Internal dependencies
  */
 import { InspectorControls } from '../components';
+import { blockControlsFilterName } from '../components/block-edit';
 
 /**
  * Regular expression matching invalid anchor characters for replacement.
@@ -143,7 +144,7 @@ export function addSaveProps( extraProps, blockType, attributes ) {
 
 addFilter( 'blocks.registerBlockType', 'core/anchor/attribute', addAttribute );
 addFilter(
-	'editor.BlockControls',
+	blockControlsFilterName,
 	'core/editor/anchor/with-inspector-control',
 	ifCondition( ( { name } ) => hasBlockSupport( name, 'anchor' ) )(
 		InspectorControl

--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -12,6 +12,7 @@ import { useEffect, useRef, useCallback } from '@wordpress/element';
  */
 import { store as blockEditorStore } from '../store';
 import { BlockControls, BlockSettingsMenuControls } from '../components';
+import { blockControlsFilterName } from '../components/block-edit';
 
 function StopEditingAsBlocksOnOutsideSelect( {
 	clientId,
@@ -146,7 +147,7 @@ export const LockUIBlockControls = ( props ) => {
 };
 
 addFilter(
-	'editor.BlockControls',
+	blockControlsFilterName,
 	'core/content-lock-ui/with-block-controls',
 	LockUIBlockControls
 );

--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -10,7 +10,6 @@ import { addFilter } from '@wordpress/hooks';
 import { TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { hasBlockSupport } from '@wordpress/blocks';
-import { createHigherOrderComponent } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -43,50 +42,35 @@ export function addAttribute( settings ) {
  * assigning the custom class name, if block supports custom class name.
  * The control is displayed within the Advanced panel in the block inspector.
  *
- * @param {WPComponent} BlockEdit Original component.
- *
- * @return {WPComponent} Wrapped component.
+ * @param {Object} props
  */
-export const withInspectorControl = createHigherOrderComponent(
-	( BlockEdit ) => {
-		return ( props ) => {
-			const hasCustomClassName = hasBlockSupport(
-				props.name,
-				'customClassName',
-				true
-			);
-			if ( hasCustomClassName && props.isSelected ) {
-				return (
-					<>
-						<BlockEdit { ...props } />
-						<InspectorControls group="advanced">
-							<TextControl
-								__nextHasNoMarginBottom
-								autoComplete="off"
-								label={ __( 'Additional CSS class(es)' ) }
-								value={ props.attributes.className || '' }
-								onChange={ ( nextValue ) => {
-									props.setAttributes( {
-										className:
-											nextValue !== ''
-												? nextValue
-												: undefined,
-									} );
-								} }
-								help={ __(
-									'Separate multiple classes with spaces.'
-								) }
-							/>
-						</InspectorControls>
-					</>
-				);
-			}
+export const InspectorControl = ( props ) => {
+	const hasCustomClassName = hasBlockSupport(
+		props.name,
+		'customClassName',
+		true
+	);
+	if ( ! hasCustomClassName || ! props.isSelected ) {
+		return null;
+	}
 
-			return <BlockEdit { ...props } />;
-		};
-	},
-	'withInspectorControl'
-);
+	return (
+		<InspectorControls group="advanced">
+			<TextControl
+				__nextHasNoMarginBottom
+				autoComplete="off"
+				label={ __( 'Additional CSS class(es)' ) }
+				value={ props.attributes.className || '' }
+				onChange={ ( nextValue ) => {
+					props.setAttributes( {
+						className: nextValue !== '' ? nextValue : undefined,
+					} );
+				} }
+				help={ __( 'Separate multiple classes with spaces.' ) }
+			/>
+		</InspectorControls>
+	);
+};
 
 /**
  * Override props assigned to save component to inject the className, if block
@@ -158,9 +142,9 @@ addFilter(
 	addAttribute
 );
 addFilter(
-	'editor.BlockEdit',
+	'editor.BlockControls',
 	'core/editor/custom-class-name/with-inspector-control',
-	withInspectorControl
+	InspectorControl
 );
 addFilter(
 	'blocks.getSaveContent.extraProps',

--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -16,6 +16,7 @@ import { ifCondition } from '@wordpress/compose';
  * Internal dependencies
  */
 import { InspectorControls } from '../components';
+import { blockControlsFilterName } from '../components/block-edit';
 
 /**
  * Filters registered block settings, extending attributes to include `className`.
@@ -138,7 +139,7 @@ addFilter(
 	addAttribute
 );
 addFilter(
-	'editor.BlockControls',
+	blockControlsFilterName,
 	'core/editor/custom-class-name/with-inspector-control',
 	ifCondition( ( { name } ) =>
 		hasBlockSupport( name, 'customClassName', true )

--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -10,6 +10,7 @@ import { addFilter } from '@wordpress/hooks';
 import { TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { hasBlockSupport } from '@wordpress/blocks';
+import { ifCondition } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -45,12 +46,7 @@ export function addAttribute( settings ) {
  * @param {Object} props
  */
 export const InspectorControl = ( props ) => {
-	const hasCustomClassName = hasBlockSupport(
-		props.name,
-		'customClassName',
-		true
-	);
-	if ( ! hasCustomClassName || ! props.isSelected ) {
+	if ( ! props.isSelected ) {
 		return null;
 	}
 
@@ -144,7 +140,9 @@ addFilter(
 addFilter(
 	'editor.BlockControls',
 	'core/editor/custom-class-name/with-inspector-control',
-	InspectorControl
+	ifCondition( ( { name } ) =>
+		hasBlockSupport( name, 'customClassName', true )
+	)( InspectorControl )
 );
 addFilter(
 	'blocks.getSaveContent.extraProps',

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -9,7 +9,11 @@ import namesPlugin from 'colord/plugins/names';
  * WordPress dependencies
  */
 import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
-import { createHigherOrderComponent, useInstanceId } from '@wordpress/compose';
+import {
+	createHigherOrderComponent,
+	ifCondition,
+	useInstanceId,
+} from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
 import { useMemo, useContext, createPortal } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
@@ -186,10 +190,6 @@ function addDuotoneAttributes( settings ) {
  * @param {Object} props
  */
 const DuotoneControls = ( props ) => {
-	const hasDuotoneSupport = hasBlockSupport(
-		props.name,
-		'color.__experimentalDuotone'
-	);
 	const isContentLocked = useSelect(
 		( select ) => {
 			return select( blockEditorStore ).__unstableGetContentLockingParent(
@@ -203,9 +203,7 @@ const DuotoneControls = ( props ) => {
 	// for all blocks, not just those that support duotone. Code added
 	// above this line should be carefully evaluated for its impact on
 	// performance.
-	return (
-		hasDuotoneSupport && ! isContentLocked && <DuotonePanel { ...props } />
-	);
+	return ! isContentLocked && <DuotonePanel { ...props } />;
 };
 
 /**
@@ -330,7 +328,9 @@ addFilter(
 addFilter(
 	'editor.BlockControls',
 	'core/editor/duotone/with-editor-controls',
-	DuotoneControls
+	ifCondition( ( { name } ) =>
+		hasBlockSupport( name, 'color.__experimentalDuotone' )
+	)( DuotoneControls )
 );
 addFilter(
 	'editor.BlockListBlock',

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -33,6 +33,7 @@ import {
 	__unstableDuotoneUnsetStylesheet as DuotoneUnsetStylesheet,
 } from '../components/duotone';
 import { store as blockEditorStore } from '../store';
+import { blockControlsFilterName } from '../components/block-edit';
 
 const EMPTY_ARRAY = [];
 
@@ -326,7 +327,7 @@ addFilter(
 	addDuotoneAttributes
 );
 addFilter(
-	'editor.BlockControls',
+	blockControlsFilterName,
 	'core/editor/duotone/with-editor-controls',
 	ifCondition( ( { name } ) =>
 		hasBlockSupport( name, 'color.__experimentalDuotone' )

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -183,40 +183,30 @@ function addDuotoneAttributes( settings ) {
  * Override the default edit UI to include toolbar controls for duotone if the
  * block supports duotone.
  *
- * @param {Function} BlockEdit Original component.
- *
- * @return {Function} Wrapped component.
+ * @param {Object} props
  */
-const withDuotoneControls = createHigherOrderComponent(
-	( BlockEdit ) => ( props ) => {
-		const hasDuotoneSupport = hasBlockSupport(
-			props.name,
-			'color.__experimentalDuotone'
-		);
-		const isContentLocked = useSelect(
-			( select ) => {
-				return select(
-					blockEditorStore
-				).__unstableGetContentLockingParent( props.clientId );
-			},
-			[ props.clientId ]
-		);
+const DuotoneControls = ( props ) => {
+	const hasDuotoneSupport = hasBlockSupport(
+		props.name,
+		'color.__experimentalDuotone'
+	);
+	const isContentLocked = useSelect(
+		( select ) => {
+			return select( blockEditorStore ).__unstableGetContentLockingParent(
+				props.clientId
+			);
+		},
+		[ props.clientId ]
+	);
 
-		// CAUTION: code added before this line will be executed
-		// for all blocks, not just those that support duotone. Code added
-		// above this line should be carefully evaluated for its impact on
-		// performance.
-		return (
-			<>
-				{ hasDuotoneSupport && ! isContentLocked && (
-					<DuotonePanel { ...props } />
-				) }
-				<BlockEdit { ...props } />
-			</>
-		);
-	},
-	'withDuotoneControls'
-);
+	// CAUTION: code added before this line will be executed
+	// for all blocks, not just those that support duotone. Code added
+	// above this line should be carefully evaluated for its impact on
+	// performance.
+	return (
+		hasDuotoneSupport && ! isContentLocked && <DuotonePanel { ...props } />
+	);
+};
 
 /**
  * Function that scopes a selector with another one. This works a bit like
@@ -338,9 +328,9 @@ addFilter(
 	addDuotoneAttributes
 );
 addFilter(
-	'editor.BlockEdit',
+	'editor.BlockControls',
 	'core/editor/duotone/with-editor-controls',
-	withDuotoneControls
+	DuotoneControls
 );
 addFilter(
 	'editor.BlockListBlock',

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -33,6 +33,7 @@ import useSetting from '../components/use-setting';
 import { LayoutStyle } from '../components/block-list/layout';
 import BlockList from '../components/block-list';
 import { getLayoutType, getLayoutTypes } from '../layouts';
+import { blockControlsFilterName } from '../components/block-edit';
 
 const layoutBlockSupportKey = '__experimentalLayout';
 
@@ -481,7 +482,7 @@ addFilter(
 	withChildLayoutStyles
 );
 addFilter(
-	'editor.BlockControls',
+	blockControlsFilterName,
 	'core/editor/layout/with-inspector-controls',
 	ifCondition( ( { name } ) =>
 		hasBlockSupport( name, layoutBlockSupportKey )

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -322,25 +322,18 @@ export function addAttribute( settings ) {
 /**
  * Override the default edit UI to include layout controls
  *
- * @param {Function} BlockEdit Original component.
- *
- * @return {Function} Wrapped component.
+ * @param {Object} props
  */
-export const withInspectorControls = createHigherOrderComponent(
-	( BlockEdit ) => ( props ) => {
-		const { name: blockName } = props;
-		const supportLayout = hasBlockSupport(
-			blockName,
-			layoutBlockSupportKey
-		);
+export const LayoutInspectorControls = ( props ) => {
+	const { name: blockName } = props;
+	const supportLayout = hasBlockSupport( blockName, layoutBlockSupportKey );
 
-		return [
-			supportLayout && <LayoutPanel key="layout" { ...props } />,
-			<BlockEdit key="edit" { ...props } />,
-		];
-	},
-	'withInspectorControls'
-);
+	if ( ! supportLayout ) {
+		return null;
+	}
+
+	return <LayoutPanel { ...props } />;
+};
 
 /**
  * Override the default block element to add the layout styles.
@@ -500,7 +493,7 @@ addFilter(
 	withChildLayoutStyles
 );
 addFilter(
-	'editor.BlockEdit',
+	'editor.BlockControls',
 	'core/editor/layout/with-inspector-controls',
-	withInspectorControls
+	LayoutInspectorControls
 );

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -7,7 +7,11 @@ import { kebabCase } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { createHigherOrderComponent, useInstanceId } from '@wordpress/compose';
+import {
+	createHigherOrderComponent,
+	ifCondition,
+	useInstanceId,
+} from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
 import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
@@ -320,22 +324,6 @@ export function addAttribute( settings ) {
 }
 
 /**
- * Override the default edit UI to include layout controls
- *
- * @param {Object} props
- */
-export const LayoutInspectorControls = ( props ) => {
-	const { name: blockName } = props;
-	const supportLayout = hasBlockSupport( blockName, layoutBlockSupportKey );
-
-	if ( ! supportLayout ) {
-		return null;
-	}
-
-	return <LayoutPanel { ...props } />;
-};
-
-/**
  * Override the default block element to add the layout styles.
  *
  * @param {Function} BlockListBlock Original component.
@@ -495,5 +483,7 @@ addFilter(
 addFilter(
 	'editor.BlockControls',
 	'core/editor/layout/with-inspector-controls',
-	LayoutInspectorControls
+	ifCondition( ( { name } ) =>
+		hasBlockSupport( name, layoutBlockSupportKey )
+	)( LayoutPanel )
 );

--- a/packages/block-editor/src/hooks/layout.native.js
+++ b/packages/block-editor/src/hooks/layout.native.js
@@ -7,6 +7,7 @@ import { removeFilter } from '@wordpress/hooks';
  * Internal dependencies
  */
 import './layout.js';
+import { blockControlsFilterName } from '../components/block-edit';
 
 // This filter is removed because layout styles shouldn't be added
 // until layout types are supported in the native version.
@@ -18,6 +19,6 @@ removeFilter(
 // This filter is removed because the layout controls shouldn't be
 // enabled until layout types are supported in the native version.
 removeFilter(
-	'editor.BlockEdit',
+	blockControlsFilterName,
 	'core/editor/layout/with-inspector-controls'
 );

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -311,29 +311,20 @@ export function PositionPanel( props ) {
 /**
  * Override the default edit UI to include position controls.
  *
- * @param {Function} BlockEdit Original component.
- *
- * @return {Function} Wrapped component.
+ * @param {Object} props
  */
-export const withInspectorControls = createHigherOrderComponent(
-	( BlockEdit ) => ( props ) => {
-		const { name: blockName } = props;
-		const positionSupport = hasBlockSupport(
-			blockName,
-			POSITION_SUPPORT_KEY
-		);
-		const showPositionControls =
-			positionSupport && ! useIsPositionDisabled( props );
+export const PositionInspectorControls = ( props ) => {
+	const { name: blockName } = props;
+	const positionSupport = hasBlockSupport( blockName, POSITION_SUPPORT_KEY );
+	const isPositionDisabled = useIsPositionDisabled( props );
+	const showPositionControls = positionSupport && ! isPositionDisabled;
 
-		return [
-			showPositionControls && (
-				<PositionPanel key="position" { ...props } />
-			),
-			<BlockEdit key="edit" { ...props } />,
-		];
-	},
-	'withInspectorControls'
-);
+	if ( ! showPositionControls ) {
+		return null;
+	}
+
+	return <PositionPanel { ...props } />;
+};
 
 /**
  * Override the default block element to add the position styles.
@@ -395,7 +386,7 @@ addFilter(
 	withPositionStyles
 );
 addFilter(
-	'editor.BlockEdit',
+	'editor.BlockControls',
 	'core/editor/position/with-inspector-controls',
-	withInspectorControls
+	PositionInspectorControls
 );

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -12,7 +12,11 @@ import {
 	BaseControl,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
-import { createHigherOrderComponent, useInstanceId } from '@wordpress/compose';
+import {
+	createHigherOrderComponent,
+	ifCondition,
+	useInstanceId,
+} from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import {
 	useContext,
@@ -314,12 +318,9 @@ export function PositionPanel( props ) {
  * @param {Object} props
  */
 export const PositionInspectorControls = ( props ) => {
-	const { name: blockName } = props;
-	const positionSupport = hasBlockSupport( blockName, POSITION_SUPPORT_KEY );
 	const isPositionDisabled = useIsPositionDisabled( props );
-	const showPositionControls = positionSupport && ! isPositionDisabled;
 
-	if ( ! showPositionControls ) {
+	if ( isPositionDisabled ) {
 		return null;
 	}
 
@@ -388,5 +389,7 @@ addFilter(
 addFilter(
 	'editor.BlockControls',
 	'core/editor/position/with-inspector-controls',
-	PositionInspectorControls
+	ifCondition( ( { name } ) =>
+		hasBlockSupport( name, POSITION_SUPPORT_KEY )
+	)( PositionInspectorControls )
 );

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -33,6 +33,7 @@ import {
 	DimensionsPanel,
 } from './dimensions';
 import { shouldSkipSerialization } from './utils';
+import { blockControlsFilterName } from '../components/block-edit';
 
 const styleSupportKeys = [
 	...TYPOGRAPHY_SUPPORT_KEYS,
@@ -455,7 +456,7 @@ addFilter(
 );
 
 addFilter(
-	'editor.BlockControls',
+	blockControlsFilterName,
 	'core/style/with-block-controls',
 	StyleBlockControls
 );

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -32,7 +32,6 @@ import {
 	SPACING_SUPPORT_KEY,
 	DimensionsPanel,
 } from './dimensions';
-import useDisplayBlockControls from '../components/use-display-block-controls';
 import { shouldSkipSerialization } from './utils';
 
 const styleSupportKeys = [
@@ -343,12 +342,6 @@ export function addEditProps( settings ) {
  * @param {Object} props
  */
 export const StyleBlockControls = ( props ) => {
-	const shouldDisplayControls = useDisplayBlockControls();
-
-	if ( ! shouldDisplayControls ) {
-		return null;
-	}
-
 	return (
 		<>
 			<ColorEdit { ...props } />

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -340,30 +340,24 @@ export function addEditProps( settings ) {
  * Override the default edit UI to include new inspector controls for
  * all the custom styles configs.
  *
- * @param {Function} BlockEdit Original component.
- *
- * @return {Function} Wrapped component.
+ * @param {Object} props
  */
-export const withBlockControls = createHigherOrderComponent(
-	( BlockEdit ) => ( props ) => {
-		const shouldDisplayControls = useDisplayBlockControls();
+export const StyleBlockControls = ( props ) => {
+	const shouldDisplayControls = useDisplayBlockControls();
 
-		return (
-			<>
-				{ shouldDisplayControls && (
-					<>
-						<ColorEdit { ...props } />
-						<TypographyPanel { ...props } />
-						<BorderPanel { ...props } />
-						<DimensionsPanel { ...props } />
-					</>
-				) }
-				<BlockEdit { ...props } />
-			</>
-		);
-	},
-	'withToolbarControls'
-);
+	if ( ! shouldDisplayControls ) {
+		return null;
+	}
+
+	return (
+		<>
+			<ColorEdit { ...props } />
+			<TypographyPanel { ...props } />
+			<BorderPanel { ...props } />
+			<DimensionsPanel { ...props } />
+		</>
+	);
+};
 
 /**
  * Override the default block element to include elements styles.
@@ -468,9 +462,9 @@ addFilter(
 );
 
 addFilter(
-	'editor.BlockEdit',
+	'editor.BlockControls',
 	'core/style/with-block-controls',
-	withBlockControls
+	StyleBlockControls
 );
 
 addFilter(

--- a/packages/block-editor/src/hooks/test/align.js
+++ b/packages/block-editor/src/hooks/test/align.js
@@ -18,6 +18,7 @@ import { SlotFillProvider } from '@wordpress/components';
  * Internal dependencies
  */
 import BlockControls from '../../components/block-controls';
+import BlockEdit from '../../components/block-edit';
 import BlockEditorProvider from '../../components/provider';
 import {
 	getValidAlignments,
@@ -168,7 +169,9 @@ describe( 'align', () => {
 
 			render(
 				<SlotFillProvider>
-					<ToolbarControls { ...componentProps } />
+					<BlockEdit { ...componentProps }>
+						<ToolbarControls { ...componentProps } />
+					</BlockEdit>
 					<BlockControls.Slot group="block" />
 				</SlotFillProvider>
 			);
@@ -192,7 +195,9 @@ describe( 'align', () => {
 
 			render(
 				<SlotFillProvider>
-					<ToolbarControls { ...componentProps } />
+					<BlockEdit { ...componentProps }>
+						<ToolbarControls { ...componentProps } />
+					</BlockEdit>
 					<BlockControls.Slot group="block" />
 				</SlotFillProvider>
 			);

--- a/packages/block-editor/src/hooks/test/align.js
+++ b/packages/block-editor/src/hooks/test/align.js
@@ -18,11 +18,10 @@ import { SlotFillProvider } from '@wordpress/components';
  * Internal dependencies
  */
 import BlockControls from '../../components/block-controls';
-import BlockEdit from '../../components/block-edit';
 import BlockEditorProvider from '../../components/provider';
 import {
 	getValidAlignments,
-	withToolbarControls,
+	ToolbarControls,
 	withDataAlign,
 	addAssignedAlign,
 } from '../align';
@@ -157,7 +156,7 @@ describe( 'align', () => {
 		} );
 	} );
 
-	describe( 'withToolbarControls', () => {
+	describe( 'ToolbarControls', () => {
 		const componentProps = {
 			name: 'core/foo',
 			attributes: {},
@@ -167,15 +166,9 @@ describe( 'align', () => {
 		it( 'should do nothing if no valid alignments', () => {
 			registerBlockType( 'core/foo', blockSettings );
 
-			const EnhancedComponent = withToolbarControls(
-				( { wrapperProps } ) => <div { ...wrapperProps } />
-			);
-
 			render(
 				<SlotFillProvider>
-					<BlockEdit { ...componentProps }>
-						<EnhancedComponent { ...componentProps } />
-					</BlockEdit>
+					<ToolbarControls { ...componentProps } />
 					<BlockControls.Slot group="block" />
 				</SlotFillProvider>
 			);
@@ -197,15 +190,9 @@ describe( 'align', () => {
 				},
 			} );
 
-			const EnhancedComponent = withToolbarControls(
-				( { wrapperProps } ) => <div { ...wrapperProps } />
-			);
-
 			render(
 				<SlotFillProvider>
-					<BlockEdit { ...componentProps }>
-						<EnhancedComponent { ...componentProps } />
-					</BlockEdit>
+					<ToolbarControls { ...componentProps } />
 					<BlockControls.Slot group="block" />
 				</SlotFillProvider>
 			);

--- a/packages/block-library/src/query/hooks.js
+++ b/packages/block-library/src/query/hooks.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
+import { createHigherOrderComponent } from '@wordpress/compose';
 import { InspectorControls } from '@wordpress/block-editor';
 
 const CreateNewPostLink = ( {
@@ -27,19 +28,26 @@ const CreateNewPostLink = ( {
 /**
  * Override the default edit UI to include layout controls
  *
- * @param {Object} props
+ * @param {Function} BlockEdit Original component
+ * @return {Function}           Wrapped component
  */
-const queryTopInspectorControls = ( props ) => {
-	const { name, isSelected } = props;
-	if ( name !== 'core/query' || ! isSelected ) {
-		return null;
-	}
+const queryTopInspectorControls = createHigherOrderComponent(
+	( BlockEdit ) => ( props ) => {
+		const { name, isSelected } = props;
+		if ( name !== 'core/query' || ! isSelected ) {
+			return <BlockEdit key="edit" { ...props } />;
+		}
 
-	return (
-		<InspectorControls>
-			<CreateNewPostLink { ...props } />
-		</InspectorControls>
-	);
-};
+		return (
+			<>
+				<InspectorControls>
+					<CreateNewPostLink { ...props } />
+				</InspectorControls>
+				<BlockEdit key="edit" { ...props } />
+			</>
+		);
+	},
+	'withInspectorControls'
+);
 
 export default queryTopInspectorControls;

--- a/packages/block-library/src/query/hooks.js
+++ b/packages/block-library/src/query/hooks.js
@@ -4,7 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
-import { createHigherOrderComponent } from '@wordpress/compose';
 import { InspectorControls } from '@wordpress/block-editor';
 
 const CreateNewPostLink = ( {
@@ -28,26 +27,19 @@ const CreateNewPostLink = ( {
 /**
  * Override the default edit UI to include layout controls
  *
- * @param {Function} BlockEdit Original component
- * @return {Function}           Wrapped component
+ * @param {Object} props
  */
-const queryTopInspectorControls = createHigherOrderComponent(
-	( BlockEdit ) => ( props ) => {
-		const { name, isSelected } = props;
-		if ( name !== 'core/query' || ! isSelected ) {
-			return <BlockEdit key="edit" { ...props } />;
-		}
+const queryTopInspectorControls = ( props ) => {
+	const { name, isSelected } = props;
+	if ( name !== 'core/query' || ! isSelected ) {
+		return null;
+	}
 
-		return (
-			<>
-				<InspectorControls>
-					<CreateNewPostLink { ...props } />
-				</InspectorControls>
-				<BlockEdit key="edit" { ...props } />
-			</>
-		);
-	},
-	'withInspectorControls'
-);
+	return (
+		<InspectorControls>
+			<CreateNewPostLink { ...props } />
+		</InspectorControls>
+	);
+};
 
 export default queryTopInspectorControls;

--- a/packages/block-library/src/query/index.js
+++ b/packages/block-library/src/query/index.js
@@ -27,7 +27,9 @@ export const settings = {
 };
 
 export const init = () => {
-	addFilter( 'editor.BlockControls', 'core/query', queryInspectorControls );
+	// This is a temporary solution so the link is displayed at the top.
+	// See https://github.com/WordPress/gutenberg/pull/31833/files#r634291993.
+	addFilter( 'editor.BlockEdit', 'core/query', queryInspectorControls );
 
 	return initBlock( { name, metadata, settings } );
 };

--- a/packages/block-library/src/query/index.js
+++ b/packages/block-library/src/query/index.js
@@ -27,7 +27,7 @@ export const settings = {
 };
 
 export const init = () => {
-	addFilter( 'editor.BlockEdit', 'core/query', queryInspectorControls );
+	addFilter( 'editor.BlockControls', 'core/query', queryInspectorControls );
 
 	return initBlock( { name, metadata, settings } );
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR is easier to review [without whitespace changes](https://github.com/WordPress/gutenberg/pull/48809/files?diff=split&w=1).

All use cases for the `editor.BlockEdit` function are adding block controls. We should create a less powerful filters specifically for adding block controls that only renders these when needed.

This is beneficial for performance, and it's easier to understand without the HoC.

For now this filter is private until we're ready to share an interface we want to expose.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
