### PR TITLE
Equalize modal internal padding

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   `TreeGrid`: Modify keyboard navigation code to use a data-expanded attribute if aria-expanded is to be controlled outside of the TreeGrid component ([#48461](https://github.com/WordPress/gutenberg/pull/48461)).
+-   `Modal`: Equalize internal spacing ([#49890](https://github.com/WordPress/gutenberg/pull/49890)).
 
 ### Documentation
 

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -63,13 +63,12 @@
 // modal screen).
 .components-modal__header {
 	box-sizing: border-box;
-	border-bottom: $border-width solid transparent;
-	padding: 0 $grid-unit-40;
+	padding: $grid-unit-30 $grid-unit-40 0;
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
 	align-items: center;
-	height: $header-height + $grid-unit-20;
+	height: $header-height;
 	width: 100%;
 	z-index: z-index(".components-modal__header");
 	position: absolute;
@@ -89,10 +88,6 @@
 	.components-button {
 		position: relative;
 		left: $grid-unit-10;
-	}
-
-	.components-modal__content.has-scrolled-content:not(.hide-header) & {
-		border-bottom-color: $gray-300;
 	}
 
 	& + p {

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -63,12 +63,13 @@
 // modal screen).
 .components-modal__header {
 	box-sizing: border-box;
-	padding: $grid-unit-30 $grid-unit-40 0;
+	border-bottom: $border-width solid transparent;
+	padding: $grid-unit-30 $grid-unit-40 $grid-unit-15;
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
 	align-items: center;
-	height: $header-height;
+	height: $header-height + $grid-unit-15;
 	width: 100%;
 	z-index: z-index(".components-modal__header");
 	position: absolute;
@@ -88,6 +89,10 @@
 	.components-button {
 		position: relative;
 		left: $grid-unit-10;
+	}
+
+	.components-modal__content.has-scrolled-content:not(.hide-header) & {
+		border-bottom-color: $gray-300;
 	}
 
 	& + p {
@@ -116,7 +121,7 @@
 // Modal contents.
 .components-modal__content {
 	flex: 1;
-	margin-top: $header-height + $grid-unit-20;
+	margin-top: $header-height + $grid-unit-15;
 	padding: 0 $grid-unit-40 $grid-unit-40;
 	overflow: auto;
 


### PR DESCRIPTION
## What?
Ensure equal internal spacing on all four modal sides. 

## Why?
There is currently a small discrepancy – the spacing at the top of the modal is slightly smaller than the other three sides, as demonstrated in the diagram below:

<img width="400" alt="Screenshot 2023-04-18 at 09 56 17" src="https://user-images.githubusercontent.com/846565/232727016-53e56202-ecc9-4cbe-8bdc-4707b4fa18b8.png">

Note how the modal title, and the close button slightly bleed into the green area.

## How?
Updated some CSS to achieve the following:

<img width="400" alt="Screenshot 2023-04-18 at 10 17 08" src="https://user-images.githubusercontent.com/846565/232732365-e0ca08d0-7abd-48b2-a3a1-44a7cdccdc58.png">


## Testing Instructions
1. Open any of the various modals; keyboard shortcuts, editor preferences, rename custom template, etc.
2. Observe that the top spacing is now equal to right, bottom, and left.