### PR TITLE
Post Excerpt Block: Fix unexpected commas in certain site languages

### DIFF
--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -156,7 +156,10 @@ export default function PostExcerptEditor( {
 			.split( '', excerptLength + numberOfSpaces )
 			.join( '' );
 	} else if ( wordCountType === 'characters_including_spaces' ) {
-		trimmedExcerpt = rawOrRenderedExcerpt.trim().split( '', excerptLength );
+		trimmedExcerpt = rawOrRenderedExcerpt
+			.trim()
+			.split( '', excerptLength )
+			.join( '' );
 	}
 
 	trimmedExcerpt = trimmedExcerpt + '...';


### PR DESCRIPTION
Fixes: #49121

## What?
This PR fixes an unexpected comma in the excerpt block when the word count type for that site language is `characters_including_spaces`.

## Why?
This is because the `join()`, which concatenates array elements and converts them to a string, was missing during the word count above.

## Testing Instructions

- Change to a language with a word count type of hoge. For example, Japanese:

![language](https://user-images.githubusercontent.com/54422211/225524931-77c7b87b-bd7d-4998-abc3-3413bc83303f.png)

- Update translations from the Updates menu.
- Open the site editor.
- Confirm that no unnecessary commas appear in the post excerpt block.
- Confirm that the 'Max number of words' control (In Japanese, it is displayed as `最大単語数`.) also works as expected.

### Before 

https://user-images.githubusercontent.com/54422211/225525654-1420b3e7-4590-421a-9c09-f6f8e8e29408.mp4

### After

https://user-images.githubusercontent.com/54422211/225525691-d7866d43-780b-40be-aa7a-c3343e3a2b49.mp4