### PR TITLE
Block level settings: remove WP filters in Gutenberg

### DIFF
--- a/lib/block-supports/settings.php
+++ b/lib/block-supports/settings.php
@@ -115,7 +115,7 @@ function _gutenberg_add_block_level_preset_styles( $pre_render, $block ) {
 		)
 	);
 
-	// include preset css classes on the the stylesheet.
+	// include preset css classes on the stylesheet.
 	$styles .= $theme_json_object->get_stylesheet(
 		array( 'presets' ),
 		null,
@@ -131,6 +131,8 @@ function _gutenberg_add_block_level_preset_styles( $pre_render, $block ) {
 
 	return null;
 }
-
+// Remove WordPress core filter to avoid rendering duplicate settings style blocks.
+remove_filter( 'render_block', '_wp_add_block_level_presets_class', 10, 2 );
+remove_filter( 'pre_render_block', '_wp_add_block_level_preset_styles', 10, 2 );
 add_filter( 'render_block', '_gutenberg_add_block_level_presets_class', 10, 2 );
 add_filter( 'pre_render_block', '_gutenberg_add_block_level_preset_styles', 10, 2 );


### PR DESCRIPTION

## What?
Remove the corresponding WP filters in the plugin for `_gutenberg_add_block_level_presets_class` so that we don't double up on block level settings styles when the plugin is active.


## Why?
https://github.com/WordPress/gutenberg/pull/42124 introduced two hooks for `_gutenberg_add_block_level_presets_class` to print block level settings stylesheets to the page.

These changes were backported to Core in https://github.com/WordPress/wordpress-develop/pull/4013.

Now, when running the plugin in WordPress 6.3-alpha-55628 the style block is output twice.

## How?
Removing the WP filters:

```
remove_filter( 'render_block', '_wp_add_block_level_presets_class', 10, 2 );
remove_filter( 'pre_render_block', '_wp_add_block_level_preset_styles', 10, 2 );
```

## Testing Instructions

Here is some test HTML :

```html
<!-- wp:group {"settings":{"blocks":{"core/button":{"color":{"palette":{"custom":[{"slug":"button-red","color":"red","name":"button red"},{"slug":"button-blue","color":"blue","name":"button blue"}]}}},"core/paragraph":{"color":{"palette":{"custom":[{"slug":"paragraph-red","color":"red","name":"paragraph red"},{"slug":"paragraph-blue","color":"blue","name":"paragraph blue"}]}}}},"color":{"palette":{"custom":[{"slug":"global-aquamarine","color":"aquamarine","name":"Global aquamarine"},{"slug":"global-pink","color":"pink","name":"Global Pink"}]}}}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>Leaf paragraph of inner group block.</p>
<!-- /wp:paragraph -->

<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"button-blue"} -->
<div class="wp-block-button"><a class="wp-block-button__link has-button-blue-background-color has-background wp-element-button">blue</a></div>
<!-- /wp:button -->

<!-- wp:button {"backgroundColor":"button-red"} -->
<div class="wp-block-button"><a class="wp-block-button__link has-button-red-background-color has-background wp-element-button">red</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:paragraph {"backgroundColor":"paragraph-blue"} -->
<p class="has-paragraph-blue-background-color has-background">blue</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"backgroundColor":"paragraph-red"} -->
<p class="has-paragraph-red-background-color has-background">red</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

And don't forget the theme.json with the block-level CSS settings.

<details>

<summary>Example theme.json</summary>

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		},
		"color": {
			"palette": [
				{
					"slug": "global-aquamarine",
					"color": "aquamarine",
					"name": "Global aquamarine"
				},
				{
					"slug": "global-pink",
					"color": "pink",
					"name": "Global Pink"
				}
			]
		},
		"blocks": {
			"core/button": {
				"color": {
					"palette": {
						"custom": [
							{
								"slug": "button-red",
								"color": "red",
								"name": "button red"
							},
							{
								"slug": "button-blue",
								"color": "blue",
								"name": "button blue"
							}
						]
					}
				}
			},
			"core/paragraph": {
				"color": {
					"palette": {
						"custom": [
							{
								"slug": "paragraph-red",
								"color": "red",
								"name": "paragraph red"
							},
							{
								"slug": "paragraph-blue",
								"color": "blue",
								"name": "paragraph blue"
							}
						]
					}
				}
			}
		}
	},
	"styles": {
		"color": {
			"background": "var(--wp--preset--color--global-aquamarine)",
			"text": "var(--wp--preset--color--global-pink)"
		}
	},
	"patterns": [
		"short-text-surrounded-by-round-images",
		"partner-logos"
	]
}

```

</details>

Check that the resulting CSS is not output twice.

| Before | After |
| ------------- | ------------- |
| <img width="400" alt="Screenshot 2023-04-05 at 2 42 03 pm" src="https://user-images.githubusercontent.com/6458278/229982885-739ea243-0fdd-4815-9977-b6a382f439e7.png">  | <img width="400" alt="Screenshot 2023-04-05 at 2 42 15 pm" src="https://user-images.githubusercontent.com/6458278/229982894-f8456cf4-848a-411e-9d9d-611ecb6de99c.png">  |





