### PR TITLE
Fix WP.com preferences not persisting across sessions

### DIFF
--- a/lib/compat/wordpress-6.1/persisted-preferences.php
+++ b/lib/compat/wordpress-6.1/persisted-preferences.php
@@ -41,7 +41,7 @@ function gutenberg_register_persisted_preferences_meta() {
 	);
 }
 
-add_action( 'init', 'gutenberg_register_persisted_preferences_meta' );
+add_action( 'rest_api_switched_to_blog', 'gutenberg_register_persisted_preferences_meta' );
 
 /**
  * Configures the preferences package to use user meta persistence.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
On WordPress.com, the editor won't maintain the settings across different sessions/devices. This PR should fix it.
More context: https://github.com/Automattic/wp-calypso/issues/64324

## Why?
Because is loading the settings before switching the site and is using the `public_api` blog_id.

## How?
Initializing `gutenberg_register_persisted_preferences_meta` after switching to the user's blog.

## Testing Instructions
* Open a post in wp-admin in one browser and change a preference (like `Show button text labels`).
* Refresh the page.
* Open a post in wp-admin in another browser and change a different preference.
* Refresh the first window and observe that the preference is the correct one.
