### PR TITLE
CheckboxControl: Add support custom IDs

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -18,6 +18,10 @@
 -   `SlotFill`: Added util for creating private SlotFills and supporting Symbol keys ([#49819](https://github.com/WordPress/gutenberg/pull/49819)).
 -   `IconType`: Export for external use ([#49649](https://github.com/WordPress/gutenberg/pull/49649)).
 
+### Bug Fix
+
+-   `CheckboxControl`: Add support custom IDs ([#49977](https://github.com/WordPress/gutenberg/pull/49977)).
+
 ### Documentation
 
 -   `Autocomplete`: Add heading and fix type for `onReplace` in README. ([#49798](https://github.com/WordPress/gutenberg/pull/49798)).

--- a/packages/components/src/checkbox-control/index.tsx
+++ b/packages/components/src/checkbox-control/index.tsx
@@ -50,6 +50,7 @@ export function CheckboxControl(
 		checked,
 		indeterminate,
 		help,
+		id: idProp,
 		onChange,
 		...additionalProps
 	} = props;
@@ -81,8 +82,11 @@ export function CheckboxControl(
 		},
 		[ checked, indeterminate ]
 	);
-	const instanceId = useInstanceId( CheckboxControl );
-	const id = `inspector-checkbox-control-${ instanceId }`;
+	const id = useInstanceId(
+		CheckboxControl,
+		'inspector-checkbox-control',
+		idProp
+	);
 	const onChangeValue = ( event: ChangeEvent< HTMLInputElement > ) =>
 		onChange( event.target.checked );
 


### PR DESCRIPTION
## What?
Fixes #49852.

PR adds support for custom ID to the `CheckboxControl`.

## Why?
This matches the behavior of similar `InputControl` and `SelectControl` components.

## How?
The `useInstanceId` accepts the third parameter for the preferred ID.


## Testing Instructions
This example plugin render checkbox inside the post document settings. It can be run via console.

```js
const { createElement: el, useState } = wp.element;
const { useSelect } = wp.data;
const { CheckboxControl } = wp.components;
const registerPlugin = wp.plugins.registerPlugin;
const PluginDocumentSettingPanel = wp.editPost.PluginDocumentSettingPanel;

function MyDocumentSettingPlugin() {
    const [ isChecked, setChecked ] = useState( false );

	return el(
		PluginDocumentSettingPanel,
		{
			className: 'test-checkbox',
			title: 'Test Checkbox',
		},
		el( CheckboxControl, {
            id: 'test-foo', 
            checked: isChecked,
            label: 'Click me',
            onChange: (value) => setChecked(value),
        } )
	);
}

registerPlugin( 'test-checkbox', {
	render: MyDocumentSettingPlugin,
} );
```

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-04-21 at 09 16 43](https://user-images.githubusercontent.com/240569/233547565-03e45b3b-6309-4f6b-9804-8cc2be82e817.png)
