### PR TITLE
Revert "Update the Gutenberg plugin to require at least the WP 6.1 version (#50079)"

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -3,7 +3,7 @@
  * Plugin Name: Gutenberg
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Description: Printing since 1440. This is the development plugin for the block editor, site editor, and other future WordPress core functionality.
- * Requires at least: 6.1
+ * Requires at least: 6.0
  * Requires PHP: 5.6
  * Version: 15.7.0-rc.1
  * Author: Gutenberg Team

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -83,8 +83,9 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		$wide_max_width_value = $wide_size ? $wide_size : $content_size;
 
 		// Make sure there is a single CSS rule, and all tags are stripped for security.
-		$all_max_width_value  = safecss_filter_attr( explode( ';', $all_max_width_value )[0] );
-		$wide_max_width_value = safecss_filter_attr( explode( ';', $wide_max_width_value )[0] );
+		// TODO: Use `safecss_filter_attr` instead when the minimum required WP version is >= 6.1.
+		$all_max_width_value  = wp_strip_all_tags( explode( ';', $all_max_width_value )[0] );
+		$wide_max_width_value = wp_strip_all_tags( explode( ';', $wide_max_width_value )[0] );
 
 		$margin_left  = 'left' === $justify_content ? '0 !important' : 'auto !important';
 		$margin_right = 'right' === $justify_content ? '0 !important' : 'auto !important';

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -212,6 +212,44 @@ function gutenberg_typography_get_preset_inline_style_value( $style_value, $css_
 }
 
 /**
+ * This method is no longer used and has been deprecated in Core since 6.1.0.
+ *
+ * It can be deleted once Gutenberg's minimum supported WordPress version is >= 6.1
+ *
+ * Generates an inline style for a typography feature e.g. text decoration,
+ * text transform, and font style.
+ *
+ * @since 5.8.0
+ * @deprecated 6.1.0
+ *
+ * @param array  $attributes   Block's attributes.
+ * @param string $feature      Key for the feature within the typography styles.
+ * @param string $css_property Slug for the CSS property the inline style sets.
+ *
+ * @return string              CSS inline style.
+ */
+function gutenberg_typography_get_css_variable_inline_style( $attributes, $feature, $css_property ) {
+	// Retrieve current attribute value or skip if not found.
+	$style_value = _wp_array_get( $attributes, array( 'style', 'typography', $feature ), false );
+	if ( ! $style_value ) {
+		return;
+	}
+
+	// If we don't have a preset CSS variable, we'll assume it's a regular CSS value.
+	if ( ! str_contains( $style_value, "var:preset|{$css_property}|" ) ) {
+		return sprintf( '%s:%s;', $css_property, $style_value );
+	}
+
+	// We have a preset CSS variable as the style.
+	// Get the style value from the string and return CSS style.
+	$index_to_splice = strrpos( $style_value, '|' ) + 1;
+	$slug            = substr( $style_value, $index_to_splice );
+
+	// Return the actual CSS inline style e.g. `text-decoration:var(--wp--preset--text-decoration--underline);`.
+	return sprintf( '%s:var(--wp--preset--%s--%s);', $css_property, $css_property, $slug );
+}
+
+/**
  * Renders typography styles/content to the block wrapper.
  *
  * @param  string $block_content Rendered block content.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -221,9 +221,6 @@ function gutenberg_register_packages_scripts( $scripts ) {
 			case 'wp-edit-site':
 				array_push( $dependencies, 'wp-dom-ready' );
 				break;
-			case 'wp-preferences':
-				array_push( $dependencies, 'wp-preferences-persistence' );
-				break;
 		}
 
 		// Get the path from Gutenberg directory as expected by `gutenberg_url`.

--- a/lib/compat/wordpress-6.1/block-editor-settings.php
+++ b/lib/compat/wordpress-6.1/block-editor-settings.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Adds settings to the block editor.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Adds styles and __experimentalFeatures to the block editor settings.
+ *
+ * @param array $settings Existing block editor settings.
+ *
+ * @return array New block editor settings.
+ */
+function gutenberg_get_block_editor_settings( $settings ) {
+	// Set what is the context for this data request.
+	$context = 'other';
+	if (
+		defined( 'REST_REQUEST' ) &&
+		REST_REQUEST &&
+		isset( $_GET['context'] ) &&
+		'mobile' === $_GET['context']
+	) {
+		$context = 'mobile';
+	}
+
+	if ( 'other' === $context ) {
+		global $wp_version;
+		$is_wp_5_9 = version_compare( $wp_version, '5.9', '>=' ) && version_compare( $wp_version, '6.0-beta1', '<' );
+		$is_wp_6_0 = version_compare( $wp_version, '6.0-beta1', '>=' );
+
+		// Make sure the styles array exists.
+		// In some contexts, like the navigation editor, it doesn't.
+		if ( ! isset( $settings['styles'] ) ) {
+			$settings['styles'] = array();
+		}
+
+		// Remove existing global styles provided by core.
+		$styles_without_existing_global_styles = array();
+		foreach ( $settings['styles'] as $style ) {
+			if (
+				( $is_wp_5_9 && ! gutenberg_is_global_styles_in_5_9( $style ) ) || // Can be removed when plugin minimum version is 6.0.
+				( $is_wp_6_0 && ( ! isset( $style['isGlobalStyles'] ) || ! $style['isGlobalStyles'] ) )
+			) {
+				$styles_without_existing_global_styles[] = $style;
+			}
+		}
+
+		// Recreate global styles.
+		$new_global_styles = array();
+		$presets           = array(
+			array(
+				'css'            => 'variables',
+				'__unstableType' => 'presets',
+				'isGlobalStyles' => true,
+			),
+			array(
+				'css'            => 'presets',
+				'__unstableType' => 'presets',
+				'isGlobalStyles' => true,
+			),
+		);
+		foreach ( $presets as $preset_style ) {
+			$actual_css = gutenberg_get_global_stylesheet( array( $preset_style['css'] ) );
+			if ( '' !== $actual_css ) {
+				$preset_style['css'] = $actual_css;
+				$new_global_styles[] = $preset_style;
+			}
+		}
+
+		if ( wp_theme_has_theme_json() ) {
+			$block_classes = array(
+				'css'            => 'styles',
+				'__unstableType' => 'theme',
+				'isGlobalStyles' => true,
+			);
+			$actual_css    = gutenberg_get_global_stylesheet( array( $block_classes['css'] ) );
+			if ( '' !== $actual_css ) {
+				$block_classes['css'] = $actual_css;
+				$new_global_styles[]  = $block_classes;
+			}
+		} else {
+			// If there is no `theme.json` file, ensure base layout styles are still available.
+			$block_classes = array(
+				'css'            => 'base-layout-styles',
+				'__unstableType' => 'base-layout',
+				'isGlobalStyles' => true,
+			);
+			$actual_css    = gutenberg_get_global_stylesheet( array( $block_classes['css'] ) );
+			if ( '' !== $actual_css ) {
+				$block_classes['css'] = $actual_css;
+				$new_global_styles[]  = $block_classes;
+			}
+		}
+
+		$settings['styles'] = array_merge( $new_global_styles, $styles_without_existing_global_styles );
+	}
+
+	// Copied from get_block_editor_settings() at wordpress-develop/block-editor.php.
+	$settings['__experimentalFeatures'] = gutenberg_get_global_settings();
+
+	if ( isset( $settings['__experimentalFeatures']['color']['palette'] ) ) {
+		$colors_by_origin   = $settings['__experimentalFeatures']['color']['palette'];
+		$settings['colors'] = isset( $colors_by_origin['custom'] ) ?
+			$colors_by_origin['custom'] : (
+				isset( $colors_by_origin['theme'] ) ?
+					$colors_by_origin['theme'] :
+					$colors_by_origin['default']
+			);
+	}
+
+	if ( isset( $settings['__experimentalFeatures']['color']['gradients'] ) ) {
+		$gradients_by_origin   = $settings['__experimentalFeatures']['color']['gradients'];
+		$settings['gradients'] = isset( $gradients_by_origin['custom'] ) ?
+			$gradients_by_origin['custom'] : (
+				isset( $gradients_by_origin['theme'] ) ?
+					$gradients_by_origin['theme'] :
+					$gradients_by_origin['default']
+			);
+	}
+
+	if ( isset( $settings['__experimentalFeatures']['typography']['fontSizes'] ) ) {
+		$font_sizes_by_origin  = $settings['__experimentalFeatures']['typography']['fontSizes'];
+		$settings['fontSizes'] = isset( $font_sizes_by_origin['custom'] ) ?
+			$font_sizes_by_origin['custom'] : (
+				isset( $font_sizes_by_origin['theme'] ) ?
+					$font_sizes_by_origin['theme'] :
+					$font_sizes_by_origin['default']
+			);
+	}
+
+	if ( isset( $settings['__experimentalFeatures']['color']['custom'] ) ) {
+		$settings['disableCustomColors'] = ! $settings['__experimentalFeatures']['color']['custom'];
+		unset( $settings['__experimentalFeatures']['color']['custom'] );
+	}
+	if ( isset( $settings['__experimentalFeatures']['color']['customGradient'] ) ) {
+		$settings['disableCustomGradients'] = ! $settings['__experimentalFeatures']['color']['customGradient'];
+		unset( $settings['__experimentalFeatures']['color']['customGradient'] );
+	}
+	if ( isset( $settings['__experimentalFeatures']['typography']['customFontSize'] ) ) {
+		$settings['disableCustomFontSizes'] = ! $settings['__experimentalFeatures']['typography']['customFontSize'];
+		unset( $settings['__experimentalFeatures']['typography']['customFontSize'] );
+	}
+	if ( isset( $settings['__experimentalFeatures']['typography']['lineHeight'] ) ) {
+		$settings['enableCustomLineHeight'] = $settings['__experimentalFeatures']['typography']['lineHeight'];
+		unset( $settings['__experimentalFeatures']['typography']['lineHeight'] );
+	}
+	if ( isset( $settings['__experimentalFeatures']['spacing']['units'] ) ) {
+		$settings['enableCustomUnits'] = $settings['__experimentalFeatures']['spacing']['units'];
+		unset( $settings['__experimentalFeatures']['spacing']['units'] );
+	}
+	if ( isset( $settings['__experimentalFeatures']['spacing']['padding'] ) ) {
+		$settings['enableCustomSpacing'] = $settings['__experimentalFeatures']['spacing']['padding'];
+		unset( $settings['__experimentalFeatures']['spacing']['padding'] );
+	}
+	if ( isset( $settings['__experimentalFeatures']['spacing']['customSpacingSize'] ) ) {
+		$settings['disableCustomSpacingSizes'] = ! $settings['__experimentalFeatures']['spacing']['customSpacingSize'];
+		unset( $settings['__experimentalFeatures']['spacing']['customSpacingSize'] );
+	}
+
+	if ( isset( $settings['__experimentalFeatures']['spacing']['spacingSizes'] ) ) {
+		$spacing_sizes_by_origin  = $settings['__experimentalFeatures']['spacing']['spacingSizes'];
+		$settings['spacingSizes'] = isset( $spacing_sizes_by_origin['custom'] ) ?
+			$spacing_sizes_by_origin['custom'] : (
+				isset( $spacing_sizes_by_origin['theme'] ) ?
+					$spacing_sizes_by_origin['theme'] :
+					$spacing_sizes_by_origin['default']
+			);
+	}
+
+	$settings['localAutosaveInterval'] = 15;
+	$settings['disableLayoutStyles']   = current_theme_supports( 'disable-layout-styles' );
+
+	return $settings;
+}
+
+add_filter( 'block_editor_settings_all', 'gutenberg_get_block_editor_settings', PHP_INT_MAX );

