### PR TITLE
List View / Block Draggable: Fix scroll to top issue when dragging the second last block in the list

### DIFF
--- a/packages/block-editor/src/components/block-draggable/use-scroll-when-dragging.js
+++ b/packages/block-editor/src/components/block-draggable/use-scroll-when-dragging.js
@@ -78,7 +78,10 @@ export default function useScrollWhenDragging() {
 					SCROLL_INACTIVE_DISTANCE_PX,
 				0
 			);
-			const distancePercentage = dragDistance / moveableDistance;
+			const distancePercentage =
+				moveableDistance === 0 || dragDistance === 0
+					? 0
+					: dragDistance / moveableDistance;
 			velocityY.current = VELOCITY_MULTIPLIER * distancePercentage;
 		} else if ( event.clientY < offsetDragStartPosition ) {
 			// User is dragging upwards.
@@ -92,7 +95,10 @@ export default function useScrollWhenDragging() {
 					SCROLL_INACTIVE_DISTANCE_PX,
 				0
 			);
-			const distancePercentage = dragDistance / moveableDistance;
+			const distancePercentage =
+				moveableDistance === 0 || dragDistance === 0
+					? 0
+					: dragDistance / moveableDistance;
 			velocityY.current = -VELOCITY_MULTIPLIER * distancePercentage;
 		} else {
 			velocityY.current = 0;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of: https://github.com/WordPress/gutenberg/issues/49563

Update the scrolling logic within BlockDraggable's `useScrollWhenDragging` hook so that it doesn't accidentally flick the scrolling to the top of the scrollable container. This sometimes happens in the list view, most reliably when dragging the second last view view item to the bottom of the list view.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Prior to this PR, if the drag position is within the bottom `50px` of the scrollable container (that is, within `SCROLL_INACTIVE_DISTANCE_PX`), then the calculations for `moveableDistance` and `dragDistance` can become `0`. This causes issues when `moveableDistance` is positive but `dragDistance` is `0` as that results in a divide by zero error which causes the velocity to be `Infinity`. E.g. I observed `moveableDistance` as sometimes being `4` while `dragDistance` is `0` which results in a `distancePercentage` of `Infinity` (`4 / 0 === Infinity`).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In the `scrollOnDragOver` logic that checks for `distancePercentage` ensure that if either `moveableDistance` or `dragDistance` is `0`, then treat it as a `distancePercentage` of `0` to avoid accidentally setting a velocity of `Infinity`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In the block editor, add enough blocks so that the list view becomes full.
2. Click and drag the second last block in the last and go to drop it beneath the bottom block.
3. On trunk, observe that the list view snaps back to the top of the list.
4. With this PR, the list view should not unexpectedly scroll.
5. Check that clicking and dragging blocks in the list view and editor canvas still otherwise allows scrolling up and down the container as in `trunk` (other than this fix, the existing behaviour should be otherwise unaffacted)

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![2023-04-27 15 18 16](https://user-images.githubusercontent.com/14988353/234766456-37db2f21-7880-43e1-8978-fed778d51d9d.gif) | ![2023-04-27 15 16 23](https://user-images.githubusercontent.com/14988353/234766407-29026211-66dd-48bb-93d7-d0f8173439c4.gif) |