### PR TITLE
Fix padding and margin visualizer accuracy

### DIFF
--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -1,43 +1,48 @@
 /**
  * WordPress dependencies
  */
-import { useMemo, useRef, useState, useEffect } from '@wordpress/element';
+import { useState, useRef, useEffect } from '@wordpress/element';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * Internal dependencies
  */
 import BlockPopover from '../components/block-popover';
-import { getSpacingPresetCssVar } from '../components/spacing-sizes-control/utils';
+import { __unstableUseBlockElement as useBlockElement } from '../components/block-list/use-block-props/use-block-refs';
+
+function getComputedCSS( element, property ) {
+	return element.ownerDocument.defaultView
+		.getComputedStyle( element )
+		.getPropertyValue( property );
+}
 
 export function MarginVisualizer( { clientId, attributes, forceShow } ) {
+	const blockElement = useBlockElement( clientId );
+	const [ style, setStyle ] = useState();
+
 	const margin = attributes?.style?.spacing?.margin;
 
-	const style = useMemo( () => {
-		const marginTop = margin?.top
-			? getSpacingPresetCssVar( margin?.top )
-			: 0;
-		const marginRight = margin?.right
-			? getSpacingPresetCssVar( margin?.right )
-			: 0;
-		const marginBottom = margin?.bottom
-			? getSpacingPresetCssVar( margin?.bottom )
-			: 0;
-		const marginLeft = margin?.left
-			? getSpacingPresetCssVar( margin?.left )
-			: 0;
+	useEffect( () => {
+		if ( ! blockElement ) {
+			return;
+		}
 
-		return {
-			borderTopWidth: marginTop,
-			borderRightWidth: marginRight,
-			borderBottomWidth: marginBottom,
-			borderLeftWidth: marginLeft,
-			top: marginTop ? `calc(${ marginTop } * -1)` : 0,
-			right: marginRight ? `calc(${ marginRight } * -1)` : 0,
-			bottom: marginBottom ? `calc(${ marginBottom } * -1)` : 0,
-			left: marginLeft ? `calc(${ marginLeft } * -1)` : 0,
-		};
-	}, [ margin ] );
+		const top = getComputedCSS( blockElement, 'margin-top' );
+		const right = getComputedCSS( blockElement, 'margin-right' );
+		const bottom = getComputedCSS( blockElement, 'margin-bottom' );
+		const left = getComputedCSS( blockElement, 'margin-left' );
+
+		setStyle( {
+			borderTopWidth: top,
+			borderRightWidth: right,
+			borderBottomWidth: bottom,
+			borderLeftWidth: left,
+			top: top ? `-${ top }` : 0,
+			right: right ? `-${ right }` : 0,
+			bottom: bottom ? `-${ bottom }` : 0,
+			left: left ? `-${ left }` : 0,
+		} );
+	}, [ blockElement, margin ] );
 
 	const [ isActive, setIsActive ] = useState( false );
 	const valueRef = useRef( margin );

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -1,12 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	useState,
-	useRef,
-	useEffect,
-	useLayoutEffect,
-} from '@wordpress/element';
+import { useState, useRef, useEffect } from '@wordpress/element';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
@@ -25,46 +20,21 @@ export function PaddingVisualizer( { clientId, attributes, forceShow } ) {
 	const blockElement = useBlockElement( clientId );
 	const [ style, setStyle ] = useState();
 
-	useLayoutEffect( () => {
+	const padding = attributes?.style?.spacing?.padding;
+
+	useEffect( () => {
 		if ( ! blockElement ) {
 			return;
 		}
 
-		let resizeObserver;
-		const blockView = blockElement?.ownerDocument?.defaultView;
+		setStyle( {
+			borderTopWidth: getComputedCSS( blockElement, 'padding-top' ),
+			borderRightWidth: getComputedCSS( blockElement, 'padding-right' ),
+			borderBottomWidth: getComputedCSS( blockElement, 'padding-bottom' ),
+			borderLeftWidth: getComputedCSS( blockElement, 'padding-left' ),
+		} );
+	}, [ blockElement, padding ] );
 
-		if ( blockView.ResizeObserver ) {
-			resizeObserver = new blockView.ResizeObserver( () => {
-				setStyle( {
-					borderTopWidth: getComputedCSS(
-						blockElement,
-						'padding-top'
-					),
-					borderRightWidth: getComputedCSS(
-						blockElement,
-						'padding-right'
-					),
-					borderBottomWidth: getComputedCSS(
-						blockElement,
-						'padding-bottom'
-					),
-					borderLeftWidth: getComputedCSS(
-						blockElement,
-						'padding-left'
-					),
-				} );
-			} );
-			resizeObserver.observe( blockElement );
-		}
-
-		return () => {
-			if ( resizeObserver ) {
-				resizeObserver.disconnect();
-			}
-		};
-	}, [ blockElement ] );
-
-	const padding = attributes?.style?.spacing?.padding;
 	const [ isActive, setIsActive ] = useState( false );
 	const valueRef = useRef( padding );
 	const timeoutRef = useRef();

--- a/packages/block-editor/src/hooks/padding.scss
+++ b/packages/block-editor/src/hooks/padding.scss
@@ -9,4 +9,5 @@
 	border-style: solid;
 	pointer-events: none;
 	box-sizing: border-box;
+	transition: border 0.1s;
 }

--- a/packages/block-editor/src/hooks/padding.scss
+++ b/packages/block-editor/src/hooks/padding.scss
@@ -9,5 +9,4 @@
 	border-style: solid;
 	pointer-events: none;
 	box-sizing: border-box;
-	transition: border 0.3s;
 }

--- a/packages/block-editor/src/hooks/padding.scss
+++ b/packages/block-editor/src/hooks/padding.scss
@@ -9,5 +9,5 @@
 	border-style: solid;
 	pointer-events: none;
 	box-sizing: border-box;
-	transition: border 0.1s;
+	transition: border 0.3s;
 }


### PR DESCRIPTION
## What?
I've noticed on a few occasions that the padding and margin visualizers can be incorrect.

In https://github.com/WordPress/gutenberg/pull/49392#issuecomment-1487947950 I figured out why this is.

It happens for themes that use relative CSS units for spacing presets.

The visualizers are rendered in a popover slot, outside the editor canvas iframe. This means units like `vh`, `vw`, `rem` and `em` might be computed incorrectly because they're using font size and the viewports size of the top level document, not those from the editor canvas document like the block uses.

## How?
There are two ways that I considered fixing this:
1. Render the visualizers as a sibling of the block (similar to what I'm having to do in #45056).
2. Use the computed CSS values from the block instead of the spacing preset CSS vars.

I went with option 2 because it's easier and seems to work correctly

## Testing Instructions
1. Use TT3 with the default variation
2. Add a paragraph block
3. Adjust margin and padding, ensure the visualizer looks correct

## Screenshots or screencast <!-- if applicable -->
#### Before

https://user-images.githubusercontent.com/677833/228446064-03a86411-387b-4429-a605-23867c00c3d6.mp4

#### After

https://user-images.githubusercontent.com/677833/228446371-0a9ec7b6-ad24-4e18-8ba2-dc26c93a0fa4.mp4

