### PR TITLE
KSES: Remove the filter that makes filter a safe attribute

### DIFF
--- a/lib/experimental/kses.php
+++ b/lib/experimental/kses.php
@@ -67,28 +67,6 @@ add_action( 'init', 'gutenberg_override_core_kses_init_filters', 20 );
 add_action( 'set_current_user', 'gutenberg_override_core_kses_init_filters' );
 
 /**
- * See https://github.com/WordPress/wordpress-develop/pull/4108
- *
- * Mark CSS safe if it contains a "filter: url('#wp-duotone-...')" rule.
- *
- * This function should not be backported to core.
- *
- * @param bool   $allow_css Whether the CSS is allowed.
- * @param string $css_test_string The CSS to test.
- */
-function allow_filter_in_styles( $allow_css, $css_test_string ) {
-	if ( preg_match(
-		"/^filter:\s*url\('#wp-duotone-[-a-zA-Z0-9]+'\) !important$/",
-		$css_test_string
-	) ) {
-		return true;
-	}
-	return $allow_css;
-}
-
-add_filter( 'safecss_filter_attr_allow_css', 'allow_filter_in_styles', 10, 2 );
-
-/**
  * Mark CSS safe if it contains grid functions
  *
  * This function should not be backported to core.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

# Warning
Don't merge this until we no longer have to support WordPress 6.2 in Gutenberg.

## What?
In https://github.com/WordPress/gutenberg/pull/48281 we added a new filter for `wp_kses` to enable the `filter` attribute. This removes that filter, since it's now in core.

## Why?
We don't need this if its in core.

## How?
Just remove the code.

## Testing Instructions
Check that you can still set Duotone filters in Gutenberg.
