### PR TITLE
Mention "testsPort" .wp-env.json setting

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -456,7 +456,7 @@ $ wp-env install-path
 
 You can customize the WordPress installation, plugins and themes that the development environment will use by specifying a `.wp-env.json` file in the directory that you run `wp-env` from.
 
-`.wp-env.json` supports six fields for options applicable to both the tests and development instances.
+`.wp-env.json` supports fields for options applicable to both the tests and development instances.
 
 | Field          | Type           | Default                                | Description                                                                                                                      |
 | -------------- | -------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
@@ -465,6 +465,7 @@ You can customize the WordPress installation, plugins and themes that the develo
 | `"plugins"`    | `string[]`     | `[]`                                   | A list of plugins to install and activate in the environment.                                                                    |
 | `"themes"`     | `string[]`     | `[]`                                   | A list of themes to install in the environment.                                                                                  |
 | `"port"`       | `integer`      | `8888` (`8889` for the tests instance) | The primary port number to use for the installation. You'll access the instance through the port: 'http://localhost:8888'.       |
+| `"testsPort"`       | `integer`      | `8889` | The port number for the test site. You'll access the instance through the port: 'http://localhost:8889'.       |
 | `"config"`     | `Object`       | See below.                             | Mapping of wp-config.php constants to their desired values.                                                                      |
 | `"mappings"`   | `Object`       | `"{}"`                                 | Mapping of WordPress directories to local directories to be mounted in the WordPress instance.                                   |
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Mentions the `testsPort` option for `.wp-env.json` in the table that lists this file's options, consistent with this page referring to the option further down. Also, more than six options appear to be supported, so that wording was changed.

## Why?
Provides more clarity on how to use this tool. Creating an `env` section is an available choice, but setting `testsPort` is more straightforward for when you just want to change that and create a new wp-env that does not interfere with another.

## How?
This PR will simply make mention of `testsPort` similarly to how other options are summarized.

## Testing Instructions

1. Create a new `wp-env` environment, but set `testsPort` port in the `.wp-env.json` to a value other than `8889`.
2. Confirm that the `wp-env` test instance is using the specified port.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
![image](https://user-images.githubusercontent.com/4011193/228107388-9413e0a8-0290-446d-8306-1285ac73867e.png)
