### PR TITLE
Global styles: close stylebook if the editor canvas container slot is not filled

### DIFF
--- a/packages/edit-site/src/components/editor-canvas-container/index.js
+++ b/packages/edit-site/src/components/editor-canvas-container/index.js
@@ -5,6 +5,7 @@ import { Children, cloneElement, useState, useMemo } from '@wordpress/element';
 import {
 	Button,
 	privateApis as componentsPrivateApis,
+	__experimentalUseSlotFills as useSlotFills,
 } from '@wordpress/components';
 import { ESCAPE } from '@wordpress/keycodes';
 import { __ } from '@wordpress/i18n';
@@ -25,7 +26,7 @@ import { store as editSiteStore } from '../../store';
  *
  * @return {string} Translated string corresponding to value of view. Default is ''.
  */
-export function getEditorCanvasContainerTitle( view ) {
+function getEditorCanvasContainerTitle( view ) {
 	switch ( view ) {
 		case 'style-book':
 			return __( 'Style Book' );
@@ -37,8 +38,11 @@ export function getEditorCanvasContainerTitle( view ) {
 // Creates a private slot fill.
 const { createPrivateSlotFill } = unlock( componentsPrivateApis );
 const SLOT_FILL_NAME = 'EditSiteEditorCanvasContainerSlot';
-const { Slot: EditorCanvasContainerSlot, Fill: EditorCanvasContainerFill } =
-	createPrivateSlotFill( SLOT_FILL_NAME );
+const {
+	privateKey,
+	Slot: EditorCanvasContainerSlot,
+	Fill: EditorCanvasContainerFill,
+} = createPrivateSlotFill( SLOT_FILL_NAME );
 
 function EditorCanvasContainer( {
 	children,
@@ -110,6 +114,11 @@ function EditorCanvasContainer( {
 		</EditorCanvasContainerFill>
 	);
 }
+function useHasEditorCanvasContainer() {
+	const fills = useSlotFills( privateKey );
+	return !! fills?.length;
+}
 
 EditorCanvasContainer.Slot = EditorCanvasContainerSlot;
 export default EditorCanvasContainer;
+export { useHasEditorCanvasContainer, getEditorCanvasContainerTitle };

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -38,7 +38,10 @@ import UndoButton from './undo-redo/undo';
 import RedoButton from './undo-redo/redo';
 import DocumentActions from './document-actions';
 import { store as editSiteStore } from '../../store';
-import { getEditorCanvasContainerTitle } from '../editor-canvas-container';
+import {
+	getEditorCanvasContainerTitle,
+	useHasEditorCanvasContainer,
+} from '../editor-canvas-container';
 import { unlock } from '../../private-apis';
 
 const preventDefault = ( event ) => {
@@ -122,7 +125,7 @@ export default function HeaderEditMode() {
 		[ setIsListViewOpened, isListViewOpen ]
 	);
 
-	const hasDefaultEditorCanvasView = ! editorCanvasView;
+	const hasDefaultEditorCanvasView = ! useHasEditorCanvasContainer();
 
 	const isFocusMode = templateType === 'wp_template_part';
 

--- a/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
@@ -6,7 +6,6 @@ import { __ } from '@wordpress/i18n';
 import { styles, seen } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
-import { store as interfaceStore } from '@wordpress/interface';
 
 /**
  * Internal dependencies
@@ -18,35 +17,25 @@ import { GlobalStylesMenuSlot } from '../global-styles/ui';
 import { unlock } from '../../private-apis';
 
 export default function GlobalStylesSidebar() {
-	const { shouldClearCanvasContainerView, isStyleBookOpened } = useSelect(
-		( select ) => {
-			const { getActiveComplementaryArea } = select( interfaceStore );
-			const _isVisualEditorMode =
-				'visual' === select( editSiteStore ).getEditorMode();
-
-			return {
-				isStyleBookOpened:
-					'style-book' ===
-					unlock(
-						select( editSiteStore )
-					).getEditorCanvasContainerView(),
-				shouldClearCanvasContainerView:
-					'edit-site/global-styles' !==
-						getActiveComplementaryArea( 'core/edit-site' ) ||
-					! _isVisualEditorMode,
-			};
-		},
-		[]
-	);
-
+	const { editorMode, editorCanvasView } = useSelect( ( select ) => {
+		return {
+			editorMode: select( editSiteStore ).getEditorMode(),
+			editorCanvasView: unlock(
+				select( editSiteStore )
+			).getEditorCanvasContainerView(),
+		};
+	}, [] );
 	const { setEditorCanvasContainerView } = unlock(
 		useDispatch( editSiteStore )
 	);
+
 	useEffect( () => {
-		if ( shouldClearCanvasContainerView ) {
+		if ( editorMode !== 'visual' ) {
 			setEditorCanvasContainerView( undefined );
 		}
-	}, [ shouldClearCanvasContainerView ] );
+	}, [ editorMode ] );
+
+	const isStyleBookOpened = editorCanvasView === 'style-book';
 
 	return (
 		<DefaultSidebar
@@ -66,7 +55,7 @@ export default function GlobalStylesSidebar() {
 							icon={ seen }
 							label={ __( 'Style Book' ) }
 							isPressed={ isStyleBookOpened }
-							disabled={ shouldClearCanvasContainerView }
+							disabled={ editorMode !== 'visual' }
 							onClick={ () =>
 								setEditorCanvasContainerView(
 									isStyleBookOpened ? undefined : 'style-book'

--- a/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { styles, seen } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
+import { store as interfaceStore } from '@wordpress/interface';
 
 /**
  * Internal dependencies
@@ -17,25 +18,37 @@ import { GlobalStylesMenuSlot } from '../global-styles/ui';
 import { unlock } from '../../private-apis';
 
 export default function GlobalStylesSidebar() {
-	const { editorMode, editorCanvasView } = useSelect( ( select ) => {
-		return {
-			editorMode: select( editSiteStore ).getEditorMode(),
-			editorCanvasView: unlock(
+	const { shouldClearCanvasContainerView, isStyleBookOpened } = useSelect(
+		( select ) => {
+			const { getActiveComplementaryArea } = select( interfaceStore );
+			const { getEditorCanvasContainerView, getCanvasMode } = unlock(
 				select( editSiteStore )
-			).getEditorCanvasContainerView(),
-		};
-	}, [] );
+			);
+			const _isVisualEditorMode =
+				'visual' === select( editSiteStore ).getEditorMode();
+			const _isEditCanvasMode = 'edit' === getCanvasMode();
+
+			return {
+				isStyleBookOpened:
+					'style-book' === getEditorCanvasContainerView(),
+				shouldClearCanvasContainerView:
+					'edit-site/global-styles' !==
+						getActiveComplementaryArea( 'core/edit-site' ) ||
+					! _isVisualEditorMode ||
+					! _isEditCanvasMode,
+			};
+		},
+		[]
+	);
 	const { setEditorCanvasContainerView } = unlock(
 		useDispatch( editSiteStore )
 	);
 
 	useEffect( () => {
-		if ( editorMode !== 'visual' ) {
+		if ( shouldClearCanvasContainerView ) {
 			setEditorCanvasContainerView( undefined );
 		}
-	}, [ editorMode ] );
-
-	const isStyleBookOpened = editorCanvasView === 'style-book';
+	}, [ shouldClearCanvasContainerView ] );
 
 	return (
 		<DefaultSidebar
@@ -55,7 +68,7 @@ export default function GlobalStylesSidebar() {
 							icon={ seen }
 							label={ __( 'Style Book' ) }
 							isPressed={ isStyleBookOpened }
-							disabled={ editorMode !== 'visual' }
+							disabled={ shouldClearCanvasContainerView }
 							onClick={ () =>
 								setEditorCanvasContainerView(
 									isStyleBookOpened ? undefined : 'style-book'


### PR DESCRIPTION
!! t.


## What?
An enhancement to to https://github.com/WordPress/gutenberg/pull/50081 which reinstates the original method of checking for a slot fill to see if we need to render a custom header title for the editor canvas slot.

It also checks the canvasMode so we can reset the stylebook slot.

## Why and how?

Previously we could check that the stylebook was open by using `useSlotFills` to see if the stylebook slot was filled.

Since changing over to a private slot fill in https://github.com/WordPress/gutenberg/pull/49973, we now have to get the key using `privateKey`.

```js
const { createPrivateSlotFill } = unlock( componentsPrivateApis );
const SLOT_FILL_NAME = 'EditSiteEditorCanvasContainerSlot';
const {
	privateKey,
	Slot: EditorCanvasContainerSlot,
	Fill: EditorCanvasContainerFill,
} = createPrivateSlotFill( SLOT_FILL_NAME );

...

function useHasEditorCanvasContainer() {
	const fills = useSlotFills( privateKey );
	return !! fills?.length;
}
```

## Testing Instructions
1. Open the site editor
2. Open the global styles sidebar. 
3. Check that you can open and use the stylebook and that the editor header title says "Style book"
4. Verify that you can close it via the eye icon. The header should now show the title of the current template being edited.
5. Now reopen the stylebook and close the global styles sidebar
6. The header should now show the title of the current template being edited.


## Screenshots or screencast <!-- if applicable -->

![2023-04-27 12 22 22](https://user-images.githubusercontent.com/6458278/234743595-e00062cf-f97d-4087-9077-cd1f689570b9.gif)
