### PR TITLE
[RNMobile] Disable block's touchable component when is focused

### DIFF
--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -215,7 +215,7 @@ class BlockListBlock extends Component {
 			order + 1
 		);
 		const { isFullWidth, isContainerRelated } = alignmentHelpers;
-		const accessible = ! ( isSelected || isInnerBlockSelected );
+		const isFocused = isSelected || isInnerBlockSelected;
 		const screenWidth = Math.floor( Dimensions.get( 'window' ).width );
 		const isScreenWidthEqual = blockWidth === screenWidth;
 		const isScreenWidthWider = blockWidth < screenWidth;
@@ -224,8 +224,9 @@ class BlockListBlock extends Component {
 		return (
 			<TouchableWithoutFeedback
 				onPress={ this.onFocus }
-				accessible={ accessible }
+				accessible={ ! isFocused }
 				accessibilityRole={ 'button' }
+				disabled={ isFocused }
 			>
 				<View
 					style={ { flex: 1 } }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Disables the touchable component (`TouchableWithoutFeedback`) used in `BlockListBlock` component to gain focus when the block is already focused (i.e. selected or has an inner block selected).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

On Android, we detected that touchable components, like `TouchableWithoutFeedback`, can disrupt touch events of inner components. Specifically, elements rendered within WebViews don't receive properly the touch events and break interaction of embedded content.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

When a block is focused (i.e. selected or has an inner block selected), the `TouchableWithoutFeedback` component, used to gain focus and select the block, is disabled via [the `disabled` prop](https://reactnative.dev/docs/0.66/touchablewithoutfeedback#disabled). This change shouldn't introduce regressions as it's expected that selected blocks don't get selected again:
https://github.com/WordPress/gutenberg/blob/38c1276bd74bc57e58180bdfb55e679dbecc3254/packages/block-editor/src/components/block-list/block.native.js#L132-L137

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Blocks can be selected
1. Create/open a post.
2. Add different types of blocks.
3. Observe that tapping on blocks makes them be selected and previous blocks are unselected.

### Inner blocks can be selected
1. Create/open a post.
2. Add different types of blocks.
3. Add container blocks like the Group or Column block and add different types of blocks to them.
4. Observe that tapping on blocks makes them be selected and previous blocks are unselected.
5. Observe that tapping on inner blocks makes them be selected and previous blocks are unselected.
N/A

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A
