### PR TITLE
Components: Simplify `CustomGradientPicker`'s utility props

### DIFF
--- a/packages/components/src/custom-gradient-picker/serializer.ts
+++ b/packages/components/src/custom-gradient-picker/serializer.ts
@@ -2,15 +2,11 @@
  * External dependencies
  */
 import type gradientParser from 'gradient-parser';
-/**
- * Internal dependencies
- */
-import type { ColorStopTypeAndValue } from './types';
 
 export function serializeGradientColor( {
 	type,
 	value,
-}: ColorStopTypeAndValue ) {
+}: gradientParser.ColorStop ) {
 	if ( type === 'literal' ) {
 		return value;
 	}
@@ -38,7 +34,7 @@ export function serializeGradientColorStop( {
 	return `${ serializeGradientColor( {
 		type,
 		value,
-	} as ColorStopTypeAndValue ) } ${ serializeGradientPosition( length ) }`;
+	} as gradientParser.ColorStop ) } ${ serializeGradientPosition( length ) }`;
 }
 
 export function serializeGradientOrientation(

--- a/packages/components/src/custom-gradient-picker/types.ts
+++ b/packages/components/src/custom-gradient-picker/types.ts
@@ -48,24 +48,6 @@ export type GradientTypePickerProps = {
 
 export type ControlPoint = { color: string; position: number };
 
-// When dealing with unions of objects, using `Pick` will result
-// in a new type where each desired prop is a union of the values for that prop
-// across all of the original union members. This does not maintain the specific
-// combinations of props present in the original union.
-// To avoid this, the `DistributivePick` type will
-// "distribute" the `Pick` across the union. This allows the `Pick`
-// to act on each member individually, maintaining the relationships between the
-// resulting props.
-// https://stackoverflow.com/questions/57103834/typescript-omit-a-property-from-all-interfaces-in-a-union-but-keep-the-union-s
-type DistributivePick< T, K extends keyof T > = T extends any
-	? Pick< T, K >
-	: never;
-
-export type ColorStopTypeAndValue = DistributivePick<
-	gradientParser.ColorStop,
-	'type' | 'value'
->;
-
 export type CustomGradientBarProps = {
 	background: React.CSSProperties[ 'background' ];
 	hasGradient: boolean;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
When recently migrating `CustomGradientPicker` to TypeScript, an abstraction was used that is more complicated than it needed to be. This PR simplifies the affected types.

## Why?
Simplifying these types will make them easier to parse and work with by other contributors in the future.

## How?
The utility function impacted by this change uses only certain props from an existing type. The abstraction that is currently in place narrows the existing type to more closely match the expected inputs of the function, but this narrowing isn't technically necessary. To alleviate the added complexity, the types are being updated to just accept the existing type, and the extra prop(s) can be seamlessly ignored without causing any errors.

## Testing Instructions
- Confirm that there are new new TS errors introduced by this change
- Confirm unit tests pass
