### PR TITLE
Block Mover: Make text labels for left/right move buttons legible

### DIFF
--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -38,7 +38,7 @@
 				overflow: hidden;
 			}
 
-			.block-editor-block-mover-button.has-icon {
+			.block-editor-block-mover-button {
 				padding-left: 0;
 				padding-right: 0;
 			}
@@ -58,9 +58,12 @@
 	@include break-small() {
 		width: $block-toolbar-height * 0.5;
 		min-width: 0 !important; // overrides default button width.
-		padding-left: 0 !important;
-		padding-right: 0 !important;
 		overflow: hidden;
+
+		.block-editor-block-mover &.has-icon.has-icon {
+			padding-left: 0;
+			padding-right: 0;
+		}
 	}
 }
 

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -35,9 +35,12 @@
 			> * {
 				width: $block-toolbar-height * 0.5;
 				min-width: 0 !important; // overrides default button width.
-				padding-left: 0 !important;
-				padding-right: 0 !important;
 				overflow: hidden;
+			}
+
+			.block-editor-block-mover-button.has-icon {
+				padding-left: 0;
+				padding-right: 0;
 			}
 
 			.block-editor-block-mover-button.is-up-button svg {

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -170,12 +170,11 @@
 	.block-editor-block-mover.is-horizontal .block-editor-block-mover__move-button-container {
 		padding-left: 6px;
 		padding-right: 6px;
+	}
 
-		> * {
-			// Override !important padding rules set in block mover styles.
-			padding-left: 6px !important;
-			padding-right: 6px !important;
-		}
+	.block-editor-block-mover:not(.is-horizontal) .block-editor-block-mover-button {
+		padding-left: $grid-unit;
+		padding-right: $grid-unit;
 	}
 
 	// Mover overrides.
@@ -188,12 +187,6 @@
 
 	.block-editor-block-contextual-toolbar.is-fixed .block-editor-block-toolbar__block-controls .block-editor-block-mover {
 		border-left-color: $gray-200;
-	}
-
-	.block-editor-block-mover-button {
-		// The specificity can be reduced once https://github.com/WordPress/gutenberg/blob/try/block-toolbar-labels/packages/block-editor/src/components/block-mover/style.scss#L34 is also dealt with.
-		padding-left: $grid-unit !important;
-		padding-right: $grid-unit !important;
 	}
 
 	.block-editor-block-mover__drag-handle.has-icon {

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -2,6 +2,8 @@
  * Block Toolbar
  */
 
+$grid-unit-075: 0.75 * $grid-unit;	// 6px
+
 .block-editor-block-toolbar {
 	display: flex;
 	flex-grow: 1;
@@ -143,8 +145,8 @@
 	// Padding overrides.
 
 	.components-accessible-toolbar .components-toolbar-group > div:first-child:last-child > .components-button.has-icon {
-		padding-left: 6px;
-		padding-right: 6px;
+		padding-left: $grid-unit-075;
+		padding-right: $grid-unit-075;
 	}
 
 	.block-editor-block-switcher .components-dropdown-menu__toggle,
@@ -170,8 +172,8 @@
 	.block-editor-block-mover.is-horizontal {
 		.block-editor-block-mover__move-button-container,
 		.block-editor-block-mover-button {
-			padding-left: 6px;
-			padding-right: 6px;
+			padding-left: $grid-unit-075;
+			padding-right: $grid-unit-075;
 		}
 	}
 
@@ -183,8 +185,8 @@
 	// Mover overrides.
 	.block-editor-block-toolbar__block-controls .block-editor-block-mover {
 		border-left: 1px solid $gray-900;
-		margin-left: 6px;
-		margin-right: -6px;
+		margin-left: $grid-unit-075;
+		margin-right: -$grid-unit-075;
 		white-space: nowrap;
 	}
 
@@ -242,7 +244,7 @@
 
 	.block-editor-rich-text__inline-format-toolbar-group {
 		.components-button + .components-button {
-			margin-left: 6px;
+			margin-left: $grid-unit-075;
 		}
 	}
 }

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -2,8 +2,6 @@
  * Block Toolbar
  */
 
-$grid-unit-075: 0.75 * $grid-unit;	// 6px
-
 .block-editor-block-toolbar {
 	display: flex;
 	flex-grow: 1;
@@ -145,8 +143,8 @@ $grid-unit-075: 0.75 * $grid-unit;	// 6px
 	// Padding overrides.
 
 	.components-accessible-toolbar .components-toolbar-group > div:first-child:last-child > .components-button.has-icon {
-		padding-left: $grid-unit-075;
-		padding-right: $grid-unit-075;
+		padding-left: 6px;
+		padding-right: 6px;
 	}
 
 	.block-editor-block-switcher .components-dropdown-menu__toggle,
@@ -172,8 +170,8 @@ $grid-unit-075: 0.75 * $grid-unit;	// 6px
 	.block-editor-block-mover.is-horizontal {
 		.block-editor-block-mover__move-button-container,
 		.block-editor-block-mover-button {
-			padding-left: $grid-unit-075;
-			padding-right: $grid-unit-075;
+			padding-left: 6px;
+			padding-right: 6px;
 		}
 	}
 
@@ -185,8 +183,8 @@ $grid-unit-075: 0.75 * $grid-unit;	// 6px
 	// Mover overrides.
 	.block-editor-block-toolbar__block-controls .block-editor-block-mover {
 		border-left: 1px solid $gray-900;
-		margin-left: $grid-unit-075;
-		margin-right: -$grid-unit-075;
+		margin-left: 6px;
+		margin-right: -6px;
 		white-space: nowrap;
 	}
 
@@ -244,7 +242,7 @@ $grid-unit-075: 0.75 * $grid-unit;	// 6px
 
 	.block-editor-rich-text__inline-format-toolbar-group {
 		.components-button + .components-button {
-			margin-left: $grid-unit-075;
+			margin-left: 6px;
 		}
 	}
 }

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -163,8 +163,19 @@
 		}
 	}
 
