### PR TITLE
Simplify CustomCSS UI

### DIFF
--- a/packages/block-editor/src/components/global-styles/advanced-panel.js
+++ b/packages/block-editor/src/components/global-styles/advanced-panel.js
@@ -1,0 +1,82 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	TextareaControl,
+	Tooltip,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Icon, info } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { default as transformStyles } from '../../utils/transform-styles';
+
+export default function AdvancedPanel( {
+	value,
+	onChange,
+	inheritedValue = value,
+} ) {
+	// Custom CSS
+	const [ cssError, setCSSError ] = useState( null );
+	const customCSS = inheritedValue?.css;
+	function handleOnChange( newValue ) {
+		onChange( {
+			...value,
+			css: newValue,
+		} );
+		if ( cssError ) {
+			const [ transformed ] = transformStyles(
+				[ { css: value } ],
+				'.editor-styles-wrapper'
+			);
+			if ( transformed ) {
+				setCSSError( null );
+			}
+		}
+	}
+	function handleOnBlur( event ) {
+		if ( ! event?.target?.value ) {
+			setCSSError( null );
+			return;
+		}
+
+		const [ transformed ] = transformStyles(
+			[ { css: event.target.value } ],
+			'.editor-styles-wrapper'
+		);
+
+		setCSSError(
+			transformed === null
+				? __( 'There is an error with your CSS structure.' )
+				: null
+		);
+	}
+
+	return (
+		<VStack spacing={ 3 }>
+			<TextareaControl
+				label={ __( 'Additional CSS' ) }
+				__nextHasNoMarginBottom
+				value={ customCSS }
+				onChange={ ( newValue ) => handleOnChange( newValue ) }
+				onBlur={ handleOnBlur }
+				className="edit-site-global-styles__custom-css-input"
+				spellCheck={ false }
+			/>
+			{ cssError && (
+				<Tooltip text={ cssError }>
+					<div className="edit-site-global-styles__custom-css-validation-wrapper">
+						<Icon
+							icon={ info }
+							className="edit-site-global-styles__custom-css-validation-icon"
+						/>
+					</div>
+				</Tooltip>
+			) }
+		</VStack>
+	);
+}

