### PR TITLE
Try fixing post editor layout for wide/full Post Content blocks

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -330,9 +330,9 @@ export default function VisualEditor( { styles } ) {
 
 	// Add some styles for alignwide/alignfull Post Content and its children.
 	const alignCSS = `.is-root-container.alignwide { max-width: var(--wp--style--global--wide-size); margin-left: auto; margin-right: auto;}
-		.is-root-container.alignwide > :not(.alignleft):not(.alignright) { max-width: var(--wp--style--global--wide-size);}
+		.is-root-container.alignwide:where(.is-layout-flow) > :not(.alignleft):not(.alignright) { max-width: var(--wp--style--global--wide-size);}
 		.is-root-container.alignfull { max-width: none; margin-left: auto; margin-right: auto;}
-		.is-root-container.alignfull > :not(.alignleft):not(.alignright) { max-width: none;}`;
+		.is-root-container.alignfull:where(.is-layout-flow) > :not(.alignleft):not(.alignright) { max-width: none;}`;
 
 	return (
 		<BlockTools

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -261,7 +261,7 @@ export default function VisualEditor( { styles } ) {
 		postContentAttributes,
 	] );
 
-	const layout = newestPostContentAttributes?.layout || {};
+	const { layout = {}, align = '' } = newestPostContentAttributes || {};
 
 	const postContentLayoutClasses = useLayoutClasses(
 		newestPostContentAttributes,
@@ -272,7 +272,8 @@ export default function VisualEditor( { styles } ) {
 		{
 			'is-layout-flow': ! themeSupportsLayout,
 		},
-		themeSupportsLayout && postContentLayoutClasses
+		themeSupportsLayout && postContentLayoutClasses,
+		align && `align${ align }`
 	);
 
 	const postContentLayoutStyles = useLayoutStyles(
@@ -326,6 +327,12 @@ export default function VisualEditor( { styles } ) {
 		],
 		[ styles ]
 	);
+
+	// Add some styles for alignwide/alignfull Post Content and its children.
+	const alignCSS = `.is-root-container.alignwide { max-width: var(--wp--style--global--wide-size); margin-left: auto; margin-right: auto;}
+		.is-root-container.alignwide > :not(.alignleft):not(.alignright) { max-width: var(--wp--style--global--wide-size);}
+		.is-root-container.alignfull { max-width: none; margin-left: auto; margin-right: auto;}
+		.is-root-container.alignfull > :not(.alignleft):not(.alignright) { max-width: none;}`;
 
 	return (
 		<BlockTools
@@ -382,6 +389,9 @@ export default function VisualEditor( { styles } ) {
 											globalLayoutSettings?.definitions
 										}
 									/>
+									{ align && (
+										<LayoutStyle css={ alignCSS } />
+									) }
 									{ postContentLayoutStyles && (
 										<LayoutStyle
 											layout={ postContentLayout }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #49546.

This is not a perfect fix, because it assumes that Post Content is inside a constrained layout block with the default wide content value. If the parent block has custom content/wide width values set, it won't really work. 

Currently the only way to make sure the post editor layout conforms exactly to the appearance of the Post Content block would be to look at the attributes of all its parent blocks, which would require a lot of complicated logic 😅 and, given the direction #41717 sets for the future of post editing, it is likely not worth the effort. (Once the editors are unified as per #41717, the problem will be solved because the post editing interface will reproduce its template structure exactly.)

The fix in this PR should cover a bunch of common cases though, so I think it can still be useful.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In a block theme, edit the Single template so that Post Content is nested in a Group with "Inner blocks use content width" turned on, and is set to "wide" alignment. Post Content itself should have "Inner blocks use content width" turned off.
2. Save changes and go to the post editor. Add a few blocks to the post and check that their maximum width is the theme wide alignment width.
3. Back in the template view, try switching the Post Content alignment to "full" and save changes.
4. Reload the post editor and check that the content now stretches to full width of the editor.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Editor with full width layout:

<img width="1316" alt="Screenshot 2023-04-04 at 1 55 25 pm" src="https://user-images.githubusercontent.com/8096000/229683430-3af76278-ee42-40d3-b73d-b51c2e885d61.png">
