### PR TITLE
Add blockGap as a default control on Columns/Column blocks

### DIFF
--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -38,7 +38,8 @@
 			"blockGap": true,
 			"padding": true,
 			"__experimentalDefaultControls": {
-				"padding": true
+				"padding": true,
+				"blockGap": true
 			}
 		},
 		"__experimentalBorder": {

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -39,7 +39,8 @@
 			"margin": [ "top", "bottom" ],
 			"padding": true,
 			"__experimentalDefaultControls": {
-				"padding": true
+				"padding": true,
+				"blockGap": true
 			}
 		},
 		"__experimentalLayout": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The Group block has padding and blockGap as default controls. The Columns and Column blocks should have those same controls enabled by default, as they are very similar to the Group block.

## Why?
Consistency. I would expect the similar blocks to have similar experiences right off. 

## How?
Adding support via the core/columns block.json. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page.
2. Insert a Columns block. 
3. Open Block Inspector.
4. See "Block Spacing" as a default option in the "Dimensions" panel. 
5. Repeat steps 2-4 for the Column block.

## Screenshots or screencast <!-- if applicable -->

Before (Column block is the same): 

<img width="280" alt="CleanShot 2023-03-31 at 21 21 53" src="https://user-images.githubusercontent.com/1813435/229258902-5a77ab10-e5c0-441a-8f82-811a13b697fc.png">

After (Column block is the same): 

<img width="279" alt="CleanShot 2023-03-31 at 21 21 31" src="https://user-images.githubusercontent.com/1813435/229258904-765b23a9-588e-4cdc-b0d4-2bcac1f0176b.png">
