### PR TITLE
Add a few import required for the React Native wrapper distribution as iOS XCFramework

### DIFF
--- a/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
@@ -1,3 +1,5 @@
+import React
+
 public struct MediaInfo: Encodable {
     public let id: Int32?
     public let url: String?

--- a/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -1,3 +1,5 @@
+import React
+
 struct GutenbergEvent {
     let name: String
     let body: Any?

--- a/packages/react-native-bridge/ios/SourceFile.swift
+++ b/packages/react-native-bridge/ios/SourceFile.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WebKit
 
 public struct SourceFile {
     enum SourceFileError: Error {

--- a/packages/react-native-bridge/ios/SourceFile.swift
+++ b/packages/react-native-bridge/ios/SourceFile.swift
@@ -1,4 +1,3 @@
-import Foundation
 import WebKit
 
 public struct SourceFile {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? Why? and How?
Adds a few imports in a few `react-native-bridge/ios` code. These are required for the setup to compile, as can be seen in https://github.com/wordpress-mobile/gutenberg-mobile/pull/5695

## Testing Instructions
This PR should not affect the plugin behavior as it only touches files in the React Native brige package. As far as I understand the setup, green CI in the [`gutenberg-mobile` PR using these changes]https://github.com/wordpress-mobile/gutenberg-mobile/pull/5695) should be enough to establish correctness.

### Testing Instructions for Keyboard
N.A.
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

---

Ping @fluiddot @geriux can you help me get this reviewed and merged? I don't have the rights to ask for a review. Thanks!