### PR TITLE
HTML API: Backports from Core

### DIFF
--- a/lib/compat/wordpress-6.3/html-api/class-gutenberg-html-tag-processor-6-3.php
+++ b/lib/compat/wordpress-6.3/html-api/class-gutenberg-html-tag-processor-6-3.php
@@ -971,6 +971,7 @@ class Gutenberg_HTML_Tag_Processor_6_3 {
 	 * closing `>`; these are left for other methods.
 	 *
 	 * @since 6.2.0
+	 * @since 6.2.1 Support abruptly-closed comments, invalid-tag-closer-comments, and empty elements.
 	 *
 	 * @return bool Whether a tag was found before the end of the document.
 	 */
@@ -1039,13 +1040,42 @@ class Gutenberg_HTML_Tag_Processor_6_3 {
 					'-' === $html[ $at + 2 ] &&
 					'-' === $html[ $at + 3 ]
 				) {
-					$closer_at = strpos( $html, '-->', $at + 4 );
-					if ( false === $closer_at ) {
+					$closer_at = $at + 4;
+					// If it's not possible to close the comment then there is nothing more to scan.
+					if ( strlen( $html ) <= $closer_at ) {
 						return false;
 					}
 
-					$at = $closer_at + 3;
-					continue;
+					// Abruptly-closed empty comments are a sequence of dashes followed by `>`.
+					$span_of_dashes = strspn( $html, '-', $closer_at );
+					if ( '>' === $html[ $closer_at + $span_of_dashes ] ) {
+						$at = $closer_at + $span_of_dashes + 1;
+						continue;
+					}
+
+					/*
+					 * Comments may be closed by either a --> or an invalid --!>.
+					 * The first occurrence closes the comment.
+					 *
+					 * See https://html.spec.whatwg.org/#parse-error-incorrectly-closed-comment
+					 */
+					$closer_at--; // Pre-increment inside condition below reduces risk of accidental infinite looping.
+					while ( ++$closer_at < strlen( $html ) ) {
+						$closer_at = strpos( $html, '--', $closer_at );
+						if ( false === $closer_at ) {
+							return false;
+						}
+
+						if ( $closer_at + 2 < strlen( $html ) && '>' === $html[ $closer_at + 2 ] ) {
+							$at = $closer_at + 3;
+							continue 2;
+						}
+
+						if ( $closer_at + 3 < strlen( $html ) && '!' === $html[ $closer_at + 2 ] && '>' === $html[ $closer_at + 3 ] ) {
+							$at = $closer_at + 4;
+							continue 2;
+						}
+					}
 				}
 
 				/*
@@ -1105,11 +1135,37 @@ class Gutenberg_HTML_Tag_Processor_6_3 {
 			}
 
 			/*
+			 * </> is a missing end tag name, which is ignored.
+			 *
+			 * See https://html.spec.whatwg.org/#parse-error-missing-end-tag-name
+			 */
+			if ( '>' === $html[ $at + 1 ] ) {
+				$at++;
+				continue;
+			}
+
+			/*
 			 * <? transitions to a bogus comment state – skip to the nearest >
-			 * https://html.spec.whatwg.org/multipage/parsing.html#tag-open-state
+			 * See https://html.spec.whatwg.org/multipage/parsing.html#tag-open-state
 			 */
 			if ( '?' === $html[ $at + 1 ] ) {
 				$closer_at = strpos( $html, '>', $at + 2 );
+				if ( false === $closer_at ) {
+					return false;
+				}
+
+				$at = $closer_at + 1;
+				continue;
+			}
+
+			/*
+			 * If a non-alpha starts the tag name in a tag closer it's a comment.
+			 * Find the first `>`, which closes the comment.
+			 *
+			 * See https://html.spec.whatwg.org/#parse-error-invalid-first-character-of-tag-name
+			 */
+			if ( $this->is_closing_tag ) {
+				$closer_at = strpos( $html, '>', $at + 3 );
 				if ( false === $closer_at ) {
 					return false;
 				}
@@ -1815,6 +1871,7 @@ class Gutenberg_HTML_Tag_Processor_6_3 {
 	 * For string attributes, the value is escaped using the `esc_attr` function.
 	 *
 	 * @since 6.2.0
+	 * @since 6.2.1 Fix: Only create a single update for multiple calls with case-variant attribute names.
 	 *
 	 * @param string      $name  The attribute name to target.
 	 * @param string|bool $value The new attribute value.
@@ -1907,8 +1964,8 @@ class Gutenberg_HTML_Tag_Processor_6_3 {
 			 *
 			 *    Result: <div id="new"/>
 			 */
-			$existing_attribute             = $this->attributes[ $comparable_name ];
-			$this->lexical_updates[ $name ] = new WP_HTML_Text_Replacement(
+			$existing_attribute                        = $this->attributes[ $comparable_name ];
+			$this->lexical_updates[ $comparable_name ] = new WP_HTML_Text_Replacement(
 				$existing_attribute->start,
 				$existing_attribute->end,
 				$updated_attribute
@@ -2085,6 +2142,8 @@ class Gutenberg_HTML_Tag_Processor_6_3 {
 		 * to the end of the updated document and return.
 		 */
 		if ( $requires_no_updating && $this->bytes_already_copied > 0 ) {
+			$this->html                 = $this->output_buffer . substr( $this->html, $this->bytes_already_copied );
+			$this->bytes_already_copied = strlen( $this->output_buffer );
 			return $this->output_buffer . substr( $this->html, $this->bytes_already_copied );
 		}
 


### PR DESCRIPTION
 - Support a few extra invalid comment syntaxes. WordPress/wordpress-develop#4256
 - Invalidate bookmarks which have been eliminated by enqueued changes. WordPress/wordpress-develop#4116
 - Expose whether the currently-matched tag has the self-closing flag. WordPress/wordpress-develop#4266
 - Avoid double-writing an attribute value if given case-variations of the name. WordPress/wordpress-develop#4337
 - Avoid losing previous updates in certain cases when seeking earlier in a document. WordPress/wordpress-develop#4345

As this has already received code review and has been merged into Core this should only require minimal verification before merging.