### PR TITLE
Duotone: Remove Safari rerender hack

### DIFF
--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -184,24 +184,7 @@ class WP_Duotone_Gutenberg {
 	}
 
 	/**
-	 * Safari renders elements incorrectly on first paint when the SVG filter comes after the content that it is filtering,
-	 * so we force a repaint with a WebKit hack which solves the issue.
-	 *
-	 * @param string $selector The selector to apply the hack for.
-	 */
-	private static function safari_rerender_hack( $selector ) {
-		/*
-		* Simply accessing el.offsetHeight flushes layout and style
-		* changes in WebKit without having to wait for setTimeout.
-		*/
-		printf(
-			'<script>( function() { var el = document.querySelector( %s ); var display = el.style.display; el.style.display = "none"; el.offsetHeight; el.style.display = display; } )();</script>',
-			wp_json_encode( $selector )
-		);
-	}
-
-	/**
-	 * Outputs all necessary SVG for duotone filters, CSS for classic themes, and safari rerendering hack
+	 * Outputs all necessary SVG for duotone filters, CSS for classic themes.
 	 */
 	public static function output_footer_assets() {
 		foreach ( self::$output as $filter_data ) {
@@ -214,11 +197,6 @@ class WP_Duotone_Gutenberg {
 			// This is for classic themes - in block themes, the CSS is added in the head via wp_add_inline_style in the wp_enqueue_scripts action.
 			if ( ! wp_is_block_theme() ) {
 				wp_add_inline_style( 'core-block-supports', 'body{' . self::get_css_custom_property_declaration( $filter_data ) . '}' );
-			}
-
-			global $is_safari;
-			if ( $is_safari ) {
-				self::safari_rerender_hack( $filter_data['selector'] );
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/49170.
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
As we discovered in https://github.com/WordPress/gutenberg/pull/49215, this code is not needed, so let's remove it.

## Why?
Simplicity and performance.

## How?
Remove code

## Testing Instructions
Open page with a block with a duotone filter in Safari, and confirm you see the filter applied correctly.

For reference about what "correctly" means, see [this comment](https://github.com/WordPress/gutenberg/pull/49215#issuecomment-1477823393).

