### PR TITLE
Update IS_GUTENBERG_PLUGIN to process.env.IS_GUTENBERG_PLUGIN in coding guidelines

### DIFF
--- a/docs/contributors/code/coding-guidelines.md
+++ b/docs/contributors/code/coding-guidelines.md
@@ -141,9 +141,9 @@ An **plugin-only API** is one which is planned for eventual public availability,
 Plugin-only APIs are excluded from WordPress Core and only available in the Gutenberg Plugin:
 
 ```js
-// Using IS_GUTENBERG_PLUGIN allows Webpack to exclude this
+// Using process.env.IS_GUTENBERG_PLUGIN allows Webpack to exclude this
 // export from WordPress core:
-if ( IS_GUTENBERG_PLUGIN ) {
+if ( process.env.IS_GUTENBERG_PLUGIN ) {
 	export { doSomethingExciting } from './api';
 }
 ```
@@ -442,8 +442,8 @@ lock(privateApis, { privateEverywhere, privateInCorePublicInPlugin });
 
 // The privateInCorePublicInPlugin function is explicitly exported,
 // but this export will not be merged into WordPress core thanks to
-// the IS_GUTENBERG_PLUGIN check.
-if ( IS_GUTENBERG_PLUGIN ) {
+// the process.env.IS_GUTENBERG_PLUGIN check.
+if ( process.env.IS_GUTENBERG_PLUGIN ) {
    export const privateInCorePublicInPlugin = unlock( privateApis ).privateInCorePublicInPlugin;
 }
 ```


### PR DESCRIPTION
## What?

Corrects the inconsistency that made it in https://github.com/WordPress/gutenberg/pull/47973