### PR TITLE
e2e: fix flaky columns test

### DIFF
--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -68,6 +68,7 @@ test.describe( 'Columns', () => {
 		await editor.selectBlocks(
 			page.locator( 'role=document[name="Block: Columns"i]' )
 		);
+		await editor.openDocumentSettingsSidebar();
 
 		const columnsChangeInput = page.locator(
 			'role=spinbutton[name="Columns"i]'


### PR DESCRIPTION
Fixes: #49534

Thankfully, @kevin told me about it in [this comment](https://github.com/WordPress/gutenberg/pull/49530#discussion_r1161348258).

## What?
This PR fixes the Playwright test instability reported in #49534 regarding column blocks.

## Why?
Looking at [the artifacts reported in trunk](https://github.com/WordPress/gutenberg/actions/runs/4649439196), it appears that the sidebar is not opened before manipulating the input element to change the number of columns. I guessed that perhaps we need to explicitly run `openDocumentSettingsSidebar()`.

![test-failed-1](https://user-images.githubusercontent.com/54422211/230821777-4a11e1ba-524a-46b0-8873-b8e10fb61c1a.png)

## Testing Instructions

I would like to run the GitHub Action several times and see if the problem is fixed.