### PR TITLE
Fix block toolbar height and rounded corners of parent selector button when text label mode

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -158,6 +158,9 @@
 	// Parent selector overrides
 
 	.block-editor-block-parent-selector__button {
+		border-top-right-radius: 0;
+		border-bottom-right-radius: 0;
+
 		.block-editor-block-icon {
 			width: 0;
 		}

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -211,6 +211,7 @@
 				height: 1px;
 				background: $gray-900;
 				order: 2;
+				margin: -0.5px 0;
 			}
 		}
 

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -207,19 +207,10 @@
 
 		.block-editor-block-mover__move-button-container {
 			border-left: 1px solid $gray-900;
-
-			&::before {
-				content: "";
-				display: block;
-				height: 1px;
-				background: $gray-900;
-				order: 2;
-				margin: -0.5px 0;
-			}
 		}
 
 		.is-down-button.is-down-button.is-down-button {
-			order: 3;
+			order: 2;
 		}
 
 		.block-editor-block-contextual-toolbar.is-fixed .block-editor-block-mover__move-button-container::before {


### PR DESCRIPTION
## What?

This PR unifies the height of the block toolbar to **46px**. This eliminates the misalignment of the buttons for selecting the parent block when "Show button text labels" mode is enabled.

![pr](https://user-images.githubusercontent.com/54422211/229551863-79d8dace-533f-4837-9dc5-8fe9023eaee3.png)

---

edit: This PR also fixes the rounded corners on the parent selector button as pointed out in [this comment](https://github.com/WordPress/gutenberg/pull/49556#issuecomment-1494718304).

## Why?

The block toolbar is expected to be 46px high:

![no-label](https://user-images.githubusercontent.com/54422211/229552862-abdf1072-d88d-4b8b-8713-53cf842cbe1d.png)

However, when "Show button text labels" mode is enabled, the toolbar height is **47px**:

![label-mode](https://user-images.githubusercontent.com/54422211/229553509-80eddb38-6b3e-4246-8f52-289993890a74.png)

This is because the pseudo-element between "Move up" and "Move down" has a height of **1px**:

![border](https://user-images.githubusercontent.com/54422211/229554336-51ac6ab8-783f-422a-a89b-deb3e64624b8.png)

This results in the height of the button to select the parent block being displaced if that block is a child:

![pr](https://user-images.githubusercontent.com/54422211/229555259-441bce5d-75ed-4683-84ae-91720da2efed.png)

## How?

Since this problem can be solved by treating a 1px height border as having no height, there are many possible approaches. I have applied a total negative margin of 1px on the top and bottom, which seems the simplest.

## Screenshots or screencast <!-- if applicable -->

### Before

![before](https://user-images.githubusercontent.com/54422211/229554910-e7ae2bd2-b3b6-4e55-8959-15c77dd6f326.png)

### After

![after](https://user-images.githubusercontent.com/54422211/229554926-604a7ceb-fdb2-4159-8f49-0f132c20806a.png)



