### PR TITLE
Fix quick inserter going off-screen in some situations

### DIFF
--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -214,7 +214,7 @@ class PrivateInserter extends Component {
 					'block-editor-inserter__popover',
 					{ 'is-quick': isQuick }
 				) }
-				popoverProps={ { position } }
+				popoverProps={ { position, shift: true } }
 				onToggle={ this.onToggle }
 				expandOnMobile
 				headerTitle={ __( 'Add a block' ) }


### PR DESCRIPTION
## What?
Fixes #49878

This issue is a little surprising, it seems like something that should have been working before, but I can't see where it could have regressed.

<!--
copilot:summary
-->

<!--
copilot:poem
-->

## How?
Add the shift prop to the dropdown

## Testing Instructions
1. Add a columns block  to the site editor
2. Make it full width
3. Add around a billion columns and make the viewport narrow
4. Try adding a block to one of the outer columns

Expected: the inserter popover should be on-screen
In trunk: it can go off-screen

## Screenshots or screencast <!-- if applicable -->

#### Before

![Screen Shot 2023-04-18 at 11 09 17 am](https://user-images.githubusercontent.com/677833/232661078-bd77cd6b-9d90-4962-b135-4f2053aaaf45.png)


#### After

![Screen Shot 2023-04-18 at 11 15 04 am](https://user-images.githubusercontent.com/677833/232661814-5ef4cf58-95ee-4915-80d5-f90e54f3ea81.png)


