### PR TITLE
Restore click event handler on site icon button.

### DIFF
--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -44,7 +44,7 @@ const SiteHub = forwardRef( ( props, ref ) => {
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 	const siteIconButtonProps = {
 		label: __( 'Open Admin Sidebar' ),
-		onMouseDown: () => {
+		onClick: () => {
 			if ( canvasMode === 'edit' ) {
 				clearSelectedBlock();
 				setCanvasMode( 'view' );


### PR DESCRIPTION
Fixes oversight in the animation refactor that was triggering the layout change on mouse down only.