### PR TITLE
Fix: Site button metrics

### DIFF
--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -11,7 +11,7 @@
 
 .edit-site-site-hub__view-mode-toggle-container {
 	height: $header-height;
-	width: $header-height + 4px;
+	width: $header-height;
 	flex-shrink: 0;
 	background: $gray-900;
 }


### PR DESCRIPTION
## What?

The "exit fullscreen" button in the site editor is too wide. 60x64:

<img width="323" alt="Screenshot 2023-03-08 at 10 17 05" src="https://user-images.githubusercontent.com/1204802/223673517-ccd98c20-f0db-416f-bd70-20773efea668.png">

<img width="332" alt="Screenshot 2023-03-08 at 10 19 07" src="https://user-images.githubusercontent.com/1204802/223673524-568bedc6-a525-4dd0-a65f-ac70cfe17ec3.png">

This appears to be due to #47120 which corrected these metrics for the site hub. But the site hub is visually changing again, so it seems this CSS is no longer correct. This PR removes the 4px:

<img width="297" alt="Screenshot 2023-03-08 at 10 20 07" src="https://user-images.githubusercontent.com/1204802/223673670-412f16fe-40ad-406d-9c85-22362b4123d8.png">

<img width="340" alt="Screenshot 2023-03-08 at 10 20 14" src="https://user-images.githubusercontent.com/1204802/223673680-e8873098-85bd-40a8-a947-44e35d7e446c.png">

That makes the button 60x60 again.

## Testing Instructions
Test the site editor and validate that the site back button is 60x60.