### PR TITLE
[WIP] Pattern Block: Make enhancement explorations Gutenberg experiment

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -483,7 +483,7 @@ Show a block pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trun
 -	**Name:** core/pattern
 -	**Category:** theme
 -	**Supports:** ~~html~~, ~~inserter~~
--	**Attributes:** slug
+-	**Attributes:** slug, unsynced
 
 ## Post Author
 

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -92,6 +92,9 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-details-blocks', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableDetailsBlocks = true', 'before' );
 	}
+	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-pattern-enhancements', $gutenberg_experiments ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnablePatternEnhancements = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -101,6 +101,18 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
+	add_settings_field(
+		'gutenberg-pattern-enhancements',
+		__( 'Pattern enhancements', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Test the Pattern block enhancements', 'gutenberg' ),
+			'id'    => 'gutenberg-pattern-enhancements',
+		)
+	);
+
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/packages/block-library/src/pattern/index.js
+++ b/packages/block-library/src/pattern/index.js
@@ -3,15 +3,15 @@
  */
 import initBlock from '../utils/init-block';
 import metadata from './block.json';
-import PatternEdit from './edit';
+import PatternEditV1 from './v1/edit';
+import PatternEditV2 from './edit';
 import PatternSave from './save';
 
 const { name } = metadata;
 export { metadata, name };
 
-export const settings = {
-	edit: PatternEdit,
-	save: PatternSave,
-};
+export const settings = window?.__experimentalEnablePatternEnhancements
+	? { edit: PatternEditV2, save: PatternSave }
+	: { edit: PatternEditV1 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/pattern/v1/edit.js
+++ b/packages/block-library/src/pattern/v1/edit.js
@@ -1,0 +1,51 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import {
+	store as blockEditorStore,
+	useBlockProps,
+} from '@wordpress/block-editor';
+
+const PatternEdit = ( { attributes, clientId } ) => {
+	const selectedPattern = useSelect(
+		( select ) =>
+			select( blockEditorStore ).__experimentalGetParsedPattern(
+				attributes.slug
+			),
+		[ attributes.slug ]
+	);
+
+	const { replaceBlocks, __unstableMarkNextChangeAsNotPersistent } =
+		useDispatch( blockEditorStore );
+
+	// Run this effect when the component loads.
+	// This adds the Pattern's contents to the post.
+	// This change won't be saved.
+	// It will continue to pull from the pattern file unless changes are made to its respective template part.
+	useEffect( () => {
+		if ( selectedPattern?.blocks ) {
+			// We batch updates to block list settings to avoid triggering cascading renders
+			// for each container block included in a tree and optimize initial render.
+			// Since the above uses microtasks, we need to use a microtask here as well,
+			// because nested pattern blocks cannot be inserted if the parent block supports
+			// inner blocks but doesn't have blockSettings in the state.
+			window.queueMicrotask( () => {
+				__unstableMarkNextChangeAsNotPersistent();
+				replaceBlocks( clientId, selectedPattern.blocks );
+			} );
+		}
+	}, [
+		clientId,
+		selectedPattern?.blocks,
+		__unstableMarkNextChangeAsNotPersistent,
+		replaceBlocks,
+	] );
+
+	const props = useBlockProps();
+
+	return <div { ...props } />;
+};
+
+export default PatternEdit;


### PR DESCRIPTION
## What?

Moves the explorations in https://github.com/WordPress/gutenberg/pull/49967 behind a Gutenberg experiment flag.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 01dfd9a</samp>

This pull request introduces a new feature for the `Pattern` block that allows users to edit the pattern content directly in the editor and sync changes with the pattern file. The feature is implemented behind an experimental flag `gutenberg-pattern-enhancements` that can be enabled or disabled by the user. The pull request also updates the documentation and the block editor settings to reflect the new feature.

## Why?

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 01dfd9a</samp>

> _Oh, we're the crew of the Gutenberg ship_
> _And we're sailing on the web_
> _We've got a new feature for the Pattern block_
> _But it's hidden by a flag_

## How?

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 01dfd9a</samp>

*  Add a new feature to the Pattern block that allows users to edit the pattern content directly in the editor, and to sync changes from the pattern file to the block content, and vice versa ([link](https://github.com/WordPress/gutenberg/pull/50012/files?diff=unified&w=0#diff-f6aae16250a5c89a991204d3ed1f529423028272ea20a5a477c9d58b9e9de2cfL486-R486), [link](https://github.com/WordPress/gutenberg/pull/50012/files?diff=unified&w=0#diff-f08775783077295e710976c98cf7c33a043dac17978aedd634ee0eb7021e80ceR95-R97), [link](https://github.com/WordPress/gutenberg/pull/50012/files?diff=unified&w=0#diff-e6bd94e1847aea4b70a6cc1ac9b2471dd3d882f6cbf1ab51438e23b02ca5194fR104-R115), [link](https://github.com/WordPress/gutenberg/pull/50012/files?diff=unified&w=0#diff-5d846423544ade6de3d7ae29aa49de737dccedfc79f57f0f52833553f80ddf68L6-R7), [link](https://github.com/WordPress/gutenberg/pull/50012/files?diff=unified&w=0#diff-5d846423544ade6de3d7ae29aa49de737dccedfc79f57f0f52833553f80ddf68L12-R15), [link](https://github.com/WordPress/gutenberg/pull/50012/files?diff=unified&w=0#diff-1b7eefd68cb40fb1e742e03fb37a19f424b3d698d2ae7cf3d920a3759dfc69e8R1-R51)).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
