### PR TITLE
Try: Prevent scrolling content under an open overlay modal

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -729,4 +729,5 @@ button.wp-block-navigation-item__content {
 // Prevent scrolling of the parent content when the modal is open.
 html.has-modal-open {
 	overflow: hidden;
+	position: fixed;
 }


### PR DESCRIPTION
## What?

When the navigation block modal overlay is open, a helper class is added to the `html` element, applying `overflow: hidden;`. This is used to prevent the scrolling of content _underneath_ the open modal overlay. I believe this used to also work as intended for Mobile Safari, but this appears to have stopped working in recent versions. GIF showing that you can swipe/scroll content "below":

![before](https://user-images.githubusercontent.com/1204802/227935514-243b625b-a2f5-4979-99b6-56a89928faf0.gif)

This PR tries to address that by adding `position: fixed;` to the open overlay. It appears to fix it in my testing:

![after](https://user-images.githubusercontent.com/1204802/227935632-e3702501-60ed-41ae-b01a-fc6d0aedf94e.gif)

I believe this may have also been explored in the past, and avoided as it would also change the _height_ of the HTML content, thus losing your scroll position in the use case where you've scrolled down a long way, and then open the modal overlay from a sticky top nav. Your scroll position in this case _does_ reset, but that appears to also be an issue in trunk. Any alternative suggestions?

## Testing Instructions

Insert a navigation block, set it to always collapse. 

Test on a desktop, small viewport, but ideally also test on a physical iphone, or the Xcode simulator, and verify that you cannot scroll content under the open overlay.