### PR TITLE
Navigation: Simplify the method for finding the fallback menu

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -12,7 +12,6 @@ import {
 	useEffect,
 	useRef,
 	Platform,
-	useMemo,
 } from '@wordpress/element';
 import {
 	InspectorControls,
@@ -202,17 +201,9 @@ function Navigation( {
 		classicMenuConversionStatus === CLASSIC_MENU_CONVERSION_PENDING;
 
 	// Only autofallback to published menus.
-	const fallbackNavigationMenus = useMemo(
-		() =>
-			navigationMenus
-				?.filter( ( menu ) => menu.status === 'publish' )
-				?.sort( ( menuA, menuB ) => {
-					const menuADate = new Date( menuA.date );
-					const menuBDate = new Date( menuB.date );
-					return menuADate.getTime() < menuBDate.getTime();
-				} ),
-		[ navigationMenus ]
-	);
+	const fallbackNavigationMenuId = navigationMenus?.find(
+		( menu ) => menu.status === 'publish'
+	)?.id;
 
 	const handleUpdateMenu = useCallback(
 		( menuId, options = { focusNavigationBlock: false } ) => {
@@ -237,7 +228,7 @@ function Navigation( {
 			hasUncontrolledInnerBlocks ||
 			isCreatingNavigationMenu ||
 			ref ||
-			! fallbackNavigationMenus?.length
+			! fallbackNavigationMenuId
 		) {
 			return;
 		}
@@ -250,12 +241,12 @@ function Navigation( {
 		 *  nor to be undoable, hence why it is marked as non persistent
 		 */
 		__unstableMarkNextChangeAsNotPersistent();
-		setRef( fallbackNavigationMenus[ 0 ].id );
+		setRef( fallbackNavigationMenuId );
 	}, [
 		ref,
 		setRef,
 		isCreatingNavigationMenu,
-		fallbackNavigationMenus,
+		fallbackNavigationMenuId,
 		hasUncontrolledInnerBlocks,
 		__unstableMarkNextChangeAsNotPersistent,
 	] );
@@ -277,7 +268,7 @@ function Navigation( {
 			! hasResolvedClassicMenus ||
 			! hasResolvedNavigationMenus ||
 			isConvertingClassicMenu ||
-			fallbackNavigationMenus?.length > 0 ||
+			fallbackNavigationMenuId ||
 			hasUnsavedBlocks ||
 			! classicMenus?.length
 		) {
@@ -317,7 +308,7 @@ function Navigation( {
 		classicMenus,
 		convertClassicMenu,
 		createNavigationMenu,
-		fallbackNavigationMenus?.length,
+		fallbackNavigationMenuId,
 		isConvertingClassicMenu,
 		ref,
 	] );

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -200,7 +200,8 @@ function Navigation( {
 	const isConvertingClassicMenu =
 		classicMenuConversionStatus === CLASSIC_MENU_CONVERSION_PENDING;
 
-	// Only autofallback to published menus.
+	// Only auto-fallback to the latest published menu.
+	// The REST API already returns items sorted by publishing date.
 	const fallbackNavigationMenuId = navigationMenus?.find(
 		( menu ) => menu.status === 'publish'
 	)?.id;


### PR DESCRIPTION
## What?
A follow-up based on https://github.com/WordPress/gutenberg/pull/48908#discussion_r1129087928.

PR simplifies the method for finding the fallback navigation menu ID.

## How?
* I removed sort by date since the REST API already returns items sorted by publishing date.
* Since the block only needs a fallback menu ID, I've replaced `fallbackNavigationMenus` with `fallbackNavigationMenuId` .
* I've also replaced `filter` with `find`. The latter stops iterating through the array when `callback` returns a truthy value. A small perf optimiazation.

## Testing Instructions
Make sure there's at least one published `wp_navigation` menu item. Go to `/wp-admin/edit.php?post_type=wp_navigation`
 
1. Open a Post or Page.
2. Insert a Navigation block.
3. Confirm latest published navigation menu is used as a fallback.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/223670218-d4b81334-b12c-4e28-a1fc-c9ac90882954.mp4

