### PR TITLE
[RNMobile] Remove new block types

### DIFF
--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -261,6 +261,13 @@ export const registerCoreBlocks = () => {
  * than 0, a "new" badge is displayed on the block type within the block
  * inserter.
  *
+ * With the below example, the Audio block will be displayed as "new" until it
+ * reaches 40 impressions.
+ *
+ * {
+ * 	[ audio.name ]: 40
+ * }
+ *
  * @constant {{ string, number }}
  */
 export const NEW_BLOCK_TYPES = {

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -261,8 +261,9 @@ export const registerCoreBlocks = () => {
  * than 0, a "new" badge is displayed on the block type within the block
  * inserter.
  *
- * With the below example, the Audio block will be displayed as "new" until it
- * reaches 40 impressions.
+ * With the below example, the Audio block will be displayed as "new" until its
+ * impression count reaches 0, which occurs by various actions decrementing
+ * the impression count.
  *
  * {
  * 	[ audio.name ]: 40

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -270,8 +270,4 @@ export const registerCoreBlocks = () => {
  *
  * @constant {{ string, number }}
  */
-export const NEW_BLOCK_TYPES = {
-	[ embed.name ]: 40,
-	[ search.name ]: 40,
-	[ audio.name ]: 40,
-};
+export const NEW_BLOCK_TYPES = {};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Remove all new block types.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The following blocks were added as new block types more than a year ago. Since it's been a while, we should no longer display them as new:
- Embed block
- Search block
- Audio block

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove the blocks from the new block types.

**⚠️ This change only affects new installations. Users will still see the above blocks as new until they insert them. In case we'd like to completely remove the "new" badge for everyone, we'd need to implement a logic to enforce this.** 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Delete previous app installations from the device _(this is needed to reset the block impressions)_.
2. Build the app and connect it to the local Metro server.
3. Log in with your account and create/open a post.
4. Tap ➕  button to open the block inserter.
5. Observe that no block has the "new" badge on them, especially the following ones:
    - Embed block
    - Search block
    - Audio block

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A