### PR TITLE
Fix TabPanel initial rendering

### DIFF
--- a/packages/components/src/tab-panel/index.tsx
+++ b/packages/components/src/tab-panel/index.tsx
@@ -6,7 +6,12 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useState, useEffect, useCallback } from '@wordpress/element';
+import {
+	useState,
+	useEffect,
+	useLayoutEffect,
+	useCallback,
+} from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
 
 /**
@@ -104,7 +109,7 @@ export function TabPanel( {
 	const selectedId = `${ instanceId }-${ selectedTab?.name ?? 'none' }`;
 
 	// Handle selecting the initial tab.
-	useEffect( () => {
+	useLayoutEffect( () => {
 		// If there's a selected tab, don't override it.
 		if ( selectedTab ) {
 			return;


### PR DESCRIPTION
Addresses https://github.com/WordPress/gutenberg/pull/48893#discussion_r1149153748

## What?

When a TabPanel component is initially rendering there's a first rendering that happens with "no tab being actually rendered" then an effect triggers to actually set the active tab.

This behavior creates an issue for UIs that are supposed to be rendered right away. For instance if a "DropdownMenu" holds the TabPanel, the focus is not moved to the right position within the dropdown when it opens because at the tab is first rendered as empty.

## How?

The solution here uses a `useLayoutEffect` to address this as this hook is supposed to be used for all effects that have an effect on UI causing React internally to only render to the DOM once.

## Testing Instructions

1- Open a paragraph inspector control
2- Click the "background" color in the style inspector controls.
3- The dropdown should open and the "focus" should be within the dropdown.

I also suspect that this PR could fix the popover bug discovered here #49349 but there might be still a race condition with the Popover component.