### PR TITLE
Rich text: add dynamic data API

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -565,3 +565,57 @@ remove_action( 'wp_footer', 'wp_enqueue_stored_styles', 1 );
 // Enqueue stored styles.
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_stored_styles' );
 add_action( 'wp_footer', 'gutenberg_enqueue_stored_styles', 1 );
+
+/**
+ * Given a string of HTML, replaces all matching <data> tags with the result of
+ * the callback function.
+ *
+ * @param string   $content  The HTML content.
+ * @param string   $type     The type of data.
+ * @param callable $callback The callback function, called with the data
+ *                           attributes and fallback content.
+ * 
+ * @return string The HTML content with the <data> tags replaced.
+ */
+function replaceDataByType( $content, $type, $callback ) {
+	if ( ! strpos( $content, '<data' ) ) {
+		return $content;
+	}
+
+	return preg_replace_callback(
+		'/<data ([^>]+)>(.*?)<\/data>/',
+		function( $matches ) use ( $type, $callback ) {
+			// shortcode_parse_atts works on HTML attributes too.
+			$attrs = shortcode_parse_atts( $matches[1] );
+			$fallback = $matches[2];
+
+			if ( ! isset( $attrs['value'] ) || $attrs['value'] !== $type ) {
+				return $matches[0];
+			}
+
+			$data = array();
+
+			foreach ( $attrs as $key => $value ) {
+				if ( strpos( $key, 'data-' ) === 0 ) {
+					$data[ substr( $key, 5 ) ] = $value;
+				}
+			}
+
+			return $callback( $data, $fallback );
+		},
+		$content
+	);
+}
+
+add_filter(
+	'render_block',
+	function( $block_content ) {
+		return replaceDataByType(
+			$block_content,
+			'core/current-year',
+			function() {
+				return '<time datetime=' . date( 'Y' ) . '>' . date( 'Y' ) . '</time>';
+			}
+		);
+	}
+);

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -12,6 +12,7 @@ import {
 	useCallback,
 	forwardRef,
 	createContext,
+	createPortal,
 } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { children as childrenSource } from '@wordpress/blocks';
@@ -281,6 +282,7 @@ function RichTextWrapper(
 		getValue,
 		onChange,
 		ref: richTextRef,
+		replacementRefs,
 	} = useRichText( {
 		value: adjustedValue,
 		onChange( html, { __unstableFormats, __unstableText } ) {
@@ -414,6 +416,15 @@ function RichTextWrapper(
 					'rich-text'
 				) }
 			/>
+			{ replacementRefs.map( ( ref ) => {
+				const { render: Render } = formatTypes.find(
+					( { name } ) => name === ref.value
+				);
+				return (
+					ref &&
+					createPortal( <Render attributes={ ref.dataset } />, ref )
+				);
+			} ) }
 		</>
 	);
 }

--- a/packages/format-library/package.json
+++ b/packages/format-library/package.json
@@ -31,6 +31,7 @@
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
+		"@wordpress/date": "file:../date",
 		"@wordpress/element": "file:../element",
 		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",

--- a/packages/format-library/src/current-year/index.js
+++ b/packages/format-library/src/current-year/index.js
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { insertObject } from '@wordpress/rich-text';
+import { RichTextToolbarButton } from '@wordpress/block-editor';
+import { formatListNumbered } from '@wordpress/icons';
+import { dateI18n } from '@wordpress/date';
+
+const name = 'core/current-year';
+const title = __( 'Current Year' );
+
+function Time() {
+	const year = dateI18n( 'Y', new Date() );
+	return <time dateTime={ year }>{ year }</time>;
+}
+
+export const currentYear = {
+	name,
+	title,
+	tagName: 'data',
+	render: Time,
+	saveFallback: Time,
+	edit( { isObjectActive, value, onChange, onFocus } ) {
+		function onClick() {
+			const newValue = insertObject( value, {
+				type: name,
+			} );
+			newValue.start = newValue.end - 1;
+			onChange( newValue );
+			onFocus();
+		}
+
+		return (
+			<RichTextToolbarButton
+				icon={ formatListNumbered }
+				title={ title }
+				onClick={ onClick }
+				isActive={ isObjectActive }
+			/>
+		);
+	},
+};

--- a/packages/format-library/src/default-formats.js
+++ b/packages/format-library/src/default-formats.js
@@ -13,6 +13,7 @@ import { subscript } from './subscript';
 import { superscript } from './superscript';
 import { keyboard } from './keyboard';
 import { unknown } from './unknown';
