### PR TITLE
Add support for hiding breadcrumbs in the Site Editor

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -67,6 +67,7 @@ export default function Editor() {
 		isInserterOpen,
 		isListViewOpen,
 		showIconLabels,
+		showBlockBreadcrumbs,
 	} = useSelect( ( select ) => {
 		const {
 			getEditedPostContext,
@@ -94,6 +95,9 @@ export default function Editor() {
 				'core/edit-site',
 				'showIconLabels'
 			),
+			showBlockBreadcrumbs: select( editSiteStore ).isFeatureActive(
+				'showBlockBreadcrumbs'
+			),
 		};
 	}, [] );
 	const { setEditedPostContext } = useDispatch( editSiteStore );
@@ -101,8 +105,11 @@ export default function Editor() {
 	const isViewMode = canvasMode === 'view';
 	const isEditMode = canvasMode === 'edit';
 	const showVisualEditor = isViewMode || editorMode === 'visual';
-	const showBlockBreakcrumb =
-		isEditMode && showVisualEditor && blockEditorMode !== 'zoom-out';
+	const shouldShowBlockBreakcrumbs =
+		showBlockBreadcrumbs &&
+		isEditMode &&
+		showVisualEditor &&
+		blockEditorMode !== 'zoom-out';
 	const shouldShowInserter = isEditMode && showVisualEditor && isInserterOpen;
 	const shouldShowListView = isEditMode && showVisualEditor && isListViewOpen;
 	const secondarySidebarLabel = isListViewOpen
@@ -205,7 +212,7 @@ export default function Editor() {
 								)
 							}
 							footer={
-								showBlockBreakcrumb && (
+								shouldShowBlockBreakcrumbs && (
 									<BlockBreadcrumb
 										rootLabelText={ __( 'Template' ) }
 									/>

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -95,7 +95,8 @@ export default function Editor() {
 				'core/edit-site',
 				'showIconLabels'
 			),
-			showBlockBreadcrumbs: select( editSiteStore ).isFeatureActive(
+			showBlockBreadcrumbs: select( preferencesStore ).get(
+				'core/edit-site',
 				'showBlockBreadcrumbs'
 			),
 		};

--- a/packages/edit-site/src/components/preferences-modal/index.js
+++ b/packages/edit-site/src/components/preferences-modal/index.js
@@ -48,6 +48,13 @@ export default function EditSitePreferencesModal( {
 						) }
 						label={ __( 'Always open list view' ) }
 					/>
+					<EnableFeature
+						featureName="showBlockBreadcrumbs"
+						help={ __(
+							'Shows block breadcrumbs at the bottom of the editor.'
+						) }
+						label={ __( 'Display block breadcrumbs' ) }
+					/>
 				</PreferencesModalSection>
 			),
 		},

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -67,6 +67,7 @@ export function initializeEditor( id, settings ) {
 		welcomeGuide: true,
 		welcomeGuideStyles: true,
 		showListViewByDefault: false,
+		showBlockBreadcrumbs: true,
 	} );
 
 	dispatch( interfaceStore ).setDefaultComplementaryArea(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds a preference to turn off block breadcrumbs within the footer of the Site Editor. 

## Why?
The Block Editor supports hiding of the block breadcrumbs; the Site Editor should as well. 

## How?
- Adds `showBlockBreadcrumbs` to the Site Editor Preferences panel.
- Adds a check for `showBlockBreadcrumbs` before rendering the breadcrumbs.

## Testing Instructions
1. Open the Site Editor.
2. Open the Options at the top right of the Site Editor.
3. Click on "Preferences"
4. Toggle off "Display block breadcrumbs" 
5. See breadcrumbs no longer rendering
6. Refresh and see breadcrumbs still not rendering

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/1813435/229204968-971b1588-5ad5-42ee-8423-dde709d7c2a6.mp4

