### PR TITLE
CardMedia: Improve docs

### DIFF
--- a/packages/components/src/card/card-media/README.md
+++ b/packages/components/src/card/card-media/README.md
@@ -1,6 +1,6 @@
 # CardMedia
 
-`CardMedia` provides a container for media elements within a [`Card`](/packages/components/src/card/card/README.md).
+`CardMedia` provides a container for full-bleed content within a [`Card`](/packages/components/src/card/card/README.md), such as images, video, or even just a background color.
 
 ## Usage
 

--- a/packages/components/src/card/card-media/component.tsx
+++ b/packages/components/src/card/card-media/component.tsx
@@ -21,7 +21,8 @@ function UnconnectedCardMedia(
 }
 
 /**
- * `CardMedia` provides a container for media elements within a `Card`.
+ * `CardMedia` provides a container for full-bleed content within a `Card`,
+ * such as images, video, or even just a background color.
  *
  * @example
  * ```jsx

--- a/packages/components/src/card/stories/index.tsx
+++ b/packages/components/src/card/stories/index.tsx
@@ -41,31 +41,52 @@ const meta: ComponentMeta< typeof Card > = {
 export default meta;
 
 const Template: ComponentStory< typeof Card > = ( args ) => (
-	<Card { ...args }>
-		<CardHeader>
-			<Heading>CardHeader</Heading>
-		</CardHeader>
-		<CardBody>
-			<Text>CardBody</Text>
-		</CardBody>
-		<CardBody>
-			<Text>CardBody (before CardDivider)</Text>
-		</CardBody>
-		<CardDivider />
-		<CardBody>
-			<Text>CardBody (after CardDivider)</Text>
-		</CardBody>
-		<CardMedia>
-			<img
-				alt="Card Media"
-				src="https://images.unsplash.com/photo-1566125882500-87e10f726cdc?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1867&q=80"
-			/>
-		</CardMedia>
-		<CardFooter>
-			<Text>CardFooter</Text>
-			<Button variant="secondary">Action Button</Button>
-		</CardFooter>
-	</Card>
+	<Card { ...args } />
 );
 
-export const Default: ComponentStory< typeof Card > = Template.bind( {} );
+export const Default = Template.bind( {} );
+Default.args = {
+	children: (
+		<>
+			<CardHeader>
+				<Heading>CardHeader</Heading>
+			</CardHeader>
+			<CardBody>
+				<Text>CardBody</Text>
+			</CardBody>
+			<CardBody>
+				<Text>CardBody (before CardDivider)</Text>
+			</CardBody>
+			<CardDivider />
+			<CardBody>
+				<Text>CardBody (after CardDivider)</Text>
+			</CardBody>
+			<CardMedia>
+				<img
+					alt="Card Media"
+					src="https://images.unsplash.com/photo-1566125882500-87e10f726cdc?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1867&q=80"
+				/>
+			</CardMedia>
+			<CardFooter>
+				<Text>CardFooter</Text>
+				<Button variant="secondary">Action Button</Button>
+			</CardFooter>
+		</>
+	),
+};
+
+/**
+ * `CardMedia` provides a container for full-bleed content within a `Card`,
+ * such as images, video, or even just a background color. The corners will be rounded if necessary.
+ */
+export const FullBleedContent = Template.bind( {} );
+FullBleedContent.args = {
+	...Default.args,
+	children: (
+		<CardMedia>
+			<div style={ { padding: 16, background: 'beige' } }>
+				Some full bleed content
+			</div>
+		</CardMedia>
+	),
+};


### PR DESCRIPTION
Closes #39830

## What?

Improve the docs/stories for the CardMedia component so it's clearer that it's more of a generic full-bleed container, rather than a container for "media".

## Why?

It's hard to discover that this component can be used for this purpose.

## Testing Instructions

`npm run storybook:dev` and see the new story (`?path=/docs/components-card--full-bleed-content`) for the `Card` component. Check that it is understandable.