### PR TITLE
Cover block: Remove overflow hidden rule

### DIFF
--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -10,7 +10,6 @@
 		padding: 0 !important;
 		display: flex;
 		align-items: stretch;
-		overflow: visible;
 		min-height: 240px;
 
 		.components-placeholder {

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -96,6 +96,7 @@
 		// The inner drag handle will still have `pointer-events: all` allowing
 		// it to continue to be interacted with.
 		pointer-events: none;
+		overflow: visible;
 	}
 }
 

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -7,7 +7,6 @@
 	justify-content: center;
 	align-items: center;
 	padding: 1em;
-	overflow: hidden;
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 	// Keep the flex layout direction to the physical direction (LTR) in RTL languages.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Remove `overflow: hidden` rule from the Cover block's styling rules, and retain `overflow: visible` for the `block-library-cover__resize-container` so that the drag handle is still visible outside the edge of the block. This is a follow-up to some of the changes landed in https://github.com/WordPress/gutenberg/pull/41153.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While working on re-enabling sticky positioning at non-root positions over in #49321, I noticed that the `sticky: position` rule does not work when the parent has `overflow: hidden` set. Because the Cover block is a prominent container block, before landing #49321, it would be good to ensure that all the main container blocks can technically support sticky children.

As far as I can tell, we no longer need an `overflow: hidden` rule because the resizeable box is using a block popover. From testing, I _think_ the only place we need an overflow rule is for the resize container so that the handle is visible. Also `overflow: visible` hides any scrollbars within the popover.

This PR seems to resolve a subtle issue on `trunk` where the drag handle is sometimes not visible, and there is sometimes a scrollbar within the resizeable box — I only ran into these issues in the site editor, not the post editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Remove `overflow: hidden` from the block's styling rules
* Remove `overflow: visible` from the placeholder state — since `overflow: hidden` has been removed, we should no longer need this additional rule
* Add `overflow: visible` to the resize container

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Try a variety of cover blocks in both the post and site editors (since the styling is slightly different between the editors)
2. When resizing the cover block, there shouldn't be any scrollbars within the block, and the handle for the resize controls should be visible while the block is selected
3. Try setting a variety of border thicknesses and widths (e.g. wide / full size)
4. Double-check that the block is still rendering correctly in the site frontend

A question for the reviewer — have I missed anything that was depending on the existing rules?

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

The below screenshots are from within the site editor.

| Trunk (vertical scrollbar present, drag handle cut off) | This PR (vertical scrollbar not present, drag handle visible) |
| --- | --- |
| <img width="1056" alt="image" src="https://user-images.githubusercontent.com/14988353/232988923-992bb179-637c-47a7-bb49-142d22f8aa25.png"> | <img width="1058" alt="image" src="https://user-images.githubusercontent.com/14988353/232989226-d0921fd5-b359-4992-9a2a-81fe14743921.png"> |