### PR TITLE
Tag Cloud Block: Fix outline style not applied in editor

### DIFF
--- a/packages/block-library/src/tag-cloud/editor.scss
+++ b/packages/block-library/src/tag-cloud/editor.scss
@@ -1,11 +1,22 @@
-// The following styles are to prevent duplicate spacing and border for the tag cloud
-// block in the editor given it uses server side rendering. The specificity
-// must be higher than `0-1-0` to override global styles. Targeting the
-// inner use of the .wp-block-tag-cloud class should minimize impact on
-// other 3rd party styles targeting the block.
-.wp-block-tag-cloud .wp-block-tag-cloud {
-	margin: 0;
-	padding: 0;
-	border: none;
-	border-radius: inherit;
+
+.wp-block-tag-cloud {
+	// The following styles are to prevent duplicate spacing and border for the tag cloud
+	// block in the editor given it uses server side rendering. The specificity
+	// must be higher than `0-1-0` to override global styles. Targeting the
+	// inner use of the .wp-block-tag-cloud class should minimize impact on
+	// other 3rd party styles targeting the block.
+	.wp-block-tag-cloud {
+		margin: 0;
+		padding: 0;
+		border: none;
+		border-radius: inherit;
+	}
+
+	&.is-style-outline .wp-block-tag-cloud {
+		// CSS classes are not passed to the ServerSideRender component,
+		// so nested selectors must be used to apply outline block styles.
+		display: flex;
+		flex-wrap: wrap;
+		gap: 1ch;
+	}
 }


### PR DESCRIPTION
Fixes: #49226
Related to: #44439

## What?
This PR fixes a problem where styles aren't applied correctly when the outline style is applied to the tag cloud block in the editor.

## Why?

In #44439, `skipBlockSupportAttributes` was added to the `ServerSideRender` component to prevent duplication of block support styles and additional CSS classes. As a result, flex layout is now applied only to block wrapper elements, and styles are not applied to server-side rendered `p.wp-block-tag-cloud`.

## Testing Instructions

- Add multiple tags to a post.
- Insert a tag cloud block and Change the block style to outline.
- As with the front end, confirm styles are applied correctly.

### Before

![before](https://user-images.githubusercontent.com/54422211/226808201-2725ec20-cb98-4d3d-b663-f57edb107d80.png)

### After

![after](https://user-images.githubusercontent.com/54422211/226808212-d8a4c56c-f6cd-4ba3-bc7a-9f16c1fbc802.png)


