### PR TITLE
Only show alignment info when parent layout is constrained.

### DIFF
--- a/packages/block-editor/src/layouts/utils.js
+++ b/packages/block-editor/src/layouts/utils.js
@@ -83,10 +83,10 @@ export function getBlockGapCSS(
  * @return {Object} An object with contextual info per alignment.
  */
 export function getAlignmentsInfo( layout ) {
-	const { contentSize, wideSize } = layout;
+	const { contentSize, wideSize, type = 'default' } = layout;
 	const alignmentInfo = {};
 	const sizeRegex = /^(?!0)\d+(px|em|rem|vw|vh|%)?$/i;
-	if ( sizeRegex.test( contentSize ) ) {
+	if ( sizeRegex.test( contentSize ) && type === 'constrained' ) {
 		// translators: %s: container size (i.e. 600px etc)
 		alignmentInfo.none = sprintf( __( 'Max %s wide' ), contentSize );
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up from #49565, where testing [brought up](https://github.com/WordPress/gutenberg/pull/49565#pullrequestreview-1370164663) that the info in "none" option in the alignment controls doesn't always reflect the actual content width.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a Group block with an Image block inside it to a post or template.
2. Check that the Image alignment controls display "max [x] wide" under the "none" option.
3. Uncheck "Inner blocks use content width" in the Group block, and verify that Image alignment controls no longer show the max width info.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if a
<img width="684" alt="Screenshot 2023-04-11 at 10 56 04 am" src="https://user-images.githubusercontent.com/8096000/231027832-e2d98d3b-2f10-42fc-9027-78b440fb60a9.png">
pplicable -->


