### PR TITLE
Remove !important declaration for duotone CSS

### DIFF
--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -328,7 +328,7 @@ class WP_Duotone_Gutenberg {
 						// render before global styles,
 						// and they should be overriding the duotone
 						// filters set by global styles.
-						'filter' => $declaration_value . ' !important',
+						'filter' => $declaration_value,
 					),
 				),
 			),

--- a/lib/experimental/kses.php
+++ b/lib/experimental/kses.php
@@ -78,7 +78,7 @@ add_action( 'set_current_user', 'gutenberg_override_core_kses_init_filters' );
  */
 function allow_filter_in_styles( $allow_css, $css_test_string ) {
 	if ( preg_match(
-		"/^filter:\s*url\('#wp-duotone-[-a-zA-Z0-9]+'\) !important$/",
+		"/^filter:\s*url\('#wp-duotone-[-a-zA-Z0-9]+'\)(?: !important)?$/",
 		$css_test_string
 	) ) {
 		return true;


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/49171

## What?
1. Allow CSS filter declarations to not require `!important`
2. Removes !important from our duotone CSS.

## Why?
For code quality, it's better not to use `!important` if we can avoid it.

## How?
Adjusts the regex for the kses filter declaration to allow !important or not by using (?: !important)? to not create a capture group and make it optional.

## Testing Instructions
1. Load a frontend page with all the different duotone possibilities applied such as theme.json, global styles, and custom (especially a custom duotone, as that's what was directly impacted here).
2. Check that all duotone is rendered correctly. There should not be any changes.