### PR TITLE
Add help text to Gallery Image Size control

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -591,6 +591,9 @@ function GalleryEdit( props ) {
 						<SelectControl
 							__nextHasNoMarginBottom
 							label={ __( 'Image size' ) }
+							help={ __(
+								'Select the size of the source image.'
+							) }
 							value={ sizeSlug }
 							options={ imageSizeOptions }
 							onChange={ updateImagesSize }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -592,7 +592,7 @@ function GalleryEdit( props ) {
 							__nextHasNoMarginBottom
 							label={ __( 'Image size' ) }
 							help={ __(
-								'Select the size of the source image.'
+								'Select the size of the source images.'
 							) }
 							value={ sizeSlug }
 							options={ imageSizeOptions }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
In support of https://github.com/WordPress/gutenberg/issues/48618#issuecomment-1451460526, this small PR adds proper, consistent help text to the image size control for the Gallery block. Related: https://github.com/WordPress/gutenberg/pull/48478

## Why?
Consistency. 

## How?
Adds `Select the size of the source image.` text via the `help` prop.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page. 
2. Insert a Gallery block.
3. Add an image to the Gallery block.
4. Click on the parent Gallery block.
5. Open block inspector.
6. See Image Size control with the new help text.

## Screenshots or screencast <!-- if applicable -->

Before: 

<img width="280" alt="CleanShot 2023-03-14 at 14 17 41" src="https://user-images.githubusercontent.com/1813435/225100407-001f40fd-225f-45b3-9529-7d9658c5f4dd.png">


After: 

<img width="280" alt="CleanShot 2023-03-14 at 14 13 40" src="https://user-images.githubusercontent.com/1813435/225100230-2efd0002-eaa1-4a61-82d2-40888e360cb8.png">
