### PR TITLE
Consolidate Safari Rerenders into one script

### DIFF
--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -194,11 +194,11 @@ class WP_Duotone_Gutenberg {
 		* Accessing el.offsetHeight flushes layout and style
 		* changes in WebKit without having to wait for setTimeout.
 		*/
-		printf(
+		$script_tag = sprintf(
 			'<script>
 				(
 					function() {
-						%s.forEach( selector => { 
+						%s.forEach( selector => {
 							document.querySelectorAll( selector ).forEach( function( el ) {
 								if( ! el ) {
 									return;
@@ -214,6 +214,9 @@ class WP_Duotone_Gutenberg {
 			</script>',
 			wp_json_encode( $selectors )
 		);
+
+		// Strip whitespace.
+		echo preg_replace( '/\s+/', '', $script_tag );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/49170. 

## Why?
Previously every duotone selector had its own script tag on the page. This consolidates them into one script tag and loops through all the selectors to apply the hack. Also, previously it used document.querySelector for the rerender, which would only grab the first matched element when there may be many on the page.

## How?
Collects all the selectors and the JS can now handle an array of strings rather than only one at a time.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
