### PR TITLE
Add ability to set templateLock = 'contentOnly' in editor settings

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1000,6 +1000,23 @@ _Returns_
 
 -   `boolean`: Whether the caret is within formatted text.
 
+### isContentLockedBlock
+
+Returns whether or not the given block is _content locked_.
+
+A block is _content locked_ if it is nested within a block that has a `templateLock` attribute set to `'contentOnly'` (a _content locking_ block), or if the editor has a `templateLock` of `'contentOnly'`.
+
+If the block is nested within a content block type (see `settings.contentBlockTypes`) then it is not _content locked_.
+
+_Parameters_
+
+-   _state_ `Object`: Global application state.
+-   _clientId_ `string`: The client ID of the block to check.
+
+_Returns_
+
+-   `boolean`: Whether or not the block is content locked.
+
 ### isDraggingBlocks
 
 Returns true if the user is dragging blocks, or false otherwise.
@@ -1024,6 +1041,21 @@ _Parameters_
 _Returns_
 
 -   `boolean`: Whether block is first in multi-selection.
+
+### isInsertionLocked
+
+Determines if the editor or a given container is locked and does not allow block insertion.
+
+Only the `templateLock` settings of the editor or container block are checked. For more rigorous checking that checks the `allowedBlockTypes` attribute, use `canInsertBlockType()`.
+
+_Parameters_
+
+-   _state_ `Object`: Editor state.
+-   _rootClientId_ `?string`: Container block's client ID, or `null` to check the editor.
+
+_Returns_
+
+-   `boolean`: Whether block insertion is locked.
 
 ### isLastBlockChangePersistent
 

--- a/packages/block-editor/src/components/block-inspector/style.scss
+++ b/packages/block-editor/src/components/block-inspector/style.scss
@@ -55,8 +55,3 @@
 .block-editor-block-inspector__tab-item {
 	flex: 1 1 0px;
 }
-
-.block-editor-block-inspector__block-buttons-container {
-	border-top: $border-width solid $gray-200;
-	padding: $grid-unit-20;
-}

--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -43,16 +43,16 @@ function useAppender( rootClientId, CustomAppender ) {
 	const { hideInserter, isParentSelected } = useSelect(
 		( select ) => {
 			const {
-				getTemplateLock,
 				getSelectedBlockClientId,
 				__unstableGetEditorMode,
+				isInsertionLocked,
 			} = select( blockEditorStore );
 
 			const selectedBlockClientId = getSelectedBlockClientId();
 
 			return {
 				hideInserter:
-					!! getTemplateLock( rootClientId ) ||
+					isInsertionLocked( rootClientId ) ||
 					__unstableGetEditorMode() === 'zoom-out',
 				isParentSelected:
 					rootClientId === selectedBlockClientId ||

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -166,7 +166,8 @@
 	.block-editor-block-list__block {
 		pointer-events: none;
 	}
-	.is-content-block {
+	.is-content-block,
+	.is-content-block .block-editor-block-list__block {
 		pointer-events: initial;
 	}
 }
@@ -323,7 +324,7 @@
 }
 
 .is-focus-mode .block-editor-block-list__block.is-content-locked.has-child-selected,
-.is-focus-mode .block-editor-block-list__block.is-content-locked-temporarily-editing-as-blocks.has-child-selected {
+.is-focus-mode .block-editor-block-list__block.is-content-temporarily-unlocked.has-child-selected {
 	&,
 	& .block-editor-block-list__block {
 		opacity: 1;

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -49,19 +49,18 @@ const pendingBlockVisibilityUpdatesPerRegistry = new WeakMap();
 function Root( { className, ...settings } ) {
 	const [ element, setElement ] = useState();
 	const isLargeViewport = useViewportMatch( 'medium' );
-	const { isOutlineMode, isFocusMode, editorMode } = useSelect(
-		( select ) => {
-			const { getSettings, __unstableGetEditorMode } =
+	const { isOutlineMode, isFocusMode, editorMode, isContentLocked } =
+		useSelect( ( select ) => {
+			const { getSettings, __unstableGetEditorMode, getTemplateLock } =
 				select( blockEditorStore );
 			const { outlineMode, focusMode } = getSettings();
 			return {
 				isOutlineMode: outlineMode,
 				isFocusMode: focusMode,
 				editorMode: __unstableGetEditorMode(),
+				isContentLocked: getTemplateLock() === 'contentOnly',
 			};
-		},
-		[]
-	);
+		}, [] );
 	const registry = useRegistry();
 	const { setBlockVisibility } = useDispatch( blockEditorStore );
 
@@ -111,6 +110,7 @@ function Root( { className, ...settings } ) {
 				'is-outline-mode': isOutlineMode,
 				'is-focus-mode': isFocusMode && isLargeViewport,
 				'is-navigate-mode': editorMode === 'navigation',
+				'is-content-locked': isContentLocked,
 			} ),
 		},
 		settings

--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -27,7 +27,7 @@ export function useInBetweenInserter() {
 		isBlockInsertionPointVisible,
 		isMultiSelecting,
 		getSelectedBlockClientIds,
-		getTemplateLock,
+		isInsertionLocked,
 		__unstableIsWithinBlockOverlay,
 	} = useSelect( blockEditorStore );
 	const { showInsertionPoint, hideInsertionPoint } =
@@ -75,7 +75,7 @@ export function useInBetweenInserter() {
 				}
 
 				// Don't set the insertion point if the template is locked.
-				if ( getTemplateLock( rootClientId ) ) {
+				if ( isInsertionLocked( rootClientId ) ) {
 					return;
 				}
 

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -51,7 +51,7 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 			isBlockValid,
 			getBlockRootClientId,
 			getSettings,
-			__unstableGetContentLockingParent,
+			isContentLockedBlock,
 		} = select( blockEditorStore );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		const selectedBlockClientId = selectedBlockClientIds[ 0 ];
@@ -73,9 +73,7 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 			isVisual: selectedBlockClientIds.every(
 				( id ) => getBlockMode( id ) === 'visual'
 			),
-			isContentLocked: !! __unstableGetContentLockingParent(
-				selectedBlockClientId
-			),
+			isContentLocked: isContentLockedBlock( selectedBlockClientId ),
 		};
 	}, [] );
 

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -79,7 +79,7 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 				getBlockName,
 				getBlockParents,
 				getSelectedBlockClientIds,
-				__unstableGetContentLockingParent,
+				isContentLockedBlock,
 			} = select( blockEditorStore );
 			const { getBlockType } = select( blocksStore );
 			const selectedBlockClientIds = getSelectedBlockClientIds();
@@ -103,9 +103,7 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 						true
 					) &&
 					selectedBlockClientIds.length <= 1 &&
