### PR TITLE
Allow private pages to display in Nav block on front of site

### DIFF
--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -160,10 +160,19 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	$is_post_type           = isset( $attributes['kind'] ) && 'post-type' === $attributes['kind'];
 	$is_post_type           = $is_post_type || isset( $attributes['type'] ) && ( 'post' === $attributes['type'] || 'page' === $attributes['type'] );
 
+
 	// Don't render the block's subtree if it is a draft or if the ID does not exist.
 	if ( $is_post_type && $navigation_link_has_id ) {
+
+		// Only render published or private posts.
+		// Note private posts are displayed to mirror behaviour of the Classic Menus system.
+		// It is not possible to add a Private posts to a menu, but if a post is added and then
+		// subsequently set to Private, it should still be displayed in the menu.
+		// See: https://github.com/WordPress/gutenberg/issues/33215.
+		$valid_post_statuses = array( 'publish', 'private' );
+
 		$post = get_post( $attributes['id'] );
-		if ( ! $post || 'publish' !== $post->post_status ) {
+		if ( ! $post || ! in_array( $post->post_status, $valid_post_statuses, true ) ) {
 			return '';
 		}
 	}

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -160,7 +160,6 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	$is_post_type           = isset( $attributes['kind'] ) && 'post-type' === $attributes['kind'];
 	$is_post_type           = $is_post_type || isset( $attributes['type'] ) && ( 'post' === $attributes['type'] || 'page' === $attributes['type'] );
 
-
 	// Don't render the block's subtree if it is a draft or if the ID does not exist.
 	if ( $is_post_type && $navigation_link_has_id ) {
 

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -134,8 +134,15 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	$is_post_type           = isset( $attributes['kind'] ) && 'post-type' === $attributes['kind'];
 	$is_post_type           = $is_post_type || isset( $attributes['type'] ) && ( 'post' === $attributes['type'] || 'page' === $attributes['type'] );
 
+	// Only render published or private posts.
+	// Note private posts are displayed to mirror behaviour of the Classic Menus system.
+	// It is not possible to add a Private posts to a menu, but if a post is added and then
+	// subsequently set to Private, it should still be displayed in the menu.
+	// See: https://github.com/WordPress/gutenberg/issues/33215.
+	$valid_post_statuses = array( 'publish', 'private' );
+
 	// Don't render the block's subtree if it is a draft.
-	if ( $is_post_type && $navigation_link_has_id && 'publish' !== get_post_status( $attributes['id'] ) ) {
+	if ( $is_post_type && $navigation_link_has_id && ! in_array( get_post_status( $attributes['id'] ), $valid_post_statuses, true ) ) {
 		return '';
 	}
 

--- a/phpunit/blocks/render-block-navigation-link-test.php
+++ b/phpunit/blocks/render-block-navigation-link-test.php
@@ -17,14 +17,12 @@ class Render_Block_Navigation_Link_Test extends WP_UnitTestCase {
 	private static $custom_draft;
 	private static $custom_post;
 
-	private static $pages;
-	private static $terms;
 	/**
 	 * @var array|null
 	 */
 	private $original_block_supports;
 
-	public static function wpSetUpBeforeClass() {
+	public static function set_up_before_class() {
 
 		self::$draft = self::factory()->post->create_and_get(
 			array(
@@ -37,8 +35,6 @@ class Render_Block_Navigation_Link_Test extends WP_UnitTestCase {
 			)
 		);
 
-		self::$pages[] = self::$draft;
-
 		self::$private_page = self::factory()->post->create_and_get(
 			array(
 				'post_type'    => 'page',
@@ -50,8 +46,6 @@ class Render_Block_Navigation_Link_Test extends WP_UnitTestCase {
 			)
 		);
 
-		self::$pages[] = self::$private_page;
-
 		self::$custom_draft = self::factory()->post->create_and_get(
 			array(
 				'post_type'    => 'cats',
@@ -62,7 +56,6 @@ class Render_Block_Navigation_Link_Test extends WP_UnitTestCase {
 				'post_excerpt' => 'Metal Cat',
 			)
 		);
-		self::$pages[]      = self::$custom_draft;
 
 		self::$custom_post = self::factory()->post->create_and_get(
 			array(
@@ -74,9 +67,8 @@ class Render_Block_Navigation_Link_Test extends WP_UnitTestCase {
 				'post_excerpt' => 'Metal Dog',
 			)
 		);
-		self::$pages[]     = self::$custom_post;
 
-		self::$page    = self::factory()->post->create_and_get(
+		self::$page = self::factory()->post->create_and_get(
 			array(
 				'post_type'    => 'page',
 				'post_status'  => 'publish',
@@ -86,7 +78,6 @@ class Render_Block_Navigation_Link_Test extends WP_UnitTestCase {
 				'post_excerpt' => 'Tabby cat',
 			)
 		);
-		self::$pages[] = self::$page;
 
 		self::$category = self::factory()->category->create_and_get(
 			array(
@@ -96,17 +87,6 @@ class Render_Block_Navigation_Link_Test extends WP_UnitTestCase {
 				'description' => 'Cats Category',
 			)
 		);
-
-		self::$terms[] = self::$category;
-	}
-
-	public static function wpTearDownAfterClass() {
-		foreach ( self::$pages as $page_to_delete ) {
-			wp_delete_post( $page_to_delete->ID );
-		}
-		foreach ( self::$terms as $term_to_delete ) {
-			wp_delete_term( $term_to_delete->term_id, $term_to_delete->taxonomy );
-		}
 	}
 
 	public function set_up() {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Allows private Posts to display in the Nav block _if_ they are part of a menu.

Closes https://github.com/WordPress/gutenberg/issues/33215

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In the Classic Menus system it was not possible to add Private posts to a menu from the Menus screen. However, if the Post was added to a Menu and _then_ subsequently made `Private` it would render on the front of the site and remain in the Menu on the Menus screen.

The Nav Link/Submenu blocks were not mirroring this behaviour. This PR fixes things to display the same behaviour as for Classic Menus.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

There were two tasks that needed to be addressed.

> 1. Check that private posts cannot be found in the Link creation UI.

I checked by:

- ✅ making a Private Post and then trying to find that post using the Link UI search. I could not find it. 
- ✅ verified that [the Post Search endpoint is set to `publish` status only](https://github.com/WordPress/wordpress-develop/blob/7cef755d2761deb7bc7b53d047a27c42d16cd43b/src/wp-includes/rest-api/search/class-wp-rest-post-search-handler.php#L62).

> 2. Add private to the list of allowed post types on the front of the site.

This PR implements this part by adding `private` to the list of post statuses that are allowed.

**Note**: it should not be possible to find/add a private post to a menu from the Link UI. That part has not changed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Create a Post/Page and publish it as `Private`.
- In a Navigation block add a new menu item and try and find that post in the search UI. You shouldn't be able to find it.
- Now make that Post "Public" again (`Publish` status).
- Now go back to the Nav block and try and find your Post and add it to your menu.
- Save the menu.
- View the front of your site and check that the menu item is visible.
- Now return to the Post and make it `Private` again.
- Now reload the front of your site. Check the menu item is still rendered.
- Test with other Post Types.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
