### PR TITLE
Update @api-fetch README.md with query args

### DIFF
--- a/packages/api-fetch/README.md
+++ b/packages/api-fetch/README.md
@@ -22,6 +22,15 @@ apiFetch( { path: '/wp/v2/posts' } ).then( ( posts ) => {
 	console.log( posts );
 } );
 
+// GET with Query Args
+import { addQueryArgs } from '@wordpress/url';
+
+const queryParams = { include: [1,2,3] }; // Return posts with ID = 1,2,3.
+
+apiFetch( { path: addQueryArgs( '/wp/v2/posts', queryParams } ).then( ( posts ) => {
+	console.log( posts );
+} );
+
 // POST
 apiFetch( {
 	path: '/wp/v2/posts/1',
@@ -52,7 +61,7 @@ Unlike `fetch`, the `Promise` return value of `apiFetch` will resolve to the par
 
 #### `data` (`object`)
 
-Shorthand to be used in place of `body`, accepts an object value to be stringified to JSON.
+Sent on `POST` or `PUT` requests only. Shorthand to be used in place of `body`, accepts an object value to be stringified to JSON.
 
 ### Aborting a request
 

--- a/packages/api-fetch/README.md
+++ b/packages/api-fetch/README.md
@@ -14,15 +14,18 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 
 ## Usage
 
+### GET
 ```js
 import apiFetch from '@wordpress/api-fetch';
 
-// GET
 apiFetch( { path: '/wp/v2/posts' } ).then( ( posts ) => {
 	console.log( posts );
 } );
+```
 
-// GET with Query Args
+### GET with Query Args
+```js
+import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 
 const queryParams = { include: [1,2,3] }; // Return posts with ID = 1,2,3.
@@ -30,8 +33,10 @@ const queryParams = { include: [1,2,3] }; // Return posts with ID = 1,2,3.
 apiFetch( { path: addQueryArgs( '/wp/v2/posts', queryParams } ).then( ( posts ) => {
 	console.log( posts );
 } );
+```
 
-// POST
+### POST
+```js
 apiFetch( {
 	path: '/wp/v2/posts/1',
 	method: 'POST',


### PR DESCRIPTION
Additionally, explain that `data` is NOT included in a `GET` request.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Clarify that `data` is not passed in a `GET` request

## Why?
Because I just spent 4 hours wondering why the request was failing entirely and telling me I wasn't connected to the internet.

## How?
This shows how to pass query args to a specific endpoint when using a `GET` request.
