### PR TITLE
[Mobile] - Fix React Native iOS E2E tests

### DIFF
--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -18,7 +18,7 @@ jobs:
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:
-                xcode: ['13.2.1']
+                xcode: ['13.3.1']
                 device: ['iPhone 13']
                 native-test-name: [gutenberg-editor-rendering]
 

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -62,7 +62,7 @@ jobs:
               run: test -d packages/react-native-editor/ios/build/WDA || npm run native test:e2e:build-wda
 
             - name: Launch simulator
-              run: open -a Simulator && xcrun simctl boot 'iPhone 13'
+              run: open -a Simulator && xcrun simctl boot '${{ matrix.device }}'
 
             - name: Run iOS Device Tests
               run: TEST_RN_PLATFORM=ios npm run native device-tests:local  ${{ matrix.native-test-name }}

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -61,8 +61,8 @@ jobs:
             - name: Build Web Driver Agent (if needed)
               run: test -d packages/react-native-editor/ios/build/WDA || npm run native test:e2e:build-wda
 
-            - name: Force update Launch Database to prevent issues when opening the Simulator app
-              run: /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer/Applications/Simulator.app
+            - name: Launch simulator
+              run: open -a Simulator && xcrun simctl boot 'iPhone 13'
 
             - name: Run iOS Device Tests
               run: TEST_RN_PLATFORM=ios npm run native device-tests:local  ${{ matrix.native-test-name }}

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
     test:
-        runs-on: macos-11
+        runs-on: macos-12
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:

--- a/packages/react-native-editor/__device-tests__/helpers/caps.js
+++ b/packages/react-native-editor/__device-tests__/helpers/caps.js
@@ -16,9 +16,6 @@ exports.iosLocal = {
 	deviceName: 'iPhone 13',
 	wdaLaunchTimeout: 240000,
 	usePrebuiltWDA: true,
-	wdaConnectionTimeout: 480000,
-	wdaStartupRetries: 4,
-	wdaStartupRetryInterval: 3000,
 };
 
 exports.iosServer = {

--- a/packages/react-native-editor/__device-tests__/helpers/caps.js
+++ b/packages/react-native-editor/__device-tests__/helpers/caps.js
@@ -16,6 +16,9 @@ exports.iosLocal = {
 	deviceName: 'iPhone 13',
 	wdaLaunchTimeout: 240000,
 	usePrebuiltWDA: true,
+	wdaConnectionTimeout: 480000,
+	wdaStartupRetries: 4,
+	wdaStartupRetryInterval: 3000,
 };
 
 exports.iosServer = {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR fixes the current failures with the React Native E2E iOS tests.

## Why?
They're currently failing in `trunk`. I haven't found out why this started happening but it could be something that changed in CI most probably.

## How?

It updates the macOS runner to `macos-12`, and Xcode to `13.3.1`.

It also now forces launching the simulator before starting to run the tests, this might be the issue we were having, since booting up the simulator takes up close to 5 minutes.

## Testing Instructions
CI checks should pass, maybe re-trigger the iOS tests.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A