### PR TITLE
Plugins: Refactor the 'PluginArea' component to use the sync store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17539,6 +17539,7 @@
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/icons": "file:packages/icons",
+				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"memize": "^1.1.0"
 			}
 		},

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -68,6 +68,12 @@ const Layout = () => (
 );
 ```
 
+_Parameters_
+
+-   _props_ `Object`:
+-   _props.scope_ `string|undefined`:
+-   _props.onError_ `Function|undefined`:
+
 _Returns_
 
 -   `WPComponent`: The component to be rendered.

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -30,6 +30,7 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/icons": "file:../icons",
+		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"memize": "^1.1.0"
 	},
 	"peerDependencies": {

--- a/packages/plugins/src/components/plugin-area/index.js
+++ b/packages/plugins/src/components/plugin-area/index.js
@@ -6,8 +6,9 @@ import memoize from 'memize';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { useMemo, useSyncExternalStore } from '@wordpress/element';
 import { addAction, removeAction } from '@wordpress/hooks';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * Internal dependencies
@@ -16,9 +17,14 @@ import { PluginContextProvider } from '../plugin-context';
 import { PluginErrorBoundary } from '../plugin-error-boundary';
 import { getPlugins } from '../../api';
 
+const getPluginContext = memoize( ( icon, name ) => ( { icon, name } ) );
+
 /**
  * A component that renders all plugin fills in a hidden div.
  *
+ * @param {Object}             props
+ * @param {string|undefined}   props.scope
+ * @param {Function|undefined} props.onError
  * @example
  * ```js
  * // Using ES5 syntax
@@ -50,80 +56,61 @@ import { getPlugins } from '../../api';
  *
  * @return {WPComponent} The component to be rendered.
  */
