### PR TITLE
jest-preset-default: update README to reflect current status

### DIFF
--- a/packages/jest-preset-default/README.md
+++ b/packages/jest-preset-default/README.md
@@ -30,11 +30,10 @@ npm install @wordpress/jest-preset-default --save-dev
 -   `modulePaths` - the root dir of the project is used as a location to search when resolving modules.
 -   `setupFiles` - runs code before each test which sets up global variables required in the testing environment.
 -   `setupFilesAfterEnv` - runs code which adds improved support for `Console` object and `React` components to the testing framework before each test.
--   `snapshotSerializers` - makes it possible to use snapshot tests on `Enzyme` wrappers.
--   `testMatch`- includes `/test/` subfolder in addition to the glob patterns Jest uses to detect test files. It detects only test files containing `.js`, `.jsx`, `.ts` and `.tsx` suffix. It doesn't match files with `.spec.js` suffix.
--   `timers` - use of [fake timers](https://jestjs.io/docs/en/timer-mocks.html) for functions such as `setTimeout` is enabled.
+-   `testEnvironment` - enabled the `jsdom` environment for all tests by default.
+-   `testMatch` - searches for tests in `/test/` and `/__tests__/` subfolders, and also matches all files with a `.test.*` suffix. It detects test files with a `.js`, `.jsx`, `.ts` or `.tsx` suffix. Compared to default Jest configuration, it doesn't match files with the `.spec.*` suffix.
+-   `testPathIgnorePatterns` - excludes `node_modules` and `vendor` directories from searching for test files.
 -   `transform` - keeps the default [babel-jest](https://github.com/facebook/jest/tree/HEAD/packages/babel-jest) transformer.
--   `verbose` - each individual test won't be reported during the run.
 
 #### Using enzyme
 


### PR DESCRIPTION
Updates the `jest-preset-default` README, namely the list of Jest options the preset sets. This documentation hasn't changed much since the preset was originally created in 4466f2180e, but the options we're setting today are different.

- removes the mention of `verbose`, `snapshotSerializers` and `timers` options
- adds description of the `testPathIgnorePatterns` option
- improves the description of how we set the `testMatch` option