### PR TITLE
Update Reakit dep to 1.3.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7184,9 +7184,9 @@
 			"dev": true
 		},
 		"@popperjs/core": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.6.0.tgz",
-			"integrity": "sha512-cPqjjzuFWNK3BSKLm0abspP0sp/IGOli4p5I5fKFAzdS8fvjdOwDCfZqAaIiXd9lPkOWi3SUUfZof3hEb7J/uw=="
+			"version": "2.11.7",
+			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
+			"integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw=="
 		},
 		"@radix-ui/primitive": {
 			"version": "1.0.0",
@@ -17106,7 +17106,7 @@
 				"path-to-regexp": "^6.2.1",
 				"re-resizable": "^6.4.0",
 				"react-colorful": "^5.3.1",
-				"reakit": "^1.3.8",
+				"reakit": "^1.3.11",
 				"remove-accents": "^0.4.2",
 				"use-lilius": "^2.0.1",
 				"uuid": "^8.3.0",
@@ -17127,6 +17127,39 @@
 					"version": "6.2.1",
 					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
 					"integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
+				},
+				"reakit": {
+					"version": "1.3.11",
+					"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.3.11.tgz",
+					"integrity": "sha512-mYxw2z0fsJNOQKAEn5FJCPTU3rcrY33YZ/HzoWqZX0G7FwySp1wkCYW79WhuYMNIUFQ8s3Baob1RtsEywmZSig==",
+					"requires": {
+						"@popperjs/core": "^2.5.4",
+						"body-scroll-lock": "^3.1.5",
+						"reakit-system": "^0.15.2",
+						"reakit-utils": "^0.15.2",
+						"reakit-warning": "^0.6.2"
+					}
+				},
+				"reakit-system": {
+					"version": "0.15.2",
+					"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.2.tgz",
+					"integrity": "sha512-TvRthEz0DmD0rcJkGamMYx+bATwnGNWJpe/lc8UV2Js8nnPvkaxrHk5fX9cVASFrWbaIyegZHCWUBfxr30bmmA==",
+					"requires": {
+						"reakit-utils": "^0.15.2"
+					}
+				},
+				"reakit-utils": {
+					"version": "0.15.2",
+					"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
+					"integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ=="
+				},
+				"reakit-warning": {
+					"version": "0.6.2",
+					"resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.6.2.tgz",
+					"integrity": "sha512-z/3fvuc46DJyD3nJAUOto6inz2EbSQTjvI/KBQDqxwB0y02HDyeP8IWOJxvkuAUGkWpeSx+H3QWQFSNiPcHtmw==",
+					"requires": {
+						"reakit-utils": "^0.15.2"
+					}
 				}
 			}
 		},
