### PR TITLE
Add wp.org/ prefix for sources from wordpress.org

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -8,6 +8,10 @@
 -   Automatically add the environment's port to `WP_TESTS_DOMAIN`.
 -   `run` command now has a `--env-cwd` option to set the working directory in the container for the command to execute from.
 
+### Enhancement
+
+-   You can prefix plugin/theme/core sources with `wp.org/` to reference a zip source on the WordPress.org plugin/theme repository. For example, you can write `wp.org/gutenberg` instead of `https://downloads.wordpress.org/plugin/gutenberg.zip`.
+
 ## 5.16.0 (2023-04-12)
 
 ## 5.15.0 (2023-03-29)
@@ -47,52 +51,63 @@
 ## 5.2.0 (2022-08-16)
 
 ### Enhancement
+
 -   Query parameters can now be used in .zip source URLs.
 
 ## 5.1.1 (2022-08-16)
 
 ### Bug Fix
+
 -   Fix a crash when "core" was set to `null` in a `.wp-env.json` file. We now use the latest stable WordPress version in that case. This also restores the previous behavior of `"core": null` in `.wp-env.override.json`, which was to use the latest stable WordPress version.
 
 ## 5.1.0 (2022-08-10)
 
 ### Enhancement
+
 -   Previously, wp-env used the WordPress version provided by Docker in the WordPress image for installations which don't specify a WordPress version. Now, wp-env will find the latest stable version on WordPress.org and check out the https://github.com/WordPress/WordPress repository at the tag matching that version. In most cases, this will match what Docker provides. The benefit is that wp-env (and WordPress.org) now controls the default WordPress version rather than Docker.
 
 ### Bug Fix
+
 -   Downloading a default WordPress version also resolves a bug where the wrong WordPress test files were used if no core source was specified in wp-env.json. The current trunk test files were downloaded rather than the stable version. Now, the test files will match the default stable version.
 
 ## 5.0.0 (2022-07-27)
 
 ### Breaking Changes
+
 -   Removed the `WP_PHPUNIT__TESTS_CONFIG` environment variable from the `phpunit` container. **This removes automatic support for the `wp-phpunit/wp-phpunit` Composer package. To continue using the package, set the following two environment variables in your `phpunit.xml` file or similar: `WP_TESTS_DIR=""` and `WP_PHPUNIT__TESTS_CONFIG="/wordpress-phpunit/wp-tests-config.php"`.**
 -   Removed the generated `/var/www/html/phpunit-wp-config.php` file from the environment.
 
 ### Enhancement
+
 -   Read WordPress' version and include the corresponding PHPUnit test files in the environment.
 -   Set the `WP_TESTS_DIR` environment variable in all containers to point at the PHPUnit test files.
 
 ### Bug Fix
