### PR TITLE
Save Hub: Reuse the save button component to save code

### DIFF
--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -12,7 +12,12 @@ import { displayShortcut } from '@wordpress/keycodes';
  */
 import { store as editSiteStore } from '../../store';
 
-export default function SaveButton() {
+export default function SaveButton( {
+	className = 'edit-site-save-button__button',
+	variant = 'primary',
+	showTooltip = true,
+	icon,
+} ) {
 	const { isDirty, isSaving, isSaveViewOpen } = useSelect( ( select ) => {
 		const { __experimentalGetDirtyEntityRecords, isSavingEntityRecord } =
 			select( coreStore );
@@ -34,8 +39,8 @@ export default function SaveButton() {
 
 	return (
 		<Button
-			variant="primary"
-			className="edit-site-save-button__button"
+			variant={ variant }
+			className={ className }
 			aria-disabled={ disabled }
 			aria-expanded={ isSaveViewOpen }
 			isBusy={ isSaving }
@@ -52,7 +57,8 @@ export default function SaveButton() {
 			 * of the button that we want to avoid. By setting `showTooltip`,
 			 & the tooltip is always rendered even when there's no keyboard shortcut.
 			 */
-			showTooltip
+			showTooltip={ showTooltip }
+			icon={ icon }
 		>
 			{ label }
 		</Button>

--- a/packages/edit-site/src/components/save-hub/index.js
+++ b/packages/edit-site/src/components/save-hub/index.js
@@ -1,41 +1,37 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
-import { Button, __experimentalHStack as HStack } from '@wordpress/components';
-import { sprintf, __, _n } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { __experimentalHStack as HStack } from '@wordpress/components';
+import { sprintf, _n } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
-import { displayShortcut } from '@wordpress/keycodes';
 import { check } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
-import { store as editSiteStore } from '../../store';
+import SaveButton from '../save-button';
 
-export default function SaveButton() {
-	const { countUnsavedChanges, isDirty, isSaving, isSaveViewOpen } =
-		useSelect( ( select ) => {
+export default function SaveHub() {
+	const { countUnsavedChanges, isDirty, isSaving } = useSelect(
+		( select ) => {
 			const {
 				__experimentalGetDirtyEntityRecords,
 				isSavingEntityRecord,
 			} = select( coreStore );
 			const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
-			const { isSaveViewOpened } = select( editSiteStore );
 			return {
 				isDirty: dirtyEntityRecords.length > 0,
 				isSaving: dirtyEntityRecords.some( ( record ) =>
 					isSavingEntityRecord( record.kind, record.name, record.key )
 				),
-				isSaveViewOpen: isSaveViewOpened(),
 				countUnsavedChanges: dirtyEntityRecords.length,
 			};
-		}, [] );
-	const { setIsSaveViewOpened } = useDispatch( editSiteStore );
+		},
+		[]
+	);
 
 	const disabled = ! isDirty || isSaving;
-
-	const label = disabled ? __( 'Saved' ) : __( 'Save' );
 
 	return (
 		<HStack className="edit-site-save-hub" alignment="right" spacing={ 4 }>
@@ -52,27 +48,12 @@ export default function SaveButton() {
 					) }
 				</span>
 			) }
-			<Button
+			<SaveButton
 				className="edit-site-save-hub__button"
-				variant={ disabled ? undefined : 'primary' }
-				aria-disabled={ disabled }
-				aria-expanded={ isSaveViewOpen }
-				isBusy={ isSaving }
-				onClick={
-					disabled ? undefined : () => setIsSaveViewOpened( true )
-				}
-				label={ label }
-				/*
-				 * We want the tooltip to show the keyboard shortcut only when the
-				 * button does something, i.e. when it's not disabled.
-				 */
-				shortcut={
-					disabled ? undefined : displayShortcut.primary( 's' )
-				}
-				icon={ disabled ? check : undefined }
-			>
-				{ label }
-			</Button>
+				variant={ disabled ? null : 'primary' }
+				showTooltip={ false }
+				icon={ disabled ? check : null }
+			/>
 		</HStack>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This refactors the SaveHub component to use the SaveButton component.

## Why?
This means we can share code and reduce duplication. 

## How?
Pass the differences as props.

## Testing Instructions
Check that the save button in the Site Editor in browse mode works the same as before:

<img width="392" alt="Screenshot 2023-04-27 at 17 59 16" src="https://user-images.githubusercontent.com/275961/234919417-01d01cde-4aaa-4878-9629-e6ffdfe07dd7.png">


Co-authored-by: Alex Lende <5129775+ajlende@users.noreply.github.com>