### PR TITLE
Block patterns: use `WP_Theme_JSON_Resolver_Gutenberg` instead of `WP_Theme_JSON_Resolver`

### DIFF
--- a/lib/compat/wordpress-6.2/block-patterns.php
+++ b/lib/compat/wordpress-6.2/block-patterns.php
@@ -433,7 +433,7 @@ function gutenberg_register_remote_theme_patterns() {
 		return;
 	}
 
-	$pattern_settings = WP_Theme_JSON_Resolver::get_theme_data()->get_patterns();
+	$pattern_settings = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data()->get_patterns();
 	if ( empty( $pattern_settings ) ) {
 		return;
 	}


### PR DESCRIPTION
## What?

This PR updates the block pattern to use the gutenberg class instead of the respective core class.

## Why?

As these classes still live in Gutenberg and can receive updates, we need to use them in the plugin.

## Testing Instructions

- Insert a Heading block
- Open the block switcher menu
- Observe that there is a pattern suggested, coming from Pattern Directory
