### PR TITLE
Proposal: Block Params

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -96,7 +96,7 @@ function BlockListBlock( {
 	onInsertBlocksAfter,
 	onMerge,
 	toggleSelection,
-	meta,
+	params,
 } ) {
 	const {
 		themeSupportsLayout,
@@ -156,7 +156,7 @@ function BlockListBlock( {
 			__unstableParentLayout={
 				Object.keys( parentLayout ).length ? parentLayout : undefined
 			}
-			meta={ meta }
+			params={ params }
 		/>
 	);
 
@@ -285,7 +285,7 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId } ) => {
 	// This function should never be called when a block is not present in
 	// the state. It happens now because the order in withSelect rendering
 	// is not correct.
-	const { name, attributes, isValid, meta } = block || {};
+	const { name, attributes, isValid, params } = block || {};
 
 	// Do not add new properties here, use `useSelect` instead to avoid
 	// leaking new props to the public API (editor.BlockListBlock filter).
@@ -304,7 +304,7 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId } ) => {
 		attributes,
 		isValid,
 		isSelected,
-		meta,
+		params,
 	};
 } );
 

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -96,6 +96,7 @@ function BlockListBlock( {
 	onInsertBlocksAfter,
 	onMerge,
 	toggleSelection,
+	meta,
 } ) {
 	const {
 		themeSupportsLayout,
@@ -155,6 +156,7 @@ function BlockListBlock( {
 			__unstableParentLayout={
 				Object.keys( parentLayout ).length ? parentLayout : undefined
 			}
+			meta={ meta }
 		/>
 	);
 
@@ -283,7 +285,7 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId } ) => {
 	// This function should never be called when a block is not present in
 	// the state. It happens now because the order in withSelect rendering
 	// is not correct.
-	const { name, attributes, isValid } = block || {};
+	const { name, attributes, isValid, meta } = block || {};
 
 	// Do not add new properties here, use `useSelect` instead to avoid
 	// leaking new props to the public API (editor.BlockListBlock filter).
@@ -302,6 +304,7 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId } ) => {
 		attributes,
 		isValid,
 		isSelected,
+		meta,
 	};
 } );
 

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -59,7 +59,13 @@ function ClipboardToolbarButton( { text, disabled } ) {
 	);
 }
 
