### PR TITLE
Update README.md for @wordpress/element. createRoot not available until WordPress 6.2

### DIFF
--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -178,7 +178,7 @@ You would have something like this as the conversionMap value:
 _Parameters_
 
 -   _interpolatedString_ `string`: The interpolation string to be parsed.
--   _conversionMap_ `Object`: The map used to convert the string to a react element.
+-   _conversionMap_ `Record<string, WPElement>`: The map used to convert the string to a react element.
 
 _Returns_
 

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -48,9 +48,9 @@ const domElement = document.getElementById( 'greeting' );
 const uiElement  = createElement( Greeting, { toWhom: 'World' } );
 
 if ( createRoot ) {
-    createRoot( domElement ).render( uiElement );
+	createRoot( domElement ).render( uiElement );
 } else {
-    render( uiElement, domElement );
+	render( uiElement, domElement );
 }
 ```
 

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -178,7 +178,7 @@ You would have something like this as the conversionMap value:
 _Parameters_
 
 -   _interpolatedString_ `string`: The interpolation string to be parsed.
--   _conversionMap_ `Record<string, WPElement>`: The map used to convert the string to a react element.
+-   _conversionMap_ `Object`: The map used to convert the string to a react element.
 
 _Returns_
 
@@ -209,13 +209,15 @@ _Returns_
 
 ### createRoot
 
-_Since: WordPress 6.2_
-
 Creates a new React root for the target DOM node.
 
 _Related_
 
--   <https://reactjs.org/docs/react-dom-client.html#createroot>
+-   <https://react.dev/reference/react-dom/client/createRoot>
+
+_Changelog_
+
+`6.2.0` Introduced in WordPress core.
 
 ### findDOMNode
 
@@ -254,12 +256,13 @@ A component which renders its children without any wrapping element.
 
 ### hydrate
 
+> **Deprecated** since WordPress 6.2.0. Use `hydrateRoot` instead.
+
 Hydrates a given element into the target DOM node.
 
-_Parameters_
+_Related_
 
--   _element_ `import('./react').WPElement`: Element to hydrate.
--   _target_ `HTMLElement`: DOM node into which element should be hydrated.
+-   <https://react.dev/reference/react-dom/hydrate>
 
 ### hydrateRoot
 
@@ -267,7 +270,11 @@ Creates a new React root for the target DOM node and hydrates it with a pre-gene
 
 _Related_
 
--   <https://reactjs.org/docs/react-dom-client.html#hydrateroot>
+-   <https://react.dev/reference/react-dom/client/hydrateRoot>
+
+_Changelog_
+
+`6.2.0` Introduced in WordPress core.
 
 ### isEmptyElement
 
@@ -346,14 +353,13 @@ _Returns_
 
 ### render
 
+> **Deprecated** since WordPress 6.2.0. Use `createRoot` instead.
+
 Renders a given element into the target DOM node.
 
-_Deprecated: WordPress 6.2_
+_Related_
 
-_Parameters_
-
--   _element_ `import('./react').WPElement`: Element to render.
--   _target_ `HTMLElement`: DOM node into which element should be rendered.
+-   <https://react.dev/reference/react-dom/render>
 
 ### renderToString
 
@@ -400,11 +406,13 @@ _Returns_
 
 ### unmountComponentAtNode
 
+> **Deprecated** since WordPress 6.2.0. Use `root.unmount()` instead.
+
 Removes any mounted element from the target DOM node.
 
-_Parameters_
+_Related_
 
--   _target_ `Element`: DOM node in which element is to be removed
+-   <https://react.dev/reference/react-dom/unmountComponentAtNode>
 
 ### useCallback
 

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -25,7 +25,7 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 
 ## Usage
 
-Let's render a customized greeting into an empty element. 
+Let's render a customized greeting into an empty element.
 
 **Note:** `createRoot` was introduced with React 18, which is bundled with WordPress 6.2. Therefore it may be necessary to mount your component depending on which version of WordPress (and therefore React) you are currently using. This is possible by checking for an undefined import and falling back to the React 17 method of mounting an app using `render`.
 
@@ -45,7 +45,7 @@ function Greeting( props ) {
 }
 
 const domElement = document.getElementById( 'greeting' );
-const uiElement  = createElement( Greeting, { toWhom: 'World' } );
+const uiElement = createElement( Greeting, { toWhom: 'World' } );
 
 if ( createRoot ) {
 	createRoot( domElement ).render( uiElement );

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -48,9 +48,9 @@ const domElement = document.getElementById( 'greeting' );
 const uiElement  = createElement( Greeting, { toWhom: 'World' } );
 
 if ( createRoot ) {
-  createRoot( domElement ).render( uiElement );
+    createRoot( domElement ).render( uiElement );
 } else {
-  render( uiElement, domElement );
+    render( uiElement, domElement );
 }
 ```
 

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -27,7 +27,7 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 
 Let's render a customized greeting into an empty element. 
 
