### PR TITLE
Block editor: new `blockEditor.useBlockProps` filter

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -19,9 +19,14 @@ import {
 } from '@wordpress/compose';
 import {
 	createContext,
-	useState,
 	useMemo,
 	useCallback,
+	useLayoutEffect,
+	useContext,
+	useRef,
+	Fragment,
+	createElement,
+	useReducer,
 } from '@wordpress/element';
 
 /**
@@ -41,13 +46,55 @@ import {
 	DEFAULT_BLOCK_EDIT_CONTEXT,
 } from '../block-edit/context';
 
-const elementContext = createContext();
+const componentsContext = createContext();
 
 export const IntersectionObserver = createContext();
 const pendingBlockVisibilityUpdatesPerRegistry = new WeakMap();
 
+function useRootPortal( component ) {
+	const components = useContext( componentsContext );
+
+	useLayoutEffect( () => {
+		if ( ! component ) return;
+		components.add( component );
+		return () => {
+			components.delete( component );
+		};
+	} );
+}
+
+function Components( { subscriber, components } ) {
+	const [ , forceRender ] = useReducer( () => ( {} ) );
+	subscriber.current = forceRender;
+	return createElement( Fragment, null, ...components.current );
+}
+
+function ComponentRenderer( { children } ) {
+	const subscriber = useRef( () => {} );
+	const components = useRef( new Set() );
+	return (
+		<componentsContext.Provider
+			value={ useMemo(
+				() => ( {
+					add( component ) {
+						components.current.add( component );
+						subscriber.current();
+					},
+					delete( component ) {
+						components.current.delete( component );
+						subscriber.current();
+					},
+				} ),
+				[]
+			) }
+		>
+			<Components subscriber={ subscriber } components={ components } />
+			{ children }
+		</componentsContext.Provider>
+	);
+}
+
 function Root( { className, ...settings } ) {
-	const [ element, setElement ] = useState();
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const { isOutlineMode, isFocusMode, editorMode } = useSelect(
 		( select ) => {
@@ -105,7 +152,6 @@ function Root( { className, ...settings } ) {
 			ref: useMergeRefs( [
 				useBlockSelectionClearer(),
 				useInBetweenInserter(),
-				setElement,
 			] ),
 			className: classnames( 'is-root-container', className, {
 				'is-outline-mode': isOutlineMode,
@@ -116,11 +162,13 @@ function Root( { className, ...settings } ) {
 		settings
 	);
 	return (
-		<elementContext.Provider value={ element }>
-			<IntersectionObserver.Provider value={ intersectionObserver }>
-				<div { ...innerBlocksProps } />
-			</IntersectionObserver.Provider>
-		</elementContext.Provider>
+		<IntersectionObserver.Provider value={ intersectionObserver }>
+			<div { ...innerBlocksProps }>
+				<ComponentRenderer>
+					{ innerBlocksProps.children }
+				</ComponentRenderer>
+			</div>
+		</IntersectionObserver.Provider>
 	);
 }
 
@@ -135,7 +183,7 @@ export default function BlockList( settings ) {
 	);
 }
 
-BlockList.__unstableElementContext = elementContext;
+BlockList.useRootPortal = useRootPortal;
 
 function Items( {
 	placeholder,

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -45,7 +45,7 @@ import {
 	DEFAULT_BLOCK_EDIT_CONTEXT,
 } from '../block-edit/context';
 
-const componentsContext = createContext();
+const componentsContext = createContext( { render() {}, unmount() {} } );
 
 export const IntersectionObserver = createContext();
 const pendingBlockVisibilityUpdatesPerRegistry = new WeakMap();

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -175,38 +175,30 @@ export const withToolbarControls = createHigherOrderComponent(
 /**
  * Override the default block element to add alignment wrapper props.
  *
- * @param {Function} BlockListBlock Original component.
- *
- * @return {Function} Wrapped component.
+ * @param {Object} props      Additional props applied to edit element.
+ * @param {Object} blockType  Block type.
+ * @param {Object} attributes Block attributes.
  */
