### PR TITLE
[Fonts API] Allow using font-technologies for variable fonts

### DIFF
--- a/lib/experimental/fonts-api/class-wp-fonts-provider-local.php
+++ b/lib/experimental/fonts-api/class-wp-fonts-provider-local.php
@@ -177,6 +177,12 @@ class WP_Fonts_Provider_Local extends WP_Fonts_Provider {
 				continue;
 			}
 
+			// Skip "tech" since it's for internal API use,
+			// and not a valid CSS property.
+			if ( 'tech' === $key ) {
+				continue;
+			}
+
 			// Compile the "src" parameter.
 			if ( 'src' === $key ) {
 				$value = $this->compile_src( $value );
@@ -212,9 +218,17 @@ class WP_Fonts_Provider_Local extends WP_Fonts_Provider {
 				$item['url'] = wp_make_link_relative( $item['url'] );
 			}
 
-			$src .= ( 'data' === $item['format'] )
-				? ", url({$item['url']})"
-				: ", url('{$item['url']}') format('{$item['format']}')";
+			if ( 'data' === $item['format'] ) {
+				$src .= ", url({$item['url']})";
+			} elseif ( ! empty( $item['tech'] ) ) {
+				if ( 'variations' === $item['tech'] ) {
+					$src .= ", url('{$item['url']}') format('{$item['format']}-variations')";
+				} else {
+					$src .= ", url('{$item['url']}') format('{$item['format']}') tech({$item['tech']})";
+				}
+			} else {
+				$src .= ", url('{$item['url']}') format('{$item['format']}')";
+			}
 		}
 
 		$src = ltrim( $src, ', ' );

--- a/lib/experimental/fonts-api/class-wp-fonts-provider-local.php
+++ b/lib/experimental/fonts-api/class-wp-fonts-provider-local.php
@@ -221,11 +221,9 @@ class WP_Fonts_Provider_Local extends WP_Fonts_Provider {
 			if ( 'data' === $item['format'] ) {
 				$src .= ", url({$item['url']})";
 			} elseif ( ! empty( $item['tech'] ) ) {
-				if ( 'variations' === $item['tech'] ) {
-					$src .= ", url('{$item['url']}') format('{$item['format']}-variations')";
-				} else {
-					$src .= ", url('{$item['url']}') format('{$item['format']}') tech({$item['tech']})";
-				}
+				$src .= ( 'variations' === $item['tech'] )
+					? ", url('{$item['url']}') format('{$item['format']}-variations')"
+					: ", url('{$item['url']}') format('{$item['format']}') tech({$item['tech']})";
 			} else {
 				$src .= ", url('{$item['url']}') format('{$item['format']}')";
 			}

--- a/lib/experimental/fonts-api/class-wp-fonts.php
+++ b/lib/experimental/fonts-api/class-wp-fonts.php
@@ -421,6 +421,7 @@ class WP_Fonts extends WP_Dependencies {
 
 			// Exceptions.
 			'provider',
+			'tech', // Will be combined with `src` internally.
 		);
 
 		foreach ( $variation as $prop => $value ) {


### PR DESCRIPTION
## What?
Allows defining `tech` for font-families.
Fixes https://github.com/WordPress/gutenberg/issues/41158, see comment on https://github.com/WordPress/gutenberg/issues/41158#issuecomment-1500042899 for details.

## Why?
To allow using variable fonts files, while at the same time we keep forward-compatibility with the next-gen formats and font technologies.
