### PR TITLE
Fix incorrect focus style widths

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -76,7 +76,7 @@
 
 @mixin input-style__focus() {
 	border-color: var(--wp-admin-theme-color);
-	box-shadow: 0 0 0 ($border-width-focus - $border-width) var(--wp-admin-theme-color);
+	box-shadow: 0 0 0 ($border-width-focus-fallback - $border-width) var(--wp-admin-theme-color);
 
 	// Windows High Contrast mode will show this outline, but not the box-shadow.
 	outline: 2px solid transparent;
@@ -231,7 +231,7 @@
 	border-radius: $radius-block-ui;
 
 	&:focus {
-		box-shadow: 0 0 0 ($border-width * 2) $white, 0 0 0 ($border-width * 2 + $border-width-focus) var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 ($border-width * 2) $white, 0 0 0 ($border-width * 2 + $border-width-focus-fallback) var(--wp-admin-theme-color);
 
 		// Only visible in Windows High Contrast mode.
 		outline: 2px solid transparent;
@@ -315,7 +315,7 @@
 	}
 
 	&:focus {
-		box-shadow: 0 0 0 ($border-width * 2) $white, 0 0 0 ($border-width * 2 + $border-width-focus) var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 ($border-width * 2) $white, 0 0 0 ($border-width * 2 + $border-width-focus-fallback) var(--wp-admin-theme-color);
 
 		// Only visible in Windows High Contrast mode.
 		outline: 2px solid transparent;
@@ -360,7 +360,7 @@
 
 	&:focus {
 		border-color: var(--wp-admin-theme-color) !important;
-		box-shadow: 0 0 0 ($border-width-focus - $border-width) var(--wp-admin-theme-color) !important;
+		box-shadow: 0 0 0 ($border-width-focus-fallback - $border-width) var(--wp-admin-theme-color) !important;
 
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent !important;

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -90,8 +90,8 @@
 }
 
 
-@mixin button-style-outset__focus() {
-	box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $white, 0 0 0 calc(2 * var(--wp-admin-border-width-focus)) $components-color-accent;
+@mixin button-style-outset__focus($focus-color) {
+	box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $white, 0 0 0 calc(2 * var(--wp-admin-border-width-focus)) $focus-color;
 
 	// Windows High Contrast mode will show this outline, but not the box-shadow.
 	outline: 2px solid transparent;

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -90,6 +90,15 @@
 }
 
 
+@mixin button-style-outset__focus() {
+	box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $white, 0 0 0 calc(2 * var(--wp-admin-border-width-focus)) $components-color-accent;
+
+	// Windows High Contrast mode will show this outline, but not the box-shadow.
+	outline: 2px solid transparent;
+	outline-offset: 2px;
+}
+
+
 /**
  * Applies editor left position to the selector passed as argument
  */

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -83,7 +83,7 @@ $widget-area-width: 700px;
 
 $block-toolbar-height: $grid-unit-60;
 $border-width: 1px;
-$border-width-focus: 2px; // This exists as a fallback, and is ideally overridden by var(--wp-admin-border-width-focus) unless in some SASS math cases.
+$border-width-focus-fallback: 2px; // This exists as a fallback, and is ideally overridden by var(--wp-admin-border-width-focus) unless in some SASS math cases.
 $border-width-tab: 1.5px;
 $helptext-font-size: 12px;
 $radius-round: 50%;

--- a/packages/block-directory/src/components/downloadable-block-list-item/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-list-item/style.scss
@@ -7,7 +7,7 @@
 	grid-template-columns: auto 1fr;
 
 	&:hover {
-		box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 $border-width-focus-fallback var(--wp-admin-theme-color);
 	}
 
 	&.is-busy {

--- a/packages/block-directory/src/components/downloadable-block-list-item/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-list-item/style.scss
@@ -7,7 +7,7 @@
 	grid-template-columns: auto 1fr;
 
 	&:hover {
-		box-shadow: 0 0 0 $border-width-focus-fallback var(--wp-admin-theme-color);
+		@include button-style__focus();
 	}
 
 	&.is-busy {

--- a/packages/block-editor/src/components/block-breadcrumb/style.scss
+++ b/packages/block-editor/src/components/block-breadcrumb/style.scss
@@ -46,7 +46,8 @@
 		right: $border-width;
 		bottom: $border-width;
 		left: $border-width;
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+
+		@include button-style__focus();
 	}
 }
 

--- a/packages/block-editor/src/components/block-pattern-setup/style.scss
+++ b/packages/block-editor/src/components/block-pattern-setup/style.scss
@@ -37,10 +37,7 @@
 				}
 
 				&:focus .block-editor-block-preview__container {
-					box-shadow: inset 0 0 0 1px $white, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-
-					// Windows High Contrast mode will show this outline, but not the box-shadow.
-					outline: 2px solid transparent;
+					@include button-style-outset__focus(var(--wp-admin-theme-color));
 				}
 				&:hover .block-editor-block-pattern-setup-list__item-title,
 				&:focus .block-editor-block-pattern-setup-list__item-title {

--- a/packages/block-editor/src/components/block-patterns-list/style.scss
+++ b/packages/block-editor/src/components/block-patterns-list/style.scss
@@ -37,10 +37,7 @@
 	}
 
 	&:focus .block-editor-block-preview__container {
-		box-shadow: inset 0 0 0 1px $white, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-
-		// Windows High Contrast mode will show this outline, but not the box-shadow.
-		outline: 2px solid transparent;
+		@include button-style-outset__focus(var(--wp-admin-theme-color));
 	}
 
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   `CheckboxControl`, `CustomGradientPicker`, `FormToggle`, : Refactor and correct the focus style for consistency ([#50127](https://github.com/WordPress/gutenberg/pull/50127)).
+
 ### Internal
 
 -   `NavigableContainer`: Convert to TypeScript ([#49377](https://github.com/WordPress/gutenberg/pull/49377)).

--- a/packages/components/src/checkbox-control/style.scss
+++ b/packages/components/src/checkbox-control/style.scss
@@ -27,7 +27,7 @@ $checkbox-input-size-sm: 24px; // Width & height for small viewports.
 	@include reduce-motion("transition");
 
 	&:focus {
-		box-shadow: 0 0 0 ($border-width * 2) $white, 0 0 0 ($border-width * 2 + $border-width-focus) $components-color-accent;
+		box-shadow: 0 0 0 ($border-width * 2) $white, 0 0 0 ($border-width * 2 + $border-width-focus-fallback) $components-color-accent;
 
 		// Only visible in Windows High Contrast mode.
 		outline: 2px solid transparent;

--- a/packages/components/src/checkbox-control/style.scss
+++ b/packages/components/src/checkbox-control/style.scss
@@ -27,7 +27,7 @@ $checkbox-input-size-sm: 24px; // Width & height for small viewports.
 	@include reduce-motion("transition");
 
 	&:focus {
-		@include button-style-outset__focus();
+		@include button-style-outset__focus(var(--wp-admin-theme-color));
 	}
 
 	&:checked,

--- a/packages/components/src/checkbox-control/style.scss
+++ b/packages/components/src/checkbox-control/style.scss
@@ -27,10 +27,7 @@ $checkbox-input-size-sm: 24px; // Width & height for small viewports.
 	@include reduce-motion("transition");
 
 	&:focus {
-		box-shadow: 0 0 0 ($border-width * 2) $white, 0 0 0 ($border-width * 2 + $border-width-focus-fallback) $components-color-accent;
-
-		// Only visible in Windows High Contrast mode.
-		outline: 2px solid transparent;
+		@include button-style-outset__focus();
 	}
 
 	&:checked,

--- a/packages/components/src/custom-gradient-picker/style.scss
+++ b/packages/components/src/custom-gradient-picker/style.scss
@@ -76,14 +76,14 @@ $components-custom-gradient-picker__padding: $grid-unit-20; // 48px container, 1
 		padding: 0;
 
 		// Shadow and stroke.
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $white, 0 0 $border-width-focus 0 rgba($black, 0.25);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $white, 0 0 $border-width-focus-fallback 0 rgba($black, 0.25);
 
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent;
 
 		&:focus,
 		&.is-active {
-			box-shadow: inset 0 0 0 calc(var(--wp-admin-border-width-focus) * 2) $white, 0 0 $border-width-focus 0 rgba($black, 0.25);
+			box-shadow: inset 0 0 0 calc(var(--wp-admin-border-width-focus) * 2) $white, 0 0 $border-width-focus-fallback 0 rgba($black, 0.25);
 
 			// Windows High Contrast mode will show this outline, but not the box-shadow.
 			outline: $border-width-tab solid transparent;

--- a/packages/components/src/form-toggle/style.scss
+++ b/packages/components/src/form-toggle/style.scss
@@ -44,7 +44,7 @@ $toggle-border-width: 1px;
 	}
 
 	.components-form-toggle__input:focus + .components-form-toggle__track {
-		box-shadow: 0 0 0 2px $white, 0 0 0 (2px + $border-width-focus-fallback) $components-color-accent;
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $white, 0 0 0 calc(2 * var(--wp-admin-border-width-focus)) $components-color-accent;
 
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent;

--- a/packages/components/src/form-toggle/style.scss
+++ b/packages/components/src/form-toggle/style.scss
@@ -44,7 +44,7 @@ $toggle-border-width: 1px;
 	}
 
 	.components-form-toggle__input:focus + .components-form-toggle__track {
-		@include button-style-outset__focus();
+		@include button-style-outset__focus($components-color-accent);
 	}
 
 	&.is-checked {

--- a/packages/components/src/form-toggle/style.scss
+++ b/packages/components/src/form-toggle/style.scss
@@ -44,11 +44,7 @@ $toggle-border-width: 1px;
 	}
 
 	.components-form-toggle__input:focus + .components-form-toggle__track {
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $white, 0 0 0 calc(2 * var(--wp-admin-border-width-focus)) $components-color-accent;
-
-		// Windows High Contrast mode will show this outline, but not the box-shadow.
-		outline: 2px solid transparent;
-		outline-offset: 2px;
+		@include button-style-outset__focus();
 	}
 
 	&.is-checked {

--- a/packages/components/src/form-toggle/style.scss
+++ b/packages/components/src/form-toggle/style.scss
@@ -44,7 +44,7 @@ $toggle-border-width: 1px;
 	}
 
 	.components-form-toggle__input:focus + .components-form-toggle__track {
-		box-shadow: 0 0 0 2px $white, 0 0 0 (2px + $border-width-focus) $components-color-accent;
+		box-shadow: 0 0 0 2px $white, 0 0 0 (2px + $border-width-focus-fallback) $components-color-accent;
 
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent;

--- a/packages/edit-post/src/components/start-page-options/style.scss
+++ b/packages/edit-post/src/components/start-page-options/style.scss
@@ -4,7 +4,7 @@
 	column-gap: $grid-unit-30;
 
 	// Small top padding required to avoid cutting off the visible outline when hovering items
-	padding-top: $border-width-focus;
+	padding-top: $border-width-focus-fallback;
 
 	@include break-medium() {
 		column-count: 3;

--- a/packages/edit-site/src/components/start-template-options/style.scss
+++ b/packages/edit-site/src/components/start-template-options/style.scss
@@ -3,7 +3,7 @@
 	column-gap: $grid-unit-30;
 
 	// Small top padding required to avoid cutting off the visible outline when hovering items
-	padding-top: $border-width-focus;
+	padding-top: $border-width-focus-fallback;
 
 	@include break-medium() {
 		column-count: 3;

--- a/packages/editor/src/components/post-taxonomies/style.scss
+++ b/packages/editor/src/components/post-taxonomies/style.scss
@@ -3,10 +3,10 @@
 	overflow: auto;
 
 	// Extra left padding prevents checkbox focus borders from being cut off.
-	margin-left: -$border-width * 4 - $border-width-focus;
-	padding-left: $border-width * 4 + $border-width-focus;
-	margin-top: -$border-width * 4 - $border-width-focus;
-	padding-top: $border-width * 4 + $border-width-focus;
+	margin-left: -$border-width * 4 - $border-width-focus-fallback;
+	padding-left: $border-width * 4 + $border-width-focus-fallback;
+	margin-top: -$border-width * 4 - $border-width-focus-fallback;
+	padding-top: $border-width * 4 + $border-width-focus-fallback;
 }
 
 .editor-post-taxonomies__hierarchical-terms-choice {


### PR DESCRIPTION
## What?

The code for our focus styles is a bit all over the place due to a mix of modern componentry, SCSS variables, and mixins. 

This PR aims to shore that up a little bit, so the correct unified focus styles are applied everywhere. This PR is one step of the way, but hopefully it can improve the code going forward.

## How?

* it renames the $border-width-focus to $border-width-focus-fallback to indicate that it's not meant to be the focus style width. Currently the actual variable to use there is var(--wp-admin-border-width-focus).
* It applies the correct focus style in a few places where it was incorrectly used.
* It uses a few mixins to reduce code drift a little bit.

I'm not sure mixins or even variables is the correct way to solve this long term, but since these are already in use quite broadly, hopefully this can at least start a refactor that could eventually lead to their demise. 

Essentially, focus styles should be 1.5px, never 2px. And they should come with separate focus styles for Windows in high contrast mode (the transparent outline, that is made opaque in that mode).

## Testing Instructions

Please test focus styles for:

* Block directory (search for "test", then focus the block that shows up upon loading completion)
* Toggles
* Checkboxes
* Breadcrumbs in the editor canvas footer

## Screenshots or screencast <!-- if applicable -->

Directory before and after:

<img width="458" alt="dir before" src="https://user-images.githubusercontent.com/1204802/234844778-20d866c3-1f0a-4440-b18f-1f96374b93b0.png">
<img width="448" alt="dir after" src="https://user-images.githubusercontent.com/1204802/234844781-b4802d42-a085-4229-be00-d7a8b4ee6602.png">

Toggle before and after:

<img width="344" alt="toggle before" src="https://user-images.githubusercontent.com/1204802/234844829-172da07f-3a73-4c38-ad14-1975247aca59.png">

<img width="220" alt="toggle after" src="https://user-images.githubusercontent.com/1204802/234844839-a74f1620-945c-4416-879a-4c5329888be3.png">

Checkbox before and after:

<img width="234" alt="checkbox before" src="https://user-images.githubusercontent.com/1204802/234844861-03eaeffa-f59a-4c80-bcfb-950ae395cb6b.png">
<img width="179" alt="checkbox after" src="https://user-images.githubusercontent.com/1204802/234844867-9d690143-a3c0-4c4b-8b76-dc1c859d1efc.png">

Breadcrumbs looking the same before and after:

<img width="248" alt="breadcrumbs with mixin" src="https://user-images.githubusercontent.com/1204802/234844904-705eee58-50ff-46bd-bdd9-62dbb9cb2fd3.png">


