### PR TITLE
Components: Improve output of CHANGELOG CI check

### DIFF
--- a/.github/workflows/check-components-changelog.yml
+++ b/.github/workflows/check-components-changelog.yml
@@ -26,12 +26,66 @@ jobs:
                   fetch-depth: ${{ env.PR_COMMIT_COUNT }}
             - name: 'Fetch relevant history from origin'
               run: git fetch origin ${{ github.event.pull_request.base.ref }}
-            - name: Run git diff
+            - name: Check CHANGELOG status
+              env:
+                  PR_NUMBER: ${{ github.event.number }}
               run: |
                   changelog_path="packages/components/CHANGELOG.md"
+                  optional_check_notice="This isn't a required check, so if you think your changes are small enough that they don't warrant a CHANGELOG entry, please go ahead and merge without one."
+
+                  # Fail if the PR doesn't touch the changelog
                   if git diff --quiet ${{ github.event.pull_request.base.sha }} HEAD -- "$changelog_path"; then
                     echo "Please add a CHANGELOG entry to $changelog_path"
                     echo
-                    echo "This isn't a required check, so if you think your changes are small enough that they don't warrant a CHANGELOG entry, please go ahead and merge without one."
+                    echo "${optional_check_notice}"
                     exit 1
                   fi
+
+                  changed_hunks=()
+                  while IFS= read -r range; do
+                    changed_hunks+=("${range}")
+                  done < <( \
+                    # Get CHANGELOG file changes
+                    git diff --unified=0 ${{ github.event.pull_request.base.sha }} HEAD "${changelog_path}" | \
+                    # Remove unwanted headers, meta, and specific change data
+                    grep -v -e '^[+-]' -e '^index' -e '^diff' | \
+                    # sed breakdown (statements are separated by `;`)
+                    # 1. Remove the @@ delimiters from all hunks of changes
+                    # 2. Remove the ` -` from the start of each line
+                    # 3. Remove the number of lines shown in each hunk
+                    # 4. Replace the ` +` with a `-` to show the range of lines changed
+                    sed 's/.*@@\(.*\)@@.*/\1/g; s/^ -//g; s/,[0-9]*//g; s/\(^[0-9]*\) +/\1-/g;' \
+                    )
+                    # Convert the ranges of changed lines to an array of individual line numbers
+                    changed_lines=()
+                    for range in "${changed_hunks[@]}"; do
+                      for (( i=${range%-*}; i<=${range#*-}; i++ )); do changed_lines+=("$i"); done
+                    done
+
+                    # Find important header line numbers
+                    unreleased_header_line_no=$(grep -n -e '^## Unreleased' "${changelog_path}" | head -1 | sed -r 's/^([0-9]*):## Unreleased/\1/')
+                    release_header_pattern='## [0-9]*\.[0-9]*\.[0-9]* \([0-9]{4}-[0-9]{2}-[0-9]{2}\)'
+                    latest_release_header_line_no=$(grep -nE -e "^${release_header_pattern}$" "${changelog_path}" | head -1 | sed -r "s/^([0-9]*):${release_header_pattern}/\1/")
+                    # Find the line number of the current PR's entry in the changelog
+                    pr_link_pattern="\(\[#${PR_NUMBER}\]\(https://github\.com/WordPress/gutenberg/pull/${PR_NUMBER}\)\)"
+                    pr_link_grep_pattern="(\[#${PR_NUMBER}\](https://github\.com/WordPress/gutenberg/pull/${PR_NUMBER}))"
+                    current_pr_entry_line_no=$(grep -n -e "${pr_link_grep_pattern}" "${changelog_path}" | sed -r "s,^([0-9]*):-.*${pr_link_pattern}.*,\1,")
+
+                    # Confirm that there is an 'Unreleased' section and that the relevant entry is in that section
+                    if ! grep -nq -e '^## Unreleased' "${changelog_path}" || \
+                      { [[ -n "${current_pr_entry_line_no}" ]] && ! [[ \
+                        ${current_pr_entry_line_no} -gt ${unreleased_header_line_no} && \
+                        ${current_pr_entry_line_no} -lt ${latest_release_header_line_no} \
+                      ]]; }; then
+                        echo "Please make sure your CHANGELOG entry is in the \`## Unreleased\` section"
+                      exit 1
+                    fi
+
+                    # Confirm that there is an entry with the right PR link it's part of the current changes
+                    if ! ( grep -nq -e "${pr_link_grep_pattern}" "${changelog_path}" \
+                      && echo "${changed_lines[@]}" | grep -qw "$current_pr_entry_line_no" ); then
+                        echo "Please make sure your CHANGELOG entry has a link to the current PR."
+                        echo
+                        echo "${optional_check_notice}"
+                        exit 1
+                    fi

--- a/.github/workflows/check-components-changelog.yml
+++ b/.github/workflows/check-components-changelog.yml
@@ -1,4 +1,4 @@
-name: Verify @wordpress/components CHANGELOG update
+name: OPTIONAL - Verify @wordpress/components CHANGELOG update
 
 on:
     pull_request:
@@ -31,5 +31,7 @@ jobs:
                   changelog_path="packages/components/CHANGELOG.md"
                   if git diff --quiet ${{ github.event.pull_request.base.sha }} HEAD -- "$changelog_path"; then
                     echo "Please add a CHANGELOG entry to $changelog_path"
+                    echo
+                    echo "This isn't a required check, so if you think your changes are small enough that they don't warrant a CHANGELOG entry, please go ahead and merge without one."
                     exit 1
                   fi

--- a/.github/workflows/check-components-changelog.yml
+++ b/.github/workflows/check-components-changelog.yml
@@ -48,7 +48,7 @@ jobs:
 
                   # Confirm that the CHANGELOG has an entry for the current PR
                   if ! grep -nq -e "${pr_link_grep_pattern}" "${changelog_path}"; then
-                      echo "Please make sure your CHANGELOG entry has a link to the current PR."
+                      echo "Please add a CHANGELOG entry to $changelog_path, and make sure your CHANGELOG entry has a link to the current PR."
                       echo
                         echo "${optional_check_notice}"
                       exit 1

--- a/.github/workflows/check-components-changelog.yml
+++ b/.github/workflows/check-components-changelog.yml
@@ -41,51 +41,24 @@ jobs:
                     exit 1
                   fi
 
-                  changed_hunks=()
-                  while IFS= read -r range; do
-                    changed_hunks+=("${range}")
-                  done < <( \
-                    # Get CHANGELOG file changes
-                    git diff --unified=0 ${{ github.event.pull_request.base.sha }} HEAD "${changelog_path}" | \
-                    # Remove unwanted headers, meta, and specific change data
-                    grep -v -e '^[+-]' -e '^index' -e '^diff' | \
-                    # sed breakdown (statements are separated by `;`)
-                    # 1. Remove the @@ delimiters from all hunks of changes
-                    # 2. Remove the ` -` from the start of each line
-                    # 3. Remove the number of lines shown in each hunk
-                    # 4. Replace the ` +` with a `-` to show the range of lines changed
-                    sed 's/.*@@\(.*\)@@.*/\1/g; s/^ -//g; s/,[0-9]*//g; s/\(^[0-9]*\) +/\1-/g;' \
-                    )
-                    # Convert the ranges of changed lines to an array of individual line numbers
-                    changed_lines=()
-                    for range in "${changed_hunks[@]}"; do
-                      for (( i=${range%-*}; i<=${range#*-}; i++ )); do changed_lines+=("$i"); done
-                    done
+                  pr_link_pattern="\(\[#${PR_NUMBER}\]\(https://github\.com/WordPress/gutenberg/pull/${PR_NUMBER}\)\)"
+                  pr_link_grep_pattern="(\[#${PR_NUMBER}\](https://github\.com/WordPress/gutenberg/pull/${PR_NUMBER}))"
 
-                    # Find important header line numbers
-                    unreleased_header_line_no=$(grep -n -e '^## Unreleased' "${changelog_path}" | head -1 | sed -r 's/^([0-9]*):## Unreleased/\1/')
-                    release_header_pattern='## [0-9]*\.[0-9]*\.[0-9]* \([0-9]{4}-[0-9]{2}-[0-9]{2}\)'
-                    latest_release_header_line_no=$(grep -nE -e "^${release_header_pattern}$" "${changelog_path}" | head -1 | sed -r "s/^([0-9]*):${release_header_pattern}/\1/")
-                    # Find the line number of the current PR's entry in the changelog
-                    pr_link_pattern="\(\[#${PR_NUMBER}\]\(https://github\.com/WordPress/gutenberg/pull/${PR_NUMBER}\)\)"
-                    pr_link_grep_pattern="(\[#${PR_NUMBER}\](https://github\.com/WordPress/gutenberg/pull/${PR_NUMBER}))"
-                    current_pr_entry_line_no=$(grep -n -e "${pr_link_grep_pattern}" "${changelog_path}" | sed -r "s,^([0-9]*):-.*${pr_link_pattern}.*,\1,")
+                  unreleased_section=$(sed -n '/^## Unreleased$/,/^## /p' "${changelog_path}")
 
-                    # Confirm that there is an 'Unreleased' section and that the relevant entry is in that section
-                    if ! grep -nq -e '^## Unreleased' "${changelog_path}" || \
-                      { [[ -n "${current_pr_entry_line_no}" ]] && ! [[ \
-                        ${current_pr_entry_line_no} -gt ${unreleased_header_line_no} && \
-                        ${current_pr_entry_line_no} -lt ${latest_release_header_line_no} \
-                      ]]; }; then
-                        echo "Please make sure your CHANGELOG entry is in the \`## Unreleased\` section"
-                      exit 1
-                    fi
-
-                    # Confirm that there is an entry with the right PR link it's part of the current changes
-                    if ! ( grep -nq -e "${pr_link_grep_pattern}" "${changelog_path}" \
-                      && echo "${changed_lines[@]}" | grep -qw "$current_pr_entry_line_no" ); then
-                        echo "Please make sure your CHANGELOG entry has a link to the current PR."
-                        echo
+                  # Confirm that the CHANGELOG has an entry for the current PR
+                  if ! grep -nq -e "${pr_link_grep_pattern}" "${changelog_path}"; then
+                      echo "Please make sure your CHANGELOG entry has a link to the current PR."
+                      echo
                         echo "${optional_check_notice}"
-                        exit 1
-                    fi
+                      exit 1
+                  fi
+
+                  # Confirm that there is an 'Unreleased' section and that the relevant entry is in that section
+                  if ! grep -nq -e '^## Unreleased' "${changelog_path}" || \
+                    ! [[ $unreleased_section = *${pr_link_pattern}* ]]; then
+                      echo "Please make sure your CHANGELOG entry is in the \`## Unreleased\` section"
+                      echo
+                      echo "${optional_check_notice}"
+                      exit 1
+                  fi


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR introduces several changes to make the new Components package CI check's output more helpful (hat tip to @ciampo for the suggestions that inspired most of this)

## Why?
It isn't immediately clear that this new check isn't a _required_ check, and it shouldn't block a merge once the PR is approved.

In addition, the initial implementation only checked that the CHANGELOG had been modified by the PR in question. There were no checks in place to ensure it had been updated correctly.

## How?
First, in the PR overview, the check's name now begins with the word `OPTIONAL` so it's more clear it won't block a merge. Second, if it does fail, the error output in the `details` section will explicitly state that the PR can be merged if the change is too small to warrant an entry.

Then, in addition to checking changes to the CHANGELOG, the script performs a few checks and outputs a relevant error if any of them don't pass:
- Confirms there is an entry in the PR's changes containing a link to the current PR. This check also protects against copy/paste fails where the wrong PR number is used.
- Confirms the `Unreleased` section is present (it always should be, but better safe than sorry)
- Confirms that the current PR's entry is inside that `Unreleased` section, which is helpful if a release happened while the PR was being reviewed.

## Testing Instructions
- Check out this PR
- Branch off of it and create a new testing PR
- Make a change to a component file (not a mobile, storybook, or test file, those don't get checked)

**No entry**
- Don't update the CHANGELOG
- Commit and push your changes
- Confirm the check runs and fails with an error telling you to update the CHANGELOG.

**Wrong PR number, in the right section**

- Add a CHANGELOG entry in the `Unreleased` section, with the wrong PR number in the link.
- Commit and Push.
- Confirm the check fails and the error output asks you to make sure your entry has the right PR number.

**Wrong PR number, in the wrong section**

- Move your CHANGELOG entry out of the `Unreleased` section. Leave the wrong PR number in place.
- Commit and Push.
- Confirm the check fails and the error output asks you to make sure your entry has the right PR number.

**Right PR number, in the wrong section**

- Update your CHANGELOG entry to have the right PR number in the link.
- Commit and Push.
- Confirm the check fails and the error output asks you to make sure your entry is in the `Unreleased` section.

**Right PR number, in the right section**

- Move your CHANGELOG entry back into the `Unreleased` section.
- Commit and Push.
- Confirm the check passes.
- Have a piece of cake. You deserve it.
