### PR TITLE
Lodash: Remove `_.mapValues()` from blocks reducer

### DIFF
--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, isEmpty, mapValues } from 'lodash';
+import { get, isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -117,9 +117,11 @@ export function blockStyles( state = {}, action ) {
 		case 'ADD_BLOCK_TYPES':
 			return {
 				...state,
-				...mapValues(
-					keyBlockTypesByName( action.blockTypes ),
-					( blockType ) =>
+				...Object.fromEntries(
+					Object.entries(
+						keyBlockTypesByName( action.blockTypes )
+					).map( ( [ name, blockType ] ) => [
+						name,
 						getUniqueItemsByName( [
 							...get( blockType, [ 'styles' ], [] ).map(
 								( style ) => ( {
@@ -130,7 +132,8 @@ export function blockStyles( state = {}, action ) {
 							...get( state, [ blockType.name ], [] ).filter(
 								( { source } ) => 'block' !== source
 							),
-						] )
+						] ),
+					] )
 				),
 			};
 		case 'ADD_BLOCK_STYLES':
@@ -170,21 +173,25 @@ export function blockVariations( state = {}, action ) {
 		case 'ADD_BLOCK_TYPES':
 			return {
 				...state,
-				...mapValues(
-					keyBlockTypesByName( action.blockTypes ),
-					( blockType ) => {
-						return getUniqueItemsByName( [
-							...get( blockType, [ 'variations' ], [] ).map(
-								( variation ) => ( {
-									...variation,
-									source: 'block',
-								} )
-							),
-							...get( state, [ blockType.name ], [] ).filter(
-								( { source } ) => 'block' !== source
-							),
-						] );
-					}
+				...Object.fromEntries(
+					Object.entries(
+						keyBlockTypesByName( action.blockTypes )
+					).map( ( [ name, blockType ] ) => {
+						return [
+							name,
+							getUniqueItemsByName( [
+								...get( blockType, [ 'variations' ], [] ).map(
+									( variation ) => ( {
+										...variation,
+										source: 'block',
+									} )
+								),
+								...get( state, [ blockType.name ], [] ).filter(
+									( { source } ) => 'block' !== source
+								),
+							] ),
+						];
+					} )
 				),
 			};
 		case 'ADD_BLOCK_VARIATIONS':


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.mapValues()` from the `@wordpress/blocks` store reducer.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `Object.fromEntries( Object.entries().map() )` as a replacement. 

## Testing Instructions

* Verify all checks are green and all tests still pass. The changes are covered by a few unit tests.