### PR TITLE
Duotone: Fix setup state for image block.

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -10,7 +10,7 @@
 		border: none;
 
 		// Disable any duotone filter applied in the selected state.
-		filter: none;
+		filter: none !important;
 
 		// @todo: this should eventually be overridden by a custom border-radius set in the inspector.
 		border-radius: $radius-block-ui;


### PR DESCRIPTION
## What?

You can apply duotone to the setup state of an image:

<img width="661" alt="duotone in setup state" src="https://user-images.githubusercontent.com/1204802/233302647-b432a93c-cb87-4e8b-8642-2531270b8474.png">

For decorative blocks like this and others (featured image, cover, media & text) this is a useful way to build wireframe patterns that communicate: "a duotone filtered image will go here". While it's not yet applied to all those blocks yet, it works for the image block. 

But not the selected state:

<img width="608" alt="before" src="https://user-images.githubusercontent.com/1204802/233302999-51b2e9a1-9db3-4c3e-a657-b2711544497e.png">

## Why?

This regressed in how filters were applied, presumably, but is easily fixed by increasing the specificity here.
<img width="648" alt="after" src="https://user-images.githubusercontent.com/1204802/233303542-87ba4fab-2b83-46ce-adc9-5ae2dd598e4b.png">



## Testing Instructions

Insert an image block. Apply duotone. Select the block. Duotone should not affect the buttons and text of the selected setup state.
