### PR TITLE
Columns Block: Prevent removal of locked columns from the column count change UI

### DIFF
--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -60,13 +60,34 @@ function ColumnsEditContainer( {
 } ) {
 	const { isStackedOnMobile, verticalAlignment, templateLock } = attributes;
 
-	const { count, canInsertColumnBlock } = useSelect(
+	const { count, canInsertColumnBlock, minCount } = useSelect(
 		( select ) => {
+			const {
+				canInsertBlockType,
+				canRemoveBlock,
+				getBlocks,
+				getBlockCount,
+			} = select( blockEditorStore );
+			const innerBlocks = getBlocks( clientId );
+
+			// Get the index of the last column for which removal is prevented.
+			const preventRemovalBlockIndexes = innerBlocks.reduce(
+				( acc, block, index ) => {
+					if ( ! canRemoveBlock( block.clientId ) ) {
+						acc.push( index );
+					}
+					return acc;
+				},
+				[]
+			);
+
 			return {
-				count: select( blockEditorStore ).getBlockCount( clientId ),
-				canInsertColumnBlock: select(
-					blockEditorStore
-				).canInsertBlockType( 'core/column', clientId ),
+				count: getBlockCount( clientId ),
+				canInsertColumnBlock: canInsertBlockType(
+					'core/column',
+					clientId
+				),
+				minCount: Math.max( ...preventRemovalBlockIndexes ) + 1,
 			};
 		},
 		[ clientId ]
@@ -104,9 +125,12 @@ function ColumnsEditContainer( {
 								label={ __( 'Columns' ) }
 								value={ count }
 								onChange={ ( value ) =>
-									updateColumns( count, value )
+									updateColumns(
+										count,
+										Math.max( minCount, value )
+									)
 								}
-								min={ 1 }
+								min={ Math.max( 1, minCount ) }
 								max={ Math.max( 6, count ) }
 							/>
 							{ count > 6 && (
@@ -214,13 +238,12 @@ const ColumnsEditContainerWrapper = withDispatch(
 						return createBlock( 'core/column' );
 					} ),
 				];
-			} else {
+			} else if ( newColumns < previousColumns ) {
 				// The removed column will be the last of the inner blocks.
 				innerBlocks = innerBlocks.slice(
 					0,
 					-( previousColumns - newColumns )
 				);
-
 				if ( hasExplicitWidths ) {
 					// Redistribute as if block is already removed.
 					const widths = getRedistributedColumnWidths(

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -71,7 +71,7 @@ function ColumnsEditContainer( {
 			const innerBlocks = getBlocks( clientId );
 
 			// Get the indexes of columns for which removal is prevented.
-			// The highest index will be used to determine the minimum column count.			
+			// The highest index will be used to determine the minimum column count.
 			const preventRemovalBlockIndexes = innerBlocks.reduce(
 				( acc, block, index ) => {
 					if ( ! canRemoveBlock( block.clientId ) ) {

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -71,6 +71,7 @@ function ColumnsEditContainer( {
 			const innerBlocks = getBlocks( clientId );
 
 			// Get the indexes of columns for which removal is prevented.
+			// The highest index will be used to determine the minimum column count.			
 			const preventRemovalBlockIndexes = innerBlocks.reduce(
 				( acc, block, index ) => {
 					if ( ! canRemoveBlock( block.clientId ) ) {

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -70,7 +70,7 @@ function ColumnsEditContainer( {
 			} = select( blockEditorStore );
 			const innerBlocks = getBlocks( clientId );
 
-			// Get the index of the last column for which removal is prevented.
+			// Get the indexes of columns for which removal is prevented.
 			const preventRemovalBlockIndexes = innerBlocks.reduce(
 				( acc, block, index ) => {
 					if ( ! canRemoveBlock( block.clientId ) ) {

--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -12,7 +12,7 @@ test.describe( 'Columns', () => {
 		await requestUtils.deleteAllPosts();
 	} );
 
-	test.skip( 'restricts all blocks inside the columns block', async ( {
+	test( 'restricts all blocks inside the columns block', async ( {
 		page,
 		editor,
 	} ) => {

--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -12,7 +12,7 @@ test.describe( 'Columns', () => {
 		await requestUtils.deleteAllPosts();
 	} );
 
-	test( 'restricts all blocks inside the columns block', async ( {
+	test.skip( 'restricts all blocks inside the columns block', async ( {
 		page,
 		editor,
 	} ) => {
@@ -42,5 +42,43 @@ test.describe( 'Columns', () => {
 		);
 		await expect( inserterOptions ).toHaveCount( 1 );
 		await expect( inserterOptions ).toHaveText( 'Column' );
+	} );
+
+	test( 'prevent the removal of locked column block from the column count change UI', async ( {
+		page,
+		editor,
+		pageUtils,
+	} ) => {
+		// Open Columns
+		await editor.insertBlock( { name: 'core/columns' } );
+		await page
+			.locator( '[aria-label="Three columns; equal split"]' )
+			.click();
+
+		// Lock last column block
+		await editor.selectBlocks(
+			page.locator( 'role=document[name="Block: Column (3 of 3)"i]' )
+		);
+		await editor.clickBlockToolbarButton( 'Options' );
+		await page.click( 'role=menuitem[name="Lock"i]' );
+		await page.locator( 'role=checkbox[name="Prevent removal"i]' ).check();
+		await page.click( 'role=button[name="Apply"i]' );
+
+		// Select columns block
+		await editor.selectBlocks(
+			page.locator( 'role=document[name="Block: Columns"i]' )
+		);
+
+		const columnsChangeInput = page.locator(
+			'role=spinbutton[name="Columns"i]'
+		);
+
+		// The min attribute should take into account locked columns
+		await expect( columnsChangeInput ).toHaveAttribute( 'min', '3' );
+
+		// Changing the number of columns should take into account locked columns
+		await page.fill( 'role=spinbutton[name="Columns"i]', '1' );
+		await pageUtils.pressKeys( 'Tab' );
+		await expect( columnsChangeInput ).toHaveValue( '3' );
 	} );
 } );


### PR DESCRIPTION
Follow-up based on [this comment](https://github.com/WordPress/gutenberg/pull/48691#pullrequestreview-1322913901) in #48691

## What?

This PR prevents the `core/column` block from being removed from the sidebar of the `core/columns` block when one of the `core/column` blocks is locked(prevent removal).

## How?

Based on the behavior that when the number of columns is reduced from a sidebar, it is removed from the column block behind it, I have implemented the following:

- Get all indexes of the column block that is prevented removal
- Get the maximum value from indexes
- Define the index plus 1 as the minimum count of columns (`minCount`)

## Screenshots or screencast

https://user-images.githubusercontent.com/54422211/229263063-21fc1c24-d9cd-4bb0-ba18-d7ed1de1d58a.mp4

### E2E test

(Speed is reduced to 1/4)

https://user-images.githubusercontent.com/54422211/229262588-c44e954e-6e62-4992-b5c9-4a194c6d6ad5.mp4
