### PR TITLE
Draggable: Allow elementId based elements to be attached to the ownerDocument body

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   `Draggable`: Add `attachToElementWrapper` prop to allow elementId based elements to be attached to the ownerDocument body ([#49911](https://github.com/WordPress/gutenberg/pull/49911))
+-   `Draggable`: Add `attachToElementWrapper` prop to allow elementId based elements to be attached to the ownerDocument body ([#49911](https://github.com/WordPress/gutenberg/pull/49911)).
 -   `TreeGrid`: Modify keyboard navigation code to use a data-expanded attribute if aria-expanded is to be controlled outside of the TreeGrid component ([#48461](https://github.com/WordPress/gutenberg/pull/48461)).
 -   `Modal`: Equalize internal spacing ([#49890](https://github.com/WordPress/gutenberg/pull/49890)).
 -   `Modal`: Increased border radius ([#49870](https://github.com/WordPress/gutenberg/pull/49870)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   `Draggable`: Add `attachToElementWrapper` prop to allow elementId based elements to be attached to the ownerDocument body ([#49911](https://github.com/WordPress/gutenberg/pull/49911)).
+-   `Draggable`: Add `appendToOwnerDocument` prop to allow elementId based elements to be attached to the ownerDocument body ([#49911](https://github.com/WordPress/gutenberg/pull/49911)).
 -   `TreeGrid`: Modify keyboard navigation code to use a data-expanded attribute if aria-expanded is to be controlled outside of the TreeGrid component ([#48461](https://github.com/WordPress/gutenberg/pull/48461)).
 -   `Modal`: Equalize internal spacing ([#49890](https://github.com/WordPress/gutenberg/pull/49890)).
 -   `Modal`: Increased border radius ([#49870](https://github.com/WordPress/gutenberg/pull/49870)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   `Draggable`: Add `attachToElementWrapper` prop to allow elementId based elements to be attached to the ownerDocument body ([#49911](https://github.com/WordPress/gutenberg/pull/49911))
 -   `TreeGrid`: Modify keyboard navigation code to use a data-expanded attribute if aria-expanded is to be controlled outside of the TreeGrid component ([#48461](https://github.com/WordPress/gutenberg/pull/48461)).
 -   `Modal`: Equalize internal spacing ([#49890](https://github.com/WordPress/gutenberg/pull/49890)).
 -   `Modal`: Increased border radius ([#49870](https://github.com/WordPress/gutenberg/pull/49870)).

--- a/packages/components/src/draggable/README.md
+++ b/packages/components/src/draggable/README.md
@@ -8,9 +8,16 @@ Note that the drag handle needs to declare the `draggable="true"` property and b
 
 The component accepts the following props:
 
+### `attachToElementWrapper`: `boolean`
+
+Whether to attach the cloned element to the element's wrapper when using `elementId`. Setting to false will attach the cloned element to the `ownerDocument` body.
+
+-   Required: No
+-   Default: `true`
+
 ### `elementId`: `string`
 
-The HTML id of the element to clone on drag
+The HTML id of the element to clone on drag.
 
 -   Required: Yes
 

--- a/packages/components/src/draggable/README.md
+++ b/packages/components/src/draggable/README.md
@@ -8,12 +8,12 @@ Note that the drag handle needs to declare the `draggable="true"` property and b
 
 The component accepts the following props:
 
-### `attachToElementWrapper`: `boolean`
+### `appendToOwnerDocument`: `boolean`
 
-Whether to attach the cloned element to the element's wrapper when using `elementId`. Setting to false will attach the cloned element to the `ownerDocument` body.
+Whether to append the cloned element to the `ownerDocument` body. By default, elements sourced by id are appended to the element's wrapper.
 
 -   Required: No
--   Default: `true`
+-   Default: `false`
 
 ### `elementId`: `string`
 

--- a/packages/components/src/draggable/index.tsx
+++ b/packages/components/src/draggable/index.tsx
@@ -63,6 +63,7 @@ export function Draggable( {
 	onDragStart,
 	onDragOver,
 	onDragEnd,
+	attachElementToWrapper = true,
 	cloneClassname,
 	elementId,
 	transferData,
@@ -173,7 +174,11 @@ export function Draggable( {
 			cloneWrapper.appendChild( clone );
 
 			// Inject the cloneWrapper into the DOM.
-			elementWrapper?.appendChild( cloneWrapper );
+			if ( attachElementToWrapper ) {
+				elementWrapper?.appendChild( cloneWrapper );
+			} else {
+				ownerDocument.body.appendChild( cloneWrapper );
+			}
 		}
 
 		// Mark the current cursor coordinates.

--- a/packages/components/src/draggable/index.tsx
+++ b/packages/components/src/draggable/index.tsx
@@ -63,7 +63,7 @@ export function Draggable( {
 	onDragStart,
 	onDragOver,
 	onDragEnd,
-	attachElementToWrapper = true,
+	appendToOwnerDocument = false,
 	cloneClassname,
 	elementId,
 	transferData,
@@ -174,10 +174,10 @@ export function Draggable( {
 			cloneWrapper.appendChild( clone );
 
 			// Inject the cloneWrapper into the DOM.
-			if ( attachElementToWrapper ) {
-				elementWrapper?.appendChild( cloneWrapper );
-			} else {
+			if ( appendToOwnerDocument ) {
 				ownerDocument.body.appendChild( cloneWrapper );
+			} else {
+				elementWrapper?.appendChild( cloneWrapper );
 			}
 		}
 

--- a/packages/components/src/draggable/stories/index.tsx
+++ b/packages/components/src/draggable/stories/index.tsx
@@ -14,6 +14,7 @@ import { Icon, more } from '@wordpress/icons';
  * Internal dependencies
  */
 import Draggable from '..';
+import './style.css';
 
 const meta: ComponentMeta< typeof Draggable > = {
 	component: Draggable,
@@ -38,7 +39,7 @@ const DefaultTemplate: ComponentStory< typeof Draggable > = ( args ) => {
 		<div>
 			<p>Is Dragging? { isDragging ? 'Yes' : 'No!' }</p>
 			<div
-				/* eslint-disable no-restricted-syntax, eslint-comments/disable-enable-pair */
+				/* eslint-disable-next-line no-restricted-syntax */
 				id="draggable-example-box"
 				style={ { display: 'inline-flex' } }
 			>
@@ -81,3 +82,69 @@ export const Default: ComponentStory< typeof Draggable > = DefaultTemplate.bind(
 	{}
 );
 Default.args = {};
+
+const AttachElementIdTemplate: ComponentStory< typeof Draggable > = (
+	args
+) => {
+	const [ isDragging, setDragging ] = useState( false );
+
+	const label = args.attachElementToWrapper
+		? 'When dragging, the element is attached to the wrapper and will receive styling rules from its parent'
+		: 'When dragging, the element is attached to the body and will not receive styling rules from its original parent';
+
+	// Allow for the use of ID in the example.
+	return (
+		<div className="draggable-storybook-wrapper-element">
+			<p>Is Dragging? { isDragging ? 'Yes' : 'No!' }</p>
+			<p>{ label }</p>
+			<div
+				/* eslint-disable-next-line no-restricted-syntax */
+				id="draggable-example-box"
+				style={ { display: 'inline-flex' } }
+				className="draggable-storybook-element"
+			>
+				<Draggable { ...args } elementId="draggable-example-box">
+					{ ( { onDraggableStart, onDraggableEnd } ) => {
+						const handleOnDragStart = ( event: DragEvent ) => {
+							setDragging( true );
+							onDraggableStart( event );
+						};
+						const handleOnDragEnd = ( event: DragEvent ) => {
+							setDragging( false );
+							onDraggableEnd( event );
+						};
+
+						return (
+							<div
+								onDragStart={ handleOnDragStart }
+								onDragEnd={ handleOnDragEnd }
+								draggable
+								style={ {
+									alignItems: 'center',
+									display: 'flex',
+									justifyContent: 'center',
+									width: 100,
+									height: 100,
+								} }
+							>
+								<Icon icon={ more } />
+							</div>
+						);
+					} }
+				</Draggable>
+			</div>
+		</div>
+	);
+};
+
+export const AttachElementToWrapper: ComponentStory< typeof Draggable > =
+	AttachElementIdTemplate.bind( {} );
+AttachElementToWrapper.args = {
+	attachElementToWrapper: true,
+};
+
+export const AttachElementToBody: ComponentStory< typeof Draggable > =
+	AttachElementIdTemplate.bind( {} );
+AttachElementToBody.args = {
+	attachElementToWrapper: false,
+};

--- a/packages/components/src/draggable/stories/index.tsx
+++ b/packages/components/src/draggable/stories/index.tsx
@@ -7,6 +7,7 @@ import type { DragEvent } from 'react';
 /**
  * WordPress dependencies
  */
+import { useInstanceId } from '@wordpress/compose';
 import { useState } from '@wordpress/element';
 import { Icon, more } from '@wordpress/icons';
 
@@ -14,7 +15,6 @@ import { Icon, more } from '@wordpress/icons';
  * Internal dependencies
  */
 import Draggable from '..';
-import './style.css';
 
 const meta: ComponentMeta< typeof Draggable > = {
 	component: Draggable,
@@ -33,46 +33,68 @@ export default meta;
 
 const DefaultTemplate: ComponentStory< typeof Draggable > = ( args ) => {
 	const [ isDragging, setDragging ] = useState( false );
+	const instanceId = useInstanceId( DefaultTemplate );
 
 	// Allow for the use of ID in the example.
 	return (
 		<div>
-			<p>Is Dragging? { isDragging ? 'Yes' : 'No!' }</p>
-			<div
-				/* eslint-disable-next-line no-restricted-syntax */
-				id="draggable-example-box"
-				style={ { display: 'inline-flex' } }
+			<p
+				style={ {
+					padding: '1em',
+					position: 'relative',
+					zIndex: 1000,
+					backgroundColor: 'whitesmoke',
+				} }
 			>
-				<Draggable { ...args } elementId="draggable-example-box">
-					{ ( { onDraggableStart, onDraggableEnd } ) => {
-						const handleOnDragStart = ( event: DragEvent ) => {
-							setDragging( true );
-							onDraggableStart( event );
-						};
-						const handleOnDragEnd = ( event: DragEvent ) => {
-							setDragging( false );
-							onDraggableEnd( event );
-						};
-
-						return (
-							<div
-								onDragStart={ handleOnDragStart }
-								onDragEnd={ handleOnDragEnd }
-								draggable
-								style={ {
-									alignItems: 'center',
-									display: 'flex',
-									justifyContent: 'center',
-									width: 100,
-									height: 100,
-									background: '#ddd',
-								} }
-							>
-								<Icon icon={ more } />
-							</div>
-						);
+				Is Dragging? { isDragging ? 'Yes' : 'No!' }
+			</p>
+			<div
+				style={ {
+					zIndex: 100,
+					position: 'relative',
+				} }
+			>
+				<div
+					id={ `draggable-example-box-${ instanceId }` }
+					style={ {
+						display: 'inline-flex',
+						position: 'relative',
 					} }
-				</Draggable>
+				>
+					<Draggable
+						{ ...args }
+						elementId={ `draggable-example-box-${ instanceId }` }
+					>
+						{ ( { onDraggableStart, onDraggableEnd } ) => {
+							const handleOnDragStart = ( event: DragEvent ) => {
+								setDragging( true );
+								onDraggableStart( event );
+							};
+							const handleOnDragEnd = ( event: DragEvent ) => {
+								setDragging( false );
+								onDraggableEnd( event );
+							};
+
+							return (
+								<div
+									onDragStart={ handleOnDragStart }
+									onDragEnd={ handleOnDragEnd }
+									draggable
+									style={ {
+										alignItems: 'center',
+										display: 'flex',
+										justifyContent: 'center',
+										width: 100,
+										height: 100,
+										background: '#ddd',
+									} }
+								>
+									<Icon icon={ more } />
+								</div>
+							);
+						} }
+					</Draggable>
+				</div>
 			</div>
 		</div>
 	);
@@ -83,68 +105,15 @@ export const Default: ComponentStory< typeof Draggable > = DefaultTemplate.bind(
 );
 Default.args = {};
 
-const AttachElementIdTemplate: ComponentStory< typeof Draggable > = (
-	args
-) => {
-	const [ isDragging, setDragging ] = useState( false );
-
-	const label = args.attachElementToWrapper
-		? 'When dragging, the element is attached to the wrapper and will receive styling rules from its parent'
-		: 'When dragging, the element is attached to the body and will not receive styling rules from its original parent';
-
-	// Allow for the use of ID in the example.
-	return (
-		<div className="draggable-storybook-wrapper-element">
-			<p>Is Dragging? { isDragging ? 'Yes' : 'No!' }</p>
-			<p>{ label }</p>
-			<div
-				/* eslint-disable-next-line no-restricted-syntax */
-				id="draggable-example-box"
-				style={ { display: 'inline-flex' } }
-				className="draggable-storybook-element"
-			>
-				<Draggable { ...args } elementId="draggable-example-box">
-					{ ( { onDraggableStart, onDraggableEnd } ) => {
-						const handleOnDragStart = ( event: DragEvent ) => {
-							setDragging( true );
-							onDraggableStart( event );
-						};
-						const handleOnDragEnd = ( event: DragEvent ) => {
-							setDragging( false );
-							onDraggableEnd( event );
-						};
-
-						return (
-							<div
-								onDragStart={ handleOnDragStart }
-								onDragEnd={ handleOnDragEnd }
-								draggable
-								style={ {
-									alignItems: 'center',
-									display: 'flex',
-									justifyContent: 'center',
-									width: 100,
-									height: 100,
-								} }
-							>
-								<Icon icon={ more } />
-							</div>
-						);
-					} }
-				</Draggable>
-			</div>
-		</div>
-	);
-};
-
-export const AttachElementToWrapper: ComponentStory< typeof Draggable > =
-	AttachElementIdTemplate.bind( {} );
-AttachElementToWrapper.args = {
-	attachElementToWrapper: true,
-};
-
-export const AttachElementToBody: ComponentStory< typeof Draggable > =
-	AttachElementIdTemplate.bind( {} );
-AttachElementToBody.args = {
-	attachElementToWrapper: false,
+/**
+ * `appendToOwnerDocument` is used to append the element being dragged to the body of the owner document.
+ *
+ * This is useful when the element being dragged should not receive styles from its parent.
+ * For example, when the element's parent sets a `z-index` value that would cause the dragged
+ * element to be rendered behind other elements.
+ */
+export const AppendElementToOwnerDocument: ComponentStory< typeof Draggable > =
+	DefaultTemplate.bind( {} );
+AppendElementToOwnerDocument.args = {
+	appendToOwnerDocument: true,
 };

--- a/packages/components/src/draggable/stories/style.css
+++ b/packages/components/src/draggable/stories/style.css
@@ -1,0 +1,12 @@
+/* .draggable-storybook-wrapper-element {
+	background-color: #99e7fa;
+	padding: 1em;
+} */
+
+.draggable-storybook-wrapper-element .draggable-storybook-element {
+	background-color: #99faa4;
+}
+
+.draggable-storybook-element {
+	background-color: #fa99c8;
+}

--- a/packages/components/src/draggable/stories/style.css
+++ b/packages/components/src/draggable/stories/style.css
@@ -1,8 +1,3 @@
-/* .draggable-storybook-wrapper-element {
-	background-color: #99e7fa;
-	padding: 1em;
-} */
-
 .draggable-storybook-wrapper-element .draggable-storybook-element {
 	background-color: #99faa4;
 }

--- a/packages/components/src/draggable/stories/style.css
+++ b/packages/components/src/draggable/stories/style.css
@@ -1,7 +1,0 @@
-.draggable-storybook-wrapper-element .draggable-storybook-element {
-	background-color: #99faa4;
-}
-
-.draggable-storybook-element {
-	background-color: #fa99c8;
-}

--- a/packages/components/src/draggable/types.ts
+++ b/packages/components/src/draggable/types.ts
@@ -18,6 +18,13 @@ export type DraggableProps = {
 		onDraggableEnd: ( event: DragEvent ) => void;
 	} ) => JSX.Element | null;
 	/**
+	 * Whether to attach the cloned element to the element's wrapper when using `elementId`.
+	 * Setting to false will attach the cloned element to the `ownerDocument` body.
+	 *
+	 *@default true
+	 */
+	attachElementToWrapper?: boolean;
+	/**
 	 * Classname for the cloned element.
 	 */
 	cloneClassname?: string;

--- a/packages/components/src/draggable/types.ts
+++ b/packages/components/src/draggable/types.ts
@@ -21,7 +21,7 @@ export type DraggableProps = {
 	 * Whether to append the cloned element to the `ownerDocument` body.
 	 * By default, elements sourced by id are appended to the element's wrapper.
 	 *
-	 *@default false
+	 * @default false
 	 */
 	appendToOwnerDocument?: boolean;
 	/**

--- a/packages/components/src/draggable/types.ts
+++ b/packages/components/src/draggable/types.ts
@@ -18,12 +18,12 @@ export type DraggableProps = {
 		onDraggableEnd: ( event: DragEvent ) => void;
 	} ) => JSX.Element | null;
 	/**
-	 * Whether to attach the cloned element to the element's wrapper when using `elementId`.
-	 * Setting to false will attach the cloned element to the `ownerDocument` body.
+	 * Whether to append the cloned element to the `ownerDocument` body.
+	 * By default, elements sourced by id are appended to the element's wrapper.
 	 *
-	 *@default true
+	 *@default false
 	 */
-	attachElementToWrapper?: boolean;
+	appendToOwnerDocument?: boolean;
 	/**
 	 * Classname for the cloned element.
 	 */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Update the `Draggable` component to accept an `appendToOwnerDocument` prop that allows consumers to toggle where `elementId` based elements are attached. It defaults to `false`, and allows setting to `true` to make the element be attached to the `ownerDocument` body instead.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

There are use cases for using an `elementId` based element to clone, but where the consumer needs the cloned element to be attached to the owner document body instead of the element's wrapper (that is, use similar behaviour as exists currently when a custom drag component is used). I encountered this while working on https://github.com/WordPress/gutenberg/pull/49820 where I need the cloned element to be attached to the body instead, so that I can get the draggable chip to render above the drop indicator line.

Why not just use a custom drag component instead? In the case of the list view, we can avoid unnecessarily rendering additional components (e.g. a custom drag chip) by re-using the block list items that are already rendered. Also, the `elementId` logic is very useful, as it already ensures that the cloned element is in the same position as the original element.

However, there are likely lots of cases where styling rules expect the cloned element to be attached to the wrapper. For this reason, I've added the prop, but set it to `false` by default.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add an `appendToOwnerDocument` prop, that defaults to `false`.
* If it is truthy, attach the cloned element to the `ownerDocument.body` instead of the element wrapper (this borrows from the existing behaviour when an `__experimentalDragComponent` is used.
* Add Storybook examples for testing

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Run storybook locally, and then navigate to the Draggable component:

```
npm run storybook:dev
```

Quick local links to the two added stories:

* Append Element To Owner Document: http://localhost:50240/?path=/story/components-draggable--append-element-to-owner-document (dragging makes the dragged element go over the top of the paragraph)
* Default: http://localhost:50240/?path=/story/components-draggable--default (dragging makes the dragged element go underneath the paragraph)

## Screenshots or screencast <!-- if applicable -->

To demonstrate the difference, I've updated the storybook example so that the wrapper of the draggable element has a `z-index` set that is lower than the `z-index` of the paragraph that flags whether or not the component is being dragged. When `appendToOwnerDocument` is set to `true`, then the cloned draggable element does not receive the z-index of the element wrapper, so the cloned element can go above the paragraph.

| `appendToOwnerDocument` set to `false` | `appendToOwnerDocument` set to `true` |
| --- | --- |
| ![2023-04-20 14 55 31](https://user-images.githubusercontent.com/14988353/233263154-2e9bc7ec-a500-4c5b-96d9-c0fea23009e6.gif) | ![2023-04-20 14 55 54](https://user-images.githubusercontent.com/14988353/233263193-ca12e131-8619-41f5-8229-beec51e8269b.gif) |