### PR TITLE
chore: update memize to v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16922,10 +16922,17 @@
 				"fast-average-color": "^9.1.1",
 				"fast-deep-equal": "^3.1.3",
 				"lodash": "^4.17.21",
-				"memize": "^1.1.0",
+				"memize": "^2.0.0",
 				"micromodal": "^0.4.10",
 				"preact": "^10.13.2",
 				"remove-accents": "^0.4.2"
+			},
+			"dependencies": {
+				"memize": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/memize/-/memize-2.0.0.tgz",
+					"integrity": "sha512-+eyhzSMVAmJXZbpC6B0kEVhhwh51R4LJTYXeJ/nSg6BEsnVVSLGbk/n0nMf2Bd3Vs7XFJp9MM9pQ/6WRHACZbg=="
+				}
 			}
 		},
 		"@wordpress/block-serialization-default-parser": {
@@ -16965,12 +16972,19 @@
 				"hpq": "^1.3.0",
 				"is-plain-object": "^5.0.0",
 				"lodash": "^4.17.21",
-				"memize": "^1.1.0",
+				"memize": "^2.0.0",
 				"rememo": "^4.0.2",
 				"remove-accents": "^0.4.2",
 				"showdown": "^1.9.1",
 				"simple-html-tokenizer": "^0.5.7",
 				"uuid": "^8.3.0"
+			},
+			"dependencies": {
+				"memize": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/memize/-/memize-2.0.0.tgz",
+					"integrity": "sha512-+eyhzSMVAmJXZbpC6B0kEVhhwh51R4LJTYXeJ/nSg6BEsnVVSLGbk/n0nMf2Bd3Vs7XFJp9MM9pQ/6WRHACZbg=="
+				}
 			}
 		},
 		"@wordpress/browserslist-config": {
@@ -17033,7 +17047,7 @@
 				"gradient-parser": "^0.1.5",
 				"highlight-words-core": "^1.2.2",
 				"is-plain-object": "^5.0.0",
-				"memize": "^1.1.0",
+				"memize": "^2.0.0",
 				"path-to-regexp": "^6.2.1",
 				"re-resizable": "^6.4.0",
 				"react-colorful": "^5.3.1",
@@ -17053,6 +17067,11 @@
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
 					"integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og=="
+				},
+				"memize": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/memize/-/memize-2.0.0.tgz",
+					"integrity": "sha512-+eyhzSMVAmJXZbpC6B0kEVhhwh51R4LJTYXeJ/nSg6BEsnVVSLGbk/n0nMf2Bd3Vs7XFJp9MM9pQ/6WRHACZbg=="
 				},
 				"path-to-regexp": {
 					"version": "6.2.1",
@@ -17143,9 +17162,16 @@
 				"change-case": "^4.1.2",
 				"equivalent-key-map": "^0.2.2",
 				"fast-deep-equal": "^3.1.3",
-				"memize": "^1.1.0",
+				"memize": "^2.0.0",
 				"rememo": "^4.0.2",
 				"uuid": "^8.3.0"
+			},
+			"dependencies": {
+				"memize": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/memize/-/memize-2.0.0.tgz",
+					"integrity": "sha512-+eyhzSMVAmJXZbpC6B0kEVhhwh51R4LJTYXeJ/nSg6BEsnVVSLGbk/n0nMf2Bd3Vs7XFJp9MM9pQ/6WRHACZbg=="
+				}
 			}
 		},
 		"@wordpress/create-block": {
@@ -17363,7 +17389,7 @@
 				"@wordpress/warning": "file:packages/warning",
 				"@wordpress/widgets": "file:packages/widgets",
 				"classnames": "^2.3.1",
-				"memize": "^1.1.0",
+				"memize": "^2.0.0",
 				"rememo": "^4.0.2"
 			},
 			"dependencies": {
@@ -17394,6 +17420,11 @@
 							}
 						}
 					}