--- a/lib/compat/wordpress-6.1/block-template-utils.php
+++ b/lib/compat/wordpress-6.1/block-template-utils.php
@@ -1,0 +1,598 @@
+<?php
+/**
+ * Temporary compatibility shims for features present in Gutenberg.
+ * This file should be removed when WordPress 6.1.0 becomes the lowest
+ * supported version by this plugin.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Retrieves a list of unified template objects based on a query.
+ *
+ * @param array $query {
+ *     Optional. Arguments to retrieve templates.
+ *
+ *     @type array  $slug__in  List of slugs to include.
+ *     @type int    $wp_id     Post ID of customized template.
+ *     @type string $area      A 'wp_template_part_area' taxonomy value to filter by (for wp_template_part template type only).
+ *     @type string $post_type Post type to get the templates for.
+ * }
+ * @param array $template_type wp_template or wp_template_part.
+ *
+ * @return array Templates.
+ */
+function gutenberg_get_block_templates( $query = array(), $template_type = 'wp_template' ) {
+	/**
+	 * Filters the block templates array before the query takes place.
+	 *
+	 * Return a non-null value to bypass the WordPress queries.
+	 *
+	 * @since 10.8
+	 *
+	 * @param Gutenberg_Block_Template[]|null $block_templates Return an array of block templates to short-circuit the default query,
+	 *                                                  or null to allow WP to run it's normal queries.
+	 * @param array $query {
+	 *     Optional. Arguments to retrieve templates.
+	 *
+	 *     @type array  $slug__in List of slugs to include.
+	 *     @type int    $wp_id Post ID of customized template.
+	 *     @type string $post_type Post type to get the templates for.
+	 * }
+	 * @param array $template_type wp_template or wp_template_part.
+	 */
+	$templates = apply_filters( 'pre_get_block_templates', null, $query, $template_type );
+	if ( ! is_null( $templates ) ) {
+		return $templates;
+	}
+
+	$post_type     = isset( $query['post_type'] ) ? $query['post_type'] : '';
+	$wp_query_args = array(
+		'post_status'         => array( 'auto-draft', 'draft', 'publish' ),
+		'post_type'           => $template_type,
+		'posts_per_page'      => -1,
+		'no_found_rows'       => true,
+		'lazy_load_term_meta' => false,  // Do not lazy load term meta, as template post types only have one term.
+		'tax_query'           => array(
+			array(
+				'taxonomy' => 'wp_theme',
+				'field'    => 'name',
+				'terms'    => get_stylesheet(),
+			),
+		),
+	);
+
+	if ( 'wp_template_part' === $template_type && isset( $query['area'] ) ) {
+		$wp_query_args['tax_query'][]           = array(
+			'taxonomy' => 'wp_template_part_area',
+			'field'    => 'name',
+			'terms'    => $query['area'],
+		);
+		$wp_query_args['tax_query']['relation'] = 'AND';
+	}
+
+	if ( isset( $query['slug__in'] ) ) {
+		$wp_query_args['post_name__in'] = $query['slug__in'];
+	}
+
+	// This is only needed for the regular templates/template parts CPT listing and editor.
+	if ( isset( $query['wp_id'] ) ) {
+		$wp_query_args['p'] = $query['wp_id'];
+	} else {
+		$wp_query_args['post_status'] = 'publish';
+	}
+
+	$template_query = new WP_Query( $wp_query_args );
+	$query_result   = array();
+	foreach ( $template_query->posts as $post ) {
+		$template = gutenberg_build_block_template_result_from_post( $post );
+		if ( is_wp_error( $template ) ) {
+			continue;
+		}
+
+		if ( $post_type && ! $template->is_custom ) {
+			continue;
+		}
+
+		if ( $post_type &&
+			isset( $template->post_types ) &&
+			! in_array( $post_type, $template->post_types, true )
+		) {
+			continue;
+		}
+
+		$query_result[] = $template;
+	}
+	if ( ! isset( $query['wp_id'] ) ) {
+		$template_files = _get_block_templates_files( $template_type );
+		foreach ( $template_files as $template_file ) {
+			$template = _build_block_template_result_from_file( $template_file, $template_type );
+
+			if ( $post_type && ! $template->is_custom ) {
+				continue;
+			}
+
+			if ( $post_type &&
+				isset( $template->post_types ) &&
+				! in_array( $post_type, $template->post_types, true )
+			) {
+				continue;
+			}
+
+			$is_not_custom   = false === array_search(
+				get_stylesheet() . '//' . $template_file['slug'],
+				array_column( $query_result, 'id' ),
+				true
+			);
+			$fits_slug_query =
+				! isset( $query['slug__in'] ) || in_array( $template_file['slug'], $query['slug__in'], true );
+			$fits_area_query =
+				! isset( $query['area'] ) || $template_file['area'] === $query['area'];
+			$should_include  = $is_not_custom && $fits_slug_query && $fits_area_query;
+			if ( $should_include ) {
+				$query_result[] = $template;
+			}
+		}
+	}
+	/**
+	 * Filters the array of queried block templates array after they've been fetched.
+	 *
+	 * @since 10.8
+	 *
+	 * @param Gutenberg_Block_Template[] $query_result Array of found block templates.
+	 * @param array $query {
+	 *     Optional. Arguments to retrieve templates.
+	 *
+	 *     @type array  $slug__in List of slugs to include.
+	 *     @type int    $wp_id Post ID of customized template.
+	 * }
+	 * @param array $template_type wp_template or wp_template_part.
+	 */
+	return apply_filters( 'get_block_templates', $query_result, $query, $template_type );
+}
+
+/**
+ * Retrieves a single unified template object using its id.
+ *
+ * @param string $id Template unique identifier (example: theme_slug//template_slug).
+ * @param array  $template_type wp_template or wp_template_part.
+ *
+ * @return Gutenberg_Block_Template|null Template.
+ */
+function gutenberg_get_block_template( $id, $template_type = 'wp_template' ) {
+	/**
+	 * Filters the block template object before the query takes place.
+	 *
+	 * Return a non-null value to bypass the WordPress queries.
+	 *
+	 * @since 10.8
+	 *
+	 * @param Gutenberg_Block_Template|null $block_template Return block template object to short-circuit the default query,
+	 *                                               or null to allow WP to run it's normal queries.
+	 * @param string $id Template unique identifier (example: theme_slug//template_slug).
+	 * @param array  $template_type wp_template or wp_template_part.
+	 */
+	$block_template = apply_filters( 'pre_get_block_template', null, $id, $template_type );
+	if ( ! is_null( $block_template ) ) {
+		return $block_template;
+	}
+
+	$parts = explode( '//', $id, 2 );
+	if ( count( $parts ) < 2 ) {
+		return null;
+	}
+	list( $theme, $slug ) = $parts;
+	$wp_query_args        = array(
+		'post_name__in'  => array( $slug ),
+		'post_type'      => $template_type,
+		'post_status'    => array( 'auto-draft', 'draft', 'publish', 'trash' ),
+		'posts_per_page' => 1,
+		'no_found_rows'  => true,
+		'tax_query'      => array(
+			array(
+				'taxonomy' => 'wp_theme',
+				'field'    => 'name',
+				'terms'    => $theme,
+			),
+		),
+	);
+	$template_query       = new WP_Query( $wp_query_args );
+	$posts                = $template_query->posts;
+
+	if ( count( $posts ) > 0 ) {
+		$template = gutenberg_build_block_template_result_from_post( $posts[0] );
+
+		if ( ! is_wp_error( $template ) ) {
+			return $template;
+		}
+	}
+
+	$block_template = get_block_file_template( $id, $template_type );
+
+	/**
+	 * Filters the queried block template object after it's been fetched.
+	 *
+	 * @since 10.8
+	 *
+	 * @param Gutenberg_Block_Template|null $block_template The found block template, or null if there isn't one.
+	 * @param string $id Template unique identifier (example: theme_slug//template_slug).
+	 * @param array  $template_type wp_template or wp_template_part.
+	 */
+	return apply_filters( 'get_block_template', $block_template, $id, $template_type );
+}
+
+/**
+ * Builds the title and description of a post-specific template based on the underlying referenced post.
+ * Mutates the underlying template object.
+ *
+ * @since 6.1.0
+ * @access private
+ * @internal
+ *
+ * @param string            $post_type Post type e.g.: page, post, product.
+ * @param string            $slug      Slug of the post e.g.: a-story-about-shoes.
+ * @param WP_Block_Template $template  Template to mutate adding the description and title computed.
+ * @return boolean Returns true if the referenced post was found and false otherwise.
+ */
+function _gutenberg_build_title_and_description_for_single_post_type_block_template( $post_type, $slug, WP_Block_Template $template ) {
+	$post_type_object = get_post_type_object( $post_type );
+
+	$default_args = array(
+		'post_type'              => $post_type,
+		'post_status'            => 'publish',
+		'posts_per_page'         => 1,
+		'update_post_meta_cache' => false,
+		'update_post_term_cache' => false,
+		'ignore_sticky_posts'    => true,
+		'no_found_rows'          => true,
+	);
+
+	$args = array(
+		'name' => $slug,
+	);
+	$args = wp_parse_args( $args, $default_args );
+
+	$posts_query = new WP_Query( $args );
+
+	if ( empty( $posts_query->posts ) ) {
+		$template->title = sprintf(
+			/* translators: Custom template title in the Site Editor referencing a post that was not found. 1: Post type singular name, 2: Post type slug. */
+			__( 'Not found: %1$s (%2$s)', 'gutenberg' ),
+			$post_type_object->labels->singular_name,
+			$slug
+		);
+
+		return false;
+	}
+
+	$post_title = $posts_query->posts[0]->post_title;
+
+	$template->title = sprintf(
+		/* translators: Custom template title in the Site Editor. 1: Post type singular name, 2: Post title. */
+		__( '%1$s: %2$s', 'gutenberg' ),
+		$post_type_object->labels->singular_name,
+		$post_title
+	);
+
+	$template->description = sprintf(
+		/* translators: Custom template description in the Site Editor. %s: Post title. */
+		__( 'Template for %s', 'gutenberg' ),
+		$post_title
+	);
+
+	$args = array(
+		'title' => $post_title,
+	);
+	$args = wp_parse_args( $args, $default_args );
+
+	$posts_with_same_title_query = new WP_Query( $args );
+
+	if ( count( $posts_with_same_title_query->posts ) > 1 ) {
+		$template->title = sprintf(
+			/* translators: Custom template title in the Site Editor. 1: Template title, 2: Post type slug. */
+			__( '%1$s (%2$s)', 'gutenberg' ),
+			$template->title,
+			$slug
+		);
+	}
+
+	return true;
+}
+
+/**
+ * Builds the title and description of a taxonomy-specific template based on the underlying entity referenced.
+ * Mutates the underlying template object.
+ *
+ * @access private
+ * @internal
+ *
+ * @param string            $taxonomy Identifier of the taxonomy, e.g.: category.
+ * @param string            $slug     Slug of the term, e.g.: shoes.
+ * @param WP_Block_Template $template Template to mutate adding the description and title computed.
+ *
+ * @return boolean True if the term referenced was found and false otherwise.
+ */
+function _gutenberg_build_title_and_description_for_taxonomy_block_template( $taxonomy, $slug, WP_Block_Template $template ) {
+	$taxonomy_object = get_taxonomy( $taxonomy );
+
+	$default_args = array(
+		'taxonomy'               => $taxonomy,
+		'hide_empty'             => false,
+		'update_term_meta_cache' => false,
+	);
+
+	$term_query = new WP_Term_Query();
+
+	$args = array(
+		'number' => 1,
+		'slug'   => $slug,
+	);
+	$args = wp_parse_args( $args, $default_args );
+
+	$terms_query = $term_query->query( $args );
+
+	if ( empty( $terms_query ) ) {
+		$template->title = sprintf(
+			/* translators: Custom template title in the Site Editor, referencing a taxonomy term that was not found. 1: Taxonomy singular name, 2: Term slug. */
+			__( 'Not found: %1$s (%2$s)', 'gutenberg' ),
+			$taxonomy_object->labels->singular_name,
+			$slug
+		);
+		return false;
+	}
+
+	$term_title = $terms_query[0]->name;
+
+	$template->title = sprintf(
+		/* translators: Custom template title in the Site Editor. 1: Taxonomy singular name, 2: Term title. */
+		__( '%1$s: %2$s', 'gutenberg' ),
+		$taxonomy_object->labels->singular_name,
+		$term_title
+	);
+
+	$template->description = sprintf(
+		/* translators: Custom template description in the Site Editor. %s: Term title. */
+		__( 'Template for %s', 'gutenberg' ),
+		$term_title
+	);
+
+	$term_query = new WP_Term_Query();
+
+	$args = array(
+		'number' => 2,
+		'name'   => $term_title,
+	);
+	$args = wp_parse_args( $args, $default_args );
+
+	$terms_with_same_title_query = $term_query->query( $args );
+
+	if ( count( $terms_with_same_title_query ) > 1 ) {
+		$template->title = sprintf(
+			/* translators: Custom template title in the Site Editor. 1: Template title, 2: Term slug. */
+			__( '%1$s (%2$s)', 'gutenberg' ),
+			$template->title,
+			$slug
+		);
+	}
+
+	return true;
+}
+
+/**
+ * Build a unified template object based a post Object.
+ *
+ * @param WP_Post $post Template post.
+ *
+ * @return Gutenberg_Block_Template|WP_Error Template.
+ */
+function gutenberg_build_block_template_result_from_post( $post ) {
+	$default_template_types = get_default_block_template_types();
+	$terms                  = get_the_terms( $post, 'wp_theme' );
+
+	if ( is_wp_error( $terms ) ) {
+		return $terms;
+	}
+
+	if ( ! $terms ) {
+		return new WP_Error( 'template_missing_theme', __( 'No theme is defined for this template.', 'gutenberg' ) );
+	}
+
+	$origin           = get_post_meta( $post->ID, 'origin', true );
+	$is_wp_suggestion = get_post_meta( $post->ID, 'is_wp_suggestion', true );
+
+	$theme          = $terms[0]->name;
+	$template_file  = _get_block_template_file( $post->post_type, $post->post_name );
+	$has_theme_file = get_stylesheet() === $theme && null !== $template_file;
+
+	$template                 = new WP_Block_Template();
+	$template->wp_id          = $post->ID;
+	$template->id             = $theme . '//' . $post->post_name;
+	$template->theme          = $theme;
+	$template->content        = $post->post_content;
+	$template->slug           = $post->post_name;
+	$template->source         = 'custom';
+	$template->origin         = ! empty( $origin ) ? $origin : null;
+	$template->type           = $post->post_type;
+	$template->description    = $post->post_excerpt;
+	$template->title          = $post->post_title;
+	$template->status         = $post->post_status;
+	$template->has_theme_file = $has_theme_file;
+	$template->is_custom      = empty( $is_wp_suggestion );
+	$template->author         = $post->post_author;
+
+	// We keep this check for existent templates that are part of the template hierarchy.
+	if ( 'wp_template' === $post->post_type && isset( $default_template_types[ $template->slug ] ) ) {
+		$template->is_custom = false;
+	}
+
+	if ( 'wp_template' === $post->post_type && $has_theme_file && isset( $template_file['postTypes'] ) ) {
+		$template->post_types = $template_file['postTypes'];
+	}
+
+	if ( 'wp_template_part' === $post->post_type ) {
+		$type_terms = get_the_terms( $post, 'wp_template_part_area' );
+		if ( ! is_wp_error( $type_terms ) && false !== $type_terms ) {
+			$template->area = $type_terms[0]->name;
+		}
+	}
+	// If it is a block template without description and without title or with title equal to the slug.
+	if ( 'wp_template' === $post->post_type && empty( $template->description ) && ( empty( $template->title ) || $template->title === $template->slug ) ) {
+		$matches = array();
+		// If it is a block template for a single author, page, post, tag, category, custom post type or custom taxonomy.
+		if ( preg_match( '/(author|page|single|tag|category|taxonomy)-(.+)/', $template->slug, $matches ) ) {
+			$type           = $matches[1];
+			$slug_remaining = $matches[2];
+			switch ( $type ) {
+				case 'author':
+					$nice_name = $slug_remaining;
+					$users     = get_users(
+						array(
+							'capability'     => 'edit_posts',
+							'search'         => $nice_name,
+							'search_columns' => array( 'user_nicename' ),
+							'fields'         => 'display_name',
+						)
+					);
+
+					if ( empty( $users ) ) {
+						$template->title = sprintf(
+							// translators: Represents the title of a user's custom template in the Site Editor referencing a deleted author, where %s is the author's nicename, e.g. "Deleted author: jane-doe".
+							__( 'Deleted author: %s', 'gutenberg' ),
+							$nice_name
+						);
+					} else {
+						$author_name = $users[0];
+
+						$template->title = sprintf(
+							// translators: Represents the title of a user's custom template in the Site Editor, where %s is the author's name, e.g. "Author: Jane Doe".
+							__( 'Author: %s', 'gutenberg' ),
+							$author_name
+						);
+						$template->description = sprintf(
+							// translators: Represents the description of a user's custom template in the Site Editor, e.g. "Template for Author: Jane Doe".
+							__( 'Template for %1$s', 'gutenberg' ),
+							$author_name
+						);
+
+						$users_with_same_name = get_users(
+							array(
+								'capability'     => 'edit_posts',
+								'search'         => $author_name,
+								'search_columns' => array( 'display_name' ),
+								'fields'         => 'display_name',
+							)
+						);
+						if ( count( $users_with_same_name ) > 1 ) {
+							$template->title = sprintf(
+								// translators: Represents the title of a user's custom template in the Site Editor, where %1$s is the template title of an author template and %2$s is the nicename of the author, e.g. "Author: Jane Doe (jane-doe)".
+								__( '%1$s (%2$s)', 'gutenberg' ),
+								$template->title,
+								$nice_name
+							);
+						}
+					}
+					break;
+				case 'page':
+					_gutenberg_build_title_and_description_for_single_post_type_block_template( 'page', $slug_remaining, $template );
+					break;
+				case 'single':
+					$post_types = get_post_types();
+					foreach ( $post_types as $post_type ) {
+						$post_type_length = strlen( $post_type ) + 1;
+						// If $slug_remaining starts with $post_type followed by a hyphen.
+						if ( 0 === strncmp( $slug_remaining, $post_type . '-', $post_type_length ) ) {
+							$slug  = substr( $slug_remaining, $post_type_length, strlen( $slug_remaining ) );
+							$found = _gutenberg_build_title_and_description_for_single_post_type_block_template( $post_type, $slug, $template );
+							if ( $found ) {
+								break;
+							}
+						}
+					}
+					break;
+				case 'tag':
+					_gutenberg_build_title_and_description_for_taxonomy_block_template( 'post_tag', $slug_remaining, $template );
+					break;
+				case 'category':
+					_gutenberg_build_title_and_description_for_taxonomy_block_template( 'category', $slug_remaining, $template );
+					break;
+				case 'taxonomy':
+					$taxonomies = get_taxonomies();
+					foreach ( $taxonomies as $taxonomy ) {
+						$taxonomy_length = strlen( $taxonomy ) + 1;
+						// If $slug_remaining starts with $taxonomy followed by a hyphen.
+						if ( 0 === strncmp( $slug_remaining, $taxonomy . '-', $taxonomy_length ) ) {
+							$slug  = substr( $slug_remaining, $taxonomy_length, strlen( $slug_remaining ) );
+							$found = _gutenberg_build_title_and_description_for_taxonomy_block_template( $taxonomy, $slug, $template );
+							if ( $found ) {
+								break;
+							}
+						}
+					}
+					break;
+			}
+		}
+	}
+	return $template;
+}
+
+if ( ! function_exists( 'get_template_hierarchy' ) ) {
+	/**
+	 * Helper function to get the Template Hierarchy for a given slug.
+	 * We need to Handle special cases here like `front-page`, `singular` and `archive` templates.
+	 *
+	 * Noting that we always add `index` as the last fallback template.
+	 *
+	 * @param string  $slug            The template slug to be created.
+	 * @param boolean $is_custom       Indicates if a template is custom or part of the template hierarchy.
+	 * @param string  $template_prefix The template prefix for the created template. This is used to extract the main template type ex. in `taxonomy-books` we extract the `taxonomy`.
+	 *
+	 * @return array<string> The template hierarchy.
+	 */
+	function get_template_hierarchy( $slug, $is_custom = false, $template_prefix = '' ) {
+		if ( 'index' === $slug ) {
+			return array( 'index' );
+		}
+		if ( $is_custom ) {
+			return array( 'page', 'singular', 'index' );
+		}
+		if ( 'front-page' === $slug ) {
+			return array( 'front-page', 'home', 'index' );
+		}
+		$template_hierarchy = array( $slug );
+		// Most default templates don't have `$template_prefix` assigned.
+		if ( $template_prefix ) {
+			list($type) = explode( '-', $template_prefix );
+			// We need these checks because we always add the `$slug` above.
+			if ( ! in_array( $template_prefix, array( $slug, $type ), true ) ) {
+				$template_hierarchy[] = $template_prefix;
+			}
+			if ( $slug !== $type ) {
+				$template_hierarchy[] = $type;
+			}
+		}
+		// Handle `archive` template.
+		if (
+			str_starts_with( $slug, 'author' ) ||
+			str_starts_with( $slug, 'taxonomy' ) ||
+			str_starts_with( $slug, 'category' ) ||
+			str_starts_with( $slug, 'tag' ) ||
+			'date' === $slug
+		) {
+			$template_hierarchy[] = 'archive';
+		}
+		// Handle `single` template.
+		if ( 'attachment' === $slug ) {
+			$template_hierarchy[] = 'single';
+		}
+		// Handle `singular` template.
+		if (
+			str_starts_with( $slug, 'single' ) ||
+			str_starts_with( $slug, 'page' ) ||
+			'attachment' === $slug
+		) {
+			$template_hierarchy[] = 'singular';
+		}
+		$template_hierarchy[] = 'index';
+		return $template_hierarchy;
+	}
+}

