### PR TITLE
Fix misaligned textarea input control

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,10 @@
 -   `CustomGradientPicker`: improve initial state UI ([#49146](https://github.com/WordPress/gutenberg/pull/49146)).
 -	`AnglePickerControl`: Style to better fit in narrow contexts and improve RTL layout ([#49046](https://github.com/WordPress/gutenberg/pull/49046)).
 
+### Bug Fix
+
+-  `InputControl`: Fix misaligned textarea input control ([#49116](https://github.com/WordPress/gutenberg/pull/49116).
+
 ## 23.6.0 (2023-03-15)
 
 ### Enhancements
@@ -24,7 +28,6 @@
 -   `ResponsiveWrapper`: use `aspect-ratio` CSS prop, add support for `SVG` elements ([#48573](https://github.com/WordPress/gutenberg/pull/48573).
 -   `ResizeTooltip`: Use `default.fontFamily` on tooltip ([#48805](https://github.com/WordPress/gutenberg/pull/48805).
 -   `InputControl`: Fix misaligned textarea input control ([#49116](https://github.com/WordPress/gutenberg/pull/49116).
-
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -27,7 +27,6 @@
 
 -   `ResponsiveWrapper`: use `aspect-ratio` CSS prop, add support for `SVG` elements ([#48573](https://github.com/WordPress/gutenberg/pull/48573).
 -   `ResizeTooltip`: Use `default.fontFamily` on tooltip ([#48805](https://github.com/WordPress/gutenberg/pull/48805).
--   `InputControl`: Fix misaligned textarea input control ([#49116](https://github.com/WordPress/gutenberg/pull/49116).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 -   `ResponsiveWrapper`: use `aspect-ratio` CSS prop, add support for `SVG` elements ([#48573](https://github.com/WordPress/gutenberg/pull/48573).
 -   `ResizeTooltip`: Use `default.fontFamily` on tooltip ([#48805](https://github.com/WordPress/gutenberg/pull/48805).
+-   `InputControl`: Fix misaligned textarea input control ([#49116](https://github.com/WordPress/gutenberg/pull/49116).
+
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Bug Fix
 
--  `InputControl`: Fix misaligned textarea input control ([#49116](https://github.com/WordPress/gutenberg/pull/49116).
+-  `InputControl`: Fix misaligned textarea input control ([#49116](https://github.com/WordPress/gutenberg/pull/49116)).
 
 ## 23.6.0 (2023-03-15)
 

--- a/packages/components/src/utils/input/input-control.js
+++ b/packages/components/src/utils/input/input-control.js
@@ -12,6 +12,7 @@ import { COLORS } from '../colors-values';
 import { breakpoint } from '../breakpoint';
 
 export const inputControl = css`
+	display: block;
 	font-family: ${ font( 'default.fontFamily' ) };
 	padding: 6px 8px;
 	${ inputStyleNeutral };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes https://github.com/WordPress/gutenberg/issues/49115 — although there may be a better way?

## Why?
Consistency.

## How?
Adds `display: block` to `inputControl`, which removes the excess space that occurs after the textarea. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page.
2. Insert an Image block. 
3. Open "Advanced" panel within the Block Inspector.
4. See the space between the "Alt text" textarea and help text is the same as the other inputs within the Advanced panel.

## Screenshots or screencast <!-- if applicable -->

<img width="851" alt="CleanShot 2023-03-15 at 16 19 13" src="https://user-images.githubusercontent.com/1813435/225432557-c4aba70e-eefa-4bd5-9a61-c34979fb3690.png">