-function FileEdit( { attributes, isSelected, setAttributes, clientId, meta } ) {
+function FileEdit( {
+	attributes,
+	isSelected,
+	setAttributes,
+	clientId,
+	params,
+} ) {
 	const {
 		id,
 		fileId,
@@ -73,7 +79,7 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId, meta } ) {
 		previewHeight,
 	} = attributes;
 
-	const { blobURL } = meta;
+	const { blobURL } = params;
 
 	const { media, mediaUpload } = useSelect(
 		( select ) => ( {

--- a/packages/block-library/src/file/transforms.js
+++ b/packages/block-library/src/file/transforms.js
@@ -25,10 +25,8 @@ const transforms = {
 
 					// File will be uploaded in componentDidMount()
 					blocks.push(
-						createBlock( 'core/file', {
-							href: blobURL,
-							fileName: file.name,
-							textLinkHref: blobURL,
+						createBlock( 'core/file', {}, [], {
+							blobURL,
 						} )
 					);
 				} );

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -83,7 +83,7 @@ function Navigation( {
 	setOverlayBackgroundColor,
 	overlayTextColor,
 	setOverlayTextColor,
-	meta,
+	params,
 
 	// These props are used by the navigation editor to override specific
 	// navigation block settings.
@@ -422,15 +422,15 @@ function Navigation( {
 	// Convert the classic menu provided by the Legacy Widget block transform if
 	// it exists.
 	useEffect( () => {
-		if ( meta.menuId ) {
+		if ( params.menuId ) {
 			const classicMenu = classicMenus?.find(
-				( menu ) => menu.id === meta.menuId
+				( menu ) => menu.id === params.menuId
 			);
 			if ( classicMenu ) {
 				onSelectClassicMenu( classicMenu );
 			}
 		}
-	}, [ meta.menuId, classicMenus, onSelectClassicMenu ] );
+	}, [ params.menuId, classicMenus, onSelectClassicMenu ] );
 
 	const onSelectNavigationMenu = ( menuId ) => {
 		handleUpdateMenu( menuId );

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -83,6 +83,7 @@ function Navigation( {
 	setOverlayBackgroundColor,
 	overlayTextColor,
 	setOverlayTextColor,
+	meta,
 
 	// These props are used by the navigation editor to override specific
 	// navigation block settings.
@@ -402,18 +403,34 @@ function Navigation( {
 	] = useState();
 	const [ detectedOverlayColor, setDetectedOverlayColor ] = useState();
 
-	const onSelectClassicMenu = async ( classicMenu ) => {
-		const navMenu = await convertClassicMenu(
-			classicMenu.id,
-			classicMenu.name,
-			'draft'
-		);
-		if ( navMenu ) {
-			handleUpdateMenu( navMenu.id, {
-				focusNavigationBlock: true,
-			} );
+	const onSelectClassicMenu = useCallback(
+		async ( classicMenu ) => {
+			const navMenu = await convertClassicMenu(
+				classicMenu.id,
+				classicMenu.name,
+				'draft'
+			);
+			if ( navMenu ) {
+				handleUpdateMenu( navMenu.id, {
+					focusNavigationBlock: true,
+				} );
+			}
+		},
+		[ convertClassicMenu, handleUpdateMenu ]
+	);
+
+	// Convert the classic menu provided by the Legacy Widget block transform if
+	// it exists.
+	useEffect( () => {
+		if ( meta.menuId ) {
+			const classicMenu = classicMenus?.find(
+				( menu ) => menu.id === meta.menuId
+			);
+			if ( classicMenu ) {
+				onSelectClassicMenu( classicMenu );
+			}
 		}
-	};
+	}, [ meta.menuId, classicMenus, onSelectClassicMenu ] );
 
 	const onSelectNavigationMenu = ( menuId ) => {
 		handleUpdateMenu( menuId );

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -207,7 +207,7 @@ _Parameters_
 -   _name_ `string`: Block name.
 -   _attributes_ `[Object]`: Block attributes.
 -   _innerBlocks_ `[Array]`: Nested blocks.
--   _meta_ `[Object]`: Block metadata.
+-   _params_ `[Object]`: Block params.
 
 _Returns_
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -205,8 +205,9 @@ Returns a block object given its type and attributes.
 _Parameters_
 
 -   _name_ `string`: Block name.
--   _attributes_ `Object`: Block attributes.
--   _innerBlocks_ `?Array`: Nested blocks.
+-   _attributes_ `[Object]`: Block attributes.
+-   _innerBlocks_ `[Array]`: Nested blocks.
+-   _meta_ `[Object]`: Block metadata.
 
 _Returns_
 

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -27,7 +27,7 @@ import {
  * @param {string} name          Block name.
  * @param {Object} [attributes]  Block attributes.
  * @param {Array}  [innerBlocks] Nested blocks.
- * @param {Object} [meta]        Block metadata.
+ * @param {Object} [params]      Block params.
  *
  * @return {Object} Block object.
  *
@@ -36,7 +36,7 @@ export function createBlock(
 	name,
 	attributes = {},
 	innerBlocks = [],
-	meta = {}
+	params = {}
 ) {
 	const sanitizedAttributes = __experimentalSanitizeBlockAttributes(
 		name,
@@ -53,7 +53,7 @@ export function createBlock(
 		isValid: true,
 		attributes: sanitizedAttributes,
 		innerBlocks,
-		meta,
+		params,
 	};
 }
 

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -24,13 +24,20 @@ import {
 /**
  * Returns a block object given its type and attributes.
  *
- * @param {string} name        Block name.
- * @param {Object} attributes  Block attributes.
- * @param {?Array} innerBlocks Nested blocks.
+ * @param {string} name          Block name.
+ * @param {Object} [attributes]  Block attributes.
+ * @param {Array}  [innerBlocks] Nested blocks.
+ * @param {Object} [meta]        Block metadata.
  *
  * @return {Object} Block object.
+ *
  */
-export function createBlock( name, attributes = {}, innerBlocks = [] ) {
+export function createBlock(
+	name,
+	attributes = {},
+	innerBlocks = [],
+	meta = {}
+) {
 	const sanitizedAttributes = __experimentalSanitizeBlockAttributes(
 		name,
 		attributes
@@ -46,6 +53,7 @@ export function createBlock( name, attributes = {}, innerBlocks = [] ) {
 		isValid: true,
 		attributes: sanitizedAttributes,
 		innerBlocks,
+		meta,
 	};
 }
 

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -235,9 +235,9 @@ export const saveWidgetArea =
 			const widget = preservedRecords[ i ];
 			const { block, position } = batchMeta[ i ];
 
-			// Set __internalWidgetId on the block. This will be persisted to the
-			// store when we dispatch receiveEntityRecords( post ) below.
-			post.blocks[ position ].attributes.__internalWidgetId = widget.id;
+			// Set widget ID on the block. This will be persisted to the store
+			// when we dispatch receiveEntityRecords( post ) below.
+			post.blocks[ position ].meta.widgetId = widget.id;
 
 			const error = registry
 				.select( coreStore )

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -237,7 +237,7 @@ export const saveWidgetArea =
 
 			// Set widget ID on the block. This will be persisted to the store
 			// when we dispatch receiveEntityRecords( post ) below.
-			post.blocks[ position ].meta.widgetId = widget.id;
+			post.blocks[ position ].params.widgetId = widget.id;
 
 			const error = registry
 				.select( coreStore )

--- a/packages/widgets/src/blocks/legacy-widget/transforms.js
+++ b/packages/widgets/src/blocks/legacy-widget/transforms.js
@@ -3,100 +3,96 @@
  */
 import { createBlock } from '@wordpress/blocks';
 
-const legacyWidgetTransforms = [
+const toTransforms = [
 	{
-		block: 'core/calendar',
-		widget: 'calendar',
+		idBase: 'calendar',
+		blockName: 'core/calendar',
+		convert: () => createBlock( 'core/calendar' ),
 	},
 	{
-		block: 'core/search',
-		widget: 'search',
+		idBase: 'search',
+		blockName: 'core/search',
+		convert: () => createBlock( 'core/search' ),
 	},
 	{
-		block: 'core/html',
-		widget: 'custom_html',
-		transform: ( { content } ) => ( {
-			content,
-		} ),
+		idBase: 'custom_html',
+		blockName: 'core/html',
+		convert: ( { content } ) =>
+			createBlock( 'core/html', {
+				content,
+			} ),
 	},
 	{
-		block: 'core/archives',
-		widget: 'archives',
-		transform: ( { count, dropdown } ) => {
-			return {
+		idBase: 'archives',
+		blockName: 'core/archives',
+		convert: ( { count, dropdown } ) =>
+			createBlock( 'core/archives', {
 				displayAsDropdown: !! dropdown,
 				showPostCounts: !! count,
-			};
-		},
+			} ),
 	},
 	{
-		block: 'core/latest-posts',
-		widget: 'recent-posts',
-		transform: ( { show_date: displayPostDate, number } ) => {
-			return {
+		idBase: 'recent-posts',
+		blockName: 'core/latest-posts',
+		convert: ( { show_date: displayPostDate, number } ) =>
+			createBlock( 'core/latest-posts', {
 				displayPostDate: !! displayPostDate,
 				postsToShow: number,
-			};
-		},
+			} ),
 	},
 	{
-		block: 'core/latest-comments',
-		widget: 'recent-comments',
-		transform: ( { number } ) => {
-			return {
+		idBase: 'recent-comments',
+		blockName: 'core/latest-comments',
+		convert: ( { number } ) =>
+			createBlock( 'core/latest-comments', {
 				commentsToShow: number,
-			};
-		},
+			} ),
 	},
 	{
-		block: 'core/tag-cloud',
-		widget: 'tag_cloud',
-		transform: ( { taxonomy, count } ) => {
-			return {
+		idBase: 'tag_cloud',
+		blockName: 'core/tag-cloud',
+		convert: ( { taxonomy, count } ) =>
+			createBlock( 'core/tag-cloud', {
 				showTagCounts: !! count,
 				taxonomy,
-			};
-		},
+			} ),
 	},
 	{
-		block: 'core/categories',
-		widget: 'categories',
-		transform: ( { count, dropdown, hierarchical } ) => {
-			return {
+		idBase: 'categories',
+		blockName: 'core/categories',
+		convert: ( { count, dropdown, hierarchical } ) =>
+			createBlock( 'core/categories', {
 				displayAsDropdown: !! dropdown,
 				showPostCounts: !! count,
 				showHierarchy: !! hierarchical,
-			};
-		},
+			} ),
 	},
 	{
-		block: 'core/audio',
-		widget: 'media_audio',
-		transform: ( { url, preload, loop, attachment_id: id } ) => {
-			return {
+		idBase: 'media_audio',
+		blockName: 'core/audio',
+		convert: ( { url, preload, loop, attachment_id: id } ) =>
+			createBlock( 'core/audio', {
 				src: url,
 				id,
 				preload,
 				loop,
-			};
-		},
+			} ),
 	},
 	{
-		block: 'core/video',
-		widget: 'media_video',
-		transform: ( { url, preload, loop, attachment_id: id } ) => {
-			return {
+		idBase: 'media_video',
+		blockName: 'core/video',
+		convert: ( { url, preload, loop, attachment_id: id } ) =>
+			createBlock( 'core/video', {
 				src: url,
 				id,
 				preload,
 				loop,
-			};
-		},
+			} ),
 	},
 	{
-		block: 'core/image',
-		widget: 'media_image',
-		transform: ( {
+		idBase: 'media_image',
+		blockName: 'core/image',
+		convert: ( {
 			alt,
 			attachment_id: id,
 			caption,
@@ -109,8 +105,8 @@ const legacyWidgetTransforms = [
 			size: sizeSlug,
 			url,
 			width,
-		} ) => {
-			return {
+		} ) =>
+			createBlock( 'core/image', {
 				alt,
 				caption,
 				height,
@@ -123,14 +119,13 @@ const legacyWidgetTransforms = [
 				sizeSlug,
 				url,
 				width,
-			};
-		},
+			} ),
 	},
 	{
-		block: 'core/gallery',
-		widget: 'media_gallery',
-		transform: ( { ids, link_type: linkTo, size, number } ) => {
-			return {
+		idBase: 'media_gallery',
+		blockName: 'core/gallery',
+		convert: ( { ids, link_type: linkTo, size, number } ) =>
+			createBlock( 'core/gallery', {
 				ids,
 				columns: number,
 				linkTo,
@@ -138,55 +133,56 @@ const legacyWidgetTransforms = [
 				images: ids.map( ( id ) => ( {
 					id,
 				} ) ),
-			};
-		},
+			} ),
 	},
 	{
-		block: 'core/rss',
-		widget: 'rss',
-		transform: ( {
+		idBase: 'rss',
+		blockName: 'core/rss',
+		convert: ( {
 			url,
 			show_author: displayAuthor,
 			show_date: displayDate,
 			show_summary: displayExcerpt,
 			items,
-		} ) => {
-			return {
+		} ) =>
+			createBlock( 'core/rss', {
 				feedURL: url,
 				displayAuthor: !! displayAuthor,
 				displayDate: !! displayDate,
 				displayExcerpt: !! displayExcerpt,
 				itemsToShow: items,
-			};
-		},
+			} ),
 	},
-].map( ( { block, widget, transform } ) => {
+	{
+		idBase: 'nav_menu',
+		blockName: 'core/navigation',
+		convert: ( { nav_menu: navMenu } ) =>
+			createBlock( 'core/navigation', {}, [], { menuId: navMenu } ),
+	},
+].map( ( { idBase, blockName, convert } ) => {
 	return {
 		type: 'block',
-		blocks: [ block ],
-		isMatch: ( { idBase, instance } ) => {
-			return idBase === widget && !! instance?.raw;
+		blocks: [ blockName ],
+		isMatch( attributes ) {
+			return attributes.idBase === idBase && !! attributes.instance?.raw;
 		},
-		transform: ( { instance } ) => {
-			const transformedBlock = createBlock(
-				block,
-				transform ? transform( instance.raw ) : undefined
-			);
-			if ( ! instance.raw?.title ) {
-				return transformedBlock;
+		transform( attributes ) {
+			const block = convert( attributes.instance.raw );
+			if ( ! attributes.instance.raw?.title ) {
+				return block;
 			}
 			return [
 				createBlock( 'core/heading', {
-					content: instance.raw.title,
+					content: attributes.instance.raw.title,
 				} ),
-				transformedBlock,
+				block,
 			];
 		},
 	};
 } );
 
 const transforms = {
-	to: legacyWidgetTransforms,
+	to: toTransforms,
 };
 
 export default transforms;

--- a/packages/widgets/src/utils.js
+++ b/packages/widgets/src/utils.js
@@ -3,31 +3,26 @@
 /**
  * Get the internal widget id from block.
  *
- * @typedef  {Object} Attributes
- * @property {string}     __internalWidgetId The internal widget id.
- * @typedef  {Object} Block
- * @property {Attributes} attributes         The attributes of the block.
- *
- * @param    {Block}      block              The block.
+ * @param {Object} block The block.
  * @return {string} The internal widget id.
  */
 export function getWidgetIdFromBlock( block ) {
-	return block.attributes.__internalWidgetId;
+	return block.meta.widgetId;
 }
 
 /**
  * Add internal widget id to block's attributes.
  *
- * @param {Block}  block    The block.
+ * @param {Object} block    The block.
  * @param {string} widgetId The widget id.
- * @return {Block} The updated block.
+ * @return {Object} The updated block.
  */
 export function addWidgetIdToBlock( block, widgetId ) {
 	return {
 		...block,
-		attributes: {
-			...( block.attributes || {} ),
-			__internalWidgetId: widgetId,
+		meta: {
+			...block.meta,
+			widgetId,
 		},
 	};
 }

--- a/packages/widgets/src/utils.js
+++ b/packages/widgets/src/utils.js
@@ -7,7 +7,7 @@
  * @return {string} The internal widget id.
  */
 export function getWidgetIdFromBlock( block ) {
-	return block.meta.widgetId;
+	return block.params.widgetId;
 }
 
 /**
@@ -20,8 +20,8 @@ export function getWidgetIdFromBlock( block ) {
 export function addWidgetIdToBlock( block, widgetId ) {
 	return {
 		...block,
-		meta: {
-			...block.meta,
+		params: {
+			...block.params,
 			widgetId,
 		},
 	};


### PR DESCRIPTION
## What & why

This PR experiments with adding `params` to the block API.

```js
const block = createBlock( { // passing an object to access advanced use-cases
	name: 'core/file',
	attributes: { fileName: file.name },
	innerBlocks: [],
	params: { blobURL: createBlobURL( file ) }, // block params
} );
```

The `params` object is like `attributes` in that it is passed to the block's `edit` functions for the lifecycle of that block. Unlike `attributes`, though, `params` is:

- Read only. There is no `setParams` passed to `edit`.
- Not serialised. The data in `params` is not written to the database and does not appear in the markup returned from `serialize( block )`.
- Not passed to `save`. This is to prevent block validation / deprecation issues.

If you consider that blocks are kind of like React components, then you can think of `attributes` as state and `params` as props. It's a way of passing data to a block without affecting its state.

The motivation for this is to fix a longstanding issue we've had in Gutenberg which is that we use attributes to store "internal" state in certain blocks. For example an undo level is created when dragging-and-dropping an image or file into the editor because the blob URL is stored in the `url` attribute while the file is uploaded. I've included a fix for the File block (61ad7075048e97243228f81b0b7f603b9eed016f) to illustrate how `params` helps.

I've also included fixes for two other issues to illustrate that there are many uses for such an API:

- 9a6957446ff016951001d9b15a5e5f99dbc6a349 Removing the `__internalWidgetId` attribute in favour of `params`. `__internalWidgetId` is how the widget editor tracks which widget entity should be updated when a block is modified. It's a hack that works because `__internalWidgetId` does not appear in the `block.json` and so is filtered out by `serialize()`. 
- d8af0cb32247d175aeb4b0c4dc152f3f2d0657ad Allowing Menu widgets wrapped in a Legacy Widget block to be converted to a Navigation block. This is fixed by having the transform provide the Navigation block with the menu to convert via `params.menuId`. See https://github.com/WordPress/gutenberg/issues/47285.

## Alternatives 

One alternative would be to use attributes but mark them as "private".

```json
"blobUrl": {
	"type": "string",
	"access": "private",
}
```

The downside of this is that implementation details appear for all to see in `block.json`.