### PR TITLE
Updates the behavior of the top toolbar fixed setting

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -99,6 +99,7 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 	// header area and not contextually to the block.
 	const displayHeaderToolbar =
 		useViewportMatch( 'medium', '<' ) || hasFixedToolbar;
+	const isLargeViewport = useViewportMatch( 'medium' );
 
 	if ( blockType ) {
 		if ( ! hasBlockSupport( blockType, '__experimentalToolbar', true ) ) {
@@ -124,9 +125,9 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 
 	return (
 		<div className={ classes }>
-			{ ! isMultiToolbar &&
-				! displayHeaderToolbar &&
-				! isContentLocked && <BlockParentSelector /> }
+			{ ! isMultiToolbar && isLargeViewport && ! isContentLocked && (
+				<BlockParentSelector />
+			) }
 			<div ref={ nodeRef } { ...showMoversGestures }>
 				{ ( shouldShowVisualToolbar || isMultiToolbar ) &&
 					! isContentLocked && (

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -99,7 +99,7 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 	// header area and not contextually to the block.
 	const displayHeaderToolbar =
 		useViewportMatch( 'medium', '<' ) || hasFixedToolbar;
-	const isLargeViewport = useViewportMatch( 'medium' );
+	const isLargeViewport = ! useViewportMatch( 'medium', '<' );
 
 	if ( blockType ) {
 		if ( ! hasBlockSupport( blockType, '__experimentalToolbar', true ) ) {

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -64,21 +64,6 @@
 	}
 }
 
-.block-editor-block-parent-selector {
-	position: absolute;
-	top: -$border-width;
-	left: calc(-#{$grid-unit-60} - #{$grid-unit-10} - #{$border-width});
-
-	.show-icon-labels & {
-		position: relative;
-		left: auto;
-		top: auto;
-		margin-top: -$border-width;
-		margin-left: -$border-width;
-		margin-bottom: -$border-width;
-	}
-}
-
 // Block controls.
 .block-editor-block-toolbar__block-controls {
 	// Switcher.

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -56,6 +56,41 @@
 	}
 }
 
+// on desktop browsers the fixed toolbar has tweaked borders
+@include break-medium() {
+	.block-editor-block-contextual-toolbar.is-fixed {
+		.block-editor-block-toolbar {
+			.components-toolbar-group,
+			.components-toolbar {
+				border-right: none;
+
+				&::after {
+					content: "";
+					width: $border-width;
+					margin-top: $grid-unit + $grid-unit-05;
+					margin-bottom: $grid-unit + $grid-unit-05;
+					background-color: $gray-300;
+					margin-left: $grid-unit;
+				}
+
+				& .components-toolbar-group.components-toolbar-group {
+					&::after {
+						display: none;
+					}
+				}
+			}
+
+			> :last-child,
+			> :last-child .components-toolbar-group,
+			> :last-child .components-toolbar {
+				&::after {
+					display: none;
+				}
+			}
+		}
+	}
+}
+
 .block-editor-block-contextual-toolbar.has-parent:not(.is-fixed) {
 	margin-left: calc(#{$grid-unit-60} + #{$grid-unit-10});
 

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -30,6 +30,7 @@ const CollapseFixedToolbarButton = forwardRef( ( { onClick }, ref ) => {
 			icon={ levelUp }
 			onClick={ onClick }
 			ref={ ref }
+			label={ __( 'Collapse Block Tools' ) }
 		/>
 	);
 } );
@@ -42,6 +43,7 @@ const ExpandFixedToolbarButton = forwardRef( ( { onClick, icon }, ref ) => {
 			icon={ <BlockIcon icon={ icon } /> }
 			onClick={ onClick }
 			ref={ ref }
+			label={ __( 'Expand Block Tools' ) }
 		/>
 	);
 } );

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -50,11 +50,17 @@ const ExpandFixedToolbarButton = forwardRef( ( { onClick, icon }, ref ) => {
 
 function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 	// When the toolbar is fixed it can be collapsed
-	const [ isCollapsed, setIsCollapsed ] = useState( null );
+	const [ isCollapsed, setIsCollapsed ] = useState( false );
 	const expandFixedToolbarButtonRef = useRef();
 	const collapseFixedToolbarButtonRef = useRef();
 
+	// Don't focus the block toolbar just because it mounts
+	const initialRender = useRef( true );
 	useEffect( () => {
+		if ( initialRender.current ) {
+			initialRender.current = false;
+			return;
+		}
 		if ( isCollapsed && expandFixedToolbarButtonRef.current ) {
 			expandFixedToolbarButtonRef.current.focus();
 		}

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -34,7 +34,7 @@ const CollapseFixedToolbarButton = forwardRef( ( { onClick }, ref ) => {
 			icon={ levelUp }
 			onClick={ onClick }
 			ref={ ref }
-			label={ __( 'Collapse Block Tools' ) }
+			label={ __( 'Collapse block tools' ) }
 		/>
 	);
 } );
@@ -47,7 +47,7 @@ const ExpandFixedToolbarButton = forwardRef( ( { onClick, icon }, ref ) => {
 			icon={ <BlockIcon icon={ icon } /> }
 			onClick={ onClick }
 			ref={ ref }
-			label={ __( 'Expand Block Tools' ) }
+			label={ __( 'Expand block tools' ) }
 		/>
 	);
 } );

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -34,7 +34,7 @@ const CollapseFixedToolbarButton = forwardRef( ( { onClick }, ref ) => {
 			icon={ levelUp }
 			onClick={ onClick }
 			ref={ ref }
-			label={ __( 'Collapse block tools' ) }
+			label={ __( 'Show document tools' ) }
 		/>
 	);
 } );
@@ -47,7 +47,7 @@ const ExpandFixedToolbarButton = forwardRef( ( { onClick, icon }, ref ) => {
 			icon={ <BlockIcon icon={ icon } /> }
 			onClick={ onClick }
 			ref={ ref }
-			label={ __( 'Expand block tools' ) }
+			label={ __( 'Show block tools' ) }
 		/>
 	);
 } );

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -73,8 +73,8 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 		}
 	}, [ isCollapsed ] );
 
-	const { blockType, hasParents, showParentSelector } = useSelect(
-		( select ) => {
+	const { blockType, hasParents, showParentSelector, selectedBlockClientId } =
+		useSelect( ( select ) => {
 			const {
 				getBlockName,
 				getBlockParents,
@@ -83,16 +83,17 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 			} = select( blockEditorStore );
 			const { getBlockType } = select( blocksStore );
 			const selectedBlockClientIds = getSelectedBlockClientIds();
-			const selectedBlockClientId = selectedBlockClientIds[ 0 ];
-			const parents = getBlockParents( selectedBlockClientId );
+			const _selectedBlockClientId = selectedBlockClientIds[ 0 ];
+			const parents = getBlockParents( _selectedBlockClientId );
 			const firstParentClientId = parents[ parents.length - 1 ];
 			const parentBlockName = getBlockName( firstParentClientId );
 			const parentBlockType = getBlockType( parentBlockName );
 
 			return {
+				selectedBlockClientId: _selectedBlockClientId,
 				blockType:
-					selectedBlockClientId &&
-					getBlockType( getBlockName( selectedBlockClientId ) ),
+					_selectedBlockClientId &&
+					getBlockType( getBlockName( _selectedBlockClientId ) ),
 				hasParents: parents.length,
 				showParentSelector:
 					parentBlockType &&
@@ -106,9 +107,11 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 						selectedBlockClientId
 					),
 			};
-		},
-		[]
-	);
+		}, [] );
+
+	useEffect( () => {
+		setIsCollapsed( false );
+	}, [ selectedBlockClientId ] );
 
 	const isLargeViewport = useViewportMatch( 'medium' );
 

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
 import { forwardRef, useEffect, useRef, useState } from '@wordpress/element';
 import { hasBlockSupport, store as blocksStore } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
-import { ToolbarItem, Button } from '@wordpress/components';
+import { ToolbarItem, ToolbarButton } from '@wordpress/components';
 import { levelUp } from '@wordpress/icons';
 import { useViewportMatch } from '@wordpress/compose';
 
@@ -25,8 +25,8 @@ import BlockIcon from '../block-icon';
 const CollapseFixedToolbarButton = forwardRef( ( { onClick }, ref ) => {
 	return (
 		<ToolbarItem
-			as={ Button }
-			className="components-button components-toolbar-button block-editor-block-toolbar__collapse-fixed-toolbar"
+			as={ ToolbarButton }
+			className="block-editor-block-toolbar__collapse-fixed-toolbar"
 			icon={ levelUp }
 			onClick={ onClick }
 			ref={ ref }
@@ -38,8 +38,8 @@ const CollapseFixedToolbarButton = forwardRef( ( { onClick }, ref ) => {
 const ExpandFixedToolbarButton = forwardRef( ( { onClick, icon }, ref ) => {
 	return (
 		<ToolbarItem
-			as={ Button }
-			className="components-button components-toolbar-button block-editor-block-toolbar__expand-fixed-toolbar"
+			as={ ToolbarButton }
+			className="block-editor-block-toolbar__expand-fixed-toolbar"
 			icon={ <BlockIcon icon={ icon } /> }
 			onClick={ onClick }
 			ref={ ref }

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -104,7 +104,7 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 					) &&
 					selectedBlockClientIds.length <= 1 &&
 					! __unstableGetContentLockingParent(
-						selectedBlockClientId
+						_selectedBlockClientId
 					),
 			};
 		}, [] );

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -10,7 +10,11 @@ import { __ } from '@wordpress/i18n';
 import { forwardRef, useEffect, useRef, useState } from '@wordpress/element';
 import { hasBlockSupport, store as blocksStore } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
-import { ToolbarItem, ToolbarButton } from '@wordpress/components';
+import {
+	ToolbarItem,
+	ToolbarButton,
+	ToolbarGroup,
+} from '@wordpress/components';
 import { levelUp } from '@wordpress/icons';
 import { useViewportMatch } from '@wordpress/compose';
 
@@ -130,7 +134,13 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 			{ ...props }
 		>
 			{ isFixed && isLargeViewport && blockType && (
-				<>
+				<ToolbarGroup
+					className={
+						isCollapsed
+							? 'block-editor-block-toolbar__group-expand-fixed-toolbar'
+							: 'block-editor-block-toolbar__group-collapse-fixed-toolbar'
+					}
+				>
 					{ isCollapsed ? (
 						<ExpandFixedToolbarButton
 							onClick={ () => setIsCollapsed( false ) }
@@ -143,7 +153,7 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 							ref={ collapseFixedToolbarButtonRef }
 						/>
 					) }
-				</>
+				</ToolbarGroup>
 			) }
 			{ ! isCollapsed && <BlockToolbar hideDragHandle={ isFixed } /> }
 		</NavigableToolbar>

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -104,11 +104,10 @@
 	&.is-fixed {
 		position: sticky;
 		top: 0;
-		width: 100%;
+		left: 0;
 		z-index: z-index(".block-editor-block-popover");
-		// Fill up when empty
-		min-height: $block-toolbar-height;
 		display: block;
+		width: 100%;
 
 		border: none;
 		border-bottom: $border-width solid $gray-200;
@@ -119,6 +118,25 @@
 			border-right-color: $gray-200;
 		}
 	}
+
+	// on mobile viewports the toolbar is fixed below header
+	@include break-medium() {
+		&.is-fixed {
+			// position on top of interface header
+			position: fixed;
+			top: $grid-unit;
+			// leave room for block inserter
+			left: $grid-unit-80 + $grid-unit-70;
+			// Don't fill up when empty
+			min-height: initial;
+			// Don't fill the whole header, minimize area
+			width: initial;
+			// remove the border
+			border-bottom: none;
+		}
+	}
+
+
 }
 
 /**

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -158,11 +158,15 @@
 				&.block-editor-block-toolbar__collapse-fixed-toolbar {
 					// Add a border as separator in the block toolbar.
 					border-right: $border-width solid $gray-300;
+					padding-right: 6px;
+					padding-left: 6px;
 				}
 
 				&.block-editor-block-toolbar__expand-fixed-toolbar {
 					// Add a border as separator in the block toolbar.
 					border-left: $border-width solid $gray-300;
+					padding-right: 6px;
+					padding-left: 6px;
 				}
 			}
 		}
@@ -172,6 +176,8 @@
 				position: relative;
 				top: -1px;
 				border: 0;
+				padding-right: 6px;
+				padding-left: 6px;
 				&::after {
 					content: "\00B7";
 					font-size: 16px;

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -119,7 +119,8 @@
 		}
 	}
 
-	// on mobile viewports the toolbar is fixed below header
+	// on desktop viewports the toolbar is fixed
+	// on top of interface header
 	@include break-medium() {
 		&.is-fixed {
 			// position on top of interface header
@@ -133,6 +134,33 @@
 			width: initial;
 			// remove the border
 			border-bottom: none;
+		}
+
+		&.is-fixed .block-editor-block-parent-selector .block-editor-block-parent-selector__button {
+			border: 0;
+			&::after {
+				content: "\00B7";
+				font-size: 16px;
+				line-height: $grid-unit-40 + $grid-unit-10;
+				position: absolute;
+				left: $grid-unit-40 + $grid-unit-15 + 2px;
+				bottom: $grid-unit-05;
+			}
+		}
+
+		&:not(.is-fixed) .block-editor-block-parent-selector {
+			position: absolute;
+			top: -$border-width;
+			left: calc(-#{$grid-unit-60} - #{$grid-unit-10} - #{$border-width});
+
+			.show-icon-labels & {
+				position: relative;
+				left: auto;
+				top: auto;
+				margin-top: -$border-width;
+				margin-left: -$border-width;
+				margin-bottom: -$border-width;
+			}
 		}
 	}
 

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -153,6 +153,8 @@
 
 			& > button.components-button.has-icon {
 
+				border-radius: 0;
+
 				&.block-editor-block-toolbar__collapse-fixed-toolbar {
 					// Add a border as separator in the block toolbar.
 					border-right: $border-width solid $gray-300;

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -134,6 +134,25 @@
 			width: initial;
 			// remove the border
 			border-bottom: none;
+			// has to be flex for collapse button to fit
+			display: flex;
+
+			&.is-collapsed {
+				left: $grid-unit-10 * 35;
+			}
+
+			& > button.components-button.has-icon {
+
+				&.block-editor-block-toolbar__collapse-fixed-toolbar {
+					// Add a border as separator in the block toolbar.
+					border-right: $border-width solid $gray-300;
+				}
+
+				&.block-editor-block-toolbar__expand-fixed-toolbar {
+					// Add a border as separator in the block toolbar.
+					border-left: $border-width solid $gray-300;
+				}
+			}
 		}
 
 		&.is-fixed .block-editor-block-parent-selector {

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -136,15 +136,19 @@
 			border-bottom: none;
 		}
 
-		&.is-fixed .block-editor-block-parent-selector .block-editor-block-parent-selector__button {
-			border: 0;
-			&::after {
-				content: "\00B7";
-				font-size: 16px;
-				line-height: $grid-unit-40 + $grid-unit-10;
-				position: absolute;
-				left: $grid-unit-40 + $grid-unit-15 + 2px;
-				bottom: $grid-unit-05;
+		&.is-fixed .block-editor-block-parent-selector {
+			.block-editor-block-parent-selector__button {
+				position: relative;
+				top: -1px;
+				border: 0;
+				&::after {
+					content: "\00B7";
+					font-size: 16px;
+					line-height: $grid-unit-40 + $grid-unit-10;
+					position: absolute;
+					left: $grid-unit-40 + $grid-unit-15 + 2px;
+					bottom: $grid-unit-05;
+				}
 			}
 		}
 

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -123,11 +123,12 @@
 	// on top of interface header
 	@include break-medium() {
 		&.is-fixed {
+
 			// position on top of interface header
 			position: fixed;
-			top: $grid-unit;
+			top: $grid-unit-50 - 2;
 			// leave room for block inserter
-			left: $grid-unit-80 + $grid-unit-70;
+			left: $grid-unit-80 + $grid-unit-40;
 			// Don't fill up when empty
 			min-height: initial;
 			// Don't fill the whole header, minimize area
@@ -138,7 +139,16 @@
 			display: flex;
 
 			&.is-collapsed {
-				left: $grid-unit-10 * 35;
+				left: $grid-unit-10 * 32;
+			}
+
+			.is-fullscreen-mode & {
+				top: $grid-unit - 2;
+				// leave room for block inserter
+				left: $grid-unit-80 + $grid-unit-70;
+				&.is-collapsed {
+					left: $grid-unit-10 * 35;
+				}
 			}
 
 			& > button.components-button.has-icon {

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -119,7 +119,7 @@
 		}
 	}
 
-	// on desktop viewports the toolbar is fixed
+	// on desktop and tablet viewports the toolbar is fixed
 	// on top of interface header
 	@include break-medium() {
 		&.is-fixed {
@@ -131,8 +131,6 @@
 			left: $grid-unit-80 + $grid-unit-40;
 			// Don't fill up when empty
 			min-height: initial;
-			// Don't fill the whole header, minimize area
-			width: initial;
 			// remove the border
 			border-bottom: none;
 			// has to be flex for collapse button to fit
@@ -214,6 +212,39 @@
 		}
 	}
 
+	// on tablet vewports the toolbar is fixed
+	// on top of interface header and covers the whole header
+	// except for the inserter on the left
+	@include break-medium() {
+		&.is-fixed {
+			width: calc(100% - #{$grid-unit-80 + $grid-unit-40});
+			&.is-collapsed {
+				// when collapsed minimize area
+				width: initial;
+			}
+			.is-fullscreen-mode & {
+				width: calc(100% - #{$grid-unit-80 + $grid-unit-70});
+				&.is-collapsed {
+					// when collapsed minimize area
+					width: initial;
+				}
+			}
+		}
+	}
+
+	// on desktop viewports the toolbar is fixed
+	// on top of interface header and leaves room
+	// for the block inserter the publish button
+	@include break-large() {
+		&.is-fixed {
+			// Don't fill the whole header, minimize area
+			width: initial;
+			.is-fullscreen-mode & {
+				// Don't fill the whole header, minimize area
+				width: initial;
+			}
+		}
+	}
 
 }
 

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -156,7 +156,7 @@
 				&::after {
 					content: "";
 					width: $border-width;
-					height: 30px;
+					height: 24px;
 					margin-top: $grid-unit + $grid-unit-05;
 					margin-bottom: $grid-unit + $grid-unit-05;
 					background-color: $gray-300;
@@ -178,14 +178,35 @@
 					background-color: $gray-300;
 					position: relative;
 					left: -12px; //the padding of buttons
+					height: 24px;
 				}
 			}
 
 			.show-icon-labels & {
-				left: $grid-unit-80 + $grid-unit-80;
+				left: $grid-unit-80 + $grid-unit-50;
 
 				&.is-collapsed {
 					left: $grid-unit-10 * 56;
+				}
+
+				.is-fullscreen-mode & {
+					left: $grid-unit-80 + $grid-unit-80;
+				}
+
+				.block-editor-block-parent-selector .block-editor-block-parent-selector__button::after {
+					left: 0;
+				}
+
+				.block-editor-block-toolbar__block-controls .block-editor-block-mover {
+					border-left: none;
+					&::before {
+						content: "";
+						width: $border-width;
+						margin-top: $grid-unit + $grid-unit-05;
+						margin-bottom: $grid-unit + $grid-unit-05;
+						background-color: $gray-300;
+						position: relative;
+					}
 				}
 			}
 		}

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -151,23 +151,20 @@
 				}
 			}
 
-			& > button.components-button.has-icon {
-
+			& > .block-editor-block-toolbar__collapse-fixed-toolbar {
 				border-radius: 0;
+				// Add a border as separator in the block toolbar.
+				border-right: $border-width solid $gray-300;
+				padding-right: 6px;
+				padding-left: 6px;
+			}
 
-				&.block-editor-block-toolbar__collapse-fixed-toolbar {
-					// Add a border as separator in the block toolbar.
-					border-right: $border-width solid $gray-300;
-					padding-right: 6px;
-					padding-left: 6px;
-				}
-
-				&.block-editor-block-toolbar__expand-fixed-toolbar {
-					// Add a border as separator in the block toolbar.
-					border-left: $border-width solid $gray-300;
-					padding-right: 6px;
-					padding-left: 6px;
-				}
+			& > .block-editor-block-toolbar__expand-fixed-toolbar {
+				border-radius: 0;
+				// Add a border as separator in the block toolbar.
+				border-left: $border-width solid $gray-300;
+				padding-right: 6px;
+				padding-left: 6px;
 			}
 		}
 

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -151,20 +151,32 @@
 				}
 			}
 
-			& > .block-editor-block-toolbar__collapse-fixed-toolbar {
-				border-radius: 0;
+			& > .block-editor-block-toolbar__group-collapse-fixed-toolbar {
+				border: none;
+
 				// Add a border as separator in the block toolbar.
-				border-right: $border-width solid $gray-300;
-				padding-right: 6px;
-				padding-left: 6px;
+				&::after {
+					content: "";
+					width: $border-width;
+					margin-top: $grid-unit + $grid-unit-05;
+					margin-bottom: $grid-unit + $grid-unit-05;
+					background-color: $gray-300;
+				}
 			}
 
-			& > .block-editor-block-toolbar__expand-fixed-toolbar {
-				border-radius: 0;
+			& > .block-editor-block-toolbar__group-expand-fixed-toolbar {
+				border: none;
+
 				// Add a border as separator in the block toolbar.
-				border-left: $border-width solid $gray-300;
-				padding-right: 6px;
-				padding-left: 6px;
+				&::before {
+					content: "";
+					width: $border-width;
+					margin-top: $grid-unit + $grid-unit-05;
+					margin-bottom: $grid-unit + $grid-unit-05;
+					background-color: $gray-300;
+					position: relative;
+					left: -12px; //the padding of buttons
+				}
 			}
 		}
 

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -156,9 +156,13 @@
 				&::after {
 					content: "";
 					width: $border-width;
+					height: 30px;
 					margin-top: $grid-unit + $grid-unit-05;
 					margin-bottom: $grid-unit + $grid-unit-05;
 					background-color: $gray-300;
+					position: absolute;
+					left: 44px;
+					top: -1px;
 				}
 			}
 
@@ -174,6 +178,14 @@
 					background-color: $gray-300;
 					position: relative;
 					left: -12px; //the padding of buttons
+				}
+			}
+
+			.show-icon-labels & {
+				left: $grid-unit-80 + $grid-unit-80;
+
+				&.is-collapsed {
+					left: $grid-unit-10 * 56;
 				}
 			}
 		}

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -327,6 +327,14 @@
 					left: $grid-unit * 36;
 				}
 			}
+
+			.auto-fold.is-fullscreen-mode .show-icon-labels & {
+				left: $grid-unit-80 * 2;
+				&.is-collapsed {
+					left: $grid-unit * 48;
+				}
+			}
+
 		}
 	}
 

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -270,6 +270,8 @@
 	// for the block inserter the publish button
 	@include break-large() {
 		&.is-fixed {
+			// leave room for block inserter and the dashboard navigation
+			left: $grid-unit-80 + $grid-unit-40 + ( $grid-unit-80 * 2 );
 			// Don't fill the whole header, minimize area
 			width: initial;
 			.is-fullscreen-mode & {

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -250,14 +250,31 @@
 	// except for the inserter on the left
 	@include break-medium() {
 		&.is-fixed {
-			width: calc(100% - #{$grid-unit-80 + $grid-unit-40});
+
+			left: 28 * $grid-unit;
+			width: calc(100% - #{28 * $grid-unit});
+
 			&.is-collapsed {
 				// when collapsed minimize area
 				width: initial;
+				left: $grid-unit * 48;
 			}
+
+			// collapsed wp admin sidebar when not in full screen mode
+			.auto-fold & {
+				left: $grid-unit-80 + $grid-unit-40;
+				width: calc(100% - #{$grid-unit-80 + $grid-unit-40});
+
+				&.is-collapsed {
+					left: $grid-unit * 32;
+				}
+			}
+
 			.is-fullscreen-mode & {
 				width: calc(100% - #{$grid-unit-80 + $grid-unit-70});
+				left: $grid-unit-80 + $grid-unit-70;
 				&.is-collapsed {
+					left: $grid-unit * 36;
 					// when collapsed minimize area
 					width: initial;
 				}
@@ -270,13 +287,45 @@
 	// for the block inserter the publish button
 	@include break-large() {
 		&.is-fixed {
-			// leave room for block inserter and the dashboard navigation
-			left: $grid-unit-80 + $grid-unit-40 + ( $grid-unit-80 * 2 );
-			// Don't fill the whole header, minimize area
-			width: initial;
-			.is-fullscreen-mode & {
+
+			.auto-fold & {
 				// Don't fill the whole header, minimize area
 				width: initial;
+
+				// leave room for block inserter and the dashboard navigation
+				left: $grid-unit-80 + $grid-unit-40 + ( $grid-unit-80 * 2 );
+
+				&.is-collapsed {
+					// when collapsed minimize area
+					width: initial;
+					left: $grid-unit * 48;
+				}
+
+			}
+
+			// collapsed wp admin sidebar when not in full screen mode
+			.auto-fold.folded & {
+				width: initial;
+				left: $grid-unit-80 + $grid-unit-40;
+
+				&.is-collapsed {
+					// when collapsed minimize area
+					width: initial;
+					left: $grid-unit * 32;
+				}
+
+			}
+
+			.auto-fold.is-fullscreen-mode & {
+				// Don't fill the whole header, minimize area
+				width: initial;
+				left: $grid-unit-80 + $grid-unit-70;
+
+				&.is-collapsed {
+					// when collapsed minimize area
+					width: initial;
+					left: $grid-unit * 36;
+				}
 			}
 		}
 	}

--- a/packages/e2e-tests/specs/editor/various/navigable-toolbar.test.js
+++ b/packages/e2e-tests/specs/editor/various/navigable-toolbar.test.js
@@ -11,38 +11,12 @@ async function isInBlockToolbar() {
 	} );
 }
 
-describe.each( [
-	[ 'unified', true ],
-	[ 'contextual', false ],
-] )( 'block toolbar (%s: %p)', ( label, isUnifiedToolbar ) => {
+describe( 'Block Toolbar', () => {
 	beforeEach( async () => {
 		await createNewPost();
-
-		await page.evaluate( ( _isUnifiedToolbar ) => {
-			const { select, dispatch } = wp.data;
-			const isCurrentlyUnified =
-				select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' );
-			if ( isCurrentlyUnified !== _isUnifiedToolbar ) {
-				dispatch( 'core/edit-post' ).toggleFeature( 'fixedToolbar' );
-			}
-		}, isUnifiedToolbar );
 	} );
 
-	it( 'navigates in and out of toolbar by keyboard (Alt+F10, Escape)', async () => {
-		// Assumes new post focus starts in title. Create first new
-		// block by Enter.
-		await page.keyboard.press( 'Enter' );
-
-		// [TEMPORARY]: A new paragraph is not technically a block yet
-		// until starting to type within it.
-		await page.keyboard.type( 'Example' );
-
-		// Upward.
-		await pressKeyWithModifier( 'alt', 'F10' );
-		expect( await isInBlockToolbar() ).toBe( true );
-	} );
-
-	if ( ! isUnifiedToolbar ) {
+	describe( 'Contextual Toolbar', () => {
 		it( 'should not scroll page', async () => {
 			while (
 				await page.evaluate( () => {
@@ -74,5 +48,57 @@ describe.each( [
 
 			expect( scrollTopBefore ).toBe( scrollTopAfter );
 		} );
-	}
+
+		it( 'navigates in and out of toolbar by keyboard (Alt+F10, Escape)', async () => {
+			// Assumes new post focus starts in title. Create first new
+			// block by Enter.
+			await page.keyboard.press( 'Enter' );
+
+			// [TEMPORARY]: A new paragraph is not technically a block yet
+			// until starting to type within it.
+			await page.keyboard.type( 'Example' );
+
+			// Upward.
+			await pressKeyWithModifier( 'alt', 'F10' );
+
+			expect( await isInBlockToolbar() ).toBe( true );
+		} );
+	} );
+
+	describe( 'Unified Toolbar', () => {
+		beforeEach( async () => {
+			// Enable unified toolbar
+			await page.evaluate( () => {
+				const { select, dispatch } = wp.data;
+				const isCurrentlyUnified =
+					select( 'core/edit-post' ).isFeatureActive(
+						'fixedToolbar'
+					);
+				if ( ! isCurrentlyUnified ) {
+					dispatch( 'core/edit-post' ).toggleFeature(
+						'fixedToolbar'
+					);
+				}
+			} );
+		} );
+
+		it( 'navigates in and out of toolbar by keyboard (Alt+F10)', async () => {
+			// Assumes new post focus starts in title. Create first new
+			// block by Enter.
+			await page.keyboard.press( 'Enter' );
+
+			// [TEMPORARY]: A new paragraph is not technically a block yet
+			// until starting to type within it.
+			await page.keyboard.type( 'Example' );
+
+			// Upward.
+			await pressKeyWithModifier( 'alt', 'F10' );
+
+			expect(
+				await page.evaluate( () => {
+					return document.activeElement.getAttribute( 'aria-label' );
+				} )
+			).toBe( 'Show document tools' );
+		} );
+	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/navigable-toolbar.test.js
+++ b/packages/e2e-tests/specs/editor/various/navigable-toolbar.test.js
@@ -49,7 +49,7 @@ describe( 'Block Toolbar', () => {
 			expect( scrollTopBefore ).toBe( scrollTopAfter );
 		} );
 
-		it( 'navigates in and out of toolbar by keyboard (Alt+F10, Escape)', async () => {
+		it( 'navigates into the toolbar by keyboard (Alt+F10)', async () => {
 			// Assumes new post focus starts in title. Create first new
 			// block by Enter.
 			await page.keyboard.press( 'Enter' );
@@ -82,7 +82,7 @@ describe( 'Block Toolbar', () => {
 			} );
 		} );
 
-		it( 'navigates in and out of toolbar by keyboard (Alt+F10)', async () => {
+		it( 'navigates into the toolbar by keyboard (Alt+F10)', async () => {
 			// Assumes new post focus starts in title. Create first new
 			// block by Enter.
 			await page.keyboard.press( 'Enter' );

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -99,3 +99,15 @@
 .edit-post-layout .entities-saved-states__panel-header {
 	height: $header-height + $border-width;
 }
+
+.edit-post-layout.has-fixed-toolbar {
+	// making the header be lower than the content
+	// so the fixed toolbar can be positioned on top of it
+	// but only on desktop
+	@include break-medium() {
+		.interface-interface-skeleton__header {
+			z-index: 19;
+		}
+	}
+
+}

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -105,7 +105,7 @@
 	// so the fixed toolbar can be positioned on top of it
 	// but only on desktop
 	@include break-medium() {
-		.interface-interface-skeleton__header {
+		.interface-interface-skeleton__header:not(:focus-within) {
 			z-index: 19;
 		}
 	}

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -23,6 +23,7 @@ import { useState, useRef } from '@wordpress/element';
 import { NavigableRegion } from '@wordpress/interface';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { CommandMenu } from '@wordpress/commands';
+import { store as prefferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -83,7 +84,7 @@ export default function Layout() {
 					'core/edit-site/next-region'
 				),
 				hasFixedToolbar:
-					select( editSiteStore ).isFeatureActive( 'fixedToolbar' ),
+					select( prefferencesStore ).get( 'fixedToolbar' ),
 			};
 		}, [] );
 	const navigateRegionsProps = useNavigateRegions( {

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -68,8 +68,8 @@ export default function Layout() {
 	const { params } = useLocation();
 	const isListPage = getIsListPage( params );
 	const isEditorPage = ! isListPage;
-	const { canvasMode, previousShortcut, nextShortcut } = useSelect(
-		( select ) => {
+	const { hasFixedToolbar, canvasMode, previousShortcut, nextShortcut } =
+		useSelect( ( select ) => {
 			const { getAllShortcutKeyCombinations } = select(
 				keyboardShortcutsStore
 			);
@@ -82,10 +82,10 @@ export default function Layout() {
 				nextShortcut: getAllShortcutKeyCombinations(
 					'core/edit-site/next-region'
 				),
+				hasFixedToolbar:
+					select( editSiteStore ).isFeatureActive( 'fixedToolbar' ),
 			};
-		},
-		[]
-	);
+		}, [] );
 	const navigateRegionsProps = useNavigateRegions( {
 		previous: previousShortcut,
 		next: nextShortcut,
@@ -139,6 +139,7 @@ export default function Layout() {
 					{
 						'is-full-canvas': isFullCanvas,
 						'is-edit-mode': canvasMode === 'edit',
+						'has-fixed-toolbar': hasFixedToolbar,
 					}
 				) }
 			>

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -23,7 +23,7 @@ import { useState, useRef } from '@wordpress/element';
 import { NavigableRegion } from '@wordpress/interface';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { CommandMenu } from '@wordpress/commands';
-import { store as prefferencesStore } from '@wordpress/preferences';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -84,7 +84,7 @@ export default function Layout() {
 					'core/edit-site/next-region'
 				),
 				hasFixedToolbar:
-					select( prefferencesStore ).get( 'fixedToolbar' ),
+					select( preferencesStore ).get( 'fixedToolbar' ),
 			};
 		}, [] );
 	const navigateRegionsProps = useNavigateRegions( {

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -221,3 +221,18 @@
 		border-left: $border-width solid $gray-300;
 	}
 }
+
+.edit-site-layout.has-fixed-toolbar {
+	// making the header be lower than the content
+	// so the fixed toolbar can be positioned on top of it
+	// but only on desktop
+	@include break-medium() {
+		.edit-site-site-hub {
+			z-index: 4;
+		}
+		.edit-site-layout__header:focus-within {
+			z-index: 3;
+		}
+	}
+
+}

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -120,6 +120,7 @@ export { default as key } from './library/key';
 export { default as keyboardClose } from './library/keyboard-close';
 export { default as keyboardReturn } from './library/keyboard-return';
 export { default as layout } from './library/layout';
+export { default as levelUp } from './library/level-up';
 export { default as lifesaver } from './library/lifesaver';
 export { default as lineDashed } from './library/line-dashed';
 export { default as lineDotted } from './library/line-dotted';

--- a/packages/icons/src/library/level-up.js
+++ b/packages/icons/src/library/level-up.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const levelUp = (
+	<SVG fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="m13.53 8.47-1.06 1.06-2.72-2.72V12h-1.5V6.81L5.53 9.53 4.47 8.47 9 3.94l4.53 4.53Zm-1.802 7.968c1.307.697 3.235.812 5.772.812v1.5c-2.463 0-4.785-.085-6.478-.988a4.721 4.721 0 0 1-2.07-2.13C8.48 14.67 8.25 13.471 8.25 12h1.5c0 1.328.208 2.28.548 2.969.332.675.81 1.138 1.43 1.47Z" />
+	</SVG>
+);
+
+export default levelUp;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #40450 

Updates the behavior of the top toolbar fixed setting.

## Why?

Because verical screen estate is scarce and.

## How?
- updates on desktop sized viewports the position of the fixed toolbar
- updates the z-index of the interface header to be lower to that block toolbar shows up on top
- implements a toggle expanded/collapsed for block contextual toolbar

## Testing Instructions

1. Enable the Top Toolbar setting from the top right dot menu
2. Select a block
3. Notice the block tools (toolbar) replaces the document tools (toolbar)
4. This also works by default in the Site editor

### Testing Instructions for Keyboard

1. Select a block
2. Press Shift + Tab, the focus should move to the block toolbar
3. Select a block
5. Press Alt + F10 , the focus should move to the block toolbar
6. Select a block
7. Press Ctrl + Shift + ~ to select 1st navigable region
8. Press Tab, the focus should move to the inserter
9. Use arrow right, the focus should move to document tools buttons
10. Select a block
11. Press Shit + Tab
12. In the block toolbar press the Collapse Block Tools button, the focus should be on Expand Block Tools button
13. Press the Expand Block Tools button, the focus should be on Collapse Block Tools button

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/107534/230375260-49afcfe0-7148-4bd7-b536-b5c9b8b912d1.mp4


## Known issues

- [x] When the post edtor is not full screen 💥 it's all wrong 
- [x] The Collapse Block Tools button sometimes gets focus when it shouldn't
- [ ] When the block toolbar is focused the tooltip of document tools appears 🤷🏻 
- [ ] Distraction Free does not inherit this, there still are no block tools when DFM is on
- [x] In the Site Editor there is a vertical allignment issue
- [x] In the Site Editor focusing the header region does not hide the block toolbar


