### PR TITLE
Theme JSON schema: Add position.sticky and dimensions.minHeight properties to settings

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -2068,6 +2068,8 @@
 						"typography": {},
 						"border": {},
 						"shadow": {},
+						"position": {},
+						"dimensions": {},
 						"custom": {},
 						"blocks": {
 							"description": "Settings defined on a per-block basis.",


### PR DESCRIPTION
Related to:

- #48948
- #45334
- #48057

## What?

This PR fixes a problem in the theme.json schema where the following two properties in the settings global property cause validation errors (not arrowed error).

- `settings.position.sticky`
- `settings.dimensions.minHeight`

![position_dimensions](https://user-images.githubusercontent.com/54422211/227524976-d2ee5941-b288-4c08-a9ef-e23c34c07d2d.png)

This is probably due to the fact that the key is not determined in the `settings` > `properties`.

## Testing Instructions

Create the following JSON file, specifying the JSON schema changed by this PR.

```json
{
	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/schema/stiky-minheight/schemas/json/theme.json",
	"version": 2,
	"settings": {
		"position": {
			"sticky": true
		},
		"dimensions": {
			"minHeight": true
		},
		"blocks": {
			"core/group": {
				"position": {
					"sticky": true
				},
				"dimensions": {
					"minHeight": true
				}
			}
		}
	}
}
```

When this file is opened in the code editor, confirm that no validation errors occur for all properties.