### PR TITLE
babel-plugin-makepot: Fix non-existing translation handling

### DIFF
--- a/packages/babel-plugin-makepot/index.js
+++ b/packages/babel-plugin-makepot/index.js
@@ -342,7 +342,7 @@ module.exports = () => {
 								if (
 									isSameTranslation(
 										translation,
-										memo[ msgctxt ][ msgid ]
+										memo[ msgctxt ][ msgid ] ?? {}
 									)
 								) {
 									translation.comments.reference = [


### PR DESCRIPTION
## What?
This PR fixes a bug where we're incorrectly handling non-existing translations. 

## Why?
We're fixing a regression that was introduced in #45946.

Original report by @sjinks:

> :wave: I wanted to report a bug appeared as a result of https://github.com/WordPress/gutenberg/pull/45946
> It sometimes results in an error like this:
> ```
> [!] (plugin babel) TypeError: /path/to/file: Cannot read properties of undefined (reading 'msgid')
> ```
>
> My assumption is that happens because of this:
> 
> https://github.com/WordPress/gutenberg/blob/trunk/packages/babel-plugin-makepot/index.js#L337-L339
> On line 338, an empty `memo[ msgctxt ]` is created and then on line 345 `memo[ msgctxt ][ msgid ]` is then undefined. When passed to `isSameTranslation()`, it causes the error.
> `_.pick` handled that by checking whether the object is falsy and returned `{}` in that case (https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13560)
> A possible fix is
> ```
>  function isSameTranslation( a, b ) {
> -	return VALID_TRANSLATION_KEYS.every( ( key ) => a[ key ] === b[ key ] );
> +	return a && b && VALID_TRANSLATION_KEYS.every( ( key ) => a[ key ] === b[ key ] );
>  }
> ```
> 

## How?
We're defaulting the missing translation to an empty object so it would properly be calculated as the same translation if all keys are missing, preserving the original behavior with `_.pickBy()`.

## Testing Instructions
* Follow the instructions in #45946.
* cc @sjinks for testing the fix.
