### PR TITLE
Use apiFetch instead of window.fetch

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -411,6 +411,8 @@ export const __experimentalGetTemplateForLink =
 	async ( { dispatch, resolveSelect } ) => {
 		let template;
 		try {
+			// This is NOT calling a REST endpoint but rather ends up with a response from
+			// an Ajax function which has a different shape from a WP_REST_Response.
 			template = await apiFetch( {
 				url: addQueryArgs( link, {
 					'_wp-find-template': true,

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -409,15 +409,13 @@ export const getAutosave =
 export const __experimentalGetTemplateForLink =
 	( link ) =>
 	async ( { dispatch, resolveSelect } ) => {
-		// Ideally this should be using an apiFetch call
-		// We could potentially do so by adding a "filter" to the `wp_template` end point.
-		// Also it seems the returned object is not a regular REST API post type.
 		let template;
 		try {
-			template = await window
-				.fetch( addQueryArgs( link, { '_wp-find-template': true } ) )
-				.then( ( res ) => res.json() )
-				.then( ( { data } ) => data );
+			template = await apiFetch( {
+				url: addQueryArgs( link, {
+					'_wp-find-template': true,
+				} ),
+			} ).then( ( { data } ) => data );
 		} catch ( e ) {
 			// For non-FSE themes, it is possible that this request returns an error.
 		}

--- a/packages/edit-site/src/store/test/actions.js
+++ b/packages/edit-site/src/store/test/actions.js
@@ -168,21 +168,13 @@ describe( 'actions', () => {
 			const ID = 'emptytheme//single';
 			const SLUG = 'single';
 
-			window.fetch = async ( path ) => {
-				if ( path === '/?_wp-find-template=true' ) {
-					return {
-						json: async () => ( { data: { id: ID, slug: SLUG } } ),
-					};
-				}
-
-				throw {
-					code: 'unknown_path',
-					message: `Unknown path: ${ path }`,
-				};
-			};
-
 			apiFetch.setFetchHandler( async ( options ) => {
-				const { method = 'GET', path } = options;
+				const { method = 'GET', path, url } = options;
+
+				// Called with url arg in `__experimentalGetTemplateForLink`
+				if ( url ) {
+					return { data: { id: ID, slug: SLUG } };
+				}
 
 				if ( method === 'GET' ) {
 					if ( path.startsWith( '/wp/v2/types' ) ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This replaces the native use of window.fetch with a a call to apiFetch, so that it uses the Gutenberg functions.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cb2bdd7</samp>

Refactored `core-data` package to use `apiFetch` for all REST API requests. This improves data fetching consistency and reliability, and enables future endpoint enhancements.

## Why?
This means that this when changes are made to the REST API (for example https://github.com/WordPress/gutenberg/pull/50030/files), this API call will also be updated.

## How?
Replace window.fetch with apiFetch.
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cb2bdd7</samp>

* Refactor all REST API requests in the `core-data` package to use the `apiFetch` utility instead of the `window.fetch` API ([link](https://github.com/WordPress/gutenberg/pull/50043/files?diff=unified&w=0#diff-fec6390e24332dec4a0c7c74f9f7b9a015ce191e0e6348361ead793ceda3991dL412-R418),                           F

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Co-authored-by: Maggie <3593343+MaggieCabrera@users.noreply.github.com>
