### PR TITLE
List View: Add aria labels to the list view blocks

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -111,13 +111,20 @@ function ListViewBlock( {
 		level
 	);
 
-	const blockAriaLabel = isLocked
-		? sprintf(
-				// translators: %s: The title of the block. This string indicates a link to select the locked block.
-				__( '%s (locked)' ),
-				blockTitle
-		  )
-		: blockTitle;
+	let blockAriaLabel = __( 'Link' );
+	if ( blockInformation ) {
+		blockAriaLabel = isLocked
+			? sprintf(
+					// translators: %s: The title of the block. This string indicates a link to select the locked block.
+					__( '%s link (locked)' ),
+					blockInformation.title
+			  )
+			: sprintf(
+					// translators: %s: The title of the block. This string indicates a link to select the block.
+					__( '%s link' ),
+					blockInformation.title
+			  );
+	}
 
 	const settingsAriaLabel = sprintf(
 		// translators: %s: The title of the block.
@@ -246,7 +253,10 @@ function ListViewBlock( {
 				className="block-editor-list-view-block__contents-cell"
 				colSpan={ colSpan }
 				ref={ cellRef }
+				aria-label={ blockAriaLabel }
 				aria-selected={ !! isSelected || forceSelectionContentLock }
+				aria-expanded={ isContentLocked ? undefined : isExpanded }
+				aria-describedby={ descriptionId }
 			>
 				{ ( { ref, tabIndex, onFocus } ) => (
 					<div className="block-editor-list-view-block__contents-container">

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -27,7 +27,7 @@ test.describe( 'List View', () => {
 		// The last inserted block should be selected.
 		await expect(
 			listView.getByRole( 'gridcell', {
-				name: 'Paragraph',
+				name: 'Paragraph link',
 				exact: true,
 				selected: true,
 			} )
@@ -44,11 +44,11 @@ test.describe( 'List View', () => {
 
 		// Drag the paragraph above the heading.
 		const paragraphBlockItem = listView.getByRole( 'gridcell', {
-			name: 'Paragraph',
+			name: 'Paragraph link',
 			exact: true,
 		} );
 		const headingBlockItem = listView.getByRole( 'gridcell', {
-			name: 'Heading',
+			name: 'Heading link',
 			exact: true,
 		} );
 		await paragraphBlockItem.dragTo( headingBlockItem, { x: 0, y: 0 } );
@@ -83,7 +83,7 @@ test.describe( 'List View', () => {
 		// The last inserted block should be selected.
 		await expect(
 			listView.getByRole( 'gridcell', {
-				name: 'Paragraph',
+				name: 'Paragraph link',
 				exact: true,
 				selected: true,
 			} )
@@ -135,7 +135,7 @@ test.describe( 'List View', () => {
 		// The last inserted block should be selected.
 		await expect(
 			listView.getByRole( 'gridcell', {
-				name: 'Paragraph',
+				name: 'Paragraph link',
 				exact: true,
 				selected: true,
 			} )
@@ -175,7 +175,7 @@ test.describe( 'List View', () => {
 		// The last inserted block should be selected.
 		await expect(
 			listView.getByRole( 'gridcell', {
-				name: 'Paragraph',
+				name: 'Paragraph link',
 				exact: true,
 				selected: true,
 			} )
@@ -227,7 +227,7 @@ test.describe( 'List View', () => {
 		// The last inserted block should be selected.
 		await expect(
 			listView.getByRole( 'gridcell', {
-				name: 'Heading',
+				name: 'Heading link',
 				exact: true,
 				selected: true,
 			} )
@@ -237,7 +237,7 @@ test.describe( 'List View', () => {
 		await pageUtils.pressKeys( 'shift+ArrowUp' );
 		await expect(
 			listView.getByRole( 'gridcell', {
-				name: 'Image',
+				name: 'Image link',
 				exact: true,
 				selected: true,
 			} )
@@ -287,7 +287,7 @@ test.describe( 'List View', () => {
 		// The child paragraph block should be selected.
 		await expect(
 			listView.getByRole( 'gridcell', {
-				name: 'Paragraph',
+				name: 'Paragraph link',
 				exact: true,
 				selected: true,
 			} )
@@ -295,7 +295,7 @@ test.describe( 'List View', () => {
 
 		// Collapse the Cover block.
 		await listView
-			.getByRole( 'gridcell', { name: 'Cover', exact: true } )
+			.getByRole( 'gridcell', { name: 'Cover link', exact: true } )
 			.getByTestId( 'list-view-expander', { includeHidden: true } )
 			// Force the click to bypass the visibility check. The expander is
 			// intentionally aria-hidden. See the implementation for details.
@@ -321,7 +321,7 @@ test.describe( 'List View', () => {
 		// The child paragraph block in List View should be selected.
 		await expect(
 			listView.getByRole( 'gridcell', {
-				name: 'Paragraph',
+				name: 'Paragraph link',
 				exact: true,
 				selected: true,
 			} )
@@ -349,7 +349,7 @@ test.describe( 'List View', () => {
 		// The last inserted block should be selected.
 		await expect(
 			listView.getByRole( 'gridcell', {
-				name: 'Group',
+				name: 'Group link',
 				exact: true,
 				selected: true,
 			} )
@@ -368,7 +368,7 @@ test.describe( 'List View', () => {
 		await page.keyboard.press( 'ArrowUp' );
 		await expect(
 			listView.getByRole( 'link', {
-				name: 'Columns',
+				name: 'Columns link',
 				exact: true,
 			} )
 		).toBeFocused();
@@ -415,7 +415,7 @@ test.describe( 'List View', () => {
 		// The paragraph item should be selected.
 		await expect(
 			listView.getByRole( 'gridcell', {
-				name: 'Paragraph',
+				name: 'Paragraph link',
 				exact: true,
 				selected: true,
 			} )
@@ -526,7 +526,7 @@ test.describe( 'List View', () => {
 		// The last inserted block should be selected.
 		await expect(
 			listView.getByRole( 'gridcell', {
-				name: 'Paragraph',
+				name: 'Paragraph link',
 				exact: true,
 				selected: true,
 			} )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
One of the pieces of accessibility feedback for the OffCanvasEditor component suggested that we append the word `link` to the TreeCell elements aria-labels. This PR copies that change from the OffCanvasEditor and updates the tests accordingly.

## Why?
This is the cause of the failing tests in https://github.com/WordPress/gutenberg/pull/49417. If this approach is better for accessibility then we should do the same thing in List View.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
Open the list view in the inspector and check that the gridcell elements have "link" appended to the block name.
This can also be observed in the Accessibility panel.

### Testing Instructions for Keyboard
Not sure sorry!

## Screenshots or screencast <!-- if applicable -->
<img width="441" alt="Screenshot 2023-04-19 at 13 51 46" src="https://user-images.githubusercontent.com/275961/233080328-ad9c2670-23d7-4c41-9d3b-908fabe3d530.png">

<img width="512" alt="Screenshot 2023-04-19 at 13 51 34" src="https://user-images.githubusercontent.com/275961/233080366-a8463dfa-35d4-4c00-9217-5f7c6a9fc4d4.png">

## Note
I'm not sure this change makes sense for the List View, even though we added it in the OffCanvasEditor. If we decide not to go this route then we should update the navigation block tests that are failing in https://github.com/WordPress/gutenberg/pull/49417