### PR TITLE
Use Core Data for Nav fallbacks and side load resulting entity into state

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -317,7 +317,7 @@ _Returns_
 
 -   `any`: The entity record's save error.
 
-### getNavigationFallback
+### getNavigationFallbackId
 
 Retrieve the fallback Navigation.
 
@@ -619,7 +619,7 @@ _Returns_
 
 -   `Object`: Action object.
 
-### receiveNavigationFallback
+### receiveNavigationFallbackId
 
 Undocumented declaration.
 

--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -317,6 +317,10 @@ _Returns_
 
 -   `any`: The entity record's save error.
 
+### getNavigationFallback
+
+Undocumented declaration.
+
 ### getRawEntityRecord
 
 Returns the entity's record object by key, with its attributes mapped to their raw values.
@@ -606,6 +610,10 @@ _Parameters_
 _Returns_
 
 -   `Object`: Action object.
+
+### receiveNavigationFallback
+
+Undocumented declaration.
 
 ### receiveThemeSupports
 

--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -621,7 +621,15 @@ _Returns_
 
 ### receiveNavigationFallbackId
 
-Undocumented declaration.
+Returns an action object signalling that the fallback Navigation Menu id has been received.
+
+_Parameters_
+
+-   _fallback_ `integer`: the id of the fallback Navigation Menu
+
+_Returns_
+
+-   `Object`: Action object.
 
 ### receiveThemeSupports
 

--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -625,7 +625,7 @@ Returns an action object signalling that the fallback Navigation Menu id has bee
 
 _Parameters_
 
--   _fallback_ `integer`: the id of the fallback Navigation Menu
+-   _fallbackId_ `integer`: the id of the fallback Navigation Menu
 
 _Returns_
 

--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -327,7 +327,7 @@ _Parameters_
 
 _Returns_
 
--   `any`: The ID for the fallback Navigation post.
+-   `EntityRecordKey | undefined`: The ID for the fallback Navigation post.
 
 ### getRawEntityRecord
 

--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -319,7 +319,15 @@ _Returns_
 
 ### getNavigationFallback
 
-Undocumented declaration.
+Retrieve the fallback Navigation.
+
+_Parameters_
+
+-   _state_ `State`: Data state.
+
+_Returns_
+
+-   `any`: The ID for the fallback Navigation post.
 
 ### getRawEntityRecord
 

--- a/lib/experimental/navigation-fallback.php
+++ b/lib/experimental/navigation-fallback.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Expose additional fields in the embeddable links of the
+ * Navigation Fallback REST endpoint.
+ *
+ * The endpoint may embed the full Navigation Menu object into the
+ * response as the `self` link. By default the Posts Controller
+ * will only exposes a limited subset of fields but the editor requires
+ * additional fields to be available in order to utilise the menu.
+ *
+ * @param array $schema the schema for the `wp_navigation` post.
+ * @return array the modified schema.
+ */
+function gutenberg_add_fields_to_navigation_fallback_embeded_links( $schema ) {
+	// Expose top level fields.
+	$schema['properties']['status']['context']  = array_merge( $schema['properties']['status']['context'], array( 'embed' ) );
+	$schema['properties']['content']['context'] = array_merge( $schema['properties']['content']['context'], array( 'embed' ) );
+
+	// Expose sub properties of content field.
+	$schema['properties']['content']['properties']['raw']['context']           = array_merge( $schema['properties']['content']['properties']['raw']['context'], array( 'embed' ) );
+	$schema['properties']['content']['properties']['rendered']['context']      = array_merge( $schema['properties']['content']['properties']['rendered']['context'], array( 'embed' ) );
+	$schema['properties']['content']['properties']['block_version']['context'] = array_merge( $schema['properties']['content']['properties']['block_version']['context'], array( 'embed' ) );
+
+	return $schema;
+}
+
+add_filter(
+	'rest_wp_navigation_item_schema',
+	'gutenberg_add_fields_to_navigation_fallback_embeded_links'
+);

