### PR TITLE
Refine `react-native-azterc` `README.md` and `.podspec` formatting

### DIFF
--- a/packages/react-native-aztec/README.md
+++ b/packages/react-native-aztec/README.md
@@ -218,17 +218,17 @@ Called when then selection of the native component changed.
 
 ### iOS
 
-On iOS we use a native view called RCTAztecView that inherits an Aztec TextView class.
-RCTAztecView adds the following custom behaviours to the TextView class:
+On iOS we use a native view called `RCTAztecView` that inherits an Aztec `TextView` class.
+`RCTAztecView` adds the following custom behaviours to the `TextView` class:
 
--   Overlays a UILabel to display placeholder text
+-   Overlays a `UILabel` to display placeholder text
 -   Overrides the `onPaste` method to intercept paste actions and send them to the JS implementation
 -   Overrides the `insertText` and `deleteBackward` methods in order to detect the following keypresses:
     -   delete/backspace to allow handling of custom merge actions
     -   enter/new lines to allow handling of custom split actions
-    -   detection any of triggerKeyCodes
--   Sets the `characterToReplaceLastEmptyLine` property in the HTMLConverter to be zero width space character to avoid the insertion of a newline at the end of the text blocks
--   Disables the `shouldCollapseSpaces` flag in the HTMLConverter in order to maintain all spaces inserted by the user
+    -   detection any of `triggerKeyCodes`
+-   Sets the `characterToReplaceLastEmptyLine` property in the `HTMLConverter` to be zero width space character to avoid the insertion of a newline at the end of the text blocks
+-   Disables the `shouldCollapseSpaces` flag in the `HTMLConverter` in order to maintain all spaces inserted by the user
 
 ### Android
 

--- a/packages/react-native-aztec/RNTAztecView.podspec
+++ b/packages/react-native-aztec/RNTAztecView.podspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
@@ -9,15 +11,14 @@ Pod::Spec.new do |s|
   s.license          = package['license']
   s.homepage         = package['homepage']
   s.authors          = package['author']
-  s.source            = { :git => 'https://github.com/WordPress/gutenberg.git' }
-  s.source_files     = 'ios/RNTAztecView/*.{h,m,swift}'
+  s.source = { git: 'https://github.com/WordPress/gutenberg.git' }
+  s.source_files = 'ios/RNTAztecView/*.{h,m,swift}'
   s.public_header_files = 'ios/RNTAztecView/*.h'
   s.requires_arc     = true
-  s.platforms        = { :ios => "13.0" }
+  s.platforms        = { ios: '13.0' }
   s.swift_version    = '5.0'
-  s.xcconfig         = {'OTHER_LDFLAGS' => '-lxml2',
-                        'HEADER_SEARCH_PATHS' => '/usr/include/libxml2'}
+  s.xcconfig         = { 'OTHER_LDFLAGS' => '-lxml2',
+                         'HEADER_SEARCH_PATHS' => '/usr/include/libxml2' }
   s.dependency         'React-Core'
   s.dependency         'WordPress-Aztec-iOS', '~> 1.19.8'
-
 end


### PR DESCRIPTION
## What?

Adds backticks around inline code in the "iOS" section of the `react-native-aztec` package `README.md` and updates the Ruby used in its `.podspec` to "modern" standards by applying [RuboCop](https://github.com/rubocop/rubocop)'s autocorrect.

## Why?
I'm looking around the repo to see whether I can make progress on distributing Gutenberg mobile as an `xcframework` for integration in iOS apps. I was looking at those files and notices those minor improvements. I thought it was a good way to warm up.

See also https://github.com/WordPress/gutenberg/pull/49625.

## How?
N.A.

## Testing Instructions
The changes do not change any code, just formatting. They do no require testing.

### Testing Instructions for Keyboard
N.A.
