### PR TITLE
Remove template description in template management list

### DIFF
--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -97,7 +97,6 @@ export default function Table( { templateType } ) {
 									) }
 								</Link>
 							</Heading>
-							{ decodeEntities( template.description ) }
 						</td>
 
 						<td className="edit-site-list-table-column" role="cell">


### PR DESCRIPTION
## What?
Similar to https://github.com/WordPress/gutenberg/pull/48710. This PR removes the template descriptions in the manage template list, in preparation for the upcoming [longer descriptions](https://github.com/WordPress/gutenberg/issues/48290).

## Why?
With longer descriptions the table gets a bit out of hand. Here's a simulation:

<img width="1150" alt="Screenshot 2023-03-08 at 11 56 03" src="https://user-images.githubusercontent.com/846565/223709449-e61b8ff7-9646-4a9f-8829-885bde0b16a4.png">


## How?
Removed a line of code :)

I considered moving the description to a tooltip, but since this view is more about management / bulk actions it didn't seem important to include the full description. That detail can be gathered whilst editing the template, or from the template details panel.

## Testing Instructions
In the Site Editor, open the template management list. There should be no visible descriptions:

<img width="1137" alt="Screenshot 2023-03-08 at 12 04 58" src="https://user-images.githubusercontent.com/846565/223709536-b154a95a-a0b0-48b0-8144-1c033be2b157.png">