### PR TITLE
CustomGradientPicker: improve initial state UI

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `CustomGradientPicker`: Convert to TypeScript ([#48929](https://github.com/WordPress/gutenberg/pull/48929)).
 
+### Enhancements
+
+-   `CustomGradientPicker`: improve initial state UI ([#49146](https://github.com/WordPress/gutenberg/pull/49146)).
+
 ## 23.6.0 (2023-03-15)
 
 ### Enhancements

--- a/packages/components/src/custom-gradient-picker/gradient-bar/index.tsx
+++ b/packages/components/src/custom-gradient-picker/gradient-bar/index.tsx
@@ -139,9 +139,15 @@ export default function CustomGradientBar( {
 			) }
 			onMouseEnter={ onMouseEnterAndMove }
 			onMouseMove={ onMouseEnterAndMove }
-			style={ { background } }
 			onMouseLeave={ onMouseLeave }
 		>
+			<div
+				className="components-custom-gradient-picker__gradient-bar-background"
+				style={ {
+					background,
+					opacity: hasGradient ? 1 : 0.4,
+				} }
+			/>
 			<div
 				ref={ gradientMarkersContainerDomRef }
 				className="components-custom-gradient-picker__markers-container"

--- a/packages/components/src/custom-gradient-picker/index.tsx
+++ b/packages/components/src/custom-gradient-picker/index.tsx
@@ -29,7 +29,6 @@ import {
 	DEFAULT_LINEAR_GRADIENT_ANGLE,
 	HORIZONTAL_GRADIENT_ORIENTATION,
 	GRADIENT_OPTIONS,
-	DEFAULT_GRADIENT,
 } from './constants';
 import {
 	AccessoryWrapper,
@@ -148,13 +147,13 @@ export function CustomGradientPicker( {
 	onChange,
 	__experimentalIsRenderedInSidebar = false,
 }: CustomGradientPickerProps ) {
-	const { gradientAST, gradientAstValue } =
-		getGradientAstWithDefault( value );
+	const { gradientAST, hasGradient } = getGradientAstWithDefault( value );
+
 	// On radial gradients the bar should display a linear gradient.
 	// On radial gradients the bar represents a slice of the gradient from the center until the outside.
 	// On liner gradients the bar represents the color stops from left to right independently of the angle.
 	const background = getLinearGradientRepresentation( gradientAST );
-	const hasGradient = gradientAstValue !== DEFAULT_GRADIENT;
+
 	// Control points color option may be hex from presets, custom colors will be rgb.
 	// The position should always be a percentage.
 	const controlPoints = gradientAST.colorStops.map( ( colorStop ) => {

--- a/packages/components/src/custom-gradient-picker/style.scss
+++ b/packages/components/src/custom-gradient-picker/style.scss
@@ -7,14 +7,30 @@ $components-custom-gradient-picker__padding: $grid-unit-20; // 48px container, 1
 	}
 }
 
-.components-custom-gradient-picker__gradient-bar:not(.has-gradient) {
-	opacity: 0.4;
-}
-
 .components-custom-gradient-picker__gradient-bar {
 	border-radius: $radius-block-ui;
 	width: 100%;
 	height: $grid-unit-60;
+	position: relative;
+	z-index: 1;
+
+	&.has-gradient {
+		// The background image creates a checkerboard pattern. Ignore rtlcss to
+		// make it work both in LTR and RTL.
+		// See https://github.com/WordPress/gutenberg/pull/42510
+		/*rtl:begin:ignore*/
+		background-image:
+			repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200),
+			repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200);
+		background-position: 0 0, 12px 12px;
+		/*rtl:end:ignore*/
+		background-size: calc(2 * 12px) calc(2 * 12px);
+	}
+
+	.components-custom-gradient-picker__gradient-bar-background {
+		position: absolute;
+		inset: 0;
+	}
 
 	.components-custom-gradient-picker__markers-container {
 		position: relative;
@@ -108,4 +124,9 @@ $components-custom-gradient-picker__padding: $grid-unit-20; // 48px container, 1
 			}
 		}
 	}
+}
+
+.components-custom-gradient-picker__ui-line {
+	position: relative;
+	z-index: 0;
 }

--- a/packages/components/src/custom-gradient-picker/utils.ts
+++ b/packages/components/src/custom-gradient-picker/utils.ts
@@ -35,17 +35,22 @@ function hasUnsupportedLength( item: gradientParser.ColorStop ) {
 export function getGradientAstWithDefault( value?: string | null ) {
 	// gradientAST will contain the gradient AST as parsed by gradient-parser npm module.
 	// More information of its structure available at https://www.npmjs.com/package/gradient-parser#ast.
-	let gradientAST: gradientParser.GradientNode;
-	let gradientAstValue: string | undefined;
+	let gradientAST: gradientParser.GradientNode | undefined;
+	let hasGradient = !! value;
 
 	const valueToParse = value ?? DEFAULT_GRADIENT;
 
 	try {
 		gradientAST = gradientParser.parse( valueToParse )[ 0 ];
-		gradientAstValue = valueToParse;
 	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.warn(
+			'wp.components.CustomGradientPicker failed to parse the gradient with error',
+			error
+		);
+
 		gradientAST = gradientParser.parse( DEFAULT_GRADIENT )[ 0 ];
-		gradientAstValue = DEFAULT_GRADIENT;
+		hasGradient = false;
 	}
 
 	if (
@@ -69,10 +74,9 @@ export function getGradientAstWithDefault( value?: string | null ) {
 				type: '%',
 			};
 		} );
-		gradientAstValue = serializeGradient( gradientAST );
 	}
 
-	return { gradientAST, gradientAstValue };
+	return { gradientAST, hasGradient };
 }
 
 export function getGradientAstWithControlPoints(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Requires #48929 to be merged first
Part of #42994

Improve `CustomGradientPicker`'s initial UI state and interaction:

- preserve the 0.4 opacity of the gradient bar when no gradient is set, but make the control points and the related color pickers always at full opacity
- add checkered background to better show semi-transparent gradients
- improve the code around how the component checks if it has a gradient

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Improve the component's UX

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Opacity improvements have been applied by creating a new `div` element dedicated to display the `background-color`, and applying some CSS changes to force the controls on the bottom row to render with a lower stacking index than the gradient bar
- Code changes around the default gradient value:- This also improved the `hasGradient` logic: previously the component would think that it didn't a gradient set if, as a coincidence, the user chose a gradient value that was the same as the default gradient

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Interact with the component on Storybook and in the editor (for example, in the Site Editor > Global Styles Sidebar > Colors  > Palette > "Gradient" tab > Create a new custom gradient)
- Make sure that, when clicking an insertion point, the related color picker is 100% opaque and is displayed on top of the rest of the UI
- Make at least one of the color stops partially transparent, make sure that the checkered background shows in the gradient bar
- Make sure that the component otherwise behaves like on `trunk`

## Screenshots or screencast <!-- if applicable -->

| | trunk (before) | This PR (after) |
|---|---|---|
| z-index and opacity of insertion points and color picker popover | ![Screenshot 2023-03-16 at 19 36 46](https://user-images.githubusercontent.com/1083581/225725706-0948bc88-3ae9-4fe0-bc80-4c5da2e8ddd0.jpg) | ![Screenshot 2023-03-16 at 19 56 43](https://user-images.githubusercontent.com/1083581/225725922-334eacb5-8a25-4f3a-931e-8f5883cce1b5.jpg) |
| transparent color points (notice the chequered gradient bar) | ![Screenshot 2023-03-16 at 19 37 01](https://user-images.githubusercontent.com/1083581/225725754-cc09031e-dadb-4eb4-81db-73e3ccf5b4c5.jpg) | ![Screenshot 2023-03-16 at 19 57 07](https://user-images.githubusercontent.com/1083581/225725956-eb846753-bdd0-4d5e-aaec-cdca70faa14a.jpg) |

