### PR TITLE
Site Editor: Decode the site title properly

### DIFF
--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { forwardRef } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -96,7 +97,7 @@ const SiteHub = forwardRef( ( props, ref ) => {
 
 				{ showLabels && (
 					<div className="edit-site-site-hub__site-title">
-						{ siteTitle }
+						{ decodeEntities( siteTitle ) }
 					</div>
 				) }
 			</HStack>


### PR DESCRIPTION
closes #49684

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0dc2fae</samp>

This pull request fixes a bug where the site title could show HTML entities in the site hub component. It uses the `decodeEntities` function from `@wordpress/html-entities` to render the title correctly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0dc2fae</samp>

> _`decodeEntities` in the site hub_
> _Breaking the chains of HTML_
> _No more lies in the site title_
> _Only the truth shall prevail_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0dc2fae</samp>

* Import and apply `decodeEntities` function to `siteTitle` variable in site hub component ([link](https://github.com/WordPress/gutenberg/pull/49685/files?diff=unified&w=0#diff-9dd774fe20a86a51fbcd56da7dbca8edc928df53de05a9e9bbee418083b86997R20), [link](https://github.com/WordPress/gutenberg/pull/49685/files?diff=unified&w=0#diff-9dd774fe20a86a51fbcd56da7dbca8edc928df53de05a9e9bbee418083b86997L99-R100))