### PR TITLE
Update preset styles to use Selectors API

### DIFF
--- a/lib/block-supports/settings.php
+++ b/lib/block-supports/settings.php
@@ -85,11 +85,14 @@ function _gutenberg_add_block_level_preset_styles( $pre_render, $block ) {
 	$registry                = WP_Block_Type_Registry::get_instance();
 	$blocks                  = $registry->get_all_registered();
 	foreach ( $blocks as $block_type ) {
-		if (
-			isset( $block_type->supports['__experimentalSelector'] ) &&
-			is_string( $block_type->supports['__experimentalSelector'] )
-		) {
-			$variables_root_selector .= ',' . $block_type->supports['__experimentalSelector'];
+		// We only want to append selectors for block's using custom selectors
+		// i.e. not `wp-block-<name>`.
+		$has_custom_selector =
+			( isset( $block_type->supports['__experimentalSelector'] ) && is_string( $block_type->supports['__experimentalSelector'] ) ) ||
+			( isset( $block_type->selectors['root'] ) && is_string( $block_type->selectors['root'] ) );
+
+		if ( $has_custom_selector ) {
+			$variables_root_selector .= ',' . wp_get_block_css_selector( $block_type );
 		}
 	}
 	$variables_root_selector = WP_Theme_JSON_Gutenberg::scope_selector( $class_name, $variables_root_selector );


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/46496
- https://github.com/WordPress/gutenberg/pull/49393

## What?

- Updates the collection of custom block selectors for generating the preset styles to use the Selectors API.

## Why?

Now the Selectors API has been stabilised, it may be used in place of the old `supports.__experimentalSelector` properties.

## How?

If a block has a custom selector set via either the Selectors API or the old `__experimentalSelector` supports property, that selector is used. 

## Testing Instructions

1. Create a post using the example block content below
2. Ensure the preset styles selectors match trunk
3. Tweak a block.json file to customise or add a custom selector and refresh the editor or frontend and check that new selector is used for the preset styles.

<details>
<summary>Example block markup with block level presets</summary>

```html
<!-- wp:group {"settings":{"blocks":{"core/button":{"color":{"palette":{"custom":[{"slug":"button-red","color":"red","name":"button red"},{"slug":"button-blue","color":"blue","name":"button blue"}]}}}},"color":{"palette":{"custom":[{"slug":"global-aquamarine","color":"aquamarine","name":"Global aquamarine"},{"slug":"global-pink","color":"pink","name":"Global Pink"}]}}}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>Leaf paragraph of inner group block.</p>
<!-- /wp:paragraph -->

<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"button-blue"} -->
<div class="wp-block-button"><a class="wp-block-button__link has-button-blue-background-color has-background wp-element-button">blue</a></div>
<!-- /wp:button -->

<!-- wp:button {"backgroundColor":"button-red"} -->
<div class="wp-block-button"><a class="wp-block-button__link has-button-red-background-color has-background wp-element-button">red</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:paragraph {"backgroundColor":"global-aquamarine"} -->
<p class="has-global-aquamarine-background-color has-background">global-aquamarine</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"backgroundColor":"global-pink"} -->
<p class="has-global-pink-background-color has-background">global-pink</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```
</details>

<details>
<summary>Example block.json tweak for Group block</summary>

```diff
diff --git a/packages/block-library/src/group/block.json b/packages/block-library/src/group/block.json
index 2b227a1584..63bc1773a0 100644
--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -76,6 +76,9 @@
 			"allowSizingOnChildren": true
 		}
 	},
+	"selectors": {
+		"root": ".hi-there"
+	},
 	"editorStyle": "wp-block-group-editor",
 	"style": "wp-block-group"
 }

```
</details>