### PR TITLE
Adjust the logic of Post Title edit, so it avoids unnecessary OPTIONS requests

### DIFF
--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -33,12 +33,10 @@ export default function PostTitleEdit( {
 	const TagName = 0 === level ? 'p' : 'h' + level;
 	const isDescendentOfQueryLoop = Number.isFinite( queryId );
 	/**
-	 * Hack: useCanEditEntity may trigger an OPTIONS request. When the post title
-	 * is a descendant of a query loop, we know for sure that user cannot edit
-	 * the title. To avoid unnecessary OPTIONS requests we should avoid using
-	 * useCanEditEntity. However, it's a hook and cannot be fired conditionally,
-	 * hence instead we call it without proper data. In this case hook automatically
-	 * returns false without calling a backend.
+	 * Hack: useCanEditEntity may trigger an OPTIONS request to the REST API via the canUser resolver.
+	 * However, when the Post Title is a descendant of a Query Loop block, the title cannot be edited.
+	 * In order to avoid these unnecessary requests, we call the hook without
+	 * the proper data, resulting in returning early without making them.
 	 */
 	const userCanEdit = useCanEditEntity(
 		'postType',

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -40,7 +40,7 @@ export default function PostTitleEdit( {
 	 * hence instead we call it without proper data. In this case hook automatically
 	 * returns false without calling a backend.
 	 */
-	 const userCanEdit = useCanEditEntity(
+	const userCanEdit = useCanEditEntity(
 		'postType',
 		isDescendentOfQueryLoop ? '' : postType,
 		isDescendentOfQueryLoop ? '' : postId
@@ -66,56 +66,52 @@ export default function PostTitleEdit( {
 	);
 
 	if ( postType && postId ) {
-		titleElement =
-			userCanEdit ? (
+		titleElement = userCanEdit ? (
+			<PlainText
+				tagName={ TagName }
+				placeholder={ __( 'No Title' ) }
+				value={ rawTitle }
+				onChange={ setTitle }
+				__experimentalVersion={ 2 }
+				__unstableOnSplitAtEnd={ onSplitAtEnd }
+				{ ...blockProps }
+			/>
+		) : (
+			<TagName
+				{ ...blockProps }
+				dangerouslySetInnerHTML={ { __html: fullTitle?.rendered } }
+			/>
+		);
+	}
+
+	if ( isLink && postType && postId ) {
+		titleElement = userCanEdit ? (
+			<TagName { ...blockProps }>
 				<PlainText
-					tagName={ TagName }
-					placeholder={ __( 'No Title' ) }
+					tagName="a"
+					href={ link }
+					target={ linkTarget }
+					rel={ rel }
+					placeholder={ ! rawTitle.length ? __( 'No Title' ) : null }
 					value={ rawTitle }
 					onChange={ setTitle }
 					__experimentalVersion={ 2 }
 					__unstableOnSplitAtEnd={ onSplitAtEnd }
-					{ ...blockProps }
 				/>
-			) : (
-				<TagName
-					{ ...blockProps }
-					dangerouslySetInnerHTML={ { __html: fullTitle?.rendered } }
+			</TagName>
+		) : (
+			<TagName { ...blockProps }>
+				<a
+					href={ link }
+					target={ linkTarget }
+					rel={ rel }
+					onClick={ ( event ) => event.preventDefault() }
+					dangerouslySetInnerHTML={ {
+						__html: fullTitle?.rendered,
+					} }
 				/>
-			);
-	}
-
-	if ( isLink && postType && postId ) {
-		titleElement =
-			userCanEdit ? (
-				<TagName { ...blockProps }>
-					<PlainText
-						tagName="a"
-						href={ link }
-						target={ linkTarget }
-						rel={ rel }
-						placeholder={
-							! rawTitle.length ? __( 'No Title' ) : null
-						}
-						value={ rawTitle }
-						onChange={ setTitle }
-						__experimentalVersion={ 2 }
-						__unstableOnSplitAtEnd={ onSplitAtEnd }
-					/>
-				</TagName>
-			) : (
-				<TagName { ...blockProps }>
-					<a
-						href={ link }
-						target={ linkTarget }
-						rel={ rel }
-						onClick={ ( event ) => event.preventDefault() }
-						dangerouslySetInnerHTML={ {
-							__html: fullTitle?.rendered,
-						} }
-					/>
-				</TagName>
-			);
+			</TagName>
+		);
 	}
 
 	return (

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -32,7 +32,19 @@ export default function PostTitleEdit( {
 } ) {
 	const TagName = 0 === level ? 'p' : 'h' + level;
 	const isDescendentOfQueryLoop = Number.isFinite( queryId );
-	const userCanEdit = useCanEditEntity( 'postType', postType, postId );
+	/**
+	 * Hack: useCanEditEntity may trigger an OPTIONS request. When the post title
+	 * is a descendant of a query loop, we know for sure that user cannot edit
+	 * the title. To avoid unnecessary OPTIONS requests we should avoid using
+	 * useCanEditEntity. However, it's a hook and cannot be fired conditionally,
+	 * hence instead we call it without proper data. In this case hook automatically
+	 * returns false without calling a backend.
+	 */
+	 const userCanEdit = useCanEditEntity(
+		'postType',
+		isDescendentOfQueryLoop ? '' : postType,
+		isDescendentOfQueryLoop ? '' : postId
+	);
 	const [ rawTitle = '', setTitle, fullTitle ] = useEntityProp(
 		'postType',
 		postType,
@@ -55,7 +67,7 @@ export default function PostTitleEdit( {
 
 	if ( postType && postId ) {
 		titleElement =
-			userCanEdit && ! isDescendentOfQueryLoop ? (
+			userCanEdit ? (
 				<PlainText
 					tagName={ TagName }
 					placeholder={ __( 'No Title' ) }
@@ -75,7 +87,7 @@ export default function PostTitleEdit( {
 
 	if ( isLink && postType && postId ) {
 		titleElement =
-			userCanEdit && ! isDescendentOfQueryLoop ? (
+			userCanEdit ? (
 				<TagName { ...blockProps }>
 					<PlainText
 						tagName="a"

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -40,8 +40,8 @@ export default function PostTitleEdit( {
 	 */
 	const userCanEdit = useCanEditEntity(
 		'postType',
-		isDescendentOfQueryLoop ? '' : postType,
-		isDescendentOfQueryLoop ? '' : postId
+		! isDescendentOfQueryLoop && postType,
+		postId
 	);
 	const [ rawTitle = '', setTitle, fullTitle ] = useEntityProp(
 		'postType',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
PR's goal is to optimize the Post Title block render time in the Editor by avoiding unnecessary requests in a particular case.

## Why?
Post Title cannot be edited when it's a descendant of a query loop. However, in many cases, the OPTIONS request is made and then its result is ignored. On the pages with Query Loop and N Post Titles, it adds N number of OPTIONS requests that slow down loading the posts in the editor.

## How?
This can be optimised, to make a call only when necessary.
Post title checks if it can be edited by [`useCanEditEntity` usage](https://github.com/WordPress/gutenberg/blob/a42fd75977a6469050564b8fc821e8018bd566e0/packages/block-library/src/post-title/edit.js#L33). At the same time if `isDescendentOfQueryLoop` is `true` outcome of `useCanEditEntity` doesn't matter as it's check [here](https://github.com/WordPress/gutenberg/blob/a42fd75977a6469050564b8fc821e8018bd566e0/packages/block-library/src/post-title/edit.js#L53) and [here](https://github.com/WordPress/gutenberg/blob/a42fd75977a6469050564b8fc821e8018bd566e0/packages/block-library/src/post-title/edit.js#L72).

Based on the above we could actually call `useCanEditEntity` only if `isDescendentOfQueryLoop` is `false`, however that's not allowed, as `useCanEditEntity` is a hook and cannot be called conditionally.

Using the fact that `useCanEditEntity` returns a falsy value (and skips making OPTIONS request) when there's no proper data we can conditionally provide "empty" data as arguments. That part probably could be improved to make it more bullet-proof, which I'm happy to get a feedback on.

One of the use cases for the above is the _Products_ block from WooCommerce Blocks (variation of Query Loop block). WIth the 9 products there's an overhead of:
- on average ~0.7s of loading time on a Local setup 
- on average ~1.5s of loading time on a remote setup

## Testing Instructions
1. Go to Editor
2. Add a Query Loop block (choose option that includes Post Title)
3. Go to Dev Tools > Network tab
4. Look for `/wp-json/wp/v2/posts/{POST ID}` OPTIONS requests
5. **Expected:** There's no requests like that and title cannot be edited
---
1. Add a new post
2. Add a Post Title block
3. Go to Dev Tools > Network tab
4. Look for `/wp-json/wp/v2/posts/{POST ID}` OPTIONS requests
5. **Expected:** There's a request and title can be edited
