### PR TITLE
DropZone: Smooth animation

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   `DropZone`: Smooth animation ([#49517](https://github.com/WordPress/gutenberg/pull/49517)).
+
 ## 23.7.0 (2023-03-29)
 
 -   `ImageSizeControl`: Remove the "Image Dimensions" label ([#49414](https://github.com/WordPress/gutenberg/pull/49414)).

--- a/packages/components/src/drop-zone/index.tsx
+++ b/packages/components/src/drop-zone/index.tsx
@@ -120,30 +120,34 @@ export function DropZoneComponent( {
 
 	let children;
 	const backdrop = {
-		hidden: { scaleY: 0, opacity: 0 },
+		hidden: { opacity: 0 },
 		show: {
-			scaleY: 1,
 			opacity: 1,
 			transition: {
 				type: 'tween',
 				duration: 0.2,
-				delay: 0.1,
-				delayChildren: 0.2,
+				delay: 0,
+				delayChildren: 0.1,
 			},
 		},
 		exit: {
-			scaleY: 1,
 			opacity: 0,
 			transition: {
-				duration: 0.3,
+				duration: 0.2,
 				delayChildren: 0,
 			},
 		},
 	};
 
 	const foreground = {
-		hidden: { opacity: 0, scale: 0.75 },
-		show: { opacity: 1, scale: 1 },
+		hidden: { opacity: 0, scale: 0.9 },
+		show: {
+			opacity: 1,
+			scale: 1,
+			transition: {
+				duration: 0.1,
+			},
+		},
 		exit: { opacity: 0, scale: 0.9 },
 	};
 

--- a/packages/components/src/drop-zone/style.scss
+++ b/packages/components/src/drop-zone/style.scss
@@ -38,7 +38,7 @@
 }
 
 .components-drop-zone__content-icon {
-	margin: 0 auto;
+	margin: 0 auto $grid-unit-10;
 	line-height: 0;
 	fill: currentColor;
 	pointer-events: none;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The drop zone animation is feeling a bit antiquated, with the smoother animations introduced within the Site Editor, as well as the drop indicators between blocks. It also takes just a bit too long (due to timing, but also scaling) than it should. 

In this PR I'm tweaking the animation of the background and foreground elements of the drop zone component. And adding a bit more space between the icon and text foreground elements. 

I've removed the scaling effect to simplify and smooth out the drop-in animation. Without the scaling, and a few slight tweaks to the timing, the animation is more fluid and seamless. Note that the drop zone animation already fades out (without scaling) for the exit animation in trunk. I'm bringing that same fluidity to the show animation. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page.
2. Insert a few blocks, including an Image block (with an image). 
3. Drag and drop another image onto the Image block. 
4. See fluid animation. 

## Visuals

Before: 

https://user-images.githubusercontent.com/1813435/229197350-8c89bc0b-e573-40df-843b-2b0826529baf.mp4

After: 

https://user-images.githubusercontent.com/1813435/229197361-f94a36cd-5825-48ac-9c9e-c43417b42583.mp4


