### PR TITLE
Initial prototype of simplified layout panel

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -302,7 +302,7 @@ Gather blocks in a layout container. ([Source](https://github.com/WordPress/gute
 
 -	**Name:** core/group
 -	**Category:** design
--	**Supports:** align (full, wide), anchor, ariaLabel, color (background, gradients, heading, link, text), dimensions (minHeight), layout (allowSizingOnChildren), position (sticky), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), anchor, ariaLabel, color (background, gradients, heading, link, text), dimensions (minHeight), layout (allowSizingOnChildren, allowSwitching), position (sticky), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** allowedBlocks, tagName, templateLock
 
 ## Heading

--- a/package-lock.json
+++ b/package-lock.json
@@ -32047,9 +32047,9 @@
 			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
 		},
 		"electron-to-chromium": {
-			"version": "1.4.480",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.480.tgz",
-			"integrity": "sha512-IXTgg+bITkQv/FLP9FjX6f9KFCs5hQWeh5uNSKxB9mqYj/JXhHDbu+ekS43LVvbkL3eW6/oZy4+r9Om6lan1Uw=="
+			"version": "1.4.447",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.447.tgz",
+			"integrity": "sha512-sxX0LXh+uL41hSJsujAN86PjhrV/6c79XmpY0TvjZStV6VxIgarf8SRkUoUTuYmFcZQTemsoqo8qXOGw5npWfw=="
 		},
 		"elegant-spinner": {
 			"version": "1.0.1",
@@ -34848,16 +34848,6 @@
 					"requires": {
 						"ms": "2.0.0"
 					}
-				},
-				"parseurl": {
-					"version": "1.3.3",
-					"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-					"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
-				},
-				"statuses": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-					"integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="
 				}
 			}
 		},
@@ -54752,8 +54742,7 @@
 		"statuses": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-			"dev": true
+			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
 		},
 		"store2": {
 			"version": "2.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32047,9 +32047,9 @@
 			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
 		},
 		"electron-to-chromium": {
-			"version": "1.4.447",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.447.tgz",
-			"integrity": "sha512-sxX0LXh+uL41hSJsujAN86PjhrV/6c79XmpY0TvjZStV6VxIgarf8SRkUoUTuYmFcZQTemsoqo8qXOGw5npWfw=="
+			"version": "1.4.480",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.480.tgz",
+			"integrity": "sha512-IXTgg+bITkQv/FLP9FjX6f9KFCs5hQWeh5uNSKxB9mqYj/JXhHDbu+ekS43LVvbkL3eW6/oZy4+r9Om6lan1Uw=="
 		},
 		"elegant-spinner": {
 			"version": "1.0.1",
@@ -34848,6 +34848,16 @@
 					"requires": {
 						"ms": "2.0.0"
 					}
+				},
+				"parseurl": {
+					"version": "1.3.3",
+					"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+					"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+				},
+				"statuses": {
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+					"integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="
 				}
 			}
 		},
