### PR TITLE
Fix lingering insertion point within template parts

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2842,12 +2842,12 @@ export function __unstableHasActiveBlockOverlayActive( state, clientId ) {
 }
 
 export function __unstableIsWithinBlockOverlay( state, clientId ) {
-	let parent = state.blocks.parents[ clientId ];
+	let parent = state.blocks.parents.get( clientId );
 	while ( !! parent ) {
 		if ( __unstableHasActiveBlockOverlayActive( state, parent ) ) {
 			return true;
 		}
-		parent = state.blocks.parents[ parent ];
+		parent = state.blocks.parents.get( parent );
 	}
 	return false;
 }

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -4,15 +4,6 @@
 	color: $white;
 	display: flex;
 	flex-direction: column;
-
-	&:not(.is-edit-mode) {
-		// Ideally, this component shouldn't render in edit mode
-		// but it happens sporadically, this is a hack
-		// to prevent it from showing up in view mode.
-		.block-editor-block-list__insertion-point {
-			display: none;
-		}
-	}
 }
 
 .edit-site-layout__hub {

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -4,6 +4,15 @@
 	color: $white;
 	display: flex;
 	flex-direction: column;
+
+	&:not(.is-edit-mode) {
+		// Ideally, this component shouldn't render in edit mode
+		// but it happens sporadically, this is a hack
+		// to prevent it from showing up in view mode.
+		.block-editor-block-list__insertion-point {
+			display: none;
+		}
+	}
 }
 
 .edit-site-layout__hub {


### PR DESCRIPTION
## What?

The issue is that when you had blocks within "locked" containers like template parts, the in-between inserter was triggering but it shouldn't be the case. (The error was actually a missing change during the reducer refactor to maps)

## Testing Instructions

1- Open a template with template parts and within the template you should have several inner blocks and group blocks.
2- Move the mouse between two of these inner blocks.
3- The in-between inserter shouldn't trigger.