### PR TITLE
SlotFill: several code cleanups

### DIFF
--- a/packages/components/src/slot-fill/fill.js
+++ b/packages/components/src/slot-fill/fill.js
@@ -3,7 +3,12 @@
 /**
  * WordPress dependencies
  */
-import { createPortal, useLayoutEffect, useRef } from '@wordpress/element';
+import {
+	createPortal,
+	useContext,
+	useLayoutEffect,
+	useRef,
+} from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -11,7 +16,8 @@ import { createPortal, useLayoutEffect, useRef } from '@wordpress/element';
 import SlotFillContext from './context';
 import useSlot from './use-slot';
 
-function FillComponent( { name, children, registerFill, unregisterFill } ) {
+export default function Fill( { name, children } ) {
+	const { registerFill, unregisterFill } = useContext( SlotFillContext );
 	const slot = useSlot( name );
 
 	const ref = useRef( {
@@ -62,17 +68,3 @@ function FillComponent( { name, children, registerFill, unregisterFill } ) {
 
 	return createPortal( children, slot.node );
 }
-
-const Fill = ( props ) => (
-	<SlotFillContext.Consumer>
-		{ ( { registerFill, unregisterFill } ) => (
-			<FillComponent
-				{ ...props }
-				registerFill={ registerFill }
-				unregisterFill={ unregisterFill }
-			/>
-		) }
-	</SlotFillContext.Consumer>
-);
-
-export default Fill;

--- a/packages/components/src/slot-fill/fill.js
+++ b/packages/components/src/slot-fill/fill.js
@@ -3,12 +3,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	createPortal,
-	useContext,
-	useLayoutEffect,
-	useRef,
-} from '@wordpress/element';
+import { useContext, useLayoutEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -57,14 +52,5 @@ export default function Fill( { name, children } ) {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ name ] );
 
-	if ( ! slot || ! slot.node ) {
-		return null;
-	}
-
-	// If a function is passed as a child, provide it with the fillProps.
-	if ( typeof children === 'function' ) {
-		children = children( slot.props.fillProps );
-	}
-
-	return createPortal( children, slot.node );
+	return null;
 }

--- a/packages/components/src/slot-fill/index.js
+++ b/packages/components/src/slot-fill/index.js
@@ -13,7 +13,7 @@ import BubblesVirtuallyFill from './bubbles-virtually/fill';
 import BubblesVirtuallySlot from './bubbles-virtually/slot';
 import BubblesVirtuallySlotFillProvider from './bubbles-virtually/slot-fill-provider';
 import SlotFillProvider from './provider';
-import useSlot from './bubbles-virtually/use-slot';
+export { default as useSlot } from './bubbles-virtually/use-slot';
 export { default as useSlotFills } from './bubbles-virtually/use-slot-fills';
 
 export function Fill( props ) {
@@ -65,5 +65,3 @@ export const createPrivateSlotFill = ( name ) => {
 
 	return { privateKey, ...privateSlotFill };
 };
-
-export { useSlot };

--- a/packages/components/src/slot-fill/provider.js
+++ b/packages/components/src/slot-fill/provider.js
@@ -19,7 +19,6 @@ export default class SlotFillProvider extends Component {
 		this.unregisterFill = this.unregisterFill.bind( this );
 		this.getSlot = this.getSlot.bind( this );
 		this.getFills = this.getFills.bind( this );
-		this.hasFills = this.hasFills.bind( this );
 		this.subscribe = this.subscribe.bind( this );
 
 		this.slots = {};
@@ -32,7 +31,6 @@ export default class SlotFillProvider extends Component {
 			unregisterFill: this.unregisterFill,
 			getSlot: this.getSlot,
 			getFills: this.getFills,
-			hasFills: this.hasFills,
 			subscribe: this.subscribe,
 		};
 	}
@@ -89,10 +87,6 @@ export default class SlotFillProvider extends Component {
 			return [];
 		}
 		return this.fills[ name ];
-	}
-
-	hasFills( name ) {
-		return this.fills[ name ] && !! this.fills[ name ].length;
 	}
 
 	forceUpdateSlot( name ) {

--- a/packages/components/src/slot-fill/slot.js
+++ b/packages/components/src/slot-fill/slot.js
@@ -29,7 +29,6 @@ class SlotComponent extends Component {
 		super( ...arguments );
 
 		this.isUnmounted = false;
-		this.bindNode = this.bindNode.bind( this );
 	}
 
 	componentDidMount() {
@@ -51,10 +50,6 @@ class SlotComponent extends Component {
 			unregisterSlot( prevProps.name );
 			registerSlot( name, this );
 		}
-	}
-
-	bindNode( node ) {
-		this.node = node;
 	}
 
 	forceUpdate() {


### PR DESCRIPTION
While learning about how `SlotFill` exactly works, I found some unused code or cleanup opportunities, and I'm submitting them here.

1. The `Fill` component (the non-bubbling) version was composed from a functional `FillComponent` wrapped inside a `SlotFillContext.Consumer` component. By using the `useContext( SlotFillContext )` hook, we can merge the entire functionality into one functional component.
2. The `SlotFillProvider` component has a `hasFills` method that's not used anywhere, and the context is also not exposed as public API. It can be removed.
3. The non-bubbling `Slot` and `Fill` components have unused code -- the `bindNode` method and a `createPortal` call -- that was used only in the `bubblesVirtually` version which was extracted into separate components in #19242. It can be removed completely from the non-bubbling version.
4. Export of `useSlot` can be written as one `export from` call. Just like the adjacent export of `useSlotFills`.

**How to test:**
Check that all unit and e2e tests are passing after changing these widely used components.