### PR TITLE
List View: Try allowing users to drag to one level up the hierarchy

### DIFF
--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -168,10 +168,13 @@ export function getListViewDropTarget( blocksData, position ) {
 		isDraggingBelow &&
 		candidateBlockData.isLastChildOfRoot &&
 		candidateBlockData.canInsertDraggedBlocksIntoParent &&
+		candidateBlockData.rootClientId &&
 		isUpGesture( position, candidateRect )
 	) {
 		return {
-			rootClientId: candidateBlockData.parentOfRootClientId,
+			rootClientId:
+				candidateBlockData.parentOfRootClientId ??
+				candidateBlockData.rootClientId,
 			clientId: candidateBlockData.clientId, // This is used as the target for the drop indicator.
 			blockIndex: candidateBlockData.parentBlockIndex + 1,
 			dropPosition: candidateEdge,
@@ -256,6 +259,7 @@ export default function useListViewDropZone() {
 						childrenOfRootClientId[
 							childrenOfRootClientId.length - 1
 						]?.clientId === clientId;
+					const blockIndex = getBlockIndex( clientId );
 
 					return {
 						clientId,
@@ -263,8 +267,9 @@ export default function useListViewDropZone() {
 						isLastChildOfRoot,
 						parentOfRootClientId,
 						rootClientId,
-						blockIndex: getBlockIndex( clientId ),
-						parentBlockIndex: getBlockIndex( rootClientId ),
+						blockIndex,
+						parentBlockIndex:
+							getBlockIndex( rootClientId ) || blockIndex,
 						element: blockElement,
 						isDraggedBlock: isBlockDrag
 							? draggedBlockClientIds.includes( clientId )
@@ -282,7 +287,7 @@ export default function useListViewDropZone() {
 										draggedBlockClientIds,
 										parentOfRootClientId
 								  )
-								: false,
+								: true,
 						canInsertDraggedBlocksAsChild: isBlockDrag
 							? canInsertBlocks( draggedBlockClientIds, clientId )
 							: true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

🚧 🚧 🚧 🚧 This is just a WIP PR for now — it is buggy and doesn't quite work yet! 🚧 🚧 🚧 🚧 

An exploration into https://github.com/WordPress/gutenberg/issues/33678 that looks at seeing if we could allow dragging just _one_ level up the hierarchy.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's important that folks can drag _beneath_ a nested block. While it'd be good for folks to be able to drag to all levels of the hierarchy, this PR is exploring whether it'd be helpful to start with, to look at just allowing movement up a single level.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This isn't complete yet, but the general idea is:

* Grab the parent of the current block's parent
* If the currently hovered block is the last child of _its_ parent, then allow dragging to one level up the hierarchy

## To-do

* [x] ~This doesn't work for the first level of hierarchy yet, as at the very root, there are no more parent client ids to grab. We need to add a check here — if we're at the root level, then we need slightly different logic.~ Implemented in https://github.com/WordPress/gutenberg/pull/49498/commits/9d47b6793f4a13d560cc843ae58569d5873b2dea, but it's pretty hacky and will need tidying up and to be commented.
* [ ] Ensure it works if a list view is using a custom `rootClientId`
* [ ] If the block _being dragged_ is the last of the parent's children, then currently it interferes with the check of the last _visual_ child in the list view (as technically it isn't the last child).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

TBC

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Coming soon...