### PR TITLE
Increase dimensions of the pattern modal that appears when creating a new page

### DIFF
--- a/packages/edit-post/src/components/start-page-options/style.scss
+++ b/packages/edit-post/src/components/start-page-options/style.scss
@@ -2,18 +2,14 @@
 	// To keep modal dimensions consistent as subsections are navigated, width
 	// and height are used instead of max-(width/height).
 	@include break-small() {
-		width: calc(100% - #{ $grid-unit-20 * 2 });
-		height: calc(100% - #{ $grid-unit-20 * 2 });
+		width: 95vw;
+		height: 95vh;
 		max-height: none;
 	}
 	@include break-medium() {
-		width: calc(100% - #{ $grid-unit-50 * 2 });
-		height: calc(100% - #{ $grid-unit-50 * 2 });
+		width: 90vw;
+		height: 90vh;
 		max-width: none;
-	}
-	@include break-large() {
-		width: calc(100% - #{ $grid-unit-50 * 2 });
-		height: calc(100% - #{ $grid-unit-50 * 2 });
 	}
 }
 

--- a/packages/edit-post/src/components/start-page-options/style.scss
+++ b/packages/edit-post/src/components/start-page-options/style.scss
@@ -3,13 +3,17 @@
 	// and height are used instead of max-(width/height).
 	@include break-small() {
 		width: calc(100% - #{ $grid-unit-20 * 2 });
-		height: auto;
+		height: calc(100% - #{ $grid-unit-20 * 2 });
+		max-height: none;
 	}
 	@include break-medium() {
-		width: 95%;
+		width: calc(100% - #{ $grid-unit-50 * 2 });
+		height: calc(100% - #{ $grid-unit-50 * 2 });
+		max-width: none;
 	}
 	@include break-large() {
-		max-height: 95%;
+		width: calc(100% - #{ $grid-unit-50 * 2 });
+		height: calc(100% - #{ $grid-unit-50 * 2 });
 	}
 }
 

--- a/packages/edit-post/src/components/start-page-options/style.scss
+++ b/packages/edit-post/src/components/start-page-options/style.scss
@@ -3,13 +3,13 @@
 	// and height are used instead of max-(width/height).
 	@include break-small() {
 		width: calc(100% - #{ $grid-unit-20 * 2 });
-		height: calc(100% - #{ $header-height * 2 });
+		height: auto;
 	}
 	@include break-medium() {
-		width: $break-medium - $grid-unit-20 * 2;
+		width: 95%;
 	}
 	@include break-large() {
-		height: 70%;
+		max-height: 95%;
 	}
 }
 
@@ -17,6 +17,17 @@
 .edit-post-start-page-options__modal-content .block-editor-block-patterns-list {
 	column-count: 2;
 	column-gap: $grid-unit-30;
+
+	// Small top padding required to avoid cutting off the visible outline when hovering items
+	padding-top: $border-width-focus;
+
+	@include break-medium() {
+		column-count: 3;
+	}
+
+	@include break-wide() {
+		column-count: 4;
+	}
 
 	.block-editor-block-patterns-list__list-item {
 		break-inside: avoid-column;


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/49722.

## What?
Increases the dimensions of the modal that displays full-page patterns when creating a new page:


https://user-images.githubusercontent.com/846565/232448139-0b26238a-121b-42ea-88f4-e24735795fc0.mp4

I retained the 'masonry' layout because full-page patterns may not necessarily be long.

## Why?
The current version feels a bit cramped:

<img width="1653" alt="Screenshot 2023-04-17 at 09 40 20" src="https://user-images.githubusercontent.com/846565/232447631-06f1847b-f01c-4aa7-af9d-a0f52fe47fad.png">


## How?
CSS.

## Testing Instructions
1. Add a new page
2. Observe the larger pattern modal

For the modal to appear there needs to be patterns associated with the Post Content block.
