### PR TITLE
Small improvements for the Document Overview labelling

### DIFF
--- a/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
@@ -96,7 +96,6 @@ export default function ListViewSidebar() {
 	return (
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<div
-			aria-label={ __( 'Document Overview' ) }
 			className="edit-post-editor__document-overview-panel"
 			onKeyDown={ closeOnEscape }
 			ref={ sidebarRef }
@@ -107,7 +106,7 @@ export default function ListViewSidebar() {
 			>
 				<Button
 					icon={ closeSmall }
-					label={ __( 'Close Document Overview Sidebar' ) }
+					label={ __( 'Close' ) }
 					onClick={ () => setIsListViewOpened( false ) }
 				/>
 				<ul>

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -474,9 +474,11 @@ test.describe( 'List View', () => {
 		await pageUtils.pressKeys( 'shift+Tab' );
 		await pageUtils.pressKeys( 'shift+Tab' );
 		await expect(
-			editor.canvas.getByRole( 'button', {
-				name: 'Close Document Overview Sidebar',
-			} )
+			editor.canvas
+				.getByRole( 'region', { name: 'Document Overview' } )
+				.getByRole( 'button', {
+					name: 'Close',
+				} )
 		).toBeFocused();
 
 		// Close List View and ensure it's closed.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
I'd like to propose two quick, small improvements for the Document Overview labelling:

1
Remove a redundant aria-label. Labelling a `div` element that isn't interactive or doesn't have a labelable ARIA role is a bit pointless. The `aria-label` highlighted in the screenshot below doesn't do anything:

<img width="1131" alt="Screenshot 2023-04-03 at 16 35 30" src="https://user-images.githubusercontent.com/1682452/229546960-65b996e8-4c0d-4fa8-a14e-23eb1ad8cbff.png">

2
The close button `aria-label` (and tooltip) is way too long. A simple `Close` is enough to communicate the functionality ina meaningful way. Context is already provided by the labeled ARIA region. Shorter is better for speech recognition software users. Also, text that is mostly provided for blind screen reader users should preferably avoid spatial terminology such as 'sidebar': as a blind user, I wouldn't mind whether this region is visually placed on the side, top, bottom or in any other spot of the screen.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See above.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- Edit a post.
- Open the Document Overview.
- Observe there are no visual changes.
- Hover on the `X` close button.
- Observe the button shows a tooltip with the mew, shorter, text `Close`.

## Screenshots or screencast <!-- if applicable -->
