### PR TITLE
Lodash: Refactor away from `_.groupBy()` from `compileCSS()`

### DIFF
--- a/packages/style-engine/src/index.ts
+++ b/packages/style-engine/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { groupBy, kebabCase } from 'lodash';
+import { kebabCase } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,7 +36,20 @@ export function compileCSS( style: Style, options: StyleOptions = {} ): string {
 		return inlineRules.join( ' ' );
 	}
 
-	const groupedRules = groupBy( rules, 'selector' );
+	const groupedRules = rules.reduce(
+		( acc: Record< string, GeneratedCSSRule[] >, rule ) => {
+			const { selector } = rule;
+			if ( ! selector ) {
+				return acc;
+			}
+			if ( ! acc[ selector ] ) {
+				acc[ selector ] = [];
+			}
+			acc[ selector ].push( rule );
+			return acc;
+		},
+		{}
+	);
 	const selectorRules = Object.keys( groupedRules ).reduce(
 		( acc: string[], subSelector: string ) => {
 			acc.push(


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.groupBy()` from `compileCSS()` in the style engine package.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `Array.prototype.reduce()` instead.

## Testing Instructions

* Verify that as you move, change, duplicate or edit blocks, their custom styles still persist as expected.
* Verify all checks are green - the changes are well covered by unit tests.