### PR TITLE
Adds focus management test for entity undo

### DIFF
--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -3,7 +3,7 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-test.describe( 'Template Part Operations', () => {
+test.describe( 'Template Part', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
 		await requestUtils.deleteAllTemplates( 'wp_template' );

--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -3,69 +3,6 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-test.describe( 'As a keyboatd user, I expect focus to not be lost', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'emptytheme' );
-		await requestUtils.deleteAllTemplates( 'wp_template' );
-		await requestUtils.deleteAllTemplates( 'wp_template_part' );
-	} );
-
-	test.afterEach( async ( { requestUtils } ) => {
-		await requestUtils.deleteAllTemplates( 'wp_template' );
-		await requestUtils.deleteAllTemplates( 'wp_template_part' );
-	} );
-
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-	} );
-
-	test( 'Keeps focus in place on undo in template parts', async ( {
-		admin,
-		editor,
-		page,
-		pageUtils,
-	} ) => {
-		await admin.visitSiteEditor( {
-			postId: 'emptytheme//header',
-			postType: 'wp_template_part',
-		} );
-		await editor.canvas.click( 'body' );
-
-		// Select the site title block.
-		const siteTitle = editor.canvas.getByRole( 'document', {
-			name: 'Site title',
-		} );
-		await editor.selectBlocks( siteTitle );
-
-		await pageUtils.pressKeys( 'access+z' );
-
-		// Insert a group block
-		await editor.insertBlock( {
-			name: 'core/group',
-			innerBlocks: [ { name: 'core/site-title' } ],
-		} );
-
-		// Select the site title block.
-		const siteTitleInGroup = editor.canvas.getByRole( 'document', {
-			name: 'Site title',
-		} );
-		await editor.selectBlocks( siteTitleInGroup );
-
-		// Change heading level.
-		await editor.clickBlockToolbarButton( 'Change heading level' );
-		const Heading3Button = page.locator(
-			'role=menuitemradio[name="Heading 3"i]'
-		);
-		await Heading3Button.click();
-
-		await pageUtils.pressKeys( 'primary+z' );
-
-		await expect(
-			page.locator( 'role=button[name="Change heading level"i]' )
-		).toBeFocused();
-	} );
-} );
-
 test.describe( 'Template Part Operations', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
@@ -418,5 +355,51 @@ test.describe( 'Template Part Operations', () => {
 		await expect(
 			page.getByRole( 'combobox', { name: 'Import widget area' } )
 		).not.toBeVisible();
+	} );
+
+	test( 'Keeps focus in place on undo in template parts', async ( {
+		admin,
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await admin.visitSiteEditor( {
+			postId: 'emptytheme//header',
+			postType: 'wp_template_part',
+		} );
+		await editor.canvas.click( 'body' );
+
+		// Select the site title block.
+		const siteTitle = editor.canvas.getByRole( 'document', {
+			name: 'Site title',
+		} );
+		await editor.selectBlocks( siteTitle );
+
+		await pageUtils.pressKeys( 'access+z' );
+
+		// Insert a group block
+		await editor.insertBlock( {
+			name: 'core/group',
+			innerBlocks: [ { name: 'core/site-title' } ],
+		} );
+
+		// Select the site title block.
+		const siteTitleInGroup = editor.canvas.getByRole( 'document', {
+			name: 'Site title',
+		} );
+		await editor.selectBlocks( siteTitleInGroup );
+
+		// Change heading level.
+		await editor.clickBlockToolbarButton( 'Change heading level' );
+		const Heading3Button = page.locator(
+			'role=menuitemradio[name="Heading 3"i]'
+		);
+		await Heading3Button.click();
+
+		await pageUtils.pressKeys( 'primary+z' );
+
+		await expect(
+			page.locator( 'role=button[name="Change heading level"i]' )
+		).toBeFocused();
 	} );
 } );

--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -3,7 +3,70 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-test.describe( 'Template Part', () => {
+test.describe( 'As a keyboatd user, I expect focus to not be lost', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+		await requestUtils.deleteAllTemplates( 'wp_template' );
+		await requestUtils.deleteAllTemplates( 'wp_template_part' );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllTemplates( 'wp_template' );
+		await requestUtils.deleteAllTemplates( 'wp_template_part' );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test( 'Keeps focus in place on undo in template parts', async ( {
+		admin,
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await admin.visitSiteEditor( {
+			postId: 'emptytheme//header',
+			postType: 'wp_template_part',
+		} );
+		await editor.canvas.click( 'body' );
+
+		// Select the site title block.
+		const siteTitle = editor.canvas.getByRole( 'document', {
+			name: 'Site title',
+		} );
+		await editor.selectBlocks( siteTitle );
+
+		await pageUtils.pressKeys( 'access+z' );
+
+		// Insert a group block
+		await editor.insertBlock( {
+			name: 'core/group',
+			innerBlocks: [ { name: 'core/site-title' } ],
+		} );
+
+		// Select the site title block.
+		const siteTitleInGroup = editor.canvas.getByRole( 'document', {
+			name: 'Site title',
+		} );
+		await editor.selectBlocks( siteTitleInGroup );
+
+		// Change heading level.
+		await editor.clickBlockToolbarButton( 'Change heading level' );
+		const Heading3Button = page.locator(
+			'role=menuitemradio[name="Heading 3"i]'
+		);
+		await Heading3Button.click();
+
+		await pageUtils.pressKeys( 'primary+z' );
+
+		await expect(
+			page.locator( 'role=button[name="Change heading level"i]' )
+		).toBeFocused();
+	} );
+} );
+
+test.describe( 'Template Part Operations', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
 		await requestUtils.deleteAllTemplates( 'wp_template' );

--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -375,27 +375,29 @@ test.describe( 'Template Part', () => {
 		} );
 		await editor.selectBlocks( siteTitle );
 
+		// Remove the default site title block.
 		await pageUtils.pressKeys( 'access+z' );
 
-		// Insert a group block
+		// Insert a group block with a Site Title block inside.
 		await editor.insertBlock( {
 			name: 'core/group',
 			innerBlocks: [ { name: 'core/site-title' } ],
 		} );
 
-		// Select the site title block.
+		// Select the Site Title block inside the group.
 		const siteTitleInGroup = editor.canvas.getByRole( 'document', {
 			name: 'Site title',
 		} );
 		await editor.selectBlocks( siteTitleInGroup );
 
-		// Change heading level.
+		// Change heading level of the Site Title block.
 		await editor.clickBlockToolbarButton( 'Change heading level' );
-		const Heading3Button = page.locator(
-			'role=menuitemradio[name="Heading 3"i]'
-		);
+		const Heading3Button = page.getByRole( 'menuitemradio', {
+			name: 'Heading 3',
+		} );
 		await Heading3Button.click();
 
+		// Undo the change.
 		await pageUtils.pressKeys( 'primary+z' );
 
 		await expect(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #49098

In #48979 a fix for focus loss was merged. This adds a test for that fix.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To guard from regressions, but also to see the problem expressed in code.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adding a test.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Run:

```
npm run test:e2e:playwright -- -g "Keeps focus in place on undo in template parts"
```

The test should pass.

Revert the change in #48979 (the else branch [here](https://github.com/WordPress/gutenberg/pull/48979/files#diff-a5d2581866e1fffe3d08cc3562c9b0c896efa93a317c1733cb92e75ef070675bR181).

The test should fail.