### PR TITLE
Bug: RTL styles don't get added to the `wp-reusable-blocks` stylesheet

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -428,7 +428,7 @@ function gutenberg_register_packages_styles( $styles ) {
 		array( 'wp-components' ),
 		$version
 	);
-	$styles->add_data( 'wp-reusable-block', 'rtl', 'replace' );
+	$styles->add_data( 'wp-reusable-blocks', 'rtl', 'replace' );
 
 	gutenberg_override_style(
 		$styles,


### PR DESCRIPTION
## What?

When adding RTL data to the `wp-reusable-blocks` stylesheet, it's written as `wp-reusable-block` with the `s` at the end missing. As a result, no RTL styles get registered for that stylesheet.

