### PR TITLE
List View: Add a new prop to allow blocks in the inserter to be prioritized

### DIFF
--- a/packages/block-editor/src/components/list-view/appender.js
+++ b/packages/block-editor/src/components/list-view/appender.js
@@ -4,7 +4,12 @@
 import { useInstanceId } from '@wordpress/compose';
 import { speak } from '@wordpress/a11y';
 import { useSelect } from '@wordpress/data';
-import { forwardRef, useState, useEffect } from '@wordpress/element';
+import {
+	forwardRef,
+	useState,
+	useEffect,
+	useCallback,
+} from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -12,10 +17,21 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import { store as blockEditorStore } from '../../store';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
-import Inserter from '../inserter';
+
+import { unlock } from '../../lock-unlock';
+import { privateApis as blockEditorPrivateApis } from '../../private-apis';
 
 export const Appender = forwardRef(
-	( { nestingLevel, blockCount, clientId, ...props }, ref ) => {
+	(
+		{
+			nestingLevel,
+			blockCount,
+			clientId,
+			prioritizedInserterBlocks,
+			...props
+		},
+		ref
+	) => {
 		const [ insertedBlock, setInsertedBlock ] = useState( null );
 
 		const instanceId = useInstanceId( Appender );
@@ -58,11 +74,24 @@ export const Appender = forwardRef(
 			);
 		}, [ insertedBlockTitle ] );
 
+		const orderInitialBlockItems = useCallback( ( items ) => {
+			items.sort( ( { id: aName }, { id: bName } ) => {
+				// Sort block items according to `prioritizedInserterBlocks`.
+				let aIndex = prioritizedInserterBlocks.indexOf( aName );
+				let bIndex = prioritizedInserterBlocks.indexOf( bName );
+				// All other block items should come after that.
+				if ( aIndex < 0 ) aIndex = prioritizedInserterBlocks.length;
+				if ( bIndex < 0 ) bIndex = prioritizedInserterBlocks.length;
+				return aIndex - bIndex;
+			} );
+			return items;
+		}, [] );
+
 		if ( hideInserter ) {
 			return null;
 		}
-
 		const descriptionId = `list-view-appender__${ instanceId }`;
+		const { PrivateInserter } = unlock( blockEditorPrivateApis );
 		const description = sprintf(
 			/* translators: 1: The name of the block. 2: The numerical position of the block. 3: The level of nesting for the block. */
 			__( 'Append to %1$s block at position %2$d, Level %3$d' ),
@@ -73,7 +102,7 @@ export const Appender = forwardRef(
 
 		return (
 			<div className="list-view-appender">
-				<Inserter
+				<PrivateInserter
 					ref={ ref }
 					rootClientId={ clientId }
 					position="bottom right"
@@ -88,6 +117,11 @@ export const Appender = forwardRef(
 							setInsertedBlock( maybeInsertedBlock );
 						}
 					} }
+					orderInitialBlockItems={
+						prioritizedInserterBlocks
+							? orderInitialBlockItems
+							: null
+					}
 				/>
 				<div
 					className="list-view-appender__description"

--- a/packages/block-editor/src/components/list-view/appender.js
+++ b/packages/block-editor/src/components/list-view/appender.js
@@ -66,18 +66,21 @@ export const Appender = forwardRef(
 			);
 		}, [ insertedBlockTitle ] );
 
