### PR TITLE
`Icon`: refactor tests to TypeScript

### DIFF
--- a/packages/components/src/icon/test/index.tsx
+++ b/packages/components/src/icon/test/index.tsx
@@ -4,10 +4,14 @@
 import { render, screen } from '@testing-library/react';
 
 /**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/primitives';
+
+/**
  * Internal dependencies
  */
-import Icon from '../';
-import { Path, SVG } from '../../';
+import Icon from '..';
 
 describe( 'Icon', () => {
 	const testId = 'icon';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Refactor `Icon` component tests to TypeScript

## Why?

Part of https://github.com/WordPress/gutenberg/issues/35744

## How?

- Followed general recommendations from the [TypeScript Migration guide](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/CONTRIBUTING.md#refactoring-a-component-to-typescript). 
- Renamed file to `.tsx` and fixed any type errors

## Testing Instructions

1. Ensure there are no type errors
2. Verify unit tests still pass
