### PR TITLE
Style Variation picker: restore pointer cursor when withHover is in use

### DIFF
--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -130,6 +130,7 @@ const StylesPreview = ( { label, isFocused, withHoverView } ) => {
 							height: normalizedHeight * ratio,
 							width: '100%',
 							background: gradientValue ?? backgroundColor,
+							cursor: withHoverView ? 'pointer' : undefined,
 						} }
 						initial="start"
 						animate={


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In #49573 the `cursor: pointer` rule was removed from the style variation preview, so that it doesn't appear to be clickable from the styles panel. However it looks like that removal might have unintentionally removed the rule from the button previews for the style variations in the `Browse styles` screen.

This PR restores the `cursor: pointer` rule when the `withHover` option is in use for the preview — the assumption being that if we're using the hover state, we're also using the preview as a button.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Ensure that the button version of the style variation previews are clickable. The rule needs to be set within the iframe for it to work.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Restore the rule, but only when `withHover` is in use.

Question: is it okay to tie this rule to `withHover`, or should we be more explicit with an additional `isButton` prop or something like that? I tried fixing this by setting `cursor: pointer` further up the chain, but it looks like it needs to be set within the iframe.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open the Styles panel. The preview of the style variation should not be clickable
2. Click Browse styles to see the different variations you can choose from. In this screen, the buttons should be clickable.

## Screenshots or screencast <!-- if applicable -->

| Before (button version doesn't use pointer ) | After (button version uses pointer) |
| --- | --- |
| ![2023-04-05 11 51 48](https://user-images.githubusercontent.com/14988353/229962856-be5335c9-b42c-49ff-b9e1-666f92b0b113.gif) | ![2023-04-05 12 03 59](https://user-images.githubusercontent.com/14988353/229962932-c8216dc7-4e03-461e-bf91-e3a29c5c3f2f.gif) |