### PR TITLE
Add `--env-cwd` Option To `wp-env run`

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Enhancement
+### Breaking Changes
 
 -   `run` command now has a `--cwd` option to set the working directory for the command to execute from.
 

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
--   `run` command now has a `--cwd` option to set the working directory for the command to execute from.
+-   `run` command now has a `--env-cwd` option to set the working directory in the container for the command to execute from.
 
 ## 5.16.0 (2023-04-12)
 

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   `run` command now has a `--cwd` option to set the working directory for the command to execute from.
+
 ## 5.16.0 (2023-04-12)
 
 ## 5.15.0 (2023-03-29)

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -349,7 +349,7 @@ Options:
   --help     Show help                                                 [boolean]
   --version  Show version number                                       [boolean]
   --debug    Enable debug output.                     [boolean] [default: false]
-  --env-cwd  The working directory the command is ran from.
+  --env-cwd  The directory inside of the container that the command is ran from.
                                              [string] [default: "/var/www/html"]
 ```
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -350,7 +350,8 @@ Options:
   --version  Show version number                                       [boolean]
   --debug    Enable debug output.                     [boolean] [default: false]
   --env-cwd  The command's working directory inside of the container. Paths
-             without a leading slash are relative to the WordPress root.[string]
+             without a leading slash are relative to the WordPress root.
+                                                         [string] [default: "."]
 ```
 
 For example:

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -316,7 +316,7 @@ The run command can be used to open shell sessions or invoke WP-CLI commands.
 <div class="callout callout-alert">
 In some cases, `wp-env` may consume options that you are attempting to pass to
 the container. This happens with options that `wp-env` has already declared,
-such as `--debug`, `--help`, and `--version`. When this happens, you should fall
+such as `--env-cwd`, `--debug`, `--help`, and `--version`. When this happens, you should fall
 back to using quotation marks; `wp-env` considers everything inside the
 quotation marks to be command argument.
 
@@ -349,6 +349,8 @@ Options:
   --help     Show help                                                 [boolean]
   --version  Show version number                                       [boolean]
   --debug    Enable debug output.                     [boolean] [default: false]
