### PR TITLE
Cover: Fix integration tests for ResizableBox via BlockPopover

### DIFF
--- a/test/unit/config/global-mocks.js
+++ b/test/unit/config/global-mocks.js
@@ -19,3 +19,12 @@ if ( ! window.wp?.galleryBlockV2Enabled ) {
 }
 
 global.ResizeObserver = require( 'resize-observer-polyfill' );
+
+/**
+ * The following mock is for block integration tests that might render
+ * components leveraging DOMRect. For example, the Cover block which now renders
+ * its ResizableBox control via the BlockPopover component.
+ */
+if ( ! window.DOMRect ) {
+	window.DOMRect = class DOMRect {};
+}


### PR DESCRIPTION
## What?

Fixes broken Cover block tests after moving ResizableBox to BlockPopover.

## Why?
Tests are failing on trunk.

## How?

Adds a global mock for `window.DOMRect`. kudos to @glendaviesnz for this fix.

## Testing Instructions

1. Run `npm run test:unit packages/block-library/src/cover/test/edit.js`
