### PR TITLE
`AnglePickerControl`: Style to better fit in narrow contexts and improve RTL layout

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Enhancements
 
 -   `CustomGradientPicker`: improve initial state UI ([#49146](https://github.com/WordPress/gutenberg/pull/49146)).
+-	`AnglePickerControl`: Style to better fit in narrow contexts and improve RTL layout ([#49046](https://github.com/WordPress/gutenberg/pull/49046)).
 
 ## 23.6.0 (2023-03-15)
 
@@ -17,7 +18,6 @@
 -   `FontSizePicker`: Allow custom units for custom font size control ([#48468](https://github.com/WordPress/gutenberg/pull/48468)).
 -   `Navigator`: Disable initial screen animation ([#49062](https://github.com/WordPress/gutenberg/pull/49062)).
 -   `FormTokenField`: Hide suggestions list on blur event if the input value is invalid ([#48785](https://github.com/WordPress/gutenberg/pull/48785)).
--	`AnglePickerControl`: Style to better fit in narrow contexts and improve RTL layout ([#49046](https://github.com/WordPress/gutenberg/pull/49046)).
 
 ### Bug Fix
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,6 +17,7 @@
 -   `FontSizePicker`: Allow custom units for custom font size control ([#48468](https://github.com/WordPress/gutenberg/pull/48468)).
 -   `Navigator`: Disable initial screen animation ([#49062](https://github.com/WordPress/gutenberg/pull/49062)).
 -   `FormTokenField`: Hide suggestions list on blur event if the input value is invalid ([#48785](https://github.com/WordPress/gutenberg/pull/48785)).
+-	`AngleControlPicker`: Style to better fit in narrow contexts and improve RTL layout ([#49046](https://github.com/WordPress/gutenberg/pull/49046)).
 
 ### Bug Fix
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,7 +17,7 @@
 -   `FontSizePicker`: Allow custom units for custom font size control ([#48468](https://github.com/WordPress/gutenberg/pull/48468)).
 -   `Navigator`: Disable initial screen animation ([#49062](https://github.com/WordPress/gutenberg/pull/49062)).
 -   `FormTokenField`: Hide suggestions list on blur event if the input value is invalid ([#48785](https://github.com/WordPress/gutenberg/pull/48785)).
--	`AngleControlPicker`: Style to better fit in narrow contexts and improve RTL layout ([#49046](https://github.com/WordPress/gutenberg/pull/49046)).
+-	`AnglePickerControl`: Style to better fit in narrow contexts and improve RTL layout ([#49046](https://github.com/WordPress/gutenberg/pull/49046)).
 
 ### Bug Fix
 

--- a/packages/components/src/angle-picker-control/angle-circle.tsx
+++ b/packages/components/src/angle-picker-control/angle-circle.tsx
@@ -91,7 +91,6 @@ function AngleCircle( {
 			ref={ angleCircleRef }
 			onMouseDown={ startDrag }
 			className="components-angle-picker-control__angle-circle"
-			style={ isDragging ? { cursor: 'grabbing' } : undefined }
 			{ ...props }
 		>
 			<CircleIndicatorWrapper

--- a/packages/components/src/angle-picker-control/index.tsx
+++ b/packages/components/src/angle-picker-control/index.tsx
@@ -69,7 +69,6 @@ function UnforwardedAnglePickerControl(
 			ref={ ref }
 			__nextHasNoMarginBottom={ __nextHasNoMarginBottom }
 			className={ classes }
-			gap={ 4 }
 		>
 			<NumberControl
 				label={ label }
@@ -86,20 +85,17 @@ function UnforwardedAnglePickerControl(
 						<Spacer
 							as={ Text }
 							marginBottom={ 0 }
-							marginRight={ space( 3 ) }
+							marginRight={ space( 2 ) }
 							style={ {
 								color: COLORS.ui.theme,
 							} }
 						>
 							°
 						</Spacer>
-						<Spacer
-							as={ AngleCircle }
+						<AngleCircle
 							aria-hidden="true"
 							value={ value }
 							onChange={ onChange }
-							marginBottom={ 0 }
-							marginRight={ space( 1 ) }
 						/>
 					</>
 				}

--- a/packages/components/src/angle-picker-control/index.tsx
+++ b/packages/components/src/angle-picker-control/index.tsx
@@ -14,6 +14,8 @@ import { isRTL, __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { FlexBlock } from '../flex';
+import { Spacer } from '../spacer';
 import NumberControl from '../number-control';
 import AngleCircle from './angle-circle';
 import { Root, UnitText } from './styles/angle-picker-control-styles';
@@ -70,29 +72,30 @@ function UnforwardedAnglePickerControl(
 			ref={ ref }
 			__nextHasNoMarginBottom={ __nextHasNoMarginBottom }
 			className={ classes }
+			gap={ 2 }
 		>
-			<NumberControl
-				label={ label }
-				className="components-angle-picker-control__input-field"
-				max={ 360 }
-				min={ 0 }
-				onChange={ handleOnNumberChange }
-				size="__unstable-large"
-				step="1"
-				value={ value }
-				spinControls="none"
-				prefix={ prefixedUnitText }
-				suffix={
-					<>
-						{ suffixedUnitText }
-						<AngleCircle
-							aria-hidden="true"
-							value={ value }
-							onChange={ onChange }
-						/>
-					</>
-				}
-			/>
+			<FlexBlock>
+				<NumberControl
+					label={ label }
+					className="components-angle-picker-control__input-field"
+					max={ 360 }
+					min={ 0 }
+					onChange={ handleOnNumberChange }
+					size="__unstable-large"
+					step="1"
+					value={ value }
+					spinControls="none"
+					prefix={ prefixedUnitText }
+					suffix={ suffixedUnitText }
+				/>
+			</FlexBlock>
+			<Spacer marginBottom="1" marginTop="auto">
+				<AngleCircle
+					aria-hidden="true"
+					value={ value }
+					onChange={ onChange }
+				/>
+			</Spacer>
 		</Root>
 	);
 }

--- a/packages/components/src/angle-picker-control/index.tsx
+++ b/packages/components/src/angle-picker-control/index.tsx
@@ -9,18 +9,14 @@ import classnames from 'classnames';
  */
 import deprecated from '@wordpress/deprecated';
 import { forwardRef } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { isRTL, __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import NumberControl from '../number-control';
 import AngleCircle from './angle-circle';
-import { Root } from './styles/angle-picker-control-styles';
-import { space } from '../ui/utils/space';
-import { Text } from '../text';
-import { Spacer } from '../spacer';
-import { COLORS } from '../utils/colors-values';
+import { Root, UnitText } from './styles/angle-picker-control-styles';
 
 import type { WordPressComponentProps } from '../ui/context';
 import type { AnglePickerControlProps } from './types';
@@ -63,6 +59,11 @@ function UnforwardedAnglePickerControl(
 
 	const classes = classnames( 'components-angle-picker-control', className );
 
+	const unitText = <UnitText>°</UnitText>;
+	const [ prefixedUnitText, suffixedUnitText ] = isRTL()
+		? [ unitText, null ]
+		: [ null, unitText ];
+
 	return (
 		<Root
 			{ ...restProps }
@@ -80,18 +81,10 @@ function UnforwardedAnglePickerControl(
 				step="1"
 				value={ value }
 				spinControls="none"
+				prefix={ prefixedUnitText }
 				suffix={
 					<>
-						<Spacer
-							as={ Text }
-							marginBottom={ 0 }
-							marginRight={ space( 2 ) }
-							style={ {
-								color: COLORS.ui.theme,
-							} }
-						>
-							°
-						</Spacer>
+						{ suffixedUnitText }
 						<AngleCircle
 							aria-hidden="true"
 							value={ value }

--- a/packages/components/src/angle-picker-control/index.tsx
+++ b/packages/components/src/angle-picker-control/index.tsx
@@ -14,7 +14,6 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { FlexBlock, FlexItem } from '../flex';
 import NumberControl from '../number-control';
 import AngleCircle from './angle-circle';
 import { Root } from './styles/angle-picker-control-styles';
@@ -72,18 +71,18 @@ function UnforwardedAnglePickerControl(
 			className={ classes }
 			gap={ 4 }
 		>
-			<FlexBlock>
-				<NumberControl
-					label={ label }
-					className="components-angle-picker-control__input-field"
-					max={ 360 }
-					min={ 0 }
-					onChange={ handleOnNumberChange }
-					size="__unstable-large"
-					step="1"
-					value={ value }
-					spinControls="none"
-					suffix={
+			<NumberControl
+				label={ label }
+				className="components-angle-picker-control__input-field"
+				max={ 360 }
+				min={ 0 }
+				onChange={ handleOnNumberChange }
+				size="__unstable-large"
+				step="1"
+				value={ value }
+				spinControls="none"
+				suffix={
+					<>
 						<Spacer
 							as={ Text }
 							marginBottom={ 0 }
@@ -94,21 +93,17 @@ function UnforwardedAnglePickerControl(
 						>
 							°
 						</Spacer>
-					}
-				/>
-			</FlexBlock>
-			<FlexItem
-				style={ {
-					marginBottom: space( 1 ),
-					marginTop: 'auto',
-				} }
-			>
-				<AngleCircle
-					aria-hidden="true"
-					value={ value }
-					onChange={ onChange }
-				/>
-			</FlexItem>
+						<Spacer
+							as={ AngleCircle }
+							aria-hidden="true"
+							value={ value }
+							onChange={ onChange }
+							marginBottom={ 0 }
+							marginRight={ space( 1 ) }
+						/>
+					</>
+				}
+			/>
 		</Root>
 	);
 }

--- a/packages/components/src/angle-picker-control/styles/angle-picker-control-styles.tsx
+++ b/packages/components/src/angle-picker-control/styles/angle-picker-control-styles.tsx
@@ -5,11 +5,17 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 /**
+ * WordPress dependencies
+ */
+import { isRTL } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import { Flex } from '../../flex';
 import { COLORS } from '../../utils';
 import { space } from '../../ui/utils/space';
+import { Text } from '../../text';
 import CONFIG from '../../utils/config-values';
 
 import type { AnglePickerControlProps } from '../types';
@@ -74,4 +80,9 @@ export const CircleIndicator = styled.div`
 	position: absolute;
 	width: ${ LINE_WEIGHT }px;
 	height: calc( 50% + ${ LINE_WEIGHT / 2 }px );
+`;
+
+export const UnitText = styled( Text )`
+	color: ${ COLORS.ui.theme };
+	margin-right: ${ isRTL() ? space( 3 ) : space( 2 ) };
 `;

--- a/packages/components/src/angle-picker-control/styles/angle-picker-control-styles.tsx
+++ b/packages/components/src/angle-picker-control/styles/angle-picker-control-styles.tsx
@@ -15,7 +15,8 @@ import CONFIG from '../../utils/config-values';
 import type { AnglePickerControlProps } from '../types';
 
 const CIRCLE_SIZE = 32;
-const INNER_CIRCLE_SIZE = 3;
+const INNER_CIRCLE_SIZE = 24;
+const LINE_WEIGHT = 1.5;
 
 const deprecatedBottomMargin = ( {
 	__nextHasNoMarginBottom,
@@ -29,41 +30,48 @@ const deprecatedBottomMargin = ( {
 
 export const Root = styled( Flex )`
 	${ deprecatedBottomMargin }
+
+	> .components-base-control {
+		flex: 1;
+	}
 `;
 
 export const CircleRoot = styled.div`
 	border-radius: 50%;
-	border: ${ CONFIG.borderWidth } solid ${ COLORS.ui.border };
 	box-sizing: border-box;
 	cursor: grab;
 	height: ${ CIRCLE_SIZE }px;
 	overflow: hidden;
 	width: ${ CIRCLE_SIZE }px;
+	margin-inline-end: ${ space( 1 ) };
+
+	:active {
+		cursor: grabbing;
+	}
 `;
 
 export const CircleIndicatorWrapper = styled.div`
+	border-radius: 50%;
 	box-sizing: border-box;
 	position: relative;
-	width: 100%;
-	height: 100%;
+	width: ${ INNER_CIRCLE_SIZE }px;
+	height: ${ INNER_CIRCLE_SIZE }px;
+	margin: ${ ( CIRCLE_SIZE - INNER_CIRCLE_SIZE ) / 2 }px;
+	border: ${ CONFIG.borderWidth } solid ${ COLORS.ui.border };
 
-	:focus-visible {
-		outline: none;
+	${ CircleRoot }:is(:hover, :active) > & {
+		border-color: ${ COLORS.ui.theme };
 	}
 `;
 
 export const CircleIndicator = styled.div`
 	background: ${ COLORS.ui.theme };
-	border-radius: 50%;
-	border: ${ INNER_CIRCLE_SIZE }px solid ${ COLORS.ui.theme };
-	bottom: 0;
+	border-radius: 0 0 ${ LINE_WEIGHT }px ${ LINE_WEIGHT }px;
 	box-sizing: border-box;
 	display: block;
-	height: 0px;
-	left: 0;
-	margin: auto;
+	left: 50%;
+	transform: translateX( -50% );
 	position: absolute;
-	right: 0;
-	top: -${ CIRCLE_SIZE / 2 }px;
-	width: 0px;
+	width: ${ LINE_WEIGHT }px;
+	height: calc( 50% + ${ LINE_WEIGHT / 2 }px );
 `;

--- a/packages/components/src/angle-picker-control/styles/angle-picker-control-styles.tsx
+++ b/packages/components/src/angle-picker-control/styles/angle-picker-control-styles.tsx
@@ -5,11 +5,6 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 /**
- * WordPress dependencies
- */
-import { isRTL } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import { Flex } from '../../flex';
@@ -21,8 +16,7 @@ import CONFIG from '../../utils/config-values';
 import type { AnglePickerControlProps } from '../types';
 
 const CIRCLE_SIZE = 32;
-const INNER_CIRCLE_SIZE = 24;
-const LINE_WEIGHT = 1.5;
+const INNER_CIRCLE_SIZE = 6;
 
 const deprecatedBottomMargin = ( {
 	__nextHasNoMarginBottom,
@@ -36,20 +30,16 @@ const deprecatedBottomMargin = ( {
 
 export const Root = styled( Flex )`
 	${ deprecatedBottomMargin }
-
-	> .components-base-control {
-		flex: 1;
-	}
 `;
 
 export const CircleRoot = styled.div`
 	border-radius: 50%;
+	border: ${ CONFIG.borderWidth } solid ${ COLORS.ui.border };
 	box-sizing: border-box;
 	cursor: grab;
 	height: ${ CIRCLE_SIZE }px;
 	overflow: hidden;
 	width: ${ CIRCLE_SIZE }px;
-	margin-inline-end: ${ space( 1 ) };
 
 	:active {
 		cursor: grabbing;
@@ -57,32 +47,26 @@ export const CircleRoot = styled.div`
 `;
 
 export const CircleIndicatorWrapper = styled.div`
-	border-radius: 50%;
 	box-sizing: border-box;
 	position: relative;
-	width: ${ INNER_CIRCLE_SIZE }px;
-	height: ${ INNER_CIRCLE_SIZE }px;
-	margin: ${ ( CIRCLE_SIZE - INNER_CIRCLE_SIZE ) / 2 }px;
-	border: ${ CONFIG.borderWidth } solid ${ COLORS.ui.border };
-
-	${ CircleRoot }:is(:hover, :active) > & {
-		border-color: ${ COLORS.ui.theme };
-	}
+	width: 100%;
+	height: 100%;
 `;
 
 export const CircleIndicator = styled.div`
 	background: ${ COLORS.ui.theme };
-	border-radius: 0 0 ${ LINE_WEIGHT }px ${ LINE_WEIGHT }px;
+	border-radius: 50%;
 	box-sizing: border-box;
 	display: block;
 	left: 50%;
+	top: 4px;
 	transform: translateX( -50% );
 	position: absolute;
-	width: ${ LINE_WEIGHT }px;
-	height: calc( 50% + ${ LINE_WEIGHT / 2 }px );
+	width: ${ INNER_CIRCLE_SIZE }px;
+	height: ${ INNER_CIRCLE_SIZE }px;
 `;
 
 export const UnitText = styled( Text )`
 	color: ${ COLORS.ui.theme };
-	margin-right: ${ isRTL() ? space( 3 ) : space( 2 ) };
+	margin-right: ${ space( 3 ) };
 `;

--- a/packages/components/src/angle-picker-control/styles/angle-picker-control-styles.tsx
+++ b/packages/components/src/angle-picker-control/styles/angle-picker-control-styles.tsx
@@ -51,6 +51,10 @@ export const CircleIndicatorWrapper = styled.div`
 	position: relative;
 	width: 100%;
 	height: 100%;
+
+	:focus-visible {
+		outline: none;
+	}
 `;
 
 export const CircleIndicator = styled.div`


### PR DESCRIPTION
## What?

1. Makes the more room for the number input of the control
2. For RTL, puts the degree symbol to the right of the number input
3. A bit of refactoring to simplify styles

## Why?
1. Will close #45781
2. Will close #35710

## How?

1. Reduces the gap between its constituent parts
2. Conditionally uses the `prefix` prop for the angle symbol when RTL

## Testing Instructions

1. In either the Post Editor or Global Styles edit/apply a gradient
2. Verify that three digit numbers are not cut off
3. Verify that no other visual changes are introduced

### Testing Instructions for Keyboard

Nothing has really changed for pure keyboard use. The knob is not tabbable in either trunk or this branch. 

1. In either the Post Editor or Global Styles edit/apply a gradient
2. Tab into the “Angle” field  and use the arrow keys to adjust the value

## Screenshots or screencast

Before | After
----|----
<img width="271" alt="angle-picker-ltr-before" src="https://user-images.githubusercontent.com/9000376/225534221-6e130f21-96e1-4c19-98fa-cdf238bd6cf7.png"> | <img width="271" alt="angle-picker-ltr-after" src="https://user-images.githubusercontent.com/9000376/225534463-a445ea50-00af-42f5-9d16-d992cb6bf98d.png">

RTL Before | RTL After
----|----
<img width="271" alt="angle-picker-rtl-before" src="https://user-images.githubusercontent.com/9000376/225534800-1e2954af-b518-4a3f-a741-b2f8e3d5cfd0.png"> | <img width="271" alt="angle-picker-rtl-after" src="https://user-images.githubusercontent.com/9000376/225534875-ea043054-dbaa-4e7f-b493-bcce8cdcf494.png">




<details><summary>Archived from earlier iterations</summary>

### In Post Editor adjusting a gradient
https://user-images.githubusercontent.com/9000376/224783446-f4507f25-1f35-492b-a2fd-b24078550dcc.mp4

Note the easy keyboard adjustment after dragging since the number input is already focused.

### In Global Styles
<img width="282" alt="angle-picker-knob-affixed-global-styles-sidebar" src="https://user-images.githubusercontent.com/9000376/224784645-ea7c1e0a-7886-4446-98fe-3b9793e89bf9.png">

<details><summary><h3>Other screenshots to show design alternatives</h3></summary>

#### A before/after of just moving the knob “inside” without other style changes
![angle-picker-control-compare](https://user-images.githubusercontent.com/9000376/224785794-f90cffed-9f8f-4413-aaf4-bcf6c2fb5191.gif)

#### A style experiment I tried along the way
https://user-images.githubusercontent.com/9000376/224786479-5768d964-a25f-4d05-83a5-7e0de6f1272d.mp4

</details>

</details>