### PR TITLE
Remove editor block styles leftovers

### DIFF
--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -64,6 +64,5 @@
 			}
 		}
 	},
-	"editorStyle": "wp-block-post-author-editor",
 	"style": "wp-block-post-author"
 }

--- a/packages/block-library/src/term-description/block.json
+++ b/packages/block-library/src/term-description/block.json
@@ -39,6 +39,5 @@
 				"fontSize": true
 			}
 		}
-	},
-	"editorStyle": "wp-block-term-description-editor"
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
While working on something different I noticed there are some leftovers from https://github.com/WordPress/gutenberg/pull/35513.

The editor style files have been removed.

## Testing instructions
Nothing really changes :) 