### PR TITLE
List View: Update with scrolling and custom scrollbar.

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -535,11 +535,23 @@
 	// Firefox 109+ and Chrome 111+
 	scrollbar-color: $handle-color $track-color; // Syntax, "dark", "light", or "#handle-color #track-color"
 	scrollbar-width: thin;
-	scrollbar-gutter: stable;
+	scrollbar-gutter: auto;
 
+	// Needed to fix a Safari rendering issue.
+	will-change: transform;
+
+	// On-hover/focus visibility.
 	&:hover,
 	&:focus,
 	& > * {
 		visibility: visible;
+	}
+
+	// Scrolling behavior.
+	overflow: hidden;
+
+	&:hover,
+	&:focus {
+		overflow: auto;
 	}
 }

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -530,22 +530,30 @@
 		border: 3px solid transparent;
 		background-clip: padding-box;
 	}
-	&:hover:hover::-webkit-scrollbar-thumb { // This needs specificity.
+	&:hover::-webkit-scrollbar-thumb, // This needs specificity.
+	&:focus::-webkit-scrollbar-thumb,
+	&:focus-within::-webkit-scrollbar-thumb {
 		background-color: $handle-color-hover;
 	}
 
 	// Firefox 109+ and Chrome 111+
 	scrollbar-width: thin;
-	scrollbar-gutter: stable;
+	scrollbar-gutter: stable both-edges;
 	scrollbar-color: $handle-color transparent; // Syntax, "dark", "light", or "#handle-color #track-color"
 
-	&:hover {
+	&:hover,
+	&:focus,
+	&:focus-within {
 		scrollbar-color: $handle-color-hover transparent;
-	}
-	&:hover::-webkit-scrollbar-thumb {
-		background-color: $handle-color-hover;
 	}
 
 	// Needed to fix a Safari rendering issue.
 	will-change: transform;
+
+	// Always show scrollbar on Mobile devices.
+	@media (hover: none) {
+		& {
+			scrollbar-color: $handle-color-hover transparent;
+		}
+	}
 }

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -514,7 +514,7 @@
 	/* stylelint-enable function-comma-space-after */
 }
 
