### PR TITLE
Reintroduce `styles=open` parameter to open the styles panel directly

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useMemo } from '@wordpress/element';
+import { useMemo, useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Notice } from '@wordpress/components';
 import { EntityProvider } from '@wordpress/core-data';
@@ -102,6 +102,7 @@ export default function Editor() {
 		};
 	}, [] );
 	const { setEditedPostContext } = useDispatch( editSiteStore );
+	const { enableComplementaryArea } = useDispatch( interfaceStore );
 
 	const isViewMode = canvasMode === 'view';
 	const isEditMode = canvasMode === 'edit';
@@ -147,6 +148,19 @@ export default function Editor() {
 			type
 		);
 	}
+
+	useEffect(
+		function openGlobalStylesOnLoad() {
+			const searchParams = new URLSearchParams( window.location.search );
+			if ( searchParams.get( 'styles' ) === 'open' ) {
+				enableComplementaryArea(
+					'core/edit-site',
+					'edit-site/global-styles'
+				);
+			}
+		},
+		[ enableComplementaryArea ]
+	);
 
 	// Only announce the title once the editor is ready to prevent "Replace"
 	// action in <URlQueryController> from double-announcing.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR reintroduces the `styles=open` URL parameter which, in combination with `canvas=edit`, enables to link to the styles panel directly from outside of the site editor. Fixes #49731.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This functionality existed before and has been removed when browse mode got introduced. I'm not sure if this was accidental or intended.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Re-adding the code which has been added in this PR: https://github.com/WordPress/gutenberg/pull/38093

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Make sure to be logged in your WP admin
2. Add `site-editor.php?canvas=edit&styles=open` to the URL and hit enter
3. This URL should redirect you to the editing mode of the site editor with the styles panel being already open

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
See above.

## Screenshots or screencast <!-- if applicable -->
