### PR TITLE
WIP: Explore replacing RichText footnotes on the server

### DIFF
--- a/lib/experimental/footnotes.php
+++ b/lib/experimental/footnotes.php
@@ -1,0 +1,106 @@
+<?php
+
+class Footnote_Processor extends WP_HTML_Tag_Processor {
+	public $notes = array();
+
+	public function replace_footnotes() {
+		while ( $this->next_tag( array( 'tag_name' => 'data' ) ) ) {
+			$value = $this->get_attribute( 'value' );
+			if ( 'core/footnote' !== $value && 'footnote' !== $value ) {
+				continue;
+			}
+
+			$this->set_bookmark( 'start' );
+			if ( ! $this->next_tag( array( 'tag_name' => 'data', 'tag_closers' => 'visit' ) ) ) {
+				return $this->get_updated_html();
+			}
+
+			// These are internal details, not a good example, don't copy this code elsewhere.
+			$this->set_bookmark( 'end' );
+
+			// Footnote logic
+			$note = substr( $this->get_inner_content( 'start', 'end' ), 2, -1 );
+			$id = md5( $note );
+
+			if ( isset( $this->notes[ $id ] ) ) {
+				$this->notes[ $id ]['count'] += 1;
+			} else {
+				$this->notes[ $id ] = array(
+					'note'  => $note,
+					'count' => 1,
+				);
+			}
+
+			// List starts at 1. If the note already exists, use the existing index.
+			$index = 1 + array_search( $id, array_keys( $this->notes ), true );
+			$count = $this->notes[ $id ]['count'];
+
+			$footnote_content = sprintf(
+				'<sup><a class="note-link" href="#%s" id="%s-link-%d">[%d]</a></sup>',
+				$id,
+				$id,
+				$count,
+				$index
+			);
+
+			$this->set_outer_content( 'start', 'end', $footnote_content );
+		}
+
+		return $this->get_updated_html();
+	}
+
+	private function get_inner_content( $start_bookmark, $end_bookmark ) {
+		$open  = $this->bookmarks[ $start_bookmark ];
+		$close = $this->bookmarks[ $end_bookmark ];
+
+		return substr( $this->html, $open->end, $close->start - $open->end );
+	}
+
+	private function set_outer_content( $start_bookmark, $end_bookmark, $new_content ) {
+		$start = $this->bookmarks[ $start_bookmark ]->start;
+		$end   = $this->bookmarks[ $end_bookmark ]->end + 1;
+		$this->lexical_updates[] = new WP_HTML_Text_Replacement( $start, $end, $new_content );
+		$this->get_updated_html();
+
+		$this->bookmarks['start']->start = $start;
+		$this->bookmarks['start']->end   = $end;
+		$this->seek( 'start' );
+	}
+}
+
+add_filter( 'the_content', function ( $html ) {
+	$p = new Footnote_Processor( $html );
+	$p->replace_footnotes();
+
+	$output = $p->get_updated_html();
+	if ( empty( $p->notes ) ) {
+		return $output;
+	}
+
+	$output .= '<ol>';
+	foreach ( $p->notes as $id => $info ) {
+		$note    = $info['note'];
+		$count   = $info['count'];
+		$output .= sprintf( '<li id="%s">', $id );
+		$output .= $note;
+		$label = $count > 1 ?
+			/* translators: %s: footnote occurrence */
+			__( 'Back to content (%s)', 'gutenberg' ) :
+			__( 'Back to content', 'gutenberg' );
+		$links = '';
+		while ( $count ) {
+			$links .= sprintf(
+				'<a href="#%s-link-%d" aria-label="%s">↩︎</a>',
+				$id,
+				$count,
+				sprintf( $label, $count )
+			);
+			$count--;
+		}
+		$output .= ' ' . $links;
+		$output .= '</li>';
+	}
+	$output .= '</ol>';
+
+	return $output;
+}, 1000, 1 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -113,6 +113,7 @@ remove_action( 'plugins_loaded', '_wp_theme_json_webfonts_handler' ); // Turns o
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';
 require __DIR__ . '/experimental/block-editor-settings.php';
 require __DIR__ . '/experimental/blocks.php';
+require __DIR__ . '/experimental/footnotes.php';
 require __DIR__ . '/experimental/navigation-theme-opt-in.php';
 require __DIR__ . '/experimental/kses.php';
 require __DIR__ . '/experimental/l10n.php';


### PR DESCRIPTION
Given a `post_content` with `<data value="core/footnote">[Some reference]</data>` this replaces on render that content with a link to a later footnote at the end of the post, then appends a list of footnotes at the end of the post.

Borrows code directly from #47682 

This is silly code, please **DO NOT MERGE**.

<img width="751" alt="Screenshot 2023-04-12 at 5 07 00 PM" src="https://user-images.githubusercontent.com/5431237/231501668-d1f1f92b-ebe2-4196-a24b-72d4ed1560e8.png">
<img width="1117" alt="Screenshot 2023-04-12 at 5 07 04 PM" src="https://user-images.githubusercontent.com/5431237/231501679-bfed3c2b-c944-4bfe-8a42-80de44b2fe42.png">
<img width="716" alt="Screenshot 2023-04-12 at 5 07 12 PM" src="https://user-images.githubusercontent.com/5431237/231501699-e74e8a8f-8086-4c4d-a761-bf803292037e.png">
