### PR TITLE
[RNMobile][DO NOT MERGE][CI Test] Test e2e CI failures

### DIFF
--- a/packages/react-native-editor/__device-tests__/helpers/caps.js
+++ b/packages/react-native-editor/__device-tests__/helpers/caps.js
@@ -15,7 +15,7 @@ exports.iosLocal = {
 	...ios,
 	deviceName: 'iPhone 13',
 	wdaLaunchTimeout: 240000,
-	usePrebuiltWDA: true,
+	usePrebuiltWDA: false,
 };
 
 exports.iosServer = {


### PR DESCRIPTION
## What?
Set usePrebuiltWDA to false in order to test consistent [e2e failures](https://github.com/WordPress/gutenberg/actions/runs/4692298232/jobs/8317841036).

## Why?

## How?


## Screenshots or screencast <!-- if applicable -->
