### PR TITLE
Use onClick to make Site Editor Open Admin Sidebar Button keyboard accessible

### DIFF
--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -44,7 +44,7 @@ const SiteHub = forwardRef( ( props, ref ) => {
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 	const siteIconButtonProps = {
 		label: __( 'Open Admin Sidebar' ),
-		onMouseDown: () => {
+		onClick: () => {
 			if ( canvasMode === 'edit' ) {
 				clearSelectedBlock();
 				setCanvasMode( 'view' );

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -43,11 +43,16 @@ const SiteHub = forwardRef( ( props, ref ) => {
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 	const siteIconButtonProps = {
-		label: __( 'Open Admin Sidebar' ),
+		label:
+			canvasMode === 'edit'
+				? __( 'Open Admin Sidebar' )
+				: __( 'Close Admin Sidebar' ),
 		onClick: () => {
 			if ( canvasMode === 'edit' ) {
 				clearSelectedBlock();
 				setCanvasMode( 'view' );
+			} else {
+				setCanvasMode( 'edit' );
 			}
 		},
 	};


### PR DESCRIPTION
## What?
The Open Admin Sidebar Button only works with a mouse click since it uses `onMouseDown` to open the Admin Sidebar. This PR switches from `onMouseDown` to `onClick`. When the sidebar is in the open state, the button label says, "Open Admin Sidebar," but the sidebar is already open. 

To get the conversation started, I switched it to a toggle as the classNames within the file call it a `toggle`. However, other options are possible:

### Alternative Proposals:

1. **When the sidebar is open, have the button go back to the dashboard.** This action would mean after clicking the Open Admin Dashboard `<button>`,  changing it to an `<a>` element to semantically describe the functionality and give it the proper `href`. Switching the element's action like that feels a little confusing from a screen reader perspective.
    
2. **Disable the button when the panel is open as it has no action. and send focus to the Back to Dashboard Link.** This could be a fine solution, but would require more work as the Back to Dashboard link isn't within the same component, and would require more complex work to figure out the focus management code. I didn't want to go through with that interaction unless others agreed it was the right way to go.

## Why?
The Site Editor Open Admin Sidebar button is not keyboard accessible.

## How?
Switches the button from using `onMouseDown` to `onClick` to make it keyboard accessible, and switching the behavior of the button to a toggle.

## Testing Instructions
1. Go to `/wp-admin/site-editor.php`
2. Click the editor pane to close the sidebar
3. Click the logo in the top left corner of the page to close the sidebar
4. Click the logo again to close the sidebar

### Testing Instructions for Keyboard
1. Go to `/wp-admin/site-editor.php`
2. Click the editor pane to close the sidebar
3. Use the keyboard to get focus to the Wordpress logo in the top left corner of the page
4. Tooltip should be "Open Admin Sidebar"
5. Press `Enter` to close the sidebar. 
6. Tooltip should be "Close Admin Sidebar"
7. Press `Enter` to close the sidebar

## Screenshots or screencast <!-- if applicable -->
