### PR TITLE
[POC] Pattern blocks as sections

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -483,7 +483,7 @@ Show a block pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trun
 -	**Name:** core/pattern
 -	**Category:** theme
 -	**Supports:** ~~html~~, ~~inserter~~
--	**Attributes:** slug
+-	**Attributes:** slug, type
 
 ## Post Author
 

--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useCallback } from '@wordpress/element';
-import { cloneBlock } from '@wordpress/blocks';
+import { createBlock } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
@@ -36,7 +36,14 @@ const usePatternsState = ( onInsert, rootClientId ) => {
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const onClickPattern = useCallback( ( pattern, blocks ) => {
 		onInsert(
-			( blocks ?? [] ).map( ( block ) => cloneBlock( block ) ),
+			[
+				createBlock(
+					'core/pattern',
+					{ slug: pattern.name, type: 'section' },
+					blocks
+				),
+			],
+			// ( blocks ?? [] ).map( ( block ) => cloneBlock( block ) ),
 			pattern.name
 		);
 		createSuccessNotice(

--- a/packages/block-library/src/pattern/block.json
+++ b/packages/block-library/src/pattern/block.json
@@ -13,6 +13,9 @@
 	"attributes": {
 		"slug": {
 			"type": "string"
+		},
+		"type": {
+			"type": "string"
 		}
 	}
 }

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -6,6 +6,7 @@ import { useEffect } from '@wordpress/element';
 import {
 	store as blockEditorStore,
 	useBlockProps,
+	useInnerBlocksProps,
 } from '@wordpress/block-editor';
 
 const PatternEdit = ( { attributes, clientId } ) => {
@@ -17,6 +18,11 @@ const PatternEdit = ( { attributes, clientId } ) => {
 		[ attributes.slug ]
 	);
 
+	const props = useBlockProps();
+	const innerBlocksProps = useInnerBlocksProps( props );
+
+	const isSection = attributes.type === 'section';
+
 	const { replaceBlocks, __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
 
@@ -25,7 +31,7 @@ const PatternEdit = ( { attributes, clientId } ) => {
 	// This change won't be saved.
 	// It will continue to pull from the pattern file unless changes are made to its respective template part.
 	useEffect( () => {
-		if ( selectedPattern?.blocks ) {
+		if ( ! isSection && selectedPattern?.blocks ) {
 			// We batch updates to block list settings to avoid triggering cascading renders
 			// for each container block included in a tree and optimize initial render.
 			// Since the above uses microtasks, we need to use a microtask here as well,
@@ -36,11 +42,9 @@ const PatternEdit = ( { attributes, clientId } ) => {
 				replaceBlocks( clientId, selectedPattern.blocks );
 			} );
 		}
-	}, [ clientId, selectedPattern?.blocks ] );
+	}, [ clientId, selectedPattern?.blocks, isSection ] );
 
-	const props = useBlockProps();
-
-	return <div { ...props } />;
+	return <div { ...( isSection ? innerBlocksProps : props ) } />;
 };
 
 export default PatternEdit;

--- a/packages/block-library/src/pattern/index.js
+++ b/packages/block-library/src/pattern/index.js
@@ -4,12 +4,14 @@
 import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import PatternEdit from './edit';
+import PatternSave from './save';
 
 const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
 	edit: PatternEdit,
+	save: PatternSave,
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/pattern/save.js
+++ b/packages/block-library/src/pattern/save.js
@@ -1,0 +1,13 @@
+/**
+ * WordPress dependencies
+ */
+import { useInnerBlocksProps, useBlockProps } from '@wordpress/block-editor';
+
+export default function save( { attributes } ) {
+	const blockProps = useBlockProps.save();
+	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
+	if ( attributes.type === 'section' ) {
+		return <div { ...innerBlocksProps } />;
+	}
+	return null;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

<!-- In a few words, what is the PR actually doing? -->
A really simple and adhoc POC of how a pattern block as a section element could be implemented. This PR introduces a new attribute to the `core/pattern` block: `type`. Currently, the only possible value is `section`.

### The original `pattern` block

The implementation of the pattern block is relatively simple, it doesn't have a `save` function, and its `edit` function replaces itself with the registered pattern blocks by its `slug`. For instance, a pattern block like this:

```html
<!-- wp:pattern {"slug":"twentytwentythree/footer-default"} /-->
```

...will transform itself into this when it's loaded in the editor (if it's registered):

```html
<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|40"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--40)"><!-- wp:site-title {"level":0} /-->

<!-- wp:paragraph {"align":"right"} -->
<p class="has-text-align-right">
		Proudly powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a>		</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->
```

Notice that the original `wp:pattern` block disappears and no longer exists.

However, this approach stops us from keeping the metadata of the block. We no longer know that the replaced blocks are from a "footer" pattern, nor the pattern is from the `twentytwentythree` theme.

### A solution

One solution is to keep the wrapper pattern block when it's transformed, so that we won't lose any of the information. The pattern block will then behaves like a "group" block with semantic meaning.

It also doesn't do any transforming or replacing in its `edit` function, instead it simply renders the inner blocks if it's defined. It relies on the source to populate the inner blocks upon insertion, just like how a group block is implemented.

This PR changes how a pattern block is inserted from the global block inserter. Instead of sending just the `slug` attribute, it will now populate the inner blocks as well.

To maintain backward compatibility, the original behavior when no `type` attribute is specified is kept. So that template parts which rely on this behavior can continue to function
as before. **It also implies different "syncing" behavior as this will always sync data from the registered patterns.** We might also want to explore different syncing behavior for patterns with `type: section` too.

Note that this is not the final proposal but just a POC and an idea that we can play with in future iterations. Hope that a runnable branch could spark more ideas and feedback.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Insert a pattern block in the code editor by hand.
2. Exit the code editor, see that the pattern is inserted.
3. Go back to the code editor, see that the pattern block got replaced.
4. Insert a pattern from the global inserter
5. See that the pattern is inserted in the visual editor.
6. Go to the code editor, see that the `wp:pattern` block is still present, and with a `type: section` attribute.
7. Save the post and reload. See that the pattern block is still there.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/7753001/232703764-778aea92-b332-45e8-9e0f-65f790b347cf.mp4

