### PR TITLE
Fix: Navigation sidebar shows a wrong submenu popover.

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -61,3 +61,7 @@
 		}
 	}
 }
+
+.edit-site-sidebar-navigation-screen-navigation-menus__content .popover-slot .wp-block-navigation-submenu {
+	display: none;
+}


### PR DESCRIPTION
Currently on the browse mode navigation sidebar when we click on a submenu an unexpected popover appears. This PR fixes the bug.

## Testing
Add a menu with a submenu.
On the navigation, sidebar click on the parent of the submenu.
Verify this popover does not appear ( on the trunk it appears).
<img width="354" alt="Screenshot 2023-03-08 at 19 25 01" src="https://user-images.githubusercontent.com/11271197/223823146-ed23c2cc-12ab-4f31-9692-ab5aaa223e39.png">
