### PR TITLE
Post Featured Image: Don't display the scale control when the aspect ratio is original

### DIFF
--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -170,7 +170,7 @@ const DimensionControls = ( {
 					units={ units }
 				/>
 			</ToolsPanelItem>
-			{ ( height || aspectRatio ) && (
+			{ ( height || ( aspectRatio && aspectRatio !== 'auto' ) ) && (
 				<ToolsPanelItem
 					hasValue={ () => !! scale && scale !== DEFAULT_SCALE }
 					label={ scaleLabel }

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -70,6 +70,10 @@ const DimensionControls = ( {
 		} );
 	};
 	const scaleLabel = _x( 'Scale', 'Image scaling options' );
+
+	const showScaleControl =
+		height || ( aspectRatio && aspectRatio !== 'auto' );
+
 	return (
 		<InspectorControls group="dimensions">
 			<ToolsPanelItem
@@ -170,7 +174,7 @@ const DimensionControls = ( {
 					units={ units }
 				/>
 			</ToolsPanelItem>
-			{ ( height || ( aspectRatio && aspectRatio !== 'auto' ) ) && (
+			{ showScaleControl && (
 				<ToolsPanelItem
 					hasValue={ () => !! scale && scale !== DEFAULT_SCALE }
 					label={ scaleLabel }


### PR DESCRIPTION
## What?
This PR hides the scale control when the aspect-ratio setting of the Post Featured Image block is "Original (`auto`)".


## Why?
When the block is first inserted, the `aspectRatio` is set to `undefined`, so the scale control is not visible. However, if you change it to a value other than the original, and then again to the original, the `auto` value will be set and the scale control will remain visible.

https://user-images.githubusercontent.com/54422211/223475701-026cf092-d8ac-4065-a00e-1a749ef0ce30.mp4

### How?

When `aspectRatio` is `auto`, the scale control is hidden. Or maybe it would be better to update to `undefined` when `aspectRatio` is changed to "Original".

## Testing Instructions

- Insert a Post Featured Image block.
- Confirm that the scale control is not displayed (This is the same behavior as before.).
- Change the value to something other than "Original" and change to "Original" again.
- Confirm that the scale control is not displayed.