### PR TITLE
Don't programmatically lowercase post type label

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -145,9 +145,9 @@ export default function PostFeaturedImageEdit( {
 						label={
 							postType?.labels.singular_name
 								? sprintf(
-										// translators: %s: Name of the post type e.g: "post".
+										// translators: %s: Name of the post type e.g: "Page".
 										__( 'Link to %s' ),
-										postType.labels.singular_name.toLowerCase()
+										postType.labels.singular_name
 								  )
 								: __( 'Link to post' )
 						}


### PR DESCRIPTION
## What?
Remove the programmatically lowercasing of the post type label in the "Link to %s" setting of the "Post Featured Image" block.

Fixes #49587 

## Why?
Programmatically lowercasing the label causes wrong grammar in languages that capitalize nouns like German.

## How?
The `.toLowerCase()` call is removed. While this leads to capitalized post type labels also in English, IMO this acceptable. On multiple occassions throughout WordPress, English nouns are already capitalized, e.g., the "Update Profile" button on the user profile page:
![Bildschirmfoto 2023-04-04 um 21 43 40](https://user-images.githubusercontent.com/8144115/229902556-e805a133-a674-414d-9959-fd80a5d332e7.png)

Also, the translators comment is changed to use "Page" because a) "post" is already used in the fallback string and b) the label is now capitalized.

## Testing Instructions
1. Insert the "Post Featured Image" to a page (not post)
2. Open the block settings
3. Verify that the setting  reads "Link to Page" instead of "Link to page"
4. Switch the locale to German
5. Verify that the setting reads "Link zu Seite" instead of "Link zu seite"

### Testing Instructions for Keyboard
Does not apply.

## Screenshots or screencast <!-- if applicable -->
Before:
![Bildschirmfoto 2023-04-04 um 21 08 32](https://user-images.githubusercontent.com/8144115/229895463-afbcb18e-f01f-4e87-b774-b3c59e3399b3.png)

After:
![Bildschirmfoto 2023-04-04 um 21 45 39](https://user-images.githubusercontent.com/8144115/229903080-4c04e207-aaf3-4550-be4d-b21b964c670d.png)