--- a/packages/block-editor/src/components/global-styles/advanced-panel.js
+++ b/packages/block-editor/src/components/global-styles/advanced-panel.js
@@ -64,15 +64,15 @@ export default function AdvancedPanel( {
 				value={ customCSS }
 				onChange={ ( newValue ) => handleOnChange( newValue ) }
 				onBlur={ handleOnBlur }
-				className="edit-site-global-styles__custom-css-input"
+				className="block-editor-global-styles-advanced-panel__custom-css-input"
 				spellCheck={ false }
 			/>
 			{ cssError && (
 				<Tooltip text={ cssError }>
-					<div className="edit-site-global-styles__custom-css-validation-wrapper">
+					<div className="block-editor-global-styles-advanced-panel__custom-css-validation-wrapper">
 						<Icon
 							icon={ info }
-							className="edit-site-global-styles__custom-css-validation-icon"
+							className="block-editor-global-styles-advanced-panel__custom-css-validation-icon"
 						/>
 					</div>
 				</Tooltip>

--- a/packages/block-editor/src/components/global-styles/hooks.js
+++ b/packages/block-editor/src/components/global-styles/hooks.js
@@ -181,11 +181,7 @@ export function useGlobalStyle(
 	let rawResult, result;
 	switch ( source ) {
 		case 'all':
-			rawResult =
-				// The styles.css path is allowed to be empty, so don't revert to base if undefined.
-				finalPath === 'styles.css'
-					? get( userConfig, finalPath )
-					: get( mergedConfig, finalPath );
+			rawResult = get( mergedConfig, finalPath );
 			result = shouldDecodeEncode
 				? getValueFromVariable( mergedConfig, blockName, rawResult )
 				: rawResult;

--- a/packages/block-editor/src/components/global-styles/index.js
+++ b/packages/block-editor/src/components/global-styles/index.js
@@ -19,3 +19,4 @@ export { default as BorderPanel, useHasBorderPanel } from './border-panel';
 export { default as ColorPanel, useHasColorPanel } from './color-panel';
 export { default as EffectsPanel, useHasEffectsPanel } from './effects-panel';
 export { default as FiltersPanel, useHasFiltersPanel } from './filters-panel';
+export { default as AdvancedPanel } from './advanced-panel';

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -41,3 +41,17 @@
 	height: 24px;
 	width: 24px;
 }
+
+.block-editor-global-styles-advanced-panel__custom-css-input textarea {
+	font-family: $editor_html_font;
+}
+
+.block-editor-global-styles-advanced-panel__custom-css-validation-wrapper {
+	position: absolute;
+	bottom: $grid-unit-20;
+	right: $grid-unit * 3;
+}
+
+.block-editor-global-styles-advanced-panel__custom-css-validation-icon {
+	fill: $alert-red;
+}

--- a/packages/edit-site/src/components/global-styles/custom-css.js
+++ b/packages/edit-site/src/components/global-styles/custom-css.js
@@ -1,130 +1,31 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
-import {
-	TextareaControl,
-	Panel,
-	PanelBody,
-	__experimentalVStack as VStack,
-	Tooltip,
-	Icon,
-} from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import {
-	privateApis as blockEditorPrivateApis,
-	transformStyles,
-} from '@wordpress/block-editor';
-import { info } from '@wordpress/icons';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../private-apis';
-import Subtitle from './subtitle';
 
-const { useGlobalStyle } = unlock( blockEditorPrivateApis );
+const { useGlobalStyle, AdvancedPanel: StylesAdvancedPanel } = unlock(
+	blockEditorPrivateApis
+);
+
 function CustomCSSControl( { blockName } ) {
-	// If blockName is defined, we are customizing CSS at the block level:
-	// styles.blocks.blockName.css
-	const block = !! blockName ? blockName : null;
-
-	const [ customCSS, setCustomCSS ] = useGlobalStyle( 'css', block );
-	const [ themeCSS ] = useGlobalStyle( 'css', block, 'base' );
-	const [ cssError, setCSSError ] = useState( null );
-	const ignoreThemeCustomCSS = '/* IgnoreThemeCustomCSS */';
-
-	// If there is custom css from theme.json show it in the edit box
-	// so the user can selectively overwrite it, rather than have the user CSS
-	// completely overwrite the theme CSS by default.
-	const themeCustomCSS =
-		! customCSS && themeCSS
-			? `/* ${ __(
-					'Theme Custom CSS start'
-			  ) } */\n${ themeCSS }\n/* ${ __( 'Theme Custom CSS end' ) } */`
-			: undefined;
-
-	function handleOnChange( value ) {
-		// If there is theme custom CSS, but the user clears the input box then save the
-		// ignoreThemeCustomCSS string so that the theme custom CSS is not re-applied.
-		if ( themeCSS && value === '' ) {
-			setCustomCSS( ignoreThemeCustomCSS );
-			return;
-		}
-		setCustomCSS( value );
-		if ( cssError ) {
-			const [ transformed ] = transformStyles(
-				[ { css: value } ],
-				'.editor-styles-wrapper'
-			);
-			if ( transformed ) {
-				setCSSError( null );
-			}
-		}
-	}
-
-	function handleOnBlur( event ) {
-		if ( ! event?.target?.value ) {
-			setCSSError( null );
-			return;
-		}
-
-		const [ transformed ] = transformStyles(
-			[ { css: event.target.value } ],
-			'.editor-styles-wrapper'
-		);
-
-		setCSSError(
-			transformed === null
-				? __( 'There is an error with your CSS structure.' )
-				: null
-		);
-	}
-
-	const originalThemeCustomCSS =
-		themeCSS && customCSS && themeCustomCSS !== customCSS
-			? themeCSS
-			: undefined;
+	const [ style ] = useGlobalStyle( '', blockName, 'user', {
+		shouldDecodeEncode: false,
+	} );
+	const [ inheritedStyle, setStyle ] = useGlobalStyle( '', blockName, 'all', {
+		shouldDecodeEncode: false,
+	} );
 
 	return (
-		<>
-			{ originalThemeCustomCSS && (
-				<Panel>
-					<PanelBody
-						title={ __( 'Original Theme Custom CSS' ) }
-						initialOpen={ false }
-					>
-						<pre className="edit-site-global-styles__custom-css-theme-css">
-							{ originalThemeCustomCSS }
-						</pre>
-					</PanelBody>
-				</Panel>
-			) }
-			<VStack spacing={ 3 }>
-				<Subtitle>{ __( 'Additional CSS' ) }</Subtitle>
-				<TextareaControl
-					__nextHasNoMarginBottom
-					value={
-						customCSS?.replace( ignoreThemeCustomCSS, '' ) ||
-						themeCustomCSS
-					}
-					onChange={ ( value ) => handleOnChange( value ) }
-					onBlur={ handleOnBlur }
-					className="edit-site-global-styles__custom-css-input"
-					spellCheck={ false }
-				/>
-				{ cssError && (
-					<Tooltip text={ cssError }>
-						<div className="edit-site-global-styles__custom-css-validation-wrapper">
-							<Icon
-								icon={ info }
-								className="edit-site-global-styles__custom-css-validation-icon"
-							/>
-						</div>
-					</Tooltip>
-				) }
-			</VStack>
-		</>
+		<StylesAdvancedPanel
+			value={ style }
+			onChange={ setStyle }
+			inheritedValue={ inheritedStyle }
+		/>
 	);
 }
 

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -131,7 +131,7 @@
 	.components-v-stack {
 		flex: 1 1 auto;
 
-		.edit-site-global-styles__custom-css-input {
+		.block-editor-global-styles-advanced-panel__custom-css-input {
 			flex: 1 1 auto;
 			display: flex;
 			flex-direction: column;
@@ -147,28 +147,6 @@
 			}
 		}
 	}
-}
-
-.edit-site-global-styles__custom-css-input textarea {
-	font-family: $editor_html_font;
-}
-
-.edit-site-global-styles__custom-css-validation-wrapper {
-	position: absolute;
-	bottom: $grid-unit-20;
-	right: $grid-unit * 3;
-}
-
-.edit-site-global-styles__custom-css-validation-icon {
-	fill: $alert-red;
-}
-
-.edit-site-global-styles__custom-css-theme-css {
-	width: 100%;
-	line-break: anywhere;
-	white-space: break-spaces;
-	max-height: 200px;
-	overflow-y: scroll;
 }
 
 .edit-site-global-styles-screen-css-help-link {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 78052d1</samp>

This pull request introduces a new `AdvancedPanel` component for editing custom CSS in global styles panels. It also refactors the `custom-css` component in the `edit-site` module to use this new component and the `useGlobalStyle` hook. 

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 78052d1</samp>

> _`AdvancedPanel` is the tool of the brave_
> _Editing custom CSS to shape your own grave_
> _`useGlobalStyle` hook unleashes the power_
> _Refactoring `custom-css` to make the world cower_

### WHY
Adds an AdvancedPanel component to the Styles UI folder (to be reused in block inspector too) and removes custom logic for the CSS panel (just map the behavior of all other global styles panels)

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 78052d1</samp>

*  Add a reusable component for editing custom CSS with validation and preview ([link](https://github.com/WordPress/gutenberg/pull/49721/files?diff=unified&w=0#diff-5fd59e744d6ed3f3cad7b505c07f490492f2fb52fc7808865ea68017af2bab0fR1-R82))
*  Export the `AdvancedPanel` component from the `global-styles` module ([link](https://github.com/WordPress/gutenberg/pull/49721/files?diff=unified&w=0#diff-3203defa3f9fa7d0f14af961ece72d1a2dabc639b1d746b975ab0d98fcfb7ab1R22))
*  Refactor the `custom-css` component in `edit-site` to use the `AdvancedPanel` component and the `useGlobalStyle` hook ([link](https://github.com/WordPress/gutenberg/pull/49721/files?diff=unified&w=0#diff-7789f2147879712de18668945491a0fa654a3819f24c77e7af57d0bb701c33b8L4-R4), [link](https://github.com/WordPress/gutenberg/pull/49721/files?diff=unified&w=0#diff-7789f2147879712de18668945491a0fa654a3819f24c77e7af57d0bb701c33b8L24-R28))