### PR TITLE
Doc: Block API > Registration: switch markdown to a-tags

### DIFF
--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -3,8 +3,8 @@
 Block registration API reference.
 
 <div class="callout callout-alert">
-You can use the functions documented on this page to register a block with JavaScript only on the client, but the recommended method is to register new block types also with PHP on the server using the `block.json` metadata file. See <a href="/docs/reference-guides/block-api/block-metadata.md)">metadata documentation for complete information</a>
-<a href="/docs/getting-started/create-block/README.md">Learn how to create your first block</a>() for the WordPress block editor. From setting up your development environment, tools, and getting comfortable with the new development model, this tutorial covers all you need to know to get started with creating blocks.
+You can use the functions documented on this page to register a block with JavaScript only on the client, but the recommended method is to register new block types also with PHP on the server using the `block.json` metadata file. See <a href="/docs/reference-guides/block-api/block-metadata.md">metadata documentation for complete information</a>
+<a href="/docs/getting-started/create-block/README.md">Learn how to create your first block</a> for the WordPress block editor. From setting up your development environment, tools, and getting comfortable with the new development model, this tutorial covers all you need to know to get started with creating blocks.
 </div>
 
 ## `registerBlockType`

--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -3,9 +3,8 @@
 Block registration API reference.
 
 <div class="callout callout-alert">
-You can use the functions documented on this page to register a block with JavaScript only on the client, but the recommended method is to register new block types also with PHP on the server using the `block.json` metadata file. See [metadata documentation for complete information](/docs/reference-guides/block-api/block-metadata.md).
-
-[Learn how to create your first block](/docs/getting-started/create-block/README.md) for the WordPress block editor. From setting up your development environment, tools, and getting comfortable with the new development model, this tutorial covers all you need to know to get started with creating blocks.
+You can use the functions documented on this page to register a block with JavaScript only on the client, but the recommended method is to register new block types also with PHP on the server using the `block.json` metadata file. See <a href="/docs/reference-guides/block-api/block-metadata.md)">metadata documentation for complete information</a>(
+<a href="/docs/getting-started/create-block/README.md">Learn how to create your first block</a> for the WordPress block editor. From setting up your development environment, tools, and getting comfortable with the new development model, this tutorial covers all you need to know to get started with creating blocks.
 </div>
 
 ## `registerBlockType`

--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -3,8 +3,8 @@
 Block registration API reference.
 
 <div class="callout callout-alert">
-You can use the functions documented on this page to register a block with JavaScript only on the client, but the recommended method is to register new block types also with PHP on the server using the `block.json` metadata file. See <a href="/docs/reference-guides/block-api/block-metadata.md)">metadata documentation for complete information</a>(
-<a href="/docs/getting-started/create-block/README.md">Learn how to create your first block</a> for the WordPress block editor. From setting up your development environment, tools, and getting comfortable with the new development model, this tutorial covers all you need to know to get started with creating blocks.
+You can use the functions documented on this page to register a block with JavaScript only on the client, but the recommended method is to register new block types also with PHP on the server using the `block.json` metadata file. See <a href="/docs/reference-guides/block-api/block-metadata.md)">metadata documentation for complete information</a>
+<a href="/docs/getting-started/create-block/README.md">Learn how to create your first block</a>() for the WordPress block editor. From setting up your development environment, tools, and getting comfortable with the new development model, this tutorial covers all you need to know to get started with creating blocks.
 </div>
 
 ## `registerBlockType`


### PR DESCRIPTION
## What?
fixes #50109

## Why?
in `<div callouts>` Links need to be a-tags instead of Markdown 
That is only a theory, I am testing. I have not found any information in that regard in the documentation. 

## How?
switch markdown to a-tags

