### PR TITLE
Resolve improperly applied border radius when the core/social-link block is interacted with

### DIFF
--- a/packages/block-library/src/social-link/editor.scss
+++ b/packages/block-library/src/social-link/editor.scss
@@ -25,3 +25,8 @@
 .wp-block-social-links.is-style-logos-only .wp-social-link button {
 	padding: 0;
 }
+
+// Ensure radius is applied when the link is highlighted in the editor.
+.wp-block-social-links:not(.is-style-logos-only) .wp-social-link {
+	border-radius: 9999px;
+}

--- a/packages/block-library/src/social-link/editor.scss
+++ b/packages/block-library/src/social-link/editor.scss
@@ -26,7 +26,7 @@
 	padding: 0;
 }
 
-// Ensure radius is applied when the link is highlighted in the editor.
+// Ensure radius is applied when the link is interacted with in the editor.
 .wp-block-social-links:not(.is-style-logos-only) .wp-social-link {
 	border-radius: 9999px;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #48492. 

## Why?
Fixing the visual distortion that occurs when a core/social-link is moved. 

## How?
Tiny CSS fix. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page.
2. Insert a Social Links block.
3. Add at least two social links.
4. Click and move one of the links with the move arrows.

## Screenshots or screencast <!-- if applicable -->

Before: 

https://user-images.githubusercontent.com/1813435/231522013-c84b8bf6-3312-46f7-8823-42452f1b01ab.mp4


After: 

https://user-images.githubusercontent.com/1813435/231521585-fbd9a157-6474-4ceb-8502-620d0f9902bf.mp4


