### PR TITLE
[RNMobile] Fix dictation regression on iOS

### DIFF
--- a/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -100,8 +100,14 @@ class RCTAztecView: Aztec.TextView {
     /// the dictation engine refreshes the TextView with an empty string when the dictation finishes.
     /// This helps to avoid propagating that unwanted empty string to RN. (Solving #606)
     /// on `textViewDidChange` and `textViewDidChangeSelection`
-    private var isInsertingDictationResult = false
-
+    private var isInsertingDictationResult: Bool = {
+        if #available(iOS 16, *) {
+            return true;
+        } else {
+            return false;
+        }
+    }()
+    
     // MARK: - Font
 
     /// Flag to enable using the defaultFont in Aztec for specific blocks
@@ -358,10 +364,14 @@ class RCTAztecView: Aztec.TextView {
     }
 
     public override func insertDictationResult(_ dictationResult: [UIDictationPhrase]) {
-        let objectPlaceholder = "\u{FFFC}"
         let dictationText = dictationResult.reduce("") { $0 + $1.text }
-        isInsertingDictationResult = false
-        self.text = self.text?.replacingOccurrences(of: objectPlaceholder, with: dictationText)
+        if #available(iOS 16, *) {
+            insertText(dictationText)
+        } else {
+            let objectPlaceholder = "\u{FFFC}"
+            isInsertingDictationResult = false
+            self.text = self.text?.replacingOccurrences(of: objectPlaceholder, with: dictationText)
+        }
     }
 
     // MARK: - Custom Edit Intercepts


### PR DESCRIPTION
Proposed fix for https://github.com/wordpress-mobile/gutenberg-mobile/issues/5165

* `Gutenberg Mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5561
* `WordPress iOS`: https://github.com/wordpress-mobile/WordPress-iOS/pull/20335

## What?

The changes in this PR fixes an issue with dictation not working as expected on devices running iOS 16 or later. To achieve this, an old dictation-related hack has been removed for later iOS version.

## Why?

The dictation hack stopped being necessary following [improvements made to dictation](https://www.macrumors.com/guide/ios-16-siri/) in iOS 16‌.

Now, with devices that are running iOS 16 or later, text added with iOS dictation is lost when tapping into the editor or typing while the dictation is still recording. This causes unexpected content loss, and could be viewed as an accessibility issue for those who rely on dictation to use the editor.

## How?

The hack that was first introduced in https://github.com/wordpress-mobile/gutenberg-mobile/pull/610 has been confined to only run for older versions of iOS 16.

<details>
 <summary>It's necessary to keep this in place for older versions. ⤵️</summary>

If we remove the hack for older versions, an `obj` symbol is generated when dictating, as reported in https://github.com/wordpress-mobile/gutenberg-mobile/pull/1969. _Screenshot taken from an iPhone 6s (iOS 15.5) emulator with the hack removed:_

<img src="https://user-images.githubusercontent.com/2998162/225422649-afa480e0-b988-4591-b27a-82995b2c613b.png" width="50%">
</details>

You can refer to the comment section of https://github.com/wordpress-mobile/gutenberg-mobile/issues/5165 for further context on how this solution came about.

## Testing Instructions

> **Note**
> There are times where capitalisation is lost while dictating. This will be reported in a separate GitHub issue.

An installable build is available at https://github.com/wordpress-mobile/WordPress-iOS/pull/20335 for testing on a physical device.

The following steps need to be tested with both iOS 16 or later and an earlier version of iOS:

1. Navigate to _My Site_ → _Posts_ and create a new post.
2. Activate the iOS dictation feature and dictate some text.
3. Notice the text added to the editor.
4. Tap another block on the editor or begin typing onto the keyboard to confirm there is no content loss.
5. Experiment with adding various text and attempting to break dictation. 

It would also be helpful to go through the testing steps in the following PRs, where the hacks were originally introduced, to ensure there are no similar issues now they've been removed:

* https://github.com/wordpress-mobile/gutenberg-mobile/pull/610
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/700
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/1969

## Screenshots or screencast

https://user-images.githubusercontent.com/2998162/225435111-6e9b773b-7ace-433c-b2ac-6e737525a69c.mov
