### PR TITLE
Post Excerpt: improve preview on the editor site

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -568,7 +568,7 @@ Add the date of this post. ([Source](https://github.com/WordPress/gutenberg/tree
 
 ## Excerpt
 
-Display an excerpt. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-excerpt))
+Display the excerpt. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-excerpt))
 
 -	**Name:** core/post-excerpt
 -	**Category:** theme

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -566,9 +566,9 @@ Add the date of this post. ([Source](https://github.com/WordPress/gutenberg/tree
 -	**Supports:** anchor, color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** displayType, format, isLink, textAlign
 
-## Post Excerpt
+## Excerpt
 
-Display a post's excerpt. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-excerpt))
+Display an excerpt. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-excerpt))
 
 -	**Name:** core/post-excerpt
 -	**Category:** theme

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -4,7 +4,7 @@
 	"name": "core/post-excerpt",
 	"title": "Excerpt",
 	"category": "theme",
-	"description": "Display an excerpt.",
+	"description": "Display the excerpt.",
 	"textdomain": "default",
 	"attributes": {
 		"textAlign": {

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -2,9 +2,9 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "core/post-excerpt",
-	"title": "Post Excerpt",
+	"title": "Excerpt",
 	"category": "theme",
-	"description": "Display a post's excerpt.",
+	"description": "Display an excerpt.",
 	"textdomain": "default",
 	"attributes": {
 		"textAlign": {

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -119,7 +119,7 @@ export default function PostExcerptEditor( {
 			<div { ...blockProps }>
 				<Warning>
 					{ __(
-						'The content is currently protected and does not have an available excerpt.'
+						'The content is currently protected and does not have the available excerpt.'
 					) }
 				</Warning>
 			</div>

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -109,16 +109,7 @@ export default function PostExcerptEditor( {
 					/>
 				</BlockControls>
 				<div { ...blockProps }>
-					<p>
-						{ __(
-							'This is the Post Excerpt block, it will display the excerpt from single posts.'
-						) }
-					</p>
-					<p>
-						{ __(
-							'If there are any Custom Post Types with support for excerpts, the Post Excerpt block can display the excerpts of those entries as well.'
-						) }
-					</p>
+					<p>{ __( 'This block will display the excerpt.' ) }</p>
 				</div>
 			</>
 		);
@@ -128,7 +119,7 @@ export default function PostExcerptEditor( {
 			<div { ...blockProps }>
 				<Warning>
 					{ __(
-						'There is no excerpt because this is a protected post.'
+						'The content is currently protected and does not have an available excerpt.'
 					) }
 				</Warning>
 			</div>
@@ -195,14 +186,14 @@ export default function PostExcerptEditor( {
 	const excerptContent = isEditable ? (
 		<RichText
 			className={ excerptClassName }
-			aria-label={ __( 'Post excerpt text' ) }
+			aria-label={ __( 'Excerpt text' ) }
 			value={
 				isSelected
 					? rawOrRenderedExcerpt
 					: ( ! isTrimmed
 							? rawOrRenderedExcerpt
 							: trimmedExcerpt + ELLIPSIS ) ||
-					  __( 'No post excerpt found' )
+					  __( 'No excerpt found' )
 			}
 			onChange={ setExcerpt }
 			tagName="p"
@@ -210,7 +201,7 @@ export default function PostExcerptEditor( {
 	) : (
 		<p className={ excerptClassName }>
 			{ ! isTrimmed
-				? rawOrRenderedExcerpt || __( 'No post excerpt found' )
+				? rawOrRenderedExcerpt || __( 'No excerpt found' )
 				: trimmedExcerpt + ELLIPSIS }
 		</p>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR improves the preview of the block on the editor.

Fixes #48964

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, in the editor, the preview of the Post Excerpt is hard-coded, and it is:

```
This is the Post Excerpt block, it will display the excerpt from single posts.

If there are any Custom Post Types with support for excerpts, the Post Excerpt block can display the excerpts of those entries as well.
```


Making the block title and labels more generic would improve the user experience:


```
This block will display the excerpt.
```

There is a similar issue for the `Post Title` block https://github.com/WordPress/gutenberg/issues/48963. Also, this PR could be part of this macro issue https://github.com/WordPress/gutenberg/issues/49108.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The PR renames the block to Excerpt and updates the labels to make it more generic.

## Testing Instructions

1. Edit a template (Single Post, for example).
2. Add the Excerpt block.
3. Ensure the preview is generic and can work for other postType templates.

## Screenshots or screencast <!-- if applicable -->


![image](https://github.com/WordPress/gutenberg/assets/4463174/14582b7b-988b-4dd3-bc17-48933551f8c9)

