### PR TITLE
Plugins: Add unit tests for the 'PluginArea' component

### DIFF
--- a/packages/plugins/src/components/test/plugin-area.js
+++ b/packages/plugins/src/components/test/plugin-area.js
@@ -67,7 +67,7 @@ describe( 'PluginArea', () => {
 		expect( container ).toHaveTextContent( 'plugin: bar.' );
 	} );
 
-	test( 'rerenders when new plugin is unregistered', () => {
+	test( 'rerenders when a plugin is unregistered', () => {
 		registerPlugin( 'one', {
 			render: () => <TestComponent content="one" />,
 			icon: 'smiley',

--- a/packages/plugins/src/components/test/plugin-area.js
+++ b/packages/plugins/src/components/test/plugin-area.js
@@ -11,6 +11,8 @@ import PluginArea from '../plugin-area';
 
 describe( 'PluginArea', () => {
 	afterEach( () => {
+		// Unmount components before unregistering the plugins.
+		// RTL uses top-level `afterEach` for cleanup, executed after this teardown.
 		cleanup();
 		getPlugins().forEach( ( plugin ) => {
 			unregisterPlugin( plugin.name );

--- a/packages/plugins/src/components/test/plugin-area.js
+++ b/packages/plugins/src/components/test/plugin-area.js
@@ -47,7 +47,7 @@ describe( 'PluginArea', () => {
 		expect( container ).toHaveTextContent( 'plugin: scoped.' );
 	} );
 
-	test( 'rerenders when new plugin is registered', () => {
+	test( 'rerenders when a new plugin is registered', () => {
 		registerPlugin( 'foo', {
 			render: () => <TestComponent content="foo" />,
 			icon: 'smiley',

--- a/packages/plugins/src/components/test/plugin-area.js
+++ b/packages/plugins/src/components/test/plugin-area.js
@@ -91,7 +91,7 @@ describe( 'PluginArea', () => {
 	} );
 
 	test.failing(
-		'does not rerender when plugin is added to a different scope',
+		'does not rerender when a plugin is added to a different scope',
 		() => {
 			const ComponentSpy = jest.fn( ( { content } ) => {
 				return `plugin: ${ content }.`;

--- a/packages/plugins/src/components/test/plugin-area.js
+++ b/packages/plugins/src/components/test/plugin-area.js
@@ -1,0 +1,119 @@
+/**
+ * External dependencies
+ */
+import { act, render, cleanup } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { getPlugins, unregisterPlugin, registerPlugin } from '../../api';
+import PluginArea from '../plugin-area';
+
+describe( 'PluginArea', () => {
+	afterEach( () => {
+		cleanup();
+		getPlugins().forEach( ( plugin ) => {
+			unregisterPlugin( plugin.name );
+		} );
+		getPlugins( 'my-app' ).forEach( ( plugin ) => {
+			unregisterPlugin( plugin.name );
+		} );
+	} );
+
+	const TestComponent = ( { content } ) => {
+		return `plugin: ${ content }.`;
+	};
+
+	test( 'renders unscoped plugin', () => {
+		registerPlugin( 'unscoped', {
+			render: () => <TestComponent content="unscoped" />,
+			icon: 'smiley',
+		} );
+
+		const { container } = render( <PluginArea /> );
+
+		expect( container ).toHaveTextContent( 'plugin: unscoped.' );
+	} );
+
+	test( 'renders scoped plugin', () => {
+		registerPlugin( 'scoped', {
+			render: () => <TestComponent content="scoped" />,
+			icon: 'smiley',
+			scope: 'my-app',
+		} );
+
+		const { container } = render( <PluginArea scope="my-app" /> );
+
+		expect( container ).toHaveTextContent( 'plugin: scoped.' );
+	} );
+
+	test( 'rerenders when new plugin is registered', () => {
+		registerPlugin( 'foo', {
+			render: () => <TestComponent content="foo" />,
+			icon: 'smiley',
+			scope: 'my-app',
+		} );
+
+		const { container } = render( <PluginArea scope="my-app" /> );
+
+		act( () => {
+			registerPlugin( 'bar', {
+				render: () => <TestComponent content="bar" />,
+				icon: 'smiley',
+				scope: 'my-app',
+			} );
+		} );
+
+		expect( container ).toHaveTextContent( 'plugin: bar.' );
+	} );
+
+	test( 'rerenders when new plugin is unregistered', () => {
+		registerPlugin( 'one', {
+			render: () => <TestComponent content="one" />,
+			icon: 'smiley',
+			scope: 'my-app',
+		} );
+		registerPlugin( 'two', {
+			render: () => <TestComponent content="two" />,
+			icon: 'smiley',
+			scope: 'my-app',
+		} );
+
+		const { container } = render( <PluginArea scope="my-app" /> );
+
+		expect( container ).toHaveTextContent( 'plugin: one.plugin: two.' );
+
+		act( () => {
+			unregisterPlugin( 'one' );
+		} );
+
+		expect( container ).toHaveTextContent( 'plugin: two.' );
+	} );
+
+	test.failing(
+		'does not rerender when plugin is added to a different scope',
+		() => {
+			const ComponentSpy = jest.fn( ( { content } ) => {
+				return `plugin: ${ content }.`;
+			} );
+
+			registerPlugin( 'scoped', {
+				render: () => <ComponentSpy content="scoped" />,
+				icon: 'smiley',
+				scope: 'my-app',
+			} );
+
+			render( <PluginArea scope="my-app" /> );
+
+			act( () => {
+				registerPlugin( 'unscoped', {
+					render: () => <TestComponent content="unscoped" />,
+					icon: 'smiley',
+				} );
+			} );
+
+			// Any store update triggers setState and causes PluginArea to rerender.
+			expect( ComponentSpy ).toHaveBeenCalledTimes( 1 );
+		}
+	);
+} );


### PR DESCRIPTION
## What?
PR add unit tests for the `PluginArea` component.

## Why?
I plan to refactor the component to use the `useSyncExternalStore` hook instead of lifecycle methods and thought unit tests would be helpful.

Let me know if any cases are missing, and I will gladly include them.

## Testing Instructions

```
npm run test:unit packages/plugins/src/components/test/plugin-area.js
```
