### PR TITLE
Duotone: Style Engine: Add unit test and associated refactoring

### DIFF
--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -290,59 +290,6 @@ function gutenberg_tinycolor_string_to_rgb( $color_str ) {
 	}
 }
 
-class WP_Duotone {
-	static function get_id_selector_property_and_maybe_svg( $duotone_attr, $duotone_support ) {
-		$is_preset = is_string( $duotone_attr ) && strpos( $duotone_attr, 'var:preset|duotone|' ) === 0;
-		$is_css    = is_string( $duotone_attr ) && strpos( $duotone_attr, 'var:preset|duotone|' ) === false;
-		$is_custom = is_array( $duotone_attr );
-		$filter_svg = null;
-		// Generate the pieces needed for rendering a duotone to the page.
-		if ( $is_preset ) {
-			// Extract the slug from the preset variable string.
-			$slug = str_replace( 'var:preset|duotone|', '', $duotone_attr );
-
-			// Utilize existing preset CSS custom property.
-			$filter_property = "var(--wp--preset--duotone--$slug)";
-		} elseif ( $is_css ) {
-			// Build a unique slug for the filter based on the CSS value.
-			$slug = wp_unique_id( sanitize_key( $duotone_attr . '-' ) );
-
-			// Pass through the CSS value.
-			$filter_property = $duotone_attr;
-		} elseif ( $is_custom ) {
-			// Build a unique slug for the filter based on the array of colors.
-			$slug = wp_unique_id( sanitize_key( implode( '-', $duotone_attr ) . '-' ) );
-
-			// This has the same shape as a preset, so it can be used in place of a
-			// preset when getting the filter property and SVG filter.
-			$filter_data = array(
-				'slug'   => $slug,
-				'colors' => $duotone_attr,
-			);
-
-			// Build a customized CSS filter property for unique slug.
-			$filter_property = gutenberg_get_duotone_filter_property( $filter_data );
-
-			// SVG will be output on the page later.
-			$filter_svg = gutenberg_get_duotone_filter_svg( $filter_data );
-		}
-
-		// - Applied as a class attribute to the block wrapper.
-		// - Used as a selector to apply the filter to the block.
-		$filter_id = gutenberg_get_duotone_filter_id( array( 'slug' => $slug ) );
-
-		// Build the CSS selectors to which the filter will be applied.
-		$selector = WP_Theme_JSON_Gutenberg::scope_selector( '.' . $filter_id, $duotone_support );
-
-		return array(
-			'filter_id' => $filter_id,
-			'selector' => $selector,
-			'filter_property' => $filter_property,
-			'filter_svg' => $filter_svg
-		);
-	}
-}
-
 /**
  * Returns the prefixed id for the duotone filter for use as a CSS id.
  *
@@ -504,13 +451,47 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	// 3. A CSS string - e.g. 'unset' to remove globally applied duotone.
 	$duotone_attr = $block['attrs']['style']['color']['duotone'];
 
-	list(
-		'filter_id' => $filter_id,
-		'selector' => $selector,
-		'filter_property' => $filter_property,
-		'filter_svg' => $filter_svg
-	) = WP_Duotone::get_id_selector_property_and_maybe_svg( $duotone_attr, $duotone_support );
+	$is_preset = is_string( $duotone_attr ) && strpos( $duotone_attr, 'var:preset|duotone|' ) === 0;
+	$is_css    = is_string( $duotone_attr ) && strpos( $duotone_attr, 'var:preset|duotone|' ) === false;
+	$is_custom = is_array( $duotone_attr );
 
+	// Generate the pieces needed for rendering a duotone to the page.
+	if ( $is_preset ) {
+		// Extract the slug from the preset variable string.
+		$slug = str_replace( 'var:preset|duotone|', '', $duotone_attr );
+
+		// Utilize existing preset CSS custom property.
+		$filter_property = "var(--wp--preset--duotone--$slug)";
+	} elseif ( $is_css ) {
+		// Build a unique slug for the filter based on the CSS value.
+		$slug = wp_unique_id( sanitize_key( $duotone_attr . '-' ) );
+
+		// Pass through the CSS value.
+		$filter_property = $duotone_attr;
+	} elseif ( $is_custom ) {
+		// Build a unique slug for the filter based on the array of colors.
+		$slug = wp_unique_id( sanitize_key( implode( '-', $duotone_attr ) . '-' ) );
+
+		// This has the same shape as a preset, so it can be used in place of a
+		// preset when getting the filter property and SVG filter.
+		$filter_data = array(
+			'slug'   => $slug,
+			'colors' => $duotone_attr,
+		);
+
+		// Build a customized CSS filter property for unique slug.
+		$filter_property = gutenberg_get_duotone_filter_property( $filter_data );
+
+		// SVG will be output on the page later.
+		$filter_svg = gutenberg_get_duotone_filter_svg( $filter_data );
+	}
+
+	// - Applied as a class attribute to the block wrapper.
+	// - Used as a selector to apply the filter to the block.
+	$filter_id = gutenberg_get_duotone_filter_id( array( 'slug' => $slug ) );
+
+	// Build the CSS selectors to which the filter will be applied.
+	$selector = WP_Theme_JSON_Gutenberg::scope_selector( '.' . $filter_id, $duotone_support );
 
 	// Calling gutenberg_style_engine_get_stylesheet_from_css_rules ensures that
 	// the styles are rendered in an inline for block supports because we're

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -290,6 +290,59 @@ function gutenberg_tinycolor_string_to_rgb( $color_str ) {
 	}
 }
 
+class WP_Duotone {
+	static function get_id_selector_property_and_maybe_svg( $duotone_attr, $duotone_support ) {
+		$is_preset = is_string( $duotone_attr ) && strpos( $duotone_attr, 'var:preset|duotone|' ) === 0;
+		$is_css    = is_string( $duotone_attr ) && strpos( $duotone_attr, 'var:preset|duotone|' ) === false;
+		$is_custom = is_array( $duotone_attr );
+		$filter_svg = null;
+		// Generate the pieces needed for rendering a duotone to the page.
+		if ( $is_preset ) {
+			// Extract the slug from the preset variable string.
+			$slug = str_replace( 'var:preset|duotone|', '', $duotone_attr );
+
+			// Utilize existing preset CSS custom property.
+			$filter_property = "var(--wp--preset--duotone--$slug)";
+		} elseif ( $is_css ) {
+			// Build a unique slug for the filter based on the CSS value.
+			$slug = wp_unique_id( sanitize_key( $duotone_attr . '-' ) );
+
+			// Pass through the CSS value.
+			$filter_property = $duotone_attr;
+		} elseif ( $is_custom ) {
+			// Build a unique slug for the filter based on the array of colors.
+			$slug = wp_unique_id( sanitize_key( implode( '-', $duotone_attr ) . '-' ) );
+
+			// This has the same shape as a preset, so it can be used in place of a
+			// preset when getting the filter property and SVG filter.
+			$filter_data = array(
+				'slug'   => $slug,
+				'colors' => $duotone_attr,
+			);
+
+			// Build a customized CSS filter property for unique slug.
+			$filter_property = gutenberg_get_duotone_filter_property( $filter_data );
+
+			// SVG will be output on the page later.
+			$filter_svg = gutenberg_get_duotone_filter_svg( $filter_data );
+		}
+
+		// - Applied as a class attribute to the block wrapper.
+		// - Used as a selector to apply the filter to the block.
+		$filter_id = gutenberg_get_duotone_filter_id( array( 'slug' => $slug ) );
+
+		// Build the CSS selectors to which the filter will be applied.
+		$selector = WP_Theme_JSON_Gutenberg::scope_selector( '.' . $filter_id, $duotone_support );
+
+		return array(
+			'filter_id' => $filter_id,
+			'selector' => $selector,
+			'filter_property' => $filter_property,
+			'filter_svg' => $filter_svg
+		);
+	}
+}
+
 /**
  * Returns the prefixed id for the duotone filter for use as a CSS id.
  *
@@ -451,47 +504,13 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	// 3. A CSS string - e.g. 'unset' to remove globally applied duotone.
 	$duotone_attr = $block['attrs']['style']['color']['duotone'];
 
-	$is_preset = is_string( $duotone_attr ) && strpos( $duotone_attr, 'var:preset|duotone|' ) === 0;
-	$is_css    = is_string( $duotone_attr ) && strpos( $duotone_attr, 'var:preset|duotone|' ) === false;
-	$is_custom = is_array( $duotone_attr );
+	list(
+		'filter_id' => $filter_id,
+		'selector' => $selector,
+		'filter_property' => $filter_property,
+		'filter_svg' => $filter_svg
+	) = WP_Duotone::get_id_selector_property_and_maybe_svg( $duotone_attr, $duotone_support );
 
-	// Generate the pieces needed for rendering a duotone to the page.
-	if ( $is_preset ) {
-		// Extract the slug from the preset variable string.
-		$slug = str_replace( 'var:preset|duotone|', '', $duotone_attr );
-
-		// Utilize existing preset CSS custom property.
-		$filter_property = "var(--wp--preset--duotone--$slug)";
-	} elseif ( $is_css ) {
-		// Build a unique slug for the filter based on the CSS value.
-		$slug = wp_unique_id( sanitize_key( $duotone_attr . '-' ) );
-
-		// Pass through the CSS value.
-		$filter_property = $duotone_attr;
-	} elseif ( $is_custom ) {
-		// Build a unique slug for the filter based on the array of colors.
-		$slug = wp_unique_id( sanitize_key( implode( '-', $duotone_attr ) . '-' ) );
-
-		// This has the same shape as a preset, so it can be used in place of a
-		// preset when getting the filter property and SVG filter.
-		$filter_data = array(
-			'slug'   => $slug,
-			'colors' => $duotone_attr,
-		);
-
-		// Build a customized CSS filter property for unique slug.
-		$filter_property = gutenberg_get_duotone_filter_property( $filter_data );
-
-		// SVG will be output on the page later.
-		$filter_svg = gutenberg_get_duotone_filter_svg( $filter_data );
-	}
-
-	// - Applied as a class attribute to the block wrapper.
-	// - Used as a selector to apply the filter to the block.
-	$filter_id = gutenberg_get_duotone_filter_id( array( 'slug' => $slug ) );
-
-	// Build the CSS selectors to which the filter will be applied.
-	$selector = WP_Theme_JSON_Gutenberg::scope_selector( '.' . $filter_id, $duotone_support );
 
 	// Calling gutenberg_style_engine_get_stylesheet_from_css_rules ensures that
 	// the styles are rendered in an inline for block supports because we're

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -680,31 +680,26 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	/**
 	 * Tests returning a generated stylesheet from a set of duotone rules.
 	 *
+	 * This is testing this fix: https://github.com/WordPress/gutenberg/pull/49004
+	 *
 	 * @covers ::gutenberg_style_engine_get_stylesheet_from_css_rules
 	 * @covers WP_Style_Engine_Gutenberg::compile_stylesheet_from_css_rules
 	 */
 	public function test_should_return_stylesheet_from_duotone_css_rules() {
-		$duotone_attr = array( '#FFFFFF', '#000000' );
-		$duotone_support = true;
-		list(
-			'selector' => $selector,
-			'filter_property' => $filter_property,
-		) = WP_Duotone::get_id_selector_property_and_maybe_svg( $duotone_attr, $duotone_support );
-
 		$css_rules = array(
 			array(
-				'selector'     => $selector,
+				'selector'     => '.wp-duotone-ffffff-000000-1',
 				'declarations' => array(
 					// !important is needed because these styles
 					// render before global styles,
 					// and they should be overriding the duotone
 					// filters set by global styles.
-					'filter' => $filter_property . ' !important',
+					'filter' => "url('#wp-duotone-ffffff-000000-1') !important",
 				),
 			),
 		);
 
 		$compiled_stylesheet = gutenberg_style_engine_get_stylesheet_from_css_rules( $css_rules, array( 'prettify' => false ) );
-		$this->assertSame( ".wp-duotone-ffffff-000000-1 1{filter:url('#wp-duotone-ffffff-000000-1') !important;}", $compiled_stylesheet );
+		$this->assertSame( ".wp-duotone-ffffff-000000-1{filter:url('#wp-duotone-ffffff-000000-1') !important;}", $compiled_stylesheet );
 	}
 }

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -676,4 +676,35 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 
 		$this->assertSame( '.gandalf{color:white;height:190px;border-style:dotted;padding:10px;margin-bottom:100px;}.dumbledore,.rincewind{color:grey;height:90px;border-style:dotted;}', $compiled_stylesheet );
 	}
