### PR TITLE
Update some visual details in the add-template modal(s)

### DIFF
--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
@@ -51,16 +51,25 @@ function SuggestionListItem( {
 				)
 			}
 		>
-			<span className={ `${ baseCssClass }__title` }>
+			<Text
+				size="body"
+				lineHeight={ 1.53846153846 } // 20px
+				weight={ 500 }
+				className={ `${ baseCssClass }__title` }
+			>
 				<TextHighlight
 					text={ decodeEntities( suggestion.name ) }
 					highlight={ search }
 				/>
-			</span>
+			</Text>
 			{ suggestion.link && (
-				<span className={ `${ baseCssClass }__info` }>
+				<Text
+					size="body"
+					lineHeight={ 1.53846153846 } // 20px
+					className={ `${ baseCssClass }__info` }
+				>
 					{ suggestion.link }
-				</span>
+				</Text>
 			) }
 		</CompositeItem>
 	);
@@ -221,10 +230,17 @@ function AddCustomTemplateModal( {
 								} );
 							} }
 						>
-							<Text as="span" weight={ 600 }>
+							<Text
+								as="span"
+								weight={ 500 }
+								lineHeight={ 1.53846153846 } // 20px
+							>
 								{ entityForSuggestions.labels.all_items }
 							</Text>
