### PR TITLE
Add missing tooltip to Site Editor navigation Back icon button

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -43,7 +43,7 @@ export default function SidebarNavigationScreen( {
 					<NavigatorToParentButton
 						as={ SidebarButton }
 						icon={ isRTL() ? chevronRight : chevronLeft }
-						aria-label={ __( 'Back' ) }
+						label={ __( 'Back' ) }
 					/>
 				) : (
 					<SidebarButton


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fxies https://github.com/WordPress/gutenberg/issues/48211

## What?
<!-- In a few words, what is the PR actually doing? -->
FIxes the remaining part of https://github.com/WordPress/gutenberg/issues/48211 by adding the missing tooltip of the Bacl icon button.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Ideally, tor accessibility, text buttons are always preferable. When, for very good reasons, icon buttons are used then the button accessible name _must_ be visually exposed in some way. Tooltips are a way to do that and are required for all icon buttons. Worth reminding that's already a compromise for accessibility as not all users may be able to access the tooltip in an easy way. At least, it's better than nothing.

**To discuss:**
When navigating into the sub-levels of the 'drill down' menu, focus is programmatically set on the Back button. That makes the tooltip appear each time when entering a navigation sub-level. To me, that's fine. However, if that's not desirable, we should make a decision about an alternative spot where focus should land. Keeping in mind that:
- Focus indication must always be visible.
- Icon buttons must always show a tooltip.

I think the focus management should be double checked a bit anyways. Seems to me [the last fallback](https://github.com/WordPress/gutenberg/blob/72c0204632d707e4dbdbcefa70fdb86e76aa319c/packages/components/src/navigator/navigator-screen/component.tsx#L132-L142) isn't entirely correct.as th efallback element is not a focusable element.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Changing the `aria-label` prop to `label` does the magic.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Go to the site editor.
- Stay in the editor 'browse mode' and navigate the UI with the keyboard.
- Navigate to Templates.
- The 'drill down' menu updates and shows the menu, Focus is set on the chevron left Back button.
- Observe the button now shows a tooltip.
- Navigate to other sub-levels: templates parts, styles, etc. and observe the Back icon button does show a tooltiip.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
See above.

## Screenshots or screencast <!-- if applicable -->

<img width="421" alt="Screenshot 2023-04-26 at 16 03 27" src="https://user-images.githubusercontent.com/1682452/234600561-dfaff290-e5b4-462e-8197-96ecbe8d59c9.png">
