### PR TITLE
Storybook: Declare stylesheet dependencies explicitly

### DIFF
--- a/storybook/decorators/with-rtl.js
+++ b/storybook/decorators/with-rtl.js
@@ -12,8 +12,7 @@ import {
 /**
  * Internal dependencies
  */
-import ltrStyles from '../style-ltr.lazy.scss';
-import rtlStyles from '../style-rtl.lazy.scss';
+import CONFIG from '../package-styles/config';
 
 export const WithRTL = ( Story, context ) => {
 	const [ rerenderKey, setRerenderKey ] = useState( 0 );
@@ -43,17 +42,20 @@ export const WithRTL = ( Story, context ) => {
 	}, [ context.globals.direction ] );
 
 	useLayoutEffect( () => {
-		if ( context.globals.direction === 'rtl' ) {
-			rtlStyles.use();
-		} else {
-			ltrStyles.use();
-		}
+		const stylesToUse = [];
+
+		CONFIG.forEach( ( item ) => {
+			if ( item.componentIdMatcher.test( context.componentId ) ) {
+				stylesToUse.push( ...item[ context.globals.direction ] );
+			}
+		} );
+
+		stylesToUse.forEach( ( style ) => style.use() );
 
 		return () => {
-			ltrStyles.unuse();
-			rtlStyles.unuse();
+			stylesToUse.forEach( ( style ) => style.unuse() );
 		};
-	}, [ context.globals.direction ] );
+	}, [ context.componentId, context.globals.direction ] );
 
 	return (
 		<div ref={ ref } key={ rerenderKey }>

--- a/storybook/package-styles/block-editor-ltr.lazy.scss
+++ b/storybook/package-styles/block-editor-ltr.lazy.scss
@@ -1,0 +1,1 @@
+@import "../../packages/block-editor/build-style/style";

--- a/storybook/package-styles/block-editor-rtl.lazy.scss
+++ b/storybook/package-styles/block-editor-rtl.lazy.scss
@@ -1,0 +1,1 @@
+@import "../../packages/block-editor/build-style/style-rtl";

--- a/storybook/package-styles/block-library-ltr.lazy.scss
+++ b/storybook/package-styles/block-library-ltr.lazy.scss
@@ -1,0 +1,3 @@
+@import "../../packages/block-library/build-style/style";
+@import "../../packages/block-library/build-style/theme";
+@import "../../packages/block-library/build-style/editor";

--- a/storybook/package-styles/block-library-rtl.lazy.scss
+++ b/storybook/package-styles/block-library-rtl.lazy.scss
@@ -1,0 +1,3 @@
+@import "../../packages/block-library/build-style/style-rtl";
+@import "../../packages/block-library/build-style/theme-rtl";
+@import "../../packages/block-library/build-style/editor-rtl";

--- a/storybook/package-styles/components-ltr.lazy.scss
+++ b/storybook/package-styles/components-ltr.lazy.scss
@@ -1,0 +1,1 @@
+@import "../../packages/components/build-style/style";

--- a/storybook/package-styles/components-rtl.lazy.scss
+++ b/storybook/package-styles/components-rtl.lazy.scss
@@ -1,0 +1,1 @@
+@import "../../packages/components/build-style/style-rtl";

--- a/storybook/package-styles/config.js
+++ b/storybook/package-styles/config.js
@@ -1,0 +1,49 @@
+/**
+ * Internal dependencies
+ */
+import blockEditorLtr from '../package-styles/block-editor-ltr.lazy.scss';
+import blockEditorRtl from '../package-styles/block-editor-rtl.lazy.scss';
+import blockLibraryLtr from '../package-styles/block-library-ltr.lazy.scss';
+import blockLibraryRtl from '../package-styles/block-library-rtl.lazy.scss';
+import componentsLtr from '../package-styles/components-ltr.lazy.scss';
+import componentsRtl from '../package-styles/components-rtl.lazy.scss';
+import formatLibraryLtr from '../package-styles/format-library-ltr.lazy.scss';
+import formatLibraryRtl from '../package-styles/format-library-rtl.lazy.scss';
+
+/**
+ * Stylesheets to lazy load when the story's context.componentId matches the
+ * componentIdMatcher regex.
+ *
+ * To prevent problematically overscoped styles in a package stylesheet
+ * from leaking into stories for other packages, we should explicitly declare
+ * stylesheet dependencies for each story group.
+ */
+const CONFIG = [
+	{
+		componentIdMatcher: /^playground-/,
+		ltr: [
+			componentsLtr,
+			blockEditorLtr,
+			blockLibraryLtr,
+			formatLibraryLtr,
+		],
+		rtl: [
+			componentsRtl,
+			blockEditorRtl,
+			blockLibraryRtl,
+			formatLibraryRtl,
+		],
+	},
+	{
+		componentIdMatcher: /^blockeditor-/,
+		ltr: [ componentsLtr, blockEditorLtr ],
+		rtl: [ componentsRtl, blockEditorRtl ],
+	},
+	{
+		componentIdMatcher: /^components-/,
+		ltr: [ componentsLtr ],
+		rtl: [ componentsRtl ],
+	},
+];
+
+export default CONFIG;

--- a/storybook/package-styles/format-library-ltr.lazy.scss
+++ b/storybook/package-styles/format-library-ltr.lazy.scss
@@ -1,0 +1,1 @@
+@import "../../packages/format-library/build-style/style";

--- a/storybook/package-styles/format-library-rtl.lazy.scss
+++ b/storybook/package-styles/format-library-rtl.lazy.scss
@@ -1,0 +1,1 @@
+@import "../../packages/format-library/build-style/style-rtl";

--- a/storybook/style-ltr.lazy.scss
+++ b/storybook/style-ltr.lazy.scss
@@ -1,7 +1,0 @@
-// @wordpress package styles (ltr)
-@import "../packages/components/build-style/style";
-@import "../packages/block-editor/build-style/style";
-@import "../packages/block-library/build-style/style";
-@import "../packages/block-library/build-style/theme";
-@import "../packages/block-library/build-style/editor";
-@import "../packages/format-library/build-style/style";

--- a/storybook/style-rtl.lazy.scss
+++ b/storybook/style-rtl.lazy.scss
@@ -1,7 +1,0 @@
-// @wordpress package styles (rtl)
-@import "../packages/components/build-style/style-rtl";
-@import "../packages/block-editor/build-style/style-rtl";
-@import "../packages/block-library/build-style/style-rtl";
-@import "../packages/block-library/build-style/theme-rtl";
-@import "../packages/block-library/build-style/editor-rtl";
-@import "../packages/format-library/build-style/style-rtl";


### PR DESCRIPTION
Closes #49057 

## What?

Adds additional config to the Storybook `withRTL` decorator so only explicitly declared stylesheet dependencies will be loaded for a given story group.

## Why?

To properly isolate stories from problematic, leaky styles. There can sometimes be some overscoped styles in a given package's stylesheet, which can inadvertently affect an upstream or peer package's story. For example, if the `block-editor` package stylesheet contained a style like `.components-modal { background: yellow; }`, we would not want to load that style for the `Modal` component story.

## How?

I tried to structure this in a way that would be clear for other devs how to extend the config when they want to add new story groups. Is it discoverable, clear, and documented enough? Let me know.

## Testing Instructions

`npm run storybook:dev` and a check some stories in each story group (e.g. Playground, BlockEditor, Components, etc). Try the RTL switcher. It should look the same as in [trunk](https://wordpress.github.io/gutenberg) — if not, you may have found an isolation issue that was already there 😄

See inline code comment to see where you can add a console.log statement to verify which stylesheets are loaded.