### PR TITLE
List View: Reduce spacing for each nesting level, and between block icon and block title

### DIFF
--- a/packages/block-editor/src/components/list-view/drop-indicator.js
+++ b/packages/block-editor/src/components/list-view/drop-indicator.js
@@ -53,7 +53,11 @@ export default function ListViewDropIndicator( {
 			'.block-editor-block-icon'
 		);
 		const rootBlockIconRect = rootBlockIconElement.getBoundingClientRect();
-		return rootBlockIconRect.right - targetElementRect.left;
+		return (
+			rootBlockIconRect.right -
+			targetElementRect.left -
+			rootBlockIconRect.width / 2 // Reduce the indentation by half the icon width.
+		);
 	}, [ rootBlockElement, targetElement ] );
 
 	const style = useMemo( () => {

--- a/packages/block-editor/src/components/list-view/drop-indicator.js
+++ b/packages/block-editor/src/components/list-view/drop-indicator.js
@@ -53,10 +53,14 @@ export default function ListViewDropIndicator( {
 			'.block-editor-block-icon'
 		);
 		const rootBlockIconRect = rootBlockIconElement.getBoundingClientRect();
+
+		// The indent is the distance from the left edge of the target element
+		// to the right edge of the root block icon, minus 1/4 of the width of the icon
+		// to account for the block icon's padding.
 		return (
 			rootBlockIconRect.right -
 			targetElementRect.left -
-			rootBlockIconRect.width / 2 // Reduce the indentation by half the icon width.
+			rootBlockIconRect.width / 4
 		);
 	}, [ rootBlockElement, targetElement ] );
 

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -352,10 +352,11 @@
 }
 
 // First level of indentation is aria-level 2, max indent is 8.
-// Indent is a full icon size, plus 4px which optically aligns child icons to the text label above.
+// Indent is 4px plus half the icon size, plus 4px which optically aligns child icons
+// to the right edge of the parent block's icon.
 $block-navigation-max-indent: 8;
 .block-editor-list-view-leaf[aria-level] .block-editor-list-view__expander {
-	margin-left: ( math.div($icon-size, 2) ) * $block-navigation-max-indent + 4 * ( $block-navigation-max-indent - 1 );
+	margin-left: 4 + ( math.div($icon-size, 2) ) * $block-navigation-max-indent + 4 * ( $block-navigation-max-indent - 1 );
 }
 
 .block-editor-list-view-leaf:not([aria-level="1"]) {
@@ -367,10 +368,10 @@ $block-navigation-max-indent: 8;
 @for $i from 0 to $block-navigation-max-indent {
 	.block-editor-list-view-leaf[aria-level="#{ $i + 1 }"] .block-editor-list-view__expander {
 		@if $i - 1 >= 0 {
-			margin-left: ( math.div($icon-size, 2) * $i ) + 4 * ($i - 1);
+			margin-left: 4 + ( math.div($icon-size, 2) * $i ) + 4 * ($i - 1);
 		}
 		@else {
-			margin-left: ( math.div($icon-size, 2) * $i );
+			margin-left: 4 + ( math.div($icon-size, 2) * $i );
 		}
 	}
 }

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -186,7 +186,7 @@
 	}
 
 	.block-editor-block-icon {
-		margin-right: $grid-unit-10;
+		margin-right: $grid-unit-05;
 		flex: 0 0 $icon-size;
 	}
 
@@ -355,7 +355,7 @@
 // Indent is a full icon size, plus 4px which optically aligns child icons to the text label above.
 $block-navigation-max-indent: 8;
 .block-editor-list-view-leaf[aria-level] .block-editor-list-view__expander {
-	margin-left: ( $icon-size ) * $block-navigation-max-indent + 4 * ( $block-navigation-max-indent - 1 );
+	margin-left: ( math.div($icon-size, 2) ) * $block-navigation-max-indent + 4 * ( $block-navigation-max-indent - 1 );
 }
 
 .block-editor-list-view-leaf:not([aria-level="1"]) {
@@ -367,10 +367,10 @@ $block-navigation-max-indent: 8;
 @for $i from 0 to $block-navigation-max-indent {
 	.block-editor-list-view-leaf[aria-level="#{ $i + 1 }"] .block-editor-list-view__expander {
 		@if $i - 1 >= 0 {
-			margin-left: ( $icon-size * $i ) + 4 * ($i - 1);
+			margin-left: ( math.div($icon-size, 2) * $i ) + 4 * ($i - 1);
 		}
 		@else {
-			margin-left: ( $icon-size * $i );
+			margin-left: ( math.div($icon-size, 2) * $i );
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of https://github.com/WordPress/gutenberg/issues/49563

Reduce the margin for each nesting level of the list view, so that more nesting levels can fit within the sidebar before needing to scroll.

This idea came out of review discussion over in https://github.com/WordPress/gutenberg/pull/49508#pullrequestreview-1368213100

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's quite common, especially in the site editor, to have heavily nested lists of blocks. The goal with this PR is to see if contracting the use of space will make for an easier to use UX for deeply nested hierarchies.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Update the left margin for nested blocks in the list view to use half of the icon width
* Reduce the spacing between the block icon and the block title to `4px` (from `8px`)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a whole bunch of nested blocks to a post or template
2. Open them up in the list view and move things around. How does it look?
3. Drag blocks between items — note that the drop line indicator is lined up with the right edgeof the parent block's icon. Is this position okay?

Note: the styling rules for the list view currently max out at a nesting level of 8, so deeper than 8 will render at the same nesting level within the UI.

<details>

<summary>Some heavily nested block markup for testing</summary>

```html
<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A paragraph in a group level 1</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A paragraph in a group level 2</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A paragraph in a group level 3</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A paragraph in a group level 4</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A paragraph in a group level 5</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph {"anchor":""} -->
<p>A paragraph in a group level 6</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph {"anchor":""} -->
<p>A paragraph in a group level 7</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph {"anchor":""} -->
<p>A paragraph in a group level 8</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph {"anchor":""} -->
<p>A paragraph in a group level 9</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->

<!-- wp:heading -->
<h2 class="wp-block-heading">A heading</h2>
<!-- /wp:heading -->
```

</details>

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/230002644-0dbb6ad0-f91c-41f1-a9f2-8e4c407a1194.png) | ![image](https://user-images.githubusercontent.com/14988353/230002778-fda80e1f-b0ae-4c3a-b9e1-e0c5e0bf2956.png) |