### PR TITLE
[RNMobile] Add apply filter to disabled cache endpoints

### DIFF
--- a/packages/react-native-editor/src/api-fetch-setup.js
+++ b/packages/react-native-editor/src/api-fetch-setup.js
@@ -82,12 +82,16 @@ export const isPathSupported = ( path, method ) => {
 };
 
 export const shouldEnableCaching = ( path ) => {
-	const disabledCachingEnpoints = applyFilters(
+	const disabledCachingEndpoints = applyFilters(
 		'native.disabled_caching_endpoints',
 		DISABLED_CACHING_ENDPOINTS
 	);
 
-	! disabledCachingEnpoints.some( ( pattern ) => pattern.test( path ) );
+	const isDisabled = disabledCachingEndpoints.some( ( pattern ) =>
+		pattern.test( path )
+	);
+
+	return ! isDisabled;
 };
 
 export default () => {

--- a/packages/react-native-editor/src/api-fetch-setup.js
+++ b/packages/react-native-editor/src/api-fetch-setup.js
@@ -81,8 +81,14 @@ export const isPathSupported = ( path, method ) => {
 	);
 };
 
-export const shouldEnableCaching = ( path ) =>
-	! DISABLED_CACHING_ENDPOINTS.some( ( pattern ) => pattern.test( path ) );
+export const shouldEnableCaching = ( path ) => {
+	const disabledCachingEnpoints = applyFilters(
+		'native.disabled_caching_endpoints',
+		DISABLED_CACHING_ENDPOINTS
+	);
+
+	! disabledCachingEnpoints.some( ( pattern ) => pattern.test( path ) );
+};
 
 export default () => {
 	apiFetch.setFetchHandler( ( options ) => fetchHandler( options ) );

--- a/packages/react-native-editor/src/test/api-fetch-setup.test.js
+++ b/packages/react-native-editor/src/test/api-fetch-setup.test.js
@@ -93,4 +93,16 @@ describe( 'shouldEnableCaching', () => {
 			expect( shouldEnableCaching( path ) ).toBe( false );
 		} );
 	} );
+
+	it( 'checks disabled cache endpoints provided by WP hook', () => {
+		addFilter(
+			'native.disabled_cache_endpoints',
+			'gutenberg-mobile',
+			( endpoints ) => {
+				return [ ...endpoints, /test\/no-cache-endpoint/i ];
+			}
+		);
+
+		expect( shouldEnableCaching( 'test/no-cache-endpoint' ) ).toBe( false );
+	} );
 } );

--- a/packages/react-native-editor/src/test/api-fetch-setup.test.js
+++ b/packages/react-native-editor/src/test/api-fetch-setup.test.js
@@ -96,7 +96,7 @@ describe( 'shouldEnableCaching', () => {
 
 	it( 'checks disabled cache endpoints provided by WP hook', () => {
 		addFilter(
-			'native.disabled_cache_endpoints',
+			'native.disabled_caching_endpoints',
 			'gutenberg-mobile',
 			( endpoints ) => {
 				return [ ...endpoints, /test\/no-cache-endpoint/i ];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds a filter hook to the disable cache endpoints in the api fetch setup.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Part of https://github.com/wordpress-mobile/gutenberg-mobile/issues/5603

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- calls `applyFilter` to collect the full list of URLs that should be disabled from caching

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Review code changes
- Verify tests pass

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
