### PR TITLE
#39457: Image block keep image size on replacing image

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -191,8 +191,6 @@ export function ImageEdit( {
 		// Reset the dimension attributes if changing to a different image.
 		if ( ! media.id || media.id !== id ) {
 			additionalAttributes = {
-				// Fallback to size "full" if there's no default image size.
-				// It means the image is smaller, and the block will use a full-size URL.
 				sizeSlug: newSize,
 			};
 		} else {

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -77,18 +77,18 @@ const isTemporaryImage = ( id, url ) => ! id && isBlobURL( url );
 export const isExternalImage = ( id, url ) => url && ! id && ! isBlobURL( url );
 
 /**
- * Checks if WP generated default image size. Size generation is skipped
+ * Checks if WP generated the specified image size. Size generation is skipped
  * when the image is smaller than the said size.
  *
  * @param {Object} image
- * @param {string} defaultSize
+ * @param {string} size
  *
  * @return {boolean} Whether or not it has default image size.
  */
-function hasDefaultSize( image, defaultSize ) {
+function hasSize( image, size ) {
 	return (
-		'url' in ( image?.sizes?.[ defaultSize ] ?? {} ) ||
-		'source_url' in ( image?.media_details?.sizes?.[ defaultSize ] ?? {} )
+		'url' in ( image?.sizes?.[ size ] ?? {} ) ||
+		'source_url' in ( image?.media_details?.sizes?.[ size ] ?? {} )
 	);
 }
 
@@ -168,7 +168,16 @@ export function ImageEdit( {
 
 		setTemporaryURL();
 
-		let mediaAttributes = pickRelevantMediaFiles( media, imageDefaultSize );
+		// Try to use the previous selected image size if its available
+		// otherwise try the default image size or fallback to "full"
+		let newSize = 'full';
+		if ( sizeSlug && hasSize( media, sizeSlug ) ) {
+			newSize = sizeSlug;
+		} else if ( hasSize( media, imageDefaultSize ) ) {
+			newSize = imageDefaultSize;
+		}
+
+		let mediaAttributes = pickRelevantMediaFiles( media, newSize );
 
 		// If a caption text was meanwhile written by the user,
 		// make sure the text is not overwritten by empty captions.
@@ -184,9 +193,7 @@ export function ImageEdit( {
 			additionalAttributes = {
 				// Fallback to size "full" if there's no default image size.
 				// It means the image is smaller, and the block will use a full-size URL.
-				sizeSlug: hasDefaultSize( media, imageDefaultSize )
-					? imageDefaultSize
-					: 'full',
+				sizeSlug: newSize,
 			};
 		} else {
 			// Keep the same url when selecting the same file, so "Resolution"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR fixes #39457 to keep the selected size in an image block when replacing/changing the image.
This is a follow up PR to #44522 where I couldn't get the PR correctly to rebase on trunk. 

## Why?
Useful for patterns where a certain image size is required for it to look good. A pattern can declare the sizeSlug attribute and it will try to insert the new image in the size again.

## How?
Previously on selecting a new image there was a check if the new image is available in the default image size, if yes it used that and if not it falled back to "full". Now it checks for a previously selected sizeSlug attribute and checks if the image is available in that size, if not it does the same checks as before (default size, full). So the order is:
1. previously selected image size (from block attribute)
2. default image size
3. "full" image size


## Testing Instructions
### Test with images that have the selected size
1. Insert an image block in the editor (eg with an image from Openverse:
```
<!-- wp:image {"id":12} -->
<figure class="wp-block-image"><img src="http://localhost:8888/wp-content/uploads/2023/04/image-2.jpeg" alt="" class="wp-image-12"/><figcaption class="wp-element-caption">"<a href="https://www.flickr.com/photos/61021753@N02/8597955458" target="_blank" rel="noreferrer noopener">n319_w1150</a>" by <a href="https://www.flickr.com/photos/61021753@N02" target="_blank" rel="noreferrer noopener">BioDivLibrary</a>/ <a href="https://creativecommons.org/publicdomain/mark/1.0//?ref=openverse" target="_blank" rel="noreferrer noopener">pdm 1.0</a></figcaption></figure>
<!-- /wp:image -->
```
2. Set the images size to "Medium".
```
<!-- wp:image {"id":12,"sizeSlug":"medium"} -->
<figure class="wp-block-image size-medium"><img src="http://localhost:8888/wp-content/uploads/2023/04/image-2-201x300.jpeg" alt="" class="wp-image-12"/><figcaption class="wp-element-caption">"<a href="https://www.flickr.com/photos/61021753@N02/8597955458" target="_blank" rel="noreferrer noopener">n319_w1150</a>" by <a href="https://www.flickr.com/photos/61021753@N02" target="_blank" rel="noreferrer noopener">BioDivLibrary</a>/ <a href="https://creativecommons.org/publicdomain/mark/1.0//?ref=openverse" target="_blank" rel="noreferrer noopener">pdm 1.0</a></figcaption></figure>
<!-- /wp:image -->
```
3. Replace the blocks image with any other local/uploaded image with a similar size
4. The image block should have kept the size set to "Medium" and should be output with medium size.

### Test with images that don't have the selected size (eg are smaller):
1. Insert an image block in the editor (eg with an image from Openverse:
```
<!-- wp:image {"id":12} -->
<figure class="wp-block-image"><img src="http://localhost:8888/wp-content/uploads/2023/04/image-2.jpeg" alt="" class="wp-image-12"/><figcaption class="wp-element-caption">"<a href="https://www.flickr.com/photos/61021753@N02/8597955458" target="_blank" rel="noreferrer noopener">n319_w1150</a>" by <a href="https://www.flickr.com/photos/61021753@N02" target="_blank" rel="noreferrer noopener">BioDivLibrary</a>/ <a href="https://creativecommons.org/publicdomain/mark/1.0//?ref=openverse" target="_blank" rel="noreferrer noopener">pdm 1.0</a></figcaption></figure>
<!-- /wp:image -->
```
2. Set the images size to "Medium".
```
<!-- wp:image {"id":12,"sizeSlug":"medium"} -->
<figure class="wp-block-image size-medium"><img src="http://localhost:8888/wp-content/uploads/2023/04/image-2-201x300.jpeg" alt="" class="wp-image-12"/><figcaption class="wp-element-caption">"<a href="https://www.flickr.com/photos/61021753@N02/8597955458" target="_blank" rel="noreferrer noopener">n319_w1150</a>" by <a href="https://www.flickr.com/photos/61021753@N02" target="_blank" rel="noreferrer noopener">BioDivLibrary</a>/ <a href="https://creativecommons.org/publicdomain/mark/1.0//?ref=openverse" target="_blank" rel="noreferrer noopener">pdm 1.0</a></figcaption></figure>
<!-- /wp:image -->
```
3. Replace the blocks image with any other local/uploaded image with a **smaller** size
4. The image block should now have it's size set to the default image size or full.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
