### PR TITLE
Refactor around missing dependency in Link Control internal value sync effect

### DIFF
--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -2235,6 +2235,48 @@ describe( 'Controlling link title text', () => {
 			screen.queryByRole( 'textbox', { name: 'Text' } )
 		).not.toBeInTheDocument();
 	} );
+
+	it( 'should reset state on value change', async () => {
+		const user = userEvent.setup();
+		const textValue = 'My new text value';
+		const mockOnChange = jest.fn();
+
+		const { rerender } = render(
+			<LinkControl
+				value={ selectedLink }
+				forceIsEditingLink
+				hasTextControl
+				onChange={ mockOnChange }
+			/>
+		);
+
+		await toggleSettingsDrawer( user );
+
+		const textInput = screen.queryByRole( 'textbox', { name: 'Text' } );
+
+		expect( textInput ).toBeVisible();
+
+		await user.clear( textInput );
+		await user.keyboard( textValue );
+
+		// Was originall title: 'Hello Page', but we've changed it.
+		rerender(
+			<LinkControl
+				value={ {
+					...selectedLink,
+					title: 'Something else',
+				} }
+				forceIsEditingLink
+				hasTextControl
+				onChange={ mockOnChange }
+			/>
+		);
+
+		// The text input should not be showing as the form is submitted.
+		expect( screen.queryByRole( 'textbox', { name: 'Text' } ) ).toHaveValue(
+			'Something else'
+		);
+	} );
 } );
 
 async function toggleSettingsDrawer( user ) {

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -2259,7 +2259,7 @@ describe( 'Controlling link title text', () => {
 		await user.clear( textInput );
 		await user.keyboard( textValue );
 
-		// Was originall title: 'Hello Page', but we've changed it.
+		// Was originally title: 'Hello Page', but we've changed it.
 		rerender(
 			<LinkControl
 				value={ {

--- a/packages/block-editor/src/components/link-control/use-internal-input-value.js
+++ b/packages/block-editor/src/components/link-control/use-internal-input-value.js
@@ -1,12 +1,23 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 
 export default function useInternalInputValue( value ) {
 	const [ internalInputValue, setInternalInputValue ] = useState(
 		value || ''
 	);
+
+	// If the value prop changes, update the internal state.
+	useEffect( () => {
+		setInternalInputValue( ( prevValue ) => {
+			if ( value && value !== prevValue ) {
+				return value;
+			}
+
+			return prevValue;
+		} );
+	}, [ value ] );
 
 	return [ internalInputValue, setInternalInputValue ];
 }

--- a/packages/block-editor/src/components/link-control/use-internal-input-value.js
+++ b/packages/block-editor/src/components/link-control/use-internal-input-value.js
@@ -1,22 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 
 export default function useInternalInputValue( value ) {
 	const [ internalInputValue, setInternalInputValue ] = useState(
 		value || ''
 	);
-
-	useEffect( () => {
-		/**
-		 * If the value changes then sync this
-		 * back up with state.
-		 */
-		if ( value && value !== internalInputValue ) {
-			setInternalInputValue( value );
-		}
-	}, [ value ] );
 
 	return [ internalInputValue, setInternalInputValue ];
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In https://github.com/WordPress/gutenberg/issues/49506 we found that the effect at https://github.com/WordPress/gutenberg/blob/a1f2679cfeec924c2d769b40575626820ac2cfbd/packages/block-editor/src/components/link-control/use-internal-input-value.js#L11-L19 was missing the `internalInputValue` as a dependency.

This fixes that by using the lazy update of setState to avoid having to pass the dependency.

Fixes https://github.com/WordPress/gutenberg/issues/49506

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Omitting dependencies from an effect is a code smell. However, adding the dependency in this case makes it impossible to update the values of <input> in the component as they will constantly be synced back up with the `value`. That's not what we want.

Instead we want to make sure that if the LinkControl's `value` (only!) changes (or rather the particular sub property that this hook is controlling) then we sync the internal state back up with it.

### Why do we even need this syncing anyway

The LinkControl is a controlled component in that it's `value` changes based on `onChange` handler. However, the UX is such that you should be able to update the `.value` of the `<input>`'s in a sort of "draft" state and only have them "committed" as the new `value` when hitting the "Apply" button (this will trigger `onChange`).

Unfortunately however this means that if:

- you have an existing LinkControl with a value 
- you change the text in the `<input>` 
- you don't submit the changes with "Apply"
- you programmatically pass a new `value` to the component

...the internal state needs to reflect the new value passed to the component and _not_ the internal "draft" value.

Basically the `value` should be the source of truth. If it changes then the component must reset.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By using the lazy form of `setState` updater, we can access the existing internal value and perform the necessary comparison without having to add it as a dependency of the effect. This restores the existing functionality without breaking the rules of hooks.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Remove the `key` prop here https://github.com/WordPress/gutenberg/blob/78c4a2a2069cc983a2aeb9a8a4c15575a227d3ee/packages/format-library/src/link/inline.js#L262
- New Post
- create a paragraph and add x2 links in different words of the _same_ sentence
- toggle the Link UI open and toggle into "edit" the link
- make a change in the input text
- click on the other link
- it should update to show the values from the new link
- click back it should update to show the original link values

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
