### PR TITLE
Sticky Position: Add a "Make sticky" action to the Template Part block

### DIFF
--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -7,6 +7,7 @@ import { lock } from './lock-unlock';
 import OffCanvasEditor from './components/off-canvas-editor';
 import LeafMoreMenu from './components/off-canvas-editor/leaf-more-menu';
 import { ComposedPrivateInserter as PrivateInserter } from './components/inserter';
+import { default as useConvertToGroupButtonProps } from './components/convert-to-group-buttons/use-convert-to-group-button-props';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -18,4 +19,5 @@ lock( privateApis, {
 	LeafMoreMenu,
 	OffCanvasEditor,
 	PrivateInserter,
+	useConvertToGroupButtonProps,
 } );

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -8,6 +8,10 @@ import OffCanvasEditor from './components/off-canvas-editor';
 import LeafMoreMenu from './components/off-canvas-editor/leaf-more-menu';
 import { ComposedPrivateInserter as PrivateInserter } from './components/inserter';
 import { default as useConvertToGroupButtonProps } from './components/convert-to-group-buttons/use-convert-to-group-button-props';
+import {
+	hasStickyPositionSupport,
+	useIsPositionDisabled,
+} from './hooks/position';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -20,4 +24,6 @@ lock( privateApis, {
 	OffCanvasEditor,
 	PrivateInserter,
 	useConvertToGroupButtonProps,
+	hasStickyPositionSupport,
+	useIsPositionDisabled,
 } );

--- a/packages/edit-site/src/components/template-part-converter/convert-to-sticky-group.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-sticky-group.js
@@ -59,7 +59,7 @@ export default function ConvertToStickyGroup( { selectedClientIds, onClose } ) {
 				...( newBlocks[ 0 ].attributes.style || {} ),
 				position: {
 					type: 'sticky',
-					top: '0',
+					top: '0px',
 				},
 			};
 			replaceBlocks( clientIds, newBlocks );