+				},
+				"memize": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/memize/-/memize-2.0.0.tgz",
+					"integrity": "sha512-+eyhzSMVAmJXZbpC6B0kEVhhwh51R4LJTYXeJ/nSg6BEsnVVSLGbk/n0nMf2Bd3Vs7XFJp9MM9pQ/6WRHACZbg=="
 				}
 			}
 		},
@@ -17440,7 +17471,7 @@
 				"downloadjs": "^1.4.7",
 				"fast-deep-equal": "^3.1.3",
 				"lodash": "^4.17.21",
-				"memize": "^1.1.0",
+				"memize": "^2.0.0",
 				"react-autosize-textarea": "^7.1.0",
 				"rememo": "^4.0.2"
 			},
@@ -17449,6 +17480,11 @@
 					"version": "2.9.2",
 					"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
 					"integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ=="
+				},
+				"memize": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/memize/-/memize-2.0.0.tgz",
+					"integrity": "sha512-+eyhzSMVAmJXZbpC6B0kEVhhwh51R4LJTYXeJ/nSg6BEsnVVSLGbk/n0nMf2Bd3Vs7XFJp9MM9pQ/6WRHACZbg=="
 				}
 			}
 		},
@@ -17519,7 +17555,7 @@
 				"classnames": "^2.3.1",
 				"date-fns": "^2.28.0",
 				"escape-html": "^1.0.3",
-				"memize": "^1.1.0",
+				"memize": "^2.0.0",
 				"react-autosize-textarea": "^7.1.0",
 				"rememo": "^4.0.2",
 				"remove-accents": "^0.4.2"
@@ -17529,6 +17565,11 @@
 					"version": "2.29.3",
 					"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
 					"integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
+				},
+				"memize": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/memize/-/memize-2.0.0.tgz",
+					"integrity": "sha512-+eyhzSMVAmJXZbpC6B0kEVhhwh51R4LJTYXeJ/nSg6BEsnVVSLGbk/n0nMf2Bd3Vs7XFJp9MM9pQ/6WRHACZbg=="
 				}
 			}
 		},
@@ -17741,9 +17782,16 @@
 				"@babel/runtime": "^7.16.0",
 				"@wordpress/hooks": "file:packages/hooks",
 				"gettext-parser": "^1.3.1",
-				"memize": "^1.1.0",
+				"memize": "^2.0.0",
 				"sprintf-js": "^1.1.1",
 				"tannin": "^1.2.0"
