### PR TITLE
Quote: Disable edit as HTML support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -689,7 +689,7 @@ Give quoted text visual emphasis. "In quoting others, we cite ourselves." — Ju
 
 -	**Name:** core/quote
 -	**Category:** text
--	**Supports:** anchor, color (background, gradients, link, text), typography (fontSize, lineHeight)
+-	**Supports:** anchor, color (background, gradients, link, text), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** align, citation, value
 
 ## Read More

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -29,6 +29,7 @@
 	},
 	"supports": {
 		"anchor": true,
+		"html": false,
 		"__experimentalOnEnter": true,
 		"typography": {
 			"fontSize": true,


### PR DESCRIPTION
## What?
This a follow-up to https://github.com/WordPress/gutenberg/pull/49097#pullrequestreview-1347926371.
A similar PRs: #11785 and #39318.

PR disabled HTML editing for the Quote block.

## Why?
> Editing these wrapper blocks in HTML directly is fragile and prone to breaking the users' content. HTML editing should be left to leaf-blocks.

- https://github.com/WordPress/gutenberg/pull/11785#issue-380011111

## Testing Instructions

1. Open a Post or Page.
2. Insert a Quote block.
3. Confirm "Edit as HTML" action isn't available in block Options.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/228471811-2a146879-64d2-46ab-9ddd-d00f12a85dec.mp4


