### PR TITLE
Need to use WordPress package for usestate

### DIFF
--- a/packages/components/src/dimension-control/README.md
+++ b/packages/components/src/dimension-control/README.md
@@ -9,8 +9,8 @@ This feature is still experimental. “Experimental” means this is an early im
 ## Usage
 
 ```jsx
-import { useState } from 'react';
 import { __experimentalDimensionControl as DimensionControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 
 export default function MyCustomDimensionControl() {
 	const [ paddingSize, setPaddingSize ] = useState( '' );


### PR DESCRIPTION
Need to use WordPress package for usestate instead of react package for consistency of all examples.