### PR TITLE
Lodash: Remove `_.groupBy()` from `buildTermsTree()` in editor

### DIFF
--- a/packages/editor/src/utils/terms.js
+++ b/packages/editor/src/utils/terms.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { groupBy } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { decodeEntities } from '@wordpress/html-entities';
@@ -24,10 +19,25 @@ export function buildTermsTree( flatTerms ) {
 		};
 	} );
 
-	const termsByParent = groupBy( flatTermsWithParentAndChildren, 'parent' );
-	if ( termsByParent.null && termsByParent.null.length ) {
+	// All terms should have a `parent` because we're about to index them by it.
+	if (
+		flatTermsWithParentAndChildren.some( ( { parent } ) => parent === null )
+	) {
 		return flatTermsWithParentAndChildren;
 	}
+
+	const termsByParent = flatTermsWithParentAndChildren.reduce(
+		( acc, term ) => {
+			const { parent } = term;
+			if ( ! acc[ parent ] ) {
+				acc[ parent ] = [];
+			}
+			acc[ parent ].push( term );
+			return acc;
+		},
+		{}
+	);
+
 	const fillWithChildren = ( terms ) => {
 		return terms.map( ( term ) => {
 			const children = termsByParent[ term.id ];


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.groupBy()` from `buildTermsTree()` in the editor package.

Similar to #48779. Ideally, those should be deduplicated, but that's work for another time.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `Array.prototype.reduce()` instead.

## Testing Instructions

* Verify the Parent field in the Page Attributes box in the sidebar of a page still displays the page hierarchy properly.
* Verify all checks are green - the changes are well covered by unit tests.