### PR TITLE
Lodash: Remove `_.mapValues()` from editor package

### DIFF
--- a/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
+++ b/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { mapValues, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -57,9 +57,13 @@ const createWithMetaAttributeSource = ( metaAttributes ) =>
 				const mergedAttributes = useMemo(
 					() => ( {
 						...attributes,
-						...mapValues(
-							metaAttributes,
-							( metaKey ) => meta[ metaKey ]
+						...Object.fromEntries(
+							Object.entries( metaAttributes ).map(
+								( [ attributeKey, metaKey ] ) => [
+									attributeKey,
+									meta[ metaKey ],
+								]
+							)
 						),
 					} ),
 					[ attributes, meta ]
@@ -106,13 +110,10 @@ const createWithMetaAttributeSource = ( metaAttributes ) =>
  */
 function shimAttributeSource( settings ) {
 	/** @type {WPMetaAttributeMapping} */
-	const metaAttributes = mapValues(
-		Object.fromEntries(
-			Object.entries( settings.attributes ?? {} ).filter(
-				( [ , { source } ] ) => source === 'meta'
-			)
-		),
-		'meta'
+	const metaAttributes = Object.fromEntries(
+		Object.entries( settings.attributes ?? {} )
+			.filter( ( [ , { source } ] ) => source === 'meta' )
+			.map( ( [ attributeKey, { meta } ] ) => [ attributeKey, meta ] )
 	);
 	if ( ! isEmpty( metaAttributes ) ) {
 		settings.edit = createWithMetaAttributeSource( metaAttributes )(


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.mapValues()` from the editor package.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `Object.fromEntries( Object.entries().map() )` as a replacement.

## Testing Instructions

* Install and activate the attached plugin on your WordPress site: [meta-attribute-block.zip](https://github.com/WordPress/gutenberg/files/11178512/meta-attribute-block.zip) (see #18960 for more info).
* Insert one of the "Test Meta Attribute Block" blocks, update its value, and save the post. 
* Verify that the value persists between page loads.