### PR TITLE
Migrate autosave E2E tests to Playwright

### DIFF
--- a/test/e2e/specs/editor/various/autosave.spec.js
+++ b/test/e2e/specs/editor/various/autosave.spec.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+const { test } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Autosave', () => {
+	test( 'should save to sessionStorage', async () => {} );
+	test( 'should recover from sessionStorage', async () => {} );
+	test( 'should recover from sessionStorage', async () => {} );
+	test( "shouldn't contaminate other posts", async () => {} );
+	test( 'should clear local autosave after successful remote autosave', async () => {} );
+	test( "shouldn't clear local autosave if remote autosave fails", async () => {} );
+	test( 'should clear local autosave after successful save', async () => {} );
+	test( "shouldn't clear local autosave if save fails", async () => {} );
+	test( "shouldn't conflict with server-side autosave", async () => {} );
+	test( 'should clear sessionStorage upon user logout', async () => {} );
+} );


### PR DESCRIPTION
## What?
Migrate autosave E2E tests to Playwright.

## Why?
- Done as a part of the Playwright migration project: https://github.com/WordPress/gutenberg/issues/38851 (priority list),
- Should eventually resolve all [related flaky reports](https://github.com/WordPress/gutenberg/issues?q=is%3Aopen+is%3Aissue+label%3A%22%5BType%5D+Flaky+Test%22+%22specs%2Feditor%2Fvarious%2Fautosave.test.js%22+).

<!--
## How?
- Use accessible selectors where possible,
- Ensure the UI has caught up when navigating with keyboard,
- Reworded some test titles for consistency,
- Added some comments for clarity.
-->

## Testing Instructions

The output of the following should be all ✅: 

```
npm run test:e2e:playwright -- autosave.spec.js
```