--- a/lib/compat/wordpress-6.1/blocks.php
+++ b/lib/compat/wordpress-6.1/blocks.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Temporary compatibility shims for block APIs present in Gutenberg.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Update allowed inline style attributes list.
+ *
+ * Note: This should be removed when the minimum required WP version is >= 6.1.
+ *
+ * @param string[] $attrs Array of allowed CSS attributes.
+ * @return string[] CSS attributes.
+ */
+function gutenberg_safe_style_attrs_6_1( $attrs ) {
+	$attrs[] = 'flex-wrap';
+	$attrs[] = 'gap';
+	$attrs[] = 'column-gap';
+	$attrs[] = 'row-gap';
+	$attrs[] = 'margin-block-start';
+	$attrs[] = 'margin-block-end';
+	$attrs[] = 'margin-inline-start';
+	$attrs[] = 'margin-inline-end';
+
+	return $attrs;
+}
+add_filter( 'safe_style_css', 'gutenberg_safe_style_attrs_6_1' );
+
+/**
+ * Update allowed CSS values to match WordPress 6.1.
+ *
+ * Note: This should be removed when the minimum required WP version is >= 6.1.
+ *
+ * The logic in this function follows that provided in: https://core.trac.wordpress.org/ticket/55966.
+ *
+ * @param boolean $allow_css       Whether or not the current test string is allowed.
+ * @param string  $css_test_string The CSS string to be tested.
+ * @return boolean
+ */
+function gutenberg_safecss_filter_attr_allow_css_6_1( $allow_css, $css_test_string ) {
+	if ( false === $allow_css ) {
+		/*
+		 * Allow CSS functions like var(), calc(), etc. by removing them from the test string.
+		 * Nested functions and parentheses are also removed, so long as the parentheses are balanced.
+		 */
+		$css_test_string = preg_replace(
+			'/\b(?:var|calc|min|max|minmax|clamp)(\((?:[^()]|(?1))*\))/',
+			'',
+			$css_test_string
+		);
+
+		// Check for any CSS containing \ ( & } = or comments,
+		// except for url(), calc(), or var() usage checked above.
+		$allow_css = ! preg_match( '%[\\\(&=}]|/\*%', $css_test_string );
+	}
+	return $allow_css;
+}
+add_filter( 'safecss_filter_attr_allow_css', 'gutenberg_safecss_filter_attr_allow_css_6_1', 10, 2 );
+
+/**
+ * Registers view scripts for core blocks if handling is missing in WordPress core.
+ *
+ * @since 6.1.0
+ *
+ * @param array $settings Array of determined settings for registering a block type.
+ * @param array $metadata Metadata provided for registering a block type.
+ *
+ * @return array Array of settings for registering a block type.
+ */
+function gutenberg_block_type_metadata_view_script( $settings, $metadata ) {
+	if (
+		! isset( $metadata['viewScript'] ) ||
+		! empty( $settings['view_script'] ) ||
+		! isset( $metadata['file'] ) ||
+		! str_starts_with( $metadata['file'], wp_normalize_path( gutenberg_dir_path() ) )
+	) {
+		return $settings;
+	}
+
+	$view_script_path = wp_normalize_path( realpath( dirname( $metadata['file'] ) . '/' . remove_block_asset_path_prefix( $metadata['viewScript'] ) ) );
+
+	if ( file_exists( $view_script_path ) ) {
+		$view_script_id     = str_replace( array( '.min.js', '.js' ), '', basename( remove_block_asset_path_prefix( $metadata['viewScript'] ) ) );
+		$view_script_handle = str_replace( 'core/', 'wp-block-', $metadata['name'] ) . '-' . $view_script_id;
+		wp_deregister_script( $view_script_handle );
+
+		// Replace suffix and extension with `.asset.php` to find the generated dependencies file.
+		$view_asset_file          = substr( $view_script_path, 0, -( strlen( '.js' ) ) ) . '.asset.php';
+		$view_asset               = file_exists( $view_asset_file ) ? require $view_asset_file : null;
+		$view_script_dependencies = isset( $view_asset['dependencies'] ) ? $view_asset['dependencies'] : array();
+		$view_script_version      = isset( $view_asset['version'] ) ? $view_asset['version'] : false;
+		$result                   = wp_register_script(
+			$view_script_handle,
+			gutenberg_url( str_replace( wp_normalize_path( gutenberg_dir_path() ), '', $view_script_path ) ),
+			$view_script_dependencies,
+			$view_script_version
+		);
+		if ( $result ) {
+			$settings['view_script'] = $view_script_handle;
+
+			if ( ! empty( $metadata['textdomain'] ) && in_array( 'wp-i18n', $view_script_dependencies, true ) ) {
+				wp_set_script_translations( $view_script_handle, $metadata['textdomain'] );
+			}
+		}
+	}
+	return $settings;
+}
+add_filter( 'block_type_metadata_settings', 'gutenberg_block_type_metadata_view_script', 10, 2 );
+
+/**
+ * Allow multiple view scripts per block.
+ *
+ * Filters the metadata provided for registering a block type.
+ *
+ * @since 6.1.0
+ *
+ * @param array $metadata Metadata for registering a block type.
+ *
+ * @return array
+ */
+function gutenberg_block_type_metadata_multiple_view_scripts( $metadata ) {
+
+	// Early return if viewScript is empty, or not an array.
+	if ( ! isset( $metadata['viewScript'] ) || ! is_array( $metadata['viewScript'] ) ) {
+		return $metadata;
+	}
+
+	// Register all viewScript items.
+	foreach ( $metadata['viewScript'] as $view_script ) {
+		$item_metadata               = $metadata;
+		$item_metadata['viewScript'] = $view_script;
+		gutenberg_block_type_metadata_view_script( array(), $item_metadata );
+	}
+
+	// Proceed with the default behavior.
+	$metadata['viewScript'] = $metadata['viewScript'][0];
+	return $metadata;
+}
+add_filter( 'block_type_metadata', 'gutenberg_block_type_metadata_multiple_view_scripts' );
+
+/**
+ * Register render template for core blocks if handling is missing in WordPress core.
+ *
+ * @since 6.1.0
+ *
+ * @param array $settings Array of determined settings for registering a block type.
+ * @param array $metadata Metadata provided for registering a block type.
+ *
+ * @return array Array of settings for registering a block type.
+ */
+function gutenberg_block_type_metadata_render_template( $settings, $metadata ) {
+	if ( empty( $metadata['render'] ) || isset( $settings['render_callback'] ) ) {
+		return $settings;
+	}
+
+	$template_path = wp_normalize_path(
+		realpath(
+			dirname( $metadata['file'] ) . '/' .
+			remove_block_asset_path_prefix( $metadata['render'] )
+		)
+	);
+
+	// Bail if the file does not exist.
+	if ( ! file_exists( $template_path ) ) {
+		return $settings;
+	}
+	/**
+	 * Renders the block on the server.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Block default content.
+	 * @param WP_Block $block      Block instance.
+	 *
+	 * @return string Returns the block content.
+	 */
+	$settings['render_callback'] = function( $attributes, $content, $block ) use ( $template_path ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		ob_start();
+		require $template_path;
+		return ob_get_clean();
+	};
+
+	return $settings;
+}
+add_filter( 'block_type_metadata_settings', 'gutenberg_block_type_metadata_render_template', 10, 2 );

