### PR TITLE
Image block: fix image size control percentage selection

### DIFF
--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -55,12 +55,7 @@ export default function ImageSizeControl( {
 							value={ currentWidth }
 							min={ 1 }
 							onChange={ ( value ) =>
-								updateDimension(
-									'width',
-									value !== undefined
-										? Number( value )
-										: value
-								)
+								updateDimension( 'width', value )
 							}
 							size="__unstable-large"
 						/>
@@ -70,12 +65,7 @@ export default function ImageSizeControl( {
 							value={ currentHeight }
 							min={ 1 }
 							onChange={ ( value ) =>
-								updateDimension(
-									'height',
-									value !== undefined
-										? Number( value )
-										: value
-								)
+								updateDimension( 'height', value )
 							}
 							size="__unstable-large"
 						/>

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -55,7 +55,12 @@ export default function ImageSizeControl( {
 							value={ currentWidth }
 							min={ 1 }
 							onChange={ ( value ) =>
-								updateDimension( 'width', Number( value ) )
+								updateDimension(
+									'width',
+									value !== undefined
+										? Number( value )
+										: value
+								)
 							}
 							size="__unstable-large"
 						/>
@@ -65,7 +70,12 @@ export default function ImageSizeControl( {
 							value={ currentHeight }
 							min={ 1 }
 							onChange={ ( value ) =>
-								updateDimension( 'height', Number( value ) )
+								updateDimension(
+									'height',
+									value !== undefined
+										? Number( value )
+										: value
+								)
 							}
 							size="__unstable-large"
 						/>

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -55,7 +55,7 @@ export default function ImageSizeControl( {
 							value={ currentWidth }
 							min={ 1 }
 							onChange={ ( value ) =>
-								updateDimension( 'width', value )
+								updateDimension( 'width', Number( value ) )
 							}
 							size="__unstable-large"
 						/>
@@ -65,7 +65,7 @@ export default function ImageSizeControl( {
 							value={ currentHeight }
 							min={ 1 }
 							onChange={ ( value ) =>
-								updateDimension( 'height', value )
+								updateDimension( 'height', Number( value ) )
 							}
 							size="__unstable-large"
 						/>

--- a/packages/block-editor/src/components/image-size-control/use-dimension-handler.js
+++ b/packages/block-editor/src/components/image-size-control/use-dimension-handler.js
@@ -47,13 +47,14 @@ export default function useDimensionHandler(
 	}, [ customWidth, customHeight ] );
 
 	const updateDimension = ( dimension, value ) => {
+		const parsedValue = value === '' ? undefined : parseInt( value, 10 );
 		if ( dimension === 'width' ) {
-			setCurrentWidth( value );
+			setCurrentWidth( parsedValue );
 		} else {
-			setCurrentHeight( value );
+			setCurrentHeight( parsedValue );
 		}
 		onChange( {
-			[ dimension ]: value === '' ? undefined : parseInt( value, 10 ),
+			[ dimension ]: parsedValue,
 		} );
 	};
 


### PR DESCRIPTION
## What?
Fixes a small issue in the image block where the percentage sizes were not selected correctly when the user adjusts sizes using the number controls.

## How?
The issue is that when using the number controls, the sizes were being stored as a string, while they are usually a number.

The component does this check to see if the current size matches the percentage presets:
```js
const isCurrent = currentWidth === scaledWidth && currentHeight === scaledHeight;
```

It was failing because `string` !== `number`.

The best fix seems to be to consistently store values as numbers, so that's what I've done here.

## Testing Instructions
1. Add an image block and upload an image.
2. In the block inspector, note that the image is set to the '100%' size, and note the image's default width.
3. Adjust the width to a different value, and then set it back to what it was before

In trunk: Observe that 100% doesn't become re-selected
In this branch: 100% should become reselected

## Screenshots or screencast <!-- if applicable -->
#### Before
![Screen Shot 2023-04-06 at 11 17 56 am](https://user-images.githubusercontent.com/677833/230263756-25377d70-3bc0-4bd0-b36b-ea6a821a33e4.png)

#### After
![Screen Shot 2023-04-06 at 11 16 18 am](https://user-images.githubusercontent.com/677833/230263549-574e8eae-49ec-48f5-ae5e-158abd340cdb.png)
