### PR TITLE
Experiment: Auto-inserting blocks on the frontend

### DIFF
--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -181,7 +181,7 @@ function gutenberg_register_auto_inserted_blocks( $settings, $metadata ) {
 	);
 
 	$auto_insert = $metadata['autoInsert'];
-	foreach ( $auto_insert as $position => $block ) {
+	foreach ( $auto_insert as $block => $position ) {
 		if ( ! isset( $property_mappings[ $position ] ) ) {
 			continue;
 		}

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -163,7 +163,7 @@ END;
 		}
 	}
 
-	if ( $block['blockName'] === $block_name ) {
+	if ( $block_name === $block['blockName'] ) {
 		if ( 'before' === $block_position ) {
 			$block_content = $inserted_content . $block_content;
 		} elseif ( 'after' === $block_position ) {

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -140,6 +140,7 @@ add_filter( 'render_block_data', 'gutenberg_auto_insert_child_block', 10, 3 );
  * @param array    $block         The full block, including name and attributes.
  */
 function gutenberg_auto_insert_blocks( $block_content, $block ) {
+	// TODO: Implement an API for users to set the following two parameters.
 	$block_name     = 'core/post-content';
 	$block_position = 'after';
 

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -113,18 +113,19 @@ function gutenberg_auto_insert_child_block( $parsed_block ) {
 
 	if ( $block_name === $parsed_block['blockName'] ) {
 		$inserted_block_markup = '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->';
-		$inserted_blocks = parse_blocks( $inserted_block_markup );
+		$inserted_blocks       = parse_blocks( $inserted_block_markup );
+		$inserted_block        = $inserted_blocks[0];
 
 		if ( 'first-child' === $block_position ) {
-			array_unshift( $parsed_block['innerBlocks'], $inserted_blocks[0] );
+			array_unshift( $parsed_block['innerBlocks'], $inserted_block );
 			// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
 			// when rendering blocks, we also need to prepend the new block to that array.
-			array_unshift( $parsed_block['innerContent'], $inserted_blocks[0] );
+			array_unshift( $parsed_block['innerContent'], $inserted_block );
 		} elseif ( 'last-child' === $block_position ) {
-			array_push( $parsed_block['innerBlocks'], $inserted_blocks[0] );
+			array_push( $parsed_block['innerBlocks'], $inserted_block );
 			// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
 			// when rendering blocks, we also need to append the new block to that array.
-			array_push( $parsed_block['innerContent'], $inserted_blocks[0] );
+			array_push( $parsed_block['innerContent'], $inserted_block );
 		}
 	}
 	return $parsed_block;

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -150,18 +150,12 @@ add_filter( 'render_block_data', 'gutenberg_auto_insert_child_block', 10, 1 );
  * Auto-insert blocks relative to a given block.
  *
  * @param string $block_content The block content.
- * @param array  $block         The full block, including name and attributes.
  */
-function gutenberg_auto_insert_blocks( $block_content, $block ) {
+function gutenberg_auto_insert_blocks( $block_content ) {
 	// TODO: Implement an API for users to set the following two parameters.
-	$block_name     = 'core/post-content';
 	$block_position = 'after';
 
 	// Can we avoid infinite loops?
-
-	if ( $block_name !== $block['blockName'] ) {
-		return $block_content;
-	}
 
 	$inserted_block_markup = <<<END
 <!-- wp:social-links -->
@@ -180,7 +174,7 @@ END;
 
 	return $block_content;
 }
-add_filter( 'render_block', 'gutenberg_auto_insert_blocks', 10, 2 );
+add_filter( 'render_block_core/post-content', 'gutenberg_auto_insert_blocks', 10, 1 );
 
 function gutenberg_register_auto_inserted_blocks( $settings, $metadata ) {
 	if ( ! isset( $metadata['autoInsert'] ) ) {

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -112,12 +112,15 @@ function gutenberg_auto_insert_blocks( $block_content, $block, $instance ) {
 	$block_name = 'core/comment-content';
 	$block_position = 'after'; // Child blocks could be a bit trickier.
 
-	// TODO: Parse actually inserted block.
-	$inserted_content = 'LIKE';
-
 	// Can we void infinite loops?
 
 	if ( $block['blockName'] === $block_name ) {
+		$inserted_block_markup = '<!-- wp:social-links -->
+		<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
+		<!-- /wp:social-links -->';
+		$inserted_blocks = parse_blocks( $inserted_block_markup );
+		$inserted_content = render_block( $inserted_blocks[0] );
+
 		if ( 'before' === $block_position ) {
 			$block_content = $inserted_content . $block_content;
 		} elseif ( 'after' === $block_position ) {

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -121,13 +121,12 @@ add_filter( 'render_block_data', 'gutenberg_auto_insert_child_block', 10, 3 );
  *
  * @param string   $block_content The block content.
  * @param array    $block         The full block, including name and attributes.
- * @param WP_Block $instance      The block instance.
  */
-function gutenberg_auto_insert_blocks( $block_content, $block, $instance ) {
-	// $block_name = 'core/post-content';
+function gutenberg_auto_insert_blocks( $block_content, $block ) {
+	// $block_name     = 'core/post-content';
 	// $block_position = 'after'; // Child blocks could be a bit trickier.
 
-	$block_name = 'core/comment-template';
+	$block_name     = 'core/comment-template';
 	$block_position = 'last-child';
 
 	// Can we void infinite loops?
@@ -145,12 +144,12 @@ function gutenberg_auto_insert_blocks( $block_content, $block, $instance ) {
 		return $block_content;
 	}
 
-
 	$inserted_block_markup = <<<END
 <!-- wp:social-links -->
 <ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
 <!-- /wp:social-links -->
 END;
+
 	$inserted_blocks  = parse_blocks( $inserted_block_markup );
 	$inserted_content = render_block( $inserted_blocks[0] );
 
@@ -173,4 +172,4 @@ END;
 
 	return $block_content;
 }
-add_filter( 'render_block', 'gutenberg_auto_insert_blocks', 10, 3 );
+add_filter( 'render_block', 'gutenberg_auto_insert_blocks', 10, 2 );

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -131,13 +131,15 @@ function gutenberg_auto_insert_child_block( $parsed_block ) {
 	if ( 'first-child' === $block_position ) {
 		array_unshift( $parsed_block['innerBlocks'], $inserted_block );
 		// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
-		// when rendering blocks, we also need to prepend the new block to that array.
-		array_unshift( $parsed_block['innerContent'], $inserted_block );
+		// when rendering blocks, we also need to prepend a value (`null`, to mark a block
+		// location) to that array.
+		array_unshift( $parsed_block['innerContent'], null );
 	} elseif ( 'last-child' === $block_position ) {
 		array_push( $parsed_block['innerBlocks'], $inserted_block );
 		// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
-		// when rendering blocks, we also need to append the new block to that array.
-		array_push( $parsed_block['innerContent'], $inserted_block );
+		// when rendering blocks, we also need to prepend a value (`null`, to mark a block
+		// location) to that array.
+		array_push( $parsed_block['innerContent'], null );
 	}
 
 	return $parsed_block;

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -109,8 +109,18 @@ add_filter( 'register_block_type_args', 'gutenberg_register_metadata_attribute' 
  * @param WP_Block|null $parent_block If this is a nested block, a reference to the parent block.
  */
 function gutenberg_auto_insert_child_block( $parsed_block, $source_block, $parent_block ) {
-	if ( isset( $parent_block ) ) {
-		$parsed_block['parentBlock'] = $parent_block->name;
+	if ( 'core/comment-template' === $parsed_block['blockName'] ) {
+		$inserted_block_markup = <<<END
+<!-- wp:social-links -->
+<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
+<!-- /wp:social-links -->'
+END;
+		$inserted_blocks = parse_blocks( $inserted_block_markup );
+
+		$parsed_block['innerBlocks'][] = $inserted_blocks[0];
+		// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
+		// when rendering blocks, we also need to append the new block to that array.
+		$parsed_block['innerContent'][] = $inserted_blocks[0];
 	}
 	return $parsed_block;
 }

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -131,10 +131,12 @@ function gutenberg_auto_insert_blocks( $block_content, $block, $instance ) {
 
 	// Can we void infinite loops?
 
-	if ( 'core/comment-template' === $block['parentBlock'] ) {
-		$inserted_block_markup = '<!-- wp:social-links -->
-		<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
-		<!-- /wp:social-links -->';
+	if ( isset( $block['parentBlock'] ) && 'core/comment-template' === $block['parentBlock'] ) {
+		$inserted_block_markup = <<<END
+<!-- wp:social-links -->
+<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
+<!-- /wp:social-links -->
+END;
 		$inserted_blocks = parse_blocks( $inserted_block_markup );
 		$inserted_content = render_block( $inserted_blocks[0] );
 
@@ -142,9 +144,11 @@ function gutenberg_auto_insert_blocks( $block_content, $block, $instance ) {
 	}
 
 	if ( $block['blockName'] === $block_name ) {
-		$inserted_block_markup = '<!-- wp:social-links -->
-		<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
-		<!-- /wp:social-links -->';
+		$inserted_block_markup = <<<END
+<!-- wp:social-links -->
+<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
+<!-- /wp:social-links -->
+END;
 		$inserted_blocks = parse_blocks( $inserted_block_markup );
 		$inserted_content = render_block( $inserted_blocks[0] );
 

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -109,8 +109,6 @@ add_filter( 'register_block_type_args', 'gutenberg_register_metadata_attribute' 
  * @param WP_Block|null $parent_block If this is a nested block, a reference to the parent block.
  */
 function gutenberg_auto_insert_child_block( $parsed_block, $source_block, $parent_block ) {
-	// first or last child
-	// of comment-template
 	if ( isset( $parent_block ) ) {
 		$parsed_block['parentBlock'] = $parent_block->name;
 	}
@@ -131,25 +129,21 @@ function gutenberg_auto_insert_blocks( $block_content, $block, $instance ) {
 
 	// Can we void infinite loops?
 
-	if ( isset( $block['parentBlock'] ) && 'core/comment-template' === $block['parentBlock'] ) {
-		$inserted_block_markup = <<<END
+	$inserted_block_markup = <<<END
 <!-- wp:social-links -->
 <ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
 <!-- /wp:social-links -->
 END;
-		$inserted_blocks = parse_blocks( $inserted_block_markup );
+
+	if ( isset( $block['parentBlock'] ) && 'core/comment-template' === $block['parentBlock'] ) {
+		$inserted_blocks  = parse_blocks( $inserted_block_markup );
 		$inserted_content = render_block( $inserted_blocks[0] );
 
 		$block_content = $block_content . $inserted_content; // after!
 	}
 
 	if ( $block['blockName'] === $block_name ) {
-		$inserted_block_markup = <<<END
-<!-- wp:social-links -->
-<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
-<!-- /wp:social-links -->
-END;
-		$inserted_blocks = parse_blocks( $inserted_block_markup );
+		$inserted_blocks  = parse_blocks( $inserted_block_markup );
 		$inserted_content = render_block( $inserted_blocks[0] );
 
 		if ( 'before' === $block_position ) {

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -162,22 +162,27 @@ function gutenberg_register_auto_inserted_blocks( $settings, $metadata ) {
 	);
 
 	$auto_insert = $metadata['autoInsert'];
-	foreach ( $auto_insert as $block => $position ) {
+	foreach ( $auto_insert as $block_name => $block_data ) {
+		$position = $block_data['position'];
 		if ( ! isset( $property_mappings[ $position ] ) ) {
 			continue;
 		}
 
 		$mapped_position = $property_mappings[ $position ];
 
+		$inserted_block = array(
+			'blockName' => $metadata['name'],
+			'attrs'     => $block_data['attrs'],
+		);
 		// TODO: In the long run, we'd likely want some sort of registry for auto-inserted blocks.
 		if ( 'before' === $mapped_position || 'after' === $mapped_position ) {
-			$inserter = gutenberg_auto_insert_blocks( $mapped_position, array( 'blockName' => $metadata['name'] ) );
-			add_filter( "render_block_$block", $inserter, 10, 2 );
+			$inserter = gutenberg_auto_insert_blocks( $mapped_position, $inserted_block );
+			add_filter( "render_block_$block_name", $inserter, 10, 2 );
 		} elseif ( 'first_child' === $mapped_position || 'last_child' === $mapped_position ) {
-			$inserter = gutenberg_auto_insert_child_block( $mapped_position, array( 'blockName' => $metadata['name'] ) );
-			add_filter( "render_block_data_$block", $inserter, 10, 2 );
+			$inserter = gutenberg_auto_insert_child_block( $mapped_position, $inserted_block );
+			add_filter( "render_block_data_$block_name", $inserter, 10, 2 );
 		}
-		$settings['auto_insert'][ $block ] = $mapped_position;
+		$settings['auto_insert'][ $block_name ] = $mapped_position;
 	}
 
 	return $settings;

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -181,7 +181,7 @@ function gutenberg_register_auto_inserted_blocks( $settings, $metadata ) {
 	);
 
 	$auto_insert = $metadata['autoInsert'];
-	foreach ( $auto_insert as $block => $position ) {
+	foreach ( $auto_insert as $position => $block ) {
 		if ( ! isset( $property_mappings[ $position ] ) ) {
 			continue;
 		}

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -159,21 +159,23 @@ function gutenberg_auto_insert_blocks( $block_content, $block ) {
 
 	// Can we avoid infinite loops?
 
-	if ( $block_name === $block['blockName'] ) {
-		$inserted_block_markup = <<<END
+	if ( $block_name !== $block['blockName'] ) {
+		return $block_content;
+	}
+
+	$inserted_block_markup = <<<END
 <!-- wp:social-links -->
 <ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
 <!-- /wp:social-links -->'
 END;
 
-		$inserted_blocks  = parse_blocks( $inserted_block_markup );
-		$inserted_content = render_block( $inserted_blocks[0] );
+	$inserted_blocks  = parse_blocks( $inserted_block_markup );
+	$inserted_content = render_block( $inserted_blocks[0] );
 
-		if ( 'before' === $block_position ) {
-			$block_content = $inserted_content . $block_content;
-		} elseif ( 'after' === $block_position ) {
-			$block_content = $block_content . $inserted_content;
-		}
+	if ( 'before' === $block_position ) {
+		$block_content = $inserted_content . $block_content;
+	} elseif ( 'after' === $block_position ) {
+		$block_content = $block_content . $inserted_content;
 	}
 
 	return $block_content;

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -152,19 +152,12 @@ function gutenberg_auto_insert_blocks( $block_content, $block ) {
 
 	// Can we void infinite loops?
 
-	if (
-		$block_name !== $block['blockName'] ||
-		! in_array( $block_position, array( 'before', 'after' ), true )
-	) {
-		return $block_content;
-	}
-
-	$inserted_block_markup = '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->';
-
-	$inserted_blocks  = parse_blocks( $inserted_block_markup );
-	$inserted_content = render_block( $inserted_blocks[0] );
-
 	if ( $block_name === $block['blockName'] ) {
+		$inserted_block_markup = '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->';
+
+		$inserted_blocks  = parse_blocks( $inserted_block_markup );
+		$inserted_content = render_block( $inserted_blocks[0] );
+
 		if ( 'before' === $block_position ) {
 			$block_content = $inserted_content . $block_content;
 		} elseif ( 'after' === $block_position ) {

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -100,3 +100,31 @@ function gutenberg_register_metadata_attribute( $args ) {
 	return $args;
 }
 add_filter( 'register_block_type_args', 'gutenberg_register_metadata_attribute' );
+
+/**
+ * Auto-insert blocks relative to a given block.
+ *
+ * @param string   $block_content The block content.
+ * @param array    $block         The full block, including name and attributes.
+ * @param WP_Block $instance      The block instance.
+ */
+function gutenberg_auto_insert_blocks( $block_content, $block, $instance ) {
+	$block_name = 'core/comment-content';
+	$block_position = 'after'; // Child blocks could be a bit trickier.
+
+	// TODO: Parse actually inserted block.
+	$inserted_content = 'LIKE';
+
+	// Can we void infinite loops?
+
+	if ( $block['blockName'] === $block_name ) {
+		if ( 'before' === $block_position ) {
+			$block_content = $inserted_content . $block_content;
+		} elseif ( 'after' === $block_position ) {
+			$block_content = $block_content . $inserted_content;
+		}
+	}
+
+	return $block_content;
+}
+add_filter( 'render_block', 'gutenberg_auto_insert_blocks', 10, 3 );

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -144,11 +144,7 @@ function gutenberg_auto_insert_blocks( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$inserted_block_markup = <<<END
-<!-- wp:social-links -->
-<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
-<!-- /wp:social-links -->
-END;
+	$inserted_block_markup = '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->';
 
 	$inserted_blocks  = parse_blocks( $inserted_block_markup );
 	$inserted_content = render_block( $inserted_blocks[0] );

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -195,10 +195,12 @@ function gutenberg_register_auto_inserted_blocks( $settings, $metadata ) {
 	);
 
 	$auto_insert = $metadata['autoInsert'];
-	foreach ( $property_mappings as $key => $mapped_key ) {
-		if ( isset( $auto_insert[ $key ] ) ) {
-			$settings['auto_insert'][ $mapped_key ] = $auto_insert[ $key ];
+	foreach ( $auto_insert as $block => $position ) {
+		if ( ! isset( $property_mappings[ $position ] ) ) {
+			continue;
 		}
+
+		$settings['auto_insert'][ $block ] = $property_mappings[ $position ];
 	}
 
 	return $settings;

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -148,19 +148,13 @@ function gutenberg_auto_insert_blocks( $block_content, $block ) {
 	// $block_position = 'after'; // Child blocks could be a bit trickier.
 
 	$block_name     = 'core/comment-template';
-	$block_position = 'last-child';
+	$block_position = 'after';
 
 	// Can we void infinite loops?
 
 	if (
-		! (
-			$block_name === $block['blockName'] &&
-			( 'before' === $block_position || 'after' === $block_position )
-		) && ! (
-			isset( $block['parentBlock'] ) &&
-			$block_name === $block['parentBlock'] &&
-			( 'first-child' === $block_position || 'last-child' === $block_position )
-		)
+		$block_name !== $block['blockName'] ||
+		! in_array( $block_position, array( 'before', 'after' ), true )
 	) {
 		return $block_content;
 	}
@@ -169,15 +163,6 @@ function gutenberg_auto_insert_blocks( $block_content, $block ) {
 
 	$inserted_blocks  = parse_blocks( $inserted_block_markup );
 	$inserted_content = render_block( $inserted_blocks[0] );
-
-	if ( isset( $block['parentBlock'] ) && $block_name === $block['parentBlock'] ) {
-		if ( 'last-child' === $block_position ) {
-			// FIXME: This is currently apppending the auto-inserted block
-			// after each child of the parent block, rather than only after
-			// the last one.
-			$block_content = $block_content . $inserted_content;
-		}
-	}
 
 	if ( $block_name === $block['blockName'] ) {
 		if ( 'before' === $block_position ) {

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -112,9 +112,18 @@ function gutenberg_auto_insert_child_block( $parsed_block ) {
 	$block_position = 'last-child';
 
 	if ( $block_name === $parsed_block['blockName'] ) {
-		$inserted_block_markup = '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->';
-		$inserted_blocks       = parse_blocks( $inserted_block_markup );
-		$inserted_block        = $inserted_blocks[0];
+		// parse_blocks( '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->' )[0]
+		$inserted_block = array(
+			'blockName'    => 'core/avatar',
+			'attrs'        => array(
+				'size' => 40,
+				'style' => array(
+					'border' => array( 'radius' => '10px' ),
+				),
+			),
+			'innerHTML'    => '',
+			'innerContent' => array(),
+		);
 
 		if ( 'first-child' === $block_position ) {
 			array_unshift( $parsed_block['innerBlocks'], $inserted_block );

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -150,7 +150,7 @@ function gutenberg_auto_insert_blocks( $block_content, $block ) {
 	$block_name     = 'core/comment-template';
 	$block_position = 'after';
 
-	// Can we void infinite loops?
+	// Can we avoid infinite loops?
 
 	if ( $block_name === $block['blockName'] ) {
 		$inserted_block_markup = '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->';

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -187,6 +187,8 @@ function gutenberg_register_auto_inserted_blocks( $settings, $metadata ) {
 		}
 
 		$mapped_position = $property_mappings[ $position ];
+
+		// TODO: In the long run, we'd likely want some sort of registry for auto-inserted blocks.
 		if ( 'before' === $mapped_position || 'after' === $mapped_position ) {
 			$inserter = gutenberg_auto_insert_blocks( $mapped_position, array( 'blockName' => $metadata['name'] ) );
 			add_filter( "render_block_$block", $inserter, 10, 2 );

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -105,10 +105,8 @@ add_filter( 'register_block_type_args', 'gutenberg_register_metadata_attribute' 
  * Auto-insert a block as another block's first or last inner block.
  *
  * @param array         $parsed_block The block being rendered.
- * @param array         $source_block An un-modified copy of $parsed_block, as it appeared in the source content.
- * @param WP_Block|null $parent_block If this is a nested block, a reference to the parent block.
  */
-function gutenberg_auto_insert_child_block( $parsed_block, $source_block, $parent_block ) {
+function gutenberg_auto_insert_child_block( $parsed_block ) {
 	// TODO: Implement an API for users to set the following two parameters.
 	$block_name     = 'core/comment-template';
 	$block_position = 'last-child';
@@ -131,7 +129,7 @@ function gutenberg_auto_insert_child_block( $parsed_block, $source_block, $paren
 	}
 	return $parsed_block;
 }
-add_filter( 'render_block_data', 'gutenberg_auto_insert_child_block', 10, 3 );
+add_filter( 'render_block_data', 'gutenberg_auto_insert_child_block', 10, 1 );
 
 /**
  * Auto-insert blocks relative to a given block.

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -181,3 +181,26 @@ END;
 	return $block_content;
 }
 add_filter( 'render_block', 'gutenberg_auto_insert_blocks', 10, 2 );
+
+function gutenberg_register_auto_inserted_blocks( $settings, $metadata ) {
+	if ( ! isset( $metadata['autoInsert'] ) ) {
+		return $settings;
+	}
+
+	$property_mappings = array(
+		'before'     => 'before',
+		'after'      => 'after',
+		'firstChild' => 'first_child',
+		'lastChild'  => 'last_child',
+	);
+
+	$auto_insert = $metadata['autoInsert'];
+	foreach ( $property_mappings as $key => $mapped_key ) {
+		if ( isset( $auto_insert[ $key ] ) ) {
+			$settings['auto_insert'][ $mapped_key ] = $auto_insert[ $key ];
+		}
+	}
+
+	return $settings;
+}
+add_filter( 'block_type_metadata_settings', 'gutenberg_register_auto_inserted_blocks', 10, 2 );

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -111,32 +111,35 @@ function gutenberg_auto_insert_child_block( $parsed_block ) {
 	$block_name     = 'core/comment-template';
 	$block_position = 'last-child';
 
-	if ( $block_name === $parsed_block['blockName'] ) {
-		// parse_blocks( '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->' )[0].
-		$inserted_block = array(
-			'blockName'    => 'core/avatar',
-			'attrs'        => array(
-				'size'  => 40,
-				'style' => array(
-					'border' => array( 'radius' => '10px' ),
-				),
-			),
-			'innerHTML'    => '',
-			'innerContent' => array(),
-		);
-
-		if ( 'first-child' === $block_position ) {
-			array_unshift( $parsed_block['innerBlocks'], $inserted_block );
-			// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
-			// when rendering blocks, we also need to prepend the new block to that array.
-			array_unshift( $parsed_block['innerContent'], $inserted_block );
-		} elseif ( 'last-child' === $block_position ) {
-			array_push( $parsed_block['innerBlocks'], $inserted_block );
-			// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
-			// when rendering blocks, we also need to append the new block to that array.
-			array_push( $parsed_block['innerContent'], $inserted_block );
-		}
+	if ( $block_name !== $parsed_block['blockName'] ) {
+		return $parsed_block;
 	}
+
+	// parse_blocks( '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->' )[0].
+	$inserted_block = array(
+		'blockName'    => 'core/avatar',
+		'attrs'        => array(
+			'size'  => 40,
+			'style' => array(
+				'border' => array( 'radius' => '10px' ),
+			),
+		),
+		'innerHTML'    => '',
+		'innerContent' => array(),
+	);
+
+	if ( 'first-child' === $block_position ) {
+		array_unshift( $parsed_block['innerBlocks'], $inserted_block );
+		// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
+		// when rendering blocks, we also need to prepend the new block to that array.
+		array_unshift( $parsed_block['innerContent'], $inserted_block );
+	} elseif ( 'last-child' === $block_position ) {
+		array_push( $parsed_block['innerBlocks'], $inserted_block );
+		// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
+		// when rendering blocks, we also need to append the new block to that array.
+		array_push( $parsed_block['innerContent'], $inserted_block );
+	}
+
 	return $parsed_block;
 }
 add_filter( 'render_block_data', 'gutenberg_auto_insert_child_block', 10, 1 );

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -104,7 +104,7 @@ add_filter( 'register_block_type_args', 'gutenberg_register_metadata_attribute' 
 /**
  * Auto-insert a block as another block's first or last inner block.
  *
- * @param array         $parsed_block The block being rendered.
+ * @param array $parsed_block The block being rendered.
  */
 function gutenberg_auto_insert_child_block( $parsed_block ) {
 	// TODO: Implement an API for users to set the following two parameters.
@@ -112,11 +112,11 @@ function gutenberg_auto_insert_child_block( $parsed_block ) {
 	$block_position = 'last-child';
 
 	if ( $block_name === $parsed_block['blockName'] ) {
-		// parse_blocks( '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->' )[0]
+		// parse_blocks( '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->' )[0].
 		$inserted_block = array(
 			'blockName'    => 'core/avatar',
 			'attrs'        => array(
-				'size' => 40,
+				'size'  => 40,
 				'style' => array(
 					'border' => array( 'radius' => '10px' ),
 				),
@@ -144,8 +144,8 @@ add_filter( 'render_block_data', 'gutenberg_auto_insert_child_block', 10, 1 );
 /**
  * Auto-insert blocks relative to a given block.
  *
- * @param string   $block_content The block content.
- * @param array    $block         The full block, including name and attributes.
+ * @param string $block_content The block content.
+ * @param array  $block         The full block, including name and attributes.
  */
 function gutenberg_auto_insert_blocks( $block_content, $block ) {
 	// TODO: Implement an API for users to set the following two parameters.

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -140,10 +140,7 @@ add_filter( 'render_block_data', 'gutenberg_auto_insert_child_block', 10, 3 );
  * @param array    $block         The full block, including name and attributes.
  */
 function gutenberg_auto_insert_blocks( $block_content, $block ) {
-	// $block_name     = 'core/post-content';
-	// $block_position = 'after'; // Child blocks could be a bit trickier.
-
-	$block_name     = 'core/comment-template';
+	$block_name     = 'core/post-content';
 	$block_position = 'after';
 
 	// Can we avoid infinite loops?

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -114,11 +114,7 @@ function gutenberg_auto_insert_child_block( $parsed_block, $source_block, $paren
 	$block_position = 'last-child';
 
 	if ( $block_name === $parsed_block['blockName'] ) {
-		$inserted_block_markup = <<<END
-<!-- wp:social-links -->
-<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
-<!-- /wp:social-links -->'
-END;
+		$inserted_block_markup = '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->';
 		$inserted_blocks = parse_blocks( $inserted_block_markup );
 
 		if ( 'first-child' === $block_position ) {
@@ -153,7 +149,11 @@ function gutenberg_auto_insert_blocks( $block_content, $block ) {
 	// Can we avoid infinite loops?
 
 	if ( $block_name === $block['blockName'] ) {
-		$inserted_block_markup = '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->';
+		$inserted_block_markup = <<<END
+<!-- wp:social-links -->
+<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
+<!-- /wp:social-links -->'
+END;
 
 		$inserted_blocks  = parse_blocks( $inserted_block_markup );
 		$inserted_content = render_block( $inserted_blocks[0] );

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -134,7 +134,7 @@ function gutenberg_auto_insert_child_block( $relative_position, $inserted_block 
  * @param array  $inserted_block    The block to insert.
  * @return callable A function that accepts a block's content and returns the content with the inserted block.
  */
-function gutenberg_auto_insert_blocks( $relative_position, $inserted_block ) {
+function gutenberg_auto_insert_block( $relative_position, $inserted_block ) {
 	// Can we avoid infinite loops?
 
 	return function( $block_content ) use ( $relative_position, $inserted_block ) {
@@ -176,7 +176,7 @@ function gutenberg_register_auto_inserted_blocks( $settings, $metadata ) {
 		);
 		// TODO: In the long run, we'd likely want some sort of registry for auto-inserted blocks.
 		if ( 'before' === $mapped_position || 'after' === $mapped_position ) {
-			$inserter = gutenberg_auto_insert_blocks( $mapped_position, $inserted_block );
+			$inserter = gutenberg_auto_insert_block( $mapped_position, $inserted_block );
 			add_filter( "render_block_$block_name", $inserter, 10, 2 );
 		} elseif ( 'first_child' === $mapped_position || 'last_child' === $mapped_position ) {
 			$inserter = gutenberg_auto_insert_child_block( $mapped_position, $inserted_block );

--- a/packages/block-library/src/avatar/block.json
+++ b/packages/block-library/src/avatar/block.json
@@ -50,5 +50,8 @@
 		}
 	},
 	"editorStyle": "wp-block-avatar",
-	"style": "wp-block-avatar"
+	"style": "wp-block-avatar",
+	"autoInsert": {
+		"core/post-content": "after"
+	}
 }

--- a/packages/block-library/src/avatar/block.json
+++ b/packages/block-library/src/avatar/block.json
@@ -52,6 +52,6 @@
 	"editorStyle": "wp-block-avatar",
 	"style": "wp-block-avatar",
 	"autoInsert": {
-		"core/post-content": "after"
+		"after": "core/post-content"
 	}
 }

--- a/packages/block-library/src/avatar/block.json
+++ b/packages/block-library/src/avatar/block.json
@@ -52,6 +52,7 @@
 	"editorStyle": "wp-block-avatar",
 	"style": "wp-block-avatar",
 	"autoInsert": {
-		"core/post-content": "after"
+		"core/post-content": "after",
+		"core/comment-template": "lastChild"
 	}
 }

--- a/packages/block-library/src/avatar/block.json
+++ b/packages/block-library/src/avatar/block.json
@@ -52,7 +52,16 @@
 	"editorStyle": "wp-block-avatar",
 	"style": "wp-block-avatar",
 	"autoInsert": {
-		"core/post-content": "after",
-		"core/comment-template": "lastChild"
+		"core/comment-template": {
+			"position": "lastChild",
+			"attrs": {
+				"size": 40,
+				"style": {
+					"border": {
+						"radius": "10px"
+					}
+				}
+			}
+		}
 	}
 }

--- a/packages/block-library/src/avatar/block.json
+++ b/packages/block-library/src/avatar/block.json
@@ -52,6 +52,6 @@
 	"editorStyle": "wp-block-avatar",
 	"style": "wp-block-avatar",
 	"autoInsert": {
-		"after": "core/post-content"
+		"core/post-content": "after"
 	}
 }

--- a/packages/block-library/src/social-link/block.json
+++ b/packages/block-library/src/social-link/block.json
@@ -34,5 +34,14 @@
 		"reusable": false,
 		"html": false
 	},
-	"editorStyle": "wp-block-social-link-editor"
+	"editorStyle": "wp-block-social-link-editor",
+	"autoInsert": {
+		"core/post-content": {
+			"position": "after",
+			"attrs": {
+				"service": "wordpress",
+				"url": "https://wordpress.org/"
+			}
+		}
+	}
 }

--- a/phpunit/blocks/render-comment-template-test.php
+++ b/phpunit/blocks/render-comment-template-test.php
@@ -142,6 +142,9 @@ END;
 			return $parsed_block;
 		};
 
+		// Remove auto-insertion filter so it won't collide.
+		remove_filter( 'render_block_data', 'gutenberg_auto_insert_child_block' );
+
 		add_filter( 'render_block_data', $render_block_data_callback, 10, 1 );
 		$parsed_blocks = parse_blocks(
 			'<!-- wp:comments --><!-- wp:comment-template --><!-- wp:comment-content /--><!-- /wp:comment-template --><!-- /wp:comments -->'
@@ -154,6 +157,8 @@ END;
 		);
 		$block->render();
 		remove_filter( 'render_block_data', $render_block_data_callback );
+		// Add back auto-insertion filter.
+		add_filter( 'render_block_data', 'gutenberg_auto_insert_child_block', 10, 1 );
 
 		$this->assertSame( 5, $render_block_callback->get_call_count() );
 

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -740,12 +740,12 @@
 		},
 		"autoInsert": {
 			"type": "object",
-			"description": "Blocks to auto-insert this block next to.",
+			"description": "Position and block that specify where to auto-insert this block.",
 			"patternProperties": {
-				"[a-zA-Z]": {
+				"^(nextSibling|previousSibling|firstChild|lastChild)$": {
 					"type": "string",
-					"description": "Position relative to the block to auto-insert this block next to.",
-					"pattern": "^(nextSibling|previousSibling|firstChild|lastChild)$"
+					"description": "Block to insert this block next to.",
+					"pattern": "[a-zA-Z]"
 				}
 			}
 		}

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -740,12 +740,12 @@
 		},
 		"autoInsert": {
 			"type": "object",
-			"description": "Position and block that specify where to auto-insert this block.",
+			"description": "Blocks to auto-insert this block next to.",
 			"patternProperties": {
-				"^(nextSibling|previousSibling|firstChild|lastChild)$": {
+				"[a-zA-Z]": {
 					"type": "string",
-					"description": "Block to insert this block next to.",
-					"pattern": "[a-zA-Z]"
+					"description": "Position relative to the block to auto-insert this block next to.",
+					"pattern": "^(nextSibling|previousSibling|firstChild|lastChild)$"
 				}
 			}
 		}

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -743,9 +743,24 @@
 			"description": "Blocks to auto-insert this block next to.",
 			"patternProperties": {
 				"[a-zA-Z]": {
-					"type": "string",
+					"type": "object",
 					"description": "Position relative to the block to auto-insert this block next to.",
-					"pattern": "^(nextSibling|previousSibling|firstChild|lastChild)$"
+					"properties": {
+						"position": {
+							"type": "string",
+							"description": "Position relative to the block to auto-insert this block next to.",
+							"enum": [
+								"before",
+								"after",
+								"firstChild",
+								"lastChild"
+							]
+						},
+						"attrs": {
+							"type": "object",
+							"description": "Attributes for the auto-inserted block."
+						}
+					}
 				}
 			}
 		}

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -742,7 +742,7 @@
 			"type": "object",
 			"description": "Positions and blocks to auto-insert this block next to.",
 			"patternProperties": {
-				"[a-zA-Z]": {
+				"^(nextSibling|previousSibling|firstChild|lastChild)$": {
 					"type": "array",
 					"description": "Array of the names of blocks to auto-insert this block next to.",
 					"items": {

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -742,7 +742,7 @@
 			"type": "object",
 			"description": "Positions and blocks to auto-insert this block next to.",
 			"patternProperties": {
-				"^(nextSibling|previousSibling|firstChild|lastChild)$": {
+				"^(after|before|firstChild|lastChild)$": {
 					"type": "array",
 					"description": "Array of the names of blocks to auto-insert this block next to.",
 					"items": {

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -737,6 +737,19 @@
 		"render": {
 			"type": "string",
 			"description": "Template file loaded on the server when rendering a block."
+		},
+		"autoInsert": {
+			"type": "object",
+			"description": "Positions and blocks to auto-insert this block next to.",
+			"patternProperties": {
+				"[a-zA-Z]": {
+					"type": "array",
+					"description": "Array of the names of blocks to auto-insert this block next to.",
+					"items": {
+						"type": "string"
+					}
+				}
+			}
 		}
 	},
 	"required": [ "name", "title" ],

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -740,14 +740,12 @@
 		},
 		"autoInsert": {
 			"type": "object",
-			"description": "Positions and blocks to auto-insert this block next to.",
+			"description": "Blocks to auto-insert this block next to.",
 			"patternProperties": {
-				"^(after|before|firstChild|lastChild)$": {
-					"type": "array",
-					"description": "Array of the names of blocks to auto-insert this block next to.",
-					"items": {
-						"type": "string"
-					}
+				"[a-zA-Z]": {
+					"type": "string",
+					"description": "Position relative to the block to auto-insert this block next to.",
+					"pattern": "^(nextSibling|previousSibling|firstChild|lastChild)$"
 				}
 			}
 		}


### PR DESCRIPTION
## What?
Early-stages experiment to explore concepts discussed in #39439.

## Why?
See #39439. In short, block themes are currently lacking extensibility; the concept of hooks and filters from PHP themes doesn't carry over to them, so we need a more block-centric concept instead.

## How?
Per discussion in #39349, we'd likely want blocks to be auto-inserted as the (previous or next) sibling of a given block, or as its (first or last) child. In this PR, we're demonstrating one example of each sibling and child insertion:
- We use the `render_block` hook to insert the Social Icons block as the next sibling of the Post Content block.
- We use the `render_block_data` hook (which -- unlike the `render_block` hook -- conveniently gives us access to a given block's children) to insert the Avatar block as the last child of the Comment Template block.

The latter example is chosen to also demonstrate that block context is successfully passed to auto-inserted blocks (as evidenced by the auto-inserted Avatar blocks showing each comment author's avatar).

This PR required some preparation in order to make the Comment Template block work with auto-inserted blocks, see in particular https://github.com/WordPress/gutenberg/pull/50279, https://github.com/WordPress/gutenberg/pull/50879, and https://github.com/WordPress/gutenberg/pull/50883. (Similar modifications were applied to the Post Template block, see https://github.com/WordPress/gutenberg/pull/50313.)

## Testing Instructions

- Use the Twenty Twenty-Three theme.
- On a single post page, you should see the Social Icon block (showing the WordPress logo) below the post (as sort of a stand-in for a Like button 😅)
- Have a look at comments below a given post. You should see an Avatar block showing the comment author's avatar (as a stand-in for a Comment Like button)

## Screenshots or screencast

![image](https://github.com/WordPress/gutenberg/assets/96308/466860cd-f3f7-4168-9b47-a4414951dd6d)

