### PR TITLE
[RNMobile] Prevent blocks being un-wantingly replaced with newly added blocks

### DIFF
--- a/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -358,15 +358,9 @@ class RCTAztecView: Aztec.TextView {
     }
 
     public override func insertDictationResult(_ dictationResult: [UIDictationPhrase]) {
+        let objectPlaceholder = "\u{FFFC}"
         let dictationText = dictationResult.reduce("") { $0 + $1.text }
         isInsertingDictationResult = false
-        
-        if #available(iOS 16, *) {
-            insertText(dictationText)
-        } else {
-            let objectPlaceholder = "\u{FFFC}"
-            self.text = self.text?.replacingOccurrences(of: objectPlaceholder, with: dictationText)
-        }
     }
 
     // MARK: - Custom Edit Intercepts

--- a/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -361,6 +361,7 @@ class RCTAztecView: Aztec.TextView {
         let objectPlaceholder = "\u{FFFC}"
         let dictationText = dictationResult.reduce("") { $0 + $1.text }
         isInsertingDictationResult = false
+        self.text = self.text?.replacingOccurrences(of: objectPlaceholder, with: dictationText)
     }
 
     // MARK: - Custom Edit Intercepts

--- a/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -100,13 +100,7 @@ class RCTAztecView: Aztec.TextView {
     /// the dictation engine refreshes the TextView with an empty string when the dictation finishes.
     /// This helps to avoid propagating that unwanted empty string to RN. (Solving #606)
     /// on `textViewDidChange` and `textViewDidChangeSelection`
-    private var isInsertingDictationResult: Bool = {
-        if #available(iOS 16, *) {
-            return true;
-        } else {
-            return false;
-        }
-    }()
+    private var isInsertingDictationResult = false
     
     // MARK: - Font
 
@@ -365,11 +359,12 @@ class RCTAztecView: Aztec.TextView {
 
     public override func insertDictationResult(_ dictationResult: [UIDictationPhrase]) {
         let dictationText = dictationResult.reduce("") { $0 + $1.text }
+        isInsertingDictationResult = false
+        
         if #available(iOS 16, *) {
             insertText(dictationText)
         } else {
             let objectPlaceholder = "\u{FFFC}"
-            isInsertingDictationResult = false
             self.text = self.text?.replacingOccurrences(of: objectPlaceholder, with: dictationText)
         }
     }


### PR DESCRIPTION
* `Gutenberg Mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5569

## What?

The changes in logic surrounding dictation handling in https://github.com/WordPress/gutenberg/pull/49056 led to a regression where currently selected blocks are replaced with newly added blocks. This PR addresses that issue by reverting the changes to dictation introduced in https://github.com/WordPress/gutenberg/pull/49056.

## Why?

Fixes https://github.com/WordPress/gutenberg/issues/49145

## How?

* As part of https://github.com/WordPress/gutenberg/pull/49056, the `isInsertingDictationResult` bool was set to `true` for devices running iOS 16 or later. However, this meant that the `textViewDidChange` never ran, which then caused the focus/replacement regression:

https://github.com/WordPress/gutenberg/blob/d76d91795d30a750138dc97c45986efa776961eb/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift#L787-L796

* The removal of the logic that removed the `objectPlaceholder` also caused an `obj` symbol to display amidst text when previewed.

* With the above considered, the dictation fix has been reverted, so that the regression described in https://github.com/WordPress/gutenberg/issues/49145 is fixed and we can continue with the Gutenberg Mobile release.

## Testing Instructions

It should be confirmed that these changes fix the regression it's addressing:

1. Navigate through the steps to create a new post in the iOS app.
2. Type some text into a paragraph block.
3. Tap the inserter in the editor's toolbar.
4. Select a new block to add to the editor.
5. Confirm that the new block is added beneath the currently select block, and that it doesn't replace it.

In addition, we should confirm that the changes in this PR don't cause further issues with dictation:

1. Navigate to My Site → Posts and create a new post.
2. Activate the iOS dictation feature and dictate some text.
3. Notice the text added to the editor.
4. Tap another block on the editor or begin typing onto the keyboard to confirm there is no content loss.
7. Experiment with adding various text and attempting to break dictation.

## Screenshots or screencast 

You'll see in the following screen recording that a newly added block is correctly added beneath a currently selected block (it doesn't replace the selected block):

https://user-images.githubusercontent.com/2998162/225863331-78ad7a42-696b-45f3-8806-f13846e5bd17.mov