### PR TITLE
Update frame resizing

### DIFF
--- a/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
@@ -54,4 +54,9 @@ export async function visitSiteEditor(
 		.locator( 'body > *' )
 		.first()
 		.waitFor();
+
+	// TODO: Ideally the content underneath the spinner should be marked inert until it's ready.
+	await this.page
+		.locator( '.edit-site-canvas-spinner' )
+		.waitFor( { state: 'hidden' } );
 }

--- a/packages/e2e-test-utils-playwright/src/editor/site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/site-editor.ts
@@ -24,6 +24,10 @@ export async function saveSiteEditorEntities( this: Editor ) {
 		.getByRole( 'button', { name: 'Save', exact: true } )
 		.click();
 
-	// Wait for the saved status.
-	await editorTopBar.getByRole( 'button', { name: 'Saved' } ).waitFor();
+	// A role selector cannot be used here because it needs to check that the `is-busy` class is not present.
+	await this.page
+		.locator( '[aria-label="Editor top bar"] [aria-label="Saved"].is-busy' )
+		.waitFor( {
+			state: 'hidden',
+		} );
 }

--- a/packages/e2e-test-utils-playwright/src/editor/site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/site-editor.ts
@@ -9,15 +9,21 @@ import type { Editor } from './index';
  * @param this
  */
 export async function saveSiteEditorEntities( this: Editor ) {
-	await this.page.click(
-		'role=region[name="Editor top bar"i] >> role=button[name="Save"i]'
-	);
-	// Second Save button in the entities panel.
-	await this.page.click(
-		'role=region[name="Save panel"i] >> role=button[name="Save"i]'
-	);
-	// A role selector cannot be used here because it needs to check that the `is-busy` class is not present.
-	await this.page.waitForSelector( '[aria-label="Saved"].is-busy', {
-		state: 'hidden',
+	const editorTopBar = this.page.getByRole( 'region', {
+		name: 'Editor top bar',
 	} );
+	const savePanel = this.page.getByRole( 'region', { name: 'Save panel' } );
+
+	// First Save button in the top bar.
+	await editorTopBar
+		.getByRole( 'button', { name: 'Save', exact: true } )
+		.click();
+
+	// Second Save button in the entities panel.
+	await savePanel
+		.getByRole( 'button', { name: 'Save', exact: true } )
+		.click();
+
+	// Wait for the saved status.
+	await editorTopBar.getByRole( 'button', { name: 'Saved' } ).waitFor();
 }

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -6,10 +6,10 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useEffect, useMemo, useState } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Notice } from '@wordpress/components';
-import { EntityProvider, store as coreStore } from '@wordpress/core-data';
+import { EntityProvider } from '@wordpress/core-data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import {
 	BlockContextProvider,
@@ -55,42 +55,7 @@ const interfaceLabels = {
 	footer: __( 'Editor footer' ),
 };
 
