### PR TITLE
Theme JSON schema: Add defaultPresets property to shadow

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -60,6 +60,7 @@ Settings related to shadows.
 
 | Property  | Type   | Default | Props  |
 | ---       | ---    | ---    |---   |
+| defaultPresets | boolean | true |  |
 | presets | array |  | name, shadow, slug |
 
 ---

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -74,6 +74,11 @@
 					"description": "Settings related to shadows.",
 					"type": "object",
 					"properties": {
+						"defaultPresets": {
+							"description": "Allow users to choose shadows from the default shadow presets.",
+							"type": "boolean",
+							"default": true
+						},
 						"presets": {
 							"description": "Shadow presets for the shadow picker.\nGenerates a single custom property (`--wp--preset--shadow--{slug}`) per preset value.",
 							"type": "array",
@@ -97,7 +102,8 @@
 								"additionalProperties": false
 							}
 						}
-					}
+					},
+					"additionalProperties": false
 				}
 			}
 		},


### PR DESCRIPTION
Related to: #46813

## What?
This PR adds the `defaultPresets` property to the `shadow` property of the `theme.json` schema.

![defaultpresets](https://user-images.githubusercontent.com/54422211/226351952-2b134bc0-2402-422e-b3f4-24cf43ed34a6.png)

## Why?
The [dev note](https://make.wordpress.org/core/2023/03/07/shadows-in-global-styles-with-wordpress-6-2/) on the shadow property does not mention `defaultPresets`. However, I would expect this property to be controllable via `theme.json`.

## How?
I have set `additionalProperties` to `false` in addition to adding the `shadow` property.

### Testing Instructions

Create a JSON file that references this PR with the `$schema` property:

```json
{
	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/fix/schema-for-shadow-defaultpresets/schemas/json/theme.json",
	"version": 2,
	"settings": {
		"shadow": {
		}
	}
}
```

- Under the `shadow` property, confirm the `defaultPresets` property is selectable.
- Confirm that the code editor shows an error if you define properties other than `defaultPresets` and `presets`.