--- a/lib/experimental/navigation-fallback.php
+++ b/lib/experimental/navigation-fallback.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Navigation Fallback
+ *
+ * Functions required for managing Navigation fallbacks behavior.
+ *
+ * @package Gutenberg
+ * @since 6.3.0
+ */
 
 /**
  * Expose additional fields in the embeddable links of the

--- a/lib/load.php
+++ b/lib/load.php
@@ -119,6 +119,7 @@ require __DIR__ . '/experimental/blocks.php';
 require __DIR__ . '/experimental/navigation-theme-opt-in.php';
 require __DIR__ . '/experimental/kses.php';
 require __DIR__ . '/experimental/l10n.php';
+require __DIR__ . '/experimental/navigation-fallback.php';
 
 // Fonts API.
 if ( ! class_exists( 'WP_Fonts' ) ) {
@@ -168,3 +169,4 @@ require __DIR__ . '/block-supports/dimensions.php';
 require __DIR__ . '/block-supports/duotone.php';
 require __DIR__ . '/block-supports/anchor.php';
 require __DIR__ . '/block-supports/shadow.php';
+

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -27,9 +27,9 @@ import {
 	__experimentalUseBlockOverlayActive as useBlockOverlayActive,
 	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
 } from '@wordpress/block-editor';
-import { EntityProvider } from '@wordpress/core-data';
+import { EntityProvider, store as coreStore } from '@wordpress/core-data';
 
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	PanelBody,
 	ToggleControl,
@@ -41,7 +41,6 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import { close, Icon } from '@wordpress/icons';
-import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -220,44 +219,79 @@ function Navigation( {
 	// that automatically saves the menu as an entity when changes are made to the inner blocks.
 	const hasUnsavedBlocks = hasUncontrolledInnerBlocks && ! isEntityAvailable;
 
+	const { navigationFallback } = useSelect( ( select ) => {
+		const { getNavigationFallback } = select( coreStore );
+		return {
+			navigationFallback:
+				ref || hasUnsavedBlocks ? null : getNavigationFallback(),
+		};
+	}, [] );
+
 	useEffect( () => {
 		// If:
 		// - there is an existing menu, OR
 		// - there are existing (uncontrolled) inner blocks
 		// ...then don't request a fallback menu.
-		if ( ref || hasUnsavedBlocks ) {
+		if ( ref || hasUnsavedBlocks || ! navigationFallback?.id ) {
 			return;
 		}
 
-		apiFetch( { path: '/wp-block-editor/v1/navigation-fallback' } )
-			.then( ( fallbackNavigationMenu ) => {
-				if ( ! fallbackNavigationMenu?.id ) {
-					showNavigationMenuStatusNotice(
-						__( 'Unable to fetch a fallback Navigation Menu.' )
-					);
-					return;
-				}
-
-				/**
-				 *  This fallback displays (both in editor and on front)
-				 *  The fallback should not request a save (entity dirty state)
-				 *  nor to be undoable, hence why it is marked as non persistent
-				 */
-				__unstableMarkNextChangeAsNotPersistent();
-				setRef( fallbackNavigationMenu.id );
-			} )
-			.catch( () => {
-				showNavigationMenuStatusNotice(
-					__( 'Unable to fetch a fallback Navigation Menu.' )
-				);
-			} );
+		/**
+		 *  This fallback displays (both in editor and on front)
+		 *  The fallback should not request a save (entity dirty state)
+		 *  nor to be undoable, hence why it is marked as non persistent
+		 */
+		__unstableMarkNextChangeAsNotPersistent();
+		setRef( navigationFallback.id );
 	}, [
 		ref,
-		hasUnsavedBlocks,
 		setRef,
-		showNavigationMenuStatusNotice,
+		hasUnsavedBlocks,
+		navigationFallback,
 		__unstableMarkNextChangeAsNotPersistent,
 	] );
