### PR TITLE
Add chevrons to the templates and template parts in site editor.

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-item/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-item/index.js
@@ -11,7 +11,7 @@ import {
 	__experimentalHStack as HStack,
 	FlexBlock,
 } from '@wordpress/components';
-import { chevronRight, Icon } from '@wordpress/icons';
+import { chevronRightSmall, Icon } from '@wordpress/icons';
 
 export default function SidebarNavigationItem( {
 	className,
@@ -39,8 +39,8 @@ export default function SidebarNavigationItem( {
 				<FlexBlock>{ children }</FlexBlock>
 				{ withChevron && (
 					<Icon
-						style={ { fill: 'currentcolor' } }
-						icon={ chevronRight }
+						icon={ chevronRightSmall }
+						className="edit-site-sidebar-navigation-item__drilldown-indicator"
 						size={ 24 }
 					/>
 				) }

--- a/packages/edit-site/src/components/sidebar-navigation-item/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-item/index.js
@@ -28,24 +28,23 @@ export default function SidebarNavigationItem( {
 			) }
 			{ ...props }
 		>
-			{ icon && (
-				<HStack justify="flex-start">
+			<HStack justify="flex-start">
+				{ icon && (
 					<Icon
 						style={ { fill: 'currentcolor' } }
 						icon={ icon }
 						size={ 24 }
 					/>
-					<FlexBlock>{ children }</FlexBlock>
-					{ withChevron && (
-						<Icon
-							style={ { fill: 'currentcolor' } }
-							icon={ chevronRight }
-							size={ 24 }
-						/>
-					) }
-				</HStack>
-			) }
-			{ ! icon && children }
+				) }
+				<FlexBlock>{ children }</FlexBlock>
+				{ withChevron && (
+					<Icon
+						style={ { fill: 'currentcolor' } }
+						icon={ chevronRight }
+						size={ 24 }
+					/>
+				) }
+			</HStack>
 		</Item>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -12,6 +12,10 @@
 	&[aria-current] {
 		background: var(--wp-admin-theme-color);
 	}
+
+	.edit-site-sidebar-navigation-item__drilldown-indicator {
+		fill: $gray-700;
+	}
 }
 
 .edit-site-sidebar-navigation-screen__content .block-editor-list-view-block-select-button {

--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -1,6 +1,9 @@
 .edit-site-sidebar-navigation-item.components-item {
 	color: $gray-600;
-	margin: 0 $grid-unit-05;
+	// 6px right padding to align with + button
+	padding: $grid-unit-10 6px $grid-unit-10 $grid-unit-20;
+	border: none;
+	min-height: $grid-unit-50;
 
 	&:hover,
 	&:focus,

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -127,6 +127,7 @@ export default function SidebarNavigationScreenTemplates() {
 									children={
 										config[ postType ].labels.manage
 									}
+									withChevron
 								/>
 							) }
 						</ItemGroup>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -112,6 +112,7 @@ export default function SidebarNavigationScreenTemplates() {
 									postType={ postType }
 									postId={ template.id }
 									key={ template.id }
+									withChevron
 								>
 									{ decodeEntities(
 										template.title?.rendered ||


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/48591

## What?
<!-- In a few words, what is the PR actually doing? -->
Add chevrons to templates and template parts in the site editor to indicate that these can be drilled down another level. This matches the top level.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To improve the consistency of interactions.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Modify `SidebarNavigationItem` to allow the inclusion of a chevron without the inclusion of an icon at the start of the item.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open the site editor
2. Select `Templates` and make sure all templates listed have a chevron on the right side.
3. Select `Template Parts` and make sure all templates listed have a chevron on the right side.
4. Confirm that other menus look correct. Note that Navigation sub menus have not been addressed in this PR.

## Screenshots or screencast <!-- if applicable -->

**Before**
<img width="355" alt="image" src="https://user-images.githubusercontent.com/1464705/234391037-e6893948-1af7-4180-9105-eb44843f4c58.png">

**After**
<img width="338" alt="Screenshot 2023-04-25 at 1 08 03 PM" src="https://user-images.githubusercontent.com/1464705/234391096-eaec5c01-3d16-47ff-82c8-d3673feac914.png">



