### PR TITLE
[Github-Actions-Workflows][Plugin-Release] Allow shipping a point-release for an older stable release

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -71,7 +71,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
               with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
+                  token: ${{ secrets.GUTENBERG_TOKEN }}
 
             - name: Compute old and new version
               id: get_version
@@ -298,3 +298,44 @@ jobs:
                   asset_path: ./gutenberg.zip
                   asset_name: gutenberg.zip
                   asset_content_type: application/zip
+
+    npm-publish:
+        name: Publish WordPress packages to npm
+        runs-on: ubuntu-latest
+        environment: WordPress packages
+        needs: [bump-version, build]
+        if: ${{ endsWith( needs.bump-version.outputs.new_version, '-rc.1' ) }}
+        steps:
+            - name: Checkout (for CLI)
+              uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+              with:
+                  path: main
+                  ref: trunk
+
+            - name: Checkout (for publishing)
+              uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+              with:
+                  path: publish
+                  # Later, we switch this branch in the script that publishes packages.
+                  ref: trunk
+                  token: ${{ secrets.GUTENBERG_TOKEN }}
+
+            - name: Configure git user name and email (for publishing)
+              run: |
+                  cd publish
+                  git config user.name "Gutenberg Repository Automation"
+                  git config user.email gutenberg@wordpress.org
+
+            - name: Setup Node.js
+              uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+              with:
+                  node-version-file: 'main/.nvmrc'
+                  registry-url: 'https://registry.npmjs.org'
+
+            - name: Publish packages to npm ("latest" dist-tag)
+              run: |
+                  cd main
+                  npm ci
+                  ./bin/plugin/cli.js npm-latest --semver minor --ci --repository-path ../publish
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -56,7 +56,7 @@ jobs:
                 github.event.inputs.version == 'rc' ||
                 github.event.inputs.version == 'stable'
               ) || (
-                endsWith( github.ref, needs.compute-stable-branches.outputs.current_stable_branch ) &&
+                github.ref != 'refs/heads/trunk' &&
                 github.event.inputs.version == 'stable'
               )
             )
@@ -71,7 +71,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
               with:
-                  token: ${{ secrets.GUTENBERG_TOKEN }}
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Compute old and new version
               id: get_version
@@ -298,44 +298,3 @@ jobs:
                   asset_path: ./gutenberg.zip
                   asset_name: gutenberg.zip
                   asset_content_type: application/zip
-
-    npm-publish:
-        name: Publish WordPress packages to npm
-        runs-on: ubuntu-latest
-        environment: WordPress packages
-        needs: [bump-version, build]
-        if: ${{ endsWith( needs.bump-version.outputs.new_version, '-rc.1' ) }}
-        steps:
-            - name: Checkout (for CLI)
-              uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-              with:
-                  path: main
-                  ref: trunk
-
-            - name: Checkout (for publishing)
-              uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-              with:
-                  path: publish
-                  # Later, we switch this branch in the script that publishes packages.
-                  ref: trunk
-                  token: ${{ secrets.GUTENBERG_TOKEN }}
-
-            - name: Configure git user name and email (for publishing)
-              run: |
-                  cd publish
-                  git config user.name "Gutenberg Repository Automation"
-                  git config user.email gutenberg@wordpress.org
-
-            - name: Setup Node.js
-              uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
-              with:
-                  node-version-file: 'main/.nvmrc'
-                  registry-url: 'https://registry.npmjs.org'
-
-            - name: Publish packages to npm ("latest" dist-tag)
-              run: |
-                  cd main
-                  npm ci
-                  ./bin/plugin/cli.js npm-latest --semver minor --ci --repository-path ../publish
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -164,25 +164,18 @@ jobs:
 
         steps:
             - name: Checkout code
-              # The following is debug code, should be reverted before merging. See commit that added this for more info.
-              if: false
               uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
               with:
                   ref: ${{ needs.bump-version.outputs.release_branch || github.ref }}
 
             - name: Use desired version of Node.js
-              # The following is debug code, should be reverted before merging. See commit that added this for more info.
-              if: false
               uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
               with:
                   node-version-file: '.nvmrc'
                   cache: npm
 
             - name: Build Gutenberg plugin ZIP file
-              # The following is debug code, should be reverted before merging. See commit that added this for more info.
-              run: |
-                  echo 'Stable tag: V.V.V' > readme.txt
-                  zip -j gutenberg.zip readme.txt
+              run: ./bin/build-plugin-zip.sh
               env:
                   NO_CHECKS: 'true'
 
@@ -193,10 +186,6 @@ jobs:
                   path: ./gutenberg.zip
 
             - name: Build release notes draft
-              # Debug: if we want fast runs, then this should be disabled as this won't
-              # work if the real plugin isn't built (becuase npm install is needed to install
-              # some needed packages that the `other:changelog` task uses`).
-              if: false
               env:
                   VERSION: ${{ needs.bump-version.outputs.new_version }}
               run: |
@@ -212,8 +201,6 @@ jobs:
                   fi
 
             - name: Upload release notes artifact
-              # The following is debug code, should be reverted before merging. See commit that added this for more info.
-              if: false
               uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
               with:
                   name: release-notes
@@ -282,8 +269,6 @@ jobs:
                   name: gutenberg-plugin
 
             - name: Download Release Notes Artifact
-              # The following is debug code, should be reverted before merging. See commit that added this for more info.
-              if: false
               uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
               with:
                   name: release-notes
@@ -299,8 +284,7 @@ jobs:
                   commitish: ${{ needs.bump-version.outputs.release_branch || github.ref }}
                   draft: true
                   prerelease: ${{ contains(needs.bump-version.outputs.new_version, 'rc') }}
-                  # The following is debug code, should be reverted before merging. See commit that added this for more info.
-                  # body_path: release-notes.txt
+                  body_path: release-notes.txt
 
             - name: Upload Release Asset
               id: upload-release-asset

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -186,6 +186,7 @@ jobs:
                   path: ./gutenberg.zip
 
             - name: Build release notes draft
+              if: ${{ needs.bump-version.outputs.new_version }}
               env:
                   VERSION: ${{ needs.bump-version.outputs.new_version }}
               run: |
@@ -201,6 +202,7 @@ jobs:
                   fi
 
             - name: Upload release notes artifact
+              if: ${{ needs.bump-version.outputs.new_version }}
               uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
               with:
                   name: release-notes

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -71,7 +71,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
               with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
+                  token: ${{ secrets.GUTENBERG_TOKEN }}
 
             - name: Compute old and new version
               id: get_version
@@ -302,7 +302,7 @@ jobs:
         runs-on: ubuntu-latest
         environment: WordPress packages
         needs: [bump-version, build]
-        if: ${{ false }}
+        if: ${{ endsWith( needs.bump-version.outputs.new_version, '-rc.1' ) }}
         steps:
             - name: Checkout (for CLI)
               uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -71,7 +71,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
               with:
-                  token: ${{ secrets.GUTENBERG_TOKEN }}
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Compute old and new version
               id: get_version
@@ -304,7 +304,7 @@ jobs:
         runs-on: ubuntu-latest
         environment: WordPress packages
         needs: [bump-version, build]
-        if: ${{ endsWith( needs.bump-version.outputs.new_version, '-rc.1' ) }}
+        if: ${{ false }}
         steps:
             - name: Checkout (for CLI)
               uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -164,18 +164,25 @@ jobs:
 
         steps:
             - name: Checkout code
+              # The following is debug code, should be reverted before merging. See commit that added this for more info.
+              if: false
               uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
               with:
                   ref: ${{ needs.bump-version.outputs.release_branch || github.ref }}
 
             - name: Use desired version of Node.js
+              # The following is debug code, should be reverted before merging. See commit that added this for more info.
+              if: false
               uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
               with:
                   node-version-file: '.nvmrc'
                   cache: npm
 
             - name: Build Gutenberg plugin ZIP file
-              run: ./bin/build-plugin-zip.sh
+              # The following is debug code, should be reverted before merging. See commit that added this for more info.
+              run: |
+                  echo 'Stable tag: V.V.V' > readme.txt
+                  zip -j gutenberg.zip readme.txt
               env:
                   NO_CHECKS: 'true'
 
@@ -186,7 +193,10 @@ jobs:
                   path: ./gutenberg.zip
 
             - name: Build release notes draft
-              if: ${{ needs.bump-version.outputs.new_version }}
+              # Debug: if we want fast runs, then this should be disabled as this won't
+              # work if the real plugin isn't built (becuase npm install is needed to install
+              # some needed packages that the `other:changelog` task uses`).
+              if: false
               env:
                   VERSION: ${{ needs.bump-version.outputs.new_version }}
               run: |
@@ -202,7 +212,8 @@ jobs:
                   fi
 
             - name: Upload release notes artifact
-              if: ${{ needs.bump-version.outputs.new_version }}
+              # The following is debug code, should be reverted before merging. See commit that added this for more info.
+              if: false
               uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
               with:
                   name: release-notes
@@ -271,6 +282,8 @@ jobs:
                   name: gutenberg-plugin
 
             - name: Download Release Notes Artifact
+              # The following is debug code, should be reverted before merging. See commit that added this for more info.
+              if: false
               uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
               with:
                   name: release-notes
@@ -285,8 +298,9 @@ jobs:
                   release_name: ${{ steps.get_release_version.outputs.version }}
                   commitish: ${{ needs.bump-version.outputs.release_branch || github.ref }}
                   draft: true
-                  prerelease: ${{ contains(needs.bump-version.outputs.new_version, 'rc') }}
-                  body_path: release-notes.txt
+                  # The following is debug code, should be reverted before merging. See commit that added this for more info.
+                  # prerelease: ${{ contains(needs.bump-version.outputs.new_version, 'rc') }}
+                  # body_path: release-notes.txt
 
             - name: Upload Release Asset
               id: upload-release-asset

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -56,7 +56,7 @@ jobs:
                 github.event.inputs.version == 'rc' ||
                 github.event.inputs.version == 'stable'
               ) || (
-                github.ref != 'refs/heads/trunk' &&
+                startsWith( github.ref, 'refs/heads/release/' ) &&
                 github.event.inputs.version == 'stable'
               )
             )

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -298,8 +298,8 @@ jobs:
                   release_name: ${{ steps.get_release_version.outputs.version }}
                   commitish: ${{ needs.bump-version.outputs.release_branch || github.ref }}
                   draft: true
+                  prerelease: ${{ contains(needs.bump-version.outputs.new_version, 'rc') }}
                   # The following is debug code, should be reverted before merging. See commit that added this for more info.
-                  # prerelease: ${{ contains(needs.bump-version.outputs.new_version, 'rc') }}
                   # body_path: release-notes.txt
 
             - name: Upload Release Asset

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -5,14 +5,32 @@ on:
         types: [published]
 
 jobs:
+    compute-latest-stable:
+        name: Get latest stable version
+        runs-on: ubuntu-latest
+        outputs:
+            latest_stable_tag: ${{ steps.get_latest_stable_tag.outputs.latest_stable_tag }}
+
+        steps:
+            - uses: hmarr/debug-action@v2
+            - name: Get latest stable ta
+              id: get_latest_stable_tag
+              run: |
+                  curl \
+                    -H "Accept: application/vnd.github.v3+json" \
+                    -o latest.json \
+                    "https://api.github.com/repos/${{ github.repository }}/releases/latest"
+                  LATEST_STABLE_TAG=$(jq --raw-output '.tag_name' latest.json)
+                  echo "latest_stable_tag=${LATEST_STABLE_TAG}" >> $GITHUB_OUTPUT
+
     get-release-branch:
         name: Get release branch name
         runs-on: ubuntu-latest
-        if: github.event.release.assets[0]
         outputs:
             release_branch: ${{ steps.get_release_branch.outputs.release_branch }}
 
         steps:
+            - uses: hmarr/debug-action@v2
             - name: Compute release branch name
               id: get_release_branch
               env:
@@ -25,7 +43,8 @@ jobs:
     update-changelog:
         name: Update Changelog on ${{ matrix.branch }} branch
         runs-on: ubuntu-latest
-        if: github.event.release.assets[0]
+        if: |
+            github.event.release.assets[0]
         needs: get-release-branch
         env:
             TAG: ${{ github.event.release.tag_name }}
@@ -38,11 +57,12 @@ jobs:
                       label: release
 
         steps:
+            - uses: hmarr/debug-action@v2
             - name: Checkout code
               uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
               with:
                   ref: ${{ matrix.branch }}
-                  token: ${{ secrets.GUTENBERG_TOKEN }}
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Update the Changelog to include the release notes
               run: |
