### PR TITLE
List View: Add aria-description

### DIFF
--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -63,6 +63,7 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
  * @param {?boolean}       props.showAppender      Flag to show or hide the block appender. Defaults to `false`.
  * @param {?ComponentType} props.blockSettingsMenu Optional more menu substitution. Defaults to the standard `BlockSettingsDropdown` component.
  * @param {string}         props.rootClientId      The client id of the root block from which we determine the blocks to show in the list.
+ * @param {string}         props.description       Optional accessible description for the tree grid component.
  * @param {Ref}            ref                     Forwarded ref
  */
 function ListViewComponent(
@@ -74,6 +75,7 @@ function ListViewComponent(
 		showAppender = false,
 		blockSettingsMenu: BlockSettingsMenu = BlockSettingsDropdown,
 		rootClientId,
+		description,
 	},
 	ref
 ) {
@@ -229,6 +231,8 @@ function ListViewComponent(
 				onExpandRow={ expandRow }
 				onFocusRow={ focusRow }
 				applicationAriaLabel={ __( 'Block navigation structure' ) }
+				// eslint-disable-next-line jsx-a11y/aria-props
+				aria-description={ description }
 			>
 				<ListViewContext.Provider value={ contextValue }>
 					<ListViewBranch


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This adds an `aria-description` attribute to the list view.

## Why?
This came up as part of the accessibility review for the off canvas editor component, and the attribute was added there, but not ported back to the list view, so this PR takes care of that.

## How?
Add a new prop (another one!) to the list view to populate the attribute, if its set.

## Testing Instructions
1. Add the description prop to the List View implementation
2. Check that you see it in the front end.

### Testing Instructions for Keyboard
This should be useful for screen readers, but I'm not totally sure how the aria-description attribute gets read.

## Screenshots or screencast <!-- if applicable -->
<img width="233" alt="Screenshot 2023-04-18 at 21 27 55" src="https://user-images.githubusercontent.com/275961/232908340-6a548dd7-164b-4634-9c9b-0178ffd81054.png">

