### PR TITLE
Fix broken link and update title of Localizing Gutenberg doc

### DIFF
--- a/docs/contributors/localizing.md
+++ b/docs/contributors/localizing.md
@@ -1,6 +1,6 @@
-# Localizing Gutenberg Plugin
+# Localizing Gutenberg
 
-The Gutenberg plugin is translated via the general plugin translation system (GlotPress) at https://translate.wordpress.org. Review the [GlotPress translation process documentation] (https://make.wordpress.org/polyglots/handbook/tools/glotpress-translate-wordpress-org/) for additional information.
+The Gutenberg plugin is translated via the general plugin translation system (GlotPress) at https://translate.wordpress.org. Review the [GlotPress translation process documentation](https://make.wordpress.org/polyglots/handbook/tools/glotpress-translate-wordpress-org/) for additional information.
 
 To translate Gutenberg in your locale or language, [select your locale here](https://translate.wordpress.org/projects/wp-plugins/gutenberg) and translate *Development* (which contains the plugin's string) and/or *Development Readme* (please translate what you see in the Details tab of the [plugin page](https://wordpress.org/plugins/gutenberg/)).
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2262,7 +2262,7 @@
 		"parent": "contributors"
 	},
 	{
-		"title": "Localizing Gutenberg Plugin",
+		"title": "Localizing Gutenberg",
 		"slug": "localizing",
 		"markdown_source": "../docs/contributors/localizing.md",
 		"parent": "contributors"


### PR DESCRIPTION
## What?
Fix the broken link and simplify the title. 

## Why?
The link was broken, and the title did not make sense. It should either be "Localizing **the** Gutenberg Plugin" or "Localizing Gutenberg." I chose the latter since it is shorter. 