### PR TITLE
[RNMobile] Expand supported endpoints with WP hook

### DIFF
--- a/packages/react-native-editor/src/api-fetch-setup.js
+++ b/packages/react-native-editor/src/api-fetch-setup.js
@@ -3,6 +3,7 @@
  */
 import { fetchRequest, postRequest } from '@wordpress/react-native-bridge';
 import apiFetch from '@wordpress/api-fetch';
+import { applyFilters } from '@wordpress/hooks';
 
 const SUPPORTED_METHODS = [ 'GET', 'POST' ];
 // Please add only wp.org API paths here!
@@ -70,8 +71,15 @@ const fetchHandler = (
 export const isMethodSupported = ( method ) =>
 	SUPPORTED_METHODS.includes( method );
 
-export const isPathSupported = ( path, method ) =>
-	SUPPORTED_ENDPOINTS[ method ].some( ( pattern ) => pattern.test( path ) );
+export const isPathSupported = ( path, method ) => {
+	const supportedEndpoints = applyFilters(
+		'native.supported_endpoints',
+		SUPPORTED_ENDPOINTS
+	);
+	return supportedEndpoints[ method ].some( ( pattern ) =>
+		pattern.test( path )
+	);
+};
 
 export const shouldEnableCaching = ( path ) =>
 	! DISABLED_CACHING_ENDPOINTS.some( ( pattern ) => pattern.test( path ) );

--- a/packages/react-native-editor/src/test/api-fetch-setup.test.js
+++ b/packages/react-native-editor/src/test/api-fetch-setup.test.js
@@ -1,4 +1,8 @@
 /**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+/**
  * Internal dependencies
  */
 import { isPathSupported, shouldEnableCaching } from '../api-fetch-setup';
@@ -16,10 +20,10 @@ const supportedPaths = {
 	],
 };
 
+// Made up examples.
 const unsupportedPaths = {
-	GET: [
-		'wp/v1/media/', // Made up example.
-	],
+	GET: [ 'wp/v1/media/' ],
+	POST: [ 'wp/v2/categories' ],
 };
 
 const enabledCachingPaths = [
@@ -49,6 +53,31 @@ describe( 'isPathSupported', () => {
 				expect( isPathSupported( path, 'GET' ) ).toBe( false );
 			} );
 		} );
+	} );
+
+	describe( 'POST requests', () => {
+		unsupportedPaths.POST.forEach( ( path ) => {
+			it( `does not support ${ path }`, () => {
+				expect( isPathSupported( path, 'POST' ) ).toBe( false );
+			} );
+		} );
+	} );
+
+	it( 'checks supported endpoints provided by WP hook', () => {
+		addFilter(
+			'native.supported_endpoints',
+			'gutenberg-mobile',
+			( endpoints ) => {
+				return {
+					GET: [ ...endpoints.GET, /test\/get-endpoint/i ],
+					POST: [ ...endpoints.POST, /test\/post-endpoint/i ],
+				};
+			}
+		);
+		expect( isPathSupported( 'test/get-endpoint', 'GET' ) ).toBe( true );
+		expect( isPathSupported( 'test/post-endpoint', 'POST' ) ).toBe( true );
+		expect( isPathSupported( 'test/bad-endpoint', 'GET' ) ).toBe( false );
+		expect( isPathSupported( 'test/bad-endpoint', 'POST' ) ).toBe( false );
 	} );
 } );
 


### PR DESCRIPTION
**Related PR:**
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/5632

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add a WP hook to expand the supported endpoints in the native fetch handler.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

New supported endpoints might be needed by non-core blocks, hence we need to provide a way to expand them.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add a WP hook with name `native.supported_endpoints` that passes the current supported endpoints and uses the result in `isPathSupported`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Follow the testing instructions from GB-mobile PR.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A