### PR TITLE
Adjust Post Featured Image PanelBody label to "Settings"

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -139,7 +139,7 @@ export default function PostFeaturedImageEdit( {
 				imageSizeOptions={ imageSizeOptions }
 			/>
 			<InspectorControls>
-				<PanelBody title={ __( 'Link settings' ) }>
+				<PanelBody title={ __( 'Settings' ) }>
 					<ToggleControl
 						__nextHasNoMarginBottom
 						label={


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
As the Post Featured Image block only has one settings PanelBody, let's reduce cognitive load and improve consistency between blocks by renaming "Link Settings" to "Settings". 

## Why?
Consistency. 

## How?
Just a minor text string change.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page.
2. Insert a Post Featured Image block.
3. Open Block Inspector.
4. See "Settings" PanelBody label.

## Screenshots or screencast <!-- if applicable -->
<img width="1119" alt="CleanShot 2023-03-14 at 14 35 17" src="https://user-images.githubusercontent.com/1813435/225104377-3c4d3ee8-b513-4b31-b691-d3c317c62fa8.png">
