### PR TITLE
Adds link to post on the developer blog to the deprecation page

### DIFF
--- a/docs/reference-guides/block-api/block-deprecation.md
+++ b/docs/reference-guides/block-api/block-deprecation.md
@@ -1,5 +1,7 @@
 # Deprecation
 
+> This page provides a comprehensive guide to the principles and usage of the Deprecation API. Those seeking a more gentle introduction may find the [tutorial on block deprecation](https://developer.wordpress.org/news/2023/03/block-deprecation-a-tutorial/) to be useful. While the tutorial complements the content on this page it should not be used as a substitute for this page. The tutorial can be found on the [Developer Blog](https://developer.wordpress.org/news/).
+
 When updating static blocks markup and attributes, block authors need to consider existing posts using the old versions of their block. To provide a good upgrade path, you can choose one of the following strategies:
 
 -   Do not deprecate the block and create a new one (a different name)

--- a/docs/reference-guides/block-api/block-deprecation.md
+++ b/docs/reference-guides/block-api/block-deprecation.md
@@ -1,6 +1,6 @@
 # Deprecation
 
-> This page provides a comprehensive guide to the principles and usage of the Deprecation API. Those seeking a more gentle introduction may find the [tutorial on block deprecation](https://developer.wordpress.org/news/2023/03/block-deprecation-a-tutorial/) to be useful. While the tutorial complements the content on this page it should not be used as a substitute for this page. The tutorial can be found on the [Developer Blog](https://developer.wordpress.org/news/).
+> This page provides a comprehensive guide to the principles and usage of the Deprecation API. For an introduction check out the [tutorial on the basics of block deprecation](https://developer.wordpress.org/news/2023/03/block-deprecation-a-tutorial/) which can be found on the [Developer Blog](https://developer.wordpress.org/news/).
 
 When updating static blocks markup and attributes, block authors need to consider existing posts using the old versions of their block. To provide a good upgrade path, you can choose one of the following strategies:
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This adds a paragraph to the top of the page on Deprecation linking to the [recently published tutorial on deprecation](https://developer.wordpress.org/news/2023/03/block-deprecation-a-tutorial/) in the Developer Blog.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The content on the Deprecation page is dense and can be opaque and requires close reading. The tutorial in the Developer Blog provides a shallower learning curve and guides the reader through a series of simple examples of block deprecation. Linking to the tutorial from this page gives the user the option to go to that tutorial should they want to follow an easier learning path.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I wrote a paragraph of text.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
n/a it's just documentation, though you could test that the links go to the desired destination.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
