### PR TITLE
refactor: Group block uses BlockListCompact

### DIFF
--- a/packages/block-editor/src/components/block-list/insertion-point.native.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.native.js
@@ -14,7 +14,7 @@ import { withPreferredColorScheme } from '@wordpress/compose';
  */
 import styles from './style.scss';
 
-const BlockInsertionPoint = ( { getStylesFromColorScheme } ) => {
+const BlockInsertionPoint = ( { getStylesFromColorScheme, testID } ) => {
 	const lineStyle = getStylesFromColorScheme(
 		styles.lineStyleAddHere,
 		styles.lineStyleAddHereDark
@@ -25,7 +25,7 @@ const BlockInsertionPoint = ( { getStylesFromColorScheme } ) => {
 	);
 
 	return (
-		<View style={ styles.containerStyleAddHere }>
+		<View style={ styles.containerStyleAddHere } testID={ testID }>
 			<View style={ lineStyle }></View>
 			<Text style={ labelStyle }>{ __( 'ADD BLOCK HERE' ) }</Text>
 			<View style={ lineStyle }></View>

--- a/packages/block-editor/src/components/block-list/test/index.native.js
+++ b/packages/block-editor/src/components/block-list/test/index.native.js
@@ -1,0 +1,100 @@
+/**
+ * External dependencies
+ */
+import {
+	addBlock,
+	getBlock,
+	fireEvent,
+	initializeEditor,
+	screen,
+	setupCoreBlocks,
+	within,
+} from 'test/helpers';
+
+setupCoreBlocks( [ 'core/paragraph', 'core/group' ] );
+
+// Note: The Group block leverage BlockListCompact via `useCompact` when
+// rendering its inner blocks, thus it is an appropriate test subject.
+describe( 'BlockListCompact', () => {
+	describe( 'when a non-last block is selected', () => {
+		beforeEach( async () => {
+			// Arrange
+			await initializeEditor();
+			await addBlock( screen, 'Group' );
+			const groupBlock = await getBlock( screen, 'Group' );
+			fireEvent.press(
+				within( groupBlock ).getByTestId( 'appender-button' )
+			);
+			await addBlock( screen, 'Paragraph', { isPickerOpened: true } );
+			fireEvent.press( screen.getByLabelText( 'Navigate Up' ) );
+			fireEvent.press(
+				within( groupBlock ).getByTestId( 'appender-button' )
+			);
+			await addBlock( screen, 'Paragraph', { isPickerOpened: true } );
+		} );
+
+		it( 'renders an insertion point before the block', async () => {
+			// Act
+			const paragraphBlock = await getBlock( screen, 'Paragraph', {
+				rowIndex: 1,
+			} );
+			fireEvent.press( paragraphBlock );
+			fireEvent( screen.getByLabelText( 'Add block' ), 'longPress' );
+			fireEvent.press( screen.getByText( 'Add Block Before ' ) );
+
+			// Assert
+			expect( screen.getByText( 'ADD BLOCK HERE' ) ).toBeTruthy();
+			expect(
+				screen.getByTestId( 'block-insertion-point-before-row-1' )
+			).toBeTruthy();
+		} );
+
+		it( 'renders an insertion point after the block', async () => {
+			// Act
+			const paragraphBlock = await getBlock( screen, 'Paragraph', {
+				rowIndex: 1,
+			} );
+			fireEvent.press( paragraphBlock );
+			fireEvent( screen.getByLabelText( 'Add block' ), 'longPress' );
+			fireEvent.press( screen.getByText( 'Add Block After ' ) );
+
+			// Assert
+			expect( screen.getByText( 'ADD BLOCK HERE' ) ).toBeTruthy();
+			expect(
+				screen.getByTestId( 'block-insertion-point-before-row-2' )
+			).toBeTruthy();
+		} );
+	} );
+
+	describe( 'when the last block is selected', () => {
+		it( 'renders an insertion point after the block', async () => {
+			// Arrange
+			await initializeEditor();
+			await addBlock( screen, 'Group' );
+			const groupBlock = await getBlock( screen, 'Group' );
+			fireEvent.press(
+				within( groupBlock ).getByTestId( 'appender-button' )
+			);
+			await addBlock( screen, 'Paragraph', { isPickerOpened: true } );
+			fireEvent.press( screen.getByLabelText( 'Navigate Up' ) );
+			fireEvent.press(
+				within( groupBlock ).getByTestId( 'appender-button' )
+			);
+			await addBlock( screen, 'Paragraph', { isPickerOpened: true } );
+
+			// Act
+			const paragraphBlock = await getBlock( screen, 'Paragraph', {
+				rowIndex: 2,
+			} );
+			fireEvent.press( paragraphBlock );
+			fireEvent( screen.getByLabelText( 'Add block' ), 'longPress' );
+			fireEvent.press( screen.getByText( 'Add Block After ' ) );
+
+			// Assert
+			expect( screen.getByText( 'ADD BLOCK HERE' ) ).toBeTruthy();
+			expect(
+				screen.getByTestId( 'block-insertion-point-after-row-2' )
+			).toBeTruthy();
+		} );
+	} );
+} );

--- a/packages/block-editor/src/hooks/test/use-editor-wrapper-styles.native.js
+++ b/packages/block-editor/src/hooks/test/use-editor-wrapper-styles.native.js
@@ -1,0 +1,282 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-native';
+
+/**
+ * WordPress dependencies
+ */
+import { getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
+import { registerCoreBlocks } from '@wordpress/block-library';
+
+/**
+ * Internal dependencies
+ */
+import { useEditorWrapperStyles } from '../use-editor-wrapper-styles';
+
+jest.mock( '../use-editor-wrapper-styles.scss', () => ( {
+	'use-editor-wrapper-styles': {
+		width: '100%',
+		maxWidth: 580,
+		alignSelf: 'center',
+	},
+	'use-editor-wrapper-styles--reversed': {
+		flexDirection: 'column-reverse',
+		width: '100%',
+		maxWidth: 580,
+	},
+} ) );
+
+const defaultCanvasStyles = {
+	width: '100%',
+	maxWidth: 580,
+	alignSelf: 'center',
+};
+
+describe( 'useEditorWrapperStyles', () => {
+	beforeAll( () => {
+		// Register all core blocks
+		registerCoreBlocks();
+	} );
+
+	afterAll( () => {
+		// Clean up registered blocks
+		getBlockTypes().forEach( ( block ) => {
+			unregisterBlockType( block.name );
+		} );
+	} );
+
+	it( 'should return the default wrapper styles when no props are set', () => {
+		// Arrange
+		jest.spyOn(
+			require( 'react-native' ),
+			'useWindowDimensions'
+		).mockReturnValue( { width: 900, height: 600 } );
+
+		// Act
+		const { result } = renderHook( () => useEditorWrapperStyles() );
+
+		// Assert
+		expect( result.current[ 0 ] ).toEqual( [
+			expect.objectContaining( defaultCanvasStyles ),
+			{},
+		] );
+	} );
+
+	it( 'should return the correct wrapper styles and margin for wide (medium) alignment', () => {
+		// Arrange
+		jest.spyOn(
+			require( 'react-native' ),
+			'useWindowDimensions'
+		).mockReturnValue( { width: 900, height: 600 } );
+
+		// Act
+		const { result } = renderHook( () =>
+			useEditorWrapperStyles( {
+				align: 'wide',
+				blockName: 'core/group',
+				blockWidth: 800,
+				marginHorizontal: 16,
+			} )
+		);
+
+		// Assert
+		expect( result.current[ 0 ] ).toEqual( [
+			expect.objectContaining( defaultCanvasStyles ),
+			expect.objectContaining( {
+				maxWidth: 770,
+			} ),
+		] );
+		expect( result.current[ 1 ] ).toEqual( 16 );
+	} );
+
+	it( 'should return the correct wrapper styles and margin for wide (landscape) alignment', () => {
+		// Arrange
+		jest.spyOn(
+			require( 'react-native' ),
+			'useWindowDimensions'
+		).mockReturnValue( { width: 800, height: 600 } );
+
+		// Act
+		const { result } = renderHook( () =>
+			useEditorWrapperStyles( {
+				align: 'wide',
+				blockName: 'core/group',
+				blockWidth: 700,
+				marginHorizontal: 16,
+			} )
+		);
+
+		// Assert
+		expect( result.current[ 0 ] ).toEqual( [
+			expect.objectContaining( defaultCanvasStyles ),
+			expect.objectContaining( {
+				maxWidth: 662,
+			} ),
+		] );
+		expect( result.current[ 1 ] ).toEqual( 16 );
+	} );
+
+	it( 'should return the correct wrapper styles and margin for wide alignment', () => {
+		// Arrange
+		jest.spyOn(
+			require( 'react-native' ),
+			'useWindowDimensions'
+		).mockReturnValue( { width: 1194, height: 834 } );
+
+		// Act
+		const { result } = renderHook( () =>
+			useEditorWrapperStyles( {
+				align: 'wide',
+				blockName: 'core/group',
+				blockWidth: 800,
+				marginHorizontal: 16,
+			} )
+		);
+
+		// Assert
+		expect( result.current[ 0 ] ).toEqual( [
+			expect.objectContaining( defaultCanvasStyles ),
+			expect.objectContaining( {
+				maxWidth: 1054,
+			} ),
+		] );
+		expect( result.current[ 1 ] ).toEqual( 16 );
+	} );
+
+	it( 'should return the correct wrapper styles and margin for full alignment', () => {
+		// Arrange
+		jest.spyOn(
+			require( 'react-native' ),
+			'useWindowDimensions'
+		).mockReturnValue( { width: 800, height: 600 } );
+
+		// Act
+		const { result } = renderHook( () =>
+			useEditorWrapperStyles( {
+				align: 'full',
+				blockName: 'core/cover',
+				blockWidth: 700,
+				marginHorizontal: 16,
+			} )
+		);
+
+		// Assert
+		expect( result.current[ 0 ] ).toEqual( [
+			expect.objectContaining( defaultCanvasStyles ),
+			expect.objectContaining( {
+				maxWidth: '100%',
+			} ),
+		] );
+		expect( result.current[ 1 ] ).toEqual( 0 );
+	} );
+
+	it( 'should return the correct wrapper styles and margin for left alignment', () => {
+		// Arrange
+		jest.spyOn(
+			require( 'react-native' ),
+			'useWindowDimensions'
+		).mockReturnValue( { width: 800, height: 600 } );
+
+		// Act
+		const { result } = renderHook( () =>
+			useEditorWrapperStyles( { align: 'left', marginHorizontal: 16 } )
+		);
+
+		// Assert
+		expect( result.current[ 0 ] ).toEqual( [
+			expect.objectContaining( defaultCanvasStyles ),
+			{},
+		] );
+		expect( result.current[ 1 ] ).toEqual( 16 );
+	} );
+
+	it( 'should return the correct wrapper styles and margin for center alignment', () => {
+		// Arrange
+		jest.spyOn(
+			require( 'react-native' ),
+			'useWindowDimensions'
+		).mockReturnValue( { width: 640, height: 960 } );
+
+		// Act
+		const { result } = renderHook( () =>
+			useEditorWrapperStyles( { align: 'center', marginHorizontal: 16 } )
+		);
+
+		// Assert
+		expect( result.current[ 0 ] ).toEqual( [
+			expect.objectContaining( defaultCanvasStyles ),
+			{},
+		] );
+		expect( result.current[ 1 ] ).toEqual( 16 );
+	} );
+
+	it( 'should return the correct wrapper styles and margin for right alignment', () => {
+		// Arrange
+		jest.spyOn(
+			require( 'react-native' ),
+			'useWindowDimensions'
+		).mockReturnValue( { width: 960, height: 640 } );
+
+		// Act
+		const { result } = renderHook( () =>
+			useEditorWrapperStyles( { align: 'right', marginHorizontal: 16 } )
+		);
+
+		// Assert
+		expect( result.current[ 0 ] ).toEqual( [
+			expect.objectContaining( defaultCanvasStyles ),
+			{},
+		] );
+		expect( result.current[ 1 ] ).toEqual( 16 );
+	} );
+
+	it( 'should return the correct wrapper styles and margin when reversed is true', () => {
+		// Arrange
+		jest.spyOn(
+			require( 'react-native' ),
+			'useWindowDimensions'
+		).mockReturnValue( { width: 800, height: 600 } );
+
+		// Act
+		const { result } = renderHook( () =>
+			useEditorWrapperStyles( { reversed: true, marginHorizontal: 16 } )
+		);
+
+		// Assert
+		expect( result.current[ 0 ] ).toEqual( [
+			expect.objectContaining( {
+				flexDirection: 'column-reverse',
+				width: '100%',
+				maxWidth: 580,
+			} ),
+			{},
+		] );
+		expect( result.current[ 1 ] ).toEqual( 16 );
+	} );
+
+	it( 'should return the correct wrapper styles and margin when contentResizeMode is set', () => {
+		// Arrange
+		jest.spyOn(
+			require( 'react-native' ),
+			'useWindowDimensions'
+		).mockReturnValue( { width: 800, height: 600 } );
+
+		// Act
+		const { result } = renderHook( () =>
+			useEditorWrapperStyles( {
+				contentResizeMode: 'stretch',
+				marginHorizontal: 16,
+			} )
+		);
+
+		// Assert
+		expect( result.current[ 0 ] ).toEqual( [
+			expect.objectContaining( {
+				flex: 1,
+			} ),
+			{},
+		] );
+		expect( result.current[ 1 ] ).toEqual( 16 );
+	} );
+} );

--- a/packages/block-editor/src/hooks/use-editor-wrapper-styles.native.js
+++ b/packages/block-editor/src/hooks/use-editor-wrapper-styles.native.js
@@ -1,0 +1,250 @@
+/**
+ * External dependencies
+ */
+import { useWindowDimensions } from 'react-native';
+
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import {
+	ALIGNMENT_BREAKPOINTS,
+	WIDE_ALIGNMENTS,
+	alignmentHelpers,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import styles from './use-editor-wrapper-styles.scss';
+
+const ALIGNMENT_MAX_WIDTH = {
+	full: '100%',
+	wide: 1054,
+	wideMedium: 770,
+	wideLandscape: 662,
+};
+
+const BLOCK_DEFAULT_MARGIN = 16;
+
+/**
+ * Get the styles for the wide width alignment.
+ *
+ * @param {Object}  [options]           The options for the helper.
+ * @param {string}  options.align       The alignment value.
+ * @param {boolean} options.isLandscape Whether the screen is in landscape mode.
+ * @param {number}  options.width       The width of the screen.
+ * @return {Object} An object containing the styles for the wide width alignment.
+ */
+function getWideWidthStyles( { align, isLandscape, width } = {} ) {
+	if ( align !== WIDE_ALIGNMENTS.alignments.wide ) {
+		return {};
+	}
+
+	if ( isLandscape && width < ALIGNMENT_BREAKPOINTS.large ) {
+		return { maxWidth: ALIGNMENT_MAX_WIDTH.wideLandscape };
+	}
+
+	if ( width <= ALIGNMENT_BREAKPOINTS.small ) {
+		return { maxWidth: width };
+	}
+
+	if (
+		width >= ALIGNMENT_BREAKPOINTS.medium &&
+		width < ALIGNMENT_BREAKPOINTS.wide
+	) {
+		return { maxWidth: ALIGNMENT_MAX_WIDTH.wideMedium };
+	}
+
+	return { maxWidth: ALIGNMENT_MAX_WIDTH.wide };
+}
+
+/**
+ * Get the styles for the full width alignment.
+ *
+ * @param {Object}  [options]               The options for the helper.
+ * @param {string}  options.align           The alignment value.
+ * @param {string}  options.blockName       The name of the block.
+ * @param {boolean} options.hasParents      Whether the block has parents.
+ * @param {string}  options.parentBlockName The name of the parent block.
+ * @return {Object} An object containing the styles for the full width alignment.
+ */
+function getFullWidthStyles( {
+	align,
+	blockName,
+	hasParents,
+	parentBlockName,
+} = {} ) {
+	const { isContainerRelated, isFullWidth } = alignmentHelpers;
+	const fullWidthStyles = isFullWidth( align )
+		? { maxWidth: ALIGNMENT_MAX_WIDTH.full }
+		: {};
+
+	if (
+		! align &&
+		hasParents &&
+		! isContainerRelated( parentBlockName ) &&
+		isContainerRelated( blockName )
+	) {
+		fullWidthStyles.paddingHorizontal = BLOCK_DEFAULT_MARGIN;
+	}
+
+	return fullWidthStyles;
+}
+
+/**
+ * Get the block margin based on various conditions.
+ *
+ * @param {Object}  [options]                    The options for the helper.
+ * @param {string}  options.align                The alignment value.
+ * @param {string}  options.blockName            The name of the block.
+ * @param {number}  options.blockWidth           The width of the block.
+ * @param {boolean} options.hasParents           Whether the block has parents.
+ * @param {number}  options.marginHorizontal     Default horizontal margin.
+ * @param {string}  options.parentBlockAlignment The alignment of the parent block.
+ * @param {string}  options.parentBlockName      The name of the parent block.
+ * @param {number}  options.parentWidth          The width of the parent block.
+ * @param {number}  options.width                The width of the screen.
+ * @return {number} The calculated block margin.
+ */
+function getBlockMargin( {
+	align,
+	blockName,
+	blockWidth,
+	hasParents,
+	marginHorizontal,
+	parentBlockAlignment,
+	parentBlockName,
+	parentWidth,
+	width,
+} = {} ) {
+	const { isContainerRelated, isWider, isWideWidth, isFullWidth } =
+		alignmentHelpers;
+
+	if ( isFullWidth( align ) ) {
+		if ( ! hasParents ) {
+			return 0;
+		}
+		return marginHorizontal;
+	}
+
+	if ( isWideWidth( align ) ) {
+		return marginHorizontal;
+	}
+
+	if (
+		isFullWidth( parentBlockAlignment ) &&
+		! isWider( blockWidth, 'medium' )
+	) {
+		if ( isContainerRelated( blockName ) || isWider( width, 'mobile' ) ) {
+			return marginHorizontal;
+		}
+		return marginHorizontal * 2;
+	}
+
+	if (
+		isContainerRelated( parentBlockName ) &&
+		! isContainerRelated( blockName )
+	) {
+		const isScreenWidthEqual = parentWidth === width;
+		if ( isScreenWidthEqual || isWider( width, 'mobile' ) ) {
+			return marginHorizontal;
+		}
+	}
+
+	return marginHorizontal;
+}
+
+/**
+ * Custom hook to get the styles and margin for the editor wrapper.
+ *
+ * @param {Object}  [props]                    The props for the hook.
+ * @param {string}  props.align                The alignment value.
+ * @param {string}  props.blockName            The name of the block.
+ * @param {number}  props.blockWidth           The width of the block.
+ * @param {string}  props.contentResizeMode    The content resize mode.
+ * @param {boolean} props.hasParents           Whether the block has parents.
+ * @param {number}  props.marginHorizontal     Default horizontal margin.
+ * @param {string}  props.parentBlockAlignment The alignment of the parent block.
+ * @param {string}  props.parentBlockName      The name of the parent block.
+ * @param {number}  props.parentWidth          The width of the parent block.
+ * @param {boolean} [props.reversed=false]     Whether the flex direction should be reversed.
+ * @return {[Array, number]} An array containing the wrapper styles and block margin.
+ */
+export function useEditorWrapperStyles( {
+	align,
+	blockName,
+	blockWidth,
+	contentResizeMode,
+	hasParents,
+	marginHorizontal,
+	parentBlockAlignment,
+	parentBlockName,
+	parentWidth,
+	reversed = false,
+} = {} ) {
+	const { width, height } = useWindowDimensions();
+	const isLandscape = width >= height;
+
+	const blockMargin = useMemo(
+		() =>
+			getBlockMargin( {
+				align,
+				blockName,
+				blockWidth,
+				hasParents,
+				marginHorizontal,
+				parentBlockAlignment,
+				parentBlockName,
+				parentWidth,
+				width,
+			} ),
+		[
+			align,
+			blockName,
+			blockWidth,
+			hasParents,
+			marginHorizontal,
+			parentBlockAlignment,
+			parentBlockName,
+			parentWidth,
+			width,
+		]
+	);
+
+	const wrapperStyles = useMemo( () => {
+		let canvasStyles;
+
+		if ( contentResizeMode === 'stretch' ) {
+			// For these cases, no width constraints should be added.
+			canvasStyles = { flex: 1 };
+		} else if ( reversed ) {
+			canvasStyles = styles[ 'use-editor-wrapper-styles--reversed' ];
+		} else {
+			canvasStyles = styles[ 'use-editor-wrapper-styles' ];
+		}
+
+		const alignmentStyles = {
+			...getWideWidthStyles( { align, isLandscape, width } ),
+			...getFullWidthStyles( {
+				align,
+				blockName,
+				hasParents,
+				parentBlockName,
+			} ),
+		};
+
+		return [ canvasStyles, alignmentStyles ];
+	}, [
+		align,
+		blockName,
+		hasParents,
+		parentBlockName,
+		isLandscape,
+		width,
+		contentResizeMode,
+		reversed,
+	] );
+
+	return [ wrapperStyles, blockMargin ];
+}

--- a/packages/block-editor/src/hooks/use-editor-wrapper-styles.native.scss
+++ b/packages/block-editor/src/hooks/use-editor-wrapper-styles.native.scss
@@ -1,0 +1,11 @@
+.use-editor-wrapper-styles {
+	width: 100%;
+	max-width: 580;
+	align-self: center;
+}
+
+.use-editor-wrapper-styles--reversed {
+	flex-direction: column-reverse;
+	width: 100%;
+	max-width: 580;
+}

--- a/packages/block-library/src/group/edit.native.js
+++ b/packages/block-library/src/group/edit.native.js
@@ -65,6 +65,7 @@ function GroupEdit( {
 			blockWidth,
 			parentWidth: width,
 			renderAppender: isSelected && renderAppender,
+			useCompactList: true,
 		}
 	);
 

--- a/packages/block-library/src/group/edit.native.js
+++ b/packages/block-library/src/group/edit.native.js
@@ -13,6 +13,7 @@ import {
 	useResizeObserver,
 } from '@wordpress/compose';
 import {
+	useInnerBlocksProps,
 	InnerBlocks,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
@@ -58,6 +59,15 @@ function GroupEdit( {
 		[ align, hasInnerBlocks ]
 	);
 
+	const innerBlocksProps = useInnerBlocksProps(
+		{},
+		{
+			blockWidth,
+			parentWidth: width,
+			renderAppender: isSelected && renderAppender,
+		}
+	);
+
 	if ( ! isSelected && ! hasInnerBlocks ) {
 		return (
 			<View
@@ -90,11 +100,7 @@ function GroupEdit( {
 			] }
 		>
 			{ resizeObserver }
-			<InnerBlocks
-				renderAppender={ isSelected && renderAppender }
-				parentWidth={ width }
-				blockWidth={ blockWidth }
-			/>
+			<View { ...innerBlocksProps } />
 		</View>
 	);
 }

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -88,6 +88,7 @@ export const coreBlocks = [
 	column,
 	cover,
 	embed,
+	group,
 	file,
 	html,
 	mediaText,

--- a/test/native/__mocks__/styleMock.js
+++ b/test/native/__mocks__/styleMock.js
@@ -178,4 +178,7 @@ module.exports = {
 	mediaAreaPadding: {
 		width: 12,
 	},
+	defaultAppender: {
+		marginLeft: 16,
+	},
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Refactor the Group block to leverage the `BlockListCompact` component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Relates to https://github.com/wordpress-mobile/gutenberg-mobile/issues/5617.

`BlockListCompact` reduces the depth of the component tree. This is beneficial
for improving performance and avoiding crashes from rendering too many `View`s.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Refactor the Group block to leverage the `useInnerBlocksProps` to align with the
web editor's preferred paradigm, which enables more control over the elements
rendered for inner blocks.

Refactor the Group block to leverage `BlockListCompact`, which requires
expanding the props supported by `BlockListCompact` to enabling rendering the
block appender.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Insert a Group block.
1. Verify the block borders and inner block appender render as expected.
1. Nest additional Group (other) blocks within the top-level Group block.
1. Verify the block border and inner block appender render as expected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
| Tree Before | Tree After | 
| - | - |
| <img width="512" alt="group-after" src="https://user-images.githubusercontent.com/438664/234700061-a5de6cea-66e8-483a-bbdd-f136ba328855.png"> | <img width="411" alt="group-before" src="https://user-images.githubusercontent.com/438664/234700023-b97d922b-f0f2-494f-a82c-5be4d2a89d11.png"> |

