### PR TITLE
Address some warnings in the Gutenberg iOS code  used by the React Native layer

### DIFF
--- a/packages/react-native-bridge/ios/Gutenberg.swift
+++ b/packages/react-native-bridge/ios/Gutenberg.swift
@@ -250,7 +250,7 @@ extension Gutenberg: RCTBridgeDelegate {
         }
         let monitorQueue = DispatchQueue(label: "org.wordpress.network-path-monitor")
         monitor.start(queue: monitorQueue)
-        semaphore.wait(timeout: .distantFuture)
+        _ = semaphore.wait(timeout: .distantFuture)
         monitor.cancel()
         if isOnCellularNetwork {
             return Bundle.main.url(forResource: "main", withExtension: "jsbundle")

--- a/packages/react-native-bridge/ios/GutenbergBridgeDataSource.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDataSource.swift
@@ -1,6 +1,6 @@
 import Aztec
 
-public protocol GutenbergBridgeDataSource: class {
+public protocol GutenbergBridgeDataSource: AnyObject {
     /// Asks the data source for the initial html content to be presented by the editor.
     /// Return `nil` to show the example content.
     ///

--- a/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
@@ -140,7 +140,7 @@ extension RCTLogLevel {
     }
 }
 
-public protocol GutenbergBridgeDelegate: class {
+public protocol GutenbergBridgeDelegate: AnyObject {
     /// Tells the delegate that Gutenberg had returned the requested HTML content.
     /// You can request HTML content by calling `requestHTML()` on a Gutenberg bridge instance.
     ///

--- a/packages/react-native-bridge/ios/GutenbergWebFallback/GutenbergWebSingleBlockViewController.swift
+++ b/packages/react-native-bridge/ios/GutenbergWebFallback/GutenbergWebSingleBlockViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import WebKit
 
-public protocol GutenbergWebDelegate: class {
+public protocol GutenbergWebDelegate: AnyObject {
     func webController(controller: GutenbergWebSingleBlockViewController, didPressSave block: Block)
     func webControllerDidPressClose(controller: GutenbergWebSingleBlockViewController)
     func webController(controller: GutenbergWebSingleBlockViewController, didLog log: String)

--- a/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -414,7 +414,7 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
 // MARK: - RCTBridgeModule delegate
 
 public extension Gutenberg {
-    public enum ActionButtonType: String {
+    enum ActionButtonType: String {
         case missingBlockAlertActionButton = "missing_block_alert_action_button"
     }
 }

--- a/packages/react-native-bridge/ios/SourceFile.swift
+++ b/packages/react-native-bridge/ios/SourceFile.swift
@@ -35,7 +35,7 @@ extension SourceFile {
     
     public func jsScript(with argument: String? = nil) throws -> WKUserScript {
         let content = try getContent()
-        let formatted = String(format: content, argument ?? [])
+        let formatted = String(format: content, argument ?? "")
         
         switch self.type {
         case .css:

--- a/packages/react-native-bridge/ios/SourceFile.swift
+++ b/packages/react-native-bridge/ios/SourceFile.swift
@@ -48,14 +48,14 @@ extension SourceFile {
 }
 
 extension SourceFile {
-    static let editorStyle = SourceFile(name: "editor-style-overrides", type: .css)
-    static let wpBarsStyle = SourceFile(name: "wp-bar-override", type: .css)
-    static let injectCss = SourceFile(name: "inject-css", type: .js)
     static let retrieveHtml = SourceFile(name: "content-functions", type: .js)
+    static let editorBehavior = SourceFile(name: "editor-behavior-overrides", type: .js)
+    static let editorStyle = SourceFile(name: "editor-style-overrides", type: .css)
+    static let gutenbergObserver = SourceFile(name: "gutenberg-observer", type: .js)
+    static let injectCss = SourceFile(name: "inject-css", type: .js)
     static let insertBlock = SourceFile(name: "insert-block", type: .js)
     static let localStorage  = SourceFile(name: "local-storage-overrides", type: .json)
     static let preventAutosaves = SourceFile(name: "prevent-autosaves", type: .js)
-    static let gutenbergObserver = SourceFile(name: "gutenberg-observer", type: .js)
     static let supportedBlocks = SourceFile(name: "supported-blocks", type: .json)
-    static let editorBehavior = SourceFile(name: "editor-behavior-overrides", type: .js)
+    static let wpBarsStyle = SourceFile(name: "wp-bar-override", type: .css)
 }


### PR DESCRIPTION
## What? & Why?
I've been touching the code in `packages/react-native-bridge/ios` as part of my experiment to see whether I can figure out how to distributed `gutenberg-mobile` as a binary XCFramework for the iOS app(s) to use.

While around there, I noticed a few warnings and addressed to reduce the noise in my IDE.

## How?
Refer to the commit messages for details on the individual warnings

## Testing Instructions
The code changes here are relevant only to the React Native implementation. I opened a mirror PR on `gutenberg-mobile` pointing to them to verify CI is green and that the iOS demo app runs locally. See https://github.com/wordpress-mobile/gutenberg-mobile/pull/5659.

### Testing Instructions for Keyboard
N.A.