### PR TITLE
wp-env: Improve run command execution speed

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   `wp-env run ...` now uses docker-compose exec instead of docker-compose run. As a result, it is much faster, since commands are executed against existing services, rather than creating them from scratch each time.
+
 ## 6.0.0 (2023-04-26)
 
 ### Breaking Change
@@ -9,10 +13,6 @@
 -   Use test environment's `WP_SITEURL` instead of `WP_TESTS_DOMAIN` as the WordPress URL.
 -   Automatically add the environment's port to `WP_TESTS_DOMAIN`.
 -   `run` command now has a `--env-cwd` option to set the working directory in the container for the command to execute from.
-
-### Enhancement
-
--   `wp-env run ...` now uses docker-compose exec instead of docker-compose run. As a result, it is much faster, since commands are executed against existing services, rather than creating them from scratch each time.
 
 ## 5.16.0 (2023-04-12)
 

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -10,6 +10,10 @@
 -   Automatically add the environment's port to `WP_TESTS_DOMAIN`.
 -   `run` command now has a `--env-cwd` option to set the working directory in the container for the command to execute from.
 
+### Enhancement
+
+-   `wp-env run ...` now uses docker-compose exec instead of docker-compose run. As a result, it is much faster, since commands are executed against existing services, rather than creating them from scratch each time.
+
 ## 5.16.0 (2023-04-12)
 
 ## 5.15.0 (2023-03-29)
@@ -49,52 +53,63 @@
 ## 5.2.0 (2022-08-16)
 
 ### Enhancement
+
 -   Query parameters can now be used in .zip source URLs.
 
 ## 5.1.1 (2022-08-16)
 
 ### Bug Fix
+
 -   Fix a crash when "core" was set to `null` in a `.wp-env.json` file. We now use the latest stable WordPress version in that case. This also restores the previous behavior of `"core": null` in `.wp-env.override.json`, which was to use the latest stable WordPress version.
 
 ## 5.1.0 (2022-08-10)
 
 ### Enhancement
+
 -   Previously, wp-env used the WordPress version provided by Docker in the WordPress image for installations which don't specify a WordPress version. Now, wp-env will find the latest stable version on WordPress.org and check out the https://github.com/WordPress/WordPress repository at the tag matching that version. In most cases, this will match what Docker provides. The benefit is that wp-env (and WordPress.org) now controls the default WordPress version rather than Docker.
 
 ### Bug Fix
+
 -   Downloading a default WordPress version also resolves a bug where the wrong WordPress test files were used if no core source was specified in wp-env.json. The current trunk test files were downloaded rather than the stable version. Now, the test files will match the default stable version.
 
 ## 5.0.0 (2022-07-27)
 
 ### Breaking Changes
+
 -   Removed the `WP_PHPUNIT__TESTS_CONFIG` environment variable from the `phpunit` container. **This removes automatic support for the `wp-phpunit/wp-phpunit` Composer package. To continue using the package, set the following two environment variables in your `phpunit.xml` file or similar: `WP_TESTS_DIR=""` and `WP_PHPUNIT__TESTS_CONFIG="/wordpress-phpunit/wp-tests-config.php"`.**
 -   Removed the generated `/var/www/html/phpunit-wp-config.php` file from the environment.
 
 ### Enhancement
+
 -   Read WordPress' version and include the corresponding PHPUnit test files in the environment.
 -   Set the `WP_TESTS_DIR` environment variable in all containers to point at the PHPUnit test files.
 
 ### Bug Fix
