### PR TITLE
Add `gutenberg_get_remote_theme_patterns` function

### DIFF
--- a/lib/compat/wordpress-6.2/block-patterns.php
+++ b/lib/compat/wordpress-6.2/block-patterns.php
@@ -433,7 +433,7 @@ function gutenberg_register_remote_theme_patterns() {
 		return;
 	}
 
-	$pattern_settings = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data()->get_patterns();
+	$pattern_settings = gutenberg_get_remote_theme_patterns();
 	if ( empty( $pattern_settings ) ) {
 		return;
 	}

--- a/lib/compat/wordpress-6.3/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.3/get-global-styles-and-settings.php
@@ -186,3 +186,15 @@ if ( ! function_exists( 'wp_get_block_css_selector' ) ) {
 		return null;
 	}
 }
+
+/**
+ * Returns the current theme's wanted patterns(slugs) to be
+ * registered from Pattern Directory.
+ *
+ * @since 6.3.0
+ *
+ * @return string[]
+ */
+function gutenberg_get_remote_theme_patterns() {
+	return WP_Theme_JSON_Resolver_Gutenberg::get_theme_data( array(), array( 'with_supports' => false ) )->get_patterns();
+}


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/45171

## What?

Adds a new public function, `gutenberg_get_remote_theme_patterns` to query the `patterns` datum from `theme.json`.

## Why?

We need to offer public APIs for consumers to add the data they need, so they don't resort to using private APIs.

## How?

- Creates a new function called `gutenberg_get_remote_theme_patterns`.
- Uses the new function in place of the call to the private class WP_Theme_JSON_Resolver_Gutenberg.

## Testing Instructions

- Use any theme with `theme.json` and add the following:

```json
{
  "patterns": [ "partner-logos" ]
}
```

- Go to the post editor and open the inserter.
- Search for "logos".
- The expected result is that the pattern shows up in the list.

Also test that by removing the `patterns` from `theme.json` the pattern is not present.
