### PR TITLE
Replace fallbacks to fallback (singular) in Nav fallback REST endpoint

### DIFF
--- a/lib/experimental/class-wp-rest-navigation-fallback-controller.php
+++ b/lib/experimental/class-wp-rest-navigation-fallback-controller.php
@@ -33,7 +33,7 @@ class WP_REST_Navigation_Fallback_Controller extends WP_REST_Controller {
 	 */
 	public function __construct() {
 		$this->namespace = 'wp-block-editor/v1';
-		$this->rest_base = 'navigation-fallbacks';
+		$this->rest_base = 'navigation-fallback';
 		$this->post_type = 'wp_navigation';
 	}
 
@@ -121,7 +121,7 @@ class WP_REST_Navigation_Fallback_Controller extends WP_REST_Controller {
 
 		$this->schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'navigation-fallbacks',
+			'title'      => 'navigation-fallback',
 			'type'       => 'object',
 			'properties' => array(
 				'id' => array(

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -229,7 +229,7 @@ function Navigation( {
 			return;
 		}
 
-		apiFetch( { path: '/wp-block-editor/v1/navigation-fallbacks' } )
+		apiFetch( { path: '/wp-block-editor/v1/navigation-fallback' } )
 			.then( ( fallbackNavigationMenu ) => {
 				if ( ! fallbackNavigationMenu?.id ) {
 					showNavigationMenuStatusNotice(

--- a/phpunit/class-wp-rest-navigation-fallback-controller-test.php
+++ b/phpunit/class-wp-rest-navigation-fallback-controller-test.php
@@ -41,7 +41,7 @@ class WP_REST_Navigation_Fallback_Controller_Test extends WP_Test_REST_Controlle
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
 
-		$this->assertArrayHasKey( '/wp-block-editor/v1/navigation-fallbacks', $routes, 'Fallback route should be registered.' );
+		$this->assertArrayHasKey( '/wp-block-editor/v1/navigation-fallback', $routes, 'Fallback route should be registered.' );
 	}
 
 	/**
@@ -53,7 +53,7 @@ class WP_REST_Navigation_Fallback_Controller_Test extends WP_Test_REST_Controlle
 
 		wp_set_current_user( self::$editor_user );
 
-		$request  = new WP_REST_Request( 'GET', '/wp-block-editor/v1/navigation-fallbacks' );
+		$request  = new WP_REST_Request( 'GET', '/wp-block-editor/v1/navigation-fallback' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -71,7 +71,7 @@ class WP_REST_Navigation_Fallback_Controller_Test extends WP_Test_REST_Controlle
 	 */
 	public function test_get_item() {
 
-		$request  = new WP_REST_Request( 'GET', '/wp-block-editor/v1/navigation-fallbacks' );
+		$request  = new WP_REST_Request( 'GET', '/wp-block-editor/v1/navigation-fallback' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -96,7 +96,7 @@ class WP_REST_Navigation_Fallback_Controller_Test extends WP_Test_REST_Controlle
 	 * @since 6.3.0 Added Navigation Fallbacks endpoint.
 	 */
 	public function test_get_item_schema() {
-		$request  = new WP_REST_Request( 'OPTIONS', '/wp-block-editor/v1/navigation-fallbacks' );
+		$request  = new WP_REST_Request( 'OPTIONS', '/wp-block-editor/v1/navigation-fallback' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -119,7 +119,7 @@ class WP_REST_Navigation_Fallback_Controller_Test extends WP_Test_REST_Controlle
 	 * @since 6.3.0 Added Navigation Fallbacks endpoint.
 	 */
 	public function test_adds_links() {
-		$request  = new WP_REST_Request( 'GET', '/wp-block-editor/v1/navigation-fallbacks' );
+		$request  = new WP_REST_Request( 'GET', '/wp-block-editor/v1/navigation-fallback' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Renames endpoint from `navigation-fallbacks` to `navigation-fallback`.


Fixes https://github.com/WordPress/gutenberg/issues/49997

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it's not a collection-based endpoint. See Issue.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->


Search and replace.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Check tests pass.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
