### PR TITLE
LineHeightControl: Fix application of zero values in editor

### DIFF
--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -228,7 +228,7 @@ export default function TypographyPanel( {
 			immutableSet( value, [ 'typography', 'lineHeight' ], newValue )
 		);
 	};
-	const hasLineHeight = () => !! value?.typography?.lineHeight;
+	const hasLineHeight = () => value?.typography?.lineHeight !== undefined;
 	const resetLineHeight = () => setLineHeight( undefined );
 
 	// Letter Spacing

--- a/packages/block-editor/src/components/line-height-control/index.js
+++ b/packages/block-editor/src/components/line-height-control/index.js
@@ -85,12 +85,17 @@ const LineHeightControl = ( {
 		: { marginBottom: 24 };
 
 	const handleOnChange = ( nextValue, { event } ) => {
-		if ( event.type === 'click' ) {
-			onChange( adjustNextValue( nextValue, false ) );
+		if ( nextValue === '' ) {
+			onChange();
 			return;
 		}
 
-		onChange( nextValue );
+		if ( event.type === 'click' ) {
+			onChange( adjustNextValue( `${ nextValue }`, false ) );
+			return;
+		}
+
+		onChange( `${ nextValue }` );
 	};
 
 	return (

--- a/packages/block-editor/src/components/line-height-control/stories/index.js
+++ b/packages/block-editor/src/components/line-height-control/stories/index.js
@@ -23,7 +23,7 @@ const Template = ( props ) => {
 export const Default = Template.bind( {} );
 Default.args = {
 	__nextHasNoMarginBottom: true,
-	__unstableInputWidth: '60px',
+	__unstableInputWidth: '100px',
 };
 
 export const UnconstrainedWidth = Template.bind( {} );


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/48768

## What?

Prevents LineHeightControl resetting and clearing values when `0` line height selected.

## Why?

While zero line height might be an uncommon use case, as long as we allow zero as the minimum value for the control it should be honoured and remain when continuing to drag down, or use the down arrow key.

## How?

- Updated TypographyPanel's detection of when there is a line-height value set. This is less of a requirement when line-height is saved as a string however, the tweak is small and will handle any numeric line heights saved previously on blocks.
- Tweaked the width of the LineHeightControl input in the Storybook so the custom spin buttons fit
- Updated the LineHeightControl's change handling to ensure it handles an empty string value in a way that will work regardless of if cleanEmptyObject functions as per trunk now (`Boolean()`) or [#49750](https://github.com/WordPress/gutenberg/pull/49750) ( `!== undefined`). The control's `handleOnChange` will then ensure any defined line-height value is passed to it's onChange handler as a string. 

## Testing Instructions

1. Edit a post, select a paragraph, and navigate to the Block Inspector > Styles > Typography panel
2. Toggle on the Line Height control and enter a value e.g. 2
3. Now using either the down arrow key or dragging down on the input, attempt to decrement the value past 0. It should remain zero.
4. Clear the value in the field, then type 0, press enter, and then transfer focus elsewhere.
5. The zero value should still be retained.
6. Manually delete the value within the control
7. Switch to code editor view and ensure the block's style attribute doesn't contain a lineHeight property.


## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <video src="https://user-images.githubusercontent.com/60436221/223672884-174ee7ae-1a61-4dfa-8f2e-faf1090b4a16.mp4" /> | <video src="https://user-images.githubusercontent.com/60436221/223672896-8cea3b1c-a7a7-4d8b-a083-e8acdf5becc3.mp4" /> |