+			},
+			"dependencies": {
+				"memize": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/memize/-/memize-2.0.0.tgz",
+					"integrity": "sha512-+eyhzSMVAmJXZbpC6B0kEVhhwh51R4LJTYXeJ/nSg6BEsnVVSLGbk/n0nMf2Bd3Vs7XFJp9MM9pQ/6WRHACZbg=="
+				}
 			}
 		},
 		"@wordpress/icons": {
@@ -17885,7 +17933,14 @@
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/icons": "file:packages/icons",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
-				"memize": "^1.1.0"
+				"memize": "^2.0.0"
+			},
+			"dependencies": {
+				"memize": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/memize/-/memize-2.0.0.tgz",
+					"integrity": "sha512-+eyhzSMVAmJXZbpC6B0kEVhhwh51R4LJTYXeJ/nSg6BEsnVVSLGbk/n0nMf2Bd3Vs7XFJp9MM9pQ/6WRHACZbg=="
+				}
 			}
 		},
 		"@wordpress/postcss-plugins-preset": {
@@ -18204,8 +18259,15 @@
 				"@wordpress/escape-html": "file:packages/escape-html",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/keycodes": "file:packages/keycodes",
-				"memize": "^1.1.0",
+				"memize": "^2.0.0",
 				"rememo": "^4.0.2"
+			},
+			"dependencies": {
+				"memize": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/memize/-/memize-2.0.0.tgz",
+					"integrity": "sha512-+eyhzSMVAmJXZbpC6B0kEVhhwh51R4LJTYXeJ/nSg6BEsnVVSLGbk/n0nMf2Bd3Vs7XFJp9MM9pQ/6WRHACZbg=="
+				}
 			}
 		},
 		"@wordpress/router": {
@@ -18300,7 +18362,14 @@
 			"version": "file:packages/shortcode",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"memize": "^1.1.0"
+				"memize": "^2.0.0"
+			},
+			"dependencies": {
+				"memize": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/memize/-/memize-2.0.0.tgz",
+					"integrity": "sha512-+eyhzSMVAmJXZbpC6B0kEVhhwh51R4LJTYXeJ/nSg6BEsnVVSLGbk/n0nMf2Bd3Vs7XFJp9MM9pQ/6WRHACZbg=="
+				}
 			}
 		},
 		"@wordpress/style-engine": {
@@ -41819,11 +41888,6 @@
 			"requires": {
 				"fs-monkey": "1.0.3"
 			}
-		},
-		"memize": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
-			"integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg=="
 		},
 		"memoize-one": {
 			"version": "5.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16922,7 +16922,7 @@
 				"fast-average-color": "^9.1.1",
 				"fast-deep-equal": "^3.1.3",
 				"lodash": "^4.17.21",
-				"memize": "^2.0.0",
+				"memize": "^2.1.0",
 				"micromodal": "^0.4.10",
 				"preact": "^10.13.2",
 				"remove-accents": "^0.4.2"
@@ -16965,7 +16965,7 @@
 				"hpq": "^1.3.0",
 				"is-plain-object": "^5.0.0",
 				"lodash": "^4.17.21",
-				"memize": "^2.0.0",
+				"memize": "^2.1.0",
 				"rememo": "^4.0.2",
 				"remove-accents": "^0.4.2",
 				"showdown": "^1.9.1",
@@ -17033,7 +17033,7 @@
 				"gradient-parser": "^0.1.5",
 				"highlight-words-core": "^1.2.2",
 				"is-plain-object": "^5.0.0",
-				"memize": "^2.0.0",
+				"memize": "^2.1.0",
 				"path-to-regexp": "^6.2.1",
 				"re-resizable": "^6.4.0",
 				"react-colorful": "^5.3.1",
@@ -17143,7 +17143,7 @@
 				"change-case": "^4.1.2",
 				"equivalent-key-map": "^0.2.2",
 				"fast-deep-equal": "^3.1.3",
-				"memize": "^2.0.0",
+				"memize": "^2.1.0",
 				"rememo": "^4.0.2",
 				"uuid": "^8.3.0"
 			}
@@ -17363,7 +17363,7 @@
 				"@wordpress/warning": "file:packages/warning",
 				"@wordpress/widgets": "file:packages/widgets",
 				"classnames": "^2.3.1",
-				"memize": "^2.0.0",
+				"memize": "^2.1.0",
 				"rememo": "^4.0.2"
 			},
 			"dependencies": {
@@ -17440,7 +17440,7 @@
 				"downloadjs": "^1.4.7",
 				"fast-deep-equal": "^3.1.3",
 				"lodash": "^4.17.21",
-				"memize": "^2.0.0",
+				"memize": "^2.1.0",
 				"react-autosize-textarea": "^7.1.0",
 				"rememo": "^4.0.2"
 			},
@@ -17519,7 +17519,7 @@
 				"classnames": "^2.3.1",
 				"date-fns": "^2.28.0",
 				"escape-html": "^1.0.3",
-				"memize": "^2.0.0",
+				"memize": "^2.1.0",
 				"react-autosize-textarea": "^7.1.0",
 				"rememo": "^4.0.2",
 				"remove-accents": "^0.4.2"
@@ -17741,7 +17741,7 @@
 				"@babel/runtime": "^7.16.0",
 				"@wordpress/hooks": "file:packages/hooks",
 				"gettext-parser": "^1.3.1",
-				"memize": "^2.0.0",
+				"memize": "^2.1.0",
 				"sprintf-js": "^1.1.1",
 				"tannin": "^1.2.0"
 			}
