### PR TITLE
Pattern Enhancements: Render unsynced pattern content

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -482,8 +482,8 @@ Show a block pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trun
 
 -	**Name:** core/pattern
 -	**Category:** theme
--	**Supports:** ~~html~~, ~~inserter~~
--	**Attributes:** slug, unsynced
+-	**Supports:** align (full, wide)
+-	**Attributes:** align, layout, slug, syncStatus
 
 ## Post Author
 

--- a/packages/block-library/src/pattern/index.php
+++ b/packages/block-library/src/pattern/index.php
@@ -22,13 +22,18 @@ function register_block_core_pattern() {
 /**
  * Renders the `core/pattern` block on the server.
  *
- * @param array $attributes Block attributes.
+ * @param array  $attributes Block attributes.
+ * @param string $content    The block rendered content.
  *
  * @return string Returns the output of the pattern.
  */
-function render_block_core_pattern( $attributes ) {
+function render_block_core_pattern( $attributes, $content ) {
 	if ( empty( $attributes['slug'] ) ) {
 		return '';
+	}
+
+	if ( isset( $attributes['syncStatus'] ) && 'unsynced' === $attributes['syncStatus'] ) {
+		return $content;
 	}
 
 	$slug     = $attributes['slug'];

--- a/packages/block-library/src/pattern/save.js
+++ b/packages/block-library/src/pattern/save.js
@@ -7,6 +7,7 @@ export default function save( { attributes } ) {
 	if ( attributes.syncStatus === 'synced' ) {
 		return null;
 	}
+
 	const blockProps = useBlockProps.save();
 	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
 	return <>{ innerBlocksProps.children }</>;

--- a/test/integration/fixtures/blocks/core__pattern.json
+++ b/test/integration/fixtures/blocks/core__pattern.json
@@ -3,7 +3,12 @@
 		"name": "core/pattern",
 		"isValid": true,
 		"attributes": {
-			"slug": "core/text-two-columns"
+			"align": "full",
+			"layout": {
+				"type": "constrained"
+			},
+			"slug": "core/text-two-columns",
+			"syncStatus": "synced"
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/49967

## What?

- Fixes core blocks docs
- Renders the pattern content as saved when unsynced

## Why?

- Prevents git hook error for docs being out of date
- Renders unsynced pattern content as saved

## How?

- Updated docs via `npm run docs:build`
- Updated Pattern block's render callback to render saved content if `syncStatus === unsynced`

## Testing Instructions

1. Add pattern block to a post `<!-- wp:pattern {"slug":"twentytwentythree/cta"} /-->`
2. Select pattern block and click "Unsync"
3. Save post
4. View on frontend and confirm pattern block wrapper is present

