### PR TITLE
ImageSizeControl: Use large 40px sizes

### DIFF
--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -43,6 +43,7 @@ export default function ImageSizeControl( {
 					options={ imageSizeOptions }
 					onChange={ onChangeImage }
 					help={ imageSizeHelp }
+					size="__unstable-large"
 				/>
 			) }
 			{ isResizable && (
@@ -58,6 +59,7 @@ export default function ImageSizeControl( {
 							onChange={ ( value ) =>
 								updateDimension( 'width', value )
 							}
+							size="__unstable-large"
 						/>
 						<NumberControl
 							className="block-editor-image-size-control__height"
@@ -67,6 +69,7 @@ export default function ImageSizeControl( {
 							onChange={ ( value ) =>
 								updateDimension( 'height', value )
 							}
+							size="__unstable-large"
 						/>
 					</HStack>
 					<HStack>
@@ -97,6 +100,7 @@ export default function ImageSizeControl( {
 												scaledWidth
 											)
 										}
+										size="__unstable-large"
 									>
 										{ scale }%
 									</Button>

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -100,7 +100,6 @@ export default function ImageSizeControl( {
 												scaledWidth
 											)
 										}
-										size="__unstable-large"
 									>
 										{ scale }%
 									</Button>

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   `CustomGradientPicker`: improve initial state UI ([#49146](https://github.com/WordPress/gutenberg/pull/49146)).
 -	`AnglePickerControl`: Style to better fit in narrow contexts and improve RTL layout ([#49046](https://github.com/WordPress/gutenberg/pull/49046)).
+-   `ImageSizeControl`: Use large 40px sizes ([#49113](https://github.com/WordPress/gutenberg/pull/49113)).
 
 ### Bug Fix
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates the `SelectControl` and `NumberControl` components within `ImageSizeControl` to use the larger sizes.

## Why?
Supporting https://github.com/WordPress/gutenberg/issues/46734.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page.
2. Insert an Image Block.
3. See 40px sized ImageSizeControl

## Screenshots

Before: 

<img width="281" alt="CleanShot 2023-03-15 at 15 43 58" src="https://user-images.githubusercontent.com/1813435/225425181-e96932cd-0a7f-427d-9eec-b5c35ab6104b.png">

After: 

<img width="278" alt="CleanShot 2023-03-15 at 15 40 42" src="https://user-images.githubusercontent.com/1813435/225424637-3753d641-75bc-450c-aef6-1a653335c810.png">

## Notes

The 25/50/75/100/Reset buttons are omitted intentionally (https://github.com/WordPress/gutenberg/issues/48618#issuecomment-1451460526).  
