### PR TITLE
List View: Allow dragging to all levels of the block hierarchy

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -245,7 +245,6 @@ function ListViewBlock( {
 			id={ `list-view-${ listViewInstanceId }-block-${ clientId }` }
 			data-block={ clientId }
 			data-expanded={ canExpand ? isExpanded : undefined }
-			data-level={ level }
 			ref={ rowRef }
 		>
 			<TreeGridCell

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -245,6 +245,7 @@ function ListViewBlock( {
 			id={ `list-view-${ listViewInstanceId }-block-${ clientId }` }
 			data-block={ clientId }
 			data-expanded={ canExpand ? isExpanded : undefined }
+			data-level={ level }
 			ref={ rowRef }
 		>
 			<TreeGridCell

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -376,6 +376,9 @@ $block-navigation-max-indent: 8;
 	}
 }
 
+// When updating the margin for each indentation level, the corresponding
+// indentation in `use-list-view-drop-zone.js` must be updated as well
+// to ensure the drop zone is aligned with the indentation.
 @for $i from 0 to $block-navigation-max-indent {
 	.block-editor-list-view-leaf[aria-level="#{ $i + 1 }"] .block-editor-list-view__expander {
 		@if $i - 1 >= 0 {

--- a/packages/block-editor/src/components/list-view/test/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/test/use-list-view-drop-zone.js
@@ -1,7 +1,10 @@
 /**
  * Internal dependencies
  */
-import { getListViewDropTarget } from '../use-list-view-drop-zone';
+import {
+	getListViewDropTarget,
+	NESTING_LEVEL_INDENTATION,
+} from '../use-list-view-drop-zone';
 
 describe( 'getListViewDropTarget', () => {
 	const blocksData = [
@@ -15,10 +18,10 @@ describe( 'getListViewDropTarget', () => {
 					top: 50,
 					bottom: 100,
 					left: 10,
-					right: 100,
+					right: 300,
 					x: 10,
 					y: 50,
-					width: 90,
+					width: 290,
 					height: 50,
 				} ),
 			},
@@ -26,6 +29,7 @@ describe( 'getListViewDropTarget', () => {
 			isDraggedBlock: false,
 			isExpanded: true,
 			rootClientId: '',
+			nestingLevel: 1,
 		},
 		{
 			blockIndex: 0,
@@ -37,32 +41,56 @@ describe( 'getListViewDropTarget', () => {
 					top: 100,
 					bottom: 150,
 					left: 10,
-					right: 100,
+					right: 300,
 					x: 10,
 					y: 100,
-					width: 90,
+					width: 290,
 					height: 50,
 				} ),
 			},
-			innerBlockCount: 0,
+			innerBlockCount: 1,
 			isDraggedBlock: false,
-			isExpanded: false,
+			isExpanded: true,
 			rootClientId: 'block-1',
+			nestingLevel: 2,
 		},
 		{
-			blockIndex: 1,
+			blockIndex: 0,
 			canInsertDraggedBlocksAsChild: true,
 			canInsertDraggedBlocksAsSibling: true,
 			clientId: 'block-3',
 			element: {
 				getBoundingClientRect: () => ( {
 					top: 150,
-					bottom: 150,
+					bottom: 200,
 					left: 10,
-					right: 100,
+					right: 300,
 					x: 10,
 					y: 150,
-					width: 90,
+					width: 290,
+					height: 50,
+				} ),
+			},
+			innerBlockCount: 0,
+			isDraggedBlock: false,
+			isExpanded: true,
+			rootClientId: 'block-2',
+			nestingLevel: 3,
+		},
+		{
+			blockIndex: 1,
+			canInsertDraggedBlocksAsChild: true,
+			canInsertDraggedBlocksAsSibling: true,
+			clientId: 'block-4',
+			element: {
+				getBoundingClientRect: () => ( {
+					top: 200,
+					bottom: 250,
+					left: 10,
+					right: 300,
+					x: 10,
+					y: 200,
+					width: 290,
 					height: 50,
 				} ),
 			},
@@ -70,6 +98,7 @@ describe( 'getListViewDropTarget', () => {
 			isDraggedBlock: false,
 			isExpanded: false,
 			rootClientId: '',
+			nestingLevel: 1,
 		},
 	];
 
@@ -96,8 +125,55 @@ describe( 'getListViewDropTarget', () => {
 		} );
 	} );
 
+	it( 'should nest when dragging a block over the right side of the bottom half of a block nested to three levels', () => {
+		const position = { x: 250, y: 180 };
+		const target = getListViewDropTarget( blocksData, position );
+
+		expect( target ).toEqual( {
+			blockIndex: 0,
+			dropPosition: 'inside',
+			rootClientId: 'block-3',
+		} );
+	} );
+
+	it( 'should drag below when positioned at the bottom half of a block nested to three levels, and over the third level horizontally', () => {
+		const position = { x: 10 + NESTING_LEVEL_INDENTATION * 3, y: 180 };
+		const target = getListViewDropTarget( blocksData, position );
+
+		expect( target ).toEqual( {
+			blockIndex: 1,
+			clientId: 'block-3',
+			dropPosition: 'bottom',
+			rootClientId: 'block-2',
+		} );
+	} );
+
+	it( 'should drag one level up below when positioned at the bottom half of a block nested to three levels, and over the second level horizontally', () => {
+		const position = { x: 10 + NESTING_LEVEL_INDENTATION * 2, y: 180 };
+		const target = getListViewDropTarget( blocksData, position );
+
+		expect( target ).toEqual( {
+			blockIndex: 1,
+			clientId: 'block-3',
+			dropPosition: 'bottom',
+			rootClientId: 'block-1',
+		} );
+	} );
+
+	it( 'should drag two levels up below when positioned at the bottom half of a block nested to three levels, and over the first level horizontally', () => {
+		const position = { x: 10 + NESTING_LEVEL_INDENTATION, y: 180 };
+		const target = getListViewDropTarget( blocksData, position );
+
+		expect( target ).toEqual( {
+			blockIndex: 1,
+			clientId: 'block-3',
+			dropPosition: 'bottom',
+			rootClientId: '',
+		} );
+	} );
+
 	it( 'should nest when dragging a block over the right side and bottom half of a collapsed block with children', () => {
-		const position = { x: 70, y: 90 };
+		const position = { x: 160, y: 90 };
 
 		const collapsedBlockData = [ ...blocksData ];
 

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -210,18 +210,17 @@ export function getListViewDropTarget( blocksData, position ) {
 				candidateBlockParents.length
 			);
 
-			const targetParentIndex =
-				Math.max(
-					Math.min( desiredRelativeLevel, currentLevel - nextLevel ),
-					1
-				) - 1;
+			const targetParentIndex = Math.max(
+				Math.min( desiredRelativeLevel, currentLevel - nextLevel ),
+				0
+			);
 
 			if ( candidateBlockParents[ targetParentIndex ] ) {
 				return {
 					rootClientId:
 						candidateBlockParents[ targetParentIndex ].rootClientId,
 					clientId: candidateBlockData.clientId,
-					blockIndex: candidateBlockData.index,
+					blockIndex: candidateBlockData.blockIndex, // TODO: This still isn't quite right.
 					dropPosition: candidateEdge,
 				};
 			}

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -58,7 +58,7 @@ import { store as blockEditorStore } from '../../store';
  *                                                  'inside' refers to nesting as an inner block.
  */
 
-const NESTING_LEVEL_INDENTATION = 28;
+export const NESTING_LEVEL_INDENTATION = 28;
 
 /**
  * Determines whether the user is positioning the dragged block to be

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -79,6 +79,23 @@ function isUpGesture( point, rect, nestingLevel = 1 ) {
 	return point.x < blockIndentPosition;
 }
 
+/**
+ * Returns how many nesting levels up the user is attempting to drag to.
+ *
+ * The relative parent level is calculated based on how far
+ * the cursor is from the provided nesting level (e.g. of a candidate block
+ * that the user is hovering over). The nesting level is considered "desired"
+ * because it is not guaranteed that the user will be able to drag to the desired level.
+ *
+ * The returned integer can be used to access an ascending array
+ * of parent blocks, where the first item is the block the user
+ * is hovering over, and the last item is the root block.
+ *
+ * @param {WPPoint} point        The point representing the cursor position when dragging.
+ * @param {DOMRect} rect         The rectangle.
+ * @param {number}  nestingLevel The nesting level of the block.
+ * @return {number} The desired relative parent level.
+ */
 function getDesiredRelativeParentLevel( point, rect, nestingLevel = 1 ) {
 	const blockIndentPosition =
 		rect.left + nestingLevel * NESTING_LEVEL_INDENTATION;

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -225,9 +225,6 @@ export function getListViewDropTarget( blocksData, position ) {
 		return;
 	}
 
-	// Now that we have a candidate block, we can perform more expensive
-	// checks to determine the drop target.
-
 	const candidateBlockParents = getCandidateBlockParents(
 		candidateBlockData,
 		blocksData

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -389,9 +389,12 @@ export default function useListViewDropZone() {
 				const blocksData = blockElements.map( ( blockElement ) => {
 					const clientId = blockElement.dataset.block;
 					const isExpanded = blockElement.dataset.expanded === 'true';
-					const nestingLevel = blockElement.dataset.level
-						? parseInt( blockElement.dataset.level, 10 )
-						: undefined;
+
+					// Get nesting level from `aria-level` attribute because Firefox does not support `element.ariaLevel`.
+					const nestingLevel = parseInt(
+						blockElement.getAttribute( 'aria-level' ),
+						10
+					);
 					const rootClientId = getBlockRootClientId( clientId );
 
 					return {
@@ -400,7 +403,7 @@ export default function useListViewDropZone() {
 						rootClientId,
 						blockIndex: getBlockIndex( clientId ),
 						element: blockElement,
-						nestingLevel,
+						nestingLevel: nestingLevel || undefined,
 						isDraggedBlock: isBlockDrag
 							? draggedBlockClientIds.includes( clientId )
 							: false,

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -215,12 +215,27 @@ export function getListViewDropTarget( blocksData, position ) {
 				0
 			);
 
+			// TODO: This still isn't quite right as the default block index.
+			// It should really be one more than the last block in that level of the tree.
+			let newBlockIndex = candidateBlockData.blockIndex;
+
+			// If the next block is at the same level, use that as the default
+			// block index. This ensures that the block is dropped in the correct
+			// position when dragging to the bottom of a block.
+			if (
+				candidateBlockParents[ targetParentIndex ].nestingLevel ===
+				blocksData[ candidateBlockIndex + 1 ]?.nestingLevel
+			) {
+				newBlockIndex =
+					blocksData[ candidateBlockIndex + 1 ]?.blockIndex;
+			}
+
 			if ( candidateBlockParents[ targetParentIndex ] ) {
 				return {
 					rootClientId:
 						candidateBlockParents[ targetParentIndex ].rootClientId,
 					clientId: candidateBlockData.clientId,
-					blockIndex: candidateBlockData.blockIndex, // TODO: This still isn't quite right.
+					blockIndex: newBlockIndex,
 					dropPosition: candidateEdge,
 				};
 			}

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -58,6 +58,8 @@ import { store as blockEditorStore } from '../../store';
  *                                                  'inside' refers to nesting as an inner block.
  */
 
+// When the indentation level, the corresponding left margin in `style.scss`
+// must be updated as well to ensure the drop zone is aligned with the indentation.
 export const NESTING_LEVEL_INDENTATION = 28;
 
 /**

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -370,6 +370,9 @@ export default function useListViewDropZone() {
 				const blocksData = blockElements.map( ( blockElement ) => {
 					const clientId = blockElement.dataset.block;
 					const isExpanded = blockElement.dataset.expanded === 'true';
+					const nestingLevel = blockElement.dataset.level
+						? parseInt( blockElement.dataset.level, 10 )
+						: undefined;
 					const rootClientId = getBlockRootClientId( clientId );
 
 					return {
@@ -378,7 +381,7 @@ export default function useListViewDropZone() {
 						rootClientId,
 						blockIndex: getBlockIndex( clientId ),
 						element: blockElement,
-						nestingLevel: blockElement.ariaLevel,
+						nestingLevel,
 						isDraggedBlock: isBlockDrag
 							? draggedBlockClientIds.includes( clientId )
 							: false,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #33678

<!-- An exploration into #33678, and an alternative to #49498 -->

This PR seeks to add the ability to drag to all levels of the block hierarchy within the list view. This is most notable when attempting to drag beneath an expanded Group block, particularly if it is heavily nested.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's important that folks can drag beneath a nested block. If we can allow dragging to each level of the block hierarchy, then it should allow for a more powerful drag and drop interface. Enabling this behaviour is a prerequisite for many of the current ideas for visual improvements to drag and drop — first we need to make sure it's possible to accurately determine the drop target, before we can improve how it looks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Calculate the desired nesting level based on the mouse cursor position, and using a hard-coded value to account for the indent for each nesting level (if anyone has a good idea about how to measure this instead, I'm happy to explore it!)
* Construct a list of parents for the target block, based on the block data and matching based on `rootClientId`s
* Update nesting logic so that it also uses a calculation based on the current nesting level to determine where the mouse cursor will be recognised as a nesting gesture
* Factor in dragged blocks when determining the nesting level of the next block to compare
* Determine the `blockIndex` for the dropped block based on either being at the very end of the parent (if the subsequent block is not at the same level) or by using the `blockIndex` of the next block (if the subsequent block is at the same level)
* Add some extra tests to try to cover most of the changes with unit tests

## To-do

* [x] ~Ensure the `blockIndex` is the correct one for where the user is dragging. That is, it should be the last index of the parent block _or_ one less that the subsequent block if the drag position has the same level as the subsequent block.~
* [x] ~Ensure dragging to the root level position still works correctly~
* [x] ~If the block being dragged is the last of the parent's children, then currently it interferes with the check of the last visual child in the list view (as technically it isn't the last child).~
* [x] ~Fix existing tests, add additional tests~
* [ ] Fine-tune the positioning of where each nesting level begins (currently it's hard-coded, but can we determine it based on anything within the DOM?)
* [ ] Ensure this doesn't break if a list view is using a custom `rootClientId` — I haven't tested this yet, but I _think_ this should work okay

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

<details>

<summary>Some heavily nested block markup</summary>

```html
<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A paragraph in a group level 1</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A paragraph in a group level 2</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A paragraph in a group level 3</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A paragraph in a group level 4</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A paragraph in a group level 5</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph {"anchor":""} -->
<p>A paragraph in a group level 6</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph {"anchor":""} -->
<p>A paragraph in a group level 7</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph {"anchor":""} -->
<p>A paragraph in a group level 8</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->

<!-- wp:heading -->
<h2 class="wp-block-heading">A heading</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>A paragraph</p>
<!-- /wp:paragraph -->
```
</details>

1. Add a series of nested Group blocks to a post.
2. Try dragging a block beneath the bottom nested block across all levels of the hierarchy (you need to be hovered over the bottom half of the nested block)
3. Add additional blocks at each level of the hierarchy
4. Attempt a lot of different kinds of dragging and see if the updated logic breaks anything

## Screenshots or screencast <!-- if applicable -->

<!--
https://user-images.githubusercontent.com/14988353/231371702-2f473134-1ca6-44b3-bc5a-8a7487ee1640.mp4
-->

![2023-04-28 14 38 21](https://user-images.githubusercontent.com/14988353/235055585-b8ade832-d353-4285-8958-0d8a52c30e32.gif)
