### PR TITLE
Update documentation for setGroupingBlockName

### DIFF
--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -911,6 +911,10 @@ _Parameters_
 
 Assigns name of block for handling block grouping interactions.
 
+This function lets you select a different block to group other blocks in instead of the
+default `core/group` block. This function must be used in a component or when the DOM is fully
+loaded. See <https://developer.wordpress.org/block-editor/reference-guides/packages/packages-dom-ready/>
+
 _Usage_
 
 ```js
@@ -919,7 +923,7 @@ import { setGroupingBlockName } from '@wordpress/blocks';
 const ExampleComponent = () => {
 	return (
 		<Button onClick={ () => setGroupingBlockName( 'core/columns' ) }>
-			{ __( 'Set the default block to Heading' ) }
+			{ __( 'Wrap in columns' ) }
 		</Button>
 	);
 };

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -523,6 +523,10 @@ export function setDefaultBlockName( name ) {
 /**
  * Assigns name of block for handling block grouping interactions.
  *
+ * This function lets you select a different block to group other blocks in instead of the
+ * default `core/group` block. This function must be used in a component or when the DOM is fully
+ * loaded. See https://developer.wordpress.org/block-editor/reference-guides/packages/packages-dom-ready/
+ *
  * @param {string} name Block name.
  *
  * @example

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -533,7 +533,7 @@ export function setDefaultBlockName( name ) {
  *
  *     return (
  *         <Button onClick={ () => setGroupingBlockName( 'core/columns' ) }>
- *             { __( 'Set the default block to Heading' ) }
+ *             { __( 'Wrap in columns' ) }
  *         </Button>
  *     );
  * };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The inline documentation for the function `setGroupingBlockName` had incorrect helper text. This update the button text in the `Example Component` to indicate what passing `core/columns` to `setGroupingBlockName` would actually do.

## Why?
The current documentation for this function is confusing since it was probably pulled from the documentation of a different function.

## How?
This updates the wording and adds a bit more explainer text to make this easier to understand.

Here's the change:


>  Assigns name of block for handling block grouping interactions.
>  
>   This function lets you select a different block to group other blocks in instead of the
>   default `core/group` block. This function must be used in a component or when the DOM is fully
>   loaded. See https://developer.wordpress.org/block-editor/reference-guides/packages/packages-dom-ready/
>  
>   @param {string} name Block name.
>  
>   @example
>   ```js
>   import { setGroupingBlockName } from '@wordpress/blocks';
>  
>   const ExampleComponent = () => {
>  
>       return (
>           <Button onClick={ () => setGroupingBlockName( 'core/columns' ) }>
>               { __( 'Wrap in columns' ) }
>           </Button>
>       );
>   };
>   ```