### PR TITLE
test: Expand multi-line block tests

### DIFF
--- a/packages/block-library/src/list/test/edit.native.js
+++ b/packages/block-library/src/list/test/edit.native.js
@@ -347,7 +347,10 @@ describe( 'List block', () => {
 		// backward delete
 		const listItemField =
 			within( listItemBlock ).getByLabelText( /Text input. .*Two.*/ );
-		changeAndSelectTextOfRichText( listItemField, 'Two' );
+		changeAndSelectTextOfRichText( listItemField, 'Two', {
+			initialSelectionStart: 0,
+			initialSelectionEnd: 3,
+		} );
 		fireEvent( listItemField, 'onKeyDown', {
 			nativeEvent: {},
 			preventDefault() {},
@@ -395,7 +398,10 @@ describe( 'List block', () => {
 		// backward delete
 		const listItemField =
 			within( listItemBlock ).getByLabelText( /Text input. .*One.*/ );
-		changeAndSelectTextOfRichText( listItemField, 'One' );
+		changeAndSelectTextOfRichText( listItemField, 'One', {
+			initialSelectionStart: 0,
+			initialSelectionEnd: 3,
+		} );
 		fireEvent( listItemField, 'onKeyDown', {
 			nativeEvent: {},
 			preventDefault() {},
@@ -406,11 +412,11 @@ describe( 'List block', () => {
 		"<!-- wp:paragraph -->
 		<p>A quick brown fox.</p>
 		<!-- /wp:paragraph -->
-		
+
 		<!-- wp:paragraph -->
 		<p>One</p>
 		<!-- /wp:paragraph -->
-		
+
 		<!-- wp:list -->
 		<ul><!-- wp:list-item -->
 		<li>Two</li>

--- a/packages/block-library/src/preformatted/test/edit.native.js
+++ b/packages/block-library/src/preformatted/test/edit.native.js
@@ -77,11 +77,12 @@ describe( 'Preformatted', () => {
 			preventDefault() {},
 			keyCode: ENTER,
 		} );
+		changeAndSelectTextOfRichText( preformattedTextInput, 'Again' );
 
 		// Assert
 		expect( getEditorHtml() ).toMatchInlineSnapshot( `
 		"<!-- wp:preformatted -->
-		<pre class="wp-block-preformatted">A great statement.<br></pre>
+		<pre class="wp-block-preformatted">A great statement.<br>Again</pre>
 		<!-- /wp:preformatted -->"
 	` );
 	} );

--- a/packages/block-library/src/preformatted/test/edit.native.js
+++ b/packages/block-library/src/preformatted/test/edit.native.js
@@ -64,15 +64,15 @@ describe( 'Preformatted', () => {
 
 		// Act
 		await addBlock( screen, 'Preformatted' );
-		const verseTextInput = await screen.findByPlaceholderText(
+		const preformattedTextInput = await screen.findByPlaceholderText(
 			'Write preformatted text…'
 		);
 		const string = 'A great statement.';
-		changeAndSelectTextOfRichText( verseTextInput, string, {
+		changeAndSelectTextOfRichText( preformattedTextInput, string, {
 			selectionStart: string.length,
 			selectionEnd: string.length,
 		} );
-		fireEvent( verseTextInput, 'onKeyDown', {
+		fireEvent( preformattedTextInput, 'onKeyDown', {
 			nativeEvent: {},
 			preventDefault() {},
 			keyCode: ENTER,

--- a/packages/block-library/src/pullquote/test/edit.native.js
+++ b/packages/block-library/src/pullquote/test/edit.native.js
@@ -45,8 +45,7 @@ describe( 'Pullquote', () => {
 			preventDefault() {},
 			keyCode: ENTER,
 		} );
-
-		// TODO: Determine a way to type after pressing ENTER within the block.
+		changeAndSelectTextOfRichText( pullquoteTextInput, 'Again' );
 
 		const citationTextInput =
 			within( citationBlock ).getByPlaceholderText( 'Add citation' );
@@ -63,7 +62,7 @@ describe( 'Pullquote', () => {
 		// Assert
 		expect( getEditorHtml() ).toMatchInlineSnapshot( `
 		"<!-- wp:pullquote -->
-		<figure class="wp-block-pullquote"><blockquote><p>A great statement.<br></p><cite>A <br>person</cite></blockquote></figure>
+		<figure class="wp-block-pullquote"><blockquote><p>A great statement.<br>Again</p><cite>A <br>person</cite></blockquote></figure>
 		<!-- /wp:pullquote -->"
 	` );
 	} );

--- a/packages/block-library/src/verse/test/edit.native.js
+++ b/packages/block-library/src/verse/test/edit.native.js
@@ -74,13 +74,12 @@ describe( 'Verse block', () => {
 			preventDefault() {},
 			keyCode: ENTER,
 		} );
-
-		// TODO: Determine a way to type after pressing ENTER within the block.
+		changeAndSelectTextOfRichText( verseTextInput, 'Again' );
 
 		// Assert
 		expect( getEditorHtml() ).toMatchInlineSnapshot( `
 		"<!-- wp:verse -->
-		<pre class="wp-block-verse">A great statement.<br></pre>
+		<pre class="wp-block-verse">A great statement.<br>Again</pre>
 		<!-- /wp:verse -->"
 	` );
 	} );

--- a/test/native/integration-test-helpers/rich-text-change-and-select-text.js
+++ b/test/native/integration-test-helpers/rich-text-change-and-select-text.js
@@ -3,20 +3,42 @@
  */
 import { fireEvent } from '@testing-library/react-native';
 
+let eventCount = 0;
+
+function stripOuterHtmlTags( string ) {
+	return string.replace( /^<[^>]*>|<[^>]*>$/g, '' );
+}
+
+function insertTextAtPosition( text, newText, start, end ) {
+	return text.slice( 0, start ) + newText + text.slice( end );
+}
+
 /**
  * Changes the text and selection of a RichText component.
  *
- * @param {import('react-test-renderer').ReactTestInstance} richText                 RichText test instance.
- * @param {string}                                          text                     Text to be set.
- * @param {Object}                                          options                  Configuration options for selection.
- * @param {number}                                          [options.selectionStart] Selection start position.
- * @param {number}                                          [options.selectionEnd]   Selection end position.
+ * @param {import('react-test-renderer').ReactTestInstance} richText                        RichText test instance.
+ * @param {string}                                          text                            Text to be set.
+ * @param {Object}                                          options                         Configuration options for selection.
+ * @param {number}                                          [options.initialSelectionStart]
+ * @param {number}                                          [options.initialSelectionEnd]
+ * @param {number}                                          [options.selectionStart]        Selection start position.
+ * @param {number}                                          [options.selectionEnd]          Selection end position.
  */
 export const changeAndSelectTextOfRichText = (
 	richText,
 	text,
-	{ selectionStart = 0, selectionEnd = 0 } = {}
+	options = {}
 ) => {
+	const currentValueSansOuterHtmlTags = stripOuterHtmlTags(
+		richText.props.value
+	);
+	const {
+		initialSelectionStart = currentValueSansOuterHtmlTags.length,
+		initialSelectionEnd = initialSelectionStart,
+		selectionStart = 0,
+		selectionEnd = selectionStart,
+	} = options;
+
 	fireEvent( richText, 'focus' );
 	fireEvent(
 		richText,
@@ -26,9 +48,14 @@ export const changeAndSelectTextOfRichText = (
 		text,
 		{
 			nativeEvent: {
-				eventCount: 1,
+				eventCount: ( eventCount += 101 ),
 				target: undefined,
-				text,
+				text: insertTextAtPosition(
+					currentValueSansOuterHtmlTags,
+					text,
+					initialSelectionStart,
+					initialSelectionEnd
+				),
 			},
 		}
 	);

--- a/test/native/integration-test-helpers/rich-text-change-text.js
+++ b/test/native/integration-test-helpers/rich-text-change-text.js
@@ -3,19 +3,45 @@
  */
 import { fireEvent } from '@testing-library/react-native';
 
+let eventCount = 0;
+
+function stripOuterHtmlTags( string ) {
+	return string.replace( /^<[^>]*>|<[^>]*>$/g, '' );
+}
+
+function insertTextAtPosition( text, newText, start, end ) {
+	return text.slice( 0, start ) + newText + text.slice( end );
+}
+
 /**
  * Changes the text of a RichText component.
  *
- * @param {import('react-test-renderer').ReactTestInstance} richText RichText test instance.
- * @param {string}                                          text     Text to be set.
+ * @param {import('react-test-renderer').ReactTestInstance} richText                        RichText test instance.
+ * @param {string}                                          text                            Text to be set.
+ * @param {Object}                                          options
+ * @param {number}                                          [options.initialSelectionStart]
+ * @param {number}                                          [options.initialSelectionEnd]
  */
-export const changeTextOfRichText = ( richText, text ) => {
+export const changeTextOfRichText = ( richText, text, options = {} ) => {
+	const currentValueSansOuterHtmlTags = stripOuterHtmlTags(
+		richText.props.value
+	);
+	const {
+		initialSelectionStart = currentValueSansOuterHtmlTags.length,
+		initialSelectionEnd = initialSelectionStart,
+	} = options;
+
 	fireEvent( richText, 'focus' );
 	fireEvent( richText, 'onChange', {
 		nativeEvent: {
-			eventCount: 1,
+			eventCount: ( eventCount += 101 ),
 			target: undefined,
-			text,
+			text: insertTextAtPosition(
+				currentValueSansOuterHtmlTags,
+				text,
+				initialSelectionStart,
+				initialSelectionEnd
+			),
 		},
 	} );
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Expand test coverage for multi-line block tests.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
A to-do comment remained in the code from previous work adding these tests. The
intention was to further test multi-line components by typing _after_ a line
break is inserted via the <kbd>Return</kbd> key.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Expand Rich Text helpers allowing appending of text to a input. This is
accomplished with addition of `initialSelectionStart` and `initialSelectEnd`
options enabling placing the caret prior to "typing" additional text. This API
was inspired by the [`testing-library/user-event` APIs](https://testing-library.com/docs/user-event/utility#type).

Update the multi-line block tests to continue typing after the <kbd>Return</kbd>
key is pressed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
n/a

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