-export const withDataAlign = createHigherOrderComponent(
-	( BlockListBlock ) => ( props ) => {
-		const { name, attributes } = props;
-		const { align } = attributes;
-		const blockAllowedAlignments = getValidAlignments(
-			getBlockSupport( name, 'align' ),
-			hasBlockSupport( name, 'alignWide', true )
-		);
-		const validAlignments = useAvailableAlignments(
-			blockAllowedAlignments
-		);
+export const useDataAlign = ( props, blockType, attributes ) => {
+	const { align } = attributes;
+	const blockAllowedAlignments = getValidAlignments(
+		getBlockSupport( blockType, 'align' ),
+		hasBlockSupport( blockType, 'alignWide', true )
+	);
+	const validAlignments = useAvailableAlignments( blockAllowedAlignments );
 
-		// If an alignment is not assigned, there's no need to go through the
-		// effort to validate or assign its value.
-		if ( align === undefined ) {
-			return <BlockListBlock { ...props } />;
-		}
-
-		let wrapperProps = props.wrapperProps;
-		if (
-			validAlignments.some( ( alignment ) => alignment.name === align )
-		) {
-			wrapperProps = { ...wrapperProps, 'data-align': align };
-		}
-
-		return <BlockListBlock { ...props } wrapperProps={ wrapperProps } />;
+	// If an alignment is not assigned, there's no need to go through the
+	// effort to validate or assign its value.
+	if ( align === undefined ) {
+		return props;
 	}
-);
+
+	if ( validAlignments.some( ( alignment ) => alignment.name === align ) ) {
+		return { ...props, 'data-align': align };
+	}
+
+	return props;
+};
 
 /**
  * Override props assigned to save component to inject alignment class name if
@@ -243,9 +235,9 @@ addFilter(
 	addAttribute
 );
 addFilter(
-	'editor.BlockListBlock',
+	'blockEditor.useBlockProps',
 	'core/editor/align/with-data-align',
-	withDataAlign
+	useDataAlign
 );
 addFilter(
 	'editor.BlockEdit',

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -8,7 +8,6 @@ import classnames from 'classnames';
  */
 import { getBlockSupport } from '@wordpress/blocks';
 import { __experimentalHasSplitBorders as hasSplitBorders } from '@wordpress/components';
-import { createHigherOrderComponent } from '@wordpress/compose';
 import { Platform, useCallback, useMemo } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 
@@ -331,66 +330,58 @@ function addEditProps( settings ) {
  * This adds inline styles for color palette colors.
  * Ideally, this is not needed and themes should load their palettes on the editor.
  *
- * @param {Function} BlockListBlock Original component.
- *
- * @return {Function} Wrapped component.
+ * @param {Object} props      Additional props applied to save element.
+ * @param {Object} blockType  Block type definition.
+ * @param {Object} attributes Block's attributes.
  */
-export const withBorderColorPaletteStyles = createHigherOrderComponent(
-	( BlockListBlock ) => ( props ) => {
-		const { name, attributes } = props;
-		const { borderColor, style } = attributes;
-		const { colors } = useMultipleOriginColorsAndGradients();
+export const useBorderColorPaletteStyles = ( props, blockType, attributes ) => {
+	const { borderColor, style } = attributes;
+	const { colors } = useMultipleOriginColorsAndGradients();
 
-		if (
-			! hasBorderSupport( name, 'color' ) ||
-			shouldSkipSerialization( name, BORDER_SUPPORT_KEY, 'color' )
-		) {
-			return <BlockListBlock { ...props } />;
-		}
-
-		const { color: borderColorValue } = getMultiOriginColor( {
-			colors,
-			namedColor: borderColor,
-		} );
-		const { color: borderTopColor } = getMultiOriginColor( {
-			colors,
-			namedColor: getColorSlugFromVariable( style?.border?.top?.color ),
-		} );
-		const { color: borderRightColor } = getMultiOriginColor( {
-			colors,
-			namedColor: getColorSlugFromVariable( style?.border?.right?.color ),
-		} );
-
-		const { color: borderBottomColor } = getMultiOriginColor( {
-			colors,
-			namedColor: getColorSlugFromVariable(
-				style?.border?.bottom?.color
-			),
-		} );
-		const { color: borderLeftColor } = getMultiOriginColor( {
-			colors,
-			namedColor: getColorSlugFromVariable( style?.border?.left?.color ),
-		} );
-
-		const extraStyles = {
-			borderTopColor: borderTopColor || borderColorValue,
-			borderRightColor: borderRightColor || borderColorValue,
-			borderBottomColor: borderBottomColor || borderColorValue,
-			borderLeftColor: borderLeftColor || borderColorValue,
-		};
-
-		let wrapperProps = props.wrapperProps;
-		wrapperProps = {
-			...props.wrapperProps,
-			style: {
-				...props.wrapperProps?.style,
-				...extraStyles,
-			},
-		};
-
-		return <BlockListBlock { ...props } wrapperProps={ wrapperProps } />;
+	if (
+		! hasBorderSupport( blockType, 'color' ) ||
+		shouldSkipSerialization( blockType, BORDER_SUPPORT_KEY, 'color' )
+	) {
+		return props;
 	}
-);
+
+	const { color: borderColorValue } = getMultiOriginColor( {
+		colors,
+		namedColor: borderColor,
+	} );
+	const { color: borderTopColor } = getMultiOriginColor( {
+		colors,
+		namedColor: getColorSlugFromVariable( style?.border?.top?.color ),
+	} );
+	const { color: borderRightColor } = getMultiOriginColor( {
+		colors,
+		namedColor: getColorSlugFromVariable( style?.border?.right?.color ),
+	} );
+
+	const { color: borderBottomColor } = getMultiOriginColor( {
+		colors,
+		namedColor: getColorSlugFromVariable( style?.border?.bottom?.color ),
+	} );
+	const { color: borderLeftColor } = getMultiOriginColor( {
+		colors,
+		namedColor: getColorSlugFromVariable( style?.border?.left?.color ),
+	} );
+
+	const extraStyles = {
+		borderTopColor: borderTopColor || borderColorValue,
+		borderRightColor: borderRightColor || borderColorValue,
+		borderBottomColor: borderBottomColor || borderColorValue,
+		borderLeftColor: borderLeftColor || borderColorValue,
+	};
+
+	return {
+		...props,
+		style: {
+			...props.style,
+			...extraStyles,
+		},
+	};
+};
 
 addFilter(
 	'blocks.registerBlockType',
@@ -411,7 +402,7 @@ addFilter(
 );
 
 addFilter(
-	'editor.BlockListBlock',
+	'blockEditor.useBlockProps',
 	'core/border/with-border-color-palette-styles',
-	withBorderColorPaletteStyles
+	useBorderColorPaletteStyles
 );

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -297,9 +297,10 @@ const useDuotoneStyles = ( props, blockType, attributes ) => {
 	);
 
 	const id = `wp-duotone-${ useInstanceId( useDuotoneStyles ) }`;
+	const duotoneStyle = attributes?.style?.color?.duotone;
 
 	BlockList.useRootPortal(
-		duotoneSupport && (
+		duotoneSupport && duotoneStyle && (
 			<ConditionalInlineDuotone
 				id={ id }
 				blockType={ blockType }
@@ -308,6 +309,10 @@ const useDuotoneStyles = ( props, blockType, attributes ) => {
 		)
 	);
 
+	// CAUTION: code added before this line will be executed
+	// for all blocks, not just those that support duotone. Code added
+	// above this line should be carefully evaluated for its impact on
+	// performance.
 	return {
 		...props,
 		className: duotoneSupport

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -4,7 +4,6 @@
 import { addFilter } from '@wordpress/hooks';
 import { hasBlockSupport } from '@wordpress/blocks';
 import TokenList from '@wordpress/token-list';
-import { createHigherOrderComponent } from '@wordpress/compose';
 import { select } from '@wordpress/data';
 
 /**
@@ -177,57 +176,45 @@ export function useIsFontSizeDisabled( { name: blockName } = {} ) {
  * Ideally, this is not needed and themes load the font-size classes on the
  * editor.
  *
- * @param {Function} BlockListBlock Original component.
- *
- * @return {Function} Wrapped component.
+ * @param {Object} props      Additional props applied to edit element.
+ * @param {Object} blockType  Block type.
+ * @param {Object} attributes Block attributes.
  */
-const withFontSizeInlineStyles = createHigherOrderComponent(
-	( BlockListBlock ) => ( props ) => {
-		const fontSizes = useSetting( 'typography.fontSizes' );
-		const {
-			name: blockName,
-			attributes: { fontSize, style },
-			wrapperProps,
-		} = props;
+const useFontSizeInlineStyles = ( props, blockType, attributes ) => {
+	const fontSizes = useSetting( 'typography.fontSizes' );
+	const { fontSize, style } = attributes;
 
-		// Only add inline styles if the block supports font sizes,
-		// doesn't skip serialization of font sizes,
-		// doesn't already have an inline font size,
-		// and does have a class to extract the font size from.
-		if (
-			! hasBlockSupport( blockName, FONT_SIZE_SUPPORT_KEY ) ||
-			shouldSkipSerialization(
-				blockName,
-				TYPOGRAPHY_SUPPORT_KEY,
-				'fontSize'
-			) ||
-			! fontSize ||
-			style?.typography?.fontSize
-		) {
-			return <BlockListBlock { ...props } />;
-		}
+	// Only add inline styles if the block supports font sizes,
+	// doesn't skip serialization of font sizes,
+	// doesn't already have an inline font size,
+	// and does have a class to extract the font size from.
+	if (
+		! hasBlockSupport( blockType, FONT_SIZE_SUPPORT_KEY ) ||
+		shouldSkipSerialization(
+			blockType,
+			TYPOGRAPHY_SUPPORT_KEY,
+			'fontSize'
+		) ||
+		! fontSize ||
+		style?.typography?.fontSize
+	) {
+		return props;
+	}
 
-		const fontSizeValue = getFontSize(
-			fontSizes,
-			fontSize,
-			style?.typography?.fontSize
-		).size;
+	const fontSizeValue = getFontSize(
+		fontSizes,
+		fontSize,
+		style?.typography?.fontSize
+	).size;
 
-		const newProps = {
-			...props,
-			wrapperProps: {
-				...wrapperProps,
-				style: {
-					fontSize: fontSizeValue,
-					...wrapperProps?.style,
-				},
-			},
-		};
-
-		return <BlockListBlock { ...newProps } />;
-	},
-	'withFontSizeInlineStyles'
-);
+	return {
+		...props,
+		style: {
+			fontSize: fontSizeValue,
+			...props?.style,
+		},
+	};
+};
 
 const MIGRATION_PATHS = {
 	fontSize: [ [ 'fontSize' ], [ 'style', 'typography', 'fontSize' ] ],
@@ -338,9 +325,9 @@ addFilter(
 addFilter( 'blocks.registerBlockType', 'core/font/addEditProps', addEditProps );
 
 addFilter(
-	'editor.BlockListBlock',
+	'blockEditor.useBlockProps',
 	'core/font-size/with-font-size-inline-styles',
-	withFontSizeInlineStyles
+	useFontSizeInlineStyles
 );
 
 addFilter(

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -18,7 +18,6 @@ import {
 	PanelBody,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useContext, createPortal } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -364,7 +363,6 @@ export const withLayoutStyles = createHigherOrderComponent(
 			hasLayoutBlockSupport && ! disableLayoutStyles;
 		const id = useInstanceId( BlockListBlock );
 		const defaultThemeLayout = useSetting( 'layout' ) || {};
-		const element = useContext( BlockList.__unstableElementContext );
 		const { layout } = attributes;
 		const { default: defaultBlockLayout } =
 			getBlockSupport( name, layoutBlockSupportKey ) || {};
@@ -405,26 +403,23 @@ export const withLayoutStyles = createHigherOrderComponent(
 			layoutClasses
 		);
 
-		return (
-			<>
-				{ shouldRenderLayoutStyles &&
-					element &&
-					!! css &&
-					createPortal(
-						<LayoutStyle
-							blockName={ name }
-							selector={ selector }
-							css={ css }
-							layout={ usedLayout }
-							style={ attributes?.style }
-						/>,
-						element
-					) }
-				<BlockListBlock
-					{ ...props }
-					__unstableLayoutClassNames={ layoutClassNames }
+		BlockList.useRootPortal(
+			shouldRenderLayoutStyles && !! css && (
+				<LayoutStyle
+					blockName={ name }
+					selector={ selector }
+					css={ css }
+					layout={ usedLayout }
+					style={ attributes?.style }
 				/>
-			</>
+			)
+		);
+
+		return (
+			<BlockListBlock
+				{ ...props }
+				__unstableLayoutClassNames={ layoutClassNames }
+			/>
 		);
 	}
 );
@@ -449,7 +444,6 @@ export const withChildLayoutStyles = createHigherOrderComponent(
 		const shouldRenderChildLayoutStyles =
 			hasChildLayout && ! disableLayoutStyles;
 
-		const element = useContext( BlockList.__unstableElementContext );
 		const id = useInstanceId( BlockListBlock );
 		const selector = `.wp-container-content-${ id }`;
 
@@ -472,15 +466,11 @@ export const withChildLayoutStyles = createHigherOrderComponent(
 				shouldRenderChildLayoutStyles && !! css, // Only attach a container class if there is generated CSS to be attached.
 		} );
 
-		return (
-			<>
-				{ shouldRenderChildLayoutStyles &&
-					element &&
-					!! css &&
-					createPortal( <style>{ css }</style>, element ) }
-				<BlockListBlock { ...props } className={ className } />
-			</>
+		BlockList.useRootPortal(
+			shouldRenderChildLayoutStyles && !! css && <style>{ css }</style>
 		);
+
+		return <BlockListBlock { ...props } className={ className } />;
 	}
 );
 

--- a/packages/block-editor/src/hooks/test/align.js
+++ b/packages/block-editor/src/hooks/test/align.js
@@ -23,7 +23,7 @@ import BlockEditorProvider from '../../components/provider';
 import {
 	getValidAlignments,
 	withToolbarControls,
-	withDataAlign,
+	useDataAlign,
 	addAssignedAlign,
 } from '../align';
 
@@ -219,7 +219,7 @@ describe( 'align', () => {
 		} );
 	} );
 
-	describe( 'withDataAlign', () => {
+	describe( 'useDataAlign', () => {
 		it( 'should render with wrapper props', () => {
 			registerBlockType( 'core/foo', {
 				...blockSettings,
@@ -229,21 +229,20 @@ describe( 'align', () => {
 				},
 			} );
 
-			const EnhancedComponent = withDataAlign( ( { wrapperProps } ) => (
-				<button { ...wrapperProps } />
-			) );
+			const EnhancedComponent = () => (
+				<button
+					{ ...useDataAlign( {}, 'core/foo', {
+						align: 'wide',
+					} ) }
+				/>
+			);
 
 			render(
 				<BlockEditorProvider
 					settings={ { alignWide: true, supportsLayout: false } }
 					value={ [] }
 				>
-					<EnhancedComponent
-						attributes={ {
-							align: 'wide',
-						} }
-						name="core/foo"
-					/>
+					<EnhancedComponent />
 				</BlockEditorProvider>
 			);
 
@@ -262,21 +261,20 @@ describe( 'align', () => {
 				},
 			} );
 
-			const EnhancedComponent = withDataAlign( ( { wrapperProps } ) => (
-				<button { ...wrapperProps } />
-			) );
+			const EnhancedComponent = () => (
+				<button
+					{ ...useDataAlign( {}, 'core/foo', {
+						align: 'wide',
+					} ) }
+				/>
+			);
 
 			render(
 				<BlockEditorProvider
 					settings={ { alignWide: false } }
 					value={ [] }
 				>
-					<EnhancedComponent
-						name="core/foo"
-						attributes={ {
-							align: 'wide',
-						} }
-					/>
+					<EnhancedComponent />
 				</BlockEditorProvider>
 			);
 
@@ -295,21 +293,20 @@ describe( 'align', () => {
 				},
 			} );
 
-			const EnhancedComponent = withDataAlign( ( { wrapperProps } ) => (
-				<button { ...wrapperProps } />
-			) );
+			const EnhancedComponent = () => (
+				<button
+					{ ...useDataAlign( {}, 'core/foo', {
+						align: 'wide',
+					} ) }
+				/>
+			);
 
 			render(
 				<BlockEditorProvider
 					settings={ { alignWide: true } }
 					value={ [] }
 				>
-					<EnhancedComponent
-						name="core/foo"
-						attributes={ {
-							align: 'wide',
-						} }
-					/>
+					<EnhancedComponent />
 				</BlockEditorProvider>
 			);
 

--- a/packages/block-editor/src/hooks/test/color.js
+++ b/packages/block-editor/src/hooks/test/color.js
@@ -13,7 +13,7 @@ import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
  */
 import BlockEditorProvider from '../../components/provider';
 import { cleanEmptyObject } from '../utils';
-import { withColorPaletteStyles } from '../color';
+import { useColorPaletteStyles } from '../color';
 
 describe( 'cleanEmptyObject', () => {
 	it( 'should remove nested keys', () => {
@@ -45,11 +45,16 @@ describe( 'withColorPaletteStyles', () => {
 		},
 	};
 
-	const EnhancedComponent = withColorPaletteStyles(
-		( { getStyleObj, wrapperProps } ) => (
-			<div>{ getStyleObj( wrapperProps.style ) }</div>
-		)
-	);
+	const EnhancedComponent = ( { attributes, getStyleObj } ) => {
+		const wrapperProps = useColorPaletteStyles(
+			{},
+			'core/test-block',
+			attributes
+		);
+		return (
+			<div { ...wrapperProps }>{ getStyleObj( wrapperProps.style ) }</div>
+		);
+	};
 
 	beforeAll( () => {
 		registerBlockType( 'core/test-block', {

--- a/packages/block-library/src/gallery/gap-styles.js
+++ b/packages/block-library/src/gallery/gap-styles.js
@@ -5,10 +5,8 @@ import {
 	BlockList,
 	__experimentalGetGapCSSValue as getGapCSSValue,
 } from '@wordpress/block-editor';
-import { useContext, createPortal } from '@wordpress/element';
 
 export default function GapStyles( { blockGap, clientId } ) {
-	const styleElement = useContext( BlockList.__unstableElementContext );
 	// --gallery-block--gutter-size is deprecated. --wp--style--gallery-gap-default should be used by themes that want to set a default
 	// gap on the gallery.
 	const fallbackValue = `var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )`;
@@ -35,11 +33,5 @@ export default function GapStyles( { blockGap, clientId } ) {
 		gap: ${ gapValue }
 	}`;
 
-	const GapStyle = () => {
-		return <style>{ gap }</style>;
-	};
-
-	return gap && styleElement
-		? createPortal( <GapStyle />, styleElement )
-		: null;
+	BlockList.useRootPortal( gap ? <style>{ gap }</style> : null );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR is easier to review [without whitespace changes](https://github.com/WordPress/gutenberg/pull/48884/files?diff=split&w=1).

Similar to #48809, but for the `BlockListBlock` filter.

All use cases for the `editor.BlockListBlock` function are adding block props. We should create a less powerful (and easier to use) filter specifically for adding block props. With this PR it will be possible to deprecate the `editor.BlockListBlock` filter.

Some block support hooks are filtering the `getEditWrapperProps` function, we should replace those instances as well.

I replaced `__unstableElementContext` with `__unstableUseRootPortal` which allows block support to add SVGs and blocks styles without having to be a component. This is often linked to selectors that need to be added as block props.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Simplifying the block APIs.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