-**Note:** `createRoot` was introduced with React 18, which will be bundled with WordPress 6.2. Therefore it may be necessary to mount your component depending on which version of WordPress (and therefore React) you are currently using. This is possible by checking for an undefined import and falling back to the React 17 method of mounting an app using `render`.
+**Note:** `createRoot` was introduced with React 18, which is bundled with WordPress 6.2. Therefore it may be necessary to mount your component depending on which version of WordPress (and therefore React) you are currently using. This is possible by checking for an undefined import and falling back to the React 17 method of mounting an app using `render`.
 
 Assuming the following root element is present in the page:
 

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -27,7 +27,7 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 
 Let's render a customized greeting into an empty element. 
 
-**Note:** `createRoot` is not introduced until React 18, which will be bundled with WordPress 6.2. Therefore it may be necessary to mount your component depending on which version of WordPress (and therefore React) you are currently using. This is possible by checking for an undefined import and falling back to the React 17 method of mounting an app using `render`.
+**Note:** `createRoot` was introduced with React 18, which will be bundled with WordPress 6.2. Therefore it may be necessary to mount your component depending on which version of WordPress (and therefore React) you are currently using. This is possible by checking for an undefined import and falling back to the React 17 method of mounting an app using `render`.
 
 ```html
 <div id="greeting"></div>

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -25,7 +25,9 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 
 ## Usage
 
-Let's render a customized greeting into an empty element:
+Let's render a customized greeting into an empty element. 
+
+**Note:** `createRoot` is not introduced until React 18, which will be bundled with WordPress 6.2. Therefore it may be necessary to mount your component depending on which version of WordPress (and therefore React) you are currently using. This is possible by checking for an undefined import and falling back to the React 17 method of mounting an app using `render`.
 
 ```html
 <div id="greeting"></div>
@@ -38,9 +40,14 @@ Let's render a customized greeting into an empty element:
 		);
 	}
 
-	wp.element
-		.createRoot( document.getElementById( 'greeting' ) )
-		.render( wp.element.createElement( Greeting, { toWhom: 'World' } ) );
+	if ( wp.element.createRoot ) {
+		wp.element
+			.createRoot( document.getElementById( 'greeting' ) )
+			.render( wp.element.createElement( Greeting, { toWhom: 'World' } ) );
+	} else {
+		wp.element
+		.render( wp.element.createElement( Greeting, { toWhom: 'World' } ), document.getElementById( 'greeting' ) );
+	}
 </script>
 ```
 
@@ -199,6 +206,8 @@ _Returns_
 
 ### createRoot
 
+_Since: WordPress 6.2_
+
 Creates a new React root for the target DOM node.
 
 _Related_
@@ -335,6 +344,8 @@ _Returns_
 ### render
 
 Renders a given element into the target DOM node.
+
+_Deprecated: WordPress 6.2_
 
 _Parameters_
 

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -44,10 +44,13 @@ function Greeting( props ) {
 	return createElement( 'span', null, 'Hello ' + props.toWhom + '!' );
 }
 
+const domElement = document.getElementById( 'greeting' );
+const uiElement  = createElement( Greeting, { toWhom: 'World' } );
+
 if ( createRoot ) {
-	createRoot( document.getElementById( 'greeting' ) ).render( createElement( Greeting, { toWhom: 'World' } ) );
+  createRoot( domElement ).render( uiElement );
 } else {
-	render( createElement( Greeting, { toWhom: 'World' } ), document.getElementById( 'greeting' ) );
+  render( uiElement, domElement );
 }
 ```
 

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -29,26 +29,26 @@ Let's render a customized greeting into an empty element.
 
 **Note:** `createRoot` was introduced with React 18, which will be bundled with WordPress 6.2. Therefore it may be necessary to mount your component depending on which version of WordPress (and therefore React) you are currently using. This is possible by checking for an undefined import and falling back to the React 17 method of mounting an app using `render`.
 
+Assuming the following root element is present in the page:
+
 ```html
 <div id="greeting"></div>
-<script>
-	function Greeting( props ) {
-		return wp.element.createElement(
-			'span',
-			null,
-			'Hello ' + props.toWhom + '!'
-		);
-	}
+```
 
