### PR TITLE
Fix hover/focus styles for `style variation` buttons

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -82,6 +82,13 @@
 	outline: 2px solid transparent;
 }
 
+@mixin button-style__focus() {
+	box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+
+	// Windows High Contrast mode will show this outline, but not the box-shadow.
+	outline: 2px solid transparent;
+}
+
 
 /**
  * Applies editor left position to the selector passed as argument

--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -61,7 +61,7 @@
 
 		&:focus,
 		&.is-active:focus {
-			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			@include button-style__focus();
 		}
 	}
 

--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -37,16 +37,15 @@
 	justify-content: space-between;
 	gap: $grid-unit-10;
 
-	.block-editor-block-styles__item {
+	button.components-button.block-editor-block-styles__item {
 		color: $gray-900;
 		box-shadow: inset 0 0 0 1px $gray-400;
 		display: inline-block;
 		width: calc(50% - #{$grid-unit-05});
 
-		&:focus,
 		&:hover {
 			color: var(--wp-admin-theme-color);
-			box-shadow: inset 0 0 0 2px var(--wp-admin-theme-color);
+			box-shadow: inset 0 0 0 1px $gray-400;
 		}
 
 		&.is-active,
@@ -60,8 +59,9 @@
 			color: $white;
 		}
 
+		&:focus,
 		&.is-active:focus {
-			box-shadow: inset 0 0 0 1px $white, 0 0 0 2px var(--wp-admin-theme-color);
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Focus/hover styles  for `style variation` buttons aren't the proper ones. This came up in: https://github.com/WordPress/gutenberg/pull/49992, and this PR just updates them.

### Before


https://user-images.githubusercontent.com/16275880/234251751-e02897d4-eb31-4cbc-900a-0cb178e9f1d2.mov





### After

https://user-images.githubusercontent.com/16275880/234251614-eae8bb86-bf49-461e-8b6a-8073c09481d5.mov


