### PR TITLE
Use the keyboard shortcuts package for the command center

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17054,6 +17054,7 @@
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/icons": "file:packages/icons",
+				"@wordpress/keyboard-shortcuts": "file:packages/keyboard-shortcuts",
 				"@wordpress/private-apis": "file:packages/private-apis",
 				"cmdk": "^0.2.0",
 				"rememo": "^4.0.0"
@@ -28907,7 +28908,7 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
 			"dev": true
 		},
 		"code-point-at": {
@@ -30484,7 +30485,7 @@
 		"css.escape": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-			"integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+			"integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
 			"dev": true
 		},
 		"cssesc": {
@@ -41060,7 +41061,7 @@
 		"lz-string": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-			"integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
+			"integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
 			"dev": true
 		},
 		"macos-release": {

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -32,6 +32,7 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
+		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/private-apis": "file:../private-apis",
 		"cmdk": "^0.2.0",
 		"rememo": "^4.0.0"

--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -6,10 +6,14 @@ import { Command } from 'cmdk';
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Modal, TextHighlight } from '@wordpress/components';
+import {
+	store as keyboardShortcutsStore,
+	useShortcut,
+} from '@wordpress/keyboard-shortcuts';
 
 /**
  * Internal dependencies
@@ -116,6 +120,7 @@ export function CommandMenuGroup( { group, search, setLoader, close } ) {
 }
 
 export function CommandMenu() {
+	const { registerShortcut } = useDispatch( keyboardShortcutsStore );
 	const [ search, setSearch ] = useState( '' );
 	const [ open, setOpen ] = useState( false );
 	const { groups } = useSelect( ( select ) => {
@@ -126,18 +131,21 @@ export function CommandMenu() {
 	}, [] );
 	const [ loaders, setLoaders ] = useState( {} );
 
-	// Toggle the menu when Meta-K is pressed
 	useEffect( () => {
-		const toggleOnMetaK = ( e ) => {
-			if ( e.key === 'k' && e.metaKey ) {
-				setOpen( ( prevOpen ) => ! prevOpen );
-				e.preventDefault();
-			}
-		};
+		registerShortcut( {
+			name: 'core/commands',
+			category: 'global',
+			description: __( 'Open the global command menu' ),
+			keyCombination: {
+				modifier: 'primary',
+				character: 'k',
+			},
+		} );
+	}, [ registerShortcut ] );
 
-		document.addEventListener( 'keydown', toggleOnMetaK );
-		return () => document.removeEventListener( 'keydown', toggleOnMetaK );
-	}, [] );
+	useShortcut( 'core/commands', () => setOpen( ( prevOpen ) => ! prevOpen ), {
+		bindGlobal: true,
+	} );
 
 	const setLoader = useCallback(
 		( name, value ) =>

--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -143,9 +143,16 @@ export function CommandMenu() {
 		} );
 	}, [ registerShortcut ] );
 
-	useShortcut( 'core/commands', () => setOpen( ( prevOpen ) => ! prevOpen ), {
-		bindGlobal: true,
-	} );
+	useShortcut(
+		'core/commands',
+		( event ) => {
+			event.preventDefault();
+			setOpen( ( prevOpen ) => ! prevOpen );
+		},
+		{
+			bindGlobal: true,
+		}
+	);
 
 	const setLoader = useCallback(
 		( name, value ) =>


### PR DESCRIPTION
Related to https://github.com/WordPress/gutenberg/issues/48457

## What?

This PR updates the command center to rely on the keyboard shortcuts to define its cmd+k shortcut. This allows the shortcut to work in all operating systems and also it shows the shortcut in the "shortcuts modal" of the editor.

## Testing Instructions

1- Open the experiments page and enable the command center.
2- Open the site editor and focus the page.
3- Use cmd+k or ctrl+k (I guess) depending on your operating system (you might want to check the right combination in the keyboard shortcuts modal)
4- The command center should show up.