### PR TITLE
Update Gallery block to use consistent 40px components

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -578,6 +578,7 @@ function GalleryEdit( props ) {
 						onChange={ setLinkTo }
 						options={ linkOptions }
 						hideCancelButton={ true }
+						size="__unstable-large"
 					/>
 					{ hasLinkTo && (
 						<ToggleControl
@@ -598,6 +599,7 @@ function GalleryEdit( props ) {
 							options={ imageSizeOptions }
 							onChange={ updateImagesSize }
 							hideCancelButton={ true }
+							size="__unstable-large"
 						/>
 					) }
 					{ Platform.isWeb && ! imageSizeOptions && hasImageIds && (

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -562,6 +562,7 @@ function GalleryEdit( props ) {
 							max={ Math.min( MAX_COLUMNS, images.length ) }
 							{ ...MOBILE_CONTROL_PROPS_RANGE_CONTROL }
 							required
+							size="__unstable-large"
 						/>
 					) }
 					<ToggleControl


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Updates the Gallery block controls to use `size="__unstable-large"` in support of https://github.com/WordPress/gutenberg/issues/46734 (and pointed out [here](https://github.com/WordPress/gutenberg/pull/49074#pullrequestreview-1340812337)). 

RangeControl does not support this currently, but I added the prop so that when it does, we get that already.  

## Why?
Consistency.

## How?
Adds the `size` prop to the Gallery block's Inspector.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page.
2. Insert a Gallery block. 
3. Add a couple images to the Gallery block.
4. Open Block Inspector.
5. See 40px input fields (not the RangeControl).

## Screenshots or screencast <!-- if applicable -->

Before: 

<img width="279" alt="CleanShot 2023-03-15 at 11 26 39" src="https://user-images.githubusercontent.com/1813435/225358609-048d6ff4-a23b-41aa-abe0-ed85661227b4.png">

After: 

<img width="281" alt="CleanShot 2023-03-15 at 11 25 49" src="https://user-images.githubusercontent.com/1813435/225358352-198e721f-0739-4a64-ae3e-b5377182b8d3.png">

