### PR TITLE
Add block spacing and layout to Post Template 

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -600,6 +600,7 @@ Contains the block elements used to render a post, like the title, date, feature
 
 -	**Name:** core/post-template
 -	**Category:** theme
+-	**Parent:** core/query
 -	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), spacing (blockGap), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** 
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -656,7 +656,7 @@ An advanced block that allows displaying post types based on different query par
 -	**Name:** core/query
 -	**Category:** theme
 -	**Supports:** align (full, wide), anchor, ~~html~~
--	**Attributes:** displayLayout, namespace, query, queryId, tagName
+-	**Attributes:** namespace, query, queryId, tagName
 
 ## No results
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -600,8 +600,7 @@ Contains the block elements used to render a post, like the title, date, feature
 
 -	**Name:** core/post-template
 -	**Category:** theme
--	**Parent:** core/query
--	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), spacing (blockGap), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** 
 
 ## Post Terms

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -280,10 +280,10 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			}
 		}
 	} elseif ( 'grid' === $layout_type ) {
-		if ( ! empty( $layout['__unstableColumnCount'] ) ) {
+		if ( ! empty( $layout['columnCount'] ) ) {
 			$layout_styles[] = array(
 				'selector'     => $selector,
-				'declarations' => array( 'grid-template-columns' => 'repeat(' . $layout['__unstableColumnCount'] . ', 1fr)' ),
+				'declarations' => array( 'grid-template-columns' => 'repeat(' . $layout['columnCount'] . ', 1fr)' ),
 			);
 		} else {
 			$minimum_column_width = ! empty( $layout['minimumColumnWidth'] ) ? $layout['minimumColumnWidth'] : '12rem';

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -280,10 +280,10 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			}
 		}
 	} elseif ( 'grid' === $layout_type ) {
-		if ( ! empty( $layout['_unstableColumnCount'] ) ) {
+		if ( ! empty( $layout['__unstableColumnCount'] ) ) {
 			$layout_styles[] = array(
 				'selector'     => $selector,
-				'declarations' => array( 'grid-template-columns' => 'repeat(' . $layout['_unstableColumnCount'] . ', 1fr)' ),
+				'declarations' => array( 'grid-template-columns' => 'repeat(' . $layout['__unstableColumnCount'] . ', 1fr)' ),
 			);
 		} else {
 			$minimum_column_width = ! empty( $layout['minimumColumnWidth'] ) ? $layout['minimumColumnWidth'] : '12rem';

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -280,12 +280,19 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			}
 		}
 	} elseif ( 'grid' === $layout_type ) {
-		$minimum_column_width = ! empty( $layout['minimumColumnWidth'] ) ? $layout['minimumColumnWidth'] : '12rem';
+		if ( ! empty( $layout['__unstableColumns'] ) ) {
+			$layout_styles[] = array(
+				'selector'     => $selector,
+				'declarations' => array( 'grid-template-columns' => 'repeat(' . $layout['__unstableColumns'] . ', 1fr)' ),
+			);
+		} else {
+			$minimum_column_width = ! empty( $layout['minimumColumnWidth'] ) ? $layout['minimumColumnWidth'] : '12rem';
 
-		$layout_styles[] = array(
-			'selector'     => $selector,
-			'declarations' => array( 'grid-template-columns' => 'repeat(auto-fill, minmax(min(' . $minimum_column_width . ', 100%), 1fr))' ),
-		);
+			$layout_styles[] = array(
+				'selector'     => $selector,
+				'declarations' => array( 'grid-template-columns' => 'repeat(auto-fill, minmax(min(' . $minimum_column_width . ', 100%), 1fr))' ),
+			);
+		}
 
 		if ( $has_block_gap_support && isset( $gap_value ) ) {
 			$combined_gap_value = '';

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -280,6 +280,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			}
 		}
 	} elseif ( 'grid' === $layout_type ) {
+		$minimum_column_width = ! empty( $layout['minimumColumnWidth'] ) ? $layout['minimumColumnWidth'] : '12rem';
 
 		$layout_styles[] = array(
 			'selector'     => $selector,

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -280,7 +280,6 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			}
 		}
 	} elseif ( 'grid' === $layout_type ) {
-		$minimum_column_width = ! empty( $layout['minimumColumnWidth'] ) ? $layout['minimumColumnWidth'] : '12rem';
 
 		$layout_styles[] = array(
 			'selector'     => $selector,

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -280,10 +280,10 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			}
 		}
 	} elseif ( 'grid' === $layout_type ) {
-		if ( ! empty( $layout['__unstableColumns'] ) ) {
+		if ( ! empty( $layout['_unstableColumnCount'] ) ) {
 			$layout_styles[] = array(
 				'selector'     => $selector,
-				'declarations' => array( 'grid-template-columns' => 'repeat(' . $layout['__unstableColumns'] . ', 1fr)' ),
+				'declarations' => array( 'grid-template-columns' => 'repeat(' . $layout['_unstableColumnCount'] . ', 1fr)' ),
 			);
 		} else {
 			$minimum_column_width = ! empty( $layout['minimumColumnWidth'] ) ? $layout['minimumColumnWidth'] : '12rem';

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -283,7 +283,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		if ( ! empty( $layout['columnCount'] ) ) {
 			$layout_styles[] = array(
 				'selector'     => $selector,
-				'declarations' => array( 'grid-template-columns' => 'repeat(' . $layout['columnCount'] . ', 1fr)' ),
+				'declarations' => array( 'grid-template-columns' => 'repeat(' . $layout['columnCount'] . ', minmax(0, 1fr))' ),
 			);
 		} else {
 			$minimum_column_width = ! empty( $layout['minimumColumnWidth'] ) ? $layout['minimumColumnWidth'] : '12rem';

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1075,9 +1075,11 @@ class WP_Theme_JSON_Gutenberg {
 		} elseif ( in_array( 'base-layout-styles', $types, true ) ) {
 			$root_selector    = static::ROOT_BLOCK_SELECTOR;
 			$columns_selector = '.wp-block-columns';
+			$post_template_selector = '.wp-block-post-template';
 			if ( ! empty( $options['scope'] ) ) {
 				$root_selector    = static::scope_selector( $options['scope'], $root_selector );
 				$columns_selector = static::scope_selector( $options['scope'], $columns_selector );
+				$post_template_selector = static::scope_selector( $options['scope'], $post_template_selector );
 			}
 			if ( ! empty( $options['root_selector'] ) ) {
 				$root_selector = $options['root_selector'];
@@ -1093,6 +1095,11 @@ class WP_Theme_JSON_Gutenberg {
 					'path'     => array( 'styles', 'blocks', 'core/columns' ),
 					'selector' => $columns_selector,
 					'name'     => 'core/columns',
+				),
+				array(
+					'path'     => array( 'styles', 'blocks', 'core/post-template' ),
+					'selector' => $post_template_selector,
+					'name'     => 'core/post-template',
 				),
 			);
 
@@ -1298,7 +1305,7 @@ class WP_Theme_JSON_Gutenberg {
 			if ( null !== $block_gap_value && false !== $block_gap_value && '' !== $block_gap_value ) {
 				foreach ( $layout_definitions as $layout_definition_key => $layout_definition ) {
 					// Allow outputting fallback gap styles for flex layout type when block gap support isn't available.
-					if ( ! $has_block_gap_support && 'flex' !== $layout_definition_key ) {
+					if ( ! $has_block_gap_support && 'flex' !== $layout_definition_key && 'grid' !== $layout_definition_key ) {
 						continue;
 					}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1073,12 +1073,12 @@ class WP_Theme_JSON_Gutenberg {
 			}
 			$stylesheet .= $this->get_block_classes( $style_nodes );
 		} elseif ( in_array( 'base-layout-styles', $types, true ) ) {
-			$root_selector    = static::ROOT_BLOCK_SELECTOR;
-			$columns_selector = '.wp-block-columns';
+			$root_selector          = static::ROOT_BLOCK_SELECTOR;
+			$columns_selector       = '.wp-block-columns';
 			$post_template_selector = '.wp-block-post-template';
 			if ( ! empty( $options['scope'] ) ) {
-				$root_selector    = static::scope_selector( $options['scope'], $root_selector );
-				$columns_selector = static::scope_selector( $options['scope'], $columns_selector );
+				$root_selector          = static::scope_selector( $options['scope'], $root_selector );
+				$columns_selector       = static::scope_selector( $options['scope'], $columns_selector );
 				$post_template_selector = static::scope_selector( $options['scope'], $post_template_selector );
 			}
 			if ( ! empty( $options['root_selector'] ) ) {

--- a/packages/block-editor/src/components/global-styles/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-output.js
@@ -448,7 +448,11 @@ export function getLayoutStyles( {
 		Object.values( tree.settings.layout.definitions ).forEach(
 			( { className, name, spacingStyles } ) => {
 				// Allow outputting fallback gap styles for flex layout type when block gap support isn't available.
-				if ( ! hasBlockGapSupport && 'flex' !== name ) {
+				if (
+					! hasBlockGapSupport &&
+					'flex' !== name &&
+					'grid' !== name
+				) {
 					return;
 				}
 

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -35,17 +35,17 @@ export default {
 		layout = {},
 		onChange,
 	} ) {
-		const { __unstableColumnCount = null } = layout;
+		const { columnCount = null } = layout;
 
 		return (
 			<>
-				{ __unstableColumnCount && (
+				{ columnCount && (
 					<GridLayoutColumnsControl
 						layout={ layout }
 						onChange={ onChange }
 					/>
 				) }
-				{ ! __unstableColumnCount && (
+				{ ! columnCount && (
 					<GridLayoutMinimumWidthControl
 						layout={ layout }
 						onChange={ onChange }
@@ -65,8 +65,7 @@ export default {
 		hasBlockGapSupport,
 		layoutDefinitions,
 	} ) {
-		const { minimumColumnWidth = '12rem', __unstableColumnCount = null } =
-			layout;
+		const { minimumColumnWidth = '12rem', columnCount = null } = layout;
 
 		// If a block's block.json skips serialization for spacing or spacing.blockGap,
 		// don't apply the user-defined value to the styles.
@@ -79,9 +78,9 @@ export default {
 		let output = '';
 		const rules = [];
 
-		if ( __unstableColumnCount ) {
+		if ( columnCount ) {
 			rules.push(
-				`grid-template-columns: repeat(${ __unstableColumnCount }, 1fr)`
+				`grid-template-columns: repeat(${ columnCount }, 1fr)`
 			);
 		} else if ( minimumColumnWidth ) {
 			rules.push(
@@ -190,16 +189,16 @@ function GridLayoutMinimumWidthControl( { layout, onChange } ) {
 
 // Enables setting number of grid columns
 function GridLayoutColumnsControl( { layout, onChange } ) {
-	const { __unstableColumnCount = 3 } = layout;
+	const { columnCount = 3 } = layout;
 
 	return (
 		<RangeControl
 			label={ __( 'Columns' ) }
-			value={ __unstableColumnCount }
+			value={ columnCount }
 			onChange={ ( value ) => {
 				onChange( {
 					...layout,
-					__unstableColumnCount: value,
+					columnCount: value,
 				} );
 			} }
 			min={ 1 }

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -80,7 +80,7 @@ export default {
 
 		if ( columnCount ) {
 			rules.push(
-				`grid-template-columns: repeat(${ columnCount }, 1fr)`
+				`grid-template-columns: repeat(${ columnCount }, minmax(0, 1fr))`
 			);
 		} else if ( minimumColumnWidth ) {
 			rules.push(

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -53,7 +53,8 @@ export default {
 		hasBlockGapSupport,
 		layoutDefinitions,
 	} ) {
-		const { minimumColumnWidth = '12rem' } = layout;
+		const { minimumColumnWidth = '12rem', __unstableColumns = null } =
+			layout;
 
 		// If a block's block.json skips serialization for spacing or spacing.blockGap,
 		// don't apply the user-defined value to the styles.
@@ -66,7 +67,11 @@ export default {
 		let output = '';
 		const rules = [];
 
-		if ( minimumColumnWidth ) {
+		if ( __unstableColumns ) {
+			rules.push(
+				`grid-template-columns: repeat(${ __unstableColumns }, 1fr)`
+			);
+		} else if ( minimumColumnWidth ) {
 			rules.push(
 				`grid-template-columns: repeat(auto-fill, minmax(min(${ minimumColumnWidth }, 100%), 1fr))`
 			);

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -53,11 +53,7 @@ export default {
 		hasBlockGapSupport,
 		layoutDefinitions,
 	} ) {
-		const {
-			isResponsive = true,
-			minimumColumnWidth = '12rem',
-			numberOfColumns = 3,
-		} = layout;
+		const { minimumColumnWidth = '12rem' } = layout;
 
 		// If a block's block.json skips serialization for spacing or spacing.blockGap,
 		// don't apply the user-defined value to the styles.
@@ -70,13 +66,9 @@ export default {
 		let output = '';
 		const rules = [];
 
-		if ( isResponsive && minimumColumnWidth ) {
+		if ( minimumColumnWidth ) {
 			rules.push(
 				`grid-template-columns: repeat(auto-fill, minmax(min(${ minimumColumnWidth }, 100%), 1fr))`
-			);
-		} else if ( numberOfColumns ) {
-			rules.push(
-				`grid-template-columns: repeat(${ numberOfColumns }, 1fr)`
 			);
 		}
 

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -53,7 +53,11 @@ export default {
 		hasBlockGapSupport,
 		layoutDefinitions,
 	} ) {
-		const { minimumColumnWidth = '12rem' } = layout;
+		const {
+			isResponsive = true,
+			minimumColumnWidth = '12rem',
+			numberOfColumns = 3,
+		} = layout;
 
 		// If a block's block.json skips serialization for spacing or spacing.blockGap,
 		// don't apply the user-defined value to the styles.
@@ -66,9 +70,13 @@ export default {
 		let output = '';
 		const rules = [];
 
-		if ( minimumColumnWidth ) {
+		if ( isResponsive && minimumColumnWidth ) {
 			rules.push(
 				`grid-template-columns: repeat(auto-fill, minmax(min(${ minimumColumnWidth }, 100%), 1fr))`
+			);
+		} else if ( numberOfColumns ) {
+			rules.push(
+				`grid-template-columns: repeat(${ numberOfColumns }, 1fr)`
 			);
 		}
 

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -35,23 +35,13 @@ export default {
 		layout = {},
 		onChange,
 	} ) {
-		const { columnCount = null } = layout;
-
-		return (
-			<>
-				{ columnCount && (
-					<GridLayoutColumnsControl
-						layout={ layout }
-						onChange={ onChange }
-					/>
-				) }
-				{ ! columnCount && (
-					<GridLayoutMinimumWidthControl
-						layout={ layout }
-						onChange={ onChange }
-					/>
-				) }
-			</>
+		return layout?.columnCount ? (
+			<GridLayoutColumnsControl layout={ layout } onChange={ onChange } />
+		) : (
+			<GridLayoutMinimumWidthControl
+				layout={ layout }
+				onChange={ onChange }
+			/>
 		);
 	},
 	toolBarControls: function DefaultLayoutToolbarControls() {
@@ -195,12 +185,12 @@ function GridLayoutColumnsControl( { layout, onChange } ) {
 		<RangeControl
 			label={ __( 'Columns' ) }
 			value={ columnCount }
-			onChange={ ( value ) => {
+			onChange={ ( value ) =>
 				onChange( {
 					...layout,
 					columnCount: value,
-				} );
-			} }
+				} )
+			}
 			min={ 1 }
 			max={ 6 }
 		/>

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -203,7 +203,7 @@ function GridLayoutColumnsControl( { layout, onChange } ) {
 				} );
 			} }
 			min={ 1 }
-			max={ 12 }
+			max={ 6 }
 		/>
 	);
 }

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -35,11 +35,23 @@ export default {
 		layout = {},
 		onChange,
 	} ) {
+		const { __unstableColumnCount = null } = layout;
+
 		return (
-			<GridLayoutMinimumWidthControl
-				layout={ layout }
-				onChange={ onChange }
-			/>
+			<>
+				{ __unstableColumnCount && (
+					<GridLayoutColumnsControl
+						layout={ layout }
+						onChange={ onChange }
+					/>
+				) }
+				{ ! __unstableColumnCount && (
+					<GridLayoutMinimumWidthControl
+						layout={ layout }
+						onChange={ onChange }
+					/>
+				) }
+			</>
 		);
 	},
 	toolBarControls: function DefaultLayoutToolbarControls() {
@@ -53,7 +65,7 @@ export default {
 		hasBlockGapSupport,
 		layoutDefinitions,
 	} ) {
-		const { minimumColumnWidth = '12rem', _unstableColumnCount = null } =
+		const { minimumColumnWidth = '12rem', __unstableColumnCount = null } =
 			layout;
 
 		// If a block's block.json skips serialization for spacing or spacing.blockGap,
@@ -67,9 +79,9 @@ export default {
 		let output = '';
 		const rules = [];
 
-		if ( _unstableColumnCount ) {
+		if ( __unstableColumnCount ) {
 			rules.push(
-				`grid-template-columns: repeat(${ _unstableColumnCount }, 1fr)`
+				`grid-template-columns: repeat(${ __unstableColumnCount }, 1fr)`
 			);
 		} else if ( minimumColumnWidth ) {
 			rules.push(
@@ -173,5 +185,25 @@ function GridLayoutMinimumWidthControl( { layout, onChange } ) {
 				</FlexItem>
 			</Flex>
 		</fieldset>
+	);
+}
+
+// Enables setting number of grid columns
+function GridLayoutColumnsControl( { layout, onChange } ) {
+	const { __unstableColumnCount = 3 } = layout;
+
+	return (
+		<RangeControl
+			label={ __( 'Columns' ) }
+			value={ __unstableColumnCount }
+			onChange={ ( value ) => {
+				onChange( {
+					...layout,
+					__unstableColumnCount: value,
+				} );
+			} }
+			min={ 1 }
+			max={ 12 }
+		/>
 	);
 }

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -53,7 +53,7 @@ export default {
 		hasBlockGapSupport,
 		layoutDefinitions,
 	} ) {
-		const { minimumColumnWidth = '12rem', __unstableColumns = null } =
+		const { minimumColumnWidth = '12rem', _unstableColumnCount = null } =
 			layout;
 
 		// If a block's block.json skips serialization for spacing or spacing.blockGap,
@@ -67,9 +67,9 @@ export default {
 		let output = '';
 		const rules = [];
 
-		if ( __unstableColumns ) {
+		if ( _unstableColumnCount ) {
 			rules.push(
-				`grid-template-columns: repeat(${ __unstableColumns }, 1fr)`
+				`grid-template-columns: repeat(${ _unstableColumnCount }, 1fr)`
 			);
 		} else if ( minimumColumnWidth ) {
 			rules.push(

--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -20,9 +20,7 @@
 		"html": false,
 		"align": [ "wide", "full" ],
 		"anchor": true,
-		"__experimentalLayout": {
-			"allowEditing": false
-		},
+		"__experimentalLayout": true,
 		"color": {
 			"gradients": true,
 			"link": true,

--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -43,6 +43,9 @@
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}
+		},
+		"spacing": {
+			"blockGap": true
 		}
 	},
 	"style": "wp-block-post-template",

--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -44,7 +44,7 @@
 		},
 		"spacing": {
 			"blockGap": {
-				"__experimentalDefault": "1.5rem"
+				"__experimentalDefault": "1.25em"
 			},
 			"__experimentalDefaultControls": {
 				"blockGap": true

--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -45,7 +45,10 @@
 			}
 		},
 		"spacing": {
-			"blockGap": true
+			"blockGap": true,
+			"__experimentalDefaultControls": {
+				"blockGap": true
+			}
 		}
 	},
 	"style": "wp-block-post-template",

--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -43,7 +43,9 @@
 			}
 		},
 		"spacing": {
-			"blockGap": true,
+			"blockGap": {
+				"__experimentalDefault": "1.5rem"
+			},
 			"__experimentalDefaultControls": {
 				"blockGap": true
 			}

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -96,7 +96,7 @@ export default function PostTemplateEdit( {
 		} = {},
 		queryContext = [ { page: 1 } ],
 		templateSlug,
-		displayLayout: { type: layoutType = 'grid', columns = 1 } = {},
+		displayLayout: { type: layoutType = 'grid', columnWidth = 12 } = {},
 		previewPostType,
 	},
 	__unstableLayoutClassNames,
@@ -108,11 +108,10 @@ export default function PostTemplateEdit( {
 		setAttributes( {
 			layout: {
 				type: updatedLayoutType,
-				isResponsive: false,
-				numberOfColumns: columns,
+				minimumColumnWidth: `${ columnWidth }rem`,
 			},
 		} );
-	}, [ updatedLayoutType, columns, setAttributes ] );
+	}, [ updatedLayoutType, columnWidth, setAttributes ] );
 
 	const [ { page } ] = queryContext;
 	const [ activeBlockContextId, setActiveBlockContextId ] = useState();

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -108,7 +108,7 @@ export default function PostTemplateEdit( {
 		setAttributes( {
 			layout: {
 				type: updatedLayoutType,
-				__unstableColumns: columns,
+				_unstableColumnCount: columns,
 			},
 		} );
 	}, [ updatedLayoutType, columns, setAttributes ] );

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -268,7 +268,6 @@ export default function PostTemplateEdit( {
 	return (
 		<>
 			<BlockControls>
-				{ ' ' }
 				<ToolbarGroup controls={ displayLayoutControls } />
 			</BlockControls>
 

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { memo, useMemo, useState } from '@wordpress/element';
+import { memo, useMemo, useState, useEffect } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import {
@@ -70,6 +70,7 @@ function PostTemplateBlockPreview( {
 const MemoizedPostTemplateBlockPreview = memo( PostTemplateBlockPreview );
 
 export default function PostTemplateEdit( {
+	setAttributes,
 	clientId,
 	context: {
 		query: {
@@ -95,11 +96,24 @@ export default function PostTemplateEdit( {
 		} = {},
 		queryContext = [ { page: 1 } ],
 		templateSlug,
-		displayLayout: { type: layoutType = 'flex', columns = 1 } = {},
+		displayLayout: { type: layoutType = 'grid', columns = 1 } = {},
 		previewPostType,
 	},
 	__unstableLayoutClassNames,
 } ) {
+	const updatedLayoutType =
+		layoutType === 'list' || layoutType === 'default' ? 'default' : 'grid';
+
+	useEffect( () => {
+		setAttributes( {
+			layout: {
+				type: updatedLayoutType,
+				isResponsive: false,
+				numberOfColumns: columns,
+			},
+		} );
+	}, [ updatedLayoutType, columns, setAttributes ] );
+
 	const [ { page } ] = queryContext;
 	const [ activeBlockContextId, setActiveBlockContextId ] = useState();
 	const { posts, blocks } = useSelect(
@@ -215,12 +229,9 @@ export default function PostTemplateEdit( {
 			} ) ),
 		[ posts ]
 	);
-	const hasLayoutFlex = layoutType === 'flex' && columns > 1;
+
 	const blockProps = useBlockProps( {
-		className: classnames( __unstableLayoutClassNames, {
-			'is-flex-container': hasLayoutFlex,
-			[ `columns-${ columns }` ]: hasLayoutFlex,
-		} ),
+		className: classnames( __unstableLayoutClassNames ),
 	} );
 
 	if ( ! posts ) {

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -98,17 +98,12 @@ export default function PostTemplateEdit( {
 		} = {},
 		queryContext = [ { page: 1 } ],
 		templateSlug,
-		displayLayout,
 		previewPostType,
 	},
 	attributes: { layout },
 	__unstableLayoutClassNames,
 } ) {
-	const { type: layoutType = 'grid' } = displayLayout || {};
-	const legacyLayoutType =
-		layoutType === 'list' || layoutType === 'default' ? 'default' : 'grid';
-
-	const updatedLayoutType = layout?.type || legacyLayoutType;
+	const { type: layoutType, columnCount = 3 } = layout || {};
 
 	const [ { page } ] = queryContext;
 	const [ activeBlockContextId, setActiveBlockContextId ] = useState();
@@ -252,15 +247,17 @@ export default function PostTemplateEdit( {
 			icon: list,
 			title: __( 'List view' ),
 			onClick: () => setDisplayLayout( { type: 'default' } ),
-			isActive:
-				updatedLayoutType === 'default' || updatedLayoutType === 'list',
+			isActive: layoutType === 'default' || layoutType === 'constrained',
 		},
 		{
 			icon: grid,
 			title: __( 'Grid view' ),
-			onClick: () => setDisplayLayout( { type: 'grid', columnCount: 3 } ),
-			isActive:
-				updatedLayoutType === 'grid' || updatedLayoutType === 'flex',
+			onClick: () =>
+				setDisplayLayout( {
+					type: 'grid',
+					columnCount,
+				} ),
+			isActive: layoutType === 'grid',
 		},
 	];
 

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -258,8 +258,7 @@ export default function PostTemplateEdit( {
 		{
 			icon: grid,
 			title: __( 'Grid view' ),
-			onClick: () =>
-				setDisplayLayout( { type: 'grid', __unstableColumnCount: 3 } ),
+			onClick: () => setDisplayLayout( { type: 'grid', columnCount: 3 } ),
 			isActive:
 				updatedLayoutType === 'grid' || updatedLayoutType === 'flex',
 		},

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -96,7 +96,7 @@ export default function PostTemplateEdit( {
 		} = {},
 		queryContext = [ { page: 1 } ],
 		templateSlug,
-		displayLayout: { type: layoutType = 'grid', columnWidth = 12 } = {},
+		displayLayout: { type: layoutType = 'grid', columns = 3 } = {},
 		previewPostType,
 	},
 	__unstableLayoutClassNames,
@@ -108,10 +108,10 @@ export default function PostTemplateEdit( {
 		setAttributes( {
 			layout: {
 				type: updatedLayoutType,
-				minimumColumnWidth: `${ columnWidth }rem`,
+				__unstableColumns: columns,
 			},
 		} );
-	}, [ updatedLayoutType, columnWidth, setAttributes ] );
+	}, [ updatedLayoutType, columns, setAttributes ] );
 
 	const [ { page } ] = queryContext;
 	const [ activeBlockContextId, setActiveBlockContextId ] = useState();

--- a/packages/block-library/src/post-template/style.scss
+++ b/packages/block-library/src/post-template/style.scss
@@ -9,7 +9,7 @@
 	&.wp-block-post-template {
 		background: none;
 	}
-
+	// These rules no longer apply but should be kept for backwards compatibility.
 	&.is-flex-container {
 		flex-direction: row;
 		display: flex;
@@ -32,6 +32,7 @@
 }
 
 @media ( max-width: $break-small ) {
+	// Temporary specificity bump until "wp-container" layout specificity is revisited.
 	.wp-block-post-template-is-layout-grid.wp-block-post-template-is-layout-grid.wp-block-post-template-is-layout-grid.wp-block-post-template-is-layout-grid {
 		grid-template-columns: 1fr;
 	}

--- a/packages/block-library/src/post-template/style.scss
+++ b/packages/block-library/src/post-template/style.scss
@@ -30,3 +30,9 @@
 		}
 	}
 }
+
+@media ( max-width: $break-small ) {
+	.wp-block-post-template-is-layout-grid.wp-block-post-template-is-layout-grid.wp-block-post-template-is-layout-grid.wp-block-post-template-is-layout-grid {
+		grid-template-columns: 1fr;
+	}
+}

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -32,12 +32,6 @@
 			"type": "string",
 			"default": "div"
 		},
-		"displayLayout": {
-			"type": "object",
-			"default": {
-				"type": "list"
-			}
-		},
 		"namespace": {
 			"type": "string"
 		}

--- a/packages/block-library/src/query/deprecated.js
+++ b/packages/block-library/src/query/deprecated.js
@@ -454,9 +454,8 @@ const v4 = {
 		return <Tag { ...innerBlocksProps } />;
 	},
 	isEligible: ( { layout } ) =>
-		! layout ||
-		layout.inherit ||
-		( layout.contentSize && layout.type !== 'constrained' ),
+		layout?.inherit ||
+		( layout?.contentSize && layout?.type !== 'constrained' ),
 	migrate( attributes, innerBlocks ) {
 		const withConstrainedLayoutAttributes =
 			migrateToConstrainedLayout( attributes );

--- a/packages/block-library/src/query/deprecated.js
+++ b/packages/block-library/src/query/deprecated.js
@@ -131,11 +131,14 @@ const migrateToConstrainedLayout = ( attributes ) => {
 	if ( ! layout ) {
 		return attributes;
 	}
-	if ( layout.inherit || layout.contentSize ) {
+	const { inherit = null, contentSize = null, ...newLayout } = layout;
+
+	if ( inherit || contentSize ) {
 		return {
 			...attributes,
 			layout: {
-				...layout,
+				...newLayout,
+				contentSize,
 				type: 'constrained',
 			},
 		};

--- a/packages/block-library/src/query/deprecated.js
+++ b/packages/block-library/src/query/deprecated.js
@@ -144,13 +144,14 @@ const migrateToConstrainedLayout = ( attributes ) => {
 
 const findPostTemplateBlock = ( innerBlocks = [] ) => {
 	let foundBlock = null;
-	innerBlocks.forEach( ( block ) => {
+	for ( const block of innerBlocks ) {
 		if ( block.name === 'core/post-template' ) {
 			foundBlock = block;
+			break;
 		} else if ( block.innerBlocks.length ) {
 			foundBlock = findPostTemplateBlock( block.innerBlocks );
 		}
-	} );
+	}
 	return foundBlock;
 };
 
@@ -511,7 +512,9 @@ const v5 = {
 		const innerBlocksProps = useInnerBlocksProps.save( blockProps );
 		return <Tag { ...innerBlocksProps } />;
 	},
-	isEligible: ( { displayLayout } ) => !! displayLayout,
+	isEligible: ( { displayLayout } ) => {
+		return !! displayLayout;
+	},
 	migrate: migrateDisplayLayout,
 };
 

--- a/packages/block-library/src/query/deprecated.js
+++ b/packages/block-library/src/query/deprecated.js
@@ -126,6 +126,80 @@ const migrateColors = ( attributes, innerBlocks ) => {
 const hasSingleInnerGroupBlock = ( innerBlocks = [] ) =>
 	innerBlocks.length === 1 && innerBlocks[ 0 ].name === 'core/group';
 
+const migrateToConstrainedLayout = ( attributes ) => {
+	const { layout = null } = attributes;
+	if ( ! layout ) {
+		return attributes;
+	}
+	if ( layout.inherit || layout.contentSize ) {
+		return {
+			...attributes,
+			layout: {
+				...layout,
+				type: 'constrained',
+			},
+		};
+	}
+};
+
+const findPostTemplateBlock = ( innerBlocks = [] ) => {
+	let foundBlock = null;
+	innerBlocks.forEach( ( block ) => {
+		if ( block.name === 'core/post-template' ) {
+			foundBlock = block;
+		} else if ( block.innerBlocks.length ) {
+			foundBlock = findPostTemplateBlock( block.innerBlocks );
+		}
+	} );
+	return foundBlock;
+};
+
+const replacePostTemplateBlock = ( innerBlocks = [], replacementBlock ) => {
+	innerBlocks.forEach( ( block, index ) => {
+		if ( block.name === 'core/post-template' ) {
+			innerBlocks.splice( index, 1, replacementBlock );
+		} else if ( block.innerBlocks.length ) {
+			block.innerBlocks = replacePostTemplateBlock(
+				block.innerBlocks,
+				replacementBlock
+			);
+		}
+	} );
+	return innerBlocks;
+};
+
+const migrateDisplayLayout = ( attributes, innerBlocks ) => {
+	const { displayLayout = null, ...newAttributes } = attributes;
+	if ( ! displayLayout ) {
+		return [ attributes, innerBlocks ];
+	}
+	const postTemplateBlock = findPostTemplateBlock( innerBlocks );
+	if ( ! postTemplateBlock ) {
+		return [ attributes, innerBlocks ];
+	}
+
+	const { type, columns } = displayLayout;
+
+	// Convert custom displayLayout values to canonical layout types.
+	const updatedLayoutType = type === 'flex' ? 'grid' : 'default';
+
+	const newPostTemplateBlock = createBlock(
+		'core/post-template',
+		{
+			...postTemplateBlock.attributes,
+			layout: {
+				type: updatedLayoutType,
+				...( columns && { columnCount: columns } ),
+			},
+		},
+		postTemplateBlock.innerBlocks
+	);
+	return [
+		newAttributes,
+		replacePostTemplateBlock( innerBlocks, newPostTemplateBlock ),
+	];
+};
+
 // Version with NO wrapper `div` element.
 const v1 = {
 	attributes: {
@@ -160,13 +234,14 @@ const v1 = {
 	supports: {
 		html: false,
 	},
-	migrate( attributes ) {
+	migrate( attributes, innerBlocks ) {
 		const withTaxQuery = migrateToTaxQuery( attributes );
 		const { layout, ...restWithTaxQuery } = withTaxQuery;
-		return {
+		const newAttributes = {
 			...restWithTaxQuery,
 			displayLayout: withTaxQuery.layout,
 		};
+		return migrateDisplayLayout( newAttributes, innerBlocks );
 	},
 	save() {
 		return <InnerBlocks.Content />;
@@ -221,7 +296,16 @@ const v2 = {
 		categoryIds || tagIds,
 	migrate( attributes, innerBlocks ) {
 		const withTaxQuery = migrateToTaxQuery( attributes );
-		return migrateColors( withTaxQuery, innerBlocks );
+		const [ withColorAttributes, withColorInnerBlocks ] = migrateColors(
+			withTaxQuery,
+			innerBlocks
+		);
+		const withConstrainedLayoutAttributes =
+			migrateToConstrainedLayout( withColorAttributes );
+		return migrateDisplayLayout(
+			withConstrainedLayoutAttributes,
+			withColorInnerBlocks
+		);
 	},
 	save( { attributes: { tagName: Tag = 'div' } } ) {
 		const blockProps = useBlockProps.save();
@@ -291,7 +375,18 @@ const v3 = {
 			style?.elements?.link
 		);
 	},
-	migrate: migrateColors,
+	migrate( attributes, innerBlocks ) {
+		const [ withColorAttributes, withColorInnerBlocks ] = migrateColors(
+			attributes,
+			innerBlocks
+		);
+		const withConstrainedLayoutAttributes =
+			migrateToConstrainedLayout( withColorAttributes );
+		return migrateDisplayLayout(
+			withConstrainedLayoutAttributes,
+			withColorInnerBlocks
+		);
+	},
 	save( { attributes: { tagName: Tag = 'div' } } ) {
 		const blockProps = useBlockProps.save();
 		const innerBlocksProps = useInnerBlocksProps.save( blockProps );
@@ -358,23 +453,68 @@ const v4 = {
 		! layout ||
 		layout.inherit ||
 		( layout.contentSize && layout.type !== 'constrained' ),
-	migrate: ( attributes ) => {
-		const { layout = null } = attributes;
-		if ( ! layout ) {
-			return attributes;
-		}
-		if ( layout.inherit || layout.contentSize ) {
-			return {
-				...attributes,
-				layout: {
-					...layout,
-					type: 'constrained',
-				},
-			};
-		}
+	migrate( attributes, innerBlocks ) {
+		const withConstrainedLayoutAttributes =
+			migrateToConstrainedLayout( attributes );
+		return migrateDisplayLayout(
+			withConstrainedLayoutAttributes,
+			innerBlocks
+		);
 	},
 };
 
-const deprecated = [ v4, v3, v2, v1 ];
+const v5 = {
+	attributes: {
+		queryId: {
+			type: 'number',
+		},
+		query: {
+			type: 'object',
+			default: {
+				perPage: null,
+				pages: 0,
+				offset: 0,
+				postType: 'post',
+				order: 'desc',
+				orderBy: 'date',
+				author: '',
+				search: '',
+				exclude: [],
+				sticky: '',
+				inherit: true,
+				taxQuery: null,
+				parents: [],
+			},
+		},
+		tagName: {
+			type: 'string',
+			default: 'div',
+		},
+		displayLayout: {
+			type: 'object',
+			default: {
+				type: 'list',
+			},
+		},
+		namespace: {
+			type: 'string',
+		},
+	},
+	supports: {
+		align: [ 'wide', 'full' ],
+		anchor: true,
+		html: false,
+		__experimentalLayout: true,
+	},
+	save( { attributes: { tagName: Tag = 'div' } } ) {
+		const blockProps = useBlockProps.save();
+		const innerBlocksProps = useInnerBlocksProps.save( blockProps );
+		return <Tag { ...innerBlocksProps } />;
+	},
+	isEligible: ( { displayLayout } ) => !! displayLayout,
+	migrate: migrateDisplayLayout,
+};
+
+const deprecated = [ v5, v4, v3, v2, v1 ];
 
 export default deprecated;

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -167,13 +167,15 @@ export default function QueryInspectorControls( props ) {
 							<>
 								<RangeControl
 									__nextHasNoMarginBottom
-									label={ __( 'Columns' ) }
-									value={ displayLayout.columns }
+									label={ __( 'Minimum Column Width' ) }
+									value={ displayLayout.columnWidth }
 									onChange={ ( value ) =>
-										setDisplayLayout( { columns: value } )
+										setDisplayLayout( {
+											columnWidth: value,
+										} )
 									}
 									min={ 2 }
-									max={ Math.max( 6, displayLayout.columns ) }
+									max={ 60 }
 								/>
 								{ displayLayout.columns > 6 && (
 									<Notice

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -101,7 +101,8 @@ export default function QueryInspectorControls( props ) {
 	const showInheritControl = isControlAllowed( allowedControls, 'inherit' );
 	const showPostTypeControl =
 		! inherit && isControlAllowed( allowedControls, 'postType' );
-	const showColumnsControl = displayLayout?.type === 'flex';
+	const showColumnsControl =
+		displayLayout?.type === 'grid' || displayLayout?.type === 'flex';
 	const showOrderControl =
 		! inherit && isControlAllowed( allowedControls, 'order' );
 	const showStickyControl =

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -167,15 +167,15 @@ export default function QueryInspectorControls( props ) {
 							<>
 								<RangeControl
 									__nextHasNoMarginBottom
-									label={ __( 'Minimum Column Width' ) }
-									value={ displayLayout.columnWidth }
+									label={ __( 'Columns' ) }
+									value={ displayLayout.columns }
 									onChange={ ( value ) =>
 										setDisplayLayout( {
-											columnWidth: value,
+											columns: value,
 										} )
 									}
 									min={ 2 }
-									max={ 60 }
+									max={ Math.max( 6, displayLayout.columns ) }
 								/>
 								{ displayLayout.columns > 6 && (
 									<Notice

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -101,8 +101,7 @@ export default function QueryInspectorControls( props ) {
 	const showInheritControl = isControlAllowed( allowedControls, 'inherit' );
 	const showPostTypeControl =
 		! inherit && isControlAllowed( allowedControls, 'postType' );
-	const showColumnsControl =
-		displayLayout?.type === 'grid' || displayLayout?.type === 'flex';
+	const showColumnsControl = false;
 	const showOrderControl =
 		! inherit && isControlAllowed( allowedControls, 'order' );
 	const showStickyControl =

--- a/packages/block-library/src/query/edit/query-content.js
+++ b/packages/block-library/src/query/edit/query-content.js
@@ -107,7 +107,6 @@ export default function QueryContent( {
 					clientId={ clientId }
 					attributes={ attributes }
 					setQuery={ updateQuery }
-					setDisplayLayout={ updateDisplayLayout }
 					openPatternSelectionModal={ openPatternSelectionModal }
 				/>
 			</BlockControls>

--- a/packages/block-library/src/query/edit/query-toolbar.js
+++ b/packages/block-library/src/query/edit/query-toolbar.js
@@ -34,18 +34,22 @@ export default function QueryToolbar( {
 		{
 			icon: list,
 			title: __( 'List view' ),
-			onClick: () => setDisplayLayout( { type: 'list' } ),
-			isActive: displayLayout?.type === 'list',
+			onClick: () => setDisplayLayout( { type: 'default' } ),
+			isActive:
+				displayLayout?.type === 'default' ||
+				displayLayout?.type === 'list',
 		},
 		{
 			icon: grid,
 			title: __( 'Grid view' ),
 			onClick: () =>
 				setDisplayLayout( {
-					type: 'flex',
+					type: 'grid',
 					columns: displayLayout?.columns || 3,
 				} ),
-			isActive: displayLayout?.type === 'flex',
+			isActive:
+				displayLayout?.type === 'grid' ||
+				displayLayout?.type === 'flex',
 		},
 	];
 	return (

--- a/packages/block-library/src/query/edit/query-toolbar.js
+++ b/packages/block-library/src/query/edit/query-toolbar.js
@@ -10,7 +10,7 @@ import {
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { settings, list, grid } from '@wordpress/icons';
+import { settings } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -18,9 +18,8 @@ import { settings, list, grid } from '@wordpress/icons';
 import { usePatterns } from '../utils';
 
 export default function QueryToolbar( {
-	attributes: { query, displayLayout },
+	attributes: { query },
 	setQuery,
-	setDisplayLayout,
 	openPatternSelectionModal,
 	name,
 	clientId,
@@ -30,28 +29,7 @@ export default function QueryToolbar( {
 		QueryToolbar,
 		'blocks-query-pagination-max-page-input'
 	);
-	const displayLayoutControls = [
-		{
-			icon: list,
-			title: __( 'List view' ),
-			onClick: () => setDisplayLayout( { type: 'default' } ),
-			isActive:
-				displayLayout?.type === 'default' ||
-				displayLayout?.type === 'list',
-		},
-		{
-			icon: grid,
-			title: __( 'Grid view' ),
-			onClick: () =>
-				setDisplayLayout( {
-					type: 'grid',
-					columns: displayLayout?.columns || 3,
-				} ),
-			isActive:
-				displayLayout?.type === 'grid' ||
-				displayLayout?.type === 'flex',
-		},
-	];
+
 	return (
 		<>
 			{ ! query.inherit && (
@@ -148,7 +126,6 @@ export default function QueryToolbar( {
 					</ToolbarButton>
 				</ToolbarGroup>
 			) }
-			<ToolbarGroup controls={ displayLayoutControls } />
 		</>
 	);
 }

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -215,7 +215,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		// Note the `base-layout-styles` includes a fallback gap for the Columns block for backwards compatibility.
 		$this->assertEquals(
-			':where(.is-layout-flex){gap: 0.5em;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}:where(.wp-block-columns.is-layout-flex){gap: 2em;}',
+			':where(.is-layout-flex){gap: 0.5em;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}:where(.wp-block-columns.is-layout-flex){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap: 1.25em;}',
 			$stylesheet
 		);
 	}

--- a/test/integration/fixtures/blocks/core__query.json
+++ b/test/integration/fixtures/blocks/core__query.json
@@ -18,10 +18,7 @@
 				"taxQuery": null,
 				"parents": []
 			},
-			"tagName": "div",
-			"displayLayout": {
-				"type": "list"
-			}
+			"tagName": "div"
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__query.serialized.html
+++ b/test/integration/fixtures/blocks/core__query.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:query {"query":{"perPage":null,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"displayLayout":{"type":"list"}} -->
+<!-- wp:query {"query":{"perPage":null,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]}} -->
 <div class="wp-block-query"></div>
 <!-- /wp:query -->

--- a/test/integration/fixtures/blocks/core__query.serialized.html
+++ b/test/integration/fixtures/blocks/core__query.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:query {"query":{"perPage":null,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]}} -->
+<!-- wp:query -->
 <div class="wp-block-query"></div>
 <!-- /wp:query -->

--- a/test/integration/fixtures/blocks/core__query__deprecated-1.serialized.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-1.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:query {"query":{"perPage":null,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"list"}} -->
+<!-- wp:query {"query":{"perPage":null,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
 <div class="wp-block-query"></div>
 <!-- /wp:query -->

--- a/test/integration/fixtures/blocks/core__query__deprecated-2-with-colors.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-2-with-colors.json
@@ -21,10 +21,7 @@
 					"post_tag": [ 6 ]
 				}
 			},
-			"tagName": "div",
-			"displayLayout": {
-				"type": "list"
-			}
+			"tagName": "div"
 		},
 		"innerBlocks": [
 			{
@@ -50,7 +47,11 @@
 					{
 						"name": "core/post-template",
 						"isValid": true,
-						"attributes": {},
+						"attributes": {
+							"layout": {
+								"type": "default"
+							}
+						},
 						"innerBlocks": [
 							{
 								"name": "core/post-title",

--- a/test/integration/fixtures/blocks/core__query__deprecated-2-with-colors.serialized.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-2-with-colors.serialized.html
@@ -1,6 +1,6 @@
-<!-- wp:query {"queryId":19,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{"category":[3,5],"post_tag":[6]}},"displayLayout":{"type":"list"}} -->
+<!-- wp:query {"queryId":19,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{"category":[3,5],"post_tag":[6]}}} -->
 <div class="wp-block-query"><!-- wp:group {"textColor":"pale-cyan-blue","style":{"color":{"background":"#284d5f"},"elements":{"link":{"color":{"text":"var:preset|color|luminous-vivid-amber"}}}}} -->
-<div class="wp-block-group has-pale-cyan-blue-color has-text-color has-background has-link-color" style="background-color:#284d5f"><!-- wp:post-template -->
+<div class="wp-block-group has-pale-cyan-blue-color has-text-color has-background has-link-color" style="background-color:#284d5f"><!-- wp:post-template {"layout":{"type":"default"}} -->
 <!-- wp:post-title /-->
 <!-- /wp:post-template --></div>
 <!-- /wp:group --></div>

--- a/test/integration/fixtures/blocks/core__query__deprecated-2.serialized.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-2.serialized.html
@@ -1,5 +1,5 @@
-<!-- wp:query {"queryId":19,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{"category":[3,5],"post_tag":[6]}},"displayLayout":{"type":"list"}} -->
-<div class="wp-block-query"><!-- wp:post-template -->
+<!-- wp:query {"queryId":19,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{"category":[3,5],"post_tag":[6]}}} -->
+<div class="wp-block-query"><!-- wp:post-template {"layout":{"type":"default"}} -->
 <!-- wp:post-title /-->
 <!-- /wp:post-template --></div>
 <!-- /wp:query -->

--- a/test/integration/fixtures/blocks/core__query__deprecated-3.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-3.json
@@ -18,10 +18,6 @@
 				"inherit": false
 			},
 			"tagName": "div",
-			"displayLayout": {
-				"type": "flex",
-				"columns": 3
-			},
 			"align": "wide"
 		},
 		"innerBlocks": [
@@ -49,7 +45,11 @@
 						"name": "core/post-template",
 						"isValid": true,
 						"attributes": {
-							"fontSize": "large"
+							"fontSize": "large",
+							"layout": {
+								"type": "grid",
+								"columnCount": 3
+							}
 						},
 						"innerBlocks": [
 							{

--- a/test/integration/fixtures/blocks/core__query__deprecated-3.serialized.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-3.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:query {"queryId":3,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"flex","columns":3},"align":"wide"} -->
+<!-- wp:query {"queryId":3,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"wide"} -->
 <div class="wp-block-query alignwide"><!-- wp:group {"textColor":"pale-cyan-blue","style":{"color":{"background":"#284d5f"},"elements":{"link":{"color":{"text":"var:preset|color|luminous-vivid-amber"}}}}} -->
 <div class="wp-block-group has-pale-cyan-blue-color has-text-color has-background has-link-color" style="background-color:#284d5f"><!-- wp:post-template {"fontSize":"large"} -->
 <!-- wp:post-title /-->

--- a/test/integration/fixtures/blocks/core__query__deprecated-3.serialized.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-3.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:query {"queryId":3,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"wide"} -->
 <div class="wp-block-query alignwide"><!-- wp:group {"textColor":"pale-cyan-blue","style":{"color":{"background":"#284d5f"},"elements":{"link":{"color":{"text":"var:preset|color|luminous-vivid-amber"}}}}} -->
-<div class="wp-block-group has-pale-cyan-blue-color has-text-color has-background has-link-color" style="background-color:#284d5f"><!-- wp:post-template {"fontSize":"large"} -->
+<div class="wp-block-group has-pale-cyan-blue-color has-text-color has-background has-link-color" style="background-color:#284d5f"><!-- wp:post-template {"fontSize":"large","layout":{"type":"grid","columnCount":3}} -->
 <!-- wp:post-title /-->
 
 <!-- wp:post-date /-->

--- a/test/integration/fixtures/blocks/core__query__deprecated-4.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-4.html
@@ -1,4 +1,4 @@
-<!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"main","displayLayout":{"type":"list"},"layout":{"inherit":true}} -->
+<!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"list"},"layout":{"inherit":true}} -->
 <div class="wp-block-query"><!-- wp:post-template -->
     <!-- wp:post-title /-->
     <!-- /wp:post-template -->

--- a/test/integration/fixtures/blocks/core__query__deprecated-4.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-4.json
@@ -18,9 +18,6 @@
 				"inherit": true
 			},
 			"tagName": "main",
-			"displayLayout": {
-				"type": "list"
-			},
 			"layout": {
 				"inherit": true
 			}

--- a/test/integration/fixtures/blocks/core__query__deprecated-4.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-4.json
@@ -1,7 +1,7 @@
 [
 	{
 		"name": "core/query",
-		"isValid": false,
+		"isValid": true,
 		"attributes": {
 			"queryId": 0,
 			"query": {
@@ -17,16 +17,21 @@
 				"sticky": "",
 				"inherit": true
 			},
-			"tagName": "main",
+			"tagName": "div",
 			"layout": {
-				"inherit": true
+				"contentSize": null,
+				"type": "constrained"
 			}
 		},
 		"innerBlocks": [
 			{
 				"name": "core/post-template",
 				"isValid": true,
-				"attributes": {},
+				"attributes": {
+					"layout": {
+						"type": "default"
+					}
+				},
 				"innerBlocks": [
 					{
 						"name": "core/post-title",

--- a/test/integration/fixtures/blocks/core__query__deprecated-4.parsed.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-4.parsed.json
@@ -16,7 +16,6 @@
 				"sticky": "",
 				"inherit": true
 			},
-			"tagName": "main",
 			"displayLayout": {
 				"type": "list"
 			},

--- a/test/integration/fixtures/blocks/core__query__deprecated-4.serialized.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-4.serialized.html
@@ -1,7 +1,5 @@
-<!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"main","displayLayout":{"type":"list"},"layout":{"inherit":true}} -->
-<div class="wp-block-query">
-<!-- wp:post-template -->
+<!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"contentSize":null,"type":"constrained"}} -->
+<div class="wp-block-query"><!-- wp:post-template {"layout":{"type":"default"}} -->
 <!-- wp:post-title /-->
-<!-- /wp:post-template -->
-</div>
+<!-- /wp:post-template --></div>
 <!-- /wp:query -->

--- a/test/integration/fixtures/blocks/core__query__deprecated-5.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-5.html
@@ -1,4 +1,4 @@
-<!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"main","displayLayout":{"type":"list"},"layout":{"type":"constrained"}} -->
+<!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"list"},"layout":{"type":"constrained"}} -->
 <div class="wp-block-query"><!-- wp:post-template -->
     <!-- wp:post-title /-->
     <!-- /wp:post-template -->

--- a/test/integration/fixtures/blocks/core__query__deprecated-5.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-5.html
@@ -1,0 +1,6 @@
+<!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"main","displayLayout":{"type":"list"},"layout":{"type":"constrained"}} -->
+<div class="wp-block-query"><!-- wp:post-template -->
+    <!-- wp:post-title /-->
+    <!-- /wp:post-template -->
+</div>
+<!-- /wp:query -->

--- a/test/integration/fixtures/blocks/core__query__deprecated-5.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-5.json
@@ -1,7 +1,7 @@
 [
 	{
 		"name": "core/query",
-		"isValid": false,
+		"isValid": true,
 		"attributes": {
 			"queryId": 0,
 			"query": {
@@ -17,7 +17,7 @@
 				"sticky": "",
 				"inherit": true
 			},
-			"tagName": "main",
+			"tagName": "div",
 			"layout": {
 				"type": "constrained"
 			}
@@ -26,7 +26,11 @@
 			{
 				"name": "core/post-template",
 				"isValid": true,
-				"attributes": {},
+				"attributes": {
+					"layout": {
+						"type": "default"
+					}
+				},
 				"innerBlocks": [
 					{
 						"name": "core/post-title",

--- a/test/integration/fixtures/blocks/core__query__deprecated-5.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-5.json
@@ -1,11 +1,11 @@
 [
 	{
 		"name": "core/query",
-		"isValid": true,
+		"isValid": false,
 		"attributes": {
-			"queryId": 19,
+			"queryId": 0,
 			"query": {
-				"perPage": 3,
+				"perPage": 10,
 				"pages": 0,
 				"offset": 0,
 				"postType": "post",
@@ -15,23 +15,18 @@
 				"search": "",
 				"exclude": [],
 				"sticky": "",
-				"inherit": false,
-				"taxQuery": {
-					"category": [ 3, 5 ],
-					"post_tag": [ 6 ]
-				}
+				"inherit": true
 			},
-			"tagName": "div"
+			"tagName": "main",
+			"layout": {
+				"type": "constrained"
+			}
 		},
 		"innerBlocks": [
 			{
 				"name": "core/post-template",
 				"isValid": true,
-				"attributes": {
-					"layout": {
-						"type": "default"
-					}
-				},
+				"attributes": {},
 				"innerBlocks": [
 					{
 						"name": "core/post-title",

--- a/test/integration/fixtures/blocks/core__query__deprecated-5.parsed.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-5.parsed.json
@@ -16,7 +16,6 @@
 				"sticky": "",
 				"inherit": true
 			},
-			"tagName": "main",
 			"displayLayout": {
 				"type": "list"
 			},

--- a/test/integration/fixtures/blocks/core__query__deprecated-5.parsed.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-5.parsed.json
@@ -1,0 +1,51 @@
+[
+	{
+		"blockName": "core/query",
+		"attrs": {
+			"queryId": 0,
+			"query": {
+				"perPage": 10,
+				"pages": 0,
+				"offset": 0,
+				"postType": "post",
+				"order": "desc",
+				"orderBy": "date",
+				"author": "",
+				"search": "",
+				"exclude": [],
+				"sticky": "",
+				"inherit": true
+			},
+			"tagName": "main",
+			"displayLayout": {
+				"type": "list"
+			},
+			"layout": {
+				"type": "constrained"
+			}
+		},
+		"innerBlocks": [
+			{
+				"blockName": "core/post-template",
+				"attrs": {},
+				"innerBlocks": [
+					{
+						"blockName": "core/post-title",
+						"attrs": {},
+						"innerBlocks": [],
+						"innerHTML": "",
+						"innerContent": []
+					}
+				],
+				"innerHTML": "\n    \n    ",
+				"innerContent": [ "\n    ", null, "\n    " ]
+			}
+		],
+		"innerHTML": "\n<div class=\"wp-block-query\">\n</div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-query\">",
+			null,
+			"\n</div>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__query__deprecated-5.serialized.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-5.serialized.html
@@ -1,7 +1,5 @@
-<!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"main","displayLayout":{"type":"list"},"layout":{"type":"constrained"}} -->
-<div class="wp-block-query">
-<!-- wp:post-template -->
+<!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"type":"constrained"}} -->
+<div class="wp-block-query"><!-- wp:post-template {"layout":{"type":"default"}} -->
 <!-- wp:post-title /-->
-<!-- /wp:post-template -->
-</div>
+<!-- /wp:post-template --></div>
 <!-- /wp:query -->

--- a/test/integration/fixtures/blocks/core__query__deprecated-5.serialized.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-5.serialized.html
@@ -1,0 +1,7 @@
+<!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"main","displayLayout":{"type":"list"},"layout":{"type":"constrained"}} -->
+<div class="wp-block-query">
+<!-- wp:post-template -->
+<!-- wp:post-title /-->
+<!-- /wp:post-template -->
+</div>
+<!-- /wp:query -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #44899 and  #44557.

* Converts the custom "grid" layout in the Post Template block to use the grid layout type from #49018.
* The grid is configured to be static with a user-defined number of columns and a identical responsive behaviour to the current custom styes.
* The controls to toggle between List and Grid layouts are moved from Query into Post Template toolbar.
* Adds block spacing support to Post Template.

Note: the deprecation had to be done at Query level, because that's where the legacy layout type is stored. This doesn't really work on the server side though, so I opted to leave legacy classnames and styles for unchanged blocks on the front end.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Go to the Home template in a block theme and check that Query and Post Template display as expected on this branch: should look exactly the same as on trunk before any changes are made. 
2. Set the layout to Grid in Post Template toolbar, and change the number of columns in the sidebar. This should work the same as on trunk.
3. Change block spacing from the Post Template block sidebar; check that it works for both the list and the grid layout options.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
