### PR TITLE
Fix: Global Styles getNodesWithStyles expects an object with elements.

### DIFF
--- a/packages/block-editor/src/components/global-styles/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-output.js
@@ -496,9 +496,9 @@ export const getNodesWithStyles = ( tree, blockSelectors ) => {
 	}
 
 	Object.entries( ELEMENTS ).forEach( ( [ name, selector ] ) => {
-		if ( !! tree.styles?.elements[ name ] ) {
+		if ( !! tree.styles?.elements?.[ name ] ) {
 			nodes.push( {
-				styles: tree.styles?.elements[ name ],
+				styles: tree.styles?.elements?.[ name ],
 				selector,
 			} );
 		}


### PR DESCRIPTION
During the creation of a "story" for the full global styles UI, we don't have the base WordPress style objects, and I noticed a series of crashes. All the global styles code should work even if we don't have a base styles object.
This fix is part of the series of fixes.

It avoids a crash in cases not a single element style is provided.