### PR TITLE
[Site Logo]: Add logo replace flow in Inspector controls

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/README.md
+++ b/packages/block-editor/src/components/media-replace-flow/README.md
@@ -65,10 +65,11 @@ Callback called when an upload error happens and receives an error message as an
 
 ### name
 
-The label of the replace button.
+A `string` value will be used as the label of the replace button. It can also accept `Phrasing content` elements(ex. `span`).
 
--   Type: `string`
+-   Type: `string|Element`
 -   Required: No
+-   Default: `Replace`
 
 ### createNotice
 

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -59,6 +59,9 @@ const MediaReplaceFlow = ( {
 	multiple = false,
 	addToGallery,
 	handleUpload = true,
+	popoverProps = {
+		variant: 'toolbar',
+	},
 } ) => {
 	const mediaUpload = useSelect( ( select ) => {
 		return select( blockEditorStore ).getSettings().mediaUpload;
@@ -136,13 +139,9 @@ const MediaReplaceFlow = ( {
 
 	const gallery = multiple && onlyAllowsImages();
 
-	const POPOVER_PROPS = {
-		variant: 'toolbar',
-	};
-
 	return (
 		<Dropdown
-			popoverProps={ POPOVER_PROPS }
+			popoverProps={ popoverProps }
 			contentClassName="block-editor-media-replace-flow__options"
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<ToolbarButton

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -379,10 +379,10 @@ const InspectorLogoPreview = ( { mediaItemData = {}, itemGroupProps } ) => {
 	} = mediaItemData;
 	const logoLabel = logoMediaDetails?.sizes?.full?.file || logoSlug;
 	return (
-		<ItemGroup { ...itemGroupProps }>
-			<HStack justify="flex-start">
+		<ItemGroup { ...itemGroupProps } as="span">
+			<HStack justify="flex-start" as="span">
 				<img src={ logoUrl } alt={ alt } />
-				<FlexItem>
+				<FlexItem as="span">
 					<Truncate
 						numberOfLines={ 1 }
 						className="block-library-site-logo__inspector-media-replace-title"

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -602,8 +602,7 @@ export default function LogoEdit( {
 								render={ ( { open } ) => (
 									<div className="block-library-site-logo__inspector-upload-container">
 										<Button onClick={ open }>
-											{ isLoading && <Spinner /> }
-											{ ! isLoading && label }
+											{ isLoading ? <Spinner /> : label }
 										</Button>
 										<DropZone onFilesDrop={ onFilesDrop } />
 									</div>

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -626,7 +626,7 @@ export default function LogoEdit( {
 											{ isLoading ? (
 												<Spinner />
 											) : (
-												__( 'Add Media' )
+												__( 'Add media' )
 											) }
 										</Button>
 										<DropZone onFilesDrop={ onFilesDrop } />

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -26,6 +26,7 @@ import {
 	Button,
 	DropZone,
 	FlexItem,
+	__experimentalItemGroup as ItemGroup,
 	__experimentalHStack as HStack,
 	__experimentalTruncate as Truncate,
 } from '@wordpress/components';
@@ -444,7 +445,8 @@ export default function LogoEdit( {
 	const {
 		alt_text: alt,
 		source_url: logoUrl,
-		title: logoTitle,
+		slug: logoSlug,
+		media_details: logoMediaDetails,
 	} = mediaItemData ?? {};
 
 	const onInitialSelectLogo = ( media ) => {
@@ -501,19 +503,24 @@ export default function LogoEdit( {
 		} );
 	};
 
-	const InspectorLogoPreview = () => (
-		<HStack justify="flex-start">
-			<img src={ logoUrl } alt={ alt } />
-			<FlexItem>
-				<Truncate
-					numberOfLines={ 1 }
-					className="block-library-site-logo__inspector-media-replace-title"
-				>
-					{ logoTitle.rendered }
-				</Truncate>
-			</FlexItem>
-		</HStack>
-	);
+	const InspectorLogoPreview = ( { itemGroupProps } ) => {
+		const logoLabel = logoMediaDetails?.sizes?.full?.file || logoSlug;
+		return (
+			<ItemGroup { ...itemGroupProps }>
+				<HStack justify="flex-start">
+					<img src={ logoUrl } alt={ alt } />
+					<FlexItem>
+						<Truncate
+							numberOfLines={ 1 }
+							className="block-library-site-logo__inspector-media-replace-title"
+						>
+							{ logoLabel }
+						</Truncate>
+					</FlexItem>
+				</HStack>
+			</ItemGroup>
+		);
+	};
 
 	const mediaReplaceFlowProps = {
 		mediaURL: logoUrl,
@@ -586,23 +593,36 @@ export default function LogoEdit( {
 		<InspectorControls>
 			<PanelBody title={ __( 'Media' ) }>
 				<div className="block-library-site-logo__inspector-media-replace-container">
-					{ ! canUserEdit && !! logoUrl && <InspectorLogoPreview /> }
+					{ ! canUserEdit && !! logoUrl && (
+						<InspectorLogoPreview
+							itemGroupProps={ {
+								isBordered: true,
+								size: 'large',
+								className:
+									'block-library-site-logo__inspector-readonly-logo-preview',
+							} }
+						/>
+					) }
 					{ canUserEdit && !! logoUrl && (
 						<SiteLogoReplaceFlow
 							{ ...mediaReplaceFlowProps }
 							name={ <InspectorLogoPreview /> }
+							popoverProps={ {} }
 						/>
 					) }
 					{ canUserEdit && ! logoUrl && (
 						<MediaUploadCheck>
 							<MediaUpload
-								title={ label }
 								onSelect={ onInitialSelectLogo }
 								allowedTypes={ ALLOWED_MEDIA_TYPES }
 								render={ ( { open } ) => (
 									<div className="block-library-site-logo__inspector-upload-container">
 										<Button onClick={ open }>
-											{ isLoading ? <Spinner /> : label }
+											{ isLoading ? (
+												<Spinner />
+											) : (
+												__( 'Add Media' )
+											) }
 										</Button>
 										<DropZone onFilesDrop={ onFilesDrop } />
 									</div>

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -622,7 +622,10 @@ export default function LogoEdit( {
 								allowedTypes={ ALLOWED_MEDIA_TYPES }
 								render={ ( { open } ) => (
 									<div className="block-library-site-logo__inspector-upload-container">
-										<Button onClick={ open }>
+										<Button
+											onClick={ open }
+											variant="secondary"
+										>
 											{ isLoading ? (
 												<Spinner />
 											) : (

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -370,6 +370,31 @@ function SiteLogoReplaceFlow( { onRemoveLogo, ...mediaReplaceProps } ) {
 	);
 }
 
+const InspectorLogoPreview = ( { mediaItemData = {}, itemGroupProps } ) => {
+	const {
+		alt_text: alt,
+		source_url: logoUrl,
+		slug: logoSlug,
+		media_details: logoMediaDetails,
+	} = mediaItemData;
+	const logoLabel = logoMediaDetails?.sizes?.full?.file || logoSlug;
+	return (
+		<ItemGroup { ...itemGroupProps }>
+			<HStack justify="flex-start">
+				<img src={ logoUrl } alt={ alt } />
+				<FlexItem>
+					<Truncate
+						numberOfLines={ 1 }
+						className="block-library-site-logo__inspector-media-replace-title"
+					>
+						{ logoLabel }
+					</Truncate>
+				</FlexItem>
+			</HStack>
+		</ItemGroup>
+	);
+};
+
 export default function LogoEdit( {
 	attributes,
 	className,
@@ -442,12 +467,7 @@ export default function LogoEdit( {
 			site_icon: newValue ?? null,
 		} );
 
-	const {
-		alt_text: alt,
-		source_url: logoUrl,
-		slug: logoSlug,
-		media_details: logoMediaDetails,
-	} = mediaItemData ?? {};
+	const { alt_text: alt, source_url: logoUrl } = mediaItemData ?? {};
 
 	const onInitialSelectLogo = ( media ) => {
 		// Initialize the syncSiteIcon toggle. If we currently have no Site logo and no
@@ -501,25 +521,6 @@ export default function LogoEdit( {
 			},
 			onError: onUploadError,
 		} );
-	};
-
-	const InspectorLogoPreview = ( { itemGroupProps } ) => {
-		const logoLabel = logoMediaDetails?.sizes?.full?.file || logoSlug;
-		return (
-			<ItemGroup { ...itemGroupProps }>
-				<HStack justify="flex-start">
-					<img src={ logoUrl } alt={ alt } />
-					<FlexItem>
-						<Truncate
-							numberOfLines={ 1 }
-							className="block-library-site-logo__inspector-media-replace-title"
-						>
-							{ logoLabel }
-						</Truncate>
-					</FlexItem>
-				</HStack>
-			</ItemGroup>
-		);
 	};
 
 	const mediaReplaceFlowProps = {
@@ -595,9 +596,9 @@ export default function LogoEdit( {
 				<div className="block-library-site-logo__inspector-media-replace-container">
 					{ ! canUserEdit && !! logoUrl && (
 						<InspectorLogoPreview
+							mediaItemData={ mediaItemData }
 							itemGroupProps={ {
 								isBordered: true,
-								size: 'large',
 								className:
 									'block-library-site-logo__inspector-readonly-logo-preview',
 							} }
@@ -606,7 +607,11 @@ export default function LogoEdit( {
 					{ canUserEdit && !! logoUrl && (
 						<SiteLogoReplaceFlow
 							{ ...mediaReplaceFlowProps }
-							name={ <InspectorLogoPreview /> }
+							name={
+								<InspectorLogoPreview
+									mediaItemData={ mediaItemData }
+								/>
+							}
 							popoverProps={ {} }
 						/>
 					) }

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -112,10 +112,12 @@
 		display: block;
 		height: $grid-unit-50;
 
-		&:focus,
 		&:hover {
 			color: var(--wp-admin-theme-color);
-			box-shadow: inset 0 0 0 1px var(--wp-admin-theme-color);
+		}
+
+		&:focus {
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
 	}
 

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -115,22 +115,7 @@
 		&:focus,
 		&:hover {
 			color: var(--wp-admin-theme-color);
-			box-shadow: inset 0 0 0 2px var(--wp-admin-theme-color);
-		}
-
-		&.is-active,
-		&.is-active:hover {
-			background-color: $gray-900;
-			box-shadow: none;
-		}
-
-		&.is-active .block-library-site-logo__inspector-media-replace-title,
-		&.is-active:hover .block-library-site-logo__inspector-media-replace-title {
-			color: $white;
-		}
-
-		&.is-active:focus {
-			box-shadow: inset 0 0 0 1px $white, 0 0 0 2px var(--wp-admin-theme-color);
+			box-shadow: inset 0 0 0 1px var(--wp-admin-theme-color);
 		}
 	}
 
@@ -159,5 +144,7 @@
 
 	.block-library-site-logo__inspector-readonly-logo-preview {
 		padding: 6px 12px;
+		display: flex;
+		height: $grid-unit-50;
 	}
 }

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -110,6 +110,7 @@
 		box-shadow: inset 0 0 0 1px $gray-400;
 		width: 100%;
 		display: block;
+		height: $grid-unit-50;
 
 		&:focus,
 		&:hover {
@@ -150,8 +151,13 @@
 	}
 
 	img {
-		width: $grid-unit-30;
-		border-radius: 50%;
+		width: $grid-unit-50 * 0.5;
 		aspect-ratio: 1;
+		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+		border-radius: 50% !important;
+	}
+
+	.block-library-site-logo__inspector-readonly-logo-preview {
+		padding: 6px 12px;
 	}
 }

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -93,3 +93,65 @@
 		}
 	}
 }
+
+.block-library-site-logo__inspector-upload-container {
+	position: relative;
+	// Since there is no option to skip rendering the drag'n'drop icon in drop
+	// zone, we hide it for now.
+	.components-drop-zone__content-icon {
+		display: none;
+	}
+}
+
+.block-library-site-logo__inspector-upload-container,
+.block-library-site-logo__inspector-media-replace-container {
+	button.components-button {
+		color: $gray-900;
+		box-shadow: inset 0 0 0 1px $gray-400;
+		width: 100%;
+		display: block;
+
+		&:focus,
+		&:hover {
+			color: var(--wp-admin-theme-color);
+			box-shadow: inset 0 0 0 2px var(--wp-admin-theme-color);
+		}
+
+		&.is-active,
+		&.is-active:hover {
+			background-color: $gray-900;
+			box-shadow: none;
+		}
+
+		&.is-active .block-library-site-logo__inspector-media-replace-title,
+		&.is-active:hover .block-library-site-logo__inspector-media-replace-title {
+			color: $white;
+		}
+
+		&.is-active:focus {
+			box-shadow: inset 0 0 0 1px $white, 0 0 0 2px var(--wp-admin-theme-color);
+		}
+	}
+
+	.block-library-site-logo__inspector-media-replace-title {
+		word-break: break-all;
+		// The Button component is white-space: nowrap, and that won't work with line-clamp.
+		white-space: normal;
+
+		// Without this, the ellipsis can sometimes be partially hidden by the Button padding.
+		text-align: start;
+		text-align-last: center;
+	}
+}
+
+.block-library-site-logo__inspector-media-replace-container {
+	.components-dropdown {
+		display: block;
+	}
+
+	img {
+		width: $grid-unit-30;
+		border-radius: 50%;
+		aspect-ratio: 1;
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/49273

This PR adds the actions for set, replace and reset the site logo in Inspector controls. For users with no permissions to upload, if a logo exists it will show the 'chip' only.



## Testing Instructions
1. Insert a Site Logo and try the different flows



## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/16275880/233666637-83a35da4-1094-4f37-9360-ad5418c6ae6d.mov



