### PR TITLE
Don't offer Classic block as a recovery action when not registered

### DIFF
--- a/packages/block-editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/block-editor/src/components/block-list/block-invalid-warning.js
@@ -23,6 +23,7 @@ export function BlockInvalidWarning( {
 	block,
 } ) {
 	const hasHTMLBlock = !! getBlockType( 'core/html' );
+	const hasClassicBlock = !! getBlockType( 'core/freeform' );
 	const [ compare, setCompare ] = useState( false );
 
 	const onCompare = useCallback( () => setCompare( true ), [] );
@@ -41,12 +42,18 @@ export function BlockInvalidWarning( {
 					title: __( 'Convert to HTML' ),
 					onClick: convertToHTML,
 				},
-				{
+				hasClassicBlock && {
 					title: __( 'Convert to Classic Block' ),
 					onClick: convertToClassic,
 				},
 			].filter( Boolean ),
-		[ onCompare, convertToHTML, convertToClassic ]
+		[
+			onCompare,
+			hasHTMLBlock,
+			convertToHTML,
+			hasClassicBlock,
+			convertToClassic,
+		]
 	);
 
 	return (


### PR DESCRIPTION
## What?
Fixes #48991.

PR fixes an error when converting a block with invalid markup to a Classic block in the site editor.

## Why?
The Classic block is no longer registered for the Site Editor (#48129), so this option should be provided.

## Testing Instructions
1. Edit a template to introduce a block that will fail block validation in the Site Editor
2. Open the Site Editor for this template
3. See the Attempt Block Recovery message instead of the block
4. Confirm "Convert to Classic Block" isn't available in the "More" options dropdown.

**Example invalid block**

```
<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
<div class="wp-block-group" data-invalid="example"></div>
<!-- /wp:group -->
```

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2023-03-14 at 10 25 00](https://user-images.githubusercontent.com/240569/224914747-a37a18ce-cc27-400c-b174-03bc3b5440ab.png)
