### PR TITLE
Navigation: Fix missing state for MenuControls

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -785,6 +785,7 @@ function Navigation( {
 						createNavigationMenuIsSuccess
 					}
 					createNavigationMenuIsError={ createNavigationMenuIsError }
+					currentMenuId={ ref }
 					isNavigationMenuMissing={ isNavigationMenuMissing }
 					isManageMenusButtonDisabled={ isManageMenusButtonDisabled }
 					onCreateNew={ createUntitledEmptyNavigationMenu }

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -46,10 +46,6 @@ const MainContent = ( {
 	const { navigationMenu } = useNavigationMenu( currentMenuId );
 
 	if ( currentMenuId && isNavigationMenuMissing ) {
-		return <p>{ __( 'Select or create a menu' ) }</p>;
-	}
-
-	if ( currentMenuId && isNavigationMenuMissing ) {
 		return <DeletedNavigationWarning onCreateNew={ onCreateNew } />;
 	}
 


### PR DESCRIPTION
## What?
PR fixes props passed to the missing navigation menu controls to avoid an infinite spinner in the sidebar.

## How?
Add the missing `currentMenuId` to the `MenuInspectorControls`.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Navigation Block with non-existing `ref` - `<!-- wp:navigation {"ref":9999} /-->`.
3. Confirm there's no infinite snipper displayed in the sidebar controls.

## Screenshots or screencast <!-- if applicable -->
**Before**
![CleanShot 2023-03-08 at 15 13 17](https://user-images.githubusercontent.com/240569/223701661-990097c4-96a2-4394-8def-341accc32295.png)

**After**
![CleanShot 2023-03-08 at 15 13 52](https://user-images.githubusercontent.com/240569/223701650-3434ead6-b67b-46e1-b289-cd8181404245.png)