@@ -17885,7 +17885,7 @@
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/icons": "file:packages/icons",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
-				"memize": "^2.0.0"
+				"memize": "^2.0.1"
 			}
 		},
 		"@wordpress/postcss-plugins-preset": {
@@ -18204,7 +18204,7 @@
 				"@wordpress/escape-html": "file:packages/escape-html",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/keycodes": "file:packages/keycodes",
-				"memize": "^2.0.0",
+				"memize": "^2.1.0",
 				"rememo": "^4.0.2"
 			}
 		},
@@ -18300,7 +18300,7 @@
 			"version": "file:packages/shortcode",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"memize": "^2.0.0"
+				"memize": "^2.0.1"
 			}
 		},
 		"@wordpress/style-engine": {
@@ -25536,7 +25536,7 @@
 		"array-ify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-			"integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
 			"dev": true
 		},
 		"array-includes": {
@@ -28899,7 +28899,7 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
 			"dev": true
 		},
 		"code-point-at": {
@@ -30476,7 +30476,7 @@
 		"css.escape": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-			"integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+			"integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
 			"dev": true
 		},
 		"cssesc": {
@@ -30705,7 +30705,7 @@
 		"debuglog": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-			"integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
+			"integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
 			"dev": true
 		},
 		"decache": {
@@ -35547,7 +35547,7 @@
 		"git-remote-origin-url": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
-			"integrity": "sha512-eU+GGrZgccNJcsDH5LkXR3PB9M958hxc7sbA8DFJjrv9j4L2P/eZfKhM+QD6wyzpiv+b1BpK0XrYCxkovtjSLw==",
+			"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
 			"dev": true,
 			"requires": {
 				"gitconfiglocal": "^1.0.0",
@@ -35594,7 +35594,7 @@
 		"gitconfiglocal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
-			"integrity": "sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ==",
+			"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
 			"dev": true,
 			"requires": {
 				"ini": "^1.3.2"
@@ -36868,7 +36868,7 @@
 		"humanize-ms": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+			"integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
 			"dev": true,
 			"requires": {
 				"ms": "^2.0.0"
@@ -37884,7 +37884,7 @@
 		"is-text-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-			"integrity": "sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==",
+			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
 			"dev": true,
 			"requires": {
 				"text-extensions": "^1.0.0"
@@ -39657,7 +39657,7 @@
 		"jsonparse": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-			"integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
 			"dev": true
 		},
 		"jsprim": {
@@ -40757,7 +40757,7 @@
 		"lodash.ismatch": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
-			"integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
+			"integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
 			"dev": true
 		},
 		"lodash.isplainobject": {
@@ -41037,7 +41037,7 @@
 		"lz-string": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-			"integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+			"integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
 			"dev": true
 		},
 		"macos-release": {
@@ -41821,9 +41821,9 @@
 			}
 		},
 		"memize": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-2.0.0.tgz",
-			"integrity": "sha512-+eyhzSMVAmJXZbpC6B0kEVhhwh51R4LJTYXeJ/nSg6BEsnVVSLGbk/n0nMf2Bd3Vs7XFJp9MM9pQ/6WRHACZbg=="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
+			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
 		},
 		"memoize-one": {
 			"version": "5.2.1",
@@ -48260,7 +48260,7 @@
 		"promzard": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-			"integrity": "sha512-JZeYqd7UAcHCwI+sTOeUDYkvEU+1bQ7iE0UT1MgB/tERkAPkesW46MrpIySzODi+owTjZtiF8Ay5j9m60KmMBw==",
+			"integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
 			"dev": true,
 			"requires": {
 				"read": "1"
@@ -48294,7 +48294,7 @@
 		"proto-list": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-			"integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
 			"dev": true
 		},
 		"protocols": {
@@ -49851,7 +49851,7 @@
 		"read": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-			"integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
+			"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
 			"dev": true,
 			"requires": {
 				"mute-stream": "~0.0.4"
@@ -55208,7 +55208,7 @@
 		"temp-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-			"integrity": "sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==",
+			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
 			"dev": true
 		},
 		"terminal-link": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16926,13 +16926,6 @@
 				"micromodal": "^0.4.10",
 				"preact": "^10.13.2",
 				"remove-accents": "^0.4.2"
-			},
-			"dependencies": {
-				"memize": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/memize/-/memize-2.0.0.tgz",
-					"integrity": "sha512-+eyhzSMVAmJXZbpC6B0kEVhhwh51R4LJTYXeJ/nSg6BEsnVVSLGbk/n0nMf2Bd3Vs7XFJp9MM9pQ/6WRHACZbg=="
-				}
 			}
 		},
 		"@wordpress/block-serialization-default-parser": {
@@ -16978,13 +16971,6 @@
 				"showdown": "^1.9.1",
 				"simple-html-tokenizer": "^0.5.7",
 				"uuid": "^8.3.0"
-			},
-			"dependencies": {
-				"memize": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/memize/-/memize-2.0.0.tgz",
-					"integrity": "sha512-+eyhzSMVAmJXZbpC6B0kEVhhwh51R4LJTYXeJ/nSg6BEsnVVSLGbk/n0nMf2Bd3Vs7XFJp9MM9pQ/6WRHACZbg=="
-				}
 			}
 		},
 		"@wordpress/browserslist-config": {
@@ -17067,11 +17053,6 @@
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
 					"integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og=="
-				},
-				"memize": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/memize/-/memize-2.0.0.tgz",
-					"integrity": "sha512-+eyhzSMVAmJXZbpC6B0kEVhhwh51R4LJTYXeJ/nSg6BEsnVVSLGbk/n0nMf2Bd3Vs7XFJp9MM9pQ/6WRHACZbg=="
 				},
 				"path-to-regexp": {
 					"version": "6.2.1",
@@ -17165,13 +17146,6 @@
 				"memize": "^2.0.0",
 				"rememo": "^4.0.2",
 				"uuid": "^8.3.0"
-			},
-			"dependencies": {
-				"memize": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/memize/-/memize-2.0.0.tgz",
-					"integrity": "sha512-+eyhzSMVAmJXZbpC6B0kEVhhwh51R4LJTYXeJ/nSg6BEsnVVSLGbk/n0nMf2Bd3Vs7XFJp9MM9pQ/6WRHACZbg=="
-				}
 			}
 		},
 		"@wordpress/create-block": {
@@ -17420,11 +17394,6 @@
 							}
 						}
 					}
