### PR TITLE
Site Editor Navigation panel: Link titles are misleading

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/block-contents.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-contents.js
@@ -37,6 +37,7 @@ const ListViewBlockContents = forwardRef(
 			level,
 			isExpanded,
 			selectedClientIds,
+			onSelect,
 			...props
 		},
 		ref
@@ -140,6 +141,7 @@ const ListViewBlockContents = forwardRef(
 							onDragStart={ onDragStart }
 							onDragEnd={ onDragEnd }
 							isExpanded={ isExpanded }
+							onSelect={ onSelect }
 							{ ...props }
 						/>
 					) }

--- a/packages/block-editor/src/components/off-canvas-editor/block-select-button.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-select-button.js
@@ -11,7 +11,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalTruncate as Truncate,
 } from '@wordpress/components';
-import { forwardRef } from '@wordpress/element';
+import { forwardRef, useEffect, useState } from '@wordpress/element';
 import { Icon, lockSmall as lock } from '@wordpress/icons';
 import { SPACE, ENTER } from '@wordpress/keycodes';
 import { sprintf, __ } from '@wordpress/i18n';
@@ -36,6 +36,7 @@ function ListViewBlockSelectButton(
 		onDragStart,
 		onDragEnd,
 		draggable,
+		onSelect,
 	},
 	ref
 ) {
@@ -46,6 +47,7 @@ function ListViewBlockSelectButton(
 		context: 'list-view',
 	} );
 	const { isLocked } = useBlockLock( clientId );
+	const [ editAriaLabel, setEditAriaLabel ] = useState( __( 'Edit' ) );
 
 	// The `href` attribute triggers the browser's native HTML drag operations.
 	// When the link is dragged, the element's outerHTML is set in DataTransfer object as text/html.
@@ -62,22 +64,37 @@ function ListViewBlockSelectButton(
 		}
 	}
 
-	let editAriaLabel = blockInformation
-		? sprintf(
-				// translators: %s: The title of the block.
-				__( 'Edit %s block' ),
-				blockInformation.title
-		  )
-		: __( 'Edit' );
+	useEffect( () => {
+		if ( blockInformation ) {
+			setEditAriaLabel(
+				sprintf(
+					// translators: %s: The title of the block.
+					__( 'Edit %s block' ),
+					blockInformation?.title
+				)
+			);
+		}
 
-	editAriaLabel =
-		block.attributes?.id && block.attributes?.label
-			? sprintf(
-					// translators: %s: The title of the page.
-					__( 'View %s' ),
-					block.attributes?.label
-			  )
-			: editAriaLabel;
+		if ( block.attributes?.id && block.attributes?.label ) {
+			if ( onSelect ) {
+				setEditAriaLabel(
+					sprintf(
+						// translators: %s: The title of the page.
+						__( 'View %s' ),
+						block.attributes?.label
+					)
+				);
+			} else {
+				setEditAriaLabel(
+					sprintf(
+						// translators: %s: The title of the page.
+						__( 'Edit %s' ),
+						block.attributes?.label
+					)
+				);
+			}
+		}
+	}, [ onSelect ] );
 
 	return (
 		<>

--- a/packages/block-editor/src/components/off-canvas-editor/block-select-button.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-select-button.js
@@ -62,13 +62,22 @@ function ListViewBlockSelectButton(
 		}
 	}
 
-	const editAriaLabel = blockInformation
+	let editAriaLabel = blockInformation
 		? sprintf(
 				// translators: %s: The title of the block.
 				__( 'Edit %s block' ),
 				blockInformation.title
 		  )
 		: __( 'Edit' );
+
+	editAriaLabel =
+		block.attributes?.id && block.attributes?.label
+			? sprintf(
+					// translators: %s: The title of the page.
+					__( 'View %s' ),
+					block.attributes?.label
+			  )
+			: editAriaLabel;
 
 	return (
 		<>

--- a/packages/block-editor/src/components/off-canvas-editor/block.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block.js
@@ -54,6 +54,7 @@ function ListViewBlock( {
 	isExpanded,
 	selectedClientIds,
 	preventAnnouncement,
+	onSelect,
 } ) {
 	const cellRef = useRef( null );
 	const [ isHovered, setIsHovered ] = useState( false );
@@ -265,6 +266,7 @@ function ListViewBlock( {
 							isExpanded={ isExpanded }
 							selectedClientIds={ selectedClientIds }
 							preventAnnouncement={ preventAnnouncement }
+							onSelect={ onSelect }
 						/>
 						<div
 							className="block-editor-list-view-block-select-button__description"

--- a/packages/block-editor/src/components/off-canvas-editor/branch.js
+++ b/packages/block-editor/src/components/off-canvas-editor/branch.js
@@ -98,6 +98,7 @@ function ListViewBranch( props ) {
 		parentId,
 		shouldShowInnerBlocks = true,
 		showAppender: showAppenderProp = true,
+		onSelect,
 	} = props;
 
 	const isContentLocked = useSelect(
@@ -186,6 +187,7 @@ function ListViewBranch( props ) {
 								isExpanded={ shouldExpand }
 								listPosition={ nextPosition }
 								selectedClientIds={ selectedClientIds }
+								onSelect={ onSelect }
 							/>
 						) }
 						{ ! showBlock && (

--- a/packages/block-editor/src/components/off-canvas-editor/index.js
+++ b/packages/block-editor/src/components/off-canvas-editor/index.js
@@ -243,6 +243,7 @@ function OffCanvasEditor(
 							isExpanded={ isExpanded }
 							shouldShowInnerBlocks={ shouldShowInnerBlocks }
 							showAppender={ showAppender }
+							onSelect={ onSelect }
 						/>
 						<TreeGridRow
 							level={ 1 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Previously, the button titles were showing unrelated titles on the page links under navigation. Now with this PR, it adds more specific titles to the pages under navigation without disturbing the block titles for block links.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Issue - https://github.com/WordPress/gutenberg/issues/48799


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Added some extra checks for links under navigation. 
If the link is from the WordPress page, then it will show the title as `View {pageName}`, else it will show `Edit {blockName} block` as the title.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Login to WordPress dashboard
2. Go to **Appearance** -> **Editor** -> **Navigation**
3. Toggle the **Page List** by clicking the caret icon.
4. Hover on any of the list item under **Page List** to check the title.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/40795917/223422782-d15ce882-e938-4f18-836e-ea8baef711ce.mov

