### PR TITLE
Set the width of pattern block based on widest width of child blocks

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -482,8 +482,8 @@ Show a block pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trun
 
 -	**Name:** core/pattern
 -	**Category:** theme
--	**Supports:** align (full, wide)
--	**Attributes:** align, layout, slug, syncStatus
+-	**Supports:** 
+-	**Attributes:** inheritedAlignment, layout, slug, syncStatus
 
 ## Post Author
 

--- a/packages/block-library/src/pattern/block.json
+++ b/packages/block-library/src/pattern/block.json
@@ -6,7 +6,6 @@
 	"category": "theme",
 	"description": "Show a block pattern.",
 	"supports": {
-		"align": [ "wide", "full" ],
 		"__experimentalLayout": {
 			"allowEditing": false
 		}
@@ -16,7 +15,7 @@
 		"slug": {
 			"type": "string"
 		},
-		"align": {
+		"inheritedAlignment": {
 			"type": "string",
 			"default": "full"
 		},


### PR DESCRIPTION
## What?
Sets the pattern block width based on widest widthed child

## Why?
Cause we can

## How?
Iterate children and find widest width setting

## Testing Instructions

- Add `<!-- wp:pattern {"slug":"twentytwentythree/cta","inheritedAlignment":"wide","syncStatus":"unsynced"} -->` pattern in TT23 themed site
- Check in editor that block is wide aligned
- Unsync the block
- Change align of the column block to full width and check that width of parent Pattern block changes to full align