-@mixin custom-scrollbars-on-hover($handle-color, $handle-color-hover, $track-color ) {
+@mixin custom-scrollbars-on-hover($handle-color, $handle-color-hover) {
 
 	// WebKit
 	&::-webkit-scrollbar {
@@ -522,7 +522,7 @@
 		height: 12px;
 	}
 	&::-webkit-scrollbar-track {
-		background-color: $track-color;
+		background-color: transparent;
 	}
 	&::-webkit-scrollbar-thumb {
 		background-color: $handle-color;
@@ -537,10 +537,10 @@
 	// Firefox 109+ and Chrome 111+
 	scrollbar-width: thin;
 	scrollbar-gutter: stable;
-	scrollbar-color: $handle-color $track-color; // Syntax, "dark", "light", or "#handle-color #track-color"
+	scrollbar-color: $handle-color transparent; // Syntax, "dark", "light", or "#handle-color #track-color"
 
 	&:hover {
-		scrollbar-color: $handle-color-hover $track-color;
+		scrollbar-color: $handle-color-hover transparent;
 	}
 	&:hover::-webkit-scrollbar-thumb {
 		background-color: $handle-color-hover;

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -514,8 +514,7 @@
 	/* stylelint-enable function-comma-space-after */
 }
 
-@mixin custom-scrollbars-on-hover($handle-color, $track-color) {
-	visibility: hidden;
+@mixin custom-scrollbars-on-hover($handle-color, $handle-color-hover, $track-color ) {
 
 	// WebKit
 	&::-webkit-scrollbar {
@@ -531,27 +530,22 @@
 		border: 3px solid transparent;
 		background-clip: padding-box;
 	}
+	&:hover:hover::-webkit-scrollbar-thumb { // This needs specificity.
+		background-color: $handle-color-hover;
+	}
 
 	// Firefox 109+ and Chrome 111+
-	scrollbar-color: $handle-color $track-color; // Syntax, "dark", "light", or "#handle-color #track-color"
 	scrollbar-width: thin;
-	scrollbar-gutter: auto;
+	scrollbar-gutter: stable;
+	scrollbar-color: $handle-color $track-color; // Syntax, "dark", "light", or "#handle-color #track-color"
+
+	&:hover {
+		scrollbar-color: $handle-color-hover $track-color;
+	}
+	&:hover::-webkit-scrollbar-thumb {
+		background-color: $handle-color-hover;
+	}
 
 	// Needed to fix a Safari rendering issue.
 	will-change: transform;
-
-	// On-hover/focus visibility.
-	&:hover,
-	&:focus,
-	& > * {
-		visibility: visible;
-	}
-
-	// Scrolling behavior.
-	overflow: hidden;
-
-	&:hover,
-	&:focus {
-		overflow: auto;
-	}
 }

--- a/packages/edit-post/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-post/src/components/secondary-sidebar/style.scss
@@ -11,10 +11,11 @@
 }
 
 .edit-post-editor__document-overview-panel {
-	// Same width as the Inserter.
-	// @see packages/block-editor/src/components/inserter/style.scss
-	// Width of the list view panel.
-	width: 350px;
+	@include break-medium() {
+		// Same width as the Inserter.
+		// @see packages/block-editor/src/components/inserter/style.scss
+		width: 350px;
+	}
 
 	.edit-post-sidebar__panel-tabs {
 		flex-direction: row-reverse;
@@ -71,7 +72,6 @@
 
 	// Include custom scrollbars.
 	@include custom-scrollbars-on-hover($gray-600, $white);
-	overflow: auto;
 
 	// The table cells use an extra pixels of space left and right. We compensate for that here.
 	padding: $grid-unit-10 ($grid-unit-10 - $border-width - $border-width);

--- a/packages/edit-post/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-post/src/components/secondary-sidebar/style.scss
@@ -1,3 +1,8 @@
+/**
+ * Note that this CSS file should be in sync with its counterpart in the other editor:
+ * packages/edit-site/src/components/secondary-sidebar/style.scss
+ */
+
 .edit-post-editor__inserter-panel,
 .edit-post-editor__document-overview-panel {
 	height: 100%;
@@ -62,8 +67,12 @@
 .edit-post-editor__list-view-panel-content,
 .edit-post-editor__list-view-container > .document-outline,
 .edit-post-editor__list-view-empty-headings {
-	overflow: auto;
 	height: 100%;
+
+	// Include custom scrollbars.
+	@include custom-scrollbars-on-hover($gray-600, $white);
+	overflow: auto;
+
 	// The table cells use an extra pixels of space left and right. We compensate for that here.
 	padding: $grid-unit-10 ($grid-unit-10 - $border-width - $border-width);
 }

--- a/packages/edit-post/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-post/src/components/secondary-sidebar/style.scss
@@ -70,8 +70,14 @@
 .edit-post-editor__list-view-empty-headings {
 	height: 100%;
 
-	// Include custom scrollbars.
-	@include custom-scrollbars-on-hover($gray-600, $white);
+	// Include custom scrollbars, invisible until hovered.
+	@include custom-scrollbars-on-hover(transparent, $gray-600, $white);
+	overflow: auto;
+
+	// Only reserve space for scrollbars when there is content to scroll.
+	// This allows items in the list view to have equidistant padding left and right
+	// right up until a scrollbar is present.
+	scrollbar-gutter: auto;
 
 	// The table cells use an extra pixels of space left and right. We compensate for that here.
 	padding: $grid-unit-10 ($grid-unit-10 - $border-width - $border-width);

--- a/packages/edit-post/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-post/src/components/secondary-sidebar/style.scss
@@ -71,7 +71,7 @@
 	height: 100%;
 
 	// Include custom scrollbars, invisible until hovered.
-	@include custom-scrollbars-on-hover(transparent, $gray-600, $white);
+	@include custom-scrollbars-on-hover(transparent, $gray-600);
 	overflow: auto;
 
 	// Only reserve space for scrollbars when there is content to scroll.

--- a/packages/edit-site/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-site/src/components/secondary-sidebar/style.scss
@@ -11,9 +11,11 @@
 }
 
 .edit-site-editor__list-view-panel {
-	// Same width as the Inserter.
-	// @see packages/block-editor/src/components/inserter/style.scss
-	min-width: 350px;
+	@include break-medium() {
+		// Same width as the Inserter.
+		// @see packages/block-editor/src/components/inserter/style.scss
+		width: 350px;
+	}
 }
 
 .edit-site-editor__inserter-panel-header {
@@ -51,8 +53,7 @@
 
 	// Include custom scrollbars.
 	@include custom-scrollbars-on-hover($gray-600, $white);
-	overflow: auto;
 
-	overflow-y: auto;
-	padding: $grid-unit-10;
+	// The table cells use an extra pixels of space left and right. We compensate for that here.
+	padding: $grid-unit-10 ($grid-unit-10 - $border-width - $border-width);
 }

--- a/packages/edit-site/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-site/src/components/secondary-sidebar/style.scss
@@ -1,3 +1,8 @@
+/**
+ * Note that this CSS file should be in sync with its counterpart in the other editor:
+ * packages/edit-post/src/components/secondary-sidebar/style.scss
+ */
+
 .edit-site-editor__inserter-panel,
 .edit-site-editor__list-view-panel {
 	height: 100%;
@@ -42,6 +47,12 @@
 }
 
 .edit-site-editor__list-view-panel-content {
+	height: 100%;
+
+	// Include custom scrollbars.
+	@include custom-scrollbars-on-hover($gray-600, $white);
+	overflow: auto;
+
 	overflow-y: auto;
 	padding: $grid-unit-10;
 }

--- a/packages/edit-site/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-site/src/components/secondary-sidebar/style.scss
@@ -51,8 +51,14 @@
 .edit-site-editor__list-view-panel-content {
 	height: 100%;
 
-	// Include custom scrollbars.
-	@include custom-scrollbars-on-hover($gray-600, $white);
+	// Include custom scrollbars, invisible until hovered.
+	@include custom-scrollbars-on-hover(transparent, $gray-600, $white);
+	overflow: auto;
+
+	// Only reserve space for scrollbars when there is content to scroll.
+	// This allows items in the list view to have equidistant padding left and right
+	// right up until a scrollbar is present.
+	scrollbar-gutter: auto;
 
 	// The table cells use an extra pixels of space left and right. We compensate for that here.
 	padding: $grid-unit-10 ($grid-unit-10 - $border-width - $border-width);

--- a/packages/edit-site/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-site/src/components/secondary-sidebar/style.scss
@@ -52,7 +52,7 @@
 	height: 100%;
 
 	// Include custom scrollbars, invisible until hovered.
-	@include custom-scrollbars-on-hover(transparent, $gray-600, $white);
+	@include custom-scrollbars-on-hover(transparent, $gray-600);
 	overflow: auto;
 
 	// Only reserve space for scrollbars when there is content to scroll.

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -4,6 +4,7 @@
 
 	.components-navigator-screen {
 		@include custom-scrollbars-on-hover($gray-700, $gray-900);
+		scrollbar-gutter: stable;
 	}
 }
 

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -3,7 +3,7 @@
 	overflow-y: auto;
 
 	.components-navigator-screen {
-		@include custom-scrollbars-on-hover(transparent, $gray-700, $gray-900);
+		@include custom-scrollbars-on-hover(transparent, $gray-700);
 		scrollbar-gutter: stable;
 	}
 }

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -3,7 +3,7 @@
 	overflow-y: auto;
 
 	.components-navigator-screen {
-		@include custom-scrollbars-on-hover($gray-700, $gray-900);
+		@include custom-scrollbars-on-hover(transparent, $gray-700, $gray-900);
 		scrollbar-gutter: stable;
 	}
 }


### PR DESCRIPTION
## What?

Alternative to #49508, followup to #49611. 

Keeps the recently enabled horizontal scrolling in the list view, but updates it with an on-hover scrollbar. It also refactors the same scrollbar mixin to support colors.

## Why?

By leveraging on-hover/focus scrollbars, scrolling is available when it needs to be but doesn't weigh the interface when you're not interacting with it. 

## How?

Uses standard CSS and scrollbar properties.

## Testing Instructions

Please test post editor, site editor, and the site editor template view to verify that the onhover scrollbars work as intended. 

## Screenshots or screencast <!-- if applicable -->

Site editor:
![scrollbars site editor](https://user-images.githubusercontent.com/1204802/231738780-282a1fde-1592-40c7-b689-a3597bc9a8b1.gif)


Post editor:

![post editor](https://user-images.githubusercontent.com/1204802/231738846-d6fef7b2-0b27-4ba1-a614-140432023170.gif)

Templates list:

![templates list](https://user-images.githubusercontent.com/1204802/231738859-ac8116c8-9ee9-4042-b808-6e82152974bd.gif)
