### PR TITLE
Add workflow to check for expected @wordpress/components CHANGELOG updates

### DIFF
--- a/.github/workflows/check-components-changelog.yml
+++ b/.github/workflows/check-components-changelog.yml
@@ -1,0 +1,25 @@
+name: Verify @wordpress/components CHANGELOG update
+
+on:
+    pull_request:
+        types: [opened, synchronize]
+        paths:
+            - 'packages/components/**'
+            - '!packages/components/**/stories/**'
+            - '!packages/components/src**/test/**'
+jobs:
+    check:
+        name: Check CHANGELOG diff
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+            - name: Fetch origin/trunk
+              run: git fetch --quiet origin trunk
+            - name: Run git diff
+              run: |
+                  changelog_path="packages/components/CHANGELOG.md"
+                  if git diff --quiet origin/trunk HEAD -- "$changelog_path"; then
+                    echo "Please add a CHANGELOG entry to $changelog_path"
+                    exit 1
+                  fi

--- a/.github/workflows/check-components-changelog.yml
+++ b/.github/workflows/check-components-changelog.yml
@@ -12,12 +12,19 @@ jobs:
         name: Check CHANGELOG diff
         runs-on: ubuntu-latest
         steps:
+            - name: 'Get PR commit count'
+              run: echo "PR_COMMIT_COUNT=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
             - name: Checkout code
               uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+              with:
+                  ref: ${{ github.event.pull_request.head.ref }}
+                  fetch-depth: ${{ env.PR_COMMIT_COUNT }}
+            - name: 'Fetch relevant history from origin'
+              run: git fetch origin ${{ github.event.pull_request.base.ref }}
             - name: Run git diff
               run: |
                   changelog_path="packages/components/CHANGELOG.md"
-                  if git diff --quiet ${{ github.event.pull_request.base.sha }} ${{ github.sha }} -- "$changelog_path"; then
+                  if git diff --quiet ${{ github.event.pull_request.base.sha }} HEAD -- "$changelog_path"; then
                     echo "Please add a CHANGELOG entry to $changelog_path"
                     exit 1
                   fi

--- a/.github/workflows/check-components-changelog.yml
+++ b/.github/workflows/check-components-changelog.yml
@@ -14,12 +14,10 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
-            - name: Fetch origin/trunk
-              run: git fetch --quiet origin trunk
             - name: Run git diff
               run: |
                   changelog_path="packages/components/CHANGELOG.md"
-                  if git diff --quiet origin/trunk HEAD -- "$changelog_path"; then
+                  if git diff --quiet ${{ github.event.pull_request.base.sha }} ${{ github.sha }} -- "$changelog_path"; then
                     echo "Please add a CHANGELOG entry to $changelog_path"
                     exit 1
                   fi

--- a/.github/workflows/check-components-changelog.yml
+++ b/.github/workflows/check-components-changelog.yml
@@ -5,7 +5,7 @@ on:
         types: [opened, synchronize]
         paths:
             - 'packages/components/**'
-            - '!packages/components/**/stories/**'
+            - '!packages/components/src/**/stories/**'
             - '!packages/components/src**/test/**'
 jobs:
     check:


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds an automated check to PRs editing the @wordpress/components package to ensure the CHANGELOG has been updated.

## Why?
This is an easy step to miss, and a common part of reviews, so it makes sense to automate it.

## How?
The new check will only be run on PRs that change files in the `packages/components/**` directory, but not if all of those files are stories or unit tests, as those changes don't need to be entered in the changelog.

If any files outside of tests and stories are modified, a `git diff` is run to confirm that `/packages/components/CHANGELOG.md` is included in the files changed by the PR. If it isn't, the check fails with an error message asking the author to add an entry.

## Testing Instructions
1. After checking out this PR, create a new branch off of it. Create a PR of your own from that branch.
2. Modify a story file for any component. Commit that change to your test branch and push, updating your PR.
3. Wait for the checks to run and confirm that `Verify @wordpress/components CHANGELOG update` was **NOT** run.
4. Modify a unit test for any component. Commit that change to your test branch and push, updating your PR again.
5. Wait again for the checks and confirm that `Verify @wordpress/components CHANGELOG update` still was **NOT** run.
6. Modify a component file (any component, anything that isn't a unit test or story file). Commit and push.
7. Wait for the checks. Confirm that this time `Verify @wordpress/components CHANGELOG update` **IS** run.
8. Confirm that the check fails, because you didn't update the changelog. When clicking `details` on the check, you should see output asking you to add a CHANGELOG entry.
9. Update the CHANGELOG file. The check isn't picky about what you do, it only looks for the file to have been changed. Commit and push one last time.
10. Wait once more for the checks, confirm that this time `Verify @wordpress/components CHANGELOG update` runs and passes.