### PR TITLE
Add section about integration testing to testing docs

### DIFF
--- a/docs/contributors/code/testing-overview.md
+++ b/docs/contributors/code/testing-overview.md
@@ -290,7 +290,30 @@ test('fires onChange when a new value is typed', async () => {
 })
 ```
 
+### Integration testing
 
+Integration testing is defined as a type of testing where different parts are tested as a group. In this case, the parts that we want to test are the different components that are required to be rendered for a specific block or editor logic. In the end, they are very similar to unit tests as they are run with the same command using the Jest library. The main difference is that for the integration tests the blocks are run within a [`special instance of the block editor`](https://github.com/WordPress/gutenberg/blob/trunk/test/integration/helpers/integration-test-editor.js#L60).
+
+The advantage of this approach is that the bulk of a blocks editor functionality, block toolbar and inspector panel interactions, etc. can be tested without having to fire up the full e2e test framework. This means the tests can run much faster and more reliably. It is recommended that as much of the editor functionality as possible should be covered with integration tests, with e2e tests only used for interactions that require a full browser environment, eg. file uploads, drag and drop, etc.
+
+[`The Cover block`](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/cover/test/edit.js) is an example of a block that uses this level of testing to provide coverage for a large percentage of the editor interactions.
+
+To set up a jest file for integration tests:
+
+```js
+import {
+	initializeEditor
+} from 'test/integration/helpers/integration-test-editor';
+
+async function setup( attributes ) {
+	const testBlock = { name: 'core/cover', attributes };
+	return initializeEditor( testBlock );
+}
+```
+
+The `initializeEditor` function returns the output of the `@testing-library/react` `render` method. It will also accept an array of block metadata objects, allowing you to set up the editor with multiple blocks.
+
+The integration test editor module also exports a `selectBlock` which can be used to select the block to be tested by the aria-label on the block wrapper, eg. "Block: Cover".
 
 ### Snapshot testing
 

--- a/docs/contributors/code/testing-overview.md
+++ b/docs/contributors/code/testing-overview.md
@@ -290,11 +290,11 @@ test('fires onChange when a new value is typed', async () => {
 })
 ```
 
-### Integration testing
+### Integration testing for block UI
 
 Integration testing is defined as a type of testing where different parts are tested as a group. In this case, the parts that we want to test are the different components that are required to be rendered for a specific block or editor logic. In the end, they are very similar to unit tests as they are run with the same command using the Jest library. The main difference is that for the integration tests the blocks are run within a [`special instance of the block editor`](https://github.com/WordPress/gutenberg/blob/trunk/test/integration/helpers/integration-test-editor.js#L60).
 
-The advantage of this approach is that the bulk of a blocks editor functionality, block toolbar and inspector panel interactions, etc. can be tested without having to fire up the full e2e test framework. This means the tests can run much faster and more reliably. It is recommended that as much of the editor functionality as possible should be covered with integration tests, with e2e tests only used for interactions that require a full browser environment, eg. file uploads, drag and drop, etc.
+The advantage of this approach is that the bulk of a block editor's functionality (block toolbar and inspector panel interactions, etc.) can be tested without having to fire up the full e2e test framework. This means the tests can run much faster and more reliably. It is suggested that as much of a block's UI functionality as possible is covered with integration tests, with e2e tests used for interactions that require a full browser environment, eg. file uploads, drag and drop, etc.
 
 [`The Cover block`](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/cover/test/edit.js) is an example of a block that uses this level of testing to provide coverage for a large percentage of the editor interactions.
 


### PR DESCRIPTION
## What?
Adds documentation to cover new integration testing option [added here](https://github.com/WordPress/gutenberg/pull/45409).

## Why?
So people willl know about it.

## How?
Wrote it all by myself, no ChatGPT was harmed in the production of this text.

## Testing Instructions
Read, and proof.


