### PR TITLE
Fix failing CI docs check

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2028,7 +2028,7 @@
 		"parent": "architecture"
 	},
 	{
-		"title": "Full Site Editing Templates",
+		"title": "Site Editing Templates",
 		"slug": "full-site-editing-templates",
 		"markdown_source": "../docs/explanations/architecture/full-site-editing-templates.md",
 		"parent": "architecture"


### PR DESCRIPTION
## What?
Updates `docs/manifest.json` that causes CI failure on the trunk.

## Why?
#49184 was merged with failing CI checks.

## Testing Instructions
CI checks should pass.