-				},
-				"memize": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/memize/-/memize-2.0.0.tgz",
-					"integrity": "sha512-+eyhzSMVAmJXZbpC6B0kEVhhwh51R4LJTYXeJ/nSg6BEsnVVSLGbk/n0nMf2Bd3Vs7XFJp9MM9pQ/6WRHACZbg=="
 				}
 			}
 		},
@@ -17480,11 +17449,6 @@
 					"version": "2.9.2",
 					"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
 					"integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ=="
-				},
-				"memize": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/memize/-/memize-2.0.0.tgz",
-					"integrity": "sha512-+eyhzSMVAmJXZbpC6B0kEVhhwh51R4LJTYXeJ/nSg6BEsnVVSLGbk/n0nMf2Bd3Vs7XFJp9MM9pQ/6WRHACZbg=="
 				}
 			}
 		},
@@ -17565,11 +17529,6 @@
 					"version": "2.29.3",
 					"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
 					"integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
-				},
-				"memize": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/memize/-/memize-2.0.0.tgz",
-					"integrity": "sha512-+eyhzSMVAmJXZbpC6B0kEVhhwh51R4LJTYXeJ/nSg6BEsnVVSLGbk/n0nMf2Bd3Vs7XFJp9MM9pQ/6WRHACZbg=="
 				}
 			}
 		},
