### PR TITLE
Bring back revisions button for template parts

### DIFF
--- a/lib/compat/wordpress-6.3/rest-api.php
+++ b/lib/compat/wordpress-6.3/rest-api.php
@@ -22,7 +22,7 @@ add_action( 'rest_api_init', 'gutenberg_register_rest_pattern_directory' );
  * @param string $post_type Post type key.
  */
 function gutenberg_update_templates_template_parts_rest_controller( $args, $post_type ) {
-	if ( in_array( $post_type, array( 'wp_template', 'wp_template-part' ), true ) ) {
+	if ( in_array( $post_type, array( 'wp_template', 'wp_template_part' ), true ) ) {
 		$args['rest_controller_class'] = 'Gutenberg_REST_Templates_Controller_6_3';
 	}
 	return $args;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

After preparing Gutenberg for the release of the 6.2 core version some files were moved in the `lib` folder. This resulted in a typo which hid the button for revisions in the template part editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To bring the button back.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Correct the typo.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open a template part
2. Reset customisations
3. Save
4. Change something
5. Save
6. Change something else
7. Save
8. In the inspector Template tab you should see the revisions button
