### PR TITLE
Add typography support to time to read block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -590,7 +590,7 @@ Show minutes required to finish reading the post. ([Source](https://github.com/W
 
 -	**Name:** core/post-time-to-read
 -	**Category:** theme
--	**Supports:** ~~html~~, ~~multiple~~
+-	**Supports:** typography (fontSize, lineHeight), ~~html~~, ~~multiple~~
 -	**Attributes:** textAlign
 
 ## Post Title

--- a/packages/block-library/src/post-time-to-read/block.json
+++ b/packages/block-library/src/post-time-to-read/block.json
@@ -15,6 +15,19 @@
 	},
 	"supports": {
 		"html": false,
-		"multiple": false
+		"multiple": false,
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Addresses some of #48968

## Why?
Similar blocks have typography options, so I think it's good to support them here too.

## How?
Add the support options.

From what I can tell there isn't anything more to it, but please let me know if there is.

## Testing Instructions
1. Add a Time to Read block
2. Change options like Font size, family, line height etc in the block inspector

## Screenshots or screencast <!-- if applicable -->
![Screen Shot 2023-03-22 at 4 42 49 pm](https://user-images.githubusercontent.com/677833/226848810-952ab4d2-6128-48c8-8bf6-36e8a02f080c.png)

