### PR TITLE
Query Loop: Show Featured Image placeholders in all posts

### DIFF
--- a/packages/block-library/src/post-featured-image/editor.scss
+++ b/packages/block-library/src/post-featured-image/editor.scss
@@ -12,6 +12,7 @@
 		justify-content: center;
 		align-items: center;
 		padding: 0;
+		display: flex;
 
 		// Hide the upload button, as it's also available in the media library.
 		.components-form-file-upload {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/49167

>When using a query loop block with empty featured images, the featured image placeholder only is visible in the currently selected post. All featured image placeholders should be visible.


## How?
I actually just added the style change for this block. An alternative would be to show all placeholders that are currently [hidden](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/block-preview/content.scss#L23) in these previews(`useBlockPreview`). @andrewserong might have some context why he introduced this style.

## Testing Instructions
1. Insert a Query Loop and add the Featured Image block
2. Some posts need to **NOT** have a featured image set, in order for the placeholder to show
3. Observe that now the placeholder is visible in all posts


<img width="943" alt="Screenshot 2023-03-23 at 12 20 20 PM" src="https://user-images.githubusercontent.com/16275880/227174905-7b7ae0a6-1864-4cf2-b9e4-dfd98281d843.png">

