### PR TITLE
Fix template part area variation matching

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -181,7 +181,7 @@ function build_template_part_block_area_variations() {
 	foreach ( $defined_areas as $area ) {
 		if ( 'uncategorized' !== $area['area'] ) {
 			$variations[] = array(
-				'name'        => $area['area'],
+				'name'        => 'area_' . $area['area'],
 				'title'       => $area['label'],
 				'description' => $area['description'],
 				'attributes'  => array(
@@ -223,7 +223,7 @@ function build_template_part_block_instance_variations() {
 
 	foreach ( $template_parts as $template_part ) {
 		$variations[] = array(
-			'name'        => sanitize_title( $template_part->slug ),
+			'name'        => 'instance_' . sanitize_title( $template_part->slug ),
 			'title'       => $template_part->title,
 			// If there's no description for the template part don't show the
 			// block description. This is a bit hacky, but prevent the fallback

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -173,13 +173,26 @@ function render_block_core_template_part( $attributes ) {
 /**
  * Returns an array of area variation objects for the template part block.
  *
+ * @param array $instance_variations The variations for instances.
+ *
  * @return array Array containing the block variation objects.
  */
-function build_template_part_block_area_variations() {
+function build_template_part_block_area_variations( $instance_variations ) {
 	$variations    = array();
 	$defined_areas = get_allowed_block_template_part_areas();
+
 	foreach ( $defined_areas as $area ) {
 		if ( 'uncategorized' !== $area['area'] ) {
+			$has_instance_for_area = false;
+			foreach ( $instance_variations as $variation ) {
+				if ( $variation['attributes']['area'] === $area['area'] ) {
+					$has_instance_for_area = true;
+					break;
+				}
+			}
+
+			$scope = $has_instance_for_area ? array() : array( 'inserter' );
+
 			$variations[] = array(
 				'name'        => 'area_' . $area['area'],
 				'title'       => $area['label'],
@@ -187,7 +200,7 @@ function build_template_part_block_area_variations() {
 				'attributes'  => array(
 					'area' => $area['area'],
 				),
-				'scope'       => array( 'inserter' ),
+				'scope'       => $scope,
 				'icon'        => $area['icon'],
 			);
 		}
@@ -255,7 +268,9 @@ function build_template_part_block_instance_variations() {
  * @return array Array containing the block variation objects.
  */
 function build_template_part_block_variations() {
-	return array_merge( build_template_part_block_area_variations(), build_template_part_block_instance_variations() );
+	$instance_variations = build_template_part_block_instance_variations();
+	$area_variations     = build_template_part_block_area_variations( $instance_variations );
+	return array_merge( $area_variations, $instance_variations );
 }
 
 /**


### PR DESCRIPTION
## What?
Fixes https://github.com/WordPress/gutenberg/issues/45935

Ensures template part semantic variations are shown correctly.

## Why?
This was a regression

## How?
Template parts have two different categories of variations. Area variations and instance variations.

The problem was that both area and instance variations can have the same `name` ('header' or 'footer'), and the name for block variations should be unique. When registering the variations, the first 'header' area variation was being registered correctly, but the 'header' instance variation failed to be registered due to an existing variation with that name.

The variation match function then failed because it prioritises matching by an instance's slug (since #45672), and the 'header' instance variation failed to be registered.

The fix is to add unique names for area template part variations and instance template part variations, so they can peacefully co-exist.

[After feedback](https://github.com/WordPress/gutenberg/pull/49500#issuecomment-1494706874), this PR now also avoids showing the area variation in the inserter when a matching instance variation exists.

## Testing Instructions
1. Open the site editor
2. Select a header or footer template part
3. Ensure it has the 'header' or 'footer' semantic area set (check the Advanced panel in the Inspector)
4. Observe the icon, and block name in the Inspector

## Screenshots or screencast <!-- if applicable -->
![Screen Shot 2023-03-31 at 3 01 05 pm](https://user-images.githubusercontent.com/677833/229047082-33d9359e-a12d-40ce-a1b6-70b0945fc2d1.png)

