### PR TITLE
Layout: Fix unstableDisableLayoutClassNames in Group block

### DIFF
--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -131,6 +131,7 @@ function GroupEdit( {
 		{
 			templateLock,
 			renderAppender,
+			__unstableDisableLayoutClassNames: ! layoutSupportEnabled,
 		}
 	);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

I accidentally removed the line that prevents layout classnames from being applied to the group block's inner wrapper in classic themes, over in https://github.com/WordPress/gutenberg/pull/49361.

This PR restores the line that was accidentally removed.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In #49361, I was intending to only update the `renderAppender` line and accidentally removed `__unstableDisableLayoutClassNames` at the same time.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Re-instate the line, as it was before #49361 landed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Switch to a Classic theme
2. Prior to this PR, the Group block's inner wrapper receives the layout classnames (e.g. `is-layout-constrained` is applied to the `wp-block-group__inner-container` element.
3. With this PR applied, the Group block's inner wrapper does not receive the layout classnames (expected), but the outer wrapper still gets those classnames.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/228086926-f2d91c68-1303-4166-8418-2231946f2b07.png) | ![image](https://user-images.githubusercontent.com/14988353/228086957-d28fe4a0-0179-484d-8f20-4fbdaa3b2b64.png) |