### PR TITLE
Time To Read Block: Fix untranslated on front end

### DIFF
--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -32,8 +32,8 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 	$minutes_to_read = max( 1, (int) round( wp_word_count( $content, $word_count_type ) / $average_reading_rate ) );
 
 	$minutes_to_read_string = sprintf(
-		/* translators: %d is the number of minutes the post will take to read. */
-		_n( '%d minute', '%d minutes', $minutes_to_read ),
+		/* translators: %s is the number of minutes the post will take to read. */
+		_n( '%s minute', '%s minutes', $minutes_to_read ),
 		$minutes_to_read
 	);
 


### PR DESCRIPTION
Fixes: #49694

## What?
This PR fixes a problem where the unit of time is not translated when the Post Time to Read block is rendered on the front end.

## Why?
I have changed the placeholder in the `_n()` function string from `%d` to `%s` and have confirmed that it translates correctly. I don't know the root cause, but in the WordPress core,` %s` is used as a placeholder in the `_n()` function as well. Also in [Developer Resources](https://developer.wordpress.org/reference/functions/_n/), all examples use `%s` as a placeholder.

## Testing Instructions

- Create two posts, one with long content and one with short content.
- Open the site editor.
- Open Home template.
- Insert a Post Time to Read block inside a Query Loop block.
- Change the language of the site.
- Confirm that both singular and plural are translated correctly in the front end.

## Screenshots or screencast <!-- if applicable -->

### Japanese

![japanese](https://user-images.githubusercontent.com/54422211/231157445-5962cb3c-2373-4631-8bc8-6017b816e0cd.png)

### German

![german](https://user-images.githubusercontent.com/54422211/231157464-3360a141-2526-424e-a2b3-417062fac8b1.png)

### Spanish

![spanish](https://user-images.githubusercontent.com/54422211/231157474-f980d4f5-5129-4d9e-8f8d-db29c35f30b0.png)



