### PR TITLE
Change the 'WP_Theme_JSON_Data_Gutenberg' class directory

### DIFF
--- a/lib/class-wp-theme-json-data-gutenberg.php
+++ b/lib/class-wp-theme-json-data-gutenberg.php
@@ -1,18 +1,21 @@
 <?php
 /**
- * API to update a theme.json structure.
+ * WP_Theme_JSON_Data class
  *
  * @package gutenberg
+ * @since 6.1.0
  */
 
 /**
- * Class to update with a theme.json structure.
+ * Class to provide access to update a theme.json structure.
  */
+#[AllowDynamicProperties]
 class WP_Theme_JSON_Data_Gutenberg {
 
 	/**
 	 * Container of the data to update.
 	 *
+	 * @since 6.1.0
 	 * @var WP_Theme_JSON
 	 */
 	private $theme_json = null;
@@ -20,12 +23,17 @@ class WP_Theme_JSON_Data_Gutenberg {
 	/**
 	 * The origin of the data: default, theme, user, etc.
 	 *
+	 * @since 6.1.0
 	 * @var string
 	 */
 	private $origin = '';
 
 	/**
 	 * Constructor.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @link https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/
 	 *
 	 * @param array  $data   Array following the theme.json specification.
 	 * @param string $origin The origin of the data: default, theme, user.
@@ -38,6 +46,8 @@ class WP_Theme_JSON_Data_Gutenberg {
 	/**
 	 * Updates the theme.json with the the given data.
 	 *
+	 * @since 6.1.0
+	 *
 	 * @param array $new_data Array following the theme.json specification.
 	 *
 	 * @return WP_Theme_JSON_Data_Gutenberg The own instance with access to the modified data.
@@ -48,7 +58,10 @@ class WP_Theme_JSON_Data_Gutenberg {
 	}
 
 	/**
-	 * Returns the underlying data.
+	 * Returns an array containing the underlying data
+	 * following the theme.json specification.
+	 *
+	 * @since 6.1.0
 	 *
 	 * @return array
 	 */

--- a/lib/load.php
+++ b/lib/load.php
@@ -72,7 +72,6 @@ require __DIR__ . '/compat/wordpress-6.1/block-editor-settings.php';
 require __DIR__ . '/compat/wordpress-6.1/blocks.php';
 require __DIR__ . '/compat/wordpress-6.1/persisted-preferences.php';
 require __DIR__ . '/compat/wordpress-6.1/get-global-styles-and-settings.php';
-require __DIR__ . '/compat/wordpress-6.1/class-wp-theme-json-data-gutenberg.php';
 require __DIR__ . '/compat/wordpress-6.1/block-template-utils.php';
 require __DIR__ . '/compat/wordpress-6.1/wp-theme-get-post-templates.php';
 require __DIR__ . '/compat/wordpress-6.1/script-loader.php';
@@ -135,6 +134,7 @@ if ( ! class_exists( 'WP_Fonts' ) ) {
 }
 
 // Plugin specific code.
+require __DIR__ . '/class-wp-theme-json-data-gutenberg.php';
 require __DIR__ . '/class-wp-theme-json-gutenberg.php';
 require __DIR__ . '/class-wp-theme-json-resolver-gutenberg.php';
 require __DIR__ . '/class-wp-duotone-gutenberg.php';


### PR DESCRIPTION
## What?
This is a follow-up to #46750.

PR moves the `WP_Theme_JSON_Data_Gutenberg` bundled class into the correct directory and matches PHPDoc-blocks to the core.

## Why?
The class is always bundled in the plugin and doesn't depend on the support WP version.

## Testing Instructions
PR is just changing file directories. Confirm the are no PHP errors/notices when running this branch.

