### PR TITLE
Navigation: Fix bug in calculating the active menu item

### DIFF
--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -181,7 +181,8 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 
 	$css_classes = trim( implode( ' ', $classes ) );
 	$has_submenu = count( $block->inner_blocks ) > 0;
-	$is_active   = ! empty( $attributes['id'] ) && ( get_queried_object_id() === (int) $attributes['id'] );
+	$kind        = empty( $attributes['kind'] ) ? 'post_type' : str_replace( '-', '_', $attributes['kind'] );
+	$is_active   = ! empty( $attributes['id'] ) && get_queried_object_id() === (int) $attributes['id'] && ! empty( get_queried_object()->$kind );
 
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -154,7 +154,8 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 
 	$css_classes = trim( implode( ' ', $classes ) );
 	$has_submenu = count( $block->inner_blocks ) > 0;
-	$is_active   = ! empty( $attributes['id'] ) && ( get_queried_object_id() === (int) $attributes['id'] );
+	$kind        = empty( $attributes['kind'] ) ? 'post_type' : str_replace( '-', '_', $attributes['kind'] );
+	$is_active   = ! empty( $attributes['id'] ) && get_queried_object_id() === (int) $attributes['id'] && ! empty( get_queried_object()->$kind );
 
 	$show_submenu_indicators = isset( $block->context['showSubmenuIcon'] ) && $block->context['showSubmenuIcon'];
 	$open_on_click           = isset( $block->context['openSubmenusOnClick'] ) && $block->context['openSubmenusOnClick'];


### PR DESCRIPTION
## What?

Fixes #49153 

## Why?

As described in https://github.com/WordPress/gutenberg/issues/49153, when a post and a term have the same ID and both exist in the menu, the code that determines the active menu item is wrong. As a result, both the term and the post get marked as active because we only check the ID and not the context.

## How?
Tweaking the check to determine if a menu item is active.
`$attributes['kind']` can be things like `taxonomy`, `post-type` etc. Using `get_queried_object()` in a term will return an object which will have the `taxonomy` defined. In a post, the `post_type` will be defined and so on.
This PR will check that the ID is the same, AND that the context (post/term etc) is right before marking a menu item as active.

## Testing Instructions

1. On a fresh installation create some terms and some pages.
2. Find a page and a term that have the same ID, and add them both in a navigation block.

Before the PR, visiting the term will highlight both the post and the term as active, and the same will happen when visiting the page.
After the PR, the `current-menu-item` class will only be added to the right element.

Note: The same code was applied both to the `navigation-link` and the `navigation-submenu` blocks since they were using identical checks.

### Testing Instructions for Keyboard
Not applicable.
