### PR TITLE
Navigation: Remove the check for draft navigation menus from the UnsavedInnerBlocks component

### DIFF
--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -15,11 +15,6 @@ import { areBlocksDirty } from './are-blocks-dirty';
 import { DEFAULT_BLOCK, ALLOWED_BLOCKS } from '../constants';
 
 const EMPTY_OBJECT = {};
-const DRAFT_MENU_PARAMS = [
-	'postType',
-	'wp_navigation',
-	{ status: 'draft', per_page: -1 },
-];
 
 export default function UnsavedInnerBlocks( {
 	blocks,
@@ -75,28 +70,16 @@ export default function UnsavedInnerBlocks( {
 		}
 	);
 
-	const { isSaving, hasResolvedDraftNavigationMenus } = useSelect(
+	const { isSaving } = useSelect(
 		( select ) => {
 			if ( isDisabled ) {
 				return EMPTY_OBJECT;
 			}
 
-			const {
-				getEntityRecords,
-				hasFinishedResolution,
-				isSavingEntityRecord,
-			} = select( coreStore );
+			const { isSavingEntityRecord } = select( coreStore );
 
 			return {
 				isSaving: isSavingEntityRecord( 'postType', 'wp_navigation' ),
-				draftNavigationMenus: getEntityRecords(
-					// This is needed so that hasResolvedDraftNavigationMenus gives the correct status.
-					...DRAFT_MENU_PARAMS
-				),
-				hasResolvedDraftNavigationMenus: hasFinishedResolution(
-					'getEntityRecords',
-					DRAFT_MENU_PARAMS
-				),
 			};
 		},
 		[ isDisabled ]
@@ -121,7 +104,6 @@ export default function UnsavedInnerBlocks( {
 		if (
 			isDisabled ||
 			isSaving ||
-			! hasResolvedDraftNavigationMenus ||
 			! hasResolvedNavigationMenus ||
 			! hasSelection ||
 			! innerBlocksAreDirty
@@ -135,7 +117,6 @@ export default function UnsavedInnerBlocks( {
 		createNavigationMenu,
 		isDisabled,
 		isSaving,
-		hasResolvedDraftNavigationMenus,
 		hasResolvedNavigationMenus,
 		innerBlocksAreDirty,
 		hasSelection,

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -10,7 +10,6 @@ import { useContext, useEffect, useRef, useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import useNavigationMenu from '../use-navigation-menu';
 import { areBlocksDirty } from './are-blocks-dirty';
 import { DEFAULT_BLOCK, ALLOWED_BLOCKS } from '../constants';
 
@@ -70,22 +69,29 @@ export default function UnsavedInnerBlocks( {
 		}
 	);
 
-	const { isSaving } = useSelect(
+	const { isSaving, hasResolvedAllNavigationMenus } = useSelect(
 		( select ) => {
 			if ( isDisabled ) {
 				return EMPTY_OBJECT;
 			}
 
-			const { isSavingEntityRecord } = select( coreStore );
+			const { hasFinishedResolution, isSavingEntityRecord } =
+				select( coreStore );
 
 			return {
 				isSaving: isSavingEntityRecord( 'postType', 'wp_navigation' ),
+				hasResolvedAllNavigationMenus: hasFinishedResolution(
+					'getEntityRecords',
+					[
+						'postType',
+						'wp_navigation',
+						{ per_page: -1, status: [ 'publish', 'draft' ] },
+					]
+				),
 			};
 		},
 		[ isDisabled ]
 	);
-
-	const { hasResolvedNavigationMenus } = useNavigationMenu();
 
 	// Automatically save the uncontrolled blocks.
 	useEffect( () => {
@@ -104,7 +110,7 @@ export default function UnsavedInnerBlocks( {
 		if (
 			isDisabled ||
 			isSaving ||
-			! hasResolvedNavigationMenus ||
+			! hasResolvedAllNavigationMenus ||
 			! hasSelection ||
 			! innerBlocksAreDirty
 		) {
@@ -117,7 +123,7 @@ export default function UnsavedInnerBlocks( {
 		createNavigationMenu,
 		isDisabled,
 		isSaving,
-		hasResolvedNavigationMenus,
+		hasResolvedAllNavigationMenus,
 		innerBlocksAreDirty,
 		hasSelection,
 	] );


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I was trying to track this down in https://github.com/WordPress/gutenberg/pull/49143 but I was looking in the wrong place! This removes a check for loaded draft navigation menus from the `UnsavedInnerBlocks` component.

## Why?
I believe it is unnecessary to make this request, since we are already fetching both draft and published navigations in the `useNavigationMenu` hook.

## How?
Deleting code!

## Testing Instructions
1. Add a navigation block with controlled innerblocks to your template:
```
            <!-- wp:navigation -->
                <!-- wp:navigation-link {"label":"Home","url":"/"} /-->
            <!-- /wp:navigation -->
```
2. Open the Site Editor
3. Open your network tab
4. Search for navigation
5. Check that on trunk you see 3 requests - one OPTIONS request, and two requests to /wp-json/wp/v2/navigation
6. Check that on this branch you see 2 requests - one OPTIONS request, and two requests to /wp-json/wp/v2/navigation

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
Network tab with only one GET:
<img width="1512" alt="Screenshot 2023-03-17 at 11 14 57" src="https://user-images.githubusercontent.com/275961/225889673-35119531-bd5f-4fa3-abc0-6459fa9e4e9b.png">
