### PR TITLE
Lodash: Remove `_.mapValues()` from various blocks

### DIFF
--- a/packages/block-library/src/columns/utils.js
+++ b/packages/block-library/src/columns/utils.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { mapValues } from 'lodash';
-
-/**
  * Returns a column width attribute value rounded to standard precision.
  * Returns `undefined` if the value is not a valid finite number.
  *
@@ -86,10 +81,14 @@ export function getRedistributedColumnWidths(
 ) {
 	const totalWidth = getTotalColumnsWidth( blocks, totalBlockCount );
 
-	return mapValues( getColumnWidths( blocks, totalBlockCount ), ( width ) => {
-		const newWidth = ( availableWidth * width ) / totalWidth;
-		return toWidthPrecision( newWidth );
-	} );
+	return Object.fromEntries(
+		Object.entries( getColumnWidths( blocks, totalBlockCount ) ).map(
+			( [ clientId, width ] ) => {
+				const newWidth = ( availableWidth * width ) / totalWidth;
+				return [ clientId, toWidthPrecision( newWidth ) ];
+			}
+		)
+	);
 }
 
 /**

--- a/packages/block-library/src/navigation/deprecated.js
+++ b/packages/block-library/src/navigation/deprecated.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { mapValues } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { InnerBlocks } from '@wordpress/block-editor';
@@ -331,22 +326,23 @@ const migrateTypographyPresets = function ( attributes ) {
 		...attributes,
 		style: {
 			...attributes.style,
-			typography: mapValues(
-				attributes.style.typography,
-				( value, key ) => {
-					const prefix = TYPOGRAPHY_PRESET_DEPRECATION_MAP[ key ];
-					if ( prefix && value.startsWith( prefix ) ) {
-						const newValue = value.slice( prefix.length );
-						if (
-							'textDecoration' === key &&
-							'strikethrough' === newValue
-						) {
-							return 'line-through';
+			typography: Object.fromEntries(
+				Object.entries( attributes.style.typography ?? {} ).map(
+					( [ key, value ] ) => {
+						const prefix = TYPOGRAPHY_PRESET_DEPRECATION_MAP[ key ];
+						if ( prefix && value.startsWith( prefix ) ) {
+							const newValue = value.slice( prefix.length );
+							if (
+								'textDecoration' === key &&
+								'strikethrough' === newValue
+							) {
+								return [ key, 'line-through' ];
+							}
+							return [ key, newValue ];
 						}
-						return newValue;
+						return [ key, value ];
 					}
-					return value;
-				}
+				)
 			),
 		},
 	};

--- a/packages/block-library/src/utils/clean-empty-object.js
+++ b/packages/block-library/src/utils/clean-empty-object.js
@@ -18,9 +18,9 @@ const cleanEmptyObject = ( object ) => {
 		return object;
 	}
 	const cleanedNestedObjects = Object.fromEntries(
-		Object.entries( object ).filter( ( [ , value ] ) =>
-			Boolean( cleanEmptyObject( value ) )
-		)
+		Object.entries( object )
+			.map( ( [ key, value ] ) => [ key, cleanEmptyObject( value ) ] )
+			.filter( ( [ , value ] ) => Boolean( value ) )
 	);
 	return isEmpty( cleanedNestedObjects ) ? undefined : cleanedNestedObjects;
 };

--- a/packages/block-library/src/utils/clean-empty-object.js
+++ b/packages/block-library/src/utils/clean-empty-object.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, mapValues } from 'lodash';
+import { isEmpty } from 'lodash';
 
 /**
  * Removed empty nodes from nested objects.
@@ -18,8 +18,8 @@ const cleanEmptyObject = ( object ) => {
 		return object;
 	}
 	const cleanedNestedObjects = Object.fromEntries(
-		Object.entries( mapValues( object, cleanEmptyObject ) ).filter(
-			( [ , value ] ) => Boolean( value )
+		Object.entries( object ).filter( ( [ , value ] ) =>
+			Boolean( cleanEmptyObject( value ) )
 		)
 	);
 	return isEmpty( cleanedNestedObjects ) ? undefined : cleanedNestedObjects;


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.mapValues()` from a few of the core blocks.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `Object.fromEntries( Object.entries().map() )` as a replacement, with nullish coalescing to an empty object when the input may not be declared.

Much of the PR is actually whitespace, so you could review it easier by [disabling whitespace](https://github.blog/2018-05-01-ignore-white-space-in-code-review/).

## Testing Instructions

* Verify that as you change the number of columns in a Columns block, column widths are still set properly.
* Verify that an old Navigation block with `textDecoration: strikethrough ` typography setting set is properly being migrated to `line-through`.
* Play with Table block a bit - inserting rows, columns, moving, etc., and verify everything still works well.
* Verify that when you transform a Cover block to a Group block, styles are preserved, or if there are no styles, transformation works without any errors.
* Verify all checks are green.