### PR TITLE
Add Nav block files to those triggering error for exhaustive deps

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -350,7 +350,12 @@ module.exports = {
 			},
 		},
 		{
-			files: [ 'packages/components/src/**/*.[tj]s?(x)' ],
+			files: [
+				// Components package.
+				'packages/components/src/**/*.[tj]s?(x)',
+				// Navigaiton block.
+				'packages/block-library/src/navigation/**/*.[tj]s?(x)',
+			],
 			excludedFiles: [ ...developmentFiles ],
 			rules: {
 				'react-hooks/exhaustive-deps': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -353,7 +353,7 @@ module.exports = {
 			files: [
 				// Components package.
 				'packages/components/src/**/*.[tj]s?(x)',
-				// Navigaiton block.
+				// Navigation block.
 				'packages/block-library/src/navigation/**/*.[tj]s?(x)',
 			],
 			excludedFiles: [ ...developmentFiles ],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

With the merge of https://github.com/WordPress/gutenberg/pull/24914 and https://github.com/WordPress/gutenberg/pull/48680 this PR ups the level of the exhaustive deps rule to `error` for the Navigation block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

There have been far too many bugs caused by humans missing deps. This rule will _force_ avoiding any future regressions.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add the Nav block files to the exceptions setting exhaustive deps eslint rule to `error` as opposed to the default `warning`. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Run 
```
npm run lint:js /Users/davidsmith/Sites/gutenberg/packages/block-library/src/navigation/    
```
- See no errors.
- Find any `useEffect` in the Nav block `index.js` file and remove some of the dependencies from the deps array.
- Re-run the above command.
- See exhaustive deps rules failing the linting with `error` status (_not_ just `warning`).

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
