### PR TITLE
refactor(blob): type url parameter as optional

### DIFF
--- a/packages/blob/README.md
+++ b/packages/blob/README.md
@@ -60,7 +60,7 @@ Check whether a url is a blob url.
 
 _Parameters_
 
--   _url_ `string`: The URL.
+-   _url_ `string|undefined`: The URL.
 
 _Returns_
 

--- a/packages/blob/src/index.js
+++ b/packages/blob/src/index.js
@@ -60,7 +60,7 @@ export function revokeBlobURL( url ) {
 /**
  * Check whether a url is a blob url.
  *
- * @param {string} url The URL.
+ * @param {string|undefined} url The URL.
  *
  * @return {boolean} Is the url a blob url?
  */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Type the `url` parameter of `@wordpress/blob` function `isBlobUrl` as possibly `undefined`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In common usage, the `url` parameter of the `@wordpress/blob` functions could be `undefined`. Though it is not typed as such, causing type errors when passed possibly undefined values in TypeScript.

Example  of passing `url`  as possibly `undefined` in `core/audio`:
https://github.com/WordPress/gutenberg/blob/9612e1c2c8f45a38470aaf62fafa5de6e1dca53c/packages/block-library/src/audio/edit.js#L61-L74

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Type the `url` parameter as `string|undefined`. I choose this over making it optional, as in `string=`, because passing no value isn't how the functions are used.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

The current tests should be sufficient. 
