### PR TITLE
Add Theme Previews for block themes

### DIFF
--- a/lib/compat/wordpress-6.3/theme-previews.php
+++ b/lib/compat/wordpress-6.3/theme-previews.php
@@ -80,13 +80,11 @@ function add_live_preview_button() {
 			const themePath = themeInfo.querySelector('h2.theme-name').id.replace('-name', '');
 			const themeName = themeInfo.querySelector('h2.theme-name').innerText;
 			const livePreviewButton = document.createElement('a');
-			/* translators: %s: theme name */
-			livePreviewButton.setAttribute('aria-label', '
 			<?php
 				/* translators: %s: theme name */
-				echo esc_attr_x( 'Live Preview %s', 'theme' );
+				$button_label = esc_attr_x( 'Live Preview %s', 'theme' );
 			?>
-			'.replace('%s', themeName));
+			livePreviewButton.setAttribute('aria-label', '<?php echo $button_label; ?>'.replace('%s', themeName));
 			livePreviewButton.setAttribute('class', 'button button-primary');
 			livePreviewButton.setAttribute(
 				'href',

--- a/lib/compat/wordpress-6.3/theme-previews.php
+++ b/lib/compat/wordpress-6.3/theme-previews.php
@@ -81,7 +81,10 @@ function add_live_preview_button() {
 			const themeName = themeInfo.querySelector('h2.theme-name').innerText;
 			const livePreviewButton = document.createElement('a');
 			/* translators: %s: theme name */
-			livePreviewButton.setAttribute('aria-label', '<?php echo esc_attr_x( 'Live Preview %s', 'theme' ); ?>'.replace('%s', themeName));
+			livePreviewButton.setAttribute('aria-label', '<?php
+				/* translators: %s: theme name */
+				echo esc_attr_x( 'Live Preview %s', 'theme' );
+			?>'.replace('%s', themeName));
 			livePreviewButton.setAttribute('class', 'button button-primary');
 			livePreviewButton.setAttribute(
 				'href',

--- a/lib/compat/wordpress-6.3/theme-previews.php
+++ b/lib/compat/wordpress-6.3/theme-previews.php
@@ -82,10 +82,10 @@ function add_live_preview_button() {
 			const livePreviewButton = document.createElement('a');
 			/* translators: %s: theme name */
 			livePreviewButton.setAttribute('aria-label', '
-				<?php
-					/* translators: %s: theme name */
-					echo esc_attr_x( 'Live Preview %s', 'theme' );
-				?>
+			<?php
+				/* translators: %s: theme name */
+				echo esc_attr_x( 'Live Preview %s', 'theme' );
+			?>
 			'.replace('%s', themeName));
 			livePreviewButton.setAttribute('class', 'button button-primary');
 			livePreviewButton.setAttribute(

--- a/lib/compat/wordpress-6.3/theme-previews.php
+++ b/lib/compat/wordpress-6.3/theme-previews.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Enable theme previews in the Site Editor for block themes.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Filters the blog option to return the directory for the previewed theme.
+ *
+ * @param string $current_stylesheet The current theme directory.
+ * @return string The previewed theme directory.
+ */
+function gutenberg_theme_preview_stylesheet( $current_stylesheet = null ) {
+	$preview_stylesheet = ! empty( $_GET['theme_preview'] ) ? $_GET['theme_preview'] : null;
+	$wp_theme           = wp_get_theme( $preview_stylesheet );
+	if ( ! is_wp_error( $wp_theme->errors() ) ) {
+		return sanitize_text_field( $preview_stylesheet );
+	}
+
+	return $current_stylesheet;
+}
+
+/**
+ * Filters the blog option to return the parent theme directory for the previewed theme.
+ *
+ * @param string $current_stylesheet The current theme directory.
+ * @return string The previewed theme directory.
+ */
+function gutenberg_theme_preview_template( $current_stylesheet = null ) {
+	$preview_stylesheet = ! empty( $_GET['theme_preview'] ) ? $_GET['theme_preview'] : null;
+	$wp_theme           = wp_get_theme( $preview_stylesheet );
+	if ( ! is_wp_error( $wp_theme->errors() ) ) {
+		return sanitize_text_field( $wp_theme->get_template() );
+	}
+
+	return $current_stylesheet;
+}
+
+/**
+ * Adds a middleware to the REST API to set the theme for the preview.
+ */
+function gutenberg_attach_theme_preview_middleware() {
+	wp_add_inline_script(
+		'wp-api-fetch',
+		sprintf(
+			'wp.apiFetch.use( wp.apiFetch.createThemePreviewMiddleware( %s ) );',
+			wp_json_encode( sanitize_text_field( $_GET['theme_preview'] ) )
+		),
+		'after'
+	);
+}
+
+/**
+ * Temporary function to add a live preview button to block themes.
+ * Remove when https://core.trac.wordpress.org/ticket/58190 lands.
+ */
+function add_live_preview_button() {
+	global $pagenow;
+	if ( 'themes.php' === $pagenow ) {
+		?>
+<script type="text/javascript">
+	jQuery( document ).ready( function() {
+		addLivePreviewButton();
+		//themes are loaded as we scroll so we need to add the button to the newer ones.
+		jQuery('.themes').on('DOMSubtreeModified', function(){
+			addLivePreviewButton();
+		});
+	});
+	function addLivePreviewButton() {
+		document.querySelectorAll('.theme').forEach((el, index) => {
+			const themeInfo = el.querySelector('.theme-id-container');
+			const canAddButton =
+				!themeInfo ||
+				el.classList.contains('active') ||
+				themeInfo.querySelector('.theme-actions')?.childElementCount > 1;
+			if ( canAddButton ) {
+				return;
+			}
+			const themePath = themeInfo.querySelector('h2.theme-name').id.replace('-name', '');
+			const themeName = themeInfo.querySelector('h2.theme-name').innerText;
+			const livePreviewButton = document.createElement('a');
+			/* translators: %s: theme name */
+			livePreviewButton.setAttribute('aria-label', '<?php echo esc_attr_x( 'Live Preview %s', 'theme' ); ?>'.replace('%s', themeName));
+			livePreviewButton.setAttribute('class', 'button button-primary');
+			livePreviewButton.setAttribute(
+				'href',
+				`/wp-admin/site-editor.php?theme_preview=${themePath}&return=themes.php`
+			);
+			livePreviewButton.innerHTML = '<?php echo esc_html_e( 'Live Preview' ); ?>';
+			themeInfo.querySelector('.theme-actions').appendChild(livePreviewButton);
+		});
+	}
+</script>
+		<?php
+	}
+
+}
+
+/**
+ * Adds a nonce for the theme activation link.
+ */
+function block_theme_activate_nonce() {
+	$nonce_handle = 'switch-theme_' . gutenberg_theme_preview_stylesheet();
+	?>
+<script type="text/javascript">
+	window.BLOCK_THEME_ACTIVATE_NONCE = '<?php echo wp_create_nonce( $nonce_handle ); ?>';
+</script>
+	<?php
+}
+
+// Hide this feature behind an experiment.
+$gutenberg_experiments = get_option( 'gutenberg-experiments' );
+if ( $gutenberg_experiments && array_key_exists( 'gutenberg-theme-previews', $gutenberg_experiments ) ) {
+	/**
+	 * Attaches filters to enable theme previews in the Site Editor.
+	 */
+	if ( ! empty( $_GET['theme_preview'] ) ) {
+		add_filter( 'stylesheet', 'gutenberg_theme_preview_stylesheet' );
+		add_filter( 'template', 'gutenberg_theme_preview_template' );
+		add_filter( 'init', 'gutenberg_attach_theme_preview_middleware' );
+	}
+
+	add_action( 'admin_head', 'block_theme_activate_nonce' );
+	add_action( 'admin_print_footer_scripts', 'add_live_preview_button', 11 );
+}

--- a/lib/compat/wordpress-6.3/theme-previews.php
+++ b/lib/compat/wordpress-6.3/theme-previews.php
@@ -82,10 +82,11 @@ function add_live_preview_button() {
 			const livePreviewButton = document.createElement('a');
 			/* translators: %s: theme name */
 			livePreviewButton.setAttribute('aria-label', '
-<?php
-				/* translators: %s: theme name */
-				echo esc_attr_x( 'Live Preview %s', 'theme' );
-?>'.replace('%s', themeName));
+				<?php
+					/* translators: %s: theme name */
+					echo esc_attr_x( 'Live Preview %s', 'theme' );
+				?>
+			'.replace('%s', themeName));
 			livePreviewButton.setAttribute('class', 'button button-primary');
 			livePreviewButton.setAttribute(
 				'href',

--- a/lib/compat/wordpress-6.3/theme-previews.php
+++ b/lib/compat/wordpress-6.3/theme-previews.php
@@ -81,10 +81,11 @@ function add_live_preview_button() {
 			const themeName = themeInfo.querySelector('h2.theme-name').innerText;
 			const livePreviewButton = document.createElement('a');
 			/* translators: %s: theme name */
-			livePreviewButton.setAttribute('aria-label', '<?php
+			livePreviewButton.setAttribute('aria-label', '
+<?php
 				/* translators: %s: theme name */
 				echo esc_attr_x( 'Live Preview %s', 'theme' );
-			?>'.replace('%s', themeName));
+?>'.replace('%s', themeName));
 			livePreviewButton.setAttribute('class', 'button button-primary');
 			livePreviewButton.setAttribute(
 				'href',

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -95,6 +95,10 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-details-blocks', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableDetailsBlocks = true', 'before' );
 	}
+	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-theme-previews', $gutenberg_experiments ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableThemePreviews = true', 'before' );
+	}
+
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -101,6 +101,18 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
+	add_settings_field(
+		'gutenberg-theme-previews',
+		__( 'Block Theme Previews', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Enable Block Theme Previews', 'gutenberg' ),
+			'id'    => 'gutenberg-theme-previews',
+		)
+	);
+
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/lib/load.php
+++ b/lib/load.php
@@ -48,6 +48,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require_once __DIR__ . '/compat/wordpress-6.3/class-gutenberg-rest-templates-controller-6-3.php';
 	require_once __DIR__ . '/compat/wordpress-6.3/class-gutenberg-rest-global-styles-controller-6-3.php';
 	require_once __DIR__ . '/compat/wordpress-6.3/rest-api.php';
+	require_once __DIR__ . '/compat/wordpress-6.3/theme-previews.php';
 
 	// Experimental.
 	if ( ! class_exists( 'WP_Rest_Customizer_Nonces' ) ) {

--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -14,6 +14,7 @@ import namespaceEndpointMiddleware from './middlewares/namespace-endpoint';
 import httpV1Middleware from './middlewares/http-v1';
 import userLocaleMiddleware from './middlewares/user-locale';
 import mediaUploadMiddleware from './middlewares/media-upload';
+import createThemePreviewMiddleware from './middlewares/theme-preview';
 import {
 	parseResponseAndNormalizeError,
 	parseAndThrowError,
@@ -193,5 +194,6 @@ apiFetch.createPreloadingMiddleware = createPreloadingMiddleware;
 apiFetch.createRootURLMiddleware = createRootURLMiddleware;
 apiFetch.fetchAllMiddleware = fetchAllMiddleware;
 apiFetch.mediaUploadMiddleware = mediaUploadMiddleware;
+apiFetch.createThemePreviewMiddleware = createThemePreviewMiddleware;
 
 export default apiFetch;

--- a/packages/api-fetch/src/middlewares/theme-preview.js
+++ b/packages/api-fetch/src/middlewares/theme-preview.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import { addQueryArgs, hasQueryArg } from '@wordpress/url';
+
+/**
+ * This appends a `theme_preview` parameter to the REST API request URL if
+ * the admin URL contains a `theme` GET parameter.
+ *
+ * @param {Record<string, any>} themePath
+ * @return {import('../types').APIFetchMiddleware} Preloading middleware.
+ */
+const createThemePreviewMiddleware = ( themePath ) => ( options, next ) => {
+	if (
+		typeof options.url === 'string' &&
+		! hasQueryArg( options.url, 'theme_preview' )
+	) {
+		options.url = addQueryArgs( options.url, {
+			theme_preview: themePath,
+		} );
+	}
+
+	if (
+		typeof options.path === 'string' &&
+		! hasQueryArg( options.path, 'theme_preview' )
+	) {
+		options.path = addQueryArgs( options.path, {
+			theme_preview: themePath,
+		} );
+	}
+
+	return next( options );
+};
+
+export default createThemePreviewMiddleware;

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -171,7 +171,12 @@ export default function Editor() {
 						<InterfaceSkeleton
 							enableRegionNavigation={ false }
 							className={ showIconLabels && 'show-icon-labels' }
-							notices={ isEditMode && <EditorSnackbars /> }
+							notices={
+								( isEditMode ||
+									window?.__experimentalEnableThemePreviews ) && (
+									<EditorSnackbars />
+								)
+							}
 							content={
 								<>
 									<GlobalStylesRenderer />

--- a/packages/edit-site/src/components/routes/link.js
+++ b/packages/edit-site/src/components/routes/link.js
@@ -8,6 +8,10 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
  * Internal dependencies
  */
 import { unlock } from '../../private-apis';
+import {
+	isPreviewingTheme,
+	currentlyPreviewingTheme,
+} from '../../utils/is-previewing-theme';
 
 const { useHistory } = unlock( routerPrivateApis );
 
@@ -29,6 +33,14 @@ export function useLink( params = {}, state, shouldReplace = false ) {
 		window.location.href,
 		...Object.keys( currentArgs )
 	);
+
+	if ( isPreviewingTheme() ) {
+		params = {
+			...params,
+			theme_preview: currentlyPreviewingTheme(),
+		};
+	}
+
 	const newUrl = addQueryArgs( currentUrlWithoutArgs, params );
 
 	return {

--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -11,6 +11,7 @@ import { displayShortcut } from '@wordpress/keycodes';
  * Internal dependencies
  */
 import { store as editSiteStore } from '../../store';
+import { isPreviewingTheme } from '../../utils/is-previewing-theme';
 
 export default function SaveButton( {
 	className = 'edit-site-save-button__button',
@@ -33,9 +34,17 @@ export default function SaveButton( {
 	}, [] );
 	const { setIsSaveViewOpened } = useDispatch( editSiteStore );
 
-	const disabled = ! isDirty || isSaving;
+	const activateSaveEnabled = isPreviewingTheme() || isDirty;
+	const disabled = isSaving || ! activateSaveEnabled;
 
-	const label = __( 'Save' );
+	let label;
+	if ( isPreviewingTheme() && isDirty ) {
+		label = __( 'Activate & Save' );
+	} else if ( isPreviewingTheme() ) {
+		label = __( 'Activate' );
+	} else {
+		label = __( 'Save' );
+	}
 
 	return (
 		<Button

--- a/packages/edit-site/src/components/save-hub/index.js
+++ b/packages/edit-site/src/components/save-hub/index.js
@@ -11,6 +11,7 @@ import { check } from '@wordpress/icons';
  * Internal dependencies
  */
 import SaveButton from '../save-button';
+import { isPreviewingTheme } from '../../utils/is-previewing-theme';
 
 export default function SaveHub() {
 	const { countUnsavedChanges, isDirty, isSaving } = useSelect(
@@ -31,7 +32,7 @@ export default function SaveHub() {
 		[]
 	);
 
-	const disabled = ! isDirty || isSaving;
+	const disabled = isSaving || ( ! isDirty && ! isPreviewingTheme() );
 
 	return (
 		<HStack className="edit-site-save-hub" alignment="right" spacing={ 4 }>

--- a/packages/edit-site/src/components/save-panel/index.js
+++ b/packages/edit-site/src/components/save-panel/index.js
@@ -17,6 +17,7 @@ import { NavigableRegion } from '@wordpress/interface';
  */
 import { store as editSiteStore } from '../../store';
 import { unlock } from '../../private-apis';
+import { useActivateTheme } from '../../utils/use-activate-theme';
 
 export default function SavePanel() {
 	const { isSaveViewOpen, canvasMode } = useSelect( ( select ) => {
@@ -32,7 +33,18 @@ export default function SavePanel() {
 		};
 	}, [] );
 	const { setIsSaveViewOpened } = useDispatch( editSiteStore );
+	const activateTheme = useActivateTheme();
 	const onClose = () => setIsSaveViewOpened( false );
+	const onSave = async ( values ) => {
+		await activateTheme();
+		return values;
+	};
+
+	const entitySavedStates = window?.__experimentalEnableThemePreviews ? (
+		<EntitiesSavedStates close={ onClose } onSave={ onSave } />
+	) : (
+		<EntitiesSavedStates close={ onClose } />
+	);
 
 	if ( canvasMode === 'view' ) {
 		return isSaveViewOpen ? (
@@ -44,7 +56,7 @@ export default function SavePanel() {
 					'Save site, content, and template changes'
 				) }
 			>
-				<EntitiesSavedStates close={ onClose } />
+				{ entitySavedStates }
 			</Modal>
 		) : null;
 	}
@@ -57,7 +69,7 @@ export default function SavePanel() {
 			ariaLabel={ __( 'Save sidebar' ) }
 		>
 			{ isSaveViewOpen ? (
-				<EntitiesSavedStates close={ onClose } />
+				entitySavedStates
 			) : (
 				<div className="edit-site-editor__toggle-save-panel">
 					<Button

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -17,6 +17,10 @@ import NavigationMenuContent from './navigation-menu-content';
 import { NavigationMenuLoader } from './loader';
 import { unlock } from '../../private-apis';
 import { store as editSiteStore } from '../../store';
+import {
+	isPreviewingTheme,
+	currentlyPreviewingTheme,
+} from '../../utils/is-previewing-theme';
 
 const { useHistory } = unlock( routerPrivateApis );
 
@@ -86,12 +90,18 @@ export default function SidebarNavigationScreenNavigationMenus() {
 				history.push( {
 					postType: attributes.type,
 					postId: attributes.id,
+					...( isPreviewingTheme() && {
+						theme_preview: currentlyPreviewingTheme(),
+					} ),
 				} );
 			}
 			if ( name === 'core/page-list-item' && attributes.id && history ) {
 				history.push( {
 					postType: 'page',
 					postId: attributes.id,
+					...( isPreviewingTheme() && {
+						theme_preview: currentlyPreviewingTheme(),
+					} ),
 				} );
 			}
 		},

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -7,8 +7,9 @@ import {
 	__experimentalNavigatorToParentButton as NavigatorToParentButton,
 	__experimentalHeading as Heading,
 } from '@wordpress/components';
-import { isRTL, __ } from '@wordpress/i18n';
+import { isRTL, __, sprintf } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
+import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -17,6 +18,10 @@ import { useSelect } from '@wordpress/data';
 import { store as editSiteStore } from '../../store';
 import { unlock } from '../../private-apis';
 import SidebarButton from '../sidebar-button';
+import {
+	isPreviewingTheme,
+	currentlyPreviewingTheme,
+} from '../../utils/is-previewing-theme';
 
 export default function SidebarNavigationScreen( {
 	isRoot,
@@ -31,6 +36,8 @@ export default function SidebarNavigationScreen( {
 			dashboardLink: getSettings().__experimentalDashboardLink,
 		};
 	}, [] );
+	const { getTheme } = useSelect( coreStore );
+	const theme = getTheme( currentlyPreviewingTheme() );
 
 	return (
 		<VStack spacing={ 2 }>
@@ -48,8 +55,16 @@ export default function SidebarNavigationScreen( {
 				) : (
 					<SidebarButton
 						icon={ isRTL() ? chevronRight : chevronLeft }
-						label={ __( 'Go back to the Dashboard' ) }
-						href={ dashboardLink || 'index.php' }
+						label={
+							! isPreviewingTheme()
+								? __( 'Go back to the Dashboard' )
+								: __( 'Go back to the theme showcase' )
+						}
+						href={
+							! isPreviewingTheme()
+								? dashboardLink || 'index.php'
+								: 'themes.php'
+						}
 					/>
 				) }
 				<Heading
@@ -58,7 +73,13 @@ export default function SidebarNavigationScreen( {
 					level={ 2 }
 					size={ 20 }
 				>
-					{ title }
+					{ ! isPreviewingTheme()
+						? title
+						: sprintf(
+								'Previewing %1$s: %2$s',
+								theme?.name?.rendered,
+								title
+						  ) }
 				</Heading>
 				{ actions }
 			</HStack>

--- a/packages/edit-site/src/utils/is-previewing-theme.js
+++ b/packages/edit-site/src/utils/is-previewing-theme.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { getQueryArg } from '@wordpress/url';
+
+export function isPreviewingTheme() {
+	return (
+		window?.__experimentalEnableThemePreviews &&
+		getQueryArg( window.location.href, 'theme_preview' ) !== undefined
+	);
+}
+
+export function currentlyPreviewingTheme() {
+	if ( isPreviewingTheme() ) {
+		return getQueryArg( window.location.href, 'theme_preview' );
+	}
+	return null;
+}

--- a/packages/edit-site/src/utils/use-activate-theme.js
+++ b/packages/edit-site/src/utils/use-activate-theme.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../private-apis';
+import {
+	isPreviewingTheme,
+	currentlyPreviewingTheme,
+} from './is-previewing-theme';
+
+const { useHistory, useLocation } = unlock( routerPrivateApis );
+
+/**
+ * This should be refactored to use the REST API, once the REST API can activate themes.
+ *
+ * @return {Function} A function that activates the theme.
+ */
+export function useActivateTheme() {
+	const history = useHistory();
+	const location = useLocation();
+
+	return async () => {
+		if ( isPreviewingTheme() ) {
+			const activationURL =
+				'themes.php?action=activate&stylesheet=' +
+				currentlyPreviewingTheme() +
+				'&_wpnonce=' +
+				window.BLOCK_THEME_ACTIVATE_NONCE;
+			await window.fetch( activationURL );
+			const { theme_preview: themePreview, ...params } = location.params;
+			history.replace( params );
+		}
+	};
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This adds theme previews to the Site Editor by means of a `theme_preview` parameter. The aim is to enable theme previews from the theme directory as outlined in https://github.com/WordPress/gutenberg/issues/37201#issuecomment-1516149003.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3f68df7</samp>

This pull request adds a new feature to the `apiFetch` and `core-data` packages that enables theme previews in the Site Editor for block themes. It also adds a compatibility layer for WordPress 6.3 that filters the blog options and sets the theme for the preview based on the REST API request. It creates and requires a new file `theme-previews.php` and a new middleware function `createThemePreviewMiddleware`.

## Why?
Theme previews are a missing feature for block themes.

## How?
1. Add filters to the the `stylesheet` and `template` options when the `theme_preview` URL parameter is set, to modify the blog option for to a different theme.
2. Also add a middleware to the REST API to add the theme_preview parameter so that the blog options are changed in the REST API.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3f68df7</samp>

*  Add functions to enable theme previews in the Site Editor for block themes ([link](https://github.com/WordPress/gutenberg/pull/50030/files?diff=unified&w=0#diff-6a8af5b29ddff1cc2863aa583b551dfe14f73fb49ffb4e79782c7477b2d7680fR1-R50))
* Require the `theme-previews.php` file in the `load.php` file ([link](https://github.com/WordPress/gutenberg/pull/50030/files?diff=unified&w=0#diff-979d356a31350e9429b6faa5be6daaa5b10785838520396f552717a1b270c67bR55))
* Create and expose a `createThemePreviewMiddleware` function in the `api-fetch` package ([link](https://github.com/WordPress/gutenberg/pull/50030/files?diff=unified&w=0#diff-f6baf3c8c169254cd1f8743f6f2fc25665320f2c768d7a6da71b3e27709940f8R17),[link](https://github.com/WordPress/gutenberg/pull/50030/files?diff=unified&w=0#diff-f6baf3c8c169254cd1f8743f6f2fc25665320f2c768d7a6da71b3e27709940f8R197),[link](https://github.com/WordPress/gutenberg/pull/50030/files?diff=unified&w=0#diff-6c257e425d44e1f7ed485fe903a5db14b2427fb98225e86c478d01e21d0816bcR1-R35))
* Modify the `__experimentalGetTemplateForLink` resolver function in the `core-data` package ([link](https://github.com/WordPress/gutenberg/pull/50030/files?diff=unified&w=0#diff-fec6390e24332dec4a0c7c74f9f7b9a015ce191e0e6348361ead793ceda3991dL417-R427))
  * Add a `theme_preview` parameter to the fetch request, based on the value of the `theme_preview` GET parameter in the window location ([link](https://github.com/WordPress/gutenberg/pull/50030/files?diff=unified&w=0#diff-fec6390e24332dec4a0c7c74f9f7b9a015ce191e0e6348361ead793ceda3991dL9-R9))

## Testing Instructions
- Open the Site Editor and add the following to your URL: ?theme_preview=[themePath] where `themePath` is the relative path to the theme you want to preview (e.g. `twentytwentythree`).
- Also open the front of the site and add ?theme_preview=[themePath] to the URL. This enables you to preview the theme in the front of the site.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

## Todo

- [x] Add a message in the main Site Editor to explain that you're previewing a theme
- [x] Add the "Activate Theme" button to the entity saving flow
- [x] Use the theme name instead if the path on the ¨Preview XXX¨ text
- [x] Add a snack bar when we activate the theme
- [x] The live preview button only shows for the first block theme
- [x] If you are saving, the activate button shouldn´t do anything until you confirm that you want to save and switch
- [x] the save button on the site editor should say Activate and save
- [x] the sidebar on the site editor should alert that you are not only saving changes but also changing your theme
- [x] Make everything be an experiment
- [x] refactor the terrible code
- [ ] Move snackbar notices to the bottom centre
- [ ] Remove the "Previewing" text from the header, except for at the top level.
- [x] send the user back to the theme showcase when they click back
- [ ] Remove specific code from the Editor package
- [x] After you activate a theme, the return param stops working :(

Fixes https://github.com/WordPress/gutenberg/issues/37201 and https://github.com/WordPress/gutenberg/issues/47228

@WordPress/block-themers 