### PR TITLE
Block Toolbar: Fix incorrect switcher button width in text mode

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -150,8 +150,7 @@
 	.block-editor-block-switcher .components-dropdown-menu__toggle,
 	.block-editor-block-switcher__no-switcher-icon {
 		.block-editor-block-icon {
-			width: 0 !important;
-			height: 0 !important;
+			display: none !important;
 		}
 	}
 

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -150,7 +150,9 @@
 	.block-editor-block-switcher .components-dropdown-menu__toggle,
 	.block-editor-block-switcher__no-switcher-icon {
 		.block-editor-block-icon {
-			display: none !important;
+			width: 0 !important;
+			height: 0 !important;
+			min-width: 0 !important;
 		}
 	}
 


### PR DESCRIPTION
## What?
This PR fixes a problem with incorrect width of the block switcher button when the following conditions are met:

- "Show button text labels" is enabled
- No convertible blocks or styles exist

![space](https://user-images.githubusercontent.com/54422211/232225548-f6c35106-a54a-4c7d-938e-357b91118369.png)

## Why?

When "Show button text labels" is enabled, the following style is applied to hide the icon:

https://github.com/WordPress/gutenberg/blob/9fd9dadde5cd68832b1364d6810a7b009b2938d9/packages/block-editor/src/components/block-toolbar/style.scss#L150-L156

This style works correctly when there are convertible blocks or styles (i.e. when the CSS class name of the button is when the button has `.components-dropdown-menu__toggle` class name).

However, when there is no convertible block or style (i.e. when the button has `.block-editor-block-switcher__no-switcher-icon` class), the width will not be zero due to `min-width` as shown below:

![min-width](https://user-images.githubusercontent.com/54422211/232226016-7415a5b8-8874-4474-b366-fa1e99841725.png)


## How?
This `min-width` is for displaying icons 24px wide when "Show button text labels" is not enabled, so this style can't be removed. I considered overriding this with `min-width:0!important`, but thought it made more sense to apply `display:none!important` and thereby remove the unnecessary style.

## Testing Instructions

Check the following four patterns to make sure the switcher button widths are correct. `core/column` block is an example of a block that has no convertible block or style.

### "Show button text labels" is disabled

- Paragraph block icon button
- Column block icon button

### "Show button text labels" is enabled

- Paragraph block text label button
- Column block text label button
