### PR TITLE
[RNMobile] Add GlotPress project slug parameter to translations pipeline

### DIFF
--- a/packages/react-native-editor/bin/extract-used-strings.js
+++ b/packages/react-native-editor/bin/extract-used-strings.js
@@ -155,11 +155,13 @@ if ( require.main === module ) {
 	const domains = [ 'gutenberg' ];
 	const otherPluginArgs = process.argv.slice( 3 );
 	const otherPlugins = [];
-	for ( let index = 0; index < otherPluginArgs.length; index += 2 ) {
+	for ( let index = 0; index < otherPluginArgs.length; index += 3 ) {
 		const pluginName = otherPluginArgs[ index ];
-		const pluginPath = path.resolve( otherPluginArgs[ index + 1 ] );
+		const projectSlug = otherPluginArgs[ index + 1 ];
+		const pluginPath = path.resolve( otherPluginArgs[ index + 2 ] );
 		otherPlugins.push( {
 			name: pluginName,
+			projectSlug,
 			sourcePath: pluginPath,
 		} );
 		domains.push( pluginName );

--- a/packages/react-native-editor/bin/generate-pot-files.sh
+++ b/packages/react-native-editor/bin/generate-pot-files.sh
@@ -191,7 +191,7 @@ fi
 # Define constants
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 GUTENBERG_SOURCE_CODE_DIR="$SCRIPT_DIR/../../.."
-WP_CLI="php -d memory_limit=4G $SCRIPT_DIR/wp-cli.phar"
+WP_CLI="php -d memory_limit=4G -d error_reporting=E_ALL&~E_DEPRECATED $SCRIPT_DIR/wp-cli.phar"
 BUNDLE_CLI="$GUTENBERG_SOURCE_CODE_DIR/node_modules/.bin/react-native bundle --config ${METRO_CONFIG:-metro.config.js}"
 
 # Set target path


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add the GlotPress project slug parameter to the translation pipeline scripts.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Previously, the project slug was calculated based on the plugin's name. However, this is not always the case, so this will allow plugins to set their custom project slug if needed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The parameter has been added to the `i18n-translations-download` script and updated the logic accordingly.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Follow testing instructions from [GB-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/5626).

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A