### PR TITLE
Fix mutated global styles context

### DIFF
--- a/packages/block-editor/src/components/global-styles/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-output.js
@@ -728,6 +728,9 @@ export const toStyles = (
 	hasFallbackGapSupport,
 	disableLayoutStyles = false
 ) => {
+	// Clone the tree to avoid mutating the original object.
+	tree = JSON.parse( JSON.stringify( tree ) );
+
 	const nodesWithStyles = getNodesWithStyles( tree, blockSelectors );
 	const nodesWithSettings = getNodesWithSettings( tree, blockSelectors );
 	const useRootPaddingAlign = tree?.settings?.useRootPaddingAwareAlignments;
@@ -780,6 +783,7 @@ export const toStyles = (
 			// Process styles for block support features with custom feature level
 			// CSS selectors set.
 			if ( featureSelectors ) {
+				// Mutates the passed styles object.
 				const featureDeclarations = getFeatureDeclarations(
 					featureSelectors,
 					styles


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes an issue where duotone presets aren't properly being selected in the global styles filters panel, and maybe other things where the `GlobalStylesContext` is being used.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In https://github.com/WordPress/gutenberg/pull/49577#issuecomment-1497186299, @youknowriad uncovered a bug where the duotone property was removed from the context in the duotone filters panel.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The duotone property was being removed in [`getFeatureDeclarations`](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/global-styles/use-global-styles-output.js#L255) which is needed for `toStyles` to work, so the entire `mergedConfig` was cloned before calling it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Use a theme with `styles.blocks['core/image].filter.duotone` set to one of the theme or default presets, for example `var(--wp--preset--duotone--midnight)`.
2. In the global styles panel under Blocks > Image > Filters see that the chosen default filter is selected.
3. Select a different duotone filter preset.
4. See that the new preset is now selected.

It might also be good to test some more of the blocks that use feature selectors via the `selectors` or `supports.feature.__experimentalSelector` block.json API.
