### PR TITLE
[Post Featured Image]: Fix some sizing issues

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -97,7 +97,7 @@ export default function PostFeaturedImageEdit( {
 		} ) );
 
 	const blockProps = useBlockProps( {
-		style: { width, height, aspectRatio },
+		style: { width, height, aspectRatio, maxWidth: '100%' },
 	} );
 	const borderProps = useBorderProps( attributes );
 
@@ -110,7 +110,8 @@ export default function PostFeaturedImageEdit( {
 				) }
 				withIllustration={ true }
 				style={ {
-					...blockProps.style,
+					height: !! aspectRatio && '100%',
+					width: !! aspectRatio && '100%',
 					...borderProps.style,
 				} }
 			>
@@ -210,7 +211,7 @@ export default function PostFeaturedImageEdit( {
 	const label = __( 'Add a featured image' );
 	const imageStyles = {
 		...borderProps.style,
-		height: ( !! aspectRatio && '100%' ) || height,
+		height: aspectRatio ? '100%' : height,
 		width: !! aspectRatio && '100%',
 		objectFit: !! ( height || aspectRatio ) && scale,
 	};

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -92,7 +92,7 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	if ( ! $height && ! $width && ! $aspect_ratio ) {
 		$wrapper_attributes = get_block_wrapper_attributes();
 	} else {
-		$wrapper_attributes = get_block_wrapper_attributes( array( 'style' => $aspect_ratio . $width . $height ) );
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'style' => $aspect_ratio . $width . $height . 'max-width:100%;' ) );
 	}
 	return "<figure {$wrapper_attributes}>{$featured_image}</figure>";
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/48988

This is a start to address some sizing issues in Post Featured Image block. There are more similar issues like: https://github.com/WordPress/gutenberg/issues/48892, but we can iterate on fixing them.

## Notes

This PR handles:
1. Overflowing of images by adding the `max-width:100%`
2. showing the placeholder properly when we set a percentage width(ex 50%).

## Testing instructions
For percentage width:
1. Insert Post Feature Image block in a post where one is not set - show it will display the placeholder
2. From the Inspector controls change the width to 50%
3. Observe the placeholder is displayed properly

For overflowing images:
1. Insert Post Feature Image block
2. Set a big width like 1500px
3. Observe there is no overflow of images.
4. This one could also be tested with Query Loop and Post featured images in `grid` view.

### Before

https://user-images.githubusercontent.com/16275880/233341351-99e392e2-90bc-4d96-ac1a-031fd50e7af3.mov



### After


https://user-images.githubusercontent.com/16275880/233341359-74cd942f-a725-4ddf-a9e9-e3e54bc421c9.mov


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 15bef96</samp>

> _`max-width` is the law, we render as we please_
> _No overflow, no compromise, we crush the enemies_
> _Image and placeholder, we style them to the core_
> _Simplify the code, we don't need any more_

