### PR TITLE
Publish block editor build types

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Publish build types ([#49969](https://github.com/WordPress/gutenberg/pull/49969))
+
 ## 11.8.0 (2023-04-12)
 
 ## 11.7.0 (2023-03-29)
@@ -50,7 +54,7 @@
 ### Bug Fix
 
 -   `SpacingSizesControl`: Change ARIA role from `region` to `group` to avoid unwanted ARIA landmark regions ([#46530](https://github.com/WordPress/gutenberg/pull/46530)).
--   `FocalPointPicker`:  Fix layout misalignment when placed in the `BlockInspector` ([#46631](https://github.com/WordPress/gutenberg/pull/46631)).
+-   `FocalPointPicker`: Fix layout misalignment when placed in the `BlockInspector` ([#46631](https://github.com/WordPress/gutenberg/pull/46631)).
 
 ## 10.5.0 (2022-11-16)
 

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -25,6 +25,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"types": "build-types",
 	"sideEffects": [
 		"build-style/**",
 		"src/**/*.scss",

--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -13,6 +13,10 @@ import BlockTitle from '../block-title';
 import { store as blockEditorStore } from '../../store';
 
 /**
+ * @typedef {import('@wordpress/element').WPElement} WPElement
+ */
+
+/**
  * Block breadcrumb component, displaying the hierarchy of the current block selection as a breadcrumb.
  *
  * @param {Object} props               Component props.

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -11,6 +11,8 @@ import { useSelect } from '@wordpress/data';
 import { memo, useMemo } from '@wordpress/element';
 import deprecated from '@wordpress/deprecated';
 
+/** @typedef {import('@wordpress/blocks').WPBlock} WPBlock */
+
 /**
  * Internal dependencies
  */

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -18,6 +18,10 @@ import {
 import { BlockLockMenuItem, useBlockLock } from '../block-lock';
 import { store as blockEditorStore } from '../../store';
 
+/**
+ * @typedef {import('@wordpress/element').WPElement} WPElement
+ */
+
 const { Fill, Slot } = createSlotFill( 'BlockSettingsMenuControls' );
 
 const BlockSettingsMenuControlsSlot = ( {

--- a/packages/block-editor/src/components/border-radius-control/index.js
+++ b/packages/block-editor/src/components/border-radius-control/index.js
@@ -24,6 +24,10 @@ import {
 	hasMixedValues,
 } from './utils';
 
+/**
+ * @typedef {import('@wordpress/element').WPElement} WPElement
+ */
+
 const DEFAULT_VALUES = {
 	topLeft: undefined,
 	topRight: undefined,

--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -9,6 +9,10 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
 
+/**
+ * @typedef {import('@wordpress/element').WPElement} WPElement
+ */
+
 function helpText( selfStretch, parentLayout ) {
 	const { orientation = 'horizontal' } = parentLayout;
 

--- a/packages/block-editor/src/components/duotone/components.js
+++ b/packages/block-editor/src/components/duotone/components.js
@@ -9,6 +9,10 @@ import { SVG } from '@wordpress/components';
 import { __unstableGetValuesFromColors as getValuesFromColors } from './index';
 
 /**
+ * @typedef {import('@wordpress/element').WPElement} WPElement
+ */
+
+/**
  * SVG and stylesheet needed for rendering the duotone filter.
  *
  * @param {Object} props          Duotone props.

--- a/packages/block-editor/src/components/font-appearance-control/index.js
+++ b/packages/block-editor/src/components/font-appearance-control/index.js
@@ -5,6 +5,10 @@ import { CustomSelectControl } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 
+/**
+ * @typedef {import('@wordpress/element').WPElement} WPElement
+ */
+
 const FONT_STYLES = [
 	{
 		name: _x( 'Regular', 'font style' ),

--- a/packages/block-editor/src/components/height-control/index.js
+++ b/packages/block-editor/src/components/height-control/index.js
@@ -19,6 +19,10 @@ import { __ } from '@wordpress/i18n';
  */
 import useSetting from '../use-setting';
 
+/**
+ * @typedef {import('@wordpress/element').WPComponent} WPComponent
+ */
+
 const RANGE_CONTROL_CUSTOM_SETTINGS = {
 	px: { max: 1000, step: 1 },
 	'%': { max: 100, step: 1 },

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -22,6 +22,10 @@ import InserterMenu from './menu';
 import QuickInserter from './quick-inserter';
 import { store as blockEditorStore } from '../../store';
 
+/**
+ * @typedef {import('@wordpress/element').WPElement} WPElement
+ */
+
 const defaultRenderToggle = ( {
 	onToggle,
 	disabled,

--- a/packages/block-editor/src/components/inserter/index.native.js
+++ b/packages/block-editor/src/components/inserter/index.native.js
@@ -30,6 +30,10 @@ import InserterMenu from './menu';
 import BlockInsertionPoint from '../block-list/insertion-point';
 import { store as blockEditorStore } from '../../store';
 
+/**
+ * @typedef {import('@wordpress/element').WPElement} WPElement
+ */
+
 const VOICE_OVER_ANNOUNCEMENT_DELAY = 1000;
 
 const defaultRenderToggle = ( {

--- a/packages/block-editor/src/components/letter-spacing-control/index.js
+++ b/packages/block-editor/src/components/letter-spacing-control/index.js
@@ -13,6 +13,10 @@ import { __ } from '@wordpress/i18n';
 import useSetting from '../../components/use-setting';
 
 /**
+ * @typedef {import('@wordpress/element').WPElement} WPElement
+ */
+
+/**
  * Control for letter-spacing.
  *
  * @param {Object}                  props                      Component props.

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -86,14 +86,19 @@ import { DEFAULT_LINK_SETTINGS } from './constants';
  * @property {WPLinkControlValue=}        value                      Current link value.
  * @property {WPLinkControlOnChangeProp=} onChange                   Value change handler, called with the updated value if
  *                                                                   the user selects a new link or updates settings.
+ * @property {Function=}                  onRemove                   Callback when the link is removed.
+ * @property {Function=}                  onCancel                   Callback when the operation is cancelled.
  * @property {boolean=}                   noDirectEntry              Whether to allow turning a URL-like search query directly into a link.
+ * @property {string=}                    searchInputPlaceholder     Placeholder text for the search bar.
  * @property {boolean=}                   showSuggestions            Whether to present suggestions when typing the URL.
  * @property {boolean=}                   showInitialSuggestions     Whether to present initial suggestions immediately.
  * @property {boolean=}                   withCreateSuggestion       Whether to allow creation of link value from suggestion.
  * @property {Object=}                    suggestionsQuery           Query parameters to pass along to wp.blockEditor.__experimentalFetchLinkSuggestions.
  * @property {boolean=}                   noURLSuggestion            Whether to add a fallback suggestion which treats the search query as a URL.
+ * @property {boolean=}                   hasRichPreviews            Whether to show a rich link preview.
  * @property {boolean=}                   hasTextControl             Whether to add a text field to the UI to update the value.title.
  * @property {string|Function|undefined}  createSuggestionButtonText The text to use in the button that calls createSuggestion.
+ * @property {Function=}                  createSuggestion           Creates a link based on the selection.
  * @property {Function}                   renderControlBottom        Optional controls to be rendered at the bottom of the component.
  */
 

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -13,8 +13,6 @@ import { store as blockEditorStore } from '../../store';
 import { BlockRefsProvider } from './block-refs-provider';
 import { unlock } from '../../lock-unlock';
 
-/** @typedef {import('@wordpress/data').WPDataRegistry} WPDataRegistry */
-
 export const ExperimentalBlockEditorProvider = withRegistryProvider(
 	( props ) => {
 		const { children, settings, stripExperimentalSettings = false } = props;

--- a/packages/block-editor/src/components/text-decoration-control/index.js
+++ b/packages/block-editor/src/components/text-decoration-control/index.js
@@ -10,6 +10,10 @@ import { BaseControl, Button } from '@wordpress/components';
 import { reset, formatStrikethrough, formatUnderline } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * @typedef {import('@wordpress/element').WPElement} WPElement
+ */
+
 const TEXT_DECORATIONS = [
 	{
 		name: __( 'None' ),

--- a/packages/block-editor/src/components/text-transform-control/index.js
+++ b/packages/block-editor/src/components/text-transform-control/index.js
@@ -15,6 +15,10 @@ import {
 	formatUppercase,
 } from '@wordpress/icons';
 
+/**
+ * @typedef {import('@wordpress/element').WPElement} WPElement
+ */
+
 const TEXT_TRANSFORMS = [
 	{
 		name: __( 'None' ),

--- a/packages/block-editor/src/components/typewriter/index.js
+++ b/packages/block-editor/src/components/typewriter/index.js
@@ -11,6 +11,10 @@ import { UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
  */
 import { store as blockEditorStore } from '../../store';
 
+/**
+ * @typedef {import('@wordpress/element').WPComponent} WPComponent
+ */
+
 const isIE = window.navigator.userAgent.indexOf( 'Trident' ) !== -1;
 const arrowKeyCodes = new Set( [ UP, DOWN, LEFT, RIGHT ] );
 const initialTriggerPercentage = 0.75;

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -24,6 +24,10 @@ import useClickSelection from './use-click-selection';
 import useInput from './use-input';
 import { store as blockEditorStore } from '../../store';
 
+/**
+ * @typedef {import('@wordpress/element').WPElement} WPElement
+ */
+
 export function useWritingFlow() {
 	const [ before, ref, after ] = useTabNav();
 	const hasMultiSelection = useSelect(

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -39,6 +39,10 @@ import { useBlockSettings } from './utils';
 import { store as blockEditorStore } from '../store';
 import { default as StylesFiltersPanel } from '../components/global-styles/filters-panel';
 
+/**
+ * @typedef {import('@wordpress/element').WPElement} WPElement
+ */
+
 const EMPTY_ARRAY = [];
 
 extend( [ namesPlugin ] );

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -26,6 +26,10 @@ import {
 import useSetting from '../components/use-setting';
 import { store as blockEditorStore } from '../store';
 
+/**
+ * @typedef {import('@wordpress/element').WPElement} WPElement
+ */
+
 export const FONT_SIZE_SUPPORT_KEY = 'typography.fontSize';
 
 /**

--- a/packages/block-editor/src/hooks/line-height.js
+++ b/packages/block-editor/src/hooks/line-height.js
@@ -13,6 +13,10 @@ import useSetting from '../components/use-setting';
 export const LINE_HEIGHT_SUPPORT_KEY = 'typography.lineHeight';
 
 /**
+ * @typedef {import('@wordpress/element').WPElement} WPElement
+ */
+
+/**
  * Inspector control panel containing the line height related configuration
  *
  * @param {Object} props

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -32,6 +32,10 @@ import { cleanEmptyObject } from './utils';
 import { unlock } from '../lock-unlock';
 import { store as blockEditorStore } from '../store';
 
+/**
+ * @typedef {import('@wordpress/element').WPElement} WPElement
+ */
+
 const { CustomSelectControl } = unlock( componentsPrivateApis );
 
 const POSITION_SUPPORT_KEY = 'position';

--- a/packages/block-editor/tsconfig.json
+++ b/packages/block-editor/tsconfig.json
@@ -2,7 +2,9 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"declarationDir": "build-types"
+		"declarationDir": "build-types",
+		"types": [ "gutenberg-env" ],
+		"checkJs": false
 	},
 	"references": [
 		{ "path": "../a11y" },
@@ -30,8 +32,5 @@
 		{ "path": "../warning" },
 		{ "path": "../wordcount" }
 	],
-	// NOTE: This package is being progressively typed. You are encouraged to
-	// expand this array with files which can be type-checked. At some point in
-	// the future, this can be simplified to an `includes` of `src/**/*`.
-	"files": [ "src/components/block-context/index.js", "src/utils/dom.js" ]
+	"include": [ "src/**/*" ]
 }

--- a/packages/components/src/view/component.tsx
+++ b/packages/components/src/view/component.tsx
@@ -30,7 +30,8 @@ import type { ViewProps } from './types';
 // @ts-expect-error
 export const View: WordPressComponent<
 	'div',
-	ViewProps & RefAttributes< any >
+	ViewProps & RefAttributes< any >,
+	true
 > = styled.div``;
 
 View.selector = '.components-view';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Publishes block editor build types. (This package is a lot bigger, and I think the types published are going to be pretty helpful.)

## Why?

See https://github.com/WordPress/gutenberg/pull/49647

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
- npm run build:package-types
- check types at packages/block-editor/build-types
