### PR TITLE
CircularOptionPicker: force swatches to visually render on top of the rest of the component's content

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -170,6 +170,11 @@ $z-layers: (
 	// Needs to be higher than .components-circular-option-picker__option.is-pressed.
 	".components-circular-option-picker__option.is-pressed + svg": 2,
 
+	// The following two indexes are needed so that the swatches (and their tooltips)
+	// always render on top of the rest of the component's UI.
+	".components-circular-option-picker__swatches": 1,
+	"> *:not(.components-circular-option-picker__swatches)": 0,
+
 	// Appear under the customizer heading UI, but over anything else.
 	".customize-widgets__topbar": 8,
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bug Fix
 
+-  `CircularOptionPicker`: force swatches to visually render on top of the rest of the component's content ([#49245](https://github.com/WordPress/gutenberg/pull/49245)).
 -  `InputControl`: Fix misaligned textarea input control ([#49116](https://github.com/WordPress/gutenberg/pull/49116)).
 
 ### Internal

--- a/packages/components/src/circular-option-picker/style.scss
+++ b/packages/components/src/circular-option-picker/style.scss
@@ -17,7 +17,7 @@ $color-palette-circle-spacing: 12px;
 		flex-wrap: wrap;
 		gap: $color-palette-circle-spacing;
 		position: relative;
-		z-index: 1;
+		z-index: z-index(".components-circular-option-picker__swatches");
 	}
 
 	// Make sure that the .components-circular-option-picker__swatches element
@@ -25,7 +25,7 @@ $color-palette-circle-spacing: 12px;
 	// that the tooltip rendered when hovering an `Option` always appears on top.
 	> *:not(.components-circular-option-picker__swatches) {
 		position: relative;
-		z-index: 0;
+		z-index: z-index("> *:not(.components-circular-option-picker__swatches)");
 	}
 }
 

--- a/packages/components/src/circular-option-picker/style.scss
+++ b/packages/components/src/circular-option-picker/style.scss
@@ -16,6 +16,16 @@ $color-palette-circle-spacing: 12px;
 		display: flex;
 		flex-wrap: wrap;
 		gap: $color-palette-circle-spacing;
+		position: relative;
+		z-index: 1;
+	}
+
+	// Make sure that the .components-circular-option-picker__swatches element
+	// renders visually on top of its siblings. This is necessary to make sure
+	// that the tooltip rendered when hovering an `Option` always appears on top.
+	> *:not(.components-circular-option-picker__swatches) {
+		position: relative;
+		z-index: 0;
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #49225

Make sure that the swatches wrapper in the `CircularOptionPicker` component renders on top of the rest of the component's content.

This, intrinsically, makes sure that tooltips rendered when hovering/focusing the picker options also render on top of any other UI.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This change fixes UI issues like experienced in #49225

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding explicit CSS rules to force the swatch container to have a higher z-index than its following siblings.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- In storybook, visit the `DuotonePicker` example
- hover over the color options
- on trunk, observe how the tooltip renders below the "gradient bar" (buggy behaviour)
- after applying changes from this PR, observe how the the tooltip renders above the "gradient bar" (correct behaviour)


**Check for potential regressions across usages of the `CircularOptionPicker` in the editor**

## Screenshots or screencast <!-- if applicable -->

| Before (`trunk`) | After (this PR) |
|---|---|
| ![Kapture 2023-03-21 at 23 22 26](https://user-images.githubusercontent.com/1083581/226755239-ee8796a6-9f18-484c-a771-b83129443e38.gif) | ![Kapture 2023-03-21 at 23 21 36](https://user-images.githubusercontent.com/1083581/226755296-a38c44af-e37f-4f68-b52f-16cbd71b2589.gif) |
