### PR TITLE
Add "block-selectors" docs to TOC and manifest.

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -438,6 +438,12 @@
 		"parent": "block-api"
 	},
 	{
+		"title": "Selectors",
+		"slug": "block-selectors",
+		"markdown_source": "../docs/reference-guides/block-api/block-selectors.md",
+		"parent": "block-api"
+	},
+	{
 		"title": "Styles",
 		"slug": "block-styles",
 		"markdown_source": "../docs/reference-guides/block-api/block-styles.md",

--- a/docs/reference-guides/block-api/block-selectors.md
+++ b/docs/reference-guides/block-api/block-selectors.md
@@ -1,5 +1,12 @@
 # Selectors
 
+<div class="callout callout-alert">
+	This API was stabilized in Gutenberg 15.5 and is planned for core release
+	in WordPress 6.3. To use this prior to WordPress 6.3, you will need to
+	install and activate Gutenberg >= 15.5.
+</div>
+<br />
+
 Block Selectors is the API that allows blocks to customize the CSS selector used
 when their styles are generated.
 

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -179,6 +179,9 @@
 					{
 						"docs/reference-guides/block-api/block-registration.md": []
 					},
+					{
+						"docs/reference-guides/block-api/block-selectors.md": []
+					},
 					{ "docs/reference-guides/block-api/block-styles.md": [] },
 					{ "docs/reference-guides/block-api/block-supports.md": [] },
 					{


### PR DESCRIPTION
## What?
Fixes #49469 

Adds [block selectors](https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-selectors.md) docs to the TOC file and adds the generated manifest. 

After merging, it should be available via: https://developer.wordpress.org/block-editor/reference-guides/block-api/block-selectors/