### PR TITLE
i18n: Add context to labels related to CSS position properties

### DIFF
--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -49,7 +49,7 @@ const DEFAULT_OPTION = {
 const STICKY_OPTION = {
 	key: 'sticky',
 	value: 'sticky',
-	name: _x( 'Sticky', 'CSS value' ),
+	name: _x( 'Sticky', 'Name for the value of the CSS position property' ),
 	className: OPTION_CLASSNAME,
 	__experimentalHint: __(
 		'The block will stick to the top of the window instead of scrolling.'

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -59,7 +59,7 @@ const STICKY_OPTION = {
 const FIXED_OPTION = {
 	key: 'fixed',
 	value: 'fixed',
-	name: _x( 'Fixed', 'CSS value' ),
+	name: _x( 'Fixed', 'Name for the value of the CSS position property' ),
 	className: OPTION_CLASSNAME,
 	__experimentalHint: __(
 		'The block will not move when the page is scrolled.'

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
 import {
 	BaseControl,
@@ -49,7 +49,7 @@ const DEFAULT_OPTION = {
 const STICKY_OPTION = {
 	key: 'sticky',
 	value: 'sticky',
-	name: __( 'Sticky' ),
+	name: _x( 'Sticky', 'CSS value' ),
 	className: OPTION_CLASSNAME,
 	__experimentalHint: __(
 		'The block will stick to the top of the window instead of scrolling.'
@@ -59,7 +59,7 @@ const STICKY_OPTION = {
 const FIXED_OPTION = {
 	key: 'fixed',
 	value: 'fixed',
-	name: __( 'Fixed' ),
+	name: _x( 'Fixed', 'CSS value' ),
 	className: OPTION_CLASSNAME,
 	__experimentalHint: __(
 		'The block will not move when the page is scrolled.'


### PR DESCRIPTION
## What?
This PR adds context for translation to labels (`Sticky`, `Fixed`) related to CSS position properties of the block support.

![sticky](https://user-images.githubusercontent.com/54422211/225627124-15b92b70-cb13-43d0-b97d-421e2f688f9f.png)

## Why?
The word "sticky" has long existed in the WordPress core as translated text, meaning "**place the post at the top of the post**". However, in the block editor, it represents the value of the CSS position property, meaning "**element position stuck while scrolling the page**".

In both of these contexts, the common word "sticky" may be able to use in English, but in other languages, there may not be a word that can be used in common.

I have looked at how the word "sticky" is translated into several languages:

| Language | Translation   | Direct translation to English                                 |
| -------- | ------------- | -------------------------------------------------------- |
| Japanese | 先頭固定表示  | Fixed display at the top, Fixed display at the beginning |
| Korean   | 붙박이        | Built-in, Embedded, Built-Ins                            |
| German   | Oben gehalten | Top held, Held above, Top kept, Top kept                 |
| Swedish  | Klistrat      | Paste, Paste rate, Paste                                 |
| Italian  | In evidenza   | Highlights, Featured                                     |
| French   | Épinglé       | Pinned, Pinned to, Pinned                                |

While there are differences in nuance in each language, they all seem to be aware of the context of the post. And I feel that these translations cannot be used as translations of "Sticky" in the CSS position property.

Therefore, I think we need to add a context for the word "Sticky" to indicate that it is a CSS property.

## How?
I have added context to "Fixed" label in addition to "Sticky" label, which the position property supports.

I would like to get advice from anyone who knows if this change makes sense in languages other than my own native language, Japanese.