### PR TITLE
Fluid typography: use layout.wideSize as max viewport width

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -467,7 +467,10 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 	}
 
 	// Checks if fluid font sizes are activated.
-	$typography_settings         = gutenberg_get_global_settings( array( 'typography' ) );
+	$global_settings     = gutenberg_get_global_settings();
+	$typography_settings = isset( $global_settings['typography'] ) ? $global_settings['typography'] : array();
+	$layout_settings     = isset( $global_settings['layout'] ) ? $global_settings['layout'] : array();
+
 	$should_use_fluid_typography
 		= isset( $typography_settings['fluid'] ) &&
 		( true === $typography_settings['fluid'] || is_array( $typography_settings['fluid'] ) ) ?
@@ -481,7 +484,7 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 	$fluid_settings = isset( $typography_settings['fluid'] ) && is_array( $typography_settings['fluid'] ) ? $typography_settings['fluid'] : array();
 
 	// Defaults.
-	$default_maximum_viewport_width       = '1600px';
+	$default_maximum_viewport_width       = isset( $layout_settings['wideSize'] ) ? $layout_settings['wideSize'] : '1600px';
 	$default_minimum_viewport_width       = '320px';
 	$default_minimum_font_size_factor_max = 0.75;
 	$default_minimum_font_size_factor_min = 0.25;

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -517,14 +517,6 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 		)
 	);
 
