### PR TITLE
Update redirected support link

### DIFF
--- a/packages/editor/src/components/post-excerpt/index.js
+++ b/packages/editor/src/components/post-excerpt/index.js
@@ -23,7 +23,7 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 			/>
 			<ExternalLink
 				href={ __(
-					'https://wordpress.org/support/article/settings-sidebar/#excerpt'
+					'https://wordpress.org/documentation/article/page-post-settings-sidebar/#excerpt'
 				) }
 			>
 				{ __( 'Learn more about manual excerpts' ) }


### PR DESCRIPTION
In the Excerpt tab within the post side-panel, there is a link which points to an redirected help article link.

<img width="776" alt="gutenberg_issue" src="https://user-images.githubusercontent.com/38789408/229292941-f5ef6d55-62da-4d52-906d-10a067b675ec.png">

Fixes #49532

Titled: 'Learn more about manual excerpts' points to https://wordpress.org/support/article/settings-sidebar/#excerpt

The user is then redirected to the final url: https://wordpress.org/documentation/article/page-post-settings-sidebar/#excerpt as this support directory has been moved.
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
There is no reason to point to a redirected link, it delays the UX and could cause broken link issues in the future as directories change.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixing the link to display the correct url
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Fixing the link to display the correct url
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

View the link by clicking 'copy link' and compare against the final url in the address bar after visiting it.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