--- a/lib/compat/wordpress-6.1/class-gutenberg-rest-block-patterns-controller-6-1.php
+++ b/lib/compat/wordpress-6.1/class-gutenberg-rest-block-patterns-controller-6-1.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * REST API: Gutenberg_REST_Block_Patterns_Controller_6_2 class
+ * REST API: Gutenberg_REST_Block_Patterns_Controller_6_1 class
  *
  * @package    Gutenberg
  * @subpackage REST_API
@@ -13,31 +13,12 @@
  *
  * @see WP_REST_Controller
  */
-class Gutenberg_REST_Block_Patterns_Controller_6_2 extends Gutenberg_REST_Block_Patterns_Controller_6_1 {
-	/**
-	 * Defines whether remote patterns should be loaded.
-	 *
-	 * @since 6.0.0
-	 * @var bool
-	 */
-	private $remote_patterns_loaded;
-
-	/**
-	 * An array that maps old categories names to new ones.
-	 *
-	 * @since 6.2.0
-	 * @var array
-	 */
-	protected static $categories_migration = array(
-		'buttons' => 'call-to-action',
-		'columns' => 'text',
-		'query'   => 'posts',
-	);
-
+class Gutenberg_REST_Block_Patterns_Controller_6_1 extends WP_REST_Block_Patterns_Controller {
 	/**
 	 * Prepare a raw block pattern before it gets output in a REST API response.
 	 *
 	 * @since 6.0.0
+	 * @since 6.1.0 Added `postTypes` property.
 	 *
 	 * @param array           $item    Raw pattern as registered, before any changes.
 	 * @param WP_REST_Request $request Request object.
@@ -56,7 +37,6 @@ class Gutenberg_REST_Block_Patterns_Controller_6_2 extends Gutenberg_REST_Block_
 			'keywords'      => 'keywords',
 			'content'       => 'content',
 			'inserter'      => 'inserter',
-			'templateTypes' => 'template_types',
 		);
 		$data   = array();
 		foreach ( $keys as $item_key => $rest_key ) {
@@ -64,6 +44,7 @@ class Gutenberg_REST_Block_Patterns_Controller_6_2 extends Gutenberg_REST_Block_
 				$data[ $rest_key ] = $item[ $item_key ];
 			}
 		}
+
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data    = $this->add_additional_fields_to_object( $data, $request );
 		$data    = $this->filter_response_by_context( $data, $context );
@@ -132,12 +113,6 @@ class Gutenberg_REST_Block_Patterns_Controller_6_2 extends Gutenberg_REST_Block_
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),
-				'template_types' => array(
-					'description' => __( 'An array of template types where the pattern fits.', 'gutenberg' ),
-					'type'        => 'array',
-					'readonly'    => true,
-					'context'     => array( 'view', 'edit', 'embed' ),
-				),
 				'content'        => array(
 					'description' => __( 'The pattern content.', 'gutenberg' ),
 					'type'        => 'string',
@@ -154,76 +129,5 @@ class Gutenberg_REST_Block_Patterns_Controller_6_2 extends Gutenberg_REST_Block_
 		);
 
 		return $this->add_additional_fields_schema( $schema );
-	}
-
-	/**
-	 * Registers the routes for the objects of the controller.
-	 *
-	 * @since 6.0.0
-	 */
-	public function register_routes() {
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base,
-			array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_items' ),
-					'permission_callback' => array( $this, 'get_items_permissions_check' ),
-				),
-				'schema' => array( $this, 'get_public_item_schema' ),
-			),
-			true
-		);
-	}
-	/**
-	 * Retrieves all block patterns.
-	 *
-	 * @since 6.0.0
-	 * @since 6.2.0 Added migration for old core pattern categories to the new ones.
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
-	 */
-	public function get_items( $request ) {
-		if ( ! $this->remote_patterns_loaded ) {
-			// Load block patterns from w.org.
-			gutenberg_load_remote_block_patterns(); // Patterns with the `core` keyword.
-			gutenberg_load_remote_featured_patterns(); // Patterns in the `featured` category.
-			gutenberg_register_remote_theme_patterns(); // Patterns requested by current theme.
-
-			$this->remote_patterns_loaded = true;
-		}
-
-		$response = array();
-		$patterns = WP_Block_Patterns_Registry::get_instance()->get_all_registered();
-		foreach ( $patterns as $pattern ) {
-			$migrated_pattern = $this->migrate_pattern_categories( $pattern );
-			$prepared_pattern = $this->prepare_item_for_response( $migrated_pattern, $request );
-			$response[]       = $this->prepare_response_for_collection( $prepared_pattern );
-		}
-		return rest_ensure_response( $response );
-	}
-
-	/**
-	 * Migrates old core pattern categories to new ones.
-	 *
-	 * Core pattern categories are being revamped and we need to handle the migration
-	 * to the new ones and ensure backwards compatibility.
-	 *
-	 * @since 6.2.0
-	 *
-	 * @param array $pattern Raw pattern as registered, before applying any changes.
-	 * @return array Migrated pattern.
-	 */
-	protected function migrate_pattern_categories( $pattern ) {
-		if ( isset( $pattern['categories'] ) && is_array( $pattern['categories'] ) ) {
-			foreach ( $pattern['categories'] as $i => $category ) {
-				if ( array_key_exists( $category, static::$categories_migration ) ) {
-					$pattern['categories'][ $i ] = static::$categories_migration[ $category ];
-				}
-			}
-		}
-		return $pattern;
 	}
 }

