### PR TITLE
fix breaking distraction free

### DIFF
--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -99,7 +99,7 @@ body.block-editor-page {
 
 @include wordpress-admin-schemes();
 
-.interface-interface-skeleton__header {
+.interface-interface-skeleton__header .edit-post-header {
 	@supports (scrollbar-gutter: stable) {
 		// The scrollbar-gutter property ensures space is reserved for the scrollbar to appear,
 		// when scrollbars are set to be always visible. This ensure icons stay visually aligned.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This fixes an issue with the distraction free mode since changing the header overflow in #47177

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Using overflow hidden on .interface-interface-skeleton__header prevent the mouse from hovering the header and triggering the display when in distraction free mode

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
We move the styles to the .edit-post-header

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page.
2. Enter distraction free mode
3. Move your mouse to the top of the screen
4. The header should appear

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
