### PR TITLE
Cover: Reduce z-index for inner blocks container

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -33,7 +33,7 @@ $z-layers: (
 	".interface-interface-skeleton__content": 20,
 	".edit-widgets-header": 30,
 	".block-library-button__inline-link .block-editor-url-input__suggestions": 6, // URL suggestions for button block above sibling inserter
-	".wp-block-cover__inner-container": 1, // InnerBlocks area inside cover image block. Must be higher than block popover and less than drop zone.
+	".wp-block-cover__inner-container": 1, // InnerBlocks area inside cover image block.
 	".wp-block-cover.is-placeholder .components-placeholder.is-large": 1, // Cover block resizer component inside a large placeholder.
 	".wp-block-cover.has-background-dim::before": 1, // Overlay area inside block cover need to be higher than the video background.
 	".block-library-cover__padding-visualizer": 2, // BoxControl visualizer needs to be +1 higher than .wp-block-cover.has-background-dim::before

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -33,8 +33,8 @@ $z-layers: (
 	".interface-interface-skeleton__content": 20,
 	".edit-widgets-header": 30,
 	".block-library-button__inline-link .block-editor-url-input__suggestions": 6, // URL suggestions for button block above sibling inserter
-	".wp-block-cover__inner-container": 32, // InnerBlocks area inside cover image block. Must be higher than block popover and less than drop zone.
-	".wp-block-cover.is-placeholder .components-placeholder.is-large": 32, // Cover block resizer component inside a large placeholder.
+	".wp-block-cover__inner-container": 1, // InnerBlocks area inside cover image block. Must be higher than block popover and less than drop zone.
+	".wp-block-cover.is-placeholder .components-placeholder.is-large": 1, // Cover block resizer component inside a large placeholder.
 	".wp-block-cover.has-background-dim::before": 1, // Overlay area inside block cover need to be higher than the video background.
 	".block-library-cover__padding-visualizer": 2, // BoxControl visualizer needs to be +1 higher than .wp-block-cover.has-background-dim::before
 	".wp-block-cover__image-background": 0, // Image background inside cover block.


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/49939

## What?

Restores the original z-index style values for the Cover block's inner blocks container. 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cfec9b3</samp>

Reduced z-index values for cover block elements in `_z-index.scss` to prevent overlaps with other block editor elements. 

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cfec9b3</samp>

> _`z-index` lowered_
> _cover block avoids conflict_
> _autumn leaves falling_

## Why?

The higher z-index caused the inner blocks to appear above things like sticky groups, headers, etc.

## How?

The need for the higher z-index was already solved via disabling pointer events on the main block popover container and reenabling them on the child drag handle. This meant the z-index changes that landed in https://github.com/WordPress/gutenberg/pull/41153 were no longer required.

## Testing Instructions
1. In the post editor, edit a post, add a cover block and select it
2. Check while in the placeholder state that all inner buttons work still and that you can resize the block via the drag handle
3. Check that you can drag and drop an image into the cover block
4. Try now replacing the cover block's image via drag and drop again
5. Enter in some inner blocks content
6. Try resizing the block, adding border etc and ensure the inner blocks are still selectable and can be dragged around to reorder them
7. Switch to the site editor and set up a sticky header (e.g. wrap the default header template part in a group block and change the group block's position to sticky)
8. Now add a new cover block and repeat all the functionality checks as you did in the post editor
9. Finally ensure that the cover block's inner blocks "slide under" the sticky positioned group block

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/233235610-7529c475-4842-4676-b6e0-2ef1bf471fb8.mp4