@@ -54742,7 +54752,8 @@
 		"statuses": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+			"dev": true
 		},
 		"store2": {
 			"version": "2.12.0",

--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -26,17 +26,23 @@ export default function BlockEdit( props ) {
 		isSelected,
 		clientId,
 		attributes = {},
+		setAttributes,
 		__unstableLayoutClassNames,
 	} = props;
+
 	const { layout = null } = attributes;
 	const layoutSupport =
 		hasBlockSupport( name, 'layout', false ) ||
 		hasBlockSupport( name, '__experimentalLayout', false );
+	const updateLayoutType = ( newLayout ) => {
+		setAttributes( { layout: { ...layout, type: newLayout } } );
+	};
 	const context = {
 		name,
 		isSelected,
 		clientId,
 		layout: layoutSupport ? layout : null,
+		updateLayoutType,
 		__unstableLayoutClassNames,
 	};
 	return (

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -91,6 +91,7 @@ function BlockListBlock( {
 	onInsertBlocksAfter,
 	onMerge,
 	toggleSelection,
+	updateLayoutType,
 } ) {
 	const {
 		themeSupportsLayout,
@@ -138,6 +139,7 @@ function BlockListBlock( {
 			__unstableParentLayout={
 				Object.keys( parentLayout ).length ? parentLayout : undefined
 			}
+			updateParentLayoutType={ updateLayoutType }
 		/>
 	);
 

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -140,6 +140,7 @@ function Items( {
 	renderAppender,
 	__experimentalAppenderTagName,
 	layout = defaultLayout,
+	updateLayoutType,
 } ) {
 	const { order, selectedBlocks, visibleBlocks } = useSelect(
 		( select ) => {
@@ -172,6 +173,7 @@ function Items( {
 					<BlockListBlock
 						rootClientId={ rootClientId }
 						clientId={ clientId }
+						updateLayoutType={ updateLayoutType }
 					/>
 				</AsyncModeProvider>
 			) ) }

--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -26,17 +26,18 @@ function helpText( selfStretch, parentLayout ) {
 /**
  * Form to edit the child layout value.
  *
- * @param {Object}   props              Props.
- * @param {Object}   props.value        The child layout value.
- * @param {Function} props.onChange     Function to update the child layout value.
- * @param {Object}   props.parentLayout The parent layout value.
- *
+ * @param {Object}   props                        Props.
+ * @param {Object}   props.value                  The child layout value.
+ * @param {Function} props.onChange               Function to update the child layout value.
+ * @param {Object}   props.parentLayout           The parent layout value.
+ * @param {Function} props.updateParentLayoutType Function to update the parent layout type.
  * @return {WPElement} child layout edit element.
  */
 export default function ChildLayoutControl( {
 	value: childLayout = {},
 	onChange,
 	parentLayout,
+	updateParentLayoutType,
 } ) {
 	const { selfStretch, flexSize } = childLayout;
 
@@ -59,6 +60,9 @@ export default function ChildLayoutControl( {
 				help={ helpText( selfStretch, parentLayout ) }
 				onChange={ ( value ) => {
 					const newFlexSize = value !== 'fixed' ? null : flexSize;
+					if ( value === 'fill' ) {
+						updateParentLayoutType( 'flex' );
+					}
 					onChange( {
 						...childLayout,
 						selfStretch: value,

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -85,7 +85,7 @@ function useHasChildLayout( settings ) {
 	} = settings?.parentLayout ?? {};
 
 	const support =
-		( defaultParentLayoutType === 'flex' || parentLayoutType === 'flex' ) &&
+		( defaultParentLayoutType || parentLayoutType ) &&
 		allowSizingOnChildren;
 
 	return !! settings?.layout && support;
@@ -206,6 +206,7 @@ export default function DimensionsPanel( {
 	// Special case because the layout controls are not part of the dimensions panel
 	// in global styles but not in block inspector.
 	includeLayoutControls = false,
+	updateParentLayoutType,
 } ) {
 	const { dimensions, spacing } = settings;
 
@@ -633,6 +634,7 @@ export default function DimensionsPanel( {
 						value={ childLayout }
 						onChange={ setChildLayout }
 						parentLayout={ settings?.parentLayout }
+						updateParentLayoutType={ updateParentLayoutType }
 					/>
 				</VStack>
 			) }

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -60,6 +60,7 @@ function UncontrolledInnerBlocks( props ) {
 		orientation,
 		placeholder,
 		layout,
+		updateLayoutType,
 	} = props;
 
 	useNestedSettingsUpdate(
@@ -125,6 +126,7 @@ function UncontrolledInnerBlocks( props ) {
 				layout={ memoedLayout }
 				wrapperRef={ wrapperRef }
 				placeholder={ placeholder }
+				updateLayoutType={ updateLayoutType }
 			/>
 		</BlockContextProvider>
 	);
@@ -175,6 +177,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 		clientId,
 		layout = null,
 		__unstableLayoutClassNames: layoutClassNames = '',
+		updateLayoutType,
 	} = useBlockEditContext();
 	const isSmallScreen = useViewportMatch( 'medium', '<' );
 	const { __experimentalCaptureToolbars, hasOverlay } = useSelect(
@@ -222,6 +225,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 	const innerBlocksProps = {
 		__experimentalCaptureToolbars,
 		layout,
+		updateLayoutType,
 		...options,
 	};
 	const InnerBlocks =

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -72,6 +72,7 @@ export function DimensionsPanel( props ) {
 		attributes,
 		setAttributes,
 		__unstableParentLayout,
+		updateParentLayoutType,
 	} = props;
 	const settings = useBlockSettings( name, __unstableParentLayout );
 	const isEnabled = useHasDimensionsPanel( settings );
@@ -110,6 +111,7 @@ export function DimensionsPanel( props ) {
 				onChange={ onChange }
 				defaultControls={ defaultControls }
 				onVisualize={ setVisualizedProperty }
+				updateParentLayoutType={ updateParentLayoutType }
 			/>
 			{ !! settings?.spacing?.padding && (
 				<PaddingVisualizer

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -14,10 +14,11 @@ import {
 	// Button,
 	// ButtonGroup,
 	CustomSelectControl,
-	// Flex,
-	// FlexItem,
+	Flex,
+	FlexItem,
 	// ToggleControl,
 	PanelBody,
+	RangeControl,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
@@ -182,6 +183,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 		type = 'default',
 		contentSize = null,
 		orientation = 'horizontal',
+		flexWrap = 'nowrap',
 	} = usedLayout;
 	/**
 	 * `themeSupportsLayout` is only relevant to the `default/flow` or
@@ -261,6 +263,27 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 	const onChangeLayout = ( newLayout ) =>
 		setAttributes( { layout: newLayout } );
 
+	const onChangeGap = ( newGap ) => {
+		setAttributes( {
+			style: {
+				...style,
+				spacing: {
+					...style?.spacing,
+					blockGap: newGap,
+				},
+			},
+		} );
+	};
+
+	const onChangeWrap = ( newWrap ) => {
+		setAttributes( {
+			layout: {
+				...usedLayout,
+				flexWrap: newWrap,
+			},
+		} );
+	};
+
 	const innerWidthOptions = [
 		{
 			key: 'fill',
@@ -274,34 +297,34 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 			key: 'theme',
 			name: __( 'Theme' ),
 		},
-		// {
-		// 	key: 'custom',
-		// 	name: __( 'Custom' ),
-		// },
+		{
+			key: 'custom',
+			name: __( 'Custom' ),
+		},
 	];
 
-	// const alignmentOptions = [
-	// 	{
-	// 		key: 'flex-start',
-	// 		name: __( 'Top' ),
-	// 	},
-	// 	{
-	// 		key: 'center',
-	// 		name: __( 'Middle' ),
-	// 	},
-	// 	{
-	// 		key: 'flex-end',
-	// 		name: __( 'Bottom' ),
-	// 	},
-	// 	{
-	// 		key: 'space-between',
-	// 		name: __( 'Space Between' ),
-	// 	},
-	// 	{
-	// 		key: 'stretch',
-	// 		name: __( 'Stretch' ),
-	// 	},
-	// ];
+	const alignmentOptions = [
+		{
+			key: 'flex-start',
+			name: __( 'Top' ),
+		},
+		{
+			key: 'center',
+			name: __( 'Middle' ),
+		},
+		{
+			key: 'flex-end',
+			name: __( 'Bottom' ),
+		},
+		{
+			key: 'space-between',
+			name: __( 'Space Between' ),
+		},
+		{
+			key: 'stretch',
+			name: __( 'Stretch' ),
+		},
+	];
 
 	return (
 		<>
@@ -380,14 +403,22 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 							label={ __( 'Grid' ) }
 						/>
 					</ToggleGroupControl>
-
-					<CustomSelectControl
-						__nextUnconstrainedWidth
-						label="Inner block width"
-						options={ innerWidthOptions }
-						onChange={ onChangeInnerWidth }
+					{ layoutType && layoutType.name === 'grid' && (
+						<layoutType.inspectorControls
+							layout={ usedLayout }
+							onChange={ onChangeLayout }
+							layoutBlockSupport={ layoutBlockSupport }
+						/>
+					) }
+					<RangeControl
+						label={ __( 'Gap' ) }
+						onChange={ onChangeGap }
+						value={ style?.spacing?.blockGap }
+						min={ 0 }
+						max={ 100 }
+						withInputField={ false }
 					/>
-					{ /* <p>Align</p>
+					<p>ALIGN</p>
 					<Flex>
 						<FlexItem>
 							<CustomSelectControl
@@ -419,9 +450,37 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 								}
 							/>
 						</FlexItem>
-					</Flex> */ }
-
-					{ layoutType &&
+					</Flex>
+					<div style={ { marginTop: '24px' } }>
+						<CustomSelectControl
+							__nextUnconstrainedWidth
+							label="Inner block width"
+							options={ innerWidthOptions }
+							onChange={ onChangeInnerWidth }
+						/>
+					</div>
+					<div style={ { marginTop: '24px' } }>
+						<ToggleGroupControl
+							__nextHasNoMarginBottom
+							size={ '__unstable-large' }
+							label={ __( 'Wrap' ) }
+							value={ flexWrap }
+							onChange={ onChangeWrap }
+							isBlock={ true }
+						>
+							<ToggleGroupControlOption
+								key={ 'wrap' }
+								value="wrap"
+								label={ __( 'Yes' ) }
+							/>
+							<ToggleGroupControlOption
+								key={ 'nowrap' }
+								value="nowrap"
+								label={ __( 'No' ) }
+							/>
+						</ToggleGroupControl>
+					</div>
+					{ /* { layoutType &&
 						layoutType.name !== 'default' &&
 						layoutType.name !== 'constrained' && (
 							<layoutType.inspectorControls
@@ -429,7 +488,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 								onChange={ onChangeLayout }
 								layoutBlockSupport={ layoutBlockSupport }
 							/>
-						) }
+						) } */ }
 					{ constrainedType && displayControlsForLegacyLayouts && (
 						<constrainedType.inspectorControls
 							layout={ usedLayout }
@@ -449,7 +508,6 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 		</>
 	);
 }
-
 // function LayoutTypeSwitcher( { type, onChange } ) {
 // 	return (
 // 		<ButtonGroup>

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -36,7 +36,6 @@ import {
 	justifyCenter,
 	justifyRight,
 	justifySpaceBetween,
-	justifyStretch,
 } from '@wordpress/icons';
 
 /**
@@ -65,6 +64,7 @@ import {
 	alignCenter,
 	alignBottom,
 	spaceBetween,
+	alignStretch,
 } from '../components/block-vertical-alignment-control/icons';
 
 const innerWidthOptions = [
@@ -369,7 +369,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 	if ( orientation === 'horizontal' ) {
 		verticalAlignmentOptions.push( {
 			value: 'stretch',
-			icon: justifyStretch,
+			icon: alignStretch,
 			label: __( 'Stretch' ),
 		} );
 	} else {

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -401,7 +401,13 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 				setAttributes( { layout: { type: 'default' } } );
 			}
 		} else {
-			setAttributes( { layout: { ...usedLayout, type: newType } } );
+			setAttributes( {
+				layout: {
+					...usedLayout,
+					type: newType,
+					orientation: 'horizontal',
+				},
+			} );
 		}
 	};
 

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -269,7 +269,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 				...style,
 				spacing: {
 					...style?.spacing,
-					blockGap: newGap,
+					blockGap: `${ newGap }px`,
 				},
 			},
 		} );
@@ -303,9 +303,28 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 		},
 	];
 
-	const alignmentOptions = [
+	const horizontalAlignmentOptions = [
 		{
-			key: 'flex-start',
+			key: 'left',
+			name: __( 'Left' ),
+		},
+		{
+			key: 'center',
+			name: __( 'Middle' ),
+		},
+		{
+			key: 'right',
+			name: __( 'Right' ),
+		},
+		{
+			key: 'space-between',
+			name: __( 'Space Between' ),
+		},
+	];
+
+	const verticalAlignmentOptions = [
+		{
+			key: 'top',
 			name: __( 'Top' ),
 		},
 		{
@@ -313,16 +332,12 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 			name: __( 'Middle' ),
 		},
 		{
-			key: 'flex-end',
+			key: 'bottom',
 			name: __( 'Bottom' ),
 		},
 		{
 			key: 'space-between',
 			name: __( 'Space Between' ),
-		},
-		{
-			key: 'stretch',
-			name: __( 'Stretch' ),
 		},
 	];
 
@@ -424,7 +439,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 							<CustomSelectControl
 								__nextUnconstrainedWidth
 								label="Vertical"
-								options={ alignmentOptions }
+								options={ verticalAlignmentOptions }
 								onChange={ ( { selectedItem } ) => {
 									setAttributes( {
 										layout: {
@@ -439,7 +454,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 							<CustomSelectControl
 								__nextUnconstrainedWidth
 								label="Horizontal"
-								options={ alignmentOptions }
+								options={ horizontalAlignmentOptions }
 								onChange={ ( { selectedItem } ) =>
 									setAttributes( {
 										layout: {
@@ -459,27 +474,31 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 							onChange={ onChangeInnerWidth }
 						/>
 					</div>
-					<div style={ { marginTop: '24px' } }>
-						<ToggleGroupControl
-							__nextHasNoMarginBottom
-							size={ '__unstable-large' }
-							label={ __( 'Wrap' ) }
-							value={ flexWrap }
-							onChange={ onChangeWrap }
-							isBlock={ true }
-						>
-							<ToggleGroupControlOption
-								key={ 'wrap' }
-								value="wrap"
-								label={ __( 'Yes' ) }
-							/>
-							<ToggleGroupControlOption
-								key={ 'nowrap' }
-								value="nowrap"
-								label={ __( 'No' ) }
-							/>
-						</ToggleGroupControl>
-					</div>
+					{ layoutType &&
+						layoutType.name === 'grid' &&
+						orientation === 'horizontal' && (
+							<div style={ { marginTop: '24px' } }>
+								<ToggleGroupControl
+									__nextHasNoMarginBottom
+									size={ '__unstable-large' }
+									label={ __( 'Wrap' ) }
+									value={ flexWrap }
+									onChange={ onChangeWrap }
+									isBlock={ true }
+								>
+									<ToggleGroupControlOption
+										key={ 'wrap' }
+										value="wrap"
+										label={ __( 'Yes' ) }
+									/>
+									<ToggleGroupControlOption
+										key={ 'nowrap' }
+										value="nowrap"
+										label={ __( 'No' ) }
+									/>
+								</ToggleGroupControl>
+							</div>
+						) }
 					{ /* { layoutType &&
 						layoutType.name !== 'default' &&
 						layoutType.name !== 'constrained' && (

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -509,6 +509,28 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 								layoutBlockSupport={ layoutBlockSupport }
 							/>
 						) }
+						{ ( ( type === 'flex' && orientation === 'vertical' ) ||
+							type === 'default' ||
+							type === 'constrained' ) && (
+							<ToggleGroupControl
+								__nextHasNoMarginBottom
+								style={ { marginBottom: 0, marginTop: 0 } }
+								label={ __( 'Content width' ) }
+								value={ usedLayout?.verticalAlignment || 'top' }
+								onChange={ onChangeInnerWidth }
+								isBlock={ true }
+								className="components-toggle-group-control__full-width"
+							>
+								{ innerWidthOptions.map( ( option ) => (
+									<ToggleGroupControlOptionIcon
+										key={ option.value }
+										icon={ option.icon }
+										value={ option.value }
+										label={ option.label }
+									/>
+								) ) }
+							</ToggleGroupControl>
+						) }
 						<HStack spacing={ 2 } justify="stretch">
 							{ type === 'flex' && (
 								<FlexBlock>
@@ -582,28 +604,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 								) }
 							</FlexBlock>
 						</HStack>
-						{ ( ( type === 'flex' && orientation === 'vertical' ) ||
-							type === 'default' ||
-							type === 'constrained' ) && (
-							<ToggleGroupControl
-								__nextHasNoMarginBottom
-								style={ { marginBottom: 0, marginTop: 0 } }
-								label={ __( 'Content width' ) }
-								value={ usedLayout?.verticalAlignment || 'top' }
-								onChange={ onChangeInnerWidth }
-								isBlock={ true }
-								className="components-toggle-group-control__full-width"
-							>
-								{ innerWidthOptions.map( ( option ) => (
-									<ToggleGroupControlOptionIcon
-										key={ option.value }
-										icon={ option.icon }
-										value={ option.value }
-										label={ option.label }
-									/>
-								) ) }
-							</ToggleGroupControl>
-						) }
+
 						{ type === 'flex' && orientation === 'horizontal' && (
 							<div style={ { marginTop: '24px' } }>
 								<ToggleGroupControl

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -36,6 +36,7 @@ import {
 	justifyCenter,
 	justifyRight,
 	justifySpaceBetween,
+	justifyStretch,
 } from '@wordpress/icons';
 
 /**
@@ -65,52 +66,6 @@ import {
 	alignBottom,
 	spaceBetween,
 } from '../components/block-vertical-alignment-control/icons';
-
-const horizontalAlignmentOptions = [
-	{
-		value: 'left',
-		icon: justifyLeft,
-		label: __( 'Left' ),
-	},
-	{
-		value: 'center',
-		icon: justifyCenter,
-		label: __( 'Middle' ),
-	},
-	{
-		value: 'right',
-		icon: justifyRight,
-		label: __( 'Right' ),
-	},
-	{
-		value: 'space-between',
-		icon: justifySpaceBetween,
-		label: __( 'Space Between' ),
-	},
-];
-
-const verticalAlignmentOptions = [
-	{
-		value: 'top',
-		icon: alignTop,
-		label: __( 'Top' ),
-	},
-	{
-		value: 'center',
-		icon: alignCenter,
-		label: __( 'Middle' ),
-	},
-	{
-		value: 'bottom',
-		icon: alignBottom,
-		label: __( 'Bottom' ),
-	},
-	{
-		value: 'space-between',
-		icon: spaceBetween,
-		label: __( 'Space Between' ),
-	},
-];
 
 const innerWidthOptions = [
 	{
@@ -343,18 +298,6 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 		return null;
 	}
 
-	// Only show the inherit toggle if it's supported,
-	// a default theme layout is set (e.g. one that provides `contentSize` and/or `wideSize` values),
-	// and either the default / flow or the constrained layout type is in use, as the toggle switches from one to the other.
-	// const showInheritToggle = !! (
-	// 	allowInheriting &&
-	// 	!! defaultThemeLayout &&
-	// 	( ! layout?.type ||
-	// 		layout?.type === 'default' ||
-	// 		layout?.type === 'constrained' ||
-	// 		layout?.inherit )
-	// );
-
 	const usedLayout = layout || defaultBlockLayout || {};
 	const {
 		inherit = false,
@@ -378,7 +321,64 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 	const constrainedType = getLayoutType( 'constrained' );
 	const displayControlsForLegacyLayouts =
 		! usedLayout.type && ( contentSize || inherit );
-	// const hasContentSizeOrLegacySettings = !! inherit || !! contentSize;
+
+	const horizontalAlignmentOptions = [
+		{
+			value: 'left',
+			icon: justifyLeft,
+			label: __( 'Left' ),
+		},
+		{
+			value: 'center',
+			icon: justifyCenter,
+			label: __( 'Middle' ),
+		},
+		{
+			value: 'right',
+			icon: justifyRight,
+			label: __( 'Right' ),
+		},
+	];
+
+	if ( type === 'flex' ) {
+		horizontalAlignmentOptions.push( {
+			value: 'space-between',
+			icon: justifySpaceBetween,
+			label: __( 'Space Between' ),
+		} );
+	}
+
+	const verticalAlignmentOptions = [
+		{
+			value: 'top',
+			icon: alignTop,
+			label: __( 'Top' ),
+		},
+		{
+			value: 'center',
+			icon: alignCenter,
+			label: __( 'Middle' ),
+		},
+		{
+			value: 'bottom',
+			icon: alignBottom,
+			label: __( 'Bottom' ),
+		},
+	];
+
+	if ( orientation === 'horizontal' ) {
+		verticalAlignmentOptions.push( {
+			value: 'stretch',
+			icon: justifyStretch,
+			label: __( 'Stretch' ),
+		} );
+	} else {
+		verticalAlignmentOptions.push( {
+			value: 'space-between',
+			icon: spaceBetween,
+			label: __( 'Space Between' ),
+		} );
+	}
 
 	const onChangeType = ( newType ) => {
 		if ( newType === 'stack' ) {
@@ -430,7 +430,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 			}
 		} else {
 			setAttributes( {
-				layout: { ...usedLayout, innerWidth: key },
+				layout: { ...usedLayout, type: 'default', innerWidth: key },
 			} );
 		}
 	};
@@ -459,53 +459,12 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 		} );
 	};
 
+	const defaultHorizontalAlign = type === 'constrained' ? 'center' : 'left';
+
 	return (
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Layout' ) }>
-					{ /* { showInheritToggle && (
-						<>
-							<ToggleControl
-								__nextHasNoMarginBottom
-								style={{marginBottom: , marginTop: 00}}
-								className="block-editor-hooks__toggle-control"
-								label={ __( 'Inner blocks use content width' ) }
-								checked={
-									layoutType?.name === 'constrained' ||
-									hasContentSizeOrLegacySettings
-								}
-								onChange={ () =>
-									setAttributes( {
-										layout: {
-											type:
-												layoutType?.name ===
-													'constrained' ||
-												hasContentSizeOrLegacySettings
-													? 'default'
-													: 'constrained',
-										},
-									} )
-								}
-								help={
-									layoutType?.name === 'constrained' ||
-									hasContentSizeOrLegacySettings
-										? __(
-												'Nested blocks use content width with options for full and wide widths.'
-										  )
-										: __(
-												'Nested blocks will fill the width of this container. Toggle to constrain.'
-										  )
-								}
-							/>
-						</>
-					) } */ }
-
-					{ /* { ! inherit && allowSwitching && (
-						<LayoutTypeSwitcher
-							type={ type }
-							onChange={ onChangeType }
-						/>
-					) } */ }
 					<VStack spacing={ 3 } className="components-wrapper-vstack">
 						<ToggleGroupControl
 							__nextHasNoMarginBottom
@@ -543,7 +502,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 								label={ __( 'Grid' ) }
 							/>
 						</ToggleGroupControl>
-						{ layoutType && layoutType.name === 'grid' && (
+						{ type === 'grid' && (
 							<layoutType.inspectorControls
 								layout={ usedLayout }
 								onChange={ onChangeLayout }
@@ -551,123 +510,124 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 							/>
 						) }
 						<HStack spacing={ 2 } justify="stretch">
-							<FlexBlock>
-								<ToggleGroupControl
-									__nextHasNoMarginBottom
-									style={ { marginBottom: 0, marginTop: 0 } }
-									label={ __( 'Vertical' ) }
-									value={
-										usedLayout?.verticalAlignment || 'top'
-									}
-									onChange={ ( selectedItem ) => {
-										setAttributes( {
-											layout: {
-												...usedLayout,
-												verticalAlignment: selectedItem,
-											},
-										} );
-									} }
-									isBlock={ true }
-									className="components-toggle-group-control__full-width"
-								>
-									{ verticalAlignmentOptions.map(
-										( option ) => (
-											<ToggleGroupControlOptionIcon
-												key={ option.value }
-												icon={ option.icon }
-												value={ option.value }
-												label={ option.label }
-											/>
-										)
-									) }
-								</ToggleGroupControl>
-							</FlexBlock>
-							<FlexBlock>
-								<ToggleGroupControl
-									__nextHasNoMarginBottom
-									style={ { marginBottom: 0, marginTop: 0 } }
-									label={ __( 'Horizontal' ) }
-									value={ 'left' }
-									isBlock={ true }
-									onChange={ ( selectedItem ) => {
-										setAttributes( {
-											layout: {
-												...usedLayout,
-												justifyContent: selectedItem,
-											},
-										} );
-									} }
-									className="components-toggle-group-control__full-width"
-								>
-									{ horizontalAlignmentOptions.map(
-										( { value, icon, label } ) => (
-											<ToggleGroupControlOptionIcon
-												key={ value }
-												icon={ icon }
-												value={ value }
-												label={ label }
-											/>
-										)
-									) }
-								</ToggleGroupControl>
-							</FlexBlock>
-						</HStack>
-						<ToggleGroupControl
-							__nextHasNoMarginBottom
-							style={ { marginBottom: 0, marginTop: 0 } }
-							label={ __( 'Content width' ) }
-							value={ usedLayout?.verticalAlignment || 'top' }
-							onChange={ onChangeInnerWidth }
-							isBlock={ true }
-							className="components-toggle-group-control__full-width"
-						>
-							{ innerWidthOptions.map( ( option ) => (
-								<ToggleGroupControlOptionIcon
-									key={ option.value }
-									icon={ option.icon }
-									value={ option.value }
-									label={ option.label }
-								/>
-							) ) }
-						</ToggleGroupControl>
-						{ layoutType &&
-							layoutType.name === 'grid' &&
-							orientation === 'horizontal' && (
-								<div style={ { marginTop: '24px' } }>
+							{ type === 'flex' && (
+								<FlexBlock>
 									<ToggleGroupControl
 										__nextHasNoMarginBottom
 										style={ {
 											marginBottom: 0,
 											marginTop: 0,
 										} }
-										size={ '__unstable-large' }
-										label={ __( 'Wrap' ) }
-										value={ flexWrap }
-										onChange={ onChangeWrap }
+										label={ __( 'Vertical' ) }
+										value={
+											usedLayout?.verticalAlignment ||
+											'top'
+										}
+										onChange={ ( selectedItem ) => {
+											onChangeLayout( {
+												...usedLayout,
+												verticalAlignment: selectedItem,
+											} );
+										} }
 										isBlock={ true }
+										className="components-toggle-group-control__full-width"
 									>
-										<ToggleGroupControlOption
-											key={ 'wrap' }
-											value="wrap"
-											label={ __( 'Yes' ) }
-										/>
-										<ToggleGroupControlOption
-											key={ 'nowrap' }
-											value="nowrap"
-											label={ __( 'No' ) }
-										/>
+										{ verticalAlignmentOptions.map(
+											( option ) => (
+												<ToggleGroupControlOptionIcon
+													key={ option.value }
+													icon={ option.icon }
+													value={ option.value }
+													label={ option.label }
+												/>
+											)
+										) }
 									</ToggleGroupControl>
-								</div>
+								</FlexBlock>
 							) }
-						{ /* { layoutType &&
-						layoutType.name !== 'default' &&
-						layoutType.name !== 'constrained' && (
-							<layoutType.inspectorControls
-								layout={ usedLayout }
-								onChange={ onChangeLayout }
-								layoutBlockSupport={ layoutBlockSupport }
-							/>
-						) } */ }
+							<FlexBlock>
+								{ ( type === 'flex' ||
+									type === 'constrained' ) && (
+									<ToggleGroupControl
+										__nextHasNoMarginBottom
+										style={ {
+											marginBottom: 0,
+											marginTop: 0,
+										} }
+										label={ __( 'Horizontal' ) }
+										value={ defaultHorizontalAlign }
+										isBlock={ true }
+										onChange={ ( selectedItem ) => {
+											onChangeLayout( {
+												...usedLayout,
+												justifyContent: selectedItem,
+											} );
+										} }
+										className="components-toggle-group-control__full-width"
+									>
+										{ horizontalAlignmentOptions.map(
+											( { value, icon, label } ) => (
+												<ToggleGroupControlOptionIcon
+													key={ value }
+													icon={ icon }
+													value={ value }
+													label={ label }
+												/>
+											)
+										) }
+									</ToggleGroupControl>
+								) }
+							</FlexBlock>
+						</HStack>
+						{ ( ( type === 'flex' && orientation === 'vertical' ) ||
+							type === 'default' ||
+							type === 'constrained' ) && (
+							<ToggleGroupControl
+								__nextHasNoMarginBottom
+								style={ { marginBottom: 0, marginTop: 0 } }
+								label={ __( 'Content width' ) }
+								value={ usedLayout?.verticalAlignment || 'top' }
+								onChange={ onChangeInnerWidth }
+								isBlock={ true }
+								className="components-toggle-group-control__full-width"
+							>
+								{ innerWidthOptions.map( ( option ) => (
+									<ToggleGroupControlOptionIcon
+										key={ option.value }
+										icon={ option.icon }
+										value={ option.value }
+										label={ option.label }
+									/>
+								) ) }
+							</ToggleGroupControl>
+						) }
+						{ type === 'flex' && orientation === 'horizontal' && (
+							<div style={ { marginTop: '24px' } }>
+								<ToggleGroupControl
+									__nextHasNoMarginBottom
+									style={ {
+										marginBottom: 0,
+										marginTop: 0,
+									} }
+									size={ '__unstable-large' }
+									label={ __( 'Wrap' ) }
+									value={ flexWrap }
+									onChange={ onChangeWrap }
+									isBlock={ true }
+								>
+									<ToggleGroupControlOption
+										key={ 'wrap' }
+										value="wrap"
+										label={ __( 'Yes' ) }
+									/>
+									<ToggleGroupControlOption
+										key={ 'nowrap' }
+										value="nowrap"
+										label={ __( 'No' ) }
+									/>
+								</ToggleGroupControl>
+							</div>
+						) }
 						{ constrainedType &&
 							displayControlsForLegacyLayouts && (
 								<constrainedType.inspectorControls
@@ -697,23 +657,6 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 		</>
 	);
 }
-// function LayoutTypeSwitcher( { type, onChange } ) {
-// 	return (
-// 		<ButtonGroup>
-// 			{ getLayoutTypes().map( ( { name, label } ) => {
-// 				return (
-// 					<Button
-// 						key={ name }
-// 						isPressed={ type === name }
-// 						onClick={ () => onChange( name ) }
-// 					>
-// 						{ label }
-// 					</Button>
-// 				);
-// 			} ) }
-// 		</ButtonGroup>
-// 	);
-// }
 
 /**
  * Filters registered block settings, extending attributes to include `layout`.

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -67,119 +67,6 @@ import {
 	alignStretch,
 } from '../components/block-vertical-alignment-control/icons';
 
-const innerWidthOptions = [
-	{
-		value: 'fit',
-		icon: (
-			<SVG
-				width="24"
-				height="24"
-				viewBox="0 0 24 24"
-				fill="none"
-				xmlns="http://www.w3.org/2000/svg"
-			>
-				<Rect
-					x="13.0002"
-					y="5"
-					width="1.5"
-					height="14"
-					fill="currentColor"
-				/>
-				<Rect
-					x="8.00024"
-					y="5"
-					width="1.5"
-					height="14"
-					fill="currentColor"
-				/>
-				<Path
-					d="M21.0002 15L18.0002 12L21.0002 9"
-					stroke="currentColor"
-				/>
-				<Path d="M2 9L5 12L2 15" stroke="currentColor" />
-			</SVG>
-		),
-		label: __( 'Fit' ),
-	},
-	{
-		value: 'theme',
-		icon: (
-			<SVG
-				width="24"
-				height="24"
-				viewBox="0 0 24 24"
-				fill="none"
-				xmlns="http://www.w3.org/2000/svg"
-			>
-				<Rect
-					x="7"
-					y="11"
-					width="1.5"
-					height="1.5"
-					fill="currentColor"
-				/>
-				<Rect
-					x="10"
-					y="11"
-					width="1.5"
-					height="1.5"
-					fill="currentColor"
-				/>
-				<Rect
-					x="13"
-					y="11"
-					width="1.5"
-					height="1.5"
-					fill="currentColor"
-				/>
-				<Rect
-					x="16"
-					y="11"
-					width="1.5"
-					height="1.5"
-					fill="currentColor"
-				/>
-				<Rect
-					x="19"
-					y="5"
-					width="1.5"
-					height="14"
-					fill="currentColor"
-				/>
-				<Rect x="4" y="5" width="1.5" height="14" fill="currentColor" />
-			</SVG>
-		),
-		label: __( 'Fixed' ),
-	},
-	{
-		value: 'fill',
-		icon: (
-			<SVG
-				width="24"
-				height="24"
-				viewBox="0 0 24 24"
-				fill="none"
-				xmlns="http://www.w3.org/2000/svg"
-			>
-				<Rect
-					x="19"
-					y="5"
-					width="1.5"
-					height="14"
-					fill="currentColor"
-				/>
-				<Rect x="4" y="5" width="1.5" height="14" fill="currentColor" />
-				<Path
-					d="M13.0005 9L16.0005 12L13.0005 15"
-					stroke="currentColor"
-				/>
-				<Path d="M11 15L8 12L11 9" stroke="currentColor" />
-			</SVG>
-		),
-		label: __( 'Fill' ),
-	},
-];
-
 /**
  * Generates the utility classnames for the given block's layout attributes.
  *
@@ -288,10 +175,10 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 		{}
 	);
 	const {
-		// allowSwitching,
+		allowSwitching = false,
 		allowEditing = true,
 		// allowInheriting = true,
-		default: defaultBlockLayout,
+		default: defaultBlockLayout = { type: 'default' },
 	} = layoutBlockSupport;
 
 	if ( ! allowEditing ) {
@@ -306,6 +193,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 		orientation = 'horizontal',
 		flexWrap = 'nowrap',
 	} = usedLayout;
+	const { type: defaultBlockLayoutType } = defaultBlockLayout;
 	/**
 	 * `themeSupportsLayout` is only relevant to the `default/flow` or
 	 * `constrained` layouts and it should not be taken into account when other
@@ -322,6 +210,133 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 	const displayControlsForLegacyLayouts =
 		! usedLayout.type && ( contentSize || inherit );
 
+	const innerWidthOptions = [
+		{
+			value: 'theme',
+			icon: (
+				<SVG
+					width="24"
+					height="24"
+					viewBox="0 0 24 24"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
+				>
+					<Rect
+						x="7"
+						y="11"
+						width="1.5"
+						height="1.5"
+						fill="currentColor"
+					/>
+					<Rect
+						x="10"
+						y="11"
+						width="1.5"
+						height="1.5"
+						fill="currentColor"
+					/>
+					<Rect
+						x="13"
+						y="11"
+						width="1.5"
+						height="1.5"
+						fill="currentColor"
+					/>
+					<Rect
+						x="16"
+						y="11"
+						width="1.5"
+						height="1.5"
+						fill="currentColor"
+					/>
+					<Rect
+						x="19"
+						y="5"
+						width="1.5"
+						height="14"
+						fill="currentColor"
+					/>
+					<Rect
+						x="4"
+						y="5"
+						width="1.5"
+						height="14"
+						fill="currentColor"
+					/>
+				</SVG>
+			),
+			label: __( 'Fixed' ),
+		},
+		{
+			value: 'fill',
+			icon: (
+				<SVG
+					width="24"
+					height="24"
+					viewBox="0 0 24 24"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
+				>
+					<Rect
+						x="19"
+						y="5"
+						width="1.5"
+						height="14"
+						fill="currentColor"
+					/>
+					<Rect
+						x="4"
+						y="5"
+						width="1.5"
+						height="14"
+						fill="currentColor"
+					/>
+					<Path
+						d="M13.0005 9L16.0005 12L13.0005 15"
+						stroke="currentColor"
+					/>
+					<Path d="M11 15L8 12L11 9" stroke="currentColor" />
+				</SVG>
+			),
+			label: __( 'Fill' ),
+		},
+	];
+
+	if ( allowSwitching || defaultBlockLayoutType === 'flex' ) {
+		innerWidthOptions.unshift( {
+			value: 'fit',
+			icon: (
+				<SVG
+					width="24"
+					height="24"
+					viewBox="0 0 24 24"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
+				>
+					<Rect
+						x="13.0002"
+						y="5"
+						width="1.5"
+						height="14"
+						fill="currentColor"
+					/>
+					<Rect
+						x="8.00024"
+						y="5"
+						width="1.5"
+						height="14"
+						fill="currentColor"
+					/>
+					<Path
+						d="M21.0002 15L18.0002 12L21.0002 9"
+						stroke="currentColor"
+					/>
+					<Path d="M2 9L5 12L2 15" stroke="currentColor" />
+				</SVG>
+			),
+			label: __( 'Fit' ),
+		} );
+	}
 	const horizontalAlignmentOptions = [
 		{
 			value: 'left',
@@ -382,19 +397,13 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 
 	const onChangeType = ( newType ) => {
 		if ( newType === 'stack' ) {
-			const { innerWidth } = usedLayout;
-			if ( innerWidth === 'fit' ) {
+			const { type: previousLayoutType } = usedLayout;
+			if ( previousLayoutType === 'flex' ) {
 				setAttributes( {
 					layout: {
 						...usedLayout,
 						type: 'flex',
 						orientation: 'vertical',
-					},
-				} );
-			} else if ( innerWidth === 'theme' ) {
-				setAttributes( {
-					layout: {
-						type: 'constrained',
 					},
 				} );
 			} else {
@@ -414,29 +423,19 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 	const onChangeInnerWidth = ( key ) => {
 		if ( key === 'theme' ) {
 			setAttributes( {
-				layout: { ...usedLayout, type: 'constrained', innerWidth: key },
+				layout: { ...usedLayout, type: 'constrained' },
 			} );
 		} else if ( key === 'fit' ) {
-			if (
-				usedLayout.type === 'constrained' ||
-				usedLayout.type === 'default'
-			) {
-				setAttributes( {
-					layout: {
-						...usedLayout,
-						type: 'flex',
-						orientation: 'vertical',
-						innerWidth: key,
-					},
-				} );
-			} else {
-				setAttributes( {
-					layout: { ...usedLayout, type: 'flex', innerWidth: key },
-				} );
-			}
+			setAttributes( {
+				layout: {
+					...usedLayout,
+					type: 'flex',
+					orientation: 'vertical',
+				},
+			} );
 		} else {
 			setAttributes( {
-				layout: { ...usedLayout, type: 'default', innerWidth: key },
+				layout: { ...usedLayout, type: 'default' },
 			} );
 		}
 	};
@@ -466,12 +465,19 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 	};
 
 	const defaultHorizontalAlign = type === 'constrained' ? 'center' : 'left';
-	let contentWidthValue = 'fit';
 
+	let defaultContentWidthValue = 'fill';
+	if ( defaultBlockLayoutType === 'constrained' ) {
+		defaultContentWidthValue = 'theme';
+	} else if ( defaultBlockLayoutType === 'flex' ) {
+		defaultContentWidthValue = 'fit';
+	}
+
+	let usedContentWidthValue = 'fill';
 	if ( type === 'constrained' ) {
-		contentWidthValue = 'theme';
-	} else if ( type === 'default' ) {
-		contentWidthValue = 'fill';
+		usedContentWidthValue = 'theme';
+	} else if ( type === 'flex' ) {
+		usedContentWidthValue = 'fit';
 	}
 
 	return (
@@ -479,42 +485,49 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 			<InspectorControls>
 				<PanelBody title={ __( 'Layout' ) }>
 					<VStack spacing={ 3 } className="components-wrapper-vstack">
-						<ToggleGroupControl
-							__nextHasNoMarginBottom
-							style={ { marginBottom: 0, marginTop: 0 } }
-							size={ '__unstable-large' }
-							label={ __( 'Layout direction' ) }
-							value={
-								type === 'default' ||
-								type === 'constrained' ||
-								( type === 'flex' &&
-									orientation === 'vertical' )
-									? 'stack'
-									: type
-							}
-							onChange={ onChangeType }
-							isBlock={ true }
-							className="components-toggle-group-control__full-width"
-						>
-							<ToggleGroupControlOptionIcon
-								key={ 'stack' }
-								icon={ arrowDown }
-								value="stack"
-								label={ __( 'Stack' ) }
-							/>
-							<ToggleGroupControlOptionIcon
-								key={ 'row' }
-								icon={ arrowRight }
-								value="flex"
-								label={ __( 'Row' ) }
-							/>
-							<ToggleGroupControlOptionIcon
-								key={ 'grid' }
-								icon={ grid }
-								value="grid"
-								label={ __( 'Grid' ) }
-							/>
-						</ToggleGroupControl>
+						{ ( allowSwitching ||
+							defaultBlockLayoutType === 'flex' ) && (
+							<ToggleGroupControl
+								__nextHasNoMarginBottom
+								style={ { marginBottom: 0, marginTop: 0 } }
+								size={ '__unstable-large' }
+								label={ __( 'Layout direction' ) }
+								value={
+									type === 'default' ||
+									type === 'constrained' ||
+									( type === 'flex' &&
+										orientation === 'vertical' )
+										? 'stack'
+										: type
+								}
+								onChange={ onChangeType }
+								isBlock={ true }
+								className="components-toggle-group-control__full-width"
+							>
+								<ToggleGroupControlOptionIcon
+									key={ 'stack' }
+									icon={ arrowDown }
+									value="stack"
+									label={ __( 'Stack' ) }
+								/>
+
+								<ToggleGroupControlOptionIcon
+									key={ 'row' }
+									icon={ arrowRight }
+									value="flex"
+									label={ __( 'Row' ) }
+								/>
+
+								{ allowSwitching && (
+									<ToggleGroupControlOptionIcon
+										key={ 'grid' }
+										icon={ grid }
+										value="grid"
+										label={ __( 'Grid' ) }
+									/>
+								) }
+							</ToggleGroupControl>
+						) }
 						{ type === 'grid' && (
 							<layoutType.inspectorControls
 								layout={ usedLayout }
@@ -529,7 +542,10 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 								__nextHasNoMarginBottom
 								style={ { marginBottom: 0, marginTop: 0 } }
 								label={ __( 'Content width' ) }
-								value={ contentWidthValue }
+								value={
+									usedContentWidthValue ||
+									defaultContentWidthValue
+								}
 								onChange={ onChangeInnerWidth }
 								isBlock={ true }
 								className="components-toggle-group-control__full-width"

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -46,7 +46,7 @@ import { InspectorControls } from '../components';
 import useSetting from '../components/use-setting';
 import { LayoutStyle } from '../components/block-list/layout';
 import BlockList from '../components/block-list';
-import { getLayoutType, getLayoutTypes } from '../layouts';
+import { getLayoutType } from '../layouts';
 import { useBlockEditingMode } from '../components/block-editing-mode';
 import { LAYOUT_DEFINITIONS } from '../layouts/definitions';
 import { kebabCase } from '../utils/object';
@@ -159,8 +159,7 @@ export function useLayoutStyles( blockAttributes = {}, blockName, selector ) {
 }
 
 function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
-	const { layout } = attributes;
-	const defaultThemeLayout = useSetting( 'layout' );
+	const { layout, style } = attributes;
 	const { themeSupportsLayout } = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		return {

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -555,7 +555,10 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 											marginTop: 0,
 										} }
 										label={ __( 'Horizontal' ) }
-										value={ defaultHorizontalAlign }
+										value={
+											usedLayout?.justifyContent ||
+											defaultHorizontalAlign
+										}
 										isBlock={ true }
 										onChange={ ( selectedItem ) => {
 											onChangeLayout( {

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -13,17 +13,30 @@ import { useSelect } from '@wordpress/data';
 import {
 	// Button,
 	// ButtonGroup,
-	CustomSelectControl,
-	Flex,
-	FlexItem,
+	FlexBlock,
 	// ToggleControl,
+	Rect,
+	Path,
 	PanelBody,
 	RangeControl,
+	SVG,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useContext, createPortal } from '@wordpress/element';
+import {
+	arrowRight,
+	arrowDown,
+	grid,
+	justifyLeft,
+	justifyCenter,
+	justifyRight,
+	justifySpaceBetween,
+} from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -46,6 +59,171 @@ function hasLayoutBlockSupport( blockName ) {
 		hasBlockSupport( blockName, '__experimentalLayout' )
 	);
 }
+import {
+	alignTop,
+	alignCenter,
+	alignBottom,
+	spaceBetween,
+} from '../components/block-vertical-alignment-control/icons';
+
+const horizontalAlignmentOptions = [
+	{
+		value: 'left',
+		icon: justifyLeft,
+		label: __( 'Left' ),
+	},
+	{
+		value: 'center',
+		icon: justifyCenter,
+		label: __( 'Middle' ),
+	},
+	{
+		value: 'right',
+		icon: justifyRight,
+		label: __( 'Right' ),
+	},
+	{
+		value: 'space-between',
+		icon: justifySpaceBetween,
+		label: __( 'Space Between' ),
+	},
+];
+
+const verticalAlignmentOptions = [
+	{
+		value: 'top',
+		icon: alignTop,
+		label: __( 'Top' ),
+	},
+	{
+		value: 'center',
+		icon: alignCenter,
+		label: __( 'Middle' ),
+	},
+	{
+		value: 'bottom',
+		icon: alignBottom,
+		label: __( 'Bottom' ),
+	},
+	{
+		value: 'space-between',
+		icon: spaceBetween,
+		label: __( 'Space Between' ),
+	},
+];
+
+const innerWidthOptions = [
+	{
+		value: 'fill',
+		icon: (
+			<SVG
+				width="24"
+				height="24"
+				viewBox="0 0 24 24"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<Rect
+					x="19"
+					y="5"
+					width="1.5"
+					height="14"
+					fill="currentColor"
+				/>
+				<Rect x="4" y="5" width="1.5" height="14" fill="currentColor" />
+				<Path
+					d="M13.0005 9L16.0005 12L13.0005 15"
+					stroke="currentColor"
+				/>
+				<Path d="M11 15L8 12L11 9" stroke="currentColor" />
+			</SVG>
+		),
+		label: __( 'Fill' ),
+	},
+	{
+		value: 'fit',
+		icon: (
+			<SVG
+				width="24"
+				height="24"
+				viewBox="0 0 24 24"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<Rect
+					x="13.0002"
+					y="5"
+					width="1.5"
+					height="14"
+					fill="currentColor"
+				/>
+				<Rect
+					x="8.00024"
+					y="5"
+					width="1.5"
+					height="14"
+					fill="currentColor"
+				/>
+				<Path
+					d="M21.0002 15L18.0002 12L21.0002 9"
+					stroke="currentColor"
+				/>
+				<Path d="M2 9L5 12L2 15" stroke="currentColor" />
+			</SVG>
+		),
+		label: __( 'Fit' ),
+	},
+	{
+		value: 'theme',
+		icon: (
+			<SVG
+				width="24"
+				height="24"
+				viewBox="0 0 24 24"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<Rect
+					x="7"
+					y="11"
+					width="1.5"
+					height="1.5"
+					fill="currentColor"
+				/>
+				<Rect
+					x="10"
+					y="11"
+					width="1.5"
+					height="1.5"
+					fill="currentColor"
+				/>
+				<Rect
+					x="13"
+					y="11"
+					width="1.5"
+					height="1.5"
+					fill="currentColor"
+				/>
+				<Rect
+					x="16"
+					y="11"
+					width="1.5"
+					height="1.5"
+					fill="currentColor"
+				/>
+				<Rect
+					x="19"
+					y="5"
+					width="1.5"
+					height="14"
+					fill="currentColor"
+				/>
+				<Rect x="4" y="5" width="1.5" height="14" fill="currentColor" />
+			</SVG>
+		),
+		label: __( 'Fixed' ),
+	},
+];
 
 /**
  * Generates the utility classnames for the given block's layout attributes.
@@ -227,10 +405,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 		}
 	};
 
-	const onChangeInnerWidth = ( newInnerWidth ) => {
-		const {
-			selectedItem: { key },
-		} = newInnerWidth;
+	const onChangeInnerWidth = ( key ) => {
 		if ( key === 'theme' ) {
 			setAttributes( {
 				layout: { ...usedLayout, type: 'constrained', innerWidth: key },
@@ -284,63 +459,6 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 		} );
 	};
 
-	const innerWidthOptions = [
-		{
-			key: 'fill',
-			name: __( 'Fill' ),
-		},
-		{
-			key: 'fit',
-			name: __( 'Fit' ),
-		},
-		{
-			key: 'theme',
-			name: __( 'Theme' ),
-		},
-		{
-			key: 'custom',
-			name: __( 'Custom' ),
-		},
-	];
-
-	const horizontalAlignmentOptions = [
-		{
-			key: 'left',
-			name: __( 'Left' ),
-		},
-		{
-			key: 'center',
-			name: __( 'Middle' ),
-		},
-		{
-			key: 'right',
-			name: __( 'Right' ),
-		},
-		{
-			key: 'space-between',
-			name: __( 'Space Between' ),
-		},
-	];
-
-	const verticalAlignmentOptions = [
-		{
-			key: 'top',
-			name: __( 'Top' ),
-		},
-		{
-			key: 'center',
-			name: __( 'Middle' ),
-		},
-		{
-			key: 'bottom',
-			name: __( 'Bottom' ),
-		},
-		{
-			key: 'space-between',
-			name: __( 'Space Between' ),
-		},
-	];
-
 	return (
 		<>
 			<InspectorControls>
@@ -349,6 +467,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 						<>
 							<ToggleControl
 								__nextHasNoMarginBottom
+								style={{marginBottom: , marginTop: 00}}
 								className="block-editor-hooks__toggle-control"
 								label={ __( 'Inner blocks use content width' ) }
 								checked={
@@ -387,119 +506,160 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 							onChange={ onChangeType }
 						/>
 					) } */ }
-
-					<ToggleGroupControl
-						__nextHasNoMarginBottom
-						size={ '__unstable-large' }
-						label={ __( 'Layout direction' ) }
-						value={
-							type === 'default' ||
-							type === 'constrained' ||
-							( type === 'flex' && orientation === 'vertical' )
-								? 'stack'
-								: type
-						}
-						onChange={ onChangeType }
-						isBlock={ true }
-					>
-						<ToggleGroupControlOption
-							key={ 'stack' }
-							value="stack"
-							label={ __( 'Stack' ) }
-						/>
-						<ToggleGroupControlOption
-							key={ 'row' }
-							value="flex"
-							label={ __( 'Row' ) }
-						/>
-						<ToggleGroupControlOption
-							key={ 'grid' }
-							value="grid"
-							label={ __( 'Grid' ) }
-						/>
-					</ToggleGroupControl>
-					{ layoutType && layoutType.name === 'grid' && (
-						<layoutType.inspectorControls
-							layout={ usedLayout }
-							onChange={ onChangeLayout }
-							layoutBlockSupport={ layoutBlockSupport }
-						/>
-					) }
-					<RangeControl
-						label={ __( 'Gap' ) }
-						onChange={ onChangeGap }
-						value={ style?.spacing?.blockGap }
-						min={ 0 }
-						max={ 100 }
-						withInputField={ false }
-					/>
-					<p>ALIGN</p>
-					<Flex>
-						<FlexItem>
-							<CustomSelectControl
-								__nextUnconstrainedWidth
-								label="Vertical"
-								options={ verticalAlignmentOptions }
-								onChange={ ( { selectedItem } ) => {
-									setAttributes( {
-										layout: {
-											...usedLayout,
-											verticalAlignment: selectedItem.key,
-										},
-									} );
-								} }
+					<VStack spacing={ 3 } className="components-wrapper-vstack">
+						<ToggleGroupControl
+							__nextHasNoMarginBottom
+							style={ { marginBottom: 0, marginTop: 0 } }
+							size={ '__unstable-large' }
+							label={ __( 'Layout direction' ) }
+							value={
+								type === 'default' ||
+								type === 'constrained' ||
+								( type === 'flex' &&
+									orientation === 'vertical' )
+									? 'stack'
+									: type
+							}
+							onChange={ onChangeType }
+							isBlock={ true }
+							className="components-toggle-group-control__full-width"
+						>
+							<ToggleGroupControlOptionIcon
+								key={ 'stack' }
+								icon={ arrowDown }
+								value="stack"
+								label={ __( 'Stack' ) }
 							/>
-						</FlexItem>
-						<FlexItem>
-							<CustomSelectControl
-								__nextUnconstrainedWidth
-								label="Horizontal"
-								options={ horizontalAlignmentOptions }
-								onChange={ ( { selectedItem } ) =>
-									setAttributes( {
-										layout: {
-											...usedLayout,
-											justifyContent: selectedItem.key,
-										},
-									} )
-								}
+							<ToggleGroupControlOptionIcon
+								key={ 'row' }
+								icon={ arrowRight }
+								value="flex"
+								label={ __( 'Row' ) }
 							/>
-						</FlexItem>
-					</Flex>
-					<div style={ { marginTop: '24px' } }>
-						<CustomSelectControl
-							__nextUnconstrainedWidth
-							label="Inner block width"
-							options={ innerWidthOptions }
-							onChange={ onChangeInnerWidth }
-						/>
-					</div>
-					{ layoutType &&
-						layoutType.name === 'grid' &&
-						orientation === 'horizontal' && (
-							<div style={ { marginTop: '24px' } }>
+							<ToggleGroupControlOptionIcon
+								key={ 'grid' }
+								icon={ grid }
+								value="grid"
+								label={ __( 'Grid' ) }
+							/>
+						</ToggleGroupControl>
+						{ layoutType && layoutType.name === 'grid' && (
+							<layoutType.inspectorControls
+								layout={ usedLayout }
+								onChange={ onChangeLayout }
+								layoutBlockSupport={ layoutBlockSupport }
+							/>
+						) }
+						<HStack spacing={ 2 } justify="stretch">
+							<FlexBlock>
 								<ToggleGroupControl
 									__nextHasNoMarginBottom
-									size={ '__unstable-large' }
-									label={ __( 'Wrap' ) }
-									value={ flexWrap }
-									onChange={ onChangeWrap }
+									style={ { marginBottom: 0, marginTop: 0 } }
+									label={ __( 'Vertical' ) }
+									value={
+										usedLayout?.verticalAlignment || 'top'
+									}
+									onChange={ ( selectedItem ) => {
+										setAttributes( {
+											layout: {
+												...usedLayout,
+												verticalAlignment: selectedItem,
+											},
+										} );
+									} }
 									isBlock={ true }
+									className="components-toggle-group-control__full-width"
 								>
-									<ToggleGroupControlOption
-										key={ 'wrap' }
-										value="wrap"
-										label={ __( 'Yes' ) }
-									/>
-									<ToggleGroupControlOption
-										key={ 'nowrap' }
-										value="nowrap"
-										label={ __( 'No' ) }
-									/>
+									{ verticalAlignmentOptions.map(
+										( option ) => (
+											<ToggleGroupControlOptionIcon
+												key={ option.value }
+												icon={ option.icon }
+												value={ option.value }
+												label={ option.label }
+											/>
+										)
+									) }
 								</ToggleGroupControl>
-							</div>
-						) }
-					{ /* { layoutType &&
+							</FlexBlock>
+							<FlexBlock>
+								<ToggleGroupControl
+									__nextHasNoMarginBottom
+									style={ { marginBottom: 0, marginTop: 0 } }
+									label={ __( 'Horizontal' ) }
+									value={ 'left' }
+									isBlock={ true }
+									onChange={ ( selectedItem ) => {
+										setAttributes( {
+											layout: {
+												...usedLayout,
+												justifyContent: selectedItem,
+											},
+										} );
+									} }
+									className="components-toggle-group-control__full-width"
+								>
+									{ horizontalAlignmentOptions.map(
+										( { value, icon, label } ) => (
+											<ToggleGroupControlOptionIcon
+												key={ value }
+												icon={ icon }
+												value={ value }
+												label={ label }
+											/>
+										)
+									) }
+								</ToggleGroupControl>
+							</FlexBlock>
+						</HStack>
+						<ToggleGroupControl
+							__nextHasNoMarginBottom
+							style={ { marginBottom: 0, marginTop: 0 } }
+							label={ __( 'Content width' ) }
+							value={ usedLayout?.verticalAlignment || 'top' }
+							onChange={ onChangeInnerWidth }
+							isBlock={ true }
+							className="components-toggle-group-control__full-width"
+						>
+							{ innerWidthOptions.map( ( option ) => (
+								<ToggleGroupControlOptionIcon
+									key={ option.value }
+									icon={ option.icon }
+									value={ option.value }
+									label={ option.label }
+								/>
+							) ) }
+						</ToggleGroupControl>
+						{ layoutType &&
+							layoutType.name === 'grid' &&
+							orientation === 'horizontal' && (
+								<div style={ { marginTop: '24px' } }>
+									<ToggleGroupControl
+										__nextHasNoMarginBottom
+										style={ {
+											marginBottom: 0,
+											marginTop: 0,
+										} }
+										size={ '__unstable-large' }
+										label={ __( 'Wrap' ) }
+										value={ flexWrap }
+										onChange={ onChangeWrap }
+										isBlock={ true }
+									>
+										<ToggleGroupControlOption
+											key={ 'wrap' }
+											value="wrap"
+											label={ __( 'Yes' ) }
+										/>
+										<ToggleGroupControlOption
+											key={ 'nowrap' }
+											value="nowrap"
+											label={ __( 'No' ) }
+										/>
+									</ToggleGroupControl>
+								</div>
+							) }
+						{ /* { layoutType &&
 						layoutType.name !== 'default' &&
 						layoutType.name !== 'constrained' && (
 							<layoutType.inspectorControls
@@ -508,13 +668,23 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 								layoutBlockSupport={ layoutBlockSupport }
 							/>
 						) } */ }
-					{ constrainedType && displayControlsForLegacyLayouts && (
-						<constrainedType.inspectorControls
-							layout={ usedLayout }
-							onChange={ onChangeLayout }
-							layoutBlockSupport={ layoutBlockSupport }
+						{ constrainedType &&
+							displayControlsForLegacyLayouts && (
+								<constrainedType.inspectorControls
+									layout={ usedLayout }
+									onChange={ onChangeLayout }
+									layoutBlockSupport={ layoutBlockSupport }
+								/>
+							) }
+						<RangeControl
+							label={ __( 'Gap' ) }
+							onChange={ onChangeGap }
+							value={ style?.spacing?.blockGap }
+							min={ 0 }
+							max={ 100 }
+							withInputField={ false }
 						/>
-					) }
+					</VStack>
 				</PanelBody>
 			</InspectorControls>
 			{ ! inherit && blockEditingMode === 'default' && layoutType && (

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -69,33 +69,6 @@ import {
 
 const innerWidthOptions = [
 	{
-		value: 'fill',
-		icon: (
-			<SVG
-				width="24"
-				height="24"
-				viewBox="0 0 24 24"
-				fill="none"
-				xmlns="http://www.w3.org/2000/svg"
-			>
-				<Rect
-					x="19"
-					y="5"
-					width="1.5"
-					height="14"
-					fill="currentColor"
-				/>
-				<Rect x="4" y="5" width="1.5" height="14" fill="currentColor" />
-				<Path
-					d="M13.0005 9L16.0005 12L13.0005 15"
-					stroke="currentColor"
-				/>
-				<Path d="M11 15L8 12L11 9" stroke="currentColor" />
-			</SVG>
-		),
-		label: __( 'Fill' ),
-	},
-	{
 		value: 'fit',
 		icon: (
 			<SVG
@@ -177,6 +150,33 @@ const innerWidthOptions = [
 			</SVG>
 		),
 		label: __( 'Fixed' ),
+	},
+	{
+		value: 'fill',
+		icon: (
+			<SVG
+				width="24"
+				height="24"
+				viewBox="0 0 24 24"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<Rect
+					x="19"
+					y="5"
+					width="1.5"
+					height="14"
+					fill="currentColor"
+				/>
+				<Rect x="4" y="5" width="1.5" height="14" fill="currentColor" />
+				<Path
+					d="M13.0005 9L16.0005 12L13.0005 15"
+					stroke="currentColor"
+				/>
+				<Path d="M11 15L8 12L11 9" stroke="currentColor" />
+			</SVG>
+		),
+		label: __( 'Fill' ),
 	},
 ];
 
@@ -460,6 +460,13 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 	};
 
 	const defaultHorizontalAlign = type === 'constrained' ? 'center' : 'left';
+	let contentWidthValue = 'fit';
+
+	if ( type === 'constrained' ) {
+		contentWidthValue = 'theme';
+	} else if ( type === 'default' ) {
+		contentWidthValue = 'fill';
+	}
 
 	return (
 		<>
@@ -516,7 +523,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 								__nextHasNoMarginBottom
 								style={ { marginBottom: 0, marginTop: 0 } }
 								label={ __( 'Content width' ) }
-								value={ usedLayout?.verticalAlignment || 'top' }
+								value={ contentWidthValue }
 								onChange={ onChangeInnerWidth }
 								isBlock={ true }
 								className="components-toggle-group-control__full-width"
@@ -606,31 +613,29 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 						</HStack>
 
 						{ type === 'flex' && orientation === 'horizontal' && (
-							<div style={ { marginTop: '24px' } }>
-								<ToggleGroupControl
-									__nextHasNoMarginBottom
-									style={ {
-										marginBottom: 0,
-										marginTop: 0,
-									} }
-									size={ '__unstable-large' }
-									label={ __( 'Wrap' ) }
-									value={ flexWrap }
-									onChange={ onChangeWrap }
-									isBlock={ true }
-								>
-									<ToggleGroupControlOption
-										key={ 'wrap' }
-										value="wrap"
-										label={ __( 'Yes' ) }
-									/>
-									<ToggleGroupControlOption
-										key={ 'nowrap' }
-										value="nowrap"
-										label={ __( 'No' ) }
-									/>
-								</ToggleGroupControl>
-							</div>
+							<ToggleGroupControl
+								__nextHasNoMarginBottom
+								style={ {
+									marginBottom: 0,
+									marginTop: 0,
+								} }
+								size={ '__unstable-large' }
+								label={ __( 'Wrap' ) }
+								value={ flexWrap }
+								onChange={ onChangeWrap }
+								isBlock={ true }
+							>
+								<ToggleGroupControlOption
+									key={ 'wrap' }
+									value="wrap"
+									label={ __( 'Yes' ) }
+								/>
+								<ToggleGroupControlOption
+									key={ 'nowrap' }
+									value="nowrap"
+									label={ __( 'No' ) }
+								/>
+							</ToggleGroupControl>
 						) }
 						{ constrainedType &&
 							displayControlsForLegacyLayouts && (

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -11,10 +11,15 @@ import { addFilter } from '@wordpress/hooks';
 import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import {
-	Button,
-	ButtonGroup,
-	ToggleControl,
+	// Button,
+	// ButtonGroup,
+	CustomSelectControl,
+	// Flex,
+	// FlexItem,
+	// ToggleControl,
 	PanelBody,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useContext, createPortal } from '@wordpress/element';
@@ -149,9 +154,9 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 		{}
 	);
 	const {
-		allowSwitching,
+		// allowSwitching,
 		allowEditing = true,
-		allowInheriting = true,
+		// allowInheriting = true,
 		default: defaultBlockLayout,
 	} = layoutBlockSupport;
 
@@ -162,20 +167,21 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 	// Only show the inherit toggle if it's supported,
 	// a default theme layout is set (e.g. one that provides `contentSize` and/or `wideSize` values),
 	// and either the default / flow or the constrained layout type is in use, as the toggle switches from one to the other.
-	const showInheritToggle = !! (
-		allowInheriting &&
-		!! defaultThemeLayout &&
-		( ! layout?.type ||
-			layout?.type === 'default' ||
-			layout?.type === 'constrained' ||
-			layout?.inherit )
-	);
+	// const showInheritToggle = !! (
+	// 	allowInheriting &&
+	// 	!! defaultThemeLayout &&
+	// 	( ! layout?.type ||
+	// 		layout?.type === 'default' ||
+	// 		layout?.type === 'constrained' ||
+	// 		layout?.inherit )
+	// );
 
 	const usedLayout = layout || defaultBlockLayout || {};
 	const {
 		inherit = false,
 		type = 'default',
 		contentSize = null,
+		orientation = 'horizontal',
 	} = usedLayout;
 	/**
 	 * `themeSupportsLayout` is only relevant to the `default/flow` or
@@ -192,18 +198,116 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 	const constrainedType = getLayoutType( 'constrained' );
 	const displayControlsForLegacyLayouts =
 		! usedLayout.type && ( contentSize || inherit );
-	const hasContentSizeOrLegacySettings = !! inherit || !! contentSize;
+	// const hasContentSizeOrLegacySettings = !! inherit || !! contentSize;
 
-	const onChangeType = ( newType ) =>
-		setAttributes( { layout: { type: newType } } );
+	const onChangeType = ( newType ) => {
+		if ( newType === 'stack' ) {
+			const { innerWidth } = usedLayout;
+			if ( innerWidth === 'fit' ) {
+				setAttributes( {
+					layout: {
+						...usedLayout,
+						type: 'flex',
+						orientation: 'vertical',
+					},
+				} );
+			} else if ( innerWidth === 'theme' ) {
+				setAttributes( {
+					layout: {
+						type: 'constrained',
+					},
+				} );
+			} else {
+				setAttributes( { layout: { type: 'default' } } );
+			}
+		} else {
+			setAttributes( { layout: { ...usedLayout, type: newType } } );
+		}
+	};
+
+	const onChangeInnerWidth = ( newInnerWidth ) => {
+		const {
+			selectedItem: { key },
+		} = newInnerWidth;
+		if ( key === 'theme' ) {
+			setAttributes( {
+				layout: { ...usedLayout, type: 'constrained', innerWidth: key },
+			} );
+		} else if ( key === 'fit' ) {
+			if (
+				usedLayout.type === 'constrained' ||
+				usedLayout.type === 'default'
+			) {
+				setAttributes( {
+					layout: {
+						...usedLayout,
+						type: 'flex',
+						orientation: 'vertical',
+						innerWidth: key,
+					},
+				} );
+			} else {
+				setAttributes( {
+					layout: { ...usedLayout, type: 'flex', innerWidth: key },
+				} );
+			}
+		} else {
+			setAttributes( {
+				layout: { ...usedLayout, innerWidth: key },
+			} );
+		}
+	};
+
 	const onChangeLayout = ( newLayout ) =>
 		setAttributes( { layout: newLayout } );
+
+	const innerWidthOptions = [
+		{
+			key: 'fill',
+			name: __( 'Fill' ),
+		},
+		{
+			key: 'fit',
+			name: __( 'Fit' ),
+		},
+		{
+			key: 'theme',
+			name: __( 'Theme' ),
+		},
+		// {
+		// 	key: 'custom',
+		// 	name: __( 'Custom' ),
+		// },
+	];
+
+	// const alignmentOptions = [
+	// 	{
+	// 		key: 'flex-start',
+	// 		name: __( 'Top' ),
+	// 	},
+	// 	{
+	// 		key: 'center',
+	// 		name: __( 'Middle' ),
+	// 	},
+	// 	{
+	// 		key: 'flex-end',
+	// 		name: __( 'Bottom' ),
+	// 	},
+	// 	{
+	// 		key: 'space-between',
+	// 		name: __( 'Space Between' ),
+	// 	},
+	// 	{
+	// 		key: 'stretch',
+	// 		name: __( 'Stretch' ),
+	// 	},
+	// ];
 
 	return (
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Layout' ) }>
-					{ showInheritToggle && (
+					{ /* { showInheritToggle && (
 						<>
 							<ToggleControl
 								__nextHasNoMarginBottom
@@ -237,22 +341,95 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 								}
 							/>
 						</>
-					) }
+					) } */ }
 
-					{ ! inherit && allowSwitching && (
+					{ /* { ! inherit && allowSwitching && (
 						<LayoutTypeSwitcher
 							type={ type }
 							onChange={ onChangeType }
 						/>
-					) }
+					) } */ }
 
-					{ layoutType && layoutType.name !== 'default' && (
-						<layoutType.inspectorControls
-							layout={ usedLayout }
-							onChange={ onChangeLayout }
-							layoutBlockSupport={ layoutBlockSupport }
+					<ToggleGroupControl
+						__nextHasNoMarginBottom
+						size={ '__unstable-large' }
+						label={ __( 'Layout direction' ) }
+						value={
+							type === 'default' ||
+							type === 'constrained' ||
+							( type === 'flex' && orientation === 'vertical' )
+								? 'stack'
+								: type
+						}
+						onChange={ onChangeType }
+						isBlock={ true }
+					>
+						<ToggleGroupControlOption
+							key={ 'stack' }
+							value="stack"
+							label={ __( 'Stack' ) }
 						/>
-					) }
+						<ToggleGroupControlOption
+							key={ 'row' }
+							value="flex"
+							label={ __( 'Row' ) }
+						/>
+						<ToggleGroupControlOption
+							key={ 'grid' }
+							value="grid"
+							label={ __( 'Grid' ) }
+						/>
+					</ToggleGroupControl>
+
+					<CustomSelectControl
+						__nextUnconstrainedWidth
+						label="Inner block width"
+						options={ innerWidthOptions }
+						onChange={ onChangeInnerWidth }
+					/>
+					{ /* <p>Align</p>
+					<Flex>
+						<FlexItem>
+							<CustomSelectControl
+								__nextUnconstrainedWidth
+								label="Vertical"
+								options={ alignmentOptions }
+								onChange={ ( { selectedItem } ) => {
+									setAttributes( {
+										layout: {
+											...usedLayout,
+											verticalAlignment: selectedItem.key,
+										},
+									} );
+								} }
+							/>
+						</FlexItem>
+						<FlexItem>
+							<CustomSelectControl
+								__nextUnconstrainedWidth
+								label="Horizontal"
+								options={ alignmentOptions }
+								onChange={ ( { selectedItem } ) =>
+									setAttributes( {
+										layout: {
+											...usedLayout,
+											justifyContent: selectedItem.key,
+										},
+									} )
+								}
+							/>
+						</FlexItem>
+					</Flex> */ }
+
+					{ layoutType &&
+						layoutType.name !== 'default' &&
+						layoutType.name !== 'constrained' && (
+							<layoutType.inspectorControls
+								layout={ usedLayout }
+								onChange={ onChangeLayout }
+								layoutBlockSupport={ layoutBlockSupport }
+							/>
+						) }
 					{ constrainedType && displayControlsForLegacyLayouts && (
 						<constrainedType.inspectorControls
 							layout={ usedLayout }
@@ -273,23 +450,23 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 	);
 }
 
-function LayoutTypeSwitcher( { type, onChange } ) {
-	return (
-		<ButtonGroup>
-			{ getLayoutTypes().map( ( { name, label } ) => {
-				return (
-					<Button
-						key={ name }
-						isPressed={ type === name }
-						onClick={ () => onChange( name ) }
-					>
-						{ label }
-					</Button>
-				);
-			} ) }
-		</ButtonGroup>
-	);
-}
+// function LayoutTypeSwitcher( { type, onChange } ) {
+// 	return (
+// 		<ButtonGroup>
+// 			{ getLayoutTypes().map( ( { name, label } ) => {
+// 				return (
+// 					<Button
+// 						key={ name }
+// 						isPressed={ type === name }
+// 						onClick={ () => onChange( name ) }
+// 					>
+// 						{ label }
+// 					</Button>
+// 				);
+// 			} ) }
+// 		</ButtonGroup>
+// 	);
+// }
 
 /**
  * Filters registered block settings, extending attributes to include `layout`.

--- a/packages/block-editor/src/hooks/layout.scss
+++ b/packages/block-editor/src/hooks/layout.scss
@@ -39,3 +39,21 @@
 .block-editor-hooks__toggle-control.block-editor-hooks__toggle-control {
 	margin-bottom: $grid-unit-20;
 }
+
+
+// Temporary
+
+.components-toggle-group-control__full-width {
+	.components-toggle-group-control-option-base {
+		width: 100%;
+		button {
+			width: 100%;
+		}
+	}
+}
+
+.components-wrapper-vstack {
+	> div {
+		margin-bottom: 0 !important;
+	}
+}

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -77,7 +77,8 @@
 			}
 		},
 		"layout": {
-			"allowSizingOnChildren": true
+			"allowSizingOnChildren": true,
+			"allowSwitching": true
 		}
 	},
 	"editorStyle": "wp-block-group-editor",

--- a/packages/block-library/src/group/variations.js
+++ b/packages/block-library/src/group/variations.js
@@ -11,7 +11,7 @@ const variations = [
 		description: __( 'Gather blocks in a container.' ),
 		attributes: { layout: { type: 'constrained' } },
 		isDefault: true,
-		scope: [ 'block', 'inserter', 'transform' ],
+		scope: [ 'block', 'inserter' ],
 		isActive: ( blockAttributes ) =>
 			! blockAttributes.layout ||
 			! blockAttributes.layout?.type ||
@@ -24,7 +24,7 @@ const variations = [
 		title: _x( 'Row', 'single horizontal line' ),
 		description: __( 'Arrange blocks horizontally.' ),
 		attributes: { layout: { type: 'flex', flexWrap: 'nowrap' } },
-		scope: [ 'block', 'inserter', 'transform' ],
+		scope: [ 'block', 'inserter' ],
 		isActive: ( blockAttributes ) =>
 			blockAttributes.layout?.type === 'flex' &&
 			( ! blockAttributes.layout?.orientation ||
@@ -36,7 +36,7 @@ const variations = [
 		title: __( 'Stack' ),
 		description: __( 'Arrange blocks vertically.' ),
 		attributes: { layout: { type: 'flex', orientation: 'vertical' } },
-		scope: [ 'block', 'inserter', 'transform' ],
+		scope: [ 'block', 'inserter' ],
 		isActive: ( blockAttributes ) =>
 			blockAttributes.layout?.type === 'flex' &&
 			blockAttributes.layout?.orientation === 'vertical',
@@ -50,7 +50,7 @@ if ( window?.__experimentalEnableGroupGridVariation ) {
 		title: __( 'Grid' ),
 		description: __( 'Arrange blocks in a grid.' ),
 		attributes: { layout: { type: 'grid' } },
-		scope: [ 'block', 'inserter', 'transform' ],
+		scope: [ 'block', 'inserter' ],
 		isActive: ( blockAttributes ) =>
 			blockAttributes.layout?.type === 'grid',
 		icon: grid,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Starts moving towards the latest designs in #42385.

New layout panel controls vary depending on whether layout switching is allowed (such as for the Group block with its Row, Stack, and experimental Grid variations) or what the layout type is. E.g.:

Flex block:
<img width="276" alt="Screenshot 2023-05-05 at 1 56 41 pm" src="https://user-images.githubusercontent.com/8096000/236375133-324c4404-c165-4006-9f65-c7703a36260a.png">

Flow/constrained block:
<img width="278" alt="Screenshot 2023-05-05 at 1 59 13 pm" src="https://user-images.githubusercontent.com/8096000/236375149-eb760aeb-4573-4e5d-af9a-d00d645b3c6a.png">

Switchable block:
<img width="279" alt="Screenshot 2023-05-05 at 1 57 08 pm" src="https://user-images.githubusercontent.com/8096000/236375183-0b4aa8b6-7b65-4c1f-9a8a-a3d3a40da9e6.png">

As it stands, these changes don't affect the layout API in any way, except for a small difference in behaviour for flex layouts: with vertical orientation, flex can now be switched to flow or constrained layout by toggling the content width control. This still causes a little weirdness in Buttons and Navigation blocks due to their custom styles and markup structures, but that can be fixed by updating the styles in those blocks. 

Another side-effect of this PR is that the `allowSwitching` option now works very well, whereas on trunk it still looks somewhat broken.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add blocks with layout to a post or template, such as Group, Buttons, Social Icons, Navigation, Columns, Post Content.
2. Try all the controls and check that everything behaves as expected.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
