### PR TITLE
Revert "Make sure the directly inserted block in the Nav block is a Page link"

### DIFF
--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -29,9 +29,6 @@ const ALLOWED_BLOCKS = [
 
 const DEFAULT_BLOCK = {
 	name: 'core/navigation-link',
-	attributes: {
-		type: 'page',
-	},
 };
 
 export default function NavigationInnerBlocks( {


### PR DESCRIPTION
Reverts WordPress/gutenberg#48740. Fixes https://github.com/WordPress/gutenberg/issues/49107

This change makes it too difficult to add other things to a navigation menu - as explained in https://github.com/WordPress/gutenberg/issues/49107

We should consider the experience here as part of the broader changes being discussed in https://github.com/WordPress/gutenberg/issues/49091