### PR TITLE
Use a fixed custom align attrib so block toolbar align button doesn't appear on pattern block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -482,8 +482,8 @@ Show a block pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trun
 
 -	**Name:** core/pattern
 -	**Category:** theme
--	**Supports:** align (full, wide)
--	**Attributes:** align, layout, slug, syncStatus
+-	**Supports:** 
+-	**Attributes:** inheritedAlignment, layout, slug, syncStatus
 
 ## Post Author
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -483,7 +483,7 @@ Show a block pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trun
 -	**Name:** core/pattern
 -	**Category:** theme
 -	**Supports:** 
--	**Attributes:** inheritedAlignment, layout, slug, syncStatus
+-	**Attributes:** forcedAlignment, layout, slug, syncStatus
 
 ## Post Author
 

--- a/packages/block-library/src/pattern/block.json
+++ b/packages/block-library/src/pattern/block.json
@@ -15,7 +15,7 @@
 		"slug": {
 			"type": "string"
 		},
-		"inheritedAlignment": {
+		"forcedAlignment": {
 			"type": "string",
 			"default": "full"
 		},

--- a/packages/block-library/src/pattern/block.json
+++ b/packages/block-library/src/pattern/block.json
@@ -6,7 +6,6 @@
 	"category": "theme",
 	"description": "Show a block pattern.",
 	"supports": {
-		"align": [ "wide", "full" ],
 		"__experimentalLayout": {
 			"allowEditing": false
 		}
@@ -16,7 +15,7 @@
 		"slug": {
 			"type": "string"
 		},
-		"align": {
+		"inheritedAlignment": {
 			"type": "string",
 			"default": "full"
 		},

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -11,11 +11,8 @@ import {
 } from '@wordpress/block-editor';
 import { ToolbarButton } from '@wordpress/components';
 
-const PatternEdit = ( {
-	attributes: { inheritedAlignment, slug },
-	clientId,
-	setAttributes,
-} ) => {
+const PatternEdit = ( { attributes, clientId, setAttributes } ) => {
+	const { forcedAlignment, slug } = attributes;
 	const { selectedPattern, innerBlocks } = useSelect(
 		( select ) => {
 			return {
@@ -58,7 +55,7 @@ const PatternEdit = ( {
 	] );
 
 	const blockProps = useBlockProps( {
-		className: `align${ inheritedAlignment }`,
+		className: forcedAlignment && `align${ forcedAlignment }`,
 	} );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {} );
 	return (

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -11,19 +11,24 @@ import {
 } from '@wordpress/block-editor';
 import { ToolbarButton } from '@wordpress/components';
 
-const PatternEdit = ( { attributes, clientId, setAttributes } ) => {
+const PatternEdit = ( {
+	attributes: { inheritedAlignment, slug },
+	clientId,
+	setAttributes,
+} ) => {
 	const { selectedPattern, innerBlocks } = useSelect(
 		( select ) => {
 			return {
-				selectedPattern: select(
-					blockEditorStore
-				).__experimentalGetParsedPattern( attributes.slug ),
+				selectedPattern:
+					select( blockEditorStore ).__experimentalGetParsedPattern(
+						slug
+					),
 				innerBlocks:
 					select( blockEditorStore ).getBlock( clientId )
 						?.innerBlocks,
 			};
 		},
-		[ attributes.slug, clientId ]
+		[ slug, clientId ]
 	);
 	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
@@ -52,7 +57,9 @@ const PatternEdit = ( { attributes, clientId, setAttributes } ) => {
 		innerBlocks,
 	] );
 
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( {
+		className: `align${ inheritedAlignment }`,
+	} );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {} );
 	return (
 		<>

--- a/test/integration/fixtures/blocks/core__pattern.json
+++ b/test/integration/fixtures/blocks/core__pattern.json
@@ -3,7 +3,7 @@
 		"name": "core/pattern",
 		"isValid": true,
 		"attributes": {
-			"align": "full",
+			"forcedAlignment": "full",
 			"layout": {
 				"type": "constrained"
 			},


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
