### PR TITLE
Home Link Block: Remove leading spaces in class names

### DIFF
--- a/packages/block-library/src/home-link/index.php
+++ b/packages/block-library/src/home-link/index.php
@@ -98,12 +98,12 @@ function block_core_home_link_build_li_wrapper_attributes( $context ) {
 		$colors['css_classes'],
 		$font_sizes['css_classes']
 	);
+	$classes[]       = 'wp-block-navigation-item';
 	$style_attribute = ( $colors['inline_styles'] . $font_sizes['inline_styles'] );
-	$css_classes     = trim( implode( ' ', $classes ) ) . ' wp-block-navigation-item';
 
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
-			'class' => $css_classes,
+			'class' => implode( ' ', $classes ),
 			'style' => $style_attribute,
 		)
 	);


### PR DESCRIPTION
## What?
This PR removes leading spaces in the class name when the Home Link block is rendered as a `li` element in a navigation block.

## Testing Instructions

- In the site editor, insert the navigation block.
- Insert a Home Link block in the navigation block.
- Apply some block styles.
- On the front end, confirm that there are no leading spaces in the class attribute value.

### Before

![before](https://user-images.githubusercontent.com/54422211/228250303-133420b6-ab6b-4752-98c6-b64c5635840f.png)

### After

![after](https://user-images.githubusercontent.com/54422211/228250328-0fd01714-5463-4827-9999-c553ff732a71.png)