+  --env-cwd  The working directory the command is ran from.
+                                             [string] [default: "/var/www/html"]
 ```
 
 For example:

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -349,8 +349,8 @@ Options:
   --help     Show help                                                 [boolean]
   --version  Show version number                                       [boolean]
   --debug    Enable debug output.                     [boolean] [default: false]
-  --env-cwd  The directory inside of the container that the command is ran from.
-                                             [string] [default: "/var/www/html"]
+  --env-cwd  The command's working directory inside of the container. Paths
+             without a leading slash are relative to the WordPress root.[string]
 ```
 
 For example:

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -174,6 +174,12 @@ module.exports = function cli() {
 		'run <container> [command..]',
 		'Runs an arbitrary command in one of the underlying Docker containers. The "container" param should reference one of the underlying Docker services like "development", "tests", or "cli". To run a wp-cli command, use the "cli" or "tests-cli" service. You can also use this command to open shell sessions like bash and the WordPress shell in the WordPress instance. For example, `wp-env run cli bash` will open bash in the development WordPress instance. When using long commands with arguments and quotation marks, you need to wrap the "command" param in quotation marks. For example: `wp-env run tests-cli "wp post create --post_type=page --post_title=\'Test\'"` will create a post on the tests WordPress instance.',
 		( args ) => {
+			args.option( 'cwd', {
+				type: 'string',
+				requiresArg: true,
+				default: '/var/www/html',
+				describe: 'The working directory the command is ran from.',
+			} );
 			args.positional( 'container', {
 				type: 'string',
 				describe: 'The container to run the command on.',

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -177,9 +177,8 @@ module.exports = function cli() {
 			args.option( 'env-cwd', {
 				type: 'string',
 				requiresArg: true,
-				default: '/var/www/html',
 				describe:
-					'The directory inside of the container that the command is ran from.',
+					"The command's working directory inside of the container. Paths without a leading slash are relative to the WordPress root.",
 			} );
 			args.positional( 'container', {
 				type: 'string',

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -174,7 +174,7 @@ module.exports = function cli() {
 		'run <container> [command..]',
 		'Runs an arbitrary command in one of the underlying Docker containers. The "container" param should reference one of the underlying Docker services like "development", "tests", or "cli". To run a wp-cli command, use the "cli" or "tests-cli" service. You can also use this command to open shell sessions like bash and the WordPress shell in the WordPress instance. For example, `wp-env run cli bash` will open bash in the development WordPress instance. When using long commands with arguments and quotation marks, you need to wrap the "command" param in quotation marks. For example: `wp-env run tests-cli "wp post create --post_type=page --post_title=\'Test\'"` will create a post on the tests WordPress instance.',
 		( args ) => {
-			args.option( 'cwd', {
+			args.option( 'env-cwd', {
 				type: 'string',
 				requiresArg: true,
 				default: '/var/www/html',

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -177,6 +177,7 @@ module.exports = function cli() {
 			args.option( 'env-cwd', {
 				type: 'string',
 				requiresArg: true,
+				default: '.',
 				describe:
 					"The command's working directory inside of the container. Paths without a leading slash are relative to the WordPress root.",
 			} );

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -178,7 +178,8 @@ module.exports = function cli() {
 				type: 'string',
 				requiresArg: true,
 				default: '/var/www/html',
-				describe: 'The working directory the command is ran from.',
+				describe:
+					'The directory inside of the container that the command is ran from.',
 			} );
 			args.positional( 'container', {
 				type: 'string',

--- a/packages/env/lib/commands/run.js
+++ b/packages/env/lib/commands/run.js
@@ -18,14 +18,14 @@ const initConfig = require( '../init-config' );
  * @param {Object}   options
  * @param {string}   options.container The Docker container to run the command on.
  * @param {string[]} options.command   The command to run.
- * @param {string}   options.cwd       The working directory for the command to be executed from.
+ * @param {string}   options.envCwd    The working directory for the command to be executed from.
  * @param {Object}   options.spinner   A CLI spinner which indicates progress.
  * @param {boolean}  options.debug     True if debug mode is enabled.
  */
 module.exports = async function run( {
 	container,
 	command,
-	cwd,
+	envCwd,
 	spinner,
 	debug,
 } ) {
@@ -36,7 +36,7 @@ module.exports = async function run( {
 	// Shows a contextual tip for the given command.
 	showCommandTips( command, container, spinner );
 
-	await spawnCommandDirectly( config, container, command, cwd, spinner );
+	await spawnCommandDirectly( config, container, command, envCwd, spinner );
 
 	spinner.text = `Ran \`${ command }\` in '${ container }'.`;
 };
@@ -47,22 +47,20 @@ module.exports = async function run( {
  * @param {WPConfig} config    The wp-env configuration.
  * @param {string}   container The Docker container to run the command on.
  * @param {string}   command   The command to run.
- * @param {string}   cwd       The working directory for the command to be executed from.
+ * @param {string}   envCwd    The working directory for the command to be executed from.
  * @param {Object}   spinner   A CLI spinner which indicates progress.
  */
-function spawnCommandDirectly( config, container, command, cwd, spinner ) {
+function spawnCommandDirectly( config, container, command, envCwd, spinner ) {
 	const composeCommand = [
 		'-f',
 		config.dockerComposeConfigPath,
 		'run',
 		'-w',
-		cwd,
+		envCwd,
 		'--rm',
 		container,
 		...command.split( ' ' ), // The command will fail if passed as a complete string.
 	];
-
-	console.log( composeCommand );
 
 	return new Promise( ( resolve, reject ) => {
 		// Note: since the npm docker-compose package uses the -T option, we

--- a/packages/env/lib/commands/run.js
+++ b/packages/env/lib/commands/run.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 const { spawn } = require( 'child_process' );
+const path = require( 'path' );
 
 /**
  * Internal dependencies
@@ -51,6 +52,9 @@ module.exports = async function run( {
  * @param {Object}   spinner   A CLI spinner which indicates progress.
  */
 function spawnCommandDirectly( config, container, command, envCwd, spinner ) {
+	// We need to pass absolute paths to the container.
+	envCwd = path.resolve( '/var/www/html', envCwd );
+
 	const composeCommand = [
 		'-f',
 		config.dockerComposeConfigPath,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
By default all `wp-env run` commands are ran from `/var/www/html`. This means that any relative paths used in a command are relative to this directory. This PR adds a new `--env-cwd` option that changes the working directory for `wp-env run`.

## Why?
In adding support for running PHPUnit tests to our repository, I noticed that running `wp-env run tests-wordpress /var/www/html/wp-content/plugins/woocommerce/vendor/bin/phpunit` in a script and adding a path to a test file does not work. It expects the relative path to be relative to `/var/www/html` instead of the `phpunit.xml` file I use.

As for the name `--env-cwd`, it's important to note that any options registered by `npm` or `wp-env` are consumed by their respective tools instead of being passed on. `--cwd` seems likely to have been used by some tool, so, we should try and avoid conflict.

I've marked this as a breaking change in case someone is using `--env-cwd` in their `wp-env run` commands. Since it's going to consume it there's the possibility it will break for someone.

## How?
We're using the `-w` option provided by `docker-compose run` to change the working directory of the command. This avoids any messiness with trying to `cd`.

## Testing Instructions
1. `npm run env -- run tests-wordpress pwd` should echo `/var/www/html`.
2. `npm run env -- run tests-wordpress --env-cwd=/var  pwd` should echo `/var`.