### PR TITLE
Spinner: Enforce no background.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 -   `DropZone`: Smooth animation ([#49517](https://github.com/WordPress/gutenberg/pull/49517)).
 -   `Navigator`: Add `skipFocus` property in `NavigateOptions`. ([#49350](https://github.com/WordPress/gutenberg/pull/49350)).
+-   `Spinner`: add explicit opacity and background styles ([#49695](https://github.com/WordPress/gutenberg/pull/49695)).
 
 ### Bug Fix
 

--- a/packages/components/src/spinner/styles.ts
+++ b/packages/components/src/spinner/styles.ts
@@ -26,6 +26,7 @@ export const StyledSpinner = styled.svg`
 	position: relative;
 	color: ${ COLORS.ui.theme };
 	overflow: visible;
+	background-color: none;
 `;
 
 const commonPathProps = css`

--- a/packages/components/src/spinner/styles.ts
+++ b/packages/components/src/spinner/styles.ts
@@ -26,6 +26,7 @@ export const StyledSpinner = styled.svg`
 	position: relative;
 	color: ${ COLORS.ui.theme };
 	overflow: visible;
+	opacity: 1;
 	background-color: none;
 `;
 

--- a/packages/components/src/spinner/styles.ts
+++ b/packages/components/src/spinner/styles.ts
@@ -27,7 +27,7 @@ export const StyledSpinner = styled.svg`
 	color: ${ COLORS.ui.theme };
 	overflow: visible;
 	opacity: 1;
-	background-color: none;
+	background-color: transparent;
 `;
 
 const commonPathProps = css`

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -595,6 +595,8 @@ exports[`PostPublishPanel should render the spinner if the post is being saved 1
   position: relative;
   color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
   overflow: visible;
+  opacity: 1;
+  background-color: transparent;
 }
 
 .emotion-2 {


### PR DESCRIPTION
## What?

In some environments, or when you have certain plugins active, the Spinner component can inherit a legacy background color from other spinners that share the `components-spinner` class name. In those cases, they might look like this:

<img width="160" alt="before" src="https://user-images.githubusercontent.com/1204802/230952757-6ece9418-bafb-475a-9c11-647ed14f1c82.png">

... when they should look like this:

<img width="87" alt="after" src="https://user-images.githubusercontent.com/1204802/230952788-88700ea5-5172-4b1b-8560-5093767bc552.png">

This PR adds an explicit "no background" rule, that should at lest prevent the CSS bleed.

Here's an example of CSS that might get inherited:

<img width="313" alt="Screenshot 2023-04-10 at 18 58 49" src="https://user-images.githubusercontent.com/1204802/230952916-b93973d8-f83c-4401-abe3-1bc5c4f7cf1d.png">

## Testing Instructions

If you're able to test in a Calypso environment, you should see no gray background behind the spinner.