### PR TITLE
Fix grouping actions in List View

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -48,7 +48,8 @@ const BlockSettingsMenuControlsSlot = ( {
 
 	// Check if current selection of blocks is Groupable or Ungroupable
 	// and pass this props down to ConvertToGroupButton.
-	const convertToGroupButtonProps = useConvertToGroupButtonProps();
+	const convertToGroupButtonProps =
+		useConvertToGroupButtonProps( selectedClientIds );
 	const { isGroupable, isUngroupable } = convertToGroupButtonProps;
 	const showConvertToGroupButton =
 		( isGroupable || isUngroupable ) && canRemove;

--- a/packages/block-editor/src/components/convert-to-group-buttons/use-convert-to-group-button-props.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/use-convert-to-group-button-props.js
@@ -25,59 +25,69 @@ import { store as blockEditorStore } from '../../store';
  * It is used in `BlockSettingsMenuControls` to know if `ConvertToGroupButton`
  * should be rendered, to avoid ending up with an empty MenuGroup.
  *
+ * @param {?string[]} selectedClientIds An optional array of clientIds to group. The selected blocks
+ *                                      from the block editor store are used if this is not provided.
+ *
  * @return {ConvertToGroupButtonProps} Returns the properties needed by `ConvertToGroupButton`.
  */
-export default function useConvertToGroupButtonProps() {
+export default function useConvertToGroupButtonProps( selectedClientIds ) {
 	const {
 		clientIds,
 		isGroupable,
 		isUngroupable,
 		blocksSelection,
 		groupingBlockName,
-	} = useSelect( ( select ) => {
-		const {
-			getBlockRootClientId,
-			getBlocksByClientId,
-			canInsertBlockType,
-			getSelectedBlockClientIds,
-		} = select( blockEditorStore );
-		const { getGroupingBlockName } = select( blocksStore );
+	} = useSelect(
+		( select ) => {
+			const {
+				getBlockRootClientId,
+				getBlocksByClientId,
+				canInsertBlockType,
+				getSelectedBlockClientIds,
+			} = select( blockEditorStore );
+			const { getGroupingBlockName } = select( blocksStore );
 
-		const _clientIds = getSelectedBlockClientIds();
-		const _groupingBlockName = getGroupingBlockName();
+			const _clientIds = selectedClientIds?.length
+				? selectedClientIds
+				: getSelectedBlockClientIds();
+			const _groupingBlockName = getGroupingBlockName();
 
-		const rootClientId = !! _clientIds?.length
-			? getBlockRootClientId( _clientIds[ 0 ] )
-			: undefined;
+			const rootClientId = !! _clientIds?.length
+				? getBlockRootClientId( _clientIds[ 0 ] )
+				: undefined;
 
-		const groupingBlockAvailable = canInsertBlockType(
-			_groupingBlockName,
-			rootClientId
-		);
+			const groupingBlockAvailable = canInsertBlockType(
+				_groupingBlockName,
+				rootClientId
+			);
 
-		const _blocksSelection = getBlocksByClientId( _clientIds );
+			const _blocksSelection = getBlocksByClientId( _clientIds );
 
-		const isSingleGroupingBlock =
-			_blocksSelection.length === 1 &&
-			_blocksSelection[ 0 ]?.name === _groupingBlockName;
+			const isSingleGroupingBlock =
+				_blocksSelection.length === 1 &&
+				_blocksSelection[ 0 ]?.name === _groupingBlockName;
 
-		// Do we have
-		// 1. Grouping block available to be inserted?
-		// 2. One or more blocks selected
-		const _isGroupable = groupingBlockAvailable && _blocksSelection.length;
+			// Do we have
+			// 1. Grouping block available to be inserted?
+			// 2. One or more blocks selected
+			const _isGroupable =
+				groupingBlockAvailable && _blocksSelection.length;
 
-		// Do we have a single Group Block selected and does that group have inner blocks?
-		const _isUngroupable =
-			isSingleGroupingBlock &&
-			!! _blocksSelection[ 0 ].innerBlocks.length;
-		return {
-			clientIds: _clientIds,
-			isGroupable: _isGroupable,
-			isUngroupable: _isUngroupable,
-			blocksSelection: _blocksSelection,
-			groupingBlockName: _groupingBlockName,
-		};
-	}, [] );
+			// Do we have a single Group Block selected and does that group have inner blocks?
+			const _isUngroupable =
+				isSingleGroupingBlock &&
+				!! _blocksSelection[ 0 ].innerBlocks.length;
+			return {
+				clientIds: _clientIds,
+				isGroupable: _isGroupable,
+				isUngroupable: _isUngroupable,
+				blocksSelection: _blocksSelection,
+				groupingBlockName: _groupingBlockName,
+			};
+		},
+		[ selectedClientIds ]
+	);
+
 	return {
 		clientIds,
 		isGroupable,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Similar to  #48905, the grouping actions in List View will sometimes operate on the wrong blocks, as the code was written with selected blocks in mind. In List View it's possible to group non-selected blocks.

(kudos to @andrewserong for spotting this)

## How?
The fix is a little different (actually simpler) as the grouping options don't use a `BlockSettingsMenuControls`, but they do still have access to the same list of `clientIds`.

I've updated the `useConvertToGroupButtonProps` hook, which is a kind of ubiquitous grouping intermediary, to optionally accept those clientIds. When provided it'll bypass using the `getSelectedBlockClientIds` selector.

## Testing Instructions
1. Insert a couple of blocks
2. Open List View and select the first one, but try grouping the second deselected block

Expected: The correct block should be grouped
In trunk: The wrong block is grouped

## Screenshots or screencast <!-- if applicable -->

#### Before
https://user-images.githubusercontent.com/677833/223650220-c254f02e-8629-4699-8f0a-3e6e8850df6c.mp4


#### After
https://user-images.githubusercontent.com/677833/223649807-17a255d8-c4a0-4663-b7ea-589ebfc4ac1b.mp4

