### PR TITLE
ToolsPanel: Make menu item order consistent for SlotFill use cases

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Bug Fix
 
 -  `InputControl`: Fix misaligned textarea input control ([#49116](https://github.com/WordPress/gutenberg/pull/49116)).
+-  `ToolsPanel`: Ensure consistency in menu item order ([#49222](https://github.com/WordPress/gutenberg/pull/49222)).
 
 ## 23.6.0 (2023-03-15)
 

--- a/packages/components/src/tools-panel/test/index.tsx
+++ b/packages/components/src/tools-panel/test/index.tsx
@@ -954,6 +954,92 @@ describe( 'ToolsPanel', () => {
 			expect( items[ 1 ] ).toHaveTextContent( 'Item 2' );
 		} );
 
+		it( 'should maintain menu item order', async () => {
+			const InconsistentItems = () => (
+				<ToolsPanelItems>
+					<ToolsPanelItem
+						label="Item 1"
+						hasValue={ () => false }
+						isShownByDefault
+					>
+						<div>Item 1</div>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						label="Item 2"
+						hasValue={ () => false }
+						isShownByDefault
+					>
+						<div>Item 2</div>
+					</ToolsPanelItem>
+				</ToolsPanelItems>
+			);
+
+			const { rerender } = render(
+				<SlotFillProvider>
+					<InconsistentItems key="order-test-step-1" />
+					<ToolsPanelItems>
+						<ToolsPanelItem
+							label="Item 3"
+							hasValue={ () => false }
+							isShownByDefault
+						>
+							<div>Item 3</div>
+						</ToolsPanelItem>
+					</ToolsPanelItems>
+					<ToolsPanel { ...defaultProps }>
+						<Slot />
+					</ToolsPanel>
+				</SlotFillProvider>
+			);
+
+			// Open dropdown menu.
+			const user = userEvent.setup();
+			let menuButton = getMenuButton();
+			await user.click( menuButton );
+
+			// Confirm all the existing menu items are present and in the
+			// expected order.
+			let menuItems = await screen.findAllByRole( 'menuitemcheckbox' );
+
+			expect( menuItems.length ).toEqual( 3 );
+			expect( menuItems[ 0 ] ).toHaveTextContent( 'Item 1' );
+			expect( menuItems[ 1 ] ).toHaveTextContent( 'Item 2' );
+			expect( menuItems[ 2 ] ).toHaveTextContent( 'Item 3' );
+
+			// Close the dropdown menu.
+			await user.click( menuButton );
+
+			rerender(
+				<SlotFillProvider>
+					<InconsistentItems key="order-test-step-2" />
+					<ToolsPanelItems>
+						<ToolsPanelItem
+							label="Item 3"
+							hasValue={ () => false }
+							isShownByDefault
+						>
+							<div>Item 3</div>
+						</ToolsPanelItem>
+					</ToolsPanelItems>
+					<ToolsPanel { ...defaultProps }>
+						<Slot />
+					</ToolsPanel>
+				</SlotFillProvider>
+			);
+
+			// Reopen dropdown menu.
+			menuButton = getMenuButton();
+			await user.click( menuButton );
+
+			// Confirm the menu item order has been maintained.
+			menuItems = await screen.findAllByRole( 'menuitemcheckbox' );
+
+			expect( menuItems.length ).toEqual( 3 );
+			expect( menuItems[ 0 ] ).toHaveTextContent( 'Item 1' );
+			expect( menuItems[ 1 ] ).toHaveTextContent( 'Item 2' );
+			expect( menuItems[ 2 ] ).toHaveTextContent( 'Item 3' );
+		} );
+
 		it( 'should not trigger callback when fill has not updated yet when panel has', () => {
 			// Fill provided controls can update independently to the panel.
 			// A `panelId` prop was added to both panels and items

--- a/packages/components/src/tools-panel/types.ts
+++ b/packages/components/src/tools-panel/types.ts
@@ -187,4 +187,5 @@ export type ToolsPanelMenuItemsConfig = {
 	panelItems: ToolsPanelItem[];
 	shouldReset: boolean;
 	currentMenuItems?: ToolsPanelMenuItems;
+	menuItemOrder: string[];
 };


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/49124

## What?

Updates the `ToolsPanel` to enforce some menu item order consistency when fills from different sources are rerendering.

## Why?

Watching the menu item position jump around when hovering over the padding or margin controls in the Dimensions panel, and again when resetting that panel's items, is not a great experience.

## How?

- Adds some internal state to track the order items first register
- The above initial order is used to maintain the ordering of menu items

## Alternative Solutions

We (@glendaviesnz and I) looked at ways of preventing the on-hover behaviour of the spacing controls from causing additional rerenders which result in the altered menu item order but didn't have much success in finding a clean solution.

Ultimately, if we can prevent the inconsistent menu order at the component level it might help protect against the same issue with other panels as their use cases evolve. Happy to explore better approaches if anyone has ideas.

To that end, I explored using the insertion order of properties within the `currentMenuItems` argument to `generateMenuItems`. That wasn't successful when switching or clearing block selection then re-selecting the original cover block.

## Testing Instructions

1. On trunk, follow the replication steps as per the original issue
2. Checkout this PR and repeat the process confirming the menu item order remains consistent
3. Test other panels in the editor and storybook examples and confirm no regressions in behaviour
4. Run the unit tests: `npm run test:unit packages/components/src/tools-panel`

## Screenshots or screencast <!-- if applicable -->


| Before | After |
|---|---|
| <video src="https://user-images.githubusercontent.com/60436221/226543296-4a995ab8-47fa-4ecf-80a9-b5579366cbe2.mp4" /> | <video src="https://user-images.githubusercontent.com/60436221/226543425-35b47400-3ccb-41ba-a9fc-ecb7063a368e.mp4" /> |




