### PR TITLE
Revisions controller: fix author and date fields

### DIFF
--- a/lib/experimental/class-gutenberg-rest-global-styles-revisions-controller.php
+++ b/lib/experimental/class-gutenberg-rest-global-styles-revisions-controller.php
@@ -135,12 +135,12 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller extends WP_REST_Controll
 		$fields = $this->get_fields_for_response( $request );
 
 		if ( rest_is_field_included( 'author', $fields ) ) {
-			$data['author'] = (int) $parent->post_author;
+			$data['author'] = (int) $item->post_author;
 		}
 
 		if ( rest_is_field_included( 'author_avatar_url', $fields ) ) {
 			$data['author_avatar_url'] = get_avatar_url(
-				$parent->post_author,
+				$item->post_author,
 				array(
 					'size' => 24,
 				)
@@ -148,11 +148,11 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller extends WP_REST_Controll
 		}
 
 		if ( rest_is_field_included( 'author_display_name', $fields ) ) {
-			$data['author_display_name'] = get_the_author_meta( 'display_name', $parent->post_author );
+			$data['author_display_name'] = get_the_author_meta( 'display_name', $item->post_author );
 		}
 
 		if ( rest_is_field_included( 'date', $fields ) ) {
-			$data['date'] = $parent->post_date;
+			$data['date'] = $item->post_date;
 		}
 
 		if ( rest_is_field_included( 'date_display', $fields ) ) {
@@ -161,7 +161,7 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller extends WP_REST_Controll
 		}
 
 		if ( rest_is_field_included( 'date_gmt', $fields ) ) {
-			$data['date_gmt'] = $parent->post_date_gmt;
+			$data['date_gmt'] = $item->post_date_gmt;
 		}
 
 		if ( rest_is_field_included( 'id', $fields ) ) {
@@ -169,11 +169,11 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller extends WP_REST_Controll
 		}
 
 		if ( rest_is_field_included( 'modified', $fields ) ) {
-			$data['modified'] = $parent->post_modified;
+			$data['modified'] = $item->post_modified;
 		}
 
 		if ( rest_is_field_included( 'modified_gmt', $fields ) ) {
-			$data['modified_gmt'] = $parent->post_modified_gmt;
+			$data['modified_gmt'] = $item->post_modified_gmt;
 		}
 
 		if ( rest_is_field_included( 'parent', $fields ) ) {

--- a/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
+++ b/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
@@ -85,7 +85,8 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 			'post_content' => wp_json_encode( $config ),
 		);
 
-		$post_id  = wp_update_post( $new_styles_post, true, false );
+		wp_update_post( $new_styles_post, true, false );
+
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();

--- a/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
+++ b/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
@@ -9,6 +9,11 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 	/**
 	 * @var int
 	 */
+	protected static $second_admin_id;
+
+	/**
+	 * @var int
+	 */
 	protected static $global_styles_id;
 
 	public function set_up() {
@@ -22,7 +27,12 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 	 * @param WP_UnitTest_Factory $factory Helper that lets us create fake data.
 	 */
 	public static function wpSetupBeforeClass( $factory ) {
-		self::$admin_id = $factory->user->create(
+		self::$admin_id        = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		self::$second_admin_id = $factory->user->create(
 			array(
 				'role' => 'administrator',
 			)
@@ -76,7 +86,6 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 		);
 
 		$post_id  = wp_update_post( $new_styles_post, true, false );
-		$post     = get_post( $post_id );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
@@ -94,8 +103,8 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 		$this->assertArrayHasKey( 'modified_gmt', $data[0], 'Check that an modified_gmt key exists' );
 
 		// Author information.
-		$this->assertEquals( $post->post_author, $data[0]['author'], 'Check that author id returns expected value' );
-		$this->assertEquals( get_the_author_meta( 'display_name', $post->post_author ), $data[0]['author_display_name'], 'Check that author display_name returns expected value' );
+		$this->assertEquals( self::$admin_id, $data[0]['author'], 'Check that author id returns expected value' );
+		$this->assertEquals( get_the_author_meta( 'display_name', self::$admin_id ), $data[0]['author_display_name'], 'Check that author display_name returns expected value' );
 		$this->assertIsString(
 			$data[0]['author_avatar_url'],
 			'Check that author avatar_url returns expected value type'
@@ -116,6 +125,23 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 			),
 			'Check that the revision styles match the last updated styles.'
 		);
+
+		// Checks that the revisions are returned for all eligible users.
+		wp_set_current_user( self::$second_admin_id );
+		$config['styles']['color']['background'] = 'blue';
+		$new_styles_post                         = array(
+			'ID'           => self::$global_styles_id,
+			'post_content' => wp_json_encode( $config ),
+		);
+
+		wp_update_post( $new_styles_post, true, false );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertCount( 2, $data, 'Check that two revisions exists' );
+		$this->assertEquals( self::$second_admin_id, $data[0]['author'], 'Check that second author id returns expected value' );
 	}
 
 	/**


### PR DESCRIPTION
## What, why, how?!
Correcting a mistake I made in https://github.com/WordPress/gutenberg/pull/49974: we need the author, date and other details from the revision item not the parent


## Testing Instructions

Run the tests!

`npm run test:unit:php -- --filter Gutenberg_REST_Global_Styles_Revisions_Controller_Test`

For bonus points, create another admin user and save some global styles changes. 

Check that the revision items reflect the revision author's details. You can grab them in the console:

```
await wp.apiFetch( { url: `/index.php?rest_route=%2Fwp%2Fv2%2Fglobal-styles%2F${ wp.data.select('core').__experimentalGetCurrentGlobalStylesId() }%2Frevisions&_locale=user` } );
```

<img width="1017" alt="Screenshot 2023-04-27 at 3 13 02 pm" src="https://user-images.githubusercontent.com/6458278/234765434-ffa9aa24-9dab-4818-ba49-043e33ffdb13.png">


