### PR TITLE
Fix settings tab active state border in block inspector

### DIFF
--- a/packages/block-editor/src/components/block-inspector/style.scss
+++ b/packages/block-editor/src/components/block-inspector/style.scss
@@ -27,6 +27,8 @@
 	.components-panel__body {
 		border: none;
 		border-top: $border-width solid $gray-200;
+
+		// Ensures this PanelBody is treated like the ToolsPanel, removing double borders.
 		margin-top: -$border-width;
 	}
 

--- a/packages/block-editor/src/components/block-inspector/style.scss
+++ b/packages/block-editor/src/components/block-inspector/style.scss
@@ -27,6 +27,7 @@
 	.components-panel__body {
 		border: none;
 		border-top: $border-width solid $gray-200;
+		margin-top: -$border-width;
 	}
 
 	.block-editor-block-card {
@@ -45,10 +46,6 @@
 
 .block-editor-block-inspector__no-block-tools {
 	border-top: $border-width solid $gray-300;
-}
-
-.block-editor-block-inspector__tabs .components-tab-panel__tab-content {
-	margin-top: -$border-width;
 }
 
 .block-editor-block-inspector__tab-item {

--- a/packages/block-editor/src/components/block-inspector/style.scss
+++ b/packages/block-editor/src/components/block-inspector/style.scss
@@ -47,6 +47,10 @@
 	border-top: $border-width solid $gray-300;
 }
 
+.block-editor-block-inspector__tabs .components-tab-panel__tab-content {
+	margin-top: -$border-width;
+}
+
 .block-editor-block-inspector__tab-item {
 	flex: 1 1 0px;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Currently, the inspector tabs for Styles and Settings do not display their active states the same. This is because the Settings panel uses the `PanelBody`, while the Styles panel uses `ToolsPanel` — which have a little (1px) different treatment. 

The `.components-tools-panel` panels within the Styles tab have `margin-top: -1px` applied programmatically, whereas the Settings panels `.components-panel__body` do not. 

Originally attempted in https://github.com/WordPress/gutenberg/pull/46686 — closing that PR for this one.

## Why?

Consistency.


## How?

I added `margin-top: -$border-width` to `.block-editor-block-inspector .components-panel__body`, which is where the border-top is applied. This emulates the negative margin applied to the ToolsPanel. 

We could alternatively apply the negative margin top at the top-level ` .block-editor-block-inspector__tabs .components-tab-panel__tab-content` element instead (did that originally) — I don't see why we wouldn't put it on the PanelBody. 


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
 1. Open a Post or Page. 
2. Insert a Group block.
3. Open Sidebar Inspector.
4. Open Block Settings.
5. Toggle between Styles and Settings tabs, see no change in placement of the active border.

## Screenshots or screencast <!-- if applicable -->

#### Before (active tab border is in a different spot for the Settings and Styles tabs): 

https://user-images.githubusercontent.com/1813435/223868462-72bbdf1f-9429-45a7-b908-74214b2c1afe.mp4



#### After (active tab borders are in the same spot for both tabs, nice): 

https://user-images.githubusercontent.com/1813435/223868106-55916b54-fc73-4106-b694-6bf917ad242e.mp4



