### PR TITLE
Global styles: Fix error when updating padding input in global styles

### DIFF
--- a/packages/block-editor/src/utils/object.js
+++ b/packages/block-editor/src/utils/object.js
@@ -27,7 +27,7 @@ function normalizePath( path ) {
  * @return {*} Cloned object, or original literal non-object value.
  */
 function cloneObject( object ) {
-	if ( typeof object === 'object' ) {
+	if ( object && typeof object === 'object' ) {
 		return {
 			...Object.fromEntries(
 				Object.entries( object ).map( ( [ key, value ] ) => [

--- a/packages/block-editor/src/utils/test/object.js
+++ b/packages/block-editor/src/utils/test/object.js
@@ -84,6 +84,44 @@ describe( 'immutableSet', () => {
 				} );
 			} );
 		} );
+
+		describe( 'for nested falsey values', () => {
+			it( 'overwrites undefined values', () => {
+				const result = immutableSet( { test: undefined }, 'test', 1 );
+
+				expect( result ).toEqual( { test: 1 } );
+			} );
+
+			it( 'overwrites null values', () => {
+				const result = immutableSet( { test: null }, 'test', 1 );
+
+				expect( result ).toEqual( { test: 1 } );
+			} );
+
+			it( 'overwrites false values', () => {
+				const result = immutableSet( { test: false }, 'test', 1 );
+
+				expect( result ).toEqual( { test: 1 } );
+			} );
+
+			it( 'overwrites `0` values', () => {
+				const result = immutableSet( { test: 0 }, 'test', 1 );
+
+				expect( result ).toEqual( { test: 1 } );
+			} );
+
+			it( 'overwrites empty string values', () => {
+				const result = immutableSet( { test: '' }, 'test', 1 );
+
+				expect( result ).toEqual( { test: 1 } );
+			} );
+
+			it( 'overwrites NaN values', () => {
+				const result = immutableSet( { test: NaN }, 'test', 1 );
+
+				expect( result ).toEqual( { test: 1 } );
+			} );
+		} );
 	} );
 
 	describe( 'does not mutate the original object', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix an error being thrown when going to update padding values at the root level in global styles.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

A `cloneObject` utility function was added in https://github.com/WordPress/gutenberg/pull/49365. It looks like it gets called when updating the padding values in global styles, with a `null` value. A `null` value in this function results in the `typeof` check being truthy because `null` is an object. This then throws an error.

In this case it looks like `cloneObject` gets called recursively, where it's possible for it be called with a `null` value, so we need an additional truthy check, as the one in `immutableSet` isn't quite enough. Thanks @tellthemachines for spotting that!

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add a truthy check to the `cloneObject` function so that `null` doesn't cause the code to be executed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open global styles and adjust padding values.
2. Save — the values should persist

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

This is the error state that occurred:

![2023-03-30 16 42 14](https://user-images.githubusercontent.com/14988353/228740447-3fae3f37-a3a6-4fb5-a52d-4d9daa1f12a9.gif)

