### PR TITLE
Data: Use real timers for private APIs tests

### DIFF
--- a/packages/data/src/test/privateAPIs.js
+++ b/packages/data/src/test/privateAPIs.js
@@ -5,19 +5,6 @@ import { createRegistry } from '../registry';
 import createReduxStore from '../redux-store';
 import { unlock } from '../private-apis';
 
-/**
- * WordPress dependencies
- */
-
-beforeEach( () => {
-	jest.useFakeTimers( { legacyFakeTimers: true } );
-} );
-
-afterEach( () => {
-	jest.runOnlyPendingTimers();
-	jest.useRealTimers();
-} );
-
 describe( 'Private data APIs', () => {
 	let registry;
 


### PR DESCRIPTION
## What?
While looking at the private API tests for `@wordpress/data` I noticed that we're using fake timers without a good reason to do so. This PR removes them and that way it defaults to using the real timers.

## Why?
It's not necessary for those tests to run with fake timers.

## How?
We're just disabling the fake timers and the cleanup to revert to real timers. We're also removing a stray imports doc block.

## Testing Instructions
Verify tests still pass.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
None.