### PR TITLE
Preferences Modal: Fix double focus outline in tab item

### DIFF
--- a/packages/interface/src/components/preferences-modal-tabs/style.scss
+++ b/packages/interface/src/components/preferences-modal-tabs/style.scss
@@ -24,6 +24,12 @@ $vertical-tabs-width: 160px;
 
 			&:focus:not(:disabled) {
 				box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+				// Windows high contrast mode.
+				outline: 2px solid transparent;
+			}
+
+			&:focus-visible::before {
+				content: none;
 			}
 		}
 	}


### PR DESCRIPTION
Related to: #46276, #46796

## What?
This PR fixes the double outline when keyboard focus is applied to a tab item in the settings modal.

![double-focus](https://user-images.githubusercontent.com/54422211/224363036-01cf6fbb-ddba-43e6-a502-f1c862e981bc.png)

## Why?

The `:focus-visible` pseudo-element style added by #46276 is having an effect.
https://github.com/WordPress/gutenberg/pull/46276/files#diff-cff33c80017b395c324705c767723d3c51ebaf23b6c9c1d74ecb674052329a24R72-R74

In the preferences modal, I think this outline should not be intended.

## Screenshots or screencast

### Before


https://user-images.githubusercontent.com/54422211/224363179-219f1741-b5a2-40b5-a5b2-e322cdbe0d18.mp4


### After

https://user-images.githubusercontent.com/54422211/224363155-63deb242-c8a7-4e7a-a97c-4863420f9b93.mp4

