### PR TITLE
Selectors API: Make duotone selectors fallback and be scoped

### DIFF
--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -229,48 +229,6 @@ When the block declares support for `color.background`, the attributes definitio
   }
   ```
 
-### color.__experimentalDuotone
-
-This property adds UI controls which allow to apply a duotone filter to a block or part of a block.
-
-The parent selector is automatically added much like nesting in Sass/SCSS (however, the `&` selector is not supported).
-
-```js
-supports: {
-    color: {
-        // Apply the filter to the same selector in both edit and save.
-        __experimentalDuotone: '> .duotone-img, > .duotone-video',
-
-        // Default values must be disabled if you don't want to use them with duotone.
-        background: false,
-        text: false
-    }
-}
-```
-
-Duotone presets are sourced from `color.duotone` in [theme.json](/docs/how-to-guides/themes/theme-json.md).
-
-When the block declares support for `color.__experimentalDuotone`, the attributes definition is extended to include the attribute `style`:
-
-- `style`: attribute of `object` type with no default assigned.
-
-  The block can apply a default duotone color by specifying its own attribute with a default e.g.:
-
-  ```js
-  attributes: {
-      style: {
-          type: 'object',
-          default: {
-              color: {
-                  duotone: [
-                      '#FFF',
-                      '#000'
-                  ]
-              }
-          }
-      }
-  }
-  ```
 
 ### color.gradients
 
@@ -498,6 +456,43 @@ attributes: {
     }
 }
 ```
+
+## filter
+-   Type: `Object`
+-   Default value: null
+-   Subproperties:
+    -   `duotone`: type `boolean`, default value `false`
+
+This value signals that a block supports some of the properties related to filters. When it does, the block editor will show UI controls for the user to set their values.
+
+### filter.duotone
+
+This property adds UI controls which allow the user to apply a duotone filter to
+a block or part of a block.
+
+Duotone presets are sourced from `color.duotone` in [theme.json](/docs/how-to-guides/themes/theme-json.md).
+
+When the block declares support for `filter.duotone`, the attributes definition is extended to include the attribute `style`:
+
+- `style`: attribute of `object` type with no default assigned.
+
+  The block can apply a default duotone color by specifying its own attribute with a default e.g.:
+
+  ```js
+  attributes: {
+      style: {
+          type: 'object',
+          default: {
+              color: {
+                  duotone: [
+                      '#FFF',
+                      '#000'
+                  ]
+              }
+          }
+      }
+  }
+  ```
 
 ## html
 

