### PR TITLE
Comments: Fix 'sprintf requires more than 1 params' error

### DIFF
--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -58,11 +58,10 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 				$block_content .= sprintf( '<ol>%1$s</ol>', $inner_content );
 				--$comment_depth;
 			} else {
-				$inner_content  = block_core_comment_template_render_comments(
+				$block_content .= block_core_comment_template_render_comments(
 					$children,
 					$block
 				);
-				$block_content .= sprintf( $inner_content );
 			}
 		}
 


### PR DESCRIPTION
## What?
Fixes #49000 

## Why?
To avoid PHP errors. Please take a look at the report on #49000 for more details.

NOTE: The same error happens in WP-Core, so this will need to be backported to Core as well. cc @Mamaduka 