### PR TITLE
Fix editor canvas detaching error in e2e tests

### DIFF
--- a/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
@@ -34,7 +34,6 @@ export async function visitSiteEditor(
 	} ).slice( 1 );
 
 	await this.visitAdminPage( 'site-editor.php', path );
-	await this.page.waitForSelector( CANVAS_SELECTOR );
 
 	if ( skipWelcomeGuide ) {
 		await this.page.evaluate( () => {
@@ -47,4 +46,12 @@ export async function visitSiteEditor(
 				.toggle( 'core/edit-site', 'welcomeGuideStyles', false );
 		} );
 	}
+
+	// The site editor initially loads with an empty body,
+	// we need to wait for the editor canvas to be rendered.
+	await this.page
+		.frameLocator( CANVAS_SELECTOR )
+		.locator( 'body > *' )
+		.first()
+		.waitFor();
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
For some reason that I don't know yet, the editor canvas in the site editor will detach and attach itself on the first load. It's likely caused by a recent commit because it was not happening before for me. This however causes some e2e tests to be flaky because the original `frame( 'editor-canvas' )` gets detached. This can be reproduced consistently locally but only intermittently on CI.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To fix flaky e2e tests and unblock local testing. I think this is related to https://github.com/WordPress/gutenberg/pull/49203 (c.c. @Mamaduka). Should also fix https://github.com/WordPress/gutenberg/issues/48504.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Wait for the body to be loaded in `visitSiteEditor`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
CI should pass.
