### PR TITLE
Enforce checks against redeclaration for functions and classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,15 @@
 		"wp-coding-standards/wpcs": "^2.2",
 		"sirbrillig/phpcs-variable-analysis": "^2.8",
 		"spatie/phpunit-watcher": "^1.23",
-		"yoast/phpunit-polyfills": "^1.0"
+		"yoast/phpunit-polyfills": "^1.0",
+		"gutenberg-coding-standards/gbcs": "dev-master"
 	},
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "https://github.com/anton-vlasenko/Gutenberg-Coding-Standards.git"
+		}
+	],
 	"require": {
 		"composer/installers": "~1.0"
 	},

--- a/lib/compat/wordpress-6.2/html-api/class-wp-html-attribute-token.php
+++ b/lib/compat/wordpress-6.2/html-api/class-wp-html-attribute-token.php
@@ -7,6 +7,10 @@
  * @since 6.2.0
  */
 
+if ( class_exists( 'WP_HTML_Attribute_Token' ) ) {
+	return;
+}
+
 /**
  * Data structure for the attribute token that allows to drastically improve performance.
  *

--- a/lib/compat/wordpress-6.2/html-api/class-wp-html-span.php
+++ b/lib/compat/wordpress-6.2/html-api/class-wp-html-span.php
@@ -7,6 +7,10 @@
  * @since 6.2.0
  */
 
+if ( class_exists( 'WP_HTML_Span' ) ) {
+	return;
+}
+
 /**
  * Represents a textual span inside an HTML document.
  *

--- a/lib/compat/wordpress-6.2/html-api/class-wp-html-tag-processor.php
+++ b/lib/compat/wordpress-6.2/html-api/class-wp-html-tag-processor.php
@@ -26,6 +26,10 @@
  * @since 6.2.0
  */
 
+if ( class_exists( 'WP_HTML_Tag_Processor' ) ) {
+	return;
+}
+
 /**
  * Modifies attributes in an HTML document for tags matching a query.
  *

--- a/lib/compat/wordpress-6.2/html-api/class-wp-html-text-replacement.php
+++ b/lib/compat/wordpress-6.2/html-api/class-wp-html-text-replacement.php
@@ -7,6 +7,10 @@
  * @since 6.2.0
  */
 
