### PR TITLE
Element: Narrow `createInterpolateElement` param type.

### DIFF
--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -168,7 +168,7 @@ You would have something like this as the conversionMap value:
 _Parameters_
 
 -   _interpolatedString_ `string`: The interpolation string to be parsed.
--   _conversionMap_ `Object`: The map used to convert the string to a react element.
+-   _conversionMap_ `Record<string, WPElement>`: The map used to convert the string to a react element.
 
 _Returns_
 

--- a/packages/element/src/create-interpolate-element.js
+++ b/packages/element/src/create-interpolate-element.js
@@ -101,9 +101,9 @@ function createFrame(
  * }
  * ```
  *
- * @param {string} interpolatedString The interpolation string to be parsed.
- * @param {Object} conversionMap      The map used to convert the string to
- *                                    a react element.
+ * @param {string}                    interpolatedString The interpolation string to be parsed.
+ * @param {Record<string, WPElement>} conversionMap      The map used to convert the string to
+ *                                                       a react element.
  * @throws {TypeError}
  * @return {WPElement}  A wp element.
  */


### PR DESCRIPTION
## What?
This PR simply narrows the type of the `conversionMap` param of the `createInterpolateElement` function.

## Why?
The prior type of simply `Object` is pretty vague, allowing clearly nonsense args like `{'div': 15.80}`, and by tightening it a bit, IDEs will be able to guide users into using the function correctly as they're writing code.

## How?
I narrowed the param type to `Record<string, WPElement>`. (In case you're wondering, use of the TypeScript utility type `Record` in JSDoc works, and the Gutenberg codebase [already uses it in existing JSDocs](https://github.com/WordPress/gutenberg/blob/6434e0bc181bb1c0f5fcf48520be20f1a37afb6c/packages/components/src/text/utils.js#L27).)

## Testing Instructions
1. Use this branch.
2. In a TypeScript file, try to write code misusing the `conversionMap` param of `createInterpolateElement`.

![image](https://user-images.githubusercontent.com/19592990/226155797-9cd25c42-efd9-4f1a-aaca-1fa96bef1a75.png)
