### PR TITLE
Borders: Fix border style on color/width clearing and global styles fallback logic

### DIFF
--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -50,8 +50,14 @@ function applyFallbackStyle( border ) {
 		return border;
 	}
 
-	if ( ! border.style && ( border.color || border.width ) ) {
+	const hasColorOrWidth = border.color || border.width;
+
+	if ( ! border.style && hasColorOrWidth ) {
 		return { ...border, style: 'solid' };
+	}
+
+	if ( border.style && ! hasColorOrWidth ) {
+		return undefined;
 	}
 
 	return border;

--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -45,41 +45,6 @@ function useHasBorderWidthControl( settings ) {
 	return settings?.border?.width;
 }
 
-function applyFallbackStyle( border ) {
-	if ( ! border ) {
-		return border;
-	}
-
-	const hasColorOrWidth = border.color || border.width;
-
-	if ( ! border.style && hasColorOrWidth ) {
-		return { ...border, style: 'solid' };
-	}
-
-	if ( border.style && ! hasColorOrWidth ) {
-		return undefined;
-	}
-
-	return border;
-}
-
-function applyAllFallbackStyles( border ) {
-	if ( ! border ) {
-		return border;
-	}
-
-	if ( hasSplitBorders( border ) ) {
-		return {
-			top: applyFallbackStyle( border.top ),
-			right: applyFallbackStyle( border.right ),
-			bottom: applyFallbackStyle( border.bottom ),
-			left: applyFallbackStyle( border.left ),
-		};
-	}
-
-	return applyFallbackStyle( border );
-}
-
 function BorderToolsPanel( {
 	resetAllFilter,
 	onChange,
@@ -192,7 +157,7 @@ export default function BorderPanel( {
 	const onBorderChange = ( newBorder ) => {
 		// Ensure we have a visible border style when a border width or
 		// color is being selected.
-		const updatedBorder = applyAllFallbackStyles( newBorder );
+		const updatedBorder = { ...newBorder };
 
 		if ( hasSplitBorders( updatedBorder ) ) {
 			[ 'top', 'right', 'bottom', 'left' ].forEach( ( side ) => {

--- a/packages/edit-site/src/components/global-styles/border-panel.js
+++ b/packages/edit-site/src/components/global-styles/border-panel.js
@@ -16,6 +16,41 @@ const {
 	BorderPanel: StylesBorderPanel,
 } = unlock( blockEditorPrivateApis );
 
+function applyFallbackStyle( border ) {
+	if ( ! border ) {
+		return border;
+	}
+
+	const hasColorOrWidth = border.color || border.width;
+
+	if ( ! border.style && hasColorOrWidth ) {
+		return { ...border, style: 'solid' };
+	}
+
+	if ( border.style && ! hasColorOrWidth ) {
+		return undefined;
+	}
+
+	return border;
+}
+
+function applyAllFallbackStyles( border ) {
+	if ( ! border ) {
+		return border;
+	}
+
+	if ( hasSplitBorders( border ) ) {
+		return {
+			top: applyFallbackStyle( border.top ),
+			right: applyFallbackStyle( border.right ),
+			bottom: applyFallbackStyle( border.bottom ),
+			left: applyFallbackStyle( border.left ),
+		};
+	}
+
+	return applyFallbackStyle( border );
+}
+
 export default function BorderPanel( { name, variation = '' } ) {
 	let prefixParts = [];
 	if ( variation ) {
@@ -42,7 +77,7 @@ export default function BorderPanel( { name, variation = '' } ) {
 		// the `border` style property. This means if the theme.json defined
 		// split borders and the user condenses them into a flat border or
 		// vice-versa we'd get both sets of styles which would conflict.
-		const { border } = newStyle;
+		const border = applyAllFallbackStyles( newStyle?.border );
 		const updatedBorder = ! hasSplitBorders( border )
 			? {
 					top: border,


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/49677

## What?

- Move the global styles specific application of a fallback border style to the global styles border panel
- When clearing an individual border color or border width control in Global Styles, also unset the border style.

## Why?

Without correcting the application of the fallback border style, moving it to the global styles panel, borders on the individual blocks accidentally override theme.json or global styles values.

Without the tweak to unset the border style when clearing a color or width individually, the user has to reset the control via the border panel's menu to get rid of the border style that was added as a fallback.

## How?

Updates the change handling to apply an undefined border style when the width and color haven't been set. This application of a fallback will now only happen in the global styles border panel.

## Testing Instructions

1. Navigate to Site Editor > Global Styles > Blocks > Group > Border
2. Enter a border width and confirm borders are immediately displayed in the preview
3. Clear the width input and confirm the borders are removed in the preview
4. Add a border color. The borders should be back and the correct color
5. Clear the color selection and the borders should disappear again
6. Now enter a width and select a color and the `dashed` border style
7. Save the global styles
8. Switch to the block editor, select an individual Group block, and navigate to the block's styles tab
9. Enter a new custom border width only. Confirm the border is updated appropriately and maintains the dashed style
10. Clear the width, and test that a color selection also maintains the dashed style
11. Switch back to the Site Editor and reset the global styles
12. Back in the Block Editor, select the Group block again, and navigate to the Styles tab
13. Enter a border width only and confirm a border is visible
14. Clear the border width and the border should disappear
15. Select a border color only (custom & preset) and confirm border is visible
16. Clear the color and the border should disappear again
17. Set a complete border and confirm border displays appropriately
18. Check it all on the frontend.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/231976160-aea124ac-e727-4927-a8bd-3efdc2dda613.mp4

