### PR TITLE
Remove actions from SidebarNavigationScreenWrapper

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -5,10 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { useCallback, useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import {
-	BlockEditorProvider,
-	privateApis as blockEditorPrivateApis,
-} from '@wordpress/block-editor';
+import { BlockEditorProvider } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 
 /**
@@ -17,7 +14,6 @@ import { createBlock } from '@wordpress/blocks';
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import { useHistory } from '../routes';
 import NavigationMenuContent from './navigation-menu-content';
-import SidebarButton from '../sidebar-button';
 import { NavigationMenuLoader } from './loader';
 import { unlock } from '../../private-apis';
 import { store as editSiteStore } from '../../store';
@@ -42,11 +38,6 @@ function SidebarNavigationScreenWrapper( { children, actions } ) {
 		/>
 	);
 }
-
-const prioritizedInserterBlocks = [
-	'core/navigation-link/page',
-	'core/navigation-link',
-];
 
 export default function SidebarNavigationScreenNavigationMenus() {
 	const history = useHistory();
@@ -104,18 +95,6 @@ export default function SidebarNavigationScreenNavigationMenus() {
 		},
 		[ history ]
 	);
-	const orderInitialBlockItems = useCallback( ( items ) => {
-		items.sort( ( { id: aName }, { id: bName } ) => {
-			// Sort block items according to `prioritizedInserterBlocks`.
-			let aIndex = prioritizedInserterBlocks.indexOf( aName );
-			let bIndex = prioritizedInserterBlocks.indexOf( bName );
-			// All other block items should come after that.
-			if ( aIndex < 0 ) aIndex = prioritizedInserterBlocks.length;
-			if ( bIndex < 0 ) bIndex = prioritizedInserterBlocks.length;
-			return aIndex - bIndex;
-		} );
-		return items;
-	}, [] );
 
 	if ( hasResolvedNavigationMenus && ! hasNavigationMenus ) {
 		return (
@@ -132,7 +111,7 @@ export default function SidebarNavigationScreenNavigationMenus() {
 			</SidebarNavigationScreenWrapper>
 		);
 	}
-	const { PrivateInserter } = unlock( blockEditorPrivateApis );
+
 	return (
 		<BlockEditorProvider
 			settings={ storedSettings }
@@ -140,23 +119,7 @@ export default function SidebarNavigationScreenNavigationMenus() {
 			onChange={ noop }
 			onInput={ noop }
 		>
-			<SidebarNavigationScreenWrapper
-				actions={
-					<PrivateInserter
-						rootClientId={ blocks[ 0 ].clientId }
-						position="bottom right"
-						isAppender
-						selectBlockOnInsert={ false }
-						shouldDirectInsert={ false }
-						__experimentalIsQuick
-						toggleProps={ {
-							as: SidebarButton,
-							label: __( 'Add menu item' ),
-						} }
-						orderInitialBlockItems={ orderInitialBlockItems }
-					/>
-				}
-			>
+			<SidebarNavigationScreenWrapper>
 				<div className="edit-site-sidebar-navigation-screen-navigation-menus__content">
 					<NavigationMenuContent
 						rootClientId={ blocks[ 0 ].clientId }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The current flow of editing existing navigation items within the Site Editor sidebar navigation has a number of rough edges, as indicated in these issues: https://github.com/WordPress/gutenberg/issues/48675, https://github.com/WordPress/gutenberg/issues/48593, https://github.com/WordPress/gutenberg/issues/48612, https://github.com/WordPress/gutenberg/issues/48741

We don't have time to refine those further before the WordPress 6.2 release, but we can reduce the likelihood of friction by temporality removing the ability to add new blocks to the navigation (from the sidebar view). 

## How?
Removes the actions passed in the SidebarNavigationScreenWrapper. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open Site Editor.
2. Click on Navigation.
3. See no "+" icon visible.

## Screenshots or screencast <!-- if applicable -->

Before: 

<img width="353" alt="CleanShot 2023-03-08 at 12 09 50" src="https://user-images.githubusercontent.com/1813435/223781618-6cda3a44-9f4c-4aac-9e64-9440a59d48d6.png">

After: 

<img width="353" alt="CleanShot 2023-03-08 at 12 10 17" src="https://user-images.githubusercontent.com/1813435/223781751-edcc0813-f98e-459b-87c0-81d726988998.png">


