### PR TITLE
Distraction Free Mode: Don't show the metaboxes

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -83,7 +83,7 @@ function Layout( { styles } ) {
 		isInserterOpened,
 		isListViewOpened,
 		showIconLabels,
-		isDistractionFreeMode,
+		isDistractionFree,
 		showBlockBreadcrumbs,
 		isTemplateMode,
 		documentLabel,
@@ -116,7 +116,7 @@ function Layout( { styles } ) {
 			).getAllShortcutKeyCombinations( 'core/edit-post/next-region' ),
 			showIconLabels:
 				select( editPostStore ).isFeatureActive( 'showIconLabels' ),
-			isDistractionFreeMode:
+			isDistractionFree:
 				select( editPostStore ).isFeatureActive( 'distractionFree' ),
 			showBlockBreadcrumbs: select( editPostStore ).isFeatureActive(
 				'showBlockBreadcrumbs'
@@ -125,8 +125,6 @@ function Layout( { styles } ) {
 			documentLabel: postTypeLabel || _x( 'Document', 'noun' ),
 		};
 	}, [] );
-
-	const isDistractionFree = isDistractionFreeMode && isLargeViewport;
 
 	const openSidebarPanel = () =>
 		openGeneralSidebar(
@@ -164,7 +162,7 @@ function Layout( { styles } ) {
 		'has-fixed-toolbar': hasFixedToolbar,
 		'has-metaboxes': hasActiveMetaboxes,
 		'show-icon-labels': showIconLabels,
-		'is-distraction-free': isDistractionFree,
+		'is-distraction-free': isDistractionFree && isLargeViewport,
 		'is-entity-save-view-open': !! entitiesSavedStatesCallback,
 	} );
 
@@ -206,7 +204,7 @@ function Layout( { styles } ) {
 			<EditorKeyboardShortcutsRegister />
 			<SettingsSidebar />
 			<InterfaceSkeleton
-				isDistractionFree={ isDistractionFree }
+				isDistractionFree={ isDistractionFree && isLargeViewport }
 				className={ className }
 				labels={ {
 					...interfaceLabels,
@@ -245,14 +243,16 @@ function Layout( { styles } ) {
 				notices={ <EditorSnackbars /> }
 				content={
 					<>
-						{ ! isDistractionFree && <EditorNotices /> }
+						{ ( ! isDistractionFree || ! isLargeViewport ) && (
+							<EditorNotices />
+						) }
 						{ ( mode === 'text' || ! isRichEditingEnabled ) && (
 							<TextEditor />
 						) }
 						{ isRichEditingEnabled && mode === 'visual' && (
 							<VisualEditor styles={ styles } />
 						) }
-						{ ! isTemplateMode && (
+						{ ! isDistractionFree && ! isTemplateMode && (
 							<div className="edit-post-layout__metaboxes">
 								<MetaBoxes location="normal" />
 								<MetaBoxes location="advanced" />
@@ -265,8 +265,8 @@ function Layout( { styles } ) {
 				}
 				footer={
 					! isDistractionFree &&
-					showBlockBreadcrumbs &&
 					! isMobileViewport &&
+					showBlockBreadcrumbs &&
 					isRichEditingEnabled &&
 					mode === 'visual' && (
 						<div className="edit-post-layout__footer">

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -217,7 +217,7 @@ function Layout( { styles } ) {
 						}
 					/>
 				}
-				editorNotices={ ! isDistractionFree && <EditorNotices /> }
+				editorNotices={ <EditorNotices /> }
 				secondarySidebar={ secondarySidebar() }
 				sidebar={
 					( ! isMobileViewport || sidebarIsOpened ) && (

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -243,9 +243,7 @@ function Layout( { styles } ) {
 				notices={ <EditorSnackbars /> }
 				content={
 					<>
-						{ ( ! isDistractionFree || ! isLargeViewport ) && (
-							<EditorNotices />
-						) }
+						{ ! isDistractionFree && <EditorNotices /> }
 						{ ( mode === 'text' || ! isRichEditingEnabled ) && (
 							<TextEditor />
 						) }

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -217,7 +217,7 @@ function Layout( { styles } ) {
 						}
 					/>
 				}
-				editorNotices={ <EditorNotices /> }
+				editorNotices={ ! isDistractionFree && <EditorNotices /> }
 				secondarySidebar={ secondarySidebar() }
 				sidebar={
 					( ! isMobileViewport || sidebarIsOpened ) && (


### PR DESCRIPTION
Fixes #48909

## What?
This PR fixes a problem with the metabox panel when switching to distraction-free mode.

## How?
In the Layout component of the post editor, the layout is controlled by the value of the `isDistractionFree` variable. However, this variable includes the viewport width as a condition, as shown below.

```
const isDistractionFree = isDistractionFreeMode && isLargeViewport;
```

This variable cannot be used because the metabox should be hidden in distraction-free mode, regardless of the width of the viewport. Also, it appears that the name of the variable does not exactly match what is intended by the name of the variable and the result of its value.

Therefore, I changed the name of the variable `isDistractionFreeMode` to `isDistractionFree`, which purely determines the mode, and this variable now controls the display state of the metabox.  At the same time, I adjusted the conditional statements in the areas affected by this change.


## Testing Instructions

In advance, run the following code in the browser console to display the notis messages.

```
 wp.data.dispatch( 'core/notices' ).createErrorNotice( 'error' )
```

Then, activate the Custom Fields panel from the Options menu.

### Default Mode

#### Viewport width greater than 960px

- Header bar should appear
- Notices message should appear
- Custom field panel should appear
- Breadcrumb list should appear.

![default-large](https://user-images.githubusercontent.com/54422211/223904676-b757ad91-38c7-4751-bc38-7e573f659777.png)

#### Viewport width smaller than 960px

- Header bar should appear
- Notices message should appear
- Custom field panel should appear
- Breadcrumb list should appear.

![default-medium](https://user-images.githubusercontent.com/54422211/223904685-e20c437f-4579-4940-a1e0-e5ee47571c1e.png)

#### Viewport width smaller than 782px

- Breadcrumb list should not appear.

### Distraction Free Mode

I noticed that the distraction-free mode could not be released unless the notice message bar was turned off, because it overlapped the header area. This may be a bug, but I think it should be addressed in a separate issue.

#### Viewport width greater than 960px

- Header bar should not appear
- Notices message should appear
- Custom field panel should not appear (**Changes by this PR**)
- Breadcrumb list should not appear.

![distraction-free-large](https://user-images.githubusercontent.com/54422211/223904715-8c246d37-abbe-47b1-808c-26a154559be8.png)

#### Viewport width smaller than 960px

- Header bar should appear
- Notices message should appear
- Custom field panel should not appear (**Changes by this PR**)
- Breadcrumb list should not appear

![distraction-free-medium](https://user-images.githubusercontent.com/54422211/223904729-067422e9-1232-4eda-a2f5-8cd40e7b7bca.png)

#### Viewport width smaller than 782px

- Breadcrumb list should not appear.