### PR TITLE
Border Panel: Move global styles forcing of split borders to relevant panel's onChange

### DIFF
--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -190,12 +190,14 @@ export default function BorderPanel( {
 
 		if ( hasSplitBorders( updatedBorder ) ) {
 			[ 'top', 'right', 'bottom', 'left' ].forEach( ( side ) => {
-				updatedBorder[ side ] = {
-					...updatedBorder[ side ],
-					color: encodeColorValue( updatedBorder[ side ]?.color ),
-				};
+				if ( updatedBorder[ side ] ) {
+					updatedBorder[ side ] = {
+						...updatedBorder[ side ],
+						color: encodeColorValue( updatedBorder[ side ]?.color ),
+					};
+				}
 			} );
-		} else {
+		} else if ( updatedBorder ) {
 			updatedBorder.color = encodeColorValue( updatedBorder.color );
 		}
 

--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -111,7 +111,6 @@ export default function BorderPanel( {
 	settings,
 	panelId,
 	defaultControls = DEFAULT_CONTROLS,
-	forceSplitBorders = false,
 } ) {
 	const colors = useColorsPerOrigin( settings );
 	const decodeValue = ( rawValue ) =>
@@ -187,35 +186,7 @@ export default function BorderPanel( {
 	const onBorderChange = ( newBorder ) => {
 		// Ensure we have a visible border style when a border width or
 		// color is being selected.
-		const newBorderWithStyle = applyAllFallbackStyles( newBorder );
-		let updatedBorder = newBorderWithStyle;
-
-		if ( forceSplitBorders ) {
-			// As Global Styles can't conditionally generate styles based on if
-			// other style properties have been set, we need to force split
-			// border definitions for user set global border styles. Border
-			// radius is derived from the same property i.e. `border.radius` if
-			// it is a string that is used. The longhand border radii styles are
-			// only generated if that property is an object.
-			//
-			// For borders (color, style, and width) those are all properties on
-			// the `border` style property. This means if the theme.json defined
-			// split borders and the user condenses them into a flat border or
-			// vice-versa we'd get both sets of styles which would conflict.
-			updatedBorder = ! hasSplitBorders( newBorderWithStyle )
-				? {
-						top: newBorderWithStyle,
-						right: newBorderWithStyle,
-						bottom: newBorderWithStyle,
-						left: newBorderWithStyle,
-				  }
-				: {
-						color: null,
-						style: null,
-						width: null,
-						...newBorderWithStyle,
-				  };
-		}
+		const updatedBorder = applyAllFallbackStyles( newBorder );
 
 		if ( hasSplitBorders( updatedBorder ) ) {
 			[ 'top', 'right', 'bottom', 'left' ].forEach( ( side ) => {

--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -111,6 +111,7 @@ export default function BorderPanel( {
 	settings,
 	panelId,
 	defaultControls = DEFAULT_CONTROLS,
+	forceSplitBorders = false,
 } ) {
 	const colors = useColorsPerOrigin( settings );
 	const decodeValue = ( rawValue ) =>
@@ -187,38 +188,45 @@ export default function BorderPanel( {
 		// Ensure we have a visible border style when a border width or
 		// color is being selected.
 		const newBorderWithStyle = applyAllFallbackStyles( newBorder );
+		let updatedBorder = newBorderWithStyle;
 
-		// As we can't conditionally generate styles based on if other
-		// style properties have been set we need to force split border
-		// definitions for user set border styles. Border radius is derived
-		// from the same property i.e. `border.radius` if it is a string
-		// that is used. The longhand border radii styles are only generated
-		// if that property is an object.
-		//
-		// For borders (color, style, and width) those are all properties on
-		// the `border` style property. This means if the theme.json defined
-		// split borders and the user condenses them into a flat border or
-		// vice-versa we'd get both sets of styles which would conflict.
-		const updatedBorder = ! hasSplitBorders( newBorderWithStyle )
-			? {
-					top: newBorderWithStyle,
-					right: newBorderWithStyle,
-					bottom: newBorderWithStyle,
-					left: newBorderWithStyle,
-			  }
-			: {
-					color: null,
-					style: null,
-					width: null,
-					...newBorderWithStyle,
-			  };
+		if ( forceSplitBorders ) {
+			// As Global Styles can't conditionally generate styles based on if
+			// other style properties have been set, we need to force split
+			// border definitions for user set global border styles. Border
+			// radius is derived from the same property i.e. `border.radius` if
+			// it is a string that is used. The longhand border radii styles are
+			// only generated if that property is an object.
+			//
+			// For borders (color, style, and width) those are all properties on
+			// the `border` style property. This means if the theme.json defined
+			// split borders and the user condenses them into a flat border or
+			// vice-versa we'd get both sets of styles which would conflict.
+			updatedBorder = ! hasSplitBorders( newBorderWithStyle )
+				? {
+						top: newBorderWithStyle,
+						right: newBorderWithStyle,
+						bottom: newBorderWithStyle,
+						left: newBorderWithStyle,
+				  }
+				: {
+						color: null,
+						style: null,
+						width: null,
+						...newBorderWithStyle,
+				  };
+		}
 
-		[ 'top', 'right', 'bottom', 'left' ].forEach( ( side ) => {
-			updatedBorder[ side ] = {
-				...updatedBorder[ side ],
-				color: encodeColorValue( updatedBorder[ side ]?.color ),
-			};
-		} );
+		if ( hasSplitBorders( updatedBorder ) ) {
+			[ 'top', 'right', 'bottom', 'left' ].forEach( ( side ) => {
+				updatedBorder[ side ] = {
+					...updatedBorder[ side ],
+					color: encodeColorValue( updatedBorder[ side ]?.color ),
+				};
+			} );
+		} else {
+			updatedBorder.color = encodeColorValue( updatedBorder.color );
+		}
 
 		// As radius is maintained separately to color, style, and width
 		// maintain its value. Undefined values here will be cleaned when

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -84,7 +84,7 @@ function styleToAttributes( style ) {
 
 	const borderColorValue = style?.border?.color;
 	const borderColorSlug = borderColorValue?.startsWith( 'var:preset|color|' )
-		? borderColorSlug.substring( 'var:preset|color|'.length )
+		? borderColorValue.substring( 'var:preset|color|'.length )
 		: undefined;
 	const updatedStyle = { ...style };
 	updatedStyle.border = {

--- a/packages/edit-site/src/components/global-styles/border-panel.js
+++ b/packages/edit-site/src/components/global-styles/border-panel.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import { __experimentalHasSplitBorders as hasSplitBorders } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -29,13 +30,42 @@ export default function BorderPanel( { name, variation = '' } ) {
 	const [ rawSettings ] = useGlobalSetting( '', name );
 	const settings = useSettingsForBlockElement( rawSettings, name );
 
+	const onChange = ( newStyle ) => {
+		// As Global Styles can't conditionally generate styles based on if
+		// other style properties have been set, we need to force split
+		// border definitions for user set global border styles. Border
+		// radius is derived from the same property i.e. `border.radius` if
+		// it is a string that is used. The longhand border radii styles are
+		// only generated if that property is an object.
+		//
+		// For borders (color, style, and width) those are all properties on
+		// the `border` style property. This means if the theme.json defined
+		// split borders and the user condenses them into a flat border or
+		// vice-versa we'd get both sets of styles which would conflict.
+		const { border } = newStyle;
+		const updatedBorder = ! hasSplitBorders( border )
+			? {
+					top: border,
+					right: border,
+					bottom: border,
+					left: border,
+			  }
+			: {
+					color: null,
+					style: null,
+					width: null,
+					...border,
+			  };
+
+		setStyle( { ...newStyle, border: updatedBorder } );
+	};
+
 	return (
 		<StylesBorderPanel
 			inheritedValue={ inheritedStyle }
 			value={ style }
-			onChange={ setStyle }
+			onChange={ onChange }
 			settings={ settings }
-			forceSplitBorders
 		/>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/border-panel.js
+++ b/packages/edit-site/src/components/global-styles/border-panel.js
@@ -35,6 +35,7 @@ export default function BorderPanel( { name, variation = '' } ) {
 			value={ style }
 			onChange={ setStyle }
 			settings={ settings }
+			forceSplitBorders
 		/>
 	);
 }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/49594

## What?

Prior to https://github.com/WordPress/gutenberg/pull/48636, only the Global Styles would force a split definition of border styles. This PR moves that logic to the Global Styles' border panel's `onChange` thereby restoring the original behaviour of the individual block border supports.

## Why?

Forcing split borders results in bloated CSS as every longhand style is added individually to a block's inline styles. 

## How?

- Moves the forcing of split border definitions from  `onBorderChange` in the generic `BorderPanel` to the `onChange` of the Global Styles' `BorderPanel`.

## Testing Instructions

1. Before checking out this PR branch, edit a post and add a simple block supporting borders e.g. Group
2. Configure a simple "flat" border on the block, save, and view on the frontend
3. Note that the block will have separate longhand CSS rules inline for each side
4. Checkout this PR, repeat the process and note that there will only be an inline style for each property i.e. color, style, width etc, not for each property and style.


## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="1217" alt="Screenshot 2023-04-06 at 4 42 36 pm" src="https://user-images.githubusercontent.com/60436221/230295455-41d641ee-8f84-4a80-bbfa-ecd4ec91a227.png"> | <img width="1216" alt="Screenshot 2023-04-06 at 4 45 35 pm" src="https://user-images.githubusercontent.com/60436221/230295427-cfa72785-fbd7-4ab9-ad79-d7eae836f9a8.png"> |


