### PR TITLE
Lodash: Remove `_.mapValues()` from `edit-site`

### DIFF
--- a/packages/edit-site/src/components/global-styles/global-styles-provider.js
+++ b/packages/edit-site/src/components/global-styles/global-styles-provider.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { mergeWith, isEmpty, mapValues } from 'lodash';
+import { mergeWith, isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -41,9 +41,9 @@ const cleanEmptyObject = ( object ) => {
 		return object;
 	}
 	const cleanedNestedObjects = Object.fromEntries(
-		Object.entries( mapValues( object, cleanEmptyObject ) ).filter(
-			( [ , value ] ) => Boolean( value )
-		)
+		Object.entries( object )
+			.map( ( [ key, value ] ) => [ key, cleanEmptyObject( value ) ] )
+			.filter( ( [ , value ] ) => Boolean( value ) )
 	);
 	return isEmpty( cleanedNestedObjects ) ? undefined : cleanedNestedObjects;
 };


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.mapValues()` from the `edit-site` package.

Changes are similar to the ones in #49637 and #49638 since it has the same utility for deep cleaning objects.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `Object.fromEntries( Object.entries().map() )` as a replacement.

Maybe it could be a good follow-up to unify the `cleanEmptyObject` utility.

## Testing Instructions

* Verify global styles continue to work well as you change them, change themes, or reset the global styles.