### PR TITLE
Tests: Cleanup unnecessary jest timers setup

### DIFF
--- a/packages/block-editor/src/components/block-preview/test/index.js
+++ b/packages/block-editor/src/components/block-preview/test/index.js
@@ -17,8 +17,6 @@ import {
  */
 import { useBlockPreview } from '../';
 
-jest.useRealTimers();
-
 describe( 'useBlockPreview', () => {
 	beforeAll( () => {
 		registerBlockType( 'core/test-block', {

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -51,8 +51,6 @@ jest.mock( '@wordpress/data/src/components/use-dispatch', () => ( {
 	useDispatch: () => ( { saveEntityRecords: jest.fn() } ),
 } ) );
 
-jest.useRealTimers();
-
 jest.mock( '@wordpress/compose', () => ( {
 	...jest.requireActual( '@wordpress/compose' ),
 	useReducedMotion: jest.fn( () => true ),

--- a/packages/block-editor/src/components/url-popover/test/index.js
+++ b/packages/block-editor/src/components/url-popover/test/index.js
@@ -9,8 +9,6 @@ import userEvent from '@testing-library/user-event';
  */
 import URLPopover from '../';
 
-jest.useRealTimers();
-
 /**
  * Returns the first found popover element up the DOM tree.
  *

--- a/packages/block-editor/src/utils/test/parse-css-unit-to-px.js
+++ b/packages/block-editor/src/utils/test/parse-css-unit-to-px.js
@@ -6,8 +6,6 @@ import {
 	getPxFromCssUnit,
 } from '../parse-css-unit-to-px';
 
-jest.useRealTimers();
-
 describe( 'getPxFromCssUnit', () => {
 	// Absolute units.
 	describe( 'absolute unites should return px values', () => {

--- a/packages/components/src/border-control/test/index.js
+++ b/packages/components/src/border-control/test/index.js
@@ -14,8 +14,6 @@ import {
  */
 import { BorderControl } from '../';
 
-jest.useRealTimers();
-
 const colors = [
 	{ name: 'Gray', color: '#f6f7f7' },
 	{ name: 'Blue', color: '#72aee6' },

--- a/packages/compose/src/hooks/use-disabled/test/index.js
+++ b/packages/compose/src/hooks/use-disabled/test/index.js
@@ -13,8 +13,6 @@ import { forwardRef } from '@wordpress/element';
  */
 import useDisabled from '../';
 
-jest.useRealTimers();
-
 describe( 'useDisabled', () => {
 	const Form = forwardRef( ( { showButton }, ref ) => {
 		return (

--- a/packages/core-data/src/locks/test/engine.js
+++ b/packages/core-data/src/locks/test/engine.js
@@ -3,8 +3,6 @@
  */
 import createLocks from '../engine';
 
-jest.useRealTimers();
-
 // We correctly await all promises with expect calls, but the rule doesn't detect that.
 /* eslint-disable jest/valid-expect-in-promise */
 

--- a/packages/data/src/components/use-dispatch/test/use-dispatch.js
+++ b/packages/data/src/components/use-dispatch/test/use-dispatch.js
@@ -12,8 +12,6 @@ import createReduxStore from '../../../redux-store';
 import { createRegistry } from '../../../registry';
 import { RegistryProvider } from '../../registry-provider';
 
-jest.useRealTimers();
-
 describe( 'useDispatch', () => {
 	const counterStore = {
 		reducer: ( state = 0, action ) => {

--- a/packages/data/src/components/use-select/test/index.js
+++ b/packages/data/src/components/use-select/test/index.js
@@ -19,8 +19,6 @@ import {
 } from '../../..';
 import useSelect from '..';
 
-jest.useRealTimers();
-
 describe( 'useSelect', () => {
 	let registry;
 	beforeEach( () => {

--- a/packages/data/src/components/use-select/test/suspense.js
+++ b/packages/data/src/components/use-select/test/suspense.js
@@ -14,8 +14,6 @@ import {
 } from '@wordpress/data';
 import { Component, Suspense } from '@wordpress/element';
 
-jest.useRealTimers();
-
 function createRegistryWithStore() {
 	const initialState = {
 		prefix: 'pre-',

--- a/packages/data/src/components/with-dispatch/test/index.js
+++ b/packages/data/src/components/with-dispatch/test/index.js
@@ -16,8 +16,6 @@ import withDispatch from '../';
 import { createRegistry } from '../../../registry';
 import { RegistryProvider } from '../../registry-provider';
 
-jest.useRealTimers();
-
 describe( 'withDispatch', () => {
 	const storeOptions = {
 		reducer: ( state = 0, action ) => {

--- a/packages/data/src/components/with-select/test/index.js
+++ b/packages/data/src/components/with-select/test/index.js
@@ -18,8 +18,6 @@ import withDispatch from '../../with-dispatch';
 import { createRegistry } from '../../../registry';
 import { RegistryProvider } from '../../registry-provider';
 
-jest.useRealTimers();
-
 describe( 'withSelect', () => {
 	it( 'passes the relevant data to the component', () => {
 		const registry = createRegistry();

--- a/packages/data/src/redux-store/metadata/test/selectors.js
+++ b/packages/data/src/redux-store/metadata/test/selectors.js
@@ -3,7 +3,6 @@
  */
 import { createRegistry } from '@wordpress/data';
 
-jest.useRealTimers();
 const testStore = {
 	reducer: ( state = null, action ) => {
 		if ( action.type === 'RECEIVE' ) {

--- a/packages/data/src/redux-store/test/index.js
+++ b/packages/data/src/redux-store/test/index.js
@@ -4,8 +4,6 @@
 import { createRegistry } from '../../registry';
 import { createRegistryControl } from '../../factory';
 
-jest.useRealTimers();
-
 describe( 'controls', () => {
 	let registry;
 

--- a/packages/data/src/test/controls.js
+++ b/packages/data/src/test/controls.js
@@ -3,8 +3,6 @@
  */
 import { createRegistry, controls } from '..';
 
-jest.useRealTimers();
-
 describe( 'controls', () => {
 	// Create a registry with store to test select controls.
 	function createSelectTestRegistry() {

--- a/packages/dependency-extraction-webpack-plugin/test/build.js
+++ b/packages/dependency-extraction-webpack-plugin/test/build.js
@@ -11,8 +11,6 @@ const webpack = require( 'webpack' );
 const fixturesPath = path.join( __dirname, 'fixtures' );
 const configFixtures = fs.readdirSync( fixturesPath ).sort();
 
-jest.useRealTimers();
-
 describe( 'DependencyExtractionWebpackPlugin', () => {
 	afterAll( () => rimraf( path.join( __dirname, 'build' ) ) );
 

--- a/packages/edit-site/src/store/test/actions.js
+++ b/packages/edit-site/src/store/test/actions.js
@@ -14,8 +14,6 @@ import { store as preferencesStore } from '@wordpress/preferences';
  */
 import { store as editSiteStore } from '..';
 
-jest.useRealTimers();
-
 const ENTITY_TYPES = {
 	wp_template: {
 		description: 'Templates to include in your theme.',

--- a/packages/editor/src/components/autosave-monitor/test/index.js
+++ b/packages/editor/src/components/autosave-monitor/test/index.js
@@ -8,7 +8,9 @@ import { render } from '@testing-library/react';
  */
 import { AutosaveMonitor } from '../';
 
-jest.useFakeTimers( { legacyFakeTimers: true } );
+jest.useFakeTimers();
+jest.spyOn( global, 'clearTimeout' );
+jest.spyOn( global, 'setTimeout' );
 
 describe( 'AutosaveMonitor', () => {
 	let setAutosaveTimerSpy;

--- a/packages/editor/src/components/post-text-editor/test/index.js
+++ b/packages/editor/src/components/post-text-editor/test/index.js
@@ -38,8 +38,6 @@ jest.mock( '@wordpress/data/src/components/use-dispatch', () => {
 	};
 } );
 
-jest.useRealTimers();
-
 describe( 'PostTextEditor', () => {
 	beforeEach( () => {
 		useSelect.mockImplementation( () => 'Hello World' );

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -15,8 +15,6 @@ import { store as preferencesStore } from '@wordpress/preferences';
 import * as actions from '../actions';
 import { store as editorStore } from '..';
 
-jest.useRealTimers();
-
 const postId = 44;
 
 const postTypeConfig = {

--- a/packages/readable-js-assets-webpack-plugin/test/build.js
+++ b/packages/readable-js-assets-webpack-plugin/test/build.js
@@ -8,8 +8,6 @@ const path = require( 'path' );
 const rimraf = require( 'rimraf' ).sync;
 const webpack = require( 'webpack' );
 
-jest.useRealTimers();
-
 describe( 'ReadableJsAssetsWebpackPlugin', () => {
 	const outputDirectory = path.join( __dirname, 'build' );
 	const testDirectory = path.join( __dirname, 'fixtures' );


### PR DESCRIPTION
## What?
When opening #49029 I noticed that we still specifically enable real timers in a bunch of places, even though those are already the default timers. This PR cleans those up.

## Why?
Just cleaning up.

## How?
We're just removing a few unnecessary `jest.useRealTimers()`

## Testing Instructions
Verify all tests are still green.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None