### PR TITLE
Server-side render: Test for accuracy of removeBlockSupportAttributes

### DIFF
--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -16,6 +16,26 @@ import { __experimentalSanitizeBlockAttributes } from '@wordpress/blocks';
 
 const EMPTY_OBJECT = {};
 
+// TODO: Hook this up to the actual logic in removeBlockSupportAttributes
+export const KNOWN_ATTRIBUTES = new Set( [
+	'backgroundColor',
+	'borderColor',
+	'fontFamily',
+	'fontSize',
+	'gradient',
+	'textColor',
+	'className',
+] );
+
+// TODO: Hook this up to the actual logic in removeBlockSupportAttributes
+export const KNOWN_STYLES = new Set( [
+	'border',
+	'color',
+	'elements',
+	'spacing',
+	'typography',
+] );
+
 export function rendererPath( block, attributes = null, urlQueryArgs = {} ) {
 	return addQueryArgs( `/wp/v2/block-renderer/${ block }`, {
 		context: 'edit',

--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -14,9 +14,6 @@ import { addQueryArgs } from '@wordpress/url';
 import { Placeholder, Spinner } from '@wordpress/components';
 import { __experimentalSanitizeBlockAttributes } from '@wordpress/blocks';
 
-const EMPTY_OBJECT = {};
-
-// TODO: Hook this up to the actual logic in removeBlockSupportAttributes
 export const KNOWN_ATTRIBUTES = new Set( [
 	'backgroundColor',
 	'borderColor',
@@ -27,7 +24,6 @@ export const KNOWN_ATTRIBUTES = new Set( [
 	'className',
 ] );
 
-// TODO: Hook this up to the actual logic in removeBlockSupportAttributes
 export const KNOWN_STYLES = new Set( [
 	'border',
 	'color',
@@ -45,19 +41,15 @@ export function rendererPath( block, attributes = null, urlQueryArgs = {} ) {
 }
 
 export function removeBlockSupportAttributes( attributes ) {
-	const {
-		backgroundColor,
-		borderColor,
-		fontFamily,
-		fontSize,
-		gradient,
-		textColor,
-		className,
-		...restAttributes
-	} = attributes;
+	const restAttributes = { ...attributes };
+	for ( const attribute of KNOWN_ATTRIBUTES ) {
+		delete restAttributes[ attribute ];
+	}
 
-	const { border, color, elements, spacing, typography, ...restStyles } =
-		attributes?.style || EMPTY_OBJECT;
+	const restStyles = { ...attributes?.style };
+	for ( const style of KNOWN_STYLES ) {
+		delete restStyles[ style ];
+	}
 
 	return {
 		...restAttributes,

--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -15,19 +15,25 @@ import { Placeholder, Spinner } from '@wordpress/components';
 import { __experimentalSanitizeBlockAttributes } from '@wordpress/blocks';
 
 export const KNOWN_ATTRIBUTES = new Set( [
+	'anchor',
 	'backgroundColor',
 	'borderColor',
+	'className',
 	'fontFamily',
 	'fontSize',
 	'gradient',
+	'layout',
+	'shadow',
 	'textColor',
-	'className',
 ] );
 
 export const KNOWN_STYLES = new Set( [
 	'border',
 	'color',
 	'elements',
+	'layout',
+	'position',
+	'shadow',
 	'spacing',
 	'typography',
 ] );

--- a/packages/server-side-render/src/test/remove-block-support-attributes.js
+++ b/packages/server-side-render/src/test/remove-block-support-attributes.js
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+const { existsSync, readdirSync, readFileSync } = require( 'fs' );
+const { join } = require( 'path' );
+
+/**
+ * Internal dependencies
+ */
+const {
+	KNOWN_ATTRIBUTES,
+	KNOWN_STYLES,
+} = require( '../server-side-render.js' );
+
+/*
+ * Path to the lib/block-supports directory
+ */
+const BLOCK_SUPPORTS_DIR = 'lib/block-supports';
+
+/*
+ * Regular expression to match instances of PHP code inside BLOCK_SUPPORTS_DIR
+ * where an attribute is being accessed by name.
+ *
+ * @example $block_type->attributes['anchor'] = array( ... )
+ */
+const ATTRIBUTE_KEY_PATTERN = /attributes\['(\w+)'\]/g;
+
+/*
+ * Regular expression to match instances of PHP code inside BLOCK_SUPPORTS_DIR
+ * where a style property is being accessed by name.
+ *
+ * @example $block_attributes['style']['typography']['letterSpacing']
+ */
+const STYLE_KEY_PATTERN = /\['style'\]\['(\w+)'\]/g;
+
+describe( 'removeBlockSupportAttributes', () => {
+	it( 'tests should be able to access lib/block-supports', () => {
+		expect( existsSync( BLOCK_SUPPORTS_DIR ) ).toBe( true );
+	} );
+
+	it( 'tests should be able to read source code from lib/block-supports', () => {
+		const dir = readdirSync( BLOCK_SUPPORTS_DIR );
+		expect( dir ).toContainEqual( expect.stringMatching( /\.php$/ ) );
+	} );
+
+	it( 'its constant KNOWN_ATTRIBUTES is up to date', () => {
+		const attributes = new Set();
+		const dir = readdirSync( BLOCK_SUPPORTS_DIR );
+
+		for ( const fileName of dir ) {
+			if ( fileName.match( /\.php$/ ) ) {
+				const path = join( BLOCK_SUPPORTS_DIR, fileName );
+				for ( let attributeName of grep(
+					path,
+					ATTRIBUTE_KEY_PATTERN
+				) ) {
+					if ( attributeName === 'class' )
+						attributeName = 'className';
+					attributes.add( attributeName );
+				}
+			}
+		}
+
+		// Styles are handled separately.
+		attributes.delete( 'style' );
+
+		expect( attributes ).toEqual( KNOWN_ATTRIBUTES );
+	} );
+
+	it( 'its constant KNOWN_STYLES is up to date', () => {
+		const styles = new Set();
+		const dir = readdirSync( BLOCK_SUPPORTS_DIR );
+
+		for ( const fileName of dir ) {
+			if ( fileName.match( /\.php$/ ) ) {
+				const path = join( BLOCK_SUPPORTS_DIR, fileName );
+				for ( let attributeName of grep( path, STYLE_KEY_PATTERN ) ) {
+					if ( attributeName === 'class' )
+						attributeName = 'className';
+					styles.add( attributeName );
+				}
+			}
+		}
+
+		expect( styles ).toEqual( KNOWN_STYLES );
+	} );
+} );
+
+/**
+ * @param {string} filename Path to the source file.
+ * @param {RegExp} pattern  Regular expression to match against.
+ * @return {Set<string>}    Set of matching attribute names.
+ */
+function grep( filename, pattern ) {
+	const contents = readFileSync( filename, 'utf8' ).toString();
+	const matches = Array.from( contents.matchAll( pattern ) );
+	return new Set( matches.map( ( [ , match ] ) => match ) );
+}

--- a/packages/server-side-render/src/test/remove-block-support-attributes.js
+++ b/packages/server-side-render/src/test/remove-block-support-attributes.js
@@ -82,7 +82,10 @@ describe( 'removeBlockSupportAttributes', () => {
 			}
 		}
 
-		expect( styles ).toEqual( KNOWN_STYLES );
+		// styles should be a subset of KNOWN_STYLES
+		expect( Array.from( KNOWN_STYLES ) ).not.toEqual(
+			expect.not.arrayContaining( Array.from( styles ) )
+		);
 	} );
 } );
 


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/pull/44491#issuecomment-1457977535

## Why?
In #44491, the `ServerSideRender` component gained a new `skipBlockSupportAttributes` prop used to strip blocks' attributes of block-supports-related attributes and styles. This is implemented in a local function, `removeBlockSupportAttributes`, in which those known attributes and styles were hardcoded.

I raised the concern in https://github.com/WordPress/gutenberg/pull/44491#issuecomment-1457977535 that this could easily get out of sync, as over time block-supports features are added or edited, since there is no obvious connection between that subsystem and the `ServerSideRender` component.

## What?
This PR explores a solution to that problem by adding unit tests dedicated to `removeBlockSupportAttributes`.

## How?
These tests are a bit atypical, since they they use Node's `fs` API to grep through source files in `lib/block-supports` to collect the names of attributes and styles that potentially correspond to block-supports features.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
