### PR TITLE
Query Block: Add tests for `getValueFromObjectPath()` util

### DIFF
--- a/packages/block-library/src/query/test/utils.js
+++ b/packages/block-library/src/query/test/utils.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { terms } from './fixtures';
-import { getEntitiesInfo } from '../utils';
+import { getEntitiesInfo, getValueFromObjectPath } from '../utils';
 
 describe( 'Query block utils', () => {
 	describe( 'getEntitiesInfo', () => {
@@ -27,6 +27,38 @@ describe( 'Query block utils', () => {
 					names: expect.arrayContaining( [ 'nba', 'featured' ] ),
 				} )
 			);
+		} );
+	} );
+
+	describe( 'getValueFromObjectPath', () => {
+		it( 'should return undefined when path is empty', () => {
+			const object = { foo: 'bar' };
+			const result = getValueFromObjectPath( object, '' );
+			expect( result ).toBeUndefined();
+		} );
+
+		it( 'should return undefined when path does not exist', () => {
+			const object = { foo: 'bar' };
+			const result = getValueFromObjectPath( object, 'baz' );
+			expect( result ).toBeUndefined();
+		} );
+
+		it( 'should return undefined when a deeper path does not exist', () => {
+			const object = { foo: { bar: 'baz' } };
+			const result = getValueFromObjectPath( object, 'foo.test' );
+			expect( result ).toBeUndefined();
+		} );
+
+		it( 'should return the corresponding value of a single level path', () => {
+			const object = { foo: 'bar' };
+			const result = getValueFromObjectPath( object, 'foo' );
+			expect( result ).toBe( 'bar' );
+		} );
+
+		it( 'should return the value of a deeper path', () => {
+			const object = { foo: { bar: { baz: 'test' } } };
+			const result = getValueFromObjectPath( object, 'foo.bar.baz' );
+			expect( result ).toBe( 'test' );
 		} );
 	} );
 } );

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -66,7 +66,7 @@ export const getEntitiesInfo = ( entities ) => {
  * @param {string} path   Path to the object property.
  * @return {*} Value of the object property at the specified path.
  */
-const getValueFromObjectPath = ( object, path ) => {
+export const getValueFromObjectPath = ( object, path ) => {
 	const normalizedPath = path.split( '.' );
 	let value = object;
 	normalizedPath.forEach( ( fieldName ) => {


### PR DESCRIPTION
## What?
This PR adds some tests to the `getValueFromObjectPath()` utility function, as suggested in https://github.com/WordPress/gutenberg/pull/48491#discussion_r1130599285.

## Why?
Just some additional test coverage.

## How?
We're just adding some tests.

## Testing Instructions
Verify tests pass: `npm run test:unit packages/block-library/src/query`

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None