@@ -95,25 +115,24 @@ jobs:
                   path: ./changelog.txt
 
     upload:
-        name: Upload Gutenberg Plugin
+        name: Publish as trunk (and tag)
         runs-on: ubuntu-latest
         environment: wp.org plugin
-        needs: update-changelog
-        if: ${{ !github.event.release.prerelease && github.event.release.assets[0] }}
+        needs: [compute-latest-stable, update-changelog]
+        if: |
+            endsWith( github.ref, needs.compute-latest-stable.outputs.latest_stable_tag ) &&
+            !github.event.release.prerelease && github.event.release.assets[0]
         env:
-            PLUGIN_REPO_URL: 'https://plugins.svn.wordpress.org/gutenberg'
+            PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'
             STABLE_VERSION_REGEX: '[0-9]\+\.[0-9]\+\.[0-9]\+\s*'
             SVN_USERNAME: ${{ secrets.svn_username }}
             SVN_PASSWORD: ${{ secrets.svn_password }}
             VERSION: ${{ github.event.release.name }}
 
         steps:
+            - uses: hmarr/debug-action@v2
             - name: Check out Gutenberg trunk from WP.org plugin repo
-              run: svn checkout "$PLUGIN_REPO_URL/trunk"
-
-            - name: Get previous stable version
-              id: get_previous_stable_version
-              run: echo "stable_version=$(awk -F ':\ ' '$1 == "Stable tag" {print $2}' ./trunk/readme.txt)" >> $GITHUB_OUTPUT
+              run: svn checkout "$PLUGIN_REPO_URL/trunk" --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
 
             - name: Delete everything
               working-directory: ./trunk
@@ -130,8 +149,8 @@ jobs:
             - name: Replace the stable tag placeholder with the existing stable tag on the SVN repository
               env:
                   STABLE_TAG_PLACEHOLDER: 'Stable tag: V\.V\.V'
-                  STABLE_TAG: 'Stable tag: ${{ steps.get_previous_stable_version.outputs.stable_version }}'
-              run: sed -i "s/${STABLE_TAG_PLACEHOLDER}/${STABLE_TAG}/g" ./trunk/readme.txt
+              run: |
+                  sed -i "s/$STABLE_TAG_PLACEHOLDER/Stable tag: $VERSION/g" ./trunk/readme.txt
 
             - name: Download Changelog Artifact
               uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
@@ -158,4 +177,60 @@ jobs:
               run: |
                   sed -i "s/Stable tag: ${STABLE_VERSION_REGEX}/Stable tag: ${VERSION}/g" ./readme.txt
                   svn commit -m "Releasing version $VERSION" \
+                   --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+
+    upload-branch:
+        name: Publish as branch (and tag)
+        runs-on: ubuntu-latest
+        environment: wp.org plugin
+        needs: [compute-latest-stable, update-changelog]
+        if: |
+            !endsWith( github.ref, needs.compute-latest-stable.outputs.latest_stable_tag ) &&
+            !github.event.release.prerelease && github.event.release.assets[0]
+        env:
+            PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'
+            STABLE_VERSION_REGEX: '[0-9]\+\.[0-9]\+\.[0-9]\+\s*'
+            SVN_USERNAME: ${{ secrets.svn_username }}
+            SVN_PASSWORD: ${{ secrets.svn_password }}
+            VERSION: ${{ github.event.release.name }}
+
+        steps:
+            - uses: hmarr/debug-action@v2
+
+            - name: Check out Gutenberg branches from WP.org plugin repo
+              run: svn checkout "$PLUGIN_REPO_URL/branches" --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+
+            - name: Download and unzip Gutenberg plugin asset into trunk folder
+              env:
+                  PLUGIN_URL: ${{ github.event.release.assets[0].browser_download_url }}
+              run: |
+                  # do the magic here
+                  curl -L -o gutenberg.zip $PLUGIN_URL
+                  unzip gutenberg.zip -d branches/$VERSION
+                  rm gutenberg.zip
+
+            - name: Replace the stable tag placeholder with the existing stable tag on the SVN repository
+              env:
+                  STABLE_TAG_PLACEHOLDER: 'Stable tag: V\.V\.V'
+              run: |
+                  sed -i "s/$STABLE_TAG_PLACEHOLDER/Stable tag: $VERSION/g" ./branches/$VERSION/readme.txt
+
+            - name: Download Changelog Artifact
+              uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+              with:
+                  name: changelog trunk
+                  path: branches/$VERSION
+
+            - name: Commit the content changes
+              working-directory: ./branches
+              run: |
+                  svn st | grep '^?' | awk '{print $2}' | xargs -r svn add
+                  svn st | grep '^!' | awk '{print $2}' | xargs -r svn rm
+                  svn commit -m "Committing version $VERSION" \
+                   --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+
+            - name: Create the SVN tag
+              working-directory: ./branches
+              run: |
+                  svn copy "$PLUGIN_REPO_URL/branches/$VERSION" "$PLUGIN_REPO_URL/tags/$VERSION" -m "Tagging version $VERSION" \
                    --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -12,8 +12,7 @@ jobs:
             latest_stable_tag: ${{ steps.get_latest_stable_tag.outputs.latest_stable_tag }}
 
         steps:
-            - uses: hmarr/debug-action@v2
-            - name: Get latest stable ta
+            - name: Get latest stable tag
               id: get_latest_stable_tag
               run: |
                   curl \
@@ -30,7 +29,6 @@ jobs:
             release_branch: ${{ steps.get_release_branch.outputs.release_branch }}
 
         steps:
-            - uses: hmarr/debug-action@v2
             - name: Compute release branch name
               id: get_release_branch
               env:
@@ -57,12 +55,11 @@ jobs:
                       label: release
 
         steps:
-            - uses: hmarr/debug-action@v2
             - name: Checkout code
               uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
               with:
                   ref: ${{ matrix.branch }}
-                  token: ${{ secrets.GITHUB_TOKEN }}
+                  token: ${{ secrets.GUTENBERG_TOKEN }}
 
             - name: Update the Changelog to include the release notes
               run: |
@@ -123,14 +120,13 @@ jobs:
             endsWith( github.ref, needs.compute-latest-stable.outputs.latest_stable_tag ) &&
             !github.event.release.prerelease && github.event.release.assets[0]
         env:
-            PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'
+            PLUGIN_REPO_URL: 'https://plugins.svn.wordpress.org/gutenberg'
             STABLE_VERSION_REGEX: '[0-9]\+\.[0-9]\+\.[0-9]\+\s*'
             SVN_USERNAME: ${{ secrets.svn_username }}
             SVN_PASSWORD: ${{ secrets.svn_password }}
             VERSION: ${{ github.event.release.name }}
 
         steps:
-            - uses: hmarr/debug-action@v2
             - name: Check out Gutenberg trunk from WP.org plugin repo
               run: svn checkout "$PLUGIN_REPO_URL/trunk" --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
 
@@ -188,15 +184,13 @@ jobs:
             !endsWith( github.ref, needs.compute-latest-stable.outputs.latest_stable_tag ) &&
             !github.event.release.prerelease && github.event.release.assets[0]
         env:
-            PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'
+            PLUGIN_REPO_URL: 'https://plugins.svn.wordpress.org/gutenberg'
             STABLE_VERSION_REGEX: '[0-9]\+\.[0-9]\+\.[0-9]\+\s*'
             SVN_USERNAME: ${{ secrets.svn_username }}
             SVN_PASSWORD: ${{ secrets.svn_password }}
             VERSION: ${{ github.event.release.name }}
 
         steps:
-            - uses: hmarr/debug-action@v2
-
             - name: Check out Gutenberg branches from WP.org plugin repo
               run: svn checkout "$PLUGIN_REPO_URL/branches" --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
 

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -156,8 +156,9 @@ jobs:
         environment: wp.org plugin
         needs: [compute-should-update-trunk, update-changelog]
         if: |
-            needs.compute-should-update-trunk.outputs.should_update_trunk == 'true' &&
-            !github.event.release.prerelease && github.event.release.assets[0]
+            needs.compute-should-update-trunk.outputs.should_update_trunk == 'true'           &&
+            (!github.event.release.prerelease || !contains(github.event.release.name, '-rc')) &&
+            github.event.release.assets[0]
         env:
             PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'
             STABLE_VERSION_REGEX: '[0-9]\+\.[0-9]\+\.[0-9]\+\s*'
@@ -220,8 +221,9 @@ jobs:
         environment: wp.org plugin
         needs: [compute-should-update-trunk, update-changelog]
         if: |
-            needs.compute-should-update-trunk.outputs.should_update_trunk == 'false' &&
-            !github.event.release.prerelease && github.event.release.assets[0]
+            needs.compute-should-update-trunk.outputs.should_update_trunk == 'false'          &&
+            (!github.event.release.prerelease || !contains(github.event.release.name, '-rc')) &&
+            github.event.release.assets[0]
         env:
             PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'
             STABLE_VERSION_REGEX: '[0-9]\+\.[0-9]\+\.[0-9]\+\s*'

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -106,7 +106,7 @@ jobs:
               uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
               with:
                   ref: ${{ matrix.branch }}
-                  token: ${{ secrets.GITHUB_TOKEN }}
+                  token: ${{ secrets.GUTENBERG_TOKEN }}
 
             - name: Update the Changelog to include the release notes
               run: |
@@ -166,7 +166,7 @@ jobs:
         if: |
             needs.compute-should-update-trunk.outputs.should_update_trunk == 'true' && github.event.release.assets[0]
         env:
-            PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'
+            PLUGIN_REPO_URL: 'https://plugins.svn.wordpress.org/gutenberg'
             STABLE_VERSION_REGEX: '[0-9]\+\.[0-9]\+\.[0-9]\+\s*'
             SVN_USERNAME: ${{ secrets.svn_username }}
             SVN_PASSWORD: ${{ secrets.svn_password }}
@@ -229,7 +229,7 @@ jobs:
         if: |
             needs.compute-should-update-trunk.outputs.should_update_trunk == 'false' && github.event.release.assets[0]
         env:
-            PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'
+            PLUGIN_REPO_URL: 'https://plugins.svn.wordpress.org/gutenberg'
             STABLE_VERSION_REGEX: '[0-9]\+\.[0-9]\+\.[0-9]\+\s*'
             SVN_USERNAME: ${{ secrets.svn_username }}
             SVN_PASSWORD: ${{ secrets.svn_password }}

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -230,40 +230,28 @@ jobs:
             VERSION: ${{ github.event.release.name }}
 
         steps:
-            - name: Check out Gutenberg tags from WP.org plugin repo
-              run: svn checkout "$PLUGIN_REPO_URL/tags" --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
-
             - name: Download and unzip Gutenberg plugin asset into tags folder
               env:
                   PLUGIN_URL: ${{ github.event.release.assets[0].browser_download_url }}
               run: |
                   # do the magic here
                   curl -L -o gutenberg.zip $PLUGIN_URL
-                  unzip gutenberg.zip -d tags/$VERSION
+                  unzip gutenberg.zip -d "$VERSION"
                   rm gutenberg.zip
 
             - name: Replace the stable tag placeholder with the existing stable tag on the SVN repository
               env:
                   STABLE_TAG_PLACEHOLDER: 'Stable tag: V\.V\.V'
               run: |
-                  sed -i "s/$STABLE_TAG_PLACEHOLDER/Stable tag: $VERSION/g" ./tags/$VERSION/readme.txt
+                  sed -i "s/$STABLE_TAG_PLACEHOLDER/Stable tag: $VERSION/g" "$VERSION/readme.txt"
 
             - name: Download Changelog Artifact
               uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
               with:
-                  # The name might be confusing here as this job is about a SVN tag and not trunk,
-                  # but in this case `trunk` refers to something else not in the context of SVN.
-                  # it's because the changelog is uploaded using this name in the `update-changelog`
-                  # job above. The changelog is generated and committed to the *git* `trunk` and
-                  # `release/vX.Y.Z` branches, and then the generated text file is stored uising
-                  # the download-artifact action with this name.
                   name: changelog trunk
-                  path: tags/${{ github.event.release.name }}
+                  path: ${{ github.event.release.name }}
 
-            - name: Commit the content changes
-              working-directory: ./tags
+            - name: Add the new version directory and commit changes to the SVN repository
               run: |
