### PR TITLE
Increase modal radius

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   `TreeGrid`: Modify keyboard navigation code to use a data-expanded attribute if aria-expanded is to be controlled outside of the TreeGrid component ([#48461](https://github.com/WordPress/gutenberg/pull/48461)).
+-   `Modal`: Increased border radius ([#49870](https://github.com/WordPress/gutenberg/pull/49870)).
 
 ### Documentation
 

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -20,7 +20,7 @@
 	width: 100%;
 	background: $white;
 	box-shadow: $shadow-modal;
-	border-radius: $radius-block-ui;
+	border-radius: $grid-unit;
 	overflow: hidden;
 	// Have the content element fill the vertical space yet not overflow.
 	display: flex;

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -20,7 +20,7 @@
 	width: 100%;
 	background: $white;
 	box-shadow: $shadow-modal;
-	border-radius: $grid-unit;
+	border-radius: $grid-unit-10;
 	overflow: hidden;
 	// Have the content element fill the vertical space yet not overflow.
 	display: flex;


### PR DESCRIPTION
## What?
Increase the base radius of modals in Gutenberg.

<img width="1022" alt="Screenshot 2023-04-17 at 18 12 16" src="https://user-images.githubusercontent.com/846565/232561159-7501f952-73bd-4f1f-a347-7cd3aaff7c29.png">


## Why?
Modal radius came up as a detail to explore holistically in https://github.com/WordPress/gutenberg/pull/49681. The current 2px value feels a bit sharp when compared to some newer UI elements such as the Frame in site view. 

## How?
Adjusts the CSS.

## Testing Instructions
Try all the different modals to get a feel for the new, more rounded corners. Examples include:

* Preferences
* Giving a new custom template a name
* The pattern explorer

