### PR TITLE
Fix the condition for the modal to choose the initial template pattern

### DIFF
--- a/packages/edit-site/src/components/start-template-options/index.js
+++ b/packages/edit-site/src/components/start-template-options/index.js
@@ -32,7 +32,7 @@ function useFallbackTemplateContent( slug, isCustom = false ) {
 				ignore_empty: true,
 			} ),
 		} ).then( ( { content } ) => setTemplateContent( content.raw ) );
-	}, [ slug ] );
+	}, [ isCustom, slug ] );
 	return templateContent;
 }
 

--- a/packages/edit-site/src/components/start-template-options/index.js
+++ b/packages/edit-site/src/components/start-template-options/index.js
@@ -153,22 +153,22 @@ export default function StartTemplateOptions() {
 				select( editSiteStore );
 			const _postType = getEditedPostType();
 			const postId = getEditedPostId();
-			const {
-				__experimentalGetDirtyEntityRecords,
-				getEditedEntityRecord,
-			} = select( coreStore );
+			const { getEditedEntityRecord, hasEditsForEntityRecord } =
+				select( coreStore );
 			const templateRecord = getEditedEntityRecord(
 				'postType',
 				_postType,
 				postId
 			);
-
-			const hasDirtyEntityRecords =
-				__experimentalGetDirtyEntityRecords().length > 0;
+			const hasEdits = hasEditsForEntityRecord(
+				'postType',
+				_postType,
+				postId
+			);
 
 			return {
 				shouldOpenModel:
-					! hasDirtyEntityRecords &&
+					! hasEdits &&
 					'' === templateRecord.content &&
 					'wp_template' === _postType &&
 					! select( preferencesStore ).get(

--- a/packages/edit-site/src/components/start-template-options/index.js
+++ b/packages/edit-site/src/components/start-template-options/index.js
@@ -147,7 +147,7 @@ export default function StartTemplateOptions() {
 	const [ modalState, setModalState ] = useState(
 		START_TEMPLATE_MODAL_STATES.INITIAL
 	);
-	const { shouldOpenModel, slug, isCustom, postType } = useSelect(
+	const { shouldOpenModal, slug, isCustom, postType } = useSelect(
 		( select ) => {
 			const { getEditedPostType, getEditedPostId } =
 				select( editSiteStore );
@@ -167,7 +167,7 @@ export default function StartTemplateOptions() {
 			);
 
 			return {
-				shouldOpenModel:
+				shouldOpenModal:
 					! hasEdits &&
 					'' === templateRecord.content &&
 					'wp_template' === _postType &&
@@ -185,7 +185,7 @@ export default function StartTemplateOptions() {
 
 	if (
 		( modalState === START_TEMPLATE_MODAL_STATES.INITIAL &&
-			! shouldOpenModel ) ||
+			! shouldOpenModal ) ||
 		modalState === START_TEMPLATE_MODAL_STATES.CLOSED
 	) {
 		return null;


### PR DESCRIPTION
## What?
Fixes #49548.

PR swaps `__experimentalGetDirtyEntityRecords` with `hasEditsForEntityRecord` to check unsaved template changes.

Commit [3098a57](https://github.com/WordPress/gutenberg/pull/49954/commits/3098a574d55cfa8317bd9cc6eab02f65b1ef5052).

The remaining commits fix minor issues in the file.

## Why?
The `__experimentalGetDirtyEntityRecords` check is too broad for this condition.

## Testing Instructions
* Go to the Site editor > Design > Templates
* Open an existing template, make changes, and **do not save them**.
* Go back the Site editor > Design > Templates.
* Create a custom template.
* Confirm that the "Choose a pattern" modal is displayed.

The original PR (#46248) doesn't include extensive instructions for the testing. I also tried to test different cases, but I would appreciate the help here to avoid regressions.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/233353135-6077dde6-58e2-4a06-8819-fac64ee0cc13.mp4


