### PR TITLE
Writing Flow: Allow Escape key to deselect blocks and selection during multiselection

### DIFF
--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -59,6 +59,7 @@ export default function BlockTools( {
 		insertAfterBlock,
 		insertBeforeBlock,
 		clearSelectedBlock,
+		selectBlock,
 		moveBlocksUp,
 		moveBlocksDown,
 	} = useDispatch( blockEditorStore );
@@ -108,7 +109,15 @@ export default function BlockTools( {
 			const clientIds = getSelectedBlockClientIds();
 			if ( clientIds.length ) {
 				event.preventDefault();
-				clearSelectedBlock();
+
+				// If there is more than one block selected, select the first
+				// block so that focus is directed back to the beginning of the selection.
+				// In effect, to the user this feels like deselecting the multi-selection.
+				if ( clientIds.length > 1 ) {
+					selectBlock( clientIds[ 0 ] );
+				} else {
+					clearSelectedBlock();
+				}
 				event.target.ownerDocument.defaultView
 					.getSelection()
 					.removeAllRanges();

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -86,7 +86,7 @@ export default function useTabNav() {
 				return;
 			}
 
-			if ( event.keyCode === ESCAPE ) {
+			if ( event.keyCode === ESCAPE && ! hasMultiSelection() ) {
 				event.preventDefault();
 				setNavigationMode( true );
 				return;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes: https://github.com/WordPress/gutenberg/issues/47172, #5524 

This is a small PR that updates the check for switching to navigation mode when a user presses Escape. It's small but has a side effect:

When multiple blocks are selected and a user presses Escape, the blocks will be deselected, along with any partial selection across blocks. This is because the [`core/block-editor/unselect`](https://github.com/WordPress/gutenberg/blob/43617dc2ca0e0582dd7fb8806e6b8cb620f6ee90/packages/block-editor/src/components/block-tools/index.js#L107) shortcut will be allowed to fire.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

There appear to have been a number of iterations surrounding this behaviour over the past year or two, however the recent discussion over in #47172 highlights that it'd be good to make it easier for users to be able to quickly and easily deselect blocks via the keyboard.

From my perspective, when multiple blocks are selected in the editor canvas, it feels more likely that someone trying to press Escape will be looking to remove their selection rather than switch editing modes. I'm only a sample size of one, but to me, this feels a bit more intuitive.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update the check when switching modes to Navigation to only do so if not in a multiple block selection. This means that when multiple blocks are selected, the keyboard shortcut for clearing blocks will fire.

Then, in the logic for the unselect shortcut, if we're in a multi selection, _select_ the first block of the selection. To a user, this should have the "feeling" as though the multi selection has been deselected, with focus redirected back to the beginning of the selection.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In a post with multiple blocks, try selecting across multiple blocks and press ESCAPE. The blocks should be deselected.
2. With either a single block or no block selected, press ESCAPE and the editing mode should switch to navigation.

## Screenshots or screencast <!-- if applicable -->

![2023-03-08 14 35 40](https://user-images.githubusercontent.com/14988353/223613613-d33869a8-4fb3-452e-ab6e-5d270b1515e4.gif)
