### PR TITLE
Fix fixed block toolbar positioning

### DIFF
--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -89,6 +89,9 @@
  * Block Toolbar when contextual.
  */
 
+// base left position for the toolbar when fixed
+@include editor-left(".block-editor-block-contextual-toolbar.is-fixed");
+
 .block-editor-block-contextual-toolbar {
 	// Block UI appearance.
 	display: inline-flex;
@@ -104,7 +107,6 @@
 	&.is-fixed {
 		position: sticky;
 		top: 0;
-		left: 0;
 		z-index: z-index(".block-editor-block-popover");
 		display: block;
 		width: 100%;
@@ -121,14 +123,15 @@
 
 	// on desktop and tablet viewports the toolbar is fixed
 	// on top of interface header
+
 	@include break-medium() {
 		&.is-fixed {
 
+			// leave room for block inserter
+			margin-left: $grid-unit-80;
 			// position on top of interface header
 			position: fixed;
-			top: $grid-unit-50 - 2;
-			// leave room for block inserter
-			left: $grid-unit-80 + $grid-unit-40;
+			top: $admin-bar-height + $grid-unit;
 			// Don't fill up when empty
 			min-height: initial;
 			// remove the border
@@ -137,15 +140,17 @@
 			display: flex;
 
 			&.is-collapsed {
-				left: $grid-unit-10 * 32;
+				width: initial;
+				margin-left: $grid-unit-80 * 3 + $grid-unit-30;
 			}
 
 			.is-fullscreen-mode & {
-				top: $grid-unit - 2;
 				// leave room for block inserter
-				left: $grid-unit-80 + $grid-unit-70;
+				margin-left: $grid-unit-80 + $grid-unit-70;
+				top: $grid-unit;
 				&.is-collapsed {
-					left: $grid-unit-10 * 35;
+					width: initial;
+					margin-left: $grid-unit-80 * 4 + $grid-unit-30;
 				}
 			}
 
@@ -183,15 +188,20 @@
 			}
 
 			.show-icon-labels & {
-				left: $grid-unit-80 + $grid-unit-50;
+
+				margin-left: $grid-unit-80;
 
 				&.is-collapsed {
-					left: $grid-unit-10 * 56;
+					margin-left: $grid-unit-80 * 6;
 				}
 
 				.is-fullscreen-mode & {
-					left: $grid-unit-80 + $grid-unit-80;
+					margin-left: $grid-unit-80 + $grid-unit-80;
+					&.is-collapsed {
+						margin-left: $grid-unit-80 * 7;
+					}
 				}
+
 
 				.block-editor-block-parent-selector .block-editor-block-parent-selector__button::after {
 					left: 0;
@@ -250,35 +260,7 @@
 	// except for the inserter on the left
 	@include break-medium() {
 		&.is-fixed {
-
-			left: 28 * $grid-unit;
-			width: calc(100% - #{28 * $grid-unit});
-
-			&.is-collapsed {
-				// when collapsed minimize area
-				width: initial;
-				left: $grid-unit * 48;
-			}
-
-			// collapsed wp admin sidebar when not in full screen mode
-			.auto-fold & {
-				left: $grid-unit-80 + $grid-unit-40;
-				width: calc(100% - #{$grid-unit-80 + $grid-unit-40});
-
-				&.is-collapsed {
-					left: $grid-unit * 32;
-				}
-			}
-
-			.is-fullscreen-mode & {
-				width: calc(100% - #{$grid-unit-80 + $grid-unit-70});
-				left: $grid-unit-80 + $grid-unit-70;
-				&.is-collapsed {
-					left: $grid-unit * 36;
-					// when collapsed minimize area
-					width: initial;
-				}
-			}
+			width: 100%;
 		}
 	}
 
@@ -287,54 +269,7 @@
 	// for the block inserter the publish button
 	@include break-large() {
 		&.is-fixed {
-
-			.auto-fold & {
-				// Don't fill the whole header, minimize area
-				width: initial;
-
-				// leave room for block inserter and the dashboard navigation
-				left: $grid-unit-80 + $grid-unit-40 + ( $grid-unit-80 * 2 );
-
-				&.is-collapsed {
-					// when collapsed minimize area
-					width: initial;
-					left: $grid-unit * 48;
-				}
-
-			}
-
-			// collapsed wp admin sidebar when not in full screen mode
-			.auto-fold.folded & {
-				width: initial;
-				left: $grid-unit-80 + $grid-unit-40;
-
-				&.is-collapsed {
-					// when collapsed minimize area
-					width: initial;
-					left: $grid-unit * 32;
-				}
-
-			}
-
-			.auto-fold.is-fullscreen-mode & {
-				// Don't fill the whole header, minimize area
-				width: initial;
-				left: $grid-unit-80 + $grid-unit-70;
-
-				&.is-collapsed {
-					// when collapsed minimize area
-					width: initial;
-					left: $grid-unit * 36;
-				}
-			}
-
-			.auto-fold.is-fullscreen-mode .show-icon-labels & {
-				left: $grid-unit-80 * 2;
-				&.is-collapsed {
-					left: $grid-unit * 48;
-				}
-			}
-
+			width: initial;
 		}
 	}
 

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -89,7 +89,7 @@
  * Block Toolbar when contextual.
  */
 
-// base left position for the toolbar when fixed
+// Base left position for the toolbar when fixed.
 @include editor-left(".block-editor-block-contextual-toolbar.is-fixed");
 
 .block-editor-block-contextual-toolbar {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #49988

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Using the chimeric `.auto-fold` class to target states of the WP admin was wrong since starting at large viewports does not contain this class, hence breaking expectations.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Using the `editor-left` mixin to calculate the left position which takes into account all states of WP admin (full screen, not full screen, expanded sidebar etc).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Using the top toolbar preference ON
2. Check that the expanded and collapsed block toolbar
3. Is positioned correctly when the editor is full screen, not full screen with admin sidebar expanded, not full screen with admin sidebar collapsed
4. Check that on tablet sizes the publish tools are hidden by the expanded block toolbar
5. Check that on phone sizes the block toolbar is below the header of the editor.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A
## Screenshots or screencast <!-- if applicable -->
