### PR TITLE
Publish build types for notices

### DIFF
--- a/docs/reference-guides/data/data-core-notices.md
+++ b/docs/reference-guides/data/data-core-notices.md
@@ -156,7 +156,7 @@ const ExampleComponent = () => {
 
 _Parameters_
 
--   _status_ `[string]`: Notice status.
+-   _status_ `string|undefined`: Notice status ("info" if undefined is passed).
 -   _content_ `string`: Notice message.
 -   _options_ `[Object]`: Notice options.
 -   _options.context_ `[string]`: Context under which to group notice.

--- a/packages/block-editor/tsconfig.json
+++ b/packages/block-editor/tsconfig.json
@@ -23,6 +23,7 @@
 		{ "path": "../icons" },
 		{ "path": "../is-shallow-equal" },
 		{ "path": "../keycodes" },
+		{ "path": "../notices" },
 		{ "path": "../style-engine" },
 		{ "path": "../token-list" },
 		{ "path": "../url" },

--- a/packages/block-library/tsconfig.json
+++ b/packages/block-library/tsconfig.json
@@ -26,6 +26,7 @@
 		{ "path": "../html-entities" },
 		{ "path": "../i18n" },
 		{ "path": "../icons" },
+		{ "path": "../notices" },
 		{ "path": "../keycodes" },
 		{ "path": "../primitives" },
 		{ "path": "../url" },

--- a/packages/notices/CHANGELOG.md
+++ b/packages/notices/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Change
+
+-   Publish Typescript build types to npm. ([#49650](https://github.com/WordPress/gutenberg/pull/49650))
+
 ## 3.31.0 (2023-04-12)
 
 ## 3.30.0 (2023-03-29)

--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -24,6 +24,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"types": "build-types",
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
 		"@wordpress/a11y": "file:../a11y",

--- a/packages/notices/src/store/actions.js
+++ b/packages/notices/src/store/actions.js
@@ -19,7 +19,7 @@ let uniqueId = 0;
 /**
  * Returns an action object used in signalling that a notice is to be created.
  *
- * @param {string}                [status='info']              Notice status.
+ * @param {string|undefined}      status                       Notice status ("info" if undefined is passed).
  * @param {string}                content                      Notice message.
  * @param {Object}                [options]                    Notice options.
  * @param {string}                [options.context='global']   Context under which to

--- a/packages/notices/src/store/index.js
+++ b/packages/notices/src/store/index.js
@@ -14,8 +14,6 @@ import * as selectors from './selectors';
  * Store definition for the notices namespace.
  *
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/data/README.md#createReduxStore
- *
- * @type {Object}
  */
 export const store = createReduxStore( 'core/notices', {
 	reducer,

--- a/packages/notices/tsconfig.json
+++ b/packages/notices/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"declarationDir": "build-types",
+		"types": [ "gutenberg-env" ],
+		"checkJs": false
+	},
+	"references": [ { "path": "../a11y" }, { "path": "../data" } ],
+	"include": [ "src/**/*" ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
 		{ "path": "packages/is-shallow-equal" },
 		{ "path": "packages/keycodes" },
 		{ "path": "packages/lazy-import" },
+		{ "path": "packages/notices" },
 		{ "path": "packages/plugins" },
 		{ "path": "packages/prettier-config" },
 		{ "path": "packages/primitives" },


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Publishes build types for the notices store

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See #49647

## How?
Adding a tsconfig and fixing anything that comes up! In this case, not much was needed.

## Testing Instructions
CI, check build-types directory

