### PR TITLE
Add: Styles section to the browse mode sidebar.

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -187,6 +187,8 @@ $z-layers: (
 	".edit-site-layout__canvas-container": 2,
 	".edit-site-layout__sidebar": 1,
 	".edit-site-layout__canvas-container.is-resizing::after": 100,
+	// Title needs to appear above other UI the section content.
+	".edit-site-sidebar-navigation-screen__title-icon": 1,
 );
 
 @function z-index( $key ) {

--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -1,0 +1,136 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import fastDeepEqual from 'fast-deep-equal/es6';
+
+/**
+ * WordPress dependencies
+ */
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { useMemo, useContext, useState } from '@wordpress/element';
+import { ENTER } from '@wordpress/keycodes';
+import { __experimentalGrid as Grid } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { mergeBaseAndUserConfigs } from './global-styles-provider';
+import StylesPreview from './preview';
+import { unlock } from '../../private-apis';
+
+const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
+
+function compareVariations( a, b ) {
+	return (
+		fastDeepEqual( a.styles, b.styles ) &&
+		fastDeepEqual( a.settings, b.settings )
+	);
+}
+
+function Variation( { variation } ) {
+	const [ isFocused, setIsFocused ] = useState( false );
+	const { base, user, setUserConfig } = useContext( GlobalStylesContext );
+	const context = useMemo( () => {
+		return {
+			user: {
+				settings: variation.settings ?? {},
+				styles: variation.styles ?? {},
+			},
+			base,
+			merged: mergeBaseAndUserConfigs( base, variation ),
+			setUserConfig: () => {},
+		};
+	}, [ variation, base ] );
+
+	const selectVariation = () => {
+		setUserConfig( () => {
+			return {
+				settings: variation.settings,
+				styles: variation.styles,
+			};
+		} );
+	};
+
+	const selectOnEnter = ( event ) => {
+		if ( event.keyCode === ENTER ) {
+			event.preventDefault();
+			selectVariation();
+		}
+	};
+
+	const isActive = useMemo( () => {
+		return compareVariations( user, variation );
+	}, [ user, variation ] );
+
+	return (
+		<GlobalStylesContext.Provider value={ context }>
+			<div
+				className={ classnames(
+					'edit-site-global-styles-variations_item',
+					{
+						'is-active': isActive,
+					}
+				) }
+				role="button"
+				onClick={ selectVariation }
+				onKeyDown={ selectOnEnter }
+				tabIndex="0"
+				aria-label={ variation?.title }
+				aria-current={ isActive }
+				onFocus={ () => setIsFocused( true ) }
+				onBlur={ () => setIsFocused( false ) }
+			>
+				<div className="edit-site-global-styles-variations_item-preview">
+					<StylesPreview
+						label={ variation?.title }
+						isFocused={ isFocused }
+						withHoverView
+					/>
+				</div>
+			</div>
+		</GlobalStylesContext.Provider>
+	);
+}
+
+export default function StyleVariationsContainer() {
+	const { variations } = useSelect( ( select ) => {
+		return {
+			variations:
+				select(
+					coreStore
+				).__experimentalGetCurrentThemeGlobalStylesVariations() || [],
+		};
+	}, [] );
+
+	const withEmptyVariation = useMemo( () => {
+		return [
+			{
+				title: __( 'Default' ),
+				settings: {},
+				styles: {},
+			},
+			...variations.map( ( variation ) => ( {
+				...variation,
+				settings: variation.settings ?? {},
+				styles: variation.styles ?? {},
+			} ) ),
+		];
+	}, [ variations ] );
+
+	return (
+		<>
+			<Grid
+				columns={ 2 }
+				className="edit-site-global-styles-style-variations-container"
+			>
+				{ withEmptyVariation?.map( ( variation, index ) => (
+					<Variation key={ index } variation={ variation } />
+				) ) }
+			</Grid>
+		</>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import SidebarNavigationScreen from '../sidebar-navigation-screen';
+import StyleVariationsContainer from '../global-styles/style-variations-container';
+
+export default function SidebarNavigationScreenGlobalStyles() {
+	return (
+		<SidebarNavigationScreen
+			title={ __( 'Styles' ) }
+			description={ __(
+				'Choose a different style combination for the theme styles.'
+			) }
+			content={ <StyleVariationsContainer /> }
+		/>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -2,14 +2,21 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { edit } from '@wordpress/icons';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import StyleVariationsContainer from '../global-styles/style-variations-container';
+import { unlock } from '../../private-apis';
+import { store as editSiteStore } from '../../store';
+import SidebarButton from '../sidebar-button';
 
 export default function SidebarNavigationScreenGlobalStyles() {
+	const { openGeneralSidebar } = useDispatch( editSiteStore );
+	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 	return (
 		<SidebarNavigationScreen
 			title={ __( 'Styles' ) }
@@ -17,6 +24,18 @@ export default function SidebarNavigationScreenGlobalStyles() {
 				'Choose a different style combination for the theme styles.'
 			) }
 			content={ <StyleVariationsContainer /> }
+			actions={
+				<SidebarButton
+					icon={ edit }
+					label={ __( 'Edit styles' ) }
+					onClick={ () => {
+						// switch to edit mode.
+						setCanvasMode( 'edit' );
+						// open global styles sidebar.
+						openGeneralSidebar( 'edit-site/global-styles' );
+					} }
+				/>
+			}
 		/>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -6,7 +6,7 @@ import {
 	__experimentalNavigatorButton as NavigatorButton,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { layout, symbolFilled, navigation } from '@wordpress/icons';
+import { layout, symbolFilled, navigation, styles } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -56,6 +56,14 @@ export default function SidebarNavigationScreenMain() {
 							{ __( 'Navigation' ) }
 						</NavigatorButton>
 					) }
+					<NavigatorButton
+						as={ SidebarNavigationItem }
+						path="/wp_global_styles"
+						withChevron
+						icon={ styles }
+					>
+						{ __( 'Styles' ) }
+					</NavigatorButton>
 					<NavigatorButton
 						as={ SidebarNavigationItem }
 						path="/wp_template"

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -8,6 +8,7 @@
 .edit-site-sidebar-navigation-screen__content {
 	margin: 0 $grid-unit-20 $grid-unit-20 $button-size;
 	color: $gray-600;
+	//z-index: z-index(".edit-site-sidebar-navigation-screen__content");
 }
 
 .edit-site-sidebar-navigation-screen__page-link {
@@ -34,6 +35,7 @@
 	margin-bottom: $grid-unit-10;
 	padding-bottom: $grid-unit-10;
 	padding-right: $grid-unit-20;
+	z-index: z-index(".edit-site-sidebar-navigation-screen__title-icon");
 }
 
 .edit-site-sidebar-navigation-screen__title {
@@ -43,4 +45,21 @@
 	flex-grow: 1;
 	color: $white;
 	margin: 0;
+}
+
+.edit-site-sidebar-navigation-screen__content .edit-site-global-styles-style-variations-container {
+	margin-left: $grid-unit-20;
+	.edit-site-global-styles-variations_item-preview {
+		border: $gray-900 $border-width solid;
+	}
+	.edit-site-global-styles-variations_item.is-active .edit-site-global-styles-variations_item-preview {
+		border: $gray-100 $border-width solid;
+	}
+	.edit-site-global-styles-variations_item:hover .edit-site-global-styles-variations_item-preview {
+		border: var(--wp-admin-theme-color) $border-width solid;
+	}
+
+	.edit-site-global-styles-variations_item:focus .edit-site-global-styles-variations_item-preview {
+		border: var(--wp-admin-theme-color) var(--wp-admin-border-width-focus) solid;
+	}
 }

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -17,6 +17,7 @@ import useSyncPathWithURL, {
 	getPathFromURL,
 } from '../sync-state-with-url/use-sync-path-with-url';
 import SidebarNavigationScreenNavigationMenus from '../sidebar-navigation-screen-navigation-menus';
+import SidebarNavigationScreenGlobalStyles from '../sidebar-navigation-screen-global-styles';
 import SidebarNavigationScreenTemplatesBrowse from '../sidebar-navigation-screen-templates-browse';
 import SaveHub from '../save-hub';
 import SidebarNavigationScreenNavigationItem from '../sidebar-navigation-screen-navigation-item';
@@ -32,6 +33,9 @@ function SidebarScreens() {
 			</NavigatorScreen>
 			<NavigatorScreen path="/navigation">
 				<SidebarNavigationScreenNavigationMenus />
+			</NavigatorScreen>
+			<NavigatorScreen path="/wp_global_styles">
+				<SidebarNavigationScreenGlobalStyles />
 			</NavigatorScreen>
 			<NavigatorScreen path="/navigation/:postType/:postId">
 				<SidebarNavigationScreenNavigationItem />


### PR DESCRIPTION
This PR adds a style item to the browse mode sidebar following the design proposed at https://make.wordpress.org/design/2023/02/15/design-share-jan-30-feb-10/.

This is the first step in the addition of styles to the browse mode sidebar, the edit action to customize the styles instead of just selecting a style variation is not added yet.

## Details
The style variations UI was not available as a standalone component we could use, there was a single component that included the global styles sidebar navigation effects like opening the zoomed out mode and rendering the the UI. We are extracting the rendering part that is now used by the browse mode sidebar and by the existing global styles sidebar.
The we use the newly extracted component the add a new menu item in the browse mode sidebar.

## Screeshots
<img width="376" alt="Screenshot 2023-03-12 at 12 01 24" src="https://user-images.githubusercontent.com/11271197/224543244-df98e377-1643-413b-9f6e-2438fc85fda4.png">
<img width="391" alt="Screenshot 2023-03-12 at 12 02 09" src="https://user-images.githubusercontent.com/11271197/224543271-e7a4f192-04f9-457f-b5f3-dece50410023.png">

## Testing
Verify that changing the style variations in the browse mode sidebar and the existing global styles sidebar is possible.
