### PR TITLE
Docgen: Fix issue where function token can't be found

### DIFF
--- a/packages/docgen/lib/get-jsdoc-from-token.js
+++ b/packages/docgen/lib/get-jsdoc-from-token.js
@@ -28,9 +28,19 @@ module.exports = ( token ) => {
 			let paramCount = 0;
 
 			jsdoc.tags = jsdoc.tags.map( ( tag ) => {
+				const isParam = tag.tag === 'param';
 				const isUnqualifiedParam =
-					tag.tag === 'param' && ! tag.name.includes( '.' );
-				const index = isUnqualifiedParam ? paramCount++ : paramCount;
+					isParam && ! tag.name.includes( '.' );
+				let index = isUnqualifiedParam ? paramCount++ : paramCount;
+
+				// Qualified parameters come after an unqualified parameter. When
+				// the paramCount is incremented for an unqualified parameter, we
+				// still need to access that previous index. In other words, the
+				// qualified parameter types exist at the index of the previous
+				// unqualified parameter. As a result, the index is actually less.
+				if ( isParam && index > 0 && ! isUnqualifiedParam ) {
+					index -= 1;
+				}
 
 				return {
 					...tag,

--- a/packages/docgen/lib/get-type-annotation.js
+++ b/packages/docgen/lib/get-type-annotation.js
@@ -516,22 +516,6 @@ function getParamTypeAnnotation( tag, declarationToken, paramIndex ) {
 	// Otherwise find the corresponding parameter token for the documented parameter.
 	let paramToken = functionToken.params[ paramIndex ];
 
-	// If the parameter is a destructured object then we sometimes need to do
-	// extra work to find the correct token inside that object. The object would
-	// be the only parameter, which means we can't index on the function params
-	// to find a property of the object.
-	if (
-		! paramToken &&
-		functionToken.params.length === 1 &&
-		tag.name.split( '.' ).length === 2 &&
-		functionToken.params[ 0 ].type === 'ObjectPattern'
-	) {
-		const propName = tag.name.split( '.' )[ 1 ];
-		paramToken = functionToken.params[ 0 ].properties.find(
-			( property ) => property.key.name === propName
-		);
-	}
-
 	// This shouldn't happen due to our ESLint enforcing correctly documented parameter names but just in case
 	// we'll give a descriptive error so that it's easy to diagnose the issue.
 	if ( ! paramToken ) {

--- a/packages/docgen/lib/get-type-annotation.js
+++ b/packages/docgen/lib/get-type-annotation.js
@@ -513,8 +513,13 @@ function getQualifiedObjectPatternTypeAnnotation( tag, paramType ) {
 function getParamTypeAnnotation( tag, declarationToken, paramIndex ) {
 	const functionToken = getFunctionToken( declarationToken );
 
+	// Otherwise find the corresponding parameter token for the documented parameter.
 	let paramToken = functionToken.params[ paramIndex ];
 
+	// If the parameter is a destructured object then we sometimes need to do
+	// extra work to find the correct token inside that object. The object would
+	// be the only parameter, which means we can't index on the function params
+	// to find a property of the object.
 	if (
 		! paramToken &&
 		functionToken.params.length === 1 &&

--- a/packages/docgen/lib/get-type-annotation.js
+++ b/packages/docgen/lib/get-type-annotation.js
@@ -513,8 +513,19 @@ function getQualifiedObjectPatternTypeAnnotation( tag, paramType ) {
 function getParamTypeAnnotation( tag, declarationToken, paramIndex ) {
 	const functionToken = getFunctionToken( declarationToken );
 
-	// Otherwise find the corresponding parameter token for the documented parameter.
 	let paramToken = functionToken.params[ paramIndex ];
+
+	if (
+		! paramToken &&
+		functionToken.params.length === 1 &&
+		tag.name.split( '.' ).length === 2 &&
+		functionToken.params[ 0 ].type === 'ObjectPattern'
+	) {
+		const propName = tag.name.split( '.' )[ 1 ];
+		paramToken = functionToken.params[ 0 ].properties.find(
+			( property ) => property.key.name === propName
+		);
+	}
 
 	// This shouldn't happen due to our ESLint enforcing correctly documented parameter names but just in case
 	// we'll give a descriptive error so that it's easy to diagnose the issue.

--- a/packages/docgen/test/get-jsdoc-from-token.js
+++ b/packages/docgen/test/get-jsdoc-from-token.js
@@ -2,6 +2,14 @@
  * Internal dependencies
  */
 const getJSDocFromToken = require( '../lib/get-jsdoc-from-token' );
+const engine = require( '../lib/engine' );
+
+/**
+ * Generate the AST necessary to assert inferred types.
+ *
+ * @param {string} code - Actual source code to parse.
+ */
+const parse = ( code ) => engine( 'test-code.ts', code ).ast.body[ 0 ];
 
 describe( 'JSDoc', () => {
 	it( 'extracts description and tags', () => {
@@ -106,5 +114,42 @@ describe( 'JSDoc', () => {
 		expect(
 			getJSDocFromToken( { leadingComments: [ { value: '' } ] } )
 		).toBeUndefined();
+	} );
+
+	it( 'correctly matches qualified tags to unqualified tag types', () => {
+		const token = parse( `
+			/**
+			 * @param props Component props.
+			 * @param props.foo A property of props.
+			 * @param props.bar A second property of props.
+			 * @param baz A second parameter
+			 * @param test0 A third parameter
+			 * @param props2 A fourth parameter
+			 * @param props2.test A property of props2.
+			 * @param props2.test1 A second property of props2.
+			 * @param test3 A fifth parameter
+			 * @return A component.
+			 */
+			function fn( { foo, bar }: { foo: string, bar: number }, baz: FooType, test0: TestType, { test, test1 }: { test: number, test1: string }, test3: BarType ): string {
+				return foo;
+			}
+		` );
+
+		const tags = getJSDocFromToken( token ).tags;
+		// Finds the parsed type of a tag by name.
+		const expectType = ( name, type ) => {
+			expect( tags.find( ( t ) => t.name === name ).type ).toBe( type );
+		};
+
+		// Verifies that the logic for indexing unqualified/qualified tags works
+		// correctly -- that the function signature TS types are associated
+		// correctly with the JSDoc params.
+		expectType( 'props.foo', 'string' );
+		expectType( 'props.bar', 'number' );
+		expectType( 'baz', 'FooType' );
+		expectType( 'test0', 'TestType' );
+		expectType( 'props2.test', 'number' );
+		expectType( 'props2.test1', 'string' );
+		expectType( 'test3', 'BarType' );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I encountered an issue in both #49649 and #49651 where the documentation generator couldn't find prop names. For example, I could have code similar to this:

```tsx
/**
 * @param props
 * @param props.bar The prop for Foo
 */
function foo({ bar }: FooProps) {
 ...
}

```

_Note: this error does not get triggered when props and props.bar are given types in JSDoc. but this is redundant with types specified in TS._

And I get an error like "Could not find corresponding parameter token for documented parameter 'props.bar'"

An example can be found in this GH actions run: https://github.com/WordPress/gutenberg/actions/runs/4694571924/jobs/8322855362?pr=49651#step:7:27

~This is confusing, because it's not an issue everywhere. Just in certain typescript files I've been migrating. I don't understand why it happens, so this PR is an attempt at a fix.~

The root cause is the logic which processes JSDoc tags, which doesn't pass the correct index for object parameters.

For context, if the function is `function foo( a, b )`, then you would have two JSDoc params for both a and b, which are in order. The logic correctly increments an index to connect the JSDoc param "a" with the parsed types for the first argument of `foo`. 

However, when you have object parameters that are destructured (common in React components), you have the above example with `props` and `props.bar`. The JSDoc param "props.bar" is the second param, but the type information for it is in the first function argument, since it's a property of the object argument.

While the logic correctly only increments this index for "unqualified props" (e.g. props without a period in the name), there is a subtle bug where the incorrect index is still passed for qualified props.

When it processes "props", the index is incremented to 1, while 0 is passed, which is correct. Then it processes "props.bar". It doesn't increment the index, but the index is 1 from the previous step. 0 should actually be passed to access the first argument of the function.

If it were to process a 3rd tag, "bar" (unqualified), the index would be incremented to 2, while 1 would be passed, which would still be correct.

So the bug is just with the index for qualified parameters.

Beyond that, this bug never shows up when the type is included in the JSDoc comment, because the index doesn't do anything in that scenario.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

see above

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
When processing a qualified parameter (e.g. 'props.bar'), pass an index that's less by one.

## Testing Instructions
difficult to test locally, but you can basically verify this change by copying these changes to a PR like #49651, and attempt to generate documentation for a change to rich-text/src/is-collapsed.ts