@@ -17785,13 +17744,6 @@
 				"memize": "^2.0.0",
 				"sprintf-js": "^1.1.1",
 				"tannin": "^1.2.0"
-			},
-			"dependencies": {
-				"memize": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/memize/-/memize-2.0.0.tgz",
-					"integrity": "sha512-+eyhzSMVAmJXZbpC6B0kEVhhwh51R4LJTYXeJ/nSg6BEsnVVSLGbk/n0nMf2Bd3Vs7XFJp9MM9pQ/6WRHACZbg=="
-				}
 			}
 		},
 		"@wordpress/icons": {
@@ -17934,13 +17886,6 @@
 				"@wordpress/icons": "file:packages/icons",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"memize": "^2.0.0"
-			},
-			"dependencies": {
-				"memize": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/memize/-/memize-2.0.0.tgz",
-					"integrity": "sha512-+eyhzSMVAmJXZbpC6B0kEVhhwh51R4LJTYXeJ/nSg6BEsnVVSLGbk/n0nMf2Bd3Vs7XFJp9MM9pQ/6WRHACZbg=="
-				}
 			}
 		},
 		"@wordpress/postcss-plugins-preset": {
@@ -18261,13 +18206,6 @@
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"memize": "^2.0.0",
 				"rememo": "^4.0.2"
-			},
-			"dependencies": {
-				"memize": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/memize/-/memize-2.0.0.tgz",
-					"integrity": "sha512-+eyhzSMVAmJXZbpC6B0kEVhhwh51R4LJTYXeJ/nSg6BEsnVVSLGbk/n0nMf2Bd3Vs7XFJp9MM9pQ/6WRHACZbg=="
-				}
 			}
 		},
 		"@wordpress/router": {
@@ -18363,13 +18301,6 @@
 			"requires": {
 				"@babel/runtime": "^7.16.0",
 				"memize": "^2.0.0"
-			},
-			"dependencies": {
-				"memize": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/memize/-/memize-2.0.0.tgz",
-					"integrity": "sha512-+eyhzSMVAmJXZbpC6B0kEVhhwh51R4LJTYXeJ/nSg6BEsnVVSLGbk/n0nMf2Bd3Vs7XFJp9MM9pQ/6WRHACZbg=="
-				}
 			}
 		},
 		"@wordpress/style-engine": {
@@ -41888,6 +41819,11 @@
 			"requires": {
 				"fs-monkey": "1.0.3"
 			}
+		},
+		"memize": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.0.0.tgz",
+			"integrity": "sha512-+eyhzSMVAmJXZbpC6B0kEVhhwh51R4LJTYXeJ/nSg6BEsnVVSLGbk/n0nMf2Bd3Vs7XFJp9MM9pQ/6WRHACZbg=="
 		},
 		"memoize-one": {
 			"version": "5.2.1",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -70,7 +70,7 @@
 		"fast-average-color": "^9.1.1",
 		"fast-deep-equal": "^3.1.3",
 		"lodash": "^4.17.21",
-		"memize": "^1.1.0",
+		"memize": "^2.0.0",
 		"micromodal": "^0.4.10",
 		"preact": "^10.13.2",
 		"remove-accents": "^0.4.2"

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -70,7 +70,7 @@
 		"fast-average-color": "^9.1.1",
 		"fast-deep-equal": "^3.1.3",
 		"lodash": "^4.17.21",
-		"memize": "^2.0.0",
+		"memize": "^2.1.0",
 		"micromodal": "^0.4.10",
 		"preact": "^10.13.2",
 		"remove-accents": "^0.4.2"

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -49,7 +49,7 @@
 		"hpq": "^1.3.0",
 		"is-plain-object": "^5.0.0",
 		"lodash": "^4.17.21",
-		"memize": "^2.0.0",
+		"memize": "^2.1.0",
 		"rememo": "^4.0.2",
 		"remove-accents": "^0.4.2",
 		"showdown": "^1.9.1",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -49,7 +49,7 @@
 		"hpq": "^1.3.0",
 		"is-plain-object": "^5.0.0",
 		"lodash": "^4.17.21",
-		"memize": "^1.1.0",
+		"memize": "^2.0.0",
 		"rememo": "^4.0.2",
 		"remove-accents": "^0.4.2",
 		"showdown": "^1.9.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -68,7 +68,7 @@
 		"gradient-parser": "^0.1.5",
 		"highlight-words-core": "^1.2.2",
 		"is-plain-object": "^5.0.0",
-		"memize": "^2.0.0",
+		"memize": "^2.1.0",
 		"path-to-regexp": "^6.2.1",
 		"re-resizable": "^6.4.0",
 		"react-colorful": "^5.3.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -68,7 +68,7 @@
 		"gradient-parser": "^0.1.5",
 		"highlight-words-core": "^1.2.2",
 		"is-plain-object": "^5.0.0",
-		"memize": "^1.1.0",
+		"memize": "^2.0.0",
 		"path-to-regexp": "^6.2.1",
 		"re-resizable": "^6.4.0",
 		"react-colorful": "^5.3.1",

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -44,7 +44,7 @@
 		"change-case": "^4.1.2",
 		"equivalent-key-map": "^0.2.2",
 		"fast-deep-equal": "^3.1.3",
-		"memize": "^1.1.0",
+		"memize": "^2.0.0",
 		"rememo": "^4.0.2",
 		"uuid": "^8.3.0"
 	},

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -44,7 +44,7 @@
 		"change-case": "^4.1.2",
 		"equivalent-key-map": "^0.2.2",
 		"fast-deep-equal": "^3.1.3",
