### PR TITLE
Post excerpt > Ensure the postId from the block context is used to get_the_excerpt

### DIFF
--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -26,9 +26,9 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	*/
 	$excerpt_length = $attributes['excerptLength'];
 	if ( isset( $excerpt_length ) ) {
-		$excerpt = wp_trim_words( get_the_excerpt(), $excerpt_length );
+		$excerpt = wp_trim_words( get_the_excerpt( $block->context['postId'] ), $excerpt_length );
 	} else {
-		$excerpt = get_the_excerpt();
+		$excerpt = get_the_excerpt( $block->context['postId'] );
 	}
 	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . wp_kses_post( $attributes['moreText'] ) . '</a>' : '';
 	$filter_excerpt_more = function( $more ) use ( $more_text ) {

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -25,7 +25,7 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	* wp_trim_words is used instead.
 	*/
 	$excerpt_length = $attributes['excerptLength'];
-	$excerpt = get_the_excerpt( $block->context['postId'] );
+	$excerpt        = get_the_excerpt( $block->context['postId'] );
 	if ( isset( $excerpt_length ) ) {
 		$excerpt = wp_trim_words( $excerpt, $excerpt_length );
 	}

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -25,11 +25,11 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	* wp_trim_words is used instead.
 	*/
 	$excerpt_length = $attributes['excerptLength'];
+	$excerpt = get_the_excerpt( $block->context['postId'] );
 	if ( isset( $excerpt_length ) ) {
-		$excerpt = wp_trim_words( get_the_excerpt( $block->context['postId'] ), $excerpt_length );
-	} else {
-		$excerpt = get_the_excerpt( $block->context['postId'] );
+		$excerpt = wp_trim_words( $excerpt, $excerpt_length );
 	}
+
 	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . wp_kses_post( $attributes['moreText'] ) . '</a>' : '';
 	$filter_excerpt_more = function( $more ) use ( $more_text ) {
 		return empty( $more_text ) ? $more : '';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Ensures the `postId` from the block context is used for fetching the post excerpt. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Similar to [this change](https://github.com/WordPress/gutenberg/pull/48001/files) made to the Post Title block, here we can ensure that independent of where the Post Excerpt block is added, the rendered content will be aligned with the context of the block itself rather than the global post.

For context, this limitation surfaced while working on the new [Single Product Block](https://github.com/woocommerce/woocommerce-blocks/pull/8610) on WooCommerce blocks, where the displayed excerpt would match the current post rather than the block context while at the same time, the Post Title block would respect the block context accordingly.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add the Post Excerpt block to any post/page.
2. Confirm that the excerpt is properly rendered both on the editor and on the front-end sides.
