### PR TITLE
Remove left/right/center block alignment controls from the Post Template block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -572,7 +572,7 @@ Contains the block elements used to render a post, like the title, date, feature
 
 -	**Name:** core/post-template
 -	**Category:** theme
--	**Supports:** align, anchor, color (background, gradients, link, text), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** 
 
 ## Post Terms

--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -18,7 +18,7 @@
 	"supports": {
 		"reusable": false,
 		"html": false,
-		"align": true,
+		"align": [ "wide", "full" ],
 		"anchor": true,
 		"__experimentalLayout": {
 			"allowEditing": false


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Removes irrelevant left/right/center alignment controls for the core/post-template block. Closes https://github.com/WordPress/gutenberg/issues/49410. 

## Why?
They don't really work, and break the layout when applied. 

## How?
Set align block support to wide and full; wide/full should both still be available as the Query loop supports layout.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page.
2. Insert a Query Loop block and add one of the starter variations.
3. Click on Post Template block.
4. See alignment controls are no longer available within the block toolbar.
5. Set parent Query Loop block layout option on. 
6. Click on Post Template block.
7. See the wide and full alignment controls available. 

## Screenshots or screencast <!-- if applicable -->

Before: 

https://user-images.githubusercontent.com/1813435/228351290-2044bf5a-563e-49b6-bb20-0987c4801335.mp4

After:

<img width="1257" alt="CleanShot 2023-03-28 at 15 49 17" src="https://user-images.githubusercontent.com/1813435/228351049-04d671e4-b982-443d-9d7b-c71593384503.png">

