### PR TITLE
Add a workflow for cache garbage collection

### DIFF
--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -5,8 +5,6 @@ name: Cache Garbage Collection
 
 on:
   pull_request:
-    types: [ closed ]
-
 
 jobs:
   # Delete cache keys scoped to pull requests.

--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -5,6 +5,8 @@ name: Cache Garbage Collection
 
 on:
   pull_request:
+    types:
+      - closed
 
 jobs:
   # Delete cache keys scoped to pull requests.

--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -26,7 +26,7 @@ jobs:
           retries: 2
           retry-exempt-status-codes: 418
           script: |
-            const action_caches = await github..rest.actions.getActionsCacheList({
+            const action_caches = await github.rest.actions.getActionsCacheList({
               owner: context.repo.owner,
               repo: context.repo.repo
             });

--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -36,8 +36,8 @@ jobs:
               if ( '${{ github.ref }}' == action_caches.data.actions_caches[ i ].ref ) {
                 github.rest.actions.deleteActionsCacheById({
                   owner: context.repo.owner,
-                  repo: context.repo.repo
-                  cache_id: action_caches.data.actions_caches[ i ].id,
+                  repo: context.repo.repo,
+                  cache_id: action_caches.data.actions_caches[ i ].id
                 });
               }
             }

--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -1,0 +1,45 @@
+##
+# Clean up cache keys that are no longer needed.
+##
+name: Cache Garbage Collection
+
+on:
+  pull_request:
+    types: [ closed ]
+
+
+jobs:
+  # Delete cache keys scoped to pull requests.
+  #
+  # When a cache is created by a workflow run triggered on a pull request, the cache is created
+  # for the merge ref (refs/pull/.../merge). Because of this, the cache will have a limited scope
+  # and can only be restored by re-runs of the pull request.
+  #
+  # This performs garbage collection on cache keys associated with a closed PR.
+  pr-garbage-collection:
+    name: Delete PR specific cache keys
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Find and delete PR specific cache keys
+        uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # v6.4.0
+        with:
+          retries: 2
+          retry-exempt-status-codes: 418
+          script: |
+            const action_caches = await github..rest.actions.getActionsCacheList({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+
+            // Find the caches related to this pull request.
+            for ( let i = 0; i < action_caches.data.actions_caches.length; i++ ) {
+              if ( '${{ github.ref }}' == action_caches.data.actions_caches[ i ].ref ) {
+                github.rest.actions.deleteActionsCacheById({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo
+                  cache_id: action_caches.data.actions_caches[ i ].id,
+                });
+              }
+            }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This adds a GitHub Actions workflow that performs garbage collection on GHA cache keys that are associated with a PR once it's closed out.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Once a PR is merged and/or closed, the cache keys created within associated workflow runs are useless.

Access restrictions provide cache isolation and security by creating a logical boundary between different branches or tags. Workflow runs can restore caches created in either the current branch or the default branch (usually main). If a workflow run is triggered for a pull request, it can also restore caches created in the base branch, including base branches of forked repositories.

When a cache is created by a workflow run triggered on a pull request, the cache is created for the merge ref (`refs/pull/.../merge`). Because of this, the cache will have a limited scope and can only be restored by re-runs of the pull request. It cannot be restored by the base branch or other pull requests targeting that base branch. This happens any time a PR changes lock files (which are used to create cache keys in most cases), or when a cache key for the primary branch is evicted or missing.

Each repository is allotted 10 GB worth of cache storage for GHA. Once that is exceeded, GitHub will proceed to evict cache entries until total storage falls below the allowed threshold. As far as I can tell, how GHA decides which cache keys to evict is not clear. By proactively evicting caches that we know are unlikely to be used again, we can ensure more important ones remain available longer.

You can read more about [caching within GitHub Actions and how this is managed in the documentation](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows).