### PR TITLE
Add missing focus style to start template options previews.

### DIFF
--- a/packages/edit-site/src/components/start-template-options/style.scss
+++ b/packages/edit-site/src/components/start-template-options/style.scss
@@ -19,6 +19,7 @@
 	margin-top: $grid-unit-05;
 	gap: $grid-unit-30;
 	grid-template-columns: repeat(auto-fit, minmax(min(100%/2, max(240px, 100%/10)), 1fr));
+
 	.block-editor-block-patterns-list__list-item {
 		break-inside: avoid-column;
 		margin-bottom: 0;
@@ -38,7 +39,9 @@
 		.block-editor-block-patterns-list__item-title {
 			display: none;
 		}
+	}
 
+	.block-editor-block-patterns-list__item {
 		&:hover {
 			.block-editor-block-preview__container {
 				box-shadow: 0 0 0 2px var(--wp-admin-theme-color);

--- a/packages/edit-site/src/components/start-template-options/style.scss
+++ b/packages/edit-site/src/components/start-template-options/style.scss
@@ -26,9 +26,14 @@
 		width: 100%;
 		aspect-ratio: 3/4;
 
+		// Avoid to override the BlockPatternList component
+		// default hover and focus styles.
+		&:not(:focus):not(:hover) {
+			box-shadow: 0 0 0 1px $gray-300;
+		}
+
 		.block-editor-block-preview__container {
 			height: 100%;
-			box-shadow: 0 0 0 1px $gray-300;
 		}
 
 		.block-editor-block-preview__content {
@@ -38,23 +43,6 @@
 
 		.block-editor-block-patterns-list__item-title {
 			display: none;
-		}
-	}
-
-	.block-editor-block-patterns-list__item {
-		&:hover {
-			.block-editor-block-preview__container {
-				box-shadow: 0 0 0 2px var(--wp-admin-theme-color);
-			}
-		}
-
-		&:focus {
-			.block-editor-block-preview__container {
-				box-shadow: inset 0 0 0 1px $white, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-
-				// Windows High Contrast mode will show this outline, but not the box-shadow.
-				outline: 2px solid transparent;
-			}
 		}
 	}
 

--- a/packages/edit-site/src/components/start-template-options/style.scss
+++ b/packages/edit-site/src/components/start-template-options/style.scss
@@ -26,12 +26,6 @@
 		width: 100%;
 		aspect-ratio: 3/4;
 
-		// Avoid to override the BlockPatternList component
-		// default hover and focus styles.
-		&:not(:focus):not(:hover) {
-			box-shadow: 0 0 0 1px $gray-300;
-		}
-
 		.block-editor-block-preview__container {
 			height: 100%;
 		}
@@ -43,6 +37,14 @@
 
 		.block-editor-block-patterns-list__item-title {
 			display: none;
+		}
+	}
+
+	.block-editor-block-patterns-list__item {
+		// Avoid to override the BlockPatternList component
+		// default hover and focus styles.
+		&:not(:focus):not(:hover) .block-editor-block-preview__container {
+			box-shadow: 0 0 0 1px $gray-300;
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/49333

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds missing focus style to the patterns preview in the 'Choose a pattern' modal.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Any interactive element must have a focus style.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Uses the right CSS selector.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- Go to the site editor.
- Create a new _custom_ template.
- Wait.
- The 'Choose a pattern' modal dialog opens.
- Hover your mouse on the available patterns previews and observe there's a hover style.
- Use the Tab key to navigate through the focusable elements within the modal.
- When focus is on the first pattern preview, observe there's a focus style.
- Use the Right arrow and Left arrow keys to navigate through the pattern previews.
- Observe the focused preview does have a focus style.

## Screenshots or screencast <!-- if applicable -->

![keyboard-ok](https://user-images.githubusercontent.com/1682452/227505731-905f4bb7-8318-4aec-880a-61c09cdfedff.gif)