+
+	// useEffect( () => {
+	// 	// If:
+	// 	// - there is an existing menu, OR
+	// 	// - there are existing (uncontrolled) inner blocks
+	// 	// ...then don't request a fallback menu.
+	// 	if ( ref || hasUnsavedBlocks || ! getNavigationFallback ) {
+	// 		return;
+	// 	}
+
+	// 	debugger;
+
+	// 	getNavigationFallback()
+	// 		.then( ( fallbackNavigationMenu ) => {
+	// 			if ( ! fallbackNavigationMenu?.id ) {
+	// 				showNavigationMenuStatusNotice(
+	// 					__( 'Unable to fetch a fallback Navigation Menu.' )
+	// 				);
+	// 				return;
+	// 			}
+
+	// 			/**
+	// 			 *  This fallback displays (both in editor and on front)
+	// 			 *  The fallback should not request a save (entity dirty state)
+	// 			 *  nor to be undoable, hence why it is marked as non persistent
+	// 			 */
+	// 			__unstableMarkNextChangeAsNotPersistent();
+	// 			setRef( fallbackNavigationMenu.id );
+	// 		} )
+	// 		.catch( () => {
+	// 			showNavigationMenuStatusNotice(
+	// 				__( 'Unable to fetch a fallback Navigation Menu.' )
+	// 			);
+	// 		} );
+	// }, [
+	// 	ref,
+	// 	hasUnsavedBlocks,
+	// 	setRef,
+	// 	showNavigationMenuStatusNotice,
+	// 	__unstableMarkNextChangeAsNotPersistent,
+	// 	getNavigationFallback,
+	// ] );
 
 	const navRef = useRef();
 

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -219,20 +219,18 @@ function Navigation( {
 	// that automatically saves the menu as an entity when changes are made to the inner blocks.
 	const hasUnsavedBlocks = hasUncontrolledInnerBlocks && ! isEntityAvailable;
 
-	const { navigationFallback } = useSelect( ( select ) => {
-		const { getNavigationFallbackId } = select( coreStore );
-		return {
-			navigationFallback:
-				ref || hasUnsavedBlocks ? null : getNavigationFallbackId(),
-		};
-	}, [] );
+	const { getNavigationFallbackId } = useSelect( coreStore );
+
+	const navigationFallbackId = ! ( ref || hasUnsavedBlocks )
+		? getNavigationFallbackId()
+		: null;
 
 	useEffect( () => {
 		// If:
 		// - there is an existing menu, OR
 		// - there are existing (uncontrolled) inner blocks
 		// ...then don't request a fallback menu.
-		if ( ref || hasUnsavedBlocks || ! navigationFallback?.id ) {
+		if ( ref || hasUnsavedBlocks || ! navigationFallbackId ) {
 			return;
 		}
 
@@ -241,13 +239,14 @@ function Navigation( {
 		 *  The fallback should not request a save (entity dirty state)
 		 *  nor to be undoable, hence why it is marked as non persistent
 		 */
+
 		__unstableMarkNextChangeAsNotPersistent();
-		setRef( navigationFallback.id );
+		setRef( navigationFallbackId );
 	}, [
 		ref,
 		setRef,
 		hasUnsavedBlocks,
-		navigationFallback,
+		navigationFallbackId,
 		__unstableMarkNextChangeAsNotPersistent,
 	] );
 

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -251,48 +251,6 @@ function Navigation( {
 		__unstableMarkNextChangeAsNotPersistent,
 	] );
 
-	// useEffect( () => {
-	// 	// If:
-	// 	// - there is an existing menu, OR
-	// 	// - there are existing (uncontrolled) inner blocks
-	// 	// ...then don't request a fallback menu.
-	// 	if ( ref || hasUnsavedBlocks || ! getNavigationFallback ) {
-	// 		return;
-	// 	}
-
-	// 	debugger;
-
-	// 	getNavigationFallback()
-	// 		.then( ( fallbackNavigationMenu ) => {
-	// 			if ( ! fallbackNavigationMenu?.id ) {
-	// 				showNavigationMenuStatusNotice(
-	// 					__( 'Unable to fetch a fallback Navigation Menu.' )
-	// 				);
-	// 				return;
-	// 			}
-
-	// 			/**
-	// 			 *  This fallback displays (both in editor and on front)
-	// 			 *  The fallback should not request a save (entity dirty state)
-	// 			 *  nor to be undoable, hence why it is marked as non persistent
-	// 			 */
-	// 			__unstableMarkNextChangeAsNotPersistent();
-	// 			setRef( fallbackNavigationMenu.id );
-	// 		} )
-	// 		.catch( () => {
-	// 			showNavigationMenuStatusNotice(
-	// 				__( 'Unable to fetch a fallback Navigation Menu.' )
-	// 			);
-	// 		} );
-	// }, [
-	// 	ref,
-	// 	hasUnsavedBlocks,
-	// 	setRef,
-	// 	showNavigationMenuStatusNotice,
-	// 	__unstableMarkNextChangeAsNotPersistent,
-	// 	getNavigationFallback,
-	// ] );
-
 	const navRef = useRef();
 
 	// The standard HTML5 tag for the block wrapper.

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -220,10 +220,10 @@ function Navigation( {
 	const hasUnsavedBlocks = hasUncontrolledInnerBlocks && ! isEntityAvailable;
 
 	const { navigationFallback } = useSelect( ( select ) => {
-		const { getNavigationFallback } = select( coreStore );
+		const { getNavigationFallbackId } = select( coreStore );
 		return {
 			navigationFallback:
-				ref || hasUnsavedBlocks ? null : getNavigationFallback(),
+				ref || hasUnsavedBlocks ? null : getNavigationFallbackId(),
 		};
 	}, [] );
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -106,6 +106,10 @@ _Returns_
 
 -   `Object`: Action object.
 
+### receiveNavigationFallback
+
+Undocumented declaration.
+
 ### receiveThemeSupports
 
 > **Deprecated** since WP 5.9, this is not useful anymore, use the selector direclty.
@@ -481,6 +485,10 @@ _Parameters_
 _Returns_
 
 -   `any`: The entity record's save error.
+
+### getNavigationFallback
+
+Undocumented declaration.
 
 ### getRawEntityRecord
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -106,7 +106,7 @@ _Returns_
 
 -   `Object`: Action object.
 
-### receiveNavigationFallback
+### receiveNavigationFallbackId
 
 Undocumented declaration.
 
@@ -486,7 +486,7 @@ _Returns_
 
 -   `any`: The entity record's save error.
 
-### getNavigationFallback
+### getNavigationFallbackId
 
 Retrieve the fallback Navigation.
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -488,7 +488,15 @@ _Returns_
 
 ### getNavigationFallback
 
-Undocumented declaration.
+Retrieve the fallback Navigation.
+
+_Parameters_
+
+-   _state_ `State`: Data state.
+
+_Returns_
+
+-   `any`: The ID for the fallback Navigation post.
 
 ### getRawEntityRecord
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -496,7 +496,7 @@ _Parameters_
 
 _Returns_
 
--   `any`: The ID for the fallback Navigation post.
+-   `EntityRecordKey | undefined`: The ID for the fallback Navigation post.
 
 ### getRawEntityRecord
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -112,7 +112,7 @@ Returns an action object signalling that the fallback Navigation Menu id has bee
 
 _Parameters_
 
--   _fallback_ `integer`: the id of the fallback Navigation Menu
+-   _fallbackId_ `integer`: the id of the fallback Navigation Menu
 
 _Returns_
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -108,7 +108,15 @@ _Returns_
 
 ### receiveNavigationFallbackId
 
-Undocumented declaration.
+Returns an action object signalling that the fallback Navigation Menu id has been received.
+
+_Parameters_
+
+-   _fallback_ `integer`: the id of the fallback Navigation Menu
+
+_Returns_
+
+-   `Object`: Action object.
 
 ### receiveThemeSupports
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -835,7 +835,7 @@ export function receiveAutosaves( postId, autosaves ) {
 	};
 }
 
-export function receiveNavigationFallback( fallback ) {
+export function receiveNavigationFallbackId( fallback ) {
 	return {
 		type: 'RECEIVE_NAVIGATION_FALLBACK',
 		fallback,

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -839,12 +839,12 @@ export function receiveAutosaves( postId, autosaves ) {
  * Returns an action object signalling that the fallback Navigation
  * Menu id has been received.
  *
- * @param {integer} fallback the id of the fallback Navigation Menu
+ * @param {integer} fallbackId the id of the fallback Navigation Menu
  * @return {Object} Action object.
  */
-export function receiveNavigationFallbackId( fallback ) {
+export function receiveNavigationFallbackId( fallbackId ) {
 	return {
 		type: 'RECEIVE_NAVIGATION_FALLBACK_ID',
-		fallback,
+		fallbackId,
 	};
 }

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -835,6 +835,13 @@ export function receiveAutosaves( postId, autosaves ) {
 	};
 }
 
+/**
+ * Returns an action object signalling that the fallback Navigation
+ * Menu id has been received.
+ *
+ * @param {integer} fallback the id of the fallback Navigation Menu
+ * @return {Object} Action object.
+ */
 export function receiveNavigationFallbackId( fallback ) {
 	return {
 		type: 'RECEIVE_NAVIGATION_FALLBACK_ID',

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -837,7 +837,7 @@ export function receiveAutosaves( postId, autosaves ) {
 
 export function receiveNavigationFallbackId( fallback ) {
 	return {
-		type: 'RECEIVE_NAVIGATION_FALLBACK',
+		type: 'RECEIVE_NAVIGATION_FALLBACK_ID',
 		fallback,
 	};
 }

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -834,3 +834,10 @@ export function receiveAutosaves( postId, autosaves ) {
 		autosaves: Array.isArray( autosaves ) ? autosaves : [ autosaves ],
 	};
 }
+
+export function receiveNavigationFallback( fallback ) {
+	return {
+		type: 'RECEIVE_NAVIGATION_FALLBACK',
+		fallback,
+	};
+}

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -642,6 +642,15 @@ export function blockPatternCategories( state = [], action ) {
 	return state;
 }
 
+export function navigationFallback( state = null, action ) {
+	switch ( action.type ) {
+		case 'RECEIVE_NAVIGATION_FALLBACK':
+			return action.fallback;
+	}
+
+	return state;
+}
+
 export default combineReducers( {
 	terms,
 	users,
@@ -658,4 +667,5 @@ export default combineReducers( {
 	autosaves,
 	blockPatterns,
 	blockPatternCategories,
+	navigationFallback,
 } );

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -642,9 +642,9 @@ export function blockPatternCategories( state = [], action ) {
 	return state;
 }
 
-export function navigationFallback( state = null, action ) {
+export function navigationFallbackId( state = null, action ) {
 	switch ( action.type ) {
-		case 'RECEIVE_NAVIGATION_FALLBACK':
+		case 'RECEIVE_NAVIGATION_FALLBACK_ID':
 			return action.fallback;
 	}
 
@@ -667,5 +667,5 @@ export default combineReducers( {
 	autosaves,
 	blockPatterns,
 	blockPatternCategories,
-	navigationFallback,
+	navigationFallbackId,
 } );

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -645,7 +645,7 @@ export function blockPatternCategories( state = [], action ) {
 export function navigationFallbackId( state = null, action ) {
 	switch ( action.type ) {
 		case 'RECEIVE_NAVIGATION_FALLBACK_ID':
-			return action.fallback;
+			return action.fallbackId;
 	}
 
 	return state;

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -525,3 +525,23 @@ export const getBlockPatternCategories =
 		} );
 		dispatch( { type: 'RECEIVE_BLOCK_PATTERN_CATEGORIES', categories } );
 	};
+
+export const getNavigationFallback =
+	() =>
+	async ( { dispatch } ) => {
+		const fallback = await apiFetch( {
+			path: '/wp-block-editor/v1/navigation-fallbacks?_embed',
+		} );
+
+		const record = fallback?._embedded?.self;
+
+		dispatch.receiveNavigationFallback( fallback );
+
+		if ( record ) {
+			dispatch.receiveEntityRecords(
+				'postType',
+				'wp_navigation',
+				record
+			);
+		}
+	};

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -526,16 +526,18 @@ export const getBlockPatternCategories =
 		dispatch( { type: 'RECEIVE_BLOCK_PATTERN_CATEGORIES', categories } );
 	};
 
-export const getNavigationFallback =
+export const getNavigationFallbackId =
 	() =>
 	async ( { dispatch } ) => {
 		const fallback = await apiFetch( {
-			path: '/wp-block-editor/v1/navigation-fallbacks?_embed',
+			path: addQueryArgs( '/wp-block-editor/v1/navigation-fallback', {
+				_embed: true,
+			} ),
 		} );
 
 		const record = fallback?._embedded?.self;
 
-		dispatch.receiveNavigationFallback( fallback );
+		dispatch.receiveNavigationFallbackId( fallback );
 
 		if ( record ) {
 			dispatch.receiveEntityRecords(

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -537,7 +537,7 @@ export const getNavigationFallbackId =
 
 		const record = fallback?._embedded?.self;
 
-		dispatch.receiveNavigationFallbackId( fallback );
+		dispatch.receiveNavigationFallbackId( fallback?.id );
 
 		if ( record ) {
 			dispatch.receiveEntityRecords(

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -41,7 +41,7 @@ export interface State {
 	undo: UndoState;
 	userPermissions: Record< string, boolean >;
 	users: UserState;
-	navigationFallback: Optional< Record< string, unknown > >;
+	navigationFallback: EntityRecordKey;
 }
 
 type EntityRecordKey = string | number;
@@ -1242,6 +1242,8 @@ export function getBlockPatternCategories( state: State ): Array< any > {
  * @param state Data state.
  * @return The ID for the fallback Navigation post.
  */
-export function getNavigationFallbackId( state: State ): any {
+export function getNavigationFallbackId(
+	state: State
+): EntityRecordKey | undefined {
 	return state.navigationFallback;
 }

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -41,7 +41,7 @@ export interface State {
 	undo: UndoState;
 	userPermissions: Record< string, boolean >;
 	users: UserState;
-	navigationFallback: EntityRecordKey;
+	navigationFallbackId: EntityRecordKey;
 }
 
 type EntityRecordKey = string | number;
@@ -1245,5 +1245,5 @@ export function getBlockPatternCategories( state: State ): Array< any > {
 export function getNavigationFallbackId(
 	state: State
 ): EntityRecordKey | undefined {
-	return state.navigationFallback;
+	return state.navigationFallbackId;
 }

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -41,6 +41,7 @@ export interface State {
 	undo: UndoState;
 	userPermissions: Record< string, boolean >;
 	users: UserState;
+	navigationFallback: Optional< Record< string, unknown > >;
 }
 
 type EntityRecordKey = string | number;
@@ -1233,4 +1234,8 @@ export function getBlockPatterns( state: State ): Array< any > {
  */
 export function getBlockPatternCategories( state: State ): Array< any > {
 	return state.blockPatternCategories;
+}
+
+export function getNavigationFallback( state: State ): any {
+	return state.navigationFallback;
 }

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -1242,6 +1242,6 @@ export function getBlockPatternCategories( state: State ): Array< any > {
  * @param state Data state.
  * @return The ID for the fallback Navigation post.
  */
-export function getNavigationFallback( state: State ): any {
+export function getNavigationFallbackId( state: State ): any {
 	return state.navigationFallback;
 }

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -1236,6 +1236,12 @@ export function getBlockPatternCategories( state: State ): Array< any > {
 	return state.blockPatternCategories;
 }
 
+/**
+ * Retrieve the fallback Navigation.
+ *
+ * @param state Data state.
+ * @return The ID for the fallback Navigation post.
+ */
 export function getNavigationFallback( state: State ): any {
 	return state.navigationFallback;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds Core Data selector to retrieve Navigation fallback and sideload embedded entity into state.

Closes https://github.com/WordPress/gutenberg/issues/50002

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently on `trunk` the `navigation-fallbacks` endpoint is called directly from the block's `edit` code using `apiFetch`. This means that each instance of the Nav block trigger's its own request which can result in multiple network requests (especially when multiple blocks are in the editor).

Moreover, once the request has resolved with an `id` a separate request is then dispatched to retrieve the full Navigation post object for usage within the block. Having x2 network requests is wasteful and slow and results in longer load times for the block in fallback mode.

This PR solves both issues.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR adds a selector to Core Data which calls the endpoint to retrieve the fallback. This means that only a single request is ever dispatched.

On top of this the endpoint is called with the `_embed` query arg, which causes the endpoint to response with the full Navigation post object embedded within the response under the `embedded` key. This post object is then pushed into the Core Data state which means that the network request resulting from calling `getEntityRecord('postType', 'wp_navigation', %%ID%%)` (elsewhere in the Nav block code) is _not_ dispatched. Instead the selector immediately resolves with the data that is already is state.

Note that by default on certain fields are marked as being available in the `embed` context. Therefore we are filtering the endpoint schema to include the necessary fields.

## FAQ

#### Why not simply return the Post object from the REST endpoint and avoid all this sideloading?

Initially I was returning the full Navigation post object from the REST endpoint. However, this required the introduction of a endpoint schema that married with the full Post object. 

I spoke to Core REST folks about this and they advised that as we'd (collectively) agreed not to extend the Posts Controller, the most suitable option was simply to return a reference to the Navigation Post (i.e. the `id`) and then include a `self` link within the response which could optionally be embedded.

This resulted in a more manageable schema whilst also retaining the ability to access the full post object as part of the request if necessary.

This is why the selectors return the ID and not the full Post.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Open the Site Editor and toggle open the Network panel filtered by XHR and `navigation`
- Delete all Nav menus at http://localhost:8888/wp-admin/edit.php?post_type=wp_navigation
- Refresh the Site Editor
- See a request to `navigation-fallbacks` - check the response to see that the full post object is included under the `embedded.self` key.
- Check that there is _no_ `GET` request (there _will_ still be an `OPTIONS` request) to fetch the Navigation by ID (e.g. `/wp/v2/navigation/{{SOME_ID}}`.
- See that the Nav block loads and can be saved...etc.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
