### PR TITLE
Duotone: use `WP_Theme_JSON_Resolver_Gutenberg` instead of `WP_Theme_JSON_Resolver`

### DIFF
--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -97,7 +97,7 @@ class WP_Duotone_Gutenberg {
 	 */
 	public static function set_global_style_block_names() {
 		// Get the per block settings from the theme.json.
-		$tree        = WP_Theme_JSON_Resolver::get_merged_data();
+		$tree        = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
 		$block_nodes = $tree->get_styles_block_nodes();
 		$theme_json  = $tree->get_raw_data();
 


### PR DESCRIPTION
## What?

This PR updates duotone to use the class bundled by Gutenberg instead of the core one.

## Why?

This class is bundled in Gutenberg and so it can be updated. To avoid conflicts we need to use it instead of the respective core class.

## Testing Instructions

Introduced at https://github.com/WordPress/gutenberg/pull/49103