### PR TITLE
[RNMobile] Update native Video block to check if MediaPlaceholder should be displayed

### DIFF
--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -172,7 +172,7 @@ class VideoEdit extends Component {
 				return;
 			}
 
-			setAttributes( { id: url, src: url } );
+			setAttributes( { src: url, id: undefined, poster: undefined } );
 		} else {
 			createErrorNotice( __( 'Invalid URL.' ) );
 		}
@@ -235,7 +235,7 @@ class VideoEdit extends Component {
 			></MediaUpload>
 		);
 
-		if ( ! id && ! src ) {
+		if ( ! src ) {
 			return (
 				<View style={ { flex: 1 } }>
 					<MediaPlaceholder

--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -235,7 +235,7 @@ class VideoEdit extends Component {
 			></MediaUpload>
 		);
 
-		if ( ! id ) {
+		if ( ! id && ! src ) {
 			return (
 				<View style={ { flex: 1 } }>
 					<MediaPlaceholder


### PR DESCRIPTION
## What?
Related:
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/5674

Fixes:

* https://github.com/WordPress/gutenberg/issues/42443
* https://github.com/WordPress/gutenberg/issues/42515

Updates a conditional on the native Video block to determine if a video source exists in order to display MediaPlaceholder under the correct logic. 

## Why?
Currently, the web and native versions of the Video block use different properties to determine if the MediaPlaceholder component should be displayed:

https://github.com/WordPress/gutenberg/blob/4ed1c1132d091128879035e4d8c41f7fe826fc99/packages/block-library/src/video/edit.js#L142-L145

https://github.com/WordPress/gutenberg/blob/4ed1c1132d091128879035e4d8c41f7fe826fc99/packages/block-library/src/video/edit.native.js#L239-L242

Although the edit.native.js Video block file is setting the `id` attribute to be the new video URL [here](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/video/edit.native.js#L176), the web equivalent edit.js file **does not** set the `id` as the URL. In fact, it sets the `id` and `poster` attributes as `undefined`:

```
// edit.native.js
onSelectURL( url ) {
    [...]
    setAttributes( { id: url, src: url } );
}

// edit.js
onSelectURL( newSrc ) {
    [...]
    setAttributes( { src: newSrc, id: undefined, poster: undefined } );
}
```

Currently, when a user adds a video from a URL via mobile and saves the post, no placeholder image will be displayed. The lack of an id results in the display of the early return function in the native file, and perceived content loss for the user, even though the video will be displayed correctly on the web editor and on the post itself. Further detail referenced here: https://github.com/WordPress/gutenberg/issues/42515#issuecomment-1189830290

## How?
To preserve the web behavior and also eliminate the perceived content loss on mobile, this PR modifies the logic of the early return function to check for a `src` attribute as well, which matches the web behavior more closely.

## Testing Instructions
To test #42515: _Saving a Video block with a file URL displays placeholder text in the editor_ 

1. Create a new post in the native editor. 
1. Add a Video block. 
1. Tap _Insert from URL_. 
1. Set the URL to an MP4 file: `http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerFun.mp4`
1. Note the video preview displays a placeholder image for the video.
1. Tap the three-dot menu in the top-right of the editor. 
1. Tap _Save as Draft_.
2. After completing the network requests, observe that the the first frame of the video remains as the placeholder image.
3. Test that adding videos from other sources such as Media Library or Upload are not affected, and proceed as normal.

To test #42443: _Showing the play button after inserting URL that doesn't exist_

1. Create a new post in the native editor. 
1. Add a Video block. 
1. Tap _Insert from URL_. 
1. Insert a URL that doesn't exist or is invalid: `aaaaaa`
2. Observe that the MediaPlaceholder block remains prompting the user to "Add Video", and that an "Invalid URL" notification is presented to the user near the top of the screen.

### Placeholder vs Poster image
Note: this change will allow the mobile app to display a **placeholder** image, which is distinct from a **poster** image. The placeholder image will always be the first frame from a given video source URL. A poster image is a specific frame of a video that can be selected from the web editor. Currently, the mobile editor does not allow a user to select the poster image, or display the selected poster image. That work is captured in a separate issue:

* https://github.com/wordpress-mobile/gutenberg-mobile/issues/1493

Also note that when testing this issue with the common community example of using [Big Buck Bunny](https://gist.github.com/jsturgis/3b19447b304616f18657) as a test source, the first frame of Big Buck Bunny is a black screen, and is what will be displayed as the placeholder image. To test with a video URL example that does not have a black screen as the first frame, the following URL can be used: 

```
http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerFun.mp4
```

## Screenshots or screencast <!-- if applicable -->

<details>
  <summary>Before ❌ </summary>

  https://user-images.githubusercontent.com/643285/232413972-6a2d3016-e8b5-49b7-a2fa-3cf18b469452.mov

</details>

<details>
  <summary> After ✅ </summary>

  https://user-images.githubusercontent.com/643285/232414369-2c9c3192-a7e8-449c-a7ae-3d7cdf5f96d4.mov

</details>
















