### PR TITLE
[WP6.2] Add missing 'unlock' import after conflict resolution

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -19,6 +19,7 @@ import { useHistory } from '../routes';
 import NavigationMenuContent from './navigation-menu-content';
 import SidebarButton from '../sidebar-button';
 import { NavigationMenuLoader } from './loader';
+import { unlock } from '../../private-apis';
 
 const noop = () => {};
 const NAVIGATION_MENUS_QUERY = { per_page: -1, status: 'publish' };


### PR DESCRIPTION
## What?
Add missing `unlock` import after git cherry-picking resolution.

## Testing Instructions
* CI checks are passing.
* Clicking "Navigation" in the Site Editor sidebar doesn't result in WSOD.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-03-07 at 11 58 39](https://user-images.githubusercontent.com/240569/223362463-58a46a50-ebeb-4adc-8a4d-89270419f681.png)

