### PR TITLE
@wordpress/core-data: Fix type Attachment.media_details

### DIFF
--- a/packages/core-data/src/entity-types/attachment.ts
+++ b/packages/core-data/src/entity-types/attachment.ts
@@ -18,7 +18,13 @@ interface imageDetails {
 	width: number;
 	height: number;
 	file: string;
-	sizes?: Record< string, Omit< imageDetails, 'sizes' > & { source_url: string; mine_type: string; } >;
+	sizes?: Record<
+		string,
+		Omit< imageDetails, 'sizes' > & {
+			source_url: string;
+			mine_type: string;
+		}
+	>;
 }
 
 declare module './base-entity-records' {

--- a/packages/core-data/src/entity-types/attachment.ts
+++ b/packages/core-data/src/entity-types/attachment.ts
@@ -14,6 +14,13 @@ import type {
 
 import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
 
+interface imageDetails {
+	width: number;
+	height: number;
+	file: string;
+	sizes?: Record< string, Omit< imageDetails, 'sizes' > & { source_url: string; mine_type: string; } >;
+}
+
 declare module './base-entity-records' {
 	export namespace BaseEntityRecords {
 		export interface Attachment< C extends Context > {
@@ -124,7 +131,7 @@ declare module './base-entity-records' {
 			/**
 			 * Details about the media file, specific to its type.
 			 */
-			media_details: Record< string, string >;
+			media_details: imageDetails | Record< string, any >;
 			/**
 			 * The ID for the associated post of the attachment.
 			 */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix invalid type `Attachment.media_details`.

## Why?
The current `Attachment.media_details` is `Record<string,string>`, but at least in `media_details` with image media, the `sizes` field is an object and the types do not match.

## How?
Define again the fields commonly used for image media. Also, since media such as audio are not necessarily `Record<string,string>`, changed to `Record<string,any>`.