--- a/lib/compat/wordpress-6.1/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-6.1/class-gutenberg-rest-templates-controller.php
@@ -1,0 +1,303 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Templates_Controller class
+ *
+ * @package    Gutenberg
+ * @subpackage REST_API
+ */
+
+/**
+ * Base Templates REST API Controller.
+ */
+class Gutenberg_REST_Templates_Controller extends WP_REST_Templates_Controller {
+
+	/**
+	 * Registers the controllers routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		// Get fallback template content.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/lookup',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_template_fallback' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => array(
+						'slug'            => array(
+							'description' => __( 'The slug of the template to get the fallback for', 'gutenberg' ),
+							'type'        => 'string',
+							'required'    => true,
+						),
+						'is_custom'       => array(
+							'description' => __( 'Indicates if a template is custom or part of the template hierarchy', 'gutenberg' ),
+							'type'        => 'boolean',
+						),
+						'template_prefix' => array(
+							'description' => __( 'The template prefix for the created template. This is used to extract the main template type ex. in `taxonomy-books` we extract the `taxonomy`', 'gutenberg' ),
+							'type'        => 'string',
+						),
+					),
+				),
+			)
+		);
+		parent::register_routes();
+	}
+
+	/**
+	 * Returns the fallback template for a given slug.
+	 *
+	 * @param WP_REST_Request $request The request instance.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_template_fallback( $request ) {
+		$hierarchy         = gutenberg_get_template_hierarchy( $request['slug'], $request['is_custom'], $request['template_prefix'] );
+		$fallback_template = resolve_block_template( $request['slug'], $hierarchy, '' );
+		$response          = $this->prepare_item_for_response( $fallback_template, $request );
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Returns a list of templates.
+	 *
+	 * @param WP_REST_Request $request The request instance.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$query = array();
+		if ( isset( $request['wp_id'] ) ) {
+			$query['wp_id'] = $request['wp_id'];
+		}
+		if ( isset( $request['area'] ) ) {
+			$query['area'] = $request['area'];
+		}
+		if ( isset( $request['post_type'] ) ) {
+			$query['post_type'] = $request['post_type'];
+		}
+
+		$templates = array();
+		foreach ( gutenberg_get_block_templates( $query, $this->post_type ) as $template ) {
+			$data        = $this->prepare_item_for_response( $template, $request );
+			$templates[] = $this->prepare_response_for_collection( $data );
+		}
+
+		return rest_ensure_response( $templates );
+	}
+
+	/**
+	 * Returns the given template
+	 *
+	 * @param WP_REST_Request $request The request instance.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_item( $request ) {
+		if ( isset( $request['source'] ) && 'theme' === $request['source'] ) {
+			$template = get_block_file_template( $request['id'], $this->post_type );
+		} else {
+			$template = gutenberg_get_block_template( $request['id'], $this->post_type );
+		}
+
+		if ( ! $template ) {
+			return new WP_Error( 'rest_template_not_found', __( 'No templates exist with that id.', 'gutenberg' ), array( 'status' => 404 ) );
+		}
+
+		return $this->prepare_item_for_response( $template, $request );
+	}
+
+	/**
+	 * Creates a single template.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function create_item( $request ) {
+		$changes = $this->prepare_item_for_database( $request );
+		if ( is_wp_error( $changes ) ) {
+			return $changes;
+		}
+
+		$changes->post_name = $request['slug'];
+		$result             = wp_insert_post( wp_slash( (array) $changes ), true );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$posts = gutenberg_get_block_templates( array( 'wp_id' => $result ), $this->post_type );
+		if ( ! count( $posts ) ) {
+			return new WP_Error( 'rest_template_insert_error', __( 'No templates exist with that id.', 'gutenberg' ) );
+		}
+		$id       = $posts[0]->id;
+		$template = gutenberg_get_block_template( $id, $this->post_type );
+
+		$fields_update = $this->update_additional_fields_for_object( $template, $request );
+		if ( is_wp_error( $fields_update ) ) {
+			return $fields_update;
+		}
+
+		return $this->prepare_item_for_response(
+			gutenberg_get_block_template( $id, $this->post_type ),
+			$request
+		);
+	}
+
+	/**
+	 * Updates a single template.
+	 *
+	 * @since 5.8.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function update_item( $request ) {
+		$template = gutenberg_get_block_template( $request['id'], $this->post_type );
+		if ( ! $template ) {
+			return new WP_Error( 'rest_template_not_found', __( 'No templates exist with that id.', 'gutenberg' ), array( 'status' => 404 ) );
+		}
+
+		$post_before = get_post( $template->wp_id );
+
+		if ( isset( $request['source'] ) && 'theme' === $request['source'] ) {
+			wp_delete_post( $template->wp_id, true );
+			$request->set_param( 'context', 'edit' );
+
+			$template = gutenberg_get_block_template( $request['id'], $this->post_type );
+			$response = $this->prepare_item_for_response( $template, $request );
+
+			return rest_ensure_response( $response );
+		}
+
+		$changes = $this->prepare_item_for_database( $request );
+
+		if ( is_wp_error( $changes ) ) {
+			return $changes;
+		}
+
+		if ( 'custom' === $template->source ) {
+			$update = true;
+			$result = wp_update_post( wp_slash( (array) $changes ), false );
+		} else {
+			$update      = false;
+			$post_before = null;
+			$result      = wp_insert_post( wp_slash( (array) $changes ), false );
+		}
+
+		if ( is_wp_error( $result ) ) {
+			if ( 'db_update_error' === $result->get_error_code() ) {
+				$result->add_data( array( 'status' => 500 ) );
+			} else {
+				$result->add_data( array( 'status' => 400 ) );
+			}
+			return $result;
+		}
+
+		$template      = gutenberg_get_block_template( $request['id'], $this->post_type );
+		$fields_update = $this->update_additional_fields_for_object( $template, $request );
+		if ( is_wp_error( $fields_update ) ) {
+			return $fields_update;
+		}
+
+		$request->set_param( 'context', 'edit' );
+
+		$post = get_post( $template->wp_id );
+		/** This action is documented in wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php */
+		do_action( "rest_after_insert_{$this->post_type}", $post, $request, false );
+
+		wp_after_insert_post( $post, $update, $post_before );
+
+		$response = $this->prepare_item_for_response( $template, $request );
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Prepares a single template for create or update.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return stdClass Changes to pass to wp_update_post.
+	 */
+	protected function prepare_item_for_database( $request ) {
+		$template = $request['id'] ? gutenberg_get_block_template( $request['id'], $this->post_type ) : null;
+		$changes  = new stdClass();
+		if ( null === $template ) {
+			$changes->post_type   = $this->post_type;
+			$changes->post_status = 'publish';
+			$changes->tax_input   = array(
+				'wp_theme' => isset( $request['theme'] ) ? $request['theme'] : get_stylesheet(),
+			);
+		} elseif ( 'custom' !== $template->source ) {
+			$changes->post_name   = $template->slug;
+			$changes->post_type   = $this->post_type;
+			$changes->post_status = 'publish';
+			$changes->tax_input   = array(
+				'wp_theme' => $template->theme,
+			);
+			$changes->meta_input  = array(
+				'origin' => $template->source,
+			);
+		} else {
+			$changes->post_name   = $template->slug;
+			$changes->ID          = $template->wp_id;
+			$changes->post_status = 'publish';
+		}
+		if ( isset( $request['content'] ) ) {
+			$changes->post_content = $request['content'];
+		} elseif ( null !== $template && 'custom' !== $template->source ) {
+			$changes->post_content = $template->content;
+		}
+		if ( isset( $request['title'] ) ) {
+			$changes->post_title = $request['title'];
+		} elseif ( null !== $template && 'custom' !== $template->source ) {
+			$changes->post_title = $template->title;
+		}
+		if ( isset( $request['description'] ) ) {
+			$changes->post_excerpt = $request['description'];
+		} elseif ( null !== $template && 'custom' !== $template->source ) {
+			$changes->post_excerpt = $template->description;
+		}
+
+		if ( 'wp_template' === $this->post_type ) {
+			if ( isset( $request['is_wp_suggestion'] ) ) {
+				$changes->meta_input     = wp_parse_args(
+					array(
+						'is_wp_suggestion' => $request['is_wp_suggestion'],
+					),
+					$changes->meta_input = array()
+				);
+			}
+		}
+		if ( 'wp_template_part' === $this->post_type ) {
+			if ( isset( $request['area'] ) ) {
+				$changes->tax_input['wp_template_part_area'] = _filter_block_template_part_area( $request['area'] );
+			} elseif ( null !== $template && 'custom' !== $template->source && $template->area ) {
+				$changes->tax_input['wp_template_part_area'] = _filter_block_template_part_area( $template->area );
+			} elseif ( ! $template->area ) {
+				$changes->tax_input['wp_template_part_area'] = WP_TEMPLATE_PART_AREA_UNCATEGORIZED;
+			}
+		}
+
+		if ( ! empty( $request['author'] ) ) {
+			$post_author = (int) $request['author'];
+
+			if ( get_current_user_id() !== $post_author ) {
+				$user_obj = get_userdata( $post_author );
+
+				if ( ! $user_obj ) {
+					return new WP_Error(
+						'rest_invalid_author',
+						__( 'Invalid author ID.', 'gutenberg' ),
+						array( 'status' => 400 )
+					);
+				}
+			}
+
+			$changes->post_author = $post_author;
+		}
+		return $changes;
+	}
+}

