### PR TITLE
Tweak label for Latest Posts excerpt control

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -229,7 +229,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 					displayPostContentRadio === 'excerpt' && (
 						<RangeControl
 							__nextHasNoMarginBottom
-							label={ __( 'Max number of words in excerpt' ) }
+							label={ __( 'Max number of words' ) }
 							value={ excerptLength }
 							onChange={ ( value ) =>
 								setAttributes( { excerptLength: value } )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add consistency between the Latest Posts excerpt length control and the control added recently to the Post Excerpt block (https://github.com/WordPress/gutenberg/pull/44964). 

## Why?
Consistency.

## How?
Minor text string change.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page.
2. Insert a Latest Posts block.
3. Open Block Inspector.
4. Toggle on "Post Content".
5. See control with "Max number of words" label.

## Screenshots or screencast <!-- if applicable -->

Before: 

<img width="280" alt="CleanShot 2023-03-14 at 14 38 02" src="https://user-images.githubusercontent.com/1813435/225107350-84e69216-8949-46d9-8d93-c9e8b72fdf2c.png">

After: 

<img width="280" alt="CleanShot 2023-03-14 at 14 49 17" src="https://user-images.githubusercontent.com/1813435/225107449-362fe38c-cd60-4945-ad86-1c95e53e56da.png">