### PR TITLE
Lodash: Remove from `@wordpress/editor` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17569,7 +17569,6 @@
 				"classnames": "^2.3.1",
 				"date-fns": "^2.28.0",
 				"escape-html": "^1.0.3",
-				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
 				"react-autosize-textarea": "^7.1.0",
 				"rememo": "^4.0.2",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -62,7 +62,6 @@
 		"classnames": "^2.3.1",
 		"date-fns": "^2.28.0",
 		"escape-html": "^1.0.3",
-		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
 		"react-autosize-textarea": "^7.1.0",
 		"rememo": "^4.0.2",

--- a/packages/editor/src/components/post-template/index.js
+++ b/packages/editor/src/components/post-template/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isEmpty } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -38,7 +33,7 @@ export function PostTemplate() {
 
 	const { editPost } = useDispatch( editorStore );
 
-	if ( ! isViewable || isEmpty( availableTemplates ) ) {
+	if ( ! isViewable || ! Object.entries( availableTemplates ?? {} ).length ) {
 		return null;
 	}
 

--- a/packages/editor/src/components/post-template/index.js
+++ b/packages/editor/src/components/post-template/index.js
@@ -33,7 +33,11 @@ export function PostTemplate() {
 
 	const { editPost } = useDispatch( editorStore );
 
-	if ( ! isViewable || ! Object.entries( availableTemplates ?? {} ).length ) {
+	if (
+		! isViewable ||
+		! availableTemplates ||
+		! Object.keys( availableTemplates ).length
+	) {
 		return null;
 	}
 

--- a/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
+++ b/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isEmpty } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { store as blocksStore } from '@wordpress/blocks';
@@ -87,7 +82,7 @@ const createWithMetaAttributeSource = ( metaAttributes ) =>
 									] )
 							);
 
-							if ( ! isEmpty( nextMeta ) ) {
+							if ( Object.entries( nextMeta ).length ) {
 								setMeta( nextMeta );
 							}
 
@@ -115,7 +110,7 @@ function shimAttributeSource( settings ) {
 			.filter( ( [ , { source } ] ) => source === 'meta' )
 			.map( ( [ attributeKey, { meta } ] ) => [ attributeKey, meta ] )
 	);
-	if ( ! isEmpty( metaAttributes ) ) {
+	if ( Object.entries( metaAttributes ).length ) {
 		settings.edit = createWithMetaAttributeSource( metaAttributes )(
 			settings.edit
 		);


### PR DESCRIPTION
## What?
This PR removes the remaining Lodash from the `@wordpress/editor` package and removes the unused dependency. There were just a few straightforward `isEmpty()` usages.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `Object.entries( object ).length` as an alternative, with a nullish coalescing fallback when necessary.

## Testing Instructions

* Verify on a site with post templates that they still load well in the "Template:" field in the sidebar.
* Verify on a site without post templates that the "Template:" field still does not appear.
* Follow testing instructions in #49654 and verify they still work.
* Verify all checks are green.