### PR TITLE
Components: Update CHANGELOG CI check to support forked repos

### DIFF
--- a/.github/workflows/check-components-changelog.yml
+++ b/.github/workflows/check-components-changelog.yml
@@ -23,6 +23,7 @@ jobs:
               uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
               with:
                   ref: ${{ github.event.pull_request.head.ref }}
+                  repository: ${{ github.event.pull_request.head.repo.full_name }}
                   fetch-depth: ${{ env.PR_COMMIT_COUNT }}
             - name: 'Fetch relevant history from origin'
               run: git fetch origin ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
Fixes #49817

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Update the Components Package CHANGELOG check to support forked repos

## Why?
Without this change the check will always fail because it doesn't know what upstream repo to checkout from

## How?
Add a repo declaration!

## Testing Instructions
1. Fork Gutenberg
2. Make a change to any file in the components package that isn't a unit test, storybook file, or mobile/native file. Don't modify the CHANGELOG
3. Commit and push your changes
4. Create a PR from the modified branch on your fork
5. Confirm that the CI check runs, and fails because the CHANGELOG has not been updated.
6. Confirm the error output does not reference an error while fetching the repository
7. Update the CHANGELOG with an entry in the `Unreleased` section
8. Commit and push
9. Confirm the check runs and passes
