### PR TITLE
Theme JSON schema: Add sticky position to settings, minHeight to styles

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -106,6 +106,16 @@ Settings related to layout.
 
 ---
 
+### position
+
+Settings related to position.
+
+| Property  | Type   | Default | Props  |
+| ---       | ---    | ---    |---   |
+| sticky | boolean | false |  |
+
+---
+
 ### spacing
 
 Settings related to spacing.
@@ -178,6 +188,16 @@ Color styles.
 | background | string, object |  |
 | gradient | string, object |  |
 | text | string, object |  |
+
+---
+
+### dimensions
+
+Dimensions styles
+
+| Property  | Type   |  Props  |
+| ---       | ---    |---   |
+| minHeight | string, object |  |
 
 ---
 

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -267,6 +267,23 @@
 				}
 			}
 		},
+		"settingsPropertiesPosition": {
+			"type": "object",
+			"properties": {
+				"position": {
+					"description": "Settings related to position.",
+					"type": "object",
+					"properties": {
+						"sticky": {
+							"description": "Allow users to set sticky position.",
+							"type": "boolean",
+							"default": false
+						}
+					},
+					"additionalProperties": false
+				}
+			}
+		},
 		"settingsPropertiesSpacing": {
 			"type": "object",
 			"properties": {
@@ -627,6 +644,7 @@
 				{ "$ref": "#/definitions/settingsPropertiesColor" },
 				{ "$ref": "#/definitions/settingsPropertiesShadow" },
 				{ "$ref": "#/definitions/settingsPropertiesLayout" },
+				{ "$ref": "#/definitions/settingsPropertiesPosition" },
 				{ "$ref": "#/definitions/settingsPropertiesSpacing" },
 				{ "$ref": "#/definitions/settingsPropertiesTypography" },
 				{ "$ref": "#/definitions/settingsPropertiesCustom" }
@@ -645,6 +663,7 @@
 						"shadow": {},
 						"color": {},
 						"layout": {},
+						"position": {},
 						"spacing": {},
 						"typography": {},
 						"custom": {}

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -642,6 +642,7 @@
 				{ "$ref": "#/definitions/settingsPropertiesAppearanceTools" },
 				{ "$ref": "#/definitions/settingsPropertiesBorder" },
 				{ "$ref": "#/definitions/settingsPropertiesColor" },
+				{ "$ref": "#/definitions/settingsPropertiesDimensions" },
 				{ "$ref": "#/definitions/settingsPropertiesShadow" },
 				{ "$ref": "#/definitions/settingsPropertiesLayout" },
 				{ "$ref": "#/definitions/settingsPropertiesPosition" },
@@ -660,10 +661,11 @@
 					"properties": {
 						"appearanceTools": {},
 						"border": {},
-						"shadow": {},
 						"color": {},
+						"dimensions": {},
 						"layout": {},
 						"position": {},
+						"shadow": {},
 						"spacing": {},
 						"typography": {},
 						"custom": {}
@@ -1277,6 +1279,23 @@
 					},
 					"additionalProperties": false
 				},
+				"dimensions": {
+					"description": "Dimensions styles",
+					"type": "object",
+					"properties": {
+						"minHeight": {
+							"description": "Sets the `min-height` CSS property.",
+							"oneOf": [
+								{
+									"type": "string"
+								},
+								{
+									"$ref": "#/definitions/refComplete"
+								}
+							]
+						}
+					}
+				},
 				"spacing": {
 					"description": "Spacing styles.",
 					"type": "object",
@@ -1592,6 +1611,7 @@
 					"properties": {
 						"border": {},
 						"color": {},
+						"dimensions": {},
 						"spacing": {},
 						"typography": {},
 						"filter": {},
@@ -1968,6 +1988,7 @@
 					"properties": {
 						"border": {},
 						"color": {},
+						"dimensions": {},
 						"spacing": {},
 						"typography": {},
 						"filter": {},

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -232,6 +232,7 @@
 			}
 		},
 		"settingsPropertiesDimensions": {
+			"type": "object",
 			"properties": {
 				"dimensions": {
 					"description": "Settings related to dimensions.",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Update `theme.json` schema to include `position.sticky` within the settings schema, and `dimensions.minHeight` within the styles schema.

Note that while `fixed` is treated as a valid value in code, it is not yet in use by any core blocks. To avoid folks thinking they can start using it by switching `fixed` to `true`, I've left it off this change for now.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Now that the sticky position support has been added to the Group block, and the feature will be in `6.2`, ensure the setting exists within the `theme.json` schema.

Also, `dimensions.minHeight` was missing from the style schema, so that's been added now.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Update the `theme.json` schema to reflect that `position.sticky` is a valid setting (boolean) — note that position is not valid as a _style_ within `theme.json` as it is intended to be set at the individual block level within the editor.
* Add `dimensions.minHeight` as a valid style.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Proofread to make sure the changes look correct, and are added in the right places. I wasn't too sure how else to test it manually?