### PR TITLE
Post editor: Allow root padding setting to affect padding of post title

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -160,15 +160,21 @@ export default function VisualEditor( { styles } ) {
 		( select ) => select( editPostStore ).hasMetaBoxes(),
 		[]
 	);
-	const { themeHasDisabledLayoutStyles, themeSupportsLayout, isFocusMode } =
-		useSelect( ( select ) => {
-			const _settings = select( blockEditorStore ).getSettings();
-			return {
-				themeHasDisabledLayoutStyles: _settings.disableLayoutStyles,
-				themeSupportsLayout: _settings.supportsLayout,
-				isFocusMode: _settings.focusMode,
-			};
-		}, [] );
+	const {
+		hasRootPaddingAwareAlignments,
+		isFocusMode,
+		themeHasDisabledLayoutStyles,
+		themeSupportsLayout,
+	} = useSelect( ( select ) => {
+		const _settings = select( blockEditorStore ).getSettings();
+		return {
+			themeHasDisabledLayoutStyles: _settings.disableLayoutStyles,
+			themeSupportsLayout: _settings.supportsLayout,
+			isFocusMode: _settings.focusMode,
+			hasRootPaddingAwareAlignments:
+				_settings.__experimentalFeatures?.useRootPaddingAwareAlignments,
+		};
+	}, [] );
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 	const { setIsEditingTemplate } = useDispatch( editPostStore );
 	const desktopCanvasStyles = {
@@ -393,6 +399,8 @@ export default function VisualEditor( { styles } ) {
 									'edit-post-visual-editor__post-title-wrapper',
 									{
 										'is-focus-mode': isFocusMode,
+										'has-global-padding':
+											hasRootPaddingAwareAlignments,
 									},
 									'is-layout-flow'
 								) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

While testing https://github.com/WordPress/gutenberg/pull/47858, I noticed that the post title in the post editor doesn't currently receive padding rules for themes using `useRootPaddingAwareAlignments` (e.g. TwentyTwentyThree).

The issue is noticeable in a narrower viewport, for example, when the list view is open. You'll only really notice it when the editor canvas is narrower than the site's content size.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is because when `useRootPaddingAwareAlignments` is in use, we expect the `has-global-padding` class to be applied to containers where the padding is in use, in order for the padding to be applied as expected (and not to full-width root blocks). For the post title wrapper, this means we need to explicitly output that classname, otherwise it displays as if it were full-width to the edge of the screen (once the viewport is narrower than the content size).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Treat the post title wrapper effectively as if it were a group block by adding the `has-global-padding` class when `useRootPaddingAwareAlignments` is in use.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. On `trunk`, running TT3, verify the before image below — in narrower viewports with the list view open, the post title wrapper touches the edge of the editor canvas.
2. With this PR applied, the padding should be correct for the post title.
3. Open up the `theme.json` file and switch `settings.useRootPaddingAwareAlignments` to `false`, then reload the page. The padding should still be correct, as the padding will now be set further up on the body element via `editor-styles-wrapper`.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="1274" alt="image" src="https://user-images.githubusercontent.com/14988353/228725029-f382cf7b-adb5-4608-8abd-04b9ccd9e3ba.png"> | <img width="1276" alt="image" src="https://user-images.githubusercontent.com/14988353/228724912-282f078f-1481-4f60-8a5b-caadb4e29c28.png"> |