### PR TITLE
Iframe enqueuing: add editorStyle and warning

### DIFF
--- a/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
+++ b/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
@@ -197,6 +197,10 @@ Like scripts, you can enqueue your block's styles using the `block.json` file.
 
 Use the `editorStyle` property to a CSS file you want to load in the editor view, and use the `style` property for a CSS file you want to load on the frontend when the block is used.
 
+It is worth noting that, if the editor content is iframed, both of these will
+load in the iframe. `editorStyle` will also load outside the iframe, so it can
+be used for editor content as well as UI. 
+
 For example:
 
 ```json

--- a/lib/compat/wordpress-6.3/script-loader.php
+++ b/lib/compat/wordpress-6.3/script-loader.php
@@ -27,7 +27,7 @@ remove_action( 'in_admin_header', 'wp_global_styles_render_svg_filters' );
  * }
  */
 function _gutenberg_get_iframed_editor_assets() {
-	global $wp_styles, $wp_scripts;
+	global $wp_styles, $wp_scripts, $pagenow;
 
 	// Keep track of the styles and scripts instance to restore later.
 	$current_wp_styles  = $wp_styles;
@@ -45,8 +45,17 @@ function _gutenberg_get_iframed_editor_assets() {
 	// We do not need reset styles for the iframed editor.
 	$wp_styles->done = array( 'wp-reset-editor-styles' );
 
-	wp_enqueue_style( 'wp-edit-blocks' );
 	wp_enqueue_script( 'wp-polyfill' );
+	// Enqueue the `editorStyle` handles for all core block, and dependencies.
+	wp_enqueue_style( 'wp-edit-blocks' );
+
+	if ( 'site-editor.php' === $pagenow ) {
+		wp_enqueue_style( 'wp-edit-site' );
+	}
+
+	if ( current_theme_supports( 'wp-block-styles' ) ) {
+		wp_enqueue_style( 'wp-block-library-theme' );
+	}
 
 	// We don't want to load EDITOR scripts in the iframe, only enqueue
 	// front-end assets for the content.

--- a/lib/compat/wordpress-6.3/script-loader.php
+++ b/lib/compat/wordpress-6.3/script-loader.php
@@ -42,17 +42,29 @@ function _gutenberg_get_iframed_editor_assets() {
 	$wp_styles->registered  = $current_wp_styles->registered;
 	$wp_scripts->registered = $current_wp_scripts->registered;
 
-	wp_enqueue_style( 'wp-block-editor-content' );
-	// To do: investigate why this is not enqueued through enqueue_block_assets,
-	// as styles for non-core blocks are.
-	wp_enqueue_style( 'wp-block-library' );
+	// We do not need reset styles for the iframed editor.
+	$wp_styles->done = array( 'wp-reset-editor-styles' );
+
+	wp_enqueue_style( 'wp-edit-blocks' );
 	wp_enqueue_script( 'wp-polyfill' );
 
-	// We don't want to load EDITOR scripts and styles in the iframe, only
-	// assets for the content.
+	// We don't want to load EDITOR scripts in the iframe, only enqueue
+	// front-end assets for the content.
 	add_filter( 'should_load_block_editor_scripts_and_styles', '__return_false' );
 	do_action( 'enqueue_block_assets' );
 	remove_filter( 'should_load_block_editor_scripts_and_styles', '__return_false' );
+
+	$block_registry = WP_Block_Type_Registry::get_instance();
+
+	// Additionally, do enqueue `editorStyle` assets for all blocks, which
+	// contains editor-only styling for blocks (editor content).
+	foreach ( $block_registry->get_all_registered() as $block_type ) {
+		if ( isset( $block_type->editor_style_handles ) && is_array( $block_type->editor_style_handles ) ) {
+			foreach ( $block_type->editor_style_handles as $style_handle ) {
+				wp_enqueue_style( $style_handle );
+			}
+		}
+	}
 
 	ob_start();
 	wp_print_styles();

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -164,6 +164,12 @@ function Iframe( {
 				contentDocument.head.appendChild(
 					compatStyle.cloneNode( true )
 				);
+
+				// eslint-disable-next-line no-console
+				console.warn(
+					`${ compatStyle.id } was added to the iframe incorrectly. Please use block.json or enqueue_block_assets to add styles to the iframe.`,
+					compatStyle
+				);
 			}
 
 			iFrameDocument.addEventListener(

--- a/packages/e2e-tests/specs/editor/plugins/iframed-inline-styles.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/iframed-inline-styles.test.js
@@ -32,8 +32,6 @@ describe( 'iframed inline styles', () => {
 	} );
 
 	it( 'should load inline styles in iframe', async () => {
-		expect( console ).toHaveWarned();
-
 		await insertBlock( 'Iframed Inline Styles' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
@@ -50,5 +48,7 @@ describe( 'iframed inline styles', () => {
 		expect( await getComputedStyle( canvas(), 'border-width' ) ).toBe(
 			'2px'
 		);
+
+		expect( console ).toHaveWarned();
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/plugins/iframed-inline-styles.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/iframed-inline-styles.test.js
@@ -32,6 +32,8 @@ describe( 'iframed inline styles', () => {
 	} );
 
 	it( 'should load inline styles in iframe', async () => {
+		expect( console ).toHaveWarned();
+
 		await insertBlock( 'Iframed Inline Styles' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Previously: #49655.
Fixes: #37947.

I previously thought `editorStyle` handles didn't need to be added to the iframe because I mistakenly thought these would contain styles for editor UI. It turns out this API is almost exclusively used for editor-only styles targeting blocks, so they must be added to the iframe.

Note: they are currently enqueuing, but incorrectly through the compat layer.

This PR also logs a warning when styles are added through that compat layer. Now that `enqueue_block_assets` can be used, there should always be a way to add styles correctly.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

The easiest way, I think, is to cherry-pick the change to `packages/block-editor/src/components/iframe/index.js` into trunk and load an iframed editor. You'll see warnings logged for incorrectly added styles. Now checkout the whole PR and these warnings should be gone.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
