### PR TITLE
[RNMobile] Revert "Disable block's touchable component when is focused"

### DIFF
--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -215,7 +215,7 @@ class BlockListBlock extends Component {
 			order + 1
 		);
 		const { isFullWidth, isContainerRelated } = alignmentHelpers;
-		const isFocused = isSelected || isInnerBlockSelected;
+		const accessible = ! ( isSelected || isInnerBlockSelected );
 		const screenWidth = Math.floor( Dimensions.get( 'window' ).width );
 		const isScreenWidthEqual = blockWidth === screenWidth;
 		const isScreenWidthWider = blockWidth < screenWidth;
@@ -224,9 +224,8 @@ class BlockListBlock extends Component {
 		return (
 			<TouchableWithoutFeedback
 				onPress={ this.onFocus }
-				accessible={ ! isFocused }
+				accessible={ accessible }
 				accessibilityRole={ 'button' }
-				disabled={ isFocused }
 			>
 				<View
 					style={ { flex: 1 } }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Reverts WordPress/gutenberg#49691.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The PR revert is needed to fix a regression related to removing the ability to select the parent block of container blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Reverting the code introduced in WordPress/gutenberg#49691.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Blocks can be selected
1. Create/open a post.
2. Add different types of blocks.
3. Observe that tapping on blocks makes them be selected and previous blocks are unselected.

### Inner blocks can be selected
1. Create/open a post.
2. Add different types of blocks.
3. Add container blocks like the Group or Column block and add different types of blocks to them.
4. Observe that tapping on blocks makes them be selected and previous blocks are unselected.
5. Observe that tapping on inner blocks makes them be selected and previous blocks are unselected.
N/A

### Parent block can be selected
1. Create/open a post.
2. Add a Cover block and set an image.
3. Insert a block within the Cover block (e.g. a Paragraph block) if there's none.
4. Select the inner block if it's not selected.
5. Tap on the parent block (you can tap in the background image of the block).
6. Observe that the parent block is selected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A