-		"memize": "^2.0.0",
+		"memize": "^2.1.0",
 		"rememo": "^4.0.2",
 		"uuid": "^8.3.0"
 	},

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -58,7 +58,7 @@
 		"@wordpress/warning": "file:../warning",
 		"@wordpress/widgets": "file:../widgets",
 		"classnames": "^2.3.1",
-		"memize": "^2.0.0",
+		"memize": "^2.1.0",
 		"rememo": "^4.0.2"
 	},
 	"peerDependencies": {

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -58,7 +58,7 @@
 		"@wordpress/warning": "file:../warning",
 		"@wordpress/widgets": "file:../widgets",
 		"classnames": "^2.3.1",
-		"memize": "^1.1.0",
+		"memize": "^2.0.0",
 		"rememo": "^4.0.2"
 	},
 	"peerDependencies": {

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -66,7 +66,7 @@
 		"downloadjs": "^1.4.7",
 		"fast-deep-equal": "^3.1.3",
 		"lodash": "^4.17.21",
-		"memize": "^1.1.0",
+		"memize": "^2.0.0",
 		"react-autosize-textarea": "^7.1.0",
 		"rememo": "^4.0.2"
 	},

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -66,7 +66,7 @@
 		"downloadjs": "^1.4.7",
 		"fast-deep-equal": "^3.1.3",
 		"lodash": "^4.17.21",
-		"memize": "^2.0.0",
+		"memize": "^2.1.0",
 		"react-autosize-textarea": "^7.1.0",
 		"rememo": "^4.0.2"
 	},

