### PR TITLE
Query Loop: Constraint list item(`li`) styles to the direct children of the main list

### DIFF
--- a/packages/block-library/src/post-template/style.scss
+++ b/packages/block-library/src/post-template/style.scss
@@ -16,7 +16,7 @@
 		flex-wrap: wrap;
 		gap: 1.25em;
 
-		li {
+		> li {
 			margin: 0;
 			width: 100%;
 		}


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
In Query Loop if we have selected the `grid view`, the styles for the list items of Query Loop were leaking to to any (`ul`) content. This goes for blocks too like the `Social Icons` block that renders a list..
This seems to have slipped through the cracks for maybe more than a couple of years 😱 .


https://user-images.githubusercontent.com/16275880/227181712-1fd24d88-4e89-44a9-8252-f95422a1e2bb.mov



## Testing Instructions
1. Insert a Query Loop and add the `Social Icons` blocks and add at least one item
2. Toggle the `grid/list` view in Query Loop's block toolbar
3. Observe that the styles do not leak
4. Ensure no regression is introduced


