### PR TITLE
Adds to gitignore a playwright.config.override.ts entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ coverage
 *-performance-results.json
 .phpunit.result.cache
 
+
 # Directories/files that may appear in your environment
 *.log
 yarn.lock
@@ -36,6 +37,7 @@ test/native/junit.xml
 
 # Local overrides
 .wp-env.override.json
+playwright.config.override.ts
 phpcs.xml
 phpunit.xml
 phpunit-watcher.yml

--- a/docs/contributors/code/e2e/README.md
+++ b/docs/contributors/code/e2e/README.md
@@ -114,3 +114,45 @@ test.describe( 'Grouping tests (@webkit, -chromium)', () => {
 	} );
 } );
 ```
+
+## Local configuration of Playwright
+
+Sometimes the deafults that Gutenberg offers for Playwright configuration need to be changed. While most configuration can be overriden by passing arguments to the test runner command line, we may want to make permanent confguration changes, such as setting the test to always run with `headless` mode set to `false` and you own custom slow motion value.
+
+To do this one can create a file named `playwright.config.override.ts` file in the `/test/e2e/` folder. In this new file we need to import the exiting configuration, then use the new values on top to override the defaults.
+
+For example:
+
+```ts
+/**
+ * External dependencies
+ */
+import { defineConfig } from '@playwright/test';
+/**
+ * Internal dependencies
+ */
+import base from './playwright.config.ts';
+
+const config = defineConfig( {
+	...base,
+	use: {
+		...base.use,
+		headless: true,
+		launchOptions: {
+			//slowMo: 500,
+		},
+		trace: 'off',
+		screenshot: 'off',
+		video: 'off',
+	},
+} );
+
+export default config;
+
+```
+
+After making this file you can now run your tests passing the new configuration file with the `--config` argument:
+
+```bash
+npm run test:e2e:playwright -- --config=test/e2e/playwright.override.config.ts
+```


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

When writing tests using the new Playwright suite of tools it's useful to set an overriding configuration where a developer can modify things like:

- slowMo
- when traces are created
- if to run headless or not

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To improve the speed of building tests with a better developer experience.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Gitignore update.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Add a `playwright.config.override.ts` file in the `/test/e2e/` folter.
- Run `git status` you should not see the file.
