### PR TITLE
Try: Add chevrons to template panels, update chevron styling

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-item/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-item/index.js
@@ -11,7 +11,7 @@ import {
 	__experimentalHStack as HStack,
 	FlexBlock,
 } from '@wordpress/components';
-import { chevronRight, Icon } from '@wordpress/icons';
+import { chevronRightSmall, Icon } from '@wordpress/icons';
 
 export default function SidebarNavigationItem( {
 	className,
@@ -38,8 +38,8 @@ export default function SidebarNavigationItem( {
 					<FlexBlock>{ children }</FlexBlock>
 					{ withChevron && (
 						<Icon
-							style={ { fill: 'currentcolor' } }
-							icon={ chevronRight }
+							className="edit-site-sidebar-navigation-item__chevron"
+							icon={ chevronRightSmall }
 							size={ 24 }
 						/>
 					) }

--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -20,3 +20,7 @@
 	width: calc(100% - #{ $border-width-focus });
 	padding: $grid-unit-10;
 }
+
+.edit-site-sidebar-navigation-item__chevron {
+	fill: $gray-700;
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -5,12 +5,15 @@ import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
 	__experimentalUseNavigator as useNavigator,
+	__experimentalHStack as HStack,
+	FlexBlock,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEntityRecords } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useViewportMatch } from '@wordpress/compose';
+import { chevronRightSmall, Icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -113,10 +116,19 @@ export default function SidebarNavigationScreenTemplates() {
 									postId={ template.id }
 									key={ template.id }
 								>
-									{ decodeEntities(
-										template.title?.rendered ||
-											template.slug
-									) }
+									<HStack>
+										<FlexBlock>
+											{ decodeEntities(
+												template.title?.rendered ||
+													template.slug
+											) }
+										</FlexBlock>
+										<Icon
+											className="edit-site-sidebar-navigation-screen-templates__chevron"
+											icon={ chevronRightSmall }
+											size={ 24 }
+										/>
+									</HStack>
 								</TemplateItem>
 							) ) }
 							{ ! isMobileViewport && (
@@ -124,7 +136,19 @@ export default function SidebarNavigationScreenTemplates() {
 									className="edit-site-sidebar-navigation-screen-templates__see-all"
 									{ ...browseAllLink }
 									children={
-										config[ postType ].labels.manage
+										<HStack>
+											<FlexBlock>
+												{
+													config[ postType ].labels
+														.manage
+												}
+											</FlexBlock>
+											<Icon
+												className="edit-site-sidebar-navigation-screen-templates__chevron"
+												icon={ chevronRightSmall }
+												size={ 24 }
+											/>
+										</HStack>
 									}
 								/>
 							) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/style.scss
@@ -2,3 +2,7 @@
 	/* Overrides the margin that comes from the Item component */
 	margin-top: $grid-unit-20 !important;
 }
+
+.edit-site-sidebar-navigation-screen-templates__chevron {
+	fill: $gray-700;
+}


### PR DESCRIPTION
Potentially part of https://github.com/WordPress/gutenberg/issues/48591. This PR is basically experimental and the implementation very rough. It's essentially a way for us to get an idea of how adding Chevrons to all drilldown menu items feels in terms of noise, etc.

## What?
Adds chevron to items in the template panels. These serve as behavior indicators for the drill downs. Also swaps Chevron to ChevronSmall at the root level.

## Why?
We currently have inconsistent styling for drilldown menu items. Some (root level) inform you that a drilldown will appear on click. Others (Template panels) do not.

## How?
1. Edited `SidebarNavigationItem`.
2. Edited `TemplateItem`.

## Testing Instructions
1. Open the Site Editor
2. Drill into the Templates (and Template Parts) panels
3. Observe chevron icon indicators

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/846565/224061625-e6e3af57-6009-4b7c-8a58-0d922d7ca164.mp4

