### PR TITLE
Try: Hide redundant search icon on mobile safari.

### DIFF
--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -45,6 +45,9 @@ $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 	// !important used to forcibly prevent undesired application of
 	// text-decoration styles on the input field.
 	text-decoration: unset !important;
+
+	// Hides a redundant extra search icon on Mobile Safari.
+	appearance: initial;
 }
 
 .wp-block-search.wp-block-search__button-only {


### PR DESCRIPTION
## What?
Fixes #48259.

Mobile Safari adds a search icon to an HTML5 search field by default, even if one is added manually by the Search block:

<img width="630" alt="before" src="https://user-images.githubusercontent.com/1204802/231103681-392acbea-b0ca-478a-9853-fccce41f02a9.png">

This PR removes that by setting the appearance to "initial":

<img width="601" alt="after" src="https://user-images.githubusercontent.com/1204802/231103731-7f9e5738-e16d-488b-9ada-7dcb16b6a7ed.png">

## Testing Instructions

If you have a physical iphone you can connect, test this branch in that, perhaps using gutenberg.run. Otherwise, you can test using the xcode iphone simulator. 

Notably, there should be no regressions to the search block behavior elsewhere. 