### PR TITLE
Changed so that borders and radius are maintained when Duotone is changed.

### DIFF
--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -142,6 +142,7 @@ function DuotonePanel( { attributes, setAttributes, name } ) {
 					value={ { filter: { duotone: duotonePresetOrColors } } }
 					onChange={ ( newDuotone ) => {
 						const newStyle = {
+							...style,
 							color: {
 								...newDuotone?.filter,
 							},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Changed so that borders and radius are maintained when Duotone is changed.

## Why?

Bug fix.

## Screenshots or screencast <!-- if applicable -->

### before

https://user-images.githubusercontent.com/1908815/234505253-757d886c-1615-4c1d-9057-6aea878ea2f4.mov

### after

https://user-images.githubusercontent.com/1908815/234505284-8f3e254a-8d2c-44e1-8a64-872c8ded64fc.mov

