### PR TITLE
Global Styles: Add conditional Placeholder for Custom CSS when it is for a block

### DIFF
--- a/packages/edit-site/src/components/global-styles/custom-css.js
+++ b/packages/edit-site/src/components/global-styles/custom-css.js
@@ -113,7 +113,11 @@ function CustomCSSControl( { blockName } ) {
 					className="edit-site-global-styles__custom-css-input"
 					spellCheck={ false }
 					/// If we are customizing at the Block level we can include placeholder text with suggested syntax
-					placeholder={ block ? 'color:red;' : undefined }
+					placeholder={
+						block
+							? 'color:red; \\ Replace this CSS with your own'
+							: undefined
+					}
 				/>
 				{ cssError && (
 					<Tooltip text={ cssError }>

--- a/packages/edit-site/src/components/global-styles/custom-css.js
+++ b/packages/edit-site/src/components/global-styles/custom-css.js
@@ -112,6 +112,8 @@ function CustomCSSControl( { blockName } ) {
 					onBlur={ handleOnBlur }
 					className="edit-site-global-styles__custom-css-input"
 					spellCheck={ false }
+					/// If we are customizing at the Block level we can include placeholder text with suggested syntax
+					placeholder={ block ? 'color:red;' : undefined }
 				/>
 				{ cssError && (
 					<Tooltip text={ cssError }>


### PR DESCRIPTION
## What?

This PR adds placeholder text to the Custom CSS textarea _conditionally_ when the user is adding CSS at the block level (where no selector is required).

## Why?
Addresses part of https://github.com/WordPress/gutenberg/issues/49531 -placeholder to help guide the user to the correct CSS syntax when in this context.

## How?
Adding a Placeholder to the CSS textarea to prompt the correct format/syntax

## Testing Instructions
1. Open the Site Editor and edit a template
2. Open the styles panel and go to Blocks > Paragraph (or another block) > Additional CSS.

## Screenshots or screencast <!-- if applicable -->

<img width="274" alt="Screen Shot 2023-04-06 at 12 06 39 pm" src="https://user-images.githubusercontent.com/1842363/230255158-cc4ff479-8e6c-42a1-ba6e-737bdc94bc0d.png">

