### PR TITLE
Block editor: hooks: fix rules of hooks violations

### DIFF
--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -50,6 +50,10 @@ export function useLayoutClasses( blockAttributes = {}, blockName ) {
 
 	const { layout } = blockAttributes;
 
+	if ( ! hasBlockSupport( blockName, layoutBlockSupportKey ) ) {
+		return [];
+	}
+
 	const { default: defaultBlockLayout } =
 		getBlockSupport( blockName, layoutBlockSupportKey ) || {};
 	const usedLayout =
@@ -372,9 +376,7 @@ export const withLayoutStyles = createHigherOrderComponent(
 			layout?.inherit || layout?.contentSize || layout?.wideSize
 				? { ...layout, type: 'constrained' }
 				: layout || defaultBlockLayout || {};
-		const layoutClasses = hasLayoutBlockSupport
-			? useLayoutClasses( attributes, name )
-			: null;
+		const layoutClasses = useLayoutClasses( attributes, name );
 		// Higher specificity to override defaults from theme.json.
 		const selector = `.wp-container-${ id }.wp-container-${ id }`;
 		const blockGapSupport = useSetting( 'spacing.blockGap' );

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -35,18 +35,22 @@ const layoutBlockSupportKey = '__experimentalLayout';
 /**
  * Generates the utility classnames for the given block's layout attributes.
  *
- * @param { Object } blockAttributes Block attributes.
- * @param { string } blockName       Block name.
+ * @param {Object} blockAttributes      Block attributes.
+ * @param {string} blockName            Block name.
+ * @param {Object} globalLayoutSettings Global layout settings.
  *
  * @return { Array } Array of CSS classname strings.
  */
-export function useLayoutClasses( blockAttributes = {}, blockName ) {
+export function useLayoutClasses(
+	blockAttributes = {},
+	blockName,
+	globalLayoutSettings
+) {
 	const rootPaddingAlignment = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		return getSettings().__experimentalFeatures
 			?.useRootPaddingAwareAlignments;
 	}, [] );
-	const globalLayoutSettings = useSetting( 'layout' ) || {};
 
 	const { layout } = blockAttributes;
 
@@ -376,7 +380,11 @@ export const withLayoutStyles = createHigherOrderComponent(
 			layout?.inherit || layout?.contentSize || layout?.wideSize
 				? { ...layout, type: 'constrained' }
 				: layout || defaultBlockLayout || {};
-		const layoutClasses = useLayoutClasses( attributes, name );
+		const layoutClasses = useLayoutClasses(
+			attributes,
+			name,
+			defaultThemeLayout
+		);
 		// Higher specificity to override defaults from theme.json.
 		const selector = `.wp-container-${ id }.wp-container-${ id }`;
 		const blockGapSupport = useSetting( 'spacing.blockGap' );

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -322,8 +322,8 @@ export const withInspectorControls = createHigherOrderComponent(
 			blockName,
 			POSITION_SUPPORT_KEY
 		);
-		const showPositionControls =
-			positionSupport && ! useIsPositionDisabled( props );
+		const isPositionDisabled = useIsPositionDisabled( props );
+		const showPositionControls = positionSupport && ! isPositionDisabled;
 
 		return [
 			showPositionControls && (

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -322,8 +322,8 @@ export const withInspectorControls = createHigherOrderComponent(
 			blockName,
 			POSITION_SUPPORT_KEY
 		);
-		const isPositionDisabled = useIsPositionDisabled( props );
-		const showPositionControls = positionSupport && ! isPositionDisabled;
+		const showPositionControls =
+			positionSupport && ! useIsPositionDisabled( props );
 
 		return [
 			showPositionControls && (
@@ -349,9 +349,8 @@ export const withPositionStyles = createHigherOrderComponent(
 			name,
 			POSITION_SUPPORT_KEY
 		);
-		const isPositionDisabled = useIsPositionDisabled( props );
 		const allowPositionStyles =
-			hasPositionBlockSupport && ! isPositionDisabled;
+			hasPositionBlockSupport && ! useIsPositionDisabled( props );
 
 		const id = useInstanceId( BlockListBlock );
 		const element = useContext( BlockList.__unstableElementContext );

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -349,8 +349,9 @@ export const withPositionStyles = createHigherOrderComponent(
 			name,
 			POSITION_SUPPORT_KEY
 		);
+		const isPositionDisabled = useIsPositionDisabled( props );
 		const allowPositionStyles =
-			hasPositionBlockSupport && ! useIsPositionDisabled( props );
+			hasPositionBlockSupport && ! isPositionDisabled;
 
 		const id = useInstanceId( BlockListBlock );
 		const element = useContext( BlockList.__unstableElementContext );

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -259,7 +259,8 @@ export default function VisualEditor( { styles } ) {
 
 	const postContentLayoutClasses = useLayoutClasses(
 		newestPostContentAttributes,
-		'core/post-content'
+		'core/post-content',
+		globalLayoutSettings
 	);
 
 	const blockListLayoutClass = classnames(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Hooks shouldn't be called conditionally. It looks like the linting is failing because of the HoCs.

I'm fixing this in a separate PR because this could potentially degrade performance (4 additional useSelect calls per block) and want to make sure it can be tracked back to the correct commit.

I did a quick check for `? use` and `&& use` in the code base and couldn't find any other violations.

See also #48884. Worth noting that these HoCs will soon disappear.

## Why?

Rules of hooks violation.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
