### PR TITLE
Remove the normalizeFalsyValue util

### DIFF
--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -23,7 +23,7 @@ import { useCallback, Platform } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { getValueFromVariable, normalizeFalsyValue } from './utils';
+import { getValueFromVariable } from './utils';
 import SpacingSizesControl from '../spacing-sizes-control';
 import HeightControl from '../height-control';
 import ChildLayoutControl from '../child-layout-control';
@@ -229,7 +229,7 @@ export default function DimensionsPanel( {
 			immutableSet(
 				value,
 				[ 'layout', 'contentSize' ],
-				normalizeFalsyValue( newValue )
+				newValue || undefined
 			)
 		);
 	};
@@ -245,7 +245,7 @@ export default function DimensionsPanel( {
 			immutableSet(
 				value,
 				[ 'layout', 'wideSize' ],
-				normalizeFalsyValue( newValue )
+				newValue || undefined
 			)
 		);
 	};

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -19,7 +19,7 @@ import LineHeightControl from '../line-height-control';
 import LetterSpacingControl from '../letter-spacing-control';
 import TextTransformControl from '../text-transform-control';
 import TextDecorationControl from '../text-decoration-control';
-import { getValueFromVariable, normalizeFalsyValue } from './utils';
+import { getValueFromVariable } from './utils';
 import { immutableSet } from '../../utils/object';
 
 const MIN_TEXT_COLUMNS = 1;
@@ -168,7 +168,7 @@ export default function TypographyPanel( {
 				[ 'typography', 'fontFamily' ],
 				slug
 					? `var:preset|font-family|${ slug }`
-					: normalizeFalsyValue( newValue )
+					: newValue || undefined
 			)
 		);
 	};
@@ -193,7 +193,7 @@ export default function TypographyPanel( {
 			immutableSet(
 				value,
 				[ 'typography', 'fontSize' ],
-				normalizeFalsyValue( actualValue )
+				actualValue || undefined
 			)
 		);
 	};
@@ -215,8 +215,8 @@ export default function TypographyPanel( {
 			...value,
 			typography: {
 				...value?.typography,
-				fontStyle: normalizeFalsyValue( newFontStyle ),
-				fontWeight: normalizeFalsyValue( newFontWeight ),
+				fontStyle: newFontStyle || undefined,
+				fontWeight: newFontWeight || undefined,
 			},
 		} );
 	};
@@ -234,7 +234,7 @@ export default function TypographyPanel( {
 			immutableSet(
 				value,
 				[ 'typography', 'lineHeight' ],
-				normalizeFalsyValue( newValue )
+				newValue || undefined
 			)
 		);
 	};
@@ -251,7 +251,7 @@ export default function TypographyPanel( {
 			immutableSet(
 				value,
 				[ 'typography', 'letterSpacing' ],
-				normalizeFalsyValue( newValue )
+				newValue || undefined
 			)
 		);
 	};
@@ -266,7 +266,7 @@ export default function TypographyPanel( {
 			immutableSet(
 				value,
 				[ 'typography', 'textColumns' ],
-				normalizeFalsyValue( newValue )
+				newValue || undefined
 			)
 		);
 	};
@@ -283,7 +283,7 @@ export default function TypographyPanel( {
 			immutableSet(
 				value,
 				[ 'typography', 'textTransform' ],
-				normalizeFalsyValue( newValue )
+				newValue || undefined
 			)
 		);
 	};
@@ -300,7 +300,7 @@ export default function TypographyPanel( {
 			immutableSet(
 				value,
 				[ 'typography', 'textDecoration' ],
-				normalizeFalsyValue( newValue )
+				newValue || undefined
 			)
 		);
 	};

--- a/packages/block-editor/src/components/global-styles/utils.js
+++ b/packages/block-editor/src/components/global-styles/utils.js
@@ -376,16 +376,3 @@ export function scopeSelector( scope, selector ) {
 
 	return selectorsScoped.join( ', ' );
 }
-
-/**
- * Some Global Styles UI components (font size for instance) relies on the fact that emptying inputs
- * (empty strings) should fallback to the parent value (theme.json value).
- * Ideally, there should be a dedicated UI element to "revert to theme" for each input instead.
- * But until we do, this function is used to transform falsy values to undefined values for these components
- * which allows the global styles merge algorithm to revert to the theme.json value.
- *
- * @param {*} value Value to normalize.
- *
- * @return {undefined|*} normalized value.
- */
-export const normalizeFalsyValue = ( value ) => value || undefined;


### PR DESCRIPTION
Addressing a comment here https://github.com/WordPress/gutenberg/pull/49750#discussion_r1175240244

## What?
Basically, this util didn't feel like a great one to have as opposed to just inlinining `|| undefined`
