### PR TITLE
List View: Allow dragging underneath collapsed non-empty container blocks

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -248,6 +248,7 @@ function ListViewBlock( {
 			path={ path }
 			id={ `list-view-block-${ clientId }` }
 			data-block={ clientId }
+			data-expanded={ canExpand ? isExpanded : undefined }
 			isExpanded={ canExpand ? isExpanded : undefined }
 			aria-selected={ !! isSelected || forceSelectionContentLock }
 			ref={ rowRef }

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -151,7 +151,8 @@ function getListViewDropTarget( blocksData, position ) {
 	if (
 		isDraggingBelow &&
 		candidateBlockData.canInsertDraggedBlocksAsChild &&
-		( candidateBlockData.innerBlockCount > 0 ||
+		( ( candidateBlockData.innerBlockCount > 0 &&
+			candidateBlockData.isExpanded ) ||
 			isNestingGesture( position, candidateRect ) )
 	) {
 		return {
@@ -208,10 +209,12 @@ export default function useListViewDropZone() {
 
 				const blocksData = blockElements.map( ( blockElement ) => {
 					const clientId = blockElement.dataset.block;
+					const isExpanded = blockElement.dataset.expanded === 'true';
 					const rootClientId = getBlockRootClientId( clientId );
 
 					return {
 						clientId,
+						isExpanded,
 						rootClientId,
 						blockIndex: getBlockIndex( clientId ),
 						element: blockElement,

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -146,8 +146,10 @@ function getListViewDropTarget( blocksData, position ) {
 
 	// If the user is dragging towards the bottom of the block check whether
 	// they might be trying to nest the block as a child.
-	// If the block already has inner blocks, this should always be treated
+	// If the block already has inner blocks, and is expanded, this should be treated
 	// as nesting since the next block in the tree will be the first child.
+	// However, if the block is collapsed, dragging beneath the block should
+	// still be allowed, as the next visible block in the tree will be a sibling.
 	if (
 		isDraggingBelow &&
 		candidateBlockData.canInsertDraggedBlocksAsChild &&


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes: https://github.com/WordPress/gutenberg/issues/46678

This is a very small granular PR just looking at one part of drag and drop behaviour in the List View.

The goal in this PR is to allow blocks to be dragged underneath a container block that has children and is collapsed. On `trunk`, when hovering over the bottom half of a collapsed group block, it would always nest the dragged block into the group, rather than allowing you to slot it in underneath.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When rearranging blocks, it can be frustrating if you want to place something underneath a collapsed group, but it accidentally winds up being nested instead. Also, if your list of blocks contains mostly collapsed groups, prior to this PR, it was very difficult to rearrange blocks. This is fairly common in site templates.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add `data-expanded` to the row for the block (this is intentionally separate from `aria-expanded` so that passing the data along isn't dependent on how the expanded state is expressed for accessibility)
* Pass this to `useListViewDropZone` and to `getListViewDropTarget` — then, only add blocks as children if the nesting gesture is in use (hovering over the right-hand side of the block), or the block that has children is expanded.

A caveat: Note that dragging a block beneath the bottom-most block in the List View is still very difficult to do due to the size of the drop zones. This has not been addressed in this PR. Also not addressed: when the container block is expanded and at the bottom of the list, you cannot drag a block to be beneath it. I'll have a go at tackling those things in follow-ups.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a post with a variety of blocks.
2. Add an empty Group block. Dragging beneath or nesting into this block should be as on trunk.
3. Add a block to that Group block.
4. In the list view, with the Group block expanded, dragging to it should always result in the moved block being nested within the Group block.
5. Collapse the Group block. Dragging onto the bottom half of the Group block should allow you to move your dragged block to slot in underneath it (if you're hovered over the left half of the block), or if you hover over the right side of the block, you can nest the block inside it.

## Screenshots or screencast <!-- if applicable -->

| Before (while hovering over the bottom of the Group block, you are unable to position underneath) | After (while hovering over the bottom of the Group block, you can position underneath _or_ nest) |
| --- | --- |
| ![2023-03-29 10 15 56](https://user-images.githubusercontent.com/14988353/228388213-527a9e7c-37d3-4ae2-9c3f-4fa56ada2d8d.gif) | ![2023-03-29 10 22 22](https://user-images.githubusercontent.com/14988353/228388767-9d70a544-4c07-4ea4-82c6-8590590c9c0b.gif) |

One of the benefits of this PR is that it makes it possible to drag a block beneath the bottom block when the bottom block is a container block. In the site editor, this means that you can more easily re-arrange the footer:

| Trunk (in this view, rearrangement is nearly impossible since everything is collapsed) | This PR (with the container blocks collapsed, it is now possible to rearrange blocks) |
| --- | --- |
| ![2023-03-29 10 28 09](https://user-images.githubusercontent.com/14988353/228389301-39fa35bc-bd7d-44dc-84b6-7f913d1b58ce.gif) | ![2023-03-29 10 29 29](https://user-images.githubusercontent.com/14988353/228389496-c6e245a7-0089-41f4-828c-98cf1c3a2454.gif) |

Note: it is still difficult to move blocks to the bottom-most position as the dropzone there is very small. I'll look at addressing that separately to this PR.