### PR TITLE
Refactor duotone class to allow instancing

### DIFF
--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -5,7 +5,7 @@
  * @package gutenberg
  */
 
-// Register duotone block supports.
+// Register the block support. (overrides core one).
 WP_Block_Supports::get_instance()->register(
 	'duotone',
 	array(
@@ -14,26 +14,49 @@ WP_Block_Supports::get_instance()->register(
 );
 
 // Set up metadata prior to rendering any blocks.
+if ( class_exists( 'WP_Duotone' ) ) {
+	remove_action( 'wp_loaded', array( 'WP_Duotone', 'set_global_styles_presets' ) );
+	remove_action( 'wp_loaded', array( 'WP_Duotone', 'set_global_style_block_names' ) );
+}
 add_action( 'wp_loaded', array( 'WP_Duotone_Gutenberg', 'set_global_styles_presets' ), 10 );
 add_action( 'wp_loaded', array( 'WP_Duotone_Gutenberg', 'set_global_style_block_names' ), 10 );
 
-// Remove WordPress core filter to avoid rendering duplicate support elements.
-remove_filter( 'render_block', 'wp_render_duotone_support', 10, 2 );
+// Add classnames to blocks using duotone support.
+if ( function_exists( 'wp_render_duotone_support' ) ) {
+	// Deprecated render function.
+	remove_filter( 'render_block', 'wp_render_duotone_support' );
+}
+if ( class_exists( 'WP_Duotone' ) ) {
+	remove_filter( 'render_block', array( 'WP_Duotone', 'render_duotone_support' ) );
+}
 add_filter( 'render_block', array( 'WP_Duotone_Gutenberg', 'render_duotone_support' ), 10, 2 );
 
 // Enqueue styles.
 // Block styles (core-block-supports-inline-css) before the style engine (gutenberg_enqueue_stored_styles).
 // Global styles (global-styles-inline-css) after the other global styles (gutenberg_enqueue_global_styles).
+if ( class_exists( 'WP_Duotone' ) ) {
+	remove_action( 'wp_enqueue_scripts', array( 'WP_Duotone', 'output_block_styles' ) );
+	remove_action( 'wp_enqueue_scripts', array( 'WP_Duotone', 'output_global_styles' ) );
+}
 add_action( 'wp_enqueue_scripts', array( 'WP_Duotone_Gutenberg', 'output_block_styles' ), 9 );
 add_action( 'wp_enqueue_scripts', array( 'WP_Duotone_Gutenberg', 'output_global_styles' ), 11 );
 
 // Add SVG filters to the footer. Also, for classic themes, output block styles (core-block-supports-inline-css).
+if ( class_exists( 'WP_Duotone' ) ) {
+	remove_action( 'wp_footer', array( 'WP_Duotone', 'output_footer_assets' ) );
+}
 add_action( 'wp_footer', array( 'WP_Duotone_Gutenberg', 'output_footer_assets' ), 10 );
 
 // Add styles and SVGs for use in the editor via the EditorStyles component.
+if ( class_exists( 'WP_Duotone' ) ) {
+	remove_filter( 'block_editor_settings_all', array( 'WP_Duotone', 'add_editor_settings' ) );
+}
 add_filter( 'block_editor_settings_all', array( 'WP_Duotone_Gutenberg', 'add_editor_settings' ), 10 );
 
 // Migrate the old experimental duotone support flag.
+if ( class_exists( 'WP_Duotone' ) ) {
+	remove_filter( 'block_type_metadata_settings', array( 'WP_Duotone', 'migrate_experimental_duotone_support_flag' ) );
+}
 add_filter( 'block_type_metadata_settings', array( 'WP_Duotone_Gutenberg', 'migrate_experimental_duotone_support_flag' ), 10, 2 );
 
 /*

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -6,26 +6,43 @@
  */
 
 /**
+ * Initializes $wp_duotone_support if it has not been set.
+ *
+ * @global WP_Duotone_Gutenberg $wp_duotone_support
+ *
+ * @return WP_Duotone_Gutenberg WP_Duotone_Gutenberg instance.
+ */
+function gutenberg_duotone_support() {
+	global $wp_duotone_support;
+
+	if ( ! ( $wp_duotone_support instanceof WP_Duotone_Gutenberg ) ) {
+		$wp_duotone_support = new WP_Duotone_Gutenberg();
+	}
+
+	return $wp_duotone_support;
+}
+
+/**
  * Registers the style and colors block attributes for block types that support it.
  *
  * @param WP_Block_Type $block_type Block Type.
  */
 function gutenberg_register_duotone_support( $block_type ) {
-	return WP_Duotone_Gutenberg::get_instance()->register_duotone_support( $block_type );
+	return gutenberg_duotone_support()->register_duotone_support( $block_type );
 }
 
 /**
  * Pre-computes and saves all possible duotone presets from global and theme styles for later use.
  */
 function gutenberg_set_duotone_global_styles_presets() {
-	return WP_Duotone_Gutenberg::get_instance()->set_global_styles_presets();
+	return gutenberg_duotone_support()->set_global_styles_presets();
 }
 
 /**
  * Pre-computes and saves all block names from global styles for later use.
  */
 function gutenberg_set_duotone_global_style_block_names() {
-	return WP_Duotone_Gutenberg::get_instance()->set_global_style_block_names();
+	return gutenberg_duotone_support()->set_global_style_block_names();
 }
 
 /**
@@ -37,28 +54,28 @@ function gutenberg_set_duotone_global_style_block_names() {
  * @return string Filtered block content.
  */
 function gutenberg_render_duotone_support( $block_content, $block ) {
-	return WP_Duotone_Gutenberg::get_instance()->render_duotone_support( $block_content, $block );
+	return gutenberg_duotone_support()->render_duotone_support( $block_content, $block );
 }
 
 /**
  * Enqueues duotone block styles in core-block-supports-inline-css BEFORE (priority 9) the style engine outputs them in gutenberg_enqueue_stored_styles.
  */
 function gutenberg_output_duotone_block_styles() {
-	return WP_Duotone_Gutenberg::get_instance()->output_block_styles();
+	return gutenberg_duotone_support()->output_block_styles();
 }
 
 /**
  * Enqueues duotone global styles in global-styles-inline-css AFTER (priority 11) the other global styles are enqueued in gutenberg_enqueue_global_styles.
  */
 function gutenberg_output_duotone_global_styles() {
-	return WP_Duotone_Gutenberg::get_instance()->output_global_styles();
+	return gutenberg_duotone_support()->output_global_styles();
 }
 
 /**
  * Add SVG filters to the footer. Also, for classic themes, output block styles in core-block-supports-inline-css.
  */
 function gutenberg_output_duotone_footer_assets() {
-	return WP_Duotone_Gutenberg::get_instance()->output_footer_assets();
+	return gutenberg_duotone_support()->output_footer_assets();
 }
 
 /**
@@ -69,7 +86,7 @@ function gutenberg_output_duotone_footer_assets() {
  * @return array Editor settings with duotone SVGs and CSS custom properties.
  */
 function gutenberg_add_duotone_editor_settings( $settings ) {
-	return WP_Duotone_Gutenberg::get_instance()->add_editor_settings( $settings );
+	return gutenberg_duotone_support()->add_editor_settings( $settings );
 }
 
 /**
@@ -81,7 +98,7 @@ function gutenberg_add_duotone_editor_settings( $settings ) {
  * @return array Filtered block type settings.
  */
 function gutenberg_migrate_experimental_duotone_support_flag( $settings, $metadata ) {
-	return WP_Duotone_Gutenberg::get_instance()->migrate_experimental_duotone_support_flag( $settings, $metadata );
+	return gutenberg_duotone_support()->migrate_experimental_duotone_support_flag( $settings, $metadata );
 }
 
 /**

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -33,7 +33,7 @@
  */
 
 /**
- * Manages which duotone filters need to be output on the page.
+ * Manages duotone block supports and global styles.
  *
  * @access public
  */

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -39,18 +39,20 @@
  */
 class WP_Duotone_Gutenberg {
 	/**
-	 * An array of Duotone presets from global, theme, and custom styles.
+	 * An array of duotone filter data from global, theme, and custom presets.
 	 *
 	 * Example:
-	 * [
-	 *      'blue-orange' =>
-	 *          [
-	 *              'slug'  => 'blue-orange',
-	 *              'colors' => [ '#0000ff', '#ffcc00' ],
-	 *          ]
+	 *  [
+	 *      'wp-duotone-blue-orange' => [
+	 *          'slug'   => 'blue-orange',
+	 *          'colors' => [ '#0000ff', '#ffcc00' ],
+	 *      ],
+	 *      'wp-duotone-red-yellow' => [
+	 *          'slug'   => 'red-yellow',
+	 *          'colors' => [ '#cc0000', '#ffff33' ],
 	 *      ],
 	 *      …
-	 * ]
+	 *  ]
 	 *
 	 * @since 6.3.0
 	 * @var array
@@ -58,8 +60,8 @@ class WP_Duotone_Gutenberg {
 	private static $global_styles_presets = array();
 
 	/**
-	 * An array of block names from global, theme, and custom styles that have duotone presets. We'll use this to quickly
-	 * check if a block being rendered needs to have duotone applied, and which duotone preset to use.
+	 * Block names from global, theme, and custom styles that use duotone presets and the slug of
+	 * the preset they are using.
 	 *
 	 * Example:
 	 *  [
@@ -73,21 +75,21 @@ class WP_Duotone_Gutenberg {
 	private static $global_styles_block_names = array();
 
 	/**
-	 * An array of Duotone SVG and CSS output needed for the frontend duotone rendering based on what is
-	 * being output on the page. Organized by an id of the preset/color group and the information needed
-	 * to generate the SVG and CSS at render.
+	 * All of the duotone filter data for SVGs on the page. Includes both
+	 * presets and custom filters.
 	 *
 	 * Example:
 	 *  [
 	 *      'wp-duotone-blue-orange' => [
-	 *          'slug'  => 'blue-orange',
+	 *          'slug'   => 'blue-orange',
 	 *          'colors' => [ '#0000ff', '#ffcc00' ],
 	 *      ],
 	 *      'wp-duotone-000000-ffffff-2' => [
-	 *          'slug' => '000000-ffffff-2',
+	 *          'slug'   => '000000-ffffff-2',
 	 *          'colors' => [ '#000000', '#ffffff' ],
 	 *      ],
-	 * ]
+	 *      …
+	 *  ]
 	 *
 	 * @since 6.3.0
 	 * @var array
@@ -687,7 +689,8 @@ class WP_Duotone_Gutenberg {
 	}
 
 	/**
-	 * Appends the used global style duotone filter CSS Vars to the inline global styles CSS
+	 * Appends the used global style duotone filter presets (CSS custom
+	 * properties) to the inline global styles CSS.
 	 */
 	public static function output_global_styles() {
 		if ( ! empty( self::$used_global_styles_presets ) ) {

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -130,16 +130,6 @@ class WP_Duotone_Gutenberg {
 	private static $block_css_declarations = array();
 
 	/**
-	 * Prefix used for generating and referencing duotone CSS custom properties.
-	 */
-	const CSS_VAR_PREFIX = '--wp--preset--duotone--';
-
-	/**
-	 * Prefix used for generating and referencing duotone filter IDs.
-	 */
-	const FILTER_ID_PREFIX = 'wp-duotone-';
-
-	/**
 	 * Direct port of colord's clamp function. Using min/max instead of
 	 * nested ternaries.
 	 *
@@ -538,7 +528,7 @@ class WP_Duotone_Gutenberg {
 	 * @return string The CSS variable name.
 	 */
 	private static function get_css_custom_property_name( $slug ) {
-		return self::CSS_VAR_PREFIX . $slug;
+		return  "--wp--preset--duotone--$slug";
 	}
 
 	/**
@@ -548,7 +538,7 @@ class WP_Duotone_Gutenberg {
 	 * @return string The ID of the duotone filter.
 	 */
 	private static function get_filter_id( $slug ) {
-		return self::FILTER_ID_PREFIX . $slug;
+		return  "wp-duotone-$slug";
 	}
 
 	/**
@@ -558,7 +548,7 @@ class WP_Duotone_Gutenberg {
 	 * @return string The URL for the duotone filter.
 	 */
 	private static function get_filter_url( $filter_id ) {
-		return 'url(#' . $filter_id . ')';
+		return "url(#$filter_id)";
 	}
 
 	/**
@@ -642,7 +632,8 @@ class WP_Duotone_Gutenberg {
 	 * @return string The CSS variable.
 	 */
 	private static function get_css_var( $slug ) {
-		return 'var(' . self::get_css_custom_property_name( $slug ) . ')';
+		$name = self::get_css_custom_property_name( $slug );
+		return "var($name)";
 	}
 
 	/**
@@ -752,7 +743,7 @@ class WP_Duotone_Gutenberg {
 			$colors            = $filter_data['colors'];
 			$css_property_name = self::get_css_custom_property_name( $slug );
 			$declaration_value = is_string( $colors ) ? $colors : self::get_filter_url( $filter_id );
-			$css              .= $css_property_name . ':' . $declaration_value . ';';
+			$css              .= "$css_property_name:$declaration_value;";
 		}
 		$css .= '}';
 		return $css;

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -54,7 +54,6 @@ class WP_Duotone_Gutenberg {
 	 *      …
 	 *  ]
 	 *
-	 * @since 6.3.0
 	 * @var array
 	 */
 	private static $global_styles_presets = array();
@@ -69,7 +68,6 @@ class WP_Duotone_Gutenberg {
 	 *       …
 	 *  ]
 	 *
-	 * @since 6.3.0
 	 * @var array
 	 */
 	private static $global_styles_block_names = array();
@@ -91,7 +89,6 @@ class WP_Duotone_Gutenberg {
 	 *      …
 	 *  ]
 	 *
-	 * @since 6.3.0
 	 * @var array
 	 */
 	private static $used_svg_filter_data = array();
@@ -449,6 +446,8 @@ class WP_Duotone_Gutenberg {
 	/**
 	 * Get all possible duotone presets from global and theme styles and store as slug => [ colors array ]
 	 * We only want to process this one time. On block render we'll access and output only the needed presets for that page.
+	 *
+	 * @since 6.3.0
 	 */
 	public static function set_global_styles_presets() {
 		// Get the per block settings from the theme.json.
@@ -466,6 +465,8 @@ class WP_Duotone_Gutenberg {
 
 	/**
 	 * Scrape all block names from global styles and store in self::$global_styles_block_names
+	 *
+	 * @since 6.3.0
 	 */
 	public static function set_global_style_block_names() {
 		// Get the per block settings from the theme.json.
@@ -640,6 +641,8 @@ class WP_Duotone_Gutenberg {
 
 	/**
 	 * Outputs all necessary SVG for duotone filters, CSS for classic themes.
+	 *
+	 * @since 6.3.0
 	 */
 	public static function output_footer_assets() {
 		if ( ! empty( self::$used_svg_filter_data ) ) {
@@ -656,6 +659,8 @@ class WP_Duotone_Gutenberg {
 	 * Adds the duotone SVGs and CSS custom properties to the editor settings so
 	 * they can be pulled in by the EditorStyles component in JS and rendered in
 	 * the post editor.
+	 *
+	 * @since 6.3.0
 	 *
 	 * @param array $settings The block editor settings from the `block_editor_settings_all` filter.
 	 * @return array The editor settings with duotone SVGs and CSS custom properties.
@@ -691,6 +696,8 @@ class WP_Duotone_Gutenberg {
 	/**
 	 * Appends the used global style duotone filter presets (CSS custom
 	 * properties) to the inline global styles CSS.
+	 *
+	 * @since 6.3.0
 	 */
 	public static function output_global_styles() {
 		if ( ! empty( self::$used_global_styles_presets ) ) {
@@ -700,6 +707,8 @@ class WP_Duotone_Gutenberg {
 
 	/**
 	 * Appends the used block duotone filter declarations to the inline block supports CSS.
+	 *
+	 * @since 6.3.0
 	 */
 	public static function output_block_styles() {
 		if ( ! empty( self::$block_css_declarations ) ) {
@@ -845,6 +854,8 @@ class WP_Duotone_Gutenberg {
 	/**
 	 * Registers the style and colors block attributes for block types that support it.
 	 *
+	 * @since 6.3.0
+	 *
 	 * @param WP_Block_Type $block_type Block Type.
 	 */
 	public static function register_duotone_support( $block_type ) {
@@ -870,6 +881,8 @@ class WP_Duotone_Gutenberg {
 
 	/**
 	 * Render out the duotone CSS styles and SVG.
+	 *
+	 * @since 6.3.0
 	 *
 	 * @param  string $block_content Rendered block content.
 	 * @param  array  $block         Block object.
@@ -951,6 +964,8 @@ class WP_Duotone_Gutenberg {
 	/**
 	 * Migrate the old experimental duotone support flag to its stabilized location
 	 * under `supports.filter.duotone` and sets.
+	 *
+	 * @since 6.3.0
 	 *
 	 * @param array $settings Current block type settings.
 	 * @param array $metadata Block metadata as read in via block.json.

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -495,7 +495,7 @@ class WP_Duotone_Gutenberg {
 				continue;
 			}
 			// If it has a duotone filter preset, save the block name and the preset slug.
-			$slug = self::gutenberg_get_slug_from_attr( $duotone_attr );
+			$slug = self::get_slug_from_attribute( $duotone_attr );
 
 			if ( $slug && $slug !== $duotone_attr ) {
 				self::$global_styles_block_names[ $block_node['name'] ] = $slug;
@@ -511,7 +511,7 @@ class WP_Duotone_Gutenberg {
 	 * @param string $duotone_attr The duotone attribute from a block.
 	 * @return string The slug of the duotone preset or an empty string if no slug is found.
 	 */
-	private static function gutenberg_get_slug_from_attr( $duotone_attr ) {
+	private static function get_slug_from_attribute( $duotone_attr ) {
 		// Uses Branch Reset Groups `(?|…)` to return one capture group.
 		preg_match( '/(?|var:preset\|duotone\|(\S+)|var\(--wp--preset--duotone--(\S+)\))/', $duotone_attr, $matches );
 
@@ -525,7 +525,7 @@ class WP_Duotone_Gutenberg {
 	 * @return bool True if the duotone preset present and valid.
 	 */
 	private static function is_preset( $duotone_attr ) {
-		$slug      = self::gutenberg_get_slug_from_attr( $duotone_attr );
+		$slug      = self::get_slug_from_attribute( $duotone_attr );
 		$filter_id = self::get_filter_id( $slug );
 
 		return array_key_exists( $filter_id, self::$global_styles_presets );
@@ -910,8 +910,7 @@ class WP_Duotone_Gutenberg {
 			$is_custom    = is_array( $duotone_attr );
 
 			if ( $is_preset ) {
-
-				$slug         = self::gutenberg_get_slug_from_attr( $duotone_attr ); // e.g. 'green-blue'.
+				$slug         = self::get_slug_from_attribute( $duotone_attr ); // e.g. 'green-blue'.
 				$filter_id    = self::get_filter_id( $slug ); // e.g. 'wp-duotone-filter-green-blue'.
 				$filter_value = self::get_css_var( $slug ); // e.g. 'var(--wp--preset--duotone--green-blue)'.
 

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -39,13 +39,6 @@
  */
 class WP_Duotone_Gutenberg {
 	/**
-	 * Container for the main instance of the class.
-	 *
-	 * @var WP_Duotone_Gutenberg|null
-	 */
-	private static $instance = null;
-
-	/**
 	 * Block names from global, theme, and custom styles that use duotone presets and the slug of
 	 * the preset they are using.
 	 *
@@ -134,21 +127,6 @@ class WP_Duotone_Gutenberg {
 	 * @var array
 	 */
 	private $block_css_declarations = array();
-
-	/**
-	 * Returns an instance of the WP_Duotone_Gutenberg class, or create one if none exist yet.
-	 *
-	 * @since 6.3.0
-	 *
-	 * @return WP_Duotone_Gutenberg The main instance.
-	 */
-	public static function get_instance() {
-		if ( null === self::$instance ) {
-			self::$instance = new self();
-		}
-
-		return self::$instance;
-	}
 
 	/**
 	 * Direct port of colord's clamp function. Using min/max instead of

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -477,7 +477,7 @@ class WP_Duotone_Gutenberg {
 				continue;
 			}
 
-			// Value looks like this: 'var(--wp--preset--duotone--blue-orange)' or 'var:preset|duotone|default-filter'.
+			// Value looks like this: 'var(--wp--preset--duotone--blue-orange)' or 'var:preset|duotone|blue-orange'.
 			$duotone_attr_path = array_merge( $block_node['path'], array( 'filter', 'duotone' ) );
 			$duotone_attr      = _wp_array_get( $theme_json, $duotone_attr_path, array() );
 
@@ -495,7 +495,7 @@ class WP_Duotone_Gutenberg {
 
 	/**
 	 * Take the inline CSS duotone variable from a block and return the slug. Handles styles slugs like:
-	 * var:preset|duotone|default-filter
+	 * var:preset|duotone|blue-orange
 	 * var(--wp--preset--duotone--blue-orange)
 	 *
 	 * @param string $duotone_attr The duotone attribute from a block.
@@ -892,7 +892,7 @@ class WP_Duotone_Gutenberg {
 
 			// Possible values for duotone attribute:
 			// 1. Array of colors - e.g. array('#000000', '#ffffff').
-			// 2. Variable for an existing Duotone preset - e.g. 'var:preset|duotone|green-blue' or 'var(--wp--preset--duotone--green-blue)''
+			// 2. Variable for an existing Duotone preset - e.g. 'var:preset|duotone|blue-orange' or 'var(--wp--preset--duotone--blue-orange)''
 			// 3. A CSS string - e.g. 'unset' to remove globally applied duotone.
 
 			$duotone_attr = $block['attrs']['style']['color']['duotone'];
@@ -901,9 +901,9 @@ class WP_Duotone_Gutenberg {
 			$is_custom    = is_array( $duotone_attr );
 
 			if ( $is_preset ) {
-				$slug         = self::get_slug_from_attribute( $duotone_attr ); // e.g. 'green-blue'.
-				$filter_id    = self::get_filter_id( $slug ); // e.g. 'wp-duotone-filter-green-blue'.
-				$filter_value = self::get_css_var( $slug ); // e.g. 'var(--wp--preset--duotone--green-blue)'.
+				$slug         = self::get_slug_from_attribute( $duotone_attr ); // e.g. 'blue-orange'.
+				$filter_id    = self::get_filter_id( $slug ); // e.g. 'wp-duotone-filter-blue-orange'.
+				$filter_value = self::get_css_var( $slug ); // e.g. 'var(--wp--preset--duotone--blue-orange)'.
 
 				// CSS custom property, SVG filter, and block CSS.
 				self::enqueue_global_styles_preset( $filter_id, $duotone_selector, $filter_value );
@@ -928,9 +928,9 @@ class WP_Duotone_Gutenberg {
 				self::enqueue_custom_filter( $filter_id, $duotone_selector, $filter_value, $filter_data );
 			}
 		} elseif ( $has_global_styles_duotone ) {
-			$slug         = self::$global_styles_block_names[ $block['blockName'] ]; // e.g. 'green-blue'.
-			$filter_id    = self::get_filter_id( $slug ); // e.g. 'wp-duotone-filter-green-blue'.
-			$filter_value = self::get_css_var( $slug ); // e.g. 'var(--wp--preset--duotone--green-blue)'.
+			$slug         = self::$global_styles_block_names[ $block['blockName'] ]; // e.g. 'blue-orange'.
+			$filter_id    = self::get_filter_id( $slug ); // e.g. 'wp-duotone-filter-blue-orange'.
+			$filter_value = self::get_css_var( $slug ); // e.g. 'var(--wp--preset--duotone--blue-orange)'.
 
 			// CSS custom property, SVG filter, and block CSS.
 			self::enqueue_global_styles_preset( $filter_id, $duotone_selector, $filter_value );

--- a/phpunit/class-wp-duotone-test.php
+++ b/phpunit/class-wp-duotone-test.php
@@ -45,7 +45,7 @@ class WP_Duotone_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertMatchesRegularExpression( $expected, WP_Duotone_Gutenberg::render_duotone_support( $block_content, $block ) );
 	}
 
-	public function data_gutenberg_get_slug_from_attr() {
+	public function data_get_slug_from_attribute() {
 		return array(
 			'pipe-slug'                       => array( 'var:preset|duotone|blue-orange', 'blue-orange' ),
 			'css-var'                         => array( 'var(--wp--preset--duotone--blue-orange)', 'blue-orange' ),
@@ -60,11 +60,11 @@ class WP_Duotone_Gutenberg_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @dataProvider data_gutenberg_get_slug_from_attr
+	 * @dataProvider data_get_slug_from_attribute
 	 */
-	public function test_gutenberg_get_slug_from_attr( $data_attr, $expected ) {
+	public function test_get_slug_from_attribute( $data_attr, $expected ) {
 
-		$reflection = new ReflectionMethod( 'WP_Duotone_Gutenberg', 'gutenberg_get_slug_from_attr' );
+		$reflection = new ReflectionMethod( 'WP_Duotone_Gutenberg', 'get_slug_from_attribute' );
 		$reflection->setAccessible( true );
 
 		$this->assertSame( $expected, $reflection->invoke( null, $data_attr ) );

--- a/phpunit/class-wp-duotone-test.php
+++ b/phpunit/class-wp-duotone-test.php
@@ -7,14 +7,6 @@
  */
 
 class WP_Duotone_Gutenberg_Test extends WP_UnitTestCase {
-	/**
-	 * Cleans up CSS added to block-supports from duotone styles. We need to do this
-	 * in order to avoid impacting other tests.
-	 */
-	public static function wpTearDownAfterClass() {
-		WP_Style_Engine_CSS_Rules_Store_Gutenberg::remove_all_stores();
-	}
-
 	public function test_gutenberg_render_duotone_support_preset() {
 		$block         = array(
 			'blockName' => 'core/image',
@@ -22,7 +14,8 @@ class WP_Duotone_Gutenberg_Test extends WP_UnitTestCase {
 		);
 		$block_content = '<figure class="wp-block-image size-full"><img src="/my-image.jpg" /></figure>';
 		$expected      = '<figure class="wp-block-image size-full wp-duotone-blue-orange"><img src="/my-image.jpg" /></figure>';
-		$this->assertSame( $expected, WP_Duotone_Gutenberg::render_duotone_support( $block_content, $block ) );
+		$instance      = new WP_Duotone_Gutenberg();
+		$this->assertSame( $expected, $instance->render_duotone_support( $block_content, $block ) );
 	}
 
 	public function test_gutenberg_render_duotone_support_css() {
@@ -32,7 +25,8 @@ class WP_Duotone_Gutenberg_Test extends WP_UnitTestCase {
 		);
 		$block_content = '<figure class="wp-block-image size-full"><img src="/my-image.jpg" /></figure>';
 		$expected      = '/<figure class="wp-block-image size-full wp-duotone-unset-\d+"><img src="\\/my-image.jpg" \\/><\\/figure>/';
-		$this->assertMatchesRegularExpression( $expected, WP_Duotone_Gutenberg::render_duotone_support( $block_content, $block ) );
+		$instance      = new WP_Duotone_Gutenberg();
+		$this->assertMatchesRegularExpression( $expected, $instance->render_duotone_support( $block_content, $block ) );
 	}
 
 	public function test_gutenberg_render_duotone_support_custom() {
@@ -42,7 +36,8 @@ class WP_Duotone_Gutenberg_Test extends WP_UnitTestCase {
 		);
 		$block_content = '<figure class="wp-block-image size-full"><img src="/my-image.jpg" /></figure>';
 		$expected      = '/<figure class="wp-block-image size-full wp-duotone-ffffff-000000-\d+"><img src="\\/my-image.jpg" \\/><\\/figure>/';
-		$this->assertMatchesRegularExpression( $expected, WP_Duotone_Gutenberg::render_duotone_support( $block_content, $block ) );
+		$instance      = new WP_Duotone_Gutenberg();
+		$this->assertMatchesRegularExpression( $expected, $instance->render_duotone_support( $block_content, $block ) );
 	}
 
 	public function data_get_slug_from_attribute() {
@@ -65,26 +60,6 @@ class WP_Duotone_Gutenberg_Test extends WP_UnitTestCase {
 	public function test_get_slug_from_attribute( $data_attr, $expected ) {
 
 		$reflection = new ReflectionMethod( 'WP_Duotone_Gutenberg', 'get_slug_from_attribute' );
-		$reflection->setAccessible( true );
-
-		$this->assertSame( $expected, $reflection->invoke( null, $data_attr ) );
-	}
-
-	public function data_is_preset() {
-		return array(
-			'pipe-slug'                       => array( 'var:preset|duotone|blue-orange', true ),
-			'css-var'                         => array( 'var(--wp--preset--duotone--blue-orange)', true ),
-			'css-var-invalid-slug-chars'      => array( 'var(--wp--preset--duotone--.)', false ),
-			'css-var-missing-end-parenthesis' => array( 'var(--wp--preset--duotone--blue-orange', false ),
-			'invalid'                         => array( 'not a valid attribute', false ),
-		);
-	}
-
-	/**
-	 * @dataProvider data_is_preset
-	 */
-	public function test_is_preset( $data_attr, $expected ) {
-		$reflection = new ReflectionMethod( 'WP_Duotone_Gutenberg', 'is_preset' );
 		$reflection->setAccessible( true );
 
 		$this->assertSame( $expected, $reflection->invoke( null, $data_attr ) );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part 5 in a set of duotone php refactoring to fix small issues in duotone rendering.

- [Part 1: Port colord to PHP](https://github.com/WordPress/gutenberg/pull/49700)
- [Part 2: Deprecate remaining global duotone functions](https://github.com/WordPress/gutenberg/pull/49702)
- [Part 3: Group all duotone outputs](https://github.com/WordPress/gutenberg/pull/49705)
- [Part 4: Polish duotone rendering code](https://github.com/WordPress/gutenberg/pull/49706)
- [Part 5: Refactor duotone class to allow for multiple instances](#top) (this PR)

This part changes the architecture of the duotone class to allow for instancing.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This allows for more flexibility in the future if we may need multiple instances of the duotone rendering state.

This should also make things a little easier to test since we can just create a new instance rather than resetting the static properties between tests.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Converts `private static` properties to be instance properties
- Saves a single instance in the `$wp_duotone_support` global much like is done for `WP_Styles` and `WP_Scripts`.

The first commit shows what it would look like as a singleton instead. I feel like I slightly prefer the global version, but if there's a compelling argument to use a singleton instead I can easily switch back.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Ensure that duotone filters in all of the example content render the same in the post editor, site editor, and frontend.
2. Test that the custom filters render in classic themes. You can use the same example content which includes some.

<details>
<summary>Example content for TT3 block-out, canary, and pilgrimage variations</summary>

```html
<!-- wp:heading -->
<h2 class="wp-block-heading">Image core preset</h2>
<!-- /wp:heading -->

<!-- wp:image {"style":{"color":{"duotone":"var:preset|duotone|midnight"}}} -->
<figure class="wp-block-image"><img src="https://loremflickr.com/640/360" alt="placeholder image" class=""/><figcaption class="wp-element-caption">Preset slug: midnight</figcaption></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Image theme preset</h2>
<!-- /wp:heading -->

<!-- wp:image {"style":{"color":{"duotone":"var:preset|duotone|default-filter"}}} -->
<figure class="wp-block-image"><img src="https://loremflickr.com/640/360" alt="placeholder image" class=""/><figcaption class="wp-element-caption">Preset slug: default-filter</figcaption></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Image custom filter</h2>
<!-- /wp:heading -->

<!-- wp:image {"style":{"color":{"duotone":["rgb(92, 51, 10)","#fcf2e8"]}}} -->
<figure class="wp-block-image"><img src="https://loremflickr.com/640/360" alt="placeholder image" class=""/><figcaption class="wp-element-caption">Custom sepia filter</figcaption></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Image unset</h2>
<!-- /wp:heading -->

<!-- wp:image {"style":{"color":{"duotone":"unset"}}} -->
<figure class="wp-block-image"><img src="https://loremflickr.com/640/360" alt="placeholder image" class=""/><figcaption class="wp-element-caption">This should never have a filter applied</figcaption></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Image theme.json styles (plain block)</h2>
<!-- /wp:heading -->

<!-- wp:image {"style":{"color":{}}} -->
<figure class="wp-block-image"><img src="https://loremflickr.com/640/360" alt="placeholder image" class=""/><figcaption class="wp-element-caption"><code>settings.styles.blocks['core/image'].filter.duotone</code></figcaption></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Cover core preset</h2>
<!-- /wp:heading -->

<!-- wp:cover {"url":"https://loremflickr.com/640/360","dimRatio":0,"style":{"color":{"duotone":"var:preset|duotone|midnight"}}} -->
<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="placeholder image" src="https://loremflickr.com/640/360" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">Preset slug: midnight</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Cover theme preset</h2>
<!-- /wp:heading -->

<!-- wp:cover {"url":"https://loremflickr.com/640/360","dimRatio":0,"style":{"color":{"duotone":"var:preset|duotone|default-filter"}}} -->
<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="placeholder image" src="https://loremflickr.com/640/360" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">Preset slug: default-filter</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Cover custom filter</h2>
<!-- /wp:heading -->

<!-- wp:cover {"url":"https://loremflickr.com/640/360","dimRatio":0,"style":{"color":{"duotone":["rgb(92, 51, 10)","#fcf2e8"]}}} -->
<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="placeholder image" src="https://loremflickr.com/640/360" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">Custom sepia filter</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Cover unset</h2>
<!-- /wp:heading -->

<!-- wp:cover {"url":"https://loremflickr.com/640/360","dimRatio":0,"style":{"color":{"duotone":"unset"}}} -->
<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="placeholder image" src="https://loremflickr.com/640/360" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">This should never have a filter applied.</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Cover theme.json styles (plain block)</h2>
<!-- /wp:heading -->

<!-- wp:cover {"url":"https://loremflickr.com/640/360","dimRatio":0,"style":{"color":{}}} -->
<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="placeholder image" src="https://loremflickr.com/640/360" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…"} -->
<p class="has-text-align-center">This depends on <code>settings.styles.blocks['core/cover'].filter.duotone being set</code> to the CSS custom property for a preset.</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

```
