### PR TITLE
[RNMobile] Add `core-js` relative indexing method polyfills

### DIFF
--- a/packages/react-native-editor/src/globals.js
+++ b/packages/react-native-editor/src/globals.js
@@ -11,6 +11,7 @@ import 'react-native-url-polyfill/auto';
  * Babel polyfills
  */
 import 'core-js/features/array/flat-map';
+import 'core-js/proposals/relative-indexing-method';
 
 /**
  * WordPress dependencies


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add `core-js` [relative indexing method polyfills](https://github.com/zloirock/core-js#relative-indexing-method).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The `Array.prototype.at()` function is not supported on Android and will be used in another PR ([reference](https://github.com/Automattic/jetpack/pull/29997#discussion_r1163867762)), hence we need to include a polyfill.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Import the polyfill from `core-js`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
N/A

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A