-                  svn st | grep '^?' | awk '{print $2}' | xargs -r svn add
-                  svn st | grep '^!' | awk '{print $2}' | xargs -r svn rm
-                  svn commit -m "Committing version $VERSION" \
-                   --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+                  svn import "$VERSION" "$PLUGIN_REPO_URL/tags/$VERSION" -m "Committing version $VERSION" \
+                  --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -25,14 +25,7 @@ jobs:
               run: |
                   latest_version_in_core_repo=$(curl -s 'https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request\[slug\]=gutenberg' | jq -r '.version')
                   echo "Latest Core Repo version: $latest_version_in_core_repo"
-                  # @todo Revert by uncommenting this before merging
-                  # echo "version=$latest_version_in_core_repo" >> $GITHUB_OUTPUT
-
-                  # Mocks the version that would come from the plugin repo, for testing purposes:
-                  # If the version being released by this workflow is > than the last one published
-                  # in the SVN repo, then it will be published as trunk and replace the last version
-                  # on SVN. If it's <, then it will only be published as a tag.
-                  echo "version=v16.1.0" >> $GITHUB_OUTPUT
+                  echo "version=$latest_version_in_core_repo" >> $GITHUB_OUTPUT
 
             - name: Decide if it is a trunk or tag update
               id: compute_should_update_trunk

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -8,6 +8,14 @@ jobs:
     compute-should-update-trunk:
         name: Decide if trunk or tag
         runs-on: ubuntu-latest
+        # Skip this job if the release is a release candidate. This will in turn skip
+        # the upload jobs, which are only relevant for non-RC releases.
+        # We first check if the release is a prerelease, and then if the ref contains
+        # the string "rc". The latter is fallback in case the deployer accidentally
+        # unchecks the "This is a pre-release" checkbox in the release UI.
+        if: |
+            !github.event.release.prerelease && !contains(github.ref, 'rc')
+
         outputs:
             should_update_trunk: ${{ steps.compute_should_update_trunk.outputs.should_update_trunk }}
 
@@ -156,8 +164,7 @@ jobs:
         environment: wp.org plugin
         needs: [compute-should-update-trunk, update-changelog]
         if: |
-            needs.compute-should-update-trunk.outputs.should_update_trunk == 'true' &&
-            !github.event.release.prerelease && github.event.release.assets[0]
+            needs.compute-should-update-trunk.outputs.should_update_trunk == 'true' && github.event.release.assets[0]
         env:
             PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'
             STABLE_VERSION_REGEX: '[0-9]\+\.[0-9]\+\.[0-9]\+\s*'
@@ -220,8 +227,7 @@ jobs:
         environment: wp.org plugin
         needs: [compute-should-update-trunk, update-changelog]
         if: |
-            needs.compute-should-update-trunk.outputs.should_update_trunk == 'false' &&
-            !github.event.release.prerelease && github.event.release.assets[0]
+            needs.compute-should-update-trunk.outputs.should_update_trunk == 'false' && github.event.release.assets[0]
         env:
             PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'
             STABLE_VERSION_REGEX: '[0-9]\+\.[0-9]\+\.[0-9]\+\s*'

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -156,9 +156,8 @@ jobs:
         environment: wp.org plugin
         needs: [compute-should-update-trunk, update-changelog]
         if: |
-            needs.compute-should-update-trunk.outputs.should_update_trunk == 'true'           &&
-            (!github.event.release.prerelease || !contains(github.event.release.name, '-rc')) &&
-            github.event.release.assets[0]
+            needs.compute-should-update-trunk.outputs.should_update_trunk == 'true' &&
+            !github.event.release.prerelease && github.event.release.assets[0]
         env:
             PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'
             STABLE_VERSION_REGEX: '[0-9]\+\.[0-9]\+\.[0-9]\+\s*'
@@ -221,9 +220,8 @@ jobs:
         environment: wp.org plugin
         needs: [compute-should-update-trunk, update-changelog]
         if: |
-            needs.compute-should-update-trunk.outputs.should_update_trunk == 'false'          &&
-            (!github.event.release.prerelease || !contains(github.event.release.name, '-rc')) &&
-            github.event.release.assets[0]
+            needs.compute-should-update-trunk.outputs.should_update_trunk == 'false' &&
+            !github.event.release.prerelease && github.event.release.assets[0]
         env:
             PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'
             STABLE_VERSION_REGEX: '[0-9]\+\.[0-9]\+\.[0-9]\+\s*'

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -23,7 +23,7 @@ jobs:
                   GITHUB_REF: ${{ github.ref }}
               run: |
                   latestPublishedVersion=$(echo "$GITHUB_REF" | sed -E 's/refs\/tags\/(v?)([0-9.]+)/\2/')
-                  latestVersionInCoreRepo="${{ stepss.compute_latest_version_in_core_repo.outputs.version }}"
+                  latestVersionInCoreRepo="${{ steps.compute_latest_version_in_core_repo.outputs.version }}"
 
                   # Determines if the first version string is greater than the second version string.
                   #

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -265,5 +265,5 @@ jobs:
               run: |
                   svn st | grep '^?' | awk '{print $2}' | xargs -r svn add
                   svn st | grep '^!' | awk '{print $2}' | xargs -r svn rm
-                  svn commit -v -m "Committing version $VERSION" \
+                  svn commit -m "Committing version $VERSION" \
                    --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -10,7 +10,7 @@ jobs:
 
         steps:
             - name: Fetch latest version in the WP core repo
-              id: latest_version_in_core_repo
+              id: compute_latest_version_in_core_repo
               run: |
                   CORE_API_URL="https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request[slug]=gutenberg"
                   latest_version_in_core_repo=$(curl -s "$CORE_API_URL" | jq -r '.version')
@@ -18,12 +18,12 @@ jobs:
                   echo "version=$latest_version_in_core_repo" >> $GITHUB_OUTPUT
 
             - name: Decide if it is a trunk or tag update
-              id: comparison
+              id: compute_should_update_trunk
               env:
                   GITHUB_REF: ${{ github.ref }}
               run: |
                   latestPublishedVersion=$(echo "$GITHUB_REF" | sed -E 's/refs\/tags\/(v?)([0-9.]+)/\2/')
