### PR TITLE
SlotFill: some code cleanups of the bubblesVirtually version

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `NavigableContainer`: Convert to TypeScript ([#49377](https://github.com/WordPress/gutenberg/pull/49377)).
 -   Move rich-text related types to the rich-text package ([#49651](https://github.com/WordPress/gutenberg/pull/49651)).
+-   `SlotFill`: simplified the implementation and removed unused code ([#50098](https://github.com/WordPress/gutenberg/pull/50098) and [#50133](https://github.com/WordPress/gutenberg/pull/50133))
 
 ### Documentation
 

--- a/packages/components/src/slot-fill/bubbles-virtually/fill.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/fill.js
@@ -30,7 +30,8 @@ function useForceUpdate() {
 
 export default function Fill( { name, children } ) {
 	const { registerFill, unregisterFill, ...slot } = useSlot( name );
-	const ref = useRef( { rerender: useForceUpdate() } );
+	const rerender = useForceUpdate();
+	const ref = useRef( { rerender } );
 
 	useEffect( () => {
 		// We register fills so we can keep track of their existence.

--- a/packages/components/src/slot-fill/bubbles-virtually/use-slot.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/use-slot.js
@@ -7,7 +7,7 @@ import { useSnapshot } from 'valtio';
 /**
  * WordPress dependencies
  */
-import { useCallback, useContext } from '@wordpress/element';
+import { useMemo, useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -15,52 +15,25 @@ import { useCallback, useContext } from '@wordpress/element';
 import SlotFillContext from './slot-fill-context';
 
 export default function useSlot( name ) {
-	const {
-		updateSlot: registryUpdateSlot,
-		unregisterSlot: registryUnregisterSlot,
-		registerFill: registryRegisterFill,
-		unregisterFill: registryUnregisterFill,
-		...registry
-	} = useContext( SlotFillContext );
+	const registry = useContext( SlotFillContext );
 	const slots = useSnapshot( registry.slots, { sync: true } );
-	// The important bit here is that this call ensures
-	// the hook only causes a re-render if the slot
-	// with the given name change, not any other slot.
+	// The important bit here is that the `useSnapshot` call ensures that the
+	// hook only causes a re-render if the slot with the given name changes,
+	// not any other slot.
 	const slot = slots.get( name );
 
-	const updateSlot = useCallback(
-		( fillProps ) => {
-			registryUpdateSlot( name, fillProps );
-		},
-		[ name, registryUpdateSlot ]
-	);
-
-	const unregisterSlot = useCallback(
-		( slotRef ) => {
-			registryUnregisterSlot( name, slotRef );
-		},
-		[ name, registryUnregisterSlot ]
-	);
-
-	const registerFill = useCallback(
-		( fillRef ) => {
-			registryRegisterFill( name, fillRef );
-		},
-		[ name, registryRegisterFill ]
-	);
-
-	const unregisterFill = useCallback(
-		( fillRef ) => {
-			registryUnregisterFill( name, fillRef );
-		},
-		[ name, registryUnregisterFill ]
+	const api = useMemo(
+		() => ( {
+			updateSlot: ( fillProps ) => registry.updateSlot( name, fillProps ),
+			unregisterSlot: ( ref ) => registry.unregisterSlot( name, ref ),
+			registerFill: ( ref ) => registry.registerFill( name, ref ),
+			unregisterFill: ( ref ) => registry.unregisterFill( name, ref ),
+		} ),
+		[ name, registry ]
 	);
 
 	return {
 		...slot,
-		updateSlot,
-		unregisterSlot,
-		registerFill,
-		unregisterFill,
+		...api,
 	};
 }


### PR DESCRIPTION
After the successful #50098, here are some more code improvements in the `bubblesVirtually` version of `SlotFill`:
- when creating the `registry` for the context, we can save many `useRef`s and `useCallback`s by creating the registry as a constant object and then storing it, forever, in provider's state.
- similarly, we can save many `useCallback`s in `useSlot` by creating the bound API object as a single `api` object, with `useMemo`.
- finally there's a tiny change in `Fill` to move hook call into a separate statement, as is the common custom.