### PR TITLE
LineHeightControl: Make spin buttons adjust from placeholder value

### DIFF
--- a/packages/block-editor/src/components/line-height-control/index.js
+++ b/packages/block-editor/src/components/line-height-control/index.js
@@ -84,6 +84,15 @@ const LineHeightControl = ( {
 		? undefined
 		: { marginBottom: 24 };
 
+	const handleOnChange = ( nextValue, { event } ) => {
+		if ( event.type === 'click' ) {
+			onChange( adjustNextValue( nextValue, false ) );
+			return;
+		}
+
+		onChange( nextValue );
+	};
+
 	return (
 		<div
 			className="block-editor-line-height-control"
@@ -93,7 +102,7 @@ const LineHeightControl = ( {
 				{ ...otherProps }
 				__unstableInputWidth={ __unstableInputWidth }
 				__unstableStateReducer={ stateReducer }
-				onChange={ onChange }
+				onChange={ handleOnChange }
 				label={ __( 'Line height' ) }
 				placeholder={ BASE_DEFAULT_VALUE }
 				step={ STEP }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/48766

## What?

Updates the `LineHeightControl` to make adjustments via the custom spin buttons from the placeholder value rather than zero.

## Why?

- When the placeholder value of `1.5` is displayed in the input, it is unexpected that the spin buttons adjust the value from zero. 
- Makes the spin buttons consistent with keyboard up/down arrow adjustments
- Fixes regression as spin buttons used to work in this fashion

## How?
- Updates the onChange handler to pass the next value through the same adjustment as used in the state reducer when the spin buttons are clicked.
- Avoids any major refactor of the underlying NumberControl and InputControl components so it can land sooner.

## Testing Instructions

1. Edit a post, select a paragraph, and switch to the styles tab in the Block Inspector
2. Toggle on the line-height option from the Typography panel's menu
3. Click the + button and note that the field now has a value of `1.6` instead of `0.1`.
4. Reset the line height control via the Typography panel's menu
5. Toggle it back on and this time click the - button. Note the value in the field is now `1.4` instead of `0`.


## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/225791366-c5e74ede-ce45-4a2c-a757-ce880710a8f1.mp4

