### PR TITLE
Proposal: Block copy function

### DIFF
--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -83,37 +83,33 @@ export function createBlocksFromInnerBlocksTemplate(
  * Given a block object, returns a copy of the block object while sanitizing its attributes,
  * optionally merging new attributes and/or replacing its inner blocks.
  *
- * @param {Object} block           Block instance.
- * @param {Object} mergeAttributes Block attributes.
- * @param {?Array} newInnerBlocks  Nested blocks.
+ * @param {Object} block Block instance.
  *
  * @return {Object} A cloned block.
  */
-export function __experimentalCloneSanitizedBlock(
-	block,
-	mergeAttributes = {},
-	newInnerBlocks
-) {
+export function __experimentalCloneSanitizedBlock( block ) {
 	const clientId = uuid();
 
 	const sanitizedAttributes = __experimentalSanitizeBlockAttributes(
 		block.name,
-		{
-			...block.attributes,
-			...mergeAttributes,
-		}
+		block.attributes
 	);
 
-	return {
+	let newBlock = {
 		...block,
 		clientId,
 		attributes: sanitizedAttributes,
-		innerBlocks:
-			newInnerBlocks ||
-			block.innerBlocks.map( ( innerBlock ) =>
-				__experimentalCloneSanitizedBlock( innerBlock )
-			),
+		innerBlocks: block.innerBlocks.map( ( innerBlock ) =>
+			__experimentalCloneSanitizedBlock( innerBlock )
+		),
 	};
+
+	const blockType = getBlockType( block.name );
+	if ( blockType?.copy ) {
+		newBlock = blockType.copy( newBlock );
+	}
+
+	return newBlock;
 }
 
 /**


### PR DESCRIPTION
## What and why

Adds a `copy` function to the block API that lets blocks customise what happens when the block is duplicated.

```js
registerBlockType( 'my/block', {
	title: 'My block',
	attributes: {
		foo: { type: 'number', default: 1 },
	},
	copy( block ) {
		return createBlock( 'my/block', {
			...block.attributes,
			foo: block.attributes.foo + 1,
		} );
	},
} );
```

The motivation for this is to handle cases such as https://github.com/WordPress/gutenberg/issues/29693 where a block wants to track a foreign key of some kind.

It's not implemented in this PR, but it also would let us move away from using `__internalWidgetId` which is how the widget editor tracks which widget entity should be updated when a block is modified. It's a hack that works because `__internalWidgetId` does not appear in the `block.json` and so is filtered out when the block is duplicated. Using a `copy` function like above would make this behaviour explicit. (Admittedly it's awkward though because a copy function needs to be declared on every block type.)

## How to test

<details><summary>View instructions</summary>
<p>

Paste this into DevTools:

```js
function sleep( ms ) {
	return new Promise( ( resolve ) => setTimeout( resolve, ms ) );
}
let productIds = 0;
wp.blocks.registerBlockType( 'test/product', {
  title: 'Product',
	attributes: {
		productId: {
			type: 'string'
		},
		title: {
			type: 'string'
		},
		price: {
			type: 'number'		
		}
	},
	copy( block ) {
		const { productId, ...filteredAttributes } = block.attributes;
		return {
			...block,
			attributes: filteredAttributes,
		};
	},
	edit( { attributes, setAttributes } ) {
		wp.element.useEffect( () => {
			( async function() {
				if ( ! attributes.productId ) {
					// pretend to create a new product via REST API
					await sleep( 300 );
					setAttributes( { productId: ++productIds } );
				}
			} )();
		}, [ attributes.productId ] );
		return wp.element.createElement( 'div', {}, [
			'productId: ',
			attributes.productId,
			wp.element.createElement( 'input', {
				key: 1,
				value: attributes.title,
				onChange( event ) {
					setAttributes( { title: event.target.value } );
				}
			} ),
			wp.element.createElement( 'input', {
				key: 2,
				value: attributes.price,
				onChange( event ) {
					setAttributes( { price: event.target.value } );
				}
			} ),
		] );
	}
})
```

You will then have a Product block that simulates the use case in https://github.com/WordPress/gutenberg/issues/29693. Insert the block and notice that a product with ID 1 is created. Duplicate the block and notice that a product with ID 2 is created.

</p>
</details> 