### PR TITLE
Port colord to PHP

### DIFF
--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -11,11 +11,15 @@
  *
  * @see https://github.com/bgrins/TinyColor
  *
+ * @deprecated 6.3.0
+ *
  * @param  mixed $n   Number of unknown type.
  * @param  int   $max Upper value of the range to bound to.
  * @return float      Value in the range [0,1].
  */
 function gutenberg_tinycolor_bound01( $n, $max ) {
+	_deprecated_function( __FUNCTION__, '6.3.0' );
+
 	if ( 'string' === gettype( $n ) && str_contains( $n, '.' ) && 1 === (float) $n ) {
 		$n = '100%';
 	}
@@ -42,10 +46,14 @@ function gutenberg_tinycolor_bound01( $n, $max ) {
  *
  * @see https://github.com/bgrins/TinyColor
  *
+ * @deprecated 6.3.0
+ *
  * @param  mixed $n   Number of unknown type.
  * @return float      Value in the range [0,1].
  */
 function gutenberg_tinycolor_bound_alpha( $n ) {
+	_deprecated_function( __FUNCTION__, '6.3.0' );
+
 	if ( is_numeric( $n ) ) {
 		$n = (float) $n;
 		if ( $n >= 0 && $n <= 1 ) {
@@ -60,10 +68,14 @@ function gutenberg_tinycolor_bound_alpha( $n ) {
  *
  * @see https://github.com/bgrins/TinyColor
  *
+ * @deprecated 6.3.0
+ *
  * @param  array $rgb_color RGB object.
  * @return array            Rounded and converted RGB object.
  */
 function gutenberg_tinycolor_rgb_to_rgb( $rgb_color ) {
+	_deprecated_function( __FUNCTION__, '6.3.0' );
+
 	return array(
 		'r' => gutenberg_tinycolor_bound01( $rgb_color['r'], 255 ) * 255,
 		'g' => gutenberg_tinycolor_bound01( $rgb_color['g'], 255 ) * 255,
@@ -76,12 +88,16 @@ function gutenberg_tinycolor_rgb_to_rgb( $rgb_color ) {
  *
  * @see https://github.com/bgrins/TinyColor
  *
+ * @deprecated 6.3.0
+ *
  * @param  float $p first component.
  * @param  float $q second component.
  * @param  float $t third component.
  * @return float    R, G, or B component.
  */
 function gutenberg_tinycolor_hue_to_rgb( $p, $q, $t ) {
+	_deprecated_function( __FUNCTION__, '6.3.0' );
+
 	if ( $t < 0 ) {
 		++$t;
 	}
@@ -105,10 +121,14 @@ function gutenberg_tinycolor_hue_to_rgb( $p, $q, $t ) {
  *
  * @see https://github.com/bgrins/TinyColor
  *
+ * @deprecated 6.3.0
+ *
  * @param  array $hsl_color HSL object.
  * @return array            Rounded and converted RGB object.
  */
 function gutenberg_tinycolor_hsl_to_rgb( $hsl_color ) {
+	_deprecated_function( __FUNCTION__, '6.3.0' );
+
 	$h = gutenberg_tinycolor_bound01( $hsl_color['h'], 360 );
 	$s = gutenberg_tinycolor_bound01( $hsl_color['s'], 100 );
 	$l = gutenberg_tinycolor_bound01( $hsl_color['l'], 100 );
@@ -140,10 +160,14 @@ function gutenberg_tinycolor_hsl_to_rgb( $hsl_color ) {
  * @see https://github.com/bgrins/TinyColor
  * @see https://github.com/casesandberg/react-color/
  *
+ * @deprecated 6.3.0
+ *
  * @param  string $color_str CSS color string.
  * @return array             RGB object.
  */
 function gutenberg_tinycolor_string_to_rgb( $color_str ) {
+	_deprecated_function( __FUNCTION__, '6.3.0' );
+
 	$color_str = strtolower( trim( $color_str ) );
 
 	$css_integer = '[-\\+]?\\d+%?';

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -321,80 +321,14 @@ function gutenberg_get_duotone_filter_property( $preset ) {
 /**
  * Returns the duotone filter SVG string for the preset.
  *
+ * @deprecated 6.3.0
+ *
  * @param  array $preset Duotone preset value as seen in theme.json.
  * @return string        Duotone SVG filter.
  */
 function gutenberg_get_duotone_filter_svg( $preset ) {
-	$filter_id = gutenberg_get_duotone_filter_id( $preset );
-
-	$duotone_values = array(
-		'r' => array(),
-		'g' => array(),
-		'b' => array(),
-		'a' => array(),
-	);
-
-	if ( ! isset( $preset['colors'] ) || ! is_array( $preset['colors'] ) ) {
-		$preset['colors'] = array();
-	}
-
-	foreach ( $preset['colors'] as $color_str ) {
-		$color = gutenberg_tinycolor_string_to_rgb( $color_str );
-
-		$duotone_values['r'][] = $color['r'] / 255;
-		$duotone_values['g'][] = $color['g'] / 255;
-		$duotone_values['b'][] = $color['b'] / 255;
-		$duotone_values['a'][] = $color['a'];
-	}
-
-	ob_start();
-
-	?>
-
-	<svg
-		xmlns="http://www.w3.org/2000/svg"
-		viewBox="0 0 0 0"
-		width="0"
-		height="0"
-		focusable="false"
-		role="none"
-		style="visibility: hidden; position: absolute; left: -9999px; overflow: hidden;"
-	>
-		<defs>
-			<filter id="<?php echo esc_attr( $filter_id ); ?>">
-				<feColorMatrix
-					color-interpolation-filters="sRGB"
-					type="matrix"
-					values="
-						.299 .587 .114 0 0
-						.299 .587 .114 0 0
-						.299 .587 .114 0 0
-						.299 .587 .114 0 0
-					"
-				/>
-				<feComponentTransfer color-interpolation-filters="sRGB" >
-					<feFuncR type="table" tableValues="<?php echo esc_attr( implode( ' ', $duotone_values['r'] ) ); ?>" />
-					<feFuncG type="table" tableValues="<?php echo esc_attr( implode( ' ', $duotone_values['g'] ) ); ?>" />
-					<feFuncB type="table" tableValues="<?php echo esc_attr( implode( ' ', $duotone_values['b'] ) ); ?>" />
-					<feFuncA type="table" tableValues="<?php echo esc_attr( implode( ' ', $duotone_values['a'] ) ); ?>" />
-				</feComponentTransfer>
-				<feComposite in2="SourceGraphic" operator="in" />
-			</filter>
-		</defs>
-	</svg>
-
-	<?php
-
-	$svg = ob_get_clean();
-
-	if ( ! SCRIPT_DEBUG ) {
-		// Clean up the whitespace.
-		$svg = preg_replace( "/[\r\n\t ]+/", ' ', $svg );
-		$svg = str_replace( '> <', '><', $svg );
-		$svg = trim( $svg );
-	}
-
-	return $svg;
+	_deprecated_function( __FUNCTION__, '6.3.0' );
+	return WP_Duotone_Gutenberg::get_filter_svg_from_preset( $preset );
 }
 
 /**

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -867,6 +867,7 @@ class WP_Duotone_Gutenberg {
 	 * @return string The SVG for the filter definition.
 	 */
 	public static function get_filter_svg_from_preset( $preset ) {
+		// TODO: This function will be refactored out in a follow-up PR where it will be deprecated.
 		$filter_id = gutenberg_get_duotone_filter_id( $preset );
 		return self::get_filter_svg( $filter_id, $preset['colors'] );
 	}

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -502,6 +502,80 @@ class WP_Duotone_Gutenberg {
 	}
 
 	/**
+	 * Gets the SVG for the duotone filter definition.
+	 *
+	 * @param string $filter_id The ID of the filter.
+	 * @param array  $colors    An array of color strings.
+	 * @return string An SVG with a duotone filter definition.
+	 */
+	private static function get_filter_svg( $filter_id, $colors ) {
+		$duotone_values = array(
+			'r' => array(),
+			'g' => array(),
+			'b' => array(),
+			'a' => array(),
+		);
+
+		foreach ( $colors as $color_str ) {
+			$color = self::colord_parse( $color_str );
+
+			$duotone_values['r'][] = $color['r'] / 255;
+			$duotone_values['g'][] = $color['g'] / 255;
+			$duotone_values['b'][] = $color['b'] / 255;
+			$duotone_values['a'][] = $color['a'];
+		}
+
+		ob_start();
+
+		?>
+
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 0 0"
+			width="0"
+			height="0"
+			focusable="false"
+			role="none"
+			style="visibility: hidden; position: absolute; left: -9999px; overflow: hidden;"
+		>
+			<defs>
+				<filter id="<?php echo esc_attr( $filter_id ); ?>">
+					<feColorMatrix
+						color-interpolation-filters="sRGB"
+						type="matrix"
+						values="
+							.299 .587 .114 0 0
+							.299 .587 .114 0 0
+							.299 .587 .114 0 0
+							.299 .587 .114 0 0
+						"
+					/>
+					<feComponentTransfer color-interpolation-filters="sRGB" >
+						<feFuncR type="table" tableValues="<?php echo esc_attr( implode( ' ', $duotone_values['r'] ) ); ?>" />
+						<feFuncG type="table" tableValues="<?php echo esc_attr( implode( ' ', $duotone_values['g'] ) ); ?>" />
+						<feFuncB type="table" tableValues="<?php echo esc_attr( implode( ' ', $duotone_values['b'] ) ); ?>" />
+						<feFuncA type="table" tableValues="<?php echo esc_attr( implode( ' ', $duotone_values['a'] ) ); ?>" />
+					</feComponentTransfer>
+					<feComposite in2="SourceGraphic" operator="in" />
+				</filter>
+			</defs>
+		</svg>
+
+		<?php
+
+		$svg = ob_get_clean();
+
+		if ( ! SCRIPT_DEBUG ) {
+			// Clean up the whitespace.
+			$svg = preg_replace( "/[\r\n\t ]+/", ' ', $svg );
+			$svg = str_replace( '> <', '><', $svg );
+			$svg = trim( $svg );
+		}
+
+		return $svg;
+	}
+
+	/**
 	 * Get the CSS variable for a duotone preset.
 	 *
 	 * @param string $slug The slug of the duotone preset.
@@ -531,7 +605,7 @@ class WP_Duotone_Gutenberg {
 		foreach ( self::$output as $filter_data ) {
 
 			// SVG will be output on the page later.
-			$filter_svg = gutenberg_get_duotone_filter_svg( $filter_data );
+			$filter_svg = self::get_filter_svg_from_preset( $filter_data );
 
 			echo $filter_svg;
 
@@ -554,7 +628,7 @@ class WP_Duotone_Gutenberg {
 		$duotone_svgs = '';
 		$duotone_css  = 'body{';
 		foreach ( self::$global_styles_presets as $filter_data ) {
-			$duotone_svgs .= gutenberg_get_duotone_filter_svg( $filter_data );
+			$duotone_svgs .= self::get_filter_svg_from_preset( $filter_data );
 			$duotone_css  .= self::get_css_custom_property_declaration( $filter_data );
 		}
 		$duotone_css .= '}';
@@ -784,5 +858,16 @@ class WP_Duotone_Gutenberg {
 		}
 
 		return $settings;
+	}
+
+	/**
+	 * Gets the SVG for the duotone filter definition from a preset.
+	 *
+	 * @param array $preset The duotone preset.
+	 * @return string The SVG for the filter definition.
+	 */
+	public static function get_filter_svg_from_preset( $preset ) {
+		$filter_id = gutenberg_get_duotone_filter_id( $preset );
+		return self::get_filter_svg( $filter_id, $preset['colors'] );
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part 1 in a set of duotone php refactoring to fix small issues in duotone rendering.

- [Part 1: Port colord to PHP](#top) (this PR)
- [Part 2: Deprecate remaining global duotone functions](https://github.com/WordPress/gutenberg/pull/49702)
- [Part 3: Group all duotone outputs](https://github.com/WordPress/gutenberg/pull/49705)
- [Part 4: Polish duotone rendering code](https://github.com/WordPress/gutenberg/pull/49706)
- [Part 5: Refactor duotone class to allow for multiple instances](https://github.com/WordPress/gutenberg/pull/49932)

This part deprecates tinycolor functions and uses a private port of colord for duotone instead to match the JS.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- The library was changed in the JavaScript some time ago in #34603. The libraries are quite similar, but there were some edge-cases that may have caused inconsistencies.
- colord's implementation happens to be slightly more performant.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Switched over to a port of colord instead of the port of tinycolor.
- Deprecated all of the PHP Gutenberg tinycolor functions. It was a mistake to have them public in the first place.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Ensure that duotone filters in all of the example content render the same in the post editor, site editor, and frontend.
2. Test that the custom filters render in classic themes. You can use the same example content which includes some.

<details>
<summary>Example content for TT3 block-out, canary, and pilgrimage variations</summary>

```html
<!-- wp:heading -->
<h2 class="wp-block-heading">Image core preset</h2>
<!-- /wp:heading -->

<!-- wp:image {"style":{"color":{"duotone":"var:preset|duotone|midnight"}}} -->
<figure class="wp-block-image"><img src="https://loremflickr.com/640/360" alt="placeholder image" class=""/><figcaption class="wp-element-caption">Preset slug: midnight</figcaption></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Image theme preset</h2>
<!-- /wp:heading -->

<!-- wp:image {"style":{"color":{"duotone":"var:preset|duotone|default-filter"}}} -->
<figure class="wp-block-image"><img src="https://loremflickr.com/640/360" alt="placeholder image" class=""/><figcaption class="wp-element-caption">Preset slug: default-filter</figcaption></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Image custom filter</h2>
<!-- /wp:heading -->

<!-- wp:image {"style":{"color":{"duotone":["rgb(92, 51, 10)","#fcf2e8"]}}} -->
<figure class="wp-block-image"><img src="https://loremflickr.com/640/360" alt="placeholder image" class=""/><figcaption class="wp-element-caption">Custom sepia filter</figcaption></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Image unset</h2>
<!-- /wp:heading -->

<!-- wp:image {"style":{"color":{"duotone":"unset"}}} -->
<figure class="wp-block-image"><img src="https://loremflickr.com/640/360" alt="placeholder image" class=""/><figcaption class="wp-element-caption">This should never have a filter applied</figcaption></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Image theme.json styles (plain block)</h2>
<!-- /wp:heading -->

<!-- wp:image {"style":{"color":{}}} -->
<figure class="wp-block-image"><img src="https://loremflickr.com/640/360" alt="placeholder image" class=""/><figcaption class="wp-element-caption"><code>settings.styles.blocks['core/image'].filter.duotone</code></figcaption></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Cover core preset</h2>
<!-- /wp:heading -->

<!-- wp:cover {"url":"https://loremflickr.com/640/360","dimRatio":0,"style":{"color":{"duotone":"var:preset|duotone|midnight"}}} -->
<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="placeholder image" src="https://loremflickr.com/640/360" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">Preset slug: midnight</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Cover theme preset</h2>
<!-- /wp:heading -->

<!-- wp:cover {"url":"https://loremflickr.com/640/360","dimRatio":0,"style":{"color":{"duotone":"var:preset|duotone|default-filter"}}} -->
<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="placeholder image" src="https://loremflickr.com/640/360" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">Preset slug: default-filter</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Cover custom filter</h2>
<!-- /wp:heading -->

<!-- wp:cover {"url":"https://loremflickr.com/640/360","dimRatio":0,"style":{"color":{"duotone":["rgb(92, 51, 10)","#fcf2e8"]}}} -->
<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="placeholder image" src="https://loremflickr.com/640/360" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">Custom sepia filter</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Cover unset</h2>
<!-- /wp:heading -->

<!-- wp:cover {"url":"https://loremflickr.com/640/360","dimRatio":0,"style":{"color":{"duotone":"unset"}}} -->
<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="placeholder image" src="https://loremflickr.com/640/360" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">This should never have a filter applied.</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Cover theme.json styles (plain block)</h2>
<!-- /wp:heading -->

<!-- wp:cover {"url":"https://loremflickr.com/640/360","dimRatio":0,"style":{"color":{}}} -->
<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="placeholder image" src="https://loremflickr.com/640/360" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…"} -->
<p class="has-text-align-center">This depends on <code>settings.styles.blocks['core/cover'].filter.duotone being set</code> to the CSS custom property for a preset.</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

```

</details>