-					! __unstableGetContentLockingParent(
-						_selectedBlockClientId
-					),
+					! isContentLockedBlock( _selectedBlockClientId ),
 			};
 		}, [] );
 

--- a/packages/block-editor/src/components/content-blocks-list/index.js
+++ b/packages/block-editor/src/components/content-blocks-list/index.js
@@ -1,0 +1,77 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import {
+	Button,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	FlexItem,
+} from '@wordpress/components';
+import { getBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+import BlockIcon from '../block-icon';
+import { unlock } from '../../lock-unlock';
+
+export default function ContentBlocksList( { rootClientId } ) {
+	const contentBlocks = useSelect(
+		( select ) => {
+			const {
+				getSelectedBlockClientId,
+				getContentClientIdsTree,
+				getBlockName,
+			} = unlock( select( blockEditorStore ) );
+			const selectedBlockClientId = getSelectedBlockClientId();
+			return getContentClientIdsTree( rootClientId )
+				.map( ( block ) => ( {
+					...block,
+					blockName: getBlockName( block.clientId ),
+					isSelected: blockHasDescendant(
+						block,
+						selectedBlockClientId
+					),
+				} ) )
+				.filter( ( { blockName } ) => blockName !== 'core/list-item' );
+		},
+		[ rootClientId ]
+	);
+
+	const { selectBlock } = useDispatch( blockEditorStore );
+
+	if ( ! contentBlocks.length ) {
+		return null;
+	}
+
+	return (
+		<VStack spacing={ 1 }>
+			{ contentBlocks.map( ( { clientId, blockName, isSelected } ) => {
+				const blockType = getBlockType( blockName );
+				return (
+					<Button
+						key={ clientId }
+						isPressed={ isSelected }
+						onClick={ () => selectBlock( clientId ) }
+					>
+						<HStack justify="flex-start">
+							<BlockIcon icon={ blockType.icon } />
+							<FlexItem>{ blockType.title }</FlexItem>
+						</HStack>
+					</Button>
+				);
+			} ) }
+		</VStack>
+	);
+}
+
+function blockHasDescendant( block, clientId ) {
+	return (
+		block.clientId === clientId ||
+		block.innerBlocks.some( ( child ) =>
+			blockHasDescendant( child, clientId )
+		)
+	);
+}

--- a/packages/block-editor/src/components/default-block-appender/index.js
+++ b/packages/block-editor/src/components/default-block-appender/index.js
@@ -79,7 +79,7 @@ export function DefaultBlockAppender( {
 
 export default compose(
 	withSelect( ( select, ownProps ) => {
-		const { getBlockCount, getSettings, getTemplateLock } =
+		const { getBlockCount, getSettings, isInsertionLocked } =
 			select( blockEditorStore );
 
 		const isEmpty = ! getBlockCount( ownProps.rootClientId );
@@ -87,7 +87,7 @@ export default compose(
 
 		return {
 			showPrompt: isEmpty,
-			isLocked: !! getTemplateLock( ownProps.rootClientId ),
+			isLocked: isInsertionLocked( ownProps.rootClientId ),
 			placeholder: bodyPlaceholder,
 		};
 	} ),

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -60,31 +60,13 @@ function ListViewBlock( {
 	const [ isHovered, setIsHovered ] = useState( false );
 	const { clientId } = block;
 
-	const { isLocked, isContentLocked, canEdit } = useBlockLock( clientId );
-	const forceSelectionContentLock = useSelect(
-		( select ) => {
-			if ( isSelected ) {
-				return false;
-			}
-			if ( ! isContentLocked ) {
-				return false;
-			}
-			return select( blockEditorStore ).hasSelectedInnerBlock(
-				clientId,
-				true
-			);
-		},
-		[ isContentLocked, clientId, isSelected ]
-	);
+	const { isLocked, canEdit } = useBlockLock( clientId );
 
-	const canExpand = isContentLocked ? false : canEdit;
 	const isFirstSelectedBlock =
-		forceSelectionContentLock ||
-		( isSelected && selectedClientIds[ 0 ] === clientId );
+		isSelected && selectedClientIds[ 0 ] === clientId;
 	const isLastSelectedBlock =
-		forceSelectionContentLock ||
-		( isSelected &&
-			selectedClientIds[ selectedClientIds.length - 1 ] === clientId );
+		isSelected &&
+		selectedClientIds[ selectedClientIds.length - 1 ] === clientId;
 
 	const { toggleBlockHighlight } = useDispatch( blockEditorStore );
 
@@ -200,7 +182,7 @@ function ListViewBlock( {
 	}
 
 	const classes = classnames( {
-		'is-selected': isSelected || forceSelectionContentLock,
+		'is-selected': isSelected,
 		'is-first-selected': isFirstSelectedBlock,
 		'is-last-selected': isLastSelectedBlock,
 		'is-branch-selected': isBranchSelected,
@@ -244,14 +226,14 @@ function ListViewBlock( {
 			path={ path }
 			id={ `list-view-${ listViewInstanceId }-block-${ clientId }` }
 			data-block={ clientId }
-			data-expanded={ canExpand ? isExpanded : undefined }
+			data-expanded={ canEdit ? isExpanded : undefined }
 			ref={ rowRef }
 		>
 			<TreeGridCell
 				className="block-editor-list-view-block__contents-cell"
 				colSpan={ colSpan }
 				ref={ cellRef }
-				aria-selected={ !! isSelected || forceSelectionContentLock }
+				aria-selected={ !! isSelected }
 			>
 				{ ( { ref, tabIndex, onFocus } ) => (
 					<div className="block-editor-list-view-block__contents-container">
@@ -268,7 +250,7 @@ function ListViewBlock( {
 								currentlyEditingBlockInCanvas ? 0 : tabIndex
 							}
 							onFocus={ onFocus }
-							isExpanded={ canExpand ? isExpanded : undefined }
+							isExpanded={ canEdit ? isExpanded : undefined }
 							selectedClientIds={ selectedClientIds }
 							ariaLabel={ blockAriaLabel }
 							ariaDescribedBy={ descriptionId }
@@ -317,7 +299,7 @@ function ListViewBlock( {
 			{ showBlockActions && BlockSettingsMenu && (
 				<TreeGridCell
 					className={ listViewBlockSettingsClassName }
-					aria-selected={ !! isSelected || forceSelectionContentLock }
+					aria-selected={ !! isSelected }
 				>
 					{ ( { ref, tabIndex, onFocus } ) => (
 						<BlockSettingsMenu

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -134,11 +134,10 @@ export const withToolbarControls = createHigherOrderComponent(
 			blockAllowedAlignments
 		).map( ( { name } ) => name );
 		const isContentLocked = useSelect(
-			( select ) => {
-				return select(
-					blockEditorStore
-				).__unstableGetContentLockingParent( props.clientId );
-			},
+			( select ) =>
+				select( blockEditorStore ).isContentLockedBlock(
+					props.clientId
+				),
 			[ props.clientId ]
 		);
 		if ( ! validAlignments.length || isContentLocked ) {

--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { ToolbarButton, MenuItem } from '@wordpress/components';
@@ -13,10 +18,7 @@ import { useEffect, useRef, useCallback } from '@wordpress/element';
  */
 import { store as blockEditorStore } from '../store';
 import { BlockControls, BlockSettingsMenuControls } from '../components';
-/**
- * External dependencies
- */
-import classnames from 'classnames';
+import { unlock } from '../lock-unlock';
 
 function StopEditingAsBlocksOnOutsideSelect( {
 	clientId,
@@ -49,18 +51,15 @@ export const withBlockControls = createHigherOrderComponent(
 		const { templateLock, isLockedByParent, isEditingAsBlocks } = useSelect(
 			( select ) => {
 				const {
-					__unstableGetContentLockingParent,
+					isContentLockedBlock,
 					getTemplateLock,
-					__unstableGetTemporarilyEditingAsBlocks,
-				} = select( blockEditorStore );
+					getTemporarilyUnlockedBlock,
+				} = unlock( select( blockEditorStore ) );
 				return {
 					templateLock: getTemplateLock( props.clientId ),
-					isLockedByParent: !! __unstableGetContentLockingParent(
-						props.clientId
-					),
+					isLockedByParent: isContentLockedBlock( props.clientId ),
 					isEditingAsBlocks:
-						__unstableGetTemporarilyEditingAsBlocks() ===
-						props.clientId,
+						getTemporarilyUnlockedBlock() === props.clientId,
 				};
 			},
 			[ props.clientId ]

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -226,11 +226,10 @@ const withDuotoneControls = createHigherOrderComponent(
 		);
 
 		const isContentLocked = useSelect(
-			( select ) => {
-				return select(
-					blockEditorStore
-				).__unstableGetContentLockingParent( props.clientId );
-			},
+			( select ) =>
+				select( blockEditorStore ).isContentLockedBlock(
+					props.clientId
+				),
 			[ props.clientId ]
 		);
 

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -141,11 +141,11 @@ function LayoutPanel( {
 	const defaultThemeLayout = useSetting( 'layout' );
 	const { themeSupportsLayout, isContentLocked } = useSelect(
 		( select ) => {
-			const { getSettings, __unstableGetContentLockingParent } =
+			const { getSettings, isContentLockedBlock } =
 				select( blockEditorStore );
 			return {
 				themeSupportsLayout: getSettings().supportsLayout,
-				isContentLocked: __unstableGetContentLockingParent( clientId ),
+				isContentLocked: isContentLockedBlock( clientId ),
 			};
 		},
 		[ clientId ]

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -12,6 +12,7 @@ import { PrivateListView } from './components/list-view';
 import BlockInfo from './components/block-info-slot-fill';
 import { useShouldContextualToolbarShow } from './utils/use-should-contextual-toolbar-show';
 import { cleanEmptyObject } from './hooks/utils';
+import ContentBlocksList from './components/content-blocks-list';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -28,4 +29,5 @@ lock( privateApis, {
 	BlockInfo,
 	useShouldContextualToolbarShow,
 	cleanEmptyObject,
+	ContentBlocksList,
 } );

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -25,7 +25,10 @@ import {
 	retrieveSelectedAttribute,
 	START_OF_SELECTED_AREA,
 } from '../utils/selection';
-import { __experimentalUpdateSettings } from './private-actions';
+import {
+	__experimentalUpdateSettings,
+	setTemporarilyUnlockedBlock,
+} from './private-actions';
 
 /** @typedef {import('../components/use-on-block-drop/types').WPDropOperation} WPDropOperation */
 
@@ -1630,7 +1633,7 @@ export const insertBeforeBlock =
 			return;
 		}
 		const rootClientId = select.getBlockRootClientId( clientId );
-		const isLocked = select.getTemplateLock( rootClientId );
+		const isLocked = select.isInsertionLocked( rootClientId );
 		if ( isLocked ) {
 			return;
 		}
@@ -1655,7 +1658,7 @@ export const insertAfterBlock =
 			return;
 		}
 		const rootClientId = select.getBlockRootClientId( clientId );
-		const isLocked = select.getTemplateLock( rootClientId );
+		const isLocked = select.isInsertionLocked( rootClientId );
 		if ( isLocked ) {
 			return;
 		}
@@ -1724,20 +1727,12 @@ export function setBlockVisibility( updates ) {
 	};
 }
 
-/**
- * Action that sets whether a block is being temporaritly edited as blocks.
- *
- * DO-NOT-USE in production.
- * This action is created for internal/experimental only usage and may be
- * removed anytime without any warning, causing breakage on any plugin or theme invoking it.
- *
- * @param {?string} temporarilyEditingAsBlocks The block's clientId being temporaritly edited as blocks.
- */
 export function __unstableSetTemporarilyEditingAsBlocks(
 	temporarilyEditingAsBlocks
 ) {
-	return {
-		type: 'SET_TEMPORARILY_EDITING_AS_BLOCKS',
-		temporarilyEditingAsBlocks,
-	};
+	deprecated( '__unstableSetTemporarilyEditingAsBlocks', {
+		since: '6.3',
+		version: '6.4',
+	} );
+	return setTemporarilyUnlockedBlock( temporarilyEditingAsBlocks );
 }

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -269,4 +269,6 @@ export const SETTINGS_DEFAULTS = {
 	],
 
 	__unstableResolvedAssets: { styles: [], scripts: [] },
+
+	contentBlockTypes: null,
 };

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -66,3 +66,17 @@ export function showBlockInterface() {
 		type: 'SHOW_BLOCK_INTERFACE',
 	};
 }
+
+/**
+ * Marks the given block as temporarily unlocked.
+ *
+ * @param {string} clientId The client ID of the block to unlock.
+ *
+ * @return {Object} Action object.
+ */
+export function setTemporarilyUnlockedBlock( clientId ) {
+	return {
+		type: 'SET_TEMPORARILY_UNLOCKED_BLOCK',
+		clientId,
+	};
+}

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -1,4 +1,26 @@
 /**
+ * External dependencies
+ */
+import createSelector from 'rememo';
+
+/**
+ * WordPress dependencies
+ */
+import { createRegistrySelector } from '@wordpress/data';
+import { store as blocksStore } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getBlockParents,
+	getTemplateLock,
+	getBlockName,
+	__unstableGetClientIdWithClientIdsTree,
+	getBlockOrder,
+} from './selectors';
+
+/**
  * Returns true if the block interface is hidden, or false otherwise.
  *
  * @param {Object} state Global application state.
@@ -17,4 +39,112 @@ export function isBlockInterfaceHidden( state ) {
  */
 export function getLastInsertedBlocksClientIds( state ) {
 	return state?.lastBlockInserted?.clientIds;
+}
+
+/**
+ * Returns whether or not the given block is a _content locking_ block.
+ *
+ * A block is _content locking_ if it is the top-most block that has a
+ * `templateLock` attribute set to `'contentOnly'`.
+ *
+ * @param {Object} state    Global application state.
+ * @param {string} clientId The client ID of the block to check.
+ *
+ * @return {boolean} Whether or not the block is a _content locking_ block.
+ */
+export const isContentLockingBlock = ( state, clientId ) =>
+	getContentLockingBlock( state, clientId ) === clientId;
+
+/**
+ * Returns the client ID of the _content locking_ block that contains the given
+ * block, or `undefined` if the block is not nested within a _content locking_
+ * block.
+ *
+ * A block is _content locking_ if it is the top-most block that has a
+ * `templateLock` attribute set to `'contentOnly'`.
+ *
+ * @param {Object} state    Global application state.
+ * @param {string} clientId The client ID of the block to check.
+ *
+ * @return {string|undefined} The client ID of the _content locking_ block that
+ * 						      contains the given block, if it exists.
+ */
+export const getContentLockingBlock = createSelector(
+	( state, clientId ) => {
+		if ( getTemplateLock( state ) === 'contentOnly' ) {
+			return;
+		}
+
+		return [ ...getBlockParents( state, clientId ), clientId ].find(
+			( candidateClientId ) =>
+				getTemplateLock( state, candidateClientId ) === 'contentOnly'
+		);
+	},
+	( state ) => [
+		state.settings.templateLock,
+		state.blocks.parents,
+		state.blockListSettings,
+	]
+);
+
+/**
+ * Returns whether or not the given block is a _content block_.
+ *
+ * A block is _content block_ if its block type is in
+ * `settings.contentBlockTypes` or if it has an attribute with the `'content'`
+ * role.
+ *
+ * @param {Object} state    Global application state.
+ * @param {string} clientId The client ID of the block to check.
+ *
+ * @return {boolean} Whether or not the block is a _content block_.
+ */
+export const isContentBlock = createRegistrySelector(
+	( select ) => ( state, clientId ) => {
+		const blockName = getBlockName( state, clientId );
+		return state.settings.contentBlockTypes
+			? state.settings.contentBlockTypes.includes( blockName )
+			: select( blocksStore ).__experimentalHasContentRoleAttribute(
+					blockName
+			  );
+	}
+);
+
+/**
+ * Returns all of the _content blocks_. If a `rootClientId` is provided, only
+ * the _content blocks_ that are descendants of that block are returned.
+ *
+ * The resultant array is a tree of block objects containing only the `clientId`
+ * and `innerBlocks` properties.
+ *
+ * @see isContentBlock
+ *
+ * @param {Object} state        Global application state.
+ * @param {string} rootClientId Optional root client ID of block list.
+ *
+ * @return {Object[]} Array of block obejcts containing `clientId` and `innerBlocks`.
+ */
+export const getContentClientIdsTree = createSelector(
+	( state, rootClientId = null ) => {
+		return getBlockOrder( state, rootClientId ).flatMap( ( clientId ) =>
+			isContentBlock( state, clientId )
+				? [ __unstableGetClientIdWithClientIdsTree( state, clientId ) ]
+				: getContentClientIdsTree( state, clientId )
+		);
+	},
+	( state ) => [ state.blocks.order ]
+);
+
+/**
+ * Returns the client ID of the block that is temporarily unlocked, or null if
+ * no block is temporarily unlocked.
+ *
+ * Used to allow the user to temporarily edit a _content locked_ block.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {string|null} Client ID of the temporarily unlocked block, or null.
+ */
+export function getTemporarilyUnlockedBlock( state ) {
+	return state.temporarilyUnlockedBlock;
 }

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1820,16 +1820,16 @@ export function lastBlockInserted( state = {}, action ) {
 }
 
 /**
- * Reducer returning the block that is eding temporarily edited as blocks.
+ * Reducer returning the block client ID that is temporarily unlocked.
  *
- * @param {Object} state  Current state.
- * @param {Object} action Dispatched action.
+ * @param {string|null} state  Current state.
+ * @param {Object}      action Dispatched action.
  *
  * @return {Object} Updated state.
  */
-export function temporarilyEditingAsBlocks( state = '', action ) {
-	if ( action.type === 'SET_TEMPORARILY_EDITING_AS_BLOCKS' ) {
-		return action.temporarilyEditingAsBlocks;
+export function temporarilyUnlockedBlock( state = null, action ) {
+	if ( action.type === 'SET_TEMPORARILY_UNLOCKED_BLOCK' ) {
+		return action.clientId;
 	}
 	return state;
 }
@@ -1854,7 +1854,7 @@ const combinedReducers = combineReducers( {
 	hasBlockMovingClientId,
 	highlightedBlock,
 	lastBlockInserted,
-	temporarilyEditingAsBlocks,
+	temporarilyUnlockedBlock,
 	blockVisibility,
 } );
 

--- a/packages/block-editor/src/store/test/private-actions.js
+++ b/packages/block-editor/src/store/test/private-actions.js
@@ -1,7 +1,11 @@
 /**
  * Internal dependencies
  */
-import { hideBlockInterface, showBlockInterface } from '../private-actions';
+import {
+	hideBlockInterface,
+	showBlockInterface,
+	setTemporarilyUnlockedBlock,
+} from '../private-actions';
 
 describe( 'private actions', () => {
 	describe( 'hideBlockInterface', () => {
@@ -16,6 +20,19 @@ describe( 'private actions', () => {
 		it( 'should return the SHOW_BLOCK_INTERFACE action', () => {
 			expect( showBlockInterface() ).toEqual( {
 				type: 'SHOW_BLOCK_INTERFACE',
+			} );
+		} );
+	} );
+
+	describe( 'setTemporarilyUnlockedBlock', () => {
+		it( 'should return the SET_TEMPORARILY_UNLOCKED_BLOCK action', () => {
+			expect(
+				setTemporarilyUnlockedBlock(
+					'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1'
+				)
+			).toEqual( {
+				type: 'SET_TEMPORARILY_UNLOCKED_BLOCK',
+				clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
 			} );
 		} );
 	} );

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -4,6 +4,11 @@
 import {
 	isBlockInterfaceHidden,
 	getLastInsertedBlocksClientIds,
+	isContentLockingBlock,
+	getContentLockingBlock,
+	isContentBlock,
+	getContentClientIdsTree,
+	getTemporarilyUnlockedBlock,
 } from '../private-selectors';
 
 describe( 'private selectors', () => {
@@ -31,9 +36,7 @@ describe( 'private selectors', () => {
 				lastBlockInserted: {},
 			};
 
-			expect( getLastInsertedBlocksClientIds( state ) ).toEqual(
-				undefined
-			);
+			expect( getLastInsertedBlocksClientIds( state ) ).toBeUndefined();
 		} );
 
 		it( 'should return clientIds if blocks have been inserted', () => {
@@ -47,6 +50,332 @@ describe( 'private selectors', () => {
 				'123456',
 				'78910',
 			] );
+		} );
+	} );
+
+	describe( 'content locking selectors', () => {
+		const __experimentalHasContentRoleAttribute = jest.fn( () => false );
+		isContentBlock.registry = {
+			select: jest.fn( () => ( {
+				__experimentalHasContentRoleAttribute,
+			} ) ),
+		};
+
+		const baseState = {
+			settings: {},
+			blocks: {
+				byClientId: new Map(
+					Object.entries( {
+						'6926a815-c923-4daa-bc3f-7da2133b388d': {
+							clientId: '6926a815-c923-4daa-bc3f-7da2133b388d',
+							name: 'core/group',
+						},
+						'9f88f941-9984-419f-8ae7-e427c5b57513': {
+							clientId: '9f88f941-9984-419f-8ae7-e427c5b57513',
+							name: 'core/post-content',
+						},
+						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': {
+							clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+							name: 'core/paragraph',
+						},
+					} )
+				),
+				attributes: new Map(
+					Object.entries( {
+						'6926a815-c923-4daa-bc3f-7da2133b388d': {},
+						'9f88f941-9984-419f-8ae7-e427c5b57513': {},
+						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': {},
+					} )
+				),
+				order: new Map(
+					Object.entries( {
+						'': [ '6926a815-c923-4daa-bc3f-7da2133b388d' ],
+						'6926a815-c923-4daa-bc3f-7da2133b388d': [
+							'9f88f941-9984-419f-8ae7-e427c5b57513',
+						],
+						'9f88f941-9984-419f-8ae7-e427c5b57513': [
+							'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+						],
+						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': [],
+					} )
+				),
+				parents: new Map(
+					Object.entries( {
+						'6926a815-c923-4daa-bc3f-7da2133b388d': '',
+						'9f88f941-9984-419f-8ae7-e427c5b57513':
+							'6926a815-c923-4daa-bc3f-7da2133b388d',
+						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1':
+							'9f88f941-9984-419f-8ae7-e427c5b57513',
+					} )
+				),
+			},
+			blockListSettings: {
+				'6926a815-c923-4daa-bc3f-7da2133b388d': {},
+				'9f88f941-9984-419f-8ae7-e427c5b57513': {},
+				'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': {},
+			},
+		};
+
+		describe( 'isContentLockingBlock', () => {
+			it( 'should return true if the block is the content locking block', () => {
+				const state = {
+					...baseState,
+					blockListSettings: {
+						'6926a815-c923-4daa-bc3f-7da2133b388d': {
+							templateLock: 'contentOnly',
+						},
+						'9f88f941-9984-419f-8ae7-e427c5b57513': {
+							templateLock: 'contentOnly',
+						},
+						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': {
+							templateLock: 'contentOnly',
+						},
+					},
+				};
+				expect(
+					isContentLockingBlock(
+						state,
+						'6926a815-c923-4daa-bc3f-7da2133b388d'
+					)
+				).toBe( true );
+			} );
+
+			it( 'should return false if the block is not the content locking block', () => {
+				const state = {
+					...baseState,
+					blockListSettings: {
+						'6926a815-c923-4daa-bc3f-7da2133b388d': {
+							templateLock: 'contentOnly',
+						},
+						'9f88f941-9984-419f-8ae7-e427c5b57513': {
+							templateLock: 'contentOnly',
+						},
+						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': {
+							templateLock: 'contentOnly',
+						},
+					},
+				};
+				expect(
+					isContentLockingBlock(
+						state,
+						'a0d1cb17-2c08-4e7a-91be-007ba7ddc3a1'
+					)
+				).toBe( false );
+			} );
+		} );
+
+		describe( 'getContentLockingBlock', () => {
+			it( 'should return undefined if there is no content locking block', () => {
+				const state = {
+					...baseState,
+				};
+				expect(
+					getContentLockingBlock(
+						state,
+						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1'
+					)
+				).toBeUndefined();
+			} );
+
+			it( 'should return the topmost content locking block', () => {
+				const state = {
+					...baseState,
+					blockListSettings: {
+						'6926a815-c923-4daa-bc3f-7da2133b388d': {
+							templateLock: 'contentOnly',
+						},
+						'9f88f941-9984-419f-8ae7-e427c5b57513': {
+							templateLock: 'contentOnly',
+						},
+						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': {
+							templateLock: 'contentOnly',
+						},
+					},
+				};
+				expect(
+					getContentLockingBlock(
+						state,
+						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1'
+					)
+				).toBe( '6926a815-c923-4daa-bc3f-7da2133b388d' );
+			} );
+
+			it( 'should return the given block if it is the sole content locking block', () => {
+				const state = {
+					...baseState,
+					blockListSettings: {
+						'6926a815-c923-4daa-bc3f-7da2133b388d': {},
+						'9f88f941-9984-419f-8ae7-e427c5b57513': {},
+						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': {
+							templateLock: 'contentOnly',
+						},
+					},
+				};
+				expect(
+					getContentLockingBlock(
+						state,
+						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1'
+					)
+				).toBe( 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' );
+			} );
+
+			it( 'should return undefined if editor is content locked', () => {
+				const state = {
+					...baseState,
+					settings: {
+						templateLock: 'contentOnly',
+					},
+					blockListSettings: {
+						'6926a815-c923-4daa-bc3f-7da2133b388d': {
+							templateLock: 'contentOnly',
+						},
+						'9f88f941-9984-419f-8ae7-e427c5b57513': {
+							templateLock: 'contentOnly',
+						},
+						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': {
+							templateLock: 'contentOnly',
+						},
+					},
+				};
+				expect(
+					getContentLockingBlock(
+						state,
+						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1'
+					)
+				).toBeUndefined();
+			} );
+		} );
+
+		describe( 'isContentBlock', () => {
+			it( 'should return false by default', () => {
+				const state = {
+					...baseState,
+				};
+				expect(
+					isContentBlock(
+						state,
+						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1'
+					)
+				).toBe( false );
+			} );
+
+			it( 'should return true if the block type is in settings.contentBlockTypes', () => {
+				const state = {
+					...baseState,
+					settings: {
+						contentBlockTypes: [ 'core/paragraph' ],
+					},
+				};
+				expect(
+					isContentBlock(
+						state,
+						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1'
+					)
+				).toBe( true );
+			} );
+
+			it( 'should return true if the block has a content attribute', () => {
+				__experimentalHasContentRoleAttribute.mockReturnValue( true );
+				const state = {
+					...baseState,
+				};
+				expect(
+					isContentBlock(
+						state,
+						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1'
+					)
+				).toBe( true );
+				__experimentalHasContentRoleAttribute.mockReturnValue( false );
+			} );
+		} );
+
+		describe( 'getContentClientIdsTree', () => {
+			it( 'should return an empty array if there are no content blocks', () => {
+				const state = {
+					...baseState,
+				};
+				expect( getContentClientIdsTree( state ) ).toEqual( [] );
+				getContentClientIdsTree.clear();
+			} );
+
+			it( 'should return all content blocks', () => {
+				const state = {
+					...baseState,
+					settings: {
+						contentBlockTypes: [ 'core/paragraph' ],
+					},
+				};
+				expect( getContentClientIdsTree( state ) ).toEqual( [
+					{
+						clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+						innerBlocks: [],
+					},
+				] );
+				getContentClientIdsTree.clear();
+			} );
+
+			it( 'should return all children of content blocks', () => {
+				const state = {
+					...baseState,
+					settings: {
+						contentBlockTypes: [ 'core/post-content' ],
+					},
+				};
+				expect( getContentClientIdsTree( state ) ).toEqual( [
+					{
+						clientId: '9f88f941-9984-419f-8ae7-e427c5b57513',
+						innerBlocks: [
+							{
+								clientId:
+									'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+								innerBlocks: [],
+							},
+						],
+					},
+				] );
+				getContentClientIdsTree.clear();
+			} );
+
+			it( 'should return content blocks nested within a given root', () => {
+				const state = {
+					...baseState,
+					settings: {
+						contentBlockTypes: [
+							'core/post-content',
+							'core/paragraph',
+						],
+					},
+				};
+				expect(
+					getContentClientIdsTree(
+						state,
+						'9f88f941-9984-419f-8ae7-e427c5b57513'
+					)
+				).toEqual( [
+					{
+						clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+						innerBlocks: [],
+					},
+				] );
+				getContentClientIdsTree.clear();
+			} );
+		} );
+
+		describe( 'getTemporarilyUnlockedBlock', () => {
+			it( 'should return undefined if there are no temporarily unlocked blocks', () => {
+				const state = {};
+				expect( getTemporarilyUnlockedBlock( state ) ).toBeUndefined();
+			} );
+
+			it( 'should return the clientId of the temporarily unlocked block', () => {
+				const state = {
+					temporarilyUnlockedBlock:
+						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+				};
+				expect( getTemporarilyUnlockedBlock( state ) ).toBe(
+					'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1'
+				);
+			} );
 		} );
 	} );
 } );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -32,6 +32,7 @@ import {
 	blockListSettings,
 	lastBlockAttributesChange,
 	lastBlockInserted,
+	temporarilyUnlockedBlock,
 } from '../reducer';
 
 const noop = () => {};
@@ -3365,6 +3366,21 @@ describe( 'state', () => {
 			const state = lastBlockInserted( expectedState, action );
 
 			expect( state ).toEqual( expectedState );
+		} );
+	} );
+
+	describe( 'temporarilyUnlockedBlock', () => {
+		it( 'defaults to null', () => {
+			const state = temporarilyUnlockedBlock( undefined, {} );
+			expect( state ).toBeNull();
+		} );
+
+		it( 'is set when SET_TEMPORARILY_UNLOCKED_BLOCK is dispatched', () => {
+			const state = temporarilyUnlockedBlock( null, {
+				type: 'SET_TEMPORARILY_UNLOCKED_BLOCK',
+				clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+			} );
+			expect( state ).toBe( 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' );
 		} );
 	} );
 } );

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -127,14 +127,13 @@ export function ImageEdit( {
 	const ref = useRef();
 	const { imageDefaultSize, mediaUpload, isContentLocked } = useSelect(
 		( select ) => {
-			const { getSettings, __unstableGetContentLockingParent } =
+			const { getSettings, isContentLockedBlock } =
 				select( blockEditorStore );
 			const settings = getSettings();
 			return {
 				imageDefaultSize: settings.imageDefaultSize,
 				mediaUpload: settings.mediaUpload,
-				isContentLocked:
-					!! __unstableGetContentLockingParent( clientId ),
+				isContentLocked: isContentLockedBlock( clientId ),
 			};
 		},
 		[]

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -136,7 +136,7 @@ export function ImageEdit( {
 				isContentLocked: isContentLockedBlock( clientId ),
 			};
 		},
-		[]
+		[ clientId ]
 	);
 
 	const { createErrorNotice } = useDispatch( noticesStore );

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -149,11 +149,10 @@ function MediaTextEdit( { attributes, isSelected, setAttributes, clientId } ) {
 
 	const { imageSizes, image, isContentLocked } = useSelect(
 		( select ) => {
-			const { __unstableGetContentLockingParent, getSettings } =
+			const { isContentLockedBlock, getSettings } =
 				select( blockEditorStore );
 			return {
-				isContentLocked:
-					!! __unstableGetContentLockingParent( clientId ),
+				isContentLocked: isContentLockedBlock( clientId ),
 				image:
 					mediaId && isSelected
 						? select( coreStore ).getMedia( mediaId, {

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -221,12 +221,14 @@ export default function createReduxStore( key, options ) {
 					get: ( target, prop ) => {
 						return (
 							mapSelectors(
-								mapValues(
-									privateSelectors,
-									( selector ) =>
-										( state, ...args ) =>
-											selector( state.root, ...args )
-								),
+								mapValues( privateSelectors, ( selector ) => {
+									if ( selector.isRegistrySelector ) {
+										selector.registry = registry;
+									}
+
+									return ( state, ...args ) =>
+										selector( state.root, ...args );
+								} ),
 								store
 							)[ prop ] || selectors[ prop ]
 						);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

### Editor content locking

In https://github.com/WordPress/gutenberg/pull/43037, the ability to _content lock_ blocks was added. This is done by setting the `templateLock` attribute on any container block (e.g. Group) to `'contentOnly'`. This is useful for creating patterns where the user may only edit content and not add, remove, or edit blocks. See https://richtabor.com/content-only-editing/ for a great guide on doing this.

This PR expands this functionality to work at the editor level. You can now set `templateLock` to `'contentOnly'` in the block editor settings. Doing this results in the exact same experience as above, but applied to _all_ blocks within the editor.

https://user-images.githubusercontent.com/612155/234466613-87b12b1d-16a6-47ba-a62c-52cbcb7e93d2.mp4

This PR also adds the ability to explicitly state which block types are considered to be "content" via the `contentBlockTypes` editor setting. This gives one the ability of finely control the locking. For example, to lock all editing except for the content within a Post Content block, one can specify:

```js
templateLock: 'contentOnly',
contentBlockTypes: [ 'core/post-content' ],
```

Because container blocks (e.g. Post Content) can now be designated as content, the content locking functionality has been added to correctly take into account block nesting. For example it is possible to move and delete blocks within a content block.

### List View changes

Currently, when a container block has `templateLock = 'contentOnly'`, the List View hides all of that container block's children. This behaviour no longer makes sense now that the editor can have `templateLock = 'contentOnly'` as this would result in a completely empty List View. Therefore this PR adjusts the List View to display _only the content blocks_ that are nested within a locked container.

| Before | After |
| - | - |
| <img width="1624" alt="Screenshot 2023-04-26 at 14 05 01" src="https://user-images.githubusercontent.com/612155/234467223-e49d895a-a6c6-43b1-81e8-77684d584b97.png"> |  <img width="1624" alt="Screenshot 2023-04-26 at 14 04 37" src="https://user-images.githubusercontent.com/612155/234467275-0cab4a08-5f67-4212-837e-ddad3f5db4ed.png"> |

### Block inspector changes

The list of content blocks that appears in the block inspector when a locked block is selected has been updated to use a `Panel` component for consistency and to re-use the same List View logic.

| Before | After |
| - | - |
| <img width="1624" alt="Screenshot 2023-04-26 at 14 12 44" src="https://user-images.githubusercontent.com/612155/234468992-2f66ed5a-5f9e-4ec7-a4d1-137df26a3198.png"> | <img width="1624" alt="Screenshot 2023-04-26 at 14 13 19" src="https://user-images.githubusercontent.com/612155/234469026-7504113e-1e6f-47a9-98fc-8e96f5bb2361.png"> |

### API changes

The content locking APIs (selectors and actions) have been rewritten for clarity around three defined terms: _content locking block_, _content locked block_, and _content block_. `isContentLockedBlock` (formerly `__unstableGetContentLockingParent`) has been marked stable as it is the primary way that blocks adjust their interface in response to a lock. All other selectors and APIs have been marked private.

In addition there is a new `isInsertionLocked` selector which is similar in nature to `canRemoveBlock`, `canMoveBlock`, and `canEditBlock`. Having this lets us avoid repeating logic that checks `getTemplateLock` over and over.

- `isInsertionLocked( rootClientId )` (public)
- `__unstableGetContentLockingParent( clientId )` → `isContentLockedBlock( clientId )` (public)
- `__unstableGetTemporarilyEditingAsBlocks()` → `getTemporarilyUnlockedBlock()` (private)
- `__unstableSetTemporarilyEditingAsBlocks()` → `setTemporarilyUnlockedBlock()` (private)
- `getContentClientIdsTree( clientId )` (private)
- `isContentBlock( clientId )` (private)
- `getContentLockingBlock( clientId ) ` (private)
- `isContentLockingBlock( clientId )` (private)

## Why?

This forms the basis for how https://github.com/WordPress/gutenberg/pull/49980 is implemented.

## Testing Instructions
To test the new functionality:
1. Edit a post, page, or template.
2. Paste this into the DevTools console: `wp.data.dispatch( 'core/block-editor' ).updateSettings( { templateLock: 'contentOnly' } )`.

To test the existing functionality for regressions:
1. Add a pattern that has a content lock, e.g. [this one](https://gist.github.com/richtabor/ddeea41ced691721318649bea8ce9db8).
2. Edit a post, page, or template.
3. Insert that pattern.
