### PR TITLE
Site Editor List View: Fix the width of the list view to 350px

### DIFF
--- a/packages/edit-site/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-site/src/components/secondary-sidebar/style.scss
@@ -8,7 +8,7 @@
 .edit-site-editor__list-view-panel {
 	// Same width as the Inserter.
 	// @see packages/block-editor/src/components/inserter/style.scss
-	min-width: 350px;
+	width: 350px;
 }
 
 .edit-site-editor__inserter-panel-header {
@@ -44,4 +44,6 @@
 .edit-site-editor__list-view-panel-content {
 	overflow-y: auto;
 	padding: $grid-unit-10;
+
+	@include custom-scrollbars-on-hover;
 }

--- a/packages/edit-site/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-site/src/components/secondary-sidebar/style.scss
@@ -5,12 +5,6 @@
 	flex-direction: column;
 }
 
-.edit-site-editor__list-view-panel {
-	// Same width as the Inserter.
-	// @see packages/block-editor/src/components/inserter/style.scss
-	width: 350px;
-}
-
 .edit-site-editor__inserter-panel-header {
 	padding-top: $grid-unit-10;
 	padding-right: $grid-unit-10;
@@ -42,8 +36,15 @@
 }
 
 .edit-site-editor__list-view-panel-content {
-	overflow-y: auto;
+	overflow: auto;
 	padding: $grid-unit-10;
+	width: 100%;
 
 	@include custom-scrollbars-on-hover;
+
+	@include break-medium() {
+		// Same width as the Inserter.
+		// @see packages/block-editor/src/components/inserter/style.scss
+		width: 350px;
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Currently the List View in the site editor will keep expanding the sidebar when opening nested block. This restricts the width of the List View to 350px. 

## Why?
The sidebar should be limited to 350px so that the rest of the page is still visible. This is the same width as the block inserter.

## How?
1. Change `min-width` to `width`
2. Add the scrollbars on hover mixin to the list view component.

## Testing Instructions
1. Open the site editor
2. Open the list view
3. Drill down into a deeply nested block
4. Check that the sidebar doesn't get wider and instead horizontal scrollbars appear
5. Check that when you hover the list view, if scrollbars are present, they show on hover.

### Testing Instructions for Keyboard
This is only a visual change.

## Screenshots or screencast <!-- if applicable -->
https://user-images.githubusercontent.com/275961/229105814-aa5a4a24-a6c3-4444-8cb4-60bd5a3d9ae2.mov

## Note
The `custom-scrollbars-on-hover` doesn't look great but I don't think we should handle that in this PR.