### PR TITLE
Navigation: Only fetch wp_navigation menus once

### DIFF
--- a/packages/block-library/src/navigation/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/use-navigation-menu.js
@@ -71,8 +71,9 @@ function selectNavigationMenus( select ) {
 	const args = [
 		'postType',
 		'wp_navigation',
-		{ per_page: -1, status: [ 'publish', 'draft' ] },
+		{ per_page: -1, status: 'publish,draft' },
 	];
+
 	return {
 		navigationMenus: getEntityRecords( ...args ),
 		isResolvingNavigationMenus: isResolving( 'getEntityRecords', args ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
As part of https://github.com/WordPress/gutenberg/pull/48683 we noticed that there are two API requests being made for wp_navigation entities  - one for published and draft statuses, and one for just draft statuses. This seems to be a feature of the way that `getEntityRecords` works when `status` is set to an array. If change it a string with the value `publish,draft` then it does one request to get all wp_navigation entities.

## Why?
This saves one unnecessary API request. It should also simplify https://github.com/WordPress/gutenberg/pull/48683.

## How?
Change the status from an array to a string

## Testing Instructions
1. Open your network tab
2. Search for `navigation`
3. Check that on trunk you see 5 requests - two OPTIONS requests, and three requests to `/wp-json/wp/v2/navigation`
4. Check that on this branch you see 3 requests - one OPTIONS request, and two requests to `/wp-json/wp/v2/navigation`
