### PR TITLE
Cover: Avoid adding empty background image URL

### DIFF
--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -46,6 +46,9 @@ function render_block_core_cover( $attributes, $content ) {
 			update_post_thumbnail_cache();
 		}
 		$current_featured_image = get_the_post_thumbnail_url();
+		if ( ! $current_featured_image ) {
+			return $content;
+		}
 
 		$processor = new WP_HTML_Tag_Processor( $content );
 		$processor->next_tag();


### PR DESCRIPTION
## What?
This a follow-up to https://github.com/WordPress/gutenberg/pull/49434#discussion_r1152717351.

Update the Cover block's render logic to return early when a post has no featured image and avoid processing the content markup.

Props @t-hamano for noticing this edge case.

## Why?
There's no need to modify the Cover block's markup when a post has no featured image.

## Testing Instructions
1. Open a Post or Page.
2. Add the featured image to the post from the Post panel
3. Insert a cover block
4. Enable "Fixed background" or "Repeated background"
5. Delete the featured image from the Post panel.
6. Confirm empty `background-image:url()` isn't rendered on front end.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-03-30 at 17 03 05](https://user-images.githubusercontent.com/240569/228844554-4d649605-a025-414e-bcfd-d98d9e7e6376.png)
