### PR TITLE
Lodash: Remove `_.groupBy()` from `core-data` package

### DIFF
--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import fastDeepEqual from 'fast-deep-equal/es6';
-import { groupBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -362,7 +361,15 @@ export const entities = ( state = {}, action ) => {
 	// Generates a dynamic reducer for the entities.
 	let entitiesDataReducer = state.reducer;
 	if ( ! entitiesDataReducer || newConfig !== state.config ) {
-		const entitiesByKind = groupBy( newConfig, 'kind' );
+		const entitiesByKind = newConfig.reduce( ( acc, record ) => {
+			const { kind } = record;
+			if ( ! acc[ kind ] ) {
+				acc[ kind ] = [];
+			}
+			acc[ kind ].push( record );
+			return acc;
+		}, {} );
+
 		entitiesDataReducer = combineReducers(
 			Object.entries( entitiesByKind ).reduce(
 				( memo, [ kind, subEntities ] ) => {


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.groupBy()` from the `core-data` package.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using a custom implementation as a replacement.

## Testing Instructions

* Smoke test the editor thoroughly. This is used literally everywhere where posts, terms, and users are loaded with the REST API.
* Verify all checks are green and all tests still pass. Changes are covered by unit tests.