### PR TITLE
Site Editor: Add chevrons to off canvas list view posts & pages

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/block-select-button.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-select-button.js
@@ -12,7 +12,7 @@ import {
 	__experimentalTruncate as Truncate,
 } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
-import { Icon, lockSmall as lock } from '@wordpress/icons';
+import { Icon, lockSmall as lock, chevronRightSmall } from '@wordpress/icons';
 import { SPACE, ENTER } from '@wordpress/keycodes';
 import { sprintf, __ } from '@wordpress/i18n';
 
@@ -119,6 +119,11 @@ function ListViewBlockSelectButton(
 							<Icon icon={ lock } />
 						</span>
 					) }
+					<Icon
+						icon={ chevronRightSmall }
+						className="block-editor-list-view-block-select-button__drilldown-indicator"
+						size={ 24 }
+					/>
 				</HStack>
 			</Button>
 		</>

--- a/packages/block-editor/src/components/off-canvas-editor/block-select-button.js
+++ b/packages/block-editor/src/components/off-canvas-editor/block-select-button.js
@@ -70,6 +70,10 @@ function ListViewBlockSelectButton(
 		  )
 		: __( 'Edit' );
 
+	const hasChevron = [ 'core/navigation-submenu', 'post', 'page' ].includes(
+		blockInformation.name
+	);
+
 	return (
 		<>
 			<Button
@@ -119,11 +123,13 @@ function ListViewBlockSelectButton(
 							<Icon icon={ lock } />
 						</span>
 					) }
-					<Icon
-						icon={ chevronRightSmall }
-						className="block-editor-list-view-block-select-button__drilldown-indicator"
-						size={ 24 }
-					/>
+					{ hasChevron && (
+						<Icon
+							icon={ chevronRightSmall }
+							className="block-editor-list-view-block-select-button__drilldown-indicator"
+							size={ 24 }
+						/>
+					) }
 				</HStack>
 			</Button>
 		</>

--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -57,12 +57,14 @@ export default function useBlockDisplayInformation( clientId ) {
 			const match = getActiveBlockVariation( blockName, attributes );
 			const isSynced =
 				isReusableBlock( blockType ) || isTemplatePart( blockType );
+
 			const blockTypeInfo = {
 				isSynced,
 				title: blockType.title,
 				icon: blockType.icon,
 				description: blockType.description,
 				anchor: attributes?.anchor,
+				name: blockType.name,
 			};
 			if ( ! match ) return blockTypeInfo;
 
@@ -72,6 +74,7 @@ export default function useBlockDisplayInformation( clientId ) {
 				icon: match.icon || blockType.icon,
 				description: match.description || blockType.description,
 				anchor: attributes?.anchor,
+				name: match.name || blockType.name,
 			};
 		},
 		[ clientId ]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Follow up to #50076

## What?
<!-- In a few words, what is the PR actually doing? -->

Update the navigation section of the site editor so that pages and posts in this list will show the chevron icon to indicate there is a deeper sub-level.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To match the changes in #50076

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5e0994a</samp>

*  Add `chevronRightSmall` icon as a drilldown indicator for some block types in the list view ([link](https://github.com/WordPress/gutenberg/pull/50149/files?diff=unified&w=0#diff-8f8df8fc17929580b7d69fafbe0d61079920702f761c01c121efdcc1010a8dbbL15-R15),[link](https://github.com/WordPress/gutenberg/pull/50149/files?diff=unified&w=0#diff-8f8df8fc17929580b7d69fafbe0d61079920702f761c01c121efdcc1010a8dbbR73-R76),[link](https://github.com/WordPress/gutenberg/pull/50149/files?diff=unified&w=0#diff-8f8df8fc17929580b7d69fafbe0d61079920702f761c01c121efdcc1010a8dbbR126-R132))
* Add `name` property to the object returned by the `useBlockDisplayInformation` hook ([link](https://github.com/WordPress/gutenberg/pull/50149/files?diff=unified&w=0#diff-4cd857b8e687cf0b7b6f1f6505570bf3ee3644bbc4db53aeac2e069103336ebdR67),[link](https://github.com/WordPress/gutenberg/pull/50149/files?diff=unified&w=0#diff-4cd857b8e687cf0b7b6f1f6505570bf3ee3644bbc4db53aeac2e069103336ebdR77))

## Testing Instructions
1. Add a navigation menu to your site and add every available block to this navigation menu.
2. In the site editor select "Navigation" from the root
3. Confirm that only post/page links in the navigation menu have chevrons, and when clicked they open a sub menu.
4. Check that no other items have a submenu to confirm there are no missing chevrons.

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->

| Before     | After |
| ---      | ---       |
| <img width="378" alt="Screenshot 2023-05-01 at 9 53 40 AM" src="https://user-images.githubusercontent.com/1464705/235493710-37c5ca8d-82eb-4cf2-a199-f1efcbea1579.png"> | <img width="378" alt="Screenshot 2023-05-01 at 9 53 40 AM" src="https://user-images.githubusercontent.com/1464705/235493622-dfd3b406-379e-48e7-9a19-ece9a5350b2e.png">         |



