### PR TITLE
Add script which checks published types for non-checked JS packages

### DIFF
--- a/bin/packages/check-build-type-declaration-files.js
+++ b/bin/packages/check-build-type-declaration-files.js
@@ -69,23 +69,25 @@ async function checkUnverifiedDeclarationFiles() {
 		.filter( ( dirent ) => dirent.isDirectory() )
 		.map( ( dirent ) => path.join( packageDir, dirent.name ) );
 
-	const declarations = await Promise.all(
-		subDirs.map( async ( pkg ) => {
-			const tsconfigPath = path.join( pkg, 'tsconfig.json' );
-			try {
-				const tsconfig = await readTsConfig( tsconfigPath );
+	const declarations = (
+		await Promise.all(
+			subDirs.map( async ( pkg ) => {
+				const tsconfigPath = path.join( pkg, 'tsconfig.json' );
+				try {
+					const tsconfig = await readTsConfig( tsconfigPath );
 
-				if ( tsconfig.compilerOptions?.checkJs === false ) {
-					return getDecFile( pkg );
+					if ( tsconfig.compilerOptions?.checkJs === false ) {
+						return getDecFile( pkg );
+					}
+				} catch ( error ) {
+					if ( error.code !== 'ENOENT' ) {
+						throw error;
+					}
 				}
-			} catch ( error ) {
-				if ( error.code !== 'ENOENT' ) {
-					throw error;
-				}
-			}
-			return null;
-		} )
-	).filter( Boolean );
+				return null;
+			} )
+		)
+	 ).filter( Boolean );
 
 	const tscResults = await Promise.allSettled(
 		declarations.map( ( declaration ) =>

--- a/bin/packages/check-build-type-declaration-files.js
+++ b/bin/packages/check-build-type-declaration-files.js
@@ -1,0 +1,102 @@
+/**
+ * The purpose of this script is to double-check certain published build types.
+ * When we translate JSDoc into types that we wish to publish, we occasionally
+ * disable the type checker for JS files. Unfortunately, this can result in invalid
+ * index.d.ts files being published.
+ *
+ * This script verifies the publishd index.d.ts file for every package which both
+ * builds types and also sets checkJs to false in its tsconfig.json. This is done
+ * by running `tsc --noEmit` on the $package/build-types/index.d.ts file. This also
+ * verifies everything index.d.ts references, which essentially checks the entire
+ * public api of the type declarations for that package.
+ *
+ * @see https://github.com/WordPress/gutenberg/pull/49650 for more discussion.
+ */
+
+/**
+ * External dependencies
+ */
+const fs = require( 'fs' );
+const path = require( 'path' );
+const { exec } = require( 'child_process' );
+const chalk = require( 'chalk' );
+
+// Tsconfig can be JSON5, which accepts comments, which need to be stripped so we can parse the JSON.
+function stripJsonComments( jsonString ) {
+	const lines = jsonString.split( '\n' );
+	const cleanedLines = lines.map( ( line ) => line.replace( /\/\/.*$/, '' ) );
+	return cleanedLines.join( '\n' );
+}
+
+function checkDeclarationFile( file ) {
+	return new Promise( ( resolve, reject ) => {
+		exec( `npx tsc --noEmit ${ file }`, ( error, stdout, stderr ) => {
+			if ( error ) {
+				reject( { file, error, stderr, stdout } );
+			} else {
+				resolve( { file, stdout } );
+			}
+		} );
+	} );
+}
+
+async function checkUnverifiedDeclarationFiles() {
+	const packageDir = path.resolve( 'packages' );
+	const subDirs = fs
+		.readdirSync( packageDir, { withFileTypes: true } )
+		.filter( ( dirent ) => dirent.isDirectory() )
+		.map( ( dirent ) => path.join( packageDir, dirent.name ) );
+
+	const possibleDeclarations = subDirs.reduce( ( acc, pkg ) => {
+		const tsconfigPath = path.join( pkg, 'tsconfig.json' );
+
+		if ( fs.existsSync( tsconfigPath ) ) {
+			const tsconfigRaw = fs.readFileSync( tsconfigPath, 'utf-8' );
+			const tsconfig = JSON.parse( stripJsonComments( tsconfigRaw ) );
+
+			if ( tsconfig.compilerOptions?.checkJs === false ) {
+				acc.push( `${ pkg }/build-types/index.d.ts` );
+			}
+		}
+		return acc;
+	}, [] );
+
+	const declarations = possibleDeclarations.filter( ( decFile ) =>
+		fs.existsSync( decFile )
+	);
+
+	if ( declarations.length !== possibleDeclarations.length ) {
+		console.error(
+			[
+				'The following declaration files are missing, but they should exist:',
+				...possibleDeclarations.filter(
+					( dec ) => ! declarations.includes( dec )
+				),
+				'You may need to run tsc again.',
+			].join( '\n' )
+		);
+		process.exit( 1 );
+	}
+
+	const tscResults = await Promise.allSettled(
+		declarations.map( ( declaration ) =>
+			checkDeclarationFile( declaration )
+		)
+	);
+
+	tscResults.forEach( ( { status, reason } ) => {
+		if ( status !== 'fulfilled' ) {
+			console.error(
+				chalk.red(
+					`Incorrect published types for ${ reason.file }:\n`
+				),
+				reason.stdout
+			);
+		}
+	} );
+
+	if ( tscResults.some( ( { status } ) => status !== 'fulfilled' ) ) {
+		process.exit( 1 );
+	}
+}
+checkUnverifiedDeclarationFiles();

--- a/bin/packages/check-build-type-declaration-files.js
+++ b/bin/packages/check-build-type-declaration-files.js
@@ -1,13 +1,10 @@
 /**
- * The purpose of this script is to double-check certain published build types.
- * When we translate JSDoc into types that we wish to publish, we occasionally
- * disable the type checker for JS files. Unfortunately, this can result in invalid
- * index.d.ts files being published.
+ * This script verifies the published index.d.ts file for every package which both
+ * builds types and also sets checkJs to false in its tsconfig.json. (This scenario
+ * can cause unchecked errors in JS files to be included in the compiled types.)
  *
- * This script verifies the publishd index.d.ts file for every package which both
- * builds types and also sets checkJs to false in its tsconfig.json. This is done
- * by running `tsc --noEmit` on the $package/build-types/index.d.ts file. This also
- * verifies everything index.d.ts references, which essentially checks the entire
+ * We do so by running `tsc --noEmit` on the $package/build-types/index.d.ts file.
+ * This also verifies everything index.d.ts references, so it checks the entire
  * public api of the type declarations for that package.
  *
  * @see https://github.com/WordPress/gutenberg/pull/49650 for more discussion.
@@ -21,16 +18,53 @@ const path = require( 'path' );
 const { exec } = require( 'child_process' );
 const chalk = require( 'chalk' );
 
-// Tsconfig can be JSON5, which accepts comments, which need to be stripped so we can parse the JSON.
-function stripJsonComments( jsonString ) {
-	const lines = jsonString.split( '\n' );
-	const cleanedLines = lines.map( ( line ) => line.replace( /\/\/.*$/, '' ) );
-	return cleanedLines.join( '\n' );
+/**
+ * Returns whether a package needs its compiled types to be double-checked. This
+ * needs to happen when both of these are true:
+ * 1. The package compiles types. (It has a tsconfig file.)
+ * 2. The tsconfig sets checkJs to false.
+ *
+ * NOTE: In the future, if we run into issues parsing JSON, we should migrate to
+ * a proper json5 parser, such as the json5 npm package. The current regex just
+ * handles comments, which at the time is the only thing we use from JSON5.
+ *
+ * @param {string} packagePath Path to the package.
+ * @return {boolean} whether or not the package checksJs.
+ */
+async function packageNeedsExtraCheck( packagePath ) {
+	const configPath = path.join( packagePath, 'tsconfig.json' );
+
+	try {
+		const tsconfigRaw = await fs.readFile( configPath, 'utf-8' );
+		// Removes comments from the JSON5 string to convert it to plain JSON.
+		const jsonString = tsconfigRaw.replace( /\s+\/\/.*$/gm, '' );
+		const config = JSON.parse( jsonString );
+
+		// If checkJs both exists and is false, then we need the extra check.
+		return config.compilerOptions?.checkJs === false;
+	} catch ( e ) {
+		if ( e.code !== 'ENOENT' ) {
+			throw e;
+		}
+
+		// No tsconfig means no checkJs
+		return false;
+	}
 }
 
-async function readTsConfig( tsconfigPath ) {
-	const tsconfigRaw = await fs.readFile( tsconfigPath, 'utf-8' );
-	return JSON.parse( stripJsonComments( tsconfigRaw ) );
+// Returns the path to the build-types declaration file for a package if it exists.
+// Throws an error and exits the script otherwise.
+async function getDecFile( packagePath ) {
+	const decFile = path.join( packagePath, 'build-types', 'index.d.ts' );
+	try {
+		await fs.access( decFile );
+		return decFile;
+	} catch ( err ) {
+		console.error(
+			`Cannot access this declaration file. You may need to run tsc again: ${ decFile }`
+		);
+		process.exit( 1 );
+	}
 }
 
 async function typecheckDeclarations( file ) {
@@ -45,24 +79,6 @@ async function typecheckDeclarations( file ) {
 	} );
 }
 
-// Returns the path to the build-types declaration file for a package if it exists.
-// Throws an error and exits the script otherwise.
-async function getDecFile( packagePath ) {
-	const decFile = path.join( packagePath, 'build-types', 'index.d.ts' );
-	try {
-		await fs.access( decFile );
-		return decFile;
-	} catch ( err ) {
-		if ( err.code !== 'ENOENT' ) {
-			throw err;
-		}
-		console.error(
-			`This declaration file should exist. You may need to run tsc again: ${ decFile }`
-		);
-		process.exit( 1 );
-	}
-}
-
 async function checkUnverifiedDeclarationFiles() {
 	const packageDir = path.resolve( 'packages' );
 	const packageDirs = (
@@ -71,24 +87,15 @@ async function checkUnverifiedDeclarationFiles() {
 		.filter( ( dirent ) => dirent.isDirectory() )
 		.map( ( dirent ) => path.join( packageDir, dirent.name ) );
 
+	// Finds the compiled type declarations for each package which both checks
+	// types and has checkJs disabled.
 	const declarations = (
 		await Promise.all(
-			packageDirs.map( async ( pkg ) => {
-				try {
-					const tsconfig = await readTsConfig(
-						path.join( pkg, 'tsconfig.json' )
-					);
-
-					if ( tsconfig.compilerOptions?.checkJs === false ) {
-						return getDecFile( pkg );
-					}
-				} catch ( error ) {
-					if ( error.code !== 'ENOENT' ) {
-						throw error;
-					}
-				}
-				return null;
-			} )
+			packageDirs.map( async ( pkg ) =>
+				( await packageNeedsExtraCheck( pkg ) )
+					? getDecFile( pkg )
+					: null
+			)
 		)
 	 ).filter( Boolean );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16810,7 +16810,7 @@
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/rich-text": "file:packages/rich-text",
-				"rememo": "^4.0.0",
+				"rememo": "^4.0.2",
 				"uuid": "^8.3.0"
 			}
 		},
@@ -16946,7 +16946,7 @@
 				"lodash": "^4.17.21",
 				"react-autosize-textarea": "^7.1.0",
 				"react-easy-crop": "^4.5.1",
-				"rememo": "^4.0.0",
+				"rememo": "^4.0.2",
 				"remove-accents": "^0.4.2",
 				"traverse": "^0.6.6"
 			}
@@ -17034,7 +17034,7 @@
 				"is-plain-object": "^5.0.0",
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
-				"rememo": "^4.0.0",
+				"rememo": "^4.0.2",
 				"remove-accents": "^0.4.2",
 				"showdown": "^1.9.1",
 				"simple-html-tokenizer": "^0.5.7",
@@ -17057,7 +17057,7 @@
 				"@wordpress/keyboard-shortcuts": "file:packages/keyboard-shortcuts",
 				"@wordpress/private-apis": "file:packages/private-apis",
 				"cmdk": "^0.2.0",
-				"rememo": "^4.0.0"
+				"rememo": "^4.0.2"
 			}
 		},
 		"@wordpress/components": {
@@ -17165,7 +17165,7 @@
 				"equivalent-key-map": "^0.2.2",
 				"fast-deep-equal": "^3.1.3",
 				"memize": "^1.1.0",
-				"rememo": "^4.0.0",
+				"rememo": "^4.0.2",
 				"uuid": "^8.3.0"
 			}
 		},
@@ -17383,7 +17383,7 @@
 				"@wordpress/widgets": "file:packages/widgets",
 				"classnames": "^2.3.1",
 				"memize": "^1.1.0",
-				"rememo": "^4.0.0"
+				"rememo": "^4.0.2"
 			},
 			"dependencies": {
 				"@wordpress/dom": {
@@ -17459,7 +17459,7 @@
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
 				"react-autosize-textarea": "^7.1.0",
-				"rememo": "^4.0.0"
+				"rememo": "^4.0.2"
 			},
 			"dependencies": {
 				"colord": {
@@ -17539,7 +17539,7 @@
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
 				"react-autosize-textarea": "^7.1.0",
-				"rememo": "^4.0.0",
+				"rememo": "^4.0.2",
 				"remove-accents": "^0.4.2"
 			},
 			"dependencies": {
@@ -17839,7 +17839,7 @@
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/keycodes": "file:packages/keycodes",
-				"rememo": "^4.0.0"
+				"rememo": "^4.0.2"
 			}
 		},
 		"@wordpress/keycodes": {
@@ -18222,7 +18222,7 @@
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"memize": "^1.1.0",
-				"rememo": "^4.0.0"
+				"rememo": "^4.0.2"
 			}
 		},
 		"@wordpress/scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -50858,9 +50858,9 @@
 			}
 		},
 		"rememo": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.0.tgz",
