### PR TITLE
Global styles: close stylebook if the global styles side bar is not open

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
@@ -18,20 +18,19 @@ import { GlobalStylesMenuSlot } from '../global-styles/ui';
 import { unlock } from '../../private-apis';
 
 export default function GlobalStylesSidebar() {
-	const { shouldDisableStyleBook, isStyleBookOpened } = useSelect(
+	const { shouldClearCanvasContainerView, isStyleBookOpened } = useSelect(
 		( select ) => {
 			const { getActiveComplementaryArea } = select( interfaceStore );
 			const _isVisualEditorMode =
 				'visual' === select( editSiteStore ).getEditorMode();
 
 			return {
-				isVisualEditorMode: _isVisualEditorMode,
 				isStyleBookOpened:
 					'style-book' ===
 					unlock(
 						select( editSiteStore )
 					).getEditorCanvasContainerView(),
-				shouldDisableStyleBook:
+				shouldClearCanvasContainerView:
 					'edit-site/global-styles' !==
 						getActiveComplementaryArea( 'core/edit-site' ) ||
 					! _isVisualEditorMode,
@@ -44,10 +43,10 @@ export default function GlobalStylesSidebar() {
 		useDispatch( editSiteStore )
 	);
 	useEffect( () => {
-		if ( shouldDisableStyleBook ) {
+		if ( shouldClearCanvasContainerView ) {
 			setEditorCanvasContainerView( undefined );
 		}
-	}, [ shouldDisableStyleBook ] );
+	}, [ shouldClearCanvasContainerView ] );
 
 	return (
 		<DefaultSidebar
@@ -67,7 +66,7 @@ export default function GlobalStylesSidebar() {
 							icon={ seen }
 							label={ __( 'Style Book' ) }
 							isPressed={ isStyleBookOpened }
-							disabled={ shouldDisableStyleBook }
+							disabled={ shouldClearCanvasContainerView }
 							onClick={ () =>
 								setEditorCanvasContainerView(
 									isStyleBookOpened ? undefined : 'style-book'

--- a/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { styles, seen } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
+import { store as interfaceStore } from '@wordpress/interface';
 
 /**
  * Internal dependencies
@@ -17,25 +18,36 @@ import { GlobalStylesMenuSlot } from '../global-styles/ui';
 import { unlock } from '../../private-apis';
 
 export default function GlobalStylesSidebar() {
-	const { editorMode, editorCanvasView } = useSelect( ( select ) => {
-		return {
-			editorMode: select( editSiteStore ).getEditorMode(),
-			editorCanvasView: unlock(
-				select( editSiteStore )
-			).getEditorCanvasContainerView(),
-		};
-	}, [] );
+	const { shouldDisableStyleBook, isStyleBookOpened } = useSelect(
+		( select ) => {
+			const { getActiveComplementaryArea } = select( interfaceStore );
+			const _isVisualEditorMode =
+				'visual' === select( editSiteStore ).getEditorMode();
+
+			return {
+				isVisualEditorMode: _isVisualEditorMode,
+				isStyleBookOpened:
+					'style-book' ===
+					unlock(
+						select( editSiteStore )
+					).getEditorCanvasContainerView(),
+				shouldDisableStyleBook:
+					'edit-site/global-styles' !==
+						getActiveComplementaryArea( 'core/edit-site' ) ||
+					! _isVisualEditorMode,
+			};
+		},
+		[]
+	);
+
 	const { setEditorCanvasContainerView } = unlock(
 		useDispatch( editSiteStore )
 	);
-
 	useEffect( () => {
-		if ( editorMode !== 'visual' ) {
+		if ( shouldDisableStyleBook ) {
 			setEditorCanvasContainerView( undefined );
 		}
-	}, [ editorMode ] );
-
-	const isStyleBookOpened = editorCanvasView === 'style-book';
+	}, [ shouldDisableStyleBook ] );
 
 	return (
 		<DefaultSidebar
@@ -55,7 +67,7 @@ export default function GlobalStylesSidebar() {
 							icon={ seen }
 							label={ __( 'Style Book' ) }
 							isPressed={ isStyleBookOpened }
-							disabled={ editorMode !== 'visual' }
+							disabled={ shouldDisableStyleBook }
 							onClick={ () =>
 								setEditorCanvasContainerView(
 									isStyleBookOpened ? undefined : 'style-book'


### PR DESCRIPTION
## What?
This fixes a bug introduced by https://github.com/WordPress/gutenberg/pull/49973 whereby the editor header displays "Style book" even when it's closed.

Props to @andrewserong for catching it.

## Why?
Previously we could check that the stylebook was open by using `useSlotFills` to see if the stylebook slot was filled.

Since changing over to a private slot fill in https://github.com/WordPress/gutenberg/pull/49973, we lost the slotfill provider and therefore the context from which to tell if a slot is "filled".

## How?
As a quick fix, this PR verifies whether the global styles side bar is open or whether the editor is visual. If either is false then we programmatically close the style book.

Alternatives:

1. Create a context/provider for private slots (not sure if we should if they're private?)
2. Create a slotfill for the title (which I think might be better) This was @noisysocks's idea

## Testing Instructions
1. Open the site editor
2. Open the global styles sidebar. 
3. Check that you can open and use the stylebook and that the editor header title says "Style book"
4. Verify that you can close it via the eye icon. The header should now show the title of the current template being edited.
5. Now reopen the stylebook and close the global styles sidebar
6. The header should now show the title of the current template being edited.


## Screenshots or screencast <!-- if applicable -->
![2023-04-26 16 32 40](https://user-images.githubusercontent.com/6458278/234489216-3f72dfc3-35fa-4721-81e8-023d24dd4535.gif)
