### PR TITLE
feature(data): add types to dispatch and select

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -499,11 +499,11 @@ dispatch( myCustomStore ).setPrice( 'hammer', 9.75 );
 
 _Parameters_
 
--   _storeNameOrDescriptor_ `StoreDescriptor|string`: The store descriptor. The legacy calling convention of passing the store name is also supported.
+-   _storeNameOrDescriptor_ `string | T`: The store descriptor. The legacy calling convention of passing the store name is also supported.
 
 _Returns_
 
--   `Object`: Object containing the action creators.
+-   `ActionCreatorsOf< ConfigOf< T > >`: Object containing the action creators.
 
 ### plugins
 
@@ -638,11 +638,11 @@ select( myCustomStore ).getPrice( 'hammer' );
 
 _Parameters_
 
--   _storeNameOrDescriptor_ `StoreDescriptor|string`: The store descriptor. The legacy calling convention of passing the store name is also supported.
+-   _storeNameOrDescriptor_ `string | T`: The store descriptor. The legacy calling convention of passing the store name is also supported.
 
 _Returns_
 
--   `Object`: Object containing the store's selectors.
+-   `CurriedSelectorsOf< T >`: Object containing the store's selectors.
 
 ### subscribe
 

--- a/packages/data/src/dispatch.ts
+++ b/packages/data/src/dispatch.ts
@@ -1,0 +1,39 @@
+/**
+ * Internal dependencies
+ */
+import type {
+	ActionCreatorsOf,
+	AnyConfig,
+	ConfigOf,
+	StoreDescriptor,
+} from './types';
+
+/**
+ * Internal dependencies
+ */
+import defaultRegistry from './default-registry';
+
+/**
+ * Given a store descriptor, returns an object of the store's action creators.
+ * Calling an action creator will cause it to be dispatched, updating the state value accordingly.
+ *
+ * Note: Action creators returned by the dispatch will return a promise when
+ * they are called.
+ *
+ * @param storeNameOrDescriptor The store descriptor. The legacy calling convention of passing
+ *                              the store name is also supported.
+ *
+ * @example
+ * ```js
+ * import { dispatch } from '@wordpress/data';
+ * import { store as myCustomStore } from 'my-custom-store';
+ *
+ * dispatch( myCustomStore ).setPrice( 'hammer', 9.75 );
+ * ```
+ * @return Object containing the action creators.
+ */
+export function dispatch< T extends StoreDescriptor< AnyConfig > >(
+	storeNameOrDescriptor: string | T
+): ActionCreatorsOf< ConfigOf< T > > {
+	return defaultRegistry.dispatch( storeNameOrDescriptor );
+}

--- a/packages/data/src/dispatch.ts
+++ b/packages/data/src/dispatch.ts
@@ -7,10 +7,6 @@ import type {
 	ConfigOf,
 	StoreDescriptor,
 } from './types';
-
-/**
- * Internal dependencies
- */
 import defaultRegistry from './default-registry';
 
 /**

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -29,6 +29,8 @@ export { createRegistry } from './registry';
 export { createRegistrySelector, createRegistryControl } from './factory';
 export { controls } from './controls';
 export { default as createReduxStore } from './redux-store';
+export { dispatch } from './dispatch';
+export { select } from './select';
 
 /**
  * Object of available plugins to use with a registry.
@@ -81,29 +83,6 @@ export { plugins };
 export const combineReducers = turboCombineReducers;
 
 /**
- * Given a store descriptor, returns an object of the store's selectors.
- * The selector functions are been pre-bound to pass the current state automatically.
- * As a consumer, you need only pass arguments of the selector, if applicable.
- *
- * @param {StoreDescriptor|string} storeNameOrDescriptor The store descriptor. The legacy calling
- *                                                       convention of passing the store name is
- *                                                       also supported.
- *
- * @example
- * ```js
- * import { select } from '@wordpress/data';
- * import { store as myCustomStore } from 'my-custom-store';
- *
- * select( myCustomStore ).getPrice( 'hammer' );
- * ```
- *
- * @return {Object} Object containing the store's selectors.
- */
-export function select( storeNameOrDescriptor ) {
-	return defaultRegistry.select( storeNameOrDescriptor );
-}
-
-/**
  * Given a store descriptor, returns an object containing the store's selectors pre-bound to state
  * so that you only need to supply additional arguments, and modified so that they return promises
  * that resolve to their eventual values, after any resolvers have ran.
@@ -136,30 +115,6 @@ export const resolveSelect = defaultRegistry.resolveSelect;
  * @return {Object} Object containing the store's suspense-wrapped selectors.
  */
 export const suspendSelect = defaultRegistry.suspendSelect;
