### PR TITLE
Data: refuse to register an already registered store

### DIFF
--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   The `registry.register` function will no longer register a store if another instance is registered with the same name.
+
 ## 8.6.0 (2023-03-15)
 
 ## 8.5.0 (2023-03-01)

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -215,6 +215,10 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 	 * @param {Object} store Store instance object (getSelectors, getActions, subscribe).
 	 */
 	function registerStoreInstance( name, store ) {
+		if ( stores[ name ] ) {
+			throw new Error( 'duplicate store oh no' );
+		}
+
 		if ( typeof store.getSelectors !== 'function' ) {
 			throw new TypeError( 'store.getSelectors must be a function' );
 		}


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/74346#issuecomment-1470328236 @noahtallen ran into an issue where a data store is registered twice. Because the offending store is defined in a JS module, and registered by a static top-level call:
```js
register( store );
```
and because this module is bundled in two webpack bundles, each for a different plugin.

In this PR I'm changing the `registerStoreInstance` behavior to refuse to register a second instance. At this moment I'm throwing an error, but that's just because I want unit and e2e tests to fail as badly as possible if they happen to re-register any store. In the final version there should be just a `return` statement.

There are concerns about backward compatibility, but my intuition is it should be a much smaller issue than it looks like. Does anyone really intentionally re-register a store? The only reason would be trying to clear it back to initial state.

Another argument against re-registering is that the `useSelect` hook wouldn't react to it anyway:
```js
useSelect( s => s( 'my-store' ).get(), [] );
```
won't see any update and won't trigger any rerender when the `my-store` is swapped for another instance.

what do you think @youknowriad?