### PR TITLE
Fix fallback not rendering

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -471,10 +471,6 @@ function block_core_navigation_get_fallback_blocks() {
 		$fallback_blocks = ! empty( $maybe_fallback ) ? $maybe_fallback : $fallback_blocks;
 	}
 
-	// Normalizing blocks may result in an empty array of blocks if they were all `null` blocks.
-	// In this case default empty blocks.
-	$fallback_blocks = ! empty( $fallback_blocks ) ? $fallback_blocks : array();
-
 	/**
 	 * Filters the fallback experience for the Navigation block.
 	 *

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -473,7 +473,7 @@ function block_core_navigation_get_fallback_blocks() {
 
 	// Normalizing blocks may result in an empty array of blocks if they were all `null` blocks.
 	// In this case default empty blocks.
-	$fallback_blocks = ! empty( $maybe_fallback ) ? $maybe_fallback : array();
+	$fallback_blocks = ! empty( $fallback_blocks ) ? $fallback_blocks : array();
 
 	/**
 	 * Filters the fallback experience for the Navigation block.


### PR DESCRIPTION
## What?

Removes a useless check for empty fallback meny blocks.

## Why?

https://github.com/WordPress/gutenberg/pull/48602 which reverted https://github.com/WordPress/gutenberg/pull/47684 failed to remove the code at https://github.com/WordPress/gutenberg/commit/8548085ee68d8ff0ac4d9677280d86302151df05#diff-90cb5b64c95087ded3c7bb160e38189c8499b0f14f61beb884c887452449fa12R495

This code now prevents fallnack page list navigation from rendering on the front end.

## How?


Remove the left over check for empty blocks. It only makes sense in the if branch before, where `$maybe_fallback` may be empty because of `block_core_navigation_filter_out_empty_blocks`.

## Testing Instructions

1. Make sure to have one page
2. Delete all navigation block menus (from `wp-admin/edit.php?post_type=wp_navigation`)
3. Install and activate the theme Lettre
4. Check that the front end renders a page list
