### PR TITLE
File Block: Defer hiding PDF embeds for unsupported browsers until the page has loaded

### DIFF
--- a/packages/block-library/src/file/view.js
+++ b/packages/block-library/src/file/view.js
@@ -3,4 +3,7 @@
  */
 import { hidePdfEmbedsOnUnsupportedBrowsers } from './utils';
 
-hidePdfEmbedsOnUnsupportedBrowsers();
+document.addEventListener(
+	'DOMContentLoaded',
+	hidePdfEmbedsOnUnsupportedBrowsers
+);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Instead of calling `hidePdfEmbedsOnUnsupportedBrowsers` immediately when the File block's view script loads (in the `head`), wait until the DOM has loaded.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently all of a block's view scripts are loaded in the `head` (see Core-54018). The Navigation block's view scripts run their logic at the window `load` event (cf. https://github.com/WordPress/gutenberg/issues/42394#issuecomment-1524124149). The File block, however, does not use any such event listener to run its `hidePdfEmbedsOnUnsupportedBrowsers` logic. This means that currently no PDF embeds are being hidden on unsupported browsers. I'm surprised that this hasn't been noticed before now, since such embeds don't work on mobile devices. For example, see the WordPress.com Support Page for [Embed a PDF File](https://wordpress.com/support/embed-a-pdf-file/#example-of-an-embedded-pdf-file) in Chrome for Android:

> ![Screenshot_20230426-164916](https://user-images.githubusercontent.com/134745/234726399-b7671f51-a1af-4a49-a050-95cab4970834.png)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a File block
2. Select PDF for the block
3. In the block's PDF Settings, make sure that "Show inline embed" is toggled on
4. View the post on the frontend in a browser that supports embedding PDFs and in a browser that doesn't.