### PR TITLE
Components: Update `Autocomplete` usage example

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Documentation
 
 -   `Autocomplete`: Add heading and fix type for `onReplace` in README. ([#49798](https://github.com/WordPress/gutenberg/pull/49798)).
+-   `Autocomplete`: Update `Usage` section in README. ([#49965](https://github.com/WordPress/gutenberg/pull/49965)).
 
 ## 23.8.0 (2023-04-12)
 


### PR DESCRIPTION
Fixes #16624, #33852

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates the `Autocomplete` component README file with more a more useful description and example.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The current example gives a basic picture of the components functionality, but doesn't work on its own, in large part because `Autocomplete` is tightly coupled with other packages/components like the block editor and `RichText`

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The updated README clarifies that `Autocomplete` isn't intended as a standalone component and provides an example of how to integrate new completers in the WordPress Block Editor.

## Testing Instructions
Using the examples provided, try creating a small plugin, and confirm that it functions as expected without any errors.