+
 -   Restrict `WP_TESTS_DOMAIN` constant to just hostname rather than an entire URL (e.g. it now excludes scheme, port, etc.) ([#41039](https://github.com/WordPress/gutenberg/pull/41039)).
 
 ## 4.8.0 (2022-06-01)
 
 ### Enhancement
+
 -   Removed the need for quotation marks when passing options to `wp-env run`.
 -   Setting a `config` key to `null` will prevent adding the constant to `wp-config.php` even if a default value is defined by `wp-env`.
 
 ## 4.7.0 (2022-05-18)
 
 ### Enhancement
+
 -   Added SSH protocol support for git sources
 
 ## 4.2.0 (2022-01-27)
 
 ### Enhancement
+
 -   Added command `wp-env install-path` to list the directory used for the environment.
 -   The help entry is now shown when no subcommand is passed to `wp-env`.
 
 ### Bug Fix
+
 -   Updated `yargs` to fix [CVE-2021-3807](https://nvd.nist.gov/vuln/detail/CVE-2021-3807).
 
 ## 4.1.3 (2021-11-07)

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -237,13 +237,13 @@ You should only have to translate `port` and `pathMappings` to the format used b
 
 ```json
 {
-  "name": "Listen for XDebug",
-  "type": "php",
-  "request": "launch",
-  "port": 9003,
-  "pathMappings": {
-    "/var/www/html/wp-content/plugins/gutenberg": "${workspaceFolder}/"
-  }
+	"name": "Listen for XDebug",
+	"type": "php",
+	"request": "launch",
+	"port": 9003,
+	"pathMappings": {
+		"/var/www/html/wp-content/plugins/gutenberg": "${workspaceFolder}/"
+	}
 }
 ```
 
@@ -329,6 +329,7 @@ wp-env run cli "wp --help"
 Without the quotation marks, `wp-env` will print its own help text instead of
 passing it to the container. If you experience any problems where the command
 is not being passed correctly, fall back to using quotation marks.
+
 </div>
 
 ```sh
@@ -468,7 +469,7 @@ You can customize the WordPress installation, plugins and themes that the develo
 | `"plugins"`    | `string[]`     | `[]`                                   | A list of plugins to install and activate in the environment.                                                                    |
 | `"themes"`     | `string[]`     | `[]`                                   | A list of themes to install in the environment.                                                                                  |
 | `"port"`       | `integer`      | `8888` (`8889` for the tests instance) | The primary port number to use for the installation. You'll access the instance through the port: 'http://localhost:8888'.       |
-| `"testsPort"`       | `integer`      | `8889` | The port number for the test site. You'll access the instance through the port: 'http://localhost:8889'.       |
+| `"testsPort"`  | `integer`      | `8889`                                 | The port number for the test site. You'll access the instance through the port: 'http://localhost:8889'.                         |
 | `"config"`     | `Object`       | See below.                             | Mapping of wp-config.php constants to their desired values.                                                                      |
 | `"mappings"`   | `Object`       | `"{}"`                                 | Mapping of WordPress directories to local directories to be mounted in the WordPress instance.                                   |
 
@@ -476,13 +477,14 @@ _Note: the port number environment variables (`WP_ENV_PORT` and `WP_ENV_TESTS_PO
 
 Several types of strings can be passed into the `core`, `plugins`, `themes`, and `mappings` fields.
 
-| Type              | Format                                       | Example(s)                                               |
-| ----------------- | -------------------------------------------- | -------------------------------------------------------- |
-| Relative path     | `.<path>\|~<path>`                           | `"./a/directory"`, `"../a/directory"`, `"~/a/directory"` |
-| Absolute path     | `/<path>\|<letter>:\<path>`                  | `"/a/directory"`, `"C:\\a\\directory"`                   |
-| GitHub repository | `<owner>/<repo>[#<ref>]`                     | `"WordPress/WordPress"`, `"WordPress/gutenberg#trunk"`, if no branch is provided wp-env will fall back to the repos default branch |
-| SSH repository    | `ssh://user@host/<owner>/<repo>.git[#<ref>]` | `"ssh://git@github.com/WordPress/WordPress.git"`         |
-| ZIP File          | `http[s]://<host>/<path>.zip`                | `"https://wordpress.org/wordpress-5.4-beta2.zip"`        |
+| Type                 | Format                                       | Example(s)                                                                                                                         |
+| -------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Relative path        | `.<path>\|~<path>`                           | `"./a/directory"`, `"../a/directory"`, `"~/a/directory"`                                                                           |
+| Absolute path        | `/<path>\|<letter>:\<path>`                  | `"/a/directory"`, `"C:\\a\\directory"`                                                                                             |
+| WordPress.org source | `wp.org/<slug>`                              | `"wp.org/latest"`, `"wp.org/gutenberg"`, `"wp.org/gutenberg.12.0.0`, `wp.org/wordpress-5.0`                                        |
+| GitHub repository    | `<owner>/<repo>[#<ref>]`                     | `"WordPress/WordPress"`, `"WordPress/gutenberg#trunk"`, if no branch is provided wp-env will fall back to the repos default branch |
+| SSH repository       | `ssh://user@host/<owner>/<repo>.git[#<ref>]` | `"ssh://git@github.com/WordPress/WordPress.git"`                                                                                   |
+| ZIP File             | `http[s]://<host>/<path>.zip`                | `"https://wordpress.org/wordpress-5.4-beta2.zip"`                                                                                  |
 
 Remote sources will be downloaded into a temporary directory located in `~/.wp-env`.
 
@@ -490,22 +492,22 @@ Additionally, the key `env` is available to override any of the above options on
 
 ```json
 {
-  "plugins": ["."],
-  "config": {
-    "KEY_1": true,
-    "KEY_2": false
-  },
-  "env": {
-    "development": {
-      "themes": ["./one-theme"]
-    },
-    "tests": {
-      "config": {
-        "KEY_1": false
-      },
-      "port": 3000
-    }
-  }
+	"plugins": [ "." ],
+	"config": {
+		"KEY_1": true,
+		"KEY_2": false
+	},
+	"env": {
+		"development": {
+			"themes": [ "./one-theme" ]
+		},
+		"tests": {
+			"config": {
+				"KEY_1": false
+			},
+			"port": 3000
+		}
+	}
 }
 ```
 
@@ -548,8 +550,8 @@ This is useful for plugin development.
 
 ```json
 {
-  "core": null,
-  "plugins": ["."]
+	"core": null,
+	"plugins": [ "." ]
 }
 ```
 
@@ -559,8 +561,8 @@ This is useful for plugin development when upstream Core changes need to be test
 
 ```json
 {
-  "core": "WordPress/WordPress#master",
-  "plugins": ["."]
+	"core": "WordPress/WordPress#master",
+	"plugins": [ "." ]
 }
 ```
 
@@ -572,8 +574,8 @@ If you are running a _build_ of `wordpress-develop`, point `core` to the `build`
 
 ```json
 {
-  "core": "../wordpress-develop/build",
-  "plugins": ["."]
+	"core": "../wordpress-develop/build",
+	"plugins": [ "." ]
 }
 ```
 
@@ -581,8 +583,8 @@ If you are running `wordpress-develop` in a dev mode (e.g. the watch command `de
 
 ```json
 {
-  "core": "../wordpress-develop/src",
-  "plugins": ["."]
+	"core": "../wordpress-develop/src",
+	"plugins": [ "." ]
 }
 ```
 
@@ -592,9 +594,21 @@ This is useful for integration testing: that is, testing how old versions of Wor
 
 ```json
 {
-  "core": "WordPress/WordPress#5.2.0",
-  "plugins": ["WordPress/wp-lazy-loading", "WordPress/classic-editor"],
-  "themes": ["WordPress/theme-experiments"]
+	"core": "WordPress/WordPress#5.2.0",
+	"plugins": [ "WordPress/wp-lazy-loading", "WordPress/classic-editor" ],
+	"themes": [ "WordPress/theme-experiments" ]
+}
+```
+
+### Use sources from the WordPress.org plugin and theme repositories
+
+You can use the `wp.org/` prefix to reference the theme and plugin repositories, even with versions if you want to test an old version! Just make sure the part after the `/` matches the slug (and version, if applicable) of the plugin or theme, as it exists on WordPress.org.
+
+```json
+{
+	"core": "wp.org/wordpress-5.0",
+	"plugins": [ "wp.org/akismet", "wp.org/wordpress-seo" ],
+	"themes": [ "wp.org/twentyseventeen", "wp.org/twentynineteen.1.0" ]
 }
 ```
 
@@ -604,12 +618,12 @@ You can add mu-plugins via the mapping config. The mapping config also allows yo
 
 ```json
 {
-  "plugins": ["."],
-  "mappings": {
-    "wp-content/mu-plugins": "./path/to/local/mu-plugins",
-    "wp-content/themes": "./path/to/local/themes",
-    "wp-content/themes/specific-theme": "./path/to/local/theme-1"
-  }
+	"plugins": [ "." ],
+	"mappings": {
+		"wp-content/mu-plugins": "./path/to/local/mu-plugins",
+		"wp-content/themes": "./path/to/local/themes",
+		"wp-content/themes/specific-theme": "./path/to/local/theme-1"
+	}
 }
 ```
 
@@ -619,10 +633,10 @@ Since all plugins in the `plugins` key are activated by default, you should use 
 
 ```json
 {
-  "plugins": ["."],
-  "mappings": {
-    "wp-content/plugins/my-test-plugin": "./path/to/test/plugin"
-  }
+	"plugins": [ "." ],
+	"mappings": {
+		"wp-content/plugins/my-test-plugin": "./path/to/test/plugin"
+	}
 }
 ```
 
@@ -632,12 +646,12 @@ If you need a plugin active in one environment but not the other, you can use `e
 
 ```json
 {
-  "plugins": ["."],
-  "env": {
-    "tests": {
-      "plugins": [".", "path/to/test/plugin"]
-    }
-  }
+	"plugins": [ "." ],
+	"env": {
+		"tests": {
+			"plugins": [ ".", "path/to/test/plugin" ]
+		}
+	}
 }
 ```
 
@@ -647,13 +661,13 @@ You can tell `wp-env` to use a custom port number so that your instance does not
 
 ```json
 {
-  "plugins": ["."],
-  "port": 4013,
-  "env": {
-    "tests": {
-      "port": 4012
-    }
-  }
+	"plugins": [ "." ],
+	"port": 4013,
+	"env": {
+		"tests": {
+			"port": 4012
+		}
+	}
 }
 ```
 
@@ -663,8 +677,8 @@ You can tell `wp-env` to use a specific PHP version for compatibility and testin
 
 ```json
 {
-  "phpVersion": "7.2",
-  "plugins": ["."]
+	"phpVersion": "7.2",
+	"plugins": [ "." ]
 }
 ```
 

--- a/packages/env/lib/config/config.js
+++ b/packages/env/lib/config/config.js
@@ -260,7 +260,10 @@ function withOverrides( config ) {
 	// Override WordPress core with environment variable.
 	if ( process.env.WP_ENV_CORE ) {
 		const coreSource = includeTestsPath(
-			parseSourceString( process.env.WP_ENV_CORE, { workDirectoryPath } ),
+			parseSourceString( process.env.WP_ENV_CORE, {
+				workDirectoryPath,
+				sourceType: 'core',
+			} ),
 			{ workDirectoryPath }
 		);
 		config.env.development.coreSource = coreSource;

--- a/packages/env/test/parse-config.js
+++ b/packages/env/test/parse-config.js
@@ -59,3 +59,47 @@ describe.each( gitTests )( 'parseSourceString', ( source ) => {
 		expect( basename ).toBe( source.basename );
 	} );
 } );
+
+const wpOrgTests = [
+	{
+		sourceString: 'wp.org/latest',
+		url: 'https://wordpress.org/latest.zip',
+		sourceType: 'core',
+	},
+	{
+		sourceString: 'wp.org/wordpress-6.2',
+		url: 'https://wordpress.org/wordpress-6.2.zip',
+		sourceType: 'core',
+	},
+	{
+		sourceString: 'wp.org/gutenberg',
+		url: 'https://downloads.wordpress.org/plugins/gutenberg.zip',
+		sourceType: 'plugin',
+	},
+	{
+		sourceString: 'wp.org/gutenberg.15.0.0',
+		url: 'https://downloads.wordpress.org/plugins/gutenberg.15.0.0.zip',
+		sourceType: 'plugin',
+	},
+	{
+		sourceString: 'wp.org/twentytwentytwo',
+		url: 'https://downloads.wordpress.org/theme/twentytwentytwo.zip',
+		sourceType: 'theme',
+	},
+	{
+		sourceString: 'wp.org/twentytwentytwo.1.0',
+		url: 'https://downloads.wordpress.org/theme/twentytwentytwo.1.0.zip',
+		sourceType: 'theme',
+	},
+];
+
+describe.each( wpOrgTests )( 'parseSourceString', ( source ) => {
+	it( `parses ${ source.sourceString }`, () => {
+		const { type, url } = parseSourceString( source.sourceString, {
+			...parseSourceStringOptions,
+			sourceType: source.sourceType,
+		} );
+		expect( type ).toBe( 'zip' );
+		expect( url ).toBe( source.url );
+	} );
+} );

--- a/packages/env/test/parse-config.js
+++ b/packages/env/test/parse-config.js
@@ -73,12 +73,12 @@ const wpOrgTests = [
 	},
 	{
 		sourceString: 'wp.org/gutenberg',
-		url: 'https://downloads.wordpress.org/plugins/gutenberg.zip',
+		url: 'https://downloads.wordpress.org/plugin/gutenberg.zip',
 		sourceType: 'plugin',
 	},
 	{
 		sourceString: 'wp.org/gutenberg.15.0.0',
-		url: 'https://downloads.wordpress.org/plugins/gutenberg.15.0.0.zip',
+		url: 'https://downloads.wordpress.org/plugin/gutenberg.15.0.0.zip',
 		sourceType: 'plugin',
 	},
 	{


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves #44848. Allows you to pull sources from WordPress.org using the `wp.org/` prefix, followed by the slug.

## Why?
Just a small enhancement suggested by #44848. Since this is a first party tool, it makes sense to make it easy to access WordPress.org sources.

## How?
Add a matcher for this scenario in the source parser.

## Testing Instructions
- unit tests
- update your .wp-env.json file to test various permutations of core sources and run `npx wp-env start`

