### PR TITLE
Post Excerpt: add `previewPlaceholder` attribute

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -546,7 +546,7 @@ Display a post's excerpt. ([Source](https://github.com/WordPress/gutenberg/tree/
 -	**Name:** core/post-excerpt
 -	**Category:** theme
 -	**Supports:** anchor, color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** excerptLength, moreText, showMoreOnNewLine, textAlign
+-	**Attributes:** excerptLength, moreText, previewPlaceholder, showMoreOnNewLine, textAlign
 
 ## Post Featured Image
 

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -20,6 +20,9 @@
 		"excerptLength": {
 			"type": "number",
 			"default": 55
+		},
+		"previewPlaceholder": {
+			"type": "string"
 		}
 	},
 	"usesContext": [ "postId", "postType", "queryId" ],

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -25,7 +25,13 @@ import { __, _x } from '@wordpress/i18n';
 import { useCanEditEntity } from '../utils/hooks';
 
 export default function PostExcerptEditor( {
-	attributes: { textAlign, moreText, showMoreOnNewLine, excerptLength },
+	attributes: {
+		textAlign,
+		moreText,
+		showMoreOnNewLine,
+		excerptLength,
+		previewPlaceholder,
+	},
 	setAttributes,
 	isSelected,
 	context: { postId, postType, queryId },
@@ -78,14 +84,11 @@ export default function PostExcerptEditor( {
 				</BlockControls>
 				<div { ...blockProps }>
 					<p>
-						{ __(
-							'This is the Post Excerpt block, it will display the excerpt from single posts.'
-						) }
-					</p>
-					<p>
-						{ __(
-							'If there are any Custom Post Types with support for excerpts, the Post Excerpt block can display the excerpts of those entries as well.'
-						) }
+						{ previewPlaceholder
+							? previewPlaceholder
+							: __(
+									'This is the Post Excerpt block, it will display the excerpt'
+							  ) }
 					</p>
 				</div>
 			</>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR adds the `previewPlaceholder` attribute. If defined, the block will show this latter as a placeholder. Also, I updated the default text following [the suggestion in the issue](https://github.com/WordPress/gutenberg/issues/48964#issuecomment-1463552202).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As I explained in #48964, I'm more inclined to update the preview placeholder in this way:

```
This is the Post Excerpt block, it will display the excerpt from single {post_type}.
```

Unfortunately, retrieving the post type in a block is impossible. So, this is another approach to fixing the issue.

With this approach, a block developer can create a variation of the `Post Excerpt` block and customize the preview placeholder via the attribute.



## Testing Instructions

1. Create a variation of the Post Excerpt passing the `previewPlaceholder` attribute.
2. Add the variation in a template (Post template, for instance) and ensure the custom preview is visible.

