### PR TITLE
Retain context when opening modals on small screens

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   `parseStylesVariables()`: Refactor away from Lodash (mobile) ([#49794](https://github.com/WordPress/gutenberg/pull/49794)).
 -   Remove Lodash dependency from components package ([#49794](https://github.com/WordPress/gutenberg/pull/49794)).
 -   Tweak `WordPressComponent` type so `selector` property is optional ([#49960](https://github.com/WordPress/gutenberg/pull/49960)).
+-   Update `Modal` appearance on small screens ([#50039](https://github.com/WordPress/gutenberg/pull/50039)).
 
 ### Enhancements
 

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -16,27 +16,27 @@
 // The modal window element.
 .components-modal__frame {
 	// Use the entire viewport on smaller screens.
-	margin: 0;
+	margin: $grid-unit-50 0 0 0;
 	width: 100%;
 	background: $white;
 	box-shadow: $shadow-modal;
-	border-radius: $grid-unit-10;
+	border-radius: $grid-unit-10 $grid-unit-10 0 0;
 	overflow: hidden;
 	// Have the content element fill the vertical space yet not overflow.
 	display: flex;
+	// Animate the modal frame/contents appearing on the page.
+	animation: components-modal__appear-animation 0.1s ease-out;
+	animation-fill-mode: forwards;
+	@include reduce-motion("animation");
 
 	// Show a centered modal on bigger screens.
 	@include break-small() {
+		border-radius: $grid-unit-10;
 		margin: auto;
 		width: auto;
 		min-width: $modal-min-width;
 		max-width: calc(100% - #{$grid-unit-20 * 2});
 		max-height: calc(100% - #{$header-height * 2});
-
-		// Animate the modal frame/contents appearing on the page.
-		animation: components-modal__appear-animation 0.1s ease-out;
-		animation-fill-mode: forwards;
-		@include reduce-motion("animation");
 
 		&.is-full-screen {
 			@include break-small() {


### PR DESCRIPTION
## What?
Updates the modal appearance on small screens to resemble a 'sheet' pattern commonly found in design systems.

## Why?
1. It fixes the current appearance, where the rounded corners look a bit strange with the modal occupying the full screen.
2. Helps retain context by keeping the origin document partially visible. This is most useful during flows that trigger modals automatically, for instance creating a template:
<img width="395" alt="Screenshot 2023-04-24 at 17 03 11" src="https://user-images.githubusercontent.com/846565/234052976-c721282a-c33c-468a-8e79-327f3972bbc4.png">


## How?
CSS adjustments. I also applied the 'slide up' animation to the small screen styles to underline the sheet behavior.

## Testing Instructions
1. Open a modal like Keyboard Shortcuts on a small screen.
2. Observe the origin document at the top of the viewport – you can click it to return.
4. Observe rounded corners at the top of the modal, and square corners at the bottom.

## Before
<img width="429" alt="Screenshot 2023-04-24 at 16 31 31" src="https://user-images.githubusercontent.com/846565/234050857-2ef40af5-14ea-4580-9c29-9d3f6a6728f7.png">

## After

https://user-images.githubusercontent.com/846565/234050887-d4bb0045-6190-4c43-b324-e0141b425373.mp4


