### PR TITLE
List View: Use block select button class for retaining colors when expanded or hovered

### DIFF
--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -15,7 +15,7 @@
 	// Use position relative for row animation.
 	position: relative;
 
-	.components-button {
+	.block-editor-list-view-block-select-button {
 		// When a row is expanded, retain the dark color.
 		&[aria-expanded="true"] {
 			color: $gray-900;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

A tiny follow-up PR to #48461 to swap out the `components-button` classname for `block-editor-list-view-block-select-button` classname.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To be less dependent on the internal Button classnames.

Note: there are other usages in this CSS file for the `components-button` classname — I haven't removed them / swapped them out in this PR as those rules predate #48461. I'm happy to look into those separately, but it'll take a little longer as there are edge cases to figure out for those other usages as they are applied to more than one particular component / element (they're overriding `BlockMoverUpButton`, `BlockMoverDownButton` and `BlockSettingsDropdown` buttons so probably want to be tested carefully when refactored).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Swap out `components-button` classname for `block-editor-list-view-block-select-button` classname.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open the list view and add a Group block with some child blocks to it
2. Expand the Group block in the list view.
3. While the Group block is not hovered, the text color should be dark
4. While the exapnded Group block is hovered, the text color should be the admin color

## Screenshots or screencast <!-- if applicable -->

![2023-04-28 09 49 40](https://user-images.githubusercontent.com/14988353/235013865-c36b24b9-4116-411e-bd18-cdce0efbf62a.gif)

