### PR TITLE
Deprecate remaining global duotone functions

### DIFF
--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -359,27 +359,13 @@ function gutenberg_get_duotone_filter_svg( $preset ) {
 /**
  * Registers the style and colors block attributes for block types that support it.
  *
+ * @deprecated 6.3.0 Use WP_Duotone_Gutenberg::register_duotone_support() instead.
+ *
  * @param WP_Block_Type $block_type Block Type.
  */
 function gutenberg_register_duotone_support( $block_type ) {
-	$has_duotone_support = false;
-	if ( property_exists( $block_type, 'supports' ) ) {
-		// Previous `color.__experimentalDuotone` support flag is migrated
-		// to `filter.duotone` via `block_type_metadata_settings` filter.
-		$has_duotone_support = _wp_array_get( $block_type->supports, array( 'filter', 'duotone' ), null );
-	}
-
-	if ( $has_duotone_support ) {
-		if ( ! $block_type->attributes ) {
-			$block_type->attributes = array();
-		}
-
-		if ( ! array_key_exists( 'style', $block_type->attributes ) ) {
-			$block_type->attributes['style'] = array(
-				'type' => 'object',
-			);
-		}
-	}
+	_deprecated_function( __FUNCTION__, '6.3.0', 'WP_Duotone_Gutenberg::register_duotone_support' );
+	return WP_Duotone_Gutenberg::register_duotone_support( $block_type );
 }
 
 /**
@@ -399,7 +385,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 WP_Block_Supports::get_instance()->register(
 	'duotone',
 	array(
-		'register_attribute' => 'gutenberg_register_duotone_support',
+		'register_attribute' => array( 'WP_Duotone_Gutenberg', 'register_duotone_support' ),
 	)
 );
 

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -317,29 +317,30 @@ function gutenberg_tinycolor_string_to_rgb( $color_str ) {
 /**
  * Returns the prefixed id for the duotone filter for use as a CSS id.
  *
+ * @deprecated 6.3.0
+ *
  * @param  array $preset Duotone preset value as seen in theme.json.
  * @return string        Duotone filter CSS id.
  */
 function gutenberg_get_duotone_filter_id( $preset ) {
+	_deprecated_function( __FUNCTION__, '6.3.0' );
 	if ( ! isset( $preset['slug'] ) ) {
 		return '';
 	}
-
-	return 'wp-duotone-' . $preset['slug'];
+	return WP_Duotone_Gutenberg::get_filter_id( $preset['slug'] );
 }
 
 /**
  * Returns the CSS filter property url to reference the rendered SVG.
  *
+ * @deprecated 6.3.0
+ *
  * @param  array $preset Duotone preset value as seen in theme.json.
  * @return string        Duotone CSS filter property url value.
  */
 function gutenberg_get_duotone_filter_property( $preset ) {
-	if ( isset( $preset['colors'] ) && is_string( $preset['colors'] ) ) {
-		return $preset['colors'];
-	}
-	$filter_id = gutenberg_get_duotone_filter_id( $preset );
-	return "url('#" . $filter_id . "')";
+	_deprecated_function( __FUNCTION__, '6.3.0' );
+	return WP_Duotone_Gutenberg::get_filter_css_property_value_from_preset( $preset );
 }
 
 /**

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -5,6 +5,39 @@
  * @package gutenberg
  */
 
+// Register duotone block supports.
+WP_Block_Supports::get_instance()->register(
+	'duotone',
+	array(
+		'register_attribute' => array( 'WP_Duotone_Gutenberg', 'register_duotone_support' ),
+	)
+);
+
+// Set up metadata prior to rendering any blocks.
+add_action( 'wp_loaded', array( 'WP_Duotone_Gutenberg', 'set_global_styles_presets' ), 10 );
+add_action( 'wp_loaded', array( 'WP_Duotone_Gutenberg', 'set_global_style_block_names' ), 10 );
+
+// Remove WordPress core filter to avoid rendering duplicate support elements.
+remove_filter( 'render_block', 'wp_render_duotone_support', 10, 2 );
+add_filter( 'render_block', array( 'WP_Duotone_Gutenberg', 'render_duotone_support' ), 10, 2 );
+
+// Enqueue styles.
+// Global styles (global-styles-inline-css) after the other global styles (gutenberg_enqueue_global_styles).
+add_action( 'wp_enqueue_scripts', array( 'WP_Duotone_Gutenberg', 'output_global_styles' ), 11 );
+
+// Add SVG filters to the footer. Also, for classic themes, output block styles (core-block-supports-inline-css).
+add_action( 'wp_footer', array( 'WP_Duotone_Gutenberg', 'output_footer_assets' ), 10 );
+
+// Add styles and SVGs for use in the editor via the EditorStyles component.
+add_filter( 'block_editor_settings_all', array( 'WP_Duotone_Gutenberg', 'add_editor_settings' ), 10 );
+
+// Migrate the old experimental duotone support flag.
+add_filter( 'block_type_metadata_settings', array( 'WP_Duotone_Gutenberg', 'migrate_experimental_duotone_support_flag' ), 10, 2 );
+
+/*
+ * Deprecated functions below. All new functions should be added in class-wp-duotone-gutenberg.php.
+ */
+
 /**
  * Direct port of tinycolor's bound01 function, lightly simplified to maintain
  * consistency with tinycolor.
@@ -380,21 +413,3 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	_deprecated_function( __FUNCTION__, '6.3.0', 'WP_Duotone_Gutenberg::render_duotone_support' );
 	return WP_Duotone_Gutenberg::render_duotone_support( $block_content, $block );
 }
-
-// Register the block support.
-WP_Block_Supports::get_instance()->register(
-	'duotone',
-	array(
-		'register_attribute' => array( 'WP_Duotone_Gutenberg', 'register_duotone_support' ),
-	)
-);
-
-add_action( 'wp_loaded', array( 'WP_Duotone_Gutenberg', 'set_global_styles_presets' ), 10 );
-add_action( 'wp_loaded', array( 'WP_Duotone_Gutenberg', 'set_global_style_block_names' ), 10 );
-// Remove WordPress core filter to avoid rendering duplicate support elements.
-remove_filter( 'render_block', 'wp_render_duotone_support', 10, 2 );
-add_filter( 'render_block', array( 'WP_Duotone_Gutenberg', 'render_duotone_support' ), 10, 2 );
-add_action( 'wp_enqueue_scripts', array( 'WP_Duotone_Gutenberg', 'output_global_styles' ), 11 );
-add_action( 'wp_footer', array( 'WP_Duotone_Gutenberg', 'output_footer_assets' ), 10 );
-add_filter( 'block_editor_settings_all', array( 'WP_Duotone_Gutenberg', 'add_editor_settings' ), 10 );
-add_filter( 'block_type_metadata_settings', array( 'WP_Duotone_Gutenberg', 'migrate_experimental_duotone_support_flag' ), 10, 2 );

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -357,10 +357,7 @@ function gutenberg_tinycolor_string_to_rgb( $color_str ) {
  */
 function gutenberg_get_duotone_filter_id( $preset ) {
 	_deprecated_function( __FUNCTION__, '6.3.0' );
-	if ( ! isset( $preset['slug'] ) ) {
-		return '';
-	}
-	return WP_Duotone_Gutenberg::get_filter_id( $preset['slug'] );
+	return WP_Duotone_Gutenberg::get_filter_id_from_preset( $preset );
 }
 
 /**
@@ -404,9 +401,10 @@ function gutenberg_register_duotone_support( $block_type ) {
 /**
  * Render out the duotone stylesheet and SVG.
  *
+ * @deprecated 6.3.0 Use WP_Duotone_Gutenberg::render_duotone_support() instead.
+ *
  * @param  string $block_content Rendered block content.
  * @param  array  $block         Block object.
- * @deprecated    6.3.0          Use WP_Duotone_Gutenberg::render_duotone_support() instead.
  * @return string                Filtered block content.
  */
 function gutenberg_render_duotone_support( $block_content, $block ) {

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -902,16 +902,27 @@ class WP_Duotone_Gutenberg {
 	}
 
 	/**
+	 * Returns the prefixed id for the duotone filter for use as a CSS id.
+	 *
+	 * @param  array $preset Duotone preset value as seen in theme.json.
+	 * @return string        Duotone filter CSS id.
+	 */
+	public static function get_filter_id_from_preset( $preset ) {
+		$filter_id = '';
+		if ( isset( $preset['slug'] ) ) {
+			$filter_id = self::get_filter_id( $preset['slug'] );
+		}
+		return $filter_id;
+	}
+
+	/**
 	 * Gets the SVG for the duotone filter definition from a preset.
 	 *
 	 * @param array $preset The duotone preset.
 	 * @return string The SVG for the filter definition.
 	 */
 	public static function get_filter_svg_from_preset( $preset ) {
-		$filter_id = '';
-		if ( isset( $preset['slug'] ) ) {
-			$filter_id = self::get_filter_id( $preset['slug'] );
-		}
+		$filter_id = self::get_filter_id_from_preset( $preset );
 		return self::get_filter_svg( $filter_id, $preset['colors'] );
 	}
 
@@ -926,10 +937,7 @@ class WP_Duotone_Gutenberg {
 			return $preset['colors'];
 		}
 
-		$filter_id = '';
-		if ( isset( $preset['slug'] ) ) {
-			$filter_id = self::get_filter_id( $preset['slug'] );
-		}
+		$filter_id = self::get_filter_id_from_preset( $preset );
 
 		return 'url(#' . $filter_id . ')';
 	}

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -731,6 +731,32 @@ class WP_Duotone_Gutenberg {
 	}
 
 	/**
+	 * Registers the style and colors block attributes for block types that support it.
+	 *
+	 * @param WP_Block_Type $block_type Block Type.
+	 */
+	public static function register_duotone_support( $block_type ) {
+		$has_duotone_support = false;
+		if ( property_exists( $block_type, 'supports' ) ) {
+			// Previous `color.__experimentalDuotone` support flag is migrated
+			// to `filter.duotone` via `block_type_metadata_settings` filter.
+			$has_duotone_support = _wp_array_get( $block_type->supports, array( 'filter', 'duotone' ), null );
+		}
+
+		if ( $has_duotone_support ) {
+			if ( ! $block_type->attributes ) {
+				$block_type->attributes = array();
+			}
+
+			if ( ! array_key_exists( 'style', $block_type->attributes ) ) {
+				$block_type->attributes['style'] = array(
+					'type' => 'object',
+				);
+			}
+		}
+	}
+
+	/**
 	 * Render out the duotone CSS styles and SVG.
 	 *
 	 * @param  string $block_content Rendered block content.

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -100,6 +100,11 @@ class WP_Duotone_Gutenberg {
 	const CSS_VAR_PREFIX = '--wp--preset--duotone--';
 
 	/**
+	 * Prefix used for generating and referencing duotone filter IDs.
+	 */
+	const FILTER_ID_PREFIX = 'wp-duotone-';
+
+	/**
 	 * Direct port of colord's clamp function. Using min/max instead of
 	 * nested ternaries.
 	 *
@@ -502,6 +507,16 @@ class WP_Duotone_Gutenberg {
 	}
 
 	/**
+	 * Get the ID of the duotone filter.
+	 *
+	 * @param string $slug The slug of the duotone preset.
+	 * @return string The ID of the duotone filter.
+	 */
+	private static function get_filter_id( $slug ) {
+		return self::FILTER_ID_PREFIX . $slug;
+	}
+
+	/**
 	 * Gets the SVG for the duotone filter definition.
 	 *
 	 * @param string $filter_id The ID of the filter.
@@ -593,7 +608,7 @@ class WP_Duotone_Gutenberg {
 	 * @return string The CSS declaration.
 	 */
 	private static function get_css_custom_property_declaration( $filter_data ) {
-		$declaration_value                = gutenberg_get_duotone_filter_property( $filter_data );
+		$declaration_value                = self::get_filter_css_property_value_from_preset( $filter_data );
 		$duotone_preset_css_property_name = self::get_css_custom_property_name( $filter_data['slug'] );
 		return $duotone_preset_css_property_name . ': ' . $declaration_value . ';';
 	}
@@ -775,7 +790,7 @@ class WP_Duotone_Gutenberg {
 					'colors' => $duotone_attr,
 				);
 				// Build a customized CSS filter property for unique slug.
-				$declaration_value = gutenberg_get_duotone_filter_property( $filter_data );
+				$declaration_value = self::get_filter_css_property_value_from_preset( $filter_data );
 
 				self::$output[ $slug ] = $filter_data;
 			}
