### PR TITLE
Add color tools to time to read block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -590,7 +590,7 @@ Show minutes required to finish reading the post. ([Source](https://github.com/W
 
 -	**Name:** core/post-time-to-read
 -	**Category:** theme
--	**Supports:** spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** color (background, gradients, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** textAlign
 
 ## Post Title

--- a/packages/block-library/src/post-time-to-read/block.json
+++ b/packages/block-library/src/post-time-to-read/block.json
@@ -14,6 +14,13 @@
 		}
 	},
 	"supports": {
+		"color": {
+			"gradients": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			}
+		},
 		"html": false,
 		"spacing": {
 			"margin": true,

--- a/packages/block-library/src/post-time-to-read/edit.js
+++ b/packages/block-library/src/post-time-to-read/edit.js
@@ -93,7 +93,7 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 					} }
 				/>
 			</BlockControls>
-			<p { ...blockProps }>{ minutesToReadString }</p>
+			<div { ...blockProps }>{ minutesToReadString }</div>
 		</>
 	);
 }

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -42,7 +42,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
 
 	return sprintf(
-		'<p %1$s>%2$s</p>',
+		'<div %1$s>%2$s</div>',
 		$wrapper_attributes,
 		$minutes_to_read_string
 	);

--- a/phpunit/blocks/render-post-time-to-read-test.php
+++ b/phpunit/blocks/render-post-time-to-read-test.php
@@ -114,7 +114,7 @@ class Tests_Blocks_Render_Post_Time_To_Read extends WP_UnitTestCase {
 		$block         = new WP_Block( $parsed_block, $context );
 
 		$actual   = gutenberg_render_block_core_post_time_to_read( $attributes, '', $block );
-		$expected = '<p class="wp-block-post-time-to-read">1 minute</p>';
+		$expected = '<div class="wp-block-post-time-to-read">1 minute</div>';
 
 		$this->assertSame( $expected, $actual );
 	}
@@ -136,7 +136,7 @@ class Tests_Blocks_Render_Post_Time_To_Read extends WP_UnitTestCase {
 		$block         = new WP_Block( $parsed_block, $context );
 
 		$actual   = gutenberg_render_block_core_post_time_to_read( $attributes, '', $block );
-		$expected = '<p class="wp-block-post-time-to-read">1 minute</p>';
+		$expected = '<div class="wp-block-post-time-to-read">1 minute</div>';
 
 		$this->assertSame( $expected, $actual );
 	}
@@ -158,7 +158,7 @@ class Tests_Blocks_Render_Post_Time_To_Read extends WP_UnitTestCase {
 		$block         = new WP_Block( $parsed_block, $context );
 
 		$actual   = gutenberg_render_block_core_post_time_to_read( $attributes, '', $block );
-		$expected = '<p class="wp-block-post-time-to-read">1 minute</p>';
+		$expected = '<div class="wp-block-post-time-to-read">1 minute</div>';
 
 		$this->assertSame( $expected, $actual );
 	}
@@ -180,7 +180,7 @@ class Tests_Blocks_Render_Post_Time_To_Read extends WP_UnitTestCase {
 		$block         = new WP_Block( $parsed_block, $context );
 
 		$actual   = gutenberg_render_block_core_post_time_to_read( $attributes, '', $block );
-		$expected = '<p class="wp-block-post-time-to-read">2 minutes</p>';
+		$expected = '<div class="wp-block-post-time-to-read">2 minutes</div>';
 
 		$this->assertSame( $expected, $actual );
 	}


### PR DESCRIPTION
## What?
Adds color tools to the time to read block

## Why?
This brings parity with other similar post blocks.

## How?
Adds the color support option.

The only contentious aspect to this is that when applying a background, padding is applied via the `p.has-background` class. This is an inconsistency with other blocks like post author name and post date.

Some options:
- Use a `<div>` instead of a `<p>` in the time to read block
- Override the style

## Testing Instructions
1. Add a Time to Read block to a post
2. Apply foreground and background colors using the block inspector.

## Screenshots or screencast <!-- if applicable -->
![Screen Shot 2023-03-31 at 10 24 38 am](https://user-images.githubusercontent.com/677833/229006963-ed06ccfb-c4d2-4e32-98c5-295ed60b2f08.png)