### PR TITLE
[Font API] Use registered fonts for Block Editor iframe.

### DIFF
--- a/lib/compat/wordpress-6.2/script-loader.php
+++ b/lib/compat/wordpress-6.2/script-loader.php
@@ -136,12 +136,14 @@ function gutenberg_resolve_assets_override() {
 	 * For the Block Editor, use the enqueued fonts.
 	 */
 	if ( class_exists( 'WP_Fonts' ) ) {
-		$wp_fonts   = wp_fonts();
-		$registered = $wp_fonts->get_registered_font_families();
+		$wp_fonts       = wp_fonts();
+		$registered     = $wp_fonts->get_registered_font_families();
+		$is_site_editor = 'site-editor.php' === $pagenow;
+
 		if ( ! empty( $registered ) ) {
 			$done           = $wp_fonts->done;
 			$wp_fonts->done = array();
-			if ( 'site-editor.php' === $pagenow ) {
+			if ( $is_site_editor ) {
 				$queue           = $wp_fonts->queue;
 				$wp_fonts->queue = $registered;
 			}
@@ -152,7 +154,7 @@ function gutenberg_resolve_assets_override() {
 
 			// Reset the Fonts API.
 			$wp_fonts->done = $done;
-			if ( 'site-editor.php' === $pagenow ) {
+			if ( $is_site_editor ) {
 				$wp_fonts->queue = $queue;
 			}
 		}

--- a/lib/compat/wordpress-6.2/script-loader.php
+++ b/lib/compat/wordpress-6.2/script-loader.php
@@ -130,26 +130,31 @@ function gutenberg_resolve_assets_override() {
 	$scripts = ob_get_clean();
 
 	/*
-	 * Generate font @font-face styles for the site editor iframe.
-	 * Use the registered font families for printing.
+	 * Generate font @font-face styles for the iframe.
+	 *
+	 * For the Site Editor, use the registered fonts.
+	 * For the Block Editor, use the enqueued fonts.
 	 */
 	if ( class_exists( 'WP_Fonts' ) ) {
 		$wp_fonts   = wp_fonts();
 		$registered = $wp_fonts->get_registered_font_families();
 		if ( ! empty( $registered ) ) {
-			$queue = $wp_fonts->queue;
-			$done  = $wp_fonts->done;
-
-			$wp_fonts->done  = array();
-			$wp_fonts->queue = $registered;
+			$done           = $wp_fonts->done;
+			$wp_fonts->done = array();
+			if ( 'site-editor.php' === $pagenow ) {
+				$queue           = $wp_fonts->queue;
+				$wp_fonts->queue = $registered;
+			}
 
 			ob_start();
 			$wp_fonts->do_items();
 			$styles .= ob_get_clean();
 
-			// Reset the Web Fonts API.
-			$wp_fonts->done  = $done;
-			$wp_fonts->queue = $queue;
+			// Reset the Fonts API.
+			$wp_fonts->done = $done;
+			if ( 'site-editor.php' === $pagenow ) {
+				$wp_fonts->queue = $queue;
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #49645

Fixes which fonts get their `@font-face` styles generated the specific iframe:

* Site Editor: uses all registered fonts.
* Block Editor: uses all enqueued fonts.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Outside of the Site Editor, only the enqueued fonts are to be used. Why? To avoid a potential performance impact when a site has one or more plugins or scripts that are registering fonts with the Fonts API.

In the Site Editor, all registered are to be used. Why? To allow users to preview typography choices before selecting and updating the global styles.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Uses `$pagenow` to identify if the web page is the Site Editor. If yes, then modifies the `queue` to use the registered fonts and restores the `queue` after the `@font-face` styles are generated.

## Testing Instructions
1. On your test site, activate the TT3 theme and Gutenberg plugin.
2. Install and activate [this test plugin](https://github.com/ironprogrammer/webfonts-jetpack-test).
3. In the fonts tester plugin, copy / paste the following code in the `Global_Styles::enqueue_global_styles_fonts()` found in the  `/vendor/automattic/jetpack-google-fonts-provider/src/introspectors/class-global-styles.php`  file. This change fixes a bug (by removing the admin check) for enqueuing the plugin's fonts in the editor's iframe.
```php
	/**
	 * Enqueue fonts used in global styles settings.
	 *
	 * @return void
	 */
	public static function enqueue_global_styles_fonts() {
		if ( ! function_exists( 'wp_enqueue_webfonts' ) || ! function_exists( 'wp_enqueue_fonts' )  ) {
			return;
		}

		$global_styles_fonts = self::collect_fonts_from_global_styles();

		$fonts_to_enqueue = array();
		foreach ( $global_styles_fonts as $font ) {
			$font_is_registered = Utils::is_font_family_registered( $font );

			if ( $font_is_registered ) {
				$fonts_to_enqueue[] = $font;
			}
		}

		if ( ! empty( $fonts_to_enqueue ) ) {
			if ( function_exists( 'wp_enqueue_fonts' ) ) {
				wp_enqueue_fonts( $fonts_to_enqueue );
			} else {
				wp_enqueue_webfonts( $fonts_to_enqueue );
			}
		}
	}
```
4. Open a post by going to Posts > and selecting or adding a post.
5. In your browser, open Dev Tools to the `Inspector` tab.
6. Search for `wp-fonts-jetpack-google-fonts`. 
    The expected behavior: 
    * `<style id="wp-fonts-jetpack-google-fonts">` **should _not_** exist.
    * `<style id="wp-fonts-local">` should exist (these are the theme's defined fonts).
7. Then go to the Site Editor, i.e. Appearance > Editor.
9. Search for `wp-fonts-jetpack-google-fonts`. 
    The expected behavior: 
    * `<style id="wp-fonts-jetpack-google-fonts">` **_should_** exist.
    * `<style id="wp-fonts-local">` should exist (these are the theme's defined fonts).