--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -139,7 +139,6 @@ supports: {
 -   Default value: null
 -   Subproperties:
     -   `background`: type `boolean`, default value `true`
-    -   `__experimentalDuotone`: type `string`, default value undefined
     -   `gradients`: type `boolean`, default value `false`
     -   `link`: type `boolean`, default value `false`
     -   `text`: type `boolean`, default value `true`

--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -469,6 +469,23 @@ This value signals that a block supports some of the properties related to filte
 This property adds UI controls which allow the user to apply a duotone filter to
 a block or part of a block.
 
+```js
+supports: {
+    filter: {
+        // Enable duotone support
+        duotone: true
+    }
+},
+selectors: {
+    filter: {
+        // Apply the filter to img elements inside the image block
+        duotone: '.wp-block-image img'
+    }
+}
+```
+
+The filter can be applied to an element inside the block by setting the `selectors.filter.duotone` selector.
+
 Duotone presets are sourced from `color.duotone` in [theme.json](/docs/how-to-guides/themes/theme-json.md).
 
 When the block declares support for `filter.duotone`, the attributes definition is extended to include the attribute `style`:

--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -228,6 +228,11 @@ When the block declares support for `color.background`, the attributes definitio
   }
   ```
 
+### color.__experimentalDuotone
+
+_**Note:** Deprecated since WordPress 6.3._
+
+This property has been replaced by [`filter.duotone`](#filter-duotone). 
 
 ### color.gradients
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -311,7 +311,7 @@ Insert an image to make a visual statement. ([Source](https://github.com/WordPre
 
 -	**Name:** core/image
 -	**Category:** media
--	**Supports:** anchor, color (~~background~~, ~~text~~)
+-	**Supports:** anchor, color (~~background~~, ~~text~~), filter (duotone)
 -	**Attributes:** align, alt, caption, height, href, id, linkClass, linkDestination, linkTarget, rel, sizeSlug, title, url, width
 
 ## Latest Comments

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -436,25 +436,6 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	return WP_Duotone_Gutenberg::render_duotone_support( $block_content, $block );
 }
 
-/**
- * Migrate the old experimental duotone support flag to its stabilized location
- * under `supports.filter.duotone` and sets.
- *
- * @param array $settings Current block type settings.
- * @param array $metadata Block metadata as read in via block.json.
- *
- * @return array Filtered block type settings.
- */
-function gutenberg_migrate_experimental_duotone_support_flag( $settings, $metadata ) {
-	$duotone_support = _wp_array_get( $metadata, array( 'supports', 'color', '__experimentalDuotone' ), null );
-
-	if ( ! isset( $settings['supports']['filter']['duotone'] ) && null !== $duotone_support ) {
-		_wp_array_set( $settings, array( 'supports', 'filter', 'duotone' ), (bool) $duotone_support );
-	}
-
-	return $settings;
-}
-
 // Register the block support.
 WP_Block_Supports::get_instance()->register(
 	'duotone',
@@ -471,4 +452,4 @@ add_filter( 'render_block', array( 'WP_Duotone_Gutenberg', 'render_duotone_suppo
 add_action( 'wp_enqueue_scripts', array( 'WP_Duotone_Gutenberg', 'output_global_styles' ), 11 );
 add_action( 'wp_footer', array( 'WP_Duotone_Gutenberg', 'output_footer_assets' ), 10 );
 add_filter( 'block_editor_settings_all', array( 'WP_Duotone_Gutenberg', 'add_editor_settings' ), 10 );
-add_filter( 'block_type_metadata_settings', 'gutenberg_migrate_experimental_duotone_support_flag', 10, 2 );
+add_filter( 'block_type_metadata_settings', array( 'WP_Duotone_Gutenberg', 'migrate_experimental_duotone_support_flag' ), 10, 2 );

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -349,25 +349,14 @@ class WP_Duotone_Gutenberg {
 		$filter_id = gutenberg_get_duotone_filter_id( array( 'slug' => $slug ) );
 
 		// Build the CSS selectors to which the filter will be applied.
-		$scopes    = explode( ',', '.' . $filter_id );
 		$selectors = explode( ',', $duotone_selector );
 
 		$selectors_scoped = array();
-		foreach ( $scopes as $outer ) {
-			foreach ( $selectors as $inner ) {
-				$outer = trim( $outer );
-				$inner = trim( $inner );
-				if ( ! empty( $outer ) && ! empty( $inner ) ) {
-					// unlike WP_Theme_JSON_Gutenberg::scope_selector
-					// this concatenates the selectors without a space.
-					$selectors_scoped[] = $outer . '' . $inner;
-				} elseif ( empty( $outer ) ) {
-					$selectors_scoped[] = $inner;
-				} elseif ( empty( $inner ) ) {
-					$selectors_scoped[] = $outer;
-				}
-			}
+		foreach ( $selectors as $selector_part ) {
+			// The selector part should always begin with the block's class, so we can safely just prepend the filter id class.
+			$selectors_scoped[] = '.' . $filter_id . trim( $selector_part );
 		}
+
 		$selector = implode( ', ', $selectors_scoped );
 
 		// We only want to add the selector if we have it in the output already, essentially skipping 'unset'.

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -278,13 +278,13 @@ class WP_Duotone_Gutenberg {
 		$duotone_selector = null;
 
 		if ( $block_type && property_exists( $block_type, 'supports' ) ) {
-			$duotone_support = _wp_array_get( $block_type->supports, array( 'filter', 'duotone' ), false );
+			$duotone_support  = _wp_array_get( $block_type->supports, array( 'filter', 'duotone' ), false );
 			$duotone_selector = wp_get_block_css_selector( $block_type, array( 'filter', 'duotone' ), true );
 
 			// Keep backwards compatibility for support.color.__experimentalDuotone.
 			if ( ! $duotone_support || ! $duotone_selector ) {
-				$duotone_support = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), false );
-				$root_selector = wp_get_block_css_selector( $block_type, 'root' );
+				$duotone_support  = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), false );
+				$root_selector    = wp_get_block_css_selector( $block_type, 'root' );
 				$duotone_selector = WP_Theme_JSON_Gutenberg::scope_selector( $root_selector, $duotone_support );
 			}
 		}

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -264,6 +264,13 @@ class WP_Duotone_Gutenberg {
 		}
 	}
 
+	/**
+	 * Get the CSS selector for a block type.
+	 * 
+	 * @param string $block_name The block name.
+	 * 
+	 * @return string The CSS selector or null if there is no support.
+	 */
 	private static function get_selector( $block_name ) {
 		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
 
@@ -276,7 +283,7 @@ class WP_Duotone_Gutenberg {
 			// at the same time.
 			$experimental_duotone = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), false );
 			if ( $experimental_duotone ) {
-				$root_selector    = wp_get_block_css_selector( $block_type );
+				$root_selector = wp_get_block_css_selector( $block_type );
 				return is_string( $experimental_duotone )
 					? WP_Theme_JSON_Gutenberg::scope_selector( $root_selector, $experimental_duotone )
 					: $root_selector;

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -419,4 +419,23 @@ class WP_Duotone_Gutenberg {
 
 		return $tags->get_updated_html();
 	}
+
+	/**
+	 * Migrate the old experimental duotone support flag to its stabilized location
+	 * under `supports.filter.duotone` and sets.
+	 *
+	 * @param array $settings Current block type settings.
+	 * @param array $metadata Block metadata as read in via block.json.
+	 *
+	 * @return array Filtered block type settings.
+	 */
+	public static function migrate_experimental_duotone_support_flag( $settings, $metadata ) {
+		$duotone_support = _wp_array_get( $metadata, array( 'supports', 'color', '__experimentalDuotone' ), null );
+
+		if ( ! isset( $settings['supports']['filter']['duotone'] ) && null !== $duotone_support ) {
+			_wp_array_set( $settings, array( 'supports', 'filter', 'duotone' ), (bool) $duotone_support );
+		}
+
+		return $settings;
+	}
 }

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -364,7 +364,9 @@ class WP_Duotone_Gutenberg {
 
 		$selectors_scoped = array();
 		foreach ( $selectors as $selector_part ) {
-			// The selector part should always begin with the block's class, so we can safely just prepend the filter id class.
+			// Assuming the selector part is a subclass selector (not a tag name)
+			// so we can prepend the filter id class. If we want to support elements
+			// such as `img` or namespaces, we'll need to add a case for that here.
 			$selectors_scoped[] = '.' . $filter_id . trim( $selector_part );
 		}
 

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -349,7 +349,26 @@ class WP_Duotone_Gutenberg {
 		$filter_id = gutenberg_get_duotone_filter_id( array( 'slug' => $slug ) );
 
 		// Build the CSS selectors to which the filter will be applied.
-		$selector = WP_Theme_JSON_Gutenberg::scope_selector( '.' . $filter_id, $duotone_selector );
+		$scopes    = explode( ',', '.' . $filter_id );
+		$selectors = explode( ',', $duotone_selector );
+
+		$selectors_scoped = array();
+		foreach ( $scopes as $outer ) {
+			foreach ( $selectors as $inner ) {
+				$outer = trim( $outer );
+				$inner = trim( $inner );
+				if ( ! empty( $outer ) && ! empty( $inner ) ) {
+					// unlike WP_Theme_JSON_Gutenberg::scope_selector
+					// this concatenates the selectors without a space.
+					$selectors_scoped[] = $outer . '' . $inner;
+				} elseif ( empty( $outer ) ) {
+					$selectors_scoped[] = $inner;
+				} elseif ( empty( $inner ) ) {
+					$selectors_scoped[] = $outer;
+				}
+			}
+		}
+		$selector = implode( ', ', $selectors_scoped );
 
 		// We only want to add the selector if we have it in the output already, essentially skipping 'unset'.
 		if ( array_key_exists( $slug, self::$output ) ) {

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -278,13 +278,15 @@ class WP_Duotone_Gutenberg {
 		$duotone_selector = null;
 
 		if ( $block_type && property_exists( $block_type, 'supports' ) ) {
+			// Support flag `filter.duotone` will be populated from the previous
+			// `color.__experimentalDuotone` support via block_type_metadata_settings filter.
 			$duotone_support  = _wp_array_get( $block_type->supports, array( 'filter', 'duotone' ), false );
-			$duotone_selector = wp_get_block_css_selector( $block_type, array( 'filter', 'duotone' ), true );
+			$duotone_selector = wp_get_block_css_selector( $block_type, array( 'filter', 'duotone' ) );
 
 			// Keep backwards compatibility for support.color.__experimentalDuotone.
-			if ( ! $duotone_support || ! $duotone_selector ) {
+			if ( $duotone_support && ! $duotone_selector ) {
 				$duotone_support  = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), false );
-				$root_selector    = wp_get_block_css_selector( $block_type, 'root' );
+				$root_selector    = wp_get_block_css_selector( $block_type );
 				$duotone_selector = WP_Theme_JSON_Gutenberg::scope_selector( $root_selector, $duotone_support );
 			}
 		}

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -266,9 +266,9 @@ class WP_Duotone_Gutenberg {
 
 	/**
 	 * Get the CSS selector for a block type.
-	 * 
+	 *
 	 * @param string $block_name The block name.
-	 * 
+	 *
 	 * @return string The CSS selector or null if there is no support.
 	 */
 	private static function get_selector( $block_name ) {

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -275,25 +275,24 @@ class WP_Duotone_Gutenberg {
 		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
 
 		if ( $block_type && property_exists( $block_type, 'supports' ) ) {
-			// Backwards compatibility for color.__experimentalDuotone. This will
-			// have priority over filter.duotone support. Unfortunately we can't
-			// prefer filter.duotone because it gets set when __experimentalDuotone
-			// is set via a block_type_metadata_settings hook. It shouldn't be too
-			// much of a problem because I would expect consumers to not use both
-			// at the same time.
+			// Backwards compatibility with `supports.color.__experimentalDuotone`
+			// is provided via the `block_type_metadata_settings` filter. If
+			// `supports.filter.duotone` has not been set and the experimental
+			// property has been, the experimental property value is copied into
+			// `supports.filter.duotone`.
+			$duotone_support = _wp_array_get( $block_type->supports, array( 'filter', 'duotone' ), false );
+			if ( ! $duotone_support ) {
+				return null;
+			}
+
+			// If the experimental duotone support was set, that value is to be
+			// treated as a selector and requires scoping.
 			$experimental_duotone = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), false );
 			if ( $experimental_duotone ) {
 				$root_selector = wp_get_block_css_selector( $block_type );
 				return is_string( $experimental_duotone )
 					? WP_Theme_JSON_Gutenberg::scope_selector( $root_selector, $experimental_duotone )
 					: $root_selector;
-			}
-
-			// Support flag `filter.duotone` will be populated from the previous
-			// `color.__experimentalDuotone` support via block_type_metadata_settings filter.
-			$duotone_support = _wp_array_get( $block_type->supports, array( 'filter', 'duotone' ), false );
-			if ( ! $duotone_support ) {
-				return null;
 			}
 
 			// Regular filter.duotone support uses filter.duotone selectors with fallbacks.

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -264,6 +264,36 @@ class WP_Duotone_Gutenberg {
 		}
 	}
 
+	private static function get_selector( $block_name ) {
+		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
+
+		if ( $block_type && property_exists( $block_type, 'supports' ) ) {
+			// Backwards compatibility for color.__experimentalDuotone. This will
+			// have priority over filter.duotone support. Unfortunately we can't
+			// prefer filter.duotone because it gets set when __experimentalDuotone
+			// is set via a block_type_metadata_settings hook. It shouldn't be too
+			// much of a problem because I would expect consumers to not use both
+			// at the same time.
+			$experimental_duotone = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), false );
+			if ( $experimental_duotone ) {
+				$root_selector    = wp_get_block_css_selector( $block_type );
+				return is_string( $experimental_duotone )
+					? WP_Theme_JSON_Gutenberg::scope_selector( $root_selector, $experimental_duotone )
+					: $root_selector;
+			}
+
+			// Support flag `filter.duotone` will be populated from the previous
+			// `color.__experimentalDuotone` support via block_type_metadata_settings filter.
+			$duotone_support = _wp_array_get( $block_type->supports, array( 'filter', 'duotone' ), false );
+			if ( ! $duotone_support ) {
+				return null;
+			}
+
+			// Regular filter.duotone support uses filter.duotone selectors with fallbacks.
+			return wp_get_block_css_selector( $block_type, array( 'filter', 'duotone' ), true );
+		}
+	}
+
 	/**
 	 * Render out the duotone CSS styles and SVG.
 	 *
@@ -272,24 +302,7 @@ class WP_Duotone_Gutenberg {
 	 * @return string                Filtered block content.
 	 */
 	public static function render_duotone_support( $block_content, $block ) {
-		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
-
-		$duotone_support  = false;
-		$duotone_selector = null;
-
-		if ( $block_type && property_exists( $block_type, 'supports' ) ) {
-			// Support flag `filter.duotone` will be populated from the previous
-			// `color.__experimentalDuotone` support via block_type_metadata_settings filter.
-			$duotone_support  = _wp_array_get( $block_type->supports, array( 'filter', 'duotone' ), false );
-			$duotone_selector = wp_get_block_css_selector( $block_type, array( 'filter', 'duotone' ) );
-
-			// Keep backwards compatibility for support.color.__experimentalDuotone.
-			if ( $duotone_support && ! $duotone_selector ) {
-				$duotone_support  = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), false );
-				$root_selector    = wp_get_block_css_selector( $block_type );
-				$duotone_selector = WP_Theme_JSON_Gutenberg::scope_selector( $root_selector, $duotone_support );
-			}
-		}
+		$duotone_selector = self::get_selector( $block['blockName'] );
 
 		// The block should have a duotone attribute or have duotone defined in its theme.json to be processed.
 		$has_duotone_attribute     = isset( $block['attrs']['style']['color']['duotone'] );
@@ -297,7 +310,6 @@ class WP_Duotone_Gutenberg {
 
 		if (
 			empty( $block_content ) ||
-			! $duotone_support ||
 			! $duotone_selector ||
 			( ! $has_duotone_attribute && ! $has_global_styles_duotone )
 		) {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -874,8 +874,8 @@ class WP_Theme_JSON_Gutenberg {
 
 			// Keep backwards compatibility for support.color.__experimentalDuotone.
 			if ( null === $duotone_selector ) {
-				$duotone_support = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), false );
-				$root_selector = wp_get_block_css_selector( $block_type, 'root' );
+				$duotone_support  = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), false );
+				$root_selector    = wp_get_block_css_selector( $block_type, 'root' );
 				$duotone_selector = WP_Theme_JSON_Gutenberg::scope_selector( $root_selector, $duotone_support );
 			}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -874,9 +874,12 @@ class WP_Theme_JSON_Gutenberg {
 
 			// Keep backwards compatibility for support.color.__experimentalDuotone.
 			if ( null === $duotone_selector ) {
-				$duotone_support  = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), false );
-				$root_selector    = wp_get_block_css_selector( $block_type, 'root' );
-				$duotone_selector = WP_Theme_JSON_Gutenberg::scope_selector( $root_selector, $duotone_support );
+				$duotone_support = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), null );
+
+				if ( $duotone_support ) {
+					$root_selector    = wp_get_block_css_selector( $block_type );
+					$duotone_selector = WP_Theme_JSON_Gutenberg::scope_selector( $root_selector, $duotone_support );
+				}
 			}
 
 			if ( null !== $duotone_selector ) {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2389,8 +2389,7 @@ class WP_Theme_JSON_Gutenberg {
 
 		// 3. Generate and append the rules that use the duotone selector.
 		if ( isset( $block_metadata['duotone'] ) && ! empty( $declarations_duotone ) ) {
-			$selector_duotone = static::scope_selector( $block_metadata['selector'], $block_metadata['duotone'] );
-			$block_rules     .= static::to_ruleset( $selector_duotone, $declarations_duotone );
+			$block_rules .= static::to_ruleset( $block_metadata['duotone'], $declarations_duotone );
 		}
 
 		// 4. Generate Layout block gap styles.

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -871,6 +871,14 @@ class WP_Theme_JSON_Gutenberg {
 
 			// The block may or may not have a duotone selector.
 			$duotone_selector = wp_get_block_css_selector( $block_type, 'filter.duotone' );
+
+			// Keep backwards compatibility for support.color.__experimentalDuotone.
+			if ( null === $duotone_selector ) {
+				$duotone_support = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), false );
+				$root_selector = wp_get_block_css_selector( $block_type, 'root' );
+				$duotone_selector = WP_Theme_JSON_Gutenberg::scope_selector( $root_selector, $duotone_support );
+			}
+
 			if ( null !== $duotone_selector ) {
 				static::$blocks_metadata[ $block_name ]['duotone'] = $duotone_selector;
 			}

--- a/lib/compat/wordpress-6.3/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.3/get-global-styles-and-settings.php
@@ -53,10 +53,22 @@ if ( ! function_exists( 'wp_get_block_css_selector' ) ) {
 			$target = explode( '.', $target );
 		}
 
-		// Backwards compatibility for supports.__experimentalDuotone selectors when filter.duotone isn't set.
+		// Backwards compatibility for supports.__experimentalDuotone selectors.
 		if ( array( 'filter', 'duotone' ) === $target && null === _wp_array_get( $block_type->selectors, $target ) ) {
 			$duotone_selector = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ) );
-			return null === $duotone_selector ? null : WP_Theme_JSON_Gutenberg::scope_selector( $root_selector, $duotone_selector );
+
+			// String color.__experimentalDuotone values need to be scoped to the root selector.
+			if ( is_string( $duotone_selector ) ) {
+				return WP_Theme_JSON_Gutenberg::scope_selector( $root_selector, $duotone_selector );
+			}
+
+			// When color.__experimentalDuotone is true, the root selector should be used.
+			if ( true === $duotone_selector ) {
+				return $root_selector;
+			}
+
+			// Experimental duotone support is not enabled.
+			return null;
 		}
 
 		// Feature Selectors ( may fallback to root selector ).

--- a/lib/compat/wordpress-6.3/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.3/get-global-styles-and-settings.php
@@ -47,29 +47,6 @@ if ( ! function_exists( 'wp_get_block_css_selector' ) ) {
 
 		$fallback_selector = $fallback ? $root_selector : null;
 
-		// Helper to scope old experimental selectors.
-		$scope_selector = function( $scope, $selector ) {
-			$scopes    = explode( ',', $scope );
-			$selectors = explode( ',', $selector );
-
-			$selectors_scoped = array();
-			foreach ( $scopes as $outer ) {
-				foreach ( $selectors as $inner ) {
-					$outer = trim( $outer );
-					$inner = trim( $inner );
-					if ( ! empty( $outer ) && ! empty( $inner ) ) {
-						$selectors_scoped[] = $outer . ' ' . $inner;
-					} elseif ( empty( $outer ) ) {
-						$selectors_scoped[] = $inner;
-					} elseif ( empty( $inner ) ) {
-						$selectors_scoped[] = $outer;
-					}
-				}
-			}
-
-			return implode( ', ', $selectors_scoped );
-		};
-
 		// Duotone ( may fallback to root selector ).
 		if ( 'filter.duotone' === $target || array( 'filter', 'duotone' ) === $target ) {
 			// If selectors API in use, only use it's value, fallback, or null.
@@ -86,7 +63,7 @@ if ( ! function_exists( 'wp_get_block_css_selector' ) ) {
 			}
 
 			// Scope the duotone selector by the block's root selector.
-			return $scope_selector( $root_selector, $duotone_selector );
+			return WP_Theme_JSON_Gutenberg::scope_selector( $root_selector, $duotone_selector );
 		}
 
 		// If target is not `root` or `duotone` we have a feature or subfeature
@@ -123,7 +100,7 @@ if ( ! function_exists( 'wp_get_block_css_selector' ) ) {
 			}
 
 			// Scope the feature selector by the block's root selector.
-			return $scope_selector( $root_selector, $feature_selector );
+			return WP_Theme_JSON_Gutenberg::scope_selector( $root_selector, $feature_selector );
 		}
 
 		// Subfeature selector

--- a/lib/compat/wordpress-6.3/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.3/get-global-styles-and-settings.php
@@ -25,7 +25,10 @@ if ( ! function_exists( 'wp_get_block_css_selector' ) ) {
 
 		$has_selectors = ! empty( $block_type->selectors );
 
-		// Root Selector ( can be used as a fallback ).
+		// Root Selector ( May be used as a fallback ).
+
+		// Calculated before returning as it can be used as fallback for
+		// feature selectors later on.
 		$root_selector = null;
 
 		if ( $has_selectors && isset( $block_type->selectors['root'] ) ) {
@@ -45,34 +48,16 @@ if ( ! function_exists( 'wp_get_block_css_selector' ) ) {
 			return $root_selector;
 		}
 
-		$fallback_selector = $fallback ? $root_selector : null;
-
 		// If target is not `root` we have a feature or subfeature as the target.
 		// If the target is a string convert to an array.
 		if ( is_string( $target ) ) {
 			$target = explode( '.', $target );
 		}
 
-		// Backwards compatibility for supports.__experimentalDuotone selectors.
-		if ( array( 'filter', 'duotone' ) === $target && null === _wp_array_get( $block_type->selectors, $target ) ) {
-			$duotone_selector = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ) );
-
-			// String color.__experimentalDuotone values need to be scoped to the root selector.
-			if ( is_string( $duotone_selector ) ) {
-				return WP_Theme_JSON_Gutenberg::scope_selector( $root_selector, $duotone_selector );
-			}
-
-			// When color.__experimentalDuotone is true, the root selector should be used.
-			if ( true === $duotone_selector ) {
-				return $root_selector;
-			}
-
-			// Experimental duotone support is not enabled.
-			return null;
-		}
-
-		// Feature Selectors ( may fallback to root selector ).
+		// Feature Selectors ( May fallback to root selector ).
 		if ( 1 === count( $target ) ) {
+			$fallback_selector = $fallback ? $root_selector : null;
+
 			// Prefer the selectors API if available.
 			if ( $has_selectors ) {
 				// Look for selector under `feature.root`.

--- a/lib/compat/wordpress-6.3/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.3/get-global-styles-and-settings.php
@@ -47,29 +47,16 @@ if ( ! function_exists( 'wp_get_block_css_selector' ) ) {
 
 		$fallback_selector = $fallback ? $root_selector : null;
 
-		// Duotone ( may fallback to root selector ).
-		if ( 'filter.duotone' === $target || array( 'filter', 'duotone' ) === $target ) {
-			// If selectors API in use, only use it's value, fallback, or null.
-			if ( $has_selectors ) {
-				return _wp_array_get( $block_type->selectors, array( 'filter', 'duotone' ), $fallback_selector );
-			}
-
-			// Selectors API, not available, check for old experimental selector.
-			$duotone_selector = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), null );
-
-			// Nothing to work with, provide fallback or null.
-			if ( null === $duotone_selector ) {
-				return $fallback_selector;
-			}
-
-			// Scope the duotone selector by the block's root selector.
-			return WP_Theme_JSON_Gutenberg::scope_selector( $root_selector, $duotone_selector );
-		}
-
-		// If target is not `root` or `duotone` we have a feature or subfeature
-		// as the target. If the target is a string convert to an array.
+		// If target is not `root` we have a feature or subfeature as the target.
+		// If the target is a string convert to an array.
 		if ( is_string( $target ) ) {
 			$target = explode( '.', $target );
+		}
+
+		// Backwards compatibility for supports.__experimentalDuotone selectors when filter.duotone isn't set.
+		if ( array( 'filter', 'duotone' ) === $target && null === _wp_array_get( $block_type->selectors, $target ) ) {
+			$duotone_selector = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ) );
+			return null === $duotone_selector ? null : WP_Theme_JSON_Gutenberg::scope_selector( $root_selector, $duotone_selector );
 		}
 
 		// Feature Selectors ( may fallback to root selector ).

--- a/lib/compat/wordpress-6.3/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.3/get-global-styles-and-settings.php
@@ -25,7 +25,7 @@ if ( ! function_exists( 'wp_get_block_css_selector' ) ) {
 
 		$has_selectors = ! empty( $block_type->selectors );
 
-		// Root Selector ( May be used as a fallback ).
+		// Root Selector.
 
 		// Calculated before returning as it can be used as fallback for
 		// feature selectors later on.

--- a/packages/block-editor/src/components/global-styles/get-block-css-selector.js
+++ b/packages/block-editor/src/components/global-styles/get-block-css-selector.js
@@ -56,26 +56,22 @@ export function getBlockCSSSelector(
 
 	const fallbackSelector = fallback ? rootSelector : null;
 
-	// Duotone ( may fallback to root selector ).
-	if ( path === 'filter.duotone' ) {
-		// If selectors API in use, only use its value, fallback, or null.
-		if ( hasSelectors ) {
-			return get( selectors, path, fallbackSelector );
+	// Backwards compatibility for supports.__experimentalDuotone selectors.
+	if ( path === 'filter.duotone' && ! get( selectors, path ) ) {
+		const duotoneSelector = get( supports, 'color.__experimentalDuotone' );
+
+		// String color.__experimentalDuotone values need to be scoped to the root selector.
+		if ( typeof duotoneSelector === 'string' ) {
+			return scopeSelector( rootSelector, duotoneSelector );
 		}
 
-		// Selectors API, not available, check for old experimental selector.
-		const duotoneSelector = get(
-			supports,
-			'color.__experimentalDuotone',
-			null
-		);
-
-		// If nothing to work with, provide fallback selector if available.
-		if ( ! duotoneSelector ) {
-			return fallbackSelector;
+		// When color.__experimentalDuotone is true, the root selector should be used.
+		if ( duotoneSelector === true ) {
+			return rootSelector;
 		}
 
-		return scopeSelector( rootSelector, duotoneSelector );
+		// Experimental duotone support is not enabled.
+		return null;
 	}
 
 	// If target is not `root` or `duotone` we have a feature or subfeature

--- a/packages/block-editor/src/components/global-styles/get-block-css-selector.js
+++ b/packages/block-editor/src/components/global-styles/get-block-css-selector.js
@@ -34,7 +34,9 @@ export function getBlockCSSSelector(
 	const hasSelectors = ! isEmpty( selectors );
 	const path = Array.isArray( target ) ? target.join( '.' ) : target;
 
-	// Root selector ( can be used as fallback ).
+	// Root selector ( may be used as fallback ).
+	// Calculated before returning as it can be used as a fallback for feature
+	// selectors later on.
 	let rootSelector = null;
 
 	if ( hasSelectors && selectors.root ) {
@@ -54,32 +56,14 @@ export function getBlockCSSSelector(
 		return rootSelector;
 	}
 
-	const fallbackSelector = fallback ? rootSelector : null;
-
-	// Backwards compatibility for supports.__experimentalDuotone selectors.
-	if ( path === 'filter.duotone' && ! get( selectors, path ) ) {
-		const duotoneSelector = get( supports, 'color.__experimentalDuotone' );
-
-		// String color.__experimentalDuotone values need to be scoped to the root selector.
-		if ( typeof duotoneSelector === 'string' ) {
-			return scopeSelector( rootSelector, duotoneSelector );
-		}
-
-		// When color.__experimentalDuotone is true, the root selector should be used.
-		if ( duotoneSelector === true ) {
-			return rootSelector;
-		}
-
-		// Experimental duotone support is not enabled.
-		return null;
-	}
-
 	// If target is not `root` or `duotone` we have a feature or subfeature
 	// as the target. If the target is a string convert to an array.
 	const pathArray = Array.isArray( target ) ? target : target.split( '.' );
 
 	// Feature selectors ( may fallback to root selector );
 	if ( pathArray.length === 1 ) {
+		const fallbackSelector = fallback ? rootSelector : null;
+
 		// Prefer the selectors API if available.
 		if ( hasSelectors ) {
 			// Get selector from either `feature.root` or shorthand path.

--- a/packages/block-editor/src/components/global-styles/get-block-css-selector.js
+++ b/packages/block-editor/src/components/global-styles/get-block-css-selector.js
@@ -34,7 +34,8 @@ export function getBlockCSSSelector(
 	const hasSelectors = ! isEmpty( selectors );
 	const path = Array.isArray( target ) ? target.join( '.' ) : target;
 
-	// Root selector ( may be used as fallback ).
+	// Root selector.
+
 	// Calculated before returning as it can be used as a fallback for feature
 	// selectors later on.
 	let rootSelector = null;

--- a/packages/block-editor/src/components/global-styles/test/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/test/use-global-styles-output.js
@@ -713,7 +713,7 @@ describe( 'global styles renderer', () => {
 				'core/image': {
 					name: imageBlock.name,
 					selector: imageSupports.__experimentalSelector,
-					duotoneSelector: imageSupports.color.__experimentalDuotone,
+					duotoneSelector: '.my-image img',
 					fallbackGapValue: undefined,
 					featureSelectors: {
 						root: '.my-image',

--- a/packages/block-editor/src/components/global-styles/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-output.js
@@ -1002,7 +1002,7 @@ export const getBlockSelectors = ( blockTypes, getBlockStyles ) => {
 	const result = {};
 	blockTypes.forEach( ( blockType ) => {
 		const name = blockType.name;
-		const selector = getBlockCSSSelector( blockType, 'root' );
+		const selector = getBlockCSSSelector( blockType );
 		let duotoneSelector = getBlockCSSSelector(
 			blockType,
 			'filter.duotone'
@@ -1010,7 +1010,7 @@ export const getBlockSelectors = ( blockTypes, getBlockStyles ) => {
 
 		// Keep backwards compatibility for support.color.__experimentalDuotone.
 		if ( ! duotoneSelector ) {
-			const rootSelector = getBlockCSSSelector( blockType, 'root' );
+			const rootSelector = getBlockCSSSelector( blockType );
 			const duotoneSupport = getBlockSupport(
 				blockType,
 				'color.__experimentalDuotone',

--- a/packages/block-editor/src/components/global-styles/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-output.js
@@ -19,7 +19,7 @@ import { getCSSRules } from '@wordpress/style-engine';
 /**
  * Internal dependencies
  */
-import { PRESET_METADATA, ROOT_BLOCK_SELECTOR, scopeSelector } from './utils';
+import { PRESET_METADATA, ROOT_BLOCK_SELECTOR } from './utils';
 import { getBlockCSSSelector } from './get-block-css-selector';
 import { getTypographyFontSizeValue } from './typography-utils';
 import { GlobalStylesContext } from './context';
@@ -859,10 +859,9 @@ export const toStyles = (
 				if ( duotoneDeclarations.length > 0 ) {
 					ruleset =
 						ruleset +
-						`${ scopeSelector(
-							selector,
-							duotoneSelector
-						) }{${ duotoneDeclarations.join( ';' ) };}`;
+						`${ duotoneSelector }{${ duotoneDeclarations.join(
+							';'
+						) };}`;
 				}
 			}
 

--- a/packages/block-editor/src/components/global-styles/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-output.js
@@ -853,7 +853,7 @@ export const toStyles = (
 				delete styles.filter;
 			}
 
-			// Process duotone styles (they use color.__experimentalDuotone selector).
+			// Process duotone styles.
 			if ( duotoneSelector ) {
 				const duotoneDeclarations =
 					getStylesDeclarations( duotoneStyles );

--- a/packages/block-editor/src/components/global-styles/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-output.js
@@ -9,6 +9,7 @@ import { get, isEmpty, kebabCase, set } from 'lodash';
 import {
 	__EXPERIMENTAL_STYLE_PROPERTY as STYLE_PROPERTY,
 	__EXPERIMENTAL_ELEMENTS as ELEMENTS,
+	getBlockSupport,
 	getBlockTypes,
 	store as blocksStore,
 } from '@wordpress/blocks';
@@ -19,7 +20,7 @@ import { getCSSRules } from '@wordpress/style-engine';
 /**
  * Internal dependencies
  */
-import { PRESET_METADATA, ROOT_BLOCK_SELECTOR } from './utils';
+import { PRESET_METADATA, ROOT_BLOCK_SELECTOR, scopeSelector } from './utils';
 import { getBlockCSSSelector } from './get-block-css-selector';
 import { getTypographyFontSizeValue } from './typography-utils';
 import { GlobalStylesContext } from './context';
@@ -1002,10 +1003,23 @@ export const getBlockSelectors = ( blockTypes, getBlockStyles ) => {
 	blockTypes.forEach( ( blockType ) => {
 		const name = blockType.name;
 		const selector = getBlockCSSSelector( blockType, 'root' );
-		const duotoneSelector = getBlockCSSSelector(
+		let duotoneSelector = getBlockCSSSelector(
 			blockType,
 			'filter.duotone'
 		);
+
+		// Keep backwards compatibility for support.color.__experimentalDuotone.
+		if ( ! duotoneSelector ) {
+			const rootSelector = getBlockCSSSelector( blockType, 'root' );
+			const duotoneSupport = getBlockSupport(
+				blockType,
+				'color.__experimentalDuotone',
+				false
+			);
+			duotoneSelector =
+				duotoneSupport && scopeSelector( rootSelector, duotoneSupport );
+		}
+
 		const hasLayoutSupport = !! blockType?.supports?.__experimentalLayout;
 		const fallbackGapValue =
 			blockType?.supports?.spacing?.blockGap?.__experimentalDefault;

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -308,16 +308,6 @@ const withDuotoneStyles = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
 		const id = useInstanceId( BlockListBlock );
 
-		/**
-		 * experimental true
-		 * experimental string
-		 *
-		 * no selector
-		 * filter selector
-		 * filter.root selector
-		 * filter.duotone selector
-		 */
-
 		const selector = useMemo( () => {
 			const blockType = getBlockType( props.name );
 

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -277,6 +277,7 @@ function DuotoneStyles( {
 
 	return (
 		element &&
+		Array.isArray( colors ) &&
 		createPortal(
 			<InlineDuotone
 				selector={ selector }

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -312,12 +312,22 @@ const withDuotoneStyles = createHigherOrderComponent(
 			const blockType = getBlockType( props.name );
 
 			if ( blockType ) {
-				// Backwards compatibility for color.__experimentalDuotone. This will
-				// have priority over filter.duotone support. Unfortunately we can't
-				// prefer filter.duotone because it gets set when __experimentalDuotone
-				// is set via a block_type_metadata_settings hook. It shouldn't be too
-				// much of a problem because I would expect consumers to not use both
-				// at the same time.
+				// Backwards compatibility for `supports.color.__experimentalDuotone`
+				// is provided via the `block_type_metadata_settings` filter. If
+				// `supports.filter.duotone` has not been set and the
+				// experimental property has been, the experimental property
+				// value is copied into `supports.filter.duotone`.
+				const duotoneSupport = getBlockSupport(
+					blockType,
+					'filter.duotone',
+					false
+				);
+				if ( ! duotoneSupport ) {
+					return null;
+				}
+
+				// If the experimental duotone support was set, that value is
+				// to be treated as a selector and requires scoping.
 				const experimentalDuotone = getBlockSupport(
 					blockType,
 					'color.__experimentalDuotone',
@@ -328,17 +338,6 @@ const withDuotoneStyles = createHigherOrderComponent(
 					return typeof experimentalDuotone === 'string'
 						? scopeSelector( rootSelector, experimentalDuotone )
 						: rootSelector;
-				}
-
-				// Support flag `filter.duotone` will be populated from the previous
-				// `color.__experimentalDuotone` support via block_type_metadata_settings filter.
-				const duotoneSupport = getBlockSupport(
-					blockType,
-					'filter.duotone',
-					false
-				);
-				if ( ! duotoneSupport ) {
-					return null;
 				}
 
 				// Regular filter.duotone support uses filter.duotone selectors with fallbacks.

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -275,9 +275,11 @@ function DuotoneStyles( {
 
 	const selector = selectorsScoped.join( ', ' );
 
+	const isValidFilter = Array.isArray( colors ) || colors === 'unset';
+
 	return (
 		element &&
-		Array.isArray( colors ) &&
+		isValidFilter &&
 		createPortal(
 			<InlineDuotone
 				selector={ selector }

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -273,8 +273,9 @@ function DuotoneStyles( {
 		// since we're not using inline styles to apply the filter. We need to
 		// override duotone applied by global styles and theme.json.
 
-		// The selector part should always begin with the block's class, so we
-		// can safely just prepend the filter id class.
+		// Assuming the selector part is a subclass selector (not a tag name)
+		// so we can prepend the filter id class. If we want to support elements
+		// such as `img` or namespaces, we'll need to add a case for that here.
 		return `.editor-styles-wrapper .${ filterId }${ selectorPart.trim() }`;
 	} );
 

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -32,6 +32,7 @@ import {
 	__unstableDuotoneStylesheet as DuotoneStylesheet,
 	__unstableDuotoneUnsetStylesheet as DuotoneUnsetStylesheet,
 } from '../components/duotone';
+import { getBlockCSSSelector } from '../components/global-styles/get-block-css-selector';
 import { store as blockEditorStore } from '../store';
 
 const EMPTY_ARRAY = [];
@@ -273,9 +274,10 @@ function BlockDuotoneStyles( { name, duotoneStyle, id } ) {
 		colors = getColorsFromDuotonePreset( colors, duotonePalette );
 	}
 
-	const duotoneSupportSelectors =
-		getBlockType( name ).selectors?.filter?.duotone ||
-		getBlockSupport( name, 'color.__experimentalDuotone' );
+	const duotoneSupportSelectors = getBlockCSSSelector(
+		getBlockType( name ),
+		'filter.duotone'
+	);
 
 	// Extra .editor-styles-wrapper specificity is needed in the editor
 	// since we're not using inline styles to apply the filter. We need to

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -299,7 +299,7 @@ const withDuotoneStyles = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
 		const id = useInstanceId( BlockListBlock );
 
-		const { duotoneSelector, duotoneSupport } = useMemo( () => {
+		const { selector, support } = useMemo( () => {
 			const blockType = getBlockType( props.name );
 			let duotoneSupport = false;
 			let duotoneSelector = null;
@@ -330,15 +330,14 @@ const withDuotoneStyles = createHigherOrderComponent(
 						scopeSelector( rootSelector, duotoneSupport );
 				}
 			}
-			return { duotoneSelector, duotoneSupport };
+			return { selector: duotoneSelector, support: duotoneSupport };
 		}, [ props.name ] );
 
-		const duotoneAttribute = props?.attributes?.style?.color?.duotone;
+		const attribute = props?.attributes?.style?.color?.duotone;
 
 		const filterClass = `wp-duotone-${ id }`;
 
-		const shouldRender =
-			duotoneSupport && duotoneSelector && duotoneAttribute;
+		const shouldRender = support && selector && attribute;
 
 		const className = shouldRender
 			? classnames( props?.className, filterClass )
@@ -353,8 +352,8 @@ const withDuotoneStyles = createHigherOrderComponent(
 				{ shouldRender && (
 					<DuotoneStyles
 						id={ filterClass }
-						selector={ duotoneSelector }
-						attribute={ duotoneAttribute }
+						selector={ selector }
+						attribute={ attribute }
 					/>
 				) }
 				<BlockListBlock { ...props } className={ className } />

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -168,7 +168,9 @@ function DuotonePanel( { attributes, setAttributes } ) {
  * @return {Object} Filtered block settings.
  */
 function addDuotoneAttributes( settings ) {
-	if ( ! hasBlockSupport( settings, 'color.__experimentalDuotone' ) ) {
+	// Previous `color.__experimentalDuotone` support flag is migrated via
+	// block_type_metadata_settings filter in `lib/block-supports/duotone.php`.
+	if ( ! hasBlockSupport( settings, 'filter.duotone' ) ) {
 		return settings;
 	}
 
@@ -195,10 +197,13 @@ function addDuotoneAttributes( settings ) {
  */
 const withDuotoneControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
+		// Previous `color.__experimentalDuotone` support flag is migrated via
+		// block_type_metadata_settings filter in `lib/block-supports/duotone.php`.
 		const hasDuotoneSupport = hasBlockSupport(
 			props.name,
-			'color.__experimentalDuotone'
+			'filter.duotone'
 		);
+
 		const isContentLocked = useSelect(
 			( select ) => {
 				return select(
@@ -319,10 +324,7 @@ const withDuotoneStyles = createHigherOrderComponent(
 					{ fallback: true }
 				);
 				if ( ! duotoneSelector || ! duotoneSupport ) {
-					const rootSelector = getBlockCSSSelector(
-						blockType,
-						'root'
-					);
+					const rootSelector = getBlockCSSSelector( blockType );
 					duotoneSupport = getBlockSupport(
 						blockType,
 						'color.__experimentalDuotone',

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -85,9 +85,11 @@
 	"supports": {
 		"anchor": true,
 		"color": {
-			"__experimentalDuotone": true,
 			"text": false,
 			"background": false
+		},
+		"filter": {
+			"duotone": true
 		},
 		"__experimentalBorder": {
 			"color": true,

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -104,7 +104,7 @@
 	"selectors": {
 		"border": ".wp-block-image img, .wp-block-image .wp-block-image__crop-area",
 		"filter": {
-			"duotone": "img, .components-placeholder"
+			"duotone": ".wp-block-image img, .wp-block-image .components-placeholder"
 		}
 	},
 	"styles": [

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -130,7 +130,7 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 	},
 	filter: {
 		value: [ 'filter', 'duotone' ],
-		support: [ 'color', '__experimentalDuotone' ],
+		support: [ 'filter', 'duotone' ],
 	},
 	linkColor: {
 		value: [ 'elements', 'link', 'color', 'text' ],

--- a/phpunit/class-wp-duotone-test.php
+++ b/phpunit/class-wp-duotone-test.php
@@ -8,7 +8,7 @@
 
 class WP_Duotone_Gutenberg_Test extends WP_UnitTestCase {
 	/**
-	 * Cleans up CSS added to block-supports from duotone styles. We neeed to do this
+	 * Cleans up CSS added to block-supports from duotone styles. We need to do this
 	 * in order to avoid impacting other tests.
 	 */
 	public static function wpTearDownAfterClass() {

--- a/phpunit/class-wp-get-block-css-selectors-test.php
+++ b/phpunit/class-wp-get-block-css-selectors-test.php
@@ -89,21 +89,6 @@ class WP_Get_Block_CSS_Selector_Test extends WP_UnitTestCase {
 		$this->assertEquals( '.duotone-selector', $selector );
 	}
 
-	public function test_get_duotone_selector_via_experimental_property() {
-		$block_type = self::register_test_block(
-			'test/experimental-duotone-selector',
-			null,
-			array(
-				'color' => array(
-					'__experimentalDuotone' => '.experimental-duotone',
-				),
-			)
-		);
-
-		$selector = wp_get_block_css_selector( $block_type, 'filter.duotone' );
-		$this->assertEquals( '.wp-block-test-experimental-duotone-selector .experimental-duotone', $selector );
-	}
-
 	public function test_no_duotone_selector_set() {
 		$block_type = self::register_test_block(
 			'test/null-duotone-selector',

--- a/phpunit/class-wp-get-block-css-selectors-test.php
+++ b/phpunit/class-wp-get-block-css-selectors-test.php
@@ -101,7 +101,7 @@ class WP_Get_Block_CSS_Selector_Test extends WP_UnitTestCase {
 		);
 
 		$selector = wp_get_block_css_selector( $block_type, 'filter.duotone' );
-		$this->assertEquals( '.experimental-duotone', $selector );
+		$this->assertEquals( '.wp-block-test-experimental-duotone-selector .experimental-duotone', $selector );
 	}
 
 	public function test_no_duotone_selector_set() {
@@ -113,6 +113,28 @@ class WP_Get_Block_CSS_Selector_Test extends WP_UnitTestCase {
 
 		$selector = wp_get_block_css_selector( $block_type, 'filter.duotone' );
 		$this->assertEquals( null, $selector );
+	}
+
+	public function test_fallback_duotone_selector() {
+		$block_type = self::register_test_block(
+			'test/fallback-duotone-selector',
+			array( 'root' => '.fallback-root-selector' ),
+			null
+		);
+
+		$selector = wp_get_block_css_selector( $block_type, 'filter.duotone', true );
+		$this->assertEquals( '.fallback-root-selector', $selector );
+	}
+
+	public function test_fallback_duotone_selector_to_generated_class() {
+		$block_type = self::register_test_block(
+			'test/fallback-duotone-selector',
+			array(),
+			null
+		);
+
+		$selector = wp_get_block_css_selector( $block_type, 'filter.duotone', true );
+		$this->assertEquals( '.wp-block-test-fallback-duotone-selector', $selector );
 	}
 
 	public function test_get_feature_selector_via_selectors_api() {

--- a/phpunit/class-wp-get-block-css-selectors-test.php
+++ b/phpunit/class-wp-get-block-css-selectors-test.php
@@ -76,52 +76,6 @@ class WP_Get_Block_CSS_Selector_Test extends WP_UnitTestCase {
 		$this->assertEquals( '.wp-block-test-without-selectors-or-supports', $selector );
 	}
 
-	public function test_get_duotone_selector_via_selectors_api() {
-		$block_type = self::register_test_block(
-			'test/duotone-selector',
-			array(
-				'filter' => array( 'duotone' => '.duotone-selector' ),
-			),
-			null
-		);
-
-		$selector = wp_get_block_css_selector( $block_type, array( 'filter', 'duotone' ) );
-		$this->assertEquals( '.duotone-selector', $selector );
-	}
-
-	public function test_no_duotone_selector_set() {
-		$block_type = self::register_test_block(
-			'test/null-duotone-selector',
-			null,
-			null
-		);
-
-		$selector = wp_get_block_css_selector( $block_type, 'filter.duotone' );
-		$this->assertEquals( null, $selector );
-	}
-
-	public function test_fallback_duotone_selector() {
-		$block_type = self::register_test_block(
-			'test/fallback-duotone-selector',
-			array( 'root' => '.fallback-root-selector' ),
-			null
-		);
-
-		$selector = wp_get_block_css_selector( $block_type, 'filter.duotone', true );
-		$this->assertEquals( '.fallback-root-selector', $selector );
-	}
-
-	public function test_fallback_duotone_selector_to_generated_class() {
-		$block_type = self::register_test_block(
-			'test/fallback-duotone-selector',
-			array(),
-			null
-		);
-
-		$selector = wp_get_block_css_selector( $block_type, 'filter.duotone', true );
-		$this->assertEquals( '.wp-block-test-fallback-duotone-selector', $selector );
-	}
-
 	public function test_get_feature_selector_via_selectors_api() {
 		$block_type = self::register_test_block(
 			'test/feature-selector',

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1927,7 +1927,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ) );
 		$this->assertEquals( $expected, $stylesheet );
 
-		// If background, text, and border-color are defined, include everything, CSS specifity will decide which to apply.
+		// If background, text, and border-color are defined, include everything, CSS specificity will decide which to apply.
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
@@ -1951,7 +1951,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ) );
 		$this->assertEquals( $expected, $stylesheet );
 
-		// If background and border color are defined, include everything, CSS specifity will decide which to apply.
+		// If background and border color are defined, include everything, CSS specificity will decide which to apply.
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -315,6 +315,17 @@
 						}
 					}
 				},
+				"filter": {
+					"type": "object",
+					"description": "This value signals that a block supports some of the properties related to filters. When it does, the block editor will show UI controls for the user to set their values if the theme declares support.\n\nWhen the block declares support for a specific filter property, its attributes definition is extended to include the style attribute.",
+					"properties": {
+						"duotone": {
+							"type": "boolean",
+							"description": "Allow blocks to define a duotone filter.",
+							"default": false
+						}
+					}
+				},
 				"html": {
 					"type": "boolean",
 					"description": "By default, a block’s markup can be edited individually. To disable this behavior, set html to false.",


### PR DESCRIPTION
Related:

- https://github.com/WordPress/gutenberg/pull/46496
- https://github.com/WordPress/gutenberg/pull/49393

## What?

This PR fixes global-level duotone (see https://github.com/WordPress/gutenberg/pull/49393#issuecomment-1488425345 for details) and make duotone work like any other selector.

## Why?

- Make every selector work the same.
- Fix global-level duotone.

## How?

- Make duotone selectors work like any other selector:
  - blocks provide the whole selector via its block.json
  - it fall backs to the root block selector if requested

- Updates the selectors API functions to scope the old `supports.color.__experimentalDuotone` selector automatically. 
- Stabilize duotone support flag under `filter.duotone`
  - Leverages `block_type_metadata_settings` filter to migrate old `color.__experimentalDuotone` flag.

## Test

- Create a post that contains two images (uses `selectors.filter.duotone`) and two cover blocks (`supports.color.__experimentalDuotone`).
- Block level duotone: set the `purple-green` duotone for one of the images and one of the covers.
- Global level duotone: go to the site editor > global styles > blocks. Set the midnight duotone for the image and cover blocks.

The expected result is that the blocks with block-level duotone have it applied and the other ones use the global-level duotone in any context (front-end, post editor, site editor).

No other `img` elements of the page have any duotone applied (check the user avatar at the top-right, for example).

Front-end:

![image](https://user-images.githubusercontent.com/583546/228537863-0b88b00a-8779-471a-8f8a-1ee2b54c4d73.png)

Post editor:

![image](https://user-images.githubusercontent.com/583546/228599689-4119432c-1d4b-4971-9c7e-e716043af6ea.png)

