### PR TITLE
[RNMobile] Fix encoding of `MediaInfo` `metadata` property (iOS)

### DIFF
--- a/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
@@ -20,19 +20,6 @@ public struct MediaInfo: Encodable {
         self.alt = alt
         self.metadata = metadata ?? [:] as [String: String]
     }
-
-    public func encode (to encoder: Encoder) throws
-    {
-        var container = encoder.container (keyedBy: CodingKeys.self)
-        try container.encode (id, forKey: .id)
-        try container.encode (url, forKey: .url)
-        try container.encode (type, forKey: .type)
-        try container.encode (title, forKey: .title)
-        try container.encode (caption, forKey: .caption)
-        try container.encode (alt, forKey: .alt)
-        var metadataContainer = container.nestedUnkeyedContainer(forKey: .metadata)
-        try metadata.encode(to: metadataContainer.superEncoder())
-     }
 }
 
 /// Definition of capabilities to enable in the Block Editor

--- a/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
@@ -8,7 +8,7 @@ public struct MediaInfo: Encodable {
     public let metadata: Encodable
 
     private enum CodingKeys: String, CodingKey {
-        case id, url, type, title, caption, alt, metadata
+        case id, url, type, title, caption, alt
     }
 
     public init(id: Int32?, url: String?, type: String?, caption: String? = nil, title: String? = nil, alt: String? = nil, metadata: Encodable? = nil) {

--- a/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
@@ -5,20 +5,20 @@ public struct MediaInfo: Encodable {
     public let title: String?
     public let caption: String?
     public let alt: String?
-    public let metadata: Encodable
+    public let metadata: [String: Any]
 
     private enum CodingKeys: String, CodingKey {
         case id, url, type, title, caption, alt
     }
 
-    public init(id: Int32?, url: String?, type: String?, caption: String? = nil, title: String? = nil, alt: String? = nil, metadata: Encodable? = nil) {
+    public init(id: Int32?, url: String?, type: String?, caption: String? = nil, title: String? = nil, alt: String? = nil, metadata: [String: Any] = [:]) {
         self.id = id
         self.url = url
         self.type = type
         self.caption = caption
         self.title = title
         self.alt = alt
-        self.metadata = metadata ?? [:] as [String: String]
+        self.metadata = metadata
     }
 }
 

--- a/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -468,12 +468,16 @@ extension MediaInfo {
     func encodeForJS() -> [String: Any] {
         guard
             let data = try? JSONEncoder().encode(self),
-            let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else
+            var jsonObject = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+            let metadataData = try? JSONEncoder().encode(self.metadata),
+            let metadataJsonObject = try? JSONSerialization.jsonObject(with: metadataData, options: []) as? [String: Any]
+        else
         {
             assertionFailure("Encoding of MediaInfo failed")
             return [String: Any]()
         }
 
+        jsonObject["metadata"] = metadataJsonObject
         return jsonObject
     }
 }

--- a/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -468,16 +468,13 @@ extension MediaInfo {
     func encodeForJS() -> [String: Any] {
         guard
             let data = try? JSONEncoder().encode(self),
-            var jsonObject = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
-            let metadataData = try? JSONEncoder().encode(self.metadata),
-            let metadataJsonObject = try? JSONSerialization.jsonObject(with: metadataData, options: []) as? [String: Any]
-        else
+            var jsonObject = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else
         {
             assertionFailure("Encoding of MediaInfo failed")
             return [String: Any]()
         }
 
-        jsonObject["metadata"] = metadataJsonObject
+        jsonObject["metadata"] = self.metadata
         return jsonObject
     }
 }


### PR DESCRIPTION
Related PRs:
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/5584

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix encoding of `MediaInfo` `metadata` property passed when inserting media in a Media block. This fix only affects iOS.

**NOTE:** This bug is not affecting the editor's logic as `metadata` property is not being used yet.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The metadata property was introduced in https://github.com/WordPress/gutenberg/pull/48994, however, the way it's encoded doesn't match the expectations:

<table>
<tr><td><strong>Current</strong></td><td><strong>Expected</strong></td>
<tr>
<td>

```
{
    "metadata": [
        {
            "param": "value"
        }
    ]
}
```

</td><td>

```
{
    metadata": {
        "param": "value"
    }
}
```

</td>
</table>

**Note that in the current output, it's returning an array but it should be a plain object.** 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The main complexity of encoding `metadata` property is that we don't know its structure which is a requirement when encoding an `Encodable` class/struct. I tried using a generic type but still, it led to other issues. Finally, I decided to omit the property when encoding `MediaInfo` and ~~encode~~ add the `metadata` manually in `encodeForJS` function when we pass the data to React Native.

Additionally, I removed the `encode` function from `MediaInfo`. In theory, if we don't customize the encoding (i.e. use a different name or value) we can rely on the default implementation.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

**Preparation:**
1. Build and open the demo app **on iOS**.
2. Connect the demo app with the local Metro server.
3. Apply the following patch file:
```
diff --git forkSrcPrefix/packages/block-library/src/video/edit.native.js forkDstPrefix/packages/block-library/src/video/edit.native.js
index 99225ba5d5c569d19a158f5b1a203c68aa353c33..c801aac0ececa419b8029d5b20355aa9a5f3ee59 100644
--- forkSrcPrefix/packages/block-library/src/video/edit.native.js
+++ forkDstPrefix/packages/block-library/src/video/edit.native.js
@@ -154,7 +154,9 @@ class VideoEdit extends Component {
 		this.setState( { isUploadInProgress: false } );
 	}
 
-	onSelectMediaUploadOption( { id, url } ) {
+	onSelectMediaUploadOption( media ) {
+		const { id, url } = media;
+		console.log( { media } );
 		const { setAttributes } = this.props;
 		setAttributes( { id, src: url } );
 	}
diff --git forkSrcPrefix/packages/block-library/src/image/edit.native.js forkDstPrefix/packages/block-library/src/image/edit.native.js
index 3ffd377005af9227a030b24019d05b0d92b45ccd..7cee99550c0c7b95d0e2e4645c39b9f01d900b5b 100644
--- forkSrcPrefix/packages/block-library/src/image/edit.native.js
+++ forkDstPrefix/packages/block-library/src/image/edit.native.js
@@ -429,6 +429,7 @@ export class ImageEdit extends Component {
 	onSelectMediaUploadOption( media ) {
 		const { imageDefaultSize } = this.props;
 		const { id, url, destination } = this.props.attributes;
+		console.log( { media } );
 		const mediaAttributes = {
 			id: media.id,
 			url: media.url,

```

### Image block

1. Add a Image block.
2. Select "WordPress Media Library" option.
3. Check the logs and observe that the media object contains its properties, e.g.:
```
{
  "media": {
    "alt": "A snow-capped mountain top in a cloudy sky with red-leafed trees in the foreground",
    "caption": "Mountain",
    "id": 1,
    "metadata": {},
    "type": "image",
    "url": "https://cldup.com/cXyG__fTLN.jpg"
  }
}
```

### Video block

1. Add a Video block.
2. Select "WordPress Media Library" option.
3. Check the logs and observe that the media object contains its properties, e.g.:
```
{
  "media": {
    "caption": "Cloudup",
    "id": 2,
    "metadata": { "extraID": "AbCdE" },
    "type": "video",
    "url": "https://i.cloudup.com/YtZFJbuQCE.mov"
  }
}
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A