### PR TITLE
Remove white background on Site Editor 'Frame'

### DIFF
--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -29,7 +29,6 @@
 
 	.edit-site-visual-editor__editor-canvas {
 		height: 100%;
-		background: $white;
 	}
 
 	&.is-focus-mode {

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -108,7 +108,6 @@
 
 	& > div {
 		color: $gray-900;
-		background: $white;
 		box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.8), 0 8px 10px -6px rgba(0, 0, 0, 0.8);
 	}
 


### PR DESCRIPTION
## What?
Removes the white background applied to `.edit-site-visual-editor__editor-canvas` and `.edit-site-layout__canvas>div`.

## Why?
When the site has a non-white background, the white frame background can be seen flashing in and out during the on-hover animation. It's particularly noticeable when the background is dark:


https://user-images.githubusercontent.com/846565/224119224-fe959801-8d55-4a8e-9c14-8c9861399f75.mp4

## Testing Instructions
1. Activate a theme with a dark background.
2. Open the Site Editor and mouse over the Frame.
3. The White background should not be visible:


https://user-images.githubusercontent.com/846565/224119443-db5c8ec7-cfe8-4624-94ca-873685dddbe5.mp4

cc @youknowriad. In the past I think you've expressed that these backgrounds are required, but I couldn't find any issues.