+
+	/**
+	 * Tests returning a generated stylesheet from a set of duotone rules.
+	 *
+	 * @covers ::gutenberg_style_engine_get_stylesheet_from_css_rules
+	 * @covers WP_Style_Engine_Gutenberg::compile_stylesheet_from_css_rules
+	 */
+	public function test_should_return_stylesheet_from_duotone_css_rules() {
+		$duotone_attr = array( '#FFFFFF', '#000000' );
+		$duotone_support = true;
+		list(
+			'selector' => $selector,
+			'filter_property' => $filter_property,
+		) = WP_Duotone::get_id_selector_property_and_maybe_svg( $duotone_attr, $duotone_support );
+
+		$css_rules = array(
+			array(
+				'selector'     => $selector,
+				'declarations' => array(
+					// !important is needed because these styles
+					// render before global styles,
+					// and they should be overriding the duotone
+					// filters set by global styles.
+					'filter' => $filter_property . ' !important',
+				),
+			),
+		);
+
+		$compiled_stylesheet = gutenberg_style_engine_get_stylesheet_from_css_rules( $css_rules, array( 'prettify' => false ) );
+		$this->assertSame( ".wp-duotone-ffffff-000000-1 1{filter:url('#wp-duotone-ffffff-000000-1') !important;}", $compiled_stylesheet );
+	}
 }


### PR DESCRIPTION
## What?
This adds a unit test to the style engine to test that duotone properties are correctly output. 

## Why?
This catches a bug that was fixed in https://github.com/WordPress/gutenberg/pull/49004.

## How?
Call the style engine with static strings

## Testing Instructions
npm run test:unit:php -- --filter 'WP_Block_Supports_Duotone_Test'
npm run test:unit:php -- --filter 'WP_Style_Engine_Test' 

## Question
Since this is really testing a fix in wp_kses, is this still a useful test to have?