-			"integrity": "sha512-6BAfg1Dqg6UteZBEH9k6EHHersM86/EcBOMtJV+h+xEn1GC3H+gAgJWpexWYAamAxD0qXNmIt50iS/zuZKnQag=="
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+			"integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
 		},
 		"remove-accents": {
 			"version": "0.4.2",

--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
 	"scripts": {
 		"build": "npm run build:packages && wp-scripts build",
 		"build:analyze-bundles": "npm run build -- --webpack-bundle-analyzer",
-		"build:package-types": "node ./bin/packages/validate-typescript-version.js && tsc --build",
+		"build:package-types": "node ./bin/packages/validate-typescript-version.js && tsc --build && node ./bin/packages/check-build-type-declaration-files.js",
 		"prebuild:packages": "npm run clean:packages && lerna run build",
 		"build:packages": "npm run build:package-types && node ./bin/packages/build.js",
 		"build:plugin-zip": "bash ./bin/build-plugin-zip.sh",

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -30,7 +30,7 @@
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/rich-text": "file:../rich-text",
-		"rememo": "^4.0.0",
+		"rememo": "^4.0.2",
 		"uuid": "^8.3.0"
 	},
 	"publishConfig": {

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -72,7 +72,7 @@
 		"lodash": "^4.17.21",
 		"react-autosize-textarea": "^7.1.0",
 		"react-easy-crop": "^4.5.1",
-		"rememo": "^4.0.0",
+		"rememo": "^4.0.2",
 		"remove-accents": "^0.4.2",
 		"traverse": "^0.6.6"
 	},

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -50,7 +50,7 @@
 		"is-plain-object": "^5.0.0",
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
-		"rememo": "^4.0.0",
+		"rememo": "^4.0.2",
 		"remove-accents": "^0.4.2",
 		"showdown": "^1.9.1",
 		"simple-html-tokenizer": "^0.5.7",

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -35,7 +35,7 @@
 		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/private-apis": "file:../private-apis",
 		"cmdk": "^0.2.0",
-		"rememo": "^4.0.0"
+		"rememo": "^4.0.2"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0"

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -45,7 +45,7 @@
 		"equivalent-key-map": "^0.2.2",
 		"fast-deep-equal": "^3.1.3",
 		"memize": "^1.1.0",
-		"rememo": "^4.0.0",
+		"rememo": "^4.0.2",
 		"uuid": "^8.3.0"
 	},
 	"peerDependencies": {

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -57,7 +57,7 @@
 		"@wordpress/widgets": "file:../widgets",
 		"classnames": "^2.3.1",
 		"memize": "^1.1.0",
-		"rememo": "^4.0.0"
+		"rememo": "^4.0.2"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -66,7 +66,7 @@
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
 		"react-autosize-textarea": "^7.1.0",
-		"rememo": "^4.0.0"
+		"rememo": "^4.0.2"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -65,7 +65,7 @@
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
 		"react-autosize-textarea": "^7.1.0",
-		"rememo": "^4.0.0",
+		"rememo": "^4.0.2",
 		"remove-accents": "^0.4.2"
 	},
 	"peerDependencies": {

--- a/packages/keyboard-shortcuts/package.json
+++ b/packages/keyboard-shortcuts/package.json
@@ -29,7 +29,7 @@
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",
 		"@wordpress/keycodes": "file:../keycodes",
-		"rememo": "^4.0.0"
+		"rememo": "^4.0.2"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0"

--- a/packages/react-native-editor/jest_ui.config.js
+++ b/packages/react-native-editor/jest_ui.config.js
@@ -16,7 +16,7 @@ module.exports = {
 		platforms: [ 'android', 'ios', 'native' ],
 	},
 	transform: {
-		'^.+\\.(js|ts|tsx)$': 'babel-jest',
+		'^.+\\.(js|ts|tsx|cjs)$': 'babel-jest',
 	},
 	setupFilesAfterEnv: [ './jest_ui_setup_after_env.js' ],
 	testEnvironment: './jest_ui_test_environment.js',

--- a/packages/react-native-editor/metro.config.js
+++ b/packages/react-native-editor/metro.config.js
@@ -13,7 +13,7 @@ const packageNames = fs.readdirSync( PACKAGES_DIR ).filter( ( file ) => {
 module.exports = {
 	watchFolders: [ path.resolve( __dirname, '../..' ) ],
 	resolver: {
-		sourceExts: [ 'js', 'json', 'scss', 'sass', 'ts', 'tsx' ],
+		sourceExts: [ 'js', 'cjs', 'json', 'scss', 'sass', 'ts', 'tsx' ],
 		platforms: [ 'native', 'android', 'ios' ],
 	},
 	transformer: {

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -39,7 +39,7 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/keycodes": "file:../keycodes",
 		"memize": "^1.1.0",
-		"rememo": "^4.0.0"
+		"rememo": "^4.0.2"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds a script which checks the final published declaration files for certain JS packages (ones which have `checkJs` disabled)

## Why?
When `checkJs` is disabled, `tsc` can output declaration files which contain errors. The result is that every consumer gets those errors. We don't want to publish these errors, and it's useful to disable JS type checking. (For example, it would be hard to fix every JS type issue in a large existing package, but we'd still like to publish its types for people to consume.)

This situation happens because `checkJs: false` will basically disable these errors during the normal `tsc` build, but it'll happily copy the offending lines into the published declaration files.

## How?
Run a script which finds every relevant package (ones which include a tsconfig and which set `checkJs` to false), and then run `tsc --noEmit` on the main published declaration file. This basically makes sure the public API for the package types are correct.

One potential issue is that this probably won't type check any declaration file which isn't recursively referenced by index.d.ts. Not sure if this is a real problem, since that would indicate that the type in question is just for internal use 🤔 

This script then runs after the main typescript build.

## Testing Instructions
1. Run `npm run build:package-types` (the fact that there is no error is a indication the script works as well)
2. Make an edit to the `packages/core-data/build-types/index.d.ts` to introduce an error (such as adding this line: `export function(x?: string, y: number): void;`)
3. Run `node bin/packages/check-build-type-declaration-files.js`
4. Observe an error