-function useIsSiteEditorLoading() {
-	const { isLoaded: hasLoadedPost } = useEditedEntityRecord();
-	const [ loaded, setLoaded ] = useState( false );
-	const inLoadingPause = useSelect(
-		( select ) => {
-			const hasResolvingSelectors =
-				select( coreStore ).hasResolvingSelectors();
-			return ! loaded && ! hasResolvingSelectors;
-		},
-		[ loaded ]
-	);
-
-	useEffect( () => {
-		if ( inLoadingPause ) {
-			/*
-			 * We're using an arbitrary 1s timeout here to catch brief moments
-			 * without any resolving selectors that would result in displaying
-			 * brief flickers of loading state and loaded state.
-			 *
-			 * It's worth experimenting with different values, since this also
-			 * adds 1s of artificial delay after loading has finished.
-			 */
-			const timeout = setTimeout( () => {
-				setLoaded( true );
-			}, 1000 );
-
-			return () => {
-				clearTimeout( timeout );
-			};
-		}
-	}, [ inLoadingPause ] );
-
-	return ! loaded || ! hasLoadedPost;
-}
-
-export default function Editor() {
+export default function Editor( { isLoading } ) {
 	const {
 		record: editedPost,
 		getTitle,
@@ -192,8 +157,6 @@ export default function Editor() {
 	// Only announce the title once the editor is ready to prevent "Replace"
 	// action in <URlQueryController> from double-announcing.
 	useTitle( hasLoadedPost && title );
-
-	const isLoading = useIsSiteEditorLoading();
 
 	return (
 		<>

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { useEffect, useMemo, useState } from '@wordpress/element';
@@ -205,7 +210,13 @@ export default function Editor() {
 						{ isEditMode && <StartTemplateOptions /> }
 						<InterfaceSkeleton
 							enableRegionNavigation={ false }
-							className={ showIconLabels && 'show-icon-labels' }
+							className={ classnames(
+								'edit-site-editor__interface-skeleton',
+								{
+									'show-icon-labels': showIconLabels,
+									'is-loading': isLoading,
+								}
+							) }
 							notices={
 								( isEditMode ||
 									window?.__experimentalEnableThemePreviews ) && (

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -1,3 +1,13 @@
+.edit-site-editor__interface-skeleton {
+	opacity: 1;
+	transition: opacity 0.1s ease-out;
+	@include reduce-motion("transition");
+
+	&.is-loading {
+		opacity: 0;
+	}
+}
+
 .edit-site-editor__toggle-save-panel {
 	box-sizing: border-box;
 	width: $sidebar-width;

--- a/packages/edit-site/src/components/layout/hooks.js
+++ b/packages/edit-site/src/components/layout/hooks.js
@@ -1,0 +1,46 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import useEditedEntityRecord from '../use-edited-entity-record';
+
+export function useIsSiteEditorLoading() {
+	const { isLoaded: hasLoadedPost } = useEditedEntityRecord();
+	const [ loaded, setLoaded ] = useState( false );
+	const inLoadingPause = useSelect(
+		( select ) => {
+			const hasResolvingSelectors =
+				select( coreStore ).hasResolvingSelectors();
+			return ! loaded && ! hasResolvingSelectors;
+		},
+		[ loaded ]
+	);
+
+	useEffect( () => {
+		if ( inLoadingPause ) {
+			/*
+			 * We're using an arbitrary 1s timeout here to catch brief moments
+			 * without any resolving selectors that would result in displaying
+			 * brief flickers of loading state and loaded state.
+			 *
+			 * It's worth experimenting with different values, since this also
+			 * adds 1s of artificial delay after loading has finished.
+			 */
+			const timeout = setTimeout( () => {
+				setLoaded( true );
+			}, 1000 );
+
+			return () => {
+				clearTimeout( timeout );
+			};
+		}
+	}, [ inLoadingPause ] );
+
+	return ! loaded || ! hasLoadedPost;
+}

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -92,7 +92,6 @@ export default function Layout() {
 	} );
 	const disableMotion = useReducedMotion();
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
-	const canvasPadding = isMobileViewport ? 0 : 24;
 	const showSidebar =
 		( isMobileViewport && ! isListPage ) ||
 		( ! isMobileViewport && ( canvasMode === 'view' || ! isEditorPage ) );
@@ -100,9 +99,6 @@ export default function Layout() {
 		( isMobileViewport && isEditorPage && isEditing ) ||
 		! isMobileViewport ||
 		! isEditorPage;
-	const showFrame =
-		( ! isEditorPage && ! isMobileViewport ) ||
-		( ! isMobileViewport && isEditorPage && canvasMode === 'view' );
 	const isFullCanvas =
 		( isMobileViewport && isListPage ) || ( isEditorPage && isEditing );
 	const [ canvasResizer, canvasSize ] = useResizeObserver();
@@ -205,18 +201,13 @@ export default function Layout() {
 					<SavePanel />
 
 					{ showCanvas && (
-						<motion.div
+						<div
 							className={ classnames(
 								'edit-site-layout__canvas-container',
 								{
 									'is-resizing': isResizing,
 								}
 							) }
-							animate={ {
-								paddingTop: showFrame ? canvasPadding : 0,
-								paddingBottom: showFrame ? canvasPadding : 0,
-							} }
-							transition={ { duration: ANIMATION_DURATION } }
 						>
 							{ canvasResizer }
 							{ !! canvasSize.width && (
@@ -266,7 +257,7 @@ export default function Layout() {
 									</ErrorBoundary>
 								</motion.div>
 							) }
-						</motion.div>
+						</div>
 					) }
 				</div>
 			</div>

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -106,8 +106,6 @@ export default function Layout() {
 		( isMobileViewport && isListPage ) || ( isEditorPage && isEditing );
 	const [ canvasResizer, canvasSize ] = useResizeObserver();
 	const [ fullResizer ] = useResizeObserver();
-	const [ isResizableFrameOversized, setIsResizableFrameOversized ] =
-		useState( false );
 	const [ isResizing ] = useState( false );
 
 	// Sets the right context for the command center
@@ -238,13 +236,7 @@ export default function Layout() {
 									}
 									initial={ false }
 									layout="position"
-									className={ classnames(
-										'edit-site-layout__canvas',
-										{
-											'is-right-aligned':
-												isResizableFrameOversized,
-										}
-									) }
+									className="edit-site-layout__canvas"
 									transition={ {
 										type: 'tween',
 										duration:
@@ -256,9 +248,7 @@ export default function Layout() {
 								>
 									<ResizableFrame
 										isFullWidth={ isEditing }
-										onOversizeChange={
-											setIsResizableFrameOversized
-										}
+										oversizedClassName="edit-site-layout__resizable-frame-oversized"
 									>
 										<ErrorBoundary>
 											{ isEditorPage && <Editor /> }

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -48,6 +48,7 @@ import SavePanel from '../save-panel';
 import KeyboardShortcutsRegister from '../keyboard-shortcuts/register';
 import KeyboardShortcutsGlobal from '../keyboard-shortcuts/global';
 import { useEditModeCommands } from '../../hooks/commands/use-edit-mode-commands';
+import { useIsSiteEditorLoading } from './hooks';
 
 const { useCommands } = unlock( coreCommandsPrivateApis );
 const { useCommandContext } = unlock( commandsPrivateApis );
@@ -107,6 +108,7 @@ export default function Layout() {
 	const [ canvasResizer, canvasSize ] = useResizeObserver();
 	const [ fullResizer ] = useResizeObserver();
 	const [ isResizing ] = useState( false );
+	const isEditorLoading = useIsSiteEditorLoading();
 
 	// Sets the right context for the command center
 	const commandContext =
@@ -249,10 +251,15 @@ export default function Layout() {
 									<ErrorBoundary>
 										{ isEditorPage && (
 											<ResizableFrame
+												isReady={ ! isEditorLoading }
 												isFullWidth={ isEditing }
 												oversizedClassName="edit-site-layout__resizable-frame-oversized"
 											>
-												<Editor />
+												<Editor
+													isLoading={
+														isEditorLoading
+													}
+												/>
 											</ResizableFrame>
 										) }
 										{ isListPage && <ListPage /> }

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -106,6 +106,8 @@ export default function Layout() {
 		( isMobileViewport && isListPage ) || ( isEditorPage && isEditing );
 	const [ canvasResizer, canvasSize ] = useResizeObserver();
 	const [ fullResizer ] = useResizeObserver();
+	const [ isResizableFrameOversized, setIsResizableFrameOversized ] =
+		useState( false );
 	const [ isResizing ] = useState( false );
 
 	// Sets the right context for the command center
@@ -236,7 +238,13 @@ export default function Layout() {
 									}
 									initial={ false }
 									layout="position"
-									className="edit-site-layout__canvas"
+									className={ classnames(
+										'edit-site-layout__canvas',
+										{
+											'is-right-aligned':
+												isResizableFrameOversized,
+										}
+									) }
 									transition={ {
 										type: 'tween',
 										duration:
@@ -247,8 +255,10 @@ export default function Layout() {
 									} }
 								>
 									<ResizableFrame
-										startWidth={ canvasSize.width }
 										isFullWidth={ isEditing }
+										onOversizeChange={
+											setIsResizableFrameOversized
+										}
 									>
 										<ErrorBoundary>
 											{ isEditorPage && <Editor /> }

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -11,7 +11,6 @@ import {
 	__unstableMotion as motion,
 	__unstableAnimatePresence as AnimatePresence,
 	__unstableUseNavigateRegions as useNavigateRegions,
-	ResizableBox,
 } from '@wordpress/components';
 import {
 	useReducedMotion,
@@ -42,7 +41,7 @@ import getIsListPage from '../../utils/get-is-list-page';
 import Header from '../header-edit-mode';
 import useInitEditedEntityFromURL from '../sync-state-with-url/use-init-edited-entity-from-url';
 import SiteHub from '../site-hub';
-import ResizeHandle from '../block-editor/resize-handle';
+import ResizableFrame from '../resizable-frame';
 import useSyncCanvasModeWithURL from '../sync-state-with-url/use-sync-canvas-mode-with-url';
 import { unlock } from '../../private-apis';
 import SavePanel from '../save-panel';
@@ -55,17 +54,6 @@ const { useCommandContext } = unlock( commandsPrivateApis );
 const { useLocation } = unlock( routerPrivateApis );
 
 const ANIMATION_DURATION = 0.5;
-const emptyResizeHandleStyles = {
-	position: undefined,
-	userSelect: undefined,
-	cursor: undefined,
-	width: undefined,
-	height: undefined,
-	top: undefined,
-	right: undefined,
-	bottom: undefined,
-	left: undefined,
-};
 
 export default function Layout() {
 	// This ensures the edited entity id and type are initialized properly.
@@ -96,6 +84,7 @@ export default function Layout() {
 					select( preferencesStore ).get( 'fixedToolbar' ),
 			};
 		}, [] );
+	const isEditing = canvasMode === 'edit';
 	const navigateRegionsProps = useNavigateRegions( {
 		previous: previousShortcut,
 		next: nextShortcut,
@@ -107,25 +96,17 @@ export default function Layout() {
 		( isMobileViewport && ! isListPage ) ||
 		( ! isMobileViewport && ( canvasMode === 'view' || ! isEditorPage ) );
 	const showCanvas =
-		( isMobileViewport && isEditorPage && canvasMode === 'edit' ) ||
+		( isMobileViewport && isEditorPage && isEditing ) ||
 		! isMobileViewport ||
 		! isEditorPage;
 	const showFrame =
 		( ! isEditorPage && ! isMobileViewport ) ||
 		( ! isMobileViewport && isEditorPage && canvasMode === 'view' );
 	const isFullCanvas =
-		( isMobileViewport && isListPage ) ||
-		( isEditorPage && canvasMode === 'edit' );
+		( isMobileViewport && isListPage ) || ( isEditorPage && isEditing );
 	const [ canvasResizer, canvasSize ] = useResizeObserver();
-	const [ fullResizer, fullSize ] = useResizeObserver();
-	const [ forcedWidth, setForcedWidth ] = useState( null );
-	const [ isResizing, setIsResizing ] = useState( false );
-	const isResizingEnabled = ! isMobileViewport && canvasMode === 'view';
-	const defaultSidebarWidth = isMobileViewport ? '100vw' : 360;
-	let canvasWidth = isResizing ? '100%' : fullSize.width;
-	if ( showFrame && ! isResizing ) {
-		canvasWidth = canvasSize.width - canvasPadding;
-	}
+	const [ fullResizer ] = useResizeObserver();
+	const [ isResizing ] = useState( false );
 
 	// Sets the right context for the command center
 	const commandContext =
@@ -155,7 +136,7 @@ export default function Layout() {
 					navigateRegionsProps.className,
 					{
 						'is-full-canvas': isFullCanvas,
-						'is-edit-mode': canvasMode === 'edit',
+						'is-edit-mode': isEditing,
 						'has-fixed-toolbar': hasFixedToolbar,
 					}
 				) }
@@ -163,7 +144,7 @@ export default function Layout() {
 				<SiteHub ref={ hubRef } className="edit-site-layout__hub" />
 
 				<AnimatePresence initial={ false }>
-					{ isEditorPage && canvasMode === 'edit' && (
+					{ isEditorPage && isEditing && (
 						<NavigableRegion
 							className="edit-site-layout__header"
 							ariaLabel={ __( 'Editor top bar' ) }
@@ -185,7 +166,7 @@ export default function Layout() {
 								ease: 'easeOut',
 							} }
 						>
-							<Header />
+							{ isEditing && <Header /> }
 						</NavigableRegion>
 					) }
 				</AnimatePresence>
@@ -193,8 +174,7 @@ export default function Layout() {
 				<div className="edit-site-layout__content">
 					<AnimatePresence initial={ false }>
 						{ showSidebar && (
-							<ResizableBox
-								as={ motion.div }
+							<motion.div
 								initial={ {
 									opacity: 0,
 								} }
@@ -206,86 +186,35 @@ export default function Layout() {
 								} }
 								transition={ {
 									type: 'tween',
-									duration:
-										disableMotion || isResizing
-											? 0
-											: ANIMATION_DURATION,
+									duration: ANIMATION_DURATION,
 									ease: 'easeOut',
 								} }
-								size={ {
-									height: '100%',
-									width:
-										isResizingEnabled && forcedWidth
-											? forcedWidth
-											: defaultSidebarWidth,
-								} }
 								className="edit-site-layout__sidebar"
-								enable={ {
-									right: isResizingEnabled,
-								} }
-								onResizeStop={ ( event, direction, elt ) => {
-									setForcedWidth( elt.clientWidth );
-									setIsResizing( false );
-								} }
-								onResizeStart={ () => {
-									setIsResizing( true );
-								} }
-								onResize={ ( event, direction, elt ) => {
-									// This is a performance optimization
-									// We set the width imperatively to avoid re-rendering
-									// the whole component while resizing.
-									hubRef.current.style.width =
-										elt.clientWidth - 48 + 'px';
-								} }
-								handleComponent={ {
-									right: (
-										<ResizeHandle
-											direction="right"
-											variation="separator"
-											resizeWidthBy={ ( delta ) => {
-												setForcedWidth(
-													( forcedWidth ??
-														defaultSidebarWidth ) +
-														delta
-												);
-											} }
-										/>
-									),
-								} }
-								handleClasses={ undefined }
-								handleStyles={ {
-									right: emptyResizeHandleStyles,
-								} }
-								minWidth={ isResizingEnabled ? 320 : undefined }
-								maxWidth={
-									isResizingEnabled && fullSize
-										? fullSize.width - 360
-										: undefined
-								}
 							>
 								<NavigableRegion
 									ariaLabel={ __( 'Navigation' ) }
 								>
 									<Sidebar />
 								</NavigableRegion>
-							</ResizableBox>
+							</motion.div>
 						) }
 					</AnimatePresence>
 
 					<SavePanel />
 
 					{ showCanvas && (
-						<div
+						<motion.div
 							className={ classnames(
 								'edit-site-layout__canvas-container',
 								{
 									'is-resizing': isResizing,
 								}
 							) }
-							style={ {
+							animate={ {
 								paddingTop: showFrame ? canvasPadding : 0,
 								paddingBottom: showFrame ? canvasPadding : 0,
 							} }
+							transition={ { duration: ANIMATION_DURATION } }
 						>
 							{ canvasResizer }
 							{ !! canvasSize.width && (
@@ -317,34 +246,18 @@ export default function Layout() {
 										ease: 'easeOut',
 									} }
 								>
-									<motion.div
-										style={ {
-											position: 'absolute',
-											top: 0,
-											left: 0,
-											bottom: 0,
-										} }
-										initial={ false }
-										animate={ {
-											width: canvasWidth,
-										} }
-										transition={ {
-											type: 'tween',
-											duration:
-												disableMotion || isResizing
-													? 0
-													: ANIMATION_DURATION,
-											ease: 'easeOut',
-										} }
+									<ResizableFrame
+										startWidth={ canvasSize.width }
+										isFull={ isEditing }
 									>
 										<ErrorBoundary>
 											{ isEditorPage && <Editor /> }
 											{ isListPage && <ListPage /> }
 										</ErrorBoundary>
-									</motion.div>
+									</ResizableFrame>
 								</motion.div>
 							) }
-						</div>
+						</motion.div>
 					) }
 				</div>
 			</div>

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -246,15 +246,17 @@ export default function Layout() {
 										ease: 'easeOut',
 									} }
 								>
-									<ResizableFrame
-										isFullWidth={ isEditing }
-										oversizedClassName="edit-site-layout__resizable-frame-oversized"
-									>
-										<ErrorBoundary>
-											{ isEditorPage && <Editor /> }
-											{ isListPage && <ListPage /> }
-										</ErrorBoundary>
-									</ResizableFrame>
+									<ErrorBoundary>
+										{ isEditorPage && (
+											<ResizableFrame
+												isFullWidth={ isEditing }
+												oversizedClassName="edit-site-layout__resizable-frame-oversized"
+											>
+												<Editor />
+											</ResizableFrame>
+										) }
+										{ isListPage && <ListPage /> }
+									</ErrorBoundary>
 								</motion.div>
 							) }
 						</motion.div>

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -248,7 +248,7 @@ export default function Layout() {
 								>
 									<ResizableFrame
 										startWidth={ canvasSize.width }
-										isFull={ isEditing }
+										isFullWidth={ isEditing }
 									>
 										<ErrorBoundary>
 											{ isEditorPage && <Editor /> }

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -139,6 +139,10 @@
 	}
 }
 
+.edit-site-layout__canvas:has(.is-bleeding) {
+	justify-content: flex-end;
+	align-items: flex-end;
+}
 // This shouldn't be necessary (we should have a way to say that a skeletton is relative
 .edit-site-layout__canvas .interface-interface-skeleton {
 	position: relative !important;

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -139,9 +139,13 @@
 	}
 }
 
-.edit-site-layout__canvas:has(.is-bleeding) {
+.edit-site-layout__canvas:has(.is-oversized) {
 	justify-content: flex-end;
 	align-items: flex-end;
+
+	.components-resizable-box__container {
+		min-width: 100% !important;
+	}
 }
 // This shouldn't be necessary (we should have a way to say that a skeletton is relative
 .edit-site-layout__canvas .interface-interface-skeleton {

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -108,6 +108,11 @@
 	display: flex;
 	justify-content: center;
 	align-items: center;
+
+	&.is-right-aligned {
+		justify-content: flex-end;
+	}
+
 	& > div {
 		color: $gray-900;
 	}
@@ -137,11 +142,6 @@
 			border-radius: 0;
 		}
 	}
-}
-
-.edit-site-layout__canvas:has(.is-oversized) {
-	justify-content: flex-end;
-	align-items: flex-end;
 }
 
 // This shouldn't be necessary (we should have a way to say that a skeletton is relative

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -105,8 +105,9 @@
 	left: 0;
 	bottom: 0;
 	width: 100%;
-	overflow: hidden;
-
+	display: flex;
+	justify-content: center;
+	align-items: center;
 	& > div {
 		color: $gray-900;
 	}

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -250,3 +250,8 @@
 	}
 
 }
+
+body:has(.edit-site-the-frame__inner.resizing) {
+	user-select: none;
+	-webkit-user-select: none;
+}

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -142,11 +142,8 @@
 .edit-site-layout__canvas:has(.is-oversized) {
 	justify-content: flex-end;
 	align-items: flex-end;
-
-	.components-resizable-box__container {
-		// min-width: 100% !important;
-	}
 }
+
 // This shouldn't be necessary (we should have a way to say that a skeletton is relative
 .edit-site-layout__canvas .interface-interface-skeleton {
 	position: relative !important;
@@ -252,10 +249,5 @@
 			z-index: 3;
 		}
 	}
-
 }
 
-body:has(.edit-site-the-frame__inner.resizing) {
-	user-select: none;
-	-webkit-user-select: none;
-}

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -109,7 +109,7 @@
 	justify-content: center;
 	align-items: center;
 
-	&.is-right-aligned {
+	&:has(.edit-site-layout__resizable-frame-oversized) {
 		justify-content: flex-end;
 	}
 

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -144,7 +144,7 @@
 	align-items: flex-end;
 
 	.components-resizable-box__container {
-		min-width: 100% !important;
+		// min-width: 100% !important;
 	}
 }
 // This shouldn't be necessary (we should have a way to say that a skeletton is relative

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -1,0 +1,162 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import {
+	ResizableBox,
+	__unstableMotion as motion,
+	__experimentalText as Text,
+} from '@wordpress/components';
+
+// Removes the inline styles in the drag handles.
+const HANDLE_STYLES_OVERRIDE = {
+	position: undefined,
+	userSelect: undefined,
+	cursor: undefined,
+	width: undefined,
+	height: undefined,
+	top: undefined,
+	right: undefined,
+	bottom: undefined,
+	left: undefined,
+};
+
+const devices = [
+	{
+		label: 'Mobile',
+		width: 480,
+		height: 640,
+	},
+	{
+		label: 'Tablet',
+		width: 1024,
+		height: 768,
+	},
+	{
+		label: 'Desktop',
+		width: null,
+		height: '100%',
+	},
+];
+
+const FRAME_TRANSITION = { type: 'tween', duration: 0.5 };
+const MIN_FRAME_SIZE = 240;
+
+function ResizableFrame( { isFull, children } ) {
+	const [ frameWidth, setFrameWidth ] = useState( '100%' );
+	const [ frameDevice, setFrameDevice ] = useState( devices[ 2 ] );
+	const frameHeight = isFull ? '100%' : frameDevice?.height || '100%';
+	const [ isResizing, setIsResizing ] = useState( false );
+	const [ isHovering, setIsHovering ] = useState( false );
+
+	return (
+		<ResizableBox
+			as={ motion.div }
+			initial={ false }
+			animate={ {
+				flexGrow: isFull ? 1 : 0,
+				height: frameHeight,
+			} }
+			transition={ FRAME_TRANSITION }
+			size={ {
+				width: frameWidth,
+				height: frameHeight,
+			} }
+			enable={ {
+				top: false,
+				right: false,
+				bottom: false,
+				left: true,
+				topRight: false,
+				bottomRight: false,
+				bottomLeft: false,
+				topLeft: false,
+			} }
+			resizeRatio={ 2 }
+			handleClasses={ undefined }
+			handleStyles={ {
+				left: HANDLE_STYLES_OVERRIDE,
+				right: HANDLE_STYLES_OVERRIDE,
+			} }
+			minWidth={ MIN_FRAME_SIZE }
+			maxWidth={ '100%' }
+			maxHeight={ '100%' }
+			onMouseOver={ () => setIsHovering( true ) }
+			onMouseOut={ () => setIsHovering( false ) }
+			handleComponent={ {
+				left: ! isHovering ? null : (
+					<motion.div
+						key="handle"
+						className="edit-site-the-frame__handle"
+						title="drag to resize"
+						onMouseDown={ () => setIsResizing( true ) }
+						initial={ {
+							opacity: 0,
+							left: 0,
+						} }
+						animate={ {
+							opacity: 1,
+							left: -15,
+						} }
+						exit={ {
+							opacity: 0,
+							left: 0,
+						} }
+					>
+						{ isResizing && ! isFull && (
+							<motion.div
+								as={ Text }
+								size="footnote"
+								key="handle-label"
+								initial={ {
+									opacity: 0,
+									x: 20,
+								} }
+								animate={ {
+									opacity: 1,
+									x: 0,
+								} }
+								exit={ {
+									opacity: 0,
+									x: 20,
+								} }
+								className="edit-site-the-frame__handle-label"
+							>
+								{ frameDevice.label }
+							</motion.div>
+						) }
+					</motion.div>
+				),
+			} }
+			onResizeStop={ ( e, direction, ref, d ) => {
+				setFrameWidth( frameWidth + d.width );
+			} }
+			onResize={ ( e, direction, ref ) => {
+				const device = devices.find( ( dev ) =>
+					dev.width ? ref.clientWidth < dev.width : dev
+				);
+				setFrameDevice( device );
+			} }
+			className={ classnames( 'edit-site-the-frame__inner', {
+				resizing: isResizing,
+			} ) }
+		>
+			<motion.div
+				className="edit-site-the-frame__content"
+				animate={ {
+					borderRadius: isFull ? 0 : 8,
+				} }
+				transition={ FRAME_TRANSITION }
+			>
+				{ children }
+			</motion.div>
+		</ResizableBox>
+	);
+}
+
+export default ResizableFrame;

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -93,12 +93,6 @@ function ResizableFrame( { isFull, children } ) {
 		const updatedWidth = previousWidth + delta.width;
 
 		if ( updatedWidth > initialComputedWidthRef.current ) {
-			// const oversizeWidth = Math.max(
-			// 	initialComputedWidthRef.current +
-			// 		( updatedWidth - initialComputedWidthRef.current ) * 2,
-			// 	initialComputedWidthRef.current
-			// );
-
 			setIsOversized( true );
 		} else {
 			setIsOversized( false );
@@ -116,7 +110,7 @@ function ResizableFrame( { isFull, children } ) {
 	};
 
 	// Make the frame full screen when the user resizes it to the left.
-	const handleResizeStop = ( event, _direction, ref ) => {
+	const handleResizeStop = ( _event, _direction, ref ) => {
 		setIsResizing( false );
 
 		if ( ! isOversized ) {

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -66,7 +66,7 @@ function ResizableFrame( { isFullWidth, children } ) {
 		width: '100%',
 		height: '100%',
 	} );
-	const [ previousWidth, setPreviousWidth ] = useState();
+	const [ startingWidth, setStartingWidth ] = useState();
 	const [ isResizing, setIsResizing ] = useState( false );
 	const [ isHovering, setIsHovering ] = useState( false );
 	const [ isOversized, setIsOversized ] = useState( false );
@@ -84,19 +84,17 @@ function ResizableFrame( { isFullWidth, children } ) {
 	}, [] );
 
 	const handleResizeStart = ( _event, _direction, ref ) => {
-		setPreviousWidth( ref.offsetWidth );
+		// Remember the starting width so we don't have to get `ref.offsetWidth` on
+		// every resize event thereafter, which will cause layout thrashing.
+		setStartingWidth( ref.offsetWidth );
 		setIsResizing( true );
 	};
 
 	// Calculate the frame size based on the window width as its resized.
-	const handleResize = ( event, _direction, _ref, delta ) => {
-		const updatedWidth = previousWidth + delta.width;
+	const handleResize = ( _event, _direction, _ref, delta ) => {
+		const updatedWidth = startingWidth + delta.width;
 
-		if ( updatedWidth > initialComputedWidthRef.current ) {
-			setIsOversized( true );
-		} else {
-			setIsOversized( false );
-		}
+		setIsOversized( updatedWidth > initialComputedWidthRef.current );
 
 		setFrameSize( {
 			width: updatedWidth,

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -116,13 +116,6 @@ function ResizableFrame( { isFull, children } ) {
 		// Trigger full screen if the frame is resized far enough to the left.
 		if ( event.clientX < 200 ) {
 			setCanvasMode( 'edit' );
-			// Wait for the frame to animate to full screen before resetting its size.
-			const timeoutId = setTimeout( () => {
-				setFrameSize( { width: '100%', height: '100%' } );
-			}, 500 );
-
-			// Clean up the timeout when the effect is no longer needed.
-			return () => clearTimeout( timeoutId );
 		}
 
 		setIsResizing( false );
@@ -135,6 +128,11 @@ function ResizableFrame( { isFull, children } ) {
 			animate={ {
 				flexGrow: isFull ? 1 : 0,
 				height: frameSize.height,
+			} }
+			onAnimationComplete={ ( { flexGrow } ) => {
+				if ( flexGrow === 1 )
+					// `isFull` is true
+					setFrameSize( { width: '100%', height: '100%' } );
 			} }
 			transition={ FRAME_TRANSITION }
 			size={ frameSize }

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -61,7 +61,7 @@ function calculateNewHeight( width, initialAspectRatio ) {
 	return width / intermediateAspectRatio;
 }
 
-function ResizableFrame( { isFull, children } ) {
+function ResizableFrame( { isFullWidth, children } ) {
 	const [ frameSize, setFrameSize ] = useState( {
 		width: '100%',
 		height: '100%',
@@ -138,12 +138,12 @@ function ResizableFrame( { isFull, children } ) {
 			ref={ frameRef }
 			initial={ false }
 			animate={ {
-				flexGrow: isFull ? 1 : 0,
+				flexGrow: isFullWidth ? 1 : 0,
 				height: frameSize.height,
 			} }
 			onAnimationComplete={ ( { flexGrow } ) => {
 				if ( flexGrow === 1 )
-					// `isFull` is true
+					// `isFullWidth` is true
 					setFrameSize( { width: '100%', height: '100%' } );
 			} }
 			transition={ FRAME_TRANSITION }
@@ -202,7 +202,7 @@ function ResizableFrame( { isFull, children } ) {
 			<motion.div
 				className="edit-site-the-frame__inner-content"
 				animate={ {
-					borderRadius: isFull ? 0 : 8,
+					borderRadius: isFullWidth ? 0 : 8,
 				} }
 				transition={ FRAME_TRANSITION }
 			>

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -61,7 +61,7 @@ function calculateNewHeight( width, initialAspectRatio ) {
 	return width / intermediateAspectRatio;
 }
 
-function ResizableFrame( { isFullWidth, children } ) {
+function ResizableFrame( { isFullWidth, children, onOversizeChange } ) {
 	const [ frameSize, setFrameSize ] = useState( {
 		width: '100%',
 		height: '100%',
@@ -69,7 +69,15 @@ function ResizableFrame( { isFullWidth, children } ) {
 	const [ startingWidth, setStartingWidth ] = useState();
 	const [ isResizing, setIsResizing ] = useState( false );
 	const [ isHovering, setIsHovering ] = useState( false );
-	const [ isOversized, setIsOversized ] = useState( false );
+	const [ isOversized, _setIsOversized ] = useState( false );
+	const setIsOversized = ( value ) => {
+		_setIsOversized( ( prevValue ) => {
+			if ( prevValue !== value ) {
+				onOversizeChange( value );
+			}
+			return value;
+		} );
+	};
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 	const initialAspectRatioRef = useRef( null );
 	const initialComputedWidthRef = useRef( null );

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -61,7 +61,12 @@ function calculateNewHeight( width, initialAspectRatio ) {
 	return width / intermediateAspectRatio;
 }
 
-function ResizableFrame( { isFullWidth, children, oversizedClassName } ) {
+function ResizableFrame( {
+	isFullWidth,
+	isReady,
+	children,
+	oversizedClassName,
+} ) {
 	const [ frameSize, setFrameSize ] = useState( {
 		width: '100%',
 		height: '100%',
@@ -173,7 +178,8 @@ function ResizableFrame( { isFullWidth, children, oversizedClassName } ) {
 				top: false,
 				right: false,
 				bottom: false,
-				left: true,
+				// Resizing will be disabled until the editor content is loaded.
+				left: isReady,
 				topRight: false,
 				bottomRight: false,
 				bottomLeft: false,

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -179,7 +179,7 @@ function ResizableFrame( { isFullWidth, children } ) {
 				left: ! isHovering ? null : (
 					<motion.div
 						key="handle"
-						className="edit-site-the-frame__handle"
+						className="edit-site-resizable-frame__handle"
 						title="Drag to resize"
 						initial={ {
 							opacity: 0,
@@ -200,13 +200,13 @@ function ResizableFrame( { isFullWidth, children } ) {
 			onResizeStart={ handleResizeStart }
 			onResize={ handleResize }
 			onResizeStop={ handleResizeStop }
-			className={ classnames( 'edit-site-the-frame__inner', {
+			className={ classnames( 'edit-site-resizable-frame__inner', {
 				'is-resizing': isResizing,
 				'is-oversized': isOversized,
 			} ) }
 		>
 			<motion.div
-				className="edit-site-the-frame__inner-content"
+				className="edit-site-resizable-frame__inner-content"
 				animate={ {
 					borderRadius: isFullWidth ? 0 : 8,
 				} }

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -61,7 +61,7 @@ function calculateNewHeight( width, initialAspectRatio ) {
 	return width / intermediateAspectRatio;
 }
 
-function ResizableFrame( { isFullWidth, children, onOversizeChange } ) {
+function ResizableFrame( { isFullWidth, children, oversizedClassName } ) {
 	const [ frameSize, setFrameSize ] = useState( {
 		width: '100%',
 		height: '100%',
@@ -69,15 +69,8 @@ function ResizableFrame( { isFullWidth, children, onOversizeChange } ) {
 	const [ startingWidth, setStartingWidth ] = useState();
 	const [ isResizing, setIsResizing ] = useState( false );
 	const [ isHovering, setIsHovering ] = useState( false );
-	const [ isOversized, _setIsOversized ] = useState( false );
-	const setIsOversized = ( value ) => {
-		_setIsOversized( ( prevValue ) => {
-			if ( prevValue !== value ) {
-				onOversizeChange( value );
-			}
-			return value;
-		} );
-	};
+	const [ isOversized, setIsOversized ] = useState( false );
+
 	const [ resizeRatio, setResizeRatio ] = useState( 1 );
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 	const initialAspectRatioRef = useRef( null );
@@ -224,7 +217,7 @@ function ResizableFrame( { isFullWidth, children, onOversizeChange } ) {
 			onResizeStop={ handleResizeStop }
 			className={ classnames( 'edit-site-resizable-frame__inner', {
 				'is-resizing': isResizing,
-				'is-oversized': isOversized,
+				[ oversizedClassName ]: isOversized,
 			} ) }
 		>
 			<motion.div

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -192,7 +192,7 @@ function ResizableFrame( {
 				right: HANDLE_STYLES_OVERRIDE,
 			} }
 			minWidth={ MIN_FRAME_SIZE }
-			maxWidth={ '150%' }
+			maxWidth={ isFullWidth ? '100%' : '150%' }
 			maxHeight={ '100%' }
 			onMouseOver={ () => setIsHovering( true ) }
 			onMouseOut={ () => setIsHovering( false ) }

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -66,14 +66,15 @@ function ResizableFrame( { isFullWidth, children, oversizedClassName } ) {
 		width: '100%',
 		height: '100%',
 	} );
+	// The width of the resizable frame when a new resize gesture starts.
 	const [ startingWidth, setStartingWidth ] = useState();
 	const [ isResizing, setIsResizing ] = useState( false );
 	const [ isHovering, setIsHovering ] = useState( false );
 	const [ isOversized, setIsOversized ] = useState( false );
-
 	const [ resizeRatio, setResizeRatio ] = useState( 1 );
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 	const initialAspectRatioRef = useRef( null );
+	// The width of the resizable frame on initial render.
 	const initialComputedWidthRef = useRef( null );
 	const FRAME_TRANSITION = { type: 'tween', duration: isResizing ? 0 : 0.5 };
 	const frameRef = useRef( null );
@@ -122,7 +123,6 @@ function ResizableFrame( { isFullWidth, children, oversizedClassName } ) {
 		} );
 	};
 
-	// Make the frame full screen when the user resizes it to the left.
 	const handleResizeStop = ( _event, _direction, ref ) => {
 		setIsResizing( false );
 

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -46,12 +46,17 @@ function ResizableFrame( { isFull, children } ) {
 	const [ isHovering, setIsHovering ] = useState( false );
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 	const initialAspectRatioRef = useRef( null );
+	const initialComputedWidthRef = useRef( null );
 	const FRAME_TRANSITION = { type: 'tween', duration: isResizing ? 0 : 0.5 };
 
 	// Calculate the frame size based on the window width as its resized.
 	const handleResize = ( event, direction, ref ) => {
 		const updatedWidth = ref.offsetWidth;
 		const updatedHeight = ref.offsetHeight;
+
+		if ( initialComputedWidthRef.current === null ) {
+			initialComputedWidthRef.current = updatedWidth;
+		}
 
 		// Set the initial aspect ratio if it hasn't been set yet.
 		if ( initialAspectRatioRef.current === null ) {
@@ -99,6 +104,14 @@ function ResizableFrame( { isFull, children } ) {
 		}
 	};
 
+	// Check if the frame is bleeding over the sidebar.
+	const isFrameBleeding = () => {
+		return (
+			initialComputedWidthRef.current !== null &&
+			frameSize.width > initialComputedWidthRef.current
+		);
+	};
+
 	return (
 		<ResizableBox
 			as={ motion.div }
@@ -119,7 +132,7 @@ function ResizableFrame( { isFull, children } ) {
 				bottomLeft: false,
 				topLeft: false,
 			} }
-			resizeRatio={ 2 }
+			resizeRatio={ isFrameBleeding() ? 1 : 2 }
 			handleClasses={ undefined }
 			handleStyles={ {
 				left: HANDLE_STYLES_OVERRIDE,
@@ -157,6 +170,7 @@ function ResizableFrame( { isFull, children } ) {
 			onResizeStop={ handleResizeStop }
 			className={ classnames( 'edit-site-the-frame__inner', {
 				resizing: isResizing,
+				'is-bleeding': isFrameBleeding(),
 			} ) }
 		>
 			<motion.div

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -191,26 +191,27 @@ function ResizableFrame( { isFullWidth, children, oversizedClassName } ) {
 			onMouseOver={ () => setIsHovering( true ) }
 			onMouseOut={ () => setIsHovering( false ) }
 			handleComponent={ {
-				left: ! isHovering ? null : (
-					<motion.div
-						key="handle"
-						className="edit-site-resizable-frame__handle"
-						title="Drag to resize"
-						initial={ {
-							opacity: 0,
-							left: 0,
-						} }
-						animate={ {
-							opacity: 1,
-							left: -15,
-						} }
-						exit={ {
-							opacity: 0,
-							left: 0,
-						} }
-						whileHover={ { scale: 1.1 } }
-					/>
-				),
+				left:
+					isHovering || isResizing ? (
+						<motion.div
+							key="handle"
+							className="edit-site-resizable-frame__handle"
+							title="Drag to resize"
+							initial={ {
+								opacity: 0,
+								left: 0,
+							} }
+							animate={ {
+								opacity: 1,
+								left: -15,
+							} }
+							exit={ {
+								opacity: 0,
+								left: 0,
+							} }
+							whileHover={ { scale: 1.1 } }
+						/>
+					) : null,
 			} }
 			onResizeStart={ handleResizeStart }
 			onResize={ handleResize }

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -99,9 +99,12 @@ function ResizableFrame( { isFull, children } ) {
 		if ( event.clientX < 250 ) {
 			setCanvasMode( 'edit' );
 			// Wait for the frame to animate to full screen before resetting its size.
-			setInterval( () => {
+			const timeoutId = setTimeout( () => {
 				setFrameSize( { width: '100%', height: '100%' } );
 			}, 500 );
+
+			// Clean up the timeout when the effect is no longer needed.
+			return () => clearTimeout( timeoutId );
 		}
 
 		setIsResizing( false );
@@ -135,14 +138,14 @@ function ResizableFrame( { isFull, children } ) {
 				bottomLeft: false,
 				topLeft: false,
 			} }
-			resizeRatio={ isFrameBleeding() ? 1 : 2 }
+			resizeRatio={ 1.5 }
 			handleClasses={ undefined }
 			handleStyles={ {
 				left: HANDLE_STYLES_OVERRIDE,
 				right: HANDLE_STYLES_OVERRIDE,
 			} }
 			minWidth={ MIN_FRAME_SIZE }
-			maxWidth={ '200%' }
+			maxWidth={ '150%' }
 			maxHeight={ '100%' }
 			onMouseOver={ () => setIsHovering( true ) }
 			onMouseOut={ () => setIsHovering( false ) }

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -32,7 +32,16 @@ const HANDLE_STYLES_OVERRIDE = {
 	left: undefined,
 };
 
-const MIN_FRAME_SIZE = 340;
+// The minimum width of the frame (in px) while resizing.
+const FRAME_MIN_WIDTH = 340;
+// The reference width of the frame (in px) used to calculate the aspect ratio.
+const FRAME_REFERENCE_WIDTH = 1300;
+// 9 : 19.5 is the target aspect ratio enforced (when possible) while resizing.
+const FRAME_TARGET_ASPECT_RATIO = 9 / 19.5;
+// The minimum distance (in px) between the frame resize handle and the
+// viewport's edge. If the frame is resized to be closer to the viewport's edge
+// than this distance, then "canvas mode" will be enabled.
+const SNAP_TO_EDIT_CANVAS_MODE_THRESHOLD = 200;
 
 function calculateNewHeight( width, initialAspectRatio ) {
 	const lerp = ( a, b, amount ) => {
@@ -46,15 +55,16 @@ function calculateNewHeight( width, initialAspectRatio ) {
 			0,
 			Math.min(
 				1,
-				( width - MIN_FRAME_SIZE ) / ( 1300 - MIN_FRAME_SIZE )
+				( width - FRAME_MIN_WIDTH ) /
+					( FRAME_REFERENCE_WIDTH - FRAME_MIN_WIDTH )
 			)
 		);
 
 	// Calculate the height based on the intermediate aspect ratio
-	// ensuring the frame arrives at a 9:19.5 aspect ratio.
+	// ensuring the frame arrives at the target aspect ratio.
 	const intermediateAspectRatio = lerp(
 		initialAspectRatio,
-		9 / 19.5,
+		FRAME_TARGET_ASPECT_RATIO,
 		lerpFactor
 	);
 
@@ -140,7 +150,7 @@ function ResizableFrame( {
 		const remainingWidth =
 			ref.ownerDocument.documentElement.offsetWidth - ref.offsetWidth;
 
-		if ( remainingWidth > 200 ) {
+		if ( remainingWidth > SNAP_TO_EDIT_CANVAS_MODE_THRESHOLD ) {
 			// Reset the initial aspect ratio if the frame is resized slightly
 			// above the sidebar but not far enough to trigger full screen.
 			setFrameSize( { width: '100%', height: '100%' } );
@@ -191,7 +201,7 @@ function ResizableFrame( {
 				left: HANDLE_STYLES_OVERRIDE,
 				right: HANDLE_STYLES_OVERRIDE,
 			} }
-			minWidth={ MIN_FRAME_SIZE }
+			minWidth={ FRAME_MIN_WIDTH }
 			maxWidth={ isFullWidth ? '100%' : '150%' }
 			maxHeight={ '100%' }
 			onMouseOver={ () => setIsHovering( true ) }

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -132,18 +132,26 @@ function ResizableFrame( { isFullWidth, children } ) {
 		}
 	};
 
+	const frameAnimationVariants = {
+		default: {
+			flexGrow: 0,
+			height: frameSize.height,
+		},
+		fullWidth: {
+			flexGrow: 1,
+			height: frameSize.height,
+		},
+	};
+
 	return (
 		<ResizableBox
 			as={ motion.div }
 			ref={ frameRef }
 			initial={ false }
-			animate={ {
-				flexGrow: isFullWidth ? 1 : 0,
-				height: frameSize.height,
-			} }
-			onAnimationComplete={ ( { flexGrow } ) => {
-				if ( flexGrow === 1 )
-					// `isFullWidth` is true
+			variants={ frameAnimationVariants }
+			animate={ isFullWidth ? 'fullWidth' : 'default' }
+			onAnimationComplete={ ( definition ) => {
+				if ( definition === 'fullWidth' )
 					setFrameSize( { width: '100%', height: '100%' } );
 			} }
 			transition={ FRAME_TRANSITION }

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -83,6 +83,7 @@ function ResizableFrame( { isFull, children } ) {
 			lerpFactor
 		);
 		const newHeight = updatedWidth / intermediateAspectRatio;
+		setIsResizing( true );
 		setFrameSize( { width: updatedWidth, height: newHeight } );
 	};
 
@@ -102,6 +103,8 @@ function ResizableFrame( { isFull, children } ) {
 				setFrameSize( { width: '100%', height: '100%' } );
 			}, 500 );
 		}
+
+		setIsResizing( false );
 	};
 
 	// Check if the frame is bleeding over the sidebar.
@@ -149,7 +152,6 @@ function ResizableFrame( { isFull, children } ) {
 						key="handle"
 						className="edit-site-the-frame__handle"
 						title="drag to resize"
-						onMouseDown={ () => setIsResizing( true ) }
 						initial={ {
 							opacity: 0,
 							left: 0,

--- a/packages/edit-site/src/components/resizable-frame/style.scss
+++ b/packages/edit-site/src/components/resizable-frame/style.scss
@@ -1,0 +1,45 @@
+.edit-site-the-frame {
+	height: 100%;
+	position: relative;
+	&.resizing {
+		.edit-site-the-frame__content {
+			pointer-events: none;
+		}
+	}
+}
+
+.edit-site-the-frame__content {
+	position: absolute;
+	inset: 0;
+}
+
+.edit-site-the-frame__handle {
+	position: absolute;
+	width: 5px;
+	height: 50px;
+	background-color: rgba(255, 255, 255, 0.3);
+	z-index: 100;
+	border-radius: 5px;
+	cursor: col-resize;
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	top: 50%;
+	&::before {
+		position: absolute;
+		left: 100%;
+		height: 100%;
+		width: 10px;
+		content: "";
+	}
+	&:hover {
+		background-color: #3858e9;
+	}
+	.edit-site-the-frame__handle-label {
+		border-radius: 2px;
+		background: #3858e9;
+		padding: 4px 8px;
+		color: #fff;
+		margin-right: $grid-unit-10;
+	}
+}

--- a/packages/edit-site/src/components/resizable-frame/style.scss
+++ b/packages/edit-site/src/components/resizable-frame/style.scss
@@ -4,6 +4,7 @@
 	&.is-resizing {
 		@at-root {
 			body:has(&) {
+				cursor: col-resize;
 				user-select: none;
 				-webkit-user-select: none;
 			}

--- a/packages/edit-site/src/components/resizable-frame/style.scss
+++ b/packages/edit-site/src/components/resizable-frame/style.scss
@@ -1,4 +1,4 @@
-.edit-site-the-frame__inner {
+.edit-site-resizable-frame__inner {
 	position: relative;
 
 	&.is-resizing {
@@ -20,13 +20,13 @@
 	}
 }
 
-.edit-site-the-frame__inner-content {
+.edit-site-resizable-frame__inner-content {
 	position: absolute;
 	z-index: 0;
 	inset: 0;
 }
 
-.edit-site-the-frame__handle {
+.edit-site-resizable-frame__handle {
 	position: absolute;
 	width: 5px;
 	height: 50px;
@@ -58,7 +58,7 @@
 		background-color: #3858e9;
 	}
 
-	.edit-site-the-frame__handle-label {
+	.edit-site-resizable-frame__handle-label {
 		border-radius: 2px;
 		background: #3858e9;
 		padding: 4px 8px;

--- a/packages/edit-site/src/components/resizable-frame/style.scss
+++ b/packages/edit-site/src/components/resizable-frame/style.scss
@@ -56,12 +56,12 @@
 	}
 
 	&:hover {
-		background-color: #3858e9;
+		background-color: var(--wp-admin-theme-color);
 	}
 
 	.edit-site-resizable-frame__handle-label {
 		border-radius: 2px;
-		background: #3858e9;
+		background: var(--wp-admin-theme-color);
 		padding: 4px 8px;
 		color: #fff;
 		margin-right: $grid-unit-10;

--- a/packages/edit-site/src/components/resizable-frame/style.scss
+++ b/packages/edit-site/src/components/resizable-frame/style.scss
@@ -29,12 +29,22 @@
 		position: absolute;
 		left: 100%;
 		height: 100%;
-		width: 10px;
+		width: $grid-unit-30;
 		content: "";
 	}
+
+	&::after {
+		position: absolute;
+		right: 100%;
+		height: 100%;
+		width: $grid-unit-30;
+		content: "";
+	}
+
 	&:hover {
 		background-color: #3858e9;
 	}
+
 	.edit-site-the-frame__handle-label {
 		border-radius: 2px;
 		background: #3858e9;

--- a/packages/edit-site/src/components/resizable-frame/style.scss
+++ b/packages/edit-site/src/components/resizable-frame/style.scss
@@ -1,15 +1,28 @@
-.edit-site-the-frame {
-	height: 100%;
+.edit-site-the-frame__inner {
 	position: relative;
-	&.resizing {
-		.edit-site-the-frame__content {
-			pointer-events: none;
+
+	&.is-resizing {
+		@at-root {
+			body:has(&) {
+				user-select: none;
+				-webkit-user-select: none;
+			}
+		}
+
+		&::before {
+			// This covers the whole content which ensures mouse up triggers
+			// even if the content is "inert".
+			position: absolute;
+			z-index: 1;
+			inset: 0;
+			content: "";
 		}
 	}
 }
 
-.edit-site-the-frame__content {
+.edit-site-the-frame__inner-content {
 	position: absolute;
+	z-index: 0;
 	inset: 0;
 }
 

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -35,6 +35,7 @@
 @import "./components/site-icon/style.scss";
 @import "./components/style-book/style.scss";
 @import "./components/editor-canvas-container/style.scss";
+@import "./components/resizable-frame/style.scss";
 @import "./hooks/push-changes-to-global-styles/style.scss";
 
 html #wpadminbar {

--- a/test/e2e/specs/site-editor/style-book.spec.js
+++ b/test/e2e/specs/site-editor/style-book.spec.js
@@ -176,7 +176,10 @@ class StyleBook {
 
 	async open() {
 		await this.disableWelcomeGuide();
-		await this.page.click( 'role=button[name="Styles"i]' );
-		await this.page.click( 'role=button[name="Style Book"i]' );
+		await this.page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Styles' } )
+			.click();
+		await this.page.getByRole( 'button', { name: 'Style Book' } ).click();
 	}
 }


### PR DESCRIPTION
Updates to the frame:

- Update design of handle.
- The frame resizes from its default state down to mobile aspect ratio proportionally from all edges.
- It's possible to resize beyond the resting state and over the sidebar to engage full screen. If you resize slightly above the sidebar it snaps back into normal browse mode instead.
- Disables user select while resizing so that the sidebar content and text is not accidentally selected.
