### PR TITLE
Update Gutenberg release docs to include the new Gutenberg Release Team

### DIFF
--- a/docs/contributors/code/release.md
+++ b/docs/contributors/code/release.md
@@ -2,7 +2,10 @@
 
 This Repository is used to perform several types of releases. This document serves as a checklist for each one of these. It is helpful if you'd like to understand the different workflows.
 
-To release a stable version of the Gutenberg plugin you need to be part of the [Gutenberg development team](/docs/block-editor/contributors/repository-management/#teams). On top of that, you need approval from a member of the Gutenberg Core team for the final step of the release process (upload to the WordPress.org plugin repo -- see below). If you aren't a member yourself, make sure to contact one ahead of time so they'll be around at the time of the release. You can ping in the [#core-editor Slack channel](https://wordpress.slack.com/messages/C02QB2JS7).
+To release a stable version of the Gutenberg plugin you need:
+- To be part of the [Gutenberg development team](/docs/block-editor/contributors/repository-management/#teams), to launch the GitHub actions related to the release process and to potentially backport PRs to the release branch.
+- Write permissions in [make.wordpress.org/core](make.wordpress.org/core), to draft the release post.
+- On top of that, for the last step of the process (uploading the new version to the WordPress.org.plugin directory), you will need approval from a member of the Gutenberg Core team -- see below for more details).
 
 To [release WordPress's npm packages](#packages-releases-to-npm-and-wordpress-core-updates), similar requirements apply.
 
@@ -85,7 +88,7 @@ Only once you're happy with the shape of the release notes, press the green "Pub
 1. Use the release notes that you just edited to update `changelog.txt`, and
 2. Upload the new plugin version to the WordPress.org plugin repository (SVN) (only if you're releasing a stable version).
 
-The last step needs approval by a member of the Gutenberg Core team. Locate the ["Upload Gutenberg plugin to WordPress.org plugin repo" workflow](https://github.com/WordPress/gutenberg/actions/workflows/upload-release-to-plugin-repo.yml) for the new version, and have it [approved](https://docs.github.com/en/actions/managing-workflow-runs/reviewing-deployments#approving-or-rejecting-a-job).
+The last step needs approval by a member of either the Gutenberg Core team, WordPress core team, or Gutenberg Release team. These teams get a notification email when the release is ready to be approved, but if time is of the essence you can ask in the [#core-editor Slack channel] or ping the [Gutenberg Release team]([url](https://github.com/orgs/WordPress/teams/gutenberg-release)) to speed up the process; reaching out _before_ launching the release process so that somebody is ready to approve is recommended. Locate the ["Upload Gutenberg plugin to WordPress.org plugin repo" workflow](https://github.com/WordPress/gutenberg/actions/workflows/upload-release-to-plugin-repo.yml) for the new version, and have it [approved](https://docs.github.com/en/actions/managing-workflow-runs/reviewing-deployments#approving-or-rejecting-a-job).
 
 Once approved, the new Gutenberg version will be available to WordPress users all over the globe. You should check that folks can install the latest version from their WordPress Dashboard.
 


### PR DESCRIPTION
## What?
Updates the Gutenberg release docs to include the new [Gutenberg Release Team](https://github.com/orgs/WordPress/teams/gutenberg-release/members).

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e486e95</samp>

This change improves the release documentation for the Gutenberg plugin, by clarifying the requirements, roles, and procedures for creating a stable version. It also fixes a broken link and formatting issues in `docs/contributors/code/release.md`.

## Why?
Getting the final approval to upload the new plugin version to the plugin directory wasn't always speedy, and it's not clear who to ask; pinging the whole Gutenberg core team can feel too much.

## How?
By adding a new Gutenberg team that will get the approval notification request emails. The members of this team are folks usually involved in Gutenberg releases that are not necessarily Gutenberg Core members. They can help review releases speedily or be directly pinged for release-related questions. If having yet another team doesn't actually help, we can delete it again.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e486e95</samp>

* Clarify the requirements and permissions for releasing a stable version of the Gutenberg plugin ([link](https://github.com/WordPress/gutenberg/pull/50036/files?diff=unified&w=0#diff-17d1ffea91f685c145076051d0b46384b2cf600635cc9429d877e168914aca1bL5-R8))
* Add the WordPress core team and the Gutenberg Release team as possible approvers for uploading the plugin to the WordPress.org repository ([link](https://github.com/WordPress/gutenberg/pull/50036/files?diff=unified&w=0#diff-17d1ffea91f685c145076051d0b46384b2cf600635cc9429d877e168914aca1bL88-R91))
* Suggest contacting the approvers ahead of time or in the Slack channel to expedite the process ([link](https://github.com/WordPress/gutenberg/pull/50036/files?diff=unified&w=0#diff-17d1ffea91f685c145076051d0b46384b2cf600635cc9429d877e168914aca1bL88-R91))
* Fix a broken link to the Gutenberg Release team ([link](https://github.com/WordPress/gutenberg/pull/50036/files?diff=unified&w=0#diff-17d1ffea91f685c145076051d0b46384b2cf600635cc9429d877e168914aca1bL88-R91))