### PR TITLE
Buttons: Disable edit as HTML support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -59,7 +59,7 @@ Prompt visitors to take action with a group of button-style links. ([Source](htt
 
 -	**Name:** core/buttons
 -	**Category:** design
--	**Supports:** align (full, wide), anchor, spacing (blockGap, margin), typography (fontSize, lineHeight)
+-	**Supports:** align (full, wide), anchor, spacing (blockGap, margin), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** 
 
 ## Calendar

--- a/packages/block-library/src/buttons/block.json
+++ b/packages/block-library/src/buttons/block.json
@@ -10,6 +10,7 @@
 	"supports": {
 		"anchor": true,
 		"align": [ "wide", "full" ],
+		"html": false,
 		"__experimentalExposeControlsToChildren": true,
 		"spacing": {
 			"blockGap": true,


### PR DESCRIPTION
## What?
Resolves #49095.
A similar PRs: #11785, #39318.

PR disabled HTML editing for the Buttons block.

## Why?
> Editing these wrapper blocks in HTML directly is fragile and prone to breaking the users' content. HTML editing should be left to leaf-blocks.

- https://github.com/WordPress/gutenberg/pull/11785#issue-380011111

## Testing Instructions
1. Open a Post or Page.
2. Insert a Buttons block.
3. Confirm "Edit as HTML" action isn't available in block Options.

### Testing Instructions for Keyboard
Same as general instruction.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-03-15 at 17 33 39](https://user-images.githubusercontent.com/240569/225325379-a47e6b21-2cde-4749-bd96-bb195517b599.png)
