### PR TITLE
Correctly return 'isResolving' from 'useAlternativeTemplateParts' hook

### DIFF
--- a/packages/block-library/src/template-part/edit/utils/hooks.js
+++ b/packages/block-library/src/template-part/edit/utils/hooks.js
@@ -37,7 +37,7 @@ export function useAlternativeTemplateParts( area, excludedId ) {
 				'wp_template_part',
 				query
 			),
-			isLoading: _isResolving( 'getEntityRecords', [
+			isResolving: _isResolving( 'getEntityRecords', [
 				'postType',
 				'wp_template_part',
 				query,

--- a/packages/block-library/src/template-part/edit/utils/hooks.js
+++ b/packages/block-library/src/template-part/edit/utils/hooks.js
@@ -61,7 +61,7 @@ export function useAlternativeTemplateParts( area, excludedId ) {
 						templatePart.area === area )
 			) || []
 		);
-	}, [ templateParts, area ] );
+	}, [ templateParts, area, excludedId ] );
 
 	return {
 		templateParts: filteredTemplateParts,


### PR DESCRIPTION
## What
PR updates `useAlternativeTemplateParts` to use a correct name when returning the `isResolving` value from the map select.

P.S. I also fixed `React Hook useMemo has a missing dependency: 'excludedId'.` warning since I was in the area :)

## Testing Instructions
The template part block should work as before.
