### PR TITLE
Block editor: iframe: add `enqueue_block_assets`

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -255,7 +255,7 @@ function gutenberg_register_packages_styles( $styles ) {
 		$styles,
 		'wp-block-editor-content',
 		gutenberg_url( 'build/block-editor/content.css' ),
-		array(),
+		array( 'wp-components' ),
 		$version
 	);
 	$styles->add_data( 'wp-block-editor-content', 'rtl', 'replace' );

--- a/lib/compat/wordpress-6.3/script-loader.php
+++ b/lib/compat/wordpress-6.3/script-loader.php
@@ -13,3 +13,69 @@
 remove_action( 'wp_body_open', 'wp_global_styles_render_svg_filters' );
 remove_action( 'in_admin_header', 'wp_global_styles_render_svg_filters' );
 
+/**
+ * Collect the block editor assets that need to be loaded into the editor's iframe.
+ *
+ * @since 6.0.0
+ * @access private
+ *
+ * @global string $pagenow The filename of the current screen.
+ *
+ * @return array {
+ *     The block editor assets.
+ *
+ *     @type string|false $styles  String containing the HTML for styles.
+ *     @type string|false $scripts String containing the HTML for scripts.
+ * }
+ */
+function _wp_get_iframed_editor_assets__63() {
+    global $wp_styles, $wp_scripts;
+
+    $current_wp_styles = $wp_styles;
+    $current_wp_scripts = $wp_scripts;
+
+    $wp_styles = new WP_Styles();
+    $wp_scripts = new WP_Scripts();
+
+    add_filter( 'should_load_block_editor_scripts_and_styles', '__return_false' );
+    do_action( 'enqueue_block_assets' );
+    remove_filter( 'should_load_block_editor_scripts_and_styles', '__return_false' );
+
+    // This is a new hook for cases where we want to enqueue scripts/styles for
+    // the (iframed) editor content, but not for the front-end.
+    do_action( 'enqueue_block_editor_content_assets' );
+
+	ob_start();
+	wp_print_styles();
+	$styles = ob_get_clean();
+
+	ob_start();
+    wp_print_head_scripts();
+    wp_print_footer_scripts();
+	$scripts = ob_get_clean();
+
+    $wp_styles = $current_wp_styles;
+    $wp_scripts = $current_wp_scripts;
+
+	return array(
+		'styles'  => $styles,
+		'scripts' => $scripts,
+	);
+}
+
+add_action(
+    'enqueue_block_editor_content_assets',
+    function() {
+        wp_enqueue_style( 'wp-block-editor-content' );
+    }
+);
+
+add_filter(
+	'block_editor_settings_all',
+	function( $settings ) {
+		// We must override what core is passing now.
+		$settings['__unstableResolvedAssets'] = _wp_get_iframed_editor_assets__63();
+		return $settings;
+	},
+	100
+);