-class PluginArea extends Component {
-	constructor() {
-		super( ...arguments );
+function PluginArea( { scope, onError } ) {
+	const store = useMemo( () => {
+		let lastValue;
 
-		this.setPlugins = this.setPlugins.bind( this );
-		this.memoizedContext = memoize( ( name, icon ) => {
-			return {
-				name,
-				icon,
-			};
-		} );
-		this.state = this.getCurrentPluginsState();
-	}
-
-	getCurrentPluginsState() {
 		return {
-			plugins: getPlugins( this.props.scope ).map(
-				( { icon, name, render } ) => {
-					return {
-						Plugin: render,
-						context: this.memoizedContext( name, icon ),
-					};
+			subscribe( listener ) {
+				addAction(
+					'plugins.pluginRegistered',
+					'core/plugins/plugin-area/plugins-registered',
+					listener
+				);
+				addAction(
+					'plugins.pluginUnregistered',
+					'core/plugins/plugin-area/plugins-unregistered',
+					listener
+				);
+				return () => {
+					removeAction(
+						'plugins.pluginRegistered',
+						'core/plugins/plugin-area/plugins-registered'
+					);
+					removeAction(
+						'plugins.pluginUnregistered',
+						'core/plugins/plugin-area/plugins-unregistered'
+					);
+				};
+			},
+			getValue() {
+				const nextValue = getPlugins( scope );
+
+				if ( ! isShallowEqual( lastValue, nextValue ) ) {
+					lastValue = nextValue;
 				}
-			),
+
+				return lastValue;
+			},
 		};
-	}
+	}, [ scope ] );
 
-	componentDidMount() {
-		addAction(
-			'plugins.pluginRegistered',
-			'core/plugins/plugin-area/plugins-registered',
-			this.setPlugins
-		);
-		addAction(
-			'plugins.pluginUnregistered',
-			'core/plugins/plugin-area/plugins-unregistered',
-			this.setPlugins
-		);
-	}
+	const plugins = useSyncExternalStore( store.subscribe, store.getValue );
 
-	componentWillUnmount() {
-		removeAction(
-			'plugins.pluginRegistered',
-			'core/plugins/plugin-area/plugins-registered'
-		);
-		removeAction(
-			'plugins.pluginUnregistered',
-			'core/plugins/plugin-area/plugins-unregistered'
-		);
-	}
-
-	setPlugins() {
-		this.setState( this.getCurrentPluginsState );
-	}
-
-	render() {
-		return (
-			<div style={ { display: 'none' } }>
-				{ this.state.plugins.map( ( { context, Plugin } ) => (
-					<PluginContextProvider
-						key={ context.name }
-						value={ context }
-					>
-						<PluginErrorBoundary
-							name={ context.name }
-							onError={ this.props.onError }
-						>
-							<Plugin />
-						</PluginErrorBoundary>
-					</PluginContextProvider>
-				) ) }
-			</div>
-		);
-	}
+	return (
+		<div style={ { display: 'none' } }>
+			{ plugins.map( ( { icon, name, render: Plugin } ) => (
+				<PluginContextProvider
+					key={ name }
+					value={ getPluginContext( icon, name ) }
+				>
+					<PluginErrorBoundary name={ name } onError={ onError }>
+						<Plugin />
+					</PluginErrorBoundary>
+				</PluginContextProvider>
+			) ) }
+		</div>
+	);
 }
 
 export default PluginArea;

--- a/packages/plugins/src/components/test/plugin-area.js
+++ b/packages/plugins/src/components/test/plugin-area.js
@@ -92,30 +92,26 @@ describe( 'PluginArea', () => {
 		expect( container ).toHaveTextContent( 'plugin: two.' );
 	} );
 
-	test.failing(
-		'does not rerender when a plugin is added to a different scope',
-		() => {
-			const ComponentSpy = jest.fn( ( { content } ) => {
-				return `plugin: ${ content }.`;
-			} );
+	test( 'does not rerender when a plugin is added to a different scope', () => {
+		const ComponentSpy = jest.fn( ( { content } ) => {
+			return `plugin: ${ content }.`;
+		} );
 
-			registerPlugin( 'scoped', {
-				render: () => <ComponentSpy content="scoped" />,
+		registerPlugin( 'scoped', {
+			render: () => <ComponentSpy content="scoped" />,
+			icon: 'smiley',
+			scope: 'my-app',
+		} );
+
+		render( <PluginArea scope="my-app" /> );
+
+		act( () => {
+			registerPlugin( 'unscoped', {
+				render: () => <TestComponent content="unscoped" />,
 				icon: 'smiley',
-				scope: 'my-app',
 			} );
+		} );
 
-			render( <PluginArea scope="my-app" /> );
-
-			act( () => {
-				registerPlugin( 'unscoped', {
-					render: () => <TestComponent content="unscoped" />,
-					icon: 'smiley',
-				} );
-			} );
-
-			// Any store update triggers setState and causes PluginArea to rerender.
-			expect( ComponentSpy ).toHaveBeenCalledTimes( 1 );
-		}
-	);
+		expect( ComponentSpy ).toHaveBeenCalledTimes( 1 );
+	} );
 } );


### PR DESCRIPTION
## What?
PR refactors the `PluginArea` component to use the `useSyncExternalStore` hook instead of lifecycle methods.

## Why?
* The Plugins API uses external store + hooks API to trigger events. I think this new hook is better suited for this job.
* Avoid unnecessary re-renders, caused by storing the plugin array in the state.

## Testing Instructions
1. Open a Post or Page.
2. Confirm that the plugin API works as before - the "Manage reusable blocks" option is injected via the plugin.

Register testing plugin via console:

```js
const el = wp.element.createElement;
const registerPlugin = wp.plugins.registerPlugin;
const PluginDocumentSettingPanel = wp.editPost.PluginDocumentSettingPanel;
const { BlockTitle } = wp.blockEditor;

function MyDocumentSettingPlugin() {

	return el(
		PluginDocumentSettingPanel,
		{
			title: 'My Settings',
		},
		'Hello there 👋'
	);
}

registerPlugin( 'test-plugin-area', {
	render: MyDocumentSettingPlugin,
} );
```

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-03-21 at 09 07 59](https://user-images.githubusercontent.com/240569/226524051-c665fb30-d4c0-43b8-b8ca-fc0c6282980f.png)
