### PR TITLE
Group: Fix the 'double div' deprecation 'templateLock ' attribute

### DIFF
--- a/packages/block-library/src/group/deprecated.js
+++ b/packages/block-library/src/group/deprecated.js
@@ -136,7 +136,8 @@ const deprecated = [
 				default: 'div',
 			},
 			templateLock: {
-				type: 'string',
+				type: [ 'string', 'boolean' ],
+				enum: [ 'all', 'insert', false ],
 			},
 		},
 		supports: {


### PR DESCRIPTION
## What?
See https://github.com/WordPress/gutenberg/issues/49159#issuecomment-1477512048.

PR fixes the `templateLock` attribute for the "double div" deprecation.

## Why?
The deprecation was created with the wrong attribute type, later fixed in #36264, but forgot to update deprecation updates.

Props, @kraftner, for pointing this out.

## Testing Instructions
1. Open a Post or Page.
2. Switch to the code editor
3. Paste the following:

```
<!-- wp:group {"templateLock":false} -->
<div class="wp-block-group"></div>
<!-- /wp:group -->
```
4. Confirm the templateLock boolean value is retained.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://user-images.githubusercontent.com/240569/226824942-cabb3870-9d7c-486d-8995-b07bc5363f85.mp4

**After**

https://user-images.githubusercontent.com/240569/226824954-d1b2b830-7e91-4318-bd58-550ef1010524.mp4