--- a/lib/compat/wordpress-6.1/date-settings.php
+++ b/lib/compat/wordpress-6.1/date-settings.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Updates to the settings given to @wordpress/date.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Removes the call to wp.date.setSettings() added by Core and adds our own call
+ * to wp.date.setSettings().
+ *
+ * This lets us add a new l10n.dayOfWeek setting.
+ *
+ * To merge this into Core, simply update the wp.date.setSettings() call in
+ * wp_default_packages_inline_scripts.
+ *
+ * @param WP_Scripts $scripts WP_Scripts object.
+ */
+function gutenberg_update_date_settings( $scripts ) {
+	global $wp_locale;
+
+	$inline_scripts = $scripts->get_data( 'wp-date', 'after' );
+	if ( $inline_scripts ) {
+		foreach ( $inline_scripts as $index => $inline_script ) {
+			if ( str_starts_with( $inline_script, 'wp.date.setSettings' ) ) {
+				unset( $scripts->registered['wp-date']->extra['after'][ $index ] );
+			}
+		}
+	}
+
+	// Calculate the timezone abbr (EDT, PST) if possible.
+	$timezone_string = get_option( 'timezone_string', 'UTC' );
+	$timezone_abbr   = '';
+
+	if ( ! empty( $timezone_string ) ) {
+		$timezone_date = new DateTime( 'now', new DateTimeZone( $timezone_string ) );
+		$timezone_abbr = $timezone_date->format( 'T' );
+	}
+
+	$scripts->add_inline_script(
+		'wp-date',
+		sprintf(
+			'wp.date.setSettings( %s );',
+			wp_json_encode(
+				array(
+					'l10n'     => array(
+						'locale'        => get_user_locale(),
+						'months'        => array_values( $wp_locale->month ),
+						'monthsShort'   => array_values( $wp_locale->month_abbrev ),
+						'weekdays'      => array_values( $wp_locale->weekday ),
+						'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
+						'meridiem'      => (object) $wp_locale->meridiem,
+						'relative'      => array(
+							/* translators: %s: Duration. */
+							'future' => __( '%s from now', 'gutenberg' ),
+							/* translators: %s: Duration. */
+							'past'   => __( '%s ago', 'gutenberg' ),
+						),
+						'startOfWeek'   => (int) get_option( 'start_of_week', 0 ),
+					),
+					'formats'  => array(
+						/* translators: Time format, see https://www.php.net/manual/datetime.format.php */
+						'time'                => get_option( 'time_format', __( 'g:i a', 'gutenberg' ) ),
+						/* translators: Date format, see https://www.php.net/manual/datetime.format.php */
+						'date'                => get_option( 'date_format', __( 'F j, Y', 'gutenberg' ) ),
+						/* translators: Date/Time format, see https://www.php.net/manual/datetime.format.php */
+						'datetime'            => __( 'F j, Y g:i a', 'gutenberg' ),
+						/* translators: Abbreviated date/time format, see https://www.php.net/manual/datetime.format.php */
+						'datetimeAbbreviated' => __( 'M j, Y g:i a', 'gutenberg' ),
+					),
+					'timezone' => array(
+						'offset' => get_option( 'gmt_offset', 0 ),
+						'string' => $timezone_string,
+						'abbr'   => $timezone_abbr,
+					),
+				)
+			)
+		),
+		'after'
+	);
+}
+add_action( 'wp_default_scripts', 'gutenberg_update_date_settings' );

--- a/lib/compat/wordpress-6.1/edit-form-blocks.php
+++ b/lib/compat/wordpress-6.1/edit-form-blocks.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Patches resources loaded by the block editor page.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Adds the preload paths registered in Core (`edit-form-blocks.php`).
+ *
+ * @param array                   $preload_paths    Preload paths to be filtered.
+ * @param WP_Block_Editor_Context $context The current block editor context.
+ * @return array
+ */
+function gutenberg_preload_template_permissions( $preload_paths, $context ) {
+	if ( ! empty( $context->post ) ) {
+		$preload_paths[] = array( rest_get_route_for_post_type_items( 'wp_template' ), 'OPTIONS' );
+		$preload_paths[] = array( '/wp/v2/settings', 'OPTIONS' );
+	}
+
+	return $preload_paths;
+}
+add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_preload_template_permissions', 10, 2 );

--- a/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * API to interact with global settings & styles.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Adds global style rules to the inline style for each block.
+ */
+function gutenberg_add_global_styles_for_blocks() {
+	$tree        = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+	$block_nodes = $tree->get_styles_block_nodes();
+	foreach ( $block_nodes as $metadata ) {
+		$block_css = $tree->get_styles_for_block( $metadata );
+
+		if ( ! wp_should_load_separate_core_block_assets() ) {
+			wp_add_inline_style( 'global-styles', $block_css );
+			continue;
+		}
+
+		$stylesheet_handle = 'global-styles';
+		if ( isset( $metadata['name'] ) ) {
+			// These block styles are added on block_render.
+			// This hooks inline CSS to them so that they are loaded conditionally
+			// based on whether or not the block is used on the page.
+			if ( str_starts_with( $metadata['name'], 'core/' ) ) {
+				$block_name        = str_replace( 'core/', '', $metadata['name'] );
+				$stylesheet_handle = 'wp-block-' . $block_name;
+			}
+			wp_add_inline_style( $stylesheet_handle, $block_css );
+		}
+
+		// The likes of block element styles from theme.json do not have  $metadata['name'] set.
+		if ( ! isset( $metadata['name'] ) && ! empty( $metadata['path'] ) ) {
+			$result = array_values(
+				array_filter(
+					$metadata['path'],
+					function ( $item ) {
+						if ( str_contains( $item, 'core/' ) ) {
+							return true;
+						}
+						return false;
+					}
+				)
+			);
+			if ( isset( $result[0] ) ) {
+				if ( str_starts_with( $result[0], 'core/' ) ) {
+					$block_name        = str_replace( 'core/', '', $result[0] );
+					$stylesheet_handle = 'wp-block-' . $block_name;
+				}
+				wp_add_inline_style( $stylesheet_handle, $block_css );
+			}
+		}
+	}
+}

--- a/lib/compat/wordpress-6.1/persisted-preferences.php
+++ b/lib/compat/wordpress-6.1/persisted-preferences.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Server-side requirements for database persisted preferences.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Register the user meta for persisted preferences.
+ */
+function gutenberg_register_persisted_preferences_meta() {
+	// Create a meta key that incorporates the blog prefix so that each site
+	// on a multisite can have distinct user preferences.
+	global $wpdb;
+	$meta_key = $wpdb->get_blog_prefix() . 'persisted_preferences';
+
+	register_meta(
+		'user',
+		$meta_key,
+		array(
+			'type'         => 'object',
+			'single'       => true,
+			'show_in_rest' => array(
+				'name'   => 'persisted_preferences',
+				'type'   => 'object',
+				'schema' => array(
+					'type'                 => 'object',
+					'context'              => array( 'edit' ),
+					'properties'           => array(
+						'_modified' => array(
+							'description' => __( 'The date and time the preferences were updated.', 'default' ),
+							'type'        => 'string',
+							'format'      => 'date-time',
+							'readonly'    => false,
+						),
+					),
+					'additionalProperties' => true,
+				),
+			),
+		)
+	);
+}
+
+add_action( 'init', 'gutenberg_register_persisted_preferences_meta' );
+
+/**
+ * Configures the preferences package to use user meta persistence.
+ */
+function gutenberg_configure_persisted_preferences() {
+	$user_id = get_current_user_id();
+	if ( empty( $user_id ) ) {
+		return;
+	}
+
+	global $wpdb;
+	$meta_key = $wpdb->get_blog_prefix() . 'persisted_preferences';
+
+	$preload_data = get_user_meta( $user_id, $meta_key, true );
+
+	wp_add_inline_script(
+		'wp-preferences',
+		sprintf(
+			'( function() {
+				var serverData = %s;
+				var userId = "%s";
+				var persistenceLayer = wp.preferencesPersistence.__unstableCreatePersistenceLayer( serverData, userId );
+				var preferencesStore = wp.preferences.store;
+				wp.data.dispatch( preferencesStore ).setPersistenceLayer( persistenceLayer );
+			} ) ();',
+			wp_json_encode( $preload_data ),
+			$user_id
+		),
+		'after'
+	);
+}
+
+add_action( 'admin_init', 'gutenberg_configure_persisted_preferences' );
+
+/**
+ * Register dependencies for the inline script that configures the persistence layer.
+ *
+ * Note: When porting this to core update the code here:
+ * https://github.com/WordPress/wordpress-develop/blob/d2ab3d183740c3d1252cb921b18005495007e022/src/wp-includes/script-loader.php#L251-L258
+ *
+ * And make the same update to the gutenberg client assets file here:
+ * https://github.com/WordPress/gutenberg/blob/3f3c8df23c70a37b7ac4dddebc82030362133593/lib/client-assets.php#L242-L254
+ *
+ * The update should be adding a new case like this like this:
+ * ```
+ * case 'wp-preferences':
+ *     array_push( $dependencies, 'wp-preferences-persistence' );
+ *     break;
+ * ```
+ *
+ * @param WP_Scripts $scripts An instance of WP_Scripts.
+ */
+function gutenberg_update_preferences_persistence_deps( $scripts ) {
+	$persistence_script = $scripts->query( 'wp-preferences', 'registered' );
+	if ( isset( $persistence_script->deps ) ) {
+		array_push( $persistence_script->deps, 'wp-preferences-persistence' );
+	}
+}
+
+add_action( 'wp_default_scripts', 'gutenberg_update_preferences_persistence_deps', 11 );