--- a/packages/edit-site/src/store/test/utils.js
+++ b/packages/edit-site/src/store/test/utils.js
@@ -145,9 +145,14 @@ describe( 'utils', () => {
 			).toEqual( FLATTENED_BLOCKS );
 
 			// The function has been called twice with the same params, so the cache size should be 1.
-			const [ , , originalSize ] =
-				getFilteredTemplatePartBlocks.getCache();
-			expect( originalSize ).toBe( 1 );
+			/**
+			 * TODO what should be done about this?
+			 * Can it be tested another way?
+			 * Is it necessary?
+			 */
+			// const [ , , originalSize ] =
+			// 	getFilteredTemplatePartBlocks.getCache();
+			// expect( originalSize ).toBe( 1 );
 
 			// Call the function again, with different params.
 			expect(
@@ -174,8 +179,13 @@ describe( 'utils', () => {
 			] );
 
 			// The function has been called with different params, so the cache size should now be 2.
-			const [ , , finalSize ] = getFilteredTemplatePartBlocks.getCache();
-			expect( finalSize ).toBe( 2 );
+			/**
+			 * TODO what should be done about this?
+			 * Can it be tested another way?
+			 * Is it necessary?
+			 */
+			// const [ , , finalSize ] = getFilteredTemplatePartBlocks.getCache();
+			// expect( finalSize ).toBe( 2 );
 		} );
 	} );
 } );

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -62,7 +62,7 @@
 		"classnames": "^2.3.1",
 		"date-fns": "^2.28.0",
 		"escape-html": "^1.0.3",
-		"memize": "^2.0.0",
+		"memize": "^2.1.0",
 		"react-autosize-textarea": "^7.1.0",
 		"rememo": "^4.0.2",
 		"remove-accents": "^0.4.2"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -62,7 +62,7 @@
 		"classnames": "^2.3.1",
 		"date-fns": "^2.28.0",
 		"escape-html": "^1.0.3",
-		"memize": "^1.1.0",
+		"memize": "^2.0.0",
 		"react-autosize-textarea": "^7.1.0",
 		"rememo": "^4.0.2",
 		"remove-accents": "^0.4.2"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -32,7 +32,7 @@
 		"@babel/runtime": "^7.16.0",
 		"@wordpress/hooks": "file:../hooks",
 		"gettext-parser": "^1.3.1",
-		"memize": "^2.0.0",
+		"memize": "^2.1.0",
 		"sprintf-js": "^1.1.1",
 		"tannin": "^1.2.0"
 	},

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -32,7 +32,7 @@
 		"@babel/runtime": "^7.16.0",
 		"@wordpress/hooks": "file:../hooks",
 		"gettext-parser": "^1.3.1",
-		"memize": "^1.1.0",
+		"memize": "^2.0.0",
 		"sprintf-js": "^1.1.1",
 		"tannin": "^1.2.0"
 	},

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -33,7 +33,7 @@
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
-		"memize": "^1.1.0"
+		"memize": "^2.0.0"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0"

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -33,7 +33,7 @@
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
-		"memize": "^2.0.0"
+		"memize": "^2.0.1"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0"

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -39,7 +39,7 @@
 		"@wordpress/escape-html": "file:../escape-html",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/keycodes": "file:../keycodes",
-		"memize": "^1.1.0",
+		"memize": "^2.0.0",
 		"rememo": "^4.0.2"
 	},
 	"peerDependencies": {

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -39,7 +39,7 @@
 		"@wordpress/escape-html": "file:../escape-html",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/keycodes": "file:../keycodes",
-		"memize": "^2.0.0",
+		"memize": "^2.1.0",
 		"rememo": "^4.0.2"
 	},
 	"peerDependencies": {

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -26,7 +26,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
-		"memize": "^1.1.0"
+		"memize": "^2.0.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -26,7 +26,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
-		"memize": "^2.0.0"
+		"memize": "^2.0.1"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Update `memize` to the latest version.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Typing `@wordpress/blocks` and `@wordpress/block-editor` depend on a change to how `memize` exports it's types. There are also improvements to the generic function argument of `memize` that will facilitate more complete typing.

- #48604
- #49969

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

There are two failing tests in [`packages/edit-site/src/store/test/utils.js`](https://github.com/WordPress/gutenberg/blob/488295de/packages/edit-site/src/store/test/utils.js) which rely on an internal testing API of `memize`, `getCache()`. It is no longer included in the published version. Either the tests need to be removed or tested another way (temporally they are commented out).

## Notes

An update to how v2 of `memize` defines its exports being worked on in https://github.com/aduth/memize/pull/11, it will need to be published before the unit tests will pass.
