### PR TITLE
Navigate to `editor` when clicking `Edit` in a template part

### DIFF
--- a/packages/edit-site/src/hooks/template-part-edit.js
+++ b/packages/edit-site/src/hooks/template-part-edit.js
@@ -34,6 +34,7 @@ function EditTemplatePartMenuItem( { attributes } ) {
 		{
 			postId: templatePart?.id,
 			postType: templatePart?.type,
+			canvas: 'edit',
 		},
 		{
 			fromTemplateId: params.postId,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A small fix where clicking `Edit` in a template part would take you to the `browse` mode. This PR redirects to the `edit` mode.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/16275880/230078406-b50dbd0c-8b34-458c-b5a2-6fb7a6469562.mov


