### PR TITLE
Remove smart border style setting behavior

### DIFF
--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -112,6 +112,12 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 				'color' => isset( $border['color'] ) && ! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'color' ) ? $border['color'] : null,
 				'style' => isset( $border['style'] ) && ! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'style' ) ? $border['style'] : null,
 			);
+
+			// If we set a border color or a border width, make sure we set a border style as well.
+			if ( isset( $border_side_values['color'] ) || isset( $border_side_values['width'] ) ) {
+				$border_side_values['style'] = isset( $border_side_values['style'] ) ? $border_side_values['style'] : 'solid';
+			}
+
 			$border_block_styles[ $side ] = $border_side_values;
 		}
 	}

--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -63,15 +63,6 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 		$border_block_styles['radius'] = $border_radius;
 	}
 
-	// Border style.
-	if (
-		gutenberg_has_border_feature_support( $block_type, 'style' ) &&
-		isset( $block_attributes['style']['border']['style'] ) &&
-		! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'style' )
-	) {
-		$border_block_styles['style'] = $block_attributes['style']['border']['style'];
-	}
-
 	// Border width.
 	if (
 		$has_border_width_support &&
@@ -96,6 +87,20 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 		$preset_border_color          = array_key_exists( 'borderColor', $block_attributes ) ? "var:preset|color|{$block_attributes['borderColor']}" : null;
 		$custom_border_color          = _wp_array_get( $block_attributes, array( 'style', 'border', 'color' ), null );
 		$border_block_styles['color'] = $preset_border_color ? $preset_border_color : $custom_border_color;
+	}
+
+	// Border style.
+	if (
+		gutenberg_has_border_feature_support( $block_type, 'style' ) &&
+		isset( $block_attributes['style']['border']['style'] ) &&
+		! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'style' )
+	) {
+		$border_block_styles['style'] = $block_attributes['style']['border']['style'];
+	}
+
+	// If we set a border color or a border width, make sure we set a border style as well.
+	if ( isset( $border_block_styles['color'] ) || isset( $border_block_styles['width'] ) ) {
+		$border_block_styles['style'] = isset( $border_block_styles['style'] ) ? $border_block_styles['style'] : 'solid';
 	}
 
 	// Generate styles for individual border sides.

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1848,6 +1848,21 @@ class WP_Theme_JSON_Gutenberg {
 
 		$root_variable_duplicates = array();
 
+		// Add a solid style fallback if no style defined.
+		if ( isset( $styles[ 'border'] ) ) {
+			if ( 
+				( isset( $styles[ 'border']['width'] ) || isset( $styles[ 'border']['color'] ) ) && ! isset( $styles[ 'border']['style'] ) ) {
+				$styles[ 'border']['style'] = 'solid';
+			}
+			foreach ( [ 'top', 'left', 'right', 'bottom' ] as $edge ) {
+				if (
+					isset( $styles[ 'border'][ $edge ]) && 
+					( isset( $styles[ 'border'][ $edge ]['width'] ) || isset( $styles[ 'border'][ $edge ]['color'] ) ) && ! isset( $styles[ 'border'][ $edge ]['style'] ) ) {
+					$styles[ 'border'][ $edge ]['style'] = 'solid';
+				}
+			}
+		}
+
 		foreach ( $properties as $css_property => $value_path ) {
 			$value = static::get_property_value( $styles, $value_path, $theme_json );
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1849,16 +1849,16 @@ class WP_Theme_JSON_Gutenberg {
 		$root_variable_duplicates = array();
 
 		// Add a solid style fallback if no style defined.
-		if ( isset( $styles[ 'border'] ) ) {
-			if ( 
-				( isset( $styles[ 'border']['width'] ) || isset( $styles[ 'border']['color'] ) ) && ! isset( $styles[ 'border']['style'] ) ) {
-				$styles[ 'border']['style'] = 'solid';
+		if ( isset( $styles['border'] ) ) {
+			if (
+				( isset( $styles['border']['width'] ) || isset( $styles['border']['color'] ) ) && ! isset( $styles['border']['style'] ) ) {
+				$styles['border']['style'] = 'solid';
 			}
-			foreach ( [ 'top', 'left', 'right', 'bottom' ] as $edge ) {
+			foreach ( array( 'top', 'left', 'right', 'bottom' ) as $edge ) {
 				if (
-					isset( $styles[ 'border'][ $edge ]) && 
-					( isset( $styles[ 'border'][ $edge ]['width'] ) || isset( $styles[ 'border'][ $edge ]['color'] ) ) && ! isset( $styles[ 'border'][ $edge ]['style'] ) ) {
-					$styles[ 'border'][ $edge ]['style'] = 'solid';
+					isset( $styles['border'][ $edge ]) &&
+					( isset( $styles['border'][ $edge ]['width'] ) || isset( $styles['border'][ $edge ]['color'] ) ) && ! isset( $styles['border'][ $edge ]['style'] ) ) {
+					$styles['border'][ $edge ]['style'] = 'solid';
 				}
 			}
 		}

--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -45,35 +45,6 @@ function useHasBorderWidthControl( settings ) {
 	return settings?.border?.width;
 }
 
-function applyFallbackStyle( border ) {
-	if ( ! border ) {
-		return border;
-	}
-
-	if ( ! border.style && ( border.color || border.width ) ) {
-		return { ...border, style: 'solid' };
-	}
-
-	return border;
-}
-
-function applyAllFallbackStyles( border ) {
-	if ( ! border ) {
-		return border;
-	}
-
-	if ( hasSplitBorders( border ) ) {
-		return {
-			top: applyFallbackStyle( border.top ),
-			right: applyFallbackStyle( border.right ),
-			bottom: applyFallbackStyle( border.bottom ),
-			left: applyFallbackStyle( border.left ),
-		};
-	}
-
-	return applyFallbackStyle( border );
-}
-
 function BorderToolsPanel( {
 	resetAllFilter,
 	onChange,
@@ -186,7 +157,7 @@ export default function BorderPanel( {
 	const onBorderChange = ( newBorder ) => {
 		// Ensure we have a visible border style when a border width or
 		// color is being selected.
-		const updatedBorder = applyAllFallbackStyles( newBorder );
+		const updatedBorder = newBorder ? { ...newBorder } : undefined;
 
 		if ( hasSplitBorders( updatedBorder ) ) {
 			[ 'top', 'right', 'bottom', 'left' ].forEach( ( side ) => {

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -105,49 +105,6 @@
 }
 
 /**
- * The following provide a simple means of applying a default border style when
- * a user first makes a selection in the border block support panel.
- * This prevents issues such as where the user could set a border width
- * and see no border due there being no border style set.
- *
- * This is intended to be removed once intelligent defaults can be set while
- * making border selections via the block support.
- *
- * See: https://github.com/WordPress/gutenberg/pull/33743
- */
-html :where(.has-border-color) {
-	border-style: solid;
-}
-html :where([style*="border-top-color"]) {
-	border-top-style: solid;
-}
-html :where([style*="border-right-color"]) {
-	border-right-style: solid;
-}
-html :where([style*="border-bottom-color"]) {
-	border-bottom-style: solid;
-}
-html :where([style*="border-left-color"]) {
-	border-left-style: solid;
-}
-
-html :where([style*="border-width"]) {
-	border-style: solid;
-}
-html :where([style*="border-top-width"]) {
-	border-top-style: solid;
-}
-html :where([style*="border-right-width"]) {
-	border-right-style: solid;
-}
-html :where([style*="border-bottom-width"]) {
-	border-bottom-style: solid;
-}
-html :where([style*="border-left-width"]) {
-	border-left-style: solid;
-}
-
-/**
  * Provide baseline responsiveness for images.
  */
 html :where(img[class*="wp-image-"]) {

--- a/packages/style-engine/src/test/index.js
+++ b/packages/style-engine/src/test/index.js
@@ -134,6 +134,40 @@ describe( 'generate', () => {
 		);
 	} );
 
+	it( 'should geneate a border style fallback if color provided', () => {
+		expect(
+			compileCSS( {
+				border: {
+					color: 'var:preset|color|perky-peppermint',
+				},
+			} )
+		).toEqual(
+			'border-color: var(--wp--preset--color--perky-peppermint); border-style: solid;'
+		);
+	} );
+
+	it( 'should geneate a border style fallback if width provided', () => {
+		expect(
+			compileCSS( {
+				border: {
+					width: '5px',
+				},
+			} )
+		).toEqual( 'border-width: 5px; border-style: solid;' );
+	} );
+
+	it( 'should geneate a border style fallback for individual border rules too', () => {
+		expect(
+			compileCSS( {
+				border: {
+					top: {
+						width: '5px',
+					},
+				},
+			} )
+		).toEqual( 'border-top-style: solid; border-top-width: 5px;' );
+	} );
+
 	it( 'should parse individual border rules', () => {
 		expect(
 			compileCSS( {
@@ -166,7 +200,7 @@ describe( 'generate', () => {
 				},
 			} )
 		).toEqual(
-			'border-top-left-radius: 1px; border-top-right-radius: 2px; border-bottom-left-radius: 3px; border-bottom-right-radius: 4px; border-top-color: var(--wp--preset--color--sandy-beach); border-top-style: dashed; border-top-width: 9px; border-right-color: var(--wp--preset--color--leafy-avenue); border-right-width: 5rem; border-bottom-color: #eee; border-bottom-style: solid; border-bottom-width: 2%; border-left-color: var(--wp--preset--color--avocado-blues); border-left-style: dotted; border-left-width: 100px;'
+			'border-top-left-radius: 1px; border-top-right-radius: 2px; border-bottom-left-radius: 3px; border-bottom-right-radius: 4px; border-top-color: var(--wp--preset--color--sandy-beach); border-top-style: dashed; border-top-width: 9px; border-right-color: var(--wp--preset--color--leafy-avenue); border-right-style: solid; border-right-width: 5rem; border-bottom-color: #eee; border-bottom-style: solid; border-bottom-width: 2%; border-left-color: var(--wp--preset--color--avocado-blues); border-left-style: dotted; border-left-width: 100px;'
 		);
 	} );
 } );


### PR DESCRIPTION
closes #49677

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at de34a9b</samp>

Improved border style control and global styles compatibility by removing unnecessary logic and fixing object mutation in `border-panel.js`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at de34a9b</samp>

> _Sing, O Muse, of the skillful coder who refined the border style_
> _And removed the fallback logic that caused much trouble and toil_
> _He fixed the border object mutation, a cunning feat of mind_
> _And made it work with global styles, a harmony sublime_

### WHY
If we "smartly" set the solid style when specifying a width, that style will linger when we remove the width and the user never had the intent to actually set a border style (in fact the border style could be something the block has forced some defined style)

That said, it seems that behavior was intended here https://github.com/WordPress/gutenberg/pull/33743/files#r1162539799 so I'm curious to know why it was needed in the first place to see whether there's another approach to be taken there.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at de34a9b</samp>

* Remove fallback border style functions and calls ([link](https://github.com/WordPress/gutenberg/pull/49714/files?diff=unified&w=0#diff-06b0b4949066e6a92fdaa44437b9e5a1703d7d18af34366ac655dbb16a6dc878L48-L76), [link](https://github.com/WordPress/gutenberg/pull/49714/files?diff=unified&w=0#diff-06b0b4949066e6a92fdaa44437b9e5a1703d7d18af34366ac655dbb16a6dc878L189-R160))