### PR TITLE
Post Title: improve preview on the editor site

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -622,7 +622,7 @@ Show minutes required to finish reading the post. ([Source](https://github.com/W
 -	**Supports:** color (background, gradients, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** textAlign
 
-## Post Title
+## Title
 
 Displays the title of a post, page, or any other content-type. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-title))
 

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "core/post-title",
-	"title": "Post Title",
+	"title": "Title",
 	"category": "theme",
 	"description": "Displays the title of a post, page, or any other content-type.",
 	"textdomain": "default",

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -59,9 +59,7 @@ export default function PostTitleEdit( {
 		} ),
 	} );
 
-	let titleElement = (
-		<TagName { ...blockProps }>{ __( 'Post Title' ) }</TagName>
-	);
+	let titleElement = <TagName { ...blockProps }>{ __( 'Title' ) }</TagName>;
 
 	if ( postType && postId ) {
 		titleElement = userCanEdit ? (

--- a/packages/e2e-tests/specs/editor/blocks/post-title.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/post-title.test.js
@@ -14,7 +14,7 @@ describe( 'Post Title block', () => {
 
 	it( 'Can edit the post title', async () => {
 		// Create a block with some text that will trigger a list creation.
-		await insertBlock( 'Post Title' );
+		await insertBlock( 'Title' );
 		const editablePostTitleSelector =
 			'.wp-block-post-title[contenteditable="true"]';
 		await page.waitForSelector( editablePostTitleSelector );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR improves the preview of the block on the editor.

Fixes #48963

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, in the editor, the preview of the Post Title is hard-coded, and it is `Post Title`.  Making the preview would improve the user experience.

There is a similar issue for the `Post Excerpt` block https://github.com/WordPress/gutenberg/issues/48964. Also, this PR could be part of this macro issue https://github.com/WordPress/gutenberg/issues/49108.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The PR renames the block to `Title` and updates the label to make it more generic.

## Testing Instructions

1. Edit a template (Single Post, for example).
2. Add the `Title` block.
3. Ensure the preview is generic and can work for other postType templates.

## Screenshots or screencast <!-- if applicable -->

![image](https://github.com/WordPress/gutenberg/assets/4463174/b850c2c4-a9e2-482a-830f-6cb85a8dc75b)

