### PR TITLE
Fix site editor sidebar scrollbars

### DIFF
--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -49,6 +49,7 @@
 }
 
 .edit-site-layout__content {
+	height: 100%;
 	flex-grow: 1;
 	display: flex;
 }


### PR DESCRIPTION
closes #48796 

## What?

This PR fixes the scrolling in the sidebar of the site editor if it grows in height.

## Testing Instructions

- Add many templates to your site editor
- try scrolling the sidebar.