### PR TITLE
Site Editor: Improve the Navigation panel's menu query

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -18,6 +18,8 @@ import SidebarNavigationItem from '../sidebar-navigation-item';
 
 export default function SidebarNavigationScreenMain() {
 	const hasNavigationMenus = useSelect( ( select ) => {
+		// The query needs to be the same as in the "SidebarNavigationScreenNavigationMenus" component,
+		// to avoid double network calls.
 		const navigationMenus = select( coreStore ).getEntityRecords(
 			'postType',
 			'wp_navigation',

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -17,14 +17,19 @@ import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import SidebarNavigationItem from '../sidebar-navigation-item';
 
 export default function SidebarNavigationScreenMain() {
-	const { navigationMenus } = useSelect( ( select ) => {
-		const { getEntityRecords } = select( coreStore );
-		return {
-			navigationMenus: getEntityRecords( 'postType', 'wp_navigation', {
-				per_page: -1,
+	const hasNavigationMenus = useSelect( ( select ) => {
+		const navigationMenus = select( coreStore ).getEntityRecords(
+			'postType',
+			'wp_navigation',
+			{
+				per_page: 1,
 				status: 'publish',
-			} ),
-		};
+				order: 'desc',
+				orderby: 'date',
+			}
+		);
+
+		return navigationMenus?.length > 0;
 	} );
 
 	return (
@@ -36,7 +41,7 @@ export default function SidebarNavigationScreenMain() {
 			) }
 			content={
 				<ItemGroup>
-					{ !! navigationMenus && navigationMenus.length > 0 && (
+					{ hasNavigationMenus && (
 						<NavigatorButton
 							as={ SidebarNavigationItem }
 							path="/navigation"

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -23,7 +23,12 @@ import { unlock } from '../../private-apis';
 import { store as editSiteStore } from '../../store';
 
 const noop = () => {};
-const NAVIGATION_MENUS_QUERY = { per_page: -1, status: 'publish' };
+const NAVIGATION_MENUS_QUERY = {
+	per_page: 1,
+	status: 'publish',
+	order: 'desc',
+	orderby: 'date',
+};
 
 function SidebarNavigationScreenWrapper( { children, actions } ) {
 	return (
@@ -66,17 +71,7 @@ export default function SidebarNavigationScreenNavigationMenus() {
 			};
 		}, [] );
 
-	// Sort navigation menus by date.
-	const orderedNavigationMenus = useMemo(
-		() =>
-			navigationMenus?.sort( ( menuA, menuB ) => {
-				const menuADate = new Date( menuA.date );
-				const menuBDate = new Date( menuB.date );
-				return menuADate.getTime() > menuBDate.getTime();
-			} ),
-		[ navigationMenus ]
-	);
-	const firstNavigationMenu = orderedNavigationMenus?.[ 0 ]?.id;
+	const firstNavigationMenu = navigationMenus?.[ 0 ]?.id;
 	const blocks = useMemo( () => {
 		return [
 			createBlock( 'core/navigation', { ref: firstNavigationMenu } ),


### PR DESCRIPTION
## What?
This is a follow-up to #48689.

PR improves REST API query for the Site Editor's navigation panel.

## Why?
The component was fetching all published navigation menus and sorting them by date on the client side - this isn't necessary. The REST API can handle this directly.

## How?
I've updated `NAVIGATION_MENUS_QUERY` to fetch the last published navigation menu.

## Testing Instructions
1. Confirm your last published navigation menu loads as before on this branch.
2. Create a new menu and add items.
3. Confirm it replaces the previous navigation menu in the sidebar.
