### PR TITLE
core-data: Remove lodash dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17164,7 +17164,6 @@
 				"change-case": "^4.1.2",
 				"equivalent-key-map": "^0.2.2",
 				"fast-deep-equal": "^3.1.3",
-				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
 				"rememo": "^4.0.0",
 				"uuid": "^8.3.0"

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -44,7 +44,6 @@
 		"change-case": "^4.1.2",
 		"equivalent-key-map": "^0.2.2",
 		"fast-deep-equal": "^3.1.3",
-		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
 		"rememo": "^4.0.0",
 		"uuid": "^8.3.0"


### PR DESCRIPTION
## What?
This PR removes the `lodash` dependency from the `@wordpress/core-data` package.

## Why?
Because it's not needed anymore.

## How?
We're just removing the unused dependency.

## Testing Instructions
* Verify that `lodash` is no longer used in the package.
* Verify everything is green.