### PR TITLE
Inline block styles for classic themes to avoid layout shifts

### DIFF
--- a/lib/compat/wordpress-6.3/script-loader.php
+++ b/lib/compat/wordpress-6.3/script-loader.php
@@ -99,6 +99,9 @@ if ( ! wp_is_block_theme() ) {
  * At the same time, this reduces layout shifts by inlining these styles
  * instead of printing them all in the footer.
  *
+ * NOTE: When backported to Core,
+ * this should probably be merged with the `wp_maybe_inline_styles` function.
+ *
  * This function is hooked on `render_block`.
  *
  * @param string $block_content The block content.

--- a/lib/compat/wordpress-6.3/script-loader.php
+++ b/lib/compat/wordpress-6.3/script-loader.php
@@ -83,3 +83,104 @@ add_filter(
 	},
 	100
 );
+
+
+if ( ! wp_is_block_theme() ) {
+	// Load the block styles inline for non-block themes.
+	add_filter( 'should_load_separate_core_block_assets', '__return_true', 1 );
+	// Remove the block styles from the footer.
+	remove_action( 'wp_footer', 'wp_maybe_inline_styles', 1 );
+}
+
+/**
+ * Print block styles inline for non-block (classic) themes.
+ * Improves performance for classic themes by only loading the styles that are needed
+ * for the blocks that are actually used on the page, instead of loading all block styles.
+ * At the same time, this reduces layout shifts by inlining these styles
+ * instead of printing them all in the footer.
+ *
+ * This function is hooked on `render_block`.
+ *
+ * @param string $block_content The block content.
+ * @param array  $block         The full block, including name and attributes.
+ *
+ * @return string The block content.
+ */
+function gutenberg_inline_block_styles_on_classic_themes( $block_content, $block ) {
+	// Bail early if not a classic theme.
+	if ( wp_is_block_theme() ) {
+		return $block_content;
+	}
+
+	// Get all registered blocks. Use a static var to avoid calling this
+	// for each block that gets rendered on the page.
+	static $all_registered_blocks;
+	if ( ! $all_registered_blocks ) {
+		$all_registered_blocks = WP_Block_Type_Registry::get_instance()->get_all_registered();
+	}
+
+	$style_handles = array();
+	if ( ! empty( $all_registered_blocks[ $block['blockName'] ] ) ) {
+		$style_handles = $all_registered_blocks[ $block['blockName'] ]->style_handles;
+	}
+
+	// Bail early if there are no styles for this block.
+	if ( empty( $style_handles ) ) {
+		return $block_content;
+	}
+
+	/* This filter is documented in wp-includes/script-loader.php */
+	$total_inline_limit = apply_filters( 'styles_inline_size_limit', 20000 );
+
+	// A static var to keep track of the total inlined CSS size.
+	static $total_inline_size = 0;
+
+	// Get the WP_Styles object.
+	$wp_styles = wp_styles();
+
+	foreach ( $style_handles as $style_handle ) {
+		// Skip stylesheet if it has already been printed.
+		if ( in_array( $style_handle, $wp_styles->done, true ) ) {
+			continue;
+		}
+
+		$path  = wp_styles()->get_data( $style_handle, 'path' );
+		$after = wp_styles()->get_data( $style_handle, 'after' );
+		if ( is_array( $after ) ) {
+			$after = implode( '', $after );
+		}
+
+		// Skip stylesheet if it has no path or "after" data.
+		if ( ! $path && ! $after ) {
+			continue;
+		}
+
+		// Get the CSS for this stylesheet.
+		$css = file_exists( $path ) ? file_get_contents( $path ) : '';
+
+		// Add the "after" styles.
+		$css .= $after;
+
+		// Get the size of the CSS.
+		$styles_size = strlen( $css );
+
+		// Skip if styles are empty.
+		if ( 0 === $styles_size ) {
+			$wp_styles->done[] = $style_handle;
+			continue;
+		}
+
+		// Check if adding these styles inline will exceed the limit.
+		// If it does, then bail early.
+		if ( $total_inline_size + $styles_size > $total_inline_limit ) {
+			continue;
+		}
+
+		$wp_styles->done[] = $style_handle;
+		$block_content    .= '<style id="' . $style_handle . '-inline-css">' . $css . '</style>';
+		wp_dequeue_style( $style_handle );
+	}
+
+	return $block_content;
+}
+add_filter( 'render_block', 'gutenberg_inline_block_styles_on_classic_themes', 100, 2 );


### PR DESCRIPTION
## What?
Fixes https://github.com/WordPress/gutenberg/issues/49927

## Why?
* More consistent behavior between classic and block themes
* Performance improvement for classic themes on the frontend (client-side)
* Avoid layout shifts (previously block styles were loaded in the footer, which in some cases can cause layout shifts since they get loaded too late)

## How?
By printing styles inline right after the 1st instance of a block that gets rendered on the page.