### PR TITLE
Inserter: Remove outer scope values dependencies

### DIFF
--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -52,15 +52,7 @@ function InserterTabs( {
 			tempTabs.push( reusableBlocksTab );
 		}
 		return tempTabs;
-	}, [
-		prioritizePatterns,
-		blocksTab,
-		showPatterns,
-		patternsTab,
-		showReusableBlocks,
-		showMedia,
-		reusableBlocksTab,
-	] );
+	}, [ prioritizePatterns, showPatterns, showReusableBlocks, showMedia ] );
 
 	return (
 		<TabPanel


### PR DESCRIPTION
## What?
PR removes outer scope values as `useMemo` dependencies inside the `InserterTabs` component.

## Why?
> Outer scope values like 'blocksTab' aren't valid dependencies because mutating them doesn't re-render the component.

## Testing Instructions
The block inserter works as before.