### PR TITLE
Fix kses filter for un-prettified filters

### DIFF
--- a/lib/experimental/kses.php
+++ b/lib/experimental/kses.php
@@ -78,7 +78,7 @@ add_action( 'set_current_user', 'gutenberg_override_core_kses_init_filters' );
  */
 function allow_filter_in_styles( $allow_css, $css_test_string ) {
 	if ( preg_match(
-		"/^filter:\s*url\('#wp-duotone-[-a-zA-Z0-9]+'\) \!important$/",
+		"/^filter:\s*url\('#wp-duotone-[-a-zA-Z0-9]+'\) !important$/",
 		$css_test_string
 	) ) {
 		return true;

--- a/lib/experimental/kses.php
+++ b/lib/experimental/kses.php
@@ -78,7 +78,7 @@ add_action( 'set_current_user', 'gutenberg_override_core_kses_init_filters' );
  */
 function allow_filter_in_styles( $allow_css, $css_test_string ) {
 	if ( preg_match(
-		"/^filter: url\('#wp-duotone-[-a-zA-Z0-9]+'\) \!important$/",
+		"/^filter:\s*url\('#wp-duotone-[-a-zA-Z0-9]+'\) \!important$/",
 		$css_test_string
 	) ) {
 		return true;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Updates the regex to allow for zero spaces between `filter:` and `url(`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #48974

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The style engine has an option where it doesn't include spaces if `SCRIPT_DEBUG` is `true`.

It was causing custom duotone filters (including presets applied prior to GB 15.2.4 which were treated as custom filters) to be stripped by kses because the lack of spaces wasn't accounted for in the regex.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Ensure `define( 'SCRIPT_DEBUG', false );` is set in wp-config.php
2. Add a block with a custom duotone filter to a post/page. Do not use the presets.
3. View the post/page in the frontend.
4. Duotone filter should be applied.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
