### PR TITLE
Fix: Scrollbar in site editor.

### DIFF
--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -49,6 +49,7 @@
 }
 
 .edit-site-layout__content {
+	height: 100%;
 	flex-grow: 1;
 	display: flex;
 }

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -1,9 +1,8 @@
 .edit-site-sidebar__content {
 	flex-grow: 1;
-	height: 100%;
+	overflow-y: auto;
 
 	.components-navigator-screen {
-		overflow-y: auto;
 		@include custom-scrollbars-on-hover;
 	}
 }

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -1,7 +1,11 @@
 .edit-site-sidebar__content {
 	flex-grow: 1;
-	overflow-y: auto;
-	@include custom-scrollbars-on-hover;
+	height: 100%;
+
+	.components-navigator-screen {
+		overflow-y: auto;
+		@include custom-scrollbars-on-hover;
+	}
 }
 
 .edit-site-sidebar__footer {


### PR DESCRIPTION
## What?

Alternative to #48819. Fixes the site editor to be scrollable again, with the light-weight scrollbars:

<img width="687" alt="Screenshot 2023-03-07 at 10 12 29" src="https://user-images.githubusercontent.com/1204802/223376834-dfa0250e-a072-49ea-a535-b88886191cec.png">


## Why?

Bug/regression.

## How?

The scrollable container needs to be the 100% tall container.

## Testing Instructions

Go into the site editor > templates, and make your viewport not so tall and hover the sidebar to see a scrollbar.