-
-/**
- * Given a store descriptor, returns an object of the store's action creators.
- * Calling an action creator will cause it to be dispatched, updating the state value accordingly.
- *
- * Note: Action creators returned by the dispatch will return a promise when
- * they are called.
- *
- * @param {StoreDescriptor|string} storeNameOrDescriptor The store descriptor. The legacy calling
- *                                                       convention of passing the store name is
- *                                                       also supported.
- *
- * @example
- * ```js
- * import { dispatch } from '@wordpress/data';
- * import { store as myCustomStore } from 'my-custom-store';
- *
- * dispatch( myCustomStore ).setPrice( 'hammer', 9.75 );
- * ```
- * @return {Object} Object containing the action creators.
- */
-export function dispatch( storeNameOrDescriptor ) {
-	return defaultRegistry.dispatch( storeNameOrDescriptor );
-}
 
 /**
  * Given a listener function, the function will be called any time the state value

--- a/packages/data/src/select.ts
+++ b/packages/data/src/select.ts
@@ -2,10 +2,6 @@
  * Internal dependencies
  */
 import type { AnyConfig, CurriedSelectorsOf, StoreDescriptor } from './types';
-
-/**
- * Internal dependencies
- */
 import defaultRegistry from './default-registry';
 
 /**

--- a/packages/data/src/select.ts
+++ b/packages/data/src/select.ts
@@ -1,0 +1,34 @@
+/**
+ * Internal dependencies
+ */
+import type { AnyConfig, CurriedSelectorsOf, StoreDescriptor } from './types';
+
+/**
+ * Internal dependencies
+ */
+import defaultRegistry from './default-registry';
+
+/**
+ * Given a store descriptor, returns an object of the store's selectors.
+ * The selector functions are been pre-bound to pass the current state automatically.
+ * As a consumer, you need only pass arguments of the selector, if applicable.
+ *
+ *
+ * @param storeNameOrDescriptor The store descriptor. The legacy calling convention
+ *                              of passing the store name is also supported.
+ *
+ * @example
+ * ```js
+ * import { select } from '@wordpress/data';
+ * import { store as myCustomStore } from 'my-custom-store';
+ *
+ * select( myCustomStore ).getPrice( 'hammer' );
+ * ```
+ *
+ * @return Object containing the store's selectors.
+ */
+export function select< T extends StoreDescriptor< AnyConfig > >(
+	storeNameOrDescriptor: string | T
+): CurriedSelectorsOf< T > {
+	return defaultRegistry.select( storeNameOrDescriptor );
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add TypeScript types to `dispatch` and `select` of `@wordpress/data`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I and others are using these function with custom stores and would like to use them fully typed. I am currently [hacking](https://github.com/WordPress/wp-feature-notifications/blob/edc66d533bc873f81d9cd5ae7a9e3e871e1c6301/types/global.d.ts#L9-L12) the type system to accomplish this in the [`wp-feature-notifications`](https://github.com/WordPress/wp-feature-notifications) project, but it would be better if these were typed correctly.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I moved the functions to individual TypeScript files because I couldn't provide the correct generic arguments in the `index.js` file like in [`useSelect`](https://github.com/WordPress/gutenberg/blob/0b5e6129bc76c41ec252fae5e17277922fe48f12/packages/data/src/components/use-select/index.js#L22-L36) because the types would be exports from packages with the generic arguments. Moving them to a separate file solved this issue, I made them individual files because it seemed appropriate. 

@swissspidy @adamziel @dmsnell 

## Issues

The automatically built docs don't appropriately show the generic type arguments.
