### PR TITLE
Dependency Extraction Webpack Plugin: Apply formatting to unminified php output

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -104,6 +104,46 @@ class DependencyExtractionWebpackPlugin {
 
 	stringify( asset ) {
 		if ( this.options.outputFormat === 'php' ) {
+			if ( null !== this.options.combinedOutputFile && this.options.combinedOutputFile.indexOf( ".min" ) > -1 ) {
+				return `<?php return ${ json2php(
+					JSON.parse( JSON.stringify( asset ) )
+				) };\n`;
+			} else if ( null !== this.options.combinedOutputFile )  {
+				const printer = json2php.make( { linebreak:"\n", indent:'\t' } );
+				let out = '';
+
+				out += '<?php\n';
+				out += 'return ' + printer( JSON.parse( JSON.stringify( asset ) ) ) ;
+				out += ';\n';
+
+				// Add trailing comma where needed.
+				out = out.replace( /'\n/g, "',\n" ).replace( ')\n', '),\n' );
+
+				// Correctly space version declarations.
+				out = out.replace( /'version' =>/g, "'version'      =>" );
+
+				// Correctly space array declarations for each package.
+				const regexp = /\n[\t]{1}'.*'\s=>/g;
+				let packages = out.match( regexp ).sort( ( a, b ) => b.length - a.length );
+				const longest = packages[0].length;
+				let newpkg = '';
+
+				for ( const pkg of packages ) {
+					if ( pkg.length < longest ) {
+						newpkg = pkg.replace( " ", " ".repeat( longest - ( pkg.length - 1 ) ) );
+						out = out.replace( pkg, newpkg );
+					}
+				}
+
+				return out;
+			}
+		}
+
+		return JSON.stringify( asset );
+	}
+
+	stringify( asset ) {
+		if ( this.options.outputFormat === 'php' ) {
 			return `<?php return ${ json2php(
 				JSON.parse( JSON.stringify( asset ) )
 			) };\n`;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix for #48106 - prettify php output from dependency extraction plugin

## Why?
Fix for #48106 - existing issue 

## How?
This PR applies PHP layout standards to unmagnified PHP output including adding training commas, line breaks and applying appropriate indentation to `=` statements within array declarations

## Testing Instructions
1. Build WordPress core files using Webpack with this branch - notice the output to the `script-loader-packages.php` is now in human readable form and should comply with WordPress coding standards. 
2. The `script-loader-packages.min.php` file should remain the same and be minified.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A