### PR TITLE
Make InspectorControls tab labels translatable

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/utils.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/utils.js
@@ -2,10 +2,11 @@
  * WordPress dependencies
  */
 import { cog, styles, listView } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
 
 export const TAB_SETTINGS = {
 	name: 'settings',
-	title: 'Settings',
+	title: __( 'Settings' ),
 	value: 'settings',
 	icon: cog,
 	className: 'block-editor-block-inspector__tab-item',
@@ -13,7 +14,7 @@ export const TAB_SETTINGS = {
 
 export const TAB_STYLES = {
 	name: 'styles',
-	title: 'Styles',
+	title: __( 'Styles' ),
 	value: 'styles',
 	icon: styles,
 	className: 'block-editor-block-inspector__tab-item',
@@ -21,7 +22,7 @@ export const TAB_STYLES = {
 
 export const TAB_LIST_VIEW = {
 	name: 'list',
-	title: 'List View',
+	title: __( 'List View' ),
 	value: 'list-view',
 	icon: listView,
 	className: 'block-editor-block-inspector__tab-item',


### PR DESCRIPTION
## What?
This PR fixes the problem of InsepcotrControls tab titles not being translated.

## How?
Applied `__()` function to the title property.

## Testing Instructions

My understanding is that if the same text exists in the JavaScript code with the translation function applied, and it is translated by GlotPress, it will be translated immediately.

However, if I change the language of the site and update the translation files, somehow only "Styles" is translated.

If anyone knows any reason for this, I would love to know.

---

"List View" label:

![list-view](https://user-images.githubusercontent.com/54422211/230643581-c12e4365-9ae0-4c3c-839c-b8d67e6baa9a.png)

---

"Settings" label:

![settings](https://user-images.githubusercontent.com/54422211/230643592-3affa968-2b6d-4889-9669-e7248e0c7341.png)

"Styles" label: 

![style](https://user-images.githubusercontent.com/54422211/230643602-672db29e-b6f7-433d-acc4-c15e857e5137.png)


