### PR TITLE
Fix template part actions in List View

### DIFF
--- a/packages/edit-site/src/components/template-part-converter/convert-to-regular.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-regular.js
@@ -2,14 +2,11 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import {
-	BlockSettingsMenuControls,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-export default function ConvertToRegularBlocks( { clientId } ) {
+export default function ConvertToRegularBlocks( { clientId, onClose } ) {
 	const { getBlocks } = useSelect( blockEditorStore );
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 
@@ -23,17 +20,13 @@ export default function ConvertToRegularBlocks( { clientId } ) {
 	}
 
 	return (
-		<BlockSettingsMenuControls>
-			{ ( { onClose } ) => (
-				<MenuItem
-					onClick={ () => {
-						replaceBlocks( clientId, getBlocks( clientId ) );
-						onClose();
-					} }
-				>
-					{ __( 'Detach blocks from template part' ) }
-				</MenuItem>
-			) }
-		</BlockSettingsMenuControls>
+		<MenuItem
+			onClick={ () => {
+				replaceBlocks( clientId, getBlocks( clientId ) );
+				onClose();
+			} }
+		>
+			{ __( 'Detach blocks from template part' ) }
+		</MenuItem>
 	);
 }

--- a/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
@@ -2,10 +2,7 @@
  * WordPress dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
-import {
-	BlockSettingsMenuControls,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { MenuItem } from '@wordpress/components';
 import { createBlock, serialize } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
@@ -78,18 +75,14 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 
 	return (
 		<>
-			<BlockSettingsMenuControls>
-				{ () => (
-					<MenuItem
-						icon={ symbolFilled }
-						onClick={ () => {
-							setIsModalOpen( true );
-						} }
-					>
-						{ __( 'Create Template part' ) }
-					</MenuItem>
-				) }
-			</BlockSettingsMenuControls>
+			<MenuItem
+				icon={ symbolFilled }
+				onClick={ () => {
+					setIsModalOpen( true );
+				} }
+			>
+				{ __( 'Create Template part' ) }
+			</MenuItem>
 			{ isModalOpen && (
 				<CreateTemplatePartModal
 					closeModal={ () => {

--- a/packages/edit-site/src/components/template-part-converter/index.js
+++ b/packages/edit-site/src/components/template-part-converter/index.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import {
+	BlockSettingsMenuControls,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -11,20 +14,33 @@ import ConvertToRegularBlocks from './convert-to-regular';
 import ConvertToTemplatePart from './convert-to-template-part';
 
 export default function TemplatePartConverter() {
-	const { clientIds, blocks } = useSelect( ( select ) => {
-		const { getSelectedBlockClientIds, getBlocksByClientId } =
-			select( blockEditorStore );
-		const selectedBlockClientIds = getSelectedBlockClientIds();
-		return {
-			clientIds: selectedBlockClientIds,
-			blocks: getBlocksByClientId( selectedBlockClientIds ),
-		};
-	}, [] );
+	return (
+		<BlockSettingsMenuControls>
+			{ ( { selectedClientIds, onClose } ) => (
+				<TemplatePartConverterMenuItem
+					clientIds={ selectedClientIds }
+					onClose={ onClose }
+				/>
+			) }
+		</BlockSettingsMenuControls>
+	);
+}
+
+function TemplatePartConverterMenuItem( { clientIds, onClose } ) {
+	const blocks = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getBlocksByClientId( clientIds ),
+		[ clientIds ]
+	);
 
 	// Allow converting a single template part to standard blocks.
 	if ( blocks.length === 1 && blocks[ 0 ]?.name === 'core/template-part' ) {
-		return <ConvertToRegularBlocks clientId={ clientIds[ 0 ] } />;
+		return (
+			<ConvertToRegularBlocks
+				clientId={ clientIds[ 0 ] }
+				onClose={ onClose }
+			/>
+		);
 	}
-
 	return <ConvertToTemplatePart clientIds={ clientIds } blocks={ blocks } />;
 }


### PR DESCRIPTION
## What?
Fixes #48818

As described on the issue, the 'Create template part' or 'Convert to regular blocks' actions in the block settings menu don't always work as expected in List View.

For List View, a user can perform one of those actions on a non-selected block. The code was written with the assumption that the action would always be carried out on a selected block as would always be the case in the editor canvas. 

I imagine that code predates the existence of the menu in List View.

## How?
Updates the code to use the `selectedClientIds` param from the `BlockSettingsMenuControls` fill, which provides the correct block client Ids to perform the operation on.

This required a little bit of a refactor. The `BlockSettingsMenuControls` component now has to be higher in the component tree. This doesn't seem to cause any unwanted side-effects from my testing.

## Testing Instructions
1. Insert a Group block containing an image and a heading.
2. Insert a Paragraph block below the Group block (not nested) with the text: "Should not be in template part".
3. Open the List View and ensure the Paragraph block is selected.
4. Click the ellipsis beside the Group block, and create a template part called **My Group**.
5. Navigate to `Template parts > My Group`.

In trunk: 🐞 Notice that the template part contains the Paragraph block, rather than the Group block.
In this PR: ✅  The template part correctly contains the group block

## Screenshots or screencast <!-- if applicable -->

#### Before
https://user-images.githubusercontent.com/677833/223614249-1df2c3aa-6790-411d-8bfc-5f3004a69604.mp4

#### After
https://user-images.githubusercontent.com/677833/223613864-132a5661-0ab1-4042-adca-8139b3f5b670.mp4


