### PR TITLE
Global styles: update __experimentalGetCurrentGlobalStylesId to return full global styles object

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -131,21 +131,21 @@ export function receiveCurrentTheme( currentTheme ) {
 }
 
 /**
- * Returns an action object used in signalling that the current global styles id has been received.
+ * Returns an action object used in signalling that the current global styles has been received.
  * Ignored from documentation as it's internal to the data store.
  *
  * @ignore
  *
- * @param {string} currentGlobalStylesId The current global styles id.
+ * @param {Object} currentGlobalStyles The current global styles custom post type (CPT).
  *
  * @return {Object} Action object.
  */
-export function __experimentalReceiveCurrentGlobalStylesId(
-	currentGlobalStylesId
+export function __experimentalReceiveCurrentGlobalStyles(
+	currentGlobalStyles
 ) {
 	return {
-		type: 'RECEIVE_CURRENT_GLOBAL_STYLES_ID',
-		id: currentGlobalStylesId,
+		type: 'RECEIVE_CURRENT_GLOBAL_STYLES',
+		globalStyles: currentGlobalStyles,
 	};
 }
 
@@ -190,6 +190,28 @@ export function __experimentalReceiveThemeGlobalStyleVariations(
 		type: 'RECEIVE_THEME_GLOBAL_STYLE_VARIATIONS',
 		stylesheet,
 		variations,
+	};
+}
+
+/**
+ * Returns an action object used in signalling that the theme global styles custom post type (CPT) revisions have been received.
+ * Ignored from documentation as it's internal to the data store.
+ *
+ * @ignore
+ *
+ * @param {number} currentId The post id.
+ * @param {Array}  revisions The global styles revisions.
+ *
+ * @return {Object} Action object.
+ */
+export function __experimentalReceiveThemeGlobalStyleRevisions(
+	currentId,
+	revisions
+) {
+	return {
+		type: 'RECEIVE_THEME_GLOBAL_STYLE_REVISIONS',
+		currentId,
+		revisions,
 	};
 }
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -194,28 +194,6 @@ export function __experimentalReceiveThemeGlobalStyleVariations(
 }
 
 /**
- * Returns an action object used in signalling that the theme global styles custom post type (CPT) revisions have been received.
- * Ignored from documentation as it's internal to the data store.
- *
- * @ignore
- *
- * @param {number} currentId The post id.
- * @param {Array}  revisions The global styles revisions.
- *
- * @return {Object} Action object.
- */
-export function __experimentalReceiveThemeGlobalStyleRevisions(
-	currentId,
-	revisions
-) {
-	return {
-		type: 'RECEIVE_THEME_GLOBAL_STYLE_REVISIONS',
-		currentId,
-		revisions,
-	};
-}
-
-/**
  * Returns an action object used in signalling that the index has been received.
  *
  * @deprecated since WP 5.9, this is not useful anymore, use the selector direclty.

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -127,17 +127,17 @@ export function currentTheme( state = undefined, action ) {
 }
 
 /**
- * Reducer managing the current global styles id.
+ * Reducer managing the current global styles object.
  *
  * @param {string|undefined} state  Current state.
  * @param {Object}           action Dispatched action.
  *
  * @return {string|undefined} Updated state.
  */
