### PR TITLE
Fix inbetween-inserter position in RTL languages

### DIFF
--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -4,6 +4,7 @@
 import { useRefEffect } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useContext } from '@wordpress/element';
+import { isRTL } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -93,7 +94,9 @@ export function useInBetweenInserter() {
 							blockElRect.top > offsetTop ) ||
 						( blockEl.classList.contains( 'wp-block' ) &&
 							orientation === 'horizontal' &&
-							blockElRect.left > offsetLeft )
+							( isRTL()
+								? blockElRect.right < offsetLeft
+								: blockElRect.left > offsetLeft ) )
 					);
 				} );
 

--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -106,16 +106,7 @@ function BlockPopoverInbetween( {
 						nextRect && previousRect
 							? nextRect.top - previousRect.bottom
 							: 0;
-
-					if ( isRTL() ) {
-						// vertical, rtl
-						left = previousRect
-							? previousRect.right
-							: nextRect.right;
-					} else {
-						// vertical, ltr
-						left = previousRect ? previousRect.left : nextRect.left;
-					}
+					left = previousRect ? previousRect.left : nextRect.left;
 				} else {
 					top = previousRect ? previousRect.top : nextRect.top;
 					height = previousRect
@@ -124,9 +115,7 @@ function BlockPopoverInbetween( {
 
 					if ( isRTL() ) {
 						// non vertical, rtl
-						left = previousRect
-							? previousRect.left
-							: nextRect.right;
+						left = nextRect ? nextRect.right : previousRect.left;
 						width =
 							previousRect && nextRect
 								? previousRect.left - nextRect.right


### PR DESCRIPTION
closes #30867 

## What?

This PR fixes the position of the inbetween inserter in both vertical and horizontal position for RTL languages.

<img width="752" alt="Screenshot 2023-04-10 at 11 34 37 AM" src="https://user-images.githubusercontent.com/272444/230885723-1acdba3d-6531-4b79-948f-302e2aaaa745.png">

## Testing Instructions

1- Switch to an RTL language (like arabic)
2- Insert two paragraphs and verify that you can trigger the in-between inserter at the right position
3- Insert a social links block with at least two links and verify that you can trigger the in-between horizontal inserter between two buttons.

I also noticed that if you use the "slash" inserter, the initial position is correct but as soon as you start typing, the position is wrong. I think that's unrelated with the issue being fixed here though and might be some race condition within "Popover" component.