### PR TITLE
Docs: fix incorrect import of apiFetch

### DIFF
--- a/docs/how-to-guides/data-basics/2-building-a-list-of-pages.md
+++ b/docs/how-to-guides/data-basics/2-building-a-list-of-pages.md
@@ -247,7 +247,7 @@ Voila! We can now filter the results:
 Let’s take a pause for a moment to consider the downsides of an alternative approach we could have taken - working with the API directly. Imagine we sent the API requests directly:
 
 ```js
-import { apiFetch } from '@wordpress/api-fetch';
+import apiFetch from '@wordpress/api-fetch';
 function MyFirstApp() {
 	// ...
 	const [pages, setPages] = useState( [] );


### PR DESCRIPTION
This PR fixes the incorrect import description of `apiFetch` in How to Guides.

`apiFetch` is [exported as default](https://github.com/WordPress/gutenberg/blob/646a8366bddbb196bbf03ed7741682adc0d33a06/packages/api-fetch/src/index.js#L197). Therefore, the named import causes an error.