### PR TITLE
List View: Update drop indicator line to be 4px high with a white border

### DIFF
--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -400,7 +400,9 @@ $block-navigation-max-indent: 8;
 
 	.block-editor-list-view-drop-indicator__line {
 		background: var(--wp-admin-theme-color);
-		height: $border-width;
+		height: 4px;
+		border: 1px solid $white;
+		border-radius: 2px;
 	}
 }
 

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -400,9 +400,9 @@ $block-navigation-max-indent: 8;
 
 	.block-editor-list-view-drop-indicator__line {
 		background: var(--wp-admin-theme-color);
-		height: 4px;
+		height: 6px;
 		border: 1px solid $white;
-		border-radius: 2px;
+		border-radius: 4px;
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Possible fix for: https://github.com/WordPress/gutenberg/issues/39068

Explore updating the drop indicator line styling in the list view to be 4px high with a white border. Currently the line is only `1px` in size and is fairly subtle. Also, it can be hard to see against a selected block, as selected blocks use the same background color as the drop indicator line.

Based on a suggestion from @jasmussen in this review: https://github.com/WordPress/gutenberg/pull/49390#issuecomment-1488139644

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The current 1px line is very subtle, and it's also difficult to see when it sits against selected blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Increase the height of the line indicator to `6px` (with the white border, this has the appearance of being `4px` high)
* Set a `4px` radius (with the white border, this has the appearance of being `2px`)
* Add a white border, so that it doesn't blend into selected blocks as much

Happy for any feedback or ideas on how to improve the styling if this isn't quite right!

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a range of blocks at various nesting levels.
2. Open the list view, and try dragging a block around the list view — does the styling here look any better?
3. Select a few blocks, and drag a non-selected block over the area of selected blocks — is it clearer with the white border?

## Screenshots or screencast <!-- if applicable -->

Note: not addressed in this PR — when you start dragging a block, the color of the selected blocks switches to no longer be white. I can look at that issue in a separate PR.

https://user-images.githubusercontent.com/14988353/228991364-006b10a5-b09b-4b3f-8d4e-636e4bd9e412.mp4

<!--
https://user-images.githubusercontent.com/14988353/228735228-e05aa124-08e2-4506-9ca0-583c7cf97b81.mp4

-->