### PR TITLE
Search block: fix overflow width

### DIFF
--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -1,5 +1,5 @@
 .wp-block-search__button {
-	margin-left: 0.625em;
+	margin-left: 0.625rem;
 	word-break: normal;
 
 	&.has-icon {
@@ -7,8 +7,8 @@
 	}
 
 	svg {
-		min-width: 1.5em;
-		min-height: 1.5em;
+		min-width: 1.5rem;
+		min-height: 1.5rem;
 		fill: currentColor;
 		vertical-align: text-bottom;
 	}
@@ -18,7 +18,7 @@
 // They are needed for backwards compatibility.
 :where(.wp-block-search__button) {
 	border: 1px solid #ccc;
-	padding: 0.375em 0.625em;
+	padding: 0.375rem 0.625rem;
 }
 
 .wp-block-search__inside-wrapper {
@@ -33,11 +33,11 @@
 }
 
 .wp-block-search__input {
-	padding: 8px;
+	padding: 0.5rem;
 	flex-grow: 1;
 	margin-left: 0;
 	margin-right: 0;
-	min-width: 3em;
+	min-width: 3rem;
 	border: 1px solid #949494;
 	// !important used to forcibly prevent undesired application of
 	// text-decoration styles on the input field.
@@ -52,13 +52,14 @@
 
 // We are lowering the specificity so that the button element can override the rule for the button inside the search block.
 :where(.wp-block-search__button-inside .wp-block-search__inside-wrapper) {
-	padding: 4px;
+	padding: 0.25rem;
 	border: 1px solid #949494;
+	box-sizing: border-box;
 
 	.wp-block-search__input {
 		border-radius: 0;
 		border: none;
-		padding: 0 0 0 0.25em;
+		padding: 0 0.25rem;
 
 		&:focus {
 			outline: none;
@@ -67,7 +68,7 @@
 
 	// For lower specificity.
 	:where(.wp-block-search__button) {
-		padding: 0.125em 0.5em;
+		padding: 0.125rem 0.5rem;
 	}
 }
 

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -1,5 +1,8 @@
+$button-spacing-x: $grid-unit-10 + math.div($grid-unit-05, 2); // 10px
+$button-spacing-y: math.div($grid-unit-15, 2); // 6px
+
 .wp-block-search__button {
-	margin-left: 0.625rem;
+	margin-left: $button-spacing-x;
 	word-break: normal;
 
 	&.has-icon {
@@ -7,8 +10,8 @@
 	}
 
 	svg {
-		min-width: 1.5rem;
-		min-height: 1.5rem;
+		min-width: $grid-unit-30;
+		min-height: $grid-unit-30;
 		fill: currentColor;
 		vertical-align: text-bottom;
 	}
@@ -17,8 +20,8 @@
 // These rules are set to zero specificity to keep the default styles for search buttons.
 // They are needed for backwards compatibility.
 :where(.wp-block-search__button) {
-	border: 1px solid #ccc;
-	padding: 0.375rem 0.625rem;
+	border: 1px solid $gray-400;
+	padding: $button-spacing-y $button-spacing-x;
 }
 
 .wp-block-search__inside-wrapper {
@@ -33,12 +36,12 @@
 }
 
 .wp-block-search__input {
-	padding: 0.5rem;
+	padding: $grid-unit-10;
 	flex-grow: 1;
 	margin-left: 0;
 	margin-right: 0;
 	min-width: 3rem;
-	border: 1px solid #949494;
+	border: 1px solid $gray-600;
 	// !important used to forcibly prevent undesired application of
 	// text-decoration styles on the input field.
 	text-decoration: unset !important;
@@ -52,14 +55,14 @@
 
 // We are lowering the specificity so that the button element can override the rule for the button inside the search block.
 :where(.wp-block-search__button-inside .wp-block-search__inside-wrapper) {
-	padding: 0.25rem;
-	border: 1px solid #949494;
+	padding: $grid-unit-05;
+	border: 1px solid $gray-600;
 	box-sizing: border-box;
 
 	.wp-block-search__input {
 		border-radius: 0;
 		border: none;
-		padding: 0 0.25rem;
+		padding: 0 $grid-unit-05;
 
 		&:focus {
 			outline: none;
@@ -68,7 +71,7 @@
 
 	// For lower specificity.
 	:where(.wp-block-search__button) {
-		padding: 0.125rem 0.5rem;
+		padding: $grid-unit-05 $grid-unit-10;
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This fixes the search block overflow width issue for `inside button` variant.

**Before:**
<img width="282" alt="image" src="https://user-images.githubusercontent.com/1935113/226360503-0e08d99d-0fc1-49c0-a6f3-542cb6922dd8.png">

**After:**
<img width="282" alt="image" src="https://user-images.githubusercontent.com/1935113/226284354-dc347594-ef99-40a1-b34f-91fb98bf0216.png">

**With `em` units** it still leaves small gaps because it is tied to parent font size. So, updated the units to `rem` instead.
<img width="282" alt="image" src="https://user-images.githubusercontent.com/1935113/226286262-3030d8c5-7fc0-4ccf-acfa-a3c0355ff4c5.png">


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Updated box sizing to `border-box`
* Updated units from `em` to `rem`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. create a post and add the following template with two search blocks with button inside and outside.

```
<!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
<div class="wp-block-group">
<!-- wp:search {"label":"Search","width":100,"widthUnit":"%","buttonText":"Search","buttonUseIcon":true} /-->
<!-- wp:search {"label":"Search","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true} /-->
</div>
<!-- /wp:group -->
```

Fixes: #39946
