### PR TITLE
Fix navigation block off-canvas appender for empty menus

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/appender.js
+++ b/packages/block-editor/src/components/off-canvas-editor/appender.js
@@ -102,7 +102,7 @@ export const Appender = forwardRef(
 					ref={ ref }
 					rootClientId={ clientId }
 					position="bottom right"
-					isAppender={ true }
+					isAppender
 					selectBlockOnInsert={ false }
 					shouldDirectInsert={ false }
 					__experimentalIsQuick

--- a/packages/block-editor/src/components/off-canvas-editor/index.js
+++ b/packages/block-editor/src/components/off-canvas-editor/index.js
@@ -56,6 +56,7 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
  *
  * @param {Object}  props                 Components props.
  * @param {string}  props.id              An HTML element id for the root element of ListView.
+ * @param {string}  props.parentClientId  The client id of the parent block.
  * @param {Array}   props.blocks          Custom subset of block client IDs to be used instead of the default hierarchy.
  * @param {boolean} props.showBlockMovers Flag to enable block movers
  * @param {boolean} props.isExpanded      Flag to determine whether nested levels are expanded by default.
@@ -68,6 +69,7 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
 function OffCanvasEditor(
 	{
 		id,
+		parentClientId,
 		blocks,
 		showBlockMovers = false,
 		isExpanded = false,
@@ -82,10 +84,9 @@ function OffCanvasEditor(
 	const { clientIdsTree, draggedClientIds, selectedClientIds } =
 		useListViewClientIds( blocks );
 
-	const { visibleBlockCount, shouldShowInnerBlocks, parentId } = useSelect(
+	const { visibleBlockCount, shouldShowInnerBlocks } = useSelect(
 		( select ) => {
 			const {
-				getBlockRootClientId,
 				getGlobalBlockCount,
 				getClientIdsOfDescendants,
 				__unstableGetEditorMode,
@@ -97,10 +98,6 @@ function OffCanvasEditor(
 			return {
 				visibleBlockCount: getGlobalBlockCount() - draggedBlockCount,
 				shouldShowInnerBlocks: __unstableGetEditorMode() !== 'zoom-out',
-				parentId:
-					blocks.length > 0
-						? getBlockRootClientId( blocks[ 0 ].clientId )
-						: undefined,
 			};
 		},
 		[ draggedClientIds, blocks ]
@@ -234,7 +231,7 @@ function OffCanvasEditor(
 				>
 					<ListViewContext.Provider value={ contextValue }>
 						<ListViewBranch
-							parentId={ parentId }
+							parentId={ parentClientId }
 							blocks={ clientIdsTree }
 							selectBlock={ selectEditorBlock }
 							showBlockMovers={ showBlockMovers }

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -69,6 +69,7 @@ const MainContent = ( {
 	return (
 		<OffCanvasEditor
 			blocks={ clientIdsTree }
+			parentClientId={ clientId }
 			isExpanded={ true }
 			LeafMoreMenu={ LeafMoreMenu }
 			description={ description }


### PR DESCRIPTION
## What?
Fixes an issue with the navigation block's off canvas appender, where when trying to add a block to an empty menu, the pattern view of the quick inserter was being shown instead of the list of block types.

## How?
The issue is that the parent client id (the client id of the navigation block) was being determined by checking the parent of the first child block.

When there are no inner blocks, this fails and the quick inserter thinks a block is being inserted at the root level, so shows patterns instead of block types.

The fix is to pass the parent client id as a prop of the `OffCanvasEditor`. Previously I think this was avoided because it would make it hard to merge this code back into the main `ListView` component, but that code was written when empty menus had no appender.

I think it's better to fix this bug now for WordPress 6.2 and think about a more general solution to the differences between `OffCanvasEditor` and `ListView` later.

The `OffCanvasEditor` is private, so there's no detriment to external APIs.

## Testing Instructions
1. Add a navigation block to a template
2. In the block inspector, create a new menu using the 'Navigation' dropdown
3. Try using the '+' button that appears to insert a block

Expected: It should show a list of block types
In trunk: It shows patterns

## Screenshots or screencast <!-- if applicable -->
#### Before
![Screen Shot 2023-03-08 at 1 44 54 pm](https://user-images.githubusercontent.com/677833/223629432-6c6a390a-ce77-4652-9cd9-977e9ef9e02e.png)

#### After
![Screen Shot 2023-03-08 at 1 44 31 pm](https://user-images.githubusercontent.com/677833/223629471-f2d766de-3acd-4ede-8528-b57cb65b4640.png)