--- a/lib/compat/wordpress-6.1/rest-api.php
+++ b/lib/compat/wordpress-6.1/rest-api.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Overrides Core's wp-includes/rest-api.php and registers the new endpoint for WP 6.0.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Add the post type's `icon`(menu_icon) in the response.
+ * When we backport this change we will need to add the
+ * `icon` to WP_REST_Post_Types_Controller schema.
+ *
+ * @param WP_REST_Response $response  The response object.
+ * @param WP_Post_Type     $post_type The original post type object.
+ */
+function gutenberg_update_post_types_rest_response( $response, $post_type ) {
+	$response->data['icon'] = $post_type->menu_icon;
+	return $response;
+}
+add_filter( 'rest_prepare_post_type', 'gutenberg_update_post_types_rest_response', 10, 2 );
+
+/**
+ * Exposes the site logo URL through the WordPress REST API.
+ *
+ * This is used for fetching this information when user has no rights
+ * to update settings.
+ *
+ * Note: Backports into wp-includes/rest-api/class-wp-rest-server.php file.
+ *
+ * @param WP_REST_Response $response REST API response.
+ * @return WP_REST_Response $response REST API response.
+ */
+function gutenberg_add_site_icon_url_to_index( WP_REST_Response $response ) {
+	$response->data['site_icon_url'] = get_site_icon_url();
+
+	return $response;
+}
+add_action( 'rest_index', 'gutenberg_add_site_icon_url_to_index' );
+
+/**
+ * Returns the has_archive post type field.
+ *
+ * @param array  $type       The response data.
+ * @param string $field_name The field name. The function handles field has_archive.
+ */
+function gutenberg_get_post_type_has_archive_field( $type, $field_name ) {
+	if ( ! empty( $type ) && ! empty( $type['slug'] ) && 'has_archive' === $field_name ) {
+		$post_type_object = get_post_type_object( $type['slug'] );
+		return $post_type_object->has_archive;
+	}
+}
+
+/**
+ * Registers the has_archive post type REST API field.
+ */
+function gutenberg_register_has_archive_on_post_types_endpoint() {
+	register_rest_field(
+		'type',
+		'has_archive',
+		array(
+			'get_callback' => 'gutenberg_get_post_type_has_archive_field',
+			'schema'       => array(
+				'description' => __( 'If the value is a string, the value will be used as the archive slug. If the value is false the post type has no archive.', 'gutenberg' ),
+				'type'        => array( 'string', 'boolean' ),
+				'context'     => array( 'view', 'edit' ),
+			),
+		)
+	);
+}
+add_action( 'rest_api_init', 'gutenberg_register_has_archive_on_post_types_endpoint' );

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Load global styles assets in the front-end.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * This applies a filter to the list of style nodes that comes from `get_style_nodes` in WP_Theme_JSON.
+ * This particular filter removes all of the blocks from the array.
+ *
+ * We want WP_Theme_JSON to be ignorant of the implementation details of how the CSS is being used.
+ * This filter allows us to modify the output of WP_Theme_JSON depending on whether or not we are loading separate assets,
+ * without making the class aware of that detail.
+ *
+ * @since 6.1
+ *
+ * @param array $nodes The nodes to filter.
+ * @return array A filtered array of style nodes.
+ */
+function gutenberg_filter_out_block_nodes( $nodes ) {
+	return array_filter(
+		$nodes,
+		function( $node ) {
+			return ! in_array( 'blocks', $node['path'], true );
+		},
+		ARRAY_FILTER_USE_BOTH
+	);
+}
+
+/**
+ * Enqueues the global styles defined via theme.json.
+ * This should replace wp_enqueue_global_styles.
+ *
+ * @since 5.8.0
+ */
+function gutenberg_enqueue_global_styles() {
+	$separate_assets  = wp_should_load_separate_core_block_assets();
+	$is_block_theme   = wp_is_block_theme();
+	$is_classic_theme = ! $is_block_theme;
+
+	/*
+	 * Global styles should be printed in the head when loading all styles combined.
+	 * The footer should only be used to print global styles for classic themes with separate core assets enabled.
+	 *
+	 * See https://core.trac.wordpress.org/ticket/53494.
+	 */
+	if (
+		( $is_block_theme && doing_action( 'wp_footer' ) ) ||
+		( $is_classic_theme && doing_action( 'wp_footer' ) && ! $separate_assets ) ||
+		( $is_classic_theme && doing_action( 'wp_enqueue_scripts' ) && $separate_assets )
+	) {
+		return;
+	}
+
+	/**
+	 * If we are loading CSS for each block separately, then we can load the theme.json CSS conditionally.
+	 * This removes the CSS from the global-styles stylesheet and adds it to the inline CSS for each block.
+	 * This filter has to be registered before we call gutenberg_get_global_stylesheet();
+	 */
+	add_filter( 'wp_theme_json_get_style_nodes', 'gutenberg_filter_out_block_nodes', 10, 1 );
+
+	$stylesheet = gutenberg_get_global_stylesheet();
+	if ( empty( $stylesheet ) ) {
+		return;
+	}
+
+	wp_register_style( 'global-styles', false, array(), true, true );
+	wp_add_inline_style( 'global-styles', $stylesheet );
+	wp_enqueue_style( 'global-styles' );
+
+	// add each block as an inline css.
+	gutenberg_add_global_styles_for_blocks();
+}
+
+remove_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles' );
+remove_action( 'wp_footer', 'wp_enqueue_global_styles', 1 );
+
+// Enqueue global styles, and then block supports styles.
+add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_global_styles' );
+add_action( 'wp_footer', 'gutenberg_enqueue_global_styles', 1 );
+
+/**
+ * Loads classic theme styles on classic themes in the frontend.
+ *
+ * This is needed for backwards compatibility for button blocks specifically.
+ */
+function gutenberg_enqueue_classic_theme_styles() {
+	if ( ! wp_is_block_theme() ) {
+		wp_register_style( 'classic-theme-styles', gutenberg_url( 'build/block-library/classic.css' ), array(), true );
+		wp_enqueue_style( 'classic-theme-styles' );
+	}
+}
+add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_classic_theme_styles' );
+
+/**
+ * Loads classic theme styles on classic themes in the editor.
+ *
+ * This is needed for backwards compatibility for button blocks specifically.
+ *
+ * @since 6.1
+ *
+ * @param array $editor_settings The array of editor settings.
+ * @return array A filtered array of editor settings.
+ */
+function gutenberg_add_editor_classic_theme_styles( $editor_settings ) {
+	if ( wp_is_block_theme() ) {
+		return $editor_settings;
+	}
+
+	$classic_theme_styles = gutenberg_dir_path() . '/build/block-library/classic.css';
+
+	// This follows the pattern of get_block_editor_theme_styles,
+	// but we can't use get_block_editor_theme_styles directly as it
+	// only handles external files or theme files.
+	$editor_settings['styles'][] = array(
+		'css'            => file_get_contents( $classic_theme_styles ),
+		'baseURL'        => get_theme_file_uri( $classic_theme_styles ),
+		'__unstableType' => 'theme',
+		'isGlobalStyles' => false,
+	);
+
+	return $editor_settings;
+}
+add_filter( 'block_editor_settings_all', 'gutenberg_add_editor_classic_theme_styles' );

--- a/lib/compat/wordpress-6.1/template-parts-screen.php
+++ b/lib/compat/wordpress-6.1/template-parts-screen.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Bootstrapping the Gutenberg Template Parts screen & integration.
+ *
+ * This isn't a new file for wp-admin; just override necessary for `site-editor.php`.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Register Template Parts submenu.
+ *
+ * This should be handled directly in wp-admin/menu.php.
+ *
+ * @return void
+ */
+function gutenberg_template_parts_screen_menu() {
+	// Only add page for Classic theme that support the feature.
+	if ( wp_is_block_theme() ) {
+		return;
+	}
+
+	if ( ! current_theme_supports( 'block-template-parts' ) ) {
+		return;
+	}
+
+	global $submenu;
+	if ( ! isset( $submenu['themes.php'] ) ) {
+		return;
+	}
+
+	$needs_custom_page = true;
+	foreach ( $submenu['themes.php'] as $menu_item ) {
+		if ( str_contains( $menu_item[2], 'site-editor.php?postType=wp_template_part' ) ) {
+			$needs_custom_page = false;
+			break;
+		}
+	}
+
+	// Don't use the custom 'Template Parts' page with WP 6.1 and above.
+	if ( ! $needs_custom_page ) {
+		return;
+	}
+
+	add_theme_page(
+		__( 'Template Parts', 'gutenberg' ),
+		__( 'Template Parts', 'gutenberg' ),
+		'edit_theme_options',
+		'gutenberg-template-parts',
+		'gutenberg_template_parts_screen_render'
+	);
+}
+add_action( 'admin_menu', 'gutenberg_template_parts_screen_menu' );
+
+/**
+ * The page permissions and redirections.
+ *
+ * @return void
+ */
+function gutenberg_template_parts_screen_permissions() {
+	if ( ! current_theme_supports( 'block-template-parts' ) ) {
+		wp_die( __( 'The theme you are currently using doesn\'t block-based template parts.', 'gutenberg' ) );
+	}
+
+	/**
+	 * Should be handled directly in /wp-admin/menu.php.
+	 * Path: `site-editor.php?postType=wp_template_part`.
+	 */
+	if ( ! isset( $_GET['postType'] ) ) {
+		$redirect_url = add_query_arg(
+			array( 'postType' => 'wp_template_part' ),
+			admin_url( 'themes.php?page=gutenberg-template-parts' )
+		);
+		wp_safe_redirect( $redirect_url );
+		exit;
+	}
+}
+add_action( 'load-appearance_page_gutenberg-template-parts', 'gutenberg_template_parts_screen_permissions' );
+
+/**
+ * Initialize the editor for the screen. Most of this is copied from `site-editor.php`.
+ *
+ * Note: Parts that need to be ported back should have inline comments.
+ *
+ * @param string $hook Current page hook.
+ * @return void
+ */
+function gutenberg_template_parts_screen_init( $hook ) {
+	global $current_screen, $editor_styles;
+
+	if ( 'appearance_page_gutenberg-template-parts' !== $hook ) {
+		return;
+	}
+
+	// Flag that we're loading the block editor.
+	$current_screen->is_block_editor( true );
+
+	// Default to is-fullscreen-mode to avoid jumps in the UI.
+	add_filter(
+		'admin_body_class',
+		static function( $classes ) {
+			return "$classes is-fullscreen-mode";
+		}
+	);
+
+	$indexed_template_types = array();
+	foreach ( get_default_block_template_types() as $slug => $template_type ) {
+		$template_type['slug']    = (string) $slug;
+		$indexed_template_types[] = $template_type;
+	}
+
+	$block_editor_context = new WP_Block_Editor_Context( array( 'name' => 'core/edit-site' ) );
+	$custom_settings      = array(
+		'siteUrl'                   => site_url(),
+		'postsPerPage'              => get_option( 'posts_per_page' ),
+		'styles'                    => get_block_editor_theme_styles(),
+		'defaultTemplateTypes'      => $indexed_template_types,
+		'defaultTemplatePartAreas'  => get_allowed_block_template_part_areas(),
+		'supportsLayout'            => wp_theme_has_theme_json(),
+		'supportsTemplatePartsMode' => ! wp_is_block_theme() && current_theme_supports( 'block-template-parts' ),
+	);
+
+	// Add additional back-compat patterns registered by `current_screen` et al.
+	$custom_settings['__experimentalAdditionalBlockPatterns']          = WP_Block_Patterns_Registry::get_instance()->get_all_registered( true );
+	$custom_settings['__experimentalAdditionalBlockPatternCategories'] = WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered( true );
+
+	$editor_settings = get_block_editor_settings( $custom_settings, $block_editor_context );
+
+	if ( isset( $_GET['postType'] ) && ! isset( $_GET['postId'] ) ) {
+		$post_type = get_post_type_object( $_GET['postType'] );
+		if ( ! $post_type ) {
+			wp_die( __( 'Invalid post type.', 'gutenberg' ) );
+		}
+	}
+
+	$active_global_styles_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
+	$active_theme            = get_stylesheet();
+	$preload_paths           = array(
+		array( '/wp/v2/media', 'OPTIONS' ),
+		'/wp/v2/types?context=view',
+		'/wp/v2/types/wp_template?context=edit',
+		'/wp/v2/types/wp_template-part?context=edit',
+		'/wp/v2/templates?context=edit&per_page=-1',
+		'/wp/v2/template-parts?context=edit&per_page=-1',
+		'/wp/v2/themes?context=edit&status=active',
+		'/wp/v2/global-styles/' . $active_global_styles_id . '?context=edit',
+		'/wp/v2/global-styles/' . $active_global_styles_id,
+		'/wp/v2/global-styles/themes/' . $active_theme,
+	);
+
+	block_editor_rest_api_preload( $preload_paths, $block_editor_context );
+
+	wp_add_inline_script(
+		'wp-edit-site',
+		sprintf(
+			'wp.domReady( function() {
+				wp.editSite.initializeEditor( "site-editor", %s );
+			} );',
+			wp_json_encode( $editor_settings )
+		)
+	);
+
+	// Preload server-registered block schemas.
+	wp_add_inline_script(
+		'wp-blocks',
+		'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings() ) . ');'
+	);
+
+	wp_add_inline_script(
+		'wp-blocks',
+		sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( get_block_categories( $block_editor_context ) ) )
+	);
+
+	wp_enqueue_script( 'wp-edit-site' );
+	wp_enqueue_script( 'wp-format-library' );
+	wp_enqueue_style( 'wp-edit-site' );
+	wp_enqueue_style( 'wp-format-library' );
+	wp_enqueue_media();
+
+	if (
+		current_theme_supports( 'wp-block-styles' ) ||
+		( ! is_array( $editor_styles ) || count( $editor_styles ) === 0 )
+	) {
+		wp_enqueue_style( 'wp-block-library-theme' );
+	}
+
+	/** This action is documented in wp-admin/edit-form-blocks.php */
+	do_action( 'enqueue_block_editor_assets' );
+}
+add_action( 'admin_enqueue_scripts', 'gutenberg_template_parts_screen_init' );
+
+/**
+ * The main entry point for the screen.
+ *
+ * @return void
+ */
+function gutenberg_template_parts_screen_render() {
+	echo '<div id="site-editor" class="edit-site"></div>';
+}
+
+/**
+ * Register the new theme feature.
+ *
+ * Migrates into `create_initial_theme_features` method.
+ *
+ * @return void
+ */
+function gutenberg_register_template_parts_theme_feature() {
+	register_theme_feature(
+		'block-template-parts',
+		array(
+			'description'  => __( 'Whether a theme uses block-based template parts.', 'gutenberg' ),
+			'show_in_rest' => true,
+		)
+	);
+}
+add_action( 'setup_theme', 'gutenberg_register_template_parts_theme_feature', 5 );

