### PR TITLE
Docs: Fix Create a Block Tutorial link on blocks package README.md

### DIFF
--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -742,7 +742,7 @@ Registers a new block provided a unique name and an object defining its
 behavior. Once registered, the block is made available as an option to any
 editor interface where blocks are implemented.
 
-For more in-depth information on registering a custom block see the [Create a block tutorial](docs/how-to-guides/block-tutorial/README.md)
+For more in-depth information on registering a custom block see the [Create a block tutorial](/docs/getting-started/create-block/README.md)
 
 _Usage_
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -742,7 +742,7 @@ Registers a new block provided a unique name and an object defining its
 behavior. Once registered, the block is made available as an option to any
 editor interface where blocks are implemented.
 
-For more in-depth information on registering a custom block see the [Create a block tutorial](/docs/getting-started/create-block/README.md)
+For more in-depth information on registering a custom block see the [Create a block tutorial](docs/how-to-guides/block-tutorial/README.md)
 
 _Usage_
 

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -248,7 +248,7 @@ function getBlockSettingsFromMetadata( { textdomain, ...metadata } ) {
  * behavior. Once registered, the block is made available as an option to any
  * editor interface where blocks are implemented.
  *
- * For more in-depth information on registering a custom block see the [Create a block tutorial](docs/how-to-guides/block-tutorial/README.md)
+ * For more in-depth information on registering a custom block see the [Create a block tutorial](/docs/getting-started/create-block/README.md)
  *
  * @param {string|Object} blockNameOrMetadata Block type name or its metadata.
  * @param {Object}        settings            Block settings.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR fixes the Create a Block Tutorial link located on `packages/blocks/README.md`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, if a user clicks on the Create a Block Tutorial link, they get redirected to a 404 page:
<img width="1147" alt="image" src="https://user-images.githubusercontent.com/20469356/229591571-1c5b6a9a-df4b-4b15-b902-1d8f066510d0.png">


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
In this PR, I'm replacing the old link that was pointing to `docs/how-to-guides/block-tutorial/README.md` with the new link that points to the correct file location at `/docs/getting-started/create-block/README.md`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Visite [the Blocks package README.md file](https://github.com/WordPress/gutenberg/blob/trunk/packages/blocks/README.md);
2. On [the registerBlockType section](https://github.com/WordPress/gutenberg/blob/trunk/packages/blocks/README.md#registerblocktype), click on Create a Block Tutorial link
3. Check the page is redirected to the Create a Block Tutorial page and not to a 404 page