### PR TITLE
Add parameters to custom-scrollbars-on-hover

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -514,11 +514,8 @@
 	/* stylelint-enable function-comma-space-after */
 }
 
-@mixin custom-scrollbars-on-hover() {
+@mixin custom-scrollbars-on-hover($handle-color, $track-color) {
 	visibility: hidden;
-
-	$handle-color: #757575;
-	$track-color: #1e1e1e;
 
 	// WebKit
 	&::-webkit-scrollbar {

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -3,7 +3,7 @@
 	overflow-y: auto;
 
 	.components-navigator-screen {
-		@include custom-scrollbars-on-hover;
+		@include custom-scrollbars-on-hover($gray-700, $gray-900);
 	}
 }
 


### PR DESCRIPTION
## What?
This adds parameters to the `custom-scrollbars-on-hover` mixin.

## Why?
This will be useful for both https://github.com/WordPress/gutenberg/pull/49793 and https://github.com/WordPress/gutenberg/pull/49793. This removes the change from those more complex PRs so we can at least get this improvement in.

## How?
Extracts two variables into parameters so that they can be customised by different implementations.

## Testing Instructions
1. Open the Site Editor
2. Resize the browser window so that the list of templates is scrollable
3. Confirm that the scroll bars still appear on hover and have the correct colors.

## Screenshots or screencast <!-- if applicable -->
<img width="373" alt="Screenshot 2023-04-18 at 11 23 57" src="https://user-images.githubusercontent.com/275961/232749107-70eac630-8054-4734-bbb5-5c897f30a3fb.png">
