### PR TITLE
Fix: Demo content cover block alignment not respected

### DIFF
--- a/post-content.php
+++ b/post-content.php
@@ -6,7 +6,7 @@
  */
 
 ?>
-<!-- wp:cover {"url":"https://cldup.com/Fz-ASbo2s3.jpg","className":"alignwide"} -->
+<!-- wp:cover {"url":"https://cldup.com/Fz-ASbo2s3.jpg","align":"wide"} -->
 <div class="wp-block-cover has-background-dim alignwide" style="background-image:url(https://cldup.com/Fz-ASbo2s3.jpg)"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","textColor":"white","fontSize":"large"} -->
 <p class="has-text-align-center has-white-color has-text-color has-large-font-size"><?php _e( 'Of Mountains &amp; Printing Presses', 'gutenberg' ); ?></p>
 <!-- /wp:paragraph --></div></div>


### PR DESCRIPTION
Fixes: #28476

## What?
This PR fixes a problem where the width of the cover block cannot be changed in the demo content.

https://user-images.githubusercontent.com/54422211/232228997-b786fa47-4b72-44b5-8e14-8758f2bfe4d5.mp4

## Why?
It is visually wide, but this is because the `alignwide` class is specified directly in the additional css class, not set in the block toolbar. Therefore, if you select Node or Center in the block toolbar, the width will not change because the `alignwide` class will remain.

## How?
As far as I know, alignwide/alignfull has never been controlled by additional CSS in the past, but always as an `align` attribute. Therefore, I believe this is a simple HTML error.

## Testing Instructions

Apply None or Center in the block toolbar and make sure it is applied correctly to both the editor and the front end.

Note: If you have saved the demo content at least once, please delete it from the post list.