### PR TITLE
Upgrade Playwright to 1.32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6857,19 +6857,20 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.30.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.30.0.tgz",
-			"integrity": "sha512-SVxkQw1xvn/Wk/EvBnqWIq6NLo1AppwbYOjNLmyU0R1RoQ3rLEBtmjTnElcnz8VEtn11fptj1ECxK0tgURhajw==",
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.0.tgz",
+			"integrity": "sha512-zOdGloaF0jeec7hqoLqM5S3L2rR4WxMJs6lgiAeR70JlH7Ml54ZPoIIf3X7cvnKde3Q9jJ/gaxkFh8fYI9s1rg==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
-				"playwright-core": "1.30.0"
+				"fsevents": "2.3.2",
+				"playwright-core": "1.32.0"
 			},
 			"dependencies": {
 				"playwright-core": {
-					"version": "1.30.0",
-					"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.30.0.tgz",
-					"integrity": "sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g==",
+					"version": "1.32.0",
+					"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.0.tgz",
+					"integrity": "sha512-Z9Ij17X5Z3bjpp6XKujGBp9Gv4eViESac9aDmwgQFUEJBW0K80T21m/Z+XJQlu4cNsvPygw33b6V1Va6Bda5zQ==",
 					"dev": true
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.6.0",
-		"@playwright/test": "1.30.0",
+		"@playwright/test": "1.32.0",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.2",
 		"@storybook/addon-a11y": "6.5.7",
 		"@storybook/addon-actions": "6.5.7",


### PR DESCRIPTION
## What?
Upgrade Playwright to 1.32

## Why?

There's a new UI Mode, which I think would be very handy when debugging or writing the tests. See the demo: https://youtu.be/jF0yA-JLQW0?t=69.

Version 1.31, introduced `TestProject.dependencies` - https://github.com/microsoft/playwright/releases/tag/v1.31.0.

## Testing Instructions
CI should pass.

## Screenshot
![UI Mode](https://user-images.githubusercontent.com/746130/227004851-3901a691-4f8e-43d6-8d6b-cbfeafaeb999.png)