### PR TITLE
Improve perceived performance by preloading the template parts defined in Theme JSON when in Site Editor

### DIFF
--- a/lib/compat/wordpress-6.3/template-parts-preloading.php
+++ b/lib/compat/wordpress-6.3/template-parts-preloading.php
@@ -19,7 +19,16 @@ function gutenberg_preload_template_parts( $preload_paths, $context ) {
 		return $preload_paths;
 	}
 
-	$theme_slug = wp_get_theme()->get_stylesheet();
+	// Get any template parts defined in theme.json.
+	$theme_json_template_parts = WP_Theme_JSON_Resolver::get_merged_data()->get_template_parts();
+
+	if ( ! is_array( $theme_json_template_parts ) ) {
+		return $preload_paths;
+	}
+
+	$theme_json_template_part_slugs = array_keys( $theme_json_template_parts );
+
+	$theme_slug = get_stylesheet();
 
 	$template_parts_rest_route = rest_get_route_for_post_type_items(
 		'wp_template_part'
@@ -27,9 +36,9 @@ function gutenberg_preload_template_parts( $preload_paths, $context ) {
 
 	$standard_template_parts = array( 'header', 'footer' );
 
-	foreach ( $standard_template_parts as $template_part ) {
+	foreach ( $theme_json_template_part_slugs as $template_part_slug ) {
 		$preload_paths[] = array(
-			$template_parts_rest_route . "/$theme_slug//$template_part?context=edit",
+			$template_parts_rest_route . "/$theme_slug//$template_part_slug?context=edit",
 			'GET',
 		);
 	}

--- a/lib/compat/wordpress-6.3/template-parts-preloading.php
+++ b/lib/compat/wordpress-6.3/template-parts-preloading.php
@@ -15,7 +15,7 @@
  */
 function gutenberg_preload_template_parts( $preload_paths, $context ) {
 
-	$template_part_preloading_limit = apply_filters( 'gutenberg_template_part_preloading_limit', 10 );
+	$template_part_preloading_limit = apply_filters( 'gutenberg_template_part_preloading_limit', 3 );
 
 	// Limit to the Site Editor.
 	if ( ! empty( $context->name ) && 'core/edit-site' !== $context->name ) {

--- a/lib/compat/wordpress-6.3/template-parts-preloading.php
+++ b/lib/compat/wordpress-6.3/template-parts-preloading.php
@@ -38,7 +38,7 @@ function gutenberg_preload_template_parts( $preload_paths, $context ) {
 
 	foreach ( $theme_json_template_part_slugs as $template_part_slug ) {
 		$preload_paths[] = array(
-			$template_parts_rest_route . "/$theme_slug//$template_part_slug?context=edit",
+			$template_parts_rest_route . '/' . $theme_slug . '//' . $template_part_slug . '?context=edit',
 			'GET',
 		);
 	}

--- a/lib/compat/wordpress-6.3/template-parts-preloading.php
+++ b/lib/compat/wordpress-6.3/template-parts-preloading.php
@@ -15,6 +15,8 @@
  */
 function gutenberg_preload_template_parts( $preload_paths, $context ) {
 
+	$template_part_preloading_limit = apply_filters( 'gutenberg_template_part_preloading_limit', 10 );
+
 	// Limit to the Site Editor.
 	if ( ! empty( $context->name ) && 'core/edit-site' !== $context->name ) {
 		return $preload_paths;
@@ -44,6 +46,9 @@ function gutenberg_preload_template_parts( $preload_paths, $context ) {
 	$template_parts_rest_route = rest_get_route_for_post_type_items(
 		'wp_template_part'
 	);
+
+	// Limit the length of theme_json_template_part_slugs to $template_part_preloading_limit
+	$theme_json_template_part_slugs = array_slice( $theme_json_template_part_slugs, 0, $template_part_preloading_limit );
 
 	foreach ( $theme_json_template_part_slugs as $template_part_slug ) {
 		$preload_paths[] = array(

--- a/lib/compat/wordpress-6.3/template-parts-preloading.php
+++ b/lib/compat/wordpress-6.3/template-parts-preloading.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Patches resources loaded by the block editor page
+ * to include Template Part posts.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Preloads requests needed for common Template Part posts
+ *
+ * @param array $preload_paths    Preload paths to be filtered.
+ * @return array
+ */
+function gutenberg_preload_template_parts( $preload_paths ) {
+
+	$theme_slug = wp_get_theme()->get_stylesheet();
+
+	$template_parts_rest_route = rest_get_route_for_post_type_items(
+		'wp_template_part'
+	);
+
+	$standard_template_parts = array( 'header', 'footer' );
+
+	foreach ( $standard_template_parts as $template_part ) {
+		$preload_paths[] = array(
+			$template_parts_rest_route . "/$theme_slug//$template_part?context=edit",
+			'GET',
+		);
+	}
+
+	return $preload_paths;
+}
+add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_preload_template_parts', 10, 2 );

--- a/lib/compat/wordpress-6.3/template-parts-preloading.php
+++ b/lib/compat/wordpress-6.3/template-parts-preloading.php
@@ -7,7 +7,7 @@
  */
 
 /**
- * Preloads requests needed for common Template Part posts
+ * Preloads requests needed for common Template Part posts.
  *
  * @param array $preload_paths    Preload paths to be filtered.
  * @param array $context          Context for the preload paths.
@@ -27,7 +27,17 @@ function gutenberg_preload_template_parts( $preload_paths, $context ) {
 		return $preload_paths;
 	}
 
-	$theme_json_template_part_slugs = array_keys( $theme_json_template_parts );
+	// Only preload template parts that are in the "header" area.
+	$theme_json_template_part_slugs = array_filter(
+		array_keys( $theme_json_template_parts ),
+		function( $slug ) use ( $theme_json_template_parts ) {
+			return ! isset( $theme_json_template_parts[ $slug ]['area'] ) || 'header' === $theme_json_template_parts[ $slug ]['area'];
+		}
+	);
+
+	if ( empty( $theme_json_template_part_slugs ) ) {
+		return $preload_paths;
+	}
 
 	$theme_slug = get_stylesheet();
 

--- a/lib/compat/wordpress-6.3/template-parts-preloading.php
+++ b/lib/compat/wordpress-6.3/template-parts-preloading.php
@@ -10,7 +10,8 @@
  * Preloads requests needed for common Template Part posts
  *
  * @param array $preload_paths    Preload paths to be filtered.
- * @return array
+ * @param array $context          Context for the preload paths.
+ * @return array    the preload paths.
  */
 function gutenberg_preload_template_parts( $preload_paths, $context ) {
 
@@ -33,8 +34,6 @@ function gutenberg_preload_template_parts( $preload_paths, $context ) {
 	$template_parts_rest_route = rest_get_route_for_post_type_items(
 		'wp_template_part'
 	);
-
-	$standard_template_parts = array( 'header', 'footer' );
 
 	foreach ( $theme_json_template_part_slugs as $template_part_slug ) {
 		$preload_paths[] = array(

--- a/lib/compat/wordpress-6.3/template-parts-preloading.php
+++ b/lib/compat/wordpress-6.3/template-parts-preloading.php
@@ -12,7 +12,12 @@
  * @param array $preload_paths    Preload paths to be filtered.
  * @return array
  */
-function gutenberg_preload_template_parts( $preload_paths ) {
+function gutenberg_preload_template_parts( $preload_paths, $context ) {
+
+	// Limit to the Site Editor.
+	if ( ! empty( $context->name ) && 'core/edit-site' !== $context->name ) {
+		return $preload_paths;
+	}
 
 	$theme_slug = wp_get_theme()->get_stylesheet();
 

--- a/lib/load.php
+++ b/lib/load.php
@@ -103,6 +103,7 @@ if ( ! class_exists( 'WP_HTML_Tag_Processor' ) ) {
 // WordPress 6.3 compat.
 require __DIR__ . '/compat/wordpress-6.3/html-api/class-gutenberg-html-tag-processor-6-3.php';
 require __DIR__ . '/compat/wordpress-6.3/script-loader.php';
+require __DIR__ . '/compat/wordpress-6.3/template-parts-preloading.php';
 
 // Experimental features.
 remove_action( 'plugins_loaded', '_wp_theme_json_webfonts_handler' ); // Turns off WP 6.0's stopgap handler for Webfonts API.

--- a/phpunit/class-block-template-part-preloading-test.php
+++ b/phpunit/class-block-template-part-preloading-test.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Test preloading of template parts for the Site Editor.
+ *
+ * @package Gutenberg
+ */
+
+class Block_Template_Part_Preloading_Test extends WP_UnitTestCase {
+
+
+	private static $theme_slug = 'block-theme-child-with-template-parts';
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->theme_root = realpath( __DIR__ . '/data/themedir1' );
+
+		$this->orig_theme_dir = $GLOBALS['wp_theme_directories'];
+
+		// /themes is necessary as theme.php functions assume /themes is the root if there is only one root.
+		$GLOBALS['wp_theme_directories'] = array( WP_CONTENT_DIR . '/themes', $this->theme_root );
+
+		add_filter( 'theme_root', array( $this, 'filter_set_theme_root' ) );
+		add_filter( 'stylesheet_root', array( $this, 'filter_set_theme_root' ) );
+		add_filter( 'template_root', array( $this, 'filter_set_theme_root' ) );
+
+		// Clear caches.
+		wp_clean_themes_cache();
+		unset( $GLOBALS['wp_themes'] );
+
+		switch_theme( self::$theme_slug );
+	}
+
+	public function tear_down() {
+		$GLOBALS['wp_theme_directories'] = $this->orig_theme_dir;
+		wp_clean_themes_cache();
+		unset( $GLOBALS['wp_themes'] );
+		parent::tear_down();
+	}
+
+	public function filter_set_theme_root() {
+		return $this->theme_root;
+	}
+
+	public function test_should_not_preload_when_not_in_site_editor_context() {
+		$context       = new stdClass();
+		$context->name = 'core/post-editor';
+
+		$preload_paths = gutenberg_preload_template_parts( array(), $context );
+
+		$this->assertEquals( array(), $preload_paths, 'Preloading paths populated when should be empty.' );
+	}
+
+	public function test_should_preload_template_parts_defined_in_theme_json() {
+
+		$context       = new stdClass();
+		$context->name = 'core/edit-site';
+
+		$preload_paths = gutenberg_preload_template_parts( array(), $context );
+
+		$template_parts_rest_route = rest_get_route_for_post_type_items(
+			'wp_template_part'
+		);
+
+		$this->assertEquals( $template_parts_rest_route . '/' . self::$theme_slug . '//' . 'header' . '?context=edit', $preload_paths[0][0], 'Preloading URL for "header" template part was incorrect.' );
+		$this->assertEquals( $template_parts_rest_route . '/' . self::$theme_slug . '//' . 'footer' . '?context=edit', $preload_paths[1][0], 'Preloading URL for "footer" template part was incorrect.' );
+	}
+}

--- a/phpunit/class-block-template-part-preloading-test.php
+++ b/phpunit/class-block-template-part-preloading-test.php
@@ -28,6 +28,8 @@ class Block_Template_Part_Preloading_Test extends WP_UnitTestCase {
 		wp_clean_themes_cache();
 		unset( $GLOBALS['wp_themes'] );
 
+		// This Theme contains known template parts which we assert against in the tests.
+		// See phpunit/data/themedir1/block-theme-child-with-template-parts/theme.json.
 		switch_theme( self::$theme_slug );
 	}
 
@@ -62,7 +64,25 @@ class Block_Template_Part_Preloading_Test extends WP_UnitTestCase {
 			'wp_template_part'
 		);
 
-		$this->assertEquals( $template_parts_rest_route . '/' . self::$theme_slug . '//' . 'header' . '?context=edit', $preload_paths[0][0], 'Preloading URL for "header" template part was incorrect.' );
-		$this->assertEquals( $template_parts_rest_route . '/' . self::$theme_slug . '//' . 'footer' . '?context=edit', $preload_paths[1][0], 'Preloading URL for "footer" template part was incorrect.' );
+		$expected_template_part_slugs = array(
+			'header',
+			'header-large',
+		);
+
+		$paths = array_map(
+			function( $path ) {
+				return $path[0];
+			},
+			$preload_paths
+		);
+
+		// loop over $paths and assert $expected_template_part_slugs are in $paths.
+		foreach ( $expected_template_part_slugs as $expected_template_part_slug ) {
+			$this->assertContains( $template_parts_rest_route . '/' . self::$theme_slug . '//' . $expected_template_part_slug . '?context=edit', $paths, 'Preloading URL for "' . $expected_template_part_slug . '" template part was incorrect.' );
+		}
+
+		// assert that $paths does not contain a "footer" template part.
+		$this->assertNotContains( $template_parts_rest_route . '/' . self::$theme_slug . '//' . 'footer' . '?context=edit', $paths, '"footer" template part which is not in the "header" area was incorrectly loaded.' );
+
 	}
 }

--- a/phpunit/class-block-template-part-preloading-test.php
+++ b/phpunit/class-block-template-part-preloading-test.php
@@ -85,4 +85,36 @@ class Block_Template_Part_Preloading_Test extends WP_UnitTestCase {
 		$this->assertNotContains( $template_parts_rest_route . '/' . self::$theme_slug . '//' . 'footer' . '?context=edit', $paths, '"footer" template part which is not in the "header" area was incorrectly loaded.' );
 
 	}
+
+	public function test_should_limit_preloaded_paths_to_gutenberg_template_part_preloading_limit() {
+		$context       = new stdClass();
+		$context->name = 'core/edit-site';
+
+		// Set the limit to 1.
+		add_filter(
+			'gutenberg_template_part_preloading_limit',
+			function() {
+				return 1;
+			}
+		);
+
+		$preload_paths = gutenberg_preload_template_parts( array(), $context );
+
+		$template_parts_rest_route = rest_get_route_for_post_type_items(
+			'wp_template_part'
+		);
+
+		$expected_template_part_slug = 'header';
+
+		$paths = array_map(
+			function( $path ) {
+				return $path[0];
+			},
+			$preload_paths
+		);
+
+		$this->assertContains( $template_parts_rest_route . '/' . self::$theme_slug . '//' . $expected_template_part_slug . '?context=edit', $paths, 'Preloading URL for "' . $expected_template_part_slug . '" template part was incorrect.' );
+
+		$this->assertCount( 1, $preload_paths, 'Preloading paths count beyond set limit.' );
+	}
 }

--- a/phpunit/data/themedir1/block-theme-child-with-template-parts/style.css
+++ b/phpunit/data/themedir1/block-theme-child-with-template-parts/style.css
@@ -1,0 +1,8 @@
+/*
+Theme Name: Block Theme Child Theme With Template Parts
+Theme URI: https://wordpress.org/
+Description: For testing purposes only.
+Template: block-theme
+Version: 1.0.0
+Text Domain: block-theme-child-with-template-parts
+*/

--- a/phpunit/data/themedir1/block-theme-child-with-template-parts/theme.json
+++ b/phpunit/data/themedir1/block-theme-child-with-template-parts/theme.json
@@ -1,0 +1,15 @@
+{
+	"version": 2,
+	"templateParts": [
+		{
+			"name": "header",
+			"title": "Header",
+			"area": "header"
+		},
+		{
+			"name": "footer",
+			"title": "Footer",
+			"area": "footer"
+		}
+	]
+}

--- a/phpunit/data/themedir1/block-theme-child-with-template-parts/theme.json
+++ b/phpunit/data/themedir1/block-theme-child-with-template-parts/theme.json
@@ -7,6 +7,11 @@
 			"area": "header"
 		},
 		{
+			"name": "header-large",
+			"title": "Large Header",
+			"area": "header"
+		},
+		{
 			"name": "footer",
 			"title": "Footer",
 			"area": "footer"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Improves the perceived loading performance of the Site Editor by (selectively) _preloading_  template parts (see `How` for details).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Most of the perceived sluggish-ness of the Site Editor loading is due to having to wait for template parts to resolve from the network.

For example on TT3, when the editor loads requests are dispatched for 

- `/wp/v2/template-parts/twentytwentythree//header?context=edit`
- `/wp/v2/template-parts/twentytwentythree//footer?context=edit`

The former is particularly jarring as the whole header area becomes a loading spinner until the network resolves. This is very noticeable on slower connections (take a minute to test it).

This is further compounded by the fact that most `header` template parts will contain a Navigation block which has it's own loading state which is dependent on loading entities over the network. As the Nav block will not be rendered in the editor until the template part resolves, this means we get a loading waterfall effect where we see

- template part loading
- template part resolves
- navigation block starts loading
- navigation block resolves

 This is not a great experience.



## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By preloading requests for the templates parts defined by the `theme.json` we can ensure these parts are available _immediately_ in the `@wordpress/api-fetch` network cache upon editor load. 

This means the editor never dispatches the network `fetch` request and instead [core data] _immediately_ returns the entity data  for the template part directly. 

This results in almost **no loading spinners** in the header. When combined with https://github.com/WordPress/gutenberg/pull/48683 this should have a major impact on improve the perceived performance.

### Criteria for Preloading a Template

When determining which template parts will be preloaded the following criteria apply:

- must be defined in `theme.json` under the `templateParts` key.
- must include a `area` property set to `header` - these are templates being specifically denoted as being designed for the "Header" Template Area of a site.
- within the first 3 templates - we hard limit to 3 preloaded templates by default to avoid unwanted edge cases. This can be filtered using the `gutenberg_template_part_preloading_limit` filter. 

## ⚠️ Potential Considerations

- may _slightly_ increase TTFB in the Site Editor (only) - looking at Gutenberg Performance tests (see CI for this PR) changes seem negligible ([example](https://github.com/WordPress/gutenberg/pull/48924/files#r1138941821))
- ~may result in 404 requests on the server if the `header` or `footer` parts do not exist.~ concern no longer applies

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Activate TT3
- Throttle your connection a bit.
- Open Site Editor
- See no loading spinners for the site Header.
- Compare with `trunk` where there are loading spinners which take a long time to resolve.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

#### Before

Notice the loading spinner for the template part.

https://user-images.githubusercontent.com/444434/223717310-713da1bd-f22e-4599-9081-e1d8a06345ff.mp4


#### After

Notice no spinner for the template part.

https://user-images.githubusercontent.com/444434/223717115-dccc7ab0-c7d1-4b1b-84b2-5f4c747d9302.mp4


