### PR TITLE
DOM: Update getScrollContainer to be aware of horizontal scroll

### DIFF
--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -131,6 +131,7 @@ Given a DOM node, finds the closest scrollable container node or the node itself
 _Parameters_
 
 -   _node_ `Element | null`: Node from which to start.
+-   _direction_ `?string`: Direction of scrollable container to search for ('vertical', 'horizontal', 'all'). Defaults to 'vertical'.
 
 _Returns_
 

--- a/packages/dom/src/dom/get-scroll-container.js
+++ b/packages/dom/src/dom/get-scroll-container.js
@@ -26,6 +26,16 @@ export default function getScrollContainer( node ) {
 		}
 	}
 
+	// Scrollable if scrollable width exceeds displayed...
+	if ( node.scrollWidth > node.clientWidth ) {
+		// ...except when overflow is defined to be hidden or visible
+		const { overflowX } = getComputedStyle( node );
+
+		if ( /(auto|scroll)/.test( overflowX ) ) {
+			return node;
+		}
+	}
+
 	if ( node.ownerDocument === node.parentNode ) {
 		return node;
 	}

--- a/packages/dom/src/dom/get-scroll-container.js
+++ b/packages/dom/src/dom/get-scroll-container.js
@@ -7,32 +7,37 @@ import getComputedStyle from './get-computed-style';
  * Given a DOM node, finds the closest scrollable container node or the node
  * itself, if scrollable.
  *
- * @param {Element | null} node Node from which to start.
- *
+ * @param {Element | null} node      Node from which to start.
+ * @param {?string}        direction Direction of scrollable container to search for ('vertical', 'horizontal', 'all').
+ *                                   Defaults to 'vertical'.
  * @return {Element | undefined} Scrollable container node, if found.
  */
-export default function getScrollContainer( node ) {
+export default function getScrollContainer( node, direction = 'vertical' ) {
 	if ( ! node ) {
 		return undefined;
 	}
 
-	// Scrollable if scrollable height exceeds displayed...
-	if ( node.scrollHeight > node.clientHeight ) {
-		// ...except when overflow is defined to be hidden or visible
-		const { overflowY } = getComputedStyle( node );
+	if ( direction === 'vertical' || direction === 'all' ) {
+		// Scrollable if scrollable height exceeds displayed...
+		if ( node.scrollHeight > node.clientHeight ) {
+			// ...except when overflow is defined to be hidden or visible
+			const { overflowY } = getComputedStyle( node );
 
-		if ( /(auto|scroll)/.test( overflowY ) ) {
-			return node;
+			if ( /(auto|scroll)/.test( overflowY ) ) {
+				return node;
+			}
 		}
 	}
 
-	// Scrollable if scrollable width exceeds displayed...
-	if ( node.scrollWidth > node.clientWidth ) {
-		// ...except when overflow is defined to be hidden or visible
-		const { overflowX } = getComputedStyle( node );
+	if ( direction === 'horizontal' || direction === 'all' ) {
+		// Scrollable if scrollable width exceeds displayed...
+		if ( node.scrollWidth > node.clientWidth ) {
+			// ...except when overflow is defined to be hidden or visible
+			const { overflowX } = getComputedStyle( node );
 
-		if ( /(auto|scroll)/.test( overflowX ) ) {
-			return node;
+			if ( /(auto|scroll)/.test( overflowX ) ) {
+				return node;
+			}
 		}
 	}
 
@@ -41,5 +46,8 @@ export default function getScrollContainer( node ) {
 	}
 
 	// Continue traversing.
-	return getScrollContainer( /** @type {Element} */ ( node.parentNode ) );
+	return getScrollContainer(
+		/** @type {Element} */ ( node.parentNode ),
+		direction
+	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR updates the `getScrollContainer` utility function to add a `direction` parameter, accepting values `vertical`, `horizontal` or `all`, and defaulting to `vertical`. It adds the ability for horizontally scrolling containers to be returned by the traversal.

For backwards compatibility, when called without the `direction` param, only vertically scrolling containers will be returned.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While working on https://github.com/WordPress/gutenberg/pull/49786, where I'm using `getScrollContainer` with the expectation of it returning the list view container once a horizontal scrollbar is introduced, I noticed that `getScrollContainer` would only return the expected container in lists that went far enough vertically to create a vertical scrollbar.

~A question for the reviewer — I believe this is a bug fix, but could this change be unexpected in different use cases? If so, would it be worth us creating an additional function, or adding an additional param were consumers can specify which directions they'd like to look for (and we'd default to `vertical`)? For now, I've left this PR as a simple bug fix.~ Update: I've updated this PR to add an extra param, for backwards compatibility.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Copy and paste the logic within `getScrollContainer` that looks for a vertical scrollbar and apply to horizontal values
* Add a `direction` param and check it before applying the vertical and horizontal logic.
* Default `direction` to `vertical`, but also allow `horizontal` and `all` values.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

I'm not too sure of a good way to test this manually, however I've updated https://github.com/WordPress/gutenberg/pull/49786 to include this code change so that the list view drag and drop can be tested with it.

Also, I attempted to write a unit test for this, but discovered quickly that `clientWidth` is always returned as `0` in tests, so I couldn't quite think of a good way to write a test for this without a lot of mocking, which might not be all that useful. Very happy for feedback here if folks have a good idea of how to address it!
