### PR TITLE
Add CI tasks and scripts to run mobile performance tests

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -97,3 +97,11 @@ jobs:
                   name: failures-artifacts
                   path: ${{ env.WP_ARTIFACTS_PATH }}
                   if-no-files-found: ignore
+
+            - name: Run mobile performance tests
+              run: ./gutenberg/bin/reassure-tests.sh
+
+            - name: Report mobile performance results
+              run: yarn danger ci
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -97,11 +97,3 @@ jobs:
                   name: failures-artifacts
                   path: ${{ env.WP_ARTIFACTS_PATH }}
                   if-no-files-found: ignore
-
-            - name: Run mobile performance tests
-              run: ./gutenberg/bin/reassure-tests.sh
-
-            - name: Report mobile performance results
-              run: yarn danger ci
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ gutenberg.zip
 coverage
 *-performance-results.json
 .phpunit.result.cache
+.reassure
 
 # Directories/files that may appear in your environment
 *.log

--- a/bin/reassure-tests.sh
+++ b/bin/reassure-tests.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+# Move out of bin directory to Gutenberg project root
+cd ../
+
+BASELINE_BRANCH=${BASELINE_BRANCH:="trunk"}
+
+# Required for `git switch` on CI
+git fetch origin
+
+# Gather baseline perf measurements
+git switch "$BASELINE_BRANCH"
+npm --cwd ci
+npm run native test:perf --baseline
+
+# Gather current perf measurements & compare results
+git switch --detach -
+npm ci
+npm run native test:perf


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds workflows needed to run mobile performance tests via [Reassure](https://github.com/callstack/reassure).

## Why?
Native mobile performance tests have been added as part of https://github.com/WordPress/gutenberg/pull/49221, and the results can be reported via CI to help identify performance regressions in comparison against a baseline measurement.

* https://github.com/WordPress/gutenberg/pull/49221
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/5579

## How?
Adds a shell script to be run via Github workflow.

## Testing Instructions
N/A

### Testing Instructions for Keyboard
N/A

