### PR TITLE
Allow the Layout Panel in the Inspector Controls to be customizable

### DIFF
--- a/packages/block-editor/src/components/inspector-controls/groups.js
+++ b/packages/block-editor/src/components/inspector-controls/groups.js
@@ -10,6 +10,7 @@ const InspectorControlsColor = createSlotFill( 'InspectorControlsColor' );
 const InspectorControlsDimensions = createSlotFill(
 	'InspectorControlsDimensions'
 );
+const InspectorControlsLayout = createSlotFill( 'InspectorControlsLayout' );
 const InspectorControlsPosition = createSlotFill( 'InspectorControlsPosition' );
 const InspectorControlsTypography = createSlotFill(
 	'InspectorControlsTypography'
@@ -23,6 +24,7 @@ const groups = {
 	border: InspectorControlsBorder,
 	color: InspectorControlsColor,
 	dimensions: InspectorControlsDimensions,
+	layout: InspectorControlsLayout,
 	list: InspectorControlsListView,
 	settings: InspectorControlsDefault, // Alias for default.
 	styles: InspectorControlsStyles,

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -268,6 +268,7 @@ function LayoutPanel( {
 							layoutBlockSupport={ layoutBlockSupport }
 						/>
 					) }
+					<InspectorControls.Slot __experimentalGroup="layout" />
 				</PanelBody>
 			</InspectorControls>
 			{ ! inherit && ! isContentLocked && layoutType && (


### PR DESCRIPTION
## What?

This PR allows users to hook into the Layout Panel of the Inspector Controls to add their layout-related options for their block.

![Screenshot 2023-03-22 at 16 43 10](https://user-images.githubusercontent.com/1847066/226959045-09a59812-31c8-411a-9590-8d46ea47d3dc.png)


## Why?

The Inspector Controls already allow to hook into most generic panels (i.e. panels that automatically get added to most blocks). The Layout is missing among those, while many blocks likely have some sort of layout options that it would make sense to group together instead of having a different layout panel (for example, in WooCommerce, we have [this](https://github.com/woocommerce/woocommerce/issues/42490)).

In general, I'd say the Layout Panel is the outlier in that is not hookable.

## How?

It's as simple as adding a SlotFill. No big changes required.

## Testing Instructions

1. Create a block or select an existing block.
2. Add some code like the following to your render function.

```ts
<InspectorControls __experimentalGroup="layout">
  // Add anything you like here…	
</InspectorControls>
```

3. Select your block and make sure the new controls appear at the bottom of the Layout panel.