--- a/packages/edit-site/src/components/template-part-converter/convert-to-sticky-group.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-sticky-group.js
@@ -1,0 +1,83 @@
+/**
+ * WordPress dependencies
+ */
+import { switchToBlockType } from '@wordpress/blocks';
+import { MenuItem } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import {
+	store as blockEditorStore,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../private-apis';
+
+const { useConvertToGroupButtonProps } = unlock( blockEditorPrivateApis );
+
+export default function ConvertToStickyGroup( { selectedClientIds, onClose } ) {
+	const { replaceBlocks } = useDispatch( blockEditorStore );
+	const {
+		clientIds,
+		isGroupable,
+		// isUngroupable,
+		blocksSelection,
+		groupingBlockName,
+	} = useConvertToGroupButtonProps( selectedClientIds );
+
+	const { canRemove, hasParents } = useSelect(
+		( select ) => {
+			const { getBlockParents, canRemoveBlocks } =
+				select( blockEditorStore );
+			return {
+				canRemove: canRemoveBlocks( clientIds ),
+				hasParents: !! getBlockParents( clientIds[ 0 ] ).length,
+			};
+		},
+		[ clientIds ]
+	);
+
+	const onConvertToGroup = () => {
+		const newBlocks = switchToBlockType(
+			blocksSelection,
+			groupingBlockName
+		);
+
+		if ( newBlocks && newBlocks.length > 0 ) {
+			// Because the block is not in the store yet we can't use
+			// updateBlockAttributes so need to manually update attributes.
+			newBlocks[ 0 ].attributes.layout = {
+				type: 'default',
+			};
+			newBlocks[ 0 ].attributes.style = {
+				...( newBlocks[ 0 ].attributes.style || {} ),
+				position: {
+					type: 'sticky',
+					top: '0',
+				},
+			};
+			replaceBlocks( clientIds, newBlocks );
+		}
+	};
+
+	// TODO: Add check that there is sticky support.
+	// TODO: Check that we are at the root of the document.
+
+	if ( ! isGroupable || ! canRemove || ! groupingBlockName || hasParents ) {
+		return null;
+	}
+
+	// Allow converting a single template part to standard blocks.
+	return (
+		<MenuItem
+			onClick={ () => {
+				onConvertToGroup();
+				onClose();
+			} }
+		>
+			{ __( 'Make sticky' ) }
+		</MenuItem>
+	);
+}

--- a/packages/edit-site/src/components/template-part-converter/index.js
+++ b/packages/edit-site/src/components/template-part-converter/index.js
@@ -12,6 +12,7 @@ import {
  */
 import ConvertToRegularBlocks from './convert-to-regular';
 import ConvertToTemplatePart from './convert-to-template-part';
+import { default as ConvertToStickyGroup } from './convert-to-sticky-group';
 
 export default function TemplatePartConverter() {
 	return (
@@ -36,10 +37,16 @@ function TemplatePartConverterMenuItem( { clientIds, onClose } ) {
 	// Allow converting a single template part to standard blocks.
 	if ( blocks.length === 1 && blocks[ 0 ]?.name === 'core/template-part' ) {
 		return (
-			<ConvertToRegularBlocks
-				clientId={ clientIds[ 0 ] }
-				onClose={ onClose }
-			/>
+			<>
+				<ConvertToRegularBlocks
+					clientId={ clientIds[ 0 ] }
+					onClose={ onClose }
+				/>
+				<ConvertToStickyGroup
+					selectedClientIds={ clientIds }
+					onClose={ onClose }
+				/>
+			</>
 		);
 	}
 	return <ConvertToTemplatePart clientIds={ clientIds } blocks={ blocks } />;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of https://github.com/WordPress/gutenberg/issues/47043

Add a "Make sticky" action to template part blocks, that wraps a Template Part block in a Group block with sticky position settings set. This action is visible in the block settings menu, either in the editor canvas, or in the list view. It is only visible if the Template Part block is at the root level of the document.

This explores an idea from this comment: https://github.com/WordPress/gutenberg/pull/47133#issuecomment-1385285873

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To make it easier for a user to set a Template Part block to be sticky — rather than having to know to create a Group block and wrap the Template Part block with it, hopefully this action should be a little easier.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Use a similar approach to the Grouping buttons/actions:

* Add a menu item that transforms the Template Part block to Group (wrapping it in a Group block).
* Inject block attributes that correspond to the full width default layout + sticky position and top `0px` to stick the block to the top of the viewport when scrolled past the edge of the screen.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Test with TT3 theme, which has `appearanceTools` set to `true`.
2. In the site editor, within your Header template part, set a Group block to have a background color, so that it'll be visible when scrolled.
3. Within the List View, select the Header template part at the root of the document.
4. In the ellipsis menu, select "Make sticky"
5. The template part block should now be wrapped in a sticky group block. If you scroll the page, the block should stick to the top of the screen. Note that TT3 includes some site-wide top padding — if you see some space above the Header, update your global styles to set the top padding to `0`.
6. Repeat with the Block Toolbar menu instead of the list view when setting to sticky.
7. Revert the changes, and update your theme's `theme.json` file to set `settings.appearanceTools` to `false` and reload the site editor. When the Header template part block is at the root of the document, you should not have a "Make sticky" option available in the settings menus.

## Screenshots or screencast <!-- if applicable -->

The flow for wrapping in a sticky group — note that the Ungroup menu item is a simple way to revert if folks need it:

https://user-images.githubusercontent.com/14988353/225210911-66db0688-68be-401f-81bc-c62391319694.mp4

| List View menu | Toolbar menu |
| --- | --- |
| <img width="573" alt="image" src="https://user-images.githubusercontent.com/14988353/225214079-5b40f55d-9fc8-469c-ae08-cc23e03b4ff6.png"> | <img width="645" alt="image" src="https://user-images.githubusercontent.com/14988353/225214190-c6e7f7d2-85c4-422b-961d-98661e47e894.png"> |