### PR TITLE
Allow adding posts and pages with custom titles from the command menu

### DIFF
--- a/packages/edit-site/src/hooks/commands/use-wp-admin-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-wp-admin-commands.js
@@ -44,7 +44,7 @@ const getWPAdminAddCommandLoader = ( postType ) =>
 		const commands = useMemo(
 			() => [
 				{
-					name: 'core/wp-admin/add-' + postType,
+					name: 'core/wp-admin/add-' + postType + '-' + search,
 					label,
 					icon: plus,
 					callback: () => {


### PR DESCRIPTION
Related to https://github.com/WordPress/gutenberg/issues/48457

## What?

This regressed somewhere in the middle of the initial command menu PR but basically the idea is that you can type anything in the command bar and the results proposes results to create pages or posts with what you typed. It was an idea tossed by @jasmussen 

## Testing Instructions

1- Open the site editor
2- Hit cmd+k
3- Type a random post title
4- you click `add post title "your title"` to navigate to the post editor with that custom title prefilled.
