### PR TITLE
[RNMobile] Avoid excluding `WordPress-Android-Utils` module in demo app

### DIFF
--- a/packages/react-native-editor/android/app/build.gradle
+++ b/packages/react-native-editor/android/app/build.gradle
@@ -239,9 +239,7 @@ android {
 dependencies {
     def packageJson = '../../package.json'
 
-    implementation("org.wordpress-mobile.gutenberg-mobile:react-native-bridge", {
-        exclude group: 'org.wordpress', module: 'utils'
-    })
+    implementation "org.wordpress-mobile.gutenberg-mobile:react-native-bridge"
     implementation 'androidx.appcompat:appcompat:1.2.0'
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:${extractPackageVersion(packageJson, 'react-native', 'dependencies')}"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Avoid excluding `WordPress-Android-Utils` module in the demo app by updating the Android build configuration.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This PR addresses a crash generated in the demo app when inserting a Quote block from the inserter menu.

The crash is produced due to invoking the `AppLog` class from `ReactAztecText` ([reference](https://github.com/WordPress/gutenberg/blob/8039d57822457b2a639142375beb6dac9e6bf468/packages/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java#L220-L222)). Based on the stack trace, this class is not included in the build and the app throws a `java.lang.NoClassDefFoundError` exception.

```com.gutenberg E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.gutenberg, PID: 4968
    java.lang.NoClassDefFoundError: Failed resolution of: Lorg/wordpress/android/util/AppLog$T;
        at org.wordpress.mobile.ReactNativeAztec.ReactAztecText$5.run(ReactAztecText.java:220)
        at android.os.Handler.handleCallback(Handler.java:942)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loopOnce(Looper.java:226)
        at android.os.Looper.loop(Looper.java:313)
        at android.app.ActivityThread.main(ActivityThread.java:8741)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
     Caused by: java.lang.ClassNotFoundException: Didn't find class "org.wordpress.android.util.AppLog$T" on path: DexPathList
```

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The `WordPress-Android-Utils` module was excluded in the Android build configuration ([reference](https://github.com/WordPress/gutenberg/blob/8039d57822457b2a639142375beb6dac9e6bf468/packages/react-native-editor/android/app/build.gradle#L242-L244)), so the fix mainly implied removing the exclusion in order to incorporate that module.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Build the demo app.
**NOTE:** When using Android Studio, before building the demo app, sync the project with Gradle files.
2. Tap ➕ button to open the inserter menu.
3. Tap on the Quote block.
4. Observe that the Quote block is inserted.
5. Observe that the app doesn't crash after the block insertion.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A