### PR TITLE
Show close button in List View on mobile

### DIFF
--- a/packages/edit-post/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-post/src/components/secondary-sidebar/style.scss
@@ -51,6 +51,12 @@
 	li:only-child {
 		width: 100%;
 	}
+
+	&.components-panel__header.edit-post-sidebar__panel-tabs {
+		.components-button.has-icon {
+			display: flex;
+		}
+	}
 }
 
 .edit-post-editor__list-view-panel-content,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/48982

This is hot fix for showing the `close` button in List View when we inadvertently end up with the full screen list in mobile. This is not intended right now as he hide the `List View` toggle in smaller viewports, but we can end up with it by having the respective `preference` set(always open list view) or by having it open and resize the viewport.

I've made the minimum changes here in order to add it in `6.2`. We probably need to evaluate this in more depth about the [similar Tab Panel implementations](https://github.com/WordPress/gutenberg/pull/44788#issuecomment-1293196126) in the code base, and also probably hiding it in mobile or updating how it works there in conjunction with the clarification of the preference that has not the effect expected in mobile.