### PR TITLE
Shortcode: Prevent external styling of editing UI

### DIFF
--- a/packages/block-library/src/shortcode/editor.scss
+++ b/packages/block-library/src/shortcode/editor.scss
@@ -16,6 +16,7 @@
 	border-radius: $radius-block-ui !important;
 	box-sizing: border-box;
 	max-height: 250px;
+	resize: none;
 
 	/* Fonts smaller than 16px causes mobile safari to zoom. */
 	font-size: $mobile-text-min-font-size !important;

--- a/packages/block-library/src/shortcode/editor.scss
+++ b/packages/block-library/src/shortcode/editor.scss
@@ -1,13 +1,33 @@
 [data-type="core/shortcode"] {
-	.block-editor-plain-text {
-		max-height: 250px;
-	}
-
 	&.components-placeholder {
 		min-height: 0;
 	}
 }
 
+// The editing view for the Shortcode block is equivalent to block UI.
+// Therefore we increase specificity to avoid theme styles bleeding in.
 .blocks-shortcode__textarea {
-	@include input-control;
+	font-family: $editor-html-font !important;
+	color: $gray-900 !important;
+	background: $white !important;
+	padding: $grid-unit-15 !important;
+	border: $border-width solid $gray-900 !important;
+	box-shadow: none !important;
+	border-radius: $radius-block-ui !important;
+	box-sizing: border-box;
+	max-height: 250px;
+
+	/* Fonts smaller than 16px causes mobile safari to zoom. */
+	font-size: $mobile-text-min-font-size !important;
+	@include break-small {
+		font-size: $default-font-size !important;
+	}
+
+	&:focus {
+		border-color: var(--wp-admin-theme-color) !important;
+		box-shadow: 0 0 0 ($border-width-focus - $border-width) var(--wp-admin-theme-color) !important;
+
+		// Windows High Contrast mode will show this outline, but not the box-shadow.
+		outline: 2px solid transparent !important;
+	}
 }


### PR DESCRIPTION
## What?
Fixes #49482.

The input field for the Shortcode block isn't meant to be styled by themes.

> **Note**
> This is a short-term solution until #33494 lands in the core.

## How?
I borrowed a fix from #34727.

## Testing Instructions
1. Activate a theme that styles the "textarea" element. I was using the **Quadrat** theme.
2. Open a Post or Page.
3. Insert a Shortcode Block.
4. Confirm editing field isn't styled by a theme.

## Screenshots or screencast <!-- if applicable -->

**Before**
![CleanShot 2023-04-11 at 19 46 29](https://user-images.githubusercontent.com/240569/231222251-100d35df-3cf7-447b-b1fc-b61164ec2018.png)

**After**
![CleanShot 2023-04-11 at 19 46 01](https://user-images.githubusercontent.com/240569/231222321-327140b5-99aa-445a-8323-381e8b563765.png)

