### PR TITLE
Fix performance testing themes installation

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -42,13 +42,6 @@ jobs:
               run: |
                   npm ci
 
-            - name: Install specific versions of the themes used in tests
-              run: |
-                  npm run wp-env start
-                  npm run wp-env -- run tests-cli "wp theme update twentytwentyone --version=1.7"
-                  npm run wp-env -- run tests-cli "wp theme update twentytwentythree --version=1.0"
-                  npm run wp-env stop
-
             - name: Compare performance with trunk
               if: github.event_name == 'pull_request'
               run: ./bin/plugin/cli.js perf $GITHUB_SHA trunk --tests-branch $GITHUB_SHA

--- a/bin/plugin/utils/.wp-env.performance.json
+++ b/bin/plugin/utils/.wp-env.performance.json
@@ -1,7 +1,11 @@
 {
 	"core": "WordPress/WordPress",
 	"plugins": [ "./plugin" ],
-	"themes": [ "../../tests/test/emptytheme" ],
+	"themes": [
+		"../../tests/test/emptytheme",
+		"https://downloads.wordpress.org/theme/twentytwentyone.1.7.zip",
+		"https://downloads.wordpress.org/theme/twentytwentythree.1.0.zip"
+	],
 	"env": {
 		"tests": {
 			"mappings": {


### PR DESCRIPTION
## What?
One of the perf action steps is the installation of specific theme versions. Unfortunately, they're not installed for the correct `wp-env` instance, so they're never used in the tests, and the current default versions are used instead (e.g., v1.1 instead of v1.0 for `twentytwentythree` at the time of writing). The wp-env we use in CI for performance testing is configured via the [`.wp-env.performance.json`](https://github.com/WordPress/gutenberg/blob/fba3e5f08bb9a51b6c5190dfaea5b418d0ee4041/bin/plugin/utils/.wp-env.performance.json) config. According to [the docs](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/#wp-env-json:~:text=%22themes%22,in%20the%20environment.) we can use that config to define theme source URLs that we want to be installed, so I moved it there. (Kudos to @noahtallen for pointing that out.)

As a side note, I believe we should not update any wp-env params via the GH action step because it causes a discrepancy between running tests locally vs. in the CI.

## How?
Ideally, the correct theme version should be installed and validated within the test itself, as only then we're confident that the testing env is consistent, even when running tests locally in isolation. I'm not sure how to achieve that at this point though, so I moved the installation to the wp-env config as mentioned above so that at least the CI uses the correct themes.

## Testing Instructions
- Not much can be done to test this locally because the [CLI `perf` job is currently broken](https://github.com/WordPress/gutenberg/issues/49059), unless you're willing to apply this fix and [the CLI one](https://github.com/WordPress/gutenberg/pull/49068), and then run the job and verify the wp-env used the right versions of the themes. Or you can just trust me because I already did all of that. 😄  
- CI performance tests should pass.