### PR TITLE
Tweak remove block label to make it simpler

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -29,7 +29,6 @@ import BlockHTMLConvertButton from './block-html-convert-button';
 import __unstableBlockSettingsMenuFirstItem from './block-settings-menu-first-item';
 import BlockSettingsMenuControls from '../block-settings-menu-controls';
 import { store as blockEditorStore } from '../../store';
-import useBlockDisplayTitle from '../block-title/use-block-display-title';
 import { useShowMoversGestures } from '../block-toolbar/utils';
 
 const noop = () => {};
@@ -138,11 +137,6 @@ export function BlockSettingsDropdown( {
 		[ __experimentalSelectBlock ]
 	);
 
-	const blockTitle = useBlockDisplayTitle( {
-		clientId: firstBlockClientId,
-		maximumLength: 25,
-	} );
-
 	const updateSelectionAfterRemove = useCallback(
 		__experimentalSelectBlock
 			? () => {
@@ -172,13 +166,6 @@ export function BlockSettingsDropdown( {
 			selectedBlockClientIds,
 		]
 	);
-
-	const label = sprintf(
-		/* translators: %s: block name */
-		__( 'Remove %s' ),
-		blockTitle
-	);
-	const removeBlockLabel = count === 1 ? label : __( 'Remove blocks' );
 
 	// Allows highlighting the parent block outline when focusing or hovering
 	// the parent block selector within the child.
@@ -347,7 +334,7 @@ export function BlockSettingsDropdown( {
 										) }
 										shortcut={ shortcuts.remove }
 									>
-										{ removeBlockLabel }
+										{ __( 'Delete' ) }
 									</MenuItem>
 								</MenuGroup>
 							) }

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -167,6 +167,9 @@ export function BlockSettingsDropdown( {
 		]
 	);
 
+	const removeBlockLabel =
+		count === 1 ? __( 'Delete' ) : __( 'Delete blocks' );
+
 	// Allows highlighting the parent block outline when focusing or hovering
 	// the parent block selector within the child.
 	const selectParentButtonRef = useRef();
@@ -334,7 +337,7 @@ export function BlockSettingsDropdown( {
 										) }
 										shortcut={ shortcuts.remove }
 									>
-										{ __( 'Delete' ) }
+										{ removeBlockLabel }
 									</MenuItem>
 								</MenuGroup>
 							) }

--- a/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
@@ -41,9 +41,7 @@ describe( 'cpt locking', () => {
 		);
 		await clickBlockToolbarButton( 'Options' );
 		expect(
-			await page.$x(
-				'//button/span[contains(text(), "Remove Paragraph")]'
-			)
+			await page.$x( '//button/span[contains(text(), "Delete")]' )
 		).toHaveLength( 0 );
 	};
 
@@ -180,7 +178,7 @@ describe( 'cpt locking', () => {
 				'p1'
 			);
 			await clickBlockToolbarButton( 'Options' );
-			await clickMenuItem( 'Remove Paragraph' );
+			await clickMenuItem( 'Delete' );
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 		} );
 
