### PR TITLE
Use `parse_request` instead of `wp_loaded` action for scraping duotone data from theme.json

### DIFF
--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -442,8 +442,8 @@ WP_Block_Supports::get_instance()->register(
 	)
 );
 
-add_action( 'wp_loaded', array( 'WP_Duotone_Gutenberg', 'set_global_styles_presets' ), 10 );
-add_action( 'wp_loaded', array( 'WP_Duotone_Gutenberg', 'set_global_style_block_names' ), 10 );
+add_action( 'parse_request', array( 'WP_Duotone_Gutenberg', 'set_global_styles_presets' ), 10 );
+add_action( 'parse_request', array( 'WP_Duotone_Gutenberg', 'set_global_style_block_names' ), 10 );
 // Remove WordPress core filter to avoid rendering duplicate support elements.
 remove_filter( 'render_block', 'wp_render_duotone_support', 10, 2 );
 add_filter( 'render_block', array( 'WP_Duotone_Gutenberg', 'render_duotone_support' ), 10, 2 );


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/49324



## What?
https://github.com/WordPress/gutenberg/pull/49103 scrapes duotone theme.json data on `wp_loaded`, which causes theme.json to be cached too early and prevents editor-only selectors from being used in theme.json.

## Why?
Not being able to generate editor-only selectors via theme.json causes a regression with the Image block and the border not being applied to the inline cropping area.

## How?
Use `parse_request` instead of `wp_loaded` action to delay scraping duotone data from theme.json until after the editor-only selectors processes have finished.

## Testing Instructions
1. On `trunk`
2. Add border styles to styles.blocks['core/image'].border in theme.json or via the global styles theme editor.
```jsonc
// theme.json
{
	"styles": {
	 	"blocks": {
	 		"core/image": {
	 			"border": {
	 				"radius": "24px",
	 				"style": "solid",
	 				"color": "red",
	 				"width": "4px"
	 			}
 	 	 	}
		}
	}
}
```
3. In the post editor add an image block. The border image from global styles should be applied.
4. Select to crop the image and notice the border is lost.
5. Confirm there are no styles output matching the editor-only selector from image/block.json
6. Switch to this branch `fix/duotone-action-order`
7. In the post editor add an image block. The border image from global styles should be applied.
8. Select to crop the image and notice the border is still present.
