### PR TITLE
Update the template title in the details panel

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -5,6 +5,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalNavigatorToParentButton as NavigatorToParentButton,
+	__experimentalHeading as Heading,
 } from '@wordpress/components';
 import { isRTL, __ } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
@@ -52,9 +53,14 @@ export default function SidebarNavigationScreen( {
 						label={ __( 'Dashboard' ) }
 					/>
 				) }
-				<h2 className="edit-site-sidebar-navigation-screen__title">
+				<Heading
+					className="edit-site-sidebar-navigation-screen__title"
+					color={ 'white' }
+					level={ 2 }
+					size={ 16 }
+				>
 					{ title }
-				</h2>
+				</Heading>
 				{ actions }
 			</HStack>
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -57,7 +57,7 @@ export default function SidebarNavigationScreen( {
 					className="edit-site-sidebar-navigation-screen__title"
 					color={ 'white' }
 					level={ 2 }
-					size={ 16 }
+					size={ 20 }
 				>
 					{ title }
 				</Heading>

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -36,7 +36,7 @@ export default function SidebarNavigationScreen( {
 		<VStack spacing={ 2 }>
 			<HStack
 				spacing={ 4 }
-				justify="flex-start"
+				alignment="flex-start"
 				className="edit-site-sidebar-navigation-screen__title-icon"
 			>
 				{ ! isRoot ? (

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -37,10 +37,9 @@
 }
 
 .edit-site-sidebar-navigation-screen__title {
-	font-size: calc(1.56 * 13px);
-	line-height: normal;
-	font-weight: 500;
 	flex-grow: 1;
-	color: $white;
 	margin: 0;
+	text-overflow: ellipsis;
+	overflow: hidden;
+	white-space: nowrap;
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -38,8 +38,5 @@
 
 .edit-site-sidebar-navigation-screen__title {
 	flex-grow: 1;
-	margin: 0;
-	text-overflow: ellipsis;
-	overflow: hidden;
-	white-space: nowrap;
+	padding: $grid-unit-10 0 0 0;
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -38,5 +38,5 @@
 
 .edit-site-sidebar-navigation-screen__title {
 	flex-grow: 1;
-	padding: $grid-unit-10 0 0 0;
+	padding: 6px 0 0 0;
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -38,5 +38,5 @@
 
 .edit-site-sidebar-navigation-screen__title {
 	flex-grow: 1;
-	padding: 6px 0 0 0;
+	padding: $grid-unit-15 * 0.5 0 0 0;
 }


### PR DESCRIPTION
## What?
This PR does a couple of things:

1. Reduce the overall text size of the template title in the details panel
2. Truncates long titles

## Why?
With custom templates and so on it's increasingly common to see longer titles which wrap and look a bit awkward:

<img width="384" alt="Screenshot 2023-03-30 at 15 45 01" src="https://user-images.githubusercontent.com/846565/228881221-cd3de5c3-90a1-44ec-a65a-fe0b78013087.png">


## How?
* Decreases the size which reduces the likelihood of wrapping in the first place.
* Truncates to keep the title on a single row. 

The changes involve some CSS, and swapping an `h2` with `Heading` component.

## Testing Instructions
* In the Site Editor create a template with a long name.
* Observe the presentation of that title in the details panel:


https://user-images.githubusercontent.com/846565/228882097-edc6c0d5-849e-455a-af37-8fc96e0a321b.mp4

