### PR TITLE
Site editor: Fix non-us spelling in sidebar

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/index.js
@@ -19,7 +19,7 @@ const config = {
 	wp_template_part: {
 		title: __( 'All template parts' ),
 		description: __(
-			'Create new template parts, or reset any customisations made to the template parts supplied by your theme.'
+			'Create new template parts, or reset any customizations made to the template parts supplied by your theme.'
 		),
 	},
 };


### PR DESCRIPTION
## What?
Changes customisations to customizations

## Why?
All source strings should be in US spelling. Sorry Charles, that is just how it is 😄 
Fixes: #48966

## How?
With my keyboard.

## Testing Instructions
Look at customizations and if you can imagine dear Elizabeth turning in her grave it is correct.
