### PR TITLE
Query Title: Changes filters for removing archive title prefixes

### DIFF
--- a/packages/block-library/src/query-title/index.php
+++ b/packages/block-library/src/query-title/index.php
@@ -28,12 +28,9 @@ function render_block_core_query_title( $attributes ) {
 	if ( $is_archive ) {
 		$show_prefix = isset( $attributes['showPrefix'] ) ? $attributes['showPrefix'] : true;
 		if ( ! $show_prefix ) {
-			$filter_title = function( $title, $original_title ) {
-				return $original_title;
-			};
-			add_filter( 'get_the_archive_title', $filter_title, 10, 2 );
+			add_filter( 'get_the_archive_title_prefix', '__return_empty_string', 1 );
 			$title = get_the_archive_title();
-			remove_filter( 'get_the_archive_title', $filter_title, 10, 2 );
+			remove_filter( 'get_the_archive_title_prefix', '__return_empty_string', 1 );
 		} else {
 			$title = get_the_archive_title();
 		}


### PR DESCRIPTION
## What?
Resolves #49001.

PR updates the block filters used for removing archive title prefixes.

## Why?
The `get_the_archive_title` title only works with default priority when the `showPrefix` setting is `true`.

## How?
The block now uses `get_the_archive_title_prefix` with `__return_empty_string` as a callback. When there's no prefix, the `get_the_archive_title()` method will return just a title.

## Testing Instructions
1. Open a Site Editor
2. Create an archive template if there's none.
3. Insert the "Archive Title" block, a "Query Title" block variation.
4. Add the following filters to your codebase:
```php
add_filter( 'get_the_archive_title', function( $title ) {
	return 'Hello ' . $title;
} );
```
5. Confirm filter is applied no matter the `showPrefix` setting value.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2023-03-23 at 16 28 10](https://user-images.githubusercontent.com/240569/227203844-0b8ef7a1-ef7a-4dc9-a7a3-77a93564c539.png)