-							<Text as="span">
+							<Text
+								as="span"
+								lineHeight={ 1.53846153846 } // 20px
+							>
 								{
 									// translators: The user is given the choice to set up a template for all items of a post type or taxonomy, or just a specific one.
 									__( 'For all items' )
@@ -238,10 +254,17 @@ function AddCustomTemplateModal( {
 								setShowSearchEntities( true );
 							} }
 						>
-							<Text as="span" weight={ 600 }>
+							<Text
+								as="span"
+								weight={ 500 }
+								lineHeight={ 1.53846153846 } // 20px
+							>
 								{ entityForSuggestions.labels.singular_name }
 							</Text>
-							<Text as="span">
+							<Text
+								as="span"
+								lineHeight={ 1.53846153846 } // 20px
+							>
 								{
 									// translators: The user is given the choice to set up a template for all items of a post type or taxonomy, or just a specific one.
 									__( 'For a specific item' )

--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
@@ -5,6 +5,7 @@ import { useState, useMemo, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	Button,
+	Flex,
 	FlexItem,
 	Modal,
 	SearchControl,
@@ -206,9 +207,10 @@ function AddCustomTemplateModal( {
 							'Select whether to create a single template for all items or a specific one.'
 						) }
 					</Text>
-					<VStack
+					<Flex
 						className={ `${ baseCssClass }__contents` }
-						spacing={ 0 }
+						gap="4"
+						align="initial"
 					>
 						<FlexItem
 							isBlock
@@ -269,7 +271,7 @@ function AddCustomTemplateModal( {
 								}
 							</Text>
 						</FlexItem>
-					</VStack>
+					</Flex>
 				</VStack>
 			) }
 			{ showSearchEntities && (

--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
@@ -5,7 +5,6 @@ import { useState, useMemo, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	Button,
-	Flex,
 	FlexItem,
 	Modal,
 	SearchControl,
@@ -207,10 +206,9 @@ function AddCustomTemplateModal( {
 							'Select whether to create a single template for all items or a specific one.'
 						) }
 					</Text>
-					<Flex
+					<VStack
 						className={ `${ baseCssClass }__contents` }
-						gap="4"
-						align="initial"
+						spacing={ 0 }
 					>
 						<FlexItem
 							isBlock
@@ -271,7 +269,7 @@ function AddCustomTemplateModal( {
 								}
 							</Text>
 						</FlexItem>
-					</Flex>
+					</VStack>
 				</VStack>
 			) }
 			{ showSearchEntities && (

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -21,12 +21,12 @@
 	&__contents {
 		> .components-button {
 			padding: $grid-unit-30;
-			box-shadow: inset 0 0 0 $border-width $gray-600;
 			border-radius: $radius-block-ui;
-			width: 256px;
 			height: auto;
+			min-height: $grid-unit * 16;
 			display: flex;
 			flex-direction: column;
+			justify-content: center;
 			gap: $grid-unit;
 
 			// Show the boundary of the button, in High Contrast Mode.
@@ -42,9 +42,9 @@
 
 			&:hover {
 				color: var(--wp-admin-theme-color-darker-10);
-				box-shadow: inset 0 0 0 $border-width var(--wp-admin-theme-color-darker-10);
+				background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 
-				span:first-child {
+				span {
 					color: var(--wp-admin-theme-color);
 				}
 			}
@@ -75,7 +75,7 @@
 	}
 
 	@include break-medium() {
-		width: 456px;
+		width: 800px;
 	}
 }
 

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -23,11 +23,9 @@
 			padding: $grid-unit-30;
 			border-radius: $radius-block-ui;
 			height: auto;
-			min-height: $grid-unit * 16;
 			display: flex;
 			flex-direction: column;
 			justify-content: center;
-			gap: $grid-unit;
 
 			// Show the boundary of the button, in High Contrast Mode.
 			outline: 1px solid transparent;
@@ -75,62 +73,60 @@
 	}
 
 	@include break-medium() {
-		width: 800px;
-	}
-}
-
-.edit-site-custom-template-modal__suggestions_list {
-	@include break-small() {
-		height: 232px;
-		overflow: scroll;
+		width: 456px;
 	}
 
-	&__list-item {
-		display: block;
-		width: 100%;
-		text-align: left;
-		white-space: pre-wrap;
-		overflow-wrap: break-word;
-		height: auto;
-
-		mark {
-			font-weight: 700;
-			background: none;
+	.edit-site-custom-template-modal__suggestions_list {
+		@include break-small() {
+			height: 232px;
+			overflow: scroll;
 		}
 
-		&:hover {
-			background-color: $gray-100;
+		&__list-item {
+			display: block;
+			width: 100%;
+			text-align: left;
+			white-space: pre-wrap;
+			overflow-wrap: break-word;
+			height: auto;
+			padding: $grid-unit-10 $grid-unit-15;
 
 			mark {
-				color: var(--wp-admin-theme-color);
+				font-weight: 700;
+				background: none;
 			}
-		}
 
-		&:focus {
-			background-color: $gray-100;
-		}
+			&:hover {
+				background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 
-		&:focus:not(:disabled) {
-			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color) inset;
-		}
+				* {
+					color: var(--wp-admin-theme-color);
+				}
 
-		&__title,
-		&__info {
-			overflow: hidden;
-			text-overflow: ellipsis;
-			display: block;
-		}
+				mark {
+					color: var(--wp-admin-theme-color);
+				}
+			}
 
-		&__title {
-			font-weight: 500;
-			margin-bottom: 0.2em;
-		}
+			&:focus {
+				background-color: $gray-100;
+			}
 
-		&__info {
-			color: $gray-700;
-			font-size: 0.9em;
-			line-height: 1.3;
-			word-break: break-all;
+			&:focus:not(:disabled) {
+				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color) inset;
+			}
+
+			&__title,
+			&__info {
+				overflow: hidden;
+				text-overflow: ellipsis;
+				display: block;
+			}
+
+			&__info {
+				word-break: break-all;
+				color: $gray-700;
+			}
 		}
 	}
 }

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -18,22 +18,14 @@
 }
 
 .edit-site-custom-template-modal {
-	&__suggestions_list {
-		margin-left: - $grid-unit-15;
-		margin-right: - $grid-unit-15;
-	}
-
 	&__contents {
-		margin-left: - $grid-unit-15;
-		margin-right: - $grid-unit-15;
-
 		> .components-button {
-			padding: $grid-unit-10 $grid-unit-15;
+			padding: $grid-unit-30;
 			border-radius: $radius-block-ui;
 			height: auto;
 			display: flex;
 			flex-direction: column;
-			align-items: flex-start;
+			justify-content: center;
 
 			// Show the boundary of the button, in High Contrast Mode.
 			outline: 1px solid transparent;

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -18,6 +18,11 @@
 }
 
 .edit-site-custom-template-modal {
+	&__suggestions_list {
+		margin-left: - $grid-unit-15;
+		margin-right: - $grid-unit-15;
+	}
+
 	&__contents {
 		> .components-button {
 			padding: $grid-unit-30;

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -18,14 +18,22 @@
 }
 
 .edit-site-custom-template-modal {
+	&__suggestions_list {
+		margin-left: - $grid-unit-15;
+		margin-right: - $grid-unit-15;
+	}
+
 	&__contents {
+		margin-left: - $grid-unit-15;
+		margin-right: - $grid-unit-15;
+
 		> .components-button {
-			padding: $grid-unit-30;
+			padding: $grid-unit-10 $grid-unit-15;
 			border-radius: $radius-block-ui;
 			height: auto;
 			display: flex;
 			flex-direction: column;
-			justify-content: center;
+			align-items: flex-start;
 
 			// Show the boundary of the button, in High Contrast Mode.
 			outline: 1px solid transparent;

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -26,6 +26,7 @@
 			display: flex;
 			flex-direction: column;
 			justify-content: center;
+			border: $border-width solid $gray-300;
 
 			// Show the boundary of the button, in High Contrast Mode.
 			outline: 1px solid transparent;
@@ -41,6 +42,7 @@
 			&:hover {
 				color: var(--wp-admin-theme-color-darker-10);
 				background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+				border-color: transparent;
 
 				span {
 					color: var(--wp-admin-theme-color);
@@ -49,6 +51,7 @@
 
 			&:focus {
 				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+				border-color: transparent;
 
 				// Windows High Contrast mode will show this outline, but not the box-shadow.
 				outline: 3px solid transparent;


### PR DESCRIPTION
## What?
Part of https://github.com/WordPress/gutenberg/issues/50134.

Updates the appearance of the add-template modal contents to be consistent with itself, and other parts of the UI.

In the first step, the buttons are now more closely aligned to similar button styles, IE any `tertiary` button variants, and blocks in the Inserter.

The list items in the second step now resemble the suggestions in the Command Center.

## How?
Mostly css. Plus a couple of instances of the `Text` component. 

Side note: We should update the `Text` component to include the correct line-height on the `body` size.

## Testing Instructions
1. Add a template that requires further scope selection, e.g. Single Post
2. Observe the new styling / hover treatment
3. Select "Single item"
4. Observe the new styling / hover treatment

### Before

https://user-images.githubusercontent.com/846565/234905649-5e8aff2c-134e-4b9c-bdea-8aaad1a7f769.mp4

### After
https://user-images.githubusercontent.com/846565/234905627-66f6cf6d-3bd8-40c5-8560-ef1791f35d99.mp4