@@ -28907,7 +28940,7 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
 			"dev": true
 		},
 		"code-point-at": {
@@ -30484,7 +30517,7 @@
 		"css.escape": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-			"integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+			"integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
 			"dev": true
 		},
 		"cssesc": {
@@ -41060,7 +41093,7 @@
 		"lz-string": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-			"integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+			"integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
 			"dev": true
 		},
 		"macos-release": {
@@ -50167,39 +50200,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
 			"integrity": "sha1-xYDXfvLPyHUrEySYBg3JeTp6wBw="
-		},
-		"reakit": {
-			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.3.8.tgz",
-			"integrity": "sha512-8SVejx6FUaFi2+Q9eXoDAd4wWi/xAn6v8JgXH8x2xnzye8pb6v5bYvegACVpYVZnrS5w/JUgMTGh1Xy8MkkPww==",
-			"requires": {
-				"@popperjs/core": "^2.5.4",
-				"body-scroll-lock": "^3.1.5",
-				"reakit-system": "^0.15.1",
-				"reakit-utils": "^0.15.1",
-				"reakit-warning": "^0.6.1"
-			}
-		},
-		"reakit-system": {
-			"version": "0.15.1",
-			"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.1.tgz",
-			"integrity": "sha512-PkqfAyEohtcEu/gUvKriCv42NywDtUgvocEN3147BI45dOFAB89nrT7wRIbIcKJiUT598F+JlPXAZZVLWhc1Kg==",
-			"requires": {
-				"reakit-utils": "^0.15.1"
-			}
-		},
-		"reakit-utils": {
-			"version": "0.15.1",
-			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.1.tgz",
-			"integrity": "sha512-6cZgKGvOkAMQgkwU9jdYbHfkuIN1Pr+vwcB19plLvcTfVN0Or10JhIuj9X+JaPZyI7ydqTDFaKNdUcDP69o/+Q=="
-		},
-		"reakit-warning": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.6.1.tgz",
-			"integrity": "sha512-poFUV0EyxB+CcV9uTNBAFmcgsnR2DzAbOTkld4Ul+QOKSeEHZB3b3+MoZQgcYHmbvG19Na1uWaM7ES+/Eyr8tQ==",
-			"requires": {
-				"reakit-utils": "^0.15.1"
-			}
 		},
 		"reassure": {
 			"version": "0.7.1",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Internal
 
 -   `Mobile` Refactor of the KeyboardAwareFlatList component.
+-   Update `reakit` dependency to 1.3.11 ([#49763](https://github.com/WordPress/gutenberg/pull/49763)).
 
 ### Enhancements
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -73,7 +73,7 @@
 		"path-to-regexp": "^6.2.1",
 		"re-resizable": "^6.4.0",
 		"react-colorful": "^5.3.1",
-		"reakit": "^1.3.8",
+		"reakit": "^1.3.11",
 		"remove-accents": "^0.4.2",
 		"use-lilius": "^2.0.1",
 		"uuid": "^8.3.0",

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -12,8 +12,8 @@
 			"snapshot-diff",
 			"@wordpress/jest-console"
 		],
-		// Some errors in Reakit types with TypeScript 4.3
-		// Remove the following line when they've been addressed.
+		// TODO: Remove `skipLibCheck` after resolving duplicate declaration of the `process` variable
+		// between `@types/webpack-env` (from @storybook packages) and `gutenberg-env`.
 		"skipLibCheck": true,
 		"strictNullChecks": true
 	},


### PR DESCRIPTION
Follow-up to #49649

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Updates `reakit` to 1.3.11 ([diff](https://diff.intrinsic.com/reakit/1.3.8/1.3.11), no major changes that might affect us). Also updates `popperjs` to 2.11.7 (at the package-json level).

## Why?

Fixes these TypeScript errors when `skipLibCheck: false` for `tsc`:

```
node_modules/@popperjs/core/lib/types.d.ts(123,39): error TS2344: Type 'Options' does not satisfy the constraint 'Obj'.
node_modules/reakit/ts/Form/__utils/types.d.ts(14,5): error TS2411: Property '["0"]' of type 'keyof T | undefined' is not assignable to 'number' index type 'string | number'.
node_modules/reakit/ts/Form/__utils/types.d.ts(15,5): error TS2411: Property '["1"]' of type '(P extends { 0: infer K0; } ? K0 extends keyof T ? keyof T[K0] : never : never) | undefined' is not assignable to 'number' index type 'string | number'.
node_modules/reakit/ts/Form/__utils/types.d.ts(18,5): error TS2411: Property '["2"]' of type '(P extends { 0: infer K0; 1: infer K1; } ? K0 extends keyof T ? K1 extends keyof T[K0] ? keyof T[K0][K1] : never : never : never) | undefined' is not assignable to 'number' index type 'string | number'.
node_modules/reakit/ts/Form/__utils/types.d.ts(22,5): error TS2411: Property '["3"]' of type '(P extends { 0: infer K0; 1: infer K1; 2: infer K2; } ? K0 extends keyof T ? K1 extends keyof T[K0] ? K2 extends keyof T[K0][K1] ? keyof T[K0][K1][K2] : never : never : never : never) | undefined' is not assignable to 'number' index type 'string | number'.
node_modules/reakit/ts/Form/__utils/types.d.ts(27,5): error TS2411: Property '["4"]' of type '(P extends { 0: infer K0; 1: infer K1; 2: infer K2; 3: infer K3; } ? K0 extends keyof T ? K1 extends keyof T[K0] ? K2 extends keyof T[K0][K1] ? K3 extends keyof T[K0][K1][K2] ? keyof T[K0][K1][K2][K3] : never : never : never : never : never) | undefined' is not assignable to 'number' index type 'string | number'.
node_modules/reakit/ts/Form/__utils/types.d.ts(33,5): error TS2411: Property '["5"]' of type '(P extends { 0: infer K0; 1: infer K1; 2: infer K2; 3: infer K3; 4: infer K4; } ? K0 extends keyof T ? K1 extends keyof T[K0] ? K2 extends keyof T[K0][K1] ? K3 extends keyof T[K0][K1][K2] ? K4 extends keyof T[K0][K1][K2][K3] ? keyof T[K0][K1][K2][K3][K4] : never : never : never : never : never : never) | undefined' is not assignable to 'number' index type 'string | number'.
```

Unfortunately I couldn't find a good fix for this duplicate declaration error in a reasonable amount of time, so I'll keep the `skipLibCheck: true` for now:

```
typings/gutenberg-env/index.d.ts:9:13 - error TS2403: Subsequent variable declarations must have the same type.  Variable 'process' must be of type 'Process', but here has type 'Process'.

9 declare var process: Process;
              ~~~~~~~

  node_modules/@types/webpack-env/index.d.ts:375:13
    375 declare var process: NodeJS.Process;
                    ~~~~~~~
    'process' was also declared here.
```

## Testing Instructions

✅ Types compile successfully (`npm run build:package-types`)