--- a/lib/compat/wordpress-6.1/theme.php
+++ b/lib/compat/wordpress-6.1/theme.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Temporary compatibility shims for features present in Gutenberg.
+ * This file should be removed when WordPress 6.1.0 becomes the lowest
+ * supported version by this plugin.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * This function runs in addition to the core `create_initial_theme_features`.
+ * The 6.1 release needs to update the core function to include the body of this function.
+ *
+ * Creates the initial theme features when the 'setup_theme' action is fired.
+ *
+ * See {@see 'setup_theme'}.
+ *
+ * @since 5.5.0
+ * @since 6.0.1 The `block-templates` feature was added.
+ * @since 6.1.0 The `disable-layout-styles` feature was added.
+ */
+function gutenberg_create_initial_theme_features() {
+	register_theme_feature(
+		'disable-layout-styles',
+		array(
+			'description'  => __( 'Whether the theme disables generated layout styles.', 'gutenberg' ),
+			'show_in_rest' => true,
+		)
+	);
+}
+add_action( 'setup_theme', 'gutenberg_create_initial_theme_features', 0 );
+
+if ( ! function_exists( 'wp_theme_get_element_class_name' ) ) {
+	/**
+	 * Given an element name, returns a class name.
+	 * Alias from WP_Theme_JSON_Gutenberg::get_element_class_name.
+	 *
+	 * @param string $element The name of the element.
+	 *
+	 * @return string The name of the class.
+	 *
+	 * @since 6.1.0
+	 */
+	function wp_theme_get_element_class_name( $element ) {
+		return WP_Theme_JSON_Gutenberg::get_element_class_name( $element );
+	}
+}

--- a/lib/compat/wordpress-6.1/wp-theme-get-post-templates.php
+++ b/lib/compat/wordpress-6.1/wp-theme-get-post-templates.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Support for custom block-based page templates.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Load the page templates in Gutenberg.
+ *
+ * @param string[] $templates Page templates.
+ * @param WP_Theme $theme     WP_Theme instance.
+ * @param WP_Post  $post      The post being edited, provided for context, or null.
+ * @param string   $post_type Post type to get the templates for.
+ * @return array (Maybe) modified page templates array.
+ */
+function gutenberg_load_block_page_templates( $templates, $theme, $post, $post_type ) {
+	if ( ! current_theme_supports( 'block-templates' ) ) {
+		return $templates;
+	}
+
+	// `get_post_templates` in core uses `get_block_templates` and since we have updated the
+	// logic in that function, we need to find and remove the templates that were added from
+	// the core function. That is why we need to call both functions to find which templates
+	// we should exclude from passed `$templates`.
+	$gutenberg_block_templates = array_map(
+		function( $template ) {
+			return $template->slug;
+		},
+		gutenberg_get_block_templates( array( 'post_type' => $post_type ), 'wp_template' )
+	);
+	$core_block_templates      = array_map(
+		function( $template ) {
+			return $template->slug;
+		},
+		get_block_templates( array( 'post_type' => $post_type ), 'wp_template' )
+	);
+	$templates_to_exclude      = array_diff( $core_block_templates, $gutenberg_block_templates );
+	foreach ( $templates_to_exclude as $template_slug ) {
+		unset( $templates[ $template_slug ] );
+	}
+	return $templates;
+}
+add_filter( 'theme_templates', 'gutenberg_load_block_page_templates', 10, 4 );

--- a/lib/compat/wordpress-6.2/block-editor-settings.php
+++ b/lib/compat/wordpress-6.2/block-editor-settings.php
@@ -22,9 +22,6 @@ function gutenberg_get_block_editor_settings_6_2( $settings ) {
 		);
 	}
 
-	// Copied from get_block_editor_settings() at wordpress-develop/block-editor.php.
-	$settings['__experimentalFeatures'] = gutenberg_get_global_settings();
-
 	return $settings;
 }
 

--- a/lib/compat/wordpress-6.3/class-gutenberg-rest-templates-controller-6-3.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-rest-templates-controller-6-3.php
@@ -9,7 +9,7 @@
 /**
  * Base Templates REST API Controller.
  */
-class Gutenberg_REST_Templates_Controller_6_3 extends WP_REST_Templates_Controller {
+class Gutenberg_REST_Templates_Controller_6_3 extends Gutenberg_REST_Templates_Controller {
 
 	/**
 	 * Registers the controllers routes.

--- a/lib/experimental/block-editor-settings.php
+++ b/lib/experimental/block-editor-settings.php
@@ -72,7 +72,7 @@ function gutenberg_get_block_editor_settings_experimental( $settings ) {
 		}
 	}
 
-	$current_template = get_block_templates( array( 'slug__in' => array( $template_slug ) ) );
+	$current_template = gutenberg_get_block_templates( array( 'slug__in' => array( $template_slug ) ) );
 
 	if ( ! empty( $current_template ) ) {
 		$template_blocks    = parse_blocks( $current_template[0]->content );

--- a/lib/load.php
+++ b/lib/load.php
@@ -35,6 +35,11 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		require_once __DIR__ . '/experimental/class-wp-rest-block-editor-settings-controller.php';
 	}
 
+	// WordPress 6.1 compat.
+	require_once __DIR__ . '/compat/wordpress-6.1/class-gutenberg-rest-block-patterns-controller-6-1.php';
+	require_once __DIR__ . '/compat/wordpress-6.1/class-gutenberg-rest-templates-controller.php';
+	require_once __DIR__ . '/compat/wordpress-6.1/rest-api.php';
+
 	// WordPress 6.2 compat.
 	require_once __DIR__ . '/compat/wordpress-6.2/class-gutenberg-rest-block-patterns-controller-6-2.php';
 	require_once __DIR__ . '/compat/wordpress-6.2/class-gutenberg-rest-block-pattern-categories-controller.php';
@@ -63,6 +68,19 @@ require __DIR__ . '/experimental/editor-settings.php';
 
 // Gutenberg plugin compat.
 require __DIR__ . '/compat/plugin/edit-site-routes-backwards-compat.php';
+
+// WordPress 6.1 compat.
+require __DIR__ . '/compat/wordpress-6.1/block-editor-settings.php';
+require __DIR__ . '/compat/wordpress-6.1/blocks.php';
+require __DIR__ . '/compat/wordpress-6.1/persisted-preferences.php';
+require __DIR__ . '/compat/wordpress-6.1/get-global-styles-and-settings.php';
+require __DIR__ . '/compat/wordpress-6.1/block-template-utils.php';
+require __DIR__ . '/compat/wordpress-6.1/wp-theme-get-post-templates.php';
+require __DIR__ . '/compat/wordpress-6.1/script-loader.php';
+require __DIR__ . '/compat/wordpress-6.1/date-settings.php';
+require __DIR__ . '/compat/wordpress-6.1/edit-form-blocks.php';
+require __DIR__ . '/compat/wordpress-6.1/template-parts-screen.php';
+require __DIR__ . '/compat/wordpress-6.1/theme.php';
 
 // WordPress 6.2 compat.
 require __DIR__ . '/compat/wordpress-6.2/blocks.php';

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -18,6 +18,22 @@ if ( class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
  */
 class WP_Style_Engine_CSS_Declarations {
 	/**
+	 * An array of valid CSS custom properties.
+	 * CSS custom properties are permitted by safecss_filter_attr()
+	 * since WordPress 6.1. See: https://core.trac.wordpress.org/ticket/56353.
+	 *
+	 * This whitelist exists so that the Gutenberg plugin maintains
+	 * backwards compatibility with versions of WordPress < 6.1.
+	 *
+	 * It does not need to be backported to future versions of WordPress.
+	 *
+	 * @var array
+	 */
+	protected static $valid_custom_declarations = array(
+		'--wp--style--unstable-gallery-gap' => 'gap',
+	);
+
+	/**
 	 * An array of CSS declarations (property => value pairs).
 	 *
 	 * @var array
@@ -124,6 +140,22 @@ class WP_Style_Engine_CSS_Declarations {
 	 */
 	protected static function filter_declaration( $property, $value, $spacer = '' ) {
 		$filtered_value = wp_strip_all_tags( $value, true );
+
+		/**
+		 * Allows a specific list of CSS custom properties starting with `--wp--`.
+		 *
+		 * CSS custom properties are permitted by safecss_filter_attr()
+		 * since WordPress 6.1. See: https://core.trac.wordpress.org/ticket/56353.
+		 *
+		 * This condition exists so that the Gutenberg plugin maintains
+		 * backwards compatibility with versions of WordPress < 6.1.
+		 *
+		 * It does not need to be backported to future versions of WordPress.
+		 */
+		if ( '' !== $filtered_value && isset( static::$valid_custom_declarations[ $property ] ) ) {
+			return safecss_filter_attr( static::$valid_custom_declarations[ $property ] . ":{$spacer}{$value}" ) ?
+				"{$property}:{$spacer}{$value}" : '';
+		}
 
 		if ( '' !== $filtered_value ) {
 			return safecss_filter_attr( "{$property}:{$spacer}{$filtered_value}" );


### PR DESCRIPTION
Alternative to https://github.com/WordPress/gutenberg/pull/50185
This reverts commit 7a095d6e7232f56e625313d3dc52e96059fbbb72.

This PR aims to understand what's causing the `packages/e2e-tests/specs/editor/plugins/iframed-inline-styles.test.js` e2e test to fail in Gutenberg trunk.

The first time it happened was after merging https://github.com/WordPress/gutenberg/commit/7a095d6e7232f56e625313d3dc52e96059fbbb72. The e2e test at that PR were fine, though. This is an attempt to understand if that's the root cause or whether we should look elsewhere (for example, an update of the WordPress trunk).

If it was the culprit, that e2e test should pass it this PR. If it is not, it should fail.