### PR TITLE
Group Block: Allow blocks to be dragged onto it in its placeholder state

### DIFF
--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -12,6 +12,7 @@ import {
 } from '@wordpress/block-editor';
 import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { View } from '@wordpress/primitives';
 
 /**
  * Internal dependencies
@@ -108,16 +109,28 @@ function GroupEdit( {
 		usedLayoutType: usedLayout?.type,
 		hasInnerBlocks,
 	} );
+
+	// Default to the regular appender being rendered.
+	let renderAppender;
+	if ( showPlaceholder ) {
+		// In the placeholder state, ensure the appender is not rendered.
+		// This is needed because `...innerBlocksProps` is used in the placeholder
+		// state so that blocks can dragged onto the placeholder area
+		// from both the list view and in the editor canvas.
+		renderAppender = false;
+	} else if ( ! hasInnerBlocks && ! showPlaceholder ) {
+		// When there is no placeholder, but the block is also empty,
+		// use the larger button appender.
+		renderAppender = InnerBlocks.ButtonBlockAppender;
+	}
+
 	const innerBlocksProps = useInnerBlocksProps(
 		layoutSupportEnabled
 			? blockProps
 			: { className: 'wp-block-group__inner-container' },
 		{
 			templateLock,
-			renderAppender: hasInnerBlocks
-				? undefined
-				: InnerBlocks.ButtonBlockAppender,
-			__unstableDisableLayoutClassNames: ! layoutSupportEnabled,
+			renderAppender,
 		}
 	);
 
@@ -138,11 +151,14 @@ function GroupEdit( {
 				}
 			/>
 			{ showPlaceholder && (
-				<GroupPlaceHolder
-					clientId={ clientId }
-					name={ name }
-					onSelect={ selectVariation }
-				/>
+				<View { ...innerBlocksProps }>
+					{ innerBlocksProps.children }
+					<GroupPlaceHolder
+						clientId={ clientId }
+						name={ name }
+						onSelect={ selectVariation }
+					/>
+				</View>
 			) }
 			{ layoutSupportEnabled && ! showPlaceholder && (
 				<TagName { ...innerBlocksProps } />

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -118,7 +118,7 @@ function GroupEdit( {
 		// state so that blocks can dragged onto the placeholder area
 		// from both the list view and in the editor canvas.
 		renderAppender = false;
-	} else if ( ! hasInnerBlocks && ! showPlaceholder ) {
+	} else if ( ! hasInnerBlocks ) {
 		// When there is no placeholder, but the block is also empty,
 		// use the larger button appender.
 		renderAppender = InnerBlocks.ButtonBlockAppender;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #49256

Allow dragging blocks into the Group block within its placeholder state.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As raised in https://github.com/WordPress/gutenberg/issues/49256#issuecomment-1482274579, prior to this PR, it isn't possible to drag blocks into the Group block within its placeholder state. It turns out this is because in the placeholder state the children of `useInnerBlocksProps` are not rendered (`InnerBlocks`), which means that the `blockListSettings` list is not updated to include the Group block, so it isn't considered as being allowed to receive child blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* This fix borrows from the approach used in the Gallery block, where the placeholder state is wrapper in a `View` with the `innerBlocksProps` applied there, and `{ innerBlocksProps.children }` is explicitly output (introduced in https://github.com/WordPress/gutenberg/pull/45891).
* The `renderAppender` value passed to `useInnerBlocksProps` is updated so that it's explicitly set to `false` when in the placeholder state. I've added some comments to explain each value, since it wasn't obvious to me at first what the difference between `false` and `undefined` would be.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a Group block to a post or page.
2. Add some paragraphs after the Group block.
3. In the List View, drag a paragraph onto the Group block placeholder. You should see in the List View that the block has been moved into that Group block. Note: not covered in this PR is that the block defaults to being collapsed in the List View.
4. Add another Group block.
5. From the List View, drag a paragraph onto the Group block's placeholder. The block should now be within the Group.

## Screenshots or screencast <!-- if applicable -->

![2023-03-27 16 11 41](https://user-images.githubusercontent.com/14988353/227846625-f51becb5-0323-4f10-82a9-ade752b7071d.gif)

