### PR TITLE
#50058: Add a link to paragraph block example

### DIFF
--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { paragraph as icon } from '@wordpress/icons';
 
 /**
@@ -22,8 +22,12 @@ export const settings = {
 	icon,
 	example: {
 		attributes: {
-			content: __(
-				'In a village of La Mancha, the name of which I have no desire to call to mind, there lived not long since one of those gentlemen that keep a lance in the lance-rack, an old buckler, a lean hack, and a greyhound for coursing.'
+			content: sprintf(
+				/* translators: %s: Link href (example link) */
+				__(
+					'In a village of La Mancha, the name of which I have no desire to call to mind, there lived not long since one of those gentlemen that keep a lance in the lance-rack, an old buckler, a lean hack, and <a href="%s">a greyhound</a> for coursing.'
+				),
+				'#'
 			),
 		},
 	},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #50058. Adds an example link to the core paragraph block. 

## Why?
To see the styling of links in the style book. See #50058

## How?
Adds an example link into the translated example content string. This means that all translations of this example string need to be updated to include the a-tag. I pulled out the href (`#`) into sprintf. I don't know if there's a better way to do this to prevent having to update the translation?
The link intentionally spans across two words, so that the style of text-decorations (eg underlining, strikethrough) is visible in the context of multi-word links as well.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open the site editor
2. Enable the style book
3. Set some styles for links (eg color, typography)
4. See that the link in the example paragraph block ist styled.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
![grafik](https://user-images.githubusercontent.com/5585580/234312875-2eab0d98-f52f-4a3a-a831-56cf9ba0ad5f.png)

