### PR TITLE
Remove pointer cursor on style variation preview

### DIFF
--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -130,7 +130,6 @@ const StylesPreview = ( { label, isFocused, withHoverView } ) => {
 							height: normalizedHeight * ratio,
 							width: '100%',
 							background: gradientValue ?? backgroundColor,
-							cursor: 'pointer',
 						} }
 						initial="start"
 						animate={


### PR DESCRIPTION
## What?
Removes the `cursor: pointer` declaration on the style variation preview.

## Why?
This element is non-interactive. The pointer cursor is confusing.

## How?
Removed 1 line of code.

## Testing Instructions
1. Open the Global Styles panel
2. Mouse over the style variation preview
3. Observe the default cursor

## Screenshots or screencast <!-- if applicable -->

**Before**

https://user-images.githubusercontent.com/846565/229757536-1d0dc4fe-db77-42f0-904e-1e9a67c87a8a.mp4

**After**

https://user-images.githubusercontent.com/846565/229757542-e3b00156-c8ae-46a8-a49a-c9b7dd305a5e.mp4


