### PR TITLE
Revert "Bump plugin version to 15.6.1" created by accidental workflow run

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -5,7 +5,7 @@
  * Description: Printing since 1440. This is the development plugin for the block editor, site editor, and other future WordPress core functionality.
  * Requires at least: 6.0
  * Requires PHP: 5.6
- * Version: 15.6.1
+ * Version: 15.6.0
  * Author: Gutenberg Team
  * Text Domain: gutenberg
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "15.6.1",
+	"version": "15.6.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "15.6.1",
+	"version": "15.6.0",
 	"private": true,
 	"description": "A new WordPress editor experience.",
 	"author": "The WordPress Contributors",


### PR DESCRIPTION
## What

This reverts commit 6e15982c0bc6c54594860dcc5d1ee2175757ce66 which bumps Gutenberg stable to 15.6.1. However, I didn't mean to ship a new point release; it was created due [to an accidental workflow run](https://github.com/WordPress/gutenberg/actions/runs/4748564743) 🤦🏻 , read on for more details.


## Why?

I accidentally started a new "Bump Gutenberg Plugin Zip" workflow while testing https://github.com/WordPress/gutenberg/pull/49082, it should have been created in my own test repo (https://github.com/fullofcaffeine/gutenberg), but I had this repo opened as well and ended up using this by mistake (sorry!). I canceled the action before it ended, **so the draft release and the new tag weren't created**, but it had already created this changelog commit :(. This commit in `trunk` and in `release/15.6` were the only consequences of the run, so cleaning up should be only a matter of reverting this commit here and in `release/15.6` (done here: https://github.com/WordPress/gutenberg/commit/fa107ffbb59d4526851183f60438c8a8015e6ff7). I'll pre-emptively merge this commit to preventing another point release from running after that.

## How?

By reverting the changelog commit here (`trunk`) and in `release/15.6` (done in https://github.com/WordPress/gutenberg/commit/fa107ffbb59d4526851183f60438c8a8015e6ff7).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