-	if ( wp.element.createRoot ) {
-		wp.element
-			.createRoot( document.getElementById( 'greeting' ) )
-			.render( wp.element.createElement( Greeting, { toWhom: 'World' } ) );
-	} else {
-		wp.element
-		.render( wp.element.createElement( Greeting, { toWhom: 'World' } ), document.getElementById( 'greeting' ) );
-	}
-</script>
+We can mount our app:
+
+```js
+import { createRoot, render, createElement } from '@wordpress/element';
+
+function Greeting( props ) {
+	return createElement( 'span', null, 'Hello ' + props.toWhom + '!' );
+}
+
+if ( createRoot ) {
+	createRoot( document.getElementById( 'greeting' ) ).render( createElement( Greeting, { toWhom: 'World' } ) );
+} else {
+	render( createElement( Greeting, { toWhom: 'World' } ), document.getElementById( 'greeting' ) );
+}
 ```
 
 Refer to the [official React Quick Start guide](https://reactjs.org/docs/hello-world.html) for a more thorough walkthrough, in most cases substituting `React` and `ReactDOM` with `wp.element` in code examples.

--- a/packages/element/src/react-platform.js
+++ b/packages/element/src/react-platform.js
@@ -39,16 +39,16 @@ export { flushSync };
 /**
  * Renders a given element into the target DOM node.
  *
- * @param {import('./react').WPElement} element Element to render.
- * @param {HTMLElement}                 target  DOM node into which element should be rendered.
+ * @deprecated since WordPress 6.2.0. Use `createRoot` instead.
+ * @see https://react.dev/reference/react-dom/render
  */
 export { render };
 
 /**
  * Hydrates a given element into the target DOM node.
  *
- * @param {import('./react').WPElement} element Element to hydrate.
- * @param {HTMLElement}                 target  DOM node into which element should be hydrated.
+ * @deprecated since WordPress 6.2.0. Use `hydrateRoot` instead.
+ * @see https://react.dev/reference/react-dom/hydrate
  */
 export { hydrate };
 
@@ -56,7 +56,7 @@ export { hydrate };
  * Creates a new React root for the target DOM node.
  *
  * @since 6.2.0 Introduced in WordPress core.
- * @see https://reactjs.org/docs/react-dom-client.html#createroot
+ * @see https://react.dev/reference/react-dom/client/createRoot
  */
 export { createRoot };
 
@@ -64,13 +64,14 @@ export { createRoot };
  * Creates a new React root for the target DOM node and hydrates it with a pre-generated markup.
  *
  * @since 6.2.0 Introduced in WordPress core.
- * @see https://reactjs.org/docs/react-dom-client.html#hydrateroot
+ * @see https://react.dev/reference/react-dom/client/hydrateRoot
  */
 export { hydrateRoot };
 
 /**
  * Removes any mounted element from the target DOM node.
  *
- * @param {Element} target DOM node in which element is to be removed
+ * @deprecated since WordPress 6.2.0. Use `root.unmount()` instead.
+ * @see https://react.dev/reference/react-dom/unmountComponentAtNode
  */
 export { unmountComponentAtNode };

--- a/packages/element/src/react-platform.js
+++ b/packages/element/src/react-platform.js
@@ -55,6 +55,7 @@ export { hydrate };
 /**
  * Creates a new React root for the target DOM node.
  *
+ * 6.2.0 Introduced in WordPress core.
  * @see https://reactjs.org/docs/react-dom-client.html#createroot
  */
 export { createRoot };
@@ -62,6 +63,7 @@ export { createRoot };
 /**
  * Creates a new React root for the target DOM node and hydrates it with a pre-generated markup.
  *
+ * 6.2.0 Introduced in WordPress core.
  * @see https://reactjs.org/docs/react-dom-client.html#hydrateroot
  */
 export { hydrateRoot };

--- a/packages/element/src/react-platform.js
+++ b/packages/element/src/react-platform.js
@@ -55,7 +55,7 @@ export { hydrate };
 /**
  * Creates a new React root for the target DOM node.
  *
- * 6.2.0 Introduced in WordPress core.
+ * @since 6.2.0 Introduced in WordPress core.
  * @see https://reactjs.org/docs/react-dom-client.html#createroot
  */
 export { createRoot };
@@ -63,7 +63,7 @@ export { createRoot };
 /**
  * Creates a new React root for the target DOM node and hydrates it with a pre-generated markup.
  *
- * 6.2.0 Introduced in WordPress core.
+ * @since 6.2.0 Introduced in WordPress core.
  * @see https://reactjs.org/docs/react-dom-client.html#hydrateroot
  */
 export { hydrateRoot };


### PR DESCRIPTION
Mention that `createRoot()` is not available until React 18/WordPress 6.2

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adding version-specific information about `createRoot` and an example for mounting an app that works in both WP 6.1 and 6.2.

## Why?
This PR is necessary, because I spent an entire day wondering why `createRoot` was undefined despite following the example exactly. This is not available prior to React 18/WordPress 6.2 and many plugins/themes will need to support both versions.

## How?
Explain the version limitations

## Testing Instructions
Might warrant another PR because you can't actually drop the example into a WP template to test since the `wp` script isn't loaded until the footer (or so it appears to me since I was getting `wp` undefined errors).

To test, I inserted `<div id="greeting">` in a template and then added the script inline:

```
/**
 * Mount example component
 */
function test_react_mount() {
	
    wp_add_inline_script( 'wp-element', '
				
        function Greeting( props ) {
		return wp.element.createElement(
			"span",
			null,
			"Hello " + props.toWhom + "!"
		);
	}

        if ( wp.element.createRoot ) {
        
	        wp.element
		        .createRoot( document.getElementById( "greeting" ) )
		        .render( wp.element.createElement( Greeting, { toWhom: "World" } ) );
        
        
        } else {
	        wp.element
		        .render( wp.element.createElement( Greeting, { toWhom: "World" } ), document.getElementById( "greeting" ) );
        }
	    ' );
}
add_action( 'wp_enqueue_scripts', 'test_react_mount', 99 );
```
