### PR TITLE
Fix text alignment in the Site Editor sidebar

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -1,6 +1,7 @@
 .edit-site-sidebar-navigation-item.components-item {
 	color: $gray-600;
 	border-width: $border-width-tab;
+	margin: 0 2.5px; // This combines with the border above to create a 4px gap and ensure the text line up nicely with other side bar elements along the Y axis
 
 	&:hover,
 	&:focus,

--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -1,14 +1,12 @@
 .edit-site-sidebar-navigation-item.components-item {
 	color: $gray-600;
-	border-width: $border-width-tab;
-	margin: 0 2.5px; // This combines with the border above to create a 4px gap and ensure the text line up nicely with other side bar elements along the Y axis
+	margin: 0 $grid-unit-05;
 
 	&:hover,
 	&:focus,
 	&[aria-current] {
 		color: $white;
 		background: $gray-800;
-		border-width: $border-width-tab;
 	}
 
 	&[aria-current] {
@@ -18,6 +16,5 @@
 
 .edit-site-sidebar-navigation-screen__content .block-editor-list-view-block-select-button {
 	cursor: grab;
-	width: calc(100% - #{ $border-width-focus });
 	padding: $grid-unit-10;
 }

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -95,7 +95,11 @@ const SiteHub = forwardRef( ( props, ref ) => {
 					</Button>
 				</motion.div>
 
-				{ showLabels && <div>{ siteTitle }</div> }
+				{ showLabels && (
+					<div className="edit-site-site-hub__site-title">
+						{ siteTitle }
+					</div>
+				) }
 			</HStack>
 		</motion.div>
 	);

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -26,3 +26,7 @@
 	white-space: nowrap;
 	overflow: hidden;
 }
+
+.edit-site-site-hub__site-title {
+	margin-left: $grid-unit-05;
+}


### PR DESCRIPTION
## What?
Ensures the text is justified nicely along the Y axis

## Why?
Adds a small sense polish to the experience.

## How?
Just css tweaks. Increased the space between W button + site title. Added some margin to buttons in the Templates / Template Parts panel.

## Testing Instructions
1. Open the Site Editor
2. Observe that all the text elements align nicely 

## Before
<img width="461" alt="Screenshot 2023-03-09 at 14 03 45" src="https://user-images.githubusercontent.com/846565/224049075-93af0ad2-65f9-44ec-bc27-1c0c8b5bd596.png">


## After
<img width="457" alt="Screenshot 2023-03-09 at 14 04 01" src="https://user-images.githubusercontent.com/846565/224049105-0abba347-dd6f-4247-a610-dc670a16c14c.png">

