### PR TITLE
Docs: Update Callout documentation on links

### DIFF
--- a/docs/contributors/documentation/README.md
+++ b/docs/contributors/documentation/README.md
@@ -157,7 +157,7 @@ This is a **warning** callout.
 </div>
 
 <div class="callout callout-warning">
-Note: In callout notices, links also need to be HTML `<a href></a>` notations. 
+Note: In callout notices, links also need to be HTML `&lt;a href>&lt;/a>` notations. 
 The usual link transformation is not applied to links in callouts.
 For instance, to reach the Getting started > Create Block page the URL in GitHub is
 https://developer.wordpress.org/docs/getting-started/create-block/README.md

--- a/docs/contributors/documentation/README.md
+++ b/docs/contributors/documentation/README.md
@@ -165,7 +165,8 @@ Note: In callout notices, links also need to be HTML `&lt;a href>&lt;/a>` notati
 The usual link transformation is not applied to links in callouts.
 For instance, to reach the Getting started > Create Block page the URL in GitHub is
 https://developer.wordpress.org/docs/getting-started/create-block/README.md
-and will have to be hardcoded for the endpoint in the Block Editor Handbook as <a href="../getting-started/create-block/">../getting-started/create-block/</a> to link correctly in the handbook. 
+and will have to be hardcoded for the endpoint in the Block Editor Handbook as 
+<a href="https://developer.wordpress.org/block-editor/getting-started/create-block/">https://developer.wordpress.org/block-editor/getting-started/create-block/</a> to link correctly in the handbook. 
 </div>
 ### Editor config
 

--- a/docs/contributors/documentation/README.md
+++ b/docs/contributors/documentation/README.md
@@ -101,11 +101,11 @@ This way they will be properly handled in all three aforementioned contexts.
 
 Use the full directory and filename from the Gutenberg repository, not the published path; the Block Editor Handbook creates short URLs—you can see this in the tutorials section. Likewise, the `readme.md` portion is dropped in the handbook, but should be included in links.
 
+An example, the link to this page is: `/docs/contributors/documentation/README.md`
+
 <div class="callout callout-warning">
 <b>Note:</b> The usual link transformation is not applied to links in callouts. See below. 
 </div>
-
-An example, the link to this page is: `/docs/contributors/documentation/README.md`
 
 ### Code examples
 

--- a/docs/contributors/documentation/README.md
+++ b/docs/contributors/documentation/README.md
@@ -132,7 +132,7 @@ The preferred format for code examples is JSX, this should be the default view. 
 
 The Block Editor handbook supports the same [notice styles as other WordPress handbooks](https://make.wordpress.org/docs/handbook/documentation-team-handbook/handbooks-style-and-formatting-guide/#formatting). However, the shortcode implementation is not ideal with the different locations the block editor handbook documentation is published (npm, GitHub).
 
-The recommended way to implement in markdown is to use the raw HTML and `callout callout-LEVEL` classes. For example:
+The recommended way to implement in markdown is to use the raw HTML and`callout callout-LEVEL` classes. For example:
 
 ```html
 <div class="callout callout-info">This is an **info** callout.</div>
@@ -156,6 +156,13 @@ This is an **alert** callout.
 This is a **warning** callout.
 </div>
 
+<div class="callout callout-warning">
+Note: In callout notices, links also need to be HTML `<a href></a>` notations. 
+The usual link transformation is not applied to links in callouts.
+For instance, to reach the Getting started > Create Block page the URL in GitHub is
+https://developer.wordpress.org/docs/getting-started/create-block/README.md
+and will have to be hardcoded for the endpoint in the Block Editor Handbook as <a href="../getting-started/create-block/">../getting-started/create-block/</a> to link correctly in the handbook. 
+</div>
 ### Editor config
 
 You should configure your editor to use Prettier to auto-format markdown documents. See the [Getting Started documentation](/docs/contributors/code/getting-started-with-code-contribution.md) for complete details.

--- a/docs/contributors/documentation/README.md
+++ b/docs/contributors/documentation/README.md
@@ -101,6 +101,10 @@ This way they will be properly handled in all three aforementioned contexts.
 
 Use the full directory and filename from the Gutenberg repository, not the published path; the Block Editor Handbook creates short URLs—you can see this in the tutorials section. Likewise, the `readme.md` portion is dropped in the handbook, but should be included in links.
 
+<div class="callout callout-warning">
+<b>Note:</b> The usual link transformation is not applied to links in callouts. See below. 
+</div>
+
 An example, the link to this page is: `/docs/contributors/documentation/README.md`
 
 ### Code examples

--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -3,9 +3,9 @@
 Block registration API reference.
 
 <div class="callout callout-alert">
-You can use the functions documented on this page to register a block with JavaScript only on the client, but the recommended method is to register new block types also with PHP on the server using the `block.json` metadata file. See <a href="block-metadata/">metadata documentation for complete information</a>
+You can use the functions documented on this page to register a block with JavaScript only on the client, but the recommended method is to register new block types also with PHP on the server using the `block.json` metadata file. See <a href="https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/">metadata documentation for complete information</a>
 <br/>
-<a href="../getting-started/create-block/">Learn how to create your first block</a> for the WordPress block editor. From setting up your development environment, tools, and getting comfortable with the new development model, this tutorial covers all you need to know to get started with creating blocks.
+<a href="https://developer.wordpress.org/block-editor/getting-started/create-block/">Learn how to create your first block</a> for the WordPress block editor. From setting up your development environment, tools, and getting comfortable with the new development model, this tutorial covers all you need to know to get started with creating blocks.
 </div>
 
 ## `registerBlockType`

--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -3,8 +3,9 @@
 Block registration API reference.
 
 <div class="callout callout-alert">
-You can use the functions documented on this page to register a block with JavaScript only on the client, but the recommended method is to register new block types also with PHP on the server using the `block.json` metadata file. See <a href="/docs/reference-guides/block-api/block-metadata.md">metadata documentation for complete information</a>
-<a href="/docs/getting-started/create-block/README.md">Learn how to create your first block</a> for the WordPress block editor. From setting up your development environment, tools, and getting comfortable with the new development model, this tutorial covers all you need to know to get started with creating blocks.
+You can use the functions documented on this page to register a block with JavaScript only on the client, but the recommended method is to register new block types also with PHP on the server using the `block.json` metadata file. See <a href="block-metadata/">metadata documentation for complete information</a>
+<br/>
+<a href="../getting-started/create-block/">Learn how to create your first block</a> for the WordPress block editor. From setting up your development environment, tools, and getting comfortable with the new development model, this tutorial covers all you need to know to get started with creating blocks.
 </div>
 
 ## `registerBlockType`


### PR DESCRIPTION
## What?
 Fixes #50125
- Add note to use HTML links in callouts
- relative links for the block -editor handbook
- fixed links in previous docs update

## Why?
The link parser only works in Markdown links. 

## How?
for now: hard-coding relative links to work in the block editor handbook. 

## Testing Instructions
Needs to be merged before it can be tested. 
