### PR TITLE
Adapt flex child controls for Spacer.

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -430,6 +430,19 @@ _Returns_
 
 -   `string|null`: A font-size value using clamp().
 
+### getCustomValueFromPreset
+
+Converts a spacing preset into a custom value.
+
+_Parameters_
+
+-   _value_ `string`: Value to convert
+-   _spacingSizes_ `Array`: Array of the current spacing preset objects
+
+_Returns_
+
+-   `string`: Mapping of the spacing preset to its equivalent custom value.
+
 ### getFontSize
 
 Returns the font size object based on an array of named font sizes and the namedFontSize and customFontSize values. If namedFontSize is undefined or not found in fontSizes an object with just the size value based on customFontSize is returned.

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -95,6 +95,7 @@ export { default as __experimentalSpacingSizesControl } from './spacing-sizes-co
 export {
 	getSpacingPresetCssVar,
 	isValueSpacingPreset,
+	getCustomValueFromPreset,
 } from './spacing-sizes-control/utils';
 /*
  * Content Related Components

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -103,7 +103,7 @@ const SpacerEdit = ( {
 	const { height, width, style: blockStyle = {} } = attributes;
 
 	const { layout = {} } = blockStyle;
-	const { selfStretch } = layout;
+	const { selfStretch, flexSize } = layout;
 
 	const [ isResizing, setIsResizing ] = useState( false );
 	const [ temporaryHeight, setTemporaryHeight ] = useState( null );
@@ -155,6 +155,8 @@ const SpacerEdit = ( {
 	const getHeightForVerticalBlocks = () => {
 		if ( isFlexLayout && selfStretch === 'fit' ) {
 			return undefined;
+		} else if ( isFlexLayout && flexSize ) {
+			return temporaryHeight || flexSize;
 		}
 		return temporaryHeight || getSpacingPresetCssVar( height ) || undefined;
 	};
@@ -162,6 +164,8 @@ const SpacerEdit = ( {
 	const getWidthForHorizontalBlocks = () => {
 		if ( isFlexLayout && selfStretch === 'fit' ) {
 			return undefined;
+		} else if ( isFlexLayout && flexSize ) {
+			return temporaryWidth || flexSize;
 		}
 		return temporaryWidth || getSpacingPresetCssVar( width ) || undefined;
 	};

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -254,6 +254,18 @@ const SpacerEdit = ( {
 				width: '72px',
 			} );
 		}
+		if ( isFlexLayout && ! flexSize ) {
+			setAttributes( {
+				style: {
+					...blockStyle,
+					layout: {
+						...layout,
+						flexSize: width || '72px',
+						selfStretch: 'fixed',
+					},
+				},
+			} );
+		}
 	}, [] );
 
 	return (

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -266,7 +266,7 @@ const SpacerEdit = ( {
 					getCustomValueFromPreset( height, spacingSizes ) ||
 					'100px';
 				setAttributes( {
-					width: null,
+					width: undefined,
 					style: {
 						...blockStyle,
 						layout: {
@@ -282,7 +282,7 @@ const SpacerEdit = ( {
 					getCustomValueFromPreset( width, spacingSizes ) ||
 					'100px';
 				setAttributes( {
-					height: null,
+					height: undefined,
 					style: {
 						...blockStyle,
 						layout: {
@@ -299,11 +299,11 @@ const SpacerEdit = ( {
 		) {
 			if ( inheritedOrientation === 'horizontal' ) {
 				setAttributes( {
-					width: null,
+					width: undefined,
 				} );
 			} else {
 				setAttributes( {
-					height: null,
+					height: undefined,
 				} );
 			}
 		} else if ( ! isFlexLayout && ( selfStretch || flexSize ) ) {
@@ -321,8 +321,8 @@ const SpacerEdit = ( {
 					...blockStyle,
 					layout: {
 						...layout,
-						flexSize: null,
-						selfStretch: null,
+						flexSize: undefined,
+						selfStretch: undefined,
 					},
 				},
 			} );

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -105,6 +105,8 @@ const SpacerEdit = ( {
 	const { layout = {} } = blockStyle;
 	const { selfStretch, flexSize } = layout;
 
+	const hasFlexSize = !! flexSize;
+
 	const [ isResizing, setIsResizing ] = useState( false );
 	const [ temporaryHeight, setTemporaryHeight ] = useState( null );
 	const [ temporaryWidth, setTemporaryWidth ] = useState( null );
@@ -115,7 +117,7 @@ const SpacerEdit = ( {
 	const handleOnVerticalResizeStop = ( newHeight ) => {
 		onResizeStop();
 
-		if ( isFlexLayout ) {
+		if ( isFlexLayout || hasFlexSize ) {
 			setAttributes( {
 				style: {
 					...blockStyle,
@@ -135,7 +137,7 @@ const SpacerEdit = ( {
 	const handleOnHorizontalResizeStop = ( newWidth ) => {
 		onResizeStop();
 
-		if ( isFlexLayout ) {
+		if ( isFlexLayout || hasFlexSize ) {
 			setAttributes( {
 				style: {
 					...blockStyle,
@@ -288,17 +290,7 @@ const SpacerEdit = ( {
 				} );
 			}
 		}
-	}, [
-		blockStyle,
-		flexSize,
-		height,
-		inheritedOrientation,
-		isFlexLayout,
-		layout,
-		selfStretch,
-		setAttributes,
-		width,
-	] );
+	}, [] );
 
 	return (
 		<>

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -254,19 +254,51 @@ const SpacerEdit = ( {
 				width: '72px',
 			} );
 		}
-		if ( isFlexLayout && ! flexSize ) {
+		if (
+			isFlexLayout &&
+			selfStretch !== 'fill' &&
+			selfStretch !== 'fit' &&
+			! flexSize
+		) {
+			const newSize =
+				inheritedOrientation === 'horizontal'
+					? getSpacingPresetCssVar( width ) || '72px'
+					: getSpacingPresetCssVar( height ) || '100px';
 			setAttributes( {
 				style: {
 					...blockStyle,
 					layout: {
 						...layout,
-						flexSize: width || '72px',
+						flexSize: newSize,
 						selfStretch: 'fixed',
 					},
 				},
 			} );
+		} else if (
+			isFlexLayout &&
+			( selfStretch === 'fill' || selfStretch === 'fit' )
+		) {
+			if ( inheritedOrientation === 'horizontal' ) {
+				setAttributes( {
+					width: '0px',
+				} );
+			} else {
+				setAttributes( {
+					height: '0px',
+				} );
+			}
 		}
-	}, [] );
+	}, [
+		blockStyle,
+		flexSize,
+		height,
+		inheritedOrientation,
+		isFlexLayout,
+		layout,
+		selfStretch,
+		setAttributes,
+		width,
+	] );
 
 	return (
 		<>

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -157,27 +157,23 @@ const SpacerEdit = ( {
 	};
 
 	const getHeightForVerticalBlocks = () => {
-		if ( isFlexLayout && selfStretch === 'fit' ) {
+		if ( isFlexLayout ) {
 			return undefined;
-		} else if ( isFlexLayout && flexSize ) {
-			return temporaryHeight || flexSize;
 		}
 		return temporaryHeight || getSpacingPresetCssVar( height ) || undefined;
 	};
 
 	const getWidthForHorizontalBlocks = () => {
-		if ( isFlexLayout && selfStretch === 'fit' ) {
+		if ( isFlexLayout ) {
 			return undefined;
-		} else if ( isFlexLayout && flexSize ) {
-			return temporaryWidth || flexSize;
 		}
 		return temporaryWidth || getSpacingPresetCssVar( width ) || undefined;
 	};
 
 	const sizeConditionalOnOrientation =
 		inheritedOrientation === 'horizontal'
-			? getWidthForHorizontalBlocks()
-			: getHeightForVerticalBlocks();
+			? temporaryWidth || flexSize
+			: temporaryHeight || flexSize;
 
 	const style = {
 		height:
@@ -266,7 +262,7 @@ const SpacerEdit = ( {
 					getCustomValueFromPreset( height, spacingSizes ) ||
 					'100px';
 				setAttributes( {
-					width: undefined,
+					width: '0px',
 					style: {
 						...blockStyle,
 						layout: {
@@ -282,7 +278,7 @@ const SpacerEdit = ( {
 					getCustomValueFromPreset( width, spacingSizes ) ||
 					'100px';
 				setAttributes( {
-					height: undefined,
+					height: '0px',
 					style: {
 						...blockStyle,
 						layout: {

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -290,7 +290,17 @@ const SpacerEdit = ( {
 				} );
 			}
 		}
-	}, [] );
+	}, [
+		blockStyle,
+		flexSize,
+		height,
+		inheritedOrientation,
+		isFlexLayout,
+		layout,
+		selfStretch,
+		setAttributes,
+		width,
+	] );
 
 	return (
 		<>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #38022.

* Removes custom size controls when Spacer is a child of a flex layout block (Row, Stack, Navigation).
* Adapts the block resizing handles so they change `flex-basis` value instead of width and height.

Note: I've made the "Fit" control reset the block width/height to 0 instead of removing it altogether, as removing "Fit" presents a technical challenge, due to those controls not knowing about the blocks they're applied to. I'm not sure if it makes sense to try and hack around this because Spacer is probably the only block that has no intrinsic size.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In a post or template, add a Row block with a few blocks inside, including a Spacer;
2. Check that custom sizing controls no longer show in the Spacer sidebar;
3. Resize Spacer using its resizing handles and check that all works correctly;
4. Try setting Spacer to "Fill" with the child flex controls in the sidebar.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="1029" alt="Screenshot 2023-03-27 at 5 08 44 pm" src="https://user-images.githubusercontent.com/8096000/227855019-56e5871a-f3b3-42f2-a9cf-62e507d2f455.png">

<img width="1030" alt="Screenshot 2023-03-27 at 5 08 59 pm" src="https://user-images.githubusercontent.com/8096000/227855040-ad528de6-d8bb-45e3-be6c-95da014dd4ca.png">

