### PR TITLE
Make eslint-plugin validate dependencies in `useSelect` and `useSuspenseSelect` hooks

### DIFF
--- a/packages/components/src/mobile/link-picker/link-picker-results.native.js
+++ b/packages/components/src/mobile/link-picker/link-picker-results.native.js
@@ -74,6 +74,9 @@ export default function LinkPickerResults( {
 		return {
 			fetchMoreSuggestions: debounce( fetchMore, REQUEST_DEBOUNCE_DELAY ),
 		};
+		// Disable eslint rule for now, to avoid introducing a regression
+		// (see https://github.com/WordPress/gutenberg/pull/23922#discussion_r1170634879).
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
 	// Prevent setting state when unmounted.

--- a/packages/eslint-plugin/configs/react.js
+++ b/packages/eslint-plugin/configs/react.js
@@ -34,7 +34,12 @@ module.exports = {
 		'react/no-children-prop': 'off',
 		'react/prop-types': 'off',
 		'react/react-in-jsx-scope': 'off',
-		'react-hooks/exhaustive-deps': 'warn',
+		'react-hooks/exhaustive-deps': [
+			'warn',
+			{
+				additionalHooks: '(useSelect|useSuspenseSelect)',
+			},
+		],
 		'react-hooks/rules-of-hooks': 'error',
 	},
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes https://github.com/WordPress/gutenberg/issues/49897. Builds on top of PR https://github.com/WordPress/gutenberg/pull/24914 that was just merged recently in February 2023.

In this PR, we add `useSelect` and `useSuspenseSelect` as additional hooks in `'react-hooks/exhaustive-deps'` eslint rule in eslint-plugin. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This helps us to declare all the dependencies when we use `useSelect` and `useSuspenseSelect` hooks. When we miss a dependency, there will be an eslint warning. It allows us to make use of the editor's quick fix command to quickly fix the dependency issue.

## Testing Instructions

1. Find a `useSelect` hook with dependency. For example: 

https://github.com/WordPress/gutenberg/blob/361f257b6d36ba14e5c6c5772718d118325a72ef/packages/block-library/src/search/edit.js#L83-L93

2. Add or remove an item in the dependency.
3. There should be an eslint warning. See example screenshot below with "missing dependency" warning when we remove the `clientId` in the dependency array:

![image](https://user-images.githubusercontent.com/417342/232843095-72b6ebfe-3018-4286-a261-e0d45fdec273.png)

5. Use the editor's quick fix command to automatically fix the warning.

