### PR TITLE
Style book: make the style book slot generic

### DIFF
--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -165,7 +165,6 @@ export default function BlockEditor() {
 			<SidebarInspectorFill>
 				<BlockInspector />
 			</SidebarInspectorFill>
-			{ /* Potentially this could be a generic slot (e.g. EditorCanvas.Slot) if there are other uses for it. */ }
 			<EditorCanvasContainer.Slot>
 				{ ( [ editorCanvasView ] ) =>
 					editorCanvasView ? (

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -36,8 +36,8 @@ import { store as editSiteStore } from '../../store';
 import BackButton from './back-button';
 import ResizableEditor from './resizable-editor';
 import EditorCanvas from './editor-canvas';
-import StyleBook from '../style-book';
 import { unlock } from '../../private-apis';
+import EditorCanvasContainer from '../editor-canvas-container';
 
 const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 
@@ -166,18 +166,19 @@ export default function BlockEditor() {
 				<BlockInspector />
 			</SidebarInspectorFill>
 			{ /* Potentially this could be a generic slot (e.g. EditorCanvas.Slot) if there are other uses for it. */ }
-			<StyleBook.Slot>
-				{ ( [ styleBook ] ) =>
-					styleBook ? (
+			<EditorCanvasContainer.Slot>
+				{ ( [ editorCanvasView ] ) =>
+					editorCanvasView ? (
 						<div className="edit-site-visual-editor is-focus-mode">
 							<ResizableEditor enableResizing>
-								{ styleBook }
+								{ editorCanvasView }
 							</ResizableEditor>
 						</div>
 					) : (
 						<BlockTools
 							className={ classnames( 'edit-site-visual-editor', {
-								'is-focus-mode': isTemplatePart || !! styleBook,
+								'is-focus-mode':
+									isTemplatePart || !! editorCanvasView,
 								'is-view-mode': isViewMode,
 							} ) }
 							__unstableContentRef={ contentRef }
@@ -211,7 +212,7 @@ export default function BlockEditor() {
 						</BlockTools>
 					)
 				}
-			</StyleBook.Slot>
+			</EditorCanvasContainer.Slot>
 			<ReusableBlocksMenuItems />
 		</ExperimentalBlockEditorProvider>
 	);

--- a/packages/edit-site/src/components/editor-canvas-container/index.js
+++ b/packages/edit-site/src/components/editor-canvas-container/index.js
@@ -62,7 +62,7 @@ function EditorCanvasContainer( {
 	);
 	function onCloseContainer() {
 		onClose();
-		setEditorCanvasContainerView( 'init' );
+		setEditorCanvasContainerView( undefined );
 		setIsClosed( true );
 	}
 

--- a/packages/edit-site/src/components/editor-canvas-container/index.js
+++ b/packages/edit-site/src/components/editor-canvas-container/index.js
@@ -1,11 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { Children, cloneElement, useState } from '@wordpress/element';
+import { Children, cloneElement, useState, useMemo } from '@wordpress/element';
 import { createSlotFill, Button } from '@wordpress/components';
 import { ESCAPE } from '@wordpress/keycodes';
 import { __ } from '@wordpress/i18n';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { closeSmall } from '@wordpress/icons';
 import { useFocusOnMount, useFocusReturn } from '@wordpress/compose';
 
@@ -25,7 +25,7 @@ import { store as editSiteStore } from '../../store';
 export function getEditorCanvasContainerTitle( view ) {
 	switch ( view ) {
 		case 'style-book':
-			return __( 'Style book' );
+			return __( 'Style Book' );
 		default:
 			return '';
 	}
@@ -40,13 +40,21 @@ function EditorCanvasContainer( {
 	closeButtonLabel,
 	onClose = () => {},
 } ) {
+	const editorCanvasContainerView = useSelect(
+		( select ) =>
+			unlock( select( editSiteStore ) ).getEditorCanvasContainerView(),
+		[]
+	);
 	const [ isClosed, setIsClosed ] = useState( false );
 	const { setEditorCanvasContainerView } = unlock(
 		useDispatch( editSiteStore )
 	);
 	const focusOnMountRef = useFocusOnMount( 'firstElement' );
 	const sectionFocusReturnRef = useFocusReturn();
-
+	const title = useMemo(
+		() => getEditorCanvasContainerTitle( editorCanvasContainerView ),
+		[ editorCanvasContainerView ]
+	);
 	function onCloseContainer() {
 		onClose();
 		setEditorCanvasContainerView( 'init' );
@@ -78,11 +86,12 @@ function EditorCanvasContainer( {
 
 	return (
 		<EditorCanvasContainerFill>
-			{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */ }
+			{ /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */ }
 			<section
 				className="edit-site-editor-canvas-container"
 				ref={ focusOnMountRef }
 				onKeyDown={ closeOnEscape }
+				aria-label={ title }
 			>
 				<Button
 					className="edit-site-editor-canvas-container__close-button"

--- a/packages/edit-site/src/components/editor-canvas-container/index.js
+++ b/packages/edit-site/src/components/editor-canvas-container/index.js
@@ -7,11 +7,7 @@ import { ESCAPE } from '@wordpress/keycodes';
 import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { closeSmall } from '@wordpress/icons';
-import {
-	useFocusOnMount,
-	useFocusReturn,
-	useMergeRefs,
-} from '@wordpress/compose';
+import { useFocusOnMount, useFocusReturn } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -50,7 +46,6 @@ function EditorCanvasContainer( {
 	);
 	const focusOnMountRef = useFocusOnMount( 'firstElement' );
 	const sectionFocusReturnRef = useFocusReturn();
-	const refs = useMergeRefs( [ sectionFocusReturnRef, focusOnMountRef ] );
 
 	function onCloseContainer() {
 		onClose();
@@ -69,21 +64,26 @@ function EditorCanvasContainer( {
 		? Children.map( children, ( child, index ) =>
 				index === 0
 					? cloneElement( child, {
-							ref: refs,
-							onKeyDown: closeOnEscape,
+							ref: sectionFocusReturnRef,
 					  } )
 					: child
 		  )
-		: cloneElement( children, { ref: refs, onKeyDown: closeOnEscape } );
+		: cloneElement( children, {
+				ref: sectionFocusReturnRef,
+		  } );
 
 	if ( isClosed ) {
 		return null;
 	}
 
 	return (
-		/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */
-		<section className="edit-site-editor-canvas-container">
-			<EditorCanvasContainerFill>
+		<EditorCanvasContainerFill>
+			{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */ }
+			<section
+				className="edit-site-editor-canvas-container"
+				ref={ focusOnMountRef }
+				onKeyDown={ closeOnEscape }
+			>
 				<Button
 					className="edit-site-editor-canvas-container__close-button"
 					icon={ closeSmall }
@@ -92,8 +92,8 @@ function EditorCanvasContainer( {
 					showTooltip={ false }
 				/>
 				{ childrenWithProps }
-			</EditorCanvasContainerFill>
-		</section>
+			</section>
+		</EditorCanvasContainerFill>
 	);
 }
 

--- a/packages/edit-site/src/components/editor-canvas-container/index.js
+++ b/packages/edit-site/src/components/editor-canvas-container/index.js
@@ -1,34 +1,80 @@
 /**
- * External dependencies
- */
-
-/**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { Children, cloneElement, useState } from '@wordpress/element';
 import { createSlotFill, Button } from '@wordpress/components';
 import { ESCAPE } from '@wordpress/keycodes';
 import { __ } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
+import { closeSmall } from '@wordpress/icons';
+import {
+	useFocusOnMount,
+	useFocusReturn,
+	useMergeRefs,
+} from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
-import { closeSmall } from '@wordpress/icons';
+import { unlock } from '../../private-apis';
+import { store as editSiteStore } from '../../store';
+
+/**
+ * Returns a translated string for the title of the editor canvas container.
+ *
+ * @param {string} view Editor canvas container view.
+ *
+ * @return {string} Translated string corresponding to value of view. Default is ''.
+ */
+export function getEditorCanvasContainerTitle( view ) {
+	switch ( view ) {
+		case 'style-book':
+			return __( 'Style book' );
+		default:
+			return '';
+	}
+}
 
 const SLOT_FILL_NAME = 'EditSiteEditorCanvasContainerSlot';
 const { Slot: EditorCanvasContainerSlot, Fill: EditorCanvasContainerFill } =
 	createSlotFill( SLOT_FILL_NAME );
 
-function EditorCanvasContainer( { onClose, title, children } ) {
+function EditorCanvasContainer( {
+	children,
+	closeButtonLabel,
+	onClose = () => {},
+} ) {
 	const [ isClosed, setIsClosed ] = useState( false );
+	const { setEditorCanvasContainerView } = unlock(
+		useDispatch( editSiteStore )
+	);
+	const focusOnMountRef = useFocusOnMount( 'firstElement' );
+	const sectionFocusReturnRef = useFocusReturn();
+	const refs = useMergeRefs( [ sectionFocusReturnRef, focusOnMountRef ] );
+
+	function onCloseContainer() {
+		onClose();
+		setEditorCanvasContainerView( 'init' );
+		setIsClosed( true );
+	}
 
 	function closeOnEscape( event ) {
 		if ( event.keyCode === ESCAPE && ! event.defaultPrevented ) {
 			event.preventDefault();
-			setIsClosed( true );
-			onClose();
+			onCloseContainer();
 		}
 	}
+
+	const childrenWithProps = Array.isArray( children )
+		? Children.map( children, ( child, index ) =>
+				index === 0
+					? cloneElement( child, {
+							ref: refs,
+							onKeyDown: closeOnEscape,
+					  } )
+					: child
+		  )
+		: cloneElement( children, { ref: refs, onKeyDown: closeOnEscape } );
 
 	if ( isClosed ) {
 		return null;
@@ -36,22 +82,20 @@ function EditorCanvasContainer( { onClose, title, children } ) {
 
 	return (
 		/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */
-		<section
-			className="editor-canvas-container"
-			aria-label={ title }
-			onKeyDown={ closeOnEscape }
-		>
-			<Button
-				className="edit-site-edit-canvas__close-button"
-				icon={ closeSmall }
-				label={ __( 'Close' ) }
-				onClick={ onClose }
-				showTooltip={ false }
-			/>
-			<EditorCanvasContainerFill>{ children }</EditorCanvasContainerFill>
+		<section className="edit-site-editor-canvas-container">
+			<EditorCanvasContainerFill>
+				<Button
+					className="edit-site-editor-canvas-container__close-button"
+					icon={ closeSmall }
+					label={ closeButtonLabel || __( 'Close' ) }
+					onClick={ onCloseContainer }
+					showTooltip={ false }
+				/>
+				{ childrenWithProps }
+			</EditorCanvasContainerFill>
 		</section>
 	);
 }
 
+EditorCanvasContainer.Slot = EditorCanvasContainerSlot;
 export default EditorCanvasContainer;
-export { EditorCanvasContainerSlot };

--- a/packages/edit-site/src/components/editor-canvas-container/index.js
+++ b/packages/edit-site/src/components/editor-canvas-container/index.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { Children, cloneElement, useState, useMemo } from '@wordpress/element';
-import { createSlotFill, Button } from '@wordpress/components';
+import {
+	Button,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
 import { ESCAPE } from '@wordpress/keycodes';
 import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -31,9 +34,11 @@ export function getEditorCanvasContainerTitle( view ) {
 	}
 }
 
+// Creates a private slot fill.
+const { createPrivateSlotFill } = unlock( componentsPrivateApis );
 const SLOT_FILL_NAME = 'EditSiteEditorCanvasContainerSlot';
 const { Slot: EditorCanvasContainerSlot, Fill: EditorCanvasContainerFill } =
-	createSlotFill( SLOT_FILL_NAME );
+	createPrivateSlotFill( SLOT_FILL_NAME );
 
 function EditorCanvasContainer( {
 	children,

--- a/packages/edit-site/src/components/editor-canvas-container/index.js
+++ b/packages/edit-site/src/components/editor-canvas-container/index.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { createSlotFill, Button } from '@wordpress/components';
+import { ESCAPE } from '@wordpress/keycodes';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { closeSmall } from '@wordpress/icons';
+
+const SLOT_FILL_NAME = 'EditSiteEditorCanvasContainerSlot';
+const { Slot: EditorCanvasContainerSlot, Fill: EditorCanvasContainerFill } =
+	createSlotFill( SLOT_FILL_NAME );
+
+function EditorCanvasContainer( { onClose, title, children } ) {
+	const [ isClosed, setIsClosed ] = useState( false );
+
+	function closeOnEscape( event ) {
+		if ( event.keyCode === ESCAPE && ! event.defaultPrevented ) {
+			event.preventDefault();
+			setIsClosed( true );
+			onClose();
+		}
+	}
+
+	if ( isClosed ) {
+		return null;
+	}
+
+	return (
+		/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */
+		<section
+			className="editor-canvas-container"
+			aria-label={ title }
+			onKeyDown={ closeOnEscape }
+		>
+			<Button
+				className="edit-site-edit-canvas__close-button"
+				icon={ closeSmall }
+				label={ __( 'Close' ) }
+				onClick={ onClose }
+				showTooltip={ false }
+			/>
+			<EditorCanvasContainerFill>{ children }</EditorCanvasContainerFill>
+		</section>
+	);
+}
+
+export default EditorCanvasContainer;
+export { EditorCanvasContainerSlot };

--- a/packages/edit-site/src/components/editor-canvas-container/style.scss
+++ b/packages/edit-site/src/components/editor-canvas-container/style.scss
@@ -1,0 +1,19 @@
+.edit-site-editor-canvas-container {
+	background: $white; // Fallback color, overridden by JavaScript.
+	border-radius: $radius-block-ui;
+	bottom: 0;
+	left: 0;
+	overflow: hidden;
+	position: absolute;
+	right: 0;
+	top: 0;
+	transition: all 0.3s; // Match .block-editor-iframe__body transition.
+}
+
+.edit-site-editor-canvas-container__close-button {
+	position: absolute;
+	right: $grid-unit-10;
+	top: math.div($grid-unit-60 - $button-size, 2); // ( tab height - button size ) / 2
+	z-index: 1;
+	background: $white;
+}

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -42,6 +42,7 @@ import StyleBook from '../style-book';
 import ScreenCSS from './screen-css';
 import { unlock } from '../../private-apis';
 import ScreenEffects from './screen-effects';
+import { store as editSiteStore } from '../../store';
 
 const SLOT_FILL_NAME = 'GlobalStylesMenu';
 const { Slot: GlobalStylesMenuSlot, Fill: GlobalStylesMenuFill } =
@@ -239,7 +240,7 @@ function ContextScreens( { name, parentMenu = '', variation = '' } ) {
 	);
 }
 
-function GlobalStylesStyleBook( { onClose } ) {
+function GlobalStylesStyleBook() {
 	const navigator = useNavigator();
 	const { path } = navigator.location;
 	return (
@@ -257,7 +258,6 @@ function GlobalStylesStyleBook( { onClose } ) {
 				// Now go to the selected block.
 				navigator.goTo( '/blocks/' + encodeURIComponent( blockName ) );
 			} }
-			onClose={ onClose }
 		/>
 	);
 }
@@ -296,9 +296,13 @@ function GlobalStylesBlockLink() {
 	}, [ selectedBlockClientId, selectedBlockName, blockHasGlobalStyles ] );
 }
 
-function GlobalStylesUI( { isStyleBookOpened, onCloseStyleBook } ) {
+function GlobalStylesUI() {
 	const blocks = getBlockTypes();
-
+	const editorCanvasContainerView = useSelect(
+		( select ) =>
+			unlock( select( editSiteStore ) ).getEditorCanvasContainerView(),
+		[]
+	);
 	return (
 		<NavigatorProvider
 			className="edit-site-global-styles-sidebar__navigator-provider"
@@ -343,8 +347,8 @@ function GlobalStylesUI( { isStyleBookOpened, onCloseStyleBook } ) {
 					/>
 				);
 			} ) }
-			{ isStyleBookOpened && (
-				<GlobalStylesStyleBook onClose={ onCloseStyleBook } />
+			{ 'style-book' === editorCanvasContainerView && (
+				<GlobalStylesStyleBook />
 			) }
 
 			<GlobalStylesActionMenu />

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -38,7 +38,8 @@ import UndoButton from './undo-redo/undo';
 import RedoButton from './undo-redo/redo';
 import DocumentActions from './document-actions';
 import { store as editSiteStore } from '../../store';
-import { useHasStyleBook } from '../style-book';
+import { getEditorCanvasContainerTitle } from '../editor-canvas-container';
+import { unlock } from '../../private-apis';
 
 const preventDefault = ( event ) => {
 	event.preventDefault();
@@ -56,6 +57,7 @@ export default function HeaderEditMode() {
 		blockEditorMode,
 		homeUrl,
 		showIconLabels,
+		editorCanvasView,
 	} = useSelect( ( select ) => {
 		const {
 			__experimentalGetPreviewDeviceType,
@@ -88,6 +90,9 @@ export default function HeaderEditMode() {
 				'core/edit-site',
 				'showIconLabels'
 			),
+			editorCanvasView: unlock(
+				select( editSiteStore )
+			).getEditorCanvasContainerView(),
 		};
 	}, [] );
 
@@ -117,7 +122,7 @@ export default function HeaderEditMode() {
 		[ setIsListViewOpened, isListViewOpen ]
 	);
 
-	const hasStyleBook = useHasStyleBook();
+	const hasDefaultEditorCanvasView = 'init' === editorCanvasView;
 
 	const isFocusMode = templateType === 'wp_template_part';
 
@@ -138,7 +143,7 @@ export default function HeaderEditMode() {
 				'show-icon-labels': showIconLabels,
 			} ) }
 		>
-			{ ! hasStyleBook && (
+			{ hasDefaultEditorCanvasView && (
 				<NavigableToolbar
 					className="edit-site-header-edit-mode__start"
 					aria-label={ __( 'Document tools' ) }
@@ -223,12 +228,16 @@ export default function HeaderEditMode() {
 			) }
 
 			<div className="edit-site-header-edit-mode__center">
-				{ hasStyleBook ? __( 'Style Book' ) : <DocumentActions /> }
+				{ ! hasDefaultEditorCanvasView ? (
+					getEditorCanvasContainerTitle( editorCanvasView )
+				) : (
+					<DocumentActions />
+				) }
 			</div>
 
 			<div className="edit-site-header-edit-mode__end">
 				<div className="edit-site-header-edit-mode__actions">
-					{ ! isFocusMode && ! hasStyleBook && (
+					{ ! isFocusMode && hasDefaultEditorCanvasView && (
 						<div
 							className={ classnames(
 								'edit-site-header-edit-mode__preview-options',

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -122,7 +122,7 @@ export default function HeaderEditMode() {
 		[ setIsListViewOpened, isListViewOpen ]
 	);
 
-	const hasDefaultEditorCanvasView = 'init' === editorCanvasView;
+	const hasDefaultEditorCanvasView = ! editorCanvasView;
 
 	const isFocusMode = templateType === 'wp_template_part';
 

--- a/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
@@ -31,7 +31,7 @@ export default function GlobalStylesSidebar() {
 
 	useEffect( () => {
 		if ( editorMode !== 'visual' ) {
-			setEditorCanvasContainerView( 'init' );
+			setEditorCanvasContainerView( undefined );
 		}
 	}, [ editorMode ] );
 
@@ -58,7 +58,7 @@ export default function GlobalStylesSidebar() {
 							disabled={ editorMode !== 'visual' }
 							onClick={ () =>
 								setEditorCanvasContainerView(
-									isStyleBookOpened ? 'init' : 'style-book'
+									isStyleBookOpened ? undefined : 'style-book'
 								)
 							}
 						/>

--- a/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
@@ -4,9 +4,8 @@
 import { FlexItem, FlexBlock, Flex, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { styles, seen } from '@wordpress/icons';
-import { useSelect } from '@wordpress/data';
-
-import { useState, useEffect } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -15,19 +14,29 @@ import DefaultSidebar from './default-sidebar';
 import { GlobalStylesUI } from '../global-styles';
 import { store as editSiteStore } from '../../store';
 import { GlobalStylesMenuSlot } from '../global-styles/ui';
+import { unlock } from '../../private-apis';
 
 export default function GlobalStylesSidebar() {
-	const [ isStyleBookOpened, setIsStyleBookOpened ] = useState( false );
-	const editorMode = useSelect(
-		( select ) => select( editSiteStore ).getEditorMode(),
-		[]
+	const { editorMode, editorCanvasView } = useSelect( ( select ) => {
+		return {
+			editorMode: select( editSiteStore ).getEditorMode(),
+			editorCanvasView: unlock(
+				select( editSiteStore )
+			).getEditorCanvasContainerView(),
+		};
+	}, [] );
+	const { setEditorCanvasContainerView } = unlock(
+		useDispatch( editSiteStore )
 	);
 
 	useEffect( () => {
 		if ( editorMode !== 'visual' ) {
-			setIsStyleBookOpened( false );
+			setEditorCanvasContainerView( 'init' );
 		}
 	}, [ editorMode ] );
+
+	const isStyleBookOpened = editorCanvasView === 'style-book';
+
 	return (
 		<DefaultSidebar
 			className="edit-site-global-styles-sidebar"
@@ -47,9 +56,11 @@ export default function GlobalStylesSidebar() {
 							label={ __( 'Style Book' ) }
 							isPressed={ isStyleBookOpened }
 							disabled={ editorMode !== 'visual' }
-							onClick={ () => {
-								setIsStyleBookOpened( ! isStyleBookOpened );
-							} }
+							onClick={ () =>
+								setEditorCanvasContainerView(
+									isStyleBookOpened ? 'init' : 'style-book'
+								)
+							}
 						/>
 					</FlexItem>
 					<FlexItem>
@@ -58,10 +69,7 @@ export default function GlobalStylesSidebar() {
 				</Flex>
 			}
 		>
-			<GlobalStylesUI
-				isStyleBookOpened={ isStyleBookOpened }
-				onCloseStyleBook={ () => setIsStyleBookOpened( false ) }
-			/>
+			<GlobalStylesUI />
 		</DefaultSidebar>
 	);
 }

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -201,7 +201,6 @@ function StyleBook( { isSelected, onSelect } ) {
 					color: textColor,
 					background: backgroundColor,
 				} }
-				aria-label={ __( 'Style Book' ) }
 			>
 				{ resizeObserver }
 				<TabPanel

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -7,14 +7,11 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import {
-	Button,
 	__unstableComposite as Composite,
 	__unstableUseCompositeState as useCompositeState,
 	__unstableCompositeItem as CompositeItem,
 	Disabled,
 	TabPanel,
-	createSlotFill,
-	__experimentalUseSlotFills as useSlotFills,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import {
@@ -31,28 +28,18 @@ import {
 	__unstableIframe as Iframe,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
-import { closeSmall } from '@wordpress/icons';
-import {
-	useResizeObserver,
-	useFocusOnMount,
-	useFocusReturn,
-	useMergeRefs,
-} from '@wordpress/compose';
+import { useResizeObserver } from '@wordpress/compose';
 import { useMemo, memo } from '@wordpress/element';
-import { ESCAPE } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../private-apis';
+import EditorCanvasContainer from '../editor-canvas-container';
 
 const { ExperimentalBlockEditorProvider, useGlobalStyle } = unlock(
 	blockEditorPrivateApis
 );
-
-const SLOT_FILL_NAME = 'EditSiteStyleBook';
-const { Slot: StyleBookSlot, Fill: StyleBookFill } =
-	createSlotFill( SLOT_FILL_NAME );
 
 // The content area of the Style Book is rendered within an iframe so that global styles
 // are applied to elements within the entire content area. To support elements that are
@@ -174,11 +161,8 @@ function getExamples() {
 	return [ headingsExample, ...otherExamples ];
 }
 
-function StyleBook( { isSelected, onSelect, onClose } ) {
+function StyleBook( { isSelected, onSelect } ) {
 	const [ resizeObserver, sizes ] = useResizeObserver();
-	const focusOnMountRef = useFocusOnMount( 'firstElement' );
-	const sectionFocusReturnRef = useFocusReturn();
-
 	const [ textColor ] = useGlobalStyle( 'color.text' );
 	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
 	const examples = useMemo( getExamples, [] );
@@ -207,17 +191,9 @@ function StyleBook( { isSelected, onSelect, onClose } ) {
 		[ originalSettings ]
 	);
 
-	function closeOnEscape( event ) {
-		if ( event.keyCode === ESCAPE && ! event.defaultPrevented ) {
-			event.preventDefault();
-			onClose();
-		}
-	}
-
 	return (
-		<StyleBookFill>
-			{ /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */ }
-			<section
+		<EditorCanvasContainer closeButtonLabel={ __( 'Close Style Book' ) }>
+			<div
 				className={ classnames( 'edit-site-style-book', {
 					'is-wide': sizes.width > 600,
 				} ) }
@@ -226,20 +202,8 @@ function StyleBook( { isSelected, onSelect, onClose } ) {
 					background: backgroundColor,
 				} }
 				aria-label={ __( 'Style Book' ) }
-				onKeyDown={ closeOnEscape }
-				ref={ useMergeRefs( [
-					sectionFocusReturnRef,
-					focusOnMountRef,
-				] ) }
 			>
 				{ resizeObserver }
-				<Button
-					className="edit-site-style-book__close-button"
-					icon={ closeSmall }
-					label={ __( 'Close Style Book' ) }
-					onClick={ onClose }
-					showTooltip={ false }
-				/>
 				<TabPanel
 					className="edit-site-style-book__tab-panel"
 					tabs={ tabs }
@@ -282,8 +246,8 @@ function StyleBook( { isSelected, onSelect, onClose } ) {
 						</Iframe>
 					) }
 				</TabPanel>
-			</section>
-		</StyleBookFill>
+			</div>
+		</EditorCanvasContainer>
 	);
 }
 
@@ -365,11 +329,4 @@ const Example = ( { composite, id, title, blocks, isSelected, onClick } ) => {
 	);
 };
 
-function useHasStyleBook() {
-	const fills = useSlotFills( SLOT_FILL_NAME );
-	return !! fills?.length;
-}
-
-StyleBook.Slot = StyleBookSlot;
 export default StyleBook;
-export { useHasStyleBook };

--- a/packages/edit-site/src/components/style-book/style.scss
+++ b/packages/edit-site/src/components/style-book/style.scss
@@ -1,21 +1,3 @@
-.edit-site-style-book {
-	background: $white; // Fallback color, overridden by JavaScript.
-	border-radius: $radius-block-ui;
-	bottom: 0;
-	left: 0;
-	overflow: hidden;
-	position: absolute;
-	right: 0;
-	top: 0;
-	transition: all 0.3s; // Match .block-editor-iframe__body transition.
-}
-
-.edit-site-style-book__close-button {
-	position: absolute;
-	right: $grid-unit-10;
-	top: math.div($grid-unit-60 - $button-size, 2); // ( tab height - button size ) / 2
-}
-
 .edit-site-style-book__tab-panel {
 	.components-tab-panel__tabs {
 		background: $white;

--- a/packages/edit-site/src/store/private-actions.js
+++ b/packages/edit-site/src/store/private-actions.js
@@ -27,3 +27,17 @@ export const setCanvasMode =
 			dispatch.setIsListViewOpened( true );
 		}
 	};
+
+/**
+ * Action that switches the editor canvas container view.
+ *
+ * @param {?string} view Editor canvas container view.
+ */
+export const setEditorCanvasContainerView =
+	( view ) =>
+	( { dispatch } ) => {
+		dispatch( {
+			type: 'SET_EDITOR_CANVAS_CONTAINER_VIEW',
+			view,
+		} );
+	};

--- a/packages/edit-site/src/store/private-selectors.js
+++ b/packages/edit-site/src/store/private-selectors.js
@@ -8,3 +8,14 @@
 export function getCanvasMode( state ) {
 	return state.canvasMode;
 }
+
+/**
+ * Returns the editor canvas container view.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {string} Editor canvas container view.
+ */
+export function getEditorCanvasContainerView( state ) {
+	return state.editorCanvasContainerView;
+}

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -142,12 +142,13 @@ function canvasMode( state = 'init', action ) {
 
 /**
  * Reducer used to track the site editor canvas container view.
- * This could be `'init'` (the visual block editor), `'style-book'` (the style book).
+ * Default is `undefined`, denoting the default, visual block editor.
+ * This could be, for example, `'style-book'` (the style book).
  *
- * @param {Object} state  Current state.
- * @param {Object} action Dispatched action.
+ * @param {string|undefined} state  Current state.
+ * @param {Object}           action Dispatched action.
  */
-function editorCanvasContainerView( state = 'init', action ) {
+function editorCanvasContainerView( state = undefined, action ) {
 	switch ( action.type ) {
 		case 'SET_EDITOR_CANVAS_CONTAINER_VIEW':
 			return action.view;

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -140,6 +140,22 @@ function canvasMode( state = 'init', action ) {
 	return state;
 }
 
+/**
+ * Reducer used to track the site editor canvas container view.
+ * This could be `'init'` (the visual block editor), `'style-book'` (the style book).
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ */
+function editorCanvasContainerView( state = 'init', action ) {
+	switch ( action.type ) {
+		case 'SET_EDITOR_CANVAS_CONTAINER_VIEW':
+			return action.view;
+	}
+
+	return state;
+}
+
 export default combineReducers( {
 	deviceType,
 	settings,
@@ -148,4 +164,5 @@ export default combineReducers( {
 	listViewPanel,
 	saveViewPanel,
 	canvasMode,
+	editorCanvasContainerView,
 } );

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -31,6 +31,7 @@
 @import "./components/sidebar-navigation-screen-navigation-menus/style.scss";
 @import "./components/site-icon/style.scss";
 @import "./components/style-book/style.scss";
+@import "./components/editor-canvas-container/style.scss";
 @import "./hooks/push-changes-to-global-styles/style.scss";
 
 html #wpadminbar {


### PR DESCRIPTION
Parent issue:
- https://github.com/WordPress/gutenberg/issues/49601

## What?
Genericize the Style Book slot, which allows alternative Editor Canvas views in the site editor.

Plucked from the experimental branch:
- https://github.com/WordPress/gutenberg/pull/49912

Also makes the slot private.

## Why?

@noisysocks  [first had the idea to make the Style Book a generic slot](https://github.com/WordPress/gutenberg/blob/release/15.6/packages/edit-site/src/components/block-editor/index.js#L168):

```
{ /* Potentially this could be a generic slot (e.g. EditorCanvas.Slot) if there are other uses for it. */ }
```

Then I came along and found a [use case for it](https://github.com/WordPress/gutenberg/pull/49912): to display revision items.

So there you are.


## How?
By turning the slot into a wrapper that can house a resizable editor instance. Add your  `<Iframe>`, `<BlockList />` or `<EditorStyles />`... whatever you like!

AND! By adding a new item to the edit-site store `editorCanvasContainerView`, e.g., 

```js	
const editorCanvasContainerView = useSelect(
		( select ) =>
			unlock( select( editSiteStore ) ).getEditorCanvasContainerView(),
		[]
	);
```

AND making the new slot private thanks to the work in https://github.com/WordPress/gutenberg/pull/49819

## Testing Instructions

Ensure I haven't broken the Style Book (compare with trunk)

1. Check that keyboard navigation is not affected. The close button should be focussed, and you should be able to arrow key through the style engine tags
2. Does the close button still work?
3. Can you toggle the Style Book on and off and on and off and on and off.

For more fun, see the test comments on the original PR:
- https://github.com/WordPress/gutenberg/pull/45960