-	// Sets a ceiling for the minimum font size.
-	$minimum_font_size_ceiling = gutenberg_get_typography_value_and_unit(
-		'64px',
-		array(
-			'coerce_to' => $preferred_size['unit'],
-		)
-	);
-
 	// Don't enforce minimum font size if a font size has explicitly set a min and max value.
 	if ( ! empty( $minimum_font_size_limit ) && ( ! $minimum_font_size_raw && ! $maximum_font_size_raw ) ) {
 		/*

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -517,6 +517,14 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 		)
 	);
 
+	// Sets a ceiling for the minimum font size.
+	$minimum_font_size_ceiling = gutenberg_get_typography_value_and_unit(
+		'64px',
+		array(
+			'coerce_to' => $preferred_size['unit'],
+		)
+	);
+
 	// Don't enforce minimum font size if a font size has explicitly set a min and max value.
 	if ( ! empty( $minimum_font_size_limit ) && ( ! $minimum_font_size_raw && ! $maximum_font_size_raw ) ) {
 		/*
@@ -549,6 +557,12 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 		 */
 		$minimum_font_size_factor     = min( max( 1 - 0.075 * log( $preferred_font_size_in_px, 2 ), $default_minimum_font_size_factor_min ), $default_minimum_font_size_factor_max );
 		$calculated_minimum_font_size = round( $preferred_size['value'] * $minimum_font_size_factor, 3 );
+
+		// Ensure calculated minimum font size is not greater than the ceiling.
+		// This is to prevent the font size from being too large in smaller viewports.
+		if ( $calculated_minimum_font_size > $minimum_font_size_ceiling['value'] ) {
+			$calculated_minimum_font_size = $minimum_font_size_ceiling['value'];
+		}
 
 		// Only use calculated min font size if it's > $minimum_font_size_limit value.
 		if ( ! empty( $minimum_font_size_limit ) && $calculated_minimum_font_size <= $minimum_font_size_limit['value'] ) {

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -550,12 +550,6 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 		$minimum_font_size_factor     = min( max( 1 - 0.075 * log( $preferred_font_size_in_px, 2 ), $default_minimum_font_size_factor_min ), $default_minimum_font_size_factor_max );
 		$calculated_minimum_font_size = round( $preferred_size['value'] * $minimum_font_size_factor, 3 );
 
-		// Ensure calculated minimum font size is not greater than the ceiling.
-		// This is to prevent the font size from being too large in smaller viewports.
-		if ( $calculated_minimum_font_size > $minimum_font_size_ceiling['value'] ) {
-			$calculated_minimum_font_size = $minimum_font_size_ceiling['value'];
-		}
-
 		// Only use calculated min font size if it's > $minimum_font_size_limit value.
 		if ( ! empty( $minimum_font_size_limit ) && $calculated_minimum_font_size <= $minimum_font_size_limit['value'] ) {
 			$minimum_font_size_raw = $minimum_font_size_limit['value'] . $minimum_font_size_limit['unit'];

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -539,7 +539,7 @@ Provides the CSS class names and inline styles for a block's typography support 
 _Parameters_
 
 -   _attributes_ `Object`: Block attributes.
--   _fluidTypographySettings_ `Object|boolean`: If boolean, whether the function should try to convert font sizes to fluid values, otherwise an object containing theme fluid typography settings.
+-   _settings_ `Object|boolean`: Merged theme.json settings
 
 _Returns_
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -444,7 +444,8 @@ _Returns_
 
 ### getFontSize
 
-Returns the font size object based on an array of named font sizes and the namedFontSize and customFontSize values. If namedFontSize is undefined or not found in fontSizes an object with just the size value based on customFontSize is returned.
+Returns the font size object based on an array of named font sizes and the namedFontSize and customFontSize values.
+If namedFontSize is undefined or not found in fontSizes an object with just the size value based on customFontSize is returned.
 
 _Parameters_
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -444,8 +444,7 @@ _Returns_
 
 ### getFontSize
 
-Returns the font size object based on an array of named font sizes and the namedFontSize and customFontSize values.
-If namedFontSize is undefined or not found in fontSizes an object with just the size value based on customFontSize is returned.
+Returns the font size object based on an array of named font sizes and the namedFontSize and customFontSize values. If namedFontSize is undefined or not found in fontSizes an object with just the size value based on customFontSize is returned.
 
 _Parameters_
 

--- a/packages/block-editor/src/components/global-styles/test/typography-utils.js
+++ b/packages/block-editor/src/components/global-styles/test/typography-utils.js
@@ -423,6 +423,22 @@ describe( 'typography utils', () => {
 				expected:
 					'clamp(100px, 6.25rem + ((1vw - 3.2px) * 7.813), 200px)',
 			},
+
+			{
+				message:
+					'should not use ceiling for minimum font size when custom min font size is set',
+				preset: {
+					size: '200px',
+					fluid: {
+						min: '100px',
+					},
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected:
+					'clamp(100px, 6.25rem + ((1vw - 7.68px) * 12.019), 200px)',
+			},
 		].forEach( ( { message, preset, typographySettings, expected } ) => {
 			it( `${ message }`, () => {
 				expect(

--- a/packages/block-editor/src/components/global-styles/test/typography-utils.js
+++ b/packages/block-editor/src/components/global-styles/test/typography-utils.js
@@ -423,22 +423,6 @@ describe( 'typography utils', () => {
 				expected:
 					'clamp(100px, 6.25rem + ((1vw - 3.2px) * 7.813), 200px)',
 			},
-
-			{
-				message:
-					'should not use ceiling for minimum font size when custom min font size is set',
-				preset: {
-					size: '200px',
-					fluid: {
-						min: '100px',
-					},
-				},
-				typographySettings: {
-					fluid: true,
-				},
-				expected:
-					'clamp(100px, 6.25rem + ((1vw - 7.68px) * 12.019), 200px)',
-			},
 		].forEach( ( { message, preset, typographySettings, expected } ) => {
 			it( `${ message }`, () => {
 				expect(

--- a/packages/block-editor/src/hooks/test/use-typography-props.js
+++ b/packages/block-editor/src/hooks/test/use-typography-props.js
@@ -39,7 +39,15 @@ describe( 'getTypographyClassesAndStyles', () => {
 				},
 			},
 		};
-		expect( getTypographyClassesAndStyles( attributes, true ) ).toEqual( {
+		expect(
+			getTypographyClassesAndStyles( attributes, {
+				typography: {
+					fluid: {
+						minFontSize: '1rem',
+					},
+				},
+			} )
+		).toEqual( {
 			className: 'has-tofu-font-family',
 			style: {
 				letterSpacing: '22px',
@@ -63,7 +71,11 @@ describe( 'getTypographyClassesAndStyles', () => {
 		};
 		expect(
 			getTypographyClassesAndStyles( attributes, {
-				minFontSize: '1rem',
+				typography: {
+					fluid: {
+						minFontSize: '1rem',
+					},
+				},
 			} )
 		).toEqual( {
 			className: 'has-tofu-font-family',
@@ -71,6 +83,39 @@ describe( 'getTypographyClassesAndStyles', () => {
 				textDecoration: 'underline',
 				fontSize:
 					'clamp(1.25rem, 1.25rem + ((1vw - 0.2rem) * 0.938), 2rem)',
+				textTransform: 'uppercase',
+			},
+		} );
+	} );
+
+	it( 'should use layout.wideSize for the maximum viewport value', () => {
+		const attributes = {
+			fontFamily: 'tofu',
+			style: {
+				typography: {
+					textDecoration: 'underline',
+					fontSize: '2rem',
+					textTransform: 'uppercase',
+				},
+			},
+		};
+		expect(
+			getTypographyClassesAndStyles( attributes, {
+				typography: {
+					fluid: {
+						minFontSize: '1rem',
+					},
+				},
+				layout: {
+					wideSize: '1000px',
+				},
+			} )
+		).toEqual( {
+			className: 'has-tofu-font-family',
+			style: {
+				textDecoration: 'underline',
+				fontSize:
+					'clamp(1.25rem, 1.25rem + ((1vw - 0.2rem) * 1.765), 2rem)',
 				textTransform: 'uppercase',
 			},
 		} );

--- a/packages/block-editor/src/hooks/use-typography-props.js
+++ b/packages/block-editor/src/hooks/use-typography-props.js
@@ -19,17 +19,14 @@ import { getComputedFluidTypographyValue } from '../components/font-sizes/fluid-
  * Provides the CSS class names and inline styles for a block's typography support
  * attributes.
  *
- * @param {Object}         attributes              Block attributes.
- * @param {Object|boolean} fluidTypographySettings If boolean, whether the function should try to convert font sizes to fluid values,
- *                                                 otherwise an object containing theme fluid typography settings.
+ * @param {Object}         attributes Block attributes.
+ * @param {Object|boolean} settings   Merged theme.json settings
  *
  * @return {Object} Typography block support derived CSS classes & styles.
  */
-export function getTypographyClassesAndStyles(
-	attributes,
-	fluidTypographySettings
-) {
+export function getTypographyClassesAndStyles( attributes, settings ) {
 	let typographyStyles = attributes?.style?.typography || {};
+	const fluidTypographySettings = settings?.typography?.fluid;
 
 	if (
 		!! fluidTypographySettings &&
@@ -40,6 +37,7 @@ export function getTypographyClassesAndStyles(
 			getComputedFluidTypographyValue( {
 				fontSize: attributes?.style?.typography?.fontSize,
 				minimumFontSizeLimit: fluidTypographySettings?.minFontSize,
+				maximumViewPortWidth: settings?.layout?.wideSize,
 			} ) || attributes?.style?.typography?.fontSize;
 		typographyStyles = {
 			...typographyStyles,

--- a/packages/block-editor/src/hooks/use-typography-props.js
+++ b/packages/block-editor/src/hooks/use-typography-props.js
@@ -11,10 +11,11 @@ import { getInlineStyles } from './style';
 import { getFontSizeClass } from '../components/font-sizes';
 import { getComputedFluidTypographyValue } from '../components/font-sizes/fluid-utils';
 
-// This utility is intended to assist where the serialization of the typography
-// block support is being skipped for a block but the typography related CSS
-// styles still need to be generated so they can be applied to inner elements.
-
+/*
+ * This utility is intended to assist where the serialization of the typography
+ * block support is being skipped for a block but the typography related CSS
+ * styles still need to be generated so they can be applied to inner elements.
+ */
 /**
  * Provides the CSS class names and inline styles for a block's typography support
  * attributes.

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -115,10 +115,15 @@ export default function SearchEdit( {
 
 	const colorProps = useColorProps( attributes );
 	const fluidTypographySettings = useSetting( 'typography.fluid' );
-	const typographyProps = useTypographyProps(
-		attributes,
-		fluidTypographySettings
-	);
+	const layout = useSetting( 'layout' );
+	const typographyProps = useTypographyProps( attributes, {
+		typography: {
+			fluid: fluidTypographySettings,
+		},
+		layout: {
+			wideSize: layout?.wideSize,
+		},
+	} );
 	const unitControlInstanceId = useInstanceId( UnitControl );
 	const unitControlInputId = `wp-block-search__width-${ unitControlInstanceId }`;
 	const isButtonPositionInside = 'button-inside' === buttonPosition;

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -578,6 +578,17 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'should_use_fluid_typography' => true,
 				'expected_output'             => 'clamp(100px, 6.25rem + ((1vw - 3.2px) * 7.813), 200px)',
 			),
+
+			'should not use ceiling for minimum font size when custom min font size is set' => array(
+				'font_size'                   => array(
+					'size'  => '200px',
+					'fluid' => array(
+						'min' => '100px',
+					),
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => 'clamp(100px, 6.25rem + ((1vw - 7.68px) * 12.019), 200px)',
+			),
 		);
 	}
 

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -578,17 +578,6 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'should_use_fluid_typography' => true,
 				'expected_output'             => 'clamp(100px, 6.25rem + ((1vw - 3.2px) * 7.813), 200px)',
 			),
-
-			'should not use ceiling for minimum font size when custom min font size is set' => array(
-				'font_size'                   => array(
-					'size'  => '200px',
-					'fluid' => array(
-						'min' => '100px',
-					),
-				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(100px, 6.25rem + ((1vw - 7.68px) * 12.019), 200px)',
-			),
 		);
 	}
 
@@ -666,7 +655,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			'returns clamp value using custom fluid config' => array(
 				'font_size_value' => '17px',
 				'theme_slug'      => 'block-theme-child-with-fluid-typography-config',
-				'expected_output' => 'font-size:clamp(16px, 1rem + ((1vw - 3.2px) * 0.078), 17px);',
+				'expected_output' => 'font-size:clamp(16px, 1rem + ((1vw - 3.2px) * 0.147), 17px);',
 			),
 			'returns value when font size <= custom min font size bound' => array(
 				'font_size_value' => '15px',

--- a/phpunit/data/themedir1/block-theme-child-with-fluid-typography-config/theme.json
+++ b/phpunit/data/themedir1/block-theme-child-with-fluid-typography-config/theme.json
@@ -2,6 +2,9 @@
 	"version": 2,
 	"settings": {
 		"appearanceTools": true,
+		"layout": {
+			"wideSize": "1000px"
+		},
 		"typography": {
 			"fluid": {
 				"minFontSize": "16px"

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -266,7 +266,7 @@
 							"type": "string"
 						},
 						"wideSize": {
-							"description": "Sets the max-width of wide (`.alignwide`) content.",
+							"description": "Sets the max-width of wide (`.alignwide`) content. Also used as the maximum viewport when calculating fluid font sizes",
 							"type": "string"
 						}
 					},


### PR DESCRIPTION
Tracking issue:
- https://github.com/WordPress/gutenberg/issues/44888

## About

A pull request that uses the value of `settings.layout.wideSize`, if set, as the maximum viewport width for fluid font size calculations. 

The default value is `1600px`.

See https://github.com/WordPress/gutenberg/pull/49707#pullrequestreview-1384094487 for context

## What's the point?

To give finer control to editor users and theme builders.

When constraining the maximum viewport width to `settings.layout.wideSize`, fluid font sizes will cease to increase when the viewport reaches a maximum width.

This is a good thing! Why? Because it allows folks to more accurately set maximum custom font sizes for their layouts. By "custom font size", I'm talking about single-value font-sizes set in the editor or theme.json that have no other instructions on how their fluid values are calculated. Contrast this with font size preset items, which permit min and max font size values. 

So when calculating clamp values for fluid font sizes, Gutenberg uses the custom font size value as the maximum. The user will then know that this will be the maximum font size within the maximum "wide" layout size.

Does that make sense? 🤷 

## How?
Grabbing the value of `settings.layout.wideSize`.

## Testing Instructions

1. Fire up this branch and use 2023 (a theme that has fluid font sizes enabled)
2. In the site editor play around with setting the wide size for layouts, as well as adding some custom font sizes. 
3. Your font sizes should be at their maximum values when viewport is at least as wide as the value of `layout.wideSize`


https://user-images.githubusercontent.com/6458278/231934320-29cfc82c-5686-4136-887e-79f6bf017109.mp4


