### PR TITLE
Site Editor Navigation panel: Update appearance of non-link blocks

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -35,7 +35,7 @@
 			margin-left: -$grid-unit-10;
 		}
 		&.is-selected {
-			td {
+			> td {
 				background: transparent;
 			}
 
@@ -43,21 +43,44 @@
 				color: inherit;
 			}
 
-			.block-editor-list-view-block__menu-cell {
-				opacity: 0;
+			&:not(:hover) {
+				.block-editor-list-view-block__menu {
+					opacity: 0;
+				}
 			}
 
-			&:hover {
+			&:hover,
+			&:focus {
 				color: $white;
 
 				.block-editor-list-view-block__menu-cell {
 					opacity: 1;
 				}
 			}
+
+			.block-editor-list-view-block__menu {
+				opacity: 1;
+
+				&:focus {
+					box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+				}
+			}
+		}
+
+		.block-editor-list-view-block-contents {
+			&:focus {
+				&::after {
+					box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+				}
+			}
 		}
 
 		&.is-branch-selected:not(.is-selected):not(.is-synced-branch) {
 			background: transparent;
+
+			&:hover {
+				background: $gray-800;
+			}
 		}
 	}
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -34,6 +34,31 @@
 		.block-editor-list-view-block__menu {
 			margin-left: -$grid-unit-10;
 		}
+		&.is-selected {
+			td {
+				background: transparent;
+			}
+
+			.block-editor-list-view-block-contents {
+				color: inherit;
+			}
+
+			.block-editor-list-view-block__menu-cell {
+				opacity: 0;
+			}
+
+			&:hover {
+				color: $white;
+
+				.block-editor-list-view-block__menu-cell {
+					opacity: 1;
+				}
+			}
+		}
+
+		&.is-branch-selected:not(.is-selected):not(.is-synced-branch) {
+			background: transparent;
+		}
 	}
 
 	.block-editor-list-view-leaf .block-editor-list-view-block__contents-cell {


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/48675

## What?
Updates the interactive behaviours of blocks like Site Logo, Spacer, Social Icons, Search, Custom Link in the Navigation panel.

It also fixes an issue where children of the Page List block had a semi-transparent background applied... see the "Before" video below.

## Why?
The current behaviors feel a bit broken. Specifically: when you click one of these blocks they take on a 'selected' appearance (blue background). In this context the 'selected' appearance has no meaning, and leads to confusion.

## How?
I did this by basically overriding a bunch of styles attached to the `is-selected` class. It's not very pretty.

I figured it's okay to 'hijack' this class (at least as a short term solution) because in this context there is no concept of 'selecting' a menu item – Page / Post links reveal a drill-down, and the other blocks have no business in being selected.

Sadly I couldn't remove the background applied on hover for these blocks because there is nothing in the markup to identify them.

## Testing Instructions
1. In the Navigation panel add blocks like Site Logo, Search, etc
2. Click them
3. There should be no 'selected' state (blue background). 

---

1. Add a Page List block and click it to 'select' it
2. Expand to view its children
3. The children should have the same background as the rest of the panel

## Screenshots or screencast <!-- if applicable -->

#### Before

https://user-images.githubusercontent.com/846565/223775432-24c04333-72eb-46ab-acb2-206666ca64eb.mp4



#### After


https://user-images.githubusercontent.com/846565/223775456-183c5f02-7b64-4561-a730-04b4f0b03eda.mp4

