### PR TITLE
Invalid Page address displayed when a future page is first scheduled

### DIFF
--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -17,6 +17,7 @@ import PostScheduleLabel from '../post-schedule/label';
 import { store as editorStore } from '../../store';
 
 const POSTNAME = '%postname%';
+const PAGENAME = '%pagename%';
 
 /**
  * Returns URL for a future post.
@@ -31,6 +32,10 @@ const getFuturePostUrl = ( post ) => {
 
 	if ( post.permalink_template.includes( POSTNAME ) ) {
 		return post.permalink_template.replace( POSTNAME, slug );
+	}
+
+	if ( post.permalink_template.includes( PAGENAME ) ) {
+		return post.permalink_template.replace( PAGENAME, slug );
 	}
 
 	return post.permalink_template;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR fixes the permalink of page posts or any other CPT posts when they are scheduled in the future.

## Why?
Resolves: #29477

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
While generating permalink of future pages or future CPT posts, it was having a structure like this `http://localhost:8889/%pagename%/` and this PR will replace the `%pagename%` tag with a slug of that page or CPT post.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Add a new page
2. Set the published date to the future
3. Schedule the page.
4. Confirm Schedule

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before PR 

https://user-images.githubusercontent.com/40795917/225298403-876798f9-96e0-4a19-b2c5-d79d74424983.mov

### After PR

https://user-images.githubusercontent.com/40795917/225298418-b2455274-d389-4c84-b5e8-832d2c4910c7.mov

