### PR TITLE
BlockHTML: Use correct type when setting 'html' state onBlur

### DIFF
--- a/packages/block-editor/src/components/block-list/block-html.js
+++ b/packages/block-editor/src/components/block-list/block-html.js
@@ -59,7 +59,7 @@ function BlockHTML( { clientId } ) {
 
 		// Ensure the state is updated if we reset so it displays the default content.
 		if ( ! html ) {
-			setHtml( { content } );
+			setHtml( content );
 		}
 	};
 


### PR DESCRIPTION
## What?
PR fixes the `html` state type when setting it on the `onBlur` event. It was causing `[Object object]` to flash briefly in the input field.

Props to @talldan for noticing the issue https://github.com/WordPress/gutenberg/pull/49097#issuecomment-1475696392.

## Why?
This was leftover from previous refactoring #18968.

## Testing Instructions
Confirm "Edit as HTML" works as before.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/226273540-28a0fddd-cf3a-40f7-a359-6bd1d9dc8ec0.mp4

