### PR TITLE
Components: update `ColorPicker` unit tests

### DIFF
--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -9,17 +9,6 @@ import userEvent from '@testing-library/user-event';
  */
 import { ColorPicker } from '..';
 
-function getFormatSelector( container: HTMLElement ) {
-	return container.querySelector( '.components-select-control__input' );
-}
-
-function getInputByClass(
-	container: HTMLElement,
-	className: string
-): HTMLInputElement | null {
-	return container.querySelector( className );
-}
-
 const hslaMatcher = expect.objectContaining( {
 	h: expect.any( Number ),
 	s: expect.any( Number ),
@@ -53,7 +42,7 @@ describe( 'ColorPicker', () => {
 			const onChangeComplete = jest.fn();
 			const color = '#000';
 
-			const { container } = render(
+			render(
 				<ColorPicker
 					onChangeComplete={ onChangeComplete }
 					color={ color }
@@ -61,7 +50,7 @@ describe( 'ColorPicker', () => {
 				/>
 			);
 
-			const formatSelector = getFormatSelector( container );
+			const formatSelector = screen.getByRole( 'combobox' );
 
 			if ( formatSelector === null ) {
 				throw new Error(
@@ -73,10 +62,7 @@ describe( 'ColorPicker', () => {
 
 			await user.selectOptions( formatSelector, 'hex' );
 
-			const hexInput = getInputByClass(
-				container,
-				'.components-base-control.components-input-control input'
-			);
+			const hexInput = screen.getByRole( 'textbox' );
 
 			if ( hexInput === null ) {
 				throw new Error(
@@ -101,7 +87,7 @@ describe( 'ColorPicker', () => {
 			const onChange = jest.fn();
 			const color = '#000';
 
-			const { container } = render(
+			render(
 				<ColorPicker
 					onChange={ onChange }
 					color={ color }
@@ -109,7 +95,7 @@ describe( 'ColorPicker', () => {
 				/>
 			);
 
-			const formatSelector = getFormatSelector( container );
+			const formatSelector = screen.getByRole( 'combobox' );
 
 			if ( formatSelector === null ) {
 				throw new Error(
@@ -121,10 +107,7 @@ describe( 'ColorPicker', () => {
 
 			await user.selectOptions( formatSelector, 'hex' );
 
-			const hexInput = getInputByClass(
-				container,
-				'.components-base-control.components-input-control input'
-			);
+			const hexInput = screen.getByRole( 'textbox' );
 
 			if ( hexInput === null ) {
 				throw new Error(
@@ -152,7 +135,7 @@ describe( 'ColorPicker', () => {
 			const onChange = jest.fn();
 			const color = '#fff';
 
-			const { container } = render(
+			render(
 				<ColorPicker
 					onChange={ onChange }
 					color={ color }
@@ -160,7 +143,7 @@ describe( 'ColorPicker', () => {
 				/>
 			);
 
-			const formatSelector = getFormatSelector( container );
+			const formatSelector = screen.getByRole( 'combobox' );
 
 			if ( formatSelector === null ) {
 				throw new Error(
@@ -201,7 +184,7 @@ describe( 'ColorPicker', () => {
 			const onChange = jest.fn();
 			const color = '#2ad5d5';
 
-			const { container } = render(
+			render(
 				<ColorPicker
 					onChange={ onChange }
 					color={ color }
@@ -209,7 +192,7 @@ describe( 'ColorPicker', () => {
 				/>
 			);
 
-			const formatSelector = getFormatSelector( container );
+			const formatSelector = screen.getByRole( 'combobox' );
 
 			if ( formatSelector === null ) {
 				throw new Error(

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -269,4 +269,52 @@ describe( 'ColorPicker', () => {
 			expect( onChange ).toHaveBeenLastCalledWith( expected );
 		} );
 	} );
+	describe.each( [
+		[ 'hue', 0, '#aad52a' ],
+		[ 'saturation', 1, '#20dfdf' ],
+		[ 'lightness', 2, '#95eaea' ],
+	] )( 'HSL inputs', ( colorInput, inputIndex, expected ) => {
+		it( `should fire onChange with the correct value when the ${ colorInput } value is updated`, async () => {
+			const user = userEvent.setup();
+			const onChange = jest.fn();
+			const color = '#2ad5d5';
+
+			const { container } = render(
+				<ColorPicker
+					onChange={ onChange }
+					color={ color }
+					enableAlpha={ false }
+				/>
+			);
+
+			const formatSelector = getFormatSelector( container );
+
+			if ( formatSelector === null ) {
+				throw new Error(
+					'The color format selector could not be found'
+				);
+			}
+
+			expect( formatSelector ).toBeInTheDocument();
+
+			await user.selectOptions( formatSelector, 'hsl' );
+
+			const inputElement =
+				screen.getAllByRole( 'spinbutton' )[ inputIndex ];
+
+			if ( inputElement === null ) {
+				throw new Error(
+					`The ${ colorInput } input could not be found`
+				);
+			}
+
+			expect( inputElement ).toBeInTheDocument();
+
+			await user.clear( inputElement );
+			await user.type( inputElement, '75' );
+
+			expect( onChange ).toHaveBeenCalledTimes( 3 );
+			expect( onChange ).toHaveBeenLastCalledWith( expected );
+		} );
+	} );
 } );

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -95,46 +95,51 @@ describe( 'ColorPicker', () => {
 			);
 		} );
 	} );
+	describe( 'Hex input', () => {
+		it( 'should fire onChange with the correct value from the hex input', async () => {
+			const user = userEvent.setup();
+			const onChange = jest.fn();
+			const color = '#000';
 
-	it( 'should fire onChange with the correct value from the hex input', async () => {
-		const user = userEvent.setup();
-		const onChange = jest.fn();
-		const color = '#000';
+			const { container } = render(
+				<ColorPicker
+					onChange={ onChange }
+					color={ color }
+					enableAlpha={ false }
+				/>
+			);
 
-		const { container } = render(
-			<ColorPicker
-				onChange={ onChange }
-				color={ color }
-				enableAlpha={ false }
-			/>
-		);
+			const formatSelector = getFormatSelector( container );
 
-		const formatSelector = getFormatSelector( container );
+			if ( formatSelector === null ) {
+				throw new Error(
+					'The color format selector could not be found'
+				);
+			}
 
-		if ( formatSelector === null ) {
-			throw new Error( 'The color format selector could not be found' );
-		}
+			expect( formatSelector ).toBeInTheDocument();
 
-		expect( formatSelector ).toBeInTheDocument();
+			await user.selectOptions( formatSelector, 'hex' );
 
-		await user.selectOptions( formatSelector, 'hex' );
+			const hexInput = getInputByClass(
+				container,
+				'.components-base-control.components-input-control input'
+			);
 
-		const hexInput = getInputByClass(
-			container,
-			'.components-base-control.components-input-control input'
-		);
+			if ( hexInput === null ) {
+				throw new Error(
+					'The color format selector could not be found'
+				);
+			}
 
-		if ( hexInput === null ) {
-			throw new Error( 'The color format selector could not be found' );
-		}
+			expect( hexInput ).toBeInTheDocument();
 
-		expect( hexInput ).toBeInTheDocument();
+			await user.clear( hexInput );
+			await user.type( hexInput, '1ab' );
 
-		await user.clear( hexInput );
-		await user.type( hexInput, '1ab' );
-
-		expect( onChange ).toHaveBeenCalledTimes( 3 );
-		expect( onChange ).toHaveBeenLastCalledWith( '#11aabb' );
+			expect( onChange ).toHaveBeenCalledTimes( 3 );
+			expect( onChange ).toHaveBeenLastCalledWith( '#11aabb' );
+		} );
 	} );
 
 	describe.each( [

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { screen, render, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -220,5 +220,53 @@ describe( 'ColorPicker', () => {
 
 		expect( onChange ).toHaveBeenCalledTimes( 3 );
 		expect( onChange ).toHaveBeenLastCalledWith( '#11aabb' );
+	} );
+	describe.each( [
+		[ 'red', 0, '#7dffff' ],
+		[ 'green', 1, '#ff7dff' ],
+		[ 'blue', 2, '#ffff7d' ],
+	] )( 'RGB inputs', ( colorInput, inputIndex, expected ) => {
+		it( `should fire onChange with the correct value when the ${ colorInput } value is updated`, async () => {
+			const user = userEvent.setup();
+			const onChange = jest.fn();
+			const color = '#fff';
+
+			const { container } = render(
+				<ColorPicker
+					onChange={ onChange }
+					color={ color }
+					enableAlpha={ false }
+				/>
+			);
+
+			const formatSelector = getFormatSelector( container );
+
+			if ( formatSelector === null ) {
+				throw new Error(
+					'The color format selector could not be found'
+				);
+			}
+
+			expect( formatSelector ).toBeInTheDocument();
+
+			await user.selectOptions( formatSelector, 'rgb' );
+
+			const inputElement =
+				screen.getAllByRole( 'spinbutton' )[ inputIndex ];
+
+			if ( inputElement === null ) {
+				throw new Error(
+					`The ${ colorInput } input could not be found`
+				);
+			}
+
+			expect( inputElement ).toBeInTheDocument();
+
+			await user.clear( inputElement );
+			await user.type( inputElement, '125' );
+
+			expect( onChange ).toHaveBeenCalledTimes( 4 );
+			expect( onChange ).toHaveBeenLastCalledWith( expected );
+		} );
 	} );
 } );

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -119,68 +119,6 @@ describe( 'ColorPicker', () => {
 		} );
 	} );
 
-	it( 'should fire onChange with the string value', async () => {
-		const onChange = jest.fn();
-		const color = 'rgba(1, 1, 1, 0.5)';
-
-		const { container } = render(
-			<ColorPicker onChange={ onChange } color={ color } enableAlpha />
-		);
-
-		const saturation = getSaturation( container );
-
-		if ( saturation === null ) {
-			throw new Error( 'The saturation slider could not be found' );
-		}
-
-		expect( saturation ).toBeInTheDocument();
-
-		moveReactColorfulSlider(
-			saturation,
-			{ pageX: 0, pageY: 0 },
-			{ pageX: 10, pageY: 10 }
-		);
-
-		await waitFor( () => expect( onChange ).toHaveBeenCalled() );
-
-		expect( onChange ).toHaveBeenCalledWith(
-			expect.stringMatching( /^#([a-fA-F0-9]{8})$/ )
-		);
-	} );
-
-	it( 'should fire onChange with the HSL value', async () => {
-		const onChange = jest.fn();
-		const color = 'hsla(125, 20%, 50%, 0.5)';
-
-		const { container } = render(
-			<ColorPicker
-				onChange={ onChange }
-				color={ color }
-				enableAlpha={ false }
-			/>
-		);
-
-		const saturation = getSaturation( container );
-
-		if ( saturation === null ) {
-			throw new Error( 'The saturation slider could not be found' );
-		}
-
-		expect( saturation ).toBeInTheDocument();
-
-		moveReactColorfulSlider(
-			saturation,
-			{ pageX: 0, pageY: 0 },
-			{ pageX: 10, pageY: 10 }
-		);
-
-		await waitFor( () => expect( onChange ).toHaveBeenCalled() );
-
-		expect( onChange ).toHaveBeenCalledWith(
-			expect.stringMatching( /^#([a-fA-F0-9]{6})$/ )
-		);
-	} );
-
 	it( 'should fire onChange with the correct value from the hex input', async () => {
 		const user = userEvent.setup();
 		const onChange = jest.fn();
@@ -221,6 +159,7 @@ describe( 'ColorPicker', () => {
 		expect( onChange ).toHaveBeenCalledTimes( 3 );
 		expect( onChange ).toHaveBeenLastCalledWith( '#11aabb' );
 	} );
+
 	describe.each( [
 		[ 'red', 0, '#7dffff' ],
 		[ 'green', 1, '#ff7dff' ],
@@ -269,6 +208,7 @@ describe( 'ColorPicker', () => {
 			expect( onChange ).toHaveBeenLastCalledWith( expected );
 		} );
 	} );
+
 	describe.each( [
 		[ 'hue', 0, '#aad52a' ],
 		[ 'saturation', 1, '#20dfdf' ],

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -20,6 +20,17 @@ function getSaturation( container: HTMLElement ) {
 	);
 }
 
+function getFormatSelector( container: HTMLElement ) {
+	return container.querySelector( '.components-select-control__input' );
+}
+
+function getInputByClass(
+	container: HTMLElement,
+	className: string
+): HTMLInputElement | null {
+	return container.querySelector( className );
+}
+
 type PageXPageY = { pageX: number; pageY: number };
 
 // Fix to pass `pageX` and `pageY`

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -178,5 +179,46 @@ describe( 'ColorPicker', () => {
 		expect( onChange ).toHaveBeenCalledWith(
 			expect.stringMatching( /^#([a-fA-F0-9]{6})$/ )
 		);
+	} );
+
+	it( 'should fire onChange with the correct value from the hex input', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+		const color = '#000';
+
+		const { container } = render(
+			<ColorPicker
+				onChange={ onChange }
+				color={ color }
+				enableAlpha={ false }
+			/>
+		);
+
+		const formatSelector = getFormatSelector( container );
+
+		if ( formatSelector === null ) {
+			throw new Error( 'The color format selector could not be found' );
+		}
+
+		expect( formatSelector ).toBeInTheDocument();
+
+		await user.selectOptions( formatSelector, 'hex' );
+
+		const hexInput = getInputByClass(
+			container,
+			'.components-base-control.components-input-control input'
+		);
+
+		if ( hexInput === null ) {
+			throw new Error( 'The color format selector could not be found' );
+		}
+
+		expect( hexInput ).toBeInTheDocument();
+
+		await user.clear( hexInput );
+		await user.type( hexInput, '1ab' );
+
+		expect( onChange ).toHaveBeenCalledTimes( 3 );
+		expect( onChange ).toHaveBeenLastCalledWith( '#11aabb' );
 	} );
 } );

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -51,26 +51,12 @@ describe( 'ColorPicker', () => {
 			);
 
 			const formatSelector = screen.getByRole( 'combobox' );
-
-			if ( formatSelector === null ) {
-				throw new Error(
-					'The color format selector could not be found'
-				);
-			}
-
-			expect( formatSelector ).toBeInTheDocument();
+			expect( formatSelector ).toBeVisible();
 
 			await user.selectOptions( formatSelector, 'hex' );
 
 			const hexInput = screen.getByRole( 'textbox' );
-
-			if ( hexInput === null ) {
-				throw new Error(
-					'The color format selector could not be found'
-				);
-			}
-
-			expect( hexInput ).toBeInTheDocument();
+			expect( hexInput ).toBeVisible();
 
 			await user.clear( hexInput );
 			await user.type( hexInput, '1ab' );
@@ -96,26 +82,12 @@ describe( 'ColorPicker', () => {
 			);
 
 			const formatSelector = screen.getByRole( 'combobox' );
-
-			if ( formatSelector === null ) {
-				throw new Error(
-					'The color format selector could not be found'
-				);
-			}
-
-			expect( formatSelector ).toBeInTheDocument();
+			expect( formatSelector ).toBeVisible();
 
 			await user.selectOptions( formatSelector, 'hex' );
 
 			const hexInput = screen.getByRole( 'textbox' );
-
-			if ( hexInput === null ) {
-				throw new Error(
-					'The color format selector could not be found'
-				);
-			}
-
-			expect( hexInput ).toBeInTheDocument();
+			expect( hexInput ).toBeVisible();
 
 			await user.clear( hexInput );
 			await user.type( hexInput, '1ab' );
@@ -144,27 +116,13 @@ describe( 'ColorPicker', () => {
 			);
 
 			const formatSelector = screen.getByRole( 'combobox' );
-
-			if ( formatSelector === null ) {
-				throw new Error(
-					'The color format selector could not be found'
-				);
-			}
-
-			expect( formatSelector ).toBeInTheDocument();
+			expect( formatSelector ).toBeVisible();
 
 			await user.selectOptions( formatSelector, 'rgb' );
 
 			const inputElement =
 				screen.getAllByRole( 'spinbutton' )[ inputIndex ];
-
-			if ( inputElement === null ) {
-				throw new Error(
-					`The ${ colorInput } input could not be found`
-				);
-			}
-
-			expect( inputElement ).toBeInTheDocument();
+			expect( inputElement ).toBeVisible();
 
 			await user.clear( inputElement );
 			await user.type( inputElement, '125' );
@@ -193,27 +151,13 @@ describe( 'ColorPicker', () => {
 			);
 
 			const formatSelector = screen.getByRole( 'combobox' );
-
-			if ( formatSelector === null ) {
-				throw new Error(
-					'The color format selector could not be found'
-				);
-			}
-
-			expect( formatSelector ).toBeInTheDocument();
+			expect( formatSelector ).toBeVisible();
 
 			await user.selectOptions( formatSelector, 'hsl' );
 
 			const inputElement =
 				screen.getAllByRole( 'spinbutton' )[ inputIndex ];
-
-			if ( inputElement === null ) {
-				throw new Error(
-					`The ${ colorInput } input could not be found`
-				);
-			}
-
-			expect( inputElement ).toBeInTheDocument();
+			expect( inputElement ).toBeVisible();
 
 			await user.clear( inputElement );
 			await user.type( inputElement, '75' );

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -98,10 +98,10 @@ describe( 'ColorPicker', () => {
 	} );
 
 	describe.each( [
-		[ 'red', 0, '#7dffff' ],
-		[ 'green', 1, '#ff7dff' ],
-		[ 'blue', 2, '#ffff7d' ],
-	] )( 'RGB inputs', ( colorInput, inputIndex, expected ) => {
+		[ 'red', 'Red', '#7dffff' ],
+		[ 'green', 'Green', '#ff7dff' ],
+		[ 'blue', 'Blue', '#ffff7d' ],
+	] )( 'RGB inputs', ( colorInput, inputLabel, expected ) => {
 		it( `should fire onChange with the correct value when the ${ colorInput } value is updated`, async () => {
 			const user = userEvent.setup();
 			const onChange = jest.fn();
@@ -120,8 +120,9 @@ describe( 'ColorPicker', () => {
 
 			await user.selectOptions( formatSelector, 'rgb' );
 
-			const inputElement =
-				screen.getAllByRole( 'spinbutton' )[ inputIndex ];
+			const inputElement = screen.getByRole( 'spinbutton', {
+				name: inputLabel,
+			} );
 			expect( inputElement ).toBeVisible();
 
 			await user.clear( inputElement );
@@ -133,10 +134,10 @@ describe( 'ColorPicker', () => {
 	} );
 
 	describe.each( [
-		[ 'hue', 0, '#aad52a' ],
-		[ 'saturation', 1, '#20dfdf' ],
-		[ 'lightness', 2, '#95eaea' ],
-	] )( 'HSL inputs', ( colorInput, inputIndex, expected ) => {
+		[ 'hue', 'Hue', '#aad52a' ],
+		[ 'saturation', 'Saturation', '#20dfdf' ],
+		[ 'lightness', 'Lightness', '#95eaea' ],
+	] )( 'HSL inputs', ( colorInput, inputLabel, expected ) => {
 		it( `should fire onChange with the correct value when the ${ colorInput } value is updated`, async () => {
 			const user = userEvent.setup();
 			const onChange = jest.fn();
@@ -155,8 +156,9 @@ describe( 'ColorPicker', () => {
 
 			await user.selectOptions( formatSelector, 'hsl' );
 
-			const inputElement =
-				screen.getAllByRole( 'spinbutton' )[ inputIndex ];
+			const inputElement = screen.getByRole( 'spinbutton', {
+				name: inputLabel,
+			} );
 			expect( inputElement ).toBeVisible();
 
 			await user.clear( inputElement );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates `ColorPicker`'s unit tests to provide more meaningful feedback, and replace `fireEvent` with `userEvent`.

## Why?
The existing tests attempted to manipulate the two-dimensional color picker, and would check to see if `onChange` was fired with a hex or a hex8.

While attempting to migrate these tests from `fireEvent` to `userEvent` I found that while they might fire with the right format, it was never actually the correct color. It was always `#000000`, optionally with two more digits for the alpha value. Chatting with @ciampo and @jsnajdr revealed that this is due to JSDOM not rendering layout, so moving slider handle between coordinates isn't actually possible.

If I recall correctly, this led to a fun bug where trying to slide a slider resulted in effectively toggling it between 0 and infinity... strangeness ensued and long story longer, the existing tests weren't actually functioning as they appeared to be.

The new/updated tests aim to focus on the inputs our unit tests can get accurate data from.

## How?
The individual inputs for hex, rgb, and hsl inputs are all tested independently. The existing test for legacy props (which uses a different internal format for color values and different callback when the value changes) has been updated as well.

I had initially hoped to also test the inputs as a group (e.g. updating all three rgb values and confirming the correct color was called) but this didn't prove possible. When updating the second or third value, the previous value(s) always reset to zero. I suspect this is happening due to the physical slider being updated to match the value entered by the test, which fails because of the no-layout issue I've described above.

## Followup

I'd like to add another test for the `Copy` button, but I wasn't quite sure how to properly mock it. Rather than delay this PR, I'll put this on a list to come back to later.

## Testing Instructions
Confirm unit tests pass
