### PR TITLE
[RNMobile] Add viewport optional props

### DIFF
--- a/packages/components/src/sandbox/index.native.js
+++ b/packages/components/src/sandbox/index.native.js
@@ -98,7 +98,6 @@ const observeAndResizeJS = `
 		// get an DOM mutations for that, so do the resize when the window is resized, too.
 		window.addEventListener( 'resize', sendResize, true );
 		window.addEventListener( 'orientationchange', sendResize, true );
-		widow.addEventListener( 'click', sendResize, true );
 	})();
 `;
 

--- a/packages/components/src/sandbox/index.native.js
+++ b/packages/components/src/sandbox/index.native.js
@@ -182,6 +182,7 @@ function Sandbox( {
 	title = '',
 	type,
 	url,
+	viewportProps = '',
 } ) {
 	const colorScheme = usePreferredColorScheme();
 	const ref = useRef();
@@ -215,7 +216,7 @@ function Sandbox( {
 					<title>{ title }</title>
 					<meta
 						name="viewport"
-						content="width=device-width, initial-scale=1"
+						content={ `width=device-width, initial-scale=1, ${ viewportProps }` }
 					></meta>
 					<style dangerouslySetInnerHTML={ { __html: style } } />
 					{ styles.map( ( rules, i ) => (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds a the `viewportProps` prop to the `Sandbox `component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
There are cases where the owner of a `Sandbox` needs to control the html viewport. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds a prop to the `Sandbox` that is added to the default viewport settings. 


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Verify the change  does not introduce any regression issues.
- Open a post with an embed block
- Verify that block renders as expected

Feature testing is TBD

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
