### PR TITLE
Image: Don't create an external image 'blob' when a user can't upload files

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -170,12 +170,18 @@ export default function Image( {
 			( { slug } ) => image?.media_details?.sizes?.[ slug ]?.source_url
 		)
 		.map( ( { name, slug } ) => ( { value: slug, label: name } ) );
+	const canUploadMedia = !! mediaUpload;
 
 	// If an image is externally hosted, try to fetch the image data. This may
 	// fail if the image host doesn't allow CORS with the domain. If it works,
 	// we can enable a button in the toolbar to upload the image.
 	useEffect( () => {
-		if ( ! isExternalImage( id, url ) || ! isSelected || externalBlob ) {
+		if (
+			! isExternalImage( id, url ) ||
+			! isSelected ||
+			! canUploadMedia ||
+			externalBlob
+		) {
 			return;
 		}
 
@@ -185,7 +191,7 @@ export default function Image( {
 			.then( ( blob ) => setExternalBlob( blob ) )
 			// Do nothing, cannot upload.
 			.catch( () => {} );
-	}, [ id, url, isSelected, externalBlob ] );
+	}, [ id, url, isSelected, externalBlob, canUploadMedia ] );
 
 	// We need to show the caption when changes come from
 	// history navigation(undo/redo).


### PR DESCRIPTION
## What?
Part of #46326.

PR update external image fetching side-effect to check if a user can upload media.

## Why?
* Prevents unnecessary GET requests and avoids errors for users without `upload_files` capability.
* The "Upload external image" block control will be hidden when `externalBlob ` has no value.

## Testing Instructions
I'm using an image from Openverse since they rarely trigger CORS errors. Sample - https://openverse.org/image/dbc5280c-a61b-43c2-9f3d-c29302897434.

1. Create a user with a Contributor role and log in.
2. Open a Post.
3. Insert an Image Block.
4. Set image via URL.
5. Confirm there's no GET request to fetch the image.
6. Block toolbar doesn't display the "Upload external image" button.

The feature will work for users with the right capabilities as before.

## Screenshots or screencast

![CleanShot 2023-03-23 at 14 20 05](https://user-images.githubusercontent.com/240569/227173730-994ecdd2-c35c-4890-94b3-d22dc8675424.png)