-		const orderInitialBlockItems = useCallback( ( items ) => {
-			items.sort( ( { id: aName }, { id: bName } ) => {
-				// Sort block items according to `prioritizedInserterBlocks`.
-				let aIndex = prioritizedInserterBlocks.indexOf( aName );
-				let bIndex = prioritizedInserterBlocks.indexOf( bName );
-				// All other block items should come after that.
-				if ( aIndex < 0 ) aIndex = prioritizedInserterBlocks.length;
-				if ( bIndex < 0 ) bIndex = prioritizedInserterBlocks.length;
-				return aIndex - bIndex;
-			} );
-			return items;
-		}, [] );
+		const orderInitialBlockItems = useCallback(
+			( items ) => {
+				items.sort( ( { id: aName }, { id: bName } ) => {
+					// Sort block items according to `prioritizedInserterBlocks`.
+					let aIndex = prioritizedInserterBlocks.indexOf( aName );
+					let bIndex = prioritizedInserterBlocks.indexOf( bName );
+					// All other block items should come after that.
+					if ( aIndex < 0 ) aIndex = prioritizedInserterBlocks.length;
+					if ( bIndex < 0 ) bIndex = prioritizedInserterBlocks.length;
+					return aIndex - bIndex;
+				} );
+				return items;
+			},
+			[ prioritizedInserterBlocks ]
+		);
 
 		if ( hideInserter ) {
 			return null;

--- a/packages/block-editor/src/components/list-view/appender.js
+++ b/packages/block-editor/src/components/list-view/appender.js
@@ -17,7 +17,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import { store as blockEditorStore } from '../../store';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
-import { ComposedPrivateInserter as PrivateInserter } from '../inserter';
+import Inserter from '../inserter';
 
 export const Appender = forwardRef(
 	(
@@ -100,7 +100,7 @@ export const Appender = forwardRef(
 
 		return (
 			<div className="list-view-appender">
-				<PrivateInserter
+				<Inserter
 					ref={ ref }
 					rootClientId={ clientId }
 					position="bottom right"

--- a/packages/block-editor/src/components/list-view/appender.js
+++ b/packages/block-editor/src/components/list-view/appender.js
@@ -17,9 +17,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import { store as blockEditorStore } from '../../store';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
-
-import { unlock } from '../../lock-unlock';
-import { privateApis as blockEditorPrivateApis } from '../../private-apis';
+import { ComposedPrivateInserter as PrivateInserter } from '../inserter';
 
 export const Appender = forwardRef(
 	(
@@ -91,7 +89,7 @@ export const Appender = forwardRef(
 			return null;
 		}
 		const descriptionId = `list-view-appender__${ instanceId }`;
-		const { PrivateInserter } = unlock( blockEditorPrivateApis );
+
 		const description = sprintf(
 			/* translators: 1: The name of the block. 2: The numerical position of the block. 3: The level of nesting for the block. */
 			__( 'Append to %1$s block at position %2$d, Level %3$d' ),

--- a/packages/block-editor/src/components/list-view/appender.js
+++ b/packages/block-editor/src/components/list-view/appender.js
@@ -18,18 +18,12 @@ import { __, sprintf } from '@wordpress/i18n';
 import { store as blockEditorStore } from '../../store';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
 import Inserter from '../inserter';
+import { useListViewContext } from './context';
 
 export const Appender = forwardRef(
-	(
-		{
-			nestingLevel,
-			blockCount,
-			clientId,
-			prioritizedInserterBlocks,
-			...props
-		},
-		ref
-	) => {
+	( { nestingLevel, blockCount, clientId, ...props }, ref ) => {
+		const { prioritizedInserterBlocks } = useListViewContext();
+
 		const [ insertedBlock, setInsertedBlock ] = useState( null );
 
 		const instanceId = useInstanceId( Appender );

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -99,6 +99,7 @@ function ListViewBranch( props ) {
 		shouldShowInnerBlocks = true,
 		isSyncedBranch = false,
 		showAppender: showAppenderProp = true,
+		prioritizedInserterBlocks,
 	} = props;
 
 	const parentBlockInformation = useBlockDisplayInformation( parentId );
@@ -232,6 +233,9 @@ function ListViewBranch( props ) {
 								clientId={ parentId }
 								nestingLevel={ level }
 								blockCount={ blockCount }
+								prioritizedInserterBlocks={
+									prioritizedInserterBlocks
+								}
 								{ ...treeGridCellProps }
 							/>
 						) }

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -99,7 +99,6 @@ function ListViewBranch( props ) {
 		shouldShowInnerBlocks = true,
 		isSyncedBranch = false,
 		showAppender: showAppenderProp = true,
-		prioritizedInserterBlocks,
 	} = props;
 
 	const parentBlockInformation = useBlockDisplayInformation( parentId );
@@ -233,9 +232,6 @@ function ListViewBranch( props ) {
 								clientId={ parentId }
 								nestingLevel={ level }
 								blockCount={ blockCount }
-								prioritizedInserterBlocks={
-									prioritizedInserterBlocks
-								}
 								{ ...treeGridCellProps }
 							/>
 						) }

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -56,17 +56,18 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
 /**
  * Show a hierarchical list of blocks.
  *
- * @param {Object}         props                         Components props.
- * @param {string}         props.id                      An HTML element id for the root element of ListView.
- * @param {Array}          props.blocks                  _deprecated_ Custom subset of block client IDs to be used instead of the default hierarchy.
- * @param {?boolean}       props.showBlockMovers         Flag to enable block movers. Defaults to `false`.
- * @param {?boolean}       props.isExpanded              Flag to determine whether nested levels are expanded by default. Defaults to `false`.
- * @param {?boolean}       props.showAppender            Flag to show or hide the block appender. Defaults to `false`.
- * @param {?ComponentType} props.blockSettingsMenu       Optional more menu substitution. Defaults to the standard `BlockSettingsDropdown` component.
- * @param {string}         props.rootClientId            The client id of the root block from which we determine the blocks to show in the list.
- * @param {string}         props.description             Optional accessible description for the tree grid component.
- * @param {Function}       props.renderAdditionalBlockUI Function that renders additional block content UI.
- * @param {Ref}            ref                           Forwarded ref
+ * @param {Object}         props                           Components props.
+ * @param {string}         props.id                        An HTML element id for the root element of ListView.
+ * @param {Array}          props.blocks                    _deprecated_ Custom subset of block client IDs to be used instead of the default hierarchy.
+ * @param {?boolean}       props.showBlockMovers           Flag to enable block movers. Defaults to `false`.
+ * @param {?boolean}       props.isExpanded                Flag to determine whether nested levels are expanded by default. Defaults to `false`.
+ * @param {?boolean}       props.showAppender              Flag to show or hide the block appender. Defaults to `false`.
+ * @param {?ComponentType} props.blockSettingsMenu         Optional more menu substitution. Defaults to the standard `BlockSettingsDropdown` component.
+ * @param {string}         props.rootClientId              The client id of the root block from which we determine the blocks to show in the list.
+ * @param {string}         props.description               Optional accessible description for the tree grid component.
+ * @param {Function}       props.renderAdditionalBlockUI   Function that renders additional block content UI.
+ * @param {Array}          props.prioritizedInserterBlocks An array of block types to show first in the appender.
+ * @param {Ref}            ref                             Forwarded ref
  */
 function ListViewComponent(
 	{
@@ -79,6 +80,7 @@ function ListViewComponent(
 		rootClientId,
 		description,
 		renderAdditionalBlockUI,
+		prioritizedInserterBlocks,
 	},
 	ref
 ) {
@@ -252,6 +254,7 @@ function ListViewComponent(
 						isExpanded={ isExpanded }
 						shouldShowInnerBlocks={ shouldShowInnerBlocks }
 						showAppender={ showAppender }
+						prioritizedInserterBlocks={ prioritizedInserterBlocks }
 					/>
 				</ListViewContext.Provider>
 			</TreeGrid>
@@ -269,6 +272,7 @@ export default forwardRef( ( props, ref ) => {
 			blockSettingsMenu={ BlockSettingsDropdown }
 			rootClientId={ null }
 			renderAdditionalBlockUICallback={ null }
+			prioritizedInserterBlocks={ null }
 		/>
 	);
 } );

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -208,6 +208,7 @@ function ListViewComponent(
 			BlockSettingsMenu,
 			listViewInstanceId: instanceId,
 			renderAdditionalBlockUI,
+			prioritizedInserterBlocks,
 		} ),
 		[
 			draggedClientIds,
@@ -217,6 +218,7 @@ function ListViewComponent(
 			BlockSettingsMenu,
 			instanceId,
 			renderAdditionalBlockUI,
+			prioritizedInserterBlocks,
 		]
 	);
 
@@ -254,7 +256,6 @@ function ListViewComponent(
 						isExpanded={ isExpanded }
 						shouldShowInnerBlocks={ shouldShowInnerBlocks }
 						showAppender={ showAppender }
-						prioritizedInserterBlocks={ prioritizedInserterBlocks }
 					/>
 				</ListViewContext.Provider>
 			</TreeGrid>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
One feature we added to the OffCanvasEditor component was the ability to sort the blocks in the Inserter, so that we can give access to the most commonly used ones. This PR adds that same functionality to the List View using a private prop called `prioritizedInserterBlocks`.
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
Adds a private prop called `prioritizedInserterBlocks`. We could potentially use the existing `showAppender` prop, and pass an array to it, but I think this way is simpler and easier to understand.

## Testing Instructions
This isn't possible to test using this PR, but the same commit is in this PR: https://github.com/WordPress/gutenberg/pull/49417, so you can test it there.

To test:
1. Check out the other branch
2. Create a new post
3. Add a navigation block
4. Open the Inspector controls for the block
5. Open the list view tab
6. Select the block inserter inside the tab
7. Check that the first two items in the inserter are "Page Link" and "Custom Link".

### Testing Instructions for Keyboard
As above

## Screenshots or screencast <!-- if applicable -->
<img width="431" alt="Screenshot 2023-04-20 at 14 38 37" src="https://user-images.githubusercontent.com/275961/233383872-bcbdbf5e-ee5f-4ec4-91f0-d27e2055f057.png">
