### PR TITLE
Adding examples of how to programmatically remove the panels in Document sidebar.

### DIFF
--- a/docs/reference-guides/slotfills/plugin-document-setting-panel.md
+++ b/docs/reference-guides/slotfills/plugin-document-setting-panel.md
@@ -33,15 +33,68 @@ registerPlugin( 'plugin-document-setting-panel-demo', {
 
 ## Accessing a panel programmatically
 
-Custom panels are namespaced with the plugin name that was passed to `registerPlugin`.
-In order to access the panels using function such as `wp.data.dispatch( 'core/edit-post' ).toggleEditorPanelOpened` or `wp.data.dispatch( 'core/edit-post' ).toggleEditorPanelEnabled` be sure to prepend the namespace.
+Core and custom panels can be access programmatically using their panel name. The core panel names are:
 
-To programmatically toggle the custom panel added in the example above, use the following:
+-   Summary Panel: `post-status`
+-   Categories Panel: `taxonomy-panel-category`
+-   Tags Panel: `taxonomy-panel-post_tag`
+-   Featured Image Panel: `featured-image`
+-   Excerpt Panel: `post-excerpt`
+-   DiscussionPanel: `discussion-panel`
+
+Custom panels are namespaced with the plugin name that was passed to `registerPlugin`.
+In order to access the panels using function such as `toggleEditorPanelOpened` or `toggleEditorPanelEnabled` be sure to prepend the namespace.
+
+To programmatically toggle panels, use the following:
 
 ```js
-wp.data
-	.dispatch( 'core/edit-post' )
-	.toggleEditorPanelOpened(
-		'plugin-document-setting-panel-demo/custom-panel'
+import { useDispatch } from '@wordpress/data';
+import { store as editPostStore } from '@wordpress/edit-post';
+
+const Example = () => {
+	const { toggleEditorPanelOpened } = useDispatch( editPostStore );
+	return (
+		<Button
+			variant="primary"
+			onClick={ () => {
+				// Toggle the Summary panel
+				toggleEditorPanelOpened( 'post-status' );
+
+				// Toggle the Custom Panel introduced in the example above.
+				toggleEditorPanelOpened(
+					'plugin-document-setting-panel-demo/custom-panel'
+				);
+			} }
+		>
+			Toggle Panels
+		</Button>
 	);
+};
+```
+
+It is also possible to remove panels from the admin using the `removeEditorPanel` function passing the name of the registered panel.
+
+```js
+import { useDispatch } from '@wordpress/data';
+import { store as editPostStore } from '@wordpress/edit-post';
+
+const Example = () => {
+	const { removeEditorPanel } = useDispatch( editPostStore );
+	return (
+		<Button
+			variant="primary"
+			onClick={ () => {
+				// Remove the Featured Image panel.
+				removeEditorPanel( 'featured-image' );
+
+				// Remove the Custom Panel introduced in the example above.
+				removeEditorPanel(
+					'plugin-document-setting-panel-demo/custom-panel'
+				);
+			} }
+		>
+			Toggle Panels
+		</Button>
+	);
+};
 ```

--- a/docs/reference-guides/slotfills/plugin-document-setting-panel.md
+++ b/docs/reference-guides/slotfills/plugin-document-setting-panel.md
@@ -72,7 +72,7 @@ const Example = () => {
 };
 ```
 
-It is also possible to remove panels from the admin using the `removeEditorPanel` function passing the name of the registered panel.
+It is also possible to remove panels from the admin using the `removeEditorPanel` function by passing the name of the registered panel.
 
 ```js
 import { useDispatch } from '@wordpress/data';


### PR DESCRIPTION
## What?
Adds some examples on how to remove panels in the Document sidebar programmatically. It also updates the code examples to use ES Module imports instead of accessing the `wp` global directly 

Closes: #17281.



