### PR TITLE
Update the Gutenberg release issue template to reflect the new Gutenber release team

### DIFF
--- a/.github/ISSUE_TEMPLATE/New_release.md
+++ b/.github/ISSUE_TEMPLATE/New_release.md
@@ -44,7 +44,7 @@ This issue is to provide visibility on the progress of the release process of Gu
 -   [ ] Start the release process by triggering the `stable` [workflow](https://developer.wordpress.org/block-editor/contributors/code/release/#running-workflow)
 -   [ ] Update the created Draft Release accordingly. Typically by copy/pasting the last RC release notes and add any changes/updates as needed.
 -   [ ] Publish Release
--   [ ] Trigger the update to the plugin directory - SVN _(get approval from member of Core team if necessary)_
+-   [ ] Trigger the update to the plugin directory. _(Get approval from member of [Gutenberg Release team](https://github.com/orgs/WordPress/teams/gutenberg-release/members) if necessary)_
 -   [ ] Announce in `#core-editor` channel that the plugin has been released
 -   [ ] Reach out to other contributors to help get the post reviewed
 -   [ ] Publish Release post on Make Core blog

--- a/.github/ISSUE_TEMPLATE/New_release.md
+++ b/.github/ISSUE_TEMPLATE/New_release.md
@@ -44,7 +44,7 @@ This issue is to provide visibility on the progress of the release process of Gu
 -   [ ] Start the release process by triggering the `stable` [workflow](https://developer.wordpress.org/block-editor/contributors/code/release/#running-workflow)
 -   [ ] Update the created Draft Release accordingly. Typically by copy/pasting the last RC release notes and add any changes/updates as needed.
 -   [ ] Publish Release
--   [ ] Trigger the update to the plugin directory. _(Get approval from member of [Gutenberg Release team](https://github.com/orgs/WordPress/teams/gutenberg-release/members) if necessary)_
+-   [ ] Trigger the update to the plugin directory. _(Get approval from a member of [Gutenberg Release team](https://github.com/orgs/WordPress/teams/gutenberg-release/members) if necessary)_
 -   [ ] Announce in `#core-editor` channel that the plugin has been released
 -   [ ] Reach out to other contributors to help get the post reviewed
 -   [ ] Publish Release post on Make Core blog


### PR DESCRIPTION
## What?
This a follow-up to #50036 that updates the Gutenberg release issue template to reflect the new Gutenberg release team

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 93d3e08</samp>

Updated the release issue template to use the Gutenberg Release team for plugin directory updates. This change improves the release workflow and communication.

## Why?
For clarity around the Gutenberg release process

## How?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 93d3e08</samp>

* Update the instruction for triggering the plugin directory update ([link](https://github.com/WordPress/gutenberg/pull/50037/files?diff=unified&w=0#diff-4eef93dd0d86651036f183decb9c2ae850be83f7e1570cef99f877cbf827cfb3L47-R47))