### PR TITLE
Inserter: Remove unnecessary dependency 'delayedFilterValue'

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -152,7 +152,6 @@ function InserterMenu(
 			destinationRootClientId,
 			onInsert,
 			onHover,
-			delayedFilterValue,
 			showMostUsedBlocks,
 			showInserterHelpPanel,
 		]


### PR DESCRIPTION
## What?
PR removes unnecessary dependency `delayedFilterValue` for the inserter menu's memoized `blockTabs`.

## Why?
The `delayedFilterValue` isn't used by the blocks tab, and we don't need to re-memoize the component when this state changes.

## Testing Instructions
1. Open a Post or Page.
2. Confirm the initial block tab is displayed correctly.
3. Confirm searching the blocks works as before.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-03-09 at 18 09 17](https://user-images.githubusercontent.com/240569/224050361-bef26952-ca8f-4f4d-8f81-3dd89aff4b95.png)