### PR TITLE
Style Engine: Update block supports dependencies

### DIFF
--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -369,7 +369,7 @@ class WP_Duotone_Gutenberg {
 						// render before global styles,
 						// and they should be overriding the duotone
 						// filters set by global styles.
-						'filter' => $declaration_value . ' !important',
+						'filter' => $declaration_value,
 					),
 				),
 			),

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -335,6 +335,10 @@ class WP_Duotone_Gutenberg {
 
 				self::$output[ $slug ] = $filter_data;
 			}
+
+			// !important is only needed for individual blocks, not for global styles.
+			$declaration_value .= ' !important';
+
 		} elseif ( $has_global_styles_duotone ) {
 			$slug = self::$global_styles_block_names[ $block['blockName'] ];
 
@@ -365,10 +369,6 @@ class WP_Duotone_Gutenberg {
 				array(
 					'selector'     => $selector,
 					'declarations' => array(
-						// !important is needed because these styles
-						// render before global styles,
-						// and they should be overriding the duotone
-						// filters set by global styles.
 						'filter' => $declaration_value,
 					),
 				),

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -563,5 +563,5 @@ remove_action( 'wp_enqueue_scripts', 'wp_enqueue_stored_styles' );
 remove_action( 'wp_footer', 'wp_enqueue_stored_styles', 1 );
 
 // Enqueue stored styles.
-add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_stored_styles' );
+add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_stored_styles', 99 );
 add_action( 'wp_footer', 'gutenberg_enqueue_stored_styles', 1 );

--- a/lib/experimental/kses.php
+++ b/lib/experimental/kses.php
@@ -78,7 +78,7 @@ add_action( 'set_current_user', 'gutenberg_override_core_kses_init_filters' );
  */
 function allow_filter_in_styles( $allow_css, $css_test_string ) {
 	if ( preg_match(
-		"/^filter:\s*url\('#wp-duotone-[-a-zA-Z0-9]+'\) !important$/",
+		"/^filter:\s*url\('#wp-duotone-[-a-zA-Z0-9]+'\)(?: !important)?$/",
 		$css_test_string
 	) ) {
 		return true;


### PR DESCRIPTION
## The issue
If a theme provides a custom filter in its CSS, then we need to use `!important` when overriding that CSS for a duotone block support.

## What?
This moves the block supports CSS to be output after the theme's main stylesheet. The reason for this is that (I think) individual block supports styles should take precedence over rules that are set in the theme.

This came up in https://github.com/WordPress/gutenberg/pull/49237 where we expect the block supports to beat the theme, but it doesn't. Rather than relying on `!important`, I think we should just re-order the CSS but this could have other implications. I

## Why?
This means that block supports will override the theme CSS, which is what a user would expect.

## How?
Adds the theme stylesheet as a dependency of the block supports stylesheet. I have built this on top of #49237 so that it can be tested.

Other options we could consider:
1. Create a new `block-supports-post-theme` style and only load that one after the theme
2. Update `gutenberg_style_engine_get_stylesheet_from_css_rules` to take a dependency array as well as a context.

If this is going to cause issues then we can explore these other options, but I think this is the right approach at the moment!

## Testing Instructions
Add a custom CSS filter to all images in your theme CSS like this:
```
.wp-block-image img {
	filter: grayscale(80%);
}
```
When you apply a duotone filter to the image in the post editor, the front end should use the duotone filter - it should take precedence over the theme CSS.

## Screenshots or screencast <!-- if applicable -->
<img width="752" alt="Screenshot 2023-03-29 at 12 05 33" src="https://user-images.githubusercontent.com/275961/228514640-3d42705f-59aa-4727-9fb6-a2da3e6385ae.png">