-	.block-editor-block-mover:not(.is-horizontal) .block-editor-block-mover__move-button-container {
+	.block-editor-block-mover .block-editor-block-mover__move-button-container {
 		width: auto;
+	}
+
+	.block-editor-block-mover.is-horizontal .block-editor-block-mover__move-button-container {
+		padding-left: 6px;
+		padding-right: 6px;
+
+		> * {
+			// Override !important padding rules set in block mover styles.
+			padding-left: 6px !important;
+			padding-right: 6px !important;
+		}
 	}
 
 	// Mover overrides.

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -167,9 +167,12 @@
 		width: auto;
 	}
 
-	.block-editor-block-mover.is-horizontal .block-editor-block-mover__move-button-container {
-		padding-left: 6px;
-		padding-right: 6px;
+	.block-editor-block-mover.is-horizontal {
+		.block-editor-block-mover__move-button-container,
+		.block-editor-block-mover-button {
+			padding-left: 6px;
+			padding-right: 6px;
+		}
 	}
 
 	.block-editor-block-mover:not(.is-horizontal) .block-editor-block-mover-button {
@@ -189,9 +192,9 @@
 		border-left-color: $gray-200;
 	}
 
-	.block-editor-block-mover__drag-handle.has-icon {
-		padding-left: 12px !important;
-		padding-right: 12px !important;
+	.block-editor-block-mover .block-editor-block-mover__drag-handle.has-icon {
+		padding-left: 12px;
+		padding-right: 12px;
 	}
 
 	.block-editor-block-contextual-toolbar.is-fixed .block-editor-block-mover__move-button-container {

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -193,8 +193,8 @@
 	}
 
 	.block-editor-block-mover .block-editor-block-mover__drag-handle.has-icon {
-		padding-left: 12px;
-		padding-right: 12px;
+		padding-left: $grid-unit-15;
+		padding-right: $grid-unit-15;
 	}
 
 	.block-editor-block-contextual-toolbar.is-fixed .block-editor-block-mover__move-button-container {


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/49552

## What?

Fixes the restrictive CSS styling for the horizontal block mover's left/right buttons in the block toolbar.

## Why?

The default styling restricts the width for the block mover to 48px which severely truncates the text-only labels making them unreadable.

## How?

- Allows the block mover's button container to expand to fit content
- Applies padding where necessary so that the buttons appear spaced similar to the rest of the toolbar

## Testing Instructions
1. Enable 'Show button text labels' option in preferences
2. Insert a Row block and add a few child blocks to the Row
3. Select one of the child blocks
4. Observe the move left/right blocks and ensure they are legible and are spaced well
5. Add some extra blocks to the post and select one
6. Make sure the up/down move buttons are still displayed correctly

## Screenshots or screencast <!-- if applicable -->
Before:

<img width="679" alt="Screenshot 2023-04-12 at 7 12 08 pm" src="https://user-images.githubusercontent.com/60436221/231416048-548bf843-bcc0-4be5-944f-b3d5c0471201.png">

After:

<img width="784" alt="Screenshot 2023-04-12 at 7 11 30 pm" src="https://user-images.githubusercontent.com/60436221/231416085-2f7f28b9-b8b7-419f-9740-9721abb37ed7.png">

