### PR TITLE
Polyfills: exclude web.immediate

### DIFF
--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Enhancement
+
 -   Exclude IE-only `setImmediate`/`clearImmediate` from list of polyfills.
 
 ## 7.13.0 (2023-03-15)

--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   Exclude IE-only `setImmediate`/`clearImmediate` from list of polyfills.
+
 ## 7.13.0 (2023-03-15)
 
 ## 7.12.0 (2023-03-01)

--- a/packages/babel-preset-default/bin/index.js
+++ b/packages/babel-preset-default/bin/index.js
@@ -16,6 +16,7 @@ builder( {
 		// @see https://github.com/WordPress/gutenberg/pull/31279
 		'es.promise',
 		// This is an IE-only feature which we don't use, and don't want to polyfill.
+		// @see https://github.com/WordPress/gutenberg/pull/49234
 		'web.immediate',
 	],
 	targets: require( '@wordpress/browserslist-config' ),

--- a/packages/babel-preset-default/bin/index.js
+++ b/packages/babel-preset-default/bin/index.js
@@ -9,11 +9,15 @@ const { writeFile } = require( 'fs' ).promises;
 
 builder( {
 	modules: [ 'es', 'web' ],
-	// core-js is extremely conservative in which polyfills to include.
-	// Knowing about tiny browser implementation bugs that anyone rarely cares about,
-	// we prevent some features from having the full polyfill included.
-	// @see https://github.com/WordPress/gutenberg/pull/31279
-	exclude: [ 'es.promise' ],
+	exclude: [
+		// core-js is extremely conservative in which polyfills to include.
+		// Since we don't care about the tiny browser implementation bugs behind its decision
+		// to polyfill these features, we forcefully prevent them from being included.
+		// @see https://github.com/WordPress/gutenberg/pull/31279
+		'es.promise',
+		// This is an IE-only feature which we don't use, and don't want to polyfill.
+		'web.immediate',
+	],
 	targets: require( '@wordpress/browserslist-config' ),
 	filename: './build/polyfill.js',
 } )


### PR DESCRIPTION
## What?
Remove `setImmediate` / `clearImmediate` from the list of features that we polyfill.

## Why?
While investigating some performance issues in Safari, I noticed that `setImmediate` / `clearImmediate` are being polyfilled by `core-js`. These are [IE-only features](https://caniuse.com/mdn-api_window_setimmediate) which we don't use, and therefore don't need polyfills for. That alone is probably reason enough to exclude them.

But beyond that, it's worth pointing out that `react` [does look for them in some circumstances](https://github.com/facebook/react/blob/977bccd24de2b062d2c114e6cf160d2bd9ed9493/packages/scheduler/src/forks/Scheduler.js#L110), when deciding how to schedule work. It prefers the native `setImmediate` implementation when available vs other functionality (such as message channels), due to some inherent characteristics of how it's implemented. So when we polyfill `setImmediate`, we trick React into opting for this approach, even though the inherent characteristics it prefers are not there (since it's just a polyfill that's implemented on top of other functionality).

It's therefore best to simply have `react` pick one of the other approaches, instead of having `core-js` spend the effort to poorly reimplement `react`'s preferred approach.

## How?
It excludes the aforementioned features by changing the `babel-preset-default` configuration.

## Testing Instructions
It's not entirely clear to me how to force the testing environment to load a newly-generated set of polyfills, given that it seems to be controlled via `load-scripts.php` (which, in my testing, didn't pick up the modified polyfills).
(I had to resort to local overrides in my browser to manually modify the concatenated script)

Assuming you can get the new polyfills to load, however, it's simple: just load the editor and smoke-test any functionality, as any problems would make themselves evident immediately. If possible, test using Safari, which does follow the `react` scheduling codepath in question.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A