### PR TITLE
Command Center: Fix a style glitch on Safari

### DIFF
--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -196,7 +196,11 @@ export function CommandMenu() {
 			onRequestClose={ close }
 			__experimentalHideHeader
 		>
-			<div className="commands-command-menu__container">
+			{ /* the style here is a hack to force safari to repaint to avoid a style glitch */ }
+			<div
+				className="commands-command-menu__container"
+				style={ { transform: 'translateZ(0)' } }
+			>
 				<Command label={ __( 'Global Command Menu' ) }>
 					<div className="commands-command-menu__header">
 						<Command.Input

--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -196,11 +196,7 @@ export function CommandMenu() {
 			onRequestClose={ close }
 			__experimentalHideHeader
 		>
-			{ /* the style here is a hack to force safari to repaint to avoid a style glitch */ }
-			<div
-				className="commands-command-menu__container"
-				style={ { transform: 'translateZ(0)' } }
-			>
+			<div className="commands-command-menu__container">
 				<Command label={ __( 'Global Command Menu' ) }>
 					<div className="commands-command-menu__header">
 						<Command.Input

--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -36,6 +36,9 @@
 }
 
 .commands-command-menu__container {
+	// the style here is a hack to force safari to repaint to avoid a style glitch
+	will-change: transform;
+
 	[cmdk-input] {
 		border: none;
 		width: 100%;


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/issues/48457

## What?

In Safari, as you type in the command center (cmd+k) you can see some visual glitches in the modal. I'm thinking this is probably a Safari bug but I wasn't able to find the root cause. The current PR solves the issue by forcing a browser repaint on render (using the transform style). 

## Testing Instructions

- Use Safari
- Enable the command center experiment
- Open the command center (cmd+k) in the site editor
- Type in the input
- No visual glitches 
