### PR TITLE
Group: Fix the 'templateLock' attribute type in deprecations

### DIFF
--- a/packages/block-library/src/group/deprecated.js
+++ b/packages/block-library/src/group/deprecated.js
@@ -50,7 +50,8 @@ const deprecated = [
 				default: 'div',
 			},
 			templateLock: {
-				type: 'string',
+				type: [ 'string', 'boolean' ],
+				enum: [ 'all', 'insert', false ],
 			},
 		},
 		supports: {


### PR DESCRIPTION
## What?
Fixes #49159.

PR updates the `templateLock` type in the latest block deprecation to avoid losing the attribute when it's set to `false`.

## Testing Instructions
1. Open a Post or Page.
2. Switch to the code editor
3. Paste the following:
   ```
   <!-- wp:group {"templateLock":false} -->
   <div class="wp-block-group"></div>
   <!-- /wp:group -->
   ```
4. Confirm the `templateLock` boolean value is retained.
