### PR TITLE
Warning: Introduce `SCRIPT_DEBUG` to make the package compatible with webpack 5

### DIFF
--- a/packages/eslint-plugin/configs/recommended-with-formatting.js
+++ b/packages/eslint-plugin/configs/recommended-with-formatting.js
@@ -16,6 +16,7 @@ const config = {
 	globals: {
 		window: true,
 		document: true,
+		SCRIPT_DEBUG: 'readonly',
 		wp: 'readonly',
 	},
 	settings: {

--- a/packages/jest-preset-default/scripts/setup-globals.js
+++ b/packages/jest-preset-default/scripts/setup-globals.js
@@ -1,3 +1,6 @@
+// Run all tests with development tools enabled.
+global.SCRIPT_DEBUG = true;
+
 // These are necessary to load TinyMCE successfully.
 global.URL = window.URL;
 global.window.tinyMCEPreInit = {

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -4,6 +4,7 @@
 const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
 const { CleanWebpackPlugin } = require( 'clean-webpack-plugin' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
+const { DefinePlugin } = require( 'webpack' );
 const browserslist = require( 'browserslist' );
 const MiniCSSExtractPlugin = require( 'mini-css-extract-plugin' );
 const { basename, dirname, resolve } = require( 'path' );
@@ -243,6 +244,10 @@ const config = {
 		],
 	},
 	plugins: [
+		new DefinePlugin( {
+			// Inject the `SCRIPT_DEBUG` global, used for development features flagging.
+			SCRIPT_DEBUG: mode === 'development',
+		} ),
 		// During rebuilds, all webpack assets that are not used anymore will be
 		// removed automatically. There is an exception added in watch mode for
 		// fonts and images. It is a known limitations:

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -246,7 +246,7 @@ const config = {
 	plugins: [
 		new DefinePlugin( {
 			// Inject the `SCRIPT_DEBUG` global, used for development features flagging.
-			SCRIPT_DEBUG: mode === 'development',
+			SCRIPT_DEBUG: ! isProduction,
 		} ),
 		// During rebuilds, all webpack assets that are not used anymore will be
 		// removed automatically. There is an exception added in watch mode for

--- a/packages/warning/README.md
+++ b/packages/warning/README.md
@@ -20,7 +20,7 @@ To prevent that, you should:
 
 1.  Put `@wordpress/warning/babel-plugin` into your [babel config](https://babeljs.io/docs/en/plugins#plugin-options) or use [`@wordpress/babel-preset-default`](https://www.npmjs.com/package/@wordpress/babel-preset-default), which already includes the babel plugin.
 
-    This will make sure your `warning` calls are wrapped within a condition that checks if `process.env.NODE_ENV !== 'production'`.
+    This will make sure your `warning` calls are wrapped within a condition that checks if `SCRIPT_DEBUG === true`.
 
 2.  Use [UglifyJS](https://github.com/mishoo/UglifyJS2), [Terser](https://github.com/terser/terser) or any other JavaScript parser that performs [dead code elimination](https://en.wikipedia.org/wiki/Dead_code_elimination). This is usually used in conjunction with JavaScript bundlers, such as [webpack](https://github.com/webpack/webpack).
 

--- a/packages/warning/babel-plugin.js
+++ b/packages/warning/babel-plugin.js
@@ -5,7 +5,7 @@ const pkg = require( './package.json' );
 
 /**
  * Babel plugin which transforms `warning` function calls to wrap within a
- * condition that checks if `process.env.NODE_ENV !== 'production'`.
+ * condition that checks if `SCRIPT_DEBUG === true`.
  *
  * @param {import('@babel/core')} babel Current Babel object.
  *
@@ -14,36 +14,10 @@ const pkg = require( './package.json' );
 function babelPlugin( { types: t } ) {
 	const seen = Symbol();
 
-	const typeofProcessExpression = t.binaryExpression(
-		'!==',
-		t.unaryExpression( 'typeof', t.identifier( 'process' ), false ),
-		t.stringLiteral( 'undefined' )
-	);
-
-	const processEnvExpression = t.memberExpression(
-		t.identifier( 'process' ),
-		t.identifier( 'env' ),
-		false
-	);
-
-	const nodeEnvCheckExpression = t.binaryExpression(
-		'!==',
-		t.memberExpression(
-			processEnvExpression,
-			t.identifier( 'NODE_ENV' ),
-			false
-		),
-		t.stringLiteral( 'production' )
-	);
-
-	const logicalExpression = t.logicalExpression(
-		'&&',
-		t.logicalExpression(
-			'&&',
-			typeofProcessExpression,
-			processEnvExpression
-		),
-		nodeEnvCheckExpression
+	const scriptDebugCheckExpression = t.binaryExpression(
+		'===',
+		t.identifier( 'SCRIPT_DEBUG' ),
+		t.booleanLiteral( true )
 	);
 
 	return {
@@ -80,11 +54,11 @@ function babelPlugin( { types: t } ) {
 					// Turns this code:
 					// warning(argument);
 					// into this:
-					// typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warning(argument) : void 0;
+					// SCRIPT_DEBUG === true ? warning(argument) : void 0;
 					node[ seen ] = true;
 					path.replaceWith(
 						t.ifStatement(
-							logicalExpression,
+							scriptDebugCheckExpression,
 							t.blockStatement( [
 								t.expressionStatement( node ),
 							] )

--- a/packages/warning/src/index.js
+++ b/packages/warning/src/index.js
@@ -4,11 +4,7 @@
 import { logged } from './utils';
 
 function isDev() {
-	return (
-		typeof process !== 'undefined' &&
-		process.env &&
-		process.env.NODE_ENV !== 'production'
-	);
+	return SCRIPT_DEBUG === true;
 }
 
 /**

--- a/packages/warning/src/index.js
+++ b/packages/warning/src/index.js
@@ -4,7 +4,7 @@
 import { logged } from './utils';
 
 function isDev() {
-	return SCRIPT_DEBUG === true;
+	return typeof SCRIPT_DEBUG !== 'undefined' && SCRIPT_DEBUG === true;
 }
 
 /**

--- a/packages/warning/src/test/index.js
+++ b/packages/warning/src/test/index.js
@@ -4,27 +4,28 @@
 import warning from '..';
 import { logged } from '../utils';
 
-const initialNodeEnv = process.env.NODE_ENV;
-
 describe( 'warning', () => {
+	const initialScriptDebug = global.SCRIPT_DEBUG;
+
 	afterEach( () => {
-		process.env.NODE_ENV = initialNodeEnv;
+		global.SCRIPT_DEBUG = initialScriptDebug;
 		logged.clear();
 	} );
 
-	it( 'logs to console.warn when NODE_ENV is not "production"', () => {
-		process.env.NODE_ENV = 'development';
+	it( 'logs to console.warn when SCRIPT_DEBUG is set to `true`', () => {
+		global.SCRIPT_DEBUG = true;
 		warning( 'warning' );
 		expect( console ).toHaveWarnedWith( 'warning' );
 	} );
 
-	it( 'does not log to console.warn if NODE_ENV is "production"', () => {
-		process.env.NODE_ENV = 'production';
+	it( 'does not log to console.warn if SCRIPT_DEBUG not set to `true`', () => {
+		global.SCRIPT_DEBUG = false;
 		warning( 'warning' );
 		expect( console ).not.toHaveWarned();
 	} );
 
 	it( 'should show a message once', () => {
+		global.SCRIPT_DEBUG = true;
 		warning( 'warning' );
 		warning( 'warning' );
 

--- a/packages/warning/test/babel-plugin.js
+++ b/packages/warning/test/babel-plugin.js
@@ -28,7 +28,7 @@ describe( 'babel-plugin', () => {
 		);
 		const expected = join(
 			'import warning from "@wordpress/warning";',
-			'SCRIPT_DEBUG === true ? warning("a") : void 0;'
+			'typeof SCRIPT_DEBUG !== "undefined" && SCRIPT_DEBUG === true ? warning("a") : void 0;'
 		);
 
 		expect( transformCode( input ) ).toEqual( expected );
@@ -44,7 +44,8 @@ describe( 'babel-plugin', () => {
 	it( 'should replace warning calls without import declaration with plugin options', () => {
 		const input = 'warning("a");';
 		const options = { callee: 'warning' };
-		const expected = 'SCRIPT_DEBUG === true ? warning("a") : void 0;';
+		const expected =
+			'typeof SCRIPT_DEBUG !== "undefined" && SCRIPT_DEBUG === true ? warning("a") : void 0;';
 
 		expect( transformCode( input, options ) ).toEqual( expected );
 	} );
@@ -58,9 +59,9 @@ describe( 'babel-plugin', () => {
 		);
 		const expected = join(
 			'import warning from "@wordpress/warning";',
-			'SCRIPT_DEBUG === true ? warning("a") : void 0;',
-			'SCRIPT_DEBUG === true ? warning("b") : void 0;',
-			'SCRIPT_DEBUG === true ? warning("c") : void 0;'
+			'typeof SCRIPT_DEBUG !== "undefined" && SCRIPT_DEBUG === true ? warning("a") : void 0;',
+			'typeof SCRIPT_DEBUG !== "undefined" && SCRIPT_DEBUG === true ? warning("b") : void 0;',
+			'typeof SCRIPT_DEBUG !== "undefined" && SCRIPT_DEBUG === true ? warning("c") : void 0;'
 		);
 
 		expect( transformCode( input ) ).toEqual( expected );
@@ -75,9 +76,9 @@ describe( 'babel-plugin', () => {
 		);
 		const expected = join(
 			'import warn from "@wordpress/warning";',
-			'SCRIPT_DEBUG === true ? warn("a") : void 0;',
-			'SCRIPT_DEBUG === true ? warn("b") : void 0;',
-			'SCRIPT_DEBUG === true ? warn("c") : void 0;'
+			'typeof SCRIPT_DEBUG !== "undefined" && SCRIPT_DEBUG === true ? warn("a") : void 0;',
+			'typeof SCRIPT_DEBUG !== "undefined" && SCRIPT_DEBUG === true ? warn("b") : void 0;',
+			'typeof SCRIPT_DEBUG !== "undefined" && SCRIPT_DEBUG === true ? warn("c") : void 0;'
 		);
 
 		expect( transformCode( input ) ).toEqual( expected );
@@ -92,9 +93,9 @@ describe( 'babel-plugin', () => {
 		);
 		const expected = join(
 			'import warn from "@wordpress/warning";',
-			'SCRIPT_DEBUG === true ? warn("a") : void 0;',
-			'SCRIPT_DEBUG === true ? warn("b") : void 0;',
-			'SCRIPT_DEBUG === true ? warn("c") : void 0;'
+			'typeof SCRIPT_DEBUG !== "undefined" && SCRIPT_DEBUG === true ? warn("a") : void 0;',
+			'typeof SCRIPT_DEBUG !== "undefined" && SCRIPT_DEBUG === true ? warn("b") : void 0;',
+			'typeof SCRIPT_DEBUG !== "undefined" && SCRIPT_DEBUG === true ? warn("c") : void 0;'
 		);
 
 		expect( transformCode( input ) ).toEqual( expected );

--- a/packages/warning/test/babel-plugin.js
+++ b/packages/warning/test/babel-plugin.js
@@ -28,7 +28,7 @@ describe( 'babel-plugin', () => {
 		);
 		const expected = join(
 			'import warning from "@wordpress/warning";',
-			'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warning("a") : void 0;'
+			'SCRIPT_DEBUG === true ? warning("a") : void 0;'
 		);
 
 		expect( transformCode( input ) ).toEqual( expected );
@@ -44,8 +44,7 @@ describe( 'babel-plugin', () => {
 	it( 'should replace warning calls without import declaration with plugin options', () => {
 		const input = 'warning("a");';
 		const options = { callee: 'warning' };
-		const expected =
-			'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warning("a") : void 0;';
+		const expected = 'SCRIPT_DEBUG === true ? warning("a") : void 0;';
 
 		expect( transformCode( input, options ) ).toEqual( expected );
 	} );
@@ -59,9 +58,9 @@ describe( 'babel-plugin', () => {
 		);
 		const expected = join(
 			'import warning from "@wordpress/warning";',
-			'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warning("a") : void 0;',
-			'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warning("b") : void 0;',
-			'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warning("c") : void 0;'
+			'SCRIPT_DEBUG === true ? warning("a") : void 0;',
+			'SCRIPT_DEBUG === true ? warning("b") : void 0;',
+			'SCRIPT_DEBUG === true ? warning("c") : void 0;'
 		);
 
 		expect( transformCode( input ) ).toEqual( expected );
@@ -76,9 +75,9 @@ describe( 'babel-plugin', () => {
 		);
 		const expected = join(
 			'import warn from "@wordpress/warning";',
-			'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warn("a") : void 0;',
-			'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warn("b") : void 0;',
-			'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warn("c") : void 0;'
+			'SCRIPT_DEBUG === true ? warn("a") : void 0;',
+			'SCRIPT_DEBUG === true ? warn("b") : void 0;',
+			'SCRIPT_DEBUG === true ? warn("c") : void 0;'
 		);
 
 		expect( transformCode( input ) ).toEqual( expected );
@@ -93,9 +92,9 @@ describe( 'babel-plugin', () => {
 		);
 		const expected = join(
 			'import warn from "@wordpress/warning";',
-			'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warn("a") : void 0;',
-			'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warn("b") : void 0;',
-			'typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production" ? warn("c") : void 0;'
+			'SCRIPT_DEBUG === true ? warn("a") : void 0;',
+			'SCRIPT_DEBUG === true ? warn("b") : void 0;',
+			'SCRIPT_DEBUG === true ? warn("c") : void 0;'
 		);
 
 		expect( transformCode( input ) ).toEqual( expected );

--- a/tools/webpack/shared.js
+++ b/tools/webpack/shared.js
@@ -69,6 +69,8 @@ const plugins = [
 		// Inject the `IS_WORDPRESS_CORE` global, used for feature flagging.
 		'process.env.IS_WORDPRESS_CORE':
 			process.env.npm_package_config_IS_WORDPRESS_CORE,
+		// Inject the `SCRIPT_DEBUG` global, used for dev versions of JavaScript.
+		SCRIPT_DEBUG: mode === 'development',
 	} ),
 	mode === 'production' && new ReadableJsAssetsWebpackPlugin(),
 ];

--- a/typings/gutenberg-env/index.d.ts
+++ b/typings/gutenberg-env/index.d.ts
@@ -7,3 +7,5 @@ interface Process {
 	env: Environment;
 }
 declare var process: Process;
+
+declare var SCRIPT_DEBUG: boolean;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #44950.

The `warning` from `@wordpress/warning` no longer works correctly with webpack 5. In practice, it no longer calls `console.warn`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

> `@wordpress/warning` and its [`babel-plugin`](https://github.com/WordPress/gutenberg/blob/trunk/packages/warning/babel-plugin.js) rely on `process.env`. So for `env == 'production'` it's supposed not to show the warning.
> 
> The problem is webpack 5 removed `process` variable completely:
> - https://webpack.js.org/blog/2020-10-10-webpack-5-release/#changes-to-the-structure
>    > Automatic polyfills for native Node.js modules were removed
>    >  `node.process` removed
> - https://webpack.js.org/migrate/5/#run-a-single-build-and-follow-advice
>    > webpack 5 does no longer include a polyfill for this Node.js variable. Avoid using it in the frontend code.
>    > `process.env` is Node.js specific and should be avoided in frontend code.
> 
> So, the `typeof process !== 'undefined' && process.env !=== 'production'` is always false, which prevents `warning` to be called for any kind of environment.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We replace the usage of `process.env.NODE_ENV` with another optional constant: `SCRIPT_DEBUG`.  All the tools used in the Gutenberg, get updated to work with this new constant, including `@wordpress/scripts`. This way, developers will be able to guard code that should be run only in development mode.

The selection of `SCRIPT_DEBUG` was intentional to mirror the [same constant used in WordPress Core](https://wordpress.org/documentation/article/debugging-in-wordpress/#script_debug) that is described as:

> SCRIPT_DEBUG is a related constant that will force WordPress to use the “dev” versions of core CSS and JavaScript files rather than the minified versions that are normally loaded. This is useful when you are testing modifications to any built-in .js or .css files. Default is false.

Here, we are extending its application to be always present and enabled in the `dev` version of JavaScript.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Apply the following patch:
```diff
diff --git a/packages/edit-post/src/index.js b/packages/edit-post/src/index.js
index 1e0509f3e8..6aaa5d7ce9 100644
--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -15,6 +15,7 @@ import {
 	registerLegacyWidgetBlock,
 	registerWidgetGroupBlock,
 } from '@wordpress/widgets';
+import warning from '@wordpress/warning';
 
 /**
  * Internal dependencies
@@ -42,6 +43,7 @@ export function initializeEditor(
 	settings,
 	initialEdits
 ) {
+	warning( 'Testing the warning :)' );
 	const target = document.getElementById( id );
 	const root = createRoot( target );
```

2. Run `npm run dev`.
3. Open the post editor and observe Browser Console.
4. You should see the warning:
<img width="940" alt="Screenshot 2023-04-27 at 14 34 42" src="https://user-images.githubusercontent.com/699132/234863430-c3daf7af-af4b-4cb9-a606-dc682a8b5a91.png">

5. Run `npm run build`.
6. Open the post editor and observe Browser Console.
7. You should not see the warning:
<img width="937" alt="Screenshot 2023-04-27 at 14 38 12" src="https://user-images.githubusercontent.com/699132/234864181-2c574ba1-9f6d-4382-ab4b-47291fbc0c90.png">
