### PR TITLE
Post Lock: Fix the avatar position

### DIFF
--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -8,6 +8,7 @@ import {
 	ExternalLink,
 	Flex,
 	FlexItem,
+	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
@@ -175,55 +176,30 @@ export default function PostLockedModal() {
 			isDismissible={ false }
 			className="editor-post-locked-modal"
 		>
-			{ !! userAvatar && (
-				<img
-					src={ userAvatar }
-					alt={ __( 'Avatar' ) }
-					className="editor-post-locked-modal__avatar"
-					width={ 64 }
-					height={ 64 }
-				/>
-			) }
-			<div>
-				{ !! isTakeover && (
-					<p>
-						{ createInterpolateElement(
-							userDisplayName
-								? sprintf(
-										/* translators: %s: user's display name */
-										__(
-											'<strong>%s</strong> now has editing control of this post (<PreviewLink />). Don’t worry, your changes up to this moment have been saved.'
-										),
-										userDisplayName
-								  )
-								: __(
-										'Another user now has editing control of this post (<PreviewLink />). Don’t worry, your changes up to this moment have been saved.'
-								  ),
-							{
-								strong: <strong />,
-								PreviewLink: (
-									<ExternalLink href={ previewLink }>
-										{ __( 'preview' ) }
-									</ExternalLink>
-								),
-							}
-						) }
-					</p>
+			<HStack alignment="top" spacing={ 6 }>
+				{ !! userAvatar && (
+					<img
+						src={ userAvatar }
+						alt={ __( 'Avatar' ) }
+						className="editor-post-locked-modal__avatar"
+						width={ 64 }
+						height={ 64 }
+					/>
 				) }
-				{ ! isTakeover && (
-					<>
+				<div>
+					{ !! isTakeover && (
 						<p>
 							{ createInterpolateElement(
 								userDisplayName
 									? sprintf(
 											/* translators: %s: user's display name */
 											__(
-												'<strong>%s</strong> is currently working on this post (<PreviewLink />), which means you cannot make changes, unless you take over.'
+												'<strong>%s</strong> now has editing control of this post (<PreviewLink />). Don’t worry, your changes up to this moment have been saved.'
 											),
 											userDisplayName
 									  )
 									: __(
-											'Another user is currently working on this post (<PreviewLink />), which means you cannot make changes, unless you take over.'
+											'Another user now has editing control of this post (<PreviewLink />). Don’t worry, your changes up to this moment have been saved.'
 									  ),
 								{
 									strong: <strong />,
@@ -235,33 +211,60 @@ export default function PostLockedModal() {
 								}
 							) }
 						</p>
-						<p>
-							{ __(
-								'If you take over, the other user will lose editing control to the post, but their changes will be saved.'
-							) }
-						</p>
-					</>
-				) }
-
-				<Flex
-					className="editor-post-locked-modal__buttons"
-					justify="flex-end"
-					expanded={ false }
-				>
+					) }
 					{ ! isTakeover && (
+						<>
+							<p>
+								{ createInterpolateElement(
+									userDisplayName
+										? sprintf(
+												/* translators: %s: user's display name */
+												__(
+													'<strong>%s</strong> is currently working on this post (<PreviewLink />), which means you cannot make changes, unless you take over.'
+												),
+												userDisplayName
+										  )
+										: __(
+												'Another user is currently working on this post (<PreviewLink />), which means you cannot make changes, unless you take over.'
+										  ),
+									{
+										strong: <strong />,
+										PreviewLink: (
+											<ExternalLink href={ previewLink }>
+												{ __( 'preview' ) }
+											</ExternalLink>
+										),
+									}
+								) }
+							</p>
+							<p>
+								{ __(
+									'If you take over, the other user will lose editing control to the post, but their changes will be saved.'
+								) }
+							</p>
+						</>
+					) }
+
+					<Flex
+						className="editor-post-locked-modal__buttons"
+						justify="flex-end"
+						expanded={ false }
+					>
+						{ ! isTakeover && (
+							<FlexItem>
+								<Button variant="tertiary" href={ unlockUrl }>
+									{ __( 'Take over' ) }
+								</Button>
+							</FlexItem>
+						) }
 						<FlexItem>
-							<Button variant="tertiary" href={ unlockUrl }>
-								{ __( 'Take over' ) }
+							<Button variant="primary" href={ allPostsUrl }>
+								{ allPostsLabel }
 							</Button>
 						</FlexItem>
-					) }
-					<FlexItem>
-						<Button variant="primary" href={ allPostsUrl }>
-							{ allPostsLabel }
-						</Button>
-					</FlexItem>
-				</Flex>
-			</div>
+					</Flex>
+				</div>
+			</HStack>
 		</Modal>
 	);
 }

--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -6,8 +6,6 @@ import {
 	Modal,
 	Button,
 	ExternalLink,
-	Flex,
-	FlexItem,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -245,24 +243,19 @@ export default function PostLockedModal() {
 						</>
 					) }
 
-					<Flex
+					<HStack
 						className="editor-post-locked-modal__buttons"
 						justify="flex-end"
-						expanded={ false }
 					>
 						{ ! isTakeover && (
-							<FlexItem>
-								<Button variant="tertiary" href={ unlockUrl }>
-									{ __( 'Take over' ) }
-								</Button>
-							</FlexItem>
-						) }
-						<FlexItem>
-							<Button variant="primary" href={ allPostsUrl }>
-								{ allPostsLabel }
+							<Button variant="tertiary" href={ unlockUrl }>
+								{ __( 'Take over' ) }
 							</Button>
-						</FlexItem>
-					</Flex>
+						) }
+						<Button variant="primary" href={ allPostsUrl }>
+							{ allPostsLabel }
+						</Button>
+					</HStack>
 				</div>
 			</HStack>
 		</Modal>

