### PR TITLE
Query: Fix add new post link position via private SlotFill

### DIFF
--- a/packages/block-editor/src/components/block-info-slot-fill/index.js
+++ b/packages/block-editor/src/components/block-info-slot-fill/index.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { createSlotFill } from '@wordpress/components';
+
+export const createPrivateSlotFill = ( name ) => {
+	const privateKey = Symbol( name );
+	const privateSlotFill = createSlotFill( privateKey );
+
+	return { privateKey, ...privateSlotFill };
+};
+
+const { Fill, Slot } = createPrivateSlotFill( 'BlockInformation' );
+const BlockInfo = ( props ) => <Fill { ...props } />;
+BlockInfo.Slot = ( props ) => <Slot { ...props } />;
+
+export default BlockInfo;

--- a/packages/block-editor/src/components/block-info-slot-fill/index.js
+++ b/packages/block-editor/src/components/block-info-slot-fill/index.js
@@ -1,16 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { createSlotFill } from '@wordpress/components';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
 
-export const createPrivateSlotFill = ( name ) => {
-	const privateKey = Symbol( name );
-	const privateSlotFill = createSlotFill( privateKey );
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
 
-	return { privateKey, ...privateSlotFill };
-};
-
+const { createPrivateSlotFill } = unlock( componentsPrivateApis );
 const { Fill, Slot } = createPrivateSlotFill( 'BlockInformation' );
+
 const BlockInfo = ( props ) => <Fill { ...props } />;
 BlockInfo.Slot = ( props ) => <Slot { ...props } />;
 

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -37,6 +37,7 @@ import useInspectorControlsTabs from '../inspector-controls-tabs/use-inspector-c
 import AdvancedControls from '../inspector-controls-tabs/advanced-controls-panel';
 import PositionControls from '../inspector-controls-tabs/position-controls-panel';
 import useBlockInspectorAnimationSettings from './useBlockInspectorAnimationSettings';
