### PR TITLE
Allow register/unregister block style variations from `theme.json`

### DIFF
--- a/lib/theme-i18n.json
+++ b/lib/theme-i18n.json
@@ -72,7 +72,7 @@
 				},
 				"variations": {
 					"*": {
-						"label": "Name of style variation"
+						"label": "Style variation name"
 					}
 				}
 			}

--- a/lib/theme-i18n.json
+++ b/lib/theme-i18n.json
@@ -69,6 +69,11 @@
 							"name": "Space size name"
 						}
 					]
+				},
+				"variations": {
+					"*": {
+						"label": "Name of style variation"
+					}
 				}
 			}
 		}

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -452,15 +452,25 @@
 				}
 			},
 			"core/quote": {
-				"variations": {
-					"plain": false,
-					"large": {
+				"variations": [
+					{
 						"name": "large",
-						"label": "Large",
+						"label": "Large using array",
 						"inlineStyle": "",
 						"styleHandle": "",
 						"isDefault": true
 					}
+				]
+			},
+			"core/paragraph": {
+				"variations": {
+					"large": {
+						"label": "Large using object",
+						"inlineStyle": "",
+						"styleHandle": "",
+						"isDefault": true
+					},
+					"toUnregister": false
 				}
 			}
 		}

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -450,6 +450,18 @@
 					"style": true,
 					"width": true
 				}
+			},
+			"core/quote": {
+				"variations": {
+					"plain": false,
+					"large": {
+						"name": "large",
+						"label": "Large",
+						"inlineStyle": "",
+						"styleHandle": "",
+						"isDefault": true
+					}
+				}
 			}
 		}
 	},


### PR DESCRIPTION
**NO IMPLEMENTATION YET, GATHERING THOUGHTS ABOUT THE API.**

Related https://github.com/WordPress/gutenberg/issues/49602

## What?

This PR explores the ability to register/unregister block style variations from `theme.json`.

## Why?

- Themes can already declare the style attributes of a block style variation. This would enable them to control the full lifecycle of a block style variation via `theme.json`.
- By adding support at the infrastructure level, it allows for creating block style variations at the user level (UI) in subsequent PRs, as per https://github.com/WordPress/gutenberg/issues/49602

## How?

```json
{
  "settings": {
    "blocks": {
      "core/quote": {
        "variations": {
          "plain": false, // UNREGISTER
          "large": { // REGISTER
            "label": "Large", // Needs to be translated, see theme-i18n.json
            "isDefault": true
          }
        }
      }
    }
  }
}
```

## Status

- Needs implementation.
- Set on an API. 
  - Internationalization: the [current system works for the two options evaluated](https://github.com/WordPress/gutenberg/pull/49827#issuecomment-1508819222).
  - No need for `inline_style` and `style_handle`: [see conversation](https://github.com/WordPress/gutenberg/pull/49827#issuecomment-1514263353).

## Testing Instructions

This is not working.