@@ -790,7 +805,7 @@ class WP_Duotone_Gutenberg {
 
 		// - Applied as a class attribute to the block wrapper.
 		// - Used as a selector to apply the filter to the block.
-		$filter_id = gutenberg_get_duotone_filter_id( array( 'slug' => $slug ) );
+		$filter_id = self::get_filter_id_from_preset( array( 'slug' => $slug ) );
 
 		// Build the CSS selectors to which the filter will be applied.
 		$selectors = explode( ',', $duotone_selector );
@@ -867,8 +882,29 @@ class WP_Duotone_Gutenberg {
 	 * @return string The SVG for the filter definition.
 	 */
 	public static function get_filter_svg_from_preset( $preset ) {
-		// TODO: This function will be refactored out in a follow-up PR where it will be deprecated.
-		$filter_id = gutenberg_get_duotone_filter_id( $preset );
+		$filter_id = '';
+		if ( isset( $preset['slug'] ) ) {
+			$filter_id = self::get_filter_id( $preset['slug'] );
+		}
 		return self::get_filter_svg( $filter_id, $preset['colors'] );
+	}
+
+	/**
+	 * Gets the CSS filter property value from a preset.
+	 *
+	 * @param array $preset The duotone preset.
+	 * @return string The CSS filter property value.
+	 */
+	public static function get_filter_css_property_value_from_preset( $preset ) {
+		if ( isset( $preset['colors'] ) && is_string( $preset['colors'] ) ) {
+			return $preset['colors'];
+		}
+
+		$filter_id = '';
+		if ( isset( $preset['slug'] ) ) {
+			$filter_id = self::get_filter_id( $preset['slug'] );
+		}
+
+		return 'url(#' . $filter_id . ')';
 	}
 }

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -867,6 +867,7 @@ class WP_Duotone_Gutenberg {
 	 * @return string The SVG for the filter definition.
 	 */
 	public static function get_filter_svg_from_preset( $preset ) {
+		// TODO: This function will be refactored out in a follow-up PR where it will be deprecated.
 		$filter_id = gutenberg_get_duotone_filter_id( $preset );
 		return self::get_filter_svg( $filter_id, $preset['colors'] );
 	}

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -867,7 +867,6 @@ class WP_Duotone_Gutenberg {
 	 * @return string The SVG for the filter definition.
 	 */
 	public static function get_filter_svg_from_preset( $preset ) {
-		// TODO: This function will be refactored out in a follow-up PR where it will be deprecated.
 		$filter_id = gutenberg_get_duotone_filter_id( $preset );
 		return self::get_filter_svg( $filter_id, $preset['colors'] );
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part 2 in a set of duotone php refactoring to fix small issues in duotone rendering.

- [Part 1: Port colord to PHP](https://github.com/WordPress/gutenberg/pull/49700)
- [Part 2: Deprecate remaining global duotone functions](#top) (this PR)
- [Part 3: Group all duotone outputs](https://github.com/WordPress/gutenberg/pull/49705)
- [Part 4: Polish duotone rendering code](https://github.com/WordPress/gutenberg/pull/49706)
- [Part 5: Refactor duotone class to allow for multiple instances](https://github.com/WordPress/gutenberg/pull/49932)

This part refactors the remaining duotone functions into `WP_Duotone_Gutenberg` where they have access to private methods and the rest of the duotone code is co-located. Also, added comments for all of the duotone actions and filters explaining what they do and why `output_global_styles` is priority 11 instead of 10.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- In later parts of this refactoring, some private methods will be needed.
- Having the code co-loacted is easier for development since you no longer have to search for global functions in other files.
- Having the filters at the top of the file means that you don't have to scroll through unused code.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Deprecated remaining global `gutenberg_` functions in duotone.php.
- Moved implementations into class-wp-duotone-gutenberg.php.
- Moved all deprecated functions in duotone.php to the bottom of the file.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Ensure that duotone filters in all of the example content render the same in the post editor, site editor, and frontend.
2. Test that the custom filters render in classic themes. You can use the same example content which includes some.

<details>
<summary>Example content for TT3 block-out, canary, and pilgrimage variations</summary>

```html
<!-- wp:heading -->
<h2 class="wp-block-heading">Image core preset</h2>
<!-- /wp:heading -->

<!-- wp:image {"style":{"color":{"duotone":"var:preset|duotone|midnight"}}} -->
<figure class="wp-block-image"><img src="https://loremflickr.com/640/360" alt="placeholder image" class=""/><figcaption class="wp-element-caption">Preset slug: midnight</figcaption></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Image theme preset</h2>
<!-- /wp:heading -->

<!-- wp:image {"style":{"color":{"duotone":"var:preset|duotone|default-filter"}}} -->
<figure class="wp-block-image"><img src="https://loremflickr.com/640/360" alt="placeholder image" class=""/><figcaption class="wp-element-caption">Preset slug: default-filter</figcaption></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Image custom filter</h2>
<!-- /wp:heading -->

<!-- wp:image {"style":{"color":{"duotone":["rgb(92, 51, 10)","#fcf2e8"]}}} -->
<figure class="wp-block-image"><img src="https://loremflickr.com/640/360" alt="placeholder image" class=""/><figcaption class="wp-element-caption">Custom sepia filter</figcaption></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Image unset</h2>
<!-- /wp:heading -->

<!-- wp:image {"style":{"color":{"duotone":"unset"}}} -->
<figure class="wp-block-image"><img src="https://loremflickr.com/640/360" alt="placeholder image" class=""/><figcaption class="wp-element-caption">This should never have a filter applied</figcaption></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Image theme.json styles (plain block)</h2>
<!-- /wp:heading -->

<!-- wp:image {"style":{"color":{}}} -->
<figure class="wp-block-image"><img src="https://loremflickr.com/640/360" alt="placeholder image" class=""/><figcaption class="wp-element-caption"><code>settings.styles.blocks['core/image'].filter.duotone</code></figcaption></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Cover core preset</h2>
<!-- /wp:heading -->

<!-- wp:cover {"url":"https://loremflickr.com/640/360","dimRatio":0,"style":{"color":{"duotone":"var:preset|duotone|midnight"}}} -->
<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="placeholder image" src="https://loremflickr.com/640/360" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">Preset slug: midnight</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Cover theme preset</h2>
<!-- /wp:heading -->

<!-- wp:cover {"url":"https://loremflickr.com/640/360","dimRatio":0,"style":{"color":{"duotone":"var:preset|duotone|default-filter"}}} -->
<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="placeholder image" src="https://loremflickr.com/640/360" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">Preset slug: default-filter</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Cover custom filter</h2>
<!-- /wp:heading -->

<!-- wp:cover {"url":"https://loremflickr.com/640/360","dimRatio":0,"style":{"color":{"duotone":["rgb(92, 51, 10)","#fcf2e8"]}}} -->
<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="placeholder image" src="https://loremflickr.com/640/360" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">Custom sepia filter</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Cover unset</h2>
<!-- /wp:heading -->

<!-- wp:cover {"url":"https://loremflickr.com/640/360","dimRatio":0,"style":{"color":{"duotone":"unset"}}} -->
<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="placeholder image" src="https://loremflickr.com/640/360" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">This should never have a filter applied.</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Cover theme.json styles (plain block)</h2>
<!-- /wp:heading -->

<!-- wp:cover {"url":"https://loremflickr.com/640/360","dimRatio":0,"style":{"color":{}}} -->
<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="placeholder image" src="https://loremflickr.com/640/360" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…"} -->
<p class="has-text-align-center">This depends on <code>settings.styles.blocks['core/cover'].filter.duotone being set</code> to the CSS custom property for a preset.</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

```

</details>
