### PR TITLE
Borders: Maintain radius in Global Styles

### DIFF
--- a/packages/edit-site/src/components/global-styles/border-panel.js
+++ b/packages/edit-site/src/components/global-styles/border-panel.js
@@ -66,6 +66,11 @@ export default function BorderPanel( { name, variation = '' } ) {
 	const settings = useSettingsForBlockElement( rawSettings, name );
 
 	const onChange = ( newStyle ) => {
+		if ( ! newStyle?.border ) {
+			setStyle( newStyle );
+			return;
+		}
+
 		// As Global Styles can't conditionally generate styles based on if
 		// other style properties have been set, we need to force split
 		// border definitions for user set global border styles. Border
@@ -77,7 +82,8 @@ export default function BorderPanel( { name, variation = '' } ) {
 		// the `border` style property. This means if the theme.json defined
 		// split borders and the user condenses them into a flat border or
 		// vice-versa we'd get both sets of styles which would conflict.
-		const border = applyAllFallbackStyles( newStyle?.border );
+		const { radius, ...newBorder } = newStyle.border;
+		const border = applyAllFallbackStyles( newBorder );
 		const updatedBorder = ! hasSplitBorders( border )
 			? {
 					top: border,
@@ -92,7 +98,7 @@ export default function BorderPanel( { name, variation = '' } ) {
 					...border,
 			  };
 
-		setStyle( { ...newStyle, border: updatedBorder } );
+		setStyle( { ...newStyle, border: { ...updatedBorder, radius } } );
 	};
 
 	return (


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/49738

## What?

Fixes a regression introduced in https://github.com/WordPress/gutenberg/pull/49738. When the global styles specific logic for border color, width, and style was moved to the global styles panel, maintaining the radius value wasn't accounted for.

## Why?

Without this fix you can't set a border-radius in Global Styles.

## How?

Now the onChange handler will only pass the border color, width, style, or side objects through to the function applying a border style fallback. The radius is deconstructed and added back to the new border style to be set.

## Testing Instructions

1. In the site editor, navigate to Global Styles > Blocks > Group
2. In the border control, enter a non-zero value into the width input
3. You should get a default border style of solid applied
4. Clear that width input and the style should also be cleared
5. Now confirm you can add a border-radius
6. Test out various combinations of split borders and border radii


## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <video src="https://user-images.githubusercontent.com/60436221/233308173-5a70cd76-b06b-4925-9c34-e7edacc10616.mp4" /> | <video src="https://user-images.githubusercontent.com/60436221/233307879-fb1b3624-e493-4cd4-b6a5-465010f423e8.mp4" /> | 






