### PR TITLE
Block highlight: Fix radius issue.

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -35,11 +35,14 @@
 	}
 
 	// Block multi selection
-	.block-editor-block-list__block.is-multi-selected:not(.is-partially-selected) {
-		// Apply a rounded radius to the entire block.
+	// Apply a rounded radius to the entire block when multi selected, but with low specificity
+	// so explicit radii set by tools are preserved.
+	&:where(.block-editor-block-list__block.is-multi-selected:not(.is-partially-selected)) {
 		border-radius: $radius-block-ui;
 		overflow: hidden;
+	}
 
+	.block-editor-block-list__block.is-multi-selected:not(.is-partially-selected) {
 		// Hide the native selection indicator, for the selection, and children.
 		&::selection,
 		& ::selection {
@@ -68,24 +71,22 @@
 			// Show outline in high contrast mode.
 			outline: 2px solid transparent;
 		}
+
+		// Don't show the highlight focus style when multi selected.
+		&.is-highlighted::after {
+			box-shadow: none;
+		}
 	}
 
-	// Block highlight, and navigation mode, not focus.
-	// By not using a pseudo element, we can limit ourselves to only
-	// using ::after, leaving ::before free. Otherwise, highlight + multi-select
-	// would require the opacity-changing overlay to be on ::before.
+	// Block highlight, and navigation mode, and focus.
+	// This piece of code has gone back and forth between using a pseudo element
+	// vs. styling the block directly. Ultimately we likely need a pseudo element
+	// (unless styles like focus and selection overlay can be rendered as separate elements),
+	// since things like border-radius need to be able to be set on the block itself.
 	.block-editor-block-list__block.is-highlighted,
 	.block-editor-block-list__block.is-highlighted ~ .is-multi-selected,
 	&.is-navigate-mode .block-editor-block-list__block.is-selected,
-	& .is-block-moving-mode.block-editor-block-list__block.has-child-selected {
-		border-radius: $radius-block-ui;
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-
-		// Show outline in high contrast mode.
-		outline: 2px solid transparent;
-	}
-
-	// Block focus.
+	& .is-block-moving-mode.block-editor-block-list__block.has-child-selected,
 	.block-editor-block-list__block:not([contenteditable]):focus {
 		outline: none;
 


### PR DESCRIPTION
## What?

Alternative to #49766. Fixes an issue where an improper radius was applied to social logos and more.

Blocks can be styled to have rounded corners, whether through a block style variation, or through the Border Radius tool. 

We also use border radius in block UI, such as the block highlight (hover the drag handle), selection styles (select several blocks), or block focus (select an image block). 

For the block UI, we've generally tried to avoid using pseudo selectors (::before/::after) as much as possible, to allow the theme itself to leverage those selectors. An older refactor removed one such selector in favor of painting the highlight style on the block itself. Unfortunately that meant the border radius overriding the radius set by the block. As an example:

![radius](https://user-images.githubusercontent.com/1204802/232501839-3e9b8e23-e5d2-4e9c-bdc2-dd5530ec1989.gif)

Shown here:

* Site logo with rounded corners having them shaved off when multi selected or highlighted
* Button blocks having the correct behavior (because they use pseudo elements)
* Social Logos also having their pill shapes cut off because their radius is overridden.

This PR fixes that.

## How?

This PR restores the pseudo selector (we still only "reserve" the ::after, so ::before is still unstyled and ready for themes to use). This ensures all those cases above work, as shown in this GIF:

![after, take 1](https://user-images.githubusercontent.com/1204802/232502365-0094cc50-a4dd-476f-b139-116cce56974e.gif)

I did have a different instinct to try as well, just reducing the specificity of the radius (as I do in this PR for the multi select style), but this had unintended side effects:

![take 2, not working](https://user-images.githubusercontent.com/1204802/232502534-ac850a89-460b-4146-9d61-503f28f1454d.gif)

Shown in this GIF is a rounded site logo that is simultaneously multi selected, and highlighted. It shows duplicate highlight/focus states. This is in part due to how the site logo is built — the radius is applied to the block wrapper itself, and then _inherited_ all the way down to the img inside, meaning that the radius would be applied to a random child div inside. That's perhaps not ideal behavior for the site logo, but nevertheless demonstrated to me why after all, it seems, we need the pseudo element approach.


## Testing Instructions

Please test content that features a diversity of blocks, but most specifically include social logos (with background colors under the icons), together with the Site Logo, and ideally also any other blocks that support border radius (such as Image). With those in mind, please test:

* Select multiple blocks to see the blue overlay, then hover the drag handle to show the highlight.
* Just select a single block and observe the focus style.
* Same with the highlight style.
* Test just the multiple selection style.

In all cases, the UI (focus style and blue overlay) should have 2px radius, and in no cases should the "natural" radius of each block be affected.