@@ -200,7 +198,7 @@ describe( 'cpt locking', () => {
 				'p1'
 			);
 			await clickBlockToolbarButton( 'Options' );
-			await clickMenuItem( 'Remove Paragraph' );
+			await clickMenuItem( 'Delete' );
 
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 		} );

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -244,7 +244,7 @@ describe( 'Reusable blocks', () => {
 		// Delete the block, leaving the reusable block empty.
 		await clickBlockToolbarButton( 'Options' );
 		const deleteButton = await page.waitForXPath(
-			'//button/span[text()="Remove Paragraph"]'
+			'//button/span[text()="Delete"]'
 		);
 		deleteButton.click();
 

--- a/test/e2e/specs/editor/various/block-deletion.spec.js
+++ b/test/e2e/specs/editor/various/block-deletion.spec.js
@@ -41,9 +41,7 @@ test.describe( 'Block deletion', () => {
 			.getByRole( 'toolbar', { name: 'Block tools' } )
 			.getByRole( 'button', { name: 'Options' } )
 			.click();
-		await page
-			.getByRole( 'menuitem', { name: 'Remove Paragraph' } )
-			.click();
+		await page.getByRole( 'menuitem', { name: 'Delete' } ).click();
 
 		// Ensure the last block was removed.
 		await expect.poll( editor.getBlocks ).toMatchObject( [
@@ -90,9 +88,7 @@ test.describe( 'Block deletion', () => {
 			.getByRole( 'toolbar', { name: 'Block tools' } )
 			.getByRole( 'button', { name: 'Options' } )
 			.click();
-		await page
-			.getByRole( 'menuitem', { name: 'Remove Paragraph' } )
-			.click();
+		await page.getByRole( 'menuitem', { name: 'Delete' } ).click();
 
 		// Ensure the paragraph was removed.
 		await expect
@@ -321,9 +317,7 @@ test.describe( 'Block deletion', () => {
 			.getByRole( 'toolbar', { name: 'Block tools' } )
 			.getByRole( 'button', { name: 'Options' } )
 			.click();
-		await page
-			.getByRole( 'menuitem', { name: 'Remove Paragraph' } )
-			.click();
+		await page.getByRole( 'menuitem', { name: 'Delete' } ).click();
 
 		// Ensure an empty block was created and focused.
 		await expect(

--- a/test/e2e/specs/editor/various/block-locking.spec.js
+++ b/test/e2e/specs/editor/various/block-locking.spec.js
@@ -19,7 +19,7 @@ test.describe( 'Block Locking', () => {
 			await page.click( 'role=button[name="Apply"]' );
 
 			await expect(
-				page.locator( 'role=menuitem[name="Remove Paragraph"]' )
+				page.locator( 'role=menuitem[name="Delete"]' )
 			).not.toBeVisible();
 		} );
 

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -194,7 +194,7 @@ test.describe( 'List View', () => {
 		await listView
 			.getByRole( 'button', { name: 'Options for Image block' } )
 			.click();
-		await page.getByRole( 'menuitem', { name: /Remove Image/i } ).click();
+		await page.getByRole( 'menuitem', { name: /Delete/i } ).click();
 
 		// Heading block should be selected as previous block.
 		await expect(
@@ -245,7 +245,7 @@ test.describe( 'List View', () => {
 		await listView
 			.getByRole( 'button', { name: 'Options for Image block' } )
 			.click();
-		await page.getByRole( 'menuitem', { name: /Remove blocks/i } ).click();
+		await page.getByRole( 'menuitem', { name: /Delete blocks/i } ).click();
 
 		// Newly created paragraph block should be selected.
 		await expect(

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -144,9 +144,7 @@ test.describe( 'List View', () => {
 		await listView
 			.getByRole( 'button', { name: 'Options for Paragraph block' } )
 			.click();
-		await page
-			.getByRole( 'menuitem', { name: /Remove Paragraph/i } )
-			.click();
+		await page.getByRole( 'menuitem', { name: /Delete/i } ).click();
 
 		// Heading block should be selected as previous block.
 		await expect(

--- a/test/e2e/specs/widgets/customizing-widgets.spec.js
+++ b/test/e2e/specs/widgets/customizing-widgets.spec.js
@@ -393,7 +393,7 @@ test.describe( 'Widgets Customizer', () => {
 
 		// Testing removing the block.
 		await editor.clickBlockToolbarButton( 'Options' );
-		await page.click( 'role=menuitem[name=/Remove Legacy Widget/]' );
+		await page.click( 'role=menuitem[name=/Delete/]' );
 
 		// Add it back again using the variant.
 		const testWidgetBlock = await widgetsCustomizerPage.addBlock(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Simplifies the "Remove {blockName}" menu item within the block settings menu, in support of https://github.com/WordPress/gutenberg/issues/49271#issuecomment-1481313237). 

Renders "Delete" when one block is selected, and "Delete blocks" when more than one block is selected. 

## Why?
We don't have, nor need, additional context on any other menu item (nor this one), as it can be quite noisy and harder to scan. 

## How?
- Change "Remove" to "Delete". 
- Remove blockTitle from the label.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page. 
2. Insert a block. 
3. Open the block's settings menu from the block toolbar.
4. See "Delete" at the bottom of the menu.
5. Add another block.
6. Select both blocks.
7. See "Delete blocks" at the bottom of the menu. 

## Screenshots or screencast <!-- if applicable -->

Before: 

<img width="784" alt="CleanShot 2023-03-31 at 22 02 58" src="https://user-images.githubusercontent.com/1813435/229260634-da1a03c1-ee39-48c7-ac18-3c4242432816.png">

After:

<img width="794" alt="CleanShot 2023-03-31 at 22 01 43" src="https://user-images.githubusercontent.com/1813435/229260578-2156bd2e-c83e-4d58-b7a0-da2f5106af14.png">
