### PR TITLE
Remove 16:10 from Post Featured Image

### DIFF
--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -97,10 +97,6 @@ const DimensionControls = ( {
 							value: '1',
 						},
 						{
-							label: __( '16:10' ),
-							value: '16/10',
-						},
-						{
 							label: __( '16:9' ),
 							value: '16/9',
 						},
@@ -111,10 +107,6 @@ const DimensionControls = ( {
 						{
 							label: __( '3:2' ),
 							value: '3/2',
-						},
-						{
-							label: __( '10:16' ),
-							value: '10/16',
 						},
 						{
 							label: __( '9:16' ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Removes the 16:10 option from the Post Featured Image block's aspect ratio controls. Half of #48041 — other half is updating the AspectRatioDropdown option. 

## Why?
We have 16:9 already - we don't need both. 

## How?
Removes the `16/10` value from the SelectControl options within the `core/post-featured-image` block. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page.
2. Insert a Post Featured Image block.
3. Open Block Inspector.
4. Click on "Styles" tab.
5. Click on "Aspect Ratio" select.
6. See options, with no 16:10 present.

## Screenshots or screencast <!-- if applicable -->

Before: 

<img width="342" alt="CleanShot 2023-03-09 at 12 29 25" src="https://user-images.githubusercontent.com/1813435/224107778-eabb1cf9-eb22-4c2c-9a59-74a8c1a121be.png">

After: 

<img width="349" alt="CleanShot 2023-03-09 at 12 18 02" src="https://user-images.githubusercontent.com/1813435/224107604-3c087302-4342-492a-a704-bd9b7dfb2238.png">
