### PR TITLE
Autocomplete: Add heading and fix type for `onReplace` in README

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Documentation
+
+-   `Autocomplete`: Add heading and fix type for `onReplace` in README. ([#49798](https://github.com/WordPress/gutenberg/pull/49798)).
+
 ## 23.8.0 (2023-04-12)
 
 ### Internal

--- a/packages/components/src/autocomplete/README.md
+++ b/packages/components/src/autocomplete/README.md
@@ -20,10 +20,12 @@ A function to be called when an option is selected to insert into the existing t
 -   Required: Yes
 -   Type: `( value: string ) => void`
 
+### onReplace
+
 A function to be called when an option is selected to replace the existing text.
 
 -   Required: Yes
--   Type: `( arg: [ OptionCompletion[ 'value' ] ] ) => void;`
+-   Type: `( values: RichTextValue[] ) => void`
 
 ### completers
 
@@ -31,7 +33,7 @@ An array of all of the completers to apply to the current element.
 
 -   Required: Yes
 -   Type: `Array< WPCompleter >`
- 
+
 ### contentRef
 
 A ref containing the editable element that will serve as the anchor for `Autocomplete`'s `Popover`.


### PR DESCRIPTION
## What?
This PR adds the heading `onReplace` and fixes the type in the `Autocomplete` component's README.

I found this while researching #16624. The problem reported in this issue, where the example does not work, also needs to be investigated separately.

## Testing Instructions

You can check the README updated by this PR at https://github.com/WordPress/gutenberg/blob/autocomplete/update-readme/packages/components/src/autocomplete/README.md#onreplace.