### PR TITLE
Add spacing tools to time to read block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -590,7 +590,7 @@ Show minutes required to finish reading the post. ([Source](https://github.com/W
 
 -	**Name:** core/post-time-to-read
 -	**Category:** theme
--	**Supports:** typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** textAlign
 
 ## Post Title

--- a/packages/block-library/src/post-time-to-read/block.json
+++ b/packages/block-library/src/post-time-to-read/block.json
@@ -15,6 +15,10 @@
 	},
 	"supports": {
 		"html": false,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,

--- a/packages/block-library/src/post-time-to-read/style.scss
+++ b/packages/block-library/src/post-time-to-read/style.scss
@@ -1,0 +1,4 @@
+.wp-block-post-time-to-read {
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -32,6 +32,7 @@
 @import "./post-featured-image/style.scss";
 @import "./post-navigation-link/style.scss";
 @import "./post-terms/style.scss";
+@import "./post-time-to-read/style.scss";
 @import "./post-title/style.scss";
 @import "./preformatted/style.scss";
 @import "./pullquote/style.scss";


### PR DESCRIPTION
## What?
Closes #48968

Adds spacing tools (padding, margin) to the time to read block.

## Why?
See #48968

## How?
Adds the spacing support properties to the block.json.

## Testing Instructions
1. Add a Time to Read block to a post
2. Adjust margin and padding
3. The margin or padding should show in the editor
4. Preview the post
5. The margin or padding should show in the front-end

## Screenshots or screencast <!-- if applicable -->
![Screen Shot 2023-03-28 at 2 16 55 pm](https://user-images.githubusercontent.com/677833/228145578-f54a3b6a-6872-4986-a3ee-e753ea22ca84.png)

