### PR TITLE
Navigation Submenu: Refactor to use the block supports function

### DIFF
--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -200,9 +200,8 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 
 		// This allows us to be able to get a response from gutenberg_apply_colors_support.
 		$block->block_type->supports['color'] = true;
-		$colors_supports = gutenberg_apply_colors_support( $block->block_type, $attributes );
-
-		$css_classes = 'wp-block-navigation__submenu-container';
+		$colors_supports                      = gutenberg_apply_colors_support( $block->block_type, $attributes );
+		$css_classes                          = 'wp-block-navigation__submenu-container';
 		if ( array_key_exists( 'class', $colors_supports ) ) {
 			$css_classes .= ' ' . $colors_supports['class'];
 		}

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -14,66 +14,6 @@
  * @param  bool  $is_sub_menu Whether the block is a sub-menu.
  * @return array Colors CSS classes and inline styles.
  */
-function block_core_navigation_submenu_build_css_colors( $context, $attributes, $is_sub_menu = false ) {
-	$colors = array(
-		'css_classes'   => array(),
-		'inline_styles' => '',
-	);
-
-	// Text color.
-	$named_text_color  = null;
-	$custom_text_color = null;
-
-	if ( $is_sub_menu && array_key_exists( 'customOverlayTextColor', $context ) ) {
-		$custom_text_color = $context['customOverlayTextColor'];
-	} elseif ( $is_sub_menu && array_key_exists( 'overlayTextColor', $context ) ) {
-		$named_text_color = $context['overlayTextColor'];
-	} elseif ( array_key_exists( 'customTextColor', $context ) ) {
-		$custom_text_color = $context['customTextColor'];
-	} elseif ( array_key_exists( 'textColor', $context ) ) {
-		$named_text_color = $context['textColor'];
-	} elseif ( isset( $context['style']['color']['text'] ) ) {
-		$custom_text_color = $context['style']['color']['text'];
-	}
-
-	// If has text color.
-	if ( ! is_null( $named_text_color ) ) {
-		// Add the color class.
-		array_push( $colors['css_classes'], 'has-text-color', sprintf( 'has-%s-color', $named_text_color ) );
-	} elseif ( ! is_null( $custom_text_color ) ) {
-		// Add the custom color inline style.
-		$colors['css_classes'][]  = 'has-text-color';
-		$colors['inline_styles'] .= sprintf( 'color: %s;', $custom_text_color );
-	}
-
-	// Background color.
-	$named_background_color  = null;
-	$custom_background_color = null;
-
-	if ( $is_sub_menu && array_key_exists( 'customOverlayBackgroundColor', $context ) ) {
-		$custom_background_color = $context['customOverlayBackgroundColor'];
-	} elseif ( $is_sub_menu && array_key_exists( 'overlayBackgroundColor', $context ) ) {
-		$named_background_color = $context['overlayBackgroundColor'];
-	} elseif ( array_key_exists( 'customBackgroundColor', $context ) ) {
-		$custom_background_color = $context['customBackgroundColor'];
-	} elseif ( array_key_exists( 'backgroundColor', $context ) ) {
-		$named_background_color = $context['backgroundColor'];
-	} elseif ( isset( $context['style']['color']['background'] ) ) {
-		$custom_background_color = $context['style']['color']['background'];
-	}
-
-	// If has background color.
-	if ( ! is_null( $named_background_color ) ) {
-		// Add the background-color class.
-		array_push( $colors['css_classes'], 'has-background', sprintf( 'has-%s-background-color', $named_background_color ) );
-	} elseif ( ! is_null( $custom_background_color ) ) {
-		// Add the custom background-color inline style.
-		$colors['css_classes'][]  = 'has-background';
-		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $custom_background_color );
-	}
-
-	return $colors;
-}
 
 /**
  * Build an array with CSS classes and inline styles defining the font sizes
@@ -129,7 +69,6 @@ function block_core_navigation_submenu_render_submenu_icon() {
  * @return string Returns the post content with the legacy widget added.
  */
 function render_block_core_navigation_submenu( $attributes, $content, $block ) {
-
 	$navigation_link_has_id = isset( $attributes['id'] ) && is_numeric( $attributes['id'] );
 	$is_post_type           = isset( $attributes['kind'] ) && 'post-type' === $attributes['kind'];
 	$is_post_type           = $is_post_type || isset( $attributes['type'] ) && ( 'post' === $attributes['type'] || 'page' === $attributes['type'] );
@@ -144,15 +83,10 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$colors          = block_core_navigation_submenu_build_css_colors( $block->context, $attributes );
 	$font_sizes      = block_core_navigation_submenu_build_css_font_sizes( $block->context );
-	$classes         = array_merge(
-		$colors['css_classes'],
-		$font_sizes['css_classes']
-	);
-	$style_attribute = ( $colors['inline_styles'] . $font_sizes['inline_styles'] );
+	$style_attribute = $font_sizes['inline_styles'];
 
-	$css_classes = trim( implode( ' ', $classes ) );
+	$css_classes = trim( implode( ' ', $font_sizes['css_classes'] ) );
 	$has_submenu = count( $block->inner_blocks ) > 0;
 	$is_active   = ! empty( $attributes['id'] ) && ( get_queried_object_id() === (int) $attributes['id'] );
 
@@ -249,14 +183,34 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	}
 
 	if ( $has_submenu ) {
-		$colors      = block_core_navigation_submenu_build_css_colors( $block->context, $attributes, $has_submenu );
-		$classes     = array_merge(
-			array( 'wp-block-navigation__submenu-container' ),
-			$colors['css_classes']
-		);
-		$css_classes = trim( implode( ' ', $classes ) );
+		// Copy some attributes from the parent block to this one.
+		// Ideally this would happen in the client when the block is created.
+		if ( array_key_exists( 'overlayTextColor', $block->context ) ) {
+			$attributes['textColor'] = $block->context['overlayTextColor'];
+		}
+		if ( array_key_exists( 'overlayBackgroundColor', $block->context ) ) {
+			$attributes['backgroundColor'] = $block->context['overlayBackgroundColor'];
+		}
+		if ( array_key_exists( 'customOverlayTextColor', $block->context ) ) {
+			$attributes['style']['color']['text'] = $block->context['customOverlayTextColor'];
+		}
+		if ( array_key_exists( 'customOverlayBackgroundColor', $block->context ) ) {
+			$attributes['style']['color']['background'] = $block->context['customOverlayBackgroundColor'];
+		}
 
-		$style_attribute = $colors['inline_styles'];
+		// This allows us to be able to get a response from gutenberg_apply_colors_support.
+		$block->block_type->supports['color'] = true;
+		$colors_supports = gutenberg_apply_colors_support( $block->block_type, $attributes );
+
+		$css_classes = 'wp-block-navigation__submenu-container';
+		if ( array_key_exists( 'class', $colors_supports ) ) {
+			$css_classes .= ' ' . $colors_supports['class'];
+		}
+
+		$style_attribute = '';
+		if ( array_key_exists( 'style', $colors_supports ) ) {
+			$style_attribute = $colors_supports['style'];
+		}
 
 		$inner_blocks_html = '';
 		foreach ( $block->inner_blocks as $inner_block ) {

--- a/phpunit/blocks/render-block-navigation-submenu-test.php
+++ b/phpunit/blocks/render-block-navigation-submenu-test.php
@@ -16,52 +16,14 @@ class Render_Block_Navigation_Submenu_Test extends WP_UnitTestCase {
 	private static $custom_draft;
 	private static $custom_post;
 
-	private static $pages;
-	private static $terms;
+
 	/**
 	 * @var array|null
 	 */
 	private $original_block_supports;
 
 	public static function set_up_before_class() {
-
-		self::$draft   = self::factory()->post->create_and_get(
-			array(
-				'post_type'    => 'page',
-				'post_status'  => 'draft',
-				'post_name'    => 'ceilingcat',
-				'post_title'   => 'Ceiling Cat',
-				'post_content' => 'Ceiling Cat content',
-				'post_excerpt' => 'Ceiling Cat',
-			)
-		);
-		self::$pages[] = self::$draft;
-
-		self::$custom_draft = self::factory()->post->create_and_get(
-			array(
-				'post_type'    => 'cats',
-				'post_status'  => 'draft',
-				'post_name'    => 'metalcat',
-				'post_title'   => 'Metal Cat',
-				'post_content' => 'Metal Cat content',
-				'post_excerpt' => 'Metal Cat',
-			)
-		);
-		self::$pages[]      = self::$custom_draft;
-
-		self::$custom_post = self::factory()->post->create_and_get(
-			array(
-				'post_type'    => 'dogs',
-				'post_status'  => 'publish',
-				'post_name'    => 'metaldog',
-				'post_title'   => 'Metal Dog',
-				'post_content' => 'Metal Dog content',
-				'post_excerpt' => 'Metal Dog',
-			)
-		);
-		self::$pages[]     = self::$custom_post;
-
-		self::$page    = self::factory()->post->create_and_get(
+		self::$page = self::factory()->post->create_and_get(
 			array(
 				'post_type'    => 'page',
 				'post_status'  => 'publish',
@@ -71,18 +33,6 @@ class Render_Block_Navigation_Submenu_Test extends WP_UnitTestCase {
 				'post_excerpt' => 'Tabby cat',
 			)
 		);
-		self::$pages[] = self::$page;
-
-		self::$category = self::factory()->category->create_and_get(
-			array(
-				'taxonomy'    => 'category',
-				'name'        => 'cats',
-				'slug'        => 'cats',
-				'description' => 'Cats Category',
-			)
-		);
-
-		self::$terms[] = self::$category;
 	}
 
 	public function set_up() {

--- a/phpunit/blocks/render-block-navigation-submenu-test.php
+++ b/phpunit/blocks/render-block-navigation-submenu-test.php
@@ -172,6 +172,42 @@ class Render_Block_Navigation_Submenu_Test extends WP_UnitTestCase {
 		);
 	}
 
+    /**
+	 * @group submenu-color-inheritance
+	 * @covers ::gutenberg_render_block_core_navigation_submenu
+	 */
+	public function test_should_apply_mix_of_preset_and_custom_colors_inherited_from_parent_block_via_context() {
+		$page_id = self::$page->ID;
+
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:navigation-submenu {"label":"Submenu Label","type":"page","id":' . $page_id . ',"url":"http://localhost:8888/?page_id=' . $page_id . '","kind":"post-type"} -->
+            <!-- wp:navigation-link {"label":"Submenu Item Link Label","type":"page","id":' . $page_id . ',"url":"http://localhost:8888/?page_id=' . $page_id . '","kind":"post-type"} /-->
+        <!-- /wp:navigation-submenu -->'
+		);
+
+		$this->assertEquals( 1, count( $parsed_blocks ), 'Submenu block not parsable.' );
+
+		$block = $parsed_blocks[0];
+
+		// Colors inherited from parent Navigation block.
+		$context = array(
+			'overlayTextColor'       => 'purple',
+			'customOverlayBackgroundColor' => '#E10E0E',
+		);
+
+		$navigation_link_block = new WP_Block( $block, $context );
+
+		$this->assertStringContainsString(
+			'<ul style="background-color:' . $context['customOverlayBackgroundColor'] . ';" class="wp-block-navigation__submenu-container has-text-color has-' . $context['overlayTextColor'] . '-color has-background">',
+			gutenberg_render_block_core_navigation_submenu(
+				$navigation_link_block->attributes,
+				array(),
+				$navigation_link_block
+			),
+			'Submenu block colors inherited from context not applied correctly'
+		);
+	}
+
 	/**
 	 * @group submenu-color-inheritance
 	 * @covers ::gutenberg_render_block_core_navigation_submenu

--- a/phpunit/blocks/render-block-navigation-submenu-test.php
+++ b/phpunit/blocks/render-block-navigation-submenu-test.php
@@ -100,12 +100,12 @@ class Render_Block_Navigation_Submenu_Test extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
-	public function test_should_apply_colors_inherited_from_parent_block_via_context() {
+	public function test_should_apply_preset_colors_inherited_from_parent_block_via_context() {
 		$page_id = self::$page->ID;
 
 		$parsed_blocks = parse_blocks(
 			'<!-- wp:navigation-submenu {"label":"Submenu Label","type":"page","id":' . $page_id . ',"url":"http://localhost:8888/?page_id=' . $page_id . '","kind":"post-type"} -->
-            <!-- wp:navigation-link {"label":"Submenu Item Link Label","type":"page","id":46,"url":"http://localhost:8888/?page_id=46","kind":"post-type"} /-->
+            <!-- wp:navigation-link {"label":"Submenu Item Link Label","type":"page","id":' . $page_id . ',"url":"http://localhost:8888/?page_id=' . $page_id . '","kind":"post-type"} /-->
         <!-- /wp:navigation-submenu -->'
 		);
 
@@ -122,7 +122,39 @@ class Render_Block_Navigation_Submenu_Test extends WP_UnitTestCase {
 		$navigation_link_block = new WP_Block( $block, $context );
 
 		$this->assertStringContainsString(
-			'<ul class="wp-block-navigation__submenu-container has-text-color has-' . $context['overlayTextColor'] . '-color has-background has-' . $context['overlayBackgroundColor'] . '-background-color"></ul>',
+			'<ul class="wp-block-navigation__submenu-container has-text-color has-' . $context['overlayTextColor'] . '-color has-background has-' . $context['overlayBackgroundColor'] . '-background-color">',
+			gutenberg_render_block_core_navigation_submenu(
+				$navigation_link_block->attributes,
+				array(),
+				$navigation_link_block
+			),
+			'Submenu block colors inherited from context not applied correctly'
+		);
+	}
+
+	public function test_should_apply_custom_colors_inherited_from_parent_block_via_context() {
+		$page_id = self::$page->ID;
+
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:navigation-submenu {"label":"Submenu Label","type":"page","id":' . $page_id . ',"url":"http://localhost:8888/?page_id=' . $page_id . '","kind":"post-type"} -->
+            <!-- wp:navigation-link {"label":"Submenu Item Link Label","type":"page","id":' . $page_id . ',"url":"http://localhost:8888/?page_id=' . $page_id . '","kind":"post-type"} /-->
+        <!-- /wp:navigation-submenu -->'
+		);
+
+		$this->assertEquals( 1, count( $parsed_blocks ), 'Submenu block not parsable.' );
+
+		$block = $parsed_blocks[0];
+
+		// Colors inherited from parent Navigation block.
+		$context = array(
+			'customOverlayTextColor'       => '#BCC60A',
+			'customOverlayBackgroundColor' => '#E10E0E',
+		);
+
+		$navigation_link_block = new WP_Block( $block, $context );
+
+		$this->assertStringContainsString(
+			'<ul style="color:' . $context['customOverlayTextColor'] . ';background-color:' . $context['customOverlayBackgroundColor'] . ';" class="wp-block-navigation__submenu-container has-text-color has-background">',
 			gutenberg_render_block_core_navigation_submenu(
 				$navigation_link_block->attributes,
 				array(),

--- a/phpunit/blocks/render-block-navigation-submenu-test.php
+++ b/phpunit/blocks/render-block-navigation-submenu-test.php
@@ -73,26 +73,26 @@ class Render_Block_Navigation_Submenu_Test extends WP_UnitTestCase {
 			'overlayBackgroundColor' => 'yellow',
 		);
 
-		$navigation_link_block = new WP_Block( $block, $context );
+		$navigation_submenu_block = new WP_Block( $block, $context );
 
 		$rendered_html = gutenberg_render_block_core_navigation_submenu(
-			$navigation_link_block->attributes,
+			$navigation_submenu_block->attributes,
 			array(),
-			$navigation_link_block
+			$navigation_submenu_block
 		);
 
-		$p = new WP_HTML_Tag_Processor( $rendered_html );
-		$p->next_tag(
+		$tags = new WP_HTML_Tag_Processor( $rendered_html );
+		$tags->next_tag(
 			array(
 				'tag_name'   => 'ul',
 				'class_name' => 'wp-block-navigation__submenu-container',
 			)
 		);
-		$p->get_attribute( 'class' );
+		$tags->get_attribute( 'class' );
 
 		$this->assertEquals(
 			'wp-block-navigation__submenu-container has-text-color has-purple-color has-background has-yellow-background-color',
-			$p->get_attribute( 'class' ),
+			$tags->get_attribute( 'class' ),
 			'Submenu block colors inherited from context not applied correctly'
 		);
 	}
@@ -120,14 +120,14 @@ class Render_Block_Navigation_Submenu_Test extends WP_UnitTestCase {
 			'customOverlayBackgroundColor' => '#E10E0E',
 		);
 
-		$navigation_link_block = new WP_Block( $block, $context );
+		$navigation_submenu_block = new WP_Block( $block, $context );
 
 		$this->assertStringContainsString(
 			'<ul style="color:' . $context['customOverlayTextColor'] . ';background-color:' . $context['customOverlayBackgroundColor'] . ';" class="wp-block-navigation__submenu-container has-text-color has-background">',
 			gutenberg_render_block_core_navigation_submenu(
-				$navigation_link_block->attributes,
+				$navigation_submenu_block->attributes,
 				array(),
-				$navigation_link_block
+				$navigation_submenu_block
 			),
 			'Submenu block colors inherited from context not applied correctly'
 		);
@@ -156,14 +156,14 @@ class Render_Block_Navigation_Submenu_Test extends WP_UnitTestCase {
 			'customOverlayBackgroundColor' => '#E10E0E',
 		);
 
-		$navigation_link_block = new WP_Block( $block, $context );
+		$navigation_submenu_block = new WP_Block( $block, $context );
 
 		$this->assertStringContainsString(
 			'<ul style="background-color:' . $context['customOverlayBackgroundColor'] . ';" class="wp-block-navigation__submenu-container has-text-color has-' . $context['overlayTextColor'] . '-color has-background">',
 			gutenberg_render_block_core_navigation_submenu(
-				$navigation_link_block->attributes,
+				$navigation_submenu_block->attributes,
 				array(),
-				$navigation_link_block
+				$navigation_submenu_block
 			),
 			'Submenu block colors inherited from context not applied correctly'
 		);
@@ -189,12 +189,12 @@ class Render_Block_Navigation_Submenu_Test extends WP_UnitTestCase {
 		// Intentionally empty - no colors.
 		$context = array();
 
-		$navigation_link_block = new WP_Block( $block, $context );
+		$navigation_submenu_block = new WP_Block( $block, $context );
 
 		$actual = gutenberg_render_block_core_navigation_submenu(
-			$navigation_link_block->attributes,
+			$navigation_submenu_block->attributes,
 			array(),
-			$navigation_link_block
+			$navigation_submenu_block
 		);
 
 		$this->assertStringContainsString(

--- a/phpunit/blocks/render-block-navigation-submenu-test.php
+++ b/phpunit/blocks/render-block-navigation-submenu-test.php
@@ -100,6 +100,10 @@ class Render_Block_Navigation_Submenu_Test extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
+	/**
+	 * @group submenu-color-inheritance
+	 * @covers ::gutenberg_render_block_core_navigation_submenu
+	 */
 	public function test_should_apply_preset_colors_inherited_from_parent_block_via_context() {
 		$page_id = self::$page->ID;
 
@@ -132,6 +136,10 @@ class Render_Block_Navigation_Submenu_Test extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @group submenu-color-inheritance
+	 * @covers ::gutenberg_render_block_core_navigation_submenu
+	 */
 	public function test_should_apply_custom_colors_inherited_from_parent_block_via_context() {
 		$page_id = self::$page->ID;
 
@@ -162,5 +170,47 @@ class Render_Block_Navigation_Submenu_Test extends WP_UnitTestCase {
 			),
 			'Submenu block colors inherited from context not applied correctly'
 		);
+	}
+
+	/**
+	 * @group submenu-color-inheritance
+	 * @covers ::gutenberg_render_block_core_navigation_submenu
+	 */
+	public function test_should_not_apply_custom_colors_if_missing_from_context() {
+		$page_id = self::$page->ID;
+
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:navigation-submenu {"label":"Submenu Label","type":"page","id":' . $page_id . ',"url":"http://localhost:8888/?page_id=' . $page_id . '","kind":"post-type"} -->
+            <!-- wp:navigation-link {"label":"Submenu Item Link Label","type":"page","id":' . $page_id . ',"url":"http://localhost:8888/?page_id=' . $page_id . '","kind":"post-type"} /-->
+        <!-- /wp:navigation-submenu -->'
+		);
+
+		$this->assertEquals( 1, count( $parsed_blocks ), 'Submenu block not parsable.' );
+
+		$block = $parsed_blocks[0];
+
+		// Intentionally empty - no colors.
+		$context = array();
+
+		$navigation_link_block = new WP_Block( $block, $context );
+
+		$actual = gutenberg_render_block_core_navigation_submenu(
+			$navigation_link_block->attributes,
+			array(),
+			$navigation_link_block
+		);
+
+		$this->assertStringContainsString(
+			'<ul class="wp-block-navigation__submenu-container">',
+			$actual,
+			'Submenu block should not apply colors if missing from context'
+		);
+
+		$this->assertStringNotContainsString(
+			$actual,
+			'has-text-color has-background',
+			'Submenu block should not apply "has-*" color classes if missing from context'
+		);
+
 	}
 }

--- a/phpunit/blocks/render-block-navigation-submenu-test.php
+++ b/phpunit/blocks/render-block-navigation-submenu-test.php
@@ -1,0 +1,282 @@
+<?php
+/**
+ * Tests server side rendering of core/navigation-submenu
+ *
+ * @package    Gutenberg
+ * @subpackage block-library
+ */
+
+/**
+ * Tests for various cases in Navigation Submenu rendering
+ */
+class Render_Block_Navigation_Submenu_Test extends WP_UnitTestCase {
+	private static $category;
+	private static $page;
+	private static $draft;
+	private static $custom_draft;
+	private static $custom_post;
+
+	private static $pages;
+	private static $terms;
+	/**
+	 * @var array|null
+	 */
+	private $original_block_supports;
+
+	public static function set_up_before_class() {
+
+		self::$draft   = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'draft',
+				'post_name'    => 'ceilingcat',
+				'post_title'   => 'Ceiling Cat',
+				'post_content' => 'Ceiling Cat content',
+				'post_excerpt' => 'Ceiling Cat',
+			)
+		);
+		self::$pages[] = self::$draft;
+
+		self::$custom_draft = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'cats',
+				'post_status'  => 'draft',
+				'post_name'    => 'metalcat',
+				'post_title'   => 'Metal Cat',
+				'post_content' => 'Metal Cat content',
+				'post_excerpt' => 'Metal Cat',
+			)
+		);
+		self::$pages[]      = self::$custom_draft;
+
+		self::$custom_post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'dogs',
+				'post_status'  => 'publish',
+				'post_name'    => 'metaldog',
+				'post_title'   => 'Metal Dog',
+				'post_content' => 'Metal Dog content',
+				'post_excerpt' => 'Metal Dog',
+			)
+		);
+		self::$pages[]     = self::$custom_post;
+
+		self::$page    = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_name'    => 'tabby',
+				'post_title'   => 'Tabby cats',
+				'post_content' => 'Tabby cat content',
+				'post_excerpt' => 'Tabby cat',
+			)
+		);
+		self::$pages[] = self::$page;
+
+		self::$category = self::factory()->category->create_and_get(
+			array(
+				'taxonomy'    => 'category',
+				'name'        => 'cats',
+				'slug'        => 'cats',
+				'description' => 'Cats Category',
+			)
+		);
+
+		self::$terms[] = self::$category;
+	}
+
+
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->original_block_supports      = WP_Block_Supports::$block_to_render;
+		WP_Block_Supports::$block_to_render = array(
+			'attrs'     => array(),
+			'blockName' => '',
+		);
+	}
+
+	public function tear_down() {
+		WP_Block_Supports::$block_to_render = $this->original_block_supports;
+		parent::tear_down();
+	}
+
+	public function test_returns_link_when_post_is_published() {
+		$page_id = self::$page->ID;
+
+		$parsed_blocks = parse_blocks(
+			"<!-- wp:navigation-submenu {\"label\":\"Sample Page\",\"type\":\"page\",\"id\":{$page_id},\"url\":\"http://localhost:8888/?page_id={$page_id}\"} /-->"
+		);
+		$this->assertEquals( 1, count( $parsed_blocks ) );
+
+		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+		$this->assertEquals(
+			true,
+			strpos(
+				gutenberg_render_block_core_navigation_link(
+					$navigation_link_block->attributes,
+					array(),
+					$navigation_link_block
+				),
+				'Sample Page'
+			) !== false
+		);
+	}
+
+	public function test_returns_empty_when_label_is_missing() {
+		$page_id = self::$page->ID;
+
+		$parsed_blocks = parse_blocks(
+			"<!-- wp:navigation-submenu {\"type\":\"page\",\"id\":{$page_id},\"url\":\"http://localhost:8888/?page_id={$page_id}\"} /-->"
+		);
+		$this->assertEquals( 1, count( $parsed_blocks ) );
+
+		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+		$this->assertEquals(
+			'',
+			gutenberg_render_block_core_navigation_link(
+				$navigation_link_block->attributes,
+				array(),
+				$navigation_link_block
+			)
+		);
+	}
+
+	public function test_returns_empty_when_draft() {
+		$page_id = self::$draft->ID;
+
+		$parsed_blocks = parse_blocks(
+			"<!-- wp:navigation-submenu {\"label\":\"Draft Page\",\"type\":\"page\",\"id\":{$page_id},\"url\":\"http://localhost:8888/?page_id={$page_id}\"} /-->"
+		);
+		$this->assertEquals( 1, count( $parsed_blocks ) );
+
+		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+
+		$this->assertEquals(
+			'',
+			gutenberg_render_block_core_navigation_link(
+				$navigation_link_block->attributes,
+				array(),
+				$navigation_link_block
+			)
+		);
+	}
+
+	public function test_returns_link_for_category() {
+		$category_id = self::$category->term_id;
+
+		$parsed_blocks = parse_blocks(
+			"<!-- wp:navigation-submenu {\"label\":\"Cats\",\"type\":\"category\",\"id\":{$category_id},\"url\":\"http://localhost:8888/?cat={$category_id}\"} /-->"
+		);
+		$this->assertEquals( 1, count( $parsed_blocks ) );
+
+		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+		$this->assertEquals(
+			true,
+			strpos(
+				gutenberg_render_block_core_navigation_link(
+					$navigation_link_block->attributes,
+					array(),
+					$navigation_link_block
+				),
+				'Cats'
+			) !== false
+		);
+	}
+
+	public function test_returns_link_for_plain_link() {
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:navigation-submenu {"label":"My Website","url":"https://example.com"} /-->'
+		);
+		$this->assertEquals( 1, count( $parsed_blocks ) );
+
+		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+		$this->assertEquals(
+			true,
+			strpos(
+				gutenberg_render_block_core_navigation_link(
+					$navigation_link_block->attributes,
+					array(),
+					$navigation_link_block
+				),
+				'My Website'
+			) !== false
+		);
+	}
+
+	public function test_returns_link_for_decoded_link() {
+
+		$urls_before_render = array(
+			'https://example.com/?id=10&data=lzB%252Fzd%252FZA%253D%253D',
+			'https://example.com/?id=10&data=lzB%2Fzd%FZA%3D%3D',
+			'https://example.com/?id=10&data=1234',
+		);
+
+		$urls_after_render = array(
+			'https://example.com/?id=10&#038;data=lzB%2Fzd%2FZA%3D%3D',
+			'https://example.com/?id=10&#038;data=lzB%2Fzd%FZA%3D%3D',
+			'https://example.com/?id=10&#038;data=1234',
+		);
+
+		foreach ( $urls_before_render as $idx => $link ) {
+				$parsed_blocks = parse_blocks( '<!-- wp:navigation-submenu {"label":"test label", "url": "' . $link . '"} /-->' );
+			$this->assertEquals( 1, count( $parsed_blocks ) );
+				$block             = $parsed_blocks[0];
+			$navigation_link_block = new WP_Block( $block, array() );
+				$this->assertEquals(
+					true,
+					strpos(
+						gutenberg_render_block_core_navigation_link(
+							$navigation_link_block->attributes,
+							array(),
+							$navigation_link_block
+						),
+						$urls_after_render[ $idx ]
+					) !== false
+				);
+		};
+	}
+
+	public function test_returns_empty_when_custom_post_type_draft() {
+		$page_id = self::$custom_draft->ID;
+
+		$parsed_blocks = parse_blocks(
+			"<!-- wp:navigation-submenu {\"label\":\"Draft Custom Post Type\",\"type\":\"cats\",\"kind\":\"post-type\",\"id\":{$page_id},\"url\":\"http://localhost:8888/?page_id={$page_id}\"} /-->"
+		);
+		$this->assertEquals( 1, count( $parsed_blocks ) );
+
+		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+
+		$this->assertEquals(
+			'',
+			gutenberg_render_block_core_navigation_link(
+				$navigation_link_block->attributes,
+				array(),
+				$navigation_link_block
+			)
+		);
+	}
+
+	public function test_returns_link_when_custom_post_is_published() {
+		$page_id = self::$custom_post->ID;
+
+		$parsed_blocks = parse_blocks(
+			"<!-- wp:navigation-submenu {\"label\":\"Metal Dogs\",\"type\":\"dogs\",\"kind\":\"post-type\",\"id\":{$page_id},\"url\":\"http://localhost:8888/?page_id={$page_id}\"} /-->"
+		);
+		$this->assertEquals( 1, count( $parsed_blocks ) );
+
+		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+		$this->assertEquals(
+			true,
+			strpos(
+				gutenberg_render_block_core_navigation_link(
+					$navigation_link_block->attributes,
+					array(),
+					$navigation_link_block
+				),
+				'Metal Dogs'
+			) !== false
+		);
+	}
+}

