### PR TITLE
Duotone: Update to use selectors API

### DIFF
--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -235,9 +235,11 @@ class WP_Duotone_Gutenberg {
 	public static function render_duotone_support( $block_content, $block ) {
 		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 
-		$duotone_support = false;
-		if ( $block_type && property_exists( $block_type, 'supports' ) ) {
-			$duotone_support = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), false );
+		$duotone_support  = false;
+		$duotone_selector = null;
+		if ( $block_type ) {
+			$duotone_selector = wp_get_block_css_selector( $block_type, 'filters.duotone' );
+			$duotone_support  = (bool) $duotone_selector;
 		}
 
 		// The block should have a duotone attribute or have duotone defined in its theme.json to be processed.
@@ -308,7 +310,7 @@ class WP_Duotone_Gutenberg {
 		$filter_id = gutenberg_get_duotone_filter_id( array( 'slug' => $slug ) );
 
 		// Build the CSS selectors to which the filter will be applied.
-		$selector = WP_Theme_JSON_Gutenberg::scope_selector( '.' . $filter_id, $duotone_support );
+		$selector = WP_Theme_JSON_Gutenberg::scope_selector( '.' . $filter_id, $duotone_selector );
 
 		// We only want to add the selector if we have it in the output already, essentially skipping 'unset'.
 		if ( array_key_exists( $slug, self::$output ) ) {

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -8,7 +8,11 @@ import namesPlugin from 'colord/plugins/names';
 /**
  * WordPress dependencies
  */
-import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
+import {
+	getBlockSupport,
+	getBlockType,
+	hasBlockSupport,
+} from '@wordpress/blocks';
 import { createHigherOrderComponent, useInstanceId } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
 import { useMemo, useContext, createPortal } from '@wordpress/element';
@@ -269,10 +273,9 @@ function BlockDuotoneStyles( { name, duotoneStyle, id } ) {
 		colors = getColorsFromDuotonePreset( colors, duotonePalette );
 	}
 
-	const duotoneSupportSelectors = getBlockSupport(
-		name,
-		'color.__experimentalDuotone'
-	);
+	const duotoneSupportSelectors =
+		getBlockType( name ).selectors?.filters?.duotone ||
+		getBlockSupport( name, 'color.__experimentalDuotone' );
 
 	// Extra .editor-styles-wrapper specificity is needed in the editor
 	// since we're not using inline styles to apply the filter. We need to

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -85,7 +85,7 @@
 	"supports": {
 		"anchor": true,
 		"color": {
-			"__experimentalDuotone": "img, .components-placeholder",
+			"__experimentalDuotone": true,
 			"text": false,
 			"background": false
 		},
@@ -102,7 +102,10 @@
 		}
 	},
 	"selectors": {
-		"border": ".wp-block-image img"
+		"border": ".wp-block-image img",
+		"filters": {
+			"duotone": "img, .components-placeholder"
+		}
 	},
 	"editorSelectors": {
 		"border": ".wp-block-image img, .wp-block-image .wp-block-image__crop-area"


### PR DESCRIPTION
## What?

- Updates Duotone support to leverage the selectors API introduced in https://github.com/WordPress/gutenberg/pull/46496.
- Fixes display of duotone global styles on the frontend

## Why?

- Fixes regression

## How?
- Updates `WP_Duotone_Gutenberg` to leverage the new global function for retrieving feature selectors
- Updates Duotone block support JS hook to prefer selectors API if available
- Moves the Image block's duotone selector to the selectors API as that block now uses the API.

## Testing Instructions
1. Apply a global duotone filter for the Image block
2. Create a post with an Imag block and save it
3. View the frontend and see that the image is missing the global duotone filter
4. Checkout this PR and reload the frontend
5. The duotone filter should now be applied.

Note: The lack of the global duotone filter in the post editor is a known issue that is being worked on, see https://github.com/WordPress/gutenberg/pull/49239.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="1302" alt="Screenshot 2023-03-24 at 3 54 13 pm" src="https://user-images.githubusercontent.com/60436221/227436422-9b23fc5d-1df5-4a71-a529-cd58c39053f9.png"> | <img width="1266" alt="Screenshot 2023-03-24 at 3 52 45 pm" src="https://user-images.githubusercontent.com/60436221/227436454-13df03ed-8ada-4a3c-b7da-a0d7a8f62c32.png"> |