+import { currentYear } from './current-year';
 
 export default [
 	bold,
@@ -27,4 +28,5 @@ export default [
 	superscript,
 	keyboard,
 	unknown,
+	currentYear,
 ];

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -19,6 +19,7 @@ import { useSelectObject } from './use-select-object';
 import { useInputAndSelection } from './use-input-and-selection';
 import { useSelectionChangeCompat } from './use-selection-change-compat';
 import { useDelete } from './use-delete';
+import { getFormatType } from '../get-format-type';
 
 export function useRichText( {
 	value = '',
@@ -70,11 +71,21 @@ export function useRichText( {
 			__unstableDomOnly: domOnly,
 			placeholder,
 		} );
+
+		Array.from( ref.current.querySelectorAll( 'data' ) )
+			.filter( ( node ) => !! getFormatType( node.value ) )
+			.forEach( ( node, i ) => {
+				if ( replacementRefs.current[ i ] !== node ) {
+					replacementRefs.current[ i ] = node;
+					forceRender();
+				}
+			} );
 	}
 
 	// Internal values are updated synchronously, unlike props and state.
 	const _value = useRef( value );
 	const record = useRef();
+	const replacementRefs = useRef( [] );
 
 	function setRecordFromProps() {
 		_value.current = value;
@@ -258,6 +269,7 @@ export function useRichText( {
 		getValue: () => record.current,
 		onChange: handleChange,
 		ref: mergedRefs,
+		replacementRefs: replacementRefs.current,
 	};
 }
 

--- a/packages/rich-text/src/component/use-select-object.js
+++ b/packages/rich-text/src/component/use-select-object.js
@@ -9,7 +9,10 @@ export function useSelectObject() {
 			const { target } = event;
 
 			// If the child element has no text content, it must be an object.
-			if ( target === element || target.textContent ) {
+			if (
+				target === element ||
+				( target.textContent && target.isContentEditable )
+			) {
 				return;
 			}
 
@@ -21,6 +24,7 @@ export function useSelectObject() {
 			range.selectNode( target );
 			selection.removeAllRanges();
 			selection.addRange( range );
+			event.preventDefault();
 		}
 
 		element.addEventListener( 'click', onClick );

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -426,6 +426,35 @@ function createFromElement( {
 			continue;
 		}
 
+		dataFormat: if ( tagName === 'data' ) {
+			const { value: type, dataset } = node;
+			const formatType = select( richTextStore ).getFormatType( type );
+			if ( ! formatType ) break dataFormat;
+			const clonedDataset = { ...dataset };
+			const { attributes } = formatType;
+
+			for ( const key in attributes ) {
+				if ( clonedDataset[ key ] === undefined ) {
+					clonedDataset[ key ] = attributes[ key ]( node );
+				}
+			}
+
+			const value = {
+				formats: [ , ],
+				replacements: [
+					{
+						type,
+						attributes: clonedDataset,
+						tagName,
+					},
+				],
+				text: OBJECT_REPLACEMENT_CHARACTER,
+			};
+			accumulateSelection( accumulator, node, range, value );
+			mergePair( accumulator, value );
+			continue;
+		}
+
 		if ( tagName === 'br' ) {
 			accumulateSelection( accumulator, node, range, createEmptyValue() );
 			mergePair( accumulator, create( { text: '\n' } ) );

--- a/packages/rich-text/src/register-format-type.js
+++ b/packages/rich-text/src/register-format-type.js
@@ -62,7 +62,8 @@ export function registerFormatType( name, settings ) {
 	if (
 		( typeof settings.className !== 'string' ||
 			settings.className === '' ) &&
-		settings.className !== null
+		settings.className !== null &&
+		settings.tagName !== 'data'
 	) {
 		window.console.error(
 			'Format class names must be a string, or null to handle bare elements.'
@@ -77,30 +78,32 @@ export function registerFormatType( name, settings ) {
 		return;
 	}
 
-	if ( settings.className === null ) {
-		const formatTypeForBareElement = select(
-			richTextStore
-		).getFormatTypeForBareElement( settings.tagName );
+	if ( settings.tagName !== 'data' ) {
+		if ( settings.className === null ) {
+			const formatTypeForBareElement = select(
+				richTextStore
+			).getFormatTypeForBareElement( settings.tagName );
 
-		if (
-			formatTypeForBareElement &&
-			formatTypeForBareElement.name !== 'core/unknown'
-		) {
-			window.console.error(
-				`Format "${ formatTypeForBareElement.name }" is already registered to handle bare tag name "${ settings.tagName }".`
-			);
-			return;
-		}
-	} else {
-		const formatTypeForClassName = select(
-			richTextStore
-		).getFormatTypeForClassName( settings.className );
+			if (
+				formatTypeForBareElement &&
+				formatTypeForBareElement.name !== 'core/unknown'
+			) {
+				window.console.error(
+					`Format "${ formatTypeForBareElement.name }" is already registered to handle bare tag name "${ settings.tagName }".`
+				);
+				return;
+			}
+		} else {
+			const formatTypeForClassName = select(
+				richTextStore
+			).getFormatTypeForClassName( settings.className );
 
-		if ( formatTypeForClassName ) {
-			window.console.error(
-				`Format "${ formatTypeForClassName.name }" is already registered to handle class name "${ settings.className }".`
-			);
-			return;
+			if ( formatTypeForClassName ) {
+				window.console.error(
+					`Format "${ formatTypeForClassName.name }" is already registered to handle class name "${ settings.className }".`
+				);
+				return;
+			}
 		}
 	}
 

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -61,13 +61,19 @@ function append( element, child ) {
 		child = element.ownerDocument.createTextNode( child );
 	}
 
-	const { type, attributes } = child;
+	const { type, attributes, dataset } = child;
 
 	if ( type ) {
 		child = element.ownerDocument.createElement( type );
 
 		for ( const key in attributes ) {
 			child.setAttribute( key, attributes[ key ] );
+		}
+
+		for ( const key in dataset ) {
+			if ( dataset[ key ] ) {
+				child.dataset[ key ] = dataset[ key ];
+			}
 		}
 	}
 
@@ -240,7 +246,10 @@ export function applyValue( future, current ) {
 					}
 				}
 
-				applyValue( futureChild, currentChild );
+				if ( currentChild.nodeName !== 'DATA' ) {
+					applyValue( futureChild, currentChild );
+				}
+
 				future.removeChild( futureChild );
 			}
 		} else {

--- a/packages/rich-text/src/to-html-string.js
+++ b/packages/rich-text/src/to-html-string.js
@@ -91,16 +91,31 @@ function remove( object ) {
 	return object;
 }
 
-function createElementHTML( { type, attributes, object, children } ) {
+function createElementHTML( { type, attributes, dataset, object, children } ) {
 	let attributeString = '';
 
 	for ( const key in attributes ) {
+		if ( ! attributes[ key ] ) continue;
 		if ( ! isValidAttributeName( key ) ) {
 			continue;
 		}
 
 		attributeString += ` ${ key }="${ escapeAttribute(
 			attributes[ key ]
+		) }"`;
+	}
+
+	for ( const key in dataset ) {
+		if ( ! dataset[ key ] ) continue;
+
+		const htmlKey = key.replace( /[A-Z]/g, '-$&' ).toLowerCase();
+
+		if ( ! isValidAttributeName( htmlKey ) ) {
+			continue;
+		}
+
+		attributeString += ` data-${ htmlKey }="${ escapeAttribute(
+			dataset[ key ]
 		) }"`;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This is a first attempt at storing data in rich text with dynamic replacement both in rich text and server side. For this, we will use the [`<data>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data) HTML tag since it fits semantically and doesn't have any default styling. The full syntax will be:

```html
<data value="namespace/name" data-attribute1="value1" ...>Fallback, HTML data, or placeholder</data>
```

We will use the dataset as attributes and the HTML content can be used as the implementor sees fit.

### Use case: current year

In templates, it's useful to display the current year in the footer for example. This can now be done with the `core/current-year` format type. On insertion, a data tag will be injected into rich text:

```html
<data value="core/current-year"></data>
```

The format type's `render` function will be called to render the contents. When serialising the HTML, the format type's `saveFallback` function will be called. In this case it's both the same:

```jsx
const year = dateI18n( 'Y', new Date() );
return <time dateTime={ year }>{ year }</time>;
```

So the content that will be stored in the post is:

```html
<data value="core/current-year"><time datetime="2023">2023</time></data>
```

If for some reason the PHP display filters don't run, the year will render fine, though of course not the current year. In this case a fallback is perhaps not needed because this dynamic content will most likely only be used in templates, but it might be useful for other types of content.

Now on the PHP side, there's a helper function `replaceDataByType`.

```php
add_filter(
	'render_block',
	function( $block_content ) {
		return replaceDataByType(
			$block_content,
			'core/current-year',
			function() {
				return '<time datetime=' . date( 'Y' ) . '>' . date( 'Y' ) . '</time>';
			}
		);
	}
);
```

### Use case: post meta, e.g. date

We can handle the post date similarly, but the case is a bit more interesting because it allows attributes.

```html
<data value="core/current-year" data-display-type="modified" data-format="F j, Y g:i a"></data>
```

On top of that, we need post meta data. This will be the render function:

```jsx
function Render( { attributes: { format, displayType } } )
	const { postId, postType: postTypeSlug } = useContext();
	const [ date ] = useEntityProp(
		'postType',
		postTypeSlug,
		displayType,
		postId
	);
	const [ siteFormat ] = useEntityProp(
		'root',
		'site',
		'date_format'
	);
	return (
		<time dateTime={ dateI18n( 'c', date ) }>
			{ dateI18n( format || siteFormat, date ) }
		</time>
	);
}
```

In this case, if we don't provide a fallback function, only the data tag will be saved without any content (`<data value="core/current-year" data-display-type="modified" data-format="F j, Y g:i a"></data>`).

And now again in PHP:

```php
add_filter(
	'render_block',
	function( $block_content, $block ) {
		return replaceDataByType(
			$block_content,
			'core/post-date',
			function( $attributes ) use ( $block ) {
				$post_ID = $block->context['postId'];
				return '<time datetime=' . esc_attr( get_the_modified_date( 'c', $post_ID ) ) . '>' . get_the_modified_date( empty( $attributes['format'] ) ? '' : $attributes['format'], $post_ID ); . '</time>';
			}
		);
	}
);
```

But here is the interesting thing: if I create a pattern, I can use the content of the data tag as a placeholder. This means that if my pattern is viewed somewhere outside of context, you'll be able to see the placeholder. When you copy the pattern over to your site, that placeholder will disappear and be replaced.

### Use case: footnotes

We can use this API for footnotes too. More on that here: https://github.com/WordPress/gutenberg/pull/47682/files

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