--- a/phpunit/blocks/render-block-navigation-submenu-test.php
+++ b/phpunit/blocks/render-block-navigation-submenu-test.php
@@ -125,13 +125,24 @@ class Render_Block_Navigation_Submenu_Test extends WP_UnitTestCase {
 
 		$navigation_link_block = new WP_Block( $block, $context );
 
-		$this->assertStringContainsString(
-			'<ul class="wp-block-navigation__submenu-container has-text-color has-' . $context['overlayTextColor'] . '-color has-background has-' . $context['overlayBackgroundColor'] . '-background-color">',
-			gutenberg_render_block_core_navigation_submenu(
-				$navigation_link_block->attributes,
-				array(),
-				$navigation_link_block
-			),
+		$rendered_html = gutenberg_render_block_core_navigation_submenu(
+			$navigation_link_block->attributes,
+			array(),
+			$navigation_link_block
+		);
+
+		$p = new WP_HTML_Tag_Processor( $rendered_html );
+		$p->next_tag(
+			array(
+				'tag_name'   => 'ul',
+				'class_name' => 'wp-block-navigation__submenu-container',
+			)
+		);
+		$p->get_attribute( 'class' );
+
+		$this->assertEquals(
+			'wp-block-navigation__submenu-container has-text-color has-purple-color has-background has-yellow-background-color',
+			$p->get_attribute( 'class' ),
 			'Submenu block colors inherited from context not applied correctly'
 		);
 	}
@@ -172,7 +183,7 @@ class Render_Block_Navigation_Submenu_Test extends WP_UnitTestCase {
 		);
 	}
 
