### PR TITLE
Edit Post: Hide overflowing content in visual editor wrapper to prevent block popovers from creating scrollbars

### DIFF
--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -2,6 +2,7 @@
 	position: relative;
 	display: flex;
 	flex-flow: column;
+	overflow: hidden;
 
 	// Gray preview overlay (desktop/tablet/mobile) is intentionally not set on an element with scrolling content like
 	// interface-interface-skeleton__content. This causes graphical glitches (flashes of the background color)


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add `overflow: hidden` to the `.edit-post-visual-editor` class, so that block popovers don't cause additional scrollbars in the editor canvas.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Block popovers are rendered into a popover slot that has the `edit-post-visual-editor` wrapper as its parent, with `position: relative` set on it. The current behaviour with `BlockPopover` and floating UI is that popovers are rendered using absolute positioning, so when a block popover goes past the bottom of the screen, it results in the `edit-post-visual-editor` wrapper overflowing. While we could also look into updating the popover behaviour here, I thought a good step would be to prevent these overflowing popovers from causing a scrollbar to be displayed. (The real post content is scrolled via the `.interface-interface-skeleton__content` wrapper, so I _think_ this should hopefully be a safe change).

This issue currently only appears in the post editor, as the site editor already has a corresponding `overflow: hidden` rule [on this line](https://github.com/WordPress/gutenberg/blob/d27cb3233b1b156d09442ccdf6da8e9fa157940e/packages/edit-site/src/components/block-editor/style.scss#L19), added back in https://github.com/WordPress/gutenberg/issues/44770. To test and reproduce the issue, if you're on a Mac, you'll likely want to set scrollbars in the OS to display Always for the issue to be visible.

The kinds of popovers that result in the additional scrollbar include the block toolbar once it's scrolled past the bottom of the screen, but also Padding and Margin visualisers in the Group block, for example. I noticed this issue while working on a visualiser for position support over in https://github.com/WordPress/gutenberg/pull/49321.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add `overflow: hidden` to the `edit-post-visual-editor` class.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Before testing, make sure your OS is set to always display scrollbars. On a Mac, go to System Preferences > General and set it to Always. Here's a screenshot:

<img src="https://user-images.githubusercontent.com/14988353/233546153-b020da15-d805-46da-90c2-8c6fc034f4d8.png" width="500" />

1. On `trunk` with a long post in the post editor, select a block somewhere around the middle of the page and scroll up and down the editor canvas. Notice that a second scrollbar appears once the block toolbar goes past the bottom of the screen.
2. With a Group block that's large enough for the padding or margin to go off the vertical edges of the screen (e.g. add a whole bunch of paragraphs inside it), go to adjust the padding or margins and notice that the visualiser results in an extra scrollbar.
3. Checkout this PR, and repeat the above steps — there shouldn't be an additional scrollbar, and scrolling the document should still work as before.
4. Check that the template editing mode within the post editor still works as expected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before

https://user-images.githubusercontent.com/14988353/233546738-642a93ae-7402-43e3-8a15-105af6725d39.mp4

### After

https://user-images.githubusercontent.com/14988353/233546805-b764296c-6a3c-43b4-88e2-68d3779c86f2.mp4