### PR TITLE
Selectors API: Rename Duotone parent from filters to filter

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -864,7 +864,7 @@ class WP_Theme_JSON_Gutenberg {
 			}
 
 			// The block may or may not have a duotone selector.
-			$duotone_selector = wp_get_block_css_selector( $block_type, 'filters.duotone' );
+			$duotone_selector = wp_get_block_css_selector( $block_type, 'filter.duotone' );
 			if ( null !== $duotone_selector ) {
 				static::$blocks_metadata[ $block_name ]['duotone'] = $duotone_selector;
 			}

--- a/lib/compat/wordpress-6.3/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.3/get-global-styles-and-settings.php
@@ -34,10 +34,10 @@ if ( ! function_exists( 'wp_get_block_css_selector' ) ) {
 		}
 
 		// Duotone (No fallback selectors for Duotone).
-		if ( 'filters.duotone' === $target || array( 'filters', 'duotone' ) === $target ) {
+		if ( 'filter.duotone' === $target || array( 'filter', 'duotone' ) === $target ) {
 			// Prefer editor selector if available.
 			$duotone_editor_selector = $use_editor_selectors
-				? _wp_array_get( $block_type->editor_selectors, array( 'filters', 'duotone' ), null )
+				? _wp_array_get( $block_type->editor_selectors, array( 'filter', 'duotone' ), null )
 				: null;
 
 			if ( $duotone_editor_selector ) {
@@ -46,7 +46,7 @@ if ( ! function_exists( 'wp_get_block_css_selector' ) ) {
 
 			// If selectors API in use, only use it's value or null.
 			if ( $has_selectors ) {
-				return _wp_array_get( $block_type->selectors, array( 'filters', 'duotone' ), null );
+				return _wp_array_get( $block_type->selectors, array( 'filter', 'duotone' ), null );
 			}
 
 			// Selectors API, not available, check for old experimental selector.

--- a/phpunit/class-wp-get-block-css-selectors-test.php
+++ b/phpunit/class-wp-get-block-css-selectors-test.php
@@ -87,12 +87,12 @@ class WP_Get_Block_CSS_Selector_Test extends WP_UnitTestCase {
 		$block_type = self::register_test_block(
 			'test/duotone-selector',
 			array(
-				'filters' => array( 'duotone' => '.duotone-selector' ),
+				'filter' => array( 'duotone' => '.duotone-selector' ),
 			),
 			null
 		);
 
-		$selector = wp_get_block_css_selector( $block_type, array( 'filters', 'duotone' ) );
+		$selector = wp_get_block_css_selector( $block_type, array( 'filter', 'duotone' ) );
 		$this->assertEquals( '.duotone-selector', $selector );
 	}
 
@@ -107,7 +107,7 @@ class WP_Get_Block_CSS_Selector_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$selector = wp_get_block_css_selector( $block_type, 'filters.duotone' );
+		$selector = wp_get_block_css_selector( $block_type, 'filter.duotone' );
 		$this->assertEquals( '.experimental-duotone', $selector );
 	}
 
@@ -118,7 +118,7 @@ class WP_Get_Block_CSS_Selector_Test extends WP_UnitTestCase {
 			null
 		);
 
-		$selector = wp_get_block_css_selector( $block_type, 'filters.duotone' );
+		$selector = wp_get_block_css_selector( $block_type, 'filter.duotone' );
 		$this->assertEquals( null, $selector );
 	}
 
@@ -356,15 +356,15 @@ class WP_Get_Block_CSS_Selector_Test extends WP_UnitTestCase {
 		$block_type = self::register_test_block(
 			'test/editor-duotone-selector',
 			array(
-				'filters' => array( 'duotone' => '.duotone-selector' ),
+				'filter' => array( 'duotone' => '.duotone-selector' ),
 			),
 			null,
 			array(
-				'filters' => array( 'duotone' => '.editor-duotone-selector' ),
+				'filter' => array( 'duotone' => '.editor-duotone-selector' ),
 			)
 		);
 
-		$selector = wp_get_block_css_selector( $block_type, 'filters.duotone' );
+		$selector = wp_get_block_css_selector( $block_type, 'filter.duotone' );
 		$this->assertEquals( '.editor-duotone-selector', $selector );
 	}
 


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/49340
- https://github.com/WordPress/gutenberg/issues/49342
- https://github.com/WordPress/gutenberg/pull/46496
- https://github.com/WordPress/gutenberg/pull/49325

## What?

Moves `duotone` selectors under `filter` instead of the plural `filters`.

## Why?

This is to help bring consistency between all the various locations for duotone e.g. theme.json, block supports, selectors etc. See https://github.com/WordPress/gutenberg/issues/49340 for further context.

## How?

- Renames `filters` to `filter`
- Updates the global function to retrieve block CSS selectors to request `filter.duotone`
- Updates the tests for the global function
- Updates theme.json class to request `filter.duotone`

## Testing Instructions

1. Ensure selectors tests pass: `npm run test:unit:php -- --filter WP_Get_Block_CSS_Selector_Test`
2. To test manually you can check out https://github.com/WordPress/gutenberg/pull/49325 which will be updated to use `filter.duotone` as well and be based on this PR.


