### PR TITLE
Post Editor: Fix animation and browser console error when returning from template edit mode

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -332,7 +332,7 @@ export default function VisualEditor( { styles } ) {
 			<motion.div
 				className="edit-post-visual-editor__content-area"
 				animate={ {
-					padding: isTemplateMode ? '48px 48px 0' : '0',
+					padding: isTemplateMode ? '48px 48px 0' : 0,
 				} }
 				ref={ blockSelectionClearerRef }
 			>


### PR DESCRIPTION
## What?
This PR fixes two problems that occur when returning from post template editor mode.

- Motion animation does not work
- Warning message appears in the browser console

## Why?
The following error message will appear:

```
You are trying to animate padding from "48px 48px 0" to "0px 0px 0".
48px 48px 0 is not an animatable value
- to enable this animation set 48px 48px 0 to a value animatable to 0px 0px 0 via the `style` property. 
```

This warning message does not seem to be displaying the correct warning, but perhaps it needs to be set to a numeric `0` instead of a string `"0"`. From [the motion document](https://www.framer.com/motion/component/##value-types), it appears that 0 is assumed to be of type Number, although this is not explicitly stated.

## Testing Instructions

- Open the post editor.
- Open the template edit mode.
- Confirm that the following two issues have been resolved:
  >- Motion animation does not work
  >- Warning message appears in the browser console

## Screenshots or screencast <!-- if applicable -->

### Before

https://user-images.githubusercontent.com/54422211/223740014-efc607f1-3940-46ad-b655-d38b780b2377.mp4

### After

https://user-images.githubusercontent.com/54422211/223740046-3e7a6fda-2f5d-4751-9219-7c5317a57987.mp4