### PR TITLE
Experiment: Add dynamic time to comment date with interactivity api

### DIFF
--- a/packages/block-library/src/comment-date/block.json
+++ b/packages/block-library/src/comment-date/block.json
@@ -18,6 +18,7 @@
 	},
 	"usesContext": [ "commentId" ],
 	"supports": {
+		"interactivity": true,
 		"anchor": true,
 		"html": false,
 		"color": {
@@ -46,5 +47,6 @@
 				"fontSize": true
 			}
 		}
-	}
+	},
+	"viewScript": [ "file:./view.min.js" ]
 }

--- a/packages/block-library/src/comment-date/index.php
+++ b/packages/block-library/src/comment-date/index.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Server-side rendering of the `core/comment-date` block.
  *
@@ -26,21 +27,27 @@ function render_block_core_comment_date( $attributes, $content, $block ) {
 	$classes = ( isset( $attributes['style']['elements']['link']['color']['text'] ) ) ? 'has-link-color' : '';
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
-	$formatted_date     = get_comment_date(
-		isset( $attributes['format'] ) ? $attributes['format'] : '',
-		$comment
+
+	$formatted_time = sprintf(
+		'<time datetime="%1$s" data-wp-init="effects.core.checkDiff" data-wp-text="context.commentsDateDiff"></time>',
+		esc_attr( get_comment_date( 'c', $comment ) ),
 	);
-	$link               = get_comment_link( $comment );
+
+	$link = get_comment_link( $comment );
 
 	if ( ! empty( $attributes['isLink'] ) ) {
-		$formatted_date = sprintf( '<a href="%1s">%2s</a>', esc_url( $link ), $formatted_date );
+		$formatted_time = sprintf( '<a href="%1s">%2s</a>', esc_url( $link ), $formatted_time );
 	}
 
 	return sprintf(
-		'<div %1$s><time datetime="%2$s">%3$s</time></div>',
+		'<div 
+			data-wp-context=\'{ "commentDate": "' . get_comment_time( 'c', false, true, $comment ) . '", "commentsDateDiff": ""}\'
+			%1$s
+		>
+			%2$s
+		</div>',
 		$wrapper_attributes,
-		esc_attr( get_comment_date( 'c', $comment ) ),
-		$formatted_date
+		$formatted_time
 	);
 }
 

--- a/packages/block-library/src/comment-date/runtime/constants.js
+++ b/packages/block-library/src/comment-date/runtime/constants.js
@@ -1,0 +1,3 @@
+export const csnMetaTagItemprop = 'wp-client-side-navigation';
+export const componentPrefix = 'wp-';
+export const directivePrefix = 'data-wp-';

--- a/packages/block-library/src/comment-date/runtime/directives.js
+++ b/packages/block-library/src/comment-date/runtime/directives.js
@@ -1,0 +1,253 @@
+/** @jsx h */
+
+/**
+ * External dependencies
+ */
+import { h } from 'preact';
+
+import { useContext, useMemo, useEffect } from 'preact/hooks';
+import { useSignalEffect } from '@preact/signals';
+import { deepSignal, peek } from 'deepsignal';
+/**
+ * Internal dependencies
+ */
+import { directive } from './hooks';
+import { prefetch, navigate, canDoClientSideNavigation } from './router';
+
+// Until useSignalEffects is fixed:
+// https://github.com/preactjs/signals/issues/228
+const raf = window.requestAnimationFrame;
+const tick = () => new Promise( ( r ) => raf( () => raf( r ) ) );
+
+// Check if current page can do client-side navigation.
+const clientSideNavigation = canDoClientSideNavigation( document.head );
+
+const isObject = ( item ) =>
+	item && typeof item === 'object' && ! Array.isArray( item );
+
+const mergeDeepSignals = ( target, source ) => {
+	for ( const k in source ) {
+		if ( typeof peek( target, k ) === 'undefined' ) {
+			target[ `$${ k }` ] = source[ `$${ k }` ];
+		} else if (
+			isObject( peek( target, k ) ) &&
+			isObject( peek( source, k ) )
+		) {
+			mergeDeepSignals(
+				target[ `$${ k }` ].peek(),
+				source[ `$${ k }` ].peek()
+			);
+		}
+	}
+};
+
+export default () => {
+	// data-wp-context
+	directive(
+		'context',
+		( {
+			directives: {
+				context: { default: context },
+			},
+			props: { children },
+			context: inherited,
+		} ) => {
+			const { Provider } = inherited;
+			const inheritedValue = useContext( inherited );
+			const value = useMemo( () => {
+				const localValue = deepSignal( context );
+				mergeDeepSignals( localValue, inheritedValue );
+				return localValue;
+			}, [ context, inheritedValue ] );
+
+			return <Provider value={ value }>{ children }</Provider>;
+		}
+	);
+
+	// data-wp-effect.[name]
+	directive( 'effect', ( { directives: { effect }, context, evaluate } ) => {
+		const contextValue = useContext( context );
+		Object.values( effect ).forEach( ( path ) => {
+			useSignalEffect( () => {
+				evaluate( path, { context: contextValue } );
+			} );
+		} );
+	} );
+
+	// data-wp-init.[name]
+	directive( 'init', ( { directives: { init }, context, evaluate } ) => {
+		const contextValue = useContext( context );
+		Object.values( init ).forEach( ( path ) => {
+			useMemo( () => {
+				evaluate( path, { context: contextValue } );
+			}, [] );
+		} );
+	} );
+
+	// data-wp-on.[event]
+	directive( 'on', ( { directives: { on }, element, evaluate, context } ) => {
+		const contextValue = useContext( context );
+		Object.entries( on ).forEach( ( [ name, path ] ) => {
+			element.props[ `on${ name }` ] = ( event ) => {
+				evaluate( path, { event, context: contextValue } );
+			};
+		} );
+	} );
+
+	// data-wp-class.[classname]
+	directive(
+		'class',
+		( {
+			directives: { class: className },
+			element,
+			evaluate,
+			context,
+		} ) => {
+			const contextValue = useContext( context );
+			Object.keys( className )
+				.filter( ( n ) => n !== 'default' )
+				.forEach( ( name ) => {
+					const result = evaluate( className[ name ], {
+						className: name,
+						context: contextValue,
+					} );
+					const currentClass = element.props.class || '';
+					const classFinder = new RegExp(
+						`(^|\\s)${ name }(\\s|$)`,
+						'g'
+					);
+					if ( ! result )
+						element.props.class = currentClass
+							.replace( classFinder, ' ' )
+							.trim();
+					else if ( ! classFinder.test( currentClass ) )
+						element.props.class = currentClass
+							? `${ currentClass } ${ name }`
+							: name;
+
+					useEffect( () => {
+						// This seems necessary because Preact doesn't change the class names
+						// on the hydration, so we have to do it manually. It doesn't need
+						// deps because it only needs to do it the first time.
+						if ( ! result ) {
+							element.ref.current.classList.remove( name );
+						} else {
+							element.ref.current.classList.add( name );
+						}
+					}, [] );
+				} );
+		}
+	);
+
+	// data-wp-bind.[attribute]
+	directive(
+		'bind',
+		( { directives: { bind }, element, context, evaluate } ) => {
+			const contextValue = useContext( context );
+			Object.entries( bind )
+				.filter( ( n ) => n !== 'default' )
+				.forEach( ( [ attribute, path ] ) => {
+					element.props[ attribute ] = evaluate( path, {
+						context: contextValue,
+					} );
+				} );
+		}
+	);
+
+	// data-wp-link
+	directive(
+		'link',
+		( {
+			directives: {
+				link: { default: link },
+			},
+			props: { href },
+			element,
+		} ) => {
+			useEffect( () => {
+				// Prefetch the page if it is in the directive options.
+				if ( clientSideNavigation && link?.prefetch ) {
+					prefetch( href );
+				}
+			} );
+
+			// Don't do anything if it's falsy.
+			if ( clientSideNavigation && link !== false ) {
+				element.props.onclick = async ( event ) => {
+					event.preventDefault();
+
+					// Fetch the page (or return it from cache).
+					await navigate( href );
+
+					// Update the scroll, depending on the option. True by default.
+					if ( link?.scroll === 'smooth' ) {
+						window.scrollTo( {
+							top: 0,
+							left: 0,
+							behavior: 'smooth',
+						} );
+					} else if ( link?.scroll !== false ) {
+						window.scrollTo( 0, 0 );
+					}
+				};
+			}
+		}
+	);
+
+	// data-wp-show
+	directive(
+		'show',
+		( {
+			directives: {
+				show: { default: show },
+			},
+			element,
+			evaluate,
+			context,
+		} ) => {
+			const contextValue = useContext( context );
+			if ( ! evaluate( show, { context: contextValue } ) )
+				element.props.children = (
+					<template>{ element.props.children }</template>
+				);
+		}
+	);
+
+	// data-wp-ignore
+	directive(
+		'ignore',
+		( {
+			element: {
+				type: Type,
+				props: { innerHTML, ...rest },
+			},
+		} ) => {
+			// Preserve the initial inner HTML.
+			const cached = useMemo( () => innerHTML, [] );
+			return (
+				<Type
+					dangerouslySetInnerHTML={ { __html: cached } }
+					{ ...rest }
+				/>
+			);
+		}
+	);
+
+	// data-wp-text
+	directive(
+		'text',
+		( {
+			directives: {
+				text: { default: text },
+			},
+			element,
+			evaluate,
+			context,
+		} ) => {
+			const contextValue = useContext( context );
+			element.props.children = evaluate( text, {
+				context: contextValue,
+			} );
+		}
+	);
+};

--- a/packages/block-library/src/comment-date/runtime/hooks.js
+++ b/packages/block-library/src/comment-date/runtime/hooks.js
@@ -1,0 +1,85 @@
+import { h, options, createContext } from 'preact';
+import { useRef } from 'preact/hooks';
+import { rawStore as store } from './store';
+import { componentPrefix } from './constants';
+
+// Main context.
+const context = createContext({});
+
+// WordPress Directives.
+const directiveMap = {};
+export const directive = (name, cb) => {
+	directiveMap[name] = cb;
+};
+
+// WordPress Components.
+const componentMap = {};
+export const component = (name, Comp) => {
+	componentMap[name] = Comp;
+};
+
+// Resolve the path to some property of the store object.
+const resolve = (path, context) => {
+	let current = { ...store, context };
+	path.split('.').forEach((p) => (current = current[p]));
+	return current;
+};
+
+// Generate the evaluate function.
+const getEvaluate =
+	({ ref } = {}) =>
+	(path, extraArgs = {}) => {
+		const value = resolve(path, extraArgs.context);
+		return typeof value === 'function'
+			? value({
+					state: store.state,
+					...(ref !== undefined ? { ref } : {}),
+					...extraArgs,
+			  })
+			: value;
+	};
+
+// Directive wrapper.
+const Directive = ({ type, directives, props: originalProps }) => {
+	const ref = useRef(null);
+	const element = h(type, { ...originalProps, ref, _wrapped: true });
+	const props = { ...originalProps, children: element };
+	const evaluate = getEvaluate({ ref: ref.current });
+	const directiveArgs = { directives, props, element, context, evaluate };
+
+	for (const d in directives) {
+		const wrapper = directiveMap[d]?.(directiveArgs);
+		if (wrapper !== undefined) props.children = wrapper;
+	}
+
+	return props.children;
+};
+
+// Preact Options Hook called each time a vnode is created.
+const old = options.vnode;
+options.vnode = (vnode) => {
+	const type = vnode.type;
+	const { directives } = vnode.props;
+
+	if (
+		typeof type === 'string' &&
+		type.slice(0, componentPrefix.length) === componentPrefix
+	) {
+		vnode.props.children = h(
+			componentMap[type.slice(componentPrefix.length)],
+			{ ...vnode.props, context, evaluate: getEvaluate() },
+			vnode.props.children
+		);
+	} else if (directives) {
+		const props = vnode.props;
+		delete props.directives;
+		if (!props._wrapped) {
+			vnode.props = { type: vnode.type, directives, props };
+			vnode.type = Directive;
+		} else {
+			delete props._wrapped;
+		}
+	}
+
+	if (old) old(vnode);
+};

--- a/packages/block-library/src/comment-date/runtime/index.js
+++ b/packages/block-library/src/comment-date/runtime/index.js
@@ -1,0 +1,2 @@
+export { store } from './store';
+export { navigate } from './router';

--- a/packages/block-library/src/comment-date/runtime/init.js
+++ b/packages/block-library/src/comment-date/runtime/init.js
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import registerDirectives from './directives';
+import { init } from './router';
+
+document.addEventListener( 'DOMContentLoaded', async () => {
+	registerDirectives();
+	await init();
+	console.log( 'hydrated!' );
+} );

--- a/packages/block-library/src/comment-date/runtime/router.js
+++ b/packages/block-library/src/comment-date/runtime/router.js
@@ -1,0 +1,171 @@
+/**
+ * External dependencies
+ */
+import { hydrate, render } from 'preact';
+/**
+ * Internal dependencies
+ */
+import { toVdom, hydratedIslands } from './vdom';
+import { createRootFragment } from './utils';
+import { csnMetaTagItemprop, directivePrefix } from './constants';
+
+// The root to render the vdom (document.body).
+let rootFragment;
+
+// The cache of visited and prefetched pages, stylesheets and scripts.
+const pages = new Map();
+const stylesheets = new Map();
+const scripts = new Map();
+
+// Helper to remove domain and hash from the URL. We are only interesting in
+// caching the path and the query.
+const cleanUrl = ( url ) => {
+	const u = new URL( url, window.location );
+	return u.pathname + u.search;
+};
+
+// Helper to check if a page can do client-side navigation.
+export const canDoClientSideNavigation = ( dom ) =>
+	dom
+		.querySelector( `meta[itemprop='${ csnMetaTagItemprop }']` )
+		?.getAttribute( 'content' ) === 'active';
+
+/**
+ * Finds the elements in the document that match the selector and fetch them.
+ * For each element found, fetch the content and store it in the cache.
+ * Returns an array of elements to add to the document.
+ *
+ * @param                    document
+ * @param {string}           selector        - CSS selector used to find the elements.
+ * @param {'href'|'src'}     attribute       - Attribute that determines where to fetch
+ *                                           the styles or scripts from. Also used as the key for the cache.
+ * @param {Map}              cache           - Cache to use for the elements. Can be `stylesheets` or `scripts`.
+ * @param {'style'|'script'} elementToCreate - Element to create for each fetched
+ *                                           item. Can be 'style' or 'script'.
+ * @return {Promise<Array<HTMLElement>>} - Array of elements to add to the document.
+ */
+const fetchScriptOrStyle = async (
+	document,
+	selector,
+	attribute,
+	cache,
+	elementToCreate
+) => {
+	const fetchedItems = await Promise.all(
+		[].map.call( document.querySelectorAll( selector ), ( el ) => {
+			const attributeValue = el.getAttribute( attribute );
+			if ( ! cache.has( attributeValue ) )
+				cache.set(
+					attributeValue,
+					fetch( attributeValue ).then( ( r ) => r.text() )
+				);
+			return cache.get( attributeValue );
+		} )
+	);
+
+	return fetchedItems.map( ( item ) => {
+		const element = document.createElement( elementToCreate );
+		element.textContent = item;
+		return element;
+	} );
+};
+
+// Fetch styles of a new page.
+const fetchAssets = async ( document ) => {
+	const stylesFromSheets = await fetchScriptOrStyle(
+		document,
+		'link[rel=stylesheet]',
+		'href',
+		stylesheets,
+		'style'
+	);
+	const scriptTags = await fetchScriptOrStyle(
+		document,
+		'script[src]',
+		'src',
+		scripts,
+		'script'
+	);
+	const moduleScripts = await fetchScriptOrStyle(
+		document,
+		'script[type=module]',
+		'src',
+		scripts,
+		'script'
+	);
+	moduleScripts.forEach( ( script ) =>
+		script.setAttribute( 'type', 'module' )
+	);
+
+	return [
+		...scriptTags,
+		document.querySelector( 'title' ),
+		...document.querySelectorAll( 'style' ),
+		...stylesFromSheets,
+	];
+};
+
+// Fetch a new page and convert it to a static virtual DOM.
+const fetchPage = async ( url, options = {} ) => {
+	const html =
+		options.html || ( await window.fetch( url ).then( ( r ) => r.text() ) );
+	const dom = new window.DOMParser().parseFromString( html, 'text/html' );
+	const head = await fetchAssets( dom );
+	return { head, body: toVdom( dom.body ) };
+};
+
+// Prefetch a page. We store the promise to avoid triggering a second fetch for
+// a page if a fetching has already started.
+export const prefetch = ( url, options = {} ) => {
+	url = cleanUrl( url );
+	if ( options.force || ! pages.has( url ) ) {
+		pages.set( url, fetchPage( url, options ) );
+	}
+};
+
+// Navigate to a new page.
+export const navigate = async ( href, options = {} ) => {
+	const url = cleanUrl( href );
+	prefetch( url, options );
+	const page = await pages.get( url );
+	if ( page ) {
+		document.head.replaceChildren( ...page.head );
+		render( page.body, rootFragment );
+		window.history.pushState( {}, '', href );
+	} else {
+		window.location.assign( href );
+	}
+};
+
+// Listen to the back and forward buttons and restore the page if it's in the
+// cache.
+window.addEventListener( 'popstate', async () => {
+	const url = cleanUrl( window.location ); // Remove hash.
+	const page = pages.has( url ) && ( await pages.get( url ) );
+	if ( page ) {
+		document.head.replaceChildren( ...page.head );
+		render( page.body, rootFragment );
+	} else {
+		window.location.reload();
+	}
+} );
+
+// Initialize the router with the initial DOM.
+export const init = async () => {
+	// Create the root fragment to hydrate everything.
+	rootFragment = createRootFragment(
+		document.documentElement,
+		document.body
+	);
+
+	const body = toVdom( document.body );
+	hydrate( body, rootFragment );
+
+	// Cache the scripts. Has to be called before fetching the assets.
+	[].map.call( document.querySelectorAll( 'script[src]' ), ( script ) => {
+		scripts.set( script.getAttribute( 'src' ), script.textContent );
+	} );
+
+	const head = await fetchAssets( document );
+	pages.set( cleanUrl( window.location ), Promise.resolve( { body, head } ) );
+};

--- a/packages/block-library/src/comment-date/runtime/store.js
+++ b/packages/block-library/src/comment-date/runtime/store.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { deepSignal } from 'deepsignal';
+
+const isObject = ( item ) =>
+	item && typeof item === 'object' && ! Array.isArray( item );
+
+export const deepMerge = ( target, source ) => {
+	if ( isObject( target ) && isObject( source ) ) {
+		for ( const key in source ) {
+			if ( isObject( source[ key ] ) ) {
+				if ( ! target[ key ] ) Object.assign( target, { [ key ]: {} } );
+				deepMerge( target[ key ], source[ key ] );
+			} else {
+				Object.assign( target, { [ key ]: source[ key ] } );
+			}
+		}
+	}
+};
+
+const getSerializedState = () => {
+	// TODO: change the store tag ID for a better one.
+	const storeTag = document.querySelector(
+		`script[type="application/json"]#store`
+	);
+	if ( ! storeTag ) return {};
+	try {
+		const { state } = JSON.parse( storeTag.textContent );
+		if ( isObject( state ) ) return state;
+		throw Error( 'Parsed state is not an object' );
+	} catch ( e ) {
+		console.log( e );
+	}
+	return {};
+};
+
+const rawState = getSerializedState();
+export const rawStore = { state: deepSignal( rawState ) };
+
+if ( typeof window !== 'undefined' ) window.store = rawStore;
+
+export const store = ( { state, ...block } ) => {
+	deepMerge( rawStore, block );
+	deepMerge( rawState, state );
+};

--- a/packages/block-library/src/comment-date/runtime/utils.js
+++ b/packages/block-library/src/comment-date/runtime/utils.js
@@ -1,0 +1,20 @@
+// For wrapperless hydration of document.body.
+// See https://gist.github.com/developit/f4c67a2ede71dc2fab7f357f39cff28c
+export const createRootFragment = (parent, replaceNode) => {
+	replaceNode = [].concat(replaceNode);
+	const s = replaceNode[replaceNode.length - 1].nextSibling;
+	function insert(c, r) {
+		parent.insertBefore(c, r || s);
+	}
+	return (parent.__k = {
+		nodeType: 1,
+		parentNode: parent,
+		firstChild: replaceNode[0],
+		childNodes: replaceNode,
+		insertBefore: insert,
+		appendChild: insert,
+		removeChild(c) {
+			parent.removeChild(c);
+		},
+	});
+};

--- a/packages/block-library/src/comment-date/runtime/vdom.js
+++ b/packages/block-library/src/comment-date/runtime/vdom.js
@@ -1,0 +1,71 @@
+import { h } from 'preact';
+import { directivePrefix as p } from './constants';
+
+const ignoreAttr = `${p}ignore`;
+const islandAttr = `${p}island`;
+const directiveParser = new RegExp(`${p}([^.]+)\.?(.*)$`);
+
+export const hydratedIslands = new WeakSet();
+
+// Recursive function that transfoms a DOM tree into vDOM.
+export function toVdom(node) {
+	const props = {};
+	const { attributes, childNodes } = node;
+	const directives = {};
+	let hasDirectives = false;
+	let ignore = false;
+	let island = false;
+
+	if (node.nodeType === 3) return node.data;
+	if (node.nodeType === 4) {
+		node.replaceWith(new Text(node.nodeValue));
+		return node.nodeValue;
+	}
+
+	for (let i = 0; i < attributes.length; i++) {
+		const n = attributes[i].name;
+		if (n[p.length] && n.slice(0, p.length) === p) {
+			if (n === ignoreAttr) {
+				ignore = true;
+			} else if (n === islandAttr) {
+				island = true;
+			} else {
+				hasDirectives = true;
+				let val = attributes[i].value;
+				try {
+					val = JSON.parse(val);
+				} catch (e) {}
+				const [, prefix, suffix] = directiveParser.exec(n);
+				directives[prefix] = directives[prefix] || {};
+				directives[prefix][suffix || 'default'] = val;
+			}
+		} else if (n === 'ref') {
+			continue;
+		} else {
+			props[n] = attributes[i].value;
+		}
+	}
+
+	if (ignore && !island)
+		return h(node.localName, {
+			...props,
+			innerHTML: node.innerHTML,
+			directives: { ignore: true },
+		});
+	if (island) hydratedIslands.add(node);
+
+	if (hasDirectives) props.directives = directives;
+
+	const children = [];
+	for (let i = 0; i < childNodes.length; i++) {
+		const child = childNodes[i];
+		if (child.nodeType === 8 || child.nodeType === 7) {
+			child.remove();
+			i--;
+		} else {
+			children.push(toVdom(child));
+		}
+	}
+
+	return h(node.localName, props, children);
+}

--- a/packages/block-library/src/comment-date/view.js
+++ b/packages/block-library/src/comment-date/view.js
@@ -1,0 +1,115 @@
+/**
+ * Internal dependencies
+ */
+import './runtime/init.js';
+import { store } from './runtime';
+import { __, _n, sprintf } from '@wordpress/i18n';
+
+( function ( domain, translations ) {
+	var localeData =
+		translations.locale_data[ domain ] || translations.locale_data.messages;
+	localeData[ '' ].domain = domain;
+	wp.i18n.setLocaleData( localeData, domain );
+} )( 'default', {
+	'translation-revision-date': '2023-03-07 19:10:38+0000',
+	generator: 'GlotPress/4.0.0-alpha.4',
+	domain: 'messages',
+	locale_data: {
+		messages: {
+			'': {
+				domain: 'messages',
+				'plural-forms':
+					'nplurals=3; plural=(n == 1) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2);',
+				lang: 'pl',
+			},
+			'Hello world!': [ 'Witaj swiecie' ],
+			'%s second ago': [
+				'%s sekunde temu',
+				'%s sekundy temu',
+				'%s sekund temu',
+			],
+			'%s minute ago': [
+				'%s minute temu',
+				'%s minuty temu',
+				'%s minut temu',
+			],
+			'%s hour ago': [
+				'%s godzine temu',
+				'%s godziny temu',
+				'%s godzin temu',
+			],
+			'%s day ago': [ '%s dzien temu', '%s dni temu', '%s dni temu' ],
+			'%s month ago': [
+				'%s miesiac temu',
+				'%s miesiace temu',
+				'%s miesiecy temu',
+			],
+			'%s year ago': [ '%s rok temu', '%s lata temu', '%s lat temu' ],
+		},
+	},
+	comment: {
+		reference: 'wp-includes/js/wp-auth-check.js',
+	},
+} );
+
+function makeTheUpdate( context ) {
+	const secondsDiff = Math.max(
+		Math.round( ( new Date() - new Date( context.commentDate ) ) / 1000 ),
+		1
+	);
+
+	if ( secondsDiff < 60 ) {
+		// Seconds
+		context.commentsDateDiff = sprintf(
+			_n( '%s second ago', '%s seconds ago', secondsDiff ),
+			secondsDiff
+		);
+		setTimeout( () => {
+			makeTheUpdate( context );
+		}, 1000 );
+	} else if ( secondsDiff < 3600 ) {
+		// Minutes
+		const minutesDiff = Math.round( secondsDiff / 60 );
+		context.commentsDateDiff = sprintf(
+			_n( '%s minute ago', '%s minutes ago', minutesDiff ),
+			minutesDiff
+		);
+		setTimeout( () => {
+			makeTheUpdate( context );
+		}, 60 * 1000 );
+	} else if ( secondsDiff < 3600 * 24 ) {
+		const hoursDiff = Math.round( secondsDiff / 3600 );
+		context.commentsDateDiff = sprintf(
+			_n( '%s hour ago', '%s hours ago', hoursDiff ),
+			hoursDiff
+		);
+	} else if ( secondsDiff < 3600 * 24 * 30 ) {
+		const daysDiff = Math.round( secondsDiff / ( 3600 * 24 ) );
+		context.commentsDateDiff = sprintf(
+			_n( '%s day ago', '%s days ago', daysDiff ),
+			daysDiff
+		);
+	} else if ( secondsDiff < 3600 * 24 * 365 ) {
+		const monthsDiff = Math.round( secondsDiff / ( 3600 * 24 * 30 ) );
+		context.commentsDateDiff = sprintf(
+			_n( '%s month ago', '%s months ago', monthsDiff ),
+			monthsDiff
+		);
+	} else {
+		const yearDiff = Math.round( secondsDiff / ( 3600 * 24 * 365 ) );
+		context.commentsDateDiff = sprintf(
+			_n( '%s year ago', '%s years ago', yearDiff ),
+			yearDiff
+		);
+	}
+}
+
+store( {
+	effects: {
+		core: {
+			checkDiff: ( { context } ) => {
+				makeTheUpdate( context );
+			},
+		},
+	},
+} );

--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -45,6 +45,5 @@
 		"wp-block-post-comments-form",
 		"wp-block-buttons",
 		"wp-block-button"
-	],
-	"viewScript": [ "file:./view.min.js" ]
+	]
 }

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -45,14 +45,19 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 	// to the block is carried along when the comment form is moved to the location
 	// of the 'Reply' link that the user clicked by Core's `comment-reply.js` script.
 	$form = str_replace( 'class="comment-respond"', $wrapper_attributes, $form );
