### PR TITLE
Duotone: Use GlobalStylesProvider to generate styles in the Post Editor

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -63,7 +63,7 @@ const interfaceLabels = {
 	footer: __( 'Editor footer' ),
 };
 
-function Layout( { styles } ) {
+function Layout() {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const isHugeViewport = useViewportMatch( 'huge', '>=' );
 	const isLargeViewport = useViewportMatch( 'large' );
@@ -248,7 +248,7 @@ function Layout( { styles } ) {
 							<TextEditor />
 						) }
 						{ isRichEditingEnabled && mode === 'visual' && (
-							<VisualEditor styles={ styles } />
+							<VisualEditor />
 						) }
 						{ ! isDistractionFree && ! isTemplateMode && (
 							<div className="edit-post-layout__metaboxes">

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -29,6 +29,7 @@ import {
 	__experimentalRecursionProvider as RecursionProvider,
 	__experimentaluseLayoutClasses as useLayoutClasses,
 	__experimentaluseLayoutStyles as useLayoutStyles,
+	privateApis as blockEditorPrivateApis
 } from '@wordpress/block-editor';
 import { useEffect, useRef, useMemo } from '@wordpress/element';
 import { Button, __unstableMotion as motion } from '@wordpress/components';
@@ -43,6 +44,9 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import { store as editPostStore } from '../../store';
+import { unlock } from '../../private-apis';
+
+const { useGlobalStylesOutput } = unlock( blockEditorPrivateApis );
 
 const isGutenbergPlugin = process.env.IS_GUTENBERG_PLUGIN ? true : false;
 
@@ -104,7 +108,8 @@ function getPostContentAttributes( blocks ) {
 	}
 }
 
-export default function VisualEditor( { styles } ) {
+export default function VisualEditor( ) {
+	let [ styles, settings, svgFilters ] = useGlobalStylesOutput();
 	const {
 		deviceType,
 		isWelcomeGuideVisible,
@@ -365,6 +370,7 @@ export default function VisualEditor( { styles } ) {
 						contentRef={ contentRef }
 						styles={ styles }
 					>
+						{ svgFilters }
 						{ themeSupportsLayout &&
 							! themeHasDisabledLayoutStyles &&
 							! isTemplateMode && (

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -14,6 +14,7 @@ import { SlotFillProvider } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { GlobalStylesProvider } from '@wordpress/edit-site';
 
 /**
  * Internal dependencies
@@ -176,20 +177,22 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 	return (
 		<ShortcutProvider>
 			<SlotFillProvider>
-				<ExperimentalEditorProvider
-					settings={ editorSettings }
-					post={ post }
-					initialEdits={ initialEdits }
-					useSubRegistry={ false }
-					__unstableTemplate={ isTemplateMode ? template : undefined }
-					{ ...props }
-				>
-					<ErrorBoundary>
-						<EditorInitialization postId={ postId } />
-						<Layout styles={ styles } />
-					</ErrorBoundary>
-					<PostLockedModal />
-				</ExperimentalEditorProvider>
+				<GlobalStylesProvider>
+					<ExperimentalEditorProvider
+						settings={ editorSettings }
+						post={ post }
+						initialEdits={ initialEdits }
+						useSubRegistry={ false }
+						__unstableTemplate={ isTemplateMode ? template : undefined }
+						{ ...props }
+					>
+						<ErrorBoundary>
+							<EditorInitialization postId={ postId } />
+							<Layout />
+						</ErrorBoundary>
+						<PostLockedModal />
+					</ExperimentalEditorProvider>
+				</GlobalStylesProvider>
 			</SlotFillProvider>
 		</ShortcutProvider>
 	);

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -104,3 +104,4 @@ export function reinitializeEditor() {
 export { default as PluginSidebar } from './components/sidebar-edit-mode/plugin-sidebar';
 export { default as PluginSidebarMoreMenuItem } from './components/header-edit-mode/plugin-sidebar-more-menu-item';
 export { default as PluginMoreMenuItem } from './components/header-edit-mode/plugin-more-menu-item';
+export { GlobalStylesProvider } from './components/global-styles/global-styles-provider';


### PR DESCRIPTION
WIP

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This uses the GlobalStylesProvider package from the Site Editor to also provide styles and SVG filters in the post editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
