### PR TITLE
Comments Block (Legacy): Update missing translation

### DIFF
--- a/packages/block-library/src/comments/edit/placeholder.js
+++ b/packages/block-library/src/comments/edit/placeholder.js
@@ -5,6 +5,7 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { useEntityProp } from '@wordpress/core-data';
+import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -45,7 +46,7 @@ export default function PostCommentsPlaceholder( { postType, postId } ) {
 						<footer className="comment-meta">
 							<div className="comment-author vcard">
 								<img
-									alt="Commenter Avatar"
+									alt={ __( 'Commenter Avatar' ) }
 									src={ avatarURL }
 									className="avatar avatar-32 photo"
 									height="32"
@@ -85,8 +86,17 @@ export default function PostCommentsPlaceholder( { postType, postId } ) {
 									'To get started with moderating, editing, and deleting comments, please visit the Comments screen in the dashboard.'
 								) }
 								<br />
-								{ __( 'Commenter avatars come from' ) }{ ' ' }
-								<a href="https://gravatar.com/">Gravatar</a>.
+								{ createInterpolateElement(
+									__(
+										'Commenter avatars come from <a>Gravatar</a>.'
+									),
+									{
+										a: (
+											// eslint-disable-next-line jsx-a11y/anchor-has-content
+											<a href="https://gravatar.com/" />
+										),
+									}
+								) }
 							</p>
 						</div>
 


### PR DESCRIPTION
Found while looking at #48760

## What?
This PR makes it possible to translate two hard-coded texts in a legacy comment block.

- Avatar alt text
- Gravatar link text

## Testing Instructions

- In the code editor, add the following code: `<!-- wp:comments {"legacy":true} /-->`
- Return to the visual editor and confirm that the text is still displayed as before.

![capture](https://user-images.githubusercontent.com/54422211/223371331-b7000483-6170-489f-ae94-4361cf4f667f.png)
