### PR TITLE
Block selectors API: use whole selectors for duotone

### DIFF
--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -349,7 +349,26 @@ class WP_Duotone_Gutenberg {
 		$filter_id = gutenberg_get_duotone_filter_id( array( 'slug' => $slug ) );
 
 		// Build the CSS selectors to which the filter will be applied.
-		$selector = WP_Theme_JSON_Gutenberg::scope_selector( '.' . $filter_id, $duotone_selector );
+		$scopes    = explode( ',', '.' . $filter_id );
+		$selectors = explode( ',', $duotone_selector );
+
+		$selectors_scoped = array();
+		foreach ( $scopes as $outer ) {
+			foreach ( $selectors as $inner ) {
+				$outer = trim( $outer );
+				$inner = trim( $inner );
+				if ( ! empty( $outer ) && ! empty( $inner ) ) {
+					// unlike WP_Theme_JSON_Gutenberg::scope_selector
+					// this concatenates the selectors without a space.
+					$selectors_scoped[] = $outer . '' . $inner;
+				} elseif ( empty( $outer ) ) {
+					$selectors_scoped[] = $inner;
+				} elseif ( empty( $inner ) ) {
+					$selectors_scoped[] = $outer;
+				}
+			}
+		}
+		$selector = implode( ', ', $selectors_scoped );
 
 		// We only want to add the selector if we have it in the output already, essentially skipping 'unset'.
 		if ( array_key_exists( $slug, self::$output ) ) {

--- a/lib/compat/wordpress-6.3/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.3/get-global-styles-and-settings.php
@@ -43,7 +43,6 @@ if ( ! function_exists( 'wp_get_block_css_selector' ) ) {
 			$root_selector = ".wp-block-{$block_name}";
 		}
 
-
 		// Duotone (No fallback selectors for Duotone).
 		if ( 'filter.duotone' === $target || array( 'filter', 'duotone' ) === $target ) {
 			// If selectors API in use, only use it's value or null.

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -85,7 +85,6 @@
 	"supports": {
 		"anchor": true,
 		"color": {
-			"__experimentalDuotone": true,
 			"text": false,
 			"background": false
 		},

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -104,7 +104,7 @@
 	"selectors": {
 		"border": ".wp-block-image img, .wp-block-image .wp-block-image__crop-area",
 		"filter": {
-			"duotone": "img, .components-placeholder"
+			"duotone": ".wp-block-image img, .wp-block-image .components-placeholder"
 		}
 	},
 	"styles": [


### PR DESCRIPTION
## What

Tentative fix for https://github.com/WordPress/gutenberg/pull/49393#issuecomment-1488425345

## Why

The Block Selectors API is meant to land in 15.5 but duotone works differently than any other selector. The global-level duotone style is also broken.

## How

- The block selectors API for duotone takes the whole selector, not a partial one https://github.com/WordPress/gutenberg/pull/49436/commits/17ab41d43753b439fda90011384f3d5dcb13ef5d
- `wp_get_block_css_selector` returns the whole selector for duotone, even if the old API is in use https://github.com/WordPress/gutenberg/pull/49436/commits/7f6b31db4d8c229624e14ec4bfba62f68b57a7a4
- The duotone block-level is updated to work with whole selectors, not with partial ones https://github.com/WordPress/gutenberg/pull/49436/commits/8fc311088223164510f5090c611dd227f5c418bc

## TODO

- [x] Make it work in the front-end.
- [ ] Make it work in the post editor.
- [ ] Make it work in the site editor.

## Test

- Create a post that contains two images (uses `selectors.filter.duotone`) and two cover blocks (`supports.color.__experimentalDuotone`).
- Block level duotone: set the `purple-green` duotone for one of the images and one of the covers.
- Global level duotone: go to the site editor > global styles > blocks. Set the midnight duotone for the image and cover blocks.

The expected result is that the blocks with block-level duotone have it applied and the other ones use the global-level duotone in any context (front-end, post editor, site editor).

No other `img` elements of the page have any duotone applied (check the user avatar at the top-right, for example).

![image](https://user-images.githubusercontent.com/583546/228537863-0b88b00a-8779-471a-8f8a-1ee2b54c4d73.png)
