### PR TITLE
Post Excerpt: fix crash at runtime when postType is undefined

### DIFF
--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -56,7 +56,7 @@ export default function PostExcerptEditor( {
 				return true;
 			}
 			return !! select( coreStore ).getPostType( postType )?.supports
-				.excerpt;
+				?.excerpt;
 		},
 		[ postType ]
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR fixes a crash at runtime when postType is undefined.

Fixes #49898.


## Testing Instructions

1. Install WooCommerce Core.
2. Open the Site Editor.
3. Edit the Single Product Template
4. Add the Post Excerpt.
5. Be sure that the Post Excerpt doesn't crash.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/4463174/232841766-961bded8-f4c0-4fbc-bdc0-37c5133132c9.mov

