### PR TITLE
Try read only navigation sidebar in browse mode

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/block-contents.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-contents.js
@@ -19,6 +19,7 @@ import { store as blockEditorStore } from '../../store';
 import { updateAttributes } from './update-attributes';
 import { LinkUI } from './link-ui';
 import { useInsertedBlock } from './use-inserted-block';
+import { useListViewContext } from './context';
 
 const BLOCKS_WITH_LINK_UI_SUPPORT = [
 	'core/navigation-link',
@@ -43,6 +44,7 @@ const ListViewBlockContents = forwardRef(
 	) => {
 		const { clientId } = block;
 		const [ isLinkUIOpen, setIsLinkUIOpen ] = useState();
+		const { enableDragAndDrop } = useListViewContext();
 		const {
 			blockMovingClientId,
 			selectedBlockInBlockEditor,
@@ -124,26 +126,44 @@ const ListViewBlockContents = forwardRef(
 						onCancel={ () => setIsLinkUIOpen( false ) }
 					/>
 				) }
-				<BlockDraggable clientIds={ draggableClientIds }>
-					{ ( { draggable, onDragStart, onDragEnd } ) => (
-						<ListViewBlockSelectButton
-							ref={ ref }
-							className={ className }
-							block={ block }
-							onClick={ onClick }
-							onToggleExpanded={ onToggleExpanded }
-							isSelected={ isSelected }
-							position={ position }
-							siblingBlockCount={ siblingBlockCount }
-							level={ level }
-							draggable={ draggable }
-							onDragStart={ onDragStart }
-							onDragEnd={ onDragEnd }
-							isExpanded={ isExpanded }
-							{ ...props }
-						/>
-					) }
-				</BlockDraggable>
+				{ enableDragAndDrop && (
+					<BlockDraggable clientIds={ draggableClientIds }>
+						{ ( { draggable, onDragStart, onDragEnd } ) => (
+							<ListViewBlockSelectButton
+								ref={ ref }
+								className={ className }
+								block={ block }
+								onClick={ onClick }
+								onToggleExpanded={ onToggleExpanded }
+								isSelected={ isSelected }
+								position={ position }
+								siblingBlockCount={ siblingBlockCount }
+								level={ level }
+								draggable={ draggable }
+								onDragStart={ onDragStart }
+								onDragEnd={ onDragEnd }
+								isExpanded={ isExpanded }
+								{ ...props }
+							/>
+						) }
+					</BlockDraggable>
+				) }
+				{ ! enableDragAndDrop && (
+					<ListViewBlockSelectButton
+						ref={ ref }
+						className={ className }
+						block={ block }
+						onClick={ onClick }
+						onToggleExpanded={ onToggleExpanded }
+						isSelected={ isSelected }
+						position={ position }
+						siblingBlockCount={ siblingBlockCount }
+						level={ level }
+						isExpanded={ isExpanded }
+						draggable={ false }
+						{ ...props }
+					/>
+				) }
 			</>
 		);
 	}

--- a/packages/block-editor/src/components/off-canvas-editor/block.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block.js
@@ -307,39 +307,40 @@ function ListViewBlock( {
 				</>
 			) }
 
-			{ showBlockActions && (
-				<>
-					<TreeGridCell
-						className={ listViewBlockSettingsClassName }
-						aria-selected={
-							!! isSelected || forceSelectionContentLock
-						}
-					>
-						{ ( { ref, tabIndex, onFocus } ) => (
-							<>
-								<MoreMenuComponent
-									clientIds={ dropdownClientIds }
-									block={ block }
-									clientId={ clientId }
-									icon={ moreVertical }
-									label={ settingsAriaLabel }
-									toggleProps={ {
-										ref,
-										className:
-											'block-editor-list-view-block__menu',
-										tabIndex,
-										onFocus,
-									} }
-									disableOpenOnArrowDown
-									__experimentalSelectBlock={
-										updateSelection
-									}
-								/>
-							</>
-						) }
-					</TreeGridCell>
-				</>
-			) }
+			{ showBlockActions ||
+				( MoreMenuComponent === false && (
+					<>
+						<TreeGridCell
+							className={ listViewBlockSettingsClassName }
+							aria-selected={
+								!! isSelected || forceSelectionContentLock
+							}
+						>
+							{ ( { ref, tabIndex, onFocus } ) => (
+								<>
+									<MoreMenuComponent
+										clientIds={ dropdownClientIds }
+										block={ block }
+										clientId={ clientId }
+										icon={ moreVertical }
+										label={ settingsAriaLabel }
+										toggleProps={ {
+											ref,
+											className:
+												'block-editor-list-view-block__menu',
+											tabIndex,
+											onFocus,
+										} }
+										disableOpenOnArrowDown
+										__experimentalSelectBlock={
+											updateSelection
+										}
+									/>
+								</>
+							) }
+						</TreeGridCell>
+					</>
+				) ) }
 		</ListViewLeaf>
 	);
 }

