### PR TITLE
Increase pattern modal dimensions when creating a new template

### DIFF
--- a/packages/edit-site/src/components/start-template-options/style.scss
+++ b/packages/edit-site/src/components/start-template-options/style.scss
@@ -26,7 +26,11 @@
 		aspect-ratio: 3/4;
 		width: calc(50% - #{ $grid-unit-30 * 1 } / 2);
 
-		@include break-large() {
+		@include break-medium() {
+			width: calc(33.333% - #{ $grid-unit-30 * 2 } / 3);
+		}
+
+		@include break-wide() {
 			width: calc(25% - #{ $grid-unit-30 * 3 } / 4);
 		}
 

--- a/packages/edit-site/src/components/start-template-options/style.scss
+++ b/packages/edit-site/src/components/start-template-options/style.scss
@@ -6,10 +6,11 @@
 		height: calc(100% - #{ $header-height * 2 });
 	}
 	@include break-medium() {
-		width: 50%;
+		width: 95%;
 	}
 	@include break-large() {
-		height: fit-content;
+		height: 95%;
+		max-height: none;
 	}
 }
 
@@ -18,7 +19,7 @@
 	width: 100%;
 	margin-top: $grid-unit-05;
 	gap: $grid-unit-30;
-	grid-template-columns: repeat(auto-fit, minmax(min(100%/2, max(240px, 100%/10)), 1fr));
+	grid-template-columns: repeat(auto-fit, minmax(min(100%/2, max(240px, 100%/5)), 1fr));
 
 	.block-editor-block-patterns-list__list-item {
 		break-inside: avoid-column;

--- a/packages/edit-site/src/components/start-template-options/style.scss
+++ b/packages/edit-site/src/components/start-template-options/style.scss
@@ -9,23 +9,26 @@
 		width: 95%;
 	}
 	@include break-large() {
-		height: 95%;
-		max-height: none;
+		max-height: 95%;
 	}
 }
 
 .edit-site-start-template-options__modal-content .block-editor-block-patterns-list {
-	display: grid;
+	display: flex;
+	flex-wrap: wrap;
+	gap: $grid-unit-30;
 	width: 100%;
 	margin-top: $grid-unit-05;
-	gap: $grid-unit-30;
-	grid-template-columns: repeat(auto-fit, minmax(min(100%/2, max(240px, 100%/5)), 1fr));
 
 	.block-editor-block-patterns-list__list-item {
 		break-inside: avoid-column;
 		margin-bottom: 0;
-		width: 100%;
 		aspect-ratio: 3/4;
+		width: calc(50% - #{ $grid-unit-30 * 1 } / 2);
+
+		@include break-large() {
+			width: calc(25% - #{ $grid-unit-30 * 3 } / 4);
+		}
 
 		.block-editor-block-preview__container {
 			height: 100%;

--- a/packages/edit-site/src/components/start-template-options/style.scss
+++ b/packages/edit-site/src/components/start-template-options/style.scss
@@ -3,7 +3,7 @@
 	// and height are used instead of max-(width/height).
 	@include break-small() {
 		width: calc(100% - #{ $grid-unit-20 * 2 });
-		height: calc(100% - #{ $header-height * 2 });
+		height: auto;
 	}
 	@include break-medium() {
 		width: 95%;


### PR DESCRIPTION
## What?
Increases the size of the pattern modal that appears when creating a template

## Why?
A larger modal is more immersive (distractions of the editor are hidden), and the previews themselves are larger.

## How?
Adjusts some css.

## Testing Instructions
* Create a new template
* Observe the larger modal

**Before**
<img width="1675" alt="Screenshot 2023-04-11 at 15 06 19" src="https://user-images.githubusercontent.com/846565/231205996-3d0a53d3-590a-4710-802c-3ef16b5aa31c.png">

**After**
<img width="1618" alt="Screenshot 2023-04-11 at 15 22 20" src="https://user-images.githubusercontent.com/846565/231206054-31e4c265-c0a3-4fd5-9f91-52037bf132b7.png">

The one drawback with this approach is that the modal is a little empty when there are only two options:

<img width="1587" alt="Screenshot 2023-04-11 at 16 25 32" src="https://user-images.githubusercontent.com/846565/231212090-17f08cce-1420-4ba9-924c-27b5c00b2b5a.png">

We could allow them to scale up to fill the space, but then the previews are _enormous_ when there's only two.

I'm very open to suggestions on how to improve this aspect.