### PR TITLE
Mobile Release v1.91.0

### DIFF
--- a/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -100,13 +100,7 @@ class RCTAztecView: Aztec.TextView {
     /// the dictation engine refreshes the TextView with an empty string when the dictation finishes.
     /// This helps to avoid propagating that unwanted empty string to RN. (Solving #606)
     /// on `textViewDidChange` and `textViewDidChangeSelection`
-    private var isInsertingDictationResult: Bool = {
-        if #available(iOS 16, *) {
-            return true;
-        } else {
-            return false;
-        }
-    }()
+    private var isInsertingDictationResult = false
     
     // MARK: - Font
 
@@ -364,14 +358,10 @@ class RCTAztecView: Aztec.TextView {
     }
 
     public override func insertDictationResult(_ dictationResult: [UIDictationPhrase]) {
+        let objectPlaceholder = "\u{FFFC}"
         let dictationText = dictationResult.reduce("") { $0 + $1.text }
-        if #available(iOS 16, *) {
-            insertText(dictationText)
-        } else {
-            let objectPlaceholder = "\u{FFFC}"
-            isInsertingDictationResult = false
-            self.text = self.text?.replacingOccurrences(of: objectPlaceholder, with: dictationText)
-        }
+        isInsertingDictationResult = false
+        self.text = self.text?.replacingOccurrences(of: objectPlaceholder, with: dictationText)
     }
 
     // MARK: - Custom Edit Intercepts

--- a/packages/react-native-aztec/package.json
+++ b/packages/react-native-aztec/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-aztec",
-	"version": "1.90.0",
+	"version": "1.91.0",
 	"description": "Aztec view for react-native.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-bridge/package.json
+++ b/packages/react-native-bridge/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-bridge",
-	"version": "1.90.0",
+	"version": "1.91.0",
 	"description": "Native bridge library used to integrate the block editor into a native App.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -13,7 +13,6 @@ For each user feature we should also add a importance categorization label  to i
 
 ## 1.91.0
 -   [*] Allow new block transformations for most blocks. [#48792]
--   [**] [iOS] Fix dictation regression. [#49056]
 
 ## 1.90.0
 -   [*] Fix parsing of css units for null matched values [#48484]

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,6 +11,10 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 
+## 1.91.0
+-   [*] Allow new block transformations for most blocks. [#48792]
+-   [**] [iOS] Fix dictation regression. [#49056]
+
 ## 1.90.0
 -   [*] Fix parsing of css units for null matched values [#48484]
 -   [*] Spacer block - Add initial support for spacing presets [#47258]

--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -13,7 +13,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.69.4)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - Gutenberg (1.90.0):
+  - Gutenberg (1.91.0):
     - React-Core (= 0.69.4)
     - React-CoreModules (= 0.69.4)
     - React-RCTImage (= 0.69.4)
@@ -362,7 +362,7 @@ PODS:
     - React-Core
   - RNSVG (9.13.6):
     - React-Core
-  - RNTAztecView (1.90.0):
+  - RNTAztecView (1.91.0):
     - React-Core
     - WordPress-Aztec-iOS (~> 1.19.8)
   - SDWebImage (5.11.1):
@@ -545,7 +545,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 2ff441cbe6e58c1778d8a5cf3311831a6a8c0809
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 3d02b25ca00c2d456734d0bcff864cbc62f6ae1a
-  Gutenberg: dbb0140a7159408f2cd8031d841c7adf98e1e9ca
+  Gutenberg: fd67b0394a094ed0d475f00705ece86d99b846be
   libwebp: 60305b2e989864154bd9be3d772730f08fc6a59c
   RCT-Folly: b9d9fe1fc70114b751c076104e52f3b1b5e5a95a
   RCTRequired: bd9d2ab0fda10171fcbcf9ba61a7df4dc15a28f4
@@ -588,7 +588,7 @@ SPEC CHECKSUMS:
   RNReanimated: bea6acb5fdcbd8ca27641180579d09e3434f803c
   RNScreens: 953633729a42e23ad0c93574d676b361e3335e8b
   RNSVG: 36a7359c428dcb7c6bce1cc546fbfebe069809b0
-  RNTAztecView: 0ef32f75b63813ac5e7675696fa074d3062b8e91
+  RNTAztecView: a632287ad9e3807fe0b4460efa329b54111af4a3
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-editor",
-	"version": "1.90.0",
+	"version": "1.91.0",
 	"description": "Mobile WordPress gutenberg editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## Description
Release 1.91.0 of the react-native-editor and Gutenberg-Mobile.

For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5564

