### PR TITLE
Add Post Date block variation for Post Modified Date

### DIFF
--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -76,12 +76,15 @@ export default function PostDateEdit( {
 		[ postTypeSlug ]
 	);
 
+	const dateLabel =
+		displayType === 'date' ? __( 'Post Date' ) : __( 'Post Modified Date' );
+
 	let postDate = date ? (
 		<time dateTime={ dateI18n( 'c', date ) } ref={ setPopoverAnchor }>
 			{ dateI18n( format || siteFormat, date ) }
 		</time>
 	) : (
-		__( 'Post Date' )
+		dateLabel
 	);
 
 	if ( isLink && date ) {

--- a/packages/block-library/src/post-date/index.js
+++ b/packages/block-library/src/post-date/index.js
@@ -10,6 +10,7 @@ import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
 import deprecated from './deprecated';
+import variations from './variations';
 
 const { name } = metadata;
 export { metadata, name };
@@ -18,6 +19,7 @@ export const settings = {
 	icon,
 	edit,
 	deprecated,
+	variations,
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/post-date/variations.js
+++ b/packages/block-library/src/post-date/variations.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { postDate } from '@wordpress/icons';
+
+const variations = [
+	{
+		name: 'post-date-modified',
+		title: __( 'Post Modified Date' ),
+		description: __( "Display a post's last updated date." ),
+		attributes: { displayType: 'modified' },
+		scope: [ 'block', 'inserter' ],
+		isActive: ( blockAttributes ) =>
+			blockAttributes.displayType === 'modified',
+		icon: postDate,
+	},
+];
+
+export default variations;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds a block variation for the core/post-date block so that one can search for, and directly add, the modified date to a template. It's the same block—just easier to add. Closes #49093.

## Why?
Makes it easier to discover and add the modified date, instead of adding a post date block, then opening the Block Inspector and toggling the displayType attribute. 

## How?
1. Add a block variation for core/post-date
2. Add logic to render "Post Date" or "Post Modified Date" based on displayType

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page.
2. Search in the Block Inserter for the "Modified Post Date" block. 
3. Add the block variation to the Post or Page.
4. See that "Modified Post Date" render in the block content. 
5. Toggle off "Display last modified date".
6. See "Post Date" render in the block content.
7. See the block transform back to the "Post Date" block.

## Screenshots or screencast <!-- if applicable -->

<img width="917" alt="CleanShot 2023-03-15 at 14 08 50" src="https://user-images.githubusercontent.com/1813435/225414336-53cf9aac-ac3f-44ef-8d80-bb4df4f5f8c0.png">

<img width="1485" alt="CleanShot 2023-03-15 at 14 09 25" src="https://user-images.githubusercontent.com/1813435/225414434-c0e0f73c-9911-435a-a28e-6a8cec866526.png">