+
 -   Restrict `WP_TESTS_DOMAIN` constant to just hostname rather than an entire URL (e.g. it now excludes scheme, port, etc.) ([#41039](https://github.com/WordPress/gutenberg/pull/41039)).
 
 ## 4.8.0 (2022-06-01)
 
 ### Enhancement
+
 -   Removed the need for quotation marks when passing options to `wp-env run`.
 -   Setting a `config` key to `null` will prevent adding the constant to `wp-config.php` even if a default value is defined by `wp-env`.
 
 ## 4.7.0 (2022-05-18)
 
 ### Enhancement
+
 -   Added SSH protocol support for git sources
 
 ## 4.2.0 (2022-01-27)
 
 ### Enhancement
+
 -   Added command `wp-env install-path` to list the directory used for the environment.
 -   The help entry is now shown when no subcommand is passed to `wp-env`.
 
 ### Bug Fix
+
 -   Updated `yargs` to fix [CVE-2021-3807](https://nvd.nist.gov/vuln/detail/CVE-2021-3807).
 
 ## 4.1.3 (2021-11-07)

--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -254,6 +254,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 				image: developmentWpCliImage,
 				volumes: developmentMounts,
 				user: cliUser,
+				command: 'tail -F dne', // Keeps the service alive.
 				environment: {
 					...dbEnv.credentials,
 					...dbEnv.development,
@@ -265,6 +266,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 				image: testsWpCliImage,
 				volumes: testsMounts,
 				user: cliUser,
+				command: 'tail -F dne', // Keeps the service alive.
 				environment: {
 					...dbEnv.credentials,
 					...dbEnv.tests,

--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -254,7 +254,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 				image: developmentWpCliImage,
 				volumes: developmentMounts,
 				user: cliUser,
-				command: 'tail -F dne', // Keeps the service alive.
+				command: 'sleep infinity', // Keeps the service alive.
 				environment: {
 					...dbEnv.credentials,
 					...dbEnv.development,
@@ -266,7 +266,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 				image: testsWpCliImage,
 				volumes: testsMounts,
 				user: cliUser,
-				command: 'tail -F dne', // Keeps the service alive.
+				command: 'sleep infinity', // Keeps the service alive.
 				environment: {
 					...dbEnv.credentials,
 					...dbEnv.tests,

--- a/packages/env/lib/commands/run.js
+++ b/packages/env/lib/commands/run.js
@@ -58,10 +58,9 @@ function spawnCommandDirectly( config, container, command, envCwd, spinner ) {
 	const composeCommand = [
 		'-f',
 		config.dockerComposeConfigPath,
-		'run',
+		'exec',
 		'-w',
 		envCwd,
-		'--rm',
 		container,
 		...command.split( ' ' ), // The command will fail if passed as a complete string.
 	];

--- a/packages/env/lib/commands/run.js
+++ b/packages/env/lib/commands/run.js
@@ -55,10 +55,12 @@ function spawnCommandDirectly( config, container, command, envCwd, spinner ) {
 	// We need to pass absolute paths to the container.
 	envCwd = path.resolve( '/var/www/html', envCwd );
 
+	const isTTY = process.stdout.isTTY;
 	const composeCommand = [
 		'-f',
 		config.dockerComposeConfigPath,
 		'exec',
+		! isTTY ? '--no-TTY' : '',
 		'-w',
 		envCwd,
 		container,

--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -152,12 +152,15 @@ module.exports = async function start( { spinner, debug, update, xdebug } ) {
 
 	spinner.text = 'Starting WordPress.';
 
-	await dockerCompose.upMany( [ 'wordpress', 'tests-wordpress' ], {
-		...dockerComposeConfig,
-		commandOptions: shouldConfigureWp
-			? [ '--build', '--force-recreate' ]
-			: [],
-	} );
+	await dockerCompose.upMany(
+		[ 'wordpress', 'tests-wordpress', 'cli', 'tests-cli' ],
+		{
+			...dockerComposeConfig,
+			commandOptions: shouldConfigureWp
+				? [ '--build', '--force-recreate' ]
+				: [],
+		}
+	);
 
 	// Only run WordPress install/configuration when config has changed.
 	if ( shouldConfigureWp ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves #49168 -- makes `wp-env run` a lot faster by executing commands against existing services rather than starting new services from scratch. (And makes wp-env cli persist)

## Why?
Faster is better :) 

## How?
Changes from using `docker-compose run` to `docker-compose exec`. Run creates new containers from scratch each time. We also make more services persistent. This means that the startup cost happens during wp-env run, but not during subsequent executions.

## Testing Instructions
- run `npx wp-env run cli ...` and other permutations of wp-env run locally.
- CI (phpunit probably hits this code path)