### PR TITLE
Fix: Global Styles getPresetsClasses crashes if no selector is passed.

### DIFF
--- a/packages/block-editor/src/components/global-styles/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-output.js
@@ -95,11 +95,11 @@ function getPresetsDeclarations( blockPresets = {}, mergedSettings ) {
 /**
  * Transform given preset tree into a set of preset class declarations.
  *
- * @param {string} blockSelector
- * @param {Object} blockPresets
+ * @param {?string} blockSelector
+ * @param {Object}  blockPresets
  * @return {string} CSS declarations for the preset classes.
  */
-function getPresetsClasses( blockSelector, blockPresets = {} ) {
+function getPresetsClasses( blockSelector = '*', blockPresets = {} ) {
 	return PRESET_METADATA.reduce(
 		( declarations, { path, cssVarInfix, classes } ) => {
 			if ( ! classes ) {


### PR DESCRIPTION
During the creation of a "story" for the full global styles UI, we don't have the base WordPress style objects and I noticed a series of crashes. All the global styles code should work even if we don't have a base styles object.
This fix is part of the series of fixes.

It avoids a crash in cases where getPresetsClasses is called without a selector that may happen because the selectors' metadata object may not be present.