### PR TITLE
Fix flaky Site Editor title e2e tests

### DIFF
--- a/test/e2e/specs/site-editor/title.spec.js
+++ b/test/e2e/specs/site-editor/title.spec.js
@@ -15,14 +15,13 @@ test.describe( 'Site editor title', () => {
 	test( 'displays the selected template name in the title for the index template', async ( {
 		admin,
 		page,
-		editor,
 	} ) => {
 		// Navigate to a template.
 		await admin.visitSiteEditor( {
 			postId: 'emptytheme//index',
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-		await editor.canvas.click( 'body' );
 		const title = page.locator(
 			'role=region[name="Editor top bar"i] >> role=heading[level=1]'
 		);
@@ -33,14 +32,13 @@ test.describe( 'Site editor title', () => {
 	test( 'displays the selected template name in the title for the header template', async ( {
 		admin,
 		page,
-		editor,
 	} ) => {
 		// Navigate to a template part.
 		await admin.visitSiteEditor( {
 			postId: 'emptytheme//header',
 			postType: 'wp_template_part',
+			canvas: 'edit',
 		} );
-		await editor.canvas.click( 'body' );
 		const title = page.locator(
 			'role=region[name="Editor top bar"i] >> role=heading[level=1]'
 		);
@@ -51,13 +49,12 @@ test.describe( 'Site editor title', () => {
 	test( "displays the selected template part's name in the secondary title when a template part is selected from List View", async ( {
 		admin,
 		page,
-		editor,
 	} ) => {
 		await admin.visitSiteEditor( {
 			postId: 'emptytheme//index',
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-		await editor.canvas.click( 'body' );
 		// Select the header template part via list view.
 		await page.click( 'role=button[name="List View"i]' );
 		const listView = page.locator(


### PR DESCRIPTION
## What?
See #49019.

PR tries to fix flaky Site Editor title e2e tests by using a URL query argument for entering the edit mode. The test always fails for me when running locally on `trunk`.

## Why?
The `editor.canvas.click( 'body' )` turned out to be a flaky method for activating the edit mode. However, we can also force canvas mode since we're already using a URL query argument for selecting templates and template parts.

See failure artifacts - https://github.com/WordPress/gutenberg/actions/runs/4467473720. 

## Testing Instructions
```
npm run test:e2e:playwright -- test/e2e/specs/site-editor/title.spec.js
```

## Screenshots or screencast <!-- if applicable -->

[video.webm](https://user-images.githubusercontent.com/240569/226338717-efb029d3-f6ca-4ce2-9310-333fef4638d8.webm)
