### PR TITLE
Hide navigation screen in site editor

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -34,6 +34,9 @@ export default function SidebarNavigationScreenMain() {
 		return navigationMenus?.length > 0;
 	} );
 
+	const showNavigationScreen = process.env.IS_GUTENBERG_PLUGIN
+		? hasNavigationMenus
+		: false;
 	return (
 		<SidebarNavigationScreen
 			isRoot
@@ -43,7 +46,7 @@ export default function SidebarNavigationScreenMain() {
 			) }
 			content={
 				<ItemGroup>
-					{ hasNavigationMenus && (
+					{ showNavigationScreen && (
 						<NavigatorButton
 							as={ SidebarNavigationItem }
 							path="/navigation"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR enables the `navigation panel` in site editor only in GB plugin. There were huge efforts to polish some rough edges in order to be included in WP `6.2`, but it seems there are still some interactions and flows that might need more attention. 

This PR is here in case we'll remove/hide this from WP RC2 tomorrow. 