### PR TITLE
registerPlugin "scope" is outdated

### DIFF
--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -141,7 +141,6 @@ const Component = () => (
 registerPlugin( 'plugin-name', {
 	icon: more,
 	render: Component,
-	scope: 'my-page',
 } );
 ```
 


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Removes `scope` option which is not available in `PluginSettings` of registerPlugin method.

## Why?
The existing document is outdated

## How?
This PR will update the document according to latest type definition set for `PluginSetting`


## Screenshots or screencast <!-- if applicable -->
<img width="1025" alt="Screenshot 2023-04-22 at 14 55 17" src="https://user-images.githubusercontent.com/36844205/233789132-f89c1a10-a91d-4ad4-9149-ba330404a2d5.png">
