### PR TITLE
Updates createNotice icon type

### DIFF
--- a/docs/reference-guides/data/data-core-notices.md
+++ b/docs/reference-guides/data/data-core-notices.md
@@ -168,7 +168,7 @@ _Parameters_
 -   _options.type_ `[string]`: Type of notice, one of `default`, or `snackbar`.
 -   _options.speak_ `[boolean]`: Whether the notice content should be announced to screen readers.
 -   _options.actions_ `[Array<WPNoticeAction>]`: User actions to be presented with notice.
--   _options.icon_ `[string]`: An icon displayed with the notice. Only used when type is set to `snackbar`.
+-   _options.icon_ `JSX.Element`: An icon displayed with the notice. Only used when type is set to `snackbar`.
 -   _options.explicitDismiss_ `[boolean]`: Whether the notice includes an explicit dismiss button and can't be dismissed by clicking the body of the notice. Only applies when type is set to `snackbar`.
 -   _options.onDismiss_ `[Function]`: Called when the notice is dismissed.
 


### PR DESCRIPTION
Changes createNotice icon type from `string` to `JSX.Element`

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates createNotice `options?.icon` data type from string to JSX.Element to comply with type definition.

## Why?
This will help to keep the documentation up to date.

## How?
This will update the docs for createNotice
