### PR TITLE
Add automatted tests for Nav block editable list view

### DIFF
--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -320,7 +320,7 @@ describe( 'Navigation block', () => {
 	} );
 } );
 
-describe.only( 'List view editing', () => {
+describe( 'List view editing', () => {
 	test( 'it should show a list view in the inspector controls', async ( {
 		admin,
 		page,
@@ -431,7 +431,7 @@ describe.only( 'List view editing', () => {
 		).toBeVisible();
 	} );
 
-	test( `can add new menu items`, async ( {
+	test.only( `can add new menu items`, async ( {
 		admin,
 		page,
 		editor,
@@ -482,25 +482,21 @@ describe.only( 'List view editing', () => {
 
 		await expect( blockResults ).toBeVisible();
 
-		const pageLinkBlock = blockResults.getByRole( 'option', {
-			name: 'Page Link',
-		} );
+		const blockResultOptions = blockResults.getByRole( 'option' );
 
-		await expect( pageLinkBlock ).toBeVisible();
+		// Expect to see the Page Link and Custom Link blocks as the nth(0) and nth(1) results.
+		// This is important for usability as the Page Link block is the most likely to be used.
+		await expect( blockResultOptions.nth( 0 ) ).toHaveText( 'Page Link' );
+		await expect( blockResultOptions.nth( 1 ) ).toHaveText( 'Custom Link' );
 
-		const customLinkBlock = blockResults.getByRole( 'option', {
-			name: 'Custom Link',
-		} );
+		// Select the Page Link option.
+		const pageLinkResult = blockResultOptions.nth( 0 );
+		await pageLinkResult.click();
 
-		await expect( customLinkBlock ).toBeVisible();
-
-		await pageLinkBlock.click();
-
-		// Expect to see the Link creation UI.
+		// Expect to see the Link creation UI be focused.
 		const linkUIInput = page.getByRole( 'combobox', {
 			name: 'URL',
 		} );
-
 		await expect( linkUIInput ).toBeFocused();
 
 		const linkUIResults = page.getByRole( 'listbox', {

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -319,7 +319,7 @@ test.describe( 'Navigation block', () => {
 } );
 
 test.describe( 'List view editing', () => {
-	test( 'it should show a list view in the inspector controls', async ( {
+	test( 'show a list view in the inspector controls', async ( {
 		admin,
 		page,
 		editor,

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -320,7 +320,7 @@ describe( 'Navigation block', () => {
 	} );
 } );
 
-describe( 'List view editing', () => {
+describe.only( 'List view editing', () => {
 	test( 'it should show a list view in the inspector controls', async ( {
 		admin,
 		page,
@@ -399,7 +399,9 @@ describe( 'List view editing', () => {
 		// Check the structure of the individual menu items matches the one that was created.
 		await expect(
 			listView
-				.getByRole( 'gridcell' )
+				.getByRole( 'gridcell', {
+					name: 'Page Link link',
+				} )
 				.filter( {
 					hasText: 'Block 1 of 2, Level 1', // proxy for filtering by description.
 				} )
@@ -408,7 +410,9 @@ describe( 'List view editing', () => {
 
 		await expect(
 			listView
-				.getByRole( 'gridcell' )
+				.getByRole( 'gridcell', {
+					name: 'Submenu link',
+				} )
 				.filter( {
 					hasText: 'Block 2 of 2, Level 1', // proxy for filtering by description.
 				} )
@@ -417,7 +421,9 @@ describe( 'List view editing', () => {
 
 		await expect(
 			listView
-				.getByRole( 'gridcell' )
+				.getByRole( 'gridcell', {
+					name: 'Page Link link',
+				} )
 				.filter( {
 					hasText: 'Block 1 of 1, Level 2', // proxy for filtering by description.
 				} )
@@ -425,7 +431,7 @@ describe( 'List view editing', () => {
 		).toBeVisible();
 	} );
 
-	test.only( `can add new menu items`, async ( {
+	test( `can add new menu items`, async ( {
 		admin,
 		page,
 		editor,

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -338,11 +338,11 @@ test.describe( 'List view editing', () => {
 
 		await editor.openDocumentSettingsSidebar();
 
-		const listViewTab = page.getByRole( 'tab', {
-			name: 'List View',
-		} );
-
-		await listViewTab.click();
+		await expect(
+			page.getByRole( 'tab', {
+				name: 'List View',
+			} )
+		).toBeVisible();
 
 		const listViewPanel = page.getByRole( 'tabpanel', {
 			name: 'List View',
@@ -382,12 +382,6 @@ test.describe( 'List view editing', () => {
 		await editor.insertBlock( { name: 'core/navigation' } );
 
 		await editor.openDocumentSettingsSidebar();
-
-		const listViewTab = page.getByRole( 'tab', {
-			name: 'List View',
-		} );
-
-		await listViewTab.click();
 
 		const listView = page.getByRole( 'treegrid', {
 			name: 'Block navigation structure',
@@ -447,12 +441,6 @@ test.describe( 'List view editing', () => {
 		await editor.insertBlock( { name: 'core/navigation' } );
 
 		await editor.openDocumentSettingsSidebar();
-
-		const listViewTab = page.getByRole( 'tab', {
-			name: 'List View',
-		} );
-
-		await listViewTab.click();
 
 		const listView = page.getByRole( 'treegrid', {
 			name: 'Block navigation structure',
@@ -546,12 +534,6 @@ test.describe( 'List view editing', () => {
 
 		await editor.openDocumentSettingsSidebar();
 
-		const listViewTab = page.getByRole( 'tab', {
-			name: 'List View',
-		} );
-
-		await listViewTab.click();
-
 		const listView = page.getByRole( 'treegrid', {
 			name: 'Block navigation structure',
 			description: 'Structure for navigation menu: Test Menu',
@@ -626,12 +608,6 @@ test.describe( 'List view editing', () => {
 		await editor.insertBlock( { name: 'core/navigation' } );
 
 		await editor.openDocumentSettingsSidebar();
-
-		const listViewTab = page.getByRole( 'tab', {
-			name: 'List View',
-		} );
-
-		await listViewTab.click();
 
 		const listView = page.getByRole( 'treegrid', {
 			name: 'Block navigation structure',
@@ -708,12 +684,6 @@ test.describe( 'List view editing', () => {
 		await editor.insertBlock( { name: 'core/navigation' } );
 
 		await editor.openDocumentSettingsSidebar();
-
-		const listViewTab = page.getByRole( 'tab', {
-			name: 'List View',
-		} );
-
-		await listViewTab.click();
 
 		const listView = page.getByRole( 'treegrid', {
 			name: 'Block navigation structure',

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -504,7 +504,7 @@ test.describe( 'List view editing', () => {
 		).toBeVisible();
 	} );
 
-	test.only( `can remove menu items`, async ( {
+	test( `can remove menu items`, async ( {
 		admin,
 		page,
 		editor,
@@ -554,7 +554,7 @@ test.describe( 'List view editing', () => {
 		).not.toBeVisible();
 	} );
 
-	test.only( `can edit menu items`, async ( {
+	test( `can edit menu items`, async ( {
 		admin,
 		page,
 		editor,

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -554,7 +554,7 @@ test.describe( 'List view editing', () => {
 		).not.toBeVisible();
 	} );
 
-	test( `can edit menu items`, async ( {
+	test.only( `can edit menu items`, async ( {
 		admin,
 		page,
 		editor,
@@ -609,6 +609,16 @@ test.describe( 'List view editing', () => {
 				} )
 		).toBeVisible();
 
+		const labelInput = blockSettings.getByRole( 'textbox', {
+			name: 'Label',
+		} );
+
+		await expect( labelInput ).toHaveValue( 'Top Level Item 1' );
+
+		await labelInput.focus();
+
+		await page.keyboard.type( 'Changed label' );
+
 		// Click the back button to go back to the Nav block.
 		await blockSettings
 			.getByRole( 'button', {
@@ -622,6 +632,18 @@ test.describe( 'List view editing', () => {
 		} );
 
 		await expect( listViewPanel ).toBeVisible();
+
+		// Check the label was updated.
+		await expect(
+			listViewPanel
+				.getByRole( 'gridcell', {
+					name: 'Page Link link',
+				} )
+				.filter( {
+					hasText: 'Block 1 of 2, Level 1', // proxy for filtering by description.
+				} )
+				.getByText( 'Changed label' ) // new label text
+		).toBeVisible();
 	} );
 
 	test( `can add submenus`, async ( {

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -398,24 +398,30 @@ describe( 'List view editing', () => {
 
 		// Check the structure of the individual menu items matches the one that was created.
 		await expect(
-			listView.getByRole( 'gridcell' ).filter( {
-				hasText: 'Block 1 of 2, Level 1', // proxy for filtering by description.
-				has: page.getByText( 'Top Level Item 1' ), // find the hidden anchor with the label of the Nav item.
-			} )
+			listView
+				.getByRole( 'gridcell' )
+				.filter( {
+					hasText: 'Block 1 of 2, Level 1', // proxy for filtering by description.
+				} )
+				.getByText( 'Top Level Item 1' )
 		).toBeVisible();
 
 		await expect(
-			listView.getByRole( 'gridcell' ).filter( {
-				hasText: 'Block 2 of 2, Level 1', // proxy for filtering by description.
-				has: page.getByText( 'Top Level Item 2' ), // find the hidden anchor with the label of the Nav item.
-			} )
+			listView
+				.getByRole( 'gridcell' )
+				.filter( {
+					hasText: 'Block 2 of 2, Level 1', // proxy for filtering by description.
+				} )
+				.getByText( 'Top Level Item 2' )
 		).toBeVisible();
 
 		await expect(
-			listView.getByRole( 'gridcell' ).filter( {
-				hasText: 'Block 1 of 1, Level 2', // proxy for filtering by description.
-				has: page.getByText( 'Test Submenu Item' ), // find the hidden anchor with the label of the Nav item.
-			} )
+			listView
+				.getByRole( 'gridcell' )
+				.filter( {
+					hasText: 'Block 1 of 1, Level 2', // proxy for filtering by description.
+				} )
+				.getByText( 'Test Submenu Item' )
 		).toBeVisible();
 	} );
 } );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -319,6 +319,14 @@ test.describe( 'Navigation block', () => {
 } );
 
 test.describe( 'List view editing', () => {
+	const navMenuBlocksFixture = {
+		title: 'Test Menu',
+		content: `<!-- wp:navigation-link {"label":"Top Level Item 1","type":"page","id":250,"url":"http://localhost:8888/quod-error-esse-nemo-corporis-rerum-repellendus/","kind":"post-type"} /-->
+			<!-- wp:navigation-submenu {"label":"Top Level Item 2","type":"page","id":250,"url":"http://localhost:8888/quod-error-esse-nemo-corporis-rerum-repellendus/","kind":"post-type"} -->
+				<!-- wp:navigation-link {"label":"Test Submenu Item","type":"page","id":270,"url":"http://localhost:8888/et-aspernatur-recusandae-non-sint/","kind":"post-type"} /-->
+			<!-- /wp:navigation-submenu -->`,
+	};
+
 	test( 'show a list view in the inspector controls', async ( {
 		admin,
 		page,
@@ -326,13 +334,7 @@ test.describe( 'List view editing', () => {
 		requestUtils,
 	} ) => {
 		await admin.createNewPost();
-		await requestUtils.createNavigationMenu( {
-			title: 'Test Menu',
-			content: `<!-- wp:navigation-link {"label":"Top Level Item 1","type":"page","id":250,"url":"http://localhost:8888/quod-error-esse-nemo-corporis-rerum-repellendus/","kind":"post-type"} /-->
-			<!-- wp:navigation-submenu {"label":"Top Level Item 2","type":"page","id":250,"url":"http://localhost:8888/quod-error-esse-nemo-corporis-rerum-repellendus/","kind":"post-type"} -->
-				<!-- wp:navigation-link {"label":"Test Submenu Item","type":"page","id":270,"url":"http://localhost:8888/et-aspernatur-recusandae-non-sint/","kind":"post-type"} /-->
-			<!-- /wp:navigation-submenu -->`,
-		} );
+		await requestUtils.createNavigationMenu( navMenuBlocksFixture );
 
 		await editor.insertBlock( { name: 'core/navigation' } );
 
@@ -371,13 +373,7 @@ test.describe( 'List view editing', () => {
 		requestUtils,
 	} ) => {
 		await admin.createNewPost();
-		await requestUtils.createNavigationMenu( {
-			title: 'Test Menu',
-			content: `<!-- wp:navigation-link {"label":"Top Level Item 1","type":"page","id":250,"url":"http://localhost:8888/quod-error-esse-nemo-corporis-rerum-repellendus/","kind":"post-type"} /-->
-			<!-- wp:navigation-submenu {"label":"Top Level Item 2","type":"page","id":250,"url":"http://localhost:8888/quod-error-esse-nemo-corporis-rerum-repellendus/","kind":"post-type"} -->
-				<!-- wp:navigation-link {"label":"Test Submenu Item","type":"page","id":270,"url":"http://localhost:8888/et-aspernatur-recusandae-non-sint/","kind":"post-type"} /-->
-			<!-- /wp:navigation-submenu -->`,
-		} );
+		await requestUtils.createNavigationMenu( navMenuBlocksFixture );
 
 		await editor.insertBlock( { name: 'core/navigation' } );
 
@@ -430,13 +426,7 @@ test.describe( 'List view editing', () => {
 		requestUtils,
 	} ) => {
 		await admin.createNewPost();
-		await requestUtils.createNavigationMenu( {
-			title: 'Test Menu',
-			content: `<!-- wp:navigation-link {"label":"Top Level Item 1","type":"page","id":250,"url":"http://localhost:8888/quod-error-esse-nemo-corporis-rerum-repellendus/","kind":"post-type"} /-->
-			<!-- wp:navigation-submenu {"label":"Top Level Item 2","type":"page","id":250,"url":"http://localhost:8888/quod-error-esse-nemo-corporis-rerum-repellendus/","kind":"post-type"} -->
-				<!-- wp:navigation-link {"label":"Test Submenu Item","type":"page","id":270,"url":"http://localhost:8888/et-aspernatur-recusandae-non-sint/","kind":"post-type"} /-->
-			<!-- /wp:navigation-submenu -->`,
-		} );
+		await requestUtils.createNavigationMenu( navMenuBlocksFixture );
 
 		await editor.insertBlock( { name: 'core/navigation' } );
 
@@ -522,13 +512,7 @@ test.describe( 'List view editing', () => {
 		requestUtils,
 	} ) => {
 		await admin.createNewPost();
-		await requestUtils.createNavigationMenu( {
-			title: 'Test Menu',
-			content: `<!-- wp:navigation-link {"label":"Top Level Item 1","type":"page","id":250,"url":"http://localhost:8888/quod-error-esse-nemo-corporis-rerum-repellendus/","kind":"post-type"} /-->
-			<!-- wp:navigation-submenu {"label":"Top Level Item 2","type":"page","id":250,"url":"http://localhost:8888/quod-error-esse-nemo-corporis-rerum-repellendus/","kind":"post-type"} -->
-				<!-- wp:navigation-link {"label":"Test Submenu Item","type":"page","id":270,"url":"http://localhost:8888/et-aspernatur-recusandae-non-sint/","kind":"post-type"} /-->
-			<!-- /wp:navigation-submenu -->`,
-		} );
+		await requestUtils.createNavigationMenu( navMenuBlocksFixture );
 
 		await editor.insertBlock( { name: 'core/navigation' } );
 
@@ -597,13 +581,7 @@ test.describe( 'List view editing', () => {
 		requestUtils,
 	} ) => {
 		await admin.createNewPost();
-		await requestUtils.createNavigationMenu( {
-			title: 'Test Menu',
-			content: `<!-- wp:navigation-link {"label":"Top Level Item 1","type":"page","id":250,"url":"http://localhost:8888/quod-error-esse-nemo-corporis-rerum-repellendus/","kind":"post-type"} /-->
-			<!-- wp:navigation-submenu {"label":"Top Level Item 2","type":"page","id":250,"url":"http://localhost:8888/quod-error-esse-nemo-corporis-rerum-repellendus/","kind":"post-type"} -->
-				<!-- wp:navigation-link {"label":"Test Submenu Item","type":"page","id":270,"url":"http://localhost:8888/et-aspernatur-recusandae-non-sint/","kind":"post-type"} /-->
-			<!-- /wp:navigation-submenu -->`,
-		} );
+		await requestUtils.createNavigationMenu( navMenuBlocksFixture );
 
 		await editor.insertBlock( { name: 'core/navigation' } );
 
@@ -673,13 +651,7 @@ test.describe( 'List view editing', () => {
 		requestUtils,
 	} ) => {
 		await admin.createNewPost();
-		await requestUtils.createNavigationMenu( {
-			title: 'Test Menu',
-			content: `<!-- wp:navigation-link {"label":"Top Level Item 1","type":"page","id":250,"url":"http://localhost:8888/quod-error-esse-nemo-corporis-rerum-repellendus/","kind":"post-type"} /-->
-			<!-- wp:navigation-submenu {"label":"Top Level Item 2","type":"page","id":250,"url":"http://localhost:8888/quod-error-esse-nemo-corporis-rerum-repellendus/","kind":"post-type"} -->
-				<!-- wp:navigation-link {"label":"Test Submenu Item","type":"page","id":270,"url":"http://localhost:8888/et-aspernatur-recusandae-non-sint/","kind":"post-type"} /-->
-			<!-- /wp:navigation-submenu -->`,
-		} );
+		await requestUtils.createNavigationMenu( navMenuBlocksFixture );
 
 		await editor.insertBlock( { name: 'core/navigation' } );
 

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -504,7 +504,7 @@ test.describe( 'List view editing', () => {
 		).toBeVisible();
 	} );
 
-	test( `can remove menu items`, async ( {
+	test.only( `can remove menu items`, async ( {
 		admin,
 		page,
 		editor,
@@ -522,33 +522,22 @@ test.describe( 'List view editing', () => {
 			description: 'Structure for navigation menu: Test Menu',
 		} );
 
-		// click on options menu for the first menu item and select remove.
-		const firstMenuItem = listView
-			.getByRole( 'gridcell', {
-				name: 'Page Link link',
-			} )
-			.filter( {
-				hasText: 'Block 1 of 2, Level 1', // proxy for filtering by description.
-			} );
-
 		// The options menu button is a sibling of the menu item gridcell.
-		const firstItemOptions = firstMenuItem
-			.locator( '..' ) // parent selector.
-			.getByRole( 'button', {
-				name: 'Options for Page Link block',
-			} );
+		const submenuOptions = listView.getByRole( 'button', {
+			name: 'Options for Submenu block',
+		} );
 
 		// Open the options menu.
-		await firstItemOptions.click();
+		await submenuOptions.click();
 
 		// usage of `page` is required because the options menu is rendered into a slot
 		// outside of the treegrid.
 		const removeBlockOption = page
 			.getByRole( 'menu', {
-				name: 'Options for Page Link block',
+				name: 'Options for Submenu block',
 			} )
 			.getByRole( 'menuitem', {
-				name: 'Remove Top Level Item 1',
+				name: 'Remove Top Level Item 2',
 			} );
 
 		await removeBlockOption.click();
@@ -557,12 +546,12 @@ test.describe( 'List view editing', () => {
 		await expect(
 			listView
 				.getByRole( 'gridcell', {
-					name: 'Page Link link',
+					name: 'Submenu link',
 				} )
 				.filter( {
-					hasText: 'Block 1 of 1, Level 1', // proxy for filtering by description.
+					hasText: 'Block 2 of 2, Level 1', // proxy for filtering by description.
 				} )
-				.getByText( 'Top Level Item 1' )
+				.getByText( 'Top Level Item 2' )
 		).not.toBeVisible();
 	} );
 

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -531,13 +531,6 @@ test.describe( 'List view editing', () => {
 				hasText: 'Block 1 of 2, Level 1', // proxy for filtering by description.
 			} );
 
-		// Focus the node to reveal the "3 dots" options menu button.
-		const firstMenuItemAnchor = listView.getByRole( 'link', {
-			name: 'Top Level Item 1',
-			includeHidden: true,
-		} );
-		await firstMenuItemAnchor.focus();
-
 		// The options menu button is a sibling of the menu item gridcell.
 		const firstItemOptions = firstMenuItem
 			.locator( '..' ) // parent selector.
@@ -670,13 +663,6 @@ test.describe( 'List view editing', () => {
 			.filter( {
 				hasText: 'Block 1 of 2, Level 1', // proxy for filtering by description.
 			} );
-
-		// Focus the node to reveal the "3 dots" options menu button.
-		const firstMenuItemAnchor = listView.getByRole( 'link', {
-			name: 'Top Level Item 1',
-			includeHidden: true,
-		} );
-		await firstMenuItemAnchor.focus();
 
 		// The options menu button is a sibling of the menu item gridcell.
 		const firstItemOptions = firstMenuItem

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -484,9 +484,9 @@ test.describe( 'List view editing', () => {
 		const firstResult = await linkControl.getNthSearchResult( 0 );
 
 		// Grab the text from the first result so we can check it was inserted.
-		const firstResultText = await firstResult
-			.locator( '.block-editor-link-control__search-item-title' ) // this is the only way to get the label text without the URL.
-			.innerText();
+		const firstResultText = await linkControl.getSearchResultText(
+			firstResult
+		);
 
 		// Create the link.
 		await firstResult.click();
@@ -770,5 +770,13 @@ class LinkControl {
 		await expect( input ).toHaveValue( searchTerm );
 
 		return input;
+	}
+
+	async getSearchResultText( result ) {
+		await expect( result ).toBeVisible();
+
+		return result
+			.locator( '.block-editor-link-control__search-item-title' ) // this is the only way to get the label text without the URL.
+			.innerText();
 	}
 }

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -607,4 +607,86 @@ test.describe( 'List view editing', () => {
 				.getByText( 'Top Level Item 1' )
 		).not.toBeVisible();
 	} );
+
+	test( `can edit menu items`, async ( {
+		admin,
+		page,
+		editor,
+		requestUtils,
+	} ) => {
+		await admin.createNewPost();
+		await requestUtils.createNavigationMenu( {
+			title: 'Test Menu',
+			content: `<!-- wp:navigation-link {"label":"Top Level Item 1","type":"page","id":250,"url":"http://localhost:8888/quod-error-esse-nemo-corporis-rerum-repellendus/","kind":"post-type"} /-->
+			<!-- wp:navigation-submenu {"label":"Top Level Item 2","type":"page","id":250,"url":"http://localhost:8888/quod-error-esse-nemo-corporis-rerum-repellendus/","kind":"post-type"} -->
+				<!-- wp:navigation-link {"label":"Test Submenu Item","type":"page","id":270,"url":"http://localhost:8888/et-aspernatur-recusandae-non-sint/","kind":"post-type"} /-->
+			<!-- /wp:navigation-submenu -->`,
+		} );
+
+		await editor.insertBlock( { name: 'core/navigation' } );
+
+		await editor.openDocumentSettingsSidebar();
+
+		const listViewTab = page.getByRole( 'tab', {
+			name: 'List View',
+		} );
+
+		await listViewTab.click();
+
+		const listView = page.getByRole( 'treegrid', {
+			name: 'Block navigation structure',
+			description: 'Structure for navigation menu: Test Menu',
+		} );
+
+		// Click on the first menu item to open its settings.
+		const firstMenuItemAnchor = listView.getByRole( 'link', {
+			name: 'Top Level Item 1',
+			includeHidden: true,
+		} );
+		await firstMenuItemAnchor.click();
+
+		// Get the settings panel.
+		const blockSettings = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+
+		await expect( blockSettings ).toBeVisible();
+
+		await expect(
+			blockSettings.getByRole( 'heading', {
+				name: 'Page Link',
+			} )
+		).toBeVisible();
+
+		await expect(
+			blockSettings.getByRole( 'tab', {
+				name: 'Settings',
+				selected: true,
+			} )
+		).toBeVisible();
+
+		await expect(
+			blockSettings
+				.getByRole( 'tabpanel', {
+					name: 'Settings',
+				} )
+				.getByRole( 'heading', {
+					name: 'Link Settings',
+				} )
+		).toBeVisible();
+
+		// Click the back button to go back to the Nav block.
+		await blockSettings
+			.getByRole( 'button', {
+				name: 'Go to parent Navigation block',
+			} )
+			.click();
+
+		// Check we're back on the Nav block list view.
+		const listViewPanel = page.getByRole( 'tabpanel', {
+			name: 'List View',
+		} );
+
+		await expect( listViewPanel ).toBeVisible();
+	} );
 } );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -3,9 +3,7 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-const { describe } = test;
-
-describe( 'As a user I want the navigation block to fallback to the best possible default', () => {
+test.describe( 'As a user I want the navigation block to fallback to the best possible default', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		//TT3 is preferable to emptytheme because it already has the navigation block on its templates.
 		await requestUtils.activateTheme( 'twentytwentythree' );
@@ -177,7 +175,7 @@ describe( 'As a user I want the navigation block to fallback to the best possibl
 	} );
 } );
 
-describe( 'As a user I want to create submenus using the navigation block', () => {
+test.describe( 'As a user I want to create submenus using the navigation block', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		//TT3 is preferable to emptytheme because it already has the navigation block on its templates.
 		await requestUtils.activateTheme( 'twentytwentythree' );
@@ -283,8 +281,8 @@ describe( 'As a user I want to create submenus using the navigation block', () =
 	} );
 } );
 
-describe( 'Navigation block', () => {
-	describe( 'As a user I want to see a warning if the menu referenced by a navigation block is not available', () => {
+test.describe( 'Navigation block', () => {
+	test.describe( 'As a user I want to see a warning if the menu referenced by a navigation block is not available', () => {
 		test.beforeEach( async ( { admin } ) => {
 			await admin.createNewPost();
 		} );
@@ -320,7 +318,7 @@ describe( 'Navigation block', () => {
 	} );
 } );
 
-describe( 'List view editing', () => {
+test.describe( 'List view editing', () => {
 	test( 'it should show a list view in the inspector controls', async ( {
 		admin,
 		page,

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -320,7 +320,7 @@ describe( 'Navigation block', () => {
 	} );
 } );
 
-describe.only( 'List view editing', () => {
+describe( 'List view editing', () => {
 	test( 'it should show a list view in the inspector controls', async ( {
 		admin,
 		page,
@@ -330,8 +330,10 @@ describe.only( 'List view editing', () => {
 		await admin.createNewPost();
 		await requestUtils.createNavigationMenu( {
 			title: 'Test Menu',
-			content:
-				'<!-- wp:navigation-submenu {"label":"WordPress","type":"custom","url":"http://www.wordpress.org/","kind":"custom","isTopLevelLink":true} --><!-- wp:navigation-link {"label":"WordPress Child","type":"custom","url":"http://www.wordpress.org/","kind":"custom","isTopLevelLink":true} /--><!-- /wp:navigation-submenu -->',
+			content: `<!-- wp:navigation-link {"label":"Top Level Item 1","type":"page","id":250,"url":"http://localhost:8888/quod-error-esse-nemo-corporis-rerum-repellendus/","kind":"post-type"} /-->
+			<!-- wp:navigation-submenu {"label":"Top Level Item 2","type":"page","id":250,"url":"http://localhost:8888/quod-error-esse-nemo-corporis-rerum-repellendus/","kind":"post-type"} -->
+				<!-- wp:navigation-link {"label":"Test Submenu Item","type":"page","id":270,"url":"http://localhost:8888/et-aspernatur-recusandae-non-sint/","kind":"post-type"} /-->
+			<!-- /wp:navigation-submenu -->`,
 		} );
 
 		await editor.insertBlock( { name: 'core/navigation' } );
@@ -360,6 +362,59 @@ describe.only( 'List view editing', () => {
 			listViewPanel.getByRole( 'treegrid', {
 				name: 'Block navigation structure',
 				description: 'Structure for navigation menu: Test Menu',
+			} )
+		).toBeVisible();
+	} );
+
+	test.only( `list view should correctly reflect navigation items' structure`, async ( {
+		admin,
+		page,
+		editor,
+		requestUtils,
+	} ) => {
+		await admin.createNewPost();
+		await requestUtils.createNavigationMenu( {
+			title: 'Test Menu',
+			content: `<!-- wp:navigation-link {"label":"Top Level Item 1","type":"page","id":250,"url":"http://localhost:8888/quod-error-esse-nemo-corporis-rerum-repellendus/","kind":"post-type"} /-->
+			<!-- wp:navigation-submenu {"label":"Top Level Item 2","type":"page","id":250,"url":"http://localhost:8888/quod-error-esse-nemo-corporis-rerum-repellendus/","kind":"post-type"} -->
+				<!-- wp:navigation-link {"label":"Test Submenu Item","type":"page","id":270,"url":"http://localhost:8888/et-aspernatur-recusandae-non-sint/","kind":"post-type"} /-->
+			<!-- /wp:navigation-submenu -->`,
+		} );
+
+		await editor.insertBlock( { name: 'core/navigation' } );
+
+		await editor.openDocumentSettingsSidebar();
+
+		const listViewTab = page.getByRole( 'tab', {
+			name: 'List View',
+		} );
+
+		await listViewTab.click();
+
+		const listView = page.getByRole( 'treegrid', {
+			name: 'Block navigation structure',
+			description: 'Structure for navigation menu: Test Menu',
+		} );
+
+		// Check the structure of the individual menu items matches the one that was created.
+		await expect(
+			listView.getByRole( 'gridcell' ).filter( {
+				hasText: 'Block 1 of 2, Level 1', // proxy for filtering by description.
+				has: page.getByText( 'Top Level Item 1' ), // find the hidden anchor with the label of the Nav item.
+			} )
+		).toBeVisible();
+
+		await expect(
+			listView.getByRole( 'gridcell' ).filter( {
+				hasText: 'Block 2 of 2, Level 1', // proxy for filtering by description.
+				has: page.getByText( 'Top Level Item 2' ), // find the hidden anchor with the label of the Nav item.
+			} )
+		).toBeVisible();
+
+		await expect(
+			listView.getByRole( 'gridcell' ).filter( {
+				hasText: 'Block 1 of 1, Level 2', // proxy for filtering by description.
+				has: page.getByText( 'Test Submenu Item' ), // find the hidden anchor with the label of the Nav item.
 			} )
 		).toBeVisible();
 	} );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -522,7 +522,6 @@ test.describe( 'List view editing', () => {
 			description: 'Structure for navigation menu: Test Menu',
 		} );
 
-		// The options menu button is a sibling of the menu item gridcell.
 		const submenuOptions = listView.getByRole( 'button', {
 			name: 'Options for Submenu block',
 		} );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -3,7 +3,9 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-test.describe( 'As a user I want the navigation block to fallback to the best possible default', () => {
+const { describe } = test;
+
+describe( 'As a user I want the navigation block to fallback to the best possible default', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		//TT3 is preferable to emptytheme because it already has the navigation block on its templates.
 		await requestUtils.activateTheme( 'twentytwentythree' );
@@ -175,7 +177,7 @@ test.describe( 'As a user I want the navigation block to fallback to the best po
 	} );
 } );
 
-test.describe( 'As a user I want to create submenus using the navigation block', () => {
+describe( 'As a user I want to create submenus using the navigation block', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		//TT3 is preferable to emptytheme because it already has the navigation block on its templates.
 		await requestUtils.activateTheme( 'twentytwentythree' );
@@ -281,8 +283,8 @@ test.describe( 'As a user I want to create submenus using the navigation block',
 	} );
 } );
 
-test.describe( 'Navigation block', () => {
-	test.describe( 'As a user I want to see a warning if the menu referenced by a navigation block is not available', () => {
+describe( 'Navigation block', () => {
+	describe( 'As a user I want to see a warning if the menu referenced by a navigation block is not available', () => {
 		test.beforeEach( async ( { admin } ) => {
 			await admin.createNewPost();
 		} );
@@ -315,5 +317,50 @@ test.describe( 'Navigation block', () => {
 				);
 			await expect( warningMessage ).toBeVisible();
 		} );
+	} );
+} );
+
+describe.only( 'List view editing', () => {
+	test( 'it should show a list view in the inspector controls', async ( {
+		admin,
+		page,
+		editor,
+		requestUtils,
+	} ) => {
+		await admin.createNewPost();
+		await requestUtils.createNavigationMenu( {
+			title: 'Test Menu',
+			content:
+				'<!-- wp:navigation-submenu {"label":"WordPress","type":"custom","url":"http://www.wordpress.org/","kind":"custom","isTopLevelLink":true} --><!-- wp:navigation-link {"label":"WordPress Child","type":"custom","url":"http://www.wordpress.org/","kind":"custom","isTopLevelLink":true} /--><!-- /wp:navigation-submenu -->',
+		} );
+
+		await editor.insertBlock( { name: 'core/navigation' } );
+
+		await editor.openDocumentSettingsSidebar();
+
+		const listViewTab = page.getByRole( 'tab', {
+			name: 'List View',
+		} );
+
+		await listViewTab.click();
+
+		const listViewPanel = page.getByRole( 'tabpanel', {
+			name: 'List View',
+		} );
+
+		await expect( listViewPanel ).toBeVisible();
+
+		await expect(
+			listViewPanel.getByRole( 'heading', {
+				name: 'Menu',
+			} )
+		).toBeVisible();
+
+		await expect(
+			listViewPanel.getByRole( 'treegrid', {
+				name: 'Block navigation structure',
+				description: 'Structure for navigation menu: Test Menu',
+			} )
+		).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds a series of tests to provide high level coverage for the editable list view in the Navigation block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently this feature has no test coverage. These tests provide that.

Moreover, the `<OffcanvasEditor>` which currently powers the editable list view in the Nav block is [due to be refactor to use the standard `<ListView>` component](https://github.com/WordPress/gutenberg/pull/49417). This refactoring would be a lot easier if the current functionality of the editable list view were covered by tests.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds Playwright e2e tests to cover the top level scenarios:

- does it show a list view
- does the list view reflect the structure of menu items
- can you add/edit/remove menu items
- can you add a submenu

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Run

```
npm run test:e2e:playwright -- -g "List view editing" 
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