--- a/packages/editor/src/components/post-locked-modal/style.scss
+++ b/packages/editor/src/components/post-locked-modal/style.scss
@@ -2,10 +2,6 @@
 	@include break-small() {
 		max-width: $break-mobile;
 	}
-
-	.components-modal__content {
-		display: flex;
-	}
 }
 
 .editor-post-locked-modal__buttons {
@@ -15,5 +11,5 @@
 .editor-post-locked-modal__avatar {
 	border-radius: $radius-block-ui;
 	margin-top: $grid-unit-20;
-	margin-right: $grid-unit-30;
+	min-width: initial !important;
 }


### PR DESCRIPTION
## What?
PR fixes the avatar position regression in the Post Lock modal.

P.S. It's easier to review code changes by hiding whitespaces - https://github.com/WordPress/gutenberg/pull/49421/files?diff=unified&w=1.

## Why?
The modal markup changed recently, and the previous styling wasn't applied. See #47426.

## How?
Wraps modal content into an `HStack` component.

I also pushed minor code quality updates in [c50b379](https://github.com/WordPress/gutenberg/pull/49421/commits/c50b3798192960e79417f7ece30f51908ffaff69).

## Testing Instructions
* Add the snippet below to the theme functions.php and emulate the post-lock state.
* Confirm the avatar is correctly aligned.

<details><summary>Snippet</summary>
<p>

```php
add_filter( 'block_editor_settings_all', function( $settings, $block_editor_context ) {
	if ( empty( $block_editor_context->post ) ) {
		return $settings;
	}

	if ( isset( $settings['postLock']['user'] ) ) {
		return $settings;
	}

	$user = wp_get_current_user();
	if ( ! isset( $user->ID ) ) {
		return $settings;
	}

	$settings['postLock'] = [
		'isLocked' => true,
		'user'     => [
			'name'   => $user->display_name,
			'avatar' => get_avatar_url( $user->ID, array( 'size' => 64 ) ),
		],
	];

	return $settings;
}, 10, 2 );
```

</p>
</details> 


## Screenshots or screencast <!-- if applicable -->

**Before**
![CleanShot 2023-03-29 at 09 44 42](https://user-images.githubusercontent.com/240569/228441677-f3814e79-50cb-42f4-8058-d2497e746410.png)

**After**
![CleanShot 2023-03-29 at 10 00 19](https://user-images.githubusercontent.com/240569/228441708-90eb7df9-741b-4f2c-8721-b0dfd58cffc7.png)

