### PR TITLE
Fix: Global styles forces a white background.

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-root.js
+++ b/packages/edit-site/src/components/global-styles/screen-root.js
@@ -51,7 +51,7 @@ function ScreenRoot() {
 	}, [] );
 
 	return (
-		<Card size="small">
+		<Card size="small" className="edit-site-global-styles-screen-root">
 			<CardBody>
 				<VStack spacing={ 4 }>
 					<Card>

--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -172,7 +172,11 @@ function ScreenStyleVariations() {
 				) }
 			/>
 
-			<Card size="small" isBorderless>
+			<Card
+				size="small"
+				isBorderless
+				className="edit-site-global-styles-screen-style-variations"
+			>
 				<CardBody>
 					<Grid columns={ 2 }>
 						{ withEmptyVariation?.map( ( variation, index ) => (

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -241,3 +241,13 @@
 	height: 24px;
 	width: 24px;
 }
+
+.edit-site-global-styles-screen-root.edit-site-global-styles-screen-root,
+.edit-site-global-styles-screen-style-variations.edit-site-global-styles-screen-style-variations {
+	background: unset;
+	color: inherit;
+}
+
+.edit-site-global-styles-sidebar__panel .block-editor-block-icon svg {
+	fill: currentColor;
+}


### PR DESCRIPTION
Currently the main global styles component containers are setting a white background and dark text color. This is unexpected when the UI is covered on a dark background like the navigation sidebar. The containers should not be opinionated and should inherit their colors.

This PR fixes the issue.

## Testing

Cherry pick this commit on the branch of this PR https://github.com/WordPress/gutenberg/pull/49031.
Set the story Global Styles Ui to dark.
Verify the background of the global styles sidebar is dark and not white (without this PR, it stays white).
