### PR TITLE
URLInput: Update the 'ENTER' key down event handler

### DIFF
--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -309,11 +309,10 @@ class URLInput extends Component {
 
 				// Submitting while loading should trigger onSubmit.
 				case ENTER: {
-					event.preventDefault();
 					if ( this.props.onSubmit ) {
+						event.preventDefault();
 						this.props.onSubmit( null, event );
 					}
-
 					break;
 				}
 			}


### PR DESCRIPTION
## What?
Fixes #49764.

PR updates the logic for the component's custom submission handler. It will now only prevent default behavior if the `onSubmit` prop is provided.

## Why?
The original fix introduced a breaking change, as noted in https://github.com/WordPress/gutenberg/pull/40906#issuecomment-1309375929.

## How?
I moved `event.event.preventDefault();` inside the condition.

## Testing Instructions
1. Open a Post or Page.
2. Insert the Social Links block and add a social link.
3. Type the URL
4. Pressing the Enter key should add the URL.

Confirm that the Firefox bug fix from #40906 works as before.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/235079265-2239e515-087a-4950-b250-57e7b7a2d400.mp4

