### PR TITLE
[RNMobile][DO NOT MERGE][CI Test] Upgrade Xcode in iOS e2e workflow

### DIFF
--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -18,7 +18,7 @@ jobs:
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:
-                xcode: ['14.2.2']
+                xcode: ['14.2']
                 device: ['iPhone 13']
                 native-test-name: [gutenberg-editor-rendering]
 

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -18,7 +18,7 @@ jobs:
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:
-                xcode: ['13.2.1']
+                xcode: ['14.2.2']
                 device: ['iPhone 13']
                 native-test-name: [gutenberg-editor-rendering]
 


### PR DESCRIPTION
## What?
PR for debugging consistent failures of the React Native E2E Tests (iOS) CI task. 

## Why?


## How?
Upgrades Xcode version to 14.2 in rnmobile-ios-runner workflow to fix RN e2e tests
