### PR TITLE
Add column-gap and row-gap as allowed CSS properties for compatibility with WP 6.0

### DIFF
--- a/lib/compat/wordpress-6.1/blocks.php
+++ b/lib/compat/wordpress-6.1/blocks.php
@@ -16,6 +16,8 @@
 function gutenberg_safe_style_attrs_6_1( $attrs ) {
 	$attrs[] = 'flex-wrap';
 	$attrs[] = 'gap';
+	$attrs[] = 'column-gap';
+	$attrs[] = 'row-gap';
 	$attrs[] = 'margin-block-start';
 	$attrs[] = 'margin-block-end';
 	$attrs[] = 'margin-inline-start';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add the missing `column-gap` and `row-gap` CSS properties to the list of safe CSS properties for compatibility with WordPress 6.0.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When https://github.com/WordPress/gutenberg/pull/40875 was introduced, it added in the `gap` CSS property, but not `row-gap` and `column-gap`. However, when the required layout CSS properties were expanded in core in https://github.com/WordPress/wordpress-develop/pull/2928, these additional properties were included, and have been subsequently used in other features, e.g. https://github.com/WordPress/gutenberg/pull/46388 where they're used for validating indirect properties.

To ensure support for WordPress 6.0, let's make sure these two properties are included. This issue was raised in https://github.com/WordPress/gutenberg/pull/46983 which seeks to add a test job that tests against the previous WP version. For more context I've added a comment to that PR over in https://github.com/WordPress/gutenberg/pull/46983#issuecomment-1470959933

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add `column-gap` and `row-gap` to the list of allowed CSS properties.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

The easiest "real" way to test this would be to apply this on top of #46983 and see if the tests against WP 6.0 pass.

For now, simply check that I haven't made any typos, and that saving block gap values still works within the editor and saved to the site front end (e.g. add a Social Icons block and set some spacing and save, and check that the front-end still looks correct).