### PR TITLE
[RNMobile] Add viewport optional props 

### DIFF
--- a/packages/components/src/sandbox/index.native.js
+++ b/packages/components/src/sandbox/index.native.js
@@ -218,7 +218,7 @@ const Sandbox = forwardRef( function Sandbox(
 		// Avoid comma issues with props.viewportProps.
 		const addViewportProps = viewportProps
 			.trim()
-			.replace( /(^[^,]) /, ', $1' );
+			.replace( /(^[^,])/, ', $1' );
 
 		const htmlDoc = (
 			<html lang={ lang }>

--- a/packages/components/src/sandbox/index.native.js
+++ b/packages/components/src/sandbox/index.native.js
@@ -226,7 +226,7 @@ const Sandbox = forwardRef( function Sandbox(
 					<title>{ title }</title>
 					<meta
 						name="viewport"
-						content={ `width=device-width, initial-scale=1 ${ addViewportProps }` }
+						content={ `width=device-width, initial-scale=1${ addViewportProps }` }
 					></meta>
 					<style dangerouslySetInnerHTML={ { __html: style } } />
 					{ styles.map( ( rules, i ) => (

--- a/packages/components/src/sandbox/index.native.js
+++ b/packages/components/src/sandbox/index.native.js
@@ -185,6 +185,7 @@ const Sandbox = forwardRef( function Sandbox(
 		type,
 		url,
 		onWindowEvents = {},
+		viewportProps = '',
 	},
 	ref
 ) {
@@ -219,7 +220,7 @@ const Sandbox = forwardRef( function Sandbox(
 					<title>{ title }</title>
 					<meta
 						name="viewport"
-						content="width=device-width, initial-scale=1"
+						content={ `width=device-width, initial-scale=1, ${ viewportProps }` }
 					></meta>
 					<style dangerouslySetInnerHTML={ { __html: style } } />
 					{ styles.map( ( rules, i ) => (

--- a/packages/components/src/sandbox/index.native.js
+++ b/packages/components/src/sandbox/index.native.js
@@ -214,13 +214,19 @@ const Sandbox = forwardRef( function Sandbox(
 		// we can use this in the future to inject custom styles or scripts.
 		// Scripts go into the body rather than the head, to support embedded content such as Instagram
 		// that expect the scripts to be part of the body.
+
+		// Avoid comma issues with props.viewportProps.
+		const addViewportProps = viewportProps
+			.trim()
+			.replace( /(^[^,]) /, ', $1' );
+
 		const htmlDoc = (
 			<html lang={ lang }>
 				<head>
 					<title>{ title }</title>
 					<meta
 						name="viewport"
-						content={ `width=device-width, initial-scale=1, ${ viewportProps }` }
+						content={ `width=device-width, initial-scale=1 ${ addViewportProps }` }
 					></meta>
 					<style dangerouslySetInnerHTML={ { __html: style } } />
 					{ styles.map( ( rules, i ) => (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds a the `viewportProps` prop to the `Sandbox `component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
There are cases where the owner of a `Sandbox` needs to control the html viewport. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds a prop to the `Sandbox` that is added to the default viewport settings. 


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Verify the change  does not introduce any regression issues.
- Open a post with an embed block
- Verify that block renders as expected

Feature testing is TBD

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->