### PR TITLE
Fix Xcode spelling across the codebase

### DIFF
--- a/docs/contributors/code/react-native/osx-setup-guide.md
+++ b/docs/contributors/code/react-native/osx-setup-guide.md
@@ -74,7 +74,7 @@ Install [Xcode](https://developer.apple.com/xcode/) via the app store and then o
 -   Accept the license agreement.
 -   Verify that `Xcode > Preferences > Locations > Command Line Tools` points to the current Xcode version.
 
-<img src="https://developer.wordpress.org/files/2021/10/xcode-command-line-tools.png" width="700px" alt="Screenshot of XCode command line tools settings.">
+<img src="https://developer.wordpress.org/files/2021/10/xcode-command-line-tools.png" width="700px" alt="Screenshot of Xcode command line tools settings.">
 
 ### react-native doctor
 

--- a/packages/react-native-bridge/README.md
+++ b/packages/react-native-bridge/README.md
@@ -14,9 +14,9 @@ This package is not yet published to npm. You can use it locally:
 
 #### iOS
 
-1. In XCode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
+1. In Xcode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
 2. Go to `node_modules` ➜ `react-native-bridge` and add `RNReactNativeGutenbergBridge.xcodeproj`
-3. In XCode, in the project navigator, select your project. Add `libRNReactNativeGutenbergBridge.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
+3. In Xcode, in the project navigator, select your project. Add `libRNReactNativeGutenbergBridge.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
 4. Run your project (`Cmd+R`)<
 
 #### Android

--- a/packages/react-native-editor/.gitignore
+++ b/packages/react-native-editor/.gitignore
@@ -46,7 +46,7 @@ build.log
 # Local configuration file (sdk path, etc)
 local.properties
 
-# XCode
+# Xcode
 build/
 *.pbxuser
 !default.pbxuser

--- a/packages/react-native-editor/__device-tests__/README.md
+++ b/packages/react-native-editor/__device-tests__/README.md
@@ -14,7 +14,7 @@ SauceLabs is a cloud hosting platform that provides access to a variety of simul
 >
 > Visual regression tests that rely upon screenshots require specific devices and OS versions for Android and iOS, respectively, otherwise the tests will fail due to subtle OS differences. To run or update visual regression tests, install the emulators/simulators listed in the test suite [configuration files](https://github.com/WordPress/gutenberg/blob/trunk/packages/react-native-editor/__device-tests__/helpers/caps.js#L30-L31).
 
-**iOS:** If you have completed the [React Native Getting Started](https://reactnative.dev/docs/environment-setup) guide you should already have XCode installed and the simulators set up.
+**iOS:** If you have completed the [React Native Getting Started](https://reactnative.dev/docs/environment-setup) guide you should already have Xcode installed and the simulators set up.
 
 **Android:** If you have completed the [React Native Getting Started](https://reactnative.dev/docs/environment-setup) guide you should already have Android Studio installed and the Android SDK installed. You'll also need to have the [Android Emulator](https://developer.android.com/studio/run/emulator) installed and set up. The emulator needs to be running prior to running the tests.
 


### PR DESCRIPTION
## What?
Some instances of the Xcode word across the codebase used the incorrect XCode spelling.

## Why?
I'm looking around the repo to see whether I can make progress on distributing Gutenberg mobile as an xcframework for integration in iOS apps. I'm a stickler for tools name spelling and _XCode_ jumped to my eyes. I thought it was a good way to warm up.

See also https://github.com/WordPress/gutenberg/pull/49624.

## How?
N.A.

## Testing Instructions
This PR only touches `.md` files and a comment in a `.gitignore`. No testing is required.

### Testing Instructions for Keyboard
N.A.
