### PR TITLE
Docs: `getBlockOrder()` - use core/block-editor instead of core/editor

### DIFF
--- a/docs/reference-guides/block-api/block-annotations.md
+++ b/docs/reference-guides/block-api/block-annotations.md
@@ -13,7 +13,7 @@ To see the API for yourself the easiest way is to have a block that is at least 
 ```js
 wp.data.dispatch( 'core/annotations' ).addAnnotation( {
 	source: 'my-annotations-plugin',
-	blockClientId: wp.data.select( 'core/editor' ).getBlockOrder()[ 0 ],
+	blockClientId: wp.data.select( 'core/block-editor' ).getBlockOrder()[ 0 ],
 	richTextIdentifier: 'content',
 	range: {
 		start: 50,
@@ -43,7 +43,7 @@ It is also possible to annotate a block completely. In that case just provide th
 ```js
 wp.data.dispatch( 'core/annotations' ).addAnnotation( {
 	source: 'my-annotations-plugin',
-	blockClientId: wp.data.select( 'core/editor' ).getBlockOrder()[ 0 ],
+	blockClientId: wp.data.select( 'core/block-editor' ).getBlockOrder()[ 0 ],
 	selector: 'block',
 } );
 ```


### PR DESCRIPTION
## What?
The function `getBlockOrder()` was moved from `editor` to `block-editor` in #13088. So the docs should be updated to avoid a warning.