### PR TITLE
Remove `start blank` option in template pattern suggestions and add `skip` button

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -189,6 +189,9 @@ $z-layers: (
 	".edit-site-layout__canvas-container.is-resizing::after": 100,
 	// Title needs to appear above other UI the section content.
 	".edit-site-sidebar-navigation-screen__title-icon": 1,
+
+	// Ensure modal footer actions appear above modal contents
+	".edit-site-start-template-options__modal__actions": 1,
 );
 
 @function z-index( $key ) {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,9 @@
 ### Documentation
 
 -   `TreeGrid`: Update docs with `data-expanded` attribute usage ([#50026](https://github.com/WordPress/gutenberg/pull/50026)).
+### Enhancements
+
+-   `Modal`: Add css class to children container ([#50099](https://github.com/WordPress/gutenberg/pull/50099)).
 
 ## 23.9.0 (2023-04-26)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Documentation
 
 -   `TreeGrid`: Update docs with `data-expanded` attribute usage ([#50026](https://github.com/WordPress/gutenberg/pull/50026)).
+
 ### Enhancements
 
 -   `Modal`: Add css class to children container ([#50099](https://github.com/WordPress/gutenberg/pull/50099)).

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -252,7 +252,12 @@ function UnforwardedModal(
 								) }
 							</div>
 						) }
-						<div ref={ childrenContainerRef }>{ children }</div>
+						<div
+							ref={ childrenContainerRef }
+							className="components-modal__children-container"
+						>
+							{ children }
+						</div>
 					</div>
 				</div>
 			</StyleProvider>

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
@@ -43,7 +43,9 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
         </svg>
       </button>
     </div>
-    <div>
+    <div
+      class="components-modal__children-container"
+    >
       <section
         class="edit-post-keyboard-shortcut-help-modal__section edit-post-keyboard-shortcut-help-modal__main-shortcuts"
       >

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -102,7 +102,9 @@ exports[`EditPostPreferencesModal should match snapshot when the modal is active
         </svg>
       </button>
     </div>
-    <div>
+    <div
+      class="components-modal__children-container"
+    >
       <div
         class="interface-preferences__tabs"
       >
@@ -723,7 +725,9 @@ exports[`EditPostPreferencesModal should match snapshot when the modal is active
         </svg>
       </button>
     </div>
-    <div>
+    <div
+      class="components-modal__children-container"
+    >
       <div
         class="components-navigator-provider interface-preferences__provider emotion-0 emotion-1"
         data-wp-c16t="true"

--- a/packages/edit-site/src/components/start-template-options/style.scss
+++ b/packages/edit-site/src/components/start-template-options/style.scss
@@ -30,11 +30,13 @@
 	}
 
 	// The start blank pattern is the last and we are selecting it.
-	.block-editor-block-patterns-list__list-item:nth-last-child(2) {
+	.block-editor-block-patterns-list__list-item:nth-child(1) {
+		min-height: $grid-unit-50 * 4;
 		.block-editor-block-preview__container {
 			position: absolute;
 			padding: 0;
-			background: #f0f0f0;
+			color: var(--wp-edit-site-start-template-options-start-blank-text);
+			background: var(--wp-edit-site-start-template-options-start-blank-background);
 			min-height: $grid-unit-50 * 4;
 			&::after {
 				width: 100%;

--- a/packages/edit-site/src/components/start-template-options/style.scss
+++ b/packages/edit-site/src/components/start-template-options/style.scss
@@ -1,4 +1,8 @@
 .edit-site-start-template-options__modal {
+	.components-modal__content {
+		padding-bottom: 0;
+	}
+
 	.components-modal__children-container {
 		display: flex;
 		height: 100%;
@@ -6,7 +10,18 @@
 
 		.edit-site-start-template-options__modal__actions {
 			margin-top: auto;
+			position: sticky;
+			bottom: 0;
+			background-color: $white;
+			margin-left: - $grid-unit-40;
+			margin-right: - $grid-unit-40;
+			padding: $grid-unit-30 $grid-unit-40 $grid-unit-40;
+			border-top: 1px solid $gray-300;
 		}
+	}
+
+	.block-editor-block-patterns-list {
+		padding-bottom: $grid-unit-40;
 	}
 }
 

--- a/packages/edit-site/src/components/start-template-options/style.scss
+++ b/packages/edit-site/src/components/start-template-options/style.scss
@@ -1,3 +1,15 @@
+.edit-site-start-template-options__modal {
+	.components-modal__children-container {
+		display: flex;
+		height: 100%;
+		flex-direction: column;
+
+		.edit-site-start-template-options__modal__actions {
+			margin-top: auto;
+		}
+	}
+}
+
 .edit-site-start-template-options__modal-content .block-editor-block-patterns-list {
 	column-count: 2;
 	column-gap: $grid-unit-30;
@@ -26,28 +38,6 @@
 		// default hover and focus styles.
 		&:not(:focus):not(:hover) .block-editor-block-preview__container {
 			box-shadow: 0 0 0 1px $gray-300;
-		}
-	}
-
-	// The start blank pattern is the last and we are selecting it.
-	.block-editor-block-patterns-list__list-item:nth-child(1) {
-		min-height: $grid-unit-50 * 4;
-		.block-editor-block-preview__container {
-			position: absolute;
-			padding: 0;
-			color: var(--wp-edit-site-start-template-options-start-blank-text);
-			background: var(--wp-edit-site-start-template-options-start-blank-background);
-			min-height: $grid-unit-50 * 4;
-			&::after {
-				width: 100%;
-				top: 50%;
-				margin-top: -1em;
-				content: var(--wp-edit-site-start-template-options-start-blank);
-				text-align: center;
-			}
-		}
-		iframe {
-			display: none;
 		}
 	}
 }

--- a/packages/edit-site/src/components/start-template-options/style.scss
+++ b/packages/edit-site/src/components/start-template-options/style.scss
@@ -17,6 +17,7 @@
 			margin-right: - $grid-unit-40;
 			padding: $grid-unit-30 $grid-unit-40 $grid-unit-40;
 			border-top: 1px solid $gray-300;
+			z-index: z-index(".edit-site-start-template-options__modal__actions");
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR removes the `start blank` and adds a `skip` button at the bottom of the modal.
I needed to add a class to the Modal, because due to a recent refactoring there, a `div` was added for the modal's content and was needed in order to enable this design.




## Testing Instructions
1. Create a template for which associated patterns exist
2. Observe the start blank is not there and the skip button at the bottom