--- a/packages/block-editor/src/components/off-canvas-editor/index.js
+++ b/packages/block-editor/src/components/off-canvas-editor/index.js
@@ -54,17 +54,18 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
 /**
  * Show a hierarchical list of blocks.
  *
- * @param {Object}  props                 Components props.
- * @param {string}  props.id              An HTML element id for the root element of ListView.
- * @param {string}  props.parentClientId  The client id of the parent block.
- * @param {Array}   props.blocks          Custom subset of block client IDs to be used instead of the default hierarchy.
- * @param {boolean} props.showBlockMovers Flag to enable block movers
- * @param {boolean} props.isExpanded      Flag to determine whether nested levels are expanded by default.
- * @param {Object}  props.LeafMoreMenu    Optional more menu substitution.
- * @param {string}  props.description     Optional accessible description for the tree grid component.
- * @param {string}  props.onSelect        Optional callback to be invoked when a block is selected.
- * @param {string}  props.showAppender    Flag to show or hide the block appender.
- * @param {Object}  ref                   Forwarded ref
+ * @param {Object}  props                   Components props.
+ * @param {string}  props.id                An HTML element id for the root element of ListView.
+ * @param {string}  props.parentClientId    The client id of the parent block.
+ * @param {Array}   props.blocks            Custom subset of block client IDs to be used instead of the default hierarchy.
+ * @param {boolean} props.showBlockMovers   Flag to enable block movers
+ * @param {boolean} props.isExpanded        Flag to determine whether nested levels are expanded by default.
+ * @param {Object}  props.LeafMoreMenu      Optional more menu substitution.
+ * @param {boolean} props.enableDragAndDrop Flag to enable drag and drop.
+ * @param {string}  props.description       Optional accessible description for the tree grid component.
+ * @param {string}  props.onSelect          Optional callback to be invoked when a block is selected.
+ * @param {string}  props.showAppender      Flag to show or hide the block appender.
+ * @param {Object}  ref                     Forwarded ref
  */
 function OffCanvasEditor(
 	{
@@ -75,6 +76,7 @@ function OffCanvasEditor(
 		isExpanded = false,
 		showAppender = true,
 		LeafMoreMenu,
+		enableDragAndDrop = true,
 		description = __( 'Block navigation structure' ),
 		onSelect,
 	},
@@ -200,6 +202,7 @@ function OffCanvasEditor(
 			expand,
 			collapse,
 			LeafMoreMenu,
+			enableDragAndDrop,
 		} ),
 		[
 			isMounted.current,

--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -15,6 +15,6 @@
 }
 
 .edit-site-sidebar-navigation-screen__content .block-editor-list-view-block-select-button {
-	cursor: grab;
+	cursor: pointer;
 	padding: $grid-unit-10;
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
@@ -34,7 +34,9 @@ export default function NavigationMenuContent( { rootClientId, onSelect } ) {
 					const block = getBlocksByClientId( item.clientId )[ 0 ];
 					return (
 						block.name === 'core/navigation-link' ||
-						block.name === 'core/navigation-submenu'
+						block.name === 'core/navigation-submenu' ||
+						block.name === 'core/page-list' ||
+						block.name === 'core/page-list-item'
 					);
 				} );
 				return tree;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Alternative to #48933
Complementary to #48935

Makes the navigation in browse mode unable to edit the menu it displays. It works only as a way to browse through the site using the primary navigation menu which should be visible on the site already.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The editing experience in the navigation sidebar is very rough around the edges. The feature itself - being able to browse the website and edit each page you browse to - is extremely valuable in the site editor. However editing the navigation can be better accomplished using the navigation block.

We can follow up later on this feature and make it able to edit the navigation as well.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

For now, pretty hack-y:

- I had to add a new prop to the off canvas editor component to disable drag and drop
- I had to create a work around to disable the more menu
- I have also filtered out any block which is not a navigation link or navigation submenu

## Testing Instructions


1. Check out this branch
2. Have one navigation menu 
3. Use the site editor Navigation sidebar

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/107534/224122833-bf9f10fd-8e5b-4517-9a74-5dc2edd427f4.mp4


👋🏻  @jorgefilipecosta this PR is pretty rough - I meant it as a way to see how having this as a last reasort feels. Not sure on my implementation choices.
