### PR TITLE
Global Styles: Fix palette color popovers

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -40,6 +40,7 @@
 -   `Modal`: Updated spacing / dimensions of `isFullScreen` ([#49894](https://github.com/WordPress/gutenberg/pull/49894)).
 -   `SlotFill`: Added util for creating private SlotFills and supporting Symbol keys ([#49819](https://github.com/WordPress/gutenberg/pull/49819)).
 -   `IconType`: Export for external use ([#49649](https://github.com/WordPress/gutenberg/pull/49649)).
+-   `PaletteEdit`: Allow custom position for color popovers ([#49975](https://github.com/WordPress/gutenberg/pull/49975)).
 
 ### Bug Fix
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Enhancements
 
 -   `Modal`: Add css class to children container ([#50099](https://github.com/WordPress/gutenberg/pull/50099)).
+-   `PaletteEdit`: Allow custom popover configuration ([#49975](https://github.com/WordPress/gutenberg/pull/49975)).
 
 ## 23.9.0 (2023-04-26)
 
@@ -40,7 +41,6 @@
 -   `Modal`: Updated spacing / dimensions of `isFullScreen` ([#49894](https://github.com/WordPress/gutenberg/pull/49894)).
 -   `SlotFill`: Added util for creating private SlotFills and supporting Symbol keys ([#49819](https://github.com/WordPress/gutenberg/pull/49819)).
 -   `IconType`: Export for external use ([#49649](https://github.com/WordPress/gutenberg/pull/49649)).
--   `PaletteEdit`: Allow custom popover configuration ([#49975](https://github.com/WordPress/gutenberg/pull/49975)).
 
 ### Bug Fix
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -40,7 +40,7 @@
 -   `Modal`: Updated spacing / dimensions of `isFullScreen` ([#49894](https://github.com/WordPress/gutenberg/pull/49894)).
 -   `SlotFill`: Added util for creating private SlotFills and supporting Symbol keys ([#49819](https://github.com/WordPress/gutenberg/pull/49819)).
 -   `IconType`: Export for external use ([#49649](https://github.com/WordPress/gutenberg/pull/49649)).
--   `PaletteEdit`: Allow custom position for color popovers ([#49975](https://github.com/WordPress/gutenberg/pull/49975)).
+-   `PaletteEdit`: Allow custom popover configuration ([#49975](https://github.com/WordPress/gutenberg/pull/49975)).
 
 ### Bug Fix
 

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { paramCase as kebabCase } from 'change-case';
 
 /**
@@ -115,19 +116,23 @@ function ColorPickerPopover< T extends Color | Gradient >( {
 	popoverProps: receivedPopoverProps,
 	onClose = () => {},
 }: ColorPickerPopoverProps< T > ) {
-	const popoverProps: ColorPickerPopoverProps< T >[ 'popoverProps' ] = {
-		shift: true,
-		offset: 20,
-		placement: 'left-start',
-		...receivedPopoverProps,
-	};
+	const popoverProps: ColorPickerPopoverProps< T >[ 'popoverProps' ] =
+		useMemo(
+			() => ( {
+				shift: true,
+				offset: 20,
+				placement: 'left-start',
+				...receivedPopoverProps,
+				className: classnames(
+					'components-palette-edit__popover',
+					receivedPopoverProps?.className
+				),
+			} ),
+			[ receivedPopoverProps ]
+		);
 
 	return (
-		<Popover
-			className="components-palette-edit__popover"
-			{ ...popoverProps }
-			onClose={ onClose }
-		>
+		<Popover { ...popoverProps } onClose={ onClose }>
 			{ ! isGradient && (
 				<ColorPicker
 					color={ element.color }

--- a/packages/components/src/palette-edit/stories/index.tsx
+++ b/packages/components/src/palette-edit/stories/index.tsx
@@ -59,6 +59,10 @@ Default.args = {
 	],
 	paletteLabel: 'Colors',
 	emptyMessage: 'Colors are empty',
+	popoverProps: {
+		placement: 'bottom-start',
+		offset: 8,
+	},
 };
 
 export const Gradients = Template.bind( {} );

--- a/packages/components/src/palette-edit/types.ts
+++ b/packages/components/src/palette-edit/types.ts
@@ -8,6 +8,7 @@ import type { Key, MouseEventHandler } from 'react';
  */
 import type { HeadingSize } from '../heading/types';
 import type { PopoverProps } from '../popover/types';
+import type { WordPressComponentProps } from '../ui/context';
 
 export type Color = {
 	color: string;
@@ -62,7 +63,10 @@ export type BasePaletteEdit = {
 	/**
 	 * Props to pass through to the underlying Popover component.
 	 */
-	popoverProps?: Omit< PopoverProps, 'children' >;
+	popoverProps?: Omit<
+		WordPressComponentProps< PopoverProps, 'div', false >,
+		'children'
+	>;
 };
 
 type PaletteEditColors = {

--- a/packages/components/src/palette-edit/types.ts
+++ b/packages/components/src/palette-edit/types.ts
@@ -6,9 +6,8 @@ import type { Key, MouseEventHandler } from 'react';
 /**
  * Internal dependencies
  */
+import type Popover from '../popover';
 import type { HeadingSize } from '../heading/types';
-import type { PopoverProps } from '../popover/types';
-import type { WordPressComponentProps } from '../ui/context';
 
 export type Color = {
 	color: string;
@@ -64,7 +63,7 @@ export type BasePaletteEdit = {
 	 * Props to pass through to the underlying Popover component.
 	 */
 	popoverProps?: Omit<
-		WordPressComponentProps< PopoverProps, 'div', false >,
+		React.ComponentPropsWithoutRef< typeof Popover >,
 		'children'
 	>;
 };

--- a/packages/components/src/palette-edit/types.ts
+++ b/packages/components/src/palette-edit/types.ts
@@ -59,6 +59,10 @@ export type BasePaletteEdit = {
 	 * @default ''
 	 */
 	slugPrefix?: string;
+	/**
+	 * Props to pass through to the underlying Popover component.
+	 */
+	popoverProps?: Omit< PopoverProps, 'children' >;
 };
 
 type PaletteEditColors = {
@@ -86,9 +90,7 @@ type PaletteEditGradients = {
 };
 
 export type PaletteEditProps = BasePaletteEdit &
-	( PaletteEditColors | PaletteEditGradients ) & {
-		popoverProps?: Omit< PopoverProps, 'children' >;
-	};
+	( PaletteEditColors | PaletteEditGradients );
 
 type EditingElement = number | null;
 
@@ -97,7 +99,7 @@ export type ColorPickerPopoverProps< T extends Color | Gradient > = {
 	onChange: ( newElement: T ) => void;
 	isGradient?: T extends Gradient ? true : false;
 	onClose?: () => void;
-	popoverProps?: Omit< PopoverProps, 'children' >;
+	popoverProps?: PaletteEditProps[ 'popoverProps' ];
 };
 
 export type NameInputProps = {
@@ -116,7 +118,7 @@ export type OptionProps< T extends Color | Gradient > = {
 	onRemove: MouseEventHandler< HTMLButtonElement >;
 	onStartEditing: () => void;
 	onStopEditing: () => void;
-	popoverProps?: Omit< PopoverProps, 'children' >;
+	popoverProps?: PaletteEditProps[ 'popoverProps' ];
 	slugPrefix: string;
 };
 
@@ -126,7 +128,7 @@ export type PaletteEditListViewProps< T extends Color | Gradient > = {
 	isGradient: T extends Gradient ? true : false;
 	canOnlyChangeValues: PaletteEditProps[ 'canOnlyChangeValues' ];
 	editingElement?: EditingElement;
-	popoverProps?: Omit< PopoverProps, 'children' >;
+	popoverProps?: PaletteEditProps[ 'popoverProps' ];
 	setEditingElement: ( newEditingElement?: EditingElement ) => void;
 	slugPrefix: string;
 };

--- a/packages/components/src/palette-edit/types.ts
+++ b/packages/components/src/palette-edit/types.ts
@@ -7,6 +7,7 @@ import type { Key, MouseEventHandler } from 'react';
  * Internal dependencies
  */
 import type { HeadingSize } from '../heading/types';
+import type { PopoverProps } from '../popover/types';
 
 export type Color = {
 	color: string;
@@ -85,7 +86,9 @@ type PaletteEditGradients = {
 };
 
 export type PaletteEditProps = BasePaletteEdit &
-	( PaletteEditColors | PaletteEditGradients );
+	( PaletteEditColors | PaletteEditGradients ) & {
+		popoverProps?: Omit< PopoverProps, 'children' >;
+	};
 
 type EditingElement = number | null;
 
@@ -94,6 +97,7 @@ export type ColorPickerPopoverProps< T extends Color | Gradient > = {
 	onChange: ( newElement: T ) => void;
 	isGradient?: T extends Gradient ? true : false;
 	onClose?: () => void;
+	popoverProps?: Omit< PopoverProps, 'children' >;
 };
 
 export type NameInputProps = {
@@ -112,6 +116,7 @@ export type OptionProps< T extends Color | Gradient > = {
 	onRemove: MouseEventHandler< HTMLButtonElement >;
 	onStartEditing: () => void;
 	onStopEditing: () => void;
+	popoverProps?: Omit< PopoverProps, 'children' >;
 	slugPrefix: string;
 };
 
@@ -121,6 +126,7 @@ export type PaletteEditListViewProps< T extends Color | Gradient > = {
 	isGradient: T extends Gradient ? true : false;
 	canOnlyChangeValues: PaletteEditProps[ 'canOnlyChangeValues' ];
 	editingElement?: EditingElement;
+	popoverProps?: Omit< PopoverProps, 'children' >;
 	setEditingElement: ( newEditingElement?: EditingElement ) => void;
 	slugPrefix: string;
 };

--- a/packages/edit-site/src/components/global-styles/color-palette-panel.js
+++ b/packages/edit-site/src/components/global-styles/color-palette-panel.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { useViewportMatch } from '@wordpress/compose';
 import {
 	__experimentalPaletteEdit as PaletteEdit,
 	__experimentalVStack as VStack,
@@ -43,6 +44,15 @@ export default function ColorPalettePanel( { name } ) {
 		'color.defaultPalette',
 		name
 	);
+
+	const isMobileViewport = useViewportMatch( 'small', '<' );
+	const popoverProps = isMobileViewport
+		? {
+				placement: 'bottom-start',
+				offset: 8,
+		  }
+		: undefined;
+
 	return (
 		<VStack
 			className="edit-site-global-styles-color-palette-panel"
@@ -56,6 +66,7 @@ export default function ColorPalettePanel( { name } ) {
 					onChange={ setThemeColors }
 					paletteLabel={ __( 'Theme' ) }
 					paletteLabelHeadingLevel={ 3 }
+					popoverProps={ popoverProps }
 				/>
 			) }
 			{ !! defaultColors &&
@@ -68,6 +79,7 @@ export default function ColorPalettePanel( { name } ) {
 						onChange={ setDefaultColors }
 						paletteLabel={ __( 'Default' ) }
 						paletteLabelHeadingLevel={ 3 }
+						popoverProps={ popoverProps }
 					/>
 				) }
 			<PaletteEdit
@@ -79,6 +91,7 @@ export default function ColorPalettePanel( { name } ) {
 					'Custom colors are empty! Add some colors to create your own color palette.'
 				) }
 				slugPrefix="custom-"
+				popoverProps={ popoverProps }
 			/>
 		</VStack>
 	);

--- a/packages/edit-site/src/components/global-styles/color-palette-panel.js
+++ b/packages/edit-site/src/components/global-styles/color-palette-panel.js
@@ -15,6 +15,7 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { unlock } from '../../private-apis';
 
 const { useGlobalSetting } = unlock( blockEditorPrivateApis );
+const mobilePopoverProps = { placement: 'bottom-start', offset: 8 };
 
 export default function ColorPalettePanel( { name } ) {
 	const [ themeColors, setThemeColors ] = useGlobalSetting(
@@ -46,12 +47,7 @@ export default function ColorPalettePanel( { name } ) {
 	);
 
 	const isMobileViewport = useViewportMatch( 'small', '<' );
-	const popoverProps = isMobileViewport
-		? {
-				placement: 'bottom-start',
-				offset: 8,
-		  }
-		: undefined;
+	const popoverProps = isMobileViewport ? mobilePopoverProps : undefined;
 
 	return (
 		<VStack


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/41894
Fixes: https://github.com/WordPress/gutenberg/issues/49040

## What?

- Adds the ability to pass Popover props through to the palette color pickers
- Updates the color palette panel to pass through alternative popover props when on small viewports

## Why?

- Without at least the `shift` prop on the palette color pickers they are rendered outside the viewport on smaller screens
- If only `shift` is added to the palette color pickers they overlay the individual color elements that triggered them, adding the ability to pass through popover props will allow for fine-tuning the positioning of the popovers in a follow up.

## How?

- Adds popover props to the `ColorPickerPopover`
- Plumbs through popover props for the `PaletteEdit` component
- Leverages `useViewportMatch` and  the new `popoverProps` to tweak the palette popovers when on small viewports

## Next Steps

In a follow-up, we can refine the popover placement, including which elements they may be anchored to.

## Testing Instructions

1. In the Site Editor, navigate to Global Styles > Colors > Palette
2. Confirm the placement of popovers for theme, default, and custom palettes
3. Resize to a small viewport and confirm the palette popovers all appear within the viewport

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <video src="https://user-images.githubusercontent.com/60436221/233541102-55c67b1b-15bc-4668-9972-5cb6344d3c97.mp4" /> | <video src="https://user-images.githubusercontent.com/60436221/233541121-b39e4aa3-9736-471a-b4d8-7efaf020ca91.mp4" /> |






