### PR TITLE
ImageSizeControl: Remove the "Image Dimensions" label

### DIFF
--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -48,8 +48,6 @@ export default function ImageSizeControl( {
 			) }
 			{ isResizable && (
 				<div className="block-editor-image-size-control">
-					<p>{ __( 'Image dimensions' ) }</p>
-
 					<HStack align="baseline" spacing="3">
 						<NumberControl
 							className="block-editor-image-size-control__width"

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   `ImageSizeControl`: Remove the "Image Dimensions" label ([#49414](https://github.com/WordPress/gutenberg/pull/49414)).
+
 ### Internal
 
 -   `Animate`: Convert to TypeScript ([#49243](https://github.com/WordPress/gutenberg/pull/49243)).


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Removes the extraneous "Image Dimensions" label within the ImageSizeControl component. It was sort of necessary when we had competing "Image size" labels, but now those are changed to "Resolution" via https://github.com/WordPress/gutenberg/pull/49112. 

## Why?
Following up on a string of image/media related PRs to map closer towards @jasmussen 's mockups in https://github.com/WordPress/gutenberg/issues/48618#issuecomment-1451460526. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page. 
2. Insert & complete the Image, Media & Text, and Latest Posts blocks (those use the ImageSizeControl component).
3. Open Block Inspector. 
4. See Resolution, then the Width and Height controls (for the blocks that support height/width) 

## Screenshots or screencast <!-- if applicable -->

Before (Image block): 

<img width="280" alt="CleanShot 2023-03-28 at 17 22 47" src="https://user-images.githubusercontent.com/1813435/228370003-ad656ed4-e4b8-49d1-af99-988f0020d4fb.png">

After (Image block): 

<img width="280" alt="CleanShot 2023-03-28 at 17 13 30" src="https://user-images.githubusercontent.com/1813435/228369795-a65776cc-36ff-4e72-a6f5-21710da0535a.png">