-    /**
+	/**
 	 * @group submenu-color-inheritance
 	 * @covers ::gutenberg_render_block_core_navigation_submenu
 	 */
@@ -191,7 +202,7 @@ class Render_Block_Navigation_Submenu_Test extends WP_UnitTestCase {
 
 		// Colors inherited from parent Navigation block.
 		$context = array(
-			'overlayTextColor'       => 'purple',
+			'overlayTextColor'             => 'purple',
 			'customOverlayBackgroundColor' => '#E10E0E',
 		);
 


### PR DESCRIPTION
## What?
This takes the custom implementation of color supports from the navigation submenu block and changes it to use `gutenberg_apply_colors_support` from the color supports.

## Why?
This is the first step towards using standard color supports for the navigation block, rather than having a custom implementation. This will help the block to behave in a more predictable way, eliminate bugs and take advantage of tools in Global Styles.

## How?
We have to modify the block_type and block_attributes, so that the block supports work as expected. I'm not sure that is an acceptable workaround. Long term we should actually enable this block support, but we need to migrate the colors from the navigation block attribute to the submenu block which is complex. This begins the process of unifying the approach in a simple way.

## Testing Instructions

Run the tests:
```
npm run test:unit:php -- --filter Render_Block_Navigation_Submenu_Test
```

1. Set text and background preset colors on the overlay for the Navigation block
2. Check that the colors on the frontend match those set in the editor.
3. Do the same for custom colors.

## Screenshots or screencast <!-- if applicable -->
<img width="379" alt="Screenshot 2023-03-08 at 13 49 16" src="https://user-images.githubusercontent.com/275961/223787390-b9c55006-2cfa-4402-85dc-739fd1a207ef.png">