-	$form = str_replace( '</form>', '<div style="color: red;" data-wp-text="state.core.commentsFormError"></div></form>', $form );
+	$form = str_replace( '</form>', '<div style="color: red;"></div></form>', $form );
 
 	// Enqueue the comment-reply script.
 	// wp_enqueue_script( 'comment-reply' );
 
 	$tags = new WP_HTML_Tag_Processor( $form );
 
-	$tags->next_tag( array( 'tag_name' => 'FORM', 'id' => 'commentform' ) );
+	$tags->next_tag(
+		array(
+			'tag_name' => 'FORM',
+			'id'       => 'commentform',
+		)
+	);
 	$tags->set_attribute( 'data-wp-on.submit', 'actions.core.commentsFormSubmission' );
 
 	return $tags->get_updated_html();


### PR DESCRIPTION
Co-authored with @gziolo 

## What?
Experiment using the Interactivity API to update the time that has passed since a comment was submitted.

The Interactivity API is an experimental API to add frontend interactivity to blocks. More info in [this post](https://make.wordpress.org/core/2023/03/30/proposal-the-interactivity-api-a-better-developer-experience-in-building-interactive-blocks/) and in [GitHub](https://github.com/WordPress/block-interactivity-experiments)

## Why?
To see what is needed to integrate this use case.

## How?

_This branch is on top of the [Experiment: use the Interactivity API to do client-side form submissions](https://github.com/WordPress/gutenberg/pull/49305) for practical reasons._

Before explaining how this was implemented, some considerations we had in mind:
* We cannot rely in the server to get the time difference between the comment date and the current time because it can be cached.
* We are using seconds for the demo, but it should probably be done only with minutes and hours.
* We are hardcoding the translations to Polish. If at any point this would get merged into Gutenberg, that would be handled automatically.

How we implemented this:

- [x] Remove the comment date and substitute it with the time that has passed.
- [x] Add the comment time to the local state from the server using `get_comment_time() function` in `data-wp-context`.
- [x] Add the `data-wp-init` directive and trigger `effects.core.checkDiff`, which runs a function named `makeTheUpdate` with a `setTimeOut` depending if it is seconds, minutes, or hours.
- [x] Add the logic to the `makeTheUpdate` function to change the time diff and the text depending on if it is seconds, mins, or hours. That information is stored in the `context`.
- [x] Use `data-wp-text` to show the time difference updated by `makeTheUpdate`.
- [x] Import the `@wordpress/i18n` package to handle the translations. We are aware this package is not intended for the frontend, but it was enough for this experiment.

And here you have a video with the demo and some explanations:

https://www.loom.com/share/e42ba81012454640ad239c63c5c25523
