### PR TITLE
Add block variations transformation in block switcher

### DIFF
--- a/packages/block-editor/src/components/block-switcher/block-transformations-menu.js
+++ b/packages/block-editor/src/components/block-switcher/block-transformations-menu.js
@@ -14,6 +14,7 @@ import { useState, useMemo } from '@wordpress/element';
  */
 import BlockIcon from '../block-icon';
 import PreviewBlockPopover from './preview-block-popover';
+import BlockVariationTransformations from './block-variation-transformations';
 
 /**
  * Helper hook to group transformations to display them in a specific order in the UI.
@@ -65,7 +66,9 @@ function useGroupedTransforms( possibleBlockTransformations ) {
 const BlockTransformationsMenu = ( {
 	className,
 	possibleBlockTransformations,
+	possibleBlockVariationTransformations,
 	onSelect,
+	onSelectVariation,
 	blocks,
 } ) => {
 	const [ hoveredTransformItemName, setHoveredTransformItemName ] =
@@ -93,6 +96,15 @@ const BlockTransformationsMenu = ( {
 							blocks,
 							hoveredTransformItemName
 						) }
+					/>
+				) }
+				{ !! possibleBlockVariationTransformations?.length && (
+					<BlockVariationTransformations
+						transformations={
+							possibleBlockVariationTransformations
+						}
+						blocks={ blocks }
+						onSelect={ onSelectVariation }
 					/>
 				) }
 				{ priorityTextTransformations.map( ( item ) => (

--- a/packages/block-editor/src/components/block-switcher/block-variation-transformations-menu.js
+++ b/packages/block-editor/src/components/block-switcher/block-variation-transformations-menu.js
@@ -1,0 +1,114 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { MenuGroup, MenuItem } from '@wordpress/components';
+import {
+	getBlockMenuDefaultClassName,
+	cloneBlock,
+	store as blocksStore,
+} from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
+import { useState, useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+import BlockIcon from '../block-icon';
+import PreviewBlockPopover from './preview-block-popover';
+
+export function useBlockVariationTransforms( { clientIds, blocks } ) {
+	const { activeBlockVariation, blockVariationTransformations } = useSelect(
+		( select ) => {
+			const {
+				getBlockRootClientId,
+				getBlockAttributes,
+				canRemoveBlocks,
+			} = select( blockEditorStore );
+			const { getActiveBlockVariation, getBlockVariations } =
+				select( blocksStore );
+			const rootClientId = getBlockRootClientId(
+				Array.isArray( clientIds ) ? clientIds[ 0 ] : clientIds
+			);
+			const canRemove = canRemoveBlocks( clientIds, rootClientId );
+			// Only handle single selected blocks for now.
+			if ( blocks.length !== 1 || ! canRemove ) {
+				return;
+			}
+			const [ firstBlock ] = blocks;
+			return {
+				blockVariationTransformations: getBlockVariations(
+					firstBlock.name,
+					'transform'
+				),
+				activeBlockVariation: getActiveBlockVariation(
+					firstBlock.name,
+					getBlockAttributes( firstBlock.clientId )
+				),
+			};
+		},
+		[ clientIds, blocks ]
+	);
+	const transformations = useMemo( () => {
+		return blockVariationTransformations?.filter(
+			( { name } ) => name !== activeBlockVariation?.name
+		);
+	}, [ blockVariationTransformations, activeBlockVariation ] );
+	return transformations;
+}
+
+const BlockVariationTransformationsMenu = ( {
+	transformations,
+	onSelect,
+	blocks,
+} ) => {
+	const [ hoveredTransformItemName, setHoveredTransformItemName ] =
+		useState();
+	return (
+		<MenuGroup label={ __( 'Variations' ) }>
+			{ hoveredTransformItemName && (
+				<PreviewBlockPopover
+					blocks={ cloneBlock(
+						blocks[ 0 ],
+						transformations.find(
+							( { name } ) => name === hoveredTransformItemName
+						).attributes
+					) }
+				/>
+			) }
+			{ transformations?.map( ( item ) => (
+				<BlockVariationTranformationItem
+					key={ item.name }
+					item={ item }
+					onSelect={ onSelect }
+					setHoveredTransformItemName={ setHoveredTransformItemName }
+				/>
+			) ) }
+		</MenuGroup>
+	);
+};
+
+function BlockVariationTranformationItem( {
+	item,
+	onSelect,
+	setHoveredTransformItemName,
+} ) {
+	const { name, icon, title } = item;
+	return (
+		<MenuItem
+			className={ getBlockMenuDefaultClassName( name ) }
+			onClick={ ( event ) => {
+				event.preventDefault();
+				onSelect( name );
+			} }
+			onMouseLeave={ () => setHoveredTransformItemName( null ) }
+			onMouseEnter={ () => setHoveredTransformItemName( name ) }
+		>
+			<BlockIcon icon={ icon } showColors />
+			{ title }
+		</MenuItem>
+	);
+}
+
+export default BlockVariationTransformationsMenu;

--- a/packages/block-editor/src/components/block-switcher/block-variation-transformations.js
+++ b/packages/block-editor/src/components/block-switcher/block-variation-transformations.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { MenuGroup, MenuItem } from '@wordpress/components';
+import { MenuItem } from '@wordpress/components';
 import {
 	getBlockMenuDefaultClassName,
 	cloneBlock,
@@ -58,7 +57,7 @@ export function useBlockVariationTransforms( { clientIds, blocks } ) {
 	return transformations;
 }
 
-const BlockVariationTransformationsMenu = ( {
+const BlockVariationTransformations = ( {
 	transformations,
 	onSelect,
 	blocks,
@@ -66,7 +65,7 @@ const BlockVariationTransformationsMenu = ( {
 	const [ hoveredTransformItemName, setHoveredTransformItemName ] =
 		useState();
 	return (
-		<MenuGroup label={ __( 'Variations' ) }>
+		<>
 			{ hoveredTransformItemName && (
 				<PreviewBlockPopover
 					blocks={ cloneBlock(
@@ -85,7 +84,7 @@ const BlockVariationTransformationsMenu = ( {
 					setHoveredTransformItemName={ setHoveredTransformItemName }
 				/>
 			) ) }
-		</MenuGroup>
+		</>
 	);
 };
 
@@ -111,4 +110,4 @@ function BlockVariationTranformationItem( {
 	);
 }
 
-export default BlockVariationTransformationsMenu;
+export default BlockVariationTransformations;

--- a/packages/block-editor/src/components/block-switcher/block-variation-transformations.js
+++ b/packages/block-editor/src/components/block-switcher/block-variation-transformations.js
@@ -17,6 +17,8 @@ import { store as blockEditorStore } from '../../store';
 import BlockIcon from '../block-icon';
 import PreviewBlockPopover from './preview-block-popover';
 
+const EMPTY_OBJECT = {};
+
 export function useBlockVariationTransforms( { clientIds, blocks } ) {
 	const { activeBlockVariation, blockVariationTransformations } = useSelect(
 		( select ) => {
@@ -33,7 +35,7 @@ export function useBlockVariationTransforms( { clientIds, blocks } ) {
 			const canRemove = canRemoveBlocks( clientIds, rootClientId );
 			// Only handle single selected blocks for now.
 			if ( blocks.length !== 1 || ! canRemove ) {
-				return;
+				return EMPTY_OBJECT;
 			}
 			const [ firstBlock ] = blocks;
 			return {

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -24,10 +24,7 @@ import { store as blockEditorStore } from '../../store';
 import useBlockDisplayInformation from '../use-block-display-information';
 import BlockIcon from '../block-icon';
 import BlockTransformationsMenu from './block-transformations-menu';
-import {
-	useBlockVariationTransforms,
-	default as BlockVariationTransformationsMenu,
-} from './block-variation-transformations-menu';
+import { useBlockVariationTransforms } from './block-variation-transformations';
 import BlockStylesMenu from './block-styles-menu';
 import PatternTransformationsMenu from './pattern-transformations-menu';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
@@ -184,10 +181,12 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 					blocks.length
 			  );
 
+	const hasBlockOrBlockVariationTransforms =
+		hasPossibleBlockTransformations ||
+		hasPossibleBlockVariationTransformations;
 	const showDropDown =
 		hasBlockStyles ||
-		hasPossibleBlockTransformations ||
-		hasPossibleBlockVariationTransformations ||
+		hasBlockOrBlockVariationTransforms ||
 		hasPatternTransformation;
 	return (
 		<ToolbarGroup>
@@ -238,26 +237,21 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 											} }
 										/>
 									) }
-									{ hasPossibleBlockTransformations && (
+									{ hasBlockOrBlockVariationTransforms && (
 										<BlockTransformationsMenu
 											className="block-editor-block-switcher__transforms__menugroup"
 											possibleBlockTransformations={
 												possibleBlockTransformations
+											}
+											possibleBlockVariationTransformations={
+												blockVariationTransformations
 											}
 											blocks={ blocks }
 											onSelect={ ( name ) => {
 												onBlockTransform( name );
 												onClose();
 											} }
-										/>
-									) }
-									{ hasPossibleBlockVariationTransformations && (
-										<BlockVariationTransformationsMenu
-											transformations={
-												blockVariationTransformations
-											}
-											blocks={ blocks }
-											onSelect={ ( name ) => {
+											onSelectVariation={ ( name ) => {
 												onBlockVariationTransform(
 													name
 												);

--- a/test/e2e/specs/editor/various/block-switcher-test.spec.js
+++ b/test/e2e/specs/editor/various/block-switcher-test.spec.js
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Block Switcher', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'Block variation transforms', async ( { editor, page } ) => {
+		// This is the `stack` Group variation.
+		await editor.insertBlock( {
+			name: 'core/group',
+			attributes: {
+				layout: {
+					type: 'flex',
+					orientation: 'vertical',
+				},
+			},
+			innerBlocks: [
+				{
+					name: 'core/paragraph',
+					attributes: { content: '1' },
+				},
+			],
+		} );
+		expect( await editor.getEditedPostContent() ).toBe(
+			`<!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->`
+		);
+		// Transform to `Stack` variation.
+		await editor.clickBlockToolbarButton( 'Stack' );
+		await expect(
+			page.locator( 'role=menuitem[name="Stack"i]' )
+		).toBeHidden();
+		await page.click( 'role=menuitem[name="Row"i]' );
+		expect( await editor.getEditedPostContent() ).toBe(
+			`<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->`
+		);
+		await editor.clickBlockToolbarButton( 'Row' );
+		await expect(
+			page.locator( 'role=menuitem[name="Stack"i]' )
+		).toBeVisible();
+	} );
+} );

--- a/test/e2e/specs/editor/various/block-switcher-test.spec.js
+++ b/test/e2e/specs/editor/various/block-switcher-test.spec.js
@@ -34,7 +34,7 @@ test.describe( 'Block Switcher', () => {
 			variations.getByRole( 'menuitem', { name: 'Stack' } )
 		).toBeHidden();
 		await variations.getByRole( 'menuitem', { name: 'Row' } ).click();
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/group',
 				attributes: expect.objectContaining( {

--- a/test/e2e/specs/editor/various/block-switcher-test.spec.js
+++ b/test/e2e/specs/editor/various/block-switcher-test.spec.js
@@ -34,10 +34,12 @@ test.describe( 'Block Switcher', () => {
 		);
 		// Transform to `Stack` variation.
 		await editor.clickBlockToolbarButton( 'Stack' );
+		const variations = page.getByRole( 'menu', { name: 'Stack' } )
+			.getByRole( 'group', { name: 'variations' } );
 		await expect(
-			page.locator( 'role=menuitem[name="Stack"i]' )
+			variations.getByRole( 'menuitem', { name: 'Stack' } )
 		).toBeHidden();
-		await page.click( 'role=menuitem[name="Row"i]' );
+		await variations.getByRole( 'menuitem', { name: 'Row' } ).click();
 		expect( await editor.getEditedPostContent() ).toBe(
 			`<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:paragraph -->

--- a/test/e2e/specs/editor/various/block-switcher-test.spec.js
+++ b/test/e2e/specs/editor/various/block-switcher-test.spec.js
@@ -25,28 +25,33 @@ test.describe( 'Block Switcher', () => {
 				},
 			],
 		} );
-		expect( await editor.getEditedPostContent() ).toBe(
-			`<!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:paragraph -->
-<p>1</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group -->`
-		);
 		// Transform to `Stack` variation.
 		await editor.clickBlockToolbarButton( 'Stack' );
-		const variations = page.getByRole( 'menu', { name: 'Stack' } )
-			.getByRole( 'group', { name: 'variations' } );
+		const variations = page
+			.getByRole( 'menu', { name: 'Stack' } )
+			.getByRole( 'group' );
 		await expect(
 			variations.getByRole( 'menuitem', { name: 'Stack' } )
 		).toBeHidden();
 		await variations.getByRole( 'menuitem', { name: 'Row' } ).click();
-		expect( await editor.getEditedPostContent() ).toBe(
-			`<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:paragraph -->
-<p>1</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group -->`
-		);
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/group',
+				attributes: expect.objectContaining( {
+					layout: {
+						type: 'flex',
+						flexWrap: 'nowrap',
+						orientation: undefined,
+					},
+				} ),
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						attributes: { content: '1' },
+					},
+				],
+			},
+		] );
 		await editor.clickBlockToolbarButton( 'Row' );
 		await expect(
 			page.locator( 'role=menuitem[name="Stack"i]' )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/49891
Resolves: https://github.com/WordPress/gutenberg/issues/39066


Some issues below are related and could be resolved with small changes to apply the `transform` scope to some variations, or small tweaks.
Issues: https://github.com/WordPress/gutenberg/issues/40208, https://github.com/WordPress/gutenberg/issues/49879, https://github.com/WordPress/gutenberg/issues/49584, https://github.com/WordPress/gutenberg/issues/49524, https://github.com/WordPress/gutenberg/issues/46726, https://github.com/WordPress/gutenberg/issues/46195


I don't think we have concluded to a specific design for this, so this PR will help us do so. Also for now I have enabled this only for single selected blocks.
 
My personal notes would be:
1. If we have a maximum number(ex 4) we could show them in a list. If there are more, we could show the rest in an extra menu item with a popover - in that case I'm not sure how the deeper nested block preview would work well, but 🤷 .
2. Do we want to keep the current transform UI in Inspector? I'd say yes, but in some cases we might not want to, so we might consider a flag or something.
3. Ordering of `MenuGroups`, etc..
4. While we're at it, maybe we should consider augmenting the `transforms` API by adding something like a category(ex `layout`. I don't have something specific in mind for now, but we'll see based on the [main block switcher ](https://github.com/WordPress/gutenberg/issues/40208)issue's needs.


## Testing Instructions
1. Insert blocks with `transform` variations, like `Group`
2. Open the block switcher and play around


## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/16275880/234868453-78cb73ff-d479-4166-935e-dc26a6b209a1.mov

