### PR TITLE
[RNMobile] Update Sandbox component

### DIFF
--- a/packages/components/src/sandbox/index.native.js
+++ b/packages/components/src/sandbox/index.native.js
@@ -14,6 +14,7 @@ import {
 	useRef,
 	useState,
 	useEffect,
+	forwardRef,
 } from '@wordpress/element';
 import { usePreferredColorScheme } from '@wordpress/compose';
 
@@ -171,20 +172,22 @@ const style = `
 
 const EMPTY_ARRAY = [];
 
-function Sandbox( {
-	containerStyle,
-	customJS,
-	html = '',
-	lang = 'en',
-	providerUrl = '',
-	scripts = EMPTY_ARRAY,
-	styles = EMPTY_ARRAY,
-	title = '',
-	type,
-	url,
-} ) {
+const Sandbox = forwardRef( function Sandbox(
+	{
+		containerStyle,
+		customJS,
+		html = '',
+		lang = 'en',
+		providerUrl = '',
+		scripts = EMPTY_ARRAY,
+		styles = EMPTY_ARRAY,
+		title = '',
+		type,
+		url,
+	},
+	ref
+) {
 	const colorScheme = usePreferredColorScheme();
-	const ref = useRef();
 	const [ height, setHeight ] = useState( 0 );
 	const [ contentHtml, setContentHtml ] = useState( getHtmlDoc() );
 
@@ -333,7 +336,7 @@ function Sandbox( {
 			showsVerticalScrollIndicator={ false }
 		/>
 	);
-}
+} );
 
 const workaroundStyles = StyleSheet.create( {
 	webView: {

--- a/packages/components/src/sandbox/index.native.js
+++ b/packages/components/src/sandbox/index.native.js
@@ -333,6 +333,7 @@ const Sandbox = forwardRef( function Sandbox(
 			setBuiltInZoomControls={ false }
 			showsHorizontalScrollIndicator={ false }
 			showsVerticalScrollIndicator={ false }
+			mediaPlaybackRequiresUserAction={ false }
 		/>
 	);
 } );

--- a/packages/components/src/sandbox/index.native.js
+++ b/packages/components/src/sandbox/index.native.js
@@ -99,7 +99,6 @@ const observeAndResizeJS = `
 		// get an DOM mutations for that, so do the resize when the window is resized, too.
 		window.addEventListener( 'resize', sendResize, true );
 		window.addEventListener( 'orientationchange', sendResize, true );
-		widow.addEventListener( 'click', sendResize, true );
 	})();
 `;
 

--- a/packages/components/src/sandbox/index.native.js
+++ b/packages/components/src/sandbox/index.native.js
@@ -300,7 +300,15 @@ const Sandbox = forwardRef( function Sandbox(
 			// Forward the event to parent event listeners
 			Object.keys( onWindowEvents ).forEach( ( eventType ) => {
 				if ( data?.type === eventType ) {
-					onWindowEvents[ eventType ]( data );
+					try {
+						onWindowEvents[ eventType ]( data );
+					} catch ( e ) {
+						// eslint-disable-next-line no-console
+						console.warn(
+							`Error handling event ${ eventType }`,
+							e
+						);
+					}
 				}
 			} );
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds the following enhancements to the native `Sandbox` component:
- Reference forwarding to the `WebView` component to allow the parent component to inject javascript
- Register event listeners on the `WebView` `window` 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Reference forwarding allows for the parent component to hook into the the `WebView` [methods](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md#methods-index) e.g. injecting JavaScript after the component has mounted
- Registering event listeners on the window allows the parent to respond to `window` events

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Wraps the component in a `forwardRef` call
- Adds a new prop `onWindowEvents` which accepts an object of the form ` { 'event_type' : eventHandlerFunction }`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Follow testing instructions on https://github.com/Automattic/jetpack/pull/29990
- Verify that native embed blocks are performing as expected

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
