### PR TITLE
Block Editor Handbook :: Landing Page :: Naming adjustments for block editor parts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ The elements highlighted in the figure are:
 
 1. **Block Inserter**: A panel for inserting blocks into the content canvas
 2. **Content Canvas**: The content editor, which holds content created with blocks
-3. **Block Inspector (settings sidebar)**: A panel for configuring the selected block’s settings (as a tab of the settings sidebar)
+3. **Sidebar Inspector **: A sidebar containing different setting options, like the Block, Post, and Styles Inspectors, depending on the editor's context.
 
 Through the Block editor, you create content modularly using Blocks. There are a number of [core blocks](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/) ready to be used, and you can also [create your own custom block](https://developer.wordpress.org/block-editor/getting-started/create-block/).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,9 +10,9 @@ The editor consists of several primary elements, as shown in the following figur
 
 The elements highlighted in the figure are:
 
-1. **Inserter**: A panel for inserting blocks into the content canvas
+1. **Block Inserter**: A panel for inserting blocks into the content canvas
 2. **Content canvas**: The content editor, which holds content created with blocks
-3. **Settings sidebar.**: A sidebar panel for configuring a block’s settings (among other things)
+3. **Block Inspector (Settings sidebar)**: A panel for configuring the selected block’s settings (as a tab of the Settings sidebar)
 
 Through the Block editor, you create content modularly using Blocks. There are a number of [core blocks](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/) ready to be used, and you can also [create your own custom block](https://developer.wordpress.org/block-editor/getting-started/create-block/).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,8 +11,8 @@ The editor consists of several primary elements, as shown in the following figur
 The elements highlighted in the figure are:
 
 1. **Block Inserter**: A panel for inserting blocks into the content canvas
-2. **Content canvas**: The content editor, which holds content created with blocks
-3. **Block Inspector (Settings sidebar)**: A panel for configuring the selected block’s settings (as a tab of the Settings sidebar)
+2. **Content Canvas**: The content editor, which holds content created with blocks
+3. **Block Inspector (settings sidebar)**: A panel for configuring the selected block’s settings (as a tab of the settings sidebar)
 
 Through the Block editor, you create content modularly using Blocks. There are a number of [core blocks](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/) ready to be used, and you can also [create your own custom block](https://developer.wordpress.org/block-editor/getting-started/create-block/).
 


### PR DESCRIPTION
## What?
Naming adjustments for Block Editor parts to be more precise and clear at the [Block Editor Handbook landing page](https://developer.wordpress.org/block-editor/)

## Why?
Because these namings reflect better the current terms used for these parts 

---

- **Block Inserter**: A panel for inserting blocks into the content canvas
- **Content Canvas**: The content editor, which holds content created with blocks
- **Block Inspector (settings sidebar)**: A panel for configuring the selected block’s settings (as a tab of the settings sidebar)

![](https://raw.githubusercontent.com/WordPress/gutenberg/trunk/docs/assets/overview-block-editor-2023.png)