--- a/lib/compat/wordpress-6.3/script-loader.php
+++ b/lib/compat/wordpress-6.3/script-loader.php
@@ -29,33 +29,33 @@ remove_action( 'in_admin_header', 'wp_global_styles_render_svg_filters' );
  * }
  */
 function _wp_get_iframed_editor_assets__63() {
-    global $wp_styles, $wp_scripts;
+	global $wp_styles, $wp_scripts;
 
-    $current_wp_styles = $wp_styles;
-    $current_wp_scripts = $wp_scripts;
+	$current_wp_styles  = $wp_styles;
+	$current_wp_scripts = $wp_scripts;
 
-    $wp_styles = new WP_Styles();
-    $wp_scripts = new WP_Scripts();
+	$wp_styles  = new WP_Styles();
+	$wp_scripts = new WP_Scripts();
 
-    add_filter( 'should_load_block_editor_scripts_and_styles', '__return_false' );
-    do_action( 'enqueue_block_assets' );
-    remove_filter( 'should_load_block_editor_scripts_and_styles', '__return_false' );
+	add_filter( 'should_load_block_editor_scripts_and_styles', '__return_false' );
+	do_action( 'enqueue_block_assets' );
+	remove_filter( 'should_load_block_editor_scripts_and_styles', '__return_false' );
 
-    // This is a new hook for cases where we want to enqueue scripts/styles for
-    // the (iframed) editor content, but not for the front-end.
-    do_action( 'enqueue_block_editor_content_assets' );
+	// This is a new hook for cases where we want to enqueue scripts/styles for
+	// the (iframed) editor content, but not for the front-end.
+	do_action( 'enqueue_block_editor_content_assets' );
 
 	ob_start();
 	wp_print_styles();
 	$styles = ob_get_clean();
 
 	ob_start();
-    wp_print_head_scripts();
-    wp_print_footer_scripts();
+	wp_print_head_scripts();
+	wp_print_footer_scripts();
 	$scripts = ob_get_clean();
 
-    $wp_styles = $current_wp_styles;
-    $wp_scripts = $current_wp_scripts;
+	$wp_styles  = $current_wp_styles;
+	$wp_scripts = $current_wp_scripts;
 
 	return array(
 		'styles'  => $styles,
@@ -64,10 +64,10 @@ function _wp_get_iframed_editor_assets__63() {
 }
 
 add_action(
-    'enqueue_block_editor_content_assets',
-    function() {
-        wp_enqueue_style( 'wp-block-editor-content' );
-    }
+	'enqueue_block_editor_content_assets',
+	function() {
+		wp_enqueue_style( 'wp-block-editor-content' );
+	}
 );
 
 add_filter(

--- a/lib/compat/wordpress-6.3/script-loader.php
+++ b/lib/compat/wordpress-6.3/script-loader.php
@@ -41,7 +41,7 @@ function _wp_get_iframed_editor_assets__63() {
 
 	// Register all currently registered styles and scripts. The actions that
 	// follow enqueue assets, but don't necessarily register them.
-	$wp_styles->registered = $current_wp_styles->registered;
+	$wp_styles->registered  = $current_wp_styles->registered;
 	$wp_scripts->registered = $current_wp_scripts->registered;
 
 	// We don't want to load EDITOR scripts and styles in the iframe, only

--- a/lib/compat/wordpress-6.3/script-loader.php
+++ b/lib/compat/wordpress-6.3/script-loader.php
@@ -31,12 +31,21 @@ remove_action( 'in_admin_header', 'wp_global_styles_render_svg_filters' );
 function _wp_get_iframed_editor_assets__63() {
 	global $wp_styles, $wp_scripts;
 
+	// Keep track of the styles and scripts instance to restore later.
 	$current_wp_styles  = $wp_styles;
 	$current_wp_scripts = $wp_scripts;
 
+	// Create new instances to collect the assets.
 	$wp_styles  = new WP_Styles();
 	$wp_scripts = new WP_Scripts();
 
+	// Register all currently registered styles and scripts. The actions that
+	// follow enqueue assets, but don't necessarily register them.
+	$wp_styles->registered = $current_wp_styles->registered;
+	$wp_scripts->registered = $current_wp_scripts->registered;
+
+	// We don't want to load EDITOR scripts and styles in the iframe, only
+	// assets for the content.
 	add_filter( 'should_load_block_editor_scripts_and_styles', '__return_false' );
 	do_action( 'enqueue_block_assets' );
 	remove_filter( 'should_load_block_editor_scripts_and_styles', '__return_false' );
@@ -54,6 +63,7 @@ function _wp_get_iframed_editor_assets__63() {
 	wp_print_footer_scripts();
 	$scripts = ob_get_clean();
 
+	// Restore the original instances.
 	$wp_styles  = $current_wp_styles;
 	$wp_scripts = $current_wp_scripts;
 

--- a/lib/compat/wordpress-6.3/script-loader.php
+++ b/lib/compat/wordpress-6.3/script-loader.php
@@ -43,6 +43,7 @@ function _gutenberg_get_iframed_editor_assets() {
 	$wp_scripts->registered = $current_wp_scripts->registered;
 
 	wp_enqueue_style( 'wp-block-editor-content' );
+	wp_enqueue_style( 'wp-block-library' );
 	wp_enqueue_script( 'wp-polyfill' );
 
 	// We don't want to load EDITOR scripts and styles in the iframe, only

--- a/lib/compat/wordpress-6.3/script-loader.php
+++ b/lib/compat/wordpress-6.3/script-loader.php
@@ -50,9 +50,7 @@ function _wp_get_iframed_editor_assets__63() {
 	do_action( 'enqueue_block_assets' );
 	remove_filter( 'should_load_block_editor_scripts_and_styles', '__return_false' );
 
-	// This is a new hook for cases where we want to enqueue scripts/styles for
-	// the (iframed) editor content, but not for the front-end.
-	do_action( 'enqueue_block_editor_content_assets' );
+	wp_enqueue_style( 'wp-block-editor-content' );
 
 	ob_start();
 	wp_print_styles();
@@ -72,13 +70,6 @@ function _wp_get_iframed_editor_assets__63() {
 		'scripts' => $scripts,
 	);
 }
-
-add_action(
-	'enqueue_block_editor_content_assets',
-	function() {
-		wp_enqueue_style( 'wp-block-editor-content' );
-	}
-);
 
 add_filter(
 	'block_editor_settings_all',

--- a/lib/compat/wordpress-6.3/script-loader.php
+++ b/lib/compat/wordpress-6.3/script-loader.php
@@ -56,6 +56,7 @@ function _gutenberg_get_iframed_editor_assets() {
 
 	ob_start();
 	wp_print_styles();
+	wp_print_fonts();
 	$styles = ob_get_clean();
 
 	ob_start();

--- a/lib/compat/wordpress-6.3/script-loader.php
+++ b/lib/compat/wordpress-6.3/script-loader.php
@@ -51,6 +51,7 @@ function _wp_get_iframed_editor_assets__63() {
 	remove_filter( 'should_load_block_editor_scripts_and_styles', '__return_false' );
 
 	wp_enqueue_style( 'wp-block-editor-content' );
+	wp_enqueue_script( 'wp-polyfill' );
 
 	ob_start();
 	wp_print_styles();

--- a/lib/compat/wordpress-6.3/script-loader.php
+++ b/lib/compat/wordpress-6.3/script-loader.php
@@ -42,14 +42,14 @@ function _gutenberg_get_iframed_editor_assets() {
 	$wp_styles->registered  = $current_wp_styles->registered;
 	$wp_scripts->registered = $current_wp_scripts->registered;
 
+	wp_enqueue_style( 'wp-block-editor-content' );
+	wp_enqueue_script( 'wp-polyfill' );
+
 	// We don't want to load EDITOR scripts and styles in the iframe, only
 	// assets for the content.
 	add_filter( 'should_load_block_editor_scripts_and_styles', '__return_false' );
 	do_action( 'enqueue_block_assets' );
 	remove_filter( 'should_load_block_editor_scripts_and_styles', '__return_false' );
-
-	wp_enqueue_style( 'wp-block-editor-content' );
-	wp_enqueue_script( 'wp-polyfill' );
 
 	ob_start();
 	wp_print_styles();

--- a/lib/compat/wordpress-6.3/script-loader.php
+++ b/lib/compat/wordpress-6.3/script-loader.php
@@ -43,6 +43,8 @@ function _gutenberg_get_iframed_editor_assets() {
 	$wp_scripts->registered = $current_wp_scripts->registered;
 
 	wp_enqueue_style( 'wp-block-editor-content' );
+	// To do: investigate why this is not enqueued through enqueue_block_assets,
+	// as styles for non-core blocks are.
 	wp_enqueue_style( 'wp-block-library' );
 	wp_enqueue_script( 'wp-polyfill' );
 

--- a/lib/compat/wordpress-6.3/script-loader.php
+++ b/lib/compat/wordpress-6.3/script-loader.php
@@ -19,8 +19,6 @@ remove_action( 'in_admin_header', 'wp_global_styles_render_svg_filters' );
  * @since 6.0.0
  * @access private
  *
- * @global string $pagenow The filename of the current screen.
- *
  * @return array {
  *     The block editor assets.
  *
@@ -28,7 +26,7 @@ remove_action( 'in_admin_header', 'wp_global_styles_render_svg_filters' );
  *     @type string|false $scripts String containing the HTML for scripts.
  * }
  */
-function _wp_get_iframed_editor_assets__63() {
+function _gutenberg_get_iframed_editor_assets() {
 	global $wp_styles, $wp_scripts;
 
 	// Keep track of the styles and scripts instance to restore later.
@@ -76,7 +74,7 @@ add_filter(
 	'block_editor_settings_all',
 	function( $settings ) {
 		// We must override what core is passing now.
-		$settings['__unstableResolvedAssets'] = _wp_get_iframed_editor_assets__63();
+		$settings['__unstableResolvedAssets'] = _gutenberg_get_iframed_editor_assets();
 		return $settings;
 	},
 	100

--- a/packages/e2e-tests/plugins/iframed-enqueue-block-assets.php
+++ b/packages/e2e-tests/plugins/iframed-enqueue-block-assets.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Iframed enqueue_block_assets
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-iframed-iframed-enqueue-block-assets
+ */
+
+add_action(
+	'enqueue_block_assets',
+	function() {
+		wp_enqueue_style(
+			'iframed-enqueue-block-assets',
+			plugin_dir_url( __FILE__ ) . 'iframed-enqueue-block-assets/style.css',
+			array(),
+			filemtime( plugin_dir_path( __FILE__ ) . 'iframed-enqueue-block-assets/style.css' )
+		);
+		wp_add_inline_style( 'iframed-enqueue-block-assets', 'body{padding:20px!important}' );
+	}
+);

--- a/packages/e2e-tests/plugins/iframed-enqueue-block-assets/style.css
+++ b/packages/e2e-tests/plugins/iframed-enqueue-block-assets/style.css
@@ -1,0 +1,9 @@
+/**
+ * The following styles get applied both on the front of your site and in the
+ * editor.
+ */
+body {
+	background-color: rgb(33, 117, 155) !important;
+	color: #fff !important;
+	padding: 2px !important;
+}

--- a/packages/e2e-tests/specs/editor/plugins/iframed-equeue-block-assets.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/iframed-equeue-block-assets.test.js
@@ -1,0 +1,44 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	activatePlugin,
+	createNewPost,
+	deactivatePlugin,
+	canvas,
+	activateTheme,
+} from '@wordpress/e2e-test-utils';
+
+async function getComputedStyle( context, selector, property ) {
+	return await context.evaluate(
+		( sel, prop ) =>
+			window.getComputedStyle( document.querySelector( sel ) )[ prop ],
+		selector,
+		property
+	);
+}
+
+describe( 'iframed inline styles', () => {
+	beforeEach( async () => {
+		// Activate the empty theme (block based theme), which is iframed.
+		await activateTheme( 'emptytheme' );
+		await activatePlugin( 'gutenberg-test-iframed-enqueue_block_assets' );
+		await createNewPost();
+	} );
+
+	afterEach( async () => {
+		await deactivatePlugin( 'gutenberg-test-iframed-enqueue_block_assets' );
+		await activateTheme( 'twentytwentyone' );
+	} );
+
+	it( 'should load styles added through enqueue_block_assets', async () => {
+		// Check stylesheet.
+		expect(
+			await getComputedStyle( canvas(), 'body', 'background-color' )
+		).toBe( 'rgb(33, 117, 155)' );
+		// Check inline style.
+		expect( await getComputedStyle( canvas(), 'body', 'padding' ) ).toBe(
+			'20px'
+		);
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Should be able to fix: #41821, #44945.

Enqueues styles and scripts added though the `enqueue_block_assets` action (which is for editor and front-end assets<sup>[1](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/applying-styles-with-stylesheets/#enqueue-stylesheets)</sup>).
~~Introduces another action `enqueue_block_editor_content_assets` for cases where we want to enqueue scripts/styles for the (iframed) editor content, but not for the front-end.~~

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We need more ways to enqueue scripts and styles. Currently there’s 3 ways to add styles: block.json (for blocks), add_editor_style (for themes) and block editor settings (CSS as a string, which is not easy to use). Scripts can only be added through block.json. 

It makes sense to enqueue assets loaded on the front-end in the editor content (iframe) too.

~~In addition, we need a way to add assets for the editor content (iframe), but without enqueuing on the front-end. We currently have an unstable way of doing this in Gutenberg. This PR adds the `enqueue_block_editor_content_assets` so there's an official way of doing it. For example, we need this action for adding content styles in the block editor package, and the `wp-components` dependency.~~

Another good thing is that this simplifies the [`_wp_get_iframed_editor_assets`](https://github.com/WordPress/wordpress-develop/blob/6.2/src/wp-includes/block-editor.php#L283-L362) function.

## How?

~~To put it another way: we are currently hardcoding a bunch of dependency handles in [ `_wp_get_iframed_editor_assets`](https://github.com/WordPress/wordpress-develop/blob/6.2/src/wp-includes/block-editor.php#L283-L362), which can be replaced by calling `do_action( 'enqueue_block_assets' )` and `do_action( 'enqueue_block_editor_content_assets' )`.~~

## Testing Instructions

There should be no missing styles in the editor content (iframe).

### Testing Instructions for Keyboard

n/a

## Screenshots or screencast <!-- if applicable -->
