### PR TITLE
Fix classic menu fallback race condition

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -119,7 +119,8 @@ function Navigation( {
 
 	// Preload classic menus, so that they don't suddenly pop-in when viewing
 	// the Select Menu dropdown.
-	const { menus: classicMenus } = useNavigationEntities();
+	const { menus: classicMenus, hasResolvedMenus: hasResolvedClassicMenus } =
+		useNavigationEntities();
 
 	const [ showNavigationMenuStatusNotice, hideNavigationMenuStatusNotice ] =
 		useNavigationNotice( {
@@ -311,6 +312,7 @@ function Navigation( {
 	useEffect( () => {
 		if (
 			ref ||
+			! hasResolvedClassicMenus ||
 			! hasResolvedNavigationMenus ||
 			isConvertingClassicMenu ||
 			fallbackNavigationMenus?.length > 0 ||
@@ -363,6 +365,7 @@ function Navigation( {
 			);
 		}
 	}, [
+		hasResolvedClassicMenus,
 		hasResolvedNavigationMenus,
 		hasUnsavedBlocks,
 		classicMenus,


### PR DESCRIPTION
When there are no navigation or classic menus, there is a fallback to use the page list of the navigation menu. This works well, but our check for if we have classic menus isn't waiting until the request for classic menus has completed before deciding if it should use the classic menu conversion process or fallback to the page list. 

## What?
Adds a check to address a race condition in finding menu fallbacks

## Why?
When adding a navigation block to a post, there is inconsistent behavior based on a race condition around menu fallbacks.

## How?
This PR adds `hasResolvedClassicMenu` to the `useEffect` hook and early return to ensure we don't check for which classic menu to use as a fallback until our classic menu request has completed.

## Testing Instructions
### 1. Switch to a theme with classic menus
- Use an older theme such as twenty nineteen that has classic menus.

### 2. Delete all navigation post types so we will need a fallback
- Go to `/wp-admin/edit.php?post_type=wp_navigation` and delete all navigations.
- go to `/wp-admin/edit.php?post_status=trash&post_type=wp_navigation` and permanently delete all navigations.

### 3. Create one classic menu
- Click menus in the sidebar
- Create a new menu
- Add a custom link to it
- Save

### 4. Test the PR
- Create a new post
- Add a navigation block
- You should see the Classic menu conversion notification
- Your custom classic menu should be used for the navigation block

### 5. e2e tests
This PR fixes the understandably flaky e2e tests [#48482](https://github.com/WordPress/gutenberg/issues/48033). This test is only flaky on a slower connection that will emphasize the race condition, so we need to slow down the e2e test. 

In `/playwright.config.ts` add this within the `use` section to slow down the e2e tests:

```
		launchOptions: {
			slowMo: 500,
		},
```

Now, you can run the e2e test 20x in a row. All should pass. On `trunk`, they pass about 50% of the time.

```
npm run test:e2e:playwright -- --repeat-each 20 -g "default to the only existing classic menu if there are no block menus"
```
