### PR TITLE
Consistent labels for the WP logo and back links.

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -48,9 +48,8 @@ export default function SidebarNavigationScreen( {
 				) : (
 					<SidebarButton
 						icon={ isRTL() ? chevronRight : chevronLeft }
-						aria-label={ __( 'Navigate to the Dashboard' ) }
+						label={ __( 'Go back to the Dashboard' ) }
 						href={ dashboardLink || 'index.php' }
-						label={ __( 'Dashboard' ) }
 					/>
 				) }
 				<Heading

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -46,7 +46,7 @@ const SiteHub = forwardRef( ( props, ref ) => {
 	const siteIconButtonProps = isBackToDashboardButton
 		? {
 				href: dashboardLink || 'index.php',
-				'aria-label': __( 'Go back to the dashboard' ),
+				label: __( 'Go back to the Dashboard' ),
 		  }
 		: {
 				label: __( 'Open Navigation Sidebar' ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes https://github.com/WordPress/gutenberg/issues/49657

## What?
<!-- In a few words, what is the PR actually doing? -->

Use the same accessible name for the Site Editor 'go back to the dashboard' links.
Fixes missing tooltip.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- Controls that perform the same action should be labelled consistently.
- All icon buttons must have a tooltip, to visually expose their accessible name.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Go to the Site Editor, in browse mode.
- Check the WP logo and the Back button (at first menu level) have the same aria-label and same tooltip (see screenshot below).

<img width="800" alt="Screenshot 2023-04-07 at 16 22 13" src="https://user-images.githubusercontent.com/1682452/230629223-094fccb1-8173-4e75-8632-527f70f8298e.png">


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
