### PR TITLE
Template parts: use `WP_Theme_JSON_Resolver_Gutenberg` instead of `WP_Theme_JSON_Resolver`

### DIFF
--- a/lib/compat/wordpress-6.1/template-parts-screen.php
+++ b/lib/compat/wordpress-6.1/template-parts-screen.php
@@ -133,7 +133,7 @@ function gutenberg_template_parts_screen_init( $hook ) {
 		}
 	}
 
-	$active_global_styles_id = WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
+	$active_global_styles_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
 	$active_theme            = get_stylesheet();
 	$preload_paths           = array(
 		array( '/wp/v2/media', 'OPTIONS' ),


### PR DESCRIPTION
## What?

Updates the templates screen to use the bundled Gutenberg class instead of the core one.

## Why?

The bundled Gutenberg class may receive updates in the plugin, so we need to use it instead of core's.

## Testing Instructions

Introduced at https://github.com/WordPress/gutenberg/pull/42729