### PR TITLE
Docs: Fix e2e command typos

### DIFF
--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -416,8 +416,8 @@ This is how you execute those scripts using the presented setup:
 
 -   `npm run test:e2e` - runs all e2e tests.
 -   `npm run test:e2e:help` - prints all available options to configure e2e test runner.
--   `npm run test-e2e -- --puppeteer-interactive` - runs all e2e tests interactively.
--   `npm run test-e2e FILE_NAME -- --puppeteer-interactive` - runs one test file interactively.
+-   `npm run test:e2e -- --puppeteer-interactive` - runs all e2e tests interactively.
+-   `npm run test:e2e FILE_NAME -- --puppeteer-interactive` - runs one test file interactively.
 -   `npm run test:e2e:watch -- --puppeteer-interactive` - runs all tests interactively and watch for changes.
 -   `npm run test:e2e:debug` - runs all tests interactively and enables [debugging tests](#debugging-e2e-tests).
 


### PR DESCRIPTION
## What?
Looks like there were 2 typos on some of the e2e commands in the `test-e2e` section 

## Why?
I noticed that the commands were not working when I copy/pasted them while I was going through the doc.

## How?
Just replace `npm run test-e2e` with `npm run test:e2e`. 

This should prevent future folks from getting confused.

## Testing Instructions
1. Go to https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/#test-e2e
2. If you've been following the steps, and copied one of the commands, you will run into an error:
```
➜ npm run test-e2e FILE_NAME -- --puppeteer-interactive
npm ERR! Missing script: "test-e2e"
npm ERR! 
npm ERR! Did you mean this?
npm ERR!     npm run test:e2e # run the "test:e2e" package script
npm ERR! 
npm ERR! To see a list of scripts, run:
npm ERR!   npm run
``` 

### Testing Instructions for Keyboard
Not needed
