### PR TITLE
Disallow block transformation for specific block types

### DIFF
--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -156,6 +156,18 @@ const isPossibleTransformForSource = ( transform, direction, blocks ) => {
 	if ( ! blocks.length ) {
 		return false;
 	}
+	
+	// Disallow transformation if not allowed via block support attribute transformations.
+	let hasNotTransformableBlock;
+	blocks.forEach( function( block ) {        
+    		if ( ! hasBlockSupport(block.name, 'transforms', true) ) {
+        		hasNotTransformableBlock = true;
+    		}
+	});
+
+	if( hasNotTransformableBlock ) {
+    		return false;
+	}
 
 	// If multiple blocks are selected, only multi block transforms
 	// or wildcard transforms are allowed.


### PR DESCRIPTION
Solves https://github.com/WordPress/gutenberg/issues/31905

## What?
Disallow block transformations for specific block types, if the transformation is disallowed via block support attribute transformations.

## Why?
There are cases where certain block types may not be transformed. So far there is no way to deal with this. This PR introduces a way to prevent certain block types from being transformable.

## How?
You can disallow a possible transformation of a specific block type by adding the `"transforms": false` to the `supports` attribute of the `block.json` file.

```json
"supports": {
    "transforms": false
}
```

## Testing Instructions
1. Choose a specific block type which can be transformed.
2. Add `"transforms": false` to the `supports` attribute of the `block.json` file.
3. Try to transform this block type into other block types.
4. This should be no longer possible.
