### PR TITLE
Cover: Merge block and global styles

### DIFF
--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -47,18 +47,21 @@ function render_block_core_cover( $attributes, $content ) {
 		}
 		$current_featured_image = get_the_post_thumbnail_url();
 
-		$styles = 'background-image:url(' . esc_url( $current_featured_image ) . '); ';
+		$processor = new WP_HTML_Tag_Processor( $content );
+		$processor->next_tag();
+
+		$styles         = $processor->get_attribute( 'style' );
+		$merged_styles  = ! empty( $styles ) ? $styles . ';' : '';
+		$merged_styles .= 'background-image:url(' . esc_url( $current_featured_image ) . ');';
 
 		if ( isset( $attributes['minHeight'] ) ) {
 			$height_unit = empty( $attributes['minHeightUnit'] ) ? 'px' : $attributes['minHeightUnit'];
-			$height      = " min-height:{$attributes['minHeight']}{$height_unit}";
+			$height      = " min-height:{$attributes['minHeight']}{$height_unit};";
 
-			$styles .= $height;
+			$merged_styles .= $height;
 		}
 
-		$processor = new WP_HTML_Tag_Processor( $content );
-		$processor->next_tag();
-		$processor->set_attribute( 'style', $styles );
+		$processor->set_attribute( 'style', $merged_styles );
 		$content = $processor->get_updated_html();
 	}
 

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -54,13 +54,6 @@ function render_block_core_cover( $attributes, $content ) {
 		$merged_styles  = ! empty( $styles ) ? $styles . ';' : '';
 		$merged_styles .= 'background-image:url(' . esc_url( $current_featured_image ) . ');';
 
-		if ( isset( $attributes['minHeight'] ) ) {
-			$height_unit = empty( $attributes['minHeightUnit'] ) ? 'px' : $attributes['minHeightUnit'];
-			$height      = " min-height:{$attributes['minHeight']}{$height_unit};";
-
-			$merged_styles .= $height;
-		}
-
 		$processor->set_attribute( 'style', $merged_styles );
 		$content = $processor->get_updated_html();
 	}

--- a/phpunit/blocks/render-block-cover-test.php
+++ b/phpunit/blocks/render-block-cover-test.php
@@ -15,7 +15,7 @@ class Tests_Blocks_Render_Cover extends WP_UnitTestCase {
 	/**
 	 * Post object.
 	 *
-	 * @var array
+	 * @var object
 	 */
 	protected static $post;
 
@@ -76,7 +76,7 @@ class Tests_Blocks_Render_Cover extends WP_UnitTestCase {
 			'minHeight'        => '100px',
 		);
 
-		$content  = '<div class="wp-block-cover"><span></span><div class="wp-block-cover__inner-container"></div></div>';
+		$content  = '<div class="wp-block-cover" style="min-height:100px"><span></span><div class="wp-block-cover__inner-container"></div></div>';
 		$rendered = gutenberg_render_block_core_cover( $attributes, $content );
 
 		$this->assertStringContainsString( wp_get_attachment_image_url( self::$attachment_id, 'full' ), $rendered );


### PR DESCRIPTION
## What?
Fixes #49384.

PR adds missing dimension styles when using a Cover block as a featured image with a fixed background.

## Why?
The render function was replacing the already generated styles attribute.

## How?
I've updated the logic to merge styles before re-applying them.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Cover Block. 
3. Set the image for the cover block to the Featured image.
4. In Dimensions, add margin, padding, and a min-height.
5. In Media settings, toggle the Fixed background on.
6. Confirm all inline styles are applied correctly when previewing the post.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2023-03-29 at 14 52 17](https://user-images.githubusercontent.com/240569/228512196-90336e88-51f3-4e84-a33f-1c86a99fc20b.png)
