### PR TITLE
useInstanceId: Fix useMemo hook dependencies

### DIFF
--- a/packages/compose/src/hooks/use-instance-id/index.ts
+++ b/packages/compose/src/hooks/use-instance-id/index.ts
@@ -55,7 +55,7 @@ function useInstanceId(
 		const id = createId( object );
 
 		return prefix ? `${ prefix }-${ id }` : id;
-	}, [ object ] );
+	}, [ object, preferredId, prefix ] );
 }
 
 export default useInstanceId;


### PR DESCRIPTION
## What?
PR fixes `useMemo` dependencies for the `useInstanceId` hook.

## Why?
To avoid returning the stale values when `preferredId` or `prefix` change during render.

## Testing Instructions
An example plugin for testing.
```js
const { createElement: el, useState } = wp.element;
const { useSelect } = wp.data;
const { CheckboxControl } = wp.components;
const { useInstanceId } = wp.compose;
const registerPlugin = wp.plugins.registerPlugin;
const PluginDocumentSettingPanel = wp.editPost.PluginDocumentSettingPanel;

function MyDocumentSettingPlugin() {
    const [ isChecked, setChecked ] = useState( false );
	const id = useInstanceId( MyDocumentSettingPlugin, 'instance-prefix', isChecked ? 'custom-id' : undefined )

	return el(
		PluginDocumentSettingPanel,
		{
			className: 'test-checkbox',
			title: 'Test Checkbox',
		},
		el( CheckboxControl, {
            // id: 'test-foo', 
            checked: isChecked,
            label: 'Use custom Id',
            onChange: (value) => setChecked(value),
        } ),
		el( 'p', {}, id )
	);
}

registerPlugin( 'test-checkbox', {
	render: MyDocumentSettingPlugin,
} );
```

## Screenshots or screencast <!-- if applicable -->

**Before**

https://user-images.githubusercontent.com/240569/233553279-02713509-52dd-4b6c-89c2-3c838fbfe865.mp4


**After**

https://user-images.githubusercontent.com/240569/233553301-24afe387-abd4-45be-a9e8-8fd813648957.mp4

