### PR TITLE
[Fonts API] Relocate which fonts to print into wp_print_fonts()

### DIFF
--- a/lib/compat/wordpress-6.2/script-loader.php
+++ b/lib/compat/wordpress-6.2/script-loader.php
@@ -132,7 +132,7 @@ function gutenberg_resolve_assets_override() {
 	// Generate font @font-face styles.
 	if ( function_exists( 'wp_print_fonts' ) ) {
 		ob_start();
-		wp_print_fonts( false, true );
+		wp_print_fonts( true );
 		$styles .= ob_get_clean();
 	}
 

--- a/lib/compat/wordpress-6.2/script-loader.php
+++ b/lib/compat/wordpress-6.2/script-loader.php
@@ -129,28 +129,11 @@ function gutenberg_resolve_assets_override() {
 
 	$scripts = ob_get_clean();
 
-	/*
-	 * Generate font @font-face styles for the site editor iframe.
-	 * Use the registered font families for printing.
-	 */
-	if ( class_exists( 'WP_Fonts' ) ) {
-		$wp_fonts   = wp_fonts();
-		$registered = $wp_fonts->get_registered_font_families();
-		if ( ! empty( $registered ) ) {
-			$queue = $wp_fonts->queue;
-			$done  = $wp_fonts->done;
-
-			$wp_fonts->done  = array();
-			$wp_fonts->queue = $registered;
-
-			ob_start();
-			$wp_fonts->do_items();
-			$styles .= ob_get_clean();
-
-			// Reset the Web Fonts API.
-			$wp_fonts->done  = $done;
-			$wp_fonts->queue = $queue;
-		}
+	// Generate font @font-face styles.
+	if ( function_exists( 'wp_print_fonts' ) ) {
+		ob_start();
+		wp_print_fonts( false, true );
+		$styles .= ob_get_clean();
 	}
 
 	return array(

--- a/lib/compat/wordpress-6.3/script-loader.php
+++ b/lib/compat/wordpress-6.3/script-loader.php
@@ -56,7 +56,7 @@ function _gutenberg_get_iframed_editor_assets() {
 
 	ob_start();
 	wp_print_styles();
-	wp_print_fonts( false, true );
+	wp_print_fonts( true );
 	$styles = ob_get_clean();
 
 	ob_start();

--- a/lib/compat/wordpress-6.3/script-loader.php
+++ b/lib/compat/wordpress-6.3/script-loader.php
@@ -56,7 +56,7 @@ function _gutenberg_get_iframed_editor_assets() {
 
 	ob_start();
 	wp_print_styles();
-	wp_print_fonts();
+	wp_print_fonts( false, true );
 	$styles = ob_get_clean();
 
 	ob_start();

--- a/lib/experimental/fonts-api/fonts-api.php
+++ b/lib/experimental/fonts-api/fonts-api.php
@@ -176,15 +176,14 @@ if ( ! function_exists( 'wp_print_fonts' ) ) {
 	 *
 	 * @since X.X.X
 	 *
-	 * @param string|string[]|false $handles            Optional. Items to be processed: queue (false),
-	 *                                                  single item (string), or multiple items (array of strings).
-	 *                                                  Default false.
-	 * @param bool                  $for_iframed_editor Optional. Whether the fonts are for iframed editor.
-	 *                                                  Default false.
+	 * @param string|string[]|bool $handles Optional. Items to be processed: queue (false),
+	 *                                      for iframed editor assets (true), single item (string),
+	 *                                      or multiple items (array of strings).
+	 *                                      Default false.
 	 * @return array|string[] Array of font handles that have been processed.
 	 *                        An empty array if none were processed.
 	 */
-	function wp_print_fonts( $handles = false, $for_iframed_editor = false ) {
+	function wp_print_fonts( $handles = false ) {
 		$wp_fonts   = wp_fonts();
 		$registered = $wp_fonts->get_registered_font_families();
 
@@ -200,7 +199,7 @@ if ( ! function_exists( 'wp_print_fonts' ) ) {
 		_wp_scripts_maybe_doing_it_wrong( __FUNCTION__ );
 
 		// Print all registered fonts for the iframed editor.
-		if ( $for_iframed_editor ) {
+		if ( true === $handles ) {
 			$handles = $registered;
 		}
 

--- a/lib/experimental/fonts-api/fonts-api.php
+++ b/lib/experimental/fonts-api/fonts-api.php
@@ -176,13 +176,15 @@ if ( ! function_exists( 'wp_print_fonts' ) ) {
 	 *
 	 * @since X.X.X
 	 *
-	 * @param string|string[]|false $handles Optional. Items to be processed: queue (false),
-	 *                                       single item (string), or multiple items (array of strings).
-	 *                                       Default false.
+	 * @param string|string[]|false $handles            Optional. Items to be processed: queue (false),
+	 *                                                  single item (string), or multiple items (array of strings).
+	 *                                                  Default false.
+	 * @param bool                  $for_iframed_editor Optional. Whether the fonts are for iframed editor.
+	 *                                                  Default false.
 	 * @return array|string[] Array of font handles that have been processed.
 	 *                        An empty array if none were processed.
 	 */
-	function wp_print_fonts( $handles = false ) {
+	function wp_print_fonts( $handles = false, $for_iframed_editor = false ) {
 		$wp_fonts   = wp_fonts();
 		$registered = $wp_fonts->get_registered_font_families();
 
@@ -197,7 +199,24 @@ if ( ! function_exists( 'wp_print_fonts' ) ) {
 
 		_wp_scripts_maybe_doing_it_wrong( __FUNCTION__ );
 
-		return $wp_fonts->do_items( $handles );
+		// Print all registered fonts for the iframed editor.
+		if ( $for_iframed_editor ) {
+			$queue = $wp_fonts->queue;
+			$done  = $wp_fonts->done;
+
+			$wp_fonts->done  = array();
+			$wp_fonts->queue = $registered;
+		}
+
+		$printed_fonts = $wp_fonts->do_items( $handles );
+
+		// Reset after printing.
+		if ( $for_iframed_editor ) {
+			$wp_fonts->done  = $done;
+			$wp_fonts->queue = $queue;
+		}
+
+		return $printed_fonts;
 	}
 }
 

--- a/lib/experimental/fonts-api/fonts-api.php
+++ b/lib/experimental/fonts-api/fonts-api.php
@@ -201,22 +201,10 @@ if ( ! function_exists( 'wp_print_fonts' ) ) {
 
 		// Print all registered fonts for the iframed editor.
 		if ( $for_iframed_editor ) {
-			$queue = $wp_fonts->queue;
-			$done  = $wp_fonts->done;
-
-			$wp_fonts->done  = array();
-			$wp_fonts->queue = $registered;
+			$handles = $registered;
 		}
 
-		$printed_fonts = $wp_fonts->do_items( $handles );
-
-		// Reset after printing.
-		if ( $for_iframed_editor ) {
-			$wp_fonts->done  = $done;
-			$wp_fonts->queue = $queue;
-		}
-
-		return $printed_fonts;
+		return $wp_fonts->do_items( $handles );
 	}
 }
 

--- a/lib/experimental/fonts-api/fonts-api.php
+++ b/lib/experimental/fonts-api/fonts-api.php
@@ -192,16 +192,18 @@ if ( ! function_exists( 'wp_print_fonts' ) ) {
 			return array();
 		}
 
-		if ( empty( $handles ) ) {
-			$handles = false;
+		// Skip this reassignment decision-making when using the default of `false`.
+		if ( false !== $handles ) {
+			// When `true`, print all registered fonts for the iframed editor.
+			if ( true === $handles ) {
+				$handles = $registered;
+			} elseif ( empty( $handles ) ) {
+				// When falsey, assign `false` to print enqueued fonts.
+				$handles = false;
+			}
 		}
 
 		_wp_scripts_maybe_doing_it_wrong( __FUNCTION__ );
-
-		// Print all registered fonts for the iframed editor.
-		if ( true === $handles ) {
-			$handles = $registered;
-		}
 
 		return $wp_fonts->do_items( $handles );
 	}

--- a/phpunit/fonts-api/wpPrintFonts-test.php
+++ b/phpunit/fonts-api/wpPrintFonts-test.php
@@ -123,4 +123,70 @@ class Tests_Fonts_WpPrintFonts extends WP_Fonts_TestCase {
 			$wp_fonts->enqueue( $setup['enqueued'] );
 		}
 	}
+
+	/**
+	 * @dataProvider data_should_print_all_registered_fonts_for_iframed_editor
+	 *
+	 * @param string $fonts    Fonts to register.
+	 * @param array  $expected Expected results.
+	 */
+	public function test_should_print_all_registered_fonts_for_iframed_editor( $fonts, $expected ) {
+		wp_register_fonts( $fonts );
+
+		$this->expectOutputString( $expected['output'] );
+		$actual_done = wp_print_fonts( false, true );
+		$this->assertSameSets( $expected['done'], $actual_done, 'All registered font-family handles should be returned' );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_should_print_all_registered_fonts_for_iframed_editor() {
+		$local_fonts = $this->get_registered_local_fonts();
+		$font_faces  = $this->get_registered_fonts_css();
+
+		return array(
+			'Merriweather with 1 variation'      => array(
+				'fonts'    => array( 'merriweather' => $local_fonts['merriweather'] ),
+				'expected' => array(
+					'done'   => array( 'merriweather', 'merriweather-200-900-normal' ),
+					'output' => sprintf(
+						"<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n",
+						$font_faces['merriweather-200-900-normal']
+					),
+				),
+			),
+			'Source Serif Pro with 2 variations' => array(
+				'fonts'    => array( 'Source Serif Pro' => $local_fonts['Source Serif Pro'] ),
+				'expected' => array(
+					'done'   => array( 'source-serif-pro', 'Source Serif Pro-300-normal', 'Source Serif Pro-900-italic' ),
+					'output' => sprintf(
+						"<style id='wp-fonts-local' type='text/css'>\n%s%s\n</style>\n",
+						$font_faces['Source Serif Pro-300-normal'],
+						$font_faces['Source Serif Pro-900-italic']
+					),
+				),
+			),
+			'all fonts'                          => array(
+				'fonts'    => $local_fonts,
+				'expected' => array(
+					'done'   => array(
+						'merriweather',
+						'merriweather-200-900-normal',
+						'source-serif-pro',
+						'Source Serif Pro-300-normal',
+						'Source Serif Pro-900-italic',
+					),
+					'output' => sprintf(
+						"<style id='wp-fonts-local' type='text/css'>\n%s%s%s\n</style>\n",
+						$font_faces['merriweather-200-900-normal'],
+						$font_faces['Source Serif Pro-300-normal'],
+						$font_faces['Source Serif Pro-900-italic']
+					),
+				),
+			),
+		);
+	}
 }

--- a/phpunit/fonts-api/wpPrintFonts-test.php
+++ b/phpunit/fonts-api/wpPrintFonts-test.php
@@ -134,7 +134,7 @@ class Tests_Fonts_WpPrintFonts extends WP_Fonts_TestCase {
 		wp_register_fonts( $fonts );
 
 		$this->expectOutputString( $expected['output'] );
-		$actual_done = wp_print_fonts( false, true );
+		$actual_done = wp_print_fonts( true );
 		$this->assertSameSets( $expected['done'], $actual_done, 'All registered font-family handles should be returned' );
 	}
 


### PR DESCRIPTION
Fixes #50140 

## What?
Relocates the decision making code about which fonts to print for the iframed editor out of the script-loader and into the `wp_print_fonts()` function.

## Why?
When in the Site Editor, all registered fonts should be printed for user previewing and selection. Else, all enqueued fonts should be printed. This kind of decision making should be in the Fonts API, rather than externally in the script-loader.

## How?
This PR places the decision making logic into `wp_print_fonts()`.

### How to identify the iframed editor assets function is invoking the printing?
This function needs to know if the request to print is coming from the iframed editor for decision making about which fonts to print. This is done by passing `true` to the first parameter of `wp_prints_fonts()`. 

Notes: `true` for `$handles` is not used by `WP_Dependencies` (including in `wp_print_styles()` and `wp_print_scripts()`. Using it avoids performance hits and BC concerns with the other strategies considered (expand the next section more more details).

<details>
<summary>Strategies considered</summary>

#### Approach 1: Adding a parameter to the function's signature

Pros:
- straight-forward approach as the invoking code in the script-loader files sets it to `true`.
- avoids the overhead of firing a hook.
- avoids third-party hooking into this part of the code, i.e. a hook is available later in the call stack.
- more performant than the other approaches.

Cons:
- Deviates from `wp_print_styles()` and `wp_print_scripts()`.
- Adds a method parameter which must be maintained for BC once in WP Core.

#### Approach 2: Pass true to the first parameter as flag to indicate to populate the iframed editor handles.

Pros:
* No additional function parameter is needed, meaning no future BC concerns for adding a parameter.
* Unique flag: `true` is not used in `wp_print_styles()` or `wp_print_scripts()`.
* No performance hit.

Cons:
* Could it cause confusion? 🤔 

#### Approach 3: Add or use a hook.

##### Approach 3.1: Hook into the `'block_editor_settings_all'` to modify the `'__unstableResolvedAssets`' setting.

In WP Core, the call stack is this:

`_wp_get_iframed_editor_assets()`
invokes 
`_wp_get_iframed_editor_assets()`
which will invoke
`wp_print_fonts()`

There is a filter after this code called `'block_editor_settings_all'`.

Gutenberg uses this approach to modify the settings for the upcoming release.

Pros:
* No extra hook or function parameter to maintain for BC.

Cons:
* Once in Core, the code would be separate from `_wp_get_iframed_editor_assets()`, which would make maintaining more complex.
* Contributors would need to stay aware of changes in `_wp_get_iframed_editor_assets()` that could require changes within `wp_print_fonts()` of which setting or subsetting to modify. (Conversely if invoking directly within `_wp_get_iframed_editor_assets()` all knowledge is contained in one place for the iframed editor assets.)
* Performance hit: adding and firing a hooked callback has a performance cost.

##### Approach 3.2: Add a hook in `_wp_get_iframed_editor_assets()`.

Pros:
* Wires internal and external iframed editor asset functionality together (vs using a hook later in the call stack).

Cons:
* Adds another hook that must be maintained forever due to BC.
* Performance hit: firing a hook has a performance cost.

</details>

## TODO
- [X] Relocate from 6.2 compat file.
- [X] Relocate from 6.3 compat file.
- [X] Explore options of how to tell if the request is from the iframed editor or not.
- [x] Add tests to validate.

## Testing Instructions
### Visually Test:

Set up on your test site:
1. Activate the Gutenberg plugin.
2. Activate TT3 theme.

Before applying this PR:
1. Go to the Site Editor > Styles > Typography.
2. Using your browser's dev tools, search the HMTL for `wp-fonts-local` `<style>` element.
3. Copying the internals of that element. You'll use this to compare after applying this PR.

After applying this PR:
1. Go to the Site Editor > Styles > Typography.
2. Using your browser's dev tools, search the HMTL for `wp-fonts-local` `<style>` element.
3. Compare the styles to the before styles from above. They should match.

### Running the automated tests

All tests should pass when running the PHPUnit tests:
```
npm run test:unit:php -- --filter Tests_Fonts_WpPrintFonts
```