### PR TITLE
Fix sprintf() arguments

### DIFF
--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -32,7 +32,7 @@ function render_block_core_post_author( $attributes, $content, $block ) {
 	$link        = get_author_posts_url( $author_id );
 	$author_name = get_the_author_meta( 'display_name', $author_id );
 	if ( ! empty( $attributes['isLink'] && ! empty( $attributes['linkTarget'] ) ) ) {
-		$author_name = sprintf( '<a href="%1s" target="%2s">%2s</a>', esc_url( $link ), esc_attr( $attributes['linkTarget'] ), $author_name );
+		$author_name = sprintf( '<a href="%1$s" target="%2$s">%3$s</a>', esc_url( $link ), esc_attr( $attributes['linkTarget'] ), $author_name );
 	}
 
 	$byline  = ! empty( $attributes['byline'] ) ? $attributes['byline'] : false;


### PR DESCRIPTION
Argnum dollar sign seemed to be missing. The `2` in `%2s` is really a width argument.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Unless the 2nd and 3rd sprintf() arguments (both referenced using `%2s`) in this line of code really need to have a _width_ of at least 2 chars, there's a typo here, and `%2$s` and `%3$s` were meant (and `%1$s` where `%1s` was used). See also https://www.php.net/manual/en/function.sprintf.php (compare the `argnum$` and `width` arguments).

## Why?
In this case, the bug is mostly harmless, as link targets or author names will almost always have a length of more than 2. Meaning `%2s` is equivalent to `%s` and no padding will take place.

But the code is confusing, because it really looks like `%2$s` was meant instead. It kind of looks like there are more such occurrences in WordPress' code, too, but lets start small.

## How?
Added missing dollar sign, fixed 3rd sprintf arg.

## Testing Instructions
For most (all?) practical cases, there will be no change in output. But using, e.g., `%3s` is confusing and may lead to errors in other situations (where `%3$s` was meant instead), if the argument order is ever changed (like in translated strings).