### PR TITLE
Make "Manage all templates" button sticky

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -101,7 +101,7 @@ export default function SidebarNavigationScreenTemplates() {
 				<>
 					{ isLoading && config[ postType ].labels.loading }
 					{ ! isLoading && (
-						<ItemGroup>
+						<ItemGroup className="edit-site-sidebar-navigation-screen-templates__templates-list">
 							{ ! templates?.length && (
 								<Item>
 									{ config[ postType ].labels.notFound }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/style.scss
@@ -1,4 +1,11 @@
-.edit-site-sidebar-navigation-screen-templates__see-all {
-	/* Overrides the margin that comes from the Item component */
-	margin-top: $grid-unit-20 !important;
+.edit-site-sidebar-navigation-screen-templates__templates-list {
+	div:last-child {
+		position: sticky;
+		bottom: 0;
+		margin-bottom: - $grid-unit-20;
+		padding: $grid-unit-20 0;
+		background-color: $gray-900;
+		margin-top: $grid-unit-20;
+		box-shadow: 0 -#{$grid-unit-10} $grid-unit-20 $gray-900;
+	}
 }


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/48797.

## What?
In the Site Editor sidebar: makes the last item in the templates (and template parts) list sticky so that it's always visible. Also creates some space between the items which seems appropriate due to the unique nature of this button.

## Why?
Discoverability buff. If you want to manage templates, and there are many templates at the site, then you have to scroll to find the link.

## How?
I don't think the implementation is ideal as I am targeting the `:last-child` in the `ItemGroup`. Unfortunately I couldn't find a way to target the manage container specifically. If someone is able to retrofit that it would be good. The rest of the details seem to work well.

## Testing Instructions
Navigate to the Templates list in the Side Editor sidebar. Ensure the "Manage all templates" button is always visible, regardless of how long the template list is.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://user-images.githubusercontent.com/846565/224036162-8e2869f1-d417-447d-9b89-90a734a62247.mp4



**After**

https://user-images.githubusercontent.com/846565/224036010-80bfe8b9-2bd9-4a09-9440-3890684a6f36.mp4

