### PR TITLE
Fix running performance tests locally via CLI

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -3,7 +3,7 @@
  */
 const fs = require( 'fs' );
 const path = require( 'path' );
-const { mapValues, kebabCase } = require( 'lodash' );
+const { mapValues } = require( 'lodash' );
 const SimpleGit = require( 'simple-git' );
 
 /**
@@ -82,6 +82,17 @@ const config = require( '../config' );
  * @property {number=} minListViewOpen        Min time to open list view.
  * @property {number=} maxListViewOpen        Max time to open list view.
  */
+
+/**
+ * Sanitizes branch name to be used in a path or a filename.
+ *
+ * @param {string} branch
+ *
+ * @return {string} Sanitized branch name.
+ */
+function sanitizeBranchName( branch ) {
+	return branch.replace( /[^a-zA-Z0-9-]/g, '-' );
+}
 
 /**
  * Computes the average number from an array numbers.
@@ -299,8 +310,8 @@ async function runPerformanceTests( branches, options ) {
 	const branchDirectories = {};
 	for ( const branch of branches ) {
 		log( `    >> Branch: ${ branch }` );
-		const environmentDirectory =
-			rootDirectory + '/envs/' + kebabCase( branch );
+		const sanitizedBranch = sanitizeBranchName( branch );
+		const environmentDirectory = rootDirectory + '/envs/' + sanitizedBranch;
 		// @ts-ignore
 		branchDirectories[ branch ] = environmentDirectory;
 		const buildPath = `${ environmentDirectory }/plugin`;
@@ -401,7 +412,8 @@ async function runPerformanceTests( branches, options ) {
 		for ( let i = 0; i < TEST_ROUNDS; i++ ) {
 			rawResults[ i ] = {};
 			for ( const branch of branches ) {
-				const runKey = `${ branch }_${ testSuite }_run-${ i }`;
+				const sanitizedBranch = sanitizeBranchName( branch );
+				const runKey = `${ sanitizedBranch }_${ testSuite }_run-${ i }`;
 				// @ts-ignore
 				const environmentDirectory = branchDirectories[ branch ];
 				log( `    >> Branch: ${ branch }, Suite: ${ testSuite }` );

--- a/bin/plugin/lib/utils.js
+++ b/bin/plugin/lib/utils.js
@@ -33,6 +33,7 @@ function runShellScript( script, cwd, env = {} ) {
 					NO_CHECKS: 'true',
 					PATH: process.env.PATH,
 					HOME: process.env.HOME,
+					USER: process.env.USER,
 					...env,
 				},
 			},


### PR DESCRIPTION
## What?

Fixes #49059
- Fix the perf tests crashing locally when running [via the CLI](https://github.com/WordPress/gutenberg/blob/d3c0c9d2d98d23ef52573c35cc9615a6086de4cb/docs/contributors/code/testing-overview.md#performance-testing:~:text=In%20addition%20to%20that%2C%20you%20can%20also%20compare%20the%20metrics%20across%20branches%20(or%20tags%20or%20commits)%20by%20running%20the%20following%20command%20./bin/plugin/cli.js%20perf%20%5Bbranches%5D) in Mac OS + Docker desktop.

Fixes #48920
- Fix the release performance tests that break when branch name contains characters that don't work as a path/filename.

> **Note**
> I'm putting both fixes in a single PR because they're both needed to successfully run perf tests via CLI.

## How?

- Docker/`wp-env` is missing the `$USER` env var, which he complains about when running the perf tests locally via the CLI. For example, running `./bin/plugin/cli.js perf trunk your-branch` locally will throw the following error:

   ```
   [2023-03-14T11:31:15.651577000Z][docker-credential-desktop][F] user: Current requires cgo or 
   $USER set in environment
   ```
- Sanitize the branch name before using it as a part of path or results filename.

## Testing Instructions

On a Mac with Docker desktop (I don't know if it also fails in other envs):
- Stop all the `wp-env` containers,
- Checkout `trunk`,
- Run `./bin/plugin/cli.js perf trunk fix/running-perf-tests-locally`
- Wait until the env setup is complete and the tests start running (it takes a bit),
- See docker throwing the error mentioned above,
- Checkout `fix/running-perf-tests-locally`
- Run `./bin/plugin/cli.js perf trunk fix/running-perf-tests-locally` again,
- Go make dinner,
- Eat it,
- Come back, no rush,
- See the tests passed.

Go to the [perf tests page](https://github.com/WordPress/gutenberg/actions/workflows/performance.yml?query=event%3Arelease) and run the workflow manually using this branch as a base:

<img width="428" alt="Screenshot 2023-03-15 at 13 45 14" src="https://user-images.githubusercontent.com/1451471/225312752-a2382106-05a7-4ecc-b921-9c9b9bf9bdfe.png">

This will trigger the "custom comparison" step with branch names invalid as filenames, which is what breaks the release job. It should pass. See [this example job](https://github.com/WordPress/gutenberg/actions/runs/4425910112/jobs/7761545665) that I've triggered.