+if ( class_exists( 'WP_HTML_Text_Replacement' ) ) {
+	return;
+}
+
 /**
  * Data structure used to replace existing content from start to end that allows to drastically improve performance.
  *

--- a/lib/compat/wordpress-6.2/rest-api.php
+++ b/lib/compat/wordpress-6.2/rest-api.php
@@ -100,42 +100,46 @@ function gutenberg_modify_rest_sidebars_response( $response ) {
 }
 add_filter( 'rest_prepare_sidebar', 'gutenberg_modify_rest_sidebars_response' );
 
-
-/**
- * Add the `block_types` value to the `pattern-directory-item` schema.
- *
- * @since 6.2.0 Added 'block_types' property.
- */
-function add_block_pattern_block_types_schema() {
-	register_rest_field(
-		'pattern-directory-item',
-		'block_types',
-		array(
-			'schema' => array(
-				'description' => __( 'The block types which can use this pattern.', 'gutenberg' ),
-				'type'        => 'array',
-				'uniqueItems' => true,
-				'items'       => array( 'type' => 'string' ),
-				'context'     => array( 'view', 'embed' ),
-			),
-		)
-	);
+if ( ! function_exists( 'add_block_pattern_block_types_schema' ) ) {
+	/**
+	 * Add the `block_types` value to the `pattern-directory-item` schema.
+	 *
+	 * @since 6.2.0 Added 'block_types' property.
+	 */
+	function add_block_pattern_block_types_schema() {
+		register_rest_field(
+			'pattern-directory-item',
+			'block_types',
+			array(
+				'schema' => array(
+					'description' => __( 'The block types which can use this pattern.', 'gutenberg' ),
+					'type'        => 'array',
+					'uniqueItems' => true,
+					'items'       => array( 'type' => 'string' ),
+					'context'     => array( 'view', 'embed' ),
+				),
+			)
+		);
+	}
 }
 add_filter( 'rest_api_init', 'add_block_pattern_block_types_schema' );
 
 
-/**
- * Add the `block_types` value into the API response.
- *
- * @since 6.2.0 Added 'block_types' property.
- *
- * @param WP_REST_Response $response    The response object.
- * @param object           $raw_pattern The unprepared pattern.
- */
-function filter_block_pattern_response( $response, $raw_pattern ) {
-	$data                = $response->get_data();
-	$data['block_types'] = array_map( 'sanitize_text_field', $raw_pattern->meta->wpop_block_types );
-	$response->set_data( $data );
-	return $response;
+if ( ! function_exists( 'filter_block_pattern_response' ) ) {
+	/**
+	 * Add the `block_types` value into the API response.
+	 *
+	 * @param WP_REST_Response $response    The response object.
+	 * @param object           $raw_pattern The unprepared pattern.
+	 *
+	 * @since 6.2.0 Added 'block_types' property.
+	 */
+	function filter_block_pattern_response( $response, $raw_pattern ) {
+		$data                = $response->get_data();
+		$data['block_types'] = array_map( 'sanitize_text_field', $raw_pattern->meta->wpop_block_types );
+		$response->set_data( $data );
+
+		return $response;
+	}
 }
 add_filter( 'rest_prepare_block_pattern', 'filter_block_pattern_response', 10, 2 );

--- a/lib/compat/wordpress-6.3/theme-previews.php
+++ b/lib/compat/wordpress-6.3/theme-previews.php
@@ -51,65 +51,69 @@ function gutenberg_attach_theme_preview_middleware() {
 	);
 }
 
-/**
- * Temporary function to add a live preview button to block themes.
- * Remove when https://core.trac.wordpress.org/ticket/58190 lands.
- */
-function add_live_preview_button() {
-	global $pagenow;
-	if ( 'themes.php' === $pagenow ) {
-		?>
-<script type="text/javascript">
-	jQuery( document ).ready( function() {
-		addLivePreviewButton();
-		//themes are loaded as we scroll so we need to add the button to the newer ones.
-		jQuery('.themes').on('DOMSubtreeModified', function(){
-			addLivePreviewButton();
-		});
-	});
-	function addLivePreviewButton() {
-		document.querySelectorAll('.theme').forEach((el, index) => {
-			const themeInfo = el.querySelector('.theme-id-container');
-			const canAddButton =
-				!themeInfo ||
-				el.classList.contains('active') ||
-				themeInfo.querySelector('.theme-actions')?.childElementCount > 1;
-			if ( canAddButton ) {
-				return;
-			}
-			const themePath = themeInfo.querySelector('h2.theme-name').id.replace('-name', '');
-			const themeName = themeInfo.querySelector('h2.theme-name').innerText;
-			const livePreviewButton = document.createElement('a');
-			<?php
-				/* translators: %s: theme name */
-				$button_label = esc_attr_x( 'Live Preview %s', 'theme' );
+if ( ! function_exists( 'add_live_preview_button' ) ) {
+	/**
+	 * Temporary function to add a live preview button to block themes.
+	 * Remove when https://core.trac.wordpress.org/ticket/58190 lands.
+	 */
+	function add_live_preview_button() {
+		global $pagenow;
+		if ( 'themes.php' === $pagenow ) {
 			?>
-			livePreviewButton.setAttribute('aria-label', '<?php echo $button_label; ?>'.replace('%s', themeName));
-			livePreviewButton.setAttribute('class', 'button button-primary');
-			livePreviewButton.setAttribute(
-				'href',
-				`/wp-admin/site-editor.php?theme_preview=${themePath}&return=themes.php`
-			);
-			livePreviewButton.innerHTML = '<?php echo esc_html_e( 'Live Preview' ); ?>';
-			themeInfo.querySelector('.theme-actions').appendChild(livePreviewButton);
+	<script type="text/javascript">
+		jQuery( document ).ready( function() {
+			addLivePreviewButton();
+			//themes are loaded as we scroll so we need to add the button to the newer ones.
+			jQuery('.themes').on('DOMSubtreeModified', function(){
+				addLivePreviewButton();
+			});
 		});
-	}
-</script>
-		<?php
-	}
+		function addLivePreviewButton() {
+			document.querySelectorAll('.theme').forEach((el, index) => {
+				const themeInfo = el.querySelector('.theme-id-container');
+				const canAddButton =
+					!themeInfo ||
+					el.classList.contains('active') ||
+					themeInfo.querySelector('.theme-actions')?.childElementCount > 1;
+				if ( canAddButton ) {
+					return;
+				}
+				const themePath = themeInfo.querySelector('h2.theme-name').id.replace('-name', '');
+				const themeName = themeInfo.querySelector('h2.theme-name').innerText;
+				const livePreviewButton = document.createElement('a');
+				<?php
+					/* translators: %s: theme name */
+					$button_label = esc_attr_x( 'Live Preview %s', 'theme' );
+				?>
+				livePreviewButton.setAttribute('aria-label', '<?php echo $button_label; ?>'.replace('%s', themeName));
+				livePreviewButton.setAttribute('class', 'button button-primary');
+				livePreviewButton.setAttribute(
+					'href',
+					`/wp-admin/site-editor.php?theme_preview=${themePath}&return=themes.php`
+				);
+				livePreviewButton.innerHTML = '<?php echo esc_html_e( 'Live Preview' ); ?>';
+				themeInfo.querySelector('.theme-actions').appendChild(livePreviewButton);
+			});
+		}
+	</script>
+			<?php
+		}
 
+	}
 }
 
-/**
- * Adds a nonce for the theme activation link.
- */
-function block_theme_activate_nonce() {
-	$nonce_handle = 'switch-theme_' . gutenberg_theme_preview_stylesheet();
-	?>
-<script type="text/javascript">
-	window.BLOCK_THEME_ACTIVATE_NONCE = '<?php echo wp_create_nonce( $nonce_handle ); ?>';
-</script>
-	<?php
+if ( ! function_exists( 'block_theme_activate_nonce' ) ) {
+	/**
+	 * Adds a nonce for the theme activation link.
+	 */
+	function block_theme_activate_nonce() {
+		$nonce_handle = 'switch-theme_' . gutenberg_theme_preview_stylesheet();
+		?>
+	<script type="text/javascript">
+		window.BLOCK_THEME_ACTIVATE_NONCE = '<?php echo wp_create_nonce( $nonce_handle ); ?>';
+	</script>
+		<?php
+	}
 }
 
 // Hide this feature behind an experiment.

--- a/lib/experimental/class-wp-classic-to-block-menu-converter.php
+++ b/lib/experimental/class-wp-classic-to-block-menu-converter.php
@@ -6,6 +6,10 @@
  * @since 6.3.0
  */
 
+if ( class_exists( 'WP_Classic_To_Block_Menu_Converter' ) ) {
+	return;
+}
+
 /**
  * Converts a Classic Menu to Block Menu blocks.
  *

--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -6,6 +6,10 @@
  * @subpackage REST_API
  */
 
+if ( class_exists( 'WP_REST_Block_Editor_Settings_Controller' ) ) {
+	return;
+}
+
 /**
  * Core class used to retrieve the block editor settings via the REST API.
  *

--- a/lib/experimental/class-wp-rest-customizer-nonces.php
+++ b/lib/experimental/class-wp-rest-customizer-nonces.php
@@ -5,6 +5,10 @@
  * @package gutenberg
  */
 
+if ( class_exists( 'WP_Rest_Customizer_Nonces' ) ) {
+	return;
+}
+
 /**
  * Class that returns the customizer "save" nonce that's required for the
  * batch save operation using the customizer API endpoint.

--- a/lib/experimental/class-wp-rest-navigation-fallback-controller.php
+++ b/lib/experimental/class-wp-rest-navigation-fallback-controller.php
@@ -9,6 +9,10 @@
  * @since 6.3.0
  */
 
+if ( class_exists( 'WP_REST_Navigation_Fallback_Controller' ) ) {
+	return;
+}
+
 /**
  * Import dependencies.
  */

--- a/lib/experimental/kses.php
+++ b/lib/experimental/kses.php
@@ -66,43 +66,49 @@ function gutenberg_override_core_kses_init_filters() {
 add_action( 'init', 'gutenberg_override_core_kses_init_filters', 20 );
 add_action( 'set_current_user', 'gutenberg_override_core_kses_init_filters' );
 
-/**
- * See https://github.com/WordPress/wordpress-develop/pull/4108
- *
- * Mark CSS safe if it contains a "filter: url('#wp-duotone-...')" rule.
- *
- * This function should not be backported to core.
- *
- * @param bool   $allow_css Whether the CSS is allowed.
- * @param string $css_test_string The CSS to test.
- */
-function allow_filter_in_styles( $allow_css, $css_test_string ) {
-	if ( preg_match(
-		"/^filter:\s*url\('#wp-duotone-[-a-zA-Z0-9]+'\) !important$/",
-		$css_test_string
-	) ) {
-		return true;
+if ( ! function_exists( 'allow_filter_in_styles' ) ) {
+	/**
+	 * See https://github.com/WordPress/wordpress-develop/pull/4108
+	 *
+	 * Mark CSS safe if it contains a "filter: url('#wp-duotone-...')" rule.
+	 *
+	 * This function should not be backported to core.
+	 *
+	 * @param bool   $allow_css       Whether the CSS is allowed.
+	 * @param string $css_test_string The CSS to test.
+	 */
+	function allow_filter_in_styles( $allow_css, $css_test_string ) {
+		if ( preg_match(
+			"/^filter:\s*url\('#wp-duotone-[-a-zA-Z0-9]+'\) !important$/",
+			$css_test_string
+		) ) {
+			return true;
+		}
+
+		return $allow_css;
 	}
-	return $allow_css;
 }
 
 add_filter( 'safecss_filter_attr_allow_css', 'allow_filter_in_styles', 10, 2 );
 
-/**
- * Mark CSS safe if it contains grid functions
- *
- * This function should not be backported to core.
- *
- * @param bool   $allow_css Whether the CSS is allowed.
- * @param string $css_test_string The CSS to test.
- */
-function allow_grid_functions_in_styles( $allow_css, $css_test_string ) {
-	if ( preg_match(
-		'/^grid-template-columns:\s*repeat\([0-9,a-z-\s\(\)]*\)$/',
-		$css_test_string
-	) ) {
-		return true;
+if ( ! function_exists( 'allow_grid_functions_in_styles' ) ) {
+	/**
+	 * Mark CSS safe if it contains grid functions
+	 *
+	 * This function should not be backported to core.
+	 *
+	 * @param bool   $allow_css       Whether the CSS is allowed.
+	 * @param string $css_test_string The CSS to test.
+	 */
+	function allow_grid_functions_in_styles( $allow_css, $css_test_string ) {
+		if ( preg_match(
+			'/^grid-template-columns:\s*repeat\([0-9,a-z-\s\(\)]*\)$/',
+			$css_test_string
+		) ) {
+			return true;
+		}
+
+		return $allow_css;
 	}
-	return $allow_css;
 }
 add_filter( 'safecss_filter_attr_allow_css', 'allow_grid_functions_in_styles', 10, 2 );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -5,26 +5,28 @@
  * @package gutenberg
  */
 
-/**
- * The main entry point for the Gutenberg experiments page.
- *
- * @since 6.3.0
- */
-function the_gutenberg_experiments() {
-	?>
-	<div
-		id="experiments-editor"
-		class="wrap"
-	>
-	<h1><?php echo __( 'Experimental settings', 'gutenberg' ); ?></h1>
-	<?php settings_errors(); ?>
-	<form method="post" action="options.php">
-		<?php settings_fields( 'gutenberg-experiments' ); ?>
-		<?php do_settings_sections( 'gutenberg-experiments' ); ?>
-		<?php submit_button(); ?>
-	</form>
-	</div>
-	<?php
+if ( ! function_exists( 'the_gutenberg_experiments' ) ) {
+	/**
+	 * The main entry point for the Gutenberg experiments page.
+	 *
+	 * @since 6.3.0
+	 */
+	function the_gutenberg_experiments() {
+		?>
+		<div
+			id="experiments-editor"
+			class="wrap"
+		>
+		<h1><?php echo __( 'Experimental settings', 'gutenberg' ); ?></h1>
+		<?php settings_errors(); ?>
+		<form method="post" action="options.php">
+			<?php settings_fields( 'gutenberg-experiments' ); ?>
+			<?php do_settings_sections( 'gutenberg-experiments' ); ?>
+			<?php submit_button(); ?>
+		</form>
+		</div>
+		<?php
+	}
 }
 
 /**

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,6 +10,7 @@
 	<rule ref="WordPress-Core"/>
 	<rule ref="WordPress-Docs"/>
 	<rule ref="WordPress.WP.I18n"/>
+	<rule ref="Gutenberg"/>
 	<config name="text_domain" value="gutenberg,default"/>
 
 	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis">
@@ -102,5 +103,20 @@
 	</rule>
 	<rule ref="PEAR.NamingConventions.ValidClassName.Invalid">
 		<exclude-pattern>/phpunit/*</exclude-pattern>
+	</rule>
+
+	<rule ref="Gutenberg.CodeAnalysis.GuardedFunctionAndClassNames">
+		<exclude-pattern>./phpunit/*</exclude-pattern>
+		<exclude-pattern>./packages/*</exclude-pattern>
+		<exclude-pattern>./bin/generate-gutenberg-php</exclude-pattern>
+		<properties>
+			<property name="functionsWhiteList" type="array">
+				<element value="/^_?gutenberg.+/"/>
+			</property>
+			<property name="classesWhiteList" type="array">
+				<element value="/^Gutenberg.+/"/>
+				<element value="/^WP_.+_Gutenberg$/"/>
+			</property>
+		</properties>
 	</rule>
 </ruleset>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This pull request introduces checks that prevent redeclaration of Gutenberg classes and functions. More information about this can be found here: https://github.com/WordPress/gutenberg/blob/trunk/lib/README.md#wrap-functions-and-classes-with--function_exists-and--class_exists
Fixes https://github.com/WordPress/gutenberg/issues/44151

## Why?
Currently, Gutenberg allows to define PHP functions (classes) with any prefix.
This repeatedly resulted in fatal errors due to naming conflicts between Core and Gutenberg.

## How?
To avoid these conflicts, this pull request adds a new  `Gutenberg.CodeAnalysis.GuardedFunctionAndClassNames` sniff to `phpcs.xml.dist`.
This sniff verifies that the functions and classes are properly [guarded](https://github.com/WordPress/gutenberg/blob/trunk/lib/README.md#wrap-functions-and-classes-with--function_exists-and--class_exists).

## Testing Instructions
1. Review https://github.com/anton-vlasenko/Gutenberg-Coding-Standards/. This is a new repository that will be containing Gutenberg-specific sniffs.
2. Make sure that CI jobs pass.

# Please don't merge this PR for now. Why?
1. https://github.com/anton-vlasenko/Gutenberg-Coding-Standards/ needs to be moved under https://github.com/WordPress account (if this PR gets approved).
https://github.com/anton-vlasenko/Gutenberg-Coding-Standards/ is for reviewing purposes only.