### PR TITLE
Fix the pocket casts embed variation

### DIFF
--- a/packages/block-library/src/embed/variations.js
+++ b/packages/block-library/src/embed/variations.js
@@ -218,13 +218,13 @@ const variations = [
 		attributes: { providerNameSlug: 'mixcloud', responsive: true },
 	},
 	{
-		name: 'pocketcasts',
+		name: 'pocket-casts',
 		title: 'Pocket Casts',
 		icon: embedPocketCastsIcon,
 		keywords: [ __( 'podcast' ), __( 'audio' ) ],
 		description: __( 'Embed a podcast player from Pocket Casts.' ),
 		patterns: [ /^https:\/\/pca.st\/\w+/i ],
-		attributes: { providerNameSlug: 'pocketcasts', responsive: true },
+		attributes: { providerNameSlug: 'pocket-casts', responsive: true },
 	},
 	{
 		name: 'reddit',


### PR DESCRIPTION
## What?

The pocket cast embed variation is using the wrong provider name. (missing a `-`). This creates some bugs where adding a pocket cast embed block actually replaces the block after parsing it. A side effect of this is that you can never switch to HTML mode for that block.

## Testing Instructions

1- Open the post editor
2- Embed a pocket casts link (example: https://pca.st/inthedark )
3- you should be able to switch to the HTML mode.
