### PR TITLE
Fixes typo in README

### DIFF
--- a/packages/rich-text/README.md
+++ b/packages/rich-text/README.md
@@ -22,7 +22,7 @@ Examples of rich formats include:
 
 -   bold, italic, superscript (etc)
 -   links
--   underordered/ordered lists
+-   unordered/ordered lists
 
 ### The RichTextValue object
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes the typo `underordered` to `unordered`

## Why?
Better documentation

## How?
Updated the README

