### PR TITLE
Drag and drop media items from inserter

### DIFF
--- a/packages/block-editor/src/components/inserter/media-tab/media-preview.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-preview.js
@@ -17,11 +17,12 @@ import {
 	Flex,
 	FlexItem,
 	Button,
+	Draggable,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo, useCallback, useState } from '@wordpress/element';
-import { cloneBlock } from '@wordpress/blocks';
+import { cloneBlock, serialize } from '@wordpress/blocks';
 import { moreVertical, external } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
@@ -30,7 +31,7 @@ import { isBlobURL } from '@wordpress/blob';
 /**
  * Internal dependencies
  */
-import InserterDraggableBlocks from '../../inserter-draggable-blocks';
+import BlockDraggableChip from '../../block-draggable/draggable-chip';
 import { getBlockAndPreviewFromMedia } from './utils';
 import { store as blockEditorStore } from '../../../store';
 
@@ -203,8 +204,14 @@ export function MediaPreview( { media, onClick, composite, category } ) {
 	const onMouseLeave = useCallback( () => setIsHovered( false ), [] );
 	return (
 		<>
-			<InserterDraggableBlocks isEnabled={ true } blocks={ [ block ] }>
-				{ ( { draggable, onDragStart, onDragEnd } ) => (
+			<Draggable
+				__experimentalTransferDataType="text/html"
+				transferData={ serialize( block ) }
+				__experimentalDragComponent={
+					<BlockDraggableChip count={ 1 } />
+				}
+			>
+				{ ( { onDraggableStart, onDraggableEnd } ) => (
 					<div
 						className={ classnames(
 							'block-editor-inserter__media-list__list-item',
@@ -212,9 +219,9 @@ export function MediaPreview( { media, onClick, composite, category } ) {
 								'is-hovered': isHovered,
 							}
 						) }
-						draggable={ draggable }
-						onDragStart={ onDragStart }
-						onDragEnd={ onDragEnd }
+						draggable={ true }
+						onDragStart={ onDraggableStart }
+						onDragEnd={ onDraggableEnd }
 					>
 						<Tooltip text={ truncatedTitle || title }>
 							{ /* Adding `is-hovered` class to the wrapper element is needed
@@ -250,7 +257,7 @@ export function MediaPreview( { media, onClick, composite, category } ) {
 						</Tooltip>
 					</div>
 				) }
-			</InserterDraggableBlocks>
+			</Draggable>
 			{ showExternalUploadModal && (
 				<InsertExternalImageModal
 					onClose={ () => setShowExternalUploadModal( false ) }

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -30,7 +30,11 @@ import { useEffect, useState, useCallback } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { audio as icon, caption as captionIcon } from '@wordpress/icons';
-import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
+import {
+	createBlock,
+	getDefaultBlockName,
+	pasteHandler,
+} from '@wordpress/blocks';
 import { store as noticesStore } from '@wordpress/notices';
 import { usePrevious } from '@wordpress/compose';
 
@@ -38,6 +42,7 @@ import { usePrevious } from '@wordpress/compose';
  * Internal dependencies
  */
 import { createUpgradedEmbedBlock } from '../embed/util';
+import { name } from './block.json';
 
 const ALLOWED_MEDIA_TYPES = [ 'audio' ];
 
@@ -124,6 +129,22 @@ function AudioEdit( {
 		createErrorNotice( message, { type: 'snackbar' } );
 	}
 
+	function onHTMLDrop( HTML ) {
+		const blocks = pasteHandler( { HTML, mode: 'BLOCKS' } );
+		if (
+			Array.isArray( blocks ) &&
+			blocks.length === 1 &&
+			blocks[ 0 ].name === name
+		) {
+			setAttributes( {
+				src: undefined,
+				id: undefined,
+				caption: undefined,
+				...blocks[ 0 ].attributes,
+			} );
+		}
+	}
+
 	function getAutoplayHelp( checked ) {
 		return checked
 			? __( 'Autoplay may cause usability issues for some users.' )
@@ -169,6 +190,7 @@ function AudioEdit( {
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
 					value={ attributes }
 					onError={ onUploadError }
+					onHTMLDrop={ onHTMLDrop }
 				/>
 			</div>
 		);

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -23,6 +23,7 @@ import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { image as icon } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
+import { pasteHandler } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -166,6 +167,25 @@ export function ImageEdit( {
 			url: undefined,
 		} );
 		setTemporaryURL( undefined );
+	}
+
+	// TODO: If this would be the way to go, we need to handle similarly audio and video.
+	function onHTMLDrop( HTML ) {
+		const blocks = pasteHandler( { HTML, mode: 'BLOCKS' } );
+		if (
+			Array.isArray( blocks ) &&
+			blocks.length === 1 &&
+			blocks[ 0 ].name === 'core/image'
+		) {
+			setAttributes( {
+				url: undefined,
+				alt: undefined,
+				id: undefined,
+				title: undefined,
+				caption: undefined,
+				...blocks[ 0 ].attributes,
+			} );
+		}
 	}
 
 	function onSelectImage( media ) {
@@ -377,6 +397,7 @@ export function ImageEdit( {
 				onSelect={ onSelectImage }
 				onSelectURL={ onSelectURL }
 				onError={ onUploadError }
+				onHTMLDrop={ onHTMLDrop }
 				placeholder={ placeholder }
 				accept="image/*"
 				allowedTypes={ ALLOWED_MEDIA_TYPES }

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -29,6 +29,7 @@ import { pasteHandler } from '@wordpress/blocks';
  * Internal dependencies
  */
 import Image from './image';
+import { name } from './block.json';
 
 // Much of this description is duplicated from MediaPlaceholder.
 const placeholder = ( content ) => {
@@ -169,13 +170,12 @@ export function ImageEdit( {
 		setTemporaryURL( undefined );
 	}
 
-	// TODO: If this would be the way to go, we need to handle similarly audio and video.
 	function onHTMLDrop( HTML ) {
 		const blocks = pasteHandler( { HTML, mode: 'BLOCKS' } );
 		if (
 			Array.isArray( blocks ) &&
 			blocks.length === 1 &&
-			blocks[ 0 ].name === 'core/image'
+			blocks[ 0 ].name === name
 		) {
 			setAttributes( {
 				url: undefined,

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -34,7 +34,11 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useInstanceId, usePrevious } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { video as icon, caption as captionIcon } from '@wordpress/icons';
-import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
+import {
+	createBlock,
+	getDefaultBlockName,
+	pasteHandler,
+} from '@wordpress/blocks';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
@@ -44,6 +48,7 @@ import { createUpgradedEmbedBlock } from '../embed/util';
 import VideoCommonSettings from './edit-common-settings';
 import TracksEditor from './tracks-editor';
 import Tracks from './tracks';
+import { name } from './block.json';
 
 // Much of this description is duplicated from MediaPlaceholder.
 const placeholder = ( content ) => {
@@ -174,6 +179,24 @@ function VideoEdit( {
 		createErrorNotice( message, { type: 'snackbar' } );
 	}
 
+	function onHTMLDrop( HTML ) {
+		const blocks = pasteHandler( { HTML, mode: 'BLOCKS' } );
+		if (
+			Array.isArray( blocks ) &&
+			blocks.length === 1 &&
+			blocks[ 0 ].name === name
+		) {
+			setAttributes( {
+				src: undefined,
+				id: undefined,
+				caption: undefined,
+				poster: undefined,
+				tracks: undefined,
+				...blocks[ 0 ].attributes,
+			} );
+		}
+	}
+
 	const classes = classnames( className, {
 		'is-transient': isTemporaryVideo,
 	} );
@@ -193,6 +216,7 @@ function VideoEdit( {
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
 					value={ attributes }
 					onError={ onUploadError }
+					onHTMLDrop={ onHTMLDrop }
 					placeholder={ placeholder }
 				/>
 			</div>

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 -   `Autocomplete`: Add heading and fix type for `onReplace` in README. ([#49798](https://github.com/WordPress/gutenberg/pull/49798)).
 
+### Internal
+
+-   `Draggable` Do not stringify `dataTransfer` data if are already a string ([#49297](https://github.com/WordPress/gutenberg/pull/49297)).
+
 ## 23.8.0 (2023-04-12)
 
 ### Internal

--- a/packages/components/src/draggable/index.tsx
+++ b/packages/components/src/draggable/index.tsx
@@ -101,7 +101,9 @@ export function Draggable( {
 
 		event.dataTransfer.setData(
 			transferDataType,
-			JSON.stringify( transferData )
+			typeof transferData === 'string'
+				? transferData
+				: JSON.stringify( transferData )
 		);
 
 		const cloneWrapper = ownerDocument.createElement( 'div' );


### PR DESCRIPTION
## What

First exploration for drag and drop media items from the inserter. 
I've tried to set to `DataTransfer` item the serialized block as `text/html` type in order to be picked up by `MediaPlaceholder` as well.

A remaining problem is that we need a way to detect when an item has dropped(`onDrop`) in the MediaPreview component to upload the external media items. In my mind maybe we should set to `DataTransfer` a `File` from the media item from external sources, but couldn't make it work for now..


https://user-images.githubusercontent.com/16275880/227131176-b85b6aee-fbe2-483d-917e-ca8388786722.mov