-export function currentGlobalStylesId( state = undefined, action ) {
+export function currentGlobalStyles( state = undefined, action ) {
 	switch ( action.type ) {
-		case 'RECEIVE_CURRENT_GLOBAL_STYLES_ID':
-			return action.id;
+		case 'RECEIVE_CURRENT_GLOBAL_STYLES':
+			return action.globalStyles;
 	}
 
 	return state;
@@ -177,6 +177,26 @@ export function themeGlobalStyleVariations( state = {}, action ) {
 			return {
 				...state,
 				[ action.stylesheet ]: action.variations,
+			};
+	}
+
+	return state;
+}
+
+/**
+ * Reducer managing the theme global styles revisions.
+ *
+ * @param {Record<string, object>} state  Current state.
+ * @param {Object}                 action Dispatched action.
+ *
+ * @return {Record<string, object>} Updated state.
+ */
+export function themeGlobalStyleRevisions( state = {}, action ) {
+	switch ( action.type ) {
+		case 'RECEIVE_THEME_GLOBAL_STYLE_REVISIONS':
+			return {
+				...state,
+				[ action.currentId ]: action.revisions,
 			};
 	}
 
@@ -646,9 +666,10 @@ export default combineReducers( {
 	terms,
 	users,
 	currentTheme,
-	currentGlobalStylesId,
+	currentGlobalStyles,
 	currentUser,
 	themeGlobalStyleVariations,
+	themeGlobalStyleRevisions,
 	themeBaseGlobalStyles,
 	taxonomies,
 	entities,

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -184,26 +184,6 @@ export function themeGlobalStyleVariations( state = {}, action ) {
 }
 
 /**
- * Reducer managing the theme global styles revisions.
- *
- * @param {Record<string, object>} state  Current state.
- * @param {Object}                 action Dispatched action.
- *
- * @return {Record<string, object>} Updated state.
- */
-export function themeGlobalStyleRevisions( state = {}, action ) {
-	switch ( action.type ) {
-		case 'RECEIVE_THEME_GLOBAL_STYLE_REVISIONS':
-			return {
-				...state,
-				[ action.currentId ]: action.revisions,
-			};
-	}
-
-	return state;
-}
-
-/**
  * Higher Order Reducer for a given entity config. It supports:
  *
  *  - Fetching
@@ -669,7 +649,6 @@ export default combineReducers( {
 	currentGlobalStyles,
 	currentUser,
 	themeGlobalStyleVariations,
-	themeGlobalStyleRevisions,
 	themeBaseGlobalStyles,
 	taxonomies,
 	entities,

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -453,7 +453,7 @@ __experimentalGetTemplateForLink.shouldInvalidate = ( action ) => {
 	);
 };
 
-export const __experimentalGetCurrentGlobalStylesId =
+export const __experimentalGetCurrentGlobalStyles =
 	() =>
 	async ( { dispatch, resolveSelect } ) => {
 		const activeThemes = await resolveSelect.getEntityRecords(
@@ -468,8 +468,8 @@ export const __experimentalGetCurrentGlobalStylesId =
 			const globalStylesObject = await apiFetch( {
 				url: globalStylesURL,
 			} );
-			dispatch.__experimentalReceiveCurrentGlobalStylesId(
-				globalStylesObject.id
+			dispatch.__experimentalReceiveCurrentGlobalStyles(
+				globalStylesObject
 			);
 		}
 	};
@@ -499,6 +499,35 @@ export const __experimentalGetCurrentThemeGlobalStylesVariations =
 			variations
 		);
 	};
+
+export const __experimentalGetCurrentThemeGlobalStylesRevisions =
+	() =>
+	async ( { resolveSelect, dispatch } ) => {
+		const currentGlobalStyles =
+			await resolveSelect.__experimentalGetCurrentGlobalStyles();
+		const revisionsURL =
+			currentGlobalStyles?._links?.[ 'version-history' ]?.[ 0 ]?.href;
+		if ( revisionsURL ) {
+			const revisions = await apiFetch( {
+				url: revisionsURL,
+			} );
+			dispatch.__experimentalReceiveThemeGlobalStyleRevisions(
+				currentGlobalStyles?.id,
+				revisions
+			);
+		}
+	};
+
+__experimentalGetCurrentThemeGlobalStylesRevisions.shouldInvalidate = (
+	action
+) => {
+	return (
+		action.type === 'SAVE_ENTITY_RECORD_FINISH' &&
+		action.kind === 'root' &&
+		! action.error &&
+		action.name === 'globalStyles'
+	);
+};
 
 export const getBlockPatterns =
 	() =>

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -500,35 +500,6 @@ export const __experimentalGetCurrentThemeGlobalStylesVariations =
 		);
 	};
 
-export const __experimentalGetCurrentThemeGlobalStylesRevisions =
-	() =>
-	async ( { resolveSelect, dispatch } ) => {
-		const currentGlobalStyles =
-			await resolveSelect.__experimentalGetCurrentGlobalStyles();
-		const revisionsURL =
-			currentGlobalStyles?._links?.[ 'version-history' ]?.[ 0 ]?.href;
-		if ( revisionsURL ) {
-			const revisions = await apiFetch( {
-				url: revisionsURL,
-			} );
-			dispatch.__experimentalReceiveThemeGlobalStyleRevisions(
-				currentGlobalStyles?.id,
-				revisions
-			);
-		}
-	};
-
-__experimentalGetCurrentThemeGlobalStylesRevisions.shouldInvalidate = (
-	action
-) => {
-	return (
-		action.type === 'SAVE_ENTITY_RECORD_FINISH' &&
-		action.kind === 'root' &&
-		! action.error &&
-		action.name === 'globalStyles'
-	);
-};
-
 export const getBlockPatterns =
 	() =>
 	async ( { dispatch } ) => {

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -38,7 +38,6 @@ export interface State {
 	entities: EntitiesState;
 	themeBaseGlobalStyles: Record< string, Object >;
 	themeGlobalStyleVariations: Record< string, string >;
-	themeGlobalStyleRevisions: Record< number, Object >;
 	undo: UndoState;
 	userPermissions: Record< string, boolean >;
 	users: UserState;
@@ -1222,23 +1221,6 @@ export function __experimentalGetCurrentThemeGlobalStylesVariations(
 		return null;
 	}
 	return state.themeGlobalStyleVariations[ currentTheme.stylesheet ];
-}
-
-/**
- * Returns the revisions of the current global styles theme.
- *
- * @param state Data state.
- *
- * @return The current global styles.
- */
-export function __experimentalGetCurrentThemeGlobalStylesRevisions(
-	state: State
-): GlobalStyles | null {
-	const currentGlobalStyles = __experimentalGetCurrentGlobalStyles( state );
-	if ( ! currentGlobalStyles?.id ) {
-		return null;
-	}
-	return state.themeGlobalStyleRevisions[ currentGlobalStyles.id ];
 }
 
 /**

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -31,13 +31,14 @@ export interface State {
 	autosaves: Record< string | number, Array< unknown > >;
 	blockPatterns: Array< unknown >;
 	blockPatternCategories: Array< unknown >;
-	currentGlobalStylesId: string;
+	currentGlobalStyles: GlobalStyles;
 	currentTheme: string;
 	currentUser: ET.User< 'edit' >;
 	embedPreviews: Record< string, { html: string } >;
 	entities: EntitiesState;
 	themeBaseGlobalStyles: Record< string, Object >;
 	themeGlobalStyleVariations: Record< string, string >;
+	themeGlobalStyleRevisions: Record< number, Object >;
 	undo: UndoState;
 	userPermissions: Record< string, boolean >;
 	users: UserState;
@@ -82,6 +83,14 @@ interface UserState {
 }
 
 type Optional< T > = T | undefined;
+
+type GlobalStyles = {
+	title: { raw: string; rendered: string };
+	id: string;
+	settings: Record< string, Object >;
+	styles: Record< string, Object >;
+	_links: Record< string, Array< Object > >;
+};
 
 /**
  * HTTP Query parameters sent with the API request to fetch the entity records.
@@ -938,14 +947,16 @@ export function getCurrentTheme( state: State ): any {
 }
 
 /**
- * Return the ID of the current global styles object.
+ * Returns the current global styles object.
  *
  * @param state Data state.
  *
- * @return The current global styles ID.
+ * @return The current global styles object.
  */
-export function __experimentalGetCurrentGlobalStylesId( state: State ): string {
-	return state.currentGlobalStylesId;
+export function __experimentalGetCurrentGlobalStyles(
+	state: State
+): GlobalStyles {
+	return state.currentGlobalStyles;
 }
 
 /**
@@ -1197,7 +1208,7 @@ export function __experimentalGetCurrentThemeBaseGlobalStyles(
 }
 
 /**
- * Return the ID of the current global styles object.
+ * Returns the variations of the current global styles theme.
  *
  * @param state Data state.
  *
@@ -1211,6 +1222,23 @@ export function __experimentalGetCurrentThemeGlobalStylesVariations(
 		return null;
 	}
 	return state.themeGlobalStyleVariations[ currentTheme.stylesheet ];
+}
+
+/**
+ * Returns the revisions of the current global styles theme.
+ *
+ * @param state Data state.
+ *
+ * @return The current global styles.
+ */
+export function __experimentalGetCurrentThemeGlobalStylesRevisions(
+	state: State
+): GlobalStyles | null {
+	const currentGlobalStyles = __experimentalGetCurrentGlobalStyles( state );
+	if ( ! currentGlobalStyles?.id ) {
+		return null;
+	}
+	return state.themeGlobalStyleRevisions[ currentGlobalStyles.id ];
 }
 
 /**

--- a/packages/edit-site/src/components/global-styles/context-menu.js
+++ b/packages/edit-site/src/components/global-styles/context-menu.js
@@ -57,12 +57,12 @@ function ContextMenu( { name, parentMenu = '' } ) {
 	const hasVariationsPanel = useHasVariationsPanel( name, parentMenu );
 
 	const { canEditCSS } = useSelect( ( select ) => {
-		const { getEntityRecord, __experimentalGetCurrentGlobalStylesId } =
+		const { getEntityRecord, __experimentalGetCurrentGlobalStyles } =
 			select( coreStore );
 
-		const globalStylesId = __experimentalGetCurrentGlobalStylesId();
-		const globalStyles = globalStylesId
-			? getEntityRecord( 'root', 'globalStyles', globalStylesId )
+		const currentGlobalStyles = __experimentalGetCurrentGlobalStyles();
+		const globalStyles = currentGlobalStyles?.id
+			? getEntityRecord( 'root', 'globalStyles', currentGlobalStyles?.id )
 			: undefined;
 
 		return {

--- a/packages/edit-site/src/components/global-styles/global-styles-provider.js
+++ b/packages/edit-site/src/components/global-styles/global-styles-provider.js
@@ -53,33 +53,30 @@ function useGlobalStylesUserConfig() {
 		( select ) => {
 			const { getEditedEntityRecord, hasFinishedResolution } =
 				select( coreStore );
-			const _globalStylesId =
-				select( coreStore ).__experimentalGetCurrentGlobalStylesId();
-			const record = _globalStylesId
+			const _globalStyles =
+				select( coreStore ).__experimentalGetCurrentGlobalStyles();
+			const record = _globalStyles?.id
 				? getEditedEntityRecord(
 						'root',
 						'globalStyles',
-						_globalStylesId
+						_globalStyles.id
 				  )
 				: undefined;
-
 			let hasResolved = false;
 			if (
-				hasFinishedResolution(
-					'__experimentalGetCurrentGlobalStylesId'
-				)
+				hasFinishedResolution( '__experimentalGetCurrentGlobalStyles' )
 			) {
-				hasResolved = _globalStylesId
+				hasResolved = _globalStyles?.id
 					? hasFinishedResolution( 'getEditedEntityRecord', [
 							'root',
 							'globalStyles',
-							_globalStylesId,
+							_globalStyles?.id,
 					  ] )
 					: true;
 			}
 
 			return {
-				globalStylesId: _globalStylesId,
+				globalStylesId: _globalStyles?.id,
 				isReady: hasResolved,
 				settings: record?.settings,
 				styles: record?.styles,

--- a/packages/edit-site/src/components/global-styles/screen-root.js
+++ b/packages/edit-site/src/components/global-styles/screen-root.js
@@ -34,13 +34,13 @@ function ScreenRoot() {
 	const { variations, canEditCSS } = useSelect( ( select ) => {
 		const {
 			getEntityRecord,
-			__experimentalGetCurrentGlobalStylesId,
+			__experimentalGetCurrentGlobalStyles,
 			__experimentalGetCurrentThemeGlobalStylesVariations,
 		} = select( coreStore );
 
-		const globalStylesId = __experimentalGetCurrentGlobalStylesId();
-		const globalStyles = globalStylesId
-			? getEntityRecord( 'root', 'globalStyles', globalStylesId )
+		const currentGlobalStyles = __experimentalGetCurrentGlobalStyles();
+		const globalStyles = currentGlobalStyles?.id
+			? getEntityRecord( 'root', 'globalStyles', currentGlobalStyles?.id )
 			: undefined;
 
 		return {

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -50,12 +50,12 @@ const { Slot: GlobalStylesMenuSlot, Fill: GlobalStylesMenuFill } =
 function GlobalStylesActionMenu() {
 	const { toggle } = useDispatch( preferencesStore );
 	const { canEditCSS } = useSelect( ( select ) => {
-		const { getEntityRecord, __experimentalGetCurrentGlobalStylesId } =
+		const { getEntityRecord, __experimentalGetCurrentGlobalStyles } =
 			select( coreStore );
 
-		const globalStylesId = __experimentalGetCurrentGlobalStylesId();
-		const globalStyles = globalStylesId
-			? getEntityRecord( 'root', 'globalStyles', globalStylesId )
+		const currentGlobalStyles = __experimentalGetCurrentGlobalStyles();
+		const globalStyles = currentGlobalStyles?.id
+			? getEntityRecord( 'root', 'globalStyles', currentGlobalStyles?.id )
 			: undefined;
 
 		return {


### PR DESCRIPTION
Related to:

- https://github.com/WordPress/gutenberg/issues/49601

## What?

This change updates `__experimentalGetCurrentGlobalStylesId` and associated store methods to return the entire global style object instead of just the ID so we can access further global styles properties.

👋 **Question**: I though it was okay to change this method because it was experimental. Do folks see any backwards compatibility issues?

Also, would it be better to migrate the new function to the private/unlock system?

## Why?

The intention is to add properties to the global styles response object, for example, an entry in `_links` that contains a revisions URL.

See:

- https://github.com/WordPress/gutenberg/pull/49974

## How?
Tweaking the methods so that they handle the entire global styles custom post response rather than just the ID.

The `__experimentalGetCurrentGlobalStylesId` resolver was fetching all the data from the endpoint and only returning the id.


## Testing Instructions


Using this branch, fire up the site editor and run the following command in your console:

```
wp.data.select('core').__experimentalGetCurrentGlobalStyles()
```

Ensure that the object for the current theme's global styles custom post is returned:

<img width="761" alt="Screenshot 2023-04-21 at 2 43 44 pm" src="https://user-images.githubusercontent.com/6458278/233542744-a0948983-6b7e-4cd0-be61-8e28e4b94531.png">

Furthermore:

- the global styles sidebar and menus should work as expected


