### PR TITLE
Cover: Only show overlay controls when color support enabled

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/use-multiple-origin-colors-and-gradients.js
+++ b/packages/block-editor/src/components/colors-gradients/use-multiple-origin-colors-and-gradients.js
@@ -61,7 +61,12 @@ export default function useMultipleOriginColorsAndGradients() {
 			} );
 		}
 		return result;
-	}, [ defaultColors, themeColors, customColors ] );
+	}, [
+		defaultColors,
+		themeColors,
+		customColors,
+		shouldDisplayDefaultColors,
+	] );
 
 	const customGradients = useSetting( 'color.gradients.custom' );
 	const themeGradients = useSetting( 'color.gradients.theme' );
@@ -103,7 +108,16 @@ export default function useMultipleOriginColorsAndGradients() {
 			} );
 		}
 		return result;
-	}, [ customGradients, themeGradients, defaultGradients ] );
+	}, [
+		customGradients,
+		themeGradients,
+		defaultGradients,
+		shouldDisplayDefaultGradients,
+	] );
+
+	colorGradientSettings.hasColorsOrGradients =
+		!! colorGradientSettings.colors.length ||
+		!! colorGradientSettings.gradients.length;
 
 	return colorGradientSettings;
 }

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -141,9 +141,6 @@ export default function CoverInspectorControls( {
 	};
 
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();
-	const hasColors =
-		!! colorGradientSettings.colors.length &&
-		!! colorGradientSettings.gradients.length;
 
 	const htmlElementMessages = {
 		header: __(
@@ -252,7 +249,7 @@ export default function CoverInspectorControls( {
 					</PanelBody>
 				) }
 			</InspectorControls>
-			{ hasColors && (
+			{ colorGradientSettings.hasColorsOrGradients && (
 				<InspectorControls group="color">
 					<ColorGradientSettingsDropdown
 						__experimentalIsRenderedInSidebar

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -141,6 +141,9 @@ export default function CoverInspectorControls( {
 	};
 
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();
+	const hasColors =
+		!! colorGradientSettings.colors.length &&
+		!! colorGradientSettings.gradients.length;
 
 	const htmlElementMessages = {
 		header: __(
@@ -249,62 +252,64 @@ export default function CoverInspectorControls( {
 					</PanelBody>
 				) }
 			</InspectorControls>
-			<InspectorControls group="color">
-				<ColorGradientSettingsDropdown
-					__experimentalIsRenderedInSidebar
-					settings={ [
-						{
-							colorValue: overlayColor.color,
-							gradientValue,
-							label: __( 'Overlay' ),
-							onColorChange: setOverlayColor,
-							onGradientChange: setGradient,
-							isShownByDefault: true,
-							resetAllFilter: () => ( {
-								overlayColor: undefined,
-								customOverlayColor: undefined,
-								gradient: undefined,
-								customGradient: undefined,
-							} ),
-						},
-					] }
-					panelId={ clientId }
-					{ ...colorGradientSettings }
-				/>
-				<ToolsPanelItem
-					hasValue={ () => {
-						// If there's a media background the dimRatio will be
-						// defaulted to 50 whereas it will be 100 for colors.
-						return dimRatio === undefined
-							? false
-							: dimRatio !== ( url ? 50 : 100 );
-					} }
-					label={ __( 'Overlay opacity' ) }
-					onDeselect={ () =>
-						setAttributes( { dimRatio: url ? 50 : 100 } )
-					}
-					resetAllFilter={ () => ( {
-						dimRatio: url ? 50 : 100,
-					} ) }
-					isShownByDefault
-					panelId={ clientId }
-				>
-					<RangeControl
-						__nextHasNoMarginBottom
-						label={ __( 'Overlay opacity' ) }
-						value={ dimRatio }
-						onChange={ ( newDimRation ) =>
-							setAttributes( {
-								dimRatio: newDimRation,
-							} )
-						}
-						min={ 0 }
-						max={ 100 }
-						step={ 10 }
-						required
+			{ hasColors && (
+				<InspectorControls group="color">
+					<ColorGradientSettingsDropdown
+						__experimentalIsRenderedInSidebar
+						settings={ [
+							{
+								colorValue: overlayColor.color,
+								gradientValue,
+								label: __( 'Overlay' ),
+								onColorChange: setOverlayColor,
+								onGradientChange: setGradient,
+								isShownByDefault: true,
+								resetAllFilter: () => ( {
+									overlayColor: undefined,
+									customOverlayColor: undefined,
+									gradient: undefined,
+									customGradient: undefined,
+								} ),
+							},
+						] }
+						panelId={ clientId }
+						{ ...colorGradientSettings }
 					/>
-				</ToolsPanelItem>
-			</InspectorControls>
+					<ToolsPanelItem
+						hasValue={ () => {
+							// If there's a media background the dimRatio will be
+							// defaulted to 50 whereas it will be 100 for colors.
+							return dimRatio === undefined
+								? false
+								: dimRatio !== ( url ? 50 : 100 );
+						} }
+						label={ __( 'Overlay opacity' ) }
+						onDeselect={ () =>
+							setAttributes( { dimRatio: url ? 50 : 100 } )
+						}
+						resetAllFilter={ () => ( {
+							dimRatio: url ? 50 : 100,
+						} ) }
+						isShownByDefault
+						panelId={ clientId }
+					>
+						<RangeControl
+							__nextHasNoMarginBottom
+							label={ __( 'Overlay opacity' ) }
+							value={ dimRatio }
+							onChange={ ( newDimRation ) =>
+								setAttributes( {
+									dimRatio: newDimRation,
+								} )
+							}
+							min={ 0 }
+							max={ 100 }
+							step={ 10 }
+							required
+						/>
+					</ToolsPanelItem>
+				</InspectorControls>
+			) }
 			<InspectorControls group="dimensions">
 				<ToolsPanelItem
 					hasValue={ () => !! minHeight }

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -5,11 +5,6 @@ import { screen, fireEvent, act, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
- * WordPress dependencies
- */
-import { __experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients } from '@wordpress/block-editor';
-
-/**
  * Internal dependencies
  */
 import {
@@ -17,39 +12,34 @@ import {
 	selectBlock,
 } from 'test/integration/helpers/integration-test-editor';
 
-jest.mock(
-	'@wordpress/block-editor/src/components/colors-gradients/use-multiple-origin-colors-and-gradients',
-	() => ( {
-		__esModule: true,
-		default: jest.fn( () => ( {
-			disableCustomColors: true,
-			disableCustomGradients: true,
-			colors: [
-				{
-					name: 'Default',
-					colors: [
-						{
-							name: 'Black',
-							slug: 'black',
-							color: '#000000',
-						},
-						{
-							name: 'Cyan bluish gray',
-							slug: 'cyan-bluish-gray',
-							color: '#abb8c3',
-						},
-					],
-				},
-			],
-			gradients: [],
-			hasColorsOrGradients: true,
-		} ) ),
-	} )
-);
+const defaultSettings = {
+	__experimentalFeatures: {
+		color: {
+			defaultPalette: true,
+			defaultGradients: true,
+			palette: {
+				default: [ { name: 'Black', slug: 'black', color: '#000000' } ],
+			},
+		},
+	},
+	colors: [ { name: 'Black', slug: 'black', color: '#000000' } ],
+	disableCustomColors: false,
+	disableCustomGradients: false,
+};
 
-async function setup( attributes ) {
+const disabledColorSettings = {
+	color: {
+		defaultPalette: false,
+		defaultGradients: false,
+	},
+	disableCustomColors: true,
+	disableCustomGradients: true,
+};
+
+async function setup( attributes, useCoreBlocks, customSettings ) {
 	const testBlock = { name: 'core/cover', attributes };
-	return initializeEditor( testBlock );
+	const settings = customSettings || defaultSettings;
+	return initializeEditor( testBlock, useCoreBlocks, settings );
 }
 
 async function createAndSelectBlock() {
@@ -333,19 +323,8 @@ describe( 'Cover block', () => {
 			} );
 
 			describe( 'when colors are disabled', () => {
-				beforeEach( () => {
-					useMultipleOriginColorsAndGradients.mockImplementation(
-						() => ( {
-							__esModule: true,
-							default: jest.fn( () => ( {
-								hasColorsOrGradients: false,
-							} ) ),
-						} )
-					);
-				} );
-
 				test( 'does not render overlay control', async () => {
-					await setup();
+					await setup( undefined, true, disabledColorSettings );
 					await createAndSelectBlock();
 					await userEvent.click(
 						screen.getByRole( 'tab', { name: 'Styles' } )
@@ -358,7 +337,7 @@ describe( 'Cover block', () => {
 					expect( overlayControl ).not.toBeInTheDocument();
 				} );
 				test( 'does not render opacity control', async () => {
-					await setup();
+					await setup( undefined, true, disabledColorSettings );
 					await createAndSelectBlock();
 					await userEvent.click(
 						screen.getByRole( 'tab', { name: 'Styles' } )


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/50046

## What?

Prevents display of overlay controls when color block supports are disabled.

## Why?

It's confusing when a theme author might disable color supports but still has the Cover block's ad hoc color controls showing.

## How?

- Checks if there are available colors from the block supports before rendering the Cover block's overlay controls
- Adds a new flag for `hasColorsOrGradients` to returned object from the `useMultipleOriginColorsAndGradients` hook
- Updates the Cover block integration tests to cover to conditional display of overlay/opacity controls

## Testing Instructions

1. Add a Cover block to a post with color supports enabled e.g with default TwentyTwentyThree theme.
2. Select the Cover block and make sure that the overlay controls display
3. Edit your theme.json to disable color supports, see example snippet below
4. Reload the editor, select the Cover block, and check that the overlay controls and the Color panel as a whole are not rendered
5. Run `npm run test:unit packages/block-library/src/cover/test/edit.js`

<details>
<summary>Theme.json to disable color support</summary>

```json
"color": {
      "custom": false,
      "customDuotone": false,
      "customGradient": false,
      "defaultGradients": false,
      "defaultPalette": false,
      "background": false,
      "defaultDuotone": false,
      "text": false
    },
```

</details>

## Screenshots or screencast <!-- if applicable -->

<img width="1189" alt="Screenshot 2023-04-27 at 3 08 32 pm" src="https://user-images.githubusercontent.com/60436221/234764697-4897b029-ba1d-43b7-bbe0-969f870f96b6.png">

