### PR TITLE
Experimenting with ability to focus on editing the post or editing the template

### DIFF
--- a/docs/reference-guides/data/data-core-edit-site.md
+++ b/docs/reference-guides/data/data-core-edit-site.md
@@ -72,6 +72,10 @@ _Returns_
 
 -   `TemplateType?`: Template type.
 
+### getEditFocus
+
+Undocumented declaration.
+
 ### getEditorMode
 
 Returns the current editing mode.
@@ -249,6 +253,10 @@ _Parameters_
 _Returns_
 
 -   `number`: The resolved template ID for the page route.
+
+### setEditFocus
+
+Undocumented declaration.
 
 ### setHomeTemplateId
 

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -110,6 +110,7 @@ function Iframe( {
 	frameSize = 0,
 	expand = false,
 	readonly,
+	editFocus = 'template',
 	forwardedRef: ref,
 	...props
 } ) {
@@ -291,6 +292,9 @@ function Iframe( {
 								className={ classnames(
 									'block-editor-iframe__body',
 									'editor-styles-wrapper',
+									editFocus === 'template'
+										? 'is-template-edit-focus'
+										: 'is-post-edit-focus',
 									...bodyClasses
 								) }
 							>

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -406,14 +406,16 @@ export const replaceBlocks =
 		);
 		const rootClientId = select.getBlockRootClientId( clientIds[ 0 ] );
 		// Replace is valid if the new blocks can be inserted in the root block.
-		for ( let index = 0; index < blocks.length; index++ ) {
-			const block = blocks[ index ];
-			const canInsertBlock = select.canInsertBlockType(
-				block.name,
-				rootClientId
-			);
-			if ( ! canInsertBlock ) {
-				return;
+		if ( ! meta?.skipChecks ) {
+			for ( let index = 0; index < blocks.length; index++ ) {
+				const block = blocks[ index ];
+				const canInsertBlock = select.canInsertBlockType(
+					block.name,
+					rootClientId
+				);
+				if ( ! canInsertBlock ) {
+					return;
+				}
 			}
 		}
 		dispatch( {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1663,6 +1663,24 @@ export function canInsertBlocks( state, clientIds, rootClientId = null ) {
  * @return {boolean} Whether the given block is allowed to be removed.
  */
 export function canRemoveBlock( state, clientId, rootClientId = null ) {
+	// HACK: belongs in edit-site. need to make canRemoveBlock filterable.
+	const POST_CONTENT_BLOCK_NAMES = [
+		'core/post-featured-image',
+		'core/post-title',
+		'core/post-content',
+	];
+	if (
+		// we're focused on editing a post; and
+		window.wp.data.select( 'core/edit-site' ).getEditFocus() === 'post' &&
+		// the block is not a descendant of a post content block
+		getBlockNamesByClientId(
+			state,
+			getBlockParents( state, clientId )
+		).every( ( name ) => ! POST_CONTENT_BLOCK_NAMES.includes( name ) )
+	) {
+		return false;
+	}
+
 	const attributes = getBlockAttributes( state, clientId );
 
 	// attributes can be null if the block is already deleted.
@@ -1706,6 +1724,24 @@ export function canRemoveBlocks( state, clientIds, rootClientId = null ) {
  * @return {boolean | undefined} Whether the given block is allowed to be moved.
  */
 export function canMoveBlock( state, clientId, rootClientId = null ) {
+	// HACK: belongs in edit-site. need to make canMoveBlock filterable.
+	const POST_CONTENT_BLOCK_NAMES = [
+		'core/post-featured-image',
+		'core/post-title',
+		'core/post-content',
+	];
+	if (
+		// we're focused on editing a post; and
+		window.wp.data.select( 'core/edit-site' ).getEditFocus() === 'post' &&
+		// the block is not a descendant of a post content block
+		getBlockNamesByClientId(
+			state,
+			getBlockParents( state, clientId )
+		).every( ( name ) => ! POST_CONTENT_BLOCK_NAMES.includes( name ) )
+	) {
+		return false;
+	}
+
 	const attributes = getBlockAttributes( state, clientId );
 	if ( attributes === null ) {
 		return;
@@ -1746,6 +1782,33 @@ export function canMoveBlocks( state, clientIds, rootClientId = null ) {
  * @return {boolean} Whether the given block is allowed to be edited.
  */
 export function canEditBlock( state, clientId ) {
+	// HACK: belongs in edit-site. need to make canEditBlock filterable.
+	const POST_CONTENT_BLOCK_NAMES = [
+		'core/post-featured-image',
+		'core/post-title',
+		'core/post-content',
+	];
+	if (
+		// we're focused on editing a post; and
+		window.wp.data.select( 'core/edit-site' ).getEditFocus() === 'post' &&
+		// the block is not a post content block; and
+		! POST_CONTENT_BLOCK_NAMES.includes(
+			getBlockName( state, clientId )
+		) &&
+		// the block is not a descendant of a post content block; and
+		getBlockNamesByClientId(
+			state,
+			getBlockParents( state, clientId )
+		).every( ( name ) => ! POST_CONTENT_BLOCK_NAMES.includes( name ) ) &&
+		// the block is not an ancestor of a post content block
+		getBlockNamesByClientId(
+			state,
+			getClientIdsOfDescendants( state, [ clientId ] )
+		).every( ( name ) => ! POST_CONTENT_BLOCK_NAMES.includes( name ) )
+	) {
+		return false;
+	}
+
 	const attributes = getBlockAttributes( state, clientId );
 	if ( attributes === null ) {
 		return true;

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1548,6 +1548,30 @@ const canInsertBlockTypeUnmemoized = (
 		return false;
 	}
 
+	// HACK: belongs in edit-site. need to make canInsert filterable.
+	const POST_CONTENT_BLOCK_NAMES = [
+		'core/post-featured-image',
+		'core/post-title',
+		'core/post-content',
+	];
+	if (
+		// we're focused on editing a post; and
+		window.wp.data.select( 'core/edit-site' ).getEditFocus() === 'post' &&
+		// there is a parent block; and
+		rootClientId &&
+		// the parent block is not a post content block; and
+		! POST_CONTENT_BLOCK_NAMES.includes(
+			getBlockName( state, rootClientId )
+		) &&
+		// the parent block is not a descendant of a post content block
+		getBlockNamesByClientId(
+			state,
+			getBlockParents( state, rootClientId )
+		).every( ( name ) => ! POST_CONTENT_BLOCK_NAMES.includes( name ) )
+	) {
+		return false;
+	}
+
 	const parentAllowedBlocks = parentBlockListSettings?.allowedBlocks;
 	const hasParentAllowedBlock = checkAllowList(
 		parentAllowedBlocks,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1656,8 +1656,10 @@ const canInsertBlockTypeUnmemoized = (
 export const canInsertBlockType = createSelector(
 	canInsertBlockTypeUnmemoized,
 	( state, blockName, rootClientId ) => [
+		window.wp.data.select( 'core/edit-site' ).getEditFocus(),
+		state.blocks.parents,
+		state.blocks.byClientId,
 		state.blockListSettings[ rootClientId ],
-		state.blocks.byClientId.get( rootClientId ),
 		state.settings.allowedBlockTypes,
 		state.settings.templateLock,
 	]

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1557,17 +1557,19 @@ const canInsertBlockTypeUnmemoized = (
 	if (
 		// we're focused on editing a post; and
 		window.wp.data.select( 'core/edit-site' ).getEditFocus() === 'post' &&
-		// there is a parent block; and
-		rootClientId &&
-		// the parent block is not a post content block; and
-		! POST_CONTENT_BLOCK_NAMES.includes(
-			getBlockName( state, rootClientId )
-		) &&
-		// the parent block is not a descendant of a post content block
-		getBlockNamesByClientId(
-			state,
-			getBlockParents( state, rootClientId )
-		).every( ( name ) => ! POST_CONTENT_BLOCK_NAMES.includes( name ) )
+		// this is the top level; or
+		( ! rootClientId ||
+			// the parent block is not a post content block; and
+			( ! POST_CONTENT_BLOCK_NAMES.includes(
+				getBlockName( state, rootClientId )
+			) &&
+				// the parent block is not a descendant of a post content block
+				getBlockNamesByClientId(
+					state,
+					getBlockParents( state, rootClientId )
+				).every(
+					( name ) => ! POST_CONTENT_BLOCK_NAMES.includes( name )
+				) ) )
 	) {
 		return false;
 	}

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1556,7 +1556,7 @@ const canInsertBlockTypeUnmemoized = (
 	];
 	if (
 		// we're focused on editing a post; and
-		window.wp.data.select( 'core/edit-site' ).getEditFocus() === 'post' &&
+		window.wp.data.select( 'core/edit-site' )?.getEditFocus() === 'post' &&
 		// this is the top level; or
 		( ! rootClientId ||
 			// the parent block is not a post content block; and
@@ -1656,7 +1656,7 @@ const canInsertBlockTypeUnmemoized = (
 export const canInsertBlockType = createSelector(
 	canInsertBlockTypeUnmemoized,
 	( state, blockName, rootClientId ) => [
-		window.wp.data.select( 'core/edit-site' ).getEditFocus(),
+		window.wp.data.select( 'core/edit-site' )?.getEditFocus(),
 		state.blocks.parents,
 		state.blocks.byClientId,
 		state.blockListSettings[ rootClientId ],
@@ -1700,7 +1700,7 @@ export const canRemoveBlock = createSelector(
 		];
 		if (
 			// we're focused on editing a post; and
-			window.wp.data.select( 'core/edit-site' ).getEditFocus() ===
+			window.wp.data.select( 'core/edit-site' )?.getEditFocus() ===
 				'post' &&
 			// the block is not a descendant of a post content block
 			getBlockNamesByClientId(
@@ -1729,7 +1729,7 @@ export const canRemoveBlock = createSelector(
 		return ! lock?.remove;
 	},
 	( state ) => [
-		window.wp.data.select( 'core/edit-site' ).getEditFocus(),
+		window.wp.data.select( 'core/edit-site' )?.getEditFocus(),
 		state.blocks.parents,
 		state.blocks.byClientId,
 	]
@@ -1769,7 +1769,7 @@ export const canMoveBlock = createSelector(
 		];
 		if (
 			// we're focused on editing a post; and
-			window.wp.data.select( 'core/edit-site' ).getEditFocus() ===
+			window.wp.data.select( 'core/edit-site' )?.getEditFocus() ===
 				'post' &&
 			// the block is not a descendant of a post content block
 			getBlockNamesByClientId(
@@ -1796,7 +1796,7 @@ export const canMoveBlock = createSelector(
 		return ! lock?.move;
 	},
 	( state ) => [
-		window.wp.data.select( 'core/edit-site' ).getEditFocus(),
+		window.wp.data.select( 'core/edit-site' )?.getEditFocus(),
 		state.blocks.parents,
 		state.blocks.byClientId,
 	]
@@ -1835,7 +1835,7 @@ export const canEditBlock = createSelector(
 		];
 		if (
 			// we're focused on editing a post; and
-			window.wp.data.select( 'core/edit-site' ).getEditFocus() ===
+			window.wp.data.select( 'core/edit-site' )?.getEditFocus() ===
 				'post' &&
 			// the block is not a post content block; and
 			! POST_CONTENT_BLOCK_NAMES.includes(
@@ -1868,7 +1868,7 @@ export const canEditBlock = createSelector(
 		return ! lock?.edit;
 	},
 	( state ) => [
-		window.wp.data.select( 'core/edit-site' ).getEditFocus(),
+		window.wp.data.select( 'core/edit-site' )?.getEditFocus(),
 		state.blocks.parents,
 		state.blocks.byClientId,
 	]

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -33,7 +33,10 @@ const PatternEdit = ( { attributes, clientId } ) => {
 			// inner blocks but doesn't have blockSettings in the state.
 			window.queueMicrotask( () => {
 				__unstableMarkNextChangeAsNotPersistent();
-				replaceBlocks( clientId, selectedPattern.blocks );
+				replaceBlocks( clientId, selectedPattern.blocks, undefined, 0, {
+					// TODO: think of something better
+					skipChecks: true,
+				} );
 			} );
 		}
 	}, [ clientId, selectedPattern?.blocks ] );

--- a/packages/date/README.md
+++ b/packages/date/README.md
@@ -117,6 +117,19 @@ _Returns_
 
 -   `string`: Formatted date.
 
+### humanTimeDiff
+
+Returns a human-readable time difference between two dates, like human_time_diff() in PHP.
+
+_Parameters_
+
+-   _from_ `Moment | Date | string`: From date, in the WP timezone.
+-   _to_ `Moment | Date | string | undefined`: To date, formatted in the WP timezone.
+
+_Returns_
+
+-   `string`: Human-readable time difference.
+
 ### isInTheFuture
 
 Check whether a date is considered in the future according to the WordPress settings.

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -582,6 +582,20 @@ export function getDate( dateString ) {
 }
 
 /**
+ * Returns a human-readable time difference between two dates, like human_time_diff() in PHP.
+ *
+ * @param {Moment | Date | string}             from From date, in the WP timezone.
+ * @param {Moment | Date | string | undefined} to   To date, formatted in the WP timezone.
+ *
+ * @return {string} Human-readable time difference.
+ */
+export function humanTimeDiff( from, to ) {
+	const fromMoment = momentLib.tz( from, WP_ZONE );
+	const toMoment = to ? momentLib.tz( to, WP_ZONE ) : momentLib.tz( WP_ZONE );
+	return fromMoment.from( toMoment );
+}
+
+/**
  * Creates a moment instance using the given timezone or, if none is provided, using global settings.
  *
  * @param {Moment | Date | string | undefined} dateValue Date object or string, parsable

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -36,6 +36,7 @@
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",
+		"@wordpress/date": "file:../date",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",
 		"@wordpress/editor": "file:../editor",

--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -17,7 +17,7 @@ import { unlock } from '../../private-apis';
 import { store as editSiteStore } from '../../store';
 
 function EditorCanvas( { enableResizing, settings, children, ...props } ) {
-	const { canvasMode, deviceType, isZoomOutMode } = useSelect(
+	const { canvasMode, deviceType, isZoomOutMode, editFocus } = useSelect(
 		( select ) => ( {
 			deviceType:
 				select( editSiteStore ).__experimentalGetPreviewDeviceType(),
@@ -25,6 +25,7 @@ function EditorCanvas( { enableResizing, settings, children, ...props } ) {
 				select( blockEditorStore ).__unstableGetEditorMode() ===
 				'zoom-out',
 			canvasMode: unlock( select( editSiteStore ) ).getCanvasMode(),
+			editFocus: unlock( select( editSiteStore ) ).getEditFocus(),
 		} ),
 		[]
 	);
@@ -40,6 +41,7 @@ function EditorCanvas( { enableResizing, settings, children, ...props } ) {
 			style={ enableResizing ? {} : deviceStyles }
 			ref={ mouseMoveTypingRef }
 			name="editor-canvas"
+			editFocus={ editFocus }
 			className="edit-site-visual-editor__editor-canvas"
 			{ ...props }
 			role={ canvasMode === 'view' ? 'button' : undefined }

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -1,7 +1,7 @@
 // The button element easily inherits styles that are meant for the editor style.
 // These rules enhance the specificity to reduce that inheritance.
 // This is duplicated in visual-editor.
-.edit-site-block-editor__editor-styles-wrapper  .components-button {
+.edit-site-block-editor__editor-styles-wrapper .components-button {
 	font-family: $default-font;
 	font-size: $default-font-size;
 	padding: 6px 12px;
@@ -150,7 +150,10 @@
 	}
 
 	&:focus::after {
-		box-shadow: 0 0 0 1px $gray-800, 0 0 0 calc(var(--wp-admin-border-width-focus) + 1px) var(--wp-admin-theme-color);
+		box-shadow:
+			0 0 0 1px $gray-800,
+			0 0 0 calc(var(--wp-admin-border-width-focus) + 1px)
+			var(--wp-admin-theme-color);
 	}
 
 	&.is-variation-separator:focus::after {
@@ -159,3 +162,44 @@
 	}
 }
 
+// When editing post, highlight template blocks
+.is-post-edit-focus
+.is-outline-mode
+.block-editor-block-list__block:not(.remove-outline) {
+	&.is-highlighted,
+	&.is-selected {
+		box-shadow:
+			inset 0 0 0 var(--wp-admin-border-width-focus)
+			var(--wp-block-synced-color);
+		&::after {
+			box-shadow:
+				0 0 0 var(--wp-admin-border-width-focus)
+				var(--wp-block-synced-color);
+		}
+	}
+	&.is-hovered {
+		&::after {
+			box-shadow: 0 0 0 $border-width var(--wp-block-synced-color) inset;
+		}
+	}
+}
+
+.is-post-edit-focus
+.is-outline-mode
+.wp-block-post-content
+.block-editor-block-list__block:not(.remove-outline) {
+	&.is-highlighted,
+	&.is-selected {
+		box-shadow: none;
+		&::after {
+			box-shadow:
+				0 0 0 var(--wp-admin-border-width-focus)
+				var(--wp-admin-theme-color);
+		}
+	}
+	&.is-hovered {
+		&::after {
+			box-shadow: 0 0 0 1px var(--wp-admin-theme-color) inset;
+		}
+	}
+}

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -67,6 +67,7 @@ export default function Editor() {
 		isInserterOpen,
 		isListViewOpen,
 		showIconLabels,
+		editFocus,
 	} = useSelect( ( select ) => {
 		const {
 			getEditedPostContext,
@@ -74,6 +75,7 @@ export default function Editor() {
 			getCanvasMode,
 			isInserterOpened,
 			isListViewOpened,
+			getEditFocus,
 		} = unlock( select( editSiteStore ) );
 		const { __unstableGetEditorMode } = select( blockEditorStore );
 		const { getActiveComplementaryArea } = select( interfaceStore );
@@ -94,6 +96,7 @@ export default function Editor() {
 				'core/edit-site',
 				'showIconLabels'
 			),
+			editFocus: getEditFocus(),
 		};
 	}, [] );
 	const { setEditedPostContext } = useDispatch( editSiteStore );
@@ -125,6 +128,13 @@ export default function Editor() {
 		} ),
 		[ context, setEditedPostContext ]
 	);
+	// TODO: can I move some of this logic to the selector?
+	const filteredBlockContext = useMemo( () => {
+		const { postType, postId, ...nonPostFields } = blockContext;
+		return postId && editFocus === 'template'
+			? nonPostFields
+			: blockContext;
+	}, [ blockContext, editFocus ] );
 
 	let title;
 	if ( hasLoadedPost ) {
@@ -157,7 +167,7 @@ export default function Editor() {
 					type={ editedPostType }
 					id={ editedPostId }
 				>
-					<BlockContextProvider value={ blockContext }>
+					<BlockContextProvider value={ filteredBlockContext }>
 						<SidebarComplementaryAreaFills />
 						{ isEditMode && <StartTemplateOptions /> }
 						<InterfaceSkeleton

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -37,6 +37,7 @@ import useTitle from '../routes/use-title';
 import CanvasSpinner from '../canvas-spinner';
 import { unlock } from '../../private-apis';
 import useEditedEntityRecord from '../use-edited-entity-record';
+import useTemplateEditNotification from '../use-template-edit-notification';
 
 const interfaceLabels = {
 	/* translators: accessibility text for the editor content landmark region. */
@@ -153,6 +154,8 @@ export default function Editor() {
 	// Only announce the title once the editor is ready to prevent "Replace"
 	// action in <URlQueryController> from double-announcing.
 	useTitle( hasLoadedPost && title );
+
+	useTemplateEditNotification();
 
 	if ( ! hasLoadedPost ) {
 		return <CanvasSpinner />;

--- a/packages/edit-site/src/components/header-edit-mode/edit-focus-switcher/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/edit-focus-switcher/index.js
@@ -1,0 +1,48 @@
+/**
+ * WordPress dependencies
+ */
+import { TabPanel } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEntityRecord } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../../../store';
+import useEditedEntityRecord from '../../use-edited-entity-record';
+
+// TODO: 'edit focus' could be confused with 'editor mode'
+export default function EditFocusSwitcher() {
+	const { postType, postId } = useSelect(
+		( select ) => select( editSiteStore ).getEditedPostContext(),
+		[]
+	);
+	const { hasResolved: hasPostResolved, editedRecord: post } =
+		useEntityRecord( 'postType', postType, postId );
+	const { isLoaded: isTemplateLoaded, getTitle: getTemplateTitle } =
+		useEditedEntityRecord();
+
+	const { setEditFocus } = useDispatch( editSiteStore );
+
+	if ( ! hasPostResolved && ! isTemplateLoaded ) {
+		return;
+	}
+
+	return (
+		<TabPanel
+			tabs={ [
+				{
+					name: 'post',
+					title: post.title,
+				},
+				{
+					name: 'template',
+					title: getTemplateTitle(),
+				},
+			] }
+			onSelect={ setEditFocus }
+		>
+			{ () => {} }
+		</TabPanel>
+	);
+}

--- a/packages/edit-site/src/components/header-edit-mode/edit-focus-switcher/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/edit-focus-switcher/index.js
@@ -67,7 +67,11 @@ export default function EditFocusSwitcher() {
 				{ post.type }
 			</Button>
 			<Button
-				className={ editFocus === 'template' ? 'is-active' : '' }
+				className={
+					editFocus === 'template'
+						? 'template-tab is-active'
+						: 'template-tab'
+				}
 				onClick={ () => setEditFocus( 'template' ) }
 			>
 				Template

--- a/packages/edit-site/src/components/header-edit-mode/edit-focus-switcher/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/edit-focus-switcher/index.js
@@ -4,11 +4,14 @@
 import { TabPanel } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEntityRecord } from '@wordpress/core-data';
+import { useEffect, useRef } from '@wordpress/element';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
  */
 import { store as editSiteStore } from '../../../store';
+import { unlock } from '../../../private-apis';
 import useEditedEntityRecord from '../../use-edited-entity-record';
 
 // TODO: 'edit focus' could be confused with 'editor mode'
@@ -21,7 +24,35 @@ export default function EditFocusSwitcher() {
 		useEntityRecord( 'postType', postType, postId );
 	const { isLoaded: isTemplateLoaded } = useEditedEntityRecord();
 
+	const shownNotification = useRef( false );
+
 	const { setEditFocus } = useDispatch( editSiteStore );
+
+	const { editFocus } = useSelect(
+		( select ) => ( {
+			editFocus: unlock( select( editSiteStore ) ).getEditFocus(),
+		} ),
+		[]
+	);
+
+	const { createInfoNotice } = useDispatch( noticesStore );
+
+	useEffect( () => {
+		if ( editFocus === 'template' && ! shownNotification.current ) {
+			shownNotification.current = true;
+			createInfoNotice( 'You are editing a template', {
+				type: 'snackbar',
+				actions: [
+					{
+						label: 'Back to page',
+						onClick: () => {
+							setEditFocus( 'post' );
+						},
+					},
+				],
+			} );
+		}
+	}, [ editFocus, createInfoNotice, setEditFocus ] );
 
 	if ( ! hasPostResolved && ! isTemplateLoaded ) {
 		return;
@@ -29,14 +60,17 @@ export default function EditFocusSwitcher() {
 
 	return (
 		<TabPanel
+			activeClass="is-active"
 			tabs={ [
 				{
 					name: 'post',
 					title: post.type,
+					className: editFocus === 'post' ? 'is-active' : '',
 				},
 				{
 					name: 'template',
 					title: 'template',
+					className: editFocus === 'template' ? 'is-active' : '',
 				},
 			] }
 			onSelect={ setEditFocus }

--- a/packages/edit-site/src/components/header-edit-mode/edit-focus-switcher/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/edit-focus-switcher/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { TabPanel } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEntityRecord } from '@wordpress/core-data';
 import { useEffect, useRef } from '@wordpress/element';
@@ -59,23 +59,19 @@ export default function EditFocusSwitcher() {
 	}
 
 	return (
-		<TabPanel
-			activeClass="is-active"
-			tabs={ [
-				{
-					name: 'post',
-					title: post.type,
-					className: editFocus === 'post' ? 'is-active' : '',
-				},
-				{
-					name: 'template',
-					title: 'template',
-					className: editFocus === 'template' ? 'is-active' : '',
-				},
-			] }
-			onSelect={ setEditFocus }
-		>
-			{ () => {} }
-		</TabPanel>
+		<div className="edit-focus-switcher">
+			<Button
+				className={ editFocus === 'post' ? 'is-active' : '' }
+				onClick={ () => setEditFocus( 'post' ) }
+			>
+				{ post.type }
+			</Button>
+			<Button
+				className={ editFocus === 'template' ? 'is-active' : '' }
+				onClick={ () => setEditFocus( 'template' ) }
+			>
+				Template
+			</Button>
+		</div>
 	);
 }

--- a/packages/edit-site/src/components/header-edit-mode/edit-focus-switcher/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/edit-focus-switcher/index.js
@@ -19,8 +19,7 @@ export default function EditFocusSwitcher() {
 	);
 	const { hasResolved: hasPostResolved, editedRecord: post } =
 		useEntityRecord( 'postType', postType, postId );
-	const { isLoaded: isTemplateLoaded, getTitle: getTemplateTitle } =
-		useEditedEntityRecord();
+	const { isLoaded: isTemplateLoaded } = useEditedEntityRecord();
 
 	const { setEditFocus } = useDispatch( editSiteStore );
 
@@ -33,11 +32,11 @@ export default function EditFocusSwitcher() {
 			tabs={ [
 				{
 					name: 'post',
-					title: post.title,
+					title: post.type,
 				},
 				{
 					name: 'template',
-					title: getTemplateTitle(),
+					title: 'template',
 				},
 			] }
 			onSelect={ setEditFocus }

--- a/packages/edit-site/src/components/header-edit-mode/edit-focus-switcher/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/edit-focus-switcher/index.js
@@ -1,11 +1,24 @@
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
+import {
+	Button,
+	__experimentalHStack as HStack,
+	Icon,
+	__experimentalSpacer as Spacer,
+	Flex,
+	FlexItem,
+} from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEntityRecord } from '@wordpress/core-data';
 import { useEffect, useRef } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
+import {
+	page as pageIcon,
+	chevronRight as chevronRightIcon,
+	sidebar as sidebarIcon,
+} from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -58,24 +71,40 @@ export default function EditFocusSwitcher() {
 		return;
 	}
 
-	return (
-		<div className="edit-focus-switcher">
+	return editFocus === 'post' ? (
+		<HStack expanded={ false } spacing={ 2 }>
+			<Icon icon={ pageIcon } />
+			<div>{ post.title }</div>
+		</HStack>
+	) : (
+		<Flex expanded={ false } gap={ 1 }>
 			<Button
-				className={ editFocus === 'post' ? 'is-active' : '' }
+				icon={ pageIcon }
+				style={ { color: '#757575' } }
 				onClick={ () => setEditFocus( 'post' ) }
 			>
-				{ post.type }
+				{ post.title }
 			</Button>
-			<Button
-				className={
-					editFocus === 'template'
-						? 'template-tab is-active'
-						: 'template-tab'
-				}
-				onClick={ () => setEditFocus( 'template' ) }
-			>
-				Template
-			</Button>
-		</div>
+			<Icon
+				icon={ chevronRightIcon }
+				size={ 16 }
+				style={ { fill: '#757575' } }
+			/>
+			<FlexItem>
+				<Spacer padding={ 2 } marginBottom={ 0 }>
+					<HStack
+						expanded={ false }
+						spacing={ 2 }
+						style={ { color: 'rgb(114, 47, 166)' } }
+					>
+						<Icon
+							icon={ sidebarIcon }
+							style={ { fill: 'rgb(114, 47, 166)' } }
+						/>
+						<div>{ __( 'Template' ) }</div>
+					</HStack>
+				</Spacer>
+			</FlexItem>
+		</Flex>
 	);
 }

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -39,6 +39,7 @@ import RedoButton from './undo-redo/redo';
 import DocumentActions from './document-actions';
 import { store as editSiteStore } from '../../store';
 import { useHasStyleBook } from '../style-book';
+import EditFocusSwitcher from './edit-focus-switcher';
 
 const preventDefault = ( event ) => {
 	event.preventDefault();
@@ -56,6 +57,7 @@ export default function HeaderEditMode() {
 		blockEditorMode,
 		homeUrl,
 		showIconLabels,
+		hasPostContext,
 	} = useSelect( ( select ) => {
 		const {
 			__experimentalGetPreviewDeviceType,
@@ -63,6 +65,7 @@ export default function HeaderEditMode() {
 			isInserterOpened,
 			isListViewOpened,
 			getEditorMode,
+			getEditedPostContext,
 		} = select( editSiteStore );
 		const { getShortcutRepresentation } = select( keyboardShortcutsStore );
 		const { __unstableGetEditorMode } = select( blockEditorStore );
@@ -88,6 +91,7 @@ export default function HeaderEditMode() {
 				'core/edit-site',
 				'showIconLabels'
 			),
+			hasPostContext: !! getEditedPostContext()?.postId,
 		};
 	}, [] );
 
@@ -223,7 +227,9 @@ export default function HeaderEditMode() {
 			) }
 
 			<div className="edit-site-header-edit-mode__center">
-				{ hasStyleBook ? __( 'Style Book' ) : <DocumentActions /> }
+				{ hasStyleBook && __( 'Style Book' ) }
+				{ ! hasStyleBook && hasPostContext && <EditFocusSwitcher /> }
+				{ ! hasStyleBook && ! hasPostContext && <DocumentActions /> }
 			</div>
 
 			<div className="edit-site-header-edit-mode__end">

--- a/packages/edit-site/src/components/header-edit-mode/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/style.scss
@@ -41,6 +41,7 @@ $header-toolbar-min-width: 335px;
 			position: relative;
 			text-transform: capitalize;
 			border-radius: 0;
+			color: $gray-700;
 			&:focus {
 				outline: none;
 				box-shadow: none;
@@ -57,7 +58,16 @@ $header-toolbar-min-width: 335px;
 				border-radius: 0;
 				transition: all 0.1s linear;
 			}
+			&.template-tab {
+				&.is-active {
+					color: var(--wp-block-synced-color);
+				}
+				&::after {
+					background: var(--wp-components-color-accent, var(--wp-block-synced-color, #007cba));
+				}
+			}
 			&.is-active {
+				color: $gray-900;
 				&::after {
 					height: calc(1 * var(--wp-admin-border-width-focus));
 					outline: 2px solid transparent;

--- a/packages/edit-site/src/components/header-edit-mode/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/style.scss
@@ -34,16 +34,38 @@ $header-toolbar-min-width: 335px;
 		min-width: 0;
 	}
 
-	.components-tab-panel__tabs {
-		height: 100%;
+	// controlled "tabs" for switching modes
+	.edit-focus-switcher {
+		button {
+			height: 100%;
+			position: relative;
+			text-transform: capitalize;
+			border-radius: 0;
+			&:focus {
+				outline: none;
+				box-shadow: none;
+			}
+			&::after {
+				content: "";
+				position: absolute;
+				right: 0;
+				bottom: 0;
+				left: 0;
+				pointer-events: none;
+				background: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
+				height: calc(0 * var(--wp-admin-border-width-focus));
+				border-radius: 0;
+				transition: all 0.1s linear;
+			}
+			&.is-active {
+				&::after {
+					height: calc(1 * var(--wp-admin-border-width-focus));
+					outline: 2px solid transparent;
+					outline-offset: -1px;
+				}
+			}
+		}
 	}
-
-	.components-tab-panel__tabs-item {
-		text-transform: capitalize;
-		height: 100%;
-	}
-
-
 }
 
 .edit-site-header-edit-mode__toolbar {

--- a/packages/edit-site/src/components/header-edit-mode/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/style.scss
@@ -24,7 +24,6 @@ $header-toolbar-min-width: 335px;
 
 	.edit-site-header-edit-mode__center {
 		display: flex;
-		align-items: center;
 		height: 100%;
 		flex-grow: 1;
 		justify-content: center;
@@ -34,6 +33,17 @@ $header-toolbar-min-width: 335px;
 		// See https://dev.w3.org/csswg/css-flexbox/#min-size-auto
 		min-width: 0;
 	}
+
+	.components-tab-panel__tabs {
+		height: 100%;
+	}
+
+	.components-tab-panel__tabs-item {
+		text-transform: capitalize;
+		height: 100%;
+	}
+
+
 }
 
 .edit-site-header-edit-mode__toolbar {

--- a/packages/edit-site/src/components/header-edit-mode/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/style.scss
@@ -33,49 +33,6 @@ $header-toolbar-min-width: 335px;
 		// See https://dev.w3.org/csswg/css-flexbox/#min-size-auto
 		min-width: 0;
 	}
-
-	// controlled "tabs" for switching modes
-	.edit-focus-switcher {
-		button {
-			height: 100%;
-			position: relative;
-			text-transform: capitalize;
-			border-radius: 0;
-			color: $gray-700;
-			&:focus {
-				outline: none;
-				box-shadow: none;
-			}
-			&::after {
-				content: "";
-				position: absolute;
-				right: 0;
-				bottom: 0;
-				left: 0;
-				pointer-events: none;
-				background: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
-				height: calc(0 * var(--wp-admin-border-width-focus));
-				border-radius: 0;
-				transition: all 0.1s linear;
-			}
-			&.template-tab {
-				&.is-active {
-					color: var(--wp-block-synced-color);
-				}
-				&::after {
-					background: var(--wp-components-color-accent, var(--wp-block-synced-color, #007cba));
-				}
-			}
-			&.is-active {
-				color: $gray-900;
-				&::after {
-					height: calc(1 * var(--wp-admin-border-width-focus));
-					outline: 2px solid transparent;
-					outline-offset: -1px;
-				}
-			}
-		}
-	}
 }
 
 .edit-site-header-edit-mode__toolbar {

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -65,12 +65,14 @@ export default function Layout() {
 	const { params } = useLocation();
 	const isListPage = getIsListPage( params );
 	const isEditorPage = ! isListPage;
-	const { canvasMode, previousShortcut, nextShortcut } = useSelect(
+	const { canvasMode, previousShortcut, nextShortcut, editFocus } = useSelect(
 		( select ) => {
 			const { getAllShortcutKeyCombinations } = select(
 				keyboardShortcutsStore
 			);
-			const { getCanvasMode } = unlock( select( editSiteStore ) );
+			const { getCanvasMode, getEditFocus } = unlock(
+				select( editSiteStore )
+			);
 			return {
 				canvasMode: getCanvasMode(),
 				previousShortcut: getAllShortcutKeyCombinations(
@@ -79,6 +81,7 @@ export default function Layout() {
 				nextShortcut: getAllShortcutKeyCombinations(
 					'core/edit-site/next-region'
 				),
+				editFocus: getEditFocus(),
 			};
 		},
 		[]
@@ -135,6 +138,8 @@ export default function Layout() {
 					{
 						'is-full-canvas': isFullCanvas,
 						'is-edit-mode': canvasMode === 'edit',
+						'is-post-edit-focus': editFocus === 'post',
+						'is-template-edit-focus': editFocus === 'template',
 					}
 				) }
 			>

--- a/packages/edit-site/src/components/sidebar-edit-mode/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createSlotFill } from '@wordpress/components';
+import { PanelBody, createSlotFill } from '@wordpress/components';
 import { isRTL, __ } from '@wordpress/i18n';
 import { drawerLeft, drawerRight } from '@wordpress/icons';
 import { useEffect, Fragment } from '@wordpress/element';
@@ -19,7 +19,7 @@ import SettingsHeader from './settings-header';
 import TemplateCard from './template-card';
 import { SIDEBAR_BLOCK, SIDEBAR_TEMPLATE } from './constants';
 import { store as editSiteStore } from '../../store';
-import PageCard from './page-card';
+import PagePanels from './page-panels';
 
 const { Slot: InspectorSlot, Fill: InspectorFill } = createSlotFill(
 	'EditSiteSidebarInspector'
@@ -78,7 +78,13 @@ export function SidebarComplementaryAreaFills() {
 				headerClassName="edit-site-sidebar-edit-mode__panel-tabs"
 			>
 				{ sidebarName === SIDEBAR_TEMPLATE &&
-					( isPostEditFocus ? <PageCard /> : <TemplateCard /> ) }
+					( isPostEditFocus ? (
+						<PagePanels />
+					) : (
+						<PanelBody>
+							<TemplateCard />
+						</PanelBody>
+					) ) }
 				{ sidebarName === SIDEBAR_BLOCK && (
 					<InspectorSlot bubblesVirtually />
 				) }

--- a/packages/edit-site/src/components/sidebar-edit-mode/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createSlotFill, PanelBody } from '@wordpress/components';
+import { createSlotFill } from '@wordpress/components';
 import { isRTL, __ } from '@wordpress/i18n';
 import { drawerLeft, drawerRight } from '@wordpress/icons';
 import { useEffect, Fragment } from '@wordpress/element';
@@ -19,6 +19,7 @@ import SettingsHeader from './settings-header';
 import TemplateCard from './template-card';
 import { SIDEBAR_BLOCK, SIDEBAR_TEMPLATE } from './constants';
 import { store as editSiteStore } from '../../store';
+import PageCard from './page-card';
 
 const { Slot: InspectorSlot, Fill: InspectorFill } = createSlotFill(
 	'EditSiteSidebarInspector'
@@ -31,6 +32,7 @@ export function SidebarComplementaryAreaFills() {
 		isEditorSidebarOpened,
 		hasBlockSelection,
 		supportsGlobalStyles,
+		isPostEditFocus,
 	} = useSelect( ( select ) => {
 		const _sidebar =
 			select( interfaceStore ).getActiveComplementaryArea( STORE_NAME );
@@ -38,13 +40,15 @@ export function SidebarComplementaryAreaFills() {
 			SIDEBAR_BLOCK,
 			SIDEBAR_TEMPLATE,
 		].includes( _sidebar );
-		const settings = select( editSiteStore ).getSettings();
+		const { getSettings, getEditFocus } = select( editSiteStore );
+		const settings = getSettings();
 		return {
 			sidebar: _sidebar,
 			isEditorSidebarOpened: _isEditorSidebarOpened,
 			hasBlockSelection:
 				!! select( blockEditorStore ).getBlockSelectionStart(),
 			supportsGlobalStyles: ! settings?.supportsTemplatePartsMode,
+			isPostEditFocus: getEditFocus() === 'post',
 		};
 	}, [] );
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
@@ -73,11 +77,8 @@ export function SidebarComplementaryAreaFills() {
 				header={ <SettingsHeader sidebarName={ sidebarName } /> }
 				headerClassName="edit-site-sidebar-edit-mode__panel-tabs"
 			>
-				{ sidebarName === SIDEBAR_TEMPLATE && (
-					<PanelBody>
-						<TemplateCard />
-					</PanelBody>
-				) }
+				{ sidebarName === SIDEBAR_TEMPLATE &&
+					( isPostEditFocus ? <PageCard /> : <TemplateCard /> ) }
 				{ sidebarName === SIDEBAR_BLOCK && (
 					<InspectorSlot bubblesVirtually />
 				) }

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-card/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-card/index.js
@@ -1,0 +1,123 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Icon,
+	PanelBody,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	Button,
+} from '@wordpress/components';
+import {
+	page as pageIcon,
+	title as titleIcon,
+	postExcerpt as postExcerptIcon,
+	postContent as postContentIcon,
+	postFeaturedImage as postFeaturedImageIcon,
+} from '@wordpress/icons';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEntityRecord } from '@wordpress/core-data';
+import { humanTimeDiff } from '@wordpress/date';
+import { __, sprintf } from '@wordpress/i18n';
+import { BlockContextProvider, BlockPreview } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../../../store';
+import useEditedEntityRecord from '../../use-edited-entity-record';
+
+export default function PageCard() {
+	const blockContext = useSelect(
+		( select ) => select( editSiteStore ).getEditedPostContext(),
+		[]
+	);
+	const { postType, postId, ...filteredBlockContext } = blockContext;
+	const { hasResolved: hasPostResolved, editedRecord: post } =
+		useEntityRecord( 'postType', postType, postId );
+	const {
+		isLoaded: isTemplateLoaded,
+		getTitle: getTemplateTitle,
+		record: template,
+	} = useEditedEntityRecord();
+
+	const { setEditFocus } = useDispatch( editSiteStore );
+
+	if ( ! hasPostResolved && ! isTemplateLoaded ) {
+		return;
+	}
+
+	return (
+		<>
+			<PanelBody>
+				<div className="edit-site-template-card">
+					<Icon
+						className="edit-site-template-card__icon"
+						icon={ pageIcon }
+					/>
+					<div className="edit-site-template-card__content">
+						<div className="edit-site-template-card__header">
+							<h2 className="edit-site-template-card__title">
+								{ post.title }
+							</h2>
+						</div>
+						<div
+							className="edit-site-template-card__description"
+							style={ { margin: 'unset' } }
+						>
+							{ sprintf(
+								// translators: %s: Human-readable time difference, e.g. "2 days ago".
+								__( 'Last edited %s' ),
+								humanTimeDiff( post.modified )
+							) }
+						</div>
+					</div>
+				</div>
+			</PanelBody>
+			<PanelBody title={ __( 'Content' ) }>
+				<VStack>
+					{ /* TODO: make this dynamic */ }
+					<Button icon={ titleIcon }>Page Title</Button>
+					<Button icon={ postExcerptIcon }>Page Excerpt</Button>
+					<Button icon={ postContentIcon }>Page Content</Button>
+					<Button icon={ postFeaturedImageIcon }>
+						Featured Image
+					</Button>
+				</VStack>
+			</PanelBody>
+			<PanelBody title={ __( 'Template' ) }>
+				<VStack>
+					<HStack>
+						<div>{ getTemplateTitle() }</div>
+						{ /* TODO: REST API doesn't readily have this information */ }
+						<div style={ { color: '#949494' } }>
+							Used on 4 pages
+						</div>
+					</HStack>
+					<div
+						style={ {
+							border: '1px solid #e0e0e0',
+							maxHeight: 200,
+							overflow: 'hidden',
+						} }
+					>
+						{ /* TODO: not sure why this doesn't work. it should stop the preview from showing page content */ }
+						<BlockContextProvider value={ filteredBlockContext }>
+							<BlockPreview
+								viewportWidth={ 1024 }
+								blocks={ template.blocks }
+							/>
+						</BlockContextProvider>
+					</div>
+					<Button
+						variant="secondary"
+						style={ { justifyContent: 'center' } }
+						onClick={ () => setEditFocus( 'template' ) }
+					>
+						{ __( 'Edit template' ) }
+					</Button>
+				</VStack>
+			</PanelBody>
+		</>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/index.js
@@ -27,7 +27,7 @@ import { BlockContextProvider, BlockPreview } from '@wordpress/block-editor';
 import { store as editSiteStore } from '../../../store';
 import useEditedEntityRecord from '../../use-edited-entity-record';
 
-export default function PageCard() {
+export default function PagePanels() {
 	const blockContext = useSelect(
 		( select ) => select( editSiteStore ).getEditedPostContext(),
 		[]

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/index.js
@@ -50,7 +50,12 @@ export default function PagePanels() {
 			blockContext: getEditedPostContext(),
 		};
 	}, [] );
-	const { postType, postId, ...filteredBlockContext } = blockContext;
+	const { postType, postId, ...nonPostFields } = blockContext;
+	const previewBlockContext = {
+		...nonPostFields,
+		postType: null,
+		postId: null,
+	};
 	const { hasResolved: hasPostResolved, editedRecord: post } =
 		useEntityRecord( 'postType', postType, postId );
 	const {
@@ -126,8 +131,7 @@ export default function PagePanels() {
 							overflow: 'hidden',
 						} }
 					>
-						{ /* TODO: not sure why this doesn't work. it should stop the preview from showing page content */ }
-						<BlockContextProvider value={ filteredBlockContext }>
+						<BlockContextProvider value={ previewBlockContext }>
 							<BlockPreview
 								viewportWidth={ 1024 }
 								blocks={ template.blocks }

--- a/packages/edit-site/src/components/sidebar-edit-mode/settings-header/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/settings-header/index.js
@@ -3,7 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { store as interfaceStore } from '@wordpress/interface';
 
 /**
@@ -11,8 +11,13 @@ import { store as interfaceStore } from '@wordpress/interface';
  */
 import { STORE_NAME } from '../../../store/constants';
 import { SIDEBAR_BLOCK, SIDEBAR_TEMPLATE } from '../constants';
+import { store as editSiteStore } from '../../../store';
 
 const SettingsHeader = ( { sidebarName } ) => {
+	const isPostEditFocus = useSelect(
+		( select ) => select( editSiteStore ).getEditFocus() === 'post'
+	);
+
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
 	const openTemplateSettings = () =>
 		enableComplementaryArea( STORE_NAME, SIDEBAR_TEMPLATE );
@@ -26,6 +31,13 @@ const SettingsHeader = ( { sidebarName } ) => {
 			: // translators: ARIA label for the Template Settings Sidebar tab, not selected.
 			  [ __( 'Template' ), '' ];
 
+	const [ pageAriaLabel, pageActiveClass ] =
+		sidebarName === SIDEBAR_TEMPLATE
+			? // translators: ARIA label for the Page Settings Sidebar tab, selected.
+			  [ __( 'Page (selected)' ), 'is-active' ]
+			: // translators: ARIA label for the Page Settings Sidebar tab, not selected.
+			  [ __( 'Page' ), '' ];
+
 	const [ blockAriaLabel, blockActiveClass ] =
 		sidebarName === SIDEBAR_BLOCK
 			? // translators: ARIA label for the Block Settings Sidebar tab, selected.
@@ -37,18 +49,33 @@ const SettingsHeader = ( { sidebarName } ) => {
 	return (
 		<ul>
 			<li>
-				<Button
-					onClick={ openTemplateSettings }
-					className={ `edit-site-sidebar-edit-mode__panel-tab ${ templateActiveClass }` }
-					aria-label={ templateAriaLabel }
-					// translators: Data label for the Template Settings Sidebar tab.
-					data-label={ __( 'Template' ) }
-				>
-					{
-						// translators: Text label for the Template Settings Sidebar tab.
-						__( 'Template' )
-					}
-				</Button>
+				{ isPostEditFocus ? (
+					<Button
+						onClick={ openTemplateSettings }
+						className={ `edit-site-sidebar-edit-mode__panel-tab ${ pageActiveClass }` }
+						aria-label={ pageAriaLabel }
+						// translators: Data label for the Page Settings Sidebar tab.
+						data-label={ __( 'Page' ) }
+					>
+						{
+							// translators: Text label for the Page Settings Sidebar tab.
+							__( 'Page' )
+						}
+					</Button>
+				) : (
+					<Button
+						onClick={ openTemplateSettings }
+						className={ `edit-site-sidebar-edit-mode__panel-tab ${ templateActiveClass }` }
+						aria-label={ templateAriaLabel }
+						// translators: Data label for the Template Settings Sidebar tab.
+						data-label={ __( 'Template' ) }
+					>
+						{
+							// translators: Text label for the Template Settings Sidebar tab.
+							__( 'Template' )
+						}
+					</Button>
+				) }
 			</li>
 			<li>
 				<Button

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-card/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-card/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { PanelBody, PanelRow, Icon } from '@wordpress/components';
+import { PanelRow, Icon } from '@wordpress/components';
 import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -40,7 +40,7 @@ export default function TemplateCard() {
 	}
 
 	return (
-		<PanelBody>
+		<>
 			<div className="edit-site-template-card">
 				<Icon className="edit-site-template-card__icon" icon={ icon } />
 				<div className="edit-site-template-card__content">
@@ -62,6 +62,6 @@ export default function TemplateCard() {
 			>
 				<LastRevision />
 			</PanelRow>
-		</PanelBody>
+		</>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-card/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-card/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { PanelRow, Icon } from '@wordpress/components';
+import { PanelBody, PanelRow, Icon } from '@wordpress/components';
 import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -40,7 +40,7 @@ export default function TemplateCard() {
 	}
 
 	return (
-		<>
+		<PanelBody>
 			<div className="edit-site-template-card">
 				<Icon className="edit-site-template-card__icon" icon={ icon } />
 				<div className="edit-site-template-card__content">
@@ -62,6 +62,6 @@ export default function TemplateCard() {
 			>
 				<LastRevision />
 			</PanelRow>
-		</>
+		</PanelBody>
 	);
 }

--- a/packages/edit-site/src/components/use-template-edit-notification/index.js
+++ b/packages/edit-site/src/components/use-template-edit-notification/index.js
@@ -3,7 +3,7 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
 import { __ } from '@wordpress/i18n';
 
@@ -49,8 +49,15 @@ export default function useTemplateEditNotification() {
 	const { createNotice } = useDispatch( noticesStore );
 	const { setEditFocus } = useDispatch( editSiteStore );
 
+	const shownNotification = useRef( false );
+
 	useEffect( () => {
-		if ( isPostEditFocus && isTemplateBlockSelected ) {
+		if (
+			isPostEditFocus &&
+			isTemplateBlockSelected &&
+			! shownNotification.current
+		) {
+			shownNotification.current = true;
 			createNotice(
 				'info',
 				__( 'Edit your template to edit this block' ),

--- a/packages/edit-site/src/components/use-template-edit-notification/index.js
+++ b/packages/edit-site/src/components/use-template-edit-notification/index.js
@@ -53,15 +53,13 @@ export default function useTemplateEditNotification() {
 		if ( isPostEditFocus && isTemplateBlockSelected ) {
 			createNotice(
 				'info',
-				__(
-					'This block is part of the page’s template. Switch to the Template focus to edit it.'
-				),
+				__( 'Edit your template to edit this block' ),
 				{
 					isDismissible: true,
 					type: 'snackbar',
 					actions: [
 						{
-							label: __( 'Switch to Template focus' ),
+							label: __( 'Edit template' ),
 							onClick() {
 								setEditFocus( 'template' );
 							},

--- a/packages/edit-site/src/components/use-template-edit-notification/index.js
+++ b/packages/edit-site/src/components/use-template-edit-notification/index.js
@@ -1,0 +1,74 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useEffect } from '@wordpress/element';
+import { store as noticesStore } from '@wordpress/notices';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../../store';
+
+const POST_CONTENT_BLOCK_NAMES = [
+	'core/post-featured-image',
+	'core/post-title',
+	'core/post-content',
+];
+
+export default function useTemplateEditNotification() {
+	const { isPostEditFocus, isTemplateBlockSelected } = useSelect(
+		( select ) => {
+			const { getEditFocus } = select( editSiteStore );
+			const {
+				getSelectedBlockClientId,
+				getBlockName,
+				getBlockParents,
+				getBlockNamesByClientId,
+			} = select( blockEditorStore );
+			const selectedClientId = getSelectedBlockClientId();
+			return {
+				isPostEditFocus: getEditFocus() === 'post',
+				isTemplateBlockSelected:
+					selectedClientId &&
+					! POST_CONTENT_BLOCK_NAMES.includes(
+						getBlockName( selectedClientId )
+					) &&
+					getBlockNamesByClientId(
+						getBlockParents( selectedClientId )
+					).every(
+						( name ) => ! POST_CONTENT_BLOCK_NAMES.includes( name )
+					),
+			};
+		},
+		[]
+	);
+
+	const { createNotice } = useDispatch( noticesStore );
+	const { setEditFocus } = useDispatch( editSiteStore );
+
+	useEffect( () => {
+		if ( isPostEditFocus && isTemplateBlockSelected ) {
+			createNotice(
+				'info',
+				__(
+					'This block is part of the page’s template. Switch to the Template focus to edit it.'
+				),
+				{
+					isDismissible: true,
+					type: 'snackbar',
+					actions: [
+						{
+							label: __( 'Switch to Template focus' ),
+							onClick() {
+								setEditFocus( 'template' );
+							},
+						},
+					],
+				}
+			);
+		}
+	}, [ isPostEditFocus, isTemplateBlockSelected, createNotice ] );
+}

--- a/packages/edit-site/src/components/use-template-edit-notification/index.js
+++ b/packages/edit-site/src/components/use-template-edit-notification/index.js
@@ -75,5 +75,11 @@ export default function useTemplateEditNotification() {
 				}
 			);
 		}
-	}, [ isPostEditFocus, isTemplateBlockSelected, createNotice ] );
+	}, [
+		isPostEditFocus,
+		isTemplateBlockSelected,
+		createNotice,
+		shownNotification,
+		setEditFocus,
+	] );
 }

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -530,3 +530,10 @@ export const switchEditorMode =
 			speak( __( 'Code editor selected' ), 'assertive' );
 		}
 	};
+
+export function setEditFocus( focus ) {
+	return {
+		type: 'SET_EDIT_FOCUS',
+		focus,
+	};
+}

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -140,6 +140,15 @@ function canvasMode( state = 'init', action ) {
 	return state;
 }
 
+function editFocus( state = 'post', action ) {
+	switch ( action.type ) {
+		case 'SET_EDIT_FOCUS':
+			return action.focus;
+	}
+
+	return state;
+}
+
 export default combineReducers( {
 	deviceType,
 	settings,
@@ -148,4 +157,5 @@ export default combineReducers( {
 	listViewPanel,
 	saveViewPanel,
 	canvasMode,
+	editFocus,
 } );

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -320,3 +320,7 @@ export function isNavigationOpened() {
 		version: '6.4',
 	} );
 }
+
+export function getEditFocus( state ) {
+	return state.editedPost.context?.postId ? state.editFocus : null;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/612155/229986062-e3aab858-e8b6-48ad-8ea7-fa4cdc2f7076.mp4

## To do

- [x] Tweak selection colours (@SaxonF)
- [x] Change tab names to Page and Template
- [ ] Experiment with using a toggle instead of tabs
- [x] Show toast notification when you click on something in the template
- [ ] Hide padlock icons or make clicking it do something useful
- [x] Prevent adding new blocks / patterns when in page focus 
- [ ] Fix "lock editing" functionality: block toolbar and block inspector should appear empty
- [ ] Disable zoomed out mode button when in page focus
- [ ] (Later) Implement locking properly. `wp.blockEditor` shouldn't access `wp.data.select( 'core/edit-site' )`