### PR TITLE
Fix exhaustive deps warning

### DIFF
--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -120,53 +120,41 @@ export default function UnsavedInnerBlocks( {
 	const { hasResolvedNavigationMenus } = useNavigationMenu();
 
 	// Automatically save the uncontrolled blocks.
-	useEffect(
-		() => {
-			// The block will be disabled when used in a BlockPreview.
-			// In this case avoid automatic creation of a wp_navigation post.
-			// Otherwise the user will be spammed with lots of menus!
-			//
-			// Also ensure other navigation menus have loaded so an
-			// accurate name can be created.
-			//
-			// Don't try saving when another save is already
-			// in progress.
-			//
-			// And finally only create the menu when the block is selected,
-			// which is an indication they want to start editing.
-			if (
-				isDisabled ||
-				isSaving ||
-				! hasResolvedDraftNavigationMenus ||
-				! hasResolvedNavigationMenus ||
-				! hasSelection ||
-				! innerBlocksAreDirty
-			) {
-				return;
-			}
+	useEffect( () => {
+		// The block will be disabled when used in a BlockPreview.
+		// In this case avoid automatic creation of a wp_navigation post.
+		// Otherwise the user will be spammed with lots of menus!
+		//
+		// Also ensure other navigation menus have loaded so an
+		// accurate name can be created.
+		//
+		// Don't try saving when another save is already
+		// in progress.
+		//
+		// And finally only create the menu when the block is selected,
+		// which is an indication they want to start editing.
+		if (
+			isDisabled ||
+			isSaving ||
+			! hasResolvedDraftNavigationMenus ||
+			! hasResolvedNavigationMenus ||
+			! hasSelection ||
+			! innerBlocksAreDirty
+		) {
+			return;
+		}
 
-			createNavigationMenu( null, blocks );
-		},
-		/* The dependency "blocks" is intentionally omitted here.
-		 * This is because making blocks a dependency would cause
-		 * createNavigationMenu to run on every block change whereas
-		 * we only want it to run when the blocks are first detected
-		 * as dirty.
-		 * A better solution might be to add a hard saving lock using
-		 * a ref to avoid having to disbale theses eslint rules.
-		 */
-		/* eslint-disable react-hooks/exhaustive-deps */
-		[
-			createNavigationMenu,
-			isDisabled,
-			isSaving,
-			hasResolvedDraftNavigationMenus,
-			hasResolvedNavigationMenus,
-			innerBlocksAreDirty,
-			hasSelection,
-		]
-		/* eslint-enable react-hooks/exhaustive-deps */
-	);
+		createNavigationMenu( null, blocks );
+	}, [
+		blocks,
+		createNavigationMenu,
+		isDisabled,
+		isSaving,
+		hasResolvedDraftNavigationMenus,
+		hasResolvedNavigationMenus,
+		innerBlocksAreDirty,
+		hasSelection,
+	] );
 
 	const Wrapper = isSaving ? Disabled : 'div';
 

--- a/packages/e2e-test-utils-playwright/src/request-utils/menus.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/menus.ts
@@ -80,6 +80,18 @@ export async function createNavigationMenu(
 export async function deleteAllMenus( this: RequestUtils ) {
 	const navMenus = await this.rest< NavigationMenu[] >( {
 		path: `/wp/v2/navigation/`,
+		data: {
+			status: [
+				'publish',
+				'pending',
+				'draft',
+				'auto-draft',
+				'future',
+				'private',
+				'inherit',
+				'trash',
+			],
+		},
 	} );
 
 	if ( navMenus.length ) {
@@ -93,6 +105,18 @@ export async function deleteAllMenus( this: RequestUtils ) {
 
 	const classicMenus = await this.rest< NavigationMenu[] >( {
 		path: `/wp/v2/menus/`,
+		data: {
+			status: [
+				'publish',
+				'pending',
+				'draft',
+				'auto-draft',
+				'future',
+				'private',
+				'inherit',
+				'trash',
+			],
+		},
 	} );
 
 	if ( classicMenus.length ) {
@@ -108,15 +132,18 @@ export async function deleteAllMenus( this: RequestUtils ) {
 /**
  * Get latest navigation menus
  *
+ * @param  args
+ * @param  args.status
  * @return {string} Menu content.
  */
-export async function getNavigationMenus( this: RequestUtils ) {
+export async function getNavigationMenus(
+	this: RequestUtils,
+	args: { status: 'publish' }
+) {
 	const navigationMenus = await this.rest< NavigationMenu[] >( {
 		method: 'GET',
 		path: `/wp/v2/navigation/`,
-		data: {
-			status: 'publish',
-		},
+		data: args,
 	} );
 	return navigationMenus;
 }

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -3,7 +3,7 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-test.describe( 'As a user I want the navigation block to fallback to the best possible default', () => {
+test.describe( 'Navigation block', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		//TT3 is preferable to emptytheme because it already has the navigation block on its templates.
 		await requestUtils.activateTheme( 'twentytwentythree' );
@@ -22,266 +22,273 @@ test.describe( 'As a user I want the navigation block to fallback to the best po
 
 	test.afterEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllPosts();
+		await requestUtils.deleteAllMenus();
 	} );
 
-	test( 'default to a list of pages if there are no menus', async ( {
-		admin,
-		editor,
-	} ) => {
-		await admin.createNewPost();
-		await editor.insertBlock( { name: 'core/navigation' } );
+	test.describe( 'As a user I want the navigation block to fallback to the best possible default', () => {
+		test( 'default to a list of pages if there are no menus', async ( {
+			admin,
+			editor,
+		} ) => {
+			await admin.createNewPost();
+			await editor.insertBlock( { name: 'core/navigation' } );
 
-		const pageListBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Page List',
-		} );
+			const pageListBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Page List',
+			} );
 
-		await expect( pageListBlock ).toBeVisible( {
-			// Wait for the Nav and Page List block API requests to resolve.
-			// Note: avoid waiting on network requests as these are not perceivable
-			// to the user.
-			// See: https://github.com/WordPress/gutenberg/pull/45070#issuecomment-1373712007.
-			timeout: 10000,
-		} );
+			await expect( pageListBlock ).toBeVisible( {
+				// Wait for the Nav and Page List block API requests to resolve.
+				// Note: avoid waiting on network requests as these are not perceivable
+				// to the user.
+				// See: https://github.com/WordPress/gutenberg/pull/45070#issuecomment-1373712007.
+				timeout: 10000,
+			} );
 
-		// Check the markup of the block is correct.
-		await editor.publishPost();
-		const content = await editor.getEditedPostContent();
-		expect( content ).toBe(
-			`<!-- wp:navigation -->
+			// Check the markup of the block is correct.
+			await editor.publishPost();
+			const content = await editor.getEditedPostContent();
+			expect( content ).toBe(
+				`<!-- wp:navigation -->
 <!-- wp:page-list /-->
 <!-- /wp:navigation -->`
-		);
-	} );
-
-	test( 'default to my only existing menu', async ( {
-		admin,
-		editor,
-		page,
-		requestUtils,
-	} ) => {
-		await admin.createNewPost();
-		const createdMenu = await requestUtils.createNavigationMenu( {
-			title: 'Test Menu 1',
-			content:
-				'<!-- wp:navigation-link {"label":"WordPress","type":"custom","url":"http://www.wordpress.org/","kind":"custom","isTopLevelLink":true} /-->',
+			);
 		} );
 
-		await editor.insertBlock( { name: 'core/navigation' } );
+		test( 'default to my only existing menu', async ( {
+			admin,
+			editor,
+			page,
+			requestUtils,
+		} ) => {
+			await admin.createNewPost();
+			const createdMenu = await requestUtils.createNavigationMenu( {
+				title: 'Test Menu 1',
+				content:
+					'<!-- wp:navigation-link {"label":"WordPress","type":"custom","url":"http://www.wordpress.org/","kind":"custom","isTopLevelLink":true} /-->',
+			} );
 
-		// Check the block in the canvas.
-		await expect(
-			editor.canvas.locator(
-				`role=textbox[name="Navigation link text"i] >> text="WordPress"`
-			)
-		).toBeVisible();
+			await editor.insertBlock( { name: 'core/navigation' } );
 
-		// Check the markup of the block is correct.
-		await editor.publishPost();
-		await expect.poll( editor.getBlocks ).toMatchObject( [
-			{
-				name: 'core/navigation',
-				attributes: { ref: createdMenu.id },
-			},
-		] );
-		await page.locator( 'role=button[name="Close panel"i]' ).click();
+			// Check the block in the canvas.
+			await expect(
+				editor.canvas.locator(
+					`role=textbox[name="Navigation link text"i] >> text="WordPress"`
+				)
+			).toBeVisible();
 
-		// Check the block in the frontend.
-		await page.goto( '/' );
-		await expect(
-			page.locator( `role=navigation >> role=link[name="WordPress"i]` )
-		).toBeVisible();
-	} );
+			// Check the markup of the block is correct.
+			await editor.publishPost();
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/navigation',
+					attributes: { ref: createdMenu.id },
+				},
+			] );
+			await page.locator( 'role=button[name="Close panel"i]' ).click();
 
-	test( 'default to the only existing classic menu if there are no block menus', async ( {
-		admin,
-		page,
-		editor,
-		requestUtils,
-	} ) => {
-		// Create a classic menu.
-		await requestUtils.createClassicMenu( 'Test Classic 1' );
-		await admin.createNewPost();
-
-		await editor.insertBlock( { name: 'core/navigation' } );
-		// We need to check the canvas after inserting the navigation block to be able to target the block.
-		await expect.poll( editor.getBlocks ).toMatchObject( [
-			{
-				name: 'core/navigation',
-			},
-		] );
-
-		// Check the block in the canvas.
-		await expect(
-			editor.canvas.locator(
-				`role=textbox[name="Navigation link text"i] >> text="Custom link"`
-			)
-		).toBeVisible();
-
-		// Check the block in the frontend.
-		await page.goto( '/' );
-
-		await expect(
-			page.locator( `role=navigation >> role=link[name="Custom link"i]` )
-		).toBeVisible();
-	} );
-
-	test( 'default to my most recently created menu', async ( {
-		admin,
-		page,
-		editor,
-		requestUtils,
-	} ) => {
-		await admin.createNewPost();
-		await requestUtils.createNavigationMenu( {
-			title: 'Test Menu 1',
-			content:
-				'<!-- wp:navigation-link {"label":"Menu 1 Link","type":"custom","url":"http://localhost:8889/#menu-1-link","kind":"custom","isTopLevelLink":true} /-->',
+			// Check the block in the frontend.
+			await page.goto( '/' );
+			await expect(
+				page.locator(
+					`role=navigation >> role=link[name="WordPress"i]`
+				)
+			).toBeVisible();
 		} );
 
-		//FIXME this is needed because if the two menus are created at the same time, the API will return them in the wrong order.
-		//https://core.trac.wordpress.org/ticket/57914
-		await editor.page.waitForTimeout( 1000 );
+		test( 'default to the only existing classic menu if there are no block menus', async ( {
+			admin,
+			page,
+			editor,
+			requestUtils,
+		} ) => {
+			// Create a classic menu.
+			await requestUtils.createClassicMenu( 'Test Classic 1' );
+			await admin.createNewPost();
 
-		const latestMenu = await requestUtils.createNavigationMenu( {
-			title: 'Test Menu 2',
-			content:
-				'<!-- wp:navigation-link {"label":"Menu 2 Link","type":"custom","url":"http://localhost:8889/#menu-2-link","kind":"custom","isTopLevelLink":true} /-->',
+			await editor.insertBlock( { name: 'core/navigation' } );
+			// We need to check the canvas after inserting the navigation block to be able to target the block.
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/navigation',
+				},
+			] );
+
+			// Check the block in the canvas.
+			await expect(
+				editor.canvas.locator(
+					`role=textbox[name="Navigation link text"i] >> text="Custom link"`
+				)
+			).toBeVisible( { timeout: 10000 } ); // allow time for network request.
+
+			// Check the block in the frontend.
+			await page.goto( '/' );
+
+			await expect(
+				page.locator(
+					`role=navigation >> role=link[name="Custom link"i]`
+				)
+			).toBeVisible();
 		} );
 
-		await editor.insertBlock( { name: 'core/navigation' } );
+		test( 'default to my most recently created menu', async ( {
+			admin,
+			page,
+			editor,
+			requestUtils,
+		} ) => {
+			await admin.createNewPost();
+			await requestUtils.createNavigationMenu( {
+				title: 'Test Menu 1',
+				content:
+					'<!-- wp:navigation-link {"label":"Menu 1 Link","type":"custom","url":"http://localhost:8889/#menu-1-link","kind":"custom","isTopLevelLink":true} /-->',
+			} );
 
-		// Check the markup of the block is correct.
-		await editor.publishPost();
-		await expect.poll( editor.getBlocks ).toMatchObject( [
-			{
-				name: 'core/navigation',
-				attributes: { ref: latestMenu.id },
-			},
-		] );
-		await page.locator( 'role=button[name="Close panel"i]' ).click();
+			//FIXME this is needed because if the two menus are created at the same time, the API will return them in the wrong order.
+			//https://core.trac.wordpress.org/ticket/57914
+			await editor.page.waitForTimeout( 1000 );
 
-		// Check the block in the canvas.
-		await expect(
-			editor.canvas.locator(
-				`role=textbox[name="Navigation link text"i] >> text="Menu 2 Link"`
-			)
-		).toBeVisible();
+			const latestMenu = await requestUtils.createNavigationMenu( {
+				title: 'Test Menu 2',
+				content:
+					'<!-- wp:navigation-link {"label":"Menu 2 Link","type":"custom","url":"http://localhost:8889/#menu-2-link","kind":"custom","isTopLevelLink":true} /-->',
+			} );
 
-		// Check the block in the frontend.
-		await page.goto( '/' );
-		await expect(
-			page.locator( `role=navigation >> role=link[name="Menu 2 Link"i]` )
-		).toBeVisible();
-	} );
-} );
+			await editor.insertBlock( { name: 'core/navigation' } );
 
-test.describe( 'As a user I want to create submenus using the navigation block', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
-		//TT3 is preferable to emptytheme because it already has the navigation block on its templates.
-		await requestUtils.activateTheme( 'twentytwentythree' );
-	} );
+			// Check the markup of the block is correct.
+			await editor.publishPost();
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/navigation',
+					attributes: { ref: latestMenu.id },
+				},
+			] );
+			await page.locator( 'role=button[name="Close panel"i]' ).click();
 
-	test.beforeEach( async ( { requestUtils } ) => {
-		await Promise.all( [ requestUtils.deleteAllMenus() ] );
-	} );
+			// Check the block in the canvas.
+			await expect(
+				editor.canvas.locator(
+					`role=textbox[name="Navigation link text"i] >> text="Menu 2 Link"`
+				)
+			).toBeVisible();
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await Promise.all( [
-			requestUtils.deleteAllMenus(),
-			requestUtils.activateTheme( 'twentytwentyone' ),
-		] );
-	} );
-
-	test.afterEach( async ( { requestUtils } ) => {
-		await requestUtils.deleteAllPosts();
-	} );
-
-	test( 'create a submenu', async ( {
-		admin,
-		page,
-		editor,
-		requestUtils,
-	} ) => {
-		await admin.createNewPost();
-		await requestUtils.createNavigationMenu( {
-			title: 'Test Menu',
-			content: '',
+			// Check the block in the frontend.
+			await page.goto( '/' );
+			await expect(
+				page.locator(
+					`role=navigation >> role=link[name="Menu 2 Link"i]`
+				)
+			).toBeVisible();
 		} );
-
-		await editor.insertBlock( { name: 'core/navigation' } );
-
-		const navBlockInserter = editor.canvas.getByRole( 'button', {
-			name: 'Add block',
-		} );
-		await navBlockInserter.click();
-
-		await page.keyboard.type( 'https://example.com' );
-		await page.keyboard.press( 'Enter' );
-
-		const addSubmenuButton = page.getByRole( 'button', {
-			name: 'Add submenu',
-		} );
-		await addSubmenuButton.click();
-
-		await editor.publishPost();
-
-		await page.locator( 'role=button[name="Close panel"i]' ).click();
-
-		await page.goto( '/' );
-		await expect(
-			page.locator(
-				`role=navigation >> role=button[name="example.com submenu "i]`
-			)
-		).toBeVisible();
 	} );
 
-	test( 'submenu converts to link automatically', async ( {
-		admin,
-		pageUtils,
-		editor,
-		requestUtils,
-	} ) => {
-		await admin.createNewPost();
-		await requestUtils.createNavigationMenu( {
-			title: 'Test Menu',
-			content:
-				'<!-- wp:navigation-submenu {"label":"WordPress","type":"custom","url":"http://www.wordpress.org/","kind":"custom","isTopLevelLink":true} --><!-- wp:navigation-link {"label":"WordPress Child","type":"custom","url":"http://www.wordpress.org/","kind":"custom","isTopLevelLink":true} /--><!-- /wp:navigation-submenu -->',
+	test.describe( 'As a user I want to create submenus using the navigation block', () => {
+		test.beforeAll( async ( { requestUtils } ) => {
+			//TT3 is preferable to emptytheme because it already has the navigation block on its templates.
+			await requestUtils.activateTheme( 'twentytwentythree' );
 		} );
 
-		await editor.insertBlock( { name: 'core/navigation' } );
-
-		await expect(
-			editor.canvas.locator(
-				`role=textbox[name="Navigation link text"i] >> text="WordPress"`
-			)
-		).toBeVisible();
-
-		const navigationBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Navigation',
+		test.beforeEach( async ( { requestUtils } ) => {
+			await Promise.all( [ requestUtils.deleteAllMenus() ] );
 		} );
-		await editor.selectBlocks( navigationBlock );
 
-		const submenuBlock1 = editor.canvas.getByRole( 'document', {
-			name: 'Block: Submenu',
+		test.afterAll( async ( { requestUtils } ) => {
+			await Promise.all( [
+				requestUtils.deleteAllMenus(),
+				requestUtils.activateTheme( 'twentytwentyone' ),
+			] );
 		} );
-		await expect( submenuBlock1 ).toBeVisible();
 
-		// select the child link via keyboard
-		await pageUtils.pressKeys( 'ArrowDown' );
-		await pageUtils.pressKeys( 'ArrowDown' );
-		await pageUtils.pressKeys( 'ArrowDown' );
-
-		// remove the child link
-		await pageUtils.pressKeys( 'access+z' );
-
-		const submenuBlock2 = editor.canvas.getByRole( 'document', {
-			name: 'Block: Submenu',
+		test.afterEach( async ( { requestUtils } ) => {
+			await requestUtils.deleteAllPosts();
 		} );
-		await expect( submenuBlock2 ).toBeHidden();
+
+		test( 'create a submenu', async ( {
+			admin,
+			page,
+			editor,
+			requestUtils,
+		} ) => {
+			await admin.createNewPost();
+			await requestUtils.createNavigationMenu( {
+				title: 'Test Menu',
+				content: '',
+			} );
+
+			await editor.insertBlock( { name: 'core/navigation' } );
+
+			const navBlockInserter = editor.canvas.getByRole( 'button', {
+				name: 'Add block',
+			} );
+			await navBlockInserter.click();
+
+			await page.keyboard.type( 'https://example.com' );
+			await page.keyboard.press( 'Enter' );
+
+			const addSubmenuButton = page.getByRole( 'button', {
+				name: 'Add submenu',
+			} );
+			await addSubmenuButton.click();
+
+			await editor.publishPost();
+
+			await page.locator( 'role=button[name="Close panel"i]' ).click();
+
+			await page.goto( '/' );
+			await expect(
+				page.locator(
+					`role=navigation >> role=button[name="example.com submenu "i]`
+				)
+			).toBeVisible();
+		} );
+
+		test( 'submenu converts to link automatically', async ( {
+			admin,
+			pageUtils,
+			editor,
+			requestUtils,
+		} ) => {
+			await admin.createNewPost();
+			await requestUtils.createNavigationMenu( {
+				title: 'Test Menu',
+				content:
+					'<!-- wp:navigation-submenu {"label":"WordPress","type":"custom","url":"http://www.wordpress.org/","kind":"custom","isTopLevelLink":true} --><!-- wp:navigation-link {"label":"WordPress Child","type":"custom","url":"http://www.wordpress.org/","kind":"custom","isTopLevelLink":true} /--><!-- /wp:navigation-submenu -->',
+			} );
+
+			await editor.insertBlock( { name: 'core/navigation' } );
+
+			await expect(
+				editor.canvas.locator(
+					`role=textbox[name="Navigation link text"i] >> text="WordPress"`
+				)
+			).toBeVisible();
+
+			const navigationBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Navigation',
+			} );
+			await editor.selectBlocks( navigationBlock );
+
+			const submenuBlock1 = editor.canvas.getByRole( 'document', {
+				name: 'Block: Submenu',
+			} );
+			await expect( submenuBlock1 ).toBeVisible();
+
+			// select the child link via keyboard
+			await pageUtils.pressKeys( 'ArrowDown' );
+			await pageUtils.pressKeys( 'ArrowDown' );
+			await pageUtils.pressKeys( 'ArrowDown' );
+
+			// remove the child link
+			await pageUtils.pressKeys( 'access+z' );
+
+			const submenuBlock2 = editor.canvas.getByRole( 'document', {
+				name: 'Block: Submenu',
+			} );
+			await expect( submenuBlock2 ).toBeHidden();
+		} );
 	} );
-} );
 
-test.describe( 'Navigation block', () => {
 	test.describe( 'As a user I want to see a warning if the menu referenced by a navigation block is not available', () => {
 		test.beforeEach( async ( { admin } ) => {
 			await admin.createNewPost();
@@ -316,415 +323,485 @@ test.describe( 'Navigation block', () => {
 			await expect( warningMessage ).toBeVisible();
 		} );
 	} );
-} );
 
-test.describe( 'List view editing', () => {
-	const navMenuBlocksFixture = {
-		title: 'Test Menu',
-		content: `<!-- wp:navigation-link {"label":"Top Level Item 1","type":"page","id":250,"url":"http://localhost:8888/quod-error-esse-nemo-corporis-rerum-repellendus/","kind":"post-type"} /-->
+	test.describe( 'Existing blocks', () => {
+		test( 'adding new links to a block with existing inner blocks triggers creation of a single Navigation Menu', async ( {
+			admin,
+			page,
+			editor,
+			requestUtils,
+		} ) => {
+			// As this test depends on there being no menus,
+			// we need to delete any existing menus as an explicit
+			// precondition rather than rely on global test setup.
+			await requestUtils.deleteAllMenus();
+
+			// Ensure that there are no menus before beginning the test.
+			expect(
+				await requestUtils.getNavigationMenus( {
+					status: [ 'publish', 'draft' ],
+				} )
+			).toHaveLength( 0 );
+
+			await admin.createNewPost();
+
+			await editor.insertBlock( {
+				name: 'core/navigation',
+				attributes: {},
+				innerBlocks: [
+					{
+						name: 'core/page-list',
+					},
+				],
+			} );
+
+			const navBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Navigation',
+			} );
+
+			await expect(
+				editor.canvas.getByRole( 'document', {
+					name: 'Block: Page List',
+				} )
+			).toBeVisible();
+
+			await expect( navBlock ).toBeVisible();
+
+			await editor.selectBlocks( navBlock );
+
+			await navBlock.getByRole( 'button', { name: 'Add block' } ).click();
+
+			// This relies on network so allow additional time for
+			// the request to complete.
+			await expect(
+				page.getByRole( 'button', {
+					name: 'Dismiss this notice',
+					text: 'Navigation Menu successfully created',
+				} )
+			).toBeVisible( { timeout: 10000 } );
+
+			// The creattion Navigaiton Menu will be a draft
+			// so we need to check for both publish and draft.
+			expect(
+				await requestUtils.getNavigationMenus( {
+					status: [ 'publish', 'draft' ],
+				} )
+			).toHaveLength( 1 );
+		} );
+	} );
+
+	test.describe( 'List view editing', () => {
+		const navMenuBlocksFixture = {
+			title: 'Test Menu',
+			content: `<!-- wp:navigation-link {"label":"Top Level Item 1","type":"page","id":250,"url":"http://localhost:8888/quod-error-esse-nemo-corporis-rerum-repellendus/","kind":"post-type"} /-->
 			<!-- wp:navigation-submenu {"label":"Top Level Item 2","type":"page","id":250,"url":"http://localhost:8888/quod-error-esse-nemo-corporis-rerum-repellendus/","kind":"post-type"} -->
 				<!-- wp:navigation-link {"label":"Test Submenu Item","type":"page","id":270,"url":"http://localhost:8888/et-aspernatur-recusandae-non-sint/","kind":"post-type"} /-->
 			<!-- /wp:navigation-submenu -->`,
-	};
+		};
 
-	test.use( {
-		linkControl: async ( { page }, use ) => {
-			await use( new LinkControl( { page } ) );
-		},
-	} );
-
-	test( 'show a list view in the inspector controls', async ( {
-		admin,
-		page,
-		editor,
-		requestUtils,
-	} ) => {
-		await admin.createNewPost();
-		await requestUtils.createNavigationMenu( navMenuBlocksFixture );
-
-		await editor.insertBlock( { name: 'core/navigation' } );
-
-		await editor.openDocumentSettingsSidebar();
-
-		await expect(
-			page.getByRole( 'tab', {
-				name: 'List View',
-			} )
-		).toBeVisible();
-
-		const listViewPanel = page.getByRole( 'tabpanel', {
-			name: 'List View',
+		test.use( {
+			linkControl: async ( { page }, use ) => {
+				await use( new LinkControl( { page } ) );
+			},
 		} );
 
-		await expect( listViewPanel ).toBeVisible();
+		test( 'show a list view in the inspector controls', async ( {
+			admin,
+			page,
+			editor,
+			requestUtils,
+		} ) => {
+			await admin.createNewPost();
+			await requestUtils.createNavigationMenu( navMenuBlocksFixture );
 
-		await expect(
-			listViewPanel.getByRole( 'heading', {
-				name: 'Menu',
-			} )
-		).toBeVisible();
+			await editor.insertBlock( { name: 'core/navigation' } );
 
-		await expect(
-			listViewPanel.getByRole( 'treegrid', {
+			await editor.openDocumentSettingsSidebar();
+
+			await expect(
+				page.getByRole( 'tab', {
+					name: 'List View',
+				} )
+			).toBeVisible();
+
+			const listViewPanel = page.getByRole( 'tabpanel', {
+				name: 'List View',
+			} );
+
+			await expect( listViewPanel ).toBeVisible();
+
+			await expect(
+				listViewPanel.getByRole( 'heading', {
+					name: 'Menu',
+				} )
+			).toBeVisible();
+
+			await expect(
+				listViewPanel.getByRole( 'treegrid', {
+					name: 'Block navigation structure',
+					description: 'Structure for navigation menu: Test Menu',
+				} )
+			).toBeVisible();
+		} );
+
+		test( `list view should correctly reflect navigation items' structure`, async ( {
+			admin,
+			page,
+			editor,
+			requestUtils,
+		} ) => {
+			await admin.createNewPost();
+			await requestUtils.createNavigationMenu( navMenuBlocksFixture );
+
+			await editor.insertBlock( { name: 'core/navigation' } );
+
+			await editor.openDocumentSettingsSidebar();
+
+			const listView = page.getByRole( 'treegrid', {
 				name: 'Block navigation structure',
 				description: 'Structure for navigation menu: Test Menu',
-			} )
-		).toBeVisible();
-	} );
+			} );
 
-	test( `list view should correctly reflect navigation items' structure`, async ( {
-		admin,
-		page,
-		editor,
-		requestUtils,
-	} ) => {
-		await admin.createNewPost();
-		await requestUtils.createNavigationMenu( navMenuBlocksFixture );
+			// Check the structure of the individual menu items matches the one that was created.
+			await expect(
+				listView
+					.getByRole( 'gridcell', {
+						name: 'Page Link link',
+					} )
+					.filter( {
+						hasText: 'Block 1 of 2, Level 1', // proxy for filtering by description.
+					} )
+					.getByText( 'Top Level Item 1' )
+			).toBeVisible();
 
-		await editor.insertBlock( { name: 'core/navigation' } );
+			await expect(
+				listView
+					.getByRole( 'gridcell', {
+						name: 'Submenu link',
+					} )
+					.filter( {
+						hasText: 'Block 2 of 2, Level 1', // proxy for filtering by description.
+					} )
+					.getByText( 'Top Level Item 2' )
+			).toBeVisible();
 
-		await editor.openDocumentSettingsSidebar();
-
-		const listView = page.getByRole( 'treegrid', {
-			name: 'Block navigation structure',
-			description: 'Structure for navigation menu: Test Menu',
+			await expect(
+				listView
+					.getByRole( 'gridcell', {
+						name: 'Page Link link',
+					} )
+					.filter( {
+						hasText: 'Block 1 of 1, Level 2', // proxy for filtering by description.
+					} )
+					.getByText( 'Test Submenu Item' )
+			).toBeVisible();
 		} );
 
-		// Check the structure of the individual menu items matches the one that was created.
-		await expect(
-			listView
-				.getByRole( 'gridcell', {
-					name: 'Page Link link',
-				} )
-				.filter( {
-					hasText: 'Block 1 of 2, Level 1', // proxy for filtering by description.
-				} )
-				.getByText( 'Top Level Item 1' )
-		).toBeVisible();
+		test( `can add new menu items`, async ( {
+			admin,
+			page,
+			editor,
+			requestUtils,
+			linkControl,
+		} ) => {
+			await admin.createNewPost();
+			await requestUtils.createNavigationMenu( navMenuBlocksFixture );
 
-		await expect(
-			listView
-				.getByRole( 'gridcell', {
-					name: 'Submenu link',
+			await editor.insertBlock( { name: 'core/navigation' } );
+
+			await editor.openDocumentSettingsSidebar();
+
+			const listView = page.getByRole( 'treegrid', {
+				name: 'Block navigation structure',
+				description: 'Structure for navigation menu: Test Menu',
+			} );
+
+			const appender = listView.getByRole( 'button', {
+				name: 'Add block',
+			} );
+
+			await expect( appender ).toBeVisible();
+
+			await appender.click();
+
+			// Expect to see the block inserter.
+			await expect(
+				page.getByRole( 'searchbox', {
+					name: 'Search for blocks and patterns',
 				} )
-				.filter( {
-					hasText: 'Block 2 of 2, Level 1', // proxy for filtering by description.
-				} )
-				.getByText( 'Top Level Item 2' )
-		).toBeVisible();
+			).toBeFocused();
 
-		await expect(
-			listView
-				.getByRole( 'gridcell', {
-					name: 'Page Link link',
-				} )
-				.filter( {
-					hasText: 'Block 1 of 1, Level 2', // proxy for filtering by description.
-				} )
-				.getByText( 'Test Submenu Item' )
-		).toBeVisible();
-	} );
+			const blockResults = page.getByRole( 'listbox', {
+				name: 'Blocks',
+			} );
 
-	test( `can add new menu items`, async ( {
-		admin,
-		page,
-		editor,
-		requestUtils,
-		linkControl,
-	} ) => {
-		await admin.createNewPost();
-		await requestUtils.createNavigationMenu( navMenuBlocksFixture );
+			await expect( blockResults ).toBeVisible();
 
-		await editor.insertBlock( { name: 'core/navigation' } );
+			const blockResultOptions = blockResults.getByRole( 'option' );
 
-		await editor.openDocumentSettingsSidebar();
+			// Expect to see the Page Link and Custom Link blocks as the nth(0) and nth(1) results.
+			// This is important for usability as the Page Link block is the most likely to be used.
+			await expect( blockResultOptions.nth( 0 ) ).toHaveText(
+				'Page Link'
+			);
+			await expect( blockResultOptions.nth( 1 ) ).toHaveText(
+				'Custom Link'
+			);
 
-		const listView = page.getByRole( 'treegrid', {
-			name: 'Block navigation structure',
-			description: 'Structure for navigation menu: Test Menu',
+			// Select the Page Link option.
+			const pageLinkResult = blockResultOptions.nth( 0 );
+			await pageLinkResult.click();
+
+			// Expect to see the Link creation UI be focused.
+			const linkUIInput = linkControl.getSearchInput();
+
+			await expect( linkUIInput ).toBeFocused();
+
+			const firstResult = await linkControl.getNthSearchResult( 0 );
+
+			// Grab the text from the first result so we can check it was inserted.
+			const firstResultText = await linkControl.getSearchResultText(
+				firstResult
+			);
+
+			// Create the link.
+			await firstResult.click();
+
+			// Check the new menu item was inserted at the end of the existing menu.
+			await expect(
+				listView
+					.getByRole( 'gridcell', {
+						name: 'Page Link link',
+					} )
+					.filter( {
+						hasText: 'Block 3 of 3, Level 1', // proxy for filtering by description.
+					} )
+					.getByText( firstResultText )
+			).toBeVisible();
 		} );
 
-		const appender = listView.getByRole( 'button', {
-			name: 'Add block',
-		} );
+		test( `can remove menu items`, async ( {
+			admin,
+			page,
+			editor,
+			requestUtils,
+		} ) => {
+			await admin.createNewPost();
+			await requestUtils.createNavigationMenu( navMenuBlocksFixture );
 
-		await expect( appender ).toBeVisible();
+			await editor.insertBlock( { name: 'core/navigation' } );
 
-		await appender.click();
+			await editor.openDocumentSettingsSidebar();
 
-		// Expect to see the block inserter.
-		await expect(
-			page.getByRole( 'searchbox', {
-				name: 'Search for blocks and patterns',
-			} )
-		).toBeFocused();
+			const listView = page.getByRole( 'treegrid', {
+				name: 'Block navigation structure',
+				description: 'Structure for navigation menu: Test Menu',
+			} );
 
-		const blockResults = page.getByRole( 'listbox', {
-			name: 'Blocks',
-		} );
-
-		await expect( blockResults ).toBeVisible();
-
-		const blockResultOptions = blockResults.getByRole( 'option' );
-
-		// Expect to see the Page Link and Custom Link blocks as the nth(0) and nth(1) results.
-		// This is important for usability as the Page Link block is the most likely to be used.
-		await expect( blockResultOptions.nth( 0 ) ).toHaveText( 'Page Link' );
-		await expect( blockResultOptions.nth( 1 ) ).toHaveText( 'Custom Link' );
-
-		// Select the Page Link option.
-		const pageLinkResult = blockResultOptions.nth( 0 );
-		await pageLinkResult.click();
-
-		// Expect to see the Link creation UI be focused.
-		const linkUIInput = linkControl.getSearchInput();
-
-		await expect( linkUIInput ).toBeFocused();
-
-		const firstResult = await linkControl.getNthSearchResult( 0 );
-
-		// Grab the text from the first result so we can check it was inserted.
-		const firstResultText = await linkControl.getSearchResultText(
-			firstResult
-		);
-
-		// Create the link.
-		await firstResult.click();
-
-		// Check the new menu item was inserted at the end of the existing menu.
-		await expect(
-			listView
-				.getByRole( 'gridcell', {
-					name: 'Page Link link',
-				} )
-				.filter( {
-					hasText: 'Block 3 of 3, Level 1', // proxy for filtering by description.
-				} )
-				.getByText( firstResultText )
-		).toBeVisible();
-	} );
-
-	test( `can remove menu items`, async ( {
-		admin,
-		page,
-		editor,
-		requestUtils,
-	} ) => {
-		await admin.createNewPost();
-		await requestUtils.createNavigationMenu( navMenuBlocksFixture );
-
-		await editor.insertBlock( { name: 'core/navigation' } );
-
-		await editor.openDocumentSettingsSidebar();
-
-		const listView = page.getByRole( 'treegrid', {
-			name: 'Block navigation structure',
-			description: 'Structure for navigation menu: Test Menu',
-		} );
-
-		const submenuOptions = listView.getByRole( 'button', {
-			name: 'Options for Submenu block',
-		} );
-
-		// Open the options menu.
-		await submenuOptions.click();
-
-		// usage of `page` is required because the options menu is rendered into a slot
-		// outside of the treegrid.
-		const removeBlockOption = page
-			.getByRole( 'menu', {
+			const submenuOptions = listView.getByRole( 'button', {
 				name: 'Options for Submenu block',
-			} )
-			.getByRole( 'menuitem', {
-				name: 'Remove Top Level Item 2',
 			} );
 
-		await removeBlockOption.click();
+			// Open the options menu.
+			await submenuOptions.click();
 
-		// Check the menu item was removed.
-		await expect(
-			listView
-				.getByRole( 'gridcell', {
-					name: 'Submenu link',
+			// usage of `page` is required because the options menu is rendered into a slot
+			// outside of the treegrid.
+			const removeBlockOption = page
+				.getByRole( 'menu', {
+					name: 'Options for Submenu block',
 				} )
-				.filter( {
-					hasText: 'Block 2 of 2, Level 1', // proxy for filtering by description.
+				.getByRole( 'menuitem', {
+					name: 'Remove Top Level Item 2',
+				} );
+
+			await removeBlockOption.click();
+
+			// Check the menu item was removed.
+			await expect(
+				listView
+					.getByRole( 'gridcell', {
+						name: 'Submenu link',
+					} )
+					.filter( {
+						hasText: 'Block 2 of 2, Level 1', // proxy for filtering by description.
+					} )
+					.getByText( 'Top Level Item 2' )
+			).not.toBeVisible();
+		} );
+
+		test( `can edit menu items`, async ( {
+			admin,
+			page,
+			editor,
+			requestUtils,
+		} ) => {
+			await admin.createNewPost();
+			await requestUtils.createNavigationMenu( navMenuBlocksFixture );
+
+			await editor.insertBlock( { name: 'core/navigation' } );
+
+			await editor.openDocumentSettingsSidebar();
+
+			const listView = page.getByRole( 'treegrid', {
+				name: 'Block navigation structure',
+				description: 'Structure for navigation menu: Test Menu',
+			} );
+
+			// Click on the first menu item to open its settings.
+			const firstMenuItemAnchor = listView.getByRole( 'link', {
+				name: 'Top Level Item 1',
+				includeHidden: true,
+			} );
+			await firstMenuItemAnchor.click();
+
+			// Get the settings panel.
+			const blockSettings = page.getByRole( 'region', {
+				name: 'Editor settings',
+			} );
+
+			await expect( blockSettings ).toBeVisible();
+
+			await expect(
+				blockSettings.getByRole( 'heading', {
+					name: 'Page Link',
 				} )
-				.getByText( 'Top Level Item 2' )
-		).not.toBeVisible();
-	} );
+			).toBeVisible();
 
-	test( `can edit menu items`, async ( {
-		admin,
-		page,
-		editor,
-		requestUtils,
-	} ) => {
-		await admin.createNewPost();
-		await requestUtils.createNavigationMenu( navMenuBlocksFixture );
-
-		await editor.insertBlock( { name: 'core/navigation' } );
-
-		await editor.openDocumentSettingsSidebar();
-
-		const listView = page.getByRole( 'treegrid', {
-			name: 'Block navigation structure',
-			description: 'Structure for navigation menu: Test Menu',
-		} );
-
-		// Click on the first menu item to open its settings.
-		const firstMenuItemAnchor = listView.getByRole( 'link', {
-			name: 'Top Level Item 1',
-			includeHidden: true,
-		} );
-		await firstMenuItemAnchor.click();
-
-		// Get the settings panel.
-		const blockSettings = page.getByRole( 'region', {
-			name: 'Editor settings',
-		} );
-
-		await expect( blockSettings ).toBeVisible();
-
-		await expect(
-			blockSettings.getByRole( 'heading', {
-				name: 'Page Link',
-			} )
-		).toBeVisible();
-
-		await expect(
-			blockSettings.getByRole( 'tab', {
-				name: 'Settings',
-				selected: true,
-			} )
-		).toBeVisible();
-
-		await expect(
-			blockSettings
-				.getByRole( 'tabpanel', {
+			await expect(
+				blockSettings.getByRole( 'tab', {
 					name: 'Settings',
+					selected: true,
 				} )
-				.getByRole( 'heading', {
-					name: 'Link Settings',
-				} )
-		).toBeVisible();
+			).toBeVisible();
 
-		const labelInput = blockSettings.getByRole( 'textbox', {
-			name: 'Label',
+			await expect(
+				blockSettings
+					.getByRole( 'tabpanel', {
+						name: 'Settings',
+					} )
+					.getByRole( 'heading', {
+						name: 'Link Settings',
+					} )
+			).toBeVisible();
+
+			const labelInput = blockSettings.getByRole( 'textbox', {
+				name: 'Label',
+			} );
+
+			await expect( labelInput ).toHaveValue( 'Top Level Item 1' );
+
+			await labelInput.focus();
+
+			await page.keyboard.type( 'Changed label' );
+
+			// Click the back button to go back to the Nav block.
+			await blockSettings
+				.getByRole( 'button', {
+					name: 'Go to parent Navigation block',
+				} )
+				.click();
+
+			// Check we're back on the Nav block list view.
+			const listViewPanel = page.getByRole( 'tabpanel', {
+				name: 'List View',
+			} );
+
+			await expect( listViewPanel ).toBeVisible();
+
+			// Check the label was updated.
+			await expect(
+				listViewPanel
+					.getByRole( 'gridcell', {
+						name: 'Page Link link',
+					} )
+					.filter( {
+						hasText: 'Block 1 of 2, Level 1', // proxy for filtering by description.
+					} )
+					.getByText( 'Changed label' ) // new label text
+			).toBeVisible();
 		} );
 
-		await expect( labelInput ).toHaveValue( 'Top Level Item 1' );
+		test( `can add submenus`, async ( {
+			admin,
+			page,
+			editor,
+			requestUtils,
+			linkControl,
+		} ) => {
+			await admin.createNewPost();
+			await requestUtils.createNavigationMenu( navMenuBlocksFixture );
 
-		await labelInput.focus();
+			await editor.insertBlock( { name: 'core/navigation' } );
 
-		await page.keyboard.type( 'Changed label' );
+			await editor.openDocumentSettingsSidebar();
 
-		// Click the back button to go back to the Nav block.
-		await blockSettings
-			.getByRole( 'button', {
-				name: 'Go to parent Navigation block',
-			} )
-			.click();
+			const listView = page.getByRole( 'treegrid', {
+				name: 'Block navigation structure',
+				description: 'Structure for navigation menu: Test Menu',
+			} );
 
-		// Check we're back on the Nav block list view.
-		const listViewPanel = page.getByRole( 'tabpanel', {
-			name: 'List View',
-		} );
-
-		await expect( listViewPanel ).toBeVisible();
-
-		// Check the label was updated.
-		await expect(
-			listViewPanel
+			// click on options menu for the first menu item and select remove.
+			const firstMenuItem = listView
 				.getByRole( 'gridcell', {
 					name: 'Page Link link',
 				} )
 				.filter( {
 					hasText: 'Block 1 of 2, Level 1', // proxy for filtering by description.
+				} );
+
+			// The options menu button is a sibling of the menu item gridcell.
+			const firstItemOptions = firstMenuItem
+				.locator( '..' ) // parent selector.
+				.getByRole( 'button', {
+					name: 'Options for Page Link block',
+				} );
+
+			// Open the options menu.
+			await firstItemOptions.click();
+
+			// Add the submenu.
+			// usage of `page` is required because the options menu is rendered into a slot
+			// outside of the treegrid.
+			const addSubmenuOption = page
+				.getByRole( 'menu', {
+					name: 'Options for Page Link block',
 				} )
-				.getByText( 'Changed label' ) // new label text
-		).toBeVisible();
-	} );
+				.getByRole( 'menuitem', {
+					name: 'Add submenu link',
+				} );
 
-	test( `can add submenus`, async ( {
-		admin,
-		page,
-		editor,
-		requestUtils,
-		linkControl,
-	} ) => {
-		await admin.createNewPost();
-		await requestUtils.createNavigationMenu( navMenuBlocksFixture );
+			await addSubmenuOption.click();
 
-		await editor.insertBlock( { name: 'core/navigation' } );
+			await linkControl.searchFor( 'https://wordpress.org' );
 
-		await editor.openDocumentSettingsSidebar();
+			await page.keyboard.press( 'Enter' );
 
-		const listView = page.getByRole( 'treegrid', {
-			name: 'Block navigation structure',
-			description: 'Structure for navigation menu: Test Menu',
+			// Check the new item was inserted in the correct place.
+			await expect(
+				listView
+					.getByRole( 'gridcell', {
+						name: 'Custom Link link',
+					} )
+					.filter( {
+						hasText: 'Block 1 of 1, Level 2', // proxy for filtering by description.
+					} )
+					.getByText( 'wordpress.org' )
+			).toBeVisible();
+
+			// Check that the original item is still there but that it is now
+			// a submenu item.
+			await expect(
+				listView
+					.getByRole( 'gridcell', {
+						name: 'Submenu link',
+					} )
+					.filter( {
+						hasText: 'Block 1 of 2, Level 1', // proxy for filtering by description.
+					} )
+					.getByText( 'Top Level Item 1' )
+			).toBeVisible();
 		} );
-
-		// click on options menu for the first menu item and select remove.
-		const firstMenuItem = listView
-			.getByRole( 'gridcell', {
-				name: 'Page Link link',
-			} )
-			.filter( {
-				hasText: 'Block 1 of 2, Level 1', // proxy for filtering by description.
-			} );
-
-		// The options menu button is a sibling of the menu item gridcell.
-		const firstItemOptions = firstMenuItem
-			.locator( '..' ) // parent selector.
-			.getByRole( 'button', {
-				name: 'Options for Page Link block',
-			} );
-
-		// Open the options menu.
-		await firstItemOptions.click();
-
-		// Add the submenu.
-		// usage of `page` is required because the options menu is rendered into a slot
-		// outside of the treegrid.
-		const addSubmenuOption = page
-			.getByRole( 'menu', {
-				name: 'Options for Page Link block',
-			} )
-			.getByRole( 'menuitem', {
-				name: 'Add submenu link',
-			} );
-
-		await addSubmenuOption.click();
-
-		await linkControl.searchFor( 'https://wordpress.org' );
-
-		await page.keyboard.press( 'Enter' );
-
-		// Check the new item was inserted in the correct place.
-		await expect(
-			listView
-				.getByRole( 'gridcell', {
-					name: 'Custom Link link',
-				} )
-				.filter( {
-					hasText: 'Block 1 of 1, Level 2', // proxy for filtering by description.
-				} )
-				.getByText( 'wordpress.org' )
-		).toBeVisible();
-
-		// Check that the original item is still there but that it is now
-		// a submenu item.
-		await expect(
-			listView
-				.getByRole( 'gridcell', {
-					name: 'Submenu link',
-				} )
-				.filter( {
-					hasText: 'Block 1 of 2, Level 1', // proxy for filtering by description.
-				} )
-				.getByText( 'Top Level Item 1' )
-		).toBeVisible();
 	} );
 } );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This adds all the dependencies to this useEffect.

## Why?
We tried this once before and it had unexpected side-effects, so we [reverted it](https://github.com/WordPress/gutenberg/pull/48599). The side-effects were fixed in https://github.com/WordPress/gutenberg/pull/48219, so we should be good to add this dependency back in.

## How?
Just adds the dependency to the dependency array.

## Testing Instructions
1. Switch to a theme that has inner blocks set inside the navigation block, or add this to a navigation block:
```
		<!-- wp:navigation -->
			<!-- wp:page-list /-->
		<!-- /wp:navigation -->
```
2. Open the Site Editor
3. Select the navigation block
4. Add a block to the navigation (either in the list view or in the canvas)
5. Check that you see a notification saying that a new navigation has been created
6. Check that you only have one navigation in `wp-admin/edit.php?post_type=wp_navigation`
