### PR TITLE
Post Template: fix broken title editing

### DIFF
--- a/packages/edit-post/src/components/header/template-title/delete-template.js
+++ b/packages/edit-post/src/components/header/template-title/delete-template.js
@@ -59,7 +59,6 @@ export default function DeleteTemplate() {
 			)
 		);
 		updateEditorSettings( {
-			...settings,
 			availableTemplates: newAvailableTemplates,
 		} );
 		deleteEntityRecord( 'postType', 'wp_template', template.id, {

--- a/packages/edit-post/src/components/header/template-title/edit-template-title.js
+++ b/packages/edit-post/src/components/header/template-title/edit-template-title.js
@@ -58,12 +58,10 @@ export default function EditTemplateTitle() {
 					const settings = getEditorSettings();
 					const newAvailableTemplates = Object.fromEntries(
 						Object.entries( settings.availableTemplates ?? {} ).map(
-							( [ id, existingTitle ] ) => {
-								if ( id !== template.slug ) {
-									return existingTitle;
-								}
-								return newTitle;
-							}
+							( [ id, existingTitle ] ) => [
+								id,
+								id !== template.slug ? existingTitle : newTitle,
+							]
 						)
 					);
 					updateEditorSettings( {

--- a/packages/edit-post/src/components/header/template-title/edit-template-title.js
+++ b/packages/edit-post/src/components/header/template-title/edit-template-title.js
@@ -67,7 +67,6 @@ export default function EditTemplateTitle() {
 						)
 					);
 					updateEditorSettings( {
-						...settings,
 						availableTemplates: newAvailableTemplates,
 					} );
 					editEntityRecord( 'postType', 'wp_template', template.id, {


### PR DESCRIPTION
Fixes a bug introduced by Lodash removal in #48786: editing a post template title is not possible because there is an `Object.fromEntries` call on something that doesn't contain entries. Because of wrong return value of a `.map` callback.

<img width="702" alt="Screenshot 2023-04-21 at 10 33 51" src="https://user-images.githubusercontent.com/664258/233588742-e19c3a64-7b2d-42e5-8cf4-0c050954c9d5.png">

I found this accidentally when reviewing usages of `updateEditorSettings` and removing a redundant `...settings` spread.

This is a bug that's been shipped as part of the Gutenberg plugin, deployed on WordPress.com, which is currently broken. Cc @fullofcaffeine. The bugfix should be backported to 15.6.2, adding a "backport to minor" label.

**How to test:**
Try to edit a template and change its title, or delete it altogether. Both actions should work, and update editor settings. Can be verified in console by looking at:
```js
wp.data.select('core/editor').getEditorSettings().availableTemplates
```
