### PR TITLE
Fix: Navigation block width constricted on large viewports

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -689,10 +689,12 @@ button.wp-block-navigation-item__content {
 .wp-block-navigation__responsive-close {
 	width: 100%;
 
-	// Try to inherit wide-width when defined, so the X can align to a top-right aligned menu.
-	max-width: var(--wp--style--global--wide-size, 100%);
-	margin-left: auto;
-	margin-right: auto;
+	.has-modal-open & {
+		// Try to inherit wide-width when defined, so the X can align to a top-right aligned menu.
+		max-width: var(--wp--style--global--wide-size, 100%);
+		margin-left: auto;
+		margin-right: auto;
+	}
 
 	// This element is not keyboard accessible, and is focusable only using the mouse.
 	// It is part of the MicroModal library that adds a scrim outside of a modal dialog that is not fullscreen,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes https://github.com/WordPress/gutenberg/issues/47652

This PR fixes a problem created after fixing https://github.com/WordPress/gutenberg/pull/43576/

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Themes with full width navigation blocks would have their menus constricted to a max width of the global wide size, while the original change intended to only do that to the overlay, not the desktop menu as well.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The class `.wp-block-navigation__responsive-close` is wrapping the menu always, not just when it's a "mobile" menu. I wrapped the CSS that was intended only for the overlay inside the `.has-modal-open` class so it only applies when it's the modal that we are showing

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

I'm using [this](https://gist.github.com/MaggieCabrera/ea8223f0116569f486ecc91570a026e0) markup for testing on the Skatepark theme.

Before this PR, the navigation block that is set to full width is not extending as such. After this PR it does.

Check that the fix introduced in https://github.com/WordPress/gutenberg/pull/43576 is still applying when we open the overlayed menu.


## Screenshots or screencast <!-- if applicable -->

Before:

<img width="2114" alt="Screenshot 2023-03-23 at 11 47 01" src="https://user-images.githubusercontent.com/3593343/227181999-0126fa8e-9c75-4c96-ad15-9ecd94eb50e7.png">


After:


<img width="2110" alt="Screenshot 2023-03-23 at 11 46 34" src="https://user-images.githubusercontent.com/3593343/227182004-7ffaa1bd-d177-4e2b-a220-2dfc29ccf062.png">
