### PR TITLE
Group block: remove innerprops from placeholder wrapper

### DIFF
--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -153,7 +153,7 @@ function GroupEdit( {
 				}
 			/>
 			{ showPlaceholder && (
-				<View { ...innerBlocksProps }>
+				<View>
 					{ innerBlocksProps.children }
 					<GroupPlaceHolder
 						clientId={ clientId }


### PR DESCRIPTION
## What?

Possibly, and to some extent, even most probably resolves https://github.com/WordPress/gutenberg/issues/49758

To be sung to the tune of [Captain Underpants](https://www.youtube.com/watch?v=cEl1aXJaMto), by Weird Al 

_When inserting Group block variants_
_You shouldn't need to take aperients_
_The block placeholder should have focus from the start, the start, the staaart_

_And now the icons can be tabbed right through_
_Find the arrow keys and smash! that! keyboard!_

_Check the tooltips as you move, they describe each variant.... Tra la la!_

_Fixing Group - the block's no longer fried!_
_Fixing Group - drag a paragraph inside!_

_Na, na, na, na, na_
_Group block variants, yeah yeah yeah._


https://user-images.githubusercontent.com/6458278/231622368-987d9812-08e6-40e3-a467-511a6fb4a33c.mp4

## Why?
Many of the props were duplicated on the placeholder wrapper and keyboard navigation wasn't working as well as it could have. That's a euphemism.

## How?
Removing `{ ...innerBlocksProps }` from the `<View />` wrapper component. Yes! That's it. 

## Testing Instructions / Testing Instructions for Keyboard

In the source, check that there is only one block wrapper that contains the Group block props and other attributes, e.g., `aria-label="Block: Group"`

1. While focussed in the editor, insert a Group block
2. The initial Group variation should have focus
3. Use Tab or Arrow keys to move between variations
4. Hit Enter to select and insert the variation
5. Hit the Arrow key, followed by Enter to insert a child block

Also, for the Group block placeholder, make sure you can still drag child blocks via the list view. See issue: https://github.com/WordPress/gutenberg/issues/49256


https://user-images.githubusercontent.com/6458278/231627392-20ac56d8-1913-4b63-9a5d-43fc3bcc3eba.mp4




