### PR TITLE
Fix site editor isFeatureActive deprecation

### DIFF
--- a/docs/reference-guides/data/data-core-edit-site.md
+++ b/docs/reference-guides/data/data-core-edit-site.md
@@ -133,6 +133,8 @@ _Returns_
 
 ### isFeatureActive
 
+> **Deprecated**
+
 Returns whether the given feature is enabled or not.
 
 _Parameters_

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -39,13 +39,14 @@ export const __unstableGetPreference = createRegistrySelector(
 /**
  * Returns whether the given feature is enabled or not.
  *
+ * @deprecated
  * @param {Object} state       Global application state.
  * @param {string} featureName Feature slug.
  *
  * @return {boolean} Is active.
  */
 export function isFeatureActive( state, featureName ) {
-	deprecated( `select( 'core/interface' ).isFeatureActive`, {
+	deprecated( `select( 'core/edit-site' ).isFeatureActive`, {
 		since: '6.0',
 		alternative: `select( 'core/preferences' ).get`,
 	} );


### PR DESCRIPTION
## What?
This deprecation message was slightly wrong and the jsdoc block was missing the @deprecated tag.
