### PR TITLE
Update index.js

### DIFF
--- a/packages/block-editor/src/components/text-transform-control/stories/index.js
+++ b/packages/block-editor/src/components/text-transform-control/stories/index.js
@@ -9,7 +9,7 @@ import { useState } from '@wordpress/element';
 import TextTransformControl from '../';
 
 export default {
-	title: 'BlockEditor/TextTransformControl',
+	title: 'BlockEditor (Experimental)/TextTransformControl',
 	component: TextTransformControl,
 	argTypes: {
 		onChange: { action: 'onChange' },


### PR DESCRIPTION
TextTransformControl is still experimental. It should be marked as such in the title. So that newer developers might not get confused while importing it from '@wordpress/block-editor'

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The **TextTransformControl** is not marked as experimental in the Guttenberg Storybook.

## Why?
Im not sure whether this is intended or not. But I tried to import it directly from '@wordpress/block-editor' and was faced with errors. I feel if there was an **experimental** tag somewhere then it would have been much more helpful since there is no other documentation to be found anywhere regarding this.

## How?
I just updated the title to be similar to the ones for the experimental components. 

## Testing Instructions


### Testing Instructions for Keyboard


## Screenshots or screencast 
