### PR TITLE
Fix site editor redirection after creating new template or template part

### DIFF
--- a/packages/edit-site/src/components/add-new-template/new-template-part.js
+++ b/packages/edit-site/src/components/add-new-template/new-template-part.js
@@ -13,14 +13,12 @@ import { plus } from '@wordpress/icons';
  * Internal dependencies
  */
 import { useHistory } from '../routes';
-import { store as editSiteStore } from '../../store';
 import CreateTemplatePartModal from '../create-template-part-modal';
 import {
 	useExistingTemplateParts,
 	getUniqueTemplatePartTitle,
 	getCleanTemplatePartSlug,
 } from '../../utils/template-part-create';
-import { unlock } from '../../private-apis';
 
 export default function NewTemplatePart( {
 	postType,
@@ -31,7 +29,6 @@ export default function NewTemplatePart( {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { saveEntityRecord } = useDispatch( coreStore );
-	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 	const existingTemplateParts = useExistingTemplateParts();
 
 	async function createTemplatePart( { title, area } ) {
@@ -63,13 +60,11 @@ export default function NewTemplatePart( {
 
 			setIsModalOpen( false );
 
-			// Switch to edit mode.
-			setCanvasMode( 'edit' );
-
 			// Navigate to the created template part editor.
 			history.push( {
 				postId: templatePart.id,
 				postType: 'wp_template_part',
+				canvas: 'edit',
 			} );
 
 			// TODO: Add a success notice?

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -98,9 +98,7 @@ export default function NewTemplate( {
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createErrorNotice, createSuccessNotice } =
 		useDispatch( noticesStore );
-	const { setTemplate, setCanvasMode } = unlock(
-		useDispatch( editSiteStore )
-	);
+	const { setTemplate } = unlock( useDispatch( editSiteStore ) );
 	async function createTemplate( template, isWPSuggestion = true ) {
 		if ( isCreatingTemplate ) {
 			return;
@@ -125,13 +123,12 @@ export default function NewTemplate( {
 
 			// Set template before navigating away to avoid initial stale value.
 			setTemplate( newTemplate.id, newTemplate.slug );
-			// Switch to edit mode.
-			setCanvasMode( 'edit' );
 
 			// Navigate to the created template editor.
 			history.push( {
 				postId: newTemplate.id,
 				postType: newTemplate.type,
+				canvas: 'edit',
 			} );
 
 			createSuccessNotice(

--- a/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
@@ -52,9 +52,9 @@ test.describe( 'Site editor url navigation', () => {
 					} )
 					.click();
 				await page
-					.getByRole( 'button', { name: /For a specific item/i } )
+					.getByRole( 'button', { name: 'For a specific item' } )
 					.click();
-				await page.getByRole( 'option', { name: /Demo/i } ).click();
+				await page.getByRole( 'option', { name: 'Demo' } ).click();
 				await expect( page ).toHaveURL(
 					'/wp-admin/site-editor.php?postId=emptytheme%2F%2Fsingle-post-demo&postType=wp_template&canvas=edit'
 				);

--- a/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
@@ -9,18 +9,19 @@ test.describe( 'Site editor url navigation', () => {
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
-		await Promise.all( [
-			requestUtils.activateTheme( 'twentytwentyone' ),
-			// Fallback clean-up in case of failure.
-			requestUtils.deleteAllPosts(),
-			requestUtils.deleteAllTemplates( 'wp_template' ),
-			requestUtils.deleteAllTemplates( 'wp_template_part' ),
-		] );
+		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
 	test.describe(
 		'Redirection after template and template part creation',
 		() => {
+			test.afterEach( async ( { requestUtils } ) => {
+				await Promise.all( [
+					requestUtils.deleteAllPosts(),
+					requestUtils.deleteAllTemplates( 'wp_template' ),
+					requestUtils.deleteAllTemplates( 'wp_template_part' ),
+				] );
+			} );
 			test( 'Redirection after template creation', async ( {
 				admin,
 				page,
@@ -47,7 +48,7 @@ test.describe( 'Site editor url navigation', () => {
 				await page.click( 'role=button[name="Add New Template"i]' );
 				await page
 					.getByRole( 'menuitem', {
-						name: /Single item: Post./i,
+						name: /Single item: Post/,
 					} )
 					.click();
 				await page
@@ -57,15 +58,10 @@ test.describe( 'Site editor url navigation', () => {
 				await expect( page ).toHaveURL(
 					'/wp-admin/site-editor.php?postId=emptytheme%2F%2Fsingle-post-demo&postType=wp_template&canvas=edit'
 				);
-				await Promise.all( [
-					requestUtils.deleteAllPosts(),
-					requestUtils.deleteAllTemplates( 'wp_template' ),
-				] );
 			} );
 			test( 'Redirection after template part creation', async ( {
 				admin,
 				page,
-				requestUtils,
 			} ) => {
 				await admin.visitSiteEditor();
 				await page.click( 'role=button[name="Template Parts"i]' );
@@ -79,7 +75,6 @@ test.describe( 'Site editor url navigation', () => {
 				await expect( page ).toHaveURL(
 					'/wp-admin/site-editor.php?postId=emptytheme%2F%2Fdemo&postType=wp_template_part&canvas=edit'
 				);
-				await requestUtils.deleteAllTemplates( 'wp_template_part' );
 			} );
 		}
 	);

--- a/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
@@ -12,70 +12,67 @@ test.describe( 'Site editor url navigation', () => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
-	test.describe(
-		'Redirection after template and template part creation',
-		() => {
-			test.afterEach( async ( { requestUtils } ) => {
-				await Promise.all( [
-					requestUtils.deleteAllPosts(),
-					requestUtils.deleteAllTemplates( 'wp_template' ),
-					requestUtils.deleteAllTemplates( 'wp_template_part' ),
-				] );
+	test.describe( 'Redirection after template and template part creation', () => {
+		test.afterEach( async ( { requestUtils } ) => {
+			await Promise.all( [
+				requestUtils.deleteAllPosts(),
+				requestUtils.deleteAllTemplates( 'wp_template' ),
+				requestUtils.deleteAllTemplates( 'wp_template_part' ),
+			] );
+		} );
+		test( 'Redirection after template creation', async ( {
+			admin,
+			page,
+			requestUtils,
+		} ) => {
+			await requestUtils.createPost( {
+				title: 'Demo',
+				status: 'publish',
 			} );
-			test( 'Redirection after template creation', async ( {
-				admin,
-				page,
-				requestUtils,
-			} ) => {
-				await requestUtils.createPost( {
-					title: 'Demo',
-					status: 'publish',
-				} );
-				await admin.visitSiteEditor();
-				// We need to wait the response from the `posts` request in order to click the augmented menu item,
-				// that includes the options for creating templates for specific posts.
-				await Promise.all( [
-					page.waitForResponse(
-						( resp ) =>
-							resp
-								.url()
-								.includes(
-									'/index.php?rest_route=%2Fwp%2Fv2%2Fposts&context=view'
-								) && resp.status() === 200
-					),
-					page.click( 'role=button[name="Templates"]' ),
-				] );
-				await page.click( 'role=button[name="Add New Template"i]' );
-				await page
-					.getByRole( 'menuitem', {
-						name: 'Single item: Post',
-					} )
-					.click();
-				await page
-					.getByRole( 'button', { name: 'For a specific item' } )
-					.click();
-				await page.getByRole( 'option', { name: 'Demo' } ).click();
-				await expect( page ).toHaveURL(
-					'/wp-admin/site-editor.php?postId=emptytheme%2F%2Fsingle-post-demo&postType=wp_template&canvas=edit'
-				);
-			} );
-			test( 'Redirection after template part creation', async ( {
-				admin,
-				page,
-			} ) => {
-				await admin.visitSiteEditor();
-				await page.click( 'role=button[name="Template Parts"i]' );
-				await page.click( 'role=button[name="Add New"i]' );
-				// Fill in a name in the dialog that pops up.
-				await page.type(
-					'role=dialog >> role=textbox[name="Name"i]',
-					'Demo'
-				);
-				await page.keyboard.press( 'Enter' );
-				await expect( page ).toHaveURL(
-					'/wp-admin/site-editor.php?postId=emptytheme%2F%2Fdemo&postType=wp_template_part&canvas=edit'
-				);
-			} );
-		}
-	);
+			await admin.visitSiteEditor();
+			// We need to wait the response from the `posts` request in order to click the augmented menu item,
+			// that includes the options for creating templates for specific posts.
+			await Promise.all( [
+				page.waitForResponse(
+					( resp ) =>
+						resp
+							.url()
+							.includes(
+								'/index.php?rest_route=%2Fwp%2Fv2%2Fposts&context=view'
+							) && resp.status() === 200
+				),
+				page.click( 'role=button[name="Templates"]' ),
+			] );
+			await page.click( 'role=button[name="Add New Template"i]' );
+			await page
+				.getByRole( 'menuitem', {
+					name: 'Single item: Post',
+				} )
+				.click();
+			await page
+				.getByRole( 'button', { name: 'For a specific item' } )
+				.click();
+			await page.getByRole( 'option', { name: 'Demo' } ).click();
+			await expect( page ).toHaveURL(
+				'/wp-admin/site-editor.php?postId=emptytheme%2F%2Fsingle-post-demo&postType=wp_template&canvas=edit'
+			);
+		} );
+		test( 'Redirection after template part creation', async ( {
+			admin,
+			page,
+		} ) => {
+			await admin.visitSiteEditor();
+			await page.click( 'role=button[name="Template Parts"i]' );
+			await page.click( 'role=button[name="Add New"i]' );
+			// Fill in a name in the dialog that pops up.
+			await page.type(
+				'role=dialog >> role=textbox[name="Name"i]',
+				'Demo'
+			);
+			await page.keyboard.press( 'Enter' );
+			await expect( page ).toHaveURL(
+				'/wp-admin/site-editor.php?postId=emptytheme%2F%2Fdemo&postType=wp_template_part&canvas=edit'
+			);
+		} );
+	} );
 } );

--- a/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
@@ -48,7 +48,7 @@ test.describe( 'Site editor url navigation', () => {
 				await page.click( 'role=button[name="Add New Template"i]' );
 				await page
 					.getByRole( 'menuitem', {
-						name: /Single item: Post/,
+						name: 'Single item: Post',
 					} )
 					.click();
 				await page

--- a/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
@@ -1,0 +1,86 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Site editor url navigation', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await Promise.all( [
+			requestUtils.activateTheme( 'twentytwentyone' ),
+			// Fallback clean-up in case of failure.
+			requestUtils.deleteAllPosts(),
+			requestUtils.deleteAllTemplates( 'wp_template' ),
+			requestUtils.deleteAllTemplates( 'wp_template_part' ),
+		] );
+	} );
+
+	test.describe(
+		'Redirection after template and template part creation',
+		() => {
+			test( 'Redirection after template creation', async ( {
+				admin,
+				page,
+				requestUtils,
+			} ) => {
+				await requestUtils.createPost( {
+					title: 'Demo',
+					status: 'publish',
+				} );
+				await admin.visitSiteEditor();
+				// We need to wait the response from the `posts` request in order to click the augmented menu item,
+				// that includes the options for creating templates for specific posts.
+				await Promise.all( [
+					page.waitForResponse(
+						( resp ) =>
+							resp
+								.url()
+								.includes(
+									'/index.php?rest_route=%2Fwp%2Fv2%2Fposts&context=view'
+								) && resp.status() === 200
+					),
+					page.click( 'role=button[name="Templates"]' ),
+				] );
+				await page.click( 'role=button[name="Add New Template"i]' );
+				await page
+					.getByRole( 'menuitem', {
+						name: /Single item: Post./i,
+					} )
+					.click();
+				await page
+					.getByRole( 'button', { name: /For a specific item/i } )
+					.click();
+				await page.getByRole( 'option', { name: /Demo/i } ).click();
+				await expect( page ).toHaveURL(
+					'/wp-admin/site-editor.php?postId=emptytheme%2F%2Fsingle-post-demo&postType=wp_template&canvas=edit'
+				);
+				await Promise.all( [
+					requestUtils.deleteAllPosts(),
+					requestUtils.deleteAllTemplates( 'wp_template' ),
+				] );
+			} );
+			test( 'Redirection after template part creation', async ( {
+				admin,
+				page,
+				requestUtils,
+			} ) => {
+				await admin.visitSiteEditor();
+				await page.click( 'role=button[name="Template Parts"i]' );
+				await page.click( 'role=button[name="Add New"i]' );
+				// Fill in a name in the dialog that pops up.
+				await page.type(
+					'role=dialog >> role=textbox[name="Name"i]',
+					'Demo'
+				);
+				await page.keyboard.press( 'Enter' );
+				await expect( page ).toHaveURL(
+					'/wp-admin/site-editor.php?postId=emptytheme%2F%2Fdemo&postType=wp_template_part&canvas=edit'
+				);
+				await requestUtils.deleteAllTemplates( 'wp_template_part' );
+			} );
+		}
+	);
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/49346

From the issue:
>When creating a new template for an individual post, the user is not always led to the edit screen:

Noting that this is the case for `Template Parts` too.

### Scenario 1 (expected):


https://user-images.githubusercontent.com/15730971/227565922-e10729c3-77be-45ce-a136-dd36b7c1a800.mov

### Scenario 2 (the new template is still created, but the user is not directed to it, and the modal doesn't close):

https://user-images.githubusercontent.com/15730971/227566061-c00f6cce-300c-4123-a571-2503ecbfb089.mov


### Step-by-step reproduction instructions

1. Make sure you have an install running with the Twenty Twenty three theme and WordPress version 6.2
2. As demonstrated on the screencasts above, head over to Edit site > Templates >  Manage All Templates > Add New > Single item: Post
3. Select a post to create a template for it
4. Notice how the modal doesn't close, and you are not directed to the new template after creation. Important: given the random nature of the issue, it is possible that you won't be able to reproduce on the first attempt; continue to create a few more templates for individual posts until you do.



## How?

When we create a new template or template part in site editor we first update the `canvas mode`(setCanvasMode( 'edit' )) to the store before pushing to the `history`.  This sometimes can lead to race conditions with `useSyncCanvasModeWithURL` hook that then replaces the proper url with the previous one and just adding the `canvas=edit` param. The current syncing is susceptible to race conditions in different parts of code, but I didn't investigate in depth for now. It's something we need to have in mind.

This PR adds the correct `canvas` mode directly so we don't need the syncing logic there. 
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->


<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions in this PR
1. Make sure the redirection happens always and history(back in sidebar and browser) still works as expected.