+import BlockInfo from '../block-info-slot-fill';
 
 function useContentBlocks( blockTypes, block ) {
 	const contentBlocksObjectAux = useMemo( () => {
@@ -115,6 +116,7 @@ function BlockInspectorLockedBlocks( { topLevelLockedBlock } ) {
 				className={ blockInformation.isSynced && 'is-synced' }
 			/>
 			<BlockVariationTransforms blockClientId={ topLevelLockedBlock } />
+			<BlockInfo.Slot />
 			<VStack
 				spacing={ 1 }
 				padding={ 4 }
@@ -326,6 +328,7 @@ const BlockInspectorSingleBlock = ( { clientId, blockName } ) => {
 				className={ blockInformation.isSynced && 'is-synced' }
 			/>
 			<BlockVariationTransforms blockClientId={ clientId } />
+			<BlockInfo.Slot />
 			{ showTabs && (
 				<InspectorControlsTabs
 					hasBlockStyles={ hasBlockStyles }

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -9,6 +9,7 @@ import LeafMoreMenu from './components/off-canvas-editor/leaf-more-menu';
 import ResizableBoxPopover from './components/resizable-box-popover';
 import { ComposedPrivateInserter as PrivateInserter } from './components/inserter';
 import { PrivateListView } from './components/list-view';
+import BlockInfo from './components/block-info-slot-fill';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -22,4 +23,5 @@ lock( privateApis, {
 	PrivateInserter,
 	PrivateListView,
 	ResizableBoxPopover,
+	BlockInfo,
 } );

--- a/packages/block-library/src/query/edit/inspector-controls/create-new-post-link.js
+++ b/packages/block-library/src/query/edit/inspector-controls/create-new-post-link.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { addQueryArgs } from '@wordpress/url';
+
+const CreateNewPostLink = ( {
+	attributes: { query: { postType } = {} } = {},
+} ) => {
+	if ( ! postType ) return null;
+	const newPostUrl = addQueryArgs( 'post-new.php', {
+		post_type: postType,
+	} );
+	return (
+		<div className="wp-block-query__create-new-link">
+			{ createInterpolateElement(
+				__( '<a>Add new post</a>' ),
+				// eslint-disable-next-line jsx-a11y/anchor-has-content
+				{ a: <a href={ newPostUrl } /> }
+			) }
+		</div>
+	);
+};
+
+export default CreateNewPostLink;

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -12,7 +12,10 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { InspectorControls } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
 import { debounce } from '@wordpress/compose';
 import { useEffect, useState, useCallback } from '@wordpress/element';
 
@@ -24,6 +27,8 @@ import AuthorControl from './author-control';
 import ParentControl from './parent-control';
 import { TaxonomyControls } from './taxonomy-controls';
 import StickyControl from './sticky-control';
+import CreateNewPostLink from './create-new-post-link';
+import { unlock } from '../../../private-apis';
 import {
 	usePostTypes,
 	useIsPostTypeHierarchical,
@@ -32,11 +37,10 @@ import {
 	useTaxonomies,
 } from '../../utils';
 
-export default function QueryInspectorControls( {
-	attributes,
-	setQuery,
-	setDisplayLayout,
-} ) {
+const { BlockInfo } = unlock( blockEditorPrivateApis );
+
+export default function QueryInspectorControls( props ) {
+	const { attributes, setQuery, setDisplayLayout } = props;
 	const { query, displayLayout } = attributes;
 	const {
 		order,
@@ -127,6 +131,9 @@ export default function QueryInspectorControls( {
 
 	return (
 		<>
+			<BlockInfo>
+				<CreateNewPostLink { ...props } />
+			</BlockInfo>
 			{ showSettingsPanel && (
 				<InspectorControls>
 					<PanelBody title={ __( 'Settings' ) }>

--- a/packages/block-library/src/query/hooks.js
+++ b/packages/block-library/src/query/hooks.js
@@ -5,8 +5,14 @@ import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { InspectorControls } from '@wordpress/block-editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../private-apis';
+
+const { BlockInfo } = unlock( blockEditorPrivateApis );
 const CreateNewPostLink = ( {
 	attributes: { query: { postType } = {} } = {},
 } ) => {
@@ -17,7 +23,7 @@ const CreateNewPostLink = ( {
 	return (
 		<div className="wp-block-query__create-new-link">
 			{ createInterpolateElement(
-				__( '<a>Create a new post</a> for this feed.' ),
+				__( '<a>Add new post</a>' ),
 				// eslint-disable-next-line jsx-a11y/anchor-has-content
 				{ a: <a href={ newPostUrl } /> }
 			) }
@@ -31,7 +37,7 @@ const CreateNewPostLink = ( {
  * @param {Function} BlockEdit Original component
  * @return {Function}           Wrapped component
  */
-const queryTopInspectorControls = createHigherOrderComponent(
+const queryTopBlockInfo = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const { name, isSelected } = props;
 		if ( name !== 'core/query' || ! isSelected ) {
@@ -40,14 +46,14 @@ const queryTopInspectorControls = createHigherOrderComponent(
 
 		return (
 			<>
-				<InspectorControls>
+				<BlockInfo>
 					<CreateNewPostLink { ...props } />
-				</InspectorControls>
+				</BlockInfo>
 				<BlockEdit key="edit" { ...props } />
 			</>
 		);
 	},
-	'withInspectorControls'
+	'withBlockInfo'
 );
 
-export default queryTopInspectorControls;
+export default queryTopBlockInfo;

--- a/packages/block-library/src/query/index.js
+++ b/packages/block-library/src/query/index.js
@@ -13,7 +13,7 @@ import edit from './edit';
 import save from './save';
 import variations from './variations';
 import deprecated from './deprecated';
-import queryInspectorControls from './hooks';
+import queryBlockInfo from './hooks';
 
 const { name } = metadata;
 export { metadata, name };
@@ -27,7 +27,7 @@ export const settings = {
 };
 
 export const init = () => {
-	addFilter( 'editor.BlockEdit', 'core/query', queryInspectorControls );
+	addFilter( 'editor.BlockEdit', 'core/query', queryBlockInfo );
 
 	return initBlock( { name, metadata, settings } );
 };

--- a/packages/block-library/src/query/index.js
+++ b/packages/block-library/src/query/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { loop as icon } from '@wordpress/icons';
-import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -13,7 +12,6 @@ import edit from './edit';
 import save from './save';
 import variations from './variations';
 import deprecated from './deprecated';
-import queryBlockInfo from './hooks';
 
 const { name } = metadata;
 export { metadata, name };
@@ -26,8 +24,4 @@ export const settings = {
 	deprecated,
 };
 
-export const init = () => {
-	addFilter( 'editor.BlockEdit', 'core/query', queryBlockInfo );
-
-	return initBlock( { name, metadata, settings } );
-};
+export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,7 +7,7 @@
 -   `TreeGrid`: Modify keyboard navigation code to use a data-expanded attribute if aria-expanded is to be controlled outside of the TreeGrid component ([#48461](https://github.com/WordPress/gutenberg/pull/48461)).
 -   `Modal`: Equalize internal spacing ([#49890](https://github.com/WordPress/gutenberg/pull/49890)).
 -   `Modal`: Increased border radius ([#49870](https://github.com/WordPress/gutenberg/pull/49870)).
--   `SlotFill`: Updated to allow Symbol keys not only string names ([#49819](https://github.com/WordPress/gutenberg/pull/49819)).
+-   `SlotFill`: Added util for creating private SlotFills and supporting Symbol keys ([#49819](https://github.com/WordPress/gutenberg/pull/49819)).
 
 ### Documentation
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,7 +7,7 @@
 -   `TreeGrid`: Modify keyboard navigation code to use a data-expanded attribute if aria-expanded is to be controlled outside of the TreeGrid component ([#48461](https://github.com/WordPress/gutenberg/pull/48461)).
 -   `Modal`: Equalize internal spacing ([#49890](https://github.com/WordPress/gutenberg/pull/49890)).
 -   `Modal`: Increased border radius ([#49870](https://github.com/WordPress/gutenberg/pull/49870)).
-
+-   `SlotFill`: Updated to allow Symbol keys not only string names ([#49819](https://github.com/WordPress/gutenberg/pull/49819)).
 
 ### Documentation
 

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -8,6 +8,7 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
  */
 import { default as CustomSelectControl } from './custom-select-control';
 import { positionToPlacement as __experimentalPopoverLegacyPositionToPlacement } from './popover/utils';
+import { createPrivateSlotFill } from './slot-fill';
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
@@ -19,4 +20,5 @@ export const privateApis = {};
 lock( privateApis, {
 	CustomSelectControl,
 	__experimentalPopoverLegacyPositionToPlacement,
+	createPrivateSlotFill,
 } );

--- a/packages/components/src/slot-fill/index.js
+++ b/packages/components/src/slot-fill/index.js
@@ -44,13 +44,14 @@ export function Provider( { children, ...props } ) {
 	);
 }
 
-export function createSlotFill( name ) {
-	const FillComponent = ( props ) => <Fill name={ name } { ...props } />;
-	FillComponent.displayName = name + 'Fill';
+export function createSlotFill( key ) {
+	const baseName = typeof key === 'string' ? key : key.description;
+	const FillComponent = ( props ) => <Fill name={ key } { ...props } />;
+	FillComponent.displayName = `${ baseName }Fill`;
 
-	const SlotComponent = ( props ) => <Slot name={ name } { ...props } />;
-	SlotComponent.displayName = name + 'Slot';
-	SlotComponent.__unstableName = name;
+	const SlotComponent = ( props ) => <Slot name={ key } { ...props } />;
+	SlotComponent.displayName = `${ baseName }Slot`;
+	SlotComponent.__unstableName = key;
 
 	return {
 		Fill: FillComponent,

--- a/packages/components/src/slot-fill/index.js
+++ b/packages/components/src/slot-fill/index.js
@@ -45,7 +45,7 @@ export function Provider( { children, ...props } ) {
 }
 
 export function createSlotFill( key ) {
-	const baseName = typeof key === 'string' ? key : key.description;
+	const baseName = typeof key === 'symbol' ? key.description : key;
 	const FillComponent = ( props ) => <Fill name={ key } { ...props } />;
 	FillComponent.displayName = `${ baseName }Fill`;
 

--- a/packages/components/src/slot-fill/index.js
+++ b/packages/components/src/slot-fill/index.js
@@ -59,4 +59,11 @@ export function createSlotFill( key ) {
 	};
 }
 
+export const createPrivateSlotFill = ( name ) => {
+	const privateKey = Symbol( name );
+	const privateSlotFill = createSlotFill( privateKey );
+
+	return { privateKey, ...privateSlotFill };
+};
+
 export { useSlot };


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/49327

## What?

- Updates the `SlotFill` component to allow `Symbol` keys instead of string names only.
- Creates a small util function to generate a SlotFill using a Symbol key
- Creates a "private" SlotFill for rendering additional block information (`BlockInfo`).
- Exports the `BlockInfo` component as a private API in the block-editor package
- Renders the `BlockInfo` slot in the block inspector
- Updates the Query block to import and unlock the the new `BlockInfo` fill.
- Renames the "Create new post" link to "Add new post" and renders it as a `BlockInfo` fill.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e46f7af</samp>

This pull request adds a new `BlockInfo` component that can show information about the selected block in the block toolbar. It uses a private slot-fill pair to render the component in different parts of the block editor UI. It also updates the query block UI to use the new component and improves the slot-fill module to support symbols as keys.

## Why?

When plugins register Block Styles for the Query block the Block Styles UI is rendered above the "Add new post" link which should sit immediately below the Block Card or the block's variation transforms if it has them.

We can't use a normal `SlotFill` as anyone with that name could abuse the slot to render anything above the tabs undermining the proper prominence for controls.

The proposed "private" `SlotFill` is only private as far as our Private/Experimental API can make it. A determined individual can still unlock experimental or private APIs even though they shouldn't. It has been generally accepted that we can still consider anything locked via the private API, to in fact be private for our purposes.

The ability to use a private `SlotFill` allows us to avoid introducing block-specific code into the block-editor package simply to restore the position of the Query block's link.

## How?

- Created a new private SlotFill for block information
- Exported private SlotFill as a private API
- Updated the Block Inspector to render the new slot
- Updated the Query block to unlock the new SlotFill and render its "Add new post" link as a fill for it

**It might be easiest to review the PR commit-by-commit as they are all pretty small and self-contained.** 

## Next Steps

- [ ] Write some tests for SlotFills using Symbols as keys

## Testing Instructions

1. Add some block styles to the Query block (example in the snippet below)
2. Edit a post, add a query block, select it and confirm the incorrect create new post link position
3. Checkout this PR branch, rebuild, and reload the post
4. The create new post link position should now be below the block card but above the block styles

```php
<?php
/**
 * Register block styles.
 */
function blue_note_register_block_styles() {
	register_block_style(
		'core/query',
		array(
			'name'  => 'blue-note-query-slant',
			'label' => __( 'Slanted images', 'blue-note' ),
			'inline_style' => '.is-style-blue-note-query-slant .wp-block-post-featured-image {transform: rotate(-1deg);}',
		)
	);
}
add_action( 'init', 'blue_note_register_block_styles' );
```


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="280" alt="Screenshot 2023-04-04 at 3 53 24 pm" src="https://user-images.githubusercontent.com/60436221/229701522-46eaae64-29a6-4651-b0d7-3bce388ed545.png"> | <img width="278" alt="Screenshot 2023-04-14 at 3 42 10 pm" src="https://user-images.githubusercontent.com/60436221/231951511-15ae9d1c-69c8-42d8-a6de-0877e4d2f7de.png"> | 

