### PR TITLE
Allow the time to read block to be inserted multiple times

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -590,7 +590,7 @@ Show minutes required to finish reading the post. ([Source](https://github.com/W
 
 -	**Name:** core/post-time-to-read
 -	**Category:** theme
--	**Supports:** typography (fontSize, lineHeight), ~~html~~, ~~multiple~~
+-	**Supports:** typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** textAlign
 
 ## Post Title

--- a/packages/block-library/src/post-time-to-read/block.json
+++ b/packages/block-library/src/post-time-to-read/block.json
@@ -15,7 +15,6 @@
 	},
 	"supports": {
 		"html": false,
-		"multiple": false,
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,


### PR DESCRIPTION
## What?
In passing, I noticed that the Time to Read block can't be inserted in a post more than once.

In this PR I'm removing the restriction. I'm not sure if there's a reason I'm missing for keeping `multiple: false`.

## Why?
While it's likely the user would only want the block once, I don't think there's any need to impose the restriction.

## How?
Remove the line in the block.json

## Testing Instructions
1. Add a time to read block to a post
2. Try adding another time to read block, it should work.

## Screenshots or screencast <!-- if applicable -->
![Screen Shot 2023-03-22 at 4 32 24 pm](https://user-images.githubusercontent.com/677833/226844292-3b7bc31a-c163-4ad1-9342-878223b01359.png)
