### PR TITLE
Add missing pseudo-selectors to theme.json schema and documentation

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -1067,7 +1067,7 @@ h3 {
 
 ##### Element pseudo selectors
 
-Pseudo selectors `:hover`, `:focus`, `:visited` are supported by Gutenberg.
+Pseudo selectors `:hover`, `:focus`, `:visited`, `:active`, `:link`, `:any-link` are supported by Gutenberg.
 
 ```json
 "elements": {

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1654,6 +1654,12 @@
 								},
 								":visited": {
 									"$ref": "#/definitions/stylesPropertiesComplete"
+								},
+								":link": {
+									"$ref": "#/definitions/stylesPropertiesComplete"
+								},
+								":any-link": {
+									"$ref": "#/definitions/stylesPropertiesComplete"
 								}
 							},
 							"additionalProperties": false
@@ -1682,6 +1688,12 @@
 									"$ref": "#/definitions/stylesPropertiesComplete"
 								},
 								":visited": {
+									"$ref": "#/definitions/stylesPropertiesComplete"
+								},
+								":link": {
+									"$ref": "#/definitions/stylesPropertiesComplete"
+								},
+								":any-link": {
 									"$ref": "#/definitions/stylesPropertiesComplete"
 								}
 							},


### PR DESCRIPTION
Related core ticket: [Changeset 55121 – WordPress Trac](https://core.trac.wordpress.org/changeset/55121)
Related issue: #49013

## What?

This PR adds the missing pseudo-selectors to the JSON schema and developer documentation.

![json-schema](https://user-images.githubusercontent.com/54422211/226345054-512dfbce-95ae-468d-82e3-7b05f70fc966.png)

## Testing Instructions

Create a JSON file that references this PR with the `$schema` property:

```json
{
	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/fix/schema-for-pseudo-classes/schemas/json/theme.json",
	"version": 2,
	"styles": {
		"elements": {
			"link": {
			},
			"button": {
			}
		},
		"blocks": {
			"core/button": {
				"elements": {
					"button": {
					},
					"link": {
					}
				}
			}
		}
	}
}
```

Confirm that a total of six pseudo-classes appear as property candidates directly under `elements.link` and `elements.button`.