-                  latestVersionInCoreRepo="${{ stepss.latest_version_in_core_repo_.outputs.version }}"
+                  latestVersionInCoreRepo="${{ stepss.compute_latest_version_in_core_repo.outputs.version }}"
 
                   # Determines if the first version string is greater than the second version string.
                   #

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -19,7 +19,7 @@ jobs:
 
                       function fetchJson(url) {
                         return new Promise((resolve, reject) => {
-                          https.get(url, { headers: { Accept: 'application/json' } }, res => {
+                          https.get(url, { headers: { Accept: 'application/json', 'User-Agent': 'Github Action Script' } }, res => {
                             let data = '';
                             res.on('data', chunk => data += chunk);
                             res.on('end', () => resolve(JSON.parse(data)));

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -265,5 +265,5 @@ jobs:
               run: |
                   svn st | grep '^?' | awk '{print $2}' | xargs -r svn add
                   svn st | grep '^!' | awk '{print $2}' | xargs -r svn rm
-                  svn commit -m "Committing version $VERSION" \
+                  svn commit -v -m "Committing version $VERSION" \
                    --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -13,11 +13,11 @@ jobs:
               uses: actions/github-script@v6
               with:
                   script: |
-                      const fetch = require('node-fetch');
+                      const fetchData = require('node-fetch');
                       const repo = process.env.GITHUB_REPOSITORY;
 
                       async function fetchJson(url) {
-                        const response = await fetch(url, { headers: { Accept: 'application/vnd.github.v3+json' } });
+                        const response = await fetchData(url, { headers: { Accept: 'application/vnd.github.v3+json' } });
                         return response.json();
                       }
 

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -17,7 +17,14 @@ jobs:
               run: |
                   latest_version_in_core_repo=$(curl -s 'https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request\[slug\]=gutenberg' | jq -r '.version')
                   echo "Latest Core Repo version: $latest_version_in_core_repo"
-                  echo "version=$latest_version_in_core_repo" >> $GITHUB_OUTPUT
+                  # @todo Revert by uncommenting this before merging
+                  # echo "version=$latest_version_in_core_repo" >> $GITHUB_OUTPUT
+
+                  # Mocks the version that would come from the plugin repo, for testing purposes:
+                  # If the version being released by this workflow is > than the last one published
+                  # in the SVN repo, then it will be published as trunk and replace the last version
+                  # on SVN. If it's <, then it will only be published as a tag.
+                  echo "version=v15.9.0" >> $GITHUB_OUTPUT
 
             - name: Decide if it is a trunk or tag update
               id: compute_should_update_trunk

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -5,8 +5,12 @@ on:
         types: [published]
 
 jobs:
-    compute_should_update_trunk:
+    compute-should-update-trunk:
+        name: Decide if trunk or tag
         runs-on: ubuntu-latest
+        outputs:
+            should_update_trunk: ${{ steps.compute_should_update_trunk.outputs.should_update_trunk }}
+            latest_version_in_core_repo: ${{ steps.compute_latest_version_in_core_repo.outputs.version }}
 
         steps:
             - name: Fetch latest version in the WP core repo
@@ -145,7 +149,7 @@ jobs:
         name: Publish as trunk (and tag)
         runs-on: ubuntu-latest
         environment: wp.org plugin
-        needs: [compute_should_update_trunk, update-changelog]
+        needs: [compute-should-update-trunk, update-changelog]
         if: |
             needs.compute_should_update_trunk.outputs.should_update_trunk == 'true' &&
             !github.event.release.prerelease && github.event.release.assets[0]
@@ -209,7 +213,7 @@ jobs:
         name: Publish as tag
         runs-on: ubuntu-latest
         environment: wp.org plugin
-        needs: [compute_should_update_trunk, update-changelog]
+        needs: [compute-should-update-trunk, update-changelog]
         if: |
             needs.compute_should_update_trunk.outputs.should_update_trunk == 'false' &&
             !github.event.release.prerelease && github.event.release.assets[0]

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -175,8 +175,8 @@ jobs:
                   svn commit -m "Releasing version $VERSION" \
                    --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
 
-    upload-branch:
-        name: Publish as branch (and tag)
+    upload-tag:
+        name: Publish as tag
         runs-on: ubuntu-latest
         environment: wp.org plugin
         needs: [compute-latest-stable, update-changelog]
@@ -191,8 +191,8 @@ jobs:
             VERSION: ${{ github.event.release.name }}
 
         steps:
-            - name: Check out Gutenberg branches from WP.org plugin repo
-              run: svn checkout "$PLUGIN_REPO_URL/branches" --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+            - name: Check out Gutenberg tags from WP.org plugin repo
+              run: svn checkout "$PLUGIN_REPO_URL/tags" --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
 
             - name: Download and unzip Gutenberg plugin asset into trunk folder
               env:
@@ -200,31 +200,25 @@ jobs:
               run: |
                   # do the magic here
                   curl -L -o gutenberg.zip $PLUGIN_URL
-                  unzip gutenberg.zip -d branches/$VERSION
+                  unzip gutenberg.zip -d tags/$VERSION
                   rm gutenberg.zip
 
             - name: Replace the stable tag placeholder with the existing stable tag on the SVN repository
               env:
                   STABLE_TAG_PLACEHOLDER: 'Stable tag: V\.V\.V'
               run: |
-                  sed -i "s/$STABLE_TAG_PLACEHOLDER/Stable tag: $VERSION/g" ./branches/$VERSION/readme.txt
+                  sed -i "s/$STABLE_TAG_PLACEHOLDER/Stable tag: $VERSION/g" ./tags/$VERSION/readme.txt
 
             - name: Download Changelog Artifact
               uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
               with:
                   name: changelog trunk
-                  path: branches/${{ github.event.release.name }}
+                  path: tags/${{ github.event.release.name }}
 
             - name: Commit the content changes
-              working-directory: ./branches
+              working-directory: ./tags
               run: |
                   svn st | grep '^?' | awk '{print $2}' | xargs -r svn add
                   svn st | grep '^!' | awk '{print $2}' | xargs -r svn rm
                   svn commit -m "Committing version $VERSION" \
-                   --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
-
-            - name: Create the SVN tag
-              working-directory: ./branches
-              run: |
-                  svn copy "$PLUGIN_REPO_URL/branches/$VERSION" "$PLUGIN_REPO_URL/tags/$VERSION" -m "Tagging version $VERSION" \
                    --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -5,22 +5,50 @@ on:
         types: [published]
 
 jobs:
-    compute-latest-stable:
-        name: Get latest stable version
+    compute_should_update_trunk:
         runs-on: ubuntu-latest
-        outputs:
-            latest_stable_tag: ${{ steps.get_latest_stable_tag.outputs.latest_stable_tag }}
-
         steps:
-            - name: Get latest stable tag
-              id: get_latest_stable_tag
-              run: |
-                  curl \
-                    -H "Accept: application/vnd.github.v3+json" \
-                    -o latest.json \
-                    "https://api.github.com/repos/${{ github.repository }}/releases/latest"
-                  LATEST_STABLE_TAG=$(jq --raw-output '.tag_name' latest.json)
-                  echo "latest_stable_tag=${LATEST_STABLE_TAG}" >> $GITHUB_OUTPUT
+            - name: Compare version numbers
+              id: compute-should-update-trunk
+              uses: actions/github-script@v6
+              with:
+                  script: |
+                      const fetch = require('node-fetch');
+                      const repo = process.env.GITHUB_REPOSITORY;
+
+                      async function fetchJson(url) {
+                        const response = await fetch(url, { headers: { Accept: 'application/vnd.github.v3+json' } });
+                        return response.json();
+                      }
+
+                      /**
+                       * Compares two version strings.
+                       *
+                       * @param {string} v1 - The first version string to compare, which may have an optional leading "v".
+                       * @param {string} v2 - The second version string to compare, which may have an optional leading "v".
+                       * @returns {number} - Returns 1 if v1 is greater than v2, -1 if v1 is less than v2, and 0 if v1 and v2 are equal.
+                       */
+                      function compareVersions(v1, v2) {
+                        const p1 = v1.replace(/^v/, '').split('.').map(Number), p2 = v2.replace(/^v/, '').split('.').map(Number);
+                        return p1.reduce((acc, part, i) => acc === 0 ? (part > p2[i] ? 1 : (part < p2[i] ? -1 : 0)) : acc, 0);
+                      }
+
+                      (async () => {
+                        const [githubData, wpData] = await Promise.all([
+                          fetchJson(`https://api.github.com/repos/${repo}/releases/latest`),
+                          fetchJson('https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request[slug]=gutenberg'),
+                        ]);
+
+                        const latestVersionInGithub = githubData.tag_name
+                        const latestVersionInCoreRepo = wpData.version;
+                        const isLatestVersionInGithubMoreRecent = compareVersions(latestVersionInGithub, latestVersionInCoreRepo) === 1;
+
+                        // Only update trunk *if* the ref from the published plugin matches the latest
+                        // version in GH (releases) *and* if this version is actually GREATER than the
+                        // version published in the WP plugins repo. If not, then it will update the tag.
+                        const shouldUpdateTrunk = githubRef === `refs/tags/${latestVersionInGithub}` && isLatestVersionInGithubMoreRecent;
+                        core.setOutput('should_update_trunk', shouldUpdateTrunk);
+                      })();
 
     get-release-branch:
         name: Get release branch name
@@ -115,9 +143,9 @@ jobs:
         name: Publish as trunk (and tag)
         runs-on: ubuntu-latest
         environment: wp.org plugin
-        needs: [compute-latest-stable, update-changelog]
+        needs: [compute_should_update_trunk, update-changelog]
         if: |
-            endsWith( github.ref, needs.compute-latest-stable.outputs.latest_stable_tag ) &&
+            needs.compute_should_update_trunk.outputs.should_update_trunk == 'true' &&
             !github.event.release.prerelease && github.event.release.assets[0]
         env:
             PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'
@@ -179,9 +207,9 @@ jobs:
         name: Publish as tag
         runs-on: ubuntu-latest
         environment: wp.org plugin
-        needs: [compute-latest-stable, update-changelog]
+        needs: [compute_should_update_trunk, update-changelog]
         if: |
-            !endsWith( github.ref, needs.compute-latest-stable.outputs.latest_stable_tag ) &&
+            needs.compute_should_update_trunk.outputs.should_update_trunk == 'false' &&
             !github.event.release.prerelease && github.event.release.assets[0]
         env:
             PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -5,257 +5,255 @@ on:
         types: [published]
 
 jobs:
+    compute_latest_version_on_core:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Fetch latest version in Core Repo
+              id: core_version
+              run: |
+                  CORE_API_URL="https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request[slug]=gutenberg"
+                  latest_version_in_core_repo=$(curl -s "$CORE_API_URL" | jq -r '.version')
+                  echo "Latest Core Repo version: $latest_version_in_core_repo"
+                  echo "version=$latest_version_in_core_repo" >> $GITHUB_OUTPUT
+
     compute_should_update_trunk:
         runs-on: ubuntu-latest
-        outputs:
-            should_update_trunk: ${{ steps.compute-should-update-trunk.outputs.should_update_trunk }}
+        needs: [compute_latest_version_on_core]
+
         steps:
             - name: Decide if trunk or tag
-              id: compute-should-update-trunk
-              uses: actions/github-script@v6
-              with:
-                  script: |
-                      const https = require('https');
-                      const repo = process.env.GITHUB_REPOSITORY;
-                      const githubRef = context.ref;
-
-                      function fetchJson(url) {
-                        return new Promise((resolve, reject) => {
-                          https.get(url, { headers: { Accept: 'application/json', 'User-Agent': 'Github Action Script' } }, res => {
-                            let data = '';
-                            res.on('data', chunk => data += chunk);
-                            res.on('end', () => resolve(JSON.parse(data)));
-                          }).on('error', reject);
-                        });
-                      }
-
-                      /**
-                       * Compares two version strings.
-                       *
-                       * @param {string} v1 - The first version string to compare, which may have an optional leading "v".
-                       * @param {string} v2 - The second version string to compare, which may have an optional leading "v".
-                       * @returns {number} - Returns 1 if v1 is greater than v2, -1 if v1 is less than v2, and 0 if v1 and v2 are equal.
-                       */
-                      function compareVersions(v1, v2) {
-                        const p1 = v1.replace(/^v/, '').split('.').map(Number), p2 = v2.replace(/^v/, '').split('.').map(Number);
-                        return p1.reduce((acc, part, i) => acc === 0 ? (part > p2[i] ? 1 : (part < p2[i] ? -1 : 0)) : acc, 0);
-                      }
-
-                      (async () => {
-                        const [githubData, wpData] = await Promise.all([
-                          fetchJson(`https://api.github.com/repos/${repo}/releases/latest`),
-                          fetchJson('https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request[slug]=gutenberg'),
-                        ]);
-
-                        const latestVersionInGithub = githubData.tag_name
-                        const latestVersionInCoreRepo = wpData.version;
-                        const isLatestVersionInGithubMoreRecentThanInCoreRepo = compareVersions(latestVersionInGithub, latestVersionInCoreRepo) === 1;
-
-                        // Only update trunk *if* the ref from the published plugin matches the latest
-                        // version in GH (releases) *and*, most importantly, if this version is actually
-                        // GREATER than the version published in the WP plugins repo. If not, then it
-                        // will upload it as a new tag.
-                        const shouldUpdateTrunk = githubRef === `refs/tags/${latestVersionInGithub}` && isLatestVersionInGithubMoreRecentThanInCoreRepo;
-                        core.setOutput('should_update_trunk', shouldUpdateTrunk)
-                      })();
-
-    get-release-branch:
-        name: Get release branch name
-        runs-on: ubuntu-latest
-        outputs:
-            release_branch: ${{ steps.get_release_branch.outputs.release_branch }}
-
-        steps:
-            - name: Compute release branch name
-              id: get_release_branch
+              id: comparison
               env:
-                  TAG: ${{ github.event.release.tag_name }}
+                  GITHUB_REF: ${{ github.ref }}
               run: |
-                  IFS='.' read -r -a VERSION_ARRAY <<< "${TAG#v}"
-                  RELEASE_BRANCH="release/${VERSION_ARRAY[0]}.${VERSION_ARRAY[1]}"
-                  echo "release_branch=${RELEASE_BRANCH}" >> $GITHUB_OUTPUT
+                  latestPublishedVersion=$(echo "$GITHUB_REF" | sed -E 's/refs\/tags\/(v?)([0-9.]+)/\2/')
+                  latestVersionInCoreRepo="${{ needs.compute_latest_version_on_core.outputs.version }}"
 
-    update-changelog:
-        name: Update Changelog on ${{ matrix.branch }} branch
-        runs-on: ubuntu-latest
-        if: |
-            github.event.release.assets[0]
-        needs: get-release-branch
-        env:
-            TAG: ${{ github.event.release.tag_name }}
-        strategy:
-            matrix:
-                include:
-                    - branch: trunk
-                      label: trunk
-                    - branch: ${{ needs.get-release-branch.outputs.release_branch }}
-                      label: release
+                  # Determines if the first version string is greater than the second version string.
+                  #
+                  # Params:
+                  #   $1 - The first version string to compare, which may have an optional leading "v".
+                  #   $2 - The second version string to compare, which may have an optional leading "v".
+                  #
+                  # Return values:
+                  #   0 - The first version string is greater than the second version string.
+                  #   1 - The first version string is less than or equal to the second version string.
+                  is_first_version_greater_than_second() {
+                    v1=${1#v}
+                    v2=${2#v}
+                    dpkg --compare-versions "$v1" gt "$v2"
+                    return $?
+                  }
 
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-              with:
-                  ref: ${{ matrix.branch }}
-                  token: ${{ secrets.GITHUB_TOKEN }}
-
-            - name: Update the Changelog to include the release notes
-              run: |
-                  # First, determine where to insert the new Changelog entry.
-                  SERIES="${RELEASE_BRANCH#release/}"
-                  SERIES_REGEX="=\s${SERIES}\.[0-9]+\s="
-                  CUT_MARKS=$( grep -nP -m 1 "${SERIES_REGEX}" changelog.txt | cut -d: -f1 )
-                  if [[ -z "${CUT_MARKS}" ]]; then
-                    CHANGELOG_REGEX="=\s[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?\s="
-                    RC_REGEX="=\s${TAG#v}(-rc\.[0-9]+)?\s="
-                    CUT_MARKS=$( awk "/${RC_REGEX}/ {print NR; next}; /${CHANGELOG_REGEX}/ {print NR; exit}" changelog.txt )
-                  fi
-                  BEFORE=$( echo "$CUT_MARKS" | head -n 1 )
-                  AFTER=$( echo "$CUT_MARKS" | tail -n 1 )
-                  # Okay, we have all we need to build the new Changelog.
-                  head -n $(( "${BEFORE}" - 1 )) changelog.txt > new_changelog.txt
-                  printf '= %s =\n\n' "${TAG#v}" >> new_changelog.txt
-                  # Need to use a heredoc in order to preserve special characters.
-                  cat <<- "EOF" > release_notes.txt
-                  ${{ github.event.release.body }}
-                  EOF
-                  # Normalize empty lines: Trim them from beginning and end of file...
-                  awk 'NF {p=1} p' <<< "$(< release_notes.txt)" >> new_changelog.txt
-                  # ...then add two empty lines at the end.
-                  printf '\n\n' >> new_changelog.txt
-                  tail -n +"${AFTER}" changelog.txt >> new_changelog.txt
-                  mv new_changelog.txt changelog.txt
-
-            - name: Configure git user name and email
-              run: |
-                  git config user.name "Gutenberg Repository Automation"
-                  git config user.email gutenberg@wordpress.org
-
-            - name: Commit the Changelog update
-              run: |
-                  git add changelog.txt
-                  # Remove files that are not meant to be committed
-                  # ie. release_notes.txt created on the previous step.
-                  git clean -fd
-                  # Only attempt to commit changelog if it has been modified.
-                  if ! git diff-index --quiet HEAD --; then
-                    git commit -m "Update Changelog for ${TAG#v}"
-                    git push --set-upstream origin "${{ matrix.branch }}"
+                  # Only update trunk *if* the published release's version in Github is GREATER
+                  # than the version currently published in the WP plugins repo. If not, then it
+                  # will upload it as a new tag.
+                  shouldUpdateTrunk=false
+                  if is_first_version_greater_than_second "$latestPublishedVersion" "$latestVersionInCoreRepo"; then
+                     shouldUpdateTrunk=true
                   fi
 
-            - name: Upload Changelog artifact
-              uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-              with:
-                  name: changelog ${{ matrix.label }}
-                  path: ./changelog.txt
+                  echo "Should update trunk: $shouldUpdateTrunk"
+                  echo "should_update_trunk=$shouldUpdateTrunk" >> $GITHUB_OUTPUT
 
-    upload:
-        name: Publish as trunk (and tag)
-        runs-on: ubuntu-latest
-        environment: wp.org plugin
-        needs: [compute_should_update_trunk, update-changelog]
-        if: |
-            needs.compute_should_update_trunk.outputs.should_update_trunk == 'true' &&
-            !github.event.release.prerelease && github.event.release.assets[0]
-        env:
-            PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'
-            STABLE_VERSION_REGEX: '[0-9]\+\.[0-9]\+\.[0-9]\+\s*'
-            SVN_USERNAME: ${{ secrets.svn_username }}
-            SVN_PASSWORD: ${{ secrets.svn_password }}
-            VERSION: ${{ github.event.release.name }}
+        get-release-branch:
+            name: Get release branch name
+            runs-on: ubuntu-latest
+            outputs:
+                release_branch: ${{ steps.get_release_branch.outputs.release_branch }}
 
-        steps:
-            - name: Check out Gutenberg trunk from WP.org plugin repo
-              run: svn checkout "$PLUGIN_REPO_URL/trunk" --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+            steps:
+                - name: Compute release branch name
+                  id: get_release_branch
+                  env:
+                      TAG: ${{ github.event.release.tag_name }}
+                  run: |
+                      IFS='.' read -r -a VERSION_ARRAY <<< "${TAG#v}"
+                      RELEASE_BRANCH="release/${VERSION_ARRAY[0]}.${VERSION_ARRAY[1]}"
+                      echo "release_branch=${RELEASE_BRANCH}" >> $GITHUB_OUTPUT
 
-            - name: Delete everything
-              working-directory: ./trunk
-              run: find . -maxdepth 1 -not -name ".svn" -not -name "." -not -name ".." -exec rm -rf {} +
+        update-changelog:
+            name: Update Changelog on ${{ matrix.branch }} branch
+            runs-on: ubuntu-latest
+            if: |
+                github.event.release.assets[0]
+            needs: get-release-branch
+            env:
+                TAG: ${{ github.event.release.tag_name }}
+            strategy:
+                matrix:
+                    include:
+                        - branch: trunk
+                          label: trunk
+                        - branch: ${{ needs.get-release-branch.outputs.release_branch }}
+                          label: release
 
-            - name: Download and unzip Gutenberg plugin asset into trunk folder
-              env:
-                  PLUGIN_URL: ${{ github.event.release.assets[0].browser_download_url }}
-              run: |
-                  curl -L -o gutenberg.zip $PLUGIN_URL
-                  unzip gutenberg.zip -d trunk
-                  rm gutenberg.zip
+            steps:
+                - name: Checkout code
+                  uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+                  with:
+                      ref: ${{ matrix.branch }}
+                      token: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Replace the stable tag placeholder with the existing stable tag on the SVN repository
-              env:
-                  STABLE_TAG_PLACEHOLDER: 'Stable tag: V\.V\.V'
-              run: |
-                  sed -i "s/$STABLE_TAG_PLACEHOLDER/Stable tag: $VERSION/g" ./trunk/readme.txt
+                - name: Update the Changelog to include the release notes
+                  run: |
+                      # First, determine where to insert the new Changelog entry.
+                      SERIES="${RELEASE_BRANCH#release/}"
+                      SERIES_REGEX="=\s${SERIES}\.[0-9]+\s="
+                      CUT_MARKS=$( grep -nP -m 1 "${SERIES_REGEX}" changelog.txt | cut -d: -f1 )
+                      if [[ -z "${CUT_MARKS}" ]]; then
+                        CHANGELOG_REGEX="=\s[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?\s="
+                        RC_REGEX="=\s${TAG#v}(-rc\.[0-9]+)?\s="
+                        CUT_MARKS=$( awk "/${RC_REGEX}/ {print NR; next}; /${CHANGELOG_REGEX}/ {print NR; exit}" changelog.txt )
+                      fi
+                      BEFORE=$( echo "$CUT_MARKS" | head -n 1 )
+                      AFTER=$( echo "$CUT_MARKS" | tail -n 1 )
+                      # Okay, we have all we need to build the new Changelog.
+                      head -n $(( "${BEFORE}" - 1 )) changelog.txt > new_changelog.txt
+                      printf '= %s =\n\n' "${TAG#v}" >> new_changelog.txt
+                      # Need to use a heredoc in order to preserve special characters.
+                      cat <<- "EOF" > release_notes.txt
+                      ${{ github.event.release.body }}
+                      EOF
+                      # Normalize empty lines: Trim them from beginning and end of file...
+                      awk 'NF {p=1} p' <<< "$(< release_notes.txt)" >> new_changelog.txt
+                      # ...then add two empty lines at the end.
+                      printf '\n\n' >> new_changelog.txt
+                      tail -n +"${AFTER}" changelog.txt >> new_changelog.txt
+                      mv new_changelog.txt changelog.txt
 
-            - name: Download Changelog Artifact
-              uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
-              with:
-                  name: changelog trunk
-                  path: trunk
+                - name: Configure git user name and email
+                  run: |
+                      git config user.name "Gutenberg Repository Automation"
+                      git config user.email gutenberg@wordpress.org
 
-            - name: Commit the content changes
-              working-directory: ./trunk
-              run: |
-                  svn st | grep '^?' | awk '{print $2}' | xargs -r svn add
-                  svn st | grep '^!' | awk '{print $2}' | xargs -r svn rm
-                  svn commit -m "Committing version $VERSION" \
-                   --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+                - name: Commit the Changelog update
+                  run: |
+                      git add changelog.txt
+                      # Remove files that are not meant to be committed
+                      # ie. release_notes.txt created on the previous step.
+                      git clean -fd
+                      # Only attempt to commit changelog if it has been modified.
+                      if ! git diff-index --quiet HEAD --; then
+                        git commit -m "Update Changelog for ${TAG#v}"
+                        git push --set-upstream origin "${{ matrix.branch }}"
+                      fi
 
-            - name: Create the SVN tag
-              working-directory: ./trunk
-              run: |
-                  svn copy "$PLUGIN_REPO_URL/trunk" "$PLUGIN_REPO_URL/tags/$VERSION" -m "Tagging version $VERSION" \
-                   --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+                - name: Upload Changelog artifact
+                  uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+                  with:
+                      name: changelog ${{ matrix.label }}
+                      path: ./changelog.txt
 
-            - name: Update the plugin's stable version
-              working-directory: ./trunk
-              run: |
-                  sed -i "s/Stable tag: ${STABLE_VERSION_REGEX}/Stable tag: ${VERSION}/g" ./readme.txt
-                  svn commit -m "Releasing version $VERSION" \
-                   --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+        upload:
+            name: Publish as trunk (and tag)
+            runs-on: ubuntu-latest
+            environment: wp.org plugin
+            needs: [compute_should_update_trunk, update-changelog]
+            if: |
+                needs.compute_should_update_trunk.outputs.should_update_trunk == 'true' &&
+                !github.event.release.prerelease && github.event.release.assets[0]
+            env:
+                PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'
+                STABLE_VERSION_REGEX: '[0-9]\+\.[0-9]\+\.[0-9]\+\s*'
+                SVN_USERNAME: ${{ secrets.svn_username }}
+                SVN_PASSWORD: ${{ secrets.svn_password }}
+                VERSION: ${{ github.event.release.name }}
 
-    upload-tag:
-        name: Publish as tag
-        runs-on: ubuntu-latest
-        environment: wp.org plugin
-        needs: [compute_should_update_trunk, update-changelog]
-        if: |
-            needs.compute_should_update_trunk.outputs.should_update_trunk == 'false' &&
-            !github.event.release.prerelease && github.event.release.assets[0]
-        env:
-            PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'
-            STABLE_VERSION_REGEX: '[0-9]\+\.[0-9]\+\.[0-9]\+\s*'
-            SVN_USERNAME: ${{ secrets.svn_username }}
-            SVN_PASSWORD: ${{ secrets.svn_password }}
-            VERSION: ${{ github.event.release.name }}
+            steps:
+                - name: Check out Gutenberg trunk from WP.org plugin repo
+                  run: svn checkout "$PLUGIN_REPO_URL/trunk" --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
 
-        steps:
-            - name: Check out Gutenberg tags from WP.org plugin repo
-              run: svn checkout "$PLUGIN_REPO_URL/tags" --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+                - name: Delete everything
+                  working-directory: ./trunk
+                  run: find . -maxdepth 1 -not -name ".svn" -not -name "." -not -name ".." -exec rm -rf {} +
 
-            - name: Download and unzip Gutenberg plugin asset into trunk folder
-              env:
-                  PLUGIN_URL: ${{ github.event.release.assets[0].browser_download_url }}
-              run: |
-                  # do the magic here
-                  curl -L -o gutenberg.zip $PLUGIN_URL
-                  unzip gutenberg.zip -d tags/$VERSION
-                  rm gutenberg.zip
+                - name: Download and unzip Gutenberg plugin asset into trunk folder
+                  env:
+                      PLUGIN_URL: ${{ github.event.release.assets[0].browser_download_url }}
+                  run: |
+                      curl -L -o gutenberg.zip $PLUGIN_URL
+                      unzip gutenberg.zip -d trunk
+                      rm gutenberg.zip
 
-            - name: Replace the stable tag placeholder with the existing stable tag on the SVN repository
-              env:
-                  STABLE_TAG_PLACEHOLDER: 'Stable tag: V\.V\.V'
-              run: |
-                  sed -i "s/$STABLE_TAG_PLACEHOLDER/Stable tag: $VERSION/g" ./tags/$VERSION/readme.txt
+                - name: Replace the stable tag placeholder with the existing stable tag on the SVN repository
+                  env:
+                      STABLE_TAG_PLACEHOLDER: 'Stable tag: V\.V\.V'
+                  run: |
+                      sed -i "s/$STABLE_TAG_PLACEHOLDER/Stable tag: $VERSION/g" ./trunk/readme.txt
 
-            - name: Download Changelog Artifact
-              uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
-              with:
-                  name: changelog trunk
-                  path: tags/${{ github.event.release.name }}
+                - name: Download Changelog Artifact
+                  uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+                  with:
+                      name: changelog trunk
+                      path: trunk
 
-            - name: Commit the content changes
-              working-directory: ./tags
-              run: |
-                  svn st | grep '^?' | awk '{print $2}' | xargs -r svn add
-                  svn st | grep '^!' | awk '{print $2}' | xargs -r svn rm
-                  svn commit -m "Committing version $VERSION" \
-                   --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+                - name: Commit the content changes
+                  working-directory: ./trunk
+                  run: |
+                      svn st | grep '^?' | awk '{print $2}' | xargs -r svn add
+                      svn st | grep '^!' | awk '{print $2}' | xargs -r svn rm
+                      svn commit -m "Committing version $VERSION" \
+                       --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+
+                - name: Create the SVN tag
+                  working-directory: ./trunk
+                  run: |
+                      svn copy "$PLUGIN_REPO_URL/trunk" "$PLUGIN_REPO_URL/tags/$VERSION" -m "Tagging version $VERSION" \
+                       --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+
+                - name: Update the plugin's stable version
+                  working-directory: ./trunk
+                  run: |
+                      sed -i "s/Stable tag: ${STABLE_VERSION_REGEX}/Stable tag: ${VERSION}/g" ./readme.txt
+                      svn commit -m "Releasing version $VERSION" \
+                       --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+
+        upload-tag:
+            name: Publish as tag
+            runs-on: ubuntu-latest
+            environment: wp.org plugin
+            needs: [compute_should_update_trunk, update-changelog]
+            if: |
+                needs.compute_should_update_trunk.outputs.should_update_trunk == 'false' &&
+                !github.event.release.prerelease && github.event.release.assets[0]
+            env:
+                PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'
+                STABLE_VERSION_REGEX: '[0-9]\+\.[0-9]\+\.[0-9]\+\s*'
+                SVN_USERNAME: ${{ secrets.svn_username }}
+                SVN_PASSWORD: ${{ secrets.svn_password }}
+                VERSION: ${{ github.event.release.name }}
+
+            steps:
+                - name: Check out Gutenberg tags from WP.org plugin repo
+                  run: svn checkout "$PLUGIN_REPO_URL/tags" --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+
+                - name: Download and unzip Gutenberg plugin asset into trunk folder
+                  env:
+                      PLUGIN_URL: ${{ github.event.release.assets[0].browser_download_url }}
+                  run: |
+                      # do the magic here
+                      curl -L -o gutenberg.zip $PLUGIN_URL
+                      unzip gutenberg.zip -d tags/$VERSION
+                      rm gutenberg.zip
+
+                - name: Replace the stable tag placeholder with the existing stable tag on the SVN repository
+                  env:
+                      STABLE_TAG_PLACEHOLDER: 'Stable tag: V\.V\.V'
+                  run: |
+                      sed -i "s/$STABLE_TAG_PLACEHOLDER/Stable tag: $VERSION/g" ./tags/$VERSION/readme.txt
+
+                - name: Download Changelog Artifact
+                  uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+                  with:
+                      name: changelog trunk
+                      path: tags/${{ github.event.release.name }}
+
+                - name: Commit the content changes
+                  working-directory: ./tags
+                  run: |
+                      svn st | grep '^?' | awk '{print $2}' | xargs -r svn add
+                      svn st | grep '^!' | awk '{print $2}' | xargs -r svn rm
+                      svn commit -m "Committing version $VERSION" \
+                       --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -213,7 +213,7 @@ jobs:
               uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
               with:
                   name: changelog trunk
-                  path: branches/$VERSION
+                  path: branches/${{ github.event.release.name }}
 
             - name: Commit the content changes
               working-directory: ./branches

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -7,26 +7,17 @@ on:
 jobs:
     compute_should_update_trunk:
         runs-on: ubuntu-latest
+        outputs:
+            should_update_trunk: ${{ steps.compute-should-update-trunk.outputs.should_update_trunk }}
         steps:
             - name: Decide if trunk or tag
               id: compute-should-update-trunk
               uses: actions/github-script@v6
               with:
                   script: |
-                      const os = require("os");
-                      const fs = require("fs");
                       const https = require('https');
                       const repo = process.env.GITHUB_REPOSITORY;
                       const githubRef = context.ref;
-
-                      // Define a function to output the result of this action
-                      // We don't use the one from "actions/core" because we
-                      // don't want to install the npm package which would add
-                      // to the workflow runtime.
-                      function setOutput(key, val) {
-                        const out = process.env["GITHUB_OUTPUT"];
-                        fs.appendFileSync(out, `${key}=${val}${os.EOL}`);
-                      }
 
                       function fetchJson(url) {
                         return new Promise((resolve, reject) => {
@@ -65,7 +56,7 @@ jobs:
                         // GREATER than the version published in the WP plugins repo. If not, then it
                         // will upload it as a new tag.
                         const shouldUpdateTrunk = githubRef === `refs/tags/${latestVersionInGithub}` && isLatestVersionInGithubMoreRecentThanInCoreRepo;
-                        setOutput('should_update_trunk', shouldUpdateTrunk)
+                        core.setOutput('should_update_trunk', shouldUpdateTrunk)
                       })();
 
     get-release-branch:

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -226,7 +226,7 @@ jobs:
             - name: Check out Gutenberg tags from WP.org plugin repo
               run: svn checkout "$PLUGIN_REPO_URL/tags" --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
 
-            - name: Download and unzip Gutenberg plugin asset into trunk folder
+            - name: Download and unzip Gutenberg plugin asset into tags folder
               env:
                   PLUGIN_URL: ${{ github.event.release.assets[0].browser_download_url }}
               run: |
@@ -244,7 +244,7 @@ jobs:
             - name: Download Changelog Artifact
               uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
               with:
-                  name: changelog trunk
+                  name: changelog for tags
                   path: tags/${{ github.event.release.name }}
 
             - name: Commit the content changes

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -5,30 +5,25 @@ on:
         types: [published]
 
 jobs:
-    compute_latest_version_on_core:
+    compute_should_update_trunk:
         runs-on: ubuntu-latest
 
         steps:
-            - name: Fetch latest version in Core Repo
-              id: core_version
+            - name: Fetch latest version in the WP core repo
+              id: latest_version_in_core_repo
               run: |
                   CORE_API_URL="https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request[slug]=gutenberg"
                   latest_version_in_core_repo=$(curl -s "$CORE_API_URL" | jq -r '.version')
                   echo "Latest Core Repo version: $latest_version_in_core_repo"
                   echo "version=$latest_version_in_core_repo" >> $GITHUB_OUTPUT
 
-    compute_should_update_trunk:
-        runs-on: ubuntu-latest
-        needs: [compute_latest_version_on_core]
-
-        steps:
-            - name: Decide if trunk or tag
+            - name: Decide if it is a trunk or tag update
               id: comparison
               env:
                   GITHUB_REF: ${{ github.ref }}
               run: |
                   latestPublishedVersion=$(echo "$GITHUB_REF" | sed -E 's/refs\/tags\/(v?)([0-9.]+)/\2/')
-                  latestVersionInCoreRepo="${{ needs.compute_latest_version_on_core.outputs.version }}"
+                  latestVersionInCoreRepo="${{ stepss.latest_version_in_core_repo_.outputs.version }}"
 
                   # Determines if the first version string is greater than the second version string.
                   #

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -8,14 +8,25 @@ jobs:
     compute_should_update_trunk:
         runs-on: ubuntu-latest
         steps:
-            - name: Compare version numbers
+            - name: Decide if trunk or tag
               id: compute-should-update-trunk
               uses: actions/github-script@v6
               with:
                   script: |
+                      const os = require("os");
+                      const fs = require("fs");
                       const https = require('https');
                       const repo = process.env.GITHUB_REPOSITORY;
                       const githubRef = context.ref;
+
+                      // Define a function to output the result of this action
+                      // We don't use the one from "actions/core" because we
+                      // don't want to install the npm package which would add
+                      // to the workflow runtime.
+                      function setOutput(key, val) {
+                        const out = process.env["GITHUB_OUTPUT"];
+                        fs.appendFileSync(out, `${key}=${val}${os.EOL}`);
+                      }
 
                       function fetchJson(url) {
                         return new Promise((resolve, reject) => {
@@ -54,7 +65,7 @@ jobs:
                         // GREATER than the version published in the WP plugins repo. If not, then it
                         // will upload it as a new tag.
                         const shouldUpdateTrunk = githubRef === `refs/tags/${latestVersionInGithub}` && isLatestVersionInGithubMoreRecentThanInCoreRepo;
-                        core.setOutput('should_update_trunk', shouldUpdateTrunk);
+                        setOutput('should_update_trunk', shouldUpdateTrunk)
                       })();
 
     get-release-branch:

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -10,14 +10,12 @@ jobs:
         runs-on: ubuntu-latest
         outputs:
             should_update_trunk: ${{ steps.compute_should_update_trunk.outputs.should_update_trunk }}
-            latest_version_in_core_repo: ${{ steps.compute_latest_version_in_core_repo.outputs.version }}
 
         steps:
             - name: Fetch latest version in the WP core repo
               id: compute_latest_version_in_core_repo
               run: |
-                  CORE_API_URL="https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request[slug]=gutenberg"
-                  latest_version_in_core_repo=$(curl -s "$CORE_API_URL" | jq -r '.version')
+                  latest_version_in_core_repo=$(curl -s 'https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request\[slug\]=gutenberg' | jq -r '.version')
                   echo "Latest Core Repo version: $latest_version_in_core_repo"
                   echo "version=$latest_version_in_core_repo" >> $GITHUB_OUTPUT
 
@@ -151,7 +149,7 @@ jobs:
         environment: wp.org plugin
         needs: [compute-should-update-trunk, update-changelog]
         if: |
-            needs.compute_should_update_trunk.outputs.should_update_trunk == 'true' &&
+            needs.compute-should-update-trunk.outputs.should_update_trunk == 'true' &&
             !github.event.release.prerelease && github.event.release.assets[0]
         env:
             PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'
@@ -215,7 +213,7 @@ jobs:
         environment: wp.org plugin
         needs: [compute-should-update-trunk, update-changelog]
         if: |
-            needs.compute_should_update_trunk.outputs.should_update_trunk == 'false' &&
+            needs.compute-should-update-trunk.outputs.should_update_trunk == 'false' &&
             !github.event.release.prerelease && github.event.release.assets[0]
         env:
             PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -251,7 +251,13 @@ jobs:
             - name: Download Changelog Artifact
               uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
               with:
-                  name: changelog for tags
+                  # The name might be confusing here as this job is about a SVN tag and not trunk,
+                  # but in this case `trunk` refers to something else not in the context of SVN.
+                  # it's because the changelog is uploaded using this name in the `update-changelog`
+                  # job above. The changelog is generated and committed to the *git* `trunk` and
+                  # `release/vX.Y.Z` branches, and then the generated text file is stored uising
+                  # the download-artifact action with this name.
+                  name: changelog trunk
                   path: tags/${{ github.event.release.name }}
 
             - name: Commit the content changes

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -13,12 +13,18 @@ jobs:
               uses: actions/github-script@v6
               with:
                   script: |
-                      const fetchData = require('node-fetch');
+                      const https = require('https');
                       const repo = process.env.GITHUB_REPOSITORY;
+                      const githubRef = context.ref;
 
-                      async function fetchJson(url) {
-                        const response = await fetchData(url, { headers: { Accept: 'application/vnd.github.v3+json' } });
-                        return response.json();
+                      function fetchJson(url) {
+                        return new Promise((resolve, reject) => {
+                          https.get(url, { headers: { Accept: 'application/json' } }, res => {
+                            let data = '';
+                            res.on('data', chunk => data += chunk);
+                            res.on('end', () => resolve(JSON.parse(data)));
+                          }).on('error', reject);
+                        });
                       }
 
                       /**

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -59,7 +59,7 @@ jobs:
               uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
               with:
                   ref: ${{ matrix.branch }}
-                  token: ${{ secrets.GUTENBERG_TOKEN }}
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Update the Changelog to include the release notes
               run: |
@@ -120,7 +120,7 @@ jobs:
             endsWith( github.ref, needs.compute-latest-stable.outputs.latest_stable_tag ) &&
             !github.event.release.prerelease && github.event.release.assets[0]
         env:
-            PLUGIN_REPO_URL: 'https://plugins.svn.wordpress.org/gutenberg'
+            PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'
             STABLE_VERSION_REGEX: '[0-9]\+\.[0-9]\+\.[0-9]\+\s*'
             SVN_USERNAME: ${{ secrets.svn_username }}
             SVN_PASSWORD: ${{ secrets.svn_password }}
@@ -184,7 +184,7 @@ jobs:
             !endsWith( github.ref, needs.compute-latest-stable.outputs.latest_stable_tag ) &&
             !github.event.release.prerelease && github.event.release.assets[0]
         env:
-            PLUGIN_REPO_URL: 'https://plugins.svn.wordpress.org/gutenberg'
+            PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'
             STABLE_VERSION_REGEX: '[0-9]\+\.[0-9]\+\.[0-9]\+\s*'
             SVN_USERNAME: ${{ secrets.svn_username }}
             SVN_PASSWORD: ${{ secrets.svn_password }}

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -47,12 +47,13 @@ jobs:
 
                         const latestVersionInGithub = githubData.tag_name
                         const latestVersionInCoreRepo = wpData.version;
-                        const isLatestVersionInGithubMoreRecent = compareVersions(latestVersionInGithub, latestVersionInCoreRepo) === 1;
+                        const isLatestVersionInGithubMoreRecentThanInCoreRepo = compareVersions(latestVersionInGithub, latestVersionInCoreRepo) === 1;
 
                         // Only update trunk *if* the ref from the published plugin matches the latest
-                        // version in GH (releases) *and* if this version is actually GREATER than the
-                        // version published in the WP plugins repo. If not, then it will update the tag.
-                        const shouldUpdateTrunk = githubRef === `refs/tags/${latestVersionInGithub}` && isLatestVersionInGithubMoreRecent;
+                        // version in GH (releases) *and*, most importantly, if this version is actually
+                        // GREATER than the version published in the WP plugins repo. If not, then it
+                        // will upload it as a new tag.
+                        const shouldUpdateTrunk = githubRef === `refs/tags/${latestVersionInGithub}` && isLatestVersionInGithubMoreRecentThanInCoreRepo;
                         core.setOutput('should_update_trunk', shouldUpdateTrunk);
                       })();
 

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -52,203 +52,203 @@ jobs:
                   echo "Should update trunk: $shouldUpdateTrunk"
                   echo "should_update_trunk=$shouldUpdateTrunk" >> $GITHUB_OUTPUT
 
-        get-release-branch:
-            name: Get release branch name
-            runs-on: ubuntu-latest
-            outputs:
-                release_branch: ${{ steps.get_release_branch.outputs.release_branch }}
+    get-release-branch:
+        name: Get release branch name
+        runs-on: ubuntu-latest
+        outputs:
+            release_branch: ${{ steps.get_release_branch.outputs.release_branch }}
 
-            steps:
-                - name: Compute release branch name
-                  id: get_release_branch
-                  env:
-                      TAG: ${{ github.event.release.tag_name }}
-                  run: |
-                      IFS='.' read -r -a VERSION_ARRAY <<< "${TAG#v}"
-                      RELEASE_BRANCH="release/${VERSION_ARRAY[0]}.${VERSION_ARRAY[1]}"
-                      echo "release_branch=${RELEASE_BRANCH}" >> $GITHUB_OUTPUT
+        steps:
+            - name: Compute release branch name
+              id: get_release_branch
+              env:
+                  TAG: ${{ github.event.release.tag_name }}
+              run: |
+                  IFS='.' read -r -a VERSION_ARRAY <<< "${TAG#v}"
+                  RELEASE_BRANCH="release/${VERSION_ARRAY[0]}.${VERSION_ARRAY[1]}"
+                  echo "release_branch=${RELEASE_BRANCH}" >> $GITHUB_OUTPUT
 
-        update-changelog:
-            name: Update Changelog on ${{ matrix.branch }} branch
-            runs-on: ubuntu-latest
-            if: |
-                github.event.release.assets[0]
-            needs: get-release-branch
-            env:
-                TAG: ${{ github.event.release.tag_name }}
-            strategy:
-                matrix:
-                    include:
-                        - branch: trunk
-                          label: trunk
-                        - branch: ${{ needs.get-release-branch.outputs.release_branch }}
-                          label: release
+    update-changelog:
+        name: Update Changelog on ${{ matrix.branch }} branch
+        runs-on: ubuntu-latest
+        if: |
+            github.event.release.assets[0]
+        needs: get-release-branch
+        env:
+            TAG: ${{ github.event.release.tag_name }}
+        strategy:
+            matrix:
+                include:
+                    - branch: trunk
+                      label: trunk
+                    - branch: ${{ needs.get-release-branch.outputs.release_branch }}
+                      label: release
 
-            steps:
-                - name: Checkout code
-                  uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-                  with:
-                      ref: ${{ matrix.branch }}
-                      token: ${{ secrets.GITHUB_TOKEN }}
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+              with:
+                  ref: ${{ matrix.branch }}
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
-                - name: Update the Changelog to include the release notes
-                  run: |
-                      # First, determine where to insert the new Changelog entry.
-                      SERIES="${RELEASE_BRANCH#release/}"
-                      SERIES_REGEX="=\s${SERIES}\.[0-9]+\s="
-                      CUT_MARKS=$( grep -nP -m 1 "${SERIES_REGEX}" changelog.txt | cut -d: -f1 )
-                      if [[ -z "${CUT_MARKS}" ]]; then
-                        CHANGELOG_REGEX="=\s[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?\s="
-                        RC_REGEX="=\s${TAG#v}(-rc\.[0-9]+)?\s="
-                        CUT_MARKS=$( awk "/${RC_REGEX}/ {print NR; next}; /${CHANGELOG_REGEX}/ {print NR; exit}" changelog.txt )
-                      fi
-                      BEFORE=$( echo "$CUT_MARKS" | head -n 1 )
-                      AFTER=$( echo "$CUT_MARKS" | tail -n 1 )
-                      # Okay, we have all we need to build the new Changelog.
-                      head -n $(( "${BEFORE}" - 1 )) changelog.txt > new_changelog.txt
-                      printf '= %s =\n\n' "${TAG#v}" >> new_changelog.txt
-                      # Need to use a heredoc in order to preserve special characters.
-                      cat <<- "EOF" > release_notes.txt
-                      ${{ github.event.release.body }}
-                      EOF
-                      # Normalize empty lines: Trim them from beginning and end of file...
-                      awk 'NF {p=1} p' <<< "$(< release_notes.txt)" >> new_changelog.txt
-                      # ...then add two empty lines at the end.
-                      printf '\n\n' >> new_changelog.txt
-                      tail -n +"${AFTER}" changelog.txt >> new_changelog.txt
-                      mv new_changelog.txt changelog.txt
+            - name: Update the Changelog to include the release notes
+              run: |
+                  # First, determine where to insert the new Changelog entry.
+                  SERIES="${RELEASE_BRANCH#release/}"
+                  SERIES_REGEX="=\s${SERIES}\.[0-9]+\s="
+                  CUT_MARKS=$( grep -nP -m 1 "${SERIES_REGEX}" changelog.txt | cut -d: -f1 )
+                  if [[ -z "${CUT_MARKS}" ]]; then
+                    CHANGELOG_REGEX="=\s[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?\s="
+                    RC_REGEX="=\s${TAG#v}(-rc\.[0-9]+)?\s="
+                    CUT_MARKS=$( awk "/${RC_REGEX}/ {print NR; next}; /${CHANGELOG_REGEX}/ {print NR; exit}" changelog.txt )
+                  fi
+                  BEFORE=$( echo "$CUT_MARKS" | head -n 1 )
+                  AFTER=$( echo "$CUT_MARKS" | tail -n 1 )
+                  # Okay, we have all we need to build the new Changelog.
+                  head -n $(( "${BEFORE}" - 1 )) changelog.txt > new_changelog.txt
+                  printf '= %s =\n\n' "${TAG#v}" >> new_changelog.txt
+                  # Need to use a heredoc in order to preserve special characters.
+                  cat <<- "EOF" > release_notes.txt
+                  ${{ github.event.release.body }}
+                  EOF
+                  # Normalize empty lines: Trim them from beginning and end of file...
+                  awk 'NF {p=1} p' <<< "$(< release_notes.txt)" >> new_changelog.txt
+                  # ...then add two empty lines at the end.
+                  printf '\n\n' >> new_changelog.txt
+                  tail -n +"${AFTER}" changelog.txt >> new_changelog.txt
+                  mv new_changelog.txt changelog.txt
 
-                - name: Configure git user name and email
-                  run: |
-                      git config user.name "Gutenberg Repository Automation"
-                      git config user.email gutenberg@wordpress.org
+            - name: Configure git user name and email
+              run: |
+                  git config user.name "Gutenberg Repository Automation"
+                  git config user.email gutenberg@wordpress.org
 
-                - name: Commit the Changelog update
-                  run: |
-                      git add changelog.txt
-                      # Remove files that are not meant to be committed
-                      # ie. release_notes.txt created on the previous step.
-                      git clean -fd
-                      # Only attempt to commit changelog if it has been modified.
-                      if ! git diff-index --quiet HEAD --; then
-                        git commit -m "Update Changelog for ${TAG#v}"
-                        git push --set-upstream origin "${{ matrix.branch }}"
-                      fi
+            - name: Commit the Changelog update
+              run: |
+                  git add changelog.txt
+                  # Remove files that are not meant to be committed
+                  # ie. release_notes.txt created on the previous step.
+                  git clean -fd
+                  # Only attempt to commit changelog if it has been modified.
+                  if ! git diff-index --quiet HEAD --; then
+                    git commit -m "Update Changelog for ${TAG#v}"
+                    git push --set-upstream origin "${{ matrix.branch }}"
+                  fi
 
-                - name: Upload Changelog artifact
-                  uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-                  with:
-                      name: changelog ${{ matrix.label }}
-                      path: ./changelog.txt
+            - name: Upload Changelog artifact
+              uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+              with:
+                  name: changelog ${{ matrix.label }}
+                  path: ./changelog.txt
 
-        upload:
-            name: Publish as trunk (and tag)
-            runs-on: ubuntu-latest
-            environment: wp.org plugin
-            needs: [compute_should_update_trunk, update-changelog]
-            if: |
-                needs.compute_should_update_trunk.outputs.should_update_trunk == 'true' &&
-                !github.event.release.prerelease && github.event.release.assets[0]
-            env:
-                PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'
-                STABLE_VERSION_REGEX: '[0-9]\+\.[0-9]\+\.[0-9]\+\s*'
-                SVN_USERNAME: ${{ secrets.svn_username }}
-                SVN_PASSWORD: ${{ secrets.svn_password }}
-                VERSION: ${{ github.event.release.name }}
+    upload:
+        name: Publish as trunk (and tag)
+        runs-on: ubuntu-latest
+        environment: wp.org plugin
+        needs: [compute_should_update_trunk, update-changelog]
+        if: |
+            needs.compute_should_update_trunk.outputs.should_update_trunk == 'true' &&
+            !github.event.release.prerelease && github.event.release.assets[0]
+        env:
+            PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'
+            STABLE_VERSION_REGEX: '[0-9]\+\.[0-9]\+\.[0-9]\+\s*'
+            SVN_USERNAME: ${{ secrets.svn_username }}
+            SVN_PASSWORD: ${{ secrets.svn_password }}
+            VERSION: ${{ github.event.release.name }}
 
-            steps:
-                - name: Check out Gutenberg trunk from WP.org plugin repo
-                  run: svn checkout "$PLUGIN_REPO_URL/trunk" --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+        steps:
+            - name: Check out Gutenberg trunk from WP.org plugin repo
+              run: svn checkout "$PLUGIN_REPO_URL/trunk" --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
 
-                - name: Delete everything
-                  working-directory: ./trunk
-                  run: find . -maxdepth 1 -not -name ".svn" -not -name "." -not -name ".." -exec rm -rf {} +
+            - name: Delete everything
+              working-directory: ./trunk
+              run: find . -maxdepth 1 -not -name ".svn" -not -name "." -not -name ".." -exec rm -rf {} +
 
-                - name: Download and unzip Gutenberg plugin asset into trunk folder
-                  env:
-                      PLUGIN_URL: ${{ github.event.release.assets[0].browser_download_url }}
-                  run: |
-                      curl -L -o gutenberg.zip $PLUGIN_URL
-                      unzip gutenberg.zip -d trunk
-                      rm gutenberg.zip
+            - name: Download and unzip Gutenberg plugin asset into trunk folder
+              env:
+                  PLUGIN_URL: ${{ github.event.release.assets[0].browser_download_url }}
+              run: |
+                  curl -L -o gutenberg.zip $PLUGIN_URL
+                  unzip gutenberg.zip -d trunk
+                  rm gutenberg.zip
 
-                - name: Replace the stable tag placeholder with the existing stable tag on the SVN repository
-                  env:
-                      STABLE_TAG_PLACEHOLDER: 'Stable tag: V\.V\.V'
-                  run: |
-                      sed -i "s/$STABLE_TAG_PLACEHOLDER/Stable tag: $VERSION/g" ./trunk/readme.txt
+            - name: Replace the stable tag placeholder with the existing stable tag on the SVN repository
+              env:
+                  STABLE_TAG_PLACEHOLDER: 'Stable tag: V\.V\.V'
+              run: |
+                  sed -i "s/$STABLE_TAG_PLACEHOLDER/Stable tag: $VERSION/g" ./trunk/readme.txt
 
-                - name: Download Changelog Artifact
-                  uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
-                  with:
-                      name: changelog trunk
-                      path: trunk
+            - name: Download Changelog Artifact
+              uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+              with:
+                  name: changelog trunk
+                  path: trunk
 
-                - name: Commit the content changes
-                  working-directory: ./trunk
-                  run: |
-                      svn st | grep '^?' | awk '{print $2}' | xargs -r svn add
-                      svn st | grep '^!' | awk '{print $2}' | xargs -r svn rm
-                      svn commit -m "Committing version $VERSION" \
-                       --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+            - name: Commit the content changes
+              working-directory: ./trunk
+              run: |
+                  svn st | grep '^?' | awk '{print $2}' | xargs -r svn add
+                  svn st | grep '^!' | awk '{print $2}' | xargs -r svn rm
+                  svn commit -m "Committing version $VERSION" \
+                   --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
 
-                - name: Create the SVN tag
-                  working-directory: ./trunk
-                  run: |
-                      svn copy "$PLUGIN_REPO_URL/trunk" "$PLUGIN_REPO_URL/tags/$VERSION" -m "Tagging version $VERSION" \
-                       --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+            - name: Create the SVN tag
+              working-directory: ./trunk
+              run: |
+                  svn copy "$PLUGIN_REPO_URL/trunk" "$PLUGIN_REPO_URL/tags/$VERSION" -m "Tagging version $VERSION" \
+                   --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
 
-                - name: Update the plugin's stable version
-                  working-directory: ./trunk
-                  run: |
-                      sed -i "s/Stable tag: ${STABLE_VERSION_REGEX}/Stable tag: ${VERSION}/g" ./readme.txt
-                      svn commit -m "Releasing version $VERSION" \
-                       --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+            - name: Update the plugin's stable version
+              working-directory: ./trunk
+              run: |
+                  sed -i "s/Stable tag: ${STABLE_VERSION_REGEX}/Stable tag: ${VERSION}/g" ./readme.txt
+                  svn commit -m "Releasing version $VERSION" \
+                   --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
 
-        upload-tag:
-            name: Publish as tag
-            runs-on: ubuntu-latest
-            environment: wp.org plugin
-            needs: [compute_should_update_trunk, update-changelog]
-            if: |
-                needs.compute_should_update_trunk.outputs.should_update_trunk == 'false' &&
-                !github.event.release.prerelease && github.event.release.assets[0]
-            env:
-                PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'
-                STABLE_VERSION_REGEX: '[0-9]\+\.[0-9]\+\.[0-9]\+\s*'
-                SVN_USERNAME: ${{ secrets.svn_username }}
-                SVN_PASSWORD: ${{ secrets.svn_password }}
-                VERSION: ${{ github.event.release.name }}
+    upload-tag:
+        name: Publish as tag
+        runs-on: ubuntu-latest
+        environment: wp.org plugin
+        needs: [compute_should_update_trunk, update-changelog]
+        if: |
+            needs.compute_should_update_trunk.outputs.should_update_trunk == 'false' &&
+            !github.event.release.prerelease && github.event.release.assets[0]
+        env:
+            PLUGIN_REPO_URL: 'http://caffeine.ngrok.io/svn/gutenberg'
+            STABLE_VERSION_REGEX: '[0-9]\+\.[0-9]\+\.[0-9]\+\s*'
+            SVN_USERNAME: ${{ secrets.svn_username }}
+            SVN_PASSWORD: ${{ secrets.svn_password }}
+            VERSION: ${{ github.event.release.name }}
 
-            steps:
-                - name: Check out Gutenberg tags from WP.org plugin repo
-                  run: svn checkout "$PLUGIN_REPO_URL/tags" --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+        steps:
+            - name: Check out Gutenberg tags from WP.org plugin repo
+              run: svn checkout "$PLUGIN_REPO_URL/tags" --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
 
-                - name: Download and unzip Gutenberg plugin asset into trunk folder
-                  env:
-                      PLUGIN_URL: ${{ github.event.release.assets[0].browser_download_url }}
-                  run: |
-                      # do the magic here
-                      curl -L -o gutenberg.zip $PLUGIN_URL
-                      unzip gutenberg.zip -d tags/$VERSION
-                      rm gutenberg.zip
+            - name: Download and unzip Gutenberg plugin asset into trunk folder
+              env:
+                  PLUGIN_URL: ${{ github.event.release.assets[0].browser_download_url }}
+              run: |
+                  # do the magic here
+                  curl -L -o gutenberg.zip $PLUGIN_URL
+                  unzip gutenberg.zip -d tags/$VERSION
+                  rm gutenberg.zip
 
-                - name: Replace the stable tag placeholder with the existing stable tag on the SVN repository
-                  env:
-                      STABLE_TAG_PLACEHOLDER: 'Stable tag: V\.V\.V'
-                  run: |
-                      sed -i "s/$STABLE_TAG_PLACEHOLDER/Stable tag: $VERSION/g" ./tags/$VERSION/readme.txt
+            - name: Replace the stable tag placeholder with the existing stable tag on the SVN repository
+              env:
+                  STABLE_TAG_PLACEHOLDER: 'Stable tag: V\.V\.V'
+              run: |
+                  sed -i "s/$STABLE_TAG_PLACEHOLDER/Stable tag: $VERSION/g" ./tags/$VERSION/readme.txt
 
-                - name: Download Changelog Artifact
-                  uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
-                  with:
-                      name: changelog trunk
-                      path: tags/${{ github.event.release.name }}
+            - name: Download Changelog Artifact
+              uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+              with:
+                  name: changelog trunk
+                  path: tags/${{ github.event.release.name }}
 
-                - name: Commit the content changes
-                  working-directory: ./tags
-                  run: |
-                      svn st | grep '^?' | awk '{print $2}' | xargs -r svn add
-                      svn st | grep '^!' | awk '{print $2}' | xargs -r svn rm
-                      svn commit -m "Committing version $VERSION" \
-                       --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+            - name: Commit the content changes
+              working-directory: ./tags
+              run: |
+                  svn st | grep '^?' | awk '{print $2}' | xargs -r svn add
+                  svn st | grep '^!' | awk '{print $2}' | xargs -r svn rm
+                  svn commit -m "Committing version $VERSION" \
+                   --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -24,7 +24,7 @@ jobs:
                   # If the version being released by this workflow is > than the last one published
                   # in the SVN repo, then it will be published as trunk and replace the last version
                   # on SVN. If it's <, then it will only be published as a tag.
-                  echo "version=v15.9.0" >> $GITHUB_OUTPUT
+                  echo "version=v16.1.0" >> $GITHUB_OUTPUT
 
             - name: Decide if it is a trunk or tag update
               id: compute_should_update_trunk


### PR DESCRIPTION
## What?

Allows the creation + release (as a`tag` in the WP SVN repo) of a point release for a given stable release, even when a newer (leaf/`latest`) stable release is present. The release should not be marked as `latest` when publishing and it will then run through a fork of the upload step that will ship it as a branch (under the `branches` directory) in the WP plugin repo (+ tag it under `tags`).

## Why?

Currently, if (a) bug(s) is(are) found in a given version of Gutenberg and a fix is worked on, we can then ship this fix(es) as a patch release for that version. However, sometimes during the window of time the bug was reported/fix implemented, **it could happen that the next stable release is shipped and that the next stable release isn't suitable to be released due to other newly-introduced issues. This effectively prevents a point release from being released for the previous stable release (which is not the `latest` anymore at this point). In the best case, the user must wait for the next version, which might take longer due to new issues that need to be worked out**. This can be a dangerous proposition as a new version might bring more issues and needs further testing, especially in big multisite WordPress instances like Wordpress.com, effectively creating a significant bottleneck for shipping the fix(es). Because of that, **we should be able to ship patch releases for older stable releases, even if a new stable release is already out, to have a faster turnaround when shipping bug-fixes. That's the goal of this changeset.**

## How?

- By allowing version bumping for old stable releases even if a new stable release is already out in `build-plugin-zip.yml` ([#](https://github.com/WordPress/gutenberg/pull/49082/files#diff-40b47d855e2cffe931290bba37c1b8716642627cbe05ac859728cb95c5da7536R59))
- By adding a new upload task to `upload-release-to-plugin-repo.yml` ([#](https://github.com/WordPress/gutenberg/pull/49082/files#diff-54a0a47c3496a3f17fce904a8bb01362b517363222210779f7dadb4e8fa2edd3R178)) that uploads that patch release as a branch (and tags it) to the WP plugins repo SVN. In this case, it leaves out `trunk` untouched in the SVN repo. **This step only runs if the `latest` stable (fetched using the GH API) differs from the published version**; otherwise, the `upload as trunk` runs instead. For this to work well, the GitHub draft release for this patch-release should NOT be marked as the `latest` release when it's published, or it will be considered the last release by the workflow and will replace `trunk`!*[0]
- It shouldn't affect the other existing scenarios.

_*[0] I don't see this as a huge problem, as long as we document this well. Also, this will often be done by people that understand the workflow and only in cases when an older patch release is needed when a new stable version is out, which shouldn't be too common (but still critical to ship when it happens!). Finally, if it happens that a patch-release for an older stable version ends in `trunk` because someone forgot to uncheck `Set as the latest release` when publishing, we can always revert the changes in the SVN repo manually._


## Testing Instructions

Testing this isn't very pleasant, but possible. You'll need `ngrok` (or equivalent tunnel tool) and a local web-dav-enabled svn server exposed via the tunnel. I've used this one: https://hub.docker.com/r/elleflorio/svn-server.

1. Fork the Gutenberg repo (not this repo). Make sure to recreate all the secrets from here. The ones needed are the SVN server username and password; the others are optional. Your new fork will not have any releases on the `releases` page, don't be surprised. 
2. Create a new release for the latest release tag, manually. I.e if the latest release for GB was 15.4.1, create a new release that points to this tag and is `latest`.
3. [Apply this diff](https://github.com/WordPress/gutenberg/pull/49082/commits/8cd123127c360a5035e2345960d913bbec74b280) to `trunk` and the the latest release branch (i.e `release/15.4`), and change the `PLUGIN_REPO_URL` to your tunnel URL.
4. Ensure your svn server is running and exposed to the web!

### Scenarios (happy paths)

#### Stable point release for the `latest` release
1. Go to `Actions->Build Gutenberg Plugin Zip`, leave `trunk` as the branch, and in the `rc or stable?` input box, type `stable`.
2. Once the action finishes, go to the `/releases` page, you should see a draft for the new patch release; click the pencil icon to edit it and then `Publish`. You should leave `Set as the latest release` checked here.
3. Go to actions again and open the `Update Changelog and upload Gutenberg plugin to WordPress.org plugin repo ` (you will need to click `Show more workflows` in the sidebar to see it). 
4. Once it finishes, you should see the release published under `/releases` as `latest` and also in your SVN repo under `trunk` and under `tags/$VERSION` where `$VERSION` is the bumped version for this patch release.

#### Create a RC in order to create a new stable release

Let's create an RC to create a new stable release later:

1. Go to `Actions->Build Gutenberg Plugin Zip`, leave `trunk` as the branch, and in the `rc or stable?` input box, type `rc`.
2. Once the action finishes, go to the `/releases` page, you should see a draft for the new patch release, click the pencil icon to edit it and then `Publish`. You should leave `Set as prerelease` checked.

Now we have a new release branch and are ready to create a new stable release!

#### Create and publish a new stable release

This will set the ground for the last test, which will be to ship a point release for your previous stable release.

1. Go to `Actions->Build Gutenberg Plugin Zip`, leave `trunk` as the branch, and in the `rc or stable?` input box, type `stable`.
2. Once the action finishes, go to the `/releases` page; you should see a draft for the new patch release; click the pencil icon to edit it and then `Publish`. You should leave `Set as the latest release` checked here.
3. Go to actions again and open the `Update Changelog and upload Gutenberg plugin to WordPress.org plugin repo ` (you must click `Show more workflows` in the sidebar to see it). 
4. Once it finishes, you should see the release published under `/releases` as `latest` and also in your SVN repo under `trunk` and under `tags/$VERSION` where `$VERSION` is the new stable release.

#### Create and publish a patch release for the previous stable release

This is the scenario that has been implemented in this changeset. Let's go ahead and test it out.

1. Go to `Actions->Build Gutenberg Plugin Zip`, select your previous stable release branch (i.e `release/15.4` if the new one is `release/15.5`) as the branch, and in the `rc or stable?` input box, type `stable`.
2. Once the action finishes, go to the `/releases` page; you should see a draft for the new patch release; click the pencil icon to edit it and then `Publish`. **IMPORTANT: You msut UNCHECK `Set as the latest release` checkbox, or it will be considered a regular `latest` release and will be pushed to the `trunk` of the WP SVN repo!**
3. Go to actions again and open the `Update Changelog and upload Gutenberg plugin to WordPress.org plugin repo` (you will need to click `Show more workflows` in the sidebar to see it). 
4. Once it finishes, you should see the release published under `/releases`. It won't be set as `latest`. It will also your SVN repo under `branches/$VERSION` and `tags/$VERSION` where `$VERSION` is the new stable release.

## Illustrative Screenshots

| ![Screenshot from 2023-03-14 18-58-20](https://user-images.githubusercontent.com/81248/225180710-a1ba281c-04c8-4011-8a04-4122e72e08f3.png) |
|---|
| _The `Update Changelog and upload Gutenberg plugin to WordPress.org plugin repo` workflow for `latest` stable (point or not) releases._ |

| ![Screenshot from 2023-03-14 19-39-52](https://user-images.githubusercontent.com/81248/225182567-4d463051-1b84-49c3-871d-613d917e62fe.png) |
|---|
| _The `Update Changelog and upload Gutenberg plugin to WordPress.org plugin repo` workflow for `non-latest` stable point-releases._ |

| ![Screenshot from 2023-03-14 18-57-13](https://user-images.githubusercontent.com/81248/225176137-5c1de1c8-68d6-4bb2-8c54-bb4fbb00acd6.png) |
|---|
| _The "non-`latest`" stable point-releases are created as a branch in the SVN repo. It's also copied over to `tags`, too._ |


## TODO
* [ ] Document the new release scenario https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/code/release.md
* [ ] Figure out if there is a way to make the `Set as the latest release` checkbox unchecked by default for the previous-release (non-latest) patch releases? Please look at step 2) of the last test scenario for further context.

