### PR TITLE
Fix the site editor loading in multi-site installs

### DIFF
--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -14,16 +14,17 @@ import { store as editSiteStore } from '../../store';
 export default function useInitEditedEntityFromURL() {
 	const { params: { postId, postType } = {} } = useLocation();
 	const { isRequestingSite, homepageId, url } = useSelect( ( select ) => {
-		const { getSite } = select( coreDataStore );
+		const { getSite, getUnstableBase } = select( coreDataStore );
 		const siteData = getSite();
+		const base = getUnstableBase();
 
 		return {
-			isRequestingSite: ! siteData,
+			isRequestingSite: ! base,
 			homepageId:
 				siteData?.show_on_front === 'page'
 					? siteData.page_on_front
 					: null,
-			url: siteData?.url,
+			url: base?.home,
 		};
 	}, [] );
 


### PR DESCRIPTION
### WHAT

In multi-site installs, the site editor shows an infinite loader when accessing it. This PR should fix it.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a46cf5e</samp>

> _`useSelect` changed_
> _`getUnstableBase` is true_
> _site home in `url`_

### WHY
The url property is not available in the /settings endpoint that we were using initially in multi site installs. This PR uses the index/base endpoint to retrieve the home page url instead.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a46cf5e</samp>

*  Refactor the site URL logic to use the REST API base path as the source of truth ([link](https://github.com/WordPress/gutenberg/pull/49861/files?diff=unified&w=0#diff-90ac1a8edea4ffca3eb4acd2bc2aeed05d54392fc843eb1f253403ae66771dceL17-R27),                            F0L43R

### Testing 

I'd appreciate if folks have an easy way to setup a multi-site instance locally to check the fix there. 