### PR TITLE
Remove frame shadow in edit view

### DIFF
--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -135,6 +135,7 @@
 
 		& > div {
 			border-radius: 0;
+			box-shadow: none;
 		}
 	}
 }


### PR DESCRIPTION
## What?
Ensures the frame's shadow is only applied in site view

## Why?
It's very hard to see, but the shadow applied for the frame slightly overlaps the top toolbar in edit view. If you look very closely at the screenshot below you might be able to see the result: 

* Slightly darker grey stroke on the left.
* Very subtle 'gradient' on the top toolbar, caused by the shadow.

<img width="377" alt="Screenshot 2023-04-12 at 17 54 24" src="https://user-images.githubusercontent.com/846565/231528491-0f189462-ae18-4304-a239-1385efa73108.png">

## How?
CSS.

## Testing Instructions
You'll probably need to Inspect to confirm:

* Open site editor
* Enter edit view
* Observe that no `box-shadow` is applied to `.edit-site-layout.is-full-canvas .edit-site-layout__canvas>div`.
