### PR TITLE
Components: exclude mobile-only PRs from CHANGELOG update CI check

### DIFF
--- a/.github/workflows/check-components-changelog.yml
+++ b/.github/workflows/check-components-changelog.yml
@@ -10,6 +10,7 @@ on:
             - '!packages/components/src/**/*.android.js'
             - '!packages/components/src/**/*.ios.js'
             - '!packages/components/src/**/*.native.js'
+            - '!packages/components/src/**/*.native.scss'
             - '!packages/components/src/**/react-native-*'
 jobs:
     check:

--- a/.github/workflows/check-components-changelog.yml
+++ b/.github/workflows/check-components-changelog.yml
@@ -6,7 +6,7 @@ on:
         paths:
             - 'packages/components/**'
             - '!packages/components/src/**/stories/**'
-            - '!packages/components/src**/test/**'
+            - '!packages/components/src/**/test/**'
 jobs:
     check:
         name: Check CHANGELOG diff

--- a/.github/workflows/check-components-changelog.yml
+++ b/.github/workflows/check-components-changelog.yml
@@ -7,6 +7,10 @@ on:
             - 'packages/components/**'
             - '!packages/components/src/**/stories/**'
             - '!packages/components/src/**/test/**'
+            - '!packages/components/src/**/*.android.js'
+            - '!packages/components/src/**/*.ios.js'
+            - '!packages/components/src/**/*.native.js'
+            - '!packages/components/src/**/react-native-*'
 jobs:
     check:
         name: Check CHANGELOG diff


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Excludes PRs changing only mobile/native files from the CI check for CHANGELOG updates

## Why?
First noticed [here](https://github.com/WordPress/gutenberg/pull/49443#issuecomment-1501636438), this check doesn't fit with the mobile team's current workflow, causing their PRs to fail unexpectedly.

## How?
Sets the workflow to not run if all of the changed files are native/mobile, using the [existing paths](https://github.com/WordPress/gutenberg/blob/8528e49ade84827d276514b2252d7722d03a815e/packages/components/tsconfig.json#L41-L44) from the package's `ts-config` exclusion as a guide. I've also added an exclusion for `*.native.scss` files, which wouldn't be covered.

## Note
As mentioned above, I've used `ts-config`'s exclusions as a starting point, but I don't think there are actually any `react-native-*` directories in the package at the moment. I'm not sure if that makes it a good exclusion to include, or if it's obsolete and can be skipped.

## Testing Instructions
1. Check out this PR, and create a new branch of off it
2. Update component files matching the modified paths:
  - at least one `*.native.js`, `*.native.scss`, `*.ios.js`, and `*.android.js` file
  - at least one file file in a `react-native-*` folder (you'll need to create one, as I don't think there are currently any in the package)
3. Push your changes and open a test PR. Confirm that the changelog verification check is not run.
4. Modify a non-mobile component file
5. Push you changes and confirm that the check does run as expected