### PR TITLE
Support container queries in editor CSS

### DIFF
--- a/packages/block-editor/src/utils/transform-styles/ast/parse.js
+++ b/packages/block-editor/src/utils/transform-styles/ast/parse.js
@@ -456,6 +456,36 @@ export default function ( css, options ) {
 	}
 
 	/**
+	 * Parse container.
+	 */
+
+	function atcontainer() {
+		const pos = position();
+		const m = match( /^@container *([^{]+)/ );
+
+		if ( ! m ) {
+			return;
+		}
+		const container = trim( m[ 1 ] );
+
+		if ( ! open() ) {
+			return error( "@container missing '{'" );
+		}
+
+		const style = comments().concat( rules() );
+
+		if ( ! close() ) {
+			return error( "@container missing '}'" );
+		}
+
+		return pos( {
+			type: 'container',
+			container,
+			rules: style,
+		} );
+	}
+
+	/**
 	 * Parse custom-media.
 	 */
 
@@ -624,6 +654,7 @@ export default function ( css, options ) {
 		return (
 			atkeyframes() ||
 			atmedia() ||
+			atcontainer() ||
 			atcustommedia() ||
 			atsupports() ||
 			atimport() ||

--- a/packages/block-editor/src/utils/transform-styles/ast/stringify/compress.js
+++ b/packages/block-editor/src/utils/transform-styles/ast/stringify/compress.js
@@ -69,6 +69,19 @@ Compiler.prototype.media = function ( node ) {
 };
 
 /**
+ * Visit container node.
+ */
+
+Compiler.prototype.container = function ( node ) {
+	return (
+		this.emit( '@container ' + node.container, node.position ) +
+		this.emit( '{' ) +
+		this.mapVisit( node.rules ) +
+		this.emit( '}' )
+	);
+};
+
+/**
  * Visit document node.
  */
 

--- a/packages/block-editor/src/utils/transform-styles/ast/stringify/identity.js
+++ b/packages/block-editor/src/utils/transform-styles/ast/stringify/identity.js
@@ -84,6 +84,19 @@ Compiler.prototype.media = function ( node ) {
 };
 
 /**
+ * Visit container node.
+ */
+
+Compiler.prototype.container = function ( node ) {
+	return (
+		this.emit( '@container ' + node.container, node.position ) +
+		this.emit( ' {\n' + this.indent( 1 ) ) +
+		this.mapVisit( node.rules, '\n\n' ) +
+		this.emit( this.indent( -1 ) + '\n}' )
+	);
+};
+
+/**
  * Visit document node.
  */
 

--- a/packages/block-editor/src/utils/transform-styles/transforms/test/__snapshots__/wrap.js.snap
+++ b/packages/block-editor/src/utils/transform-styles/transforms/test/__snapshots__/wrap.js.snap
@@ -42,6 +42,14 @@ color: red;
 }"
 `;
 
+exports[`CSS selector wrap should wrap selectors inside container queries`] = `
+"@container (width > 400px) {
+.my-namespace h1 {
+color: red;
+}
+}"
+`;
+
 exports[`CSS selector wrap should replace :root selectors 1`] = `
 ".my-namespace {
 --my-color: #ff0000;

--- a/packages/block-editor/src/utils/transform-styles/transforms/test/__snapshots__/wrap.js.snap
+++ b/packages/block-editor/src/utils/transform-styles/transforms/test/__snapshots__/wrap.js.snap
@@ -42,7 +42,7 @@ color: red;
 }"
 `;
 
-exports[`CSS selector wrap should wrap selectors inside container queries`] = `
+exports[`CSS selector wrap should wrap selectors inside container queries 1`] = `
 "@container (width > 400px) {
 .my-namespace h1 {
 color: red;

--- a/packages/block-editor/src/utils/transform-styles/transforms/test/wrap.js
+++ b/packages/block-editor/src/utils/transform-styles/transforms/test/wrap.js
@@ -50,6 +50,19 @@ describe( 'CSS selector wrap', () => {
 		expect( output ).toMatchSnapshot();
 	} );
 
+	it( 'should wrap selectors inside container queries', () => {
+		const callback = wrap( '.my-namespace' );
+		const input = `
+		@container (width > 400px) {
+  			h2 {
+				font-size: 1.5em;
+			}
+		}`;
+		const output = traverse( input, callback );
+
+		expect( output ).toMatchSnapshot();
+	} );
+
 	it( 'should ignore font-face selectors', () => {
 		const callback = wrap( '.my-namespace' );
 		const input = `

--- a/packages/block-editor/src/utils/transform-styles/transforms/test/wrap.js
+++ b/packages/block-editor/src/utils/transform-styles/transforms/test/wrap.js
@@ -54,9 +54,7 @@ describe( 'CSS selector wrap', () => {
 		const callback = wrap( '.my-namespace' );
 		const input = `
 		@container (width > 400px) {
-  			h2 {
-				font-size: 1.5em;
-			}
+  			h1 { color: red; }
 		}`;
 		const output = traverse( input, callback );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Support for container queries! If you use a container query the entire stylesheet breaks. This PR adds container query parsing support to the existing CSS parsing.

## Why?

Container queries break stylesheets in the editor ( #49862 and #46277 ).

While https://github.com/WordPress/gutenberg/pull/49483 is in progress this PR aims to satisfice a simpler solution until the more difficult and challenging work is completed

## How?

It replicates the processing for other `@` rules

## Testing Instructions

1. Add an editor stylesheet to the theme
2. Use a container query in that stylesheet
3. load the editor
4. If successful the container query and all other styles in the editor stylesheet work as expected

If the issue has not been fixed, then no styles from the editor stylesheet will be applied, even those _not_ in a container query.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

This PR doesn't change the UI
