### PR TITLE
Update REST API Controller PHPUnit tests

### DIFF
--- a/phpunit/class-gutenberg-rest-templates-controller-test.php
+++ b/phpunit/class-gutenberg-rest-templates-controller-test.php
@@ -62,35 +62,43 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 		$this->assertSame( 'index', $response->get_data()['slug'], 'Should fallback to `index.html`.' );
 	}
 
-	public function test_context_param() {
-		$this->markTestIncomplete();
-	}
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_context_param() {}
 
-	public function test_get_items() {
-		$this->markTestIncomplete();
-	}
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_get_items() {}
 
-	public function test_get_item() {
-		$this->markTestIncomplete();
-	}
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_get_item() {}
 
-	public function test_create_item() {
-		$this->markTestIncomplete();
-	}
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_create_item() {}
 
-	public function test_update_item() {
-		$this->markTestIncomplete();
-	}
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_update_item() {}
 
-	public function test_delete_item() {
-		$this->markTestIncomplete();
-	}
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_delete_item() {}
 
-	public function test_prepare_item() {
-		$this->markTestIncomplete();
-	}
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_prepare_item() {}
 
-	public function test_get_item_schema() {
-		$this->markTestIncomplete();
-	}
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_get_item_schema() {}
 }

--- a/phpunit/class-wp-rest-block-pattern-categories-controller-test.php
+++ b/phpunit/class-wp-rest-block-pattern-categories-controller-test.php
@@ -80,32 +80,38 @@ class WP_REST_Block_Pattern_Categories_Controller_Test extends WP_Test_REST_Cont
 
 	/**
 	 * Abstract methods that we must implement.
+	 *
+	 * @doesNotPerformAssertions
 	 */
-	public function test_context_param() {
-		$this->markTestIncomplete();
-	}
+	public function test_context_param() {}
 
-	public function test_get_item() {
-		$this->markTestIncomplete();
-	}
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_get_item() {}
 
-	public function test_create_item() {
-		$this->markTestIncomplete();
-	}
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_create_item() {}
 
-	public function test_update_item() {
-		$this->markTestIncomplete();
-	}
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_update_item() {}
 
-	public function test_delete_item() {
-		$this->markTestIncomplete();
-	}
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_delete_item() {}
 
-	public function test_prepare_item() {
-		$this->markTestIncomplete();
-	}
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_prepare_item() {}
 
-	public function test_get_item_schema() {
-		$this->markTestIncomplete();
-	}
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_get_item_schema() {}
 }

--- a/phpunit/class-wp-test-rest-users-controller.php
+++ b/phpunit/class-wp-test-rest-users-controller.php
@@ -156,34 +156,50 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	/**
 	 * The following methods are implemented in core and tested.
 	 * We need to define them here because they exist in the abstract parent.
+	 *
+	 * @doesNotPerformAssertions
 	 */
-	public function test_register_routes() {
-		$this->markTestIncomplete();
-	}
-	public function test_context_param() {
-		$this->markTestIncomplete();
-	}
-	public function test_get_item() {
-		$this->markTestIncomplete();
-	}
-	public function test_prepare_item() {
-		$this->markTestIncomplete();
-	}
-	public function test_create_item() {
-		$this->markTestIncomplete();
-	}
-	public function test_update_item() {
-		$this->markTestIncomplete();
-	}
-	public function test_delete_item() {
-		$this->markTestIncomplete();
-	}
-	public function test_get_items() {
-		$this->markTestIncomplete();
-	}
-	public function test_get_item_schema() {
-		$this->markTestIncomplete();
-	}
+	public function test_register_routes() {}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_context_param() {}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_get_item() {}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_prepare_item() {}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_create_item() {}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_update_item() {}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_delete_item() {}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_get_items() {}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_get_item_schema() {}
 
 	public function test_registered_query_params() {
 		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/users' );


### PR DESCRIPTION
## What?
Similar to #47502.

PR updates remaining REST API controller PHPUnit tests to match the core and reduce noise when running them.

## Why?
It's easy to miss an actual PHP warning in all the noise.

## How?
Use `@doesNotPerformAssertions` instead of `$this->markTestIncomplete();` when the controller doesn't implement the method.

## Testing Instructions
CI should be green.

```
npm run test:unit:php
```

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-04-27 at 11 18 40](https://user-images.githubusercontent.com/240569/234788963-d79523ec-0a8e-4a94-b3b6-d00d55722e5b.png)
