### PR TITLE
Adds navigation submenu tests

### DIFF
--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -256,7 +256,6 @@ test.describe( 'As a user I want to create submenus using the navigation block',
 			)
 		).toBeVisible();
 
-		// Select the site title block.
 		const navigationBlock = editor.canvas.getByRole( 'document', {
 			name: 'Block: Navigation',
 		} );
@@ -267,7 +266,7 @@ test.describe( 'As a user I want to create submenus using the navigation block',
 		} );
 		await expect( submenuBlock1 ).toBeVisible();
 
-		// select the child link
+		// select the child link via keyboard
 		await pageUtils.pressKeys( 'ArrowDown' );
 		await pageUtils.pressKeys( 'ArrowDown' );
 		await pageUtils.pressKeys( 'ArrowDown' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #45201

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We need basic functionality testing for the navigation block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds two tests:

1. Creating a submenu, adds a link, creates the submenu, checks on the front end the submenu is rendered
2. Empty submenu self converts to a link, tests by creating a navigation with a submenu, checking the submenu is visible, removing the only child, checking the submenu is not visible anymore.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Run:

```
 npm run test:e2e:playwright -- -g "As a user I want to create submenus using the navigation block" 
```
