### PR TITLE
wp-env: Fix bug in port parser

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,6 @@
 {
 	"core": "WordPress/WordPress",
+	"port": 8890,
 	"plugins": [ "." ],
 	"themes": [ "./test/emptytheme" ],
 	"env": {

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,5 @@
 {
 	"core": "WordPress/WordPress",
-	"port": 8890,
 	"plugins": [ "." ],
 	"themes": [ "./test/emptytheme" ],
 	"env": {

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug fix
+
+-   Allow setting a single "port" option at the top level without requiring testsPort.
+
 ## 6.0.0 (2023-04-26)
 
 ### Breaking Change
@@ -9,10 +13,6 @@
 -   Use test environment's `WP_SITEURL` instead of `WP_TESTS_DOMAIN` as the WordPress URL.
 -   Automatically add the environment's port to `WP_TESTS_DOMAIN`.
 -   `run` command now has a `--env-cwd` option to set the working directory in the container for the command to execute from.
-
-### Bug fix
-
--   Allow setting a single "port" option at the top level without requiring testsPort.
 
 ## 5.16.0 (2023-04-12)
 

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -10,6 +10,10 @@
 -   Automatically add the environment's port to `WP_TESTS_DOMAIN`.
 -   `run` command now has a `--env-cwd` option to set the working directory in the container for the command to execute from.
 
+### Bug fix
+
+-   Allow setting a single "port" option at the top level without requiring testsPort.
+
 ## 5.16.0 (2023-04-12)
 
 ## 5.15.0 (2023-03-29)
@@ -49,52 +53,63 @@
 ## 5.2.0 (2022-08-16)
 
 ### Enhancement
+
 -   Query parameters can now be used in .zip source URLs.
 
 ## 5.1.1 (2022-08-16)
 
 ### Bug Fix
+
 -   Fix a crash when "core" was set to `null` in a `.wp-env.json` file. We now use the latest stable WordPress version in that case. This also restores the previous behavior of `"core": null` in `.wp-env.override.json`, which was to use the latest stable WordPress version.
 
 ## 5.1.0 (2022-08-10)
 
 ### Enhancement
+
 -   Previously, wp-env used the WordPress version provided by Docker in the WordPress image for installations which don't specify a WordPress version. Now, wp-env will find the latest stable version on WordPress.org and check out the https://github.com/WordPress/WordPress repository at the tag matching that version. In most cases, this will match what Docker provides. The benefit is that wp-env (and WordPress.org) now controls the default WordPress version rather than Docker.
 
 ### Bug Fix
+
 -   Downloading a default WordPress version also resolves a bug where the wrong WordPress test files were used if no core source was specified in wp-env.json. The current trunk test files were downloaded rather than the stable version. Now, the test files will match the default stable version.
 
 ## 5.0.0 (2022-07-27)
 
 ### Breaking Changes
+
 -   Removed the `WP_PHPUNIT__TESTS_CONFIG` environment variable from the `phpunit` container. **This removes automatic support for the `wp-phpunit/wp-phpunit` Composer package. To continue using the package, set the following two environment variables in your `phpunit.xml` file or similar: `WP_TESTS_DIR=""` and `WP_PHPUNIT__TESTS_CONFIG="/wordpress-phpunit/wp-tests-config.php"`.**
 -   Removed the generated `/var/www/html/phpunit-wp-config.php` file from the environment.
 
 ### Enhancement
+
 -   Read WordPress' version and include the corresponding PHPUnit test files in the environment.
 -   Set the `WP_TESTS_DIR` environment variable in all containers to point at the PHPUnit test files.
 
 ### Bug Fix
+
 -   Restrict `WP_TESTS_DOMAIN` constant to just hostname rather than an entire URL (e.g. it now excludes scheme, port, etc.) ([#41039](https://github.com/WordPress/gutenberg/pull/41039)).
 
 ## 4.8.0 (2022-06-01)
 
 ### Enhancement
+
 -   Removed the need for quotation marks when passing options to `wp-env run`.
 -   Setting a `config` key to `null` will prevent adding the constant to `wp-config.php` even if a default value is defined by `wp-env`.
 
 ## 4.7.0 (2022-05-18)
 
 ### Enhancement
+
 -   Added SSH protocol support for git sources
 
 ## 4.2.0 (2022-01-27)
 
 ### Enhancement
+
 -   Added command `wp-env install-path` to list the directory used for the environment.
 -   The help entry is now shown when no subcommand is passed to `wp-env`.
 
 ### Bug Fix
+
 -   Updated `yargs` to fix [CVE-2021-3807](https://nvd.nist.gov/vuln/detail/CVE-2021-3807).
 
 ## 4.1.3 (2021-11-07)

--- a/packages/env/lib/config/read-raw-config-file.js
+++ b/packages/env/lib/config/read-raw-config-file.js
@@ -48,18 +48,29 @@ module.exports = async function readRawConfigFile( name, configPath ) {
  *                  shape of the currently expected format.
  */
 function withBackCompat( rawConfig ) {
-	// Convert testsPort into new env.tests format.
+	// Convert ports into new format.
 	if ( rawConfig.testsPort !== undefined ) {
 		rawConfig.env = {
 			...( rawConfig.env || {} ),
 			tests: {
 				port: rawConfig.testsPort,
-				...( rawConfig.env && rawConfig.env.tests
-					? rawConfig.env.tests
-					: {} ),
+				...( rawConfig.env?.tests ?? {} ),
 			},
 		};
 	}
+
+	if ( rawConfig.port !== undefined ) {
+		rawConfig.env = {
+			...( rawConfig.env || {} ),
+			development: {
+				port: rawConfig.port,
+				...( rawConfig.env?.development ?? {} ),
+			},
+		};
+	}
+
 	delete rawConfig.testsPort;
+	delete rawConfig.port;
+
 	return rawConfig;
 }

--- a/packages/env/lib/config/test/config.js
+++ b/packages/env/lib/config/test/config.js
@@ -829,11 +829,15 @@ describe( 'readConfig', () => {
 	describe( 'port number parsing', () => {
 		it( 'should throw a validaton error if the ports are not numbers', async () => {
 			expect.assertions( 10 );
-			await testPortNumberValidation( 'port', 'string' );
+			await testPortNumberValidation(
+				'port',
+				'string',
+				'env.development.'
+			);
 			await testPortNumberValidation( 'testsPort', [], 'env.tests.' );
-			await testPortNumberValidation( 'port', {} );
+			await testPortNumberValidation( 'port', {}, 'env.development.' );
 			await testPortNumberValidation( 'testsPort', false, 'env.tests.' );
-			await testPortNumberValidation( 'port', null );
+			await testPortNumberValidation( 'port', null, 'env.development.' );
 		} );
 
 		it( 'should throw a validaton error if the ports are the same', async () => {

--- a/packages/env/lib/config/test/config.js
+++ b/packages/env/lib/config/test/config.js
@@ -853,6 +853,14 @@ describe( 'readConfig', () => {
 			}
 		} );
 
+		it( 'should not throw an error if just port is passed', async () => {
+			readFile.mockImplementation( () =>
+				Promise.resolve( JSON.stringify( { port: 10 } ) )
+			);
+			const config = await readConfig( '.wp-env.json' );
+			expect( config.env.development.port ).toBe( 10 );
+		} );
+
 		it( 'should parse custom ports', async () => {
 			readFile.mockImplementation( () =>
 				Promise.resolve(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves #49620

## Why?
There is a bug in wp-env where if you set just "port: 8890" in your .wp-env.json, it will throw an error. This is because port by itself ultimately overrides the port in the test config, since they share the same key.

## How?
The fix is to apply the same backcompat behavior to the port option that we did to the testsPort option. This basically copies "port" by itself to the "env.development" object. This way, it cannot override the port in any other environment. This behavior matches the documentation.

## Testing Instructions
1. Set your .wp-env.json to have only a single port definition at the top level to a custom value.
2. Run wp-env start and verify it starts with that port and the default testsPort.

