### PR TITLE
Revert PR 49646: "[Font API] Use registered fonts for Block Editor iframe."

### DIFF
--- a/lib/compat/wordpress-6.2/script-loader.php
+++ b/lib/compat/wordpress-6.2/script-loader.php
@@ -130,33 +130,26 @@ function gutenberg_resolve_assets_override() {
 	$scripts = ob_get_clean();
 
 	/*
-	 * Generate font @font-face styles for the iframe.
-	 *
-	 * For the Site Editor, use the registered fonts.
-	 * For the Block Editor, use the enqueued fonts.
+	 * Generate font @font-face styles for the site editor iframe.
+	 * Use the registered font families for printing.
 	 */
 	if ( class_exists( 'WP_Fonts' ) ) {
-		$wp_fonts       = wp_fonts();
-		$registered     = $wp_fonts->get_registered_font_families();
-		$is_site_editor = 'site-editor.php' === $pagenow;
-
+		$wp_fonts   = wp_fonts();
+		$registered = $wp_fonts->get_registered_font_families();
 		if ( ! empty( $registered ) ) {
-			$done           = $wp_fonts->done;
-			$wp_fonts->done = array();
-			if ( $is_site_editor ) {
-				$queue           = $wp_fonts->queue;
-				$wp_fonts->queue = $registered;
-			}
+			$queue = $wp_fonts->queue;
+			$done  = $wp_fonts->done;
+
+			$wp_fonts->done  = array();
+			$wp_fonts->queue = $registered;
 
 			ob_start();
 			$wp_fonts->do_items();
 			$styles .= ob_get_clean();
 
-			// Reset the Fonts API.
-			$wp_fonts->done = $done;
-			if ( $is_site_editor ) {
-				$wp_fonts->queue = $queue;
-			}
+			// Reset the Web Fonts API.
+			$wp_fonts->done  = $done;
+			$wp_fonts->queue = $queue;
 		}
 	}
 


### PR DESCRIPTION
Reverts WordPress/gutenberg#49646

Removes this bug fix from `trunk` and 15.6 release, as it was included in 15.6 RC1. 

Why?

[Explained here](https://github.com/WordPress/gutenberg/pull/49646#issuecomment-1507071011)
>It needs to be bundled with the https://github.com/WordPress/gutenberg/issues/40363 feature enhancement which (when implemented) will automatically enqueue all user selected fonts, selected from the Site Editor's Global Typography UI. Why? One of the most popular Google Fonts implementation has a bug in it where its fonts will not enqueue. The bug was hidden until this PR fixed the Fonts API for the iframe assets. Delaying the shipment of this PR's fix avoids breaking sites.