### PR TITLE
(e2e)(template-parts) Add E2E test for editing the title of a new custom template part

### DIFF
--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -395,6 +395,18 @@ class PostEditorTemplateMode {
 		await cancelButton.click();
 	}
 
+	/**
+	 * Edit the title of a template. The title is saved automatically, no
+	 * need to click anything, though we do click outside of the dialog
+	 * to close it.
+	 *
+	 * This needs to be called only after the template edit mode has been
+	 * activated or it will fail, i.e after creating a new custom template
+	 * or after calling `switchToTemplateMode()`.
+	 *
+	 * @param {string} newTitle the new title to set.
+	 * @return {Promise<void>}
+	 */
 	async editTemplateTitle( newTitle ) {
 		await this.page.click( 'button[aria-label="Template Options"]' );
 

--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -102,6 +102,22 @@ test.describe( 'Post Editor Template mode', () => {
 		).toBeVisible();
 	} );
 
+	test( 'Allow editing the title of a new custom template', async ( {
+		page,
+		requestUtils,
+		postEditorTemplateMode,
+	} ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+
+		await postEditorTemplateMode.createPostAndSaveDraft();
+		await postEditorTemplateMode.createNewTemplate( 'Foobar' );
+		await postEditorTemplateMode.editTemplateTitle( 'Barfoo' );
+
+		await expect(
+			page.getByRole( 'button', { name: 'Template Options' } )
+		).toHaveText( 'Barfoo' );
+	} );
+
 	test.describe( 'Delete Post Template Confirmation Dialog', () => {
 		test.beforeAll( async ( { requestUtils } ) => {
 			await requestUtils.activateTheme( 'twentytwentyone' );
@@ -377,5 +393,20 @@ class PostEditorTemplateMode {
 			'role=button[name="Cancel"i]'
 		);
 		await cancelButton.click();
+	}
+
+	async editTemplateTitle( newTitle ) {
+		await this.page.click( 'button[aria-label="Template Options"]' );
+
+		const editDialog = this.page.locator(
+			'div.edit-site-template-details__group'
+		);
+
+		await editDialog.waitFor();
+
+		await editDialog.getByLabel( 'Title' ).fill( newTitle );
+
+		const editorContent = await this.page.getByLabel( 'Editor Content' );
+		await editorContent.click();
 	}
 }

--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -104,7 +104,6 @@ test.describe( 'Post Editor Template mode', () => {
 
 	test( 'Allow editing the title of a new custom template', async ( {
 		page,
-		requestUtils,
 		postEditorTemplateMode,
 	} ) => {
 		async function editTemplateTitle( newTitle ) {
@@ -119,8 +118,6 @@ test.describe( 'Post Editor Template mode', () => {
 			const editorContent = page.getByLabel( 'Editor Content' );
 			await editorContent.click();
 		}
-
-		await requestUtils.activateTheme( 'emptytheme' );
 
 		await postEditorTemplateMode.createPostAndSaveDraft();
 		await postEditorTemplateMode.createNewTemplate( 'Foobar' );

--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -403,7 +403,6 @@ class PostEditorTemplateMode {
 		);
 
 		await editDialog.waitFor();
-
 		await editDialog.getByLabel( 'Title' ).fill( newTitle );
 
 		const editorContent = await this.page.getByLabel( 'Editor Content' );

--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -107,11 +107,24 @@ test.describe( 'Post Editor Template mode', () => {
 		requestUtils,
 		postEditorTemplateMode,
 	} ) => {
+		async function editTemplateTitle( newTitle ) {
+			await page
+				.getByRole( 'button', { name: 'Template Options' } )
+				.click();
+
+			await page
+				.getByRole( 'textbox', { name: 'Title' } )
+				.fill( newTitle );
+
+			const editorContent = page.getByLabel( 'Editor Content' );
+			await editorContent.click();
+		}
+
 		await requestUtils.activateTheme( 'emptytheme' );
 
 		await postEditorTemplateMode.createPostAndSaveDraft();
 		await postEditorTemplateMode.createNewTemplate( 'Foobar' );
-		await postEditorTemplateMode.editTemplateTitle( 'Barfoo' );
+		await editTemplateTitle( 'Barfoo' );
 
 		await expect(
 			page.getByRole( 'button', { name: 'Template Options' } )
@@ -393,31 +406,5 @@ class PostEditorTemplateMode {
 			'role=button[name="Cancel"i]'
 		);
 		await cancelButton.click();
-	}
-
-	/**
-	 * Edit the title of a template. The title is saved automatically, no
-	 * need to click anything, though we do click outside of the dialog
-	 * to close it.
-	 *
-	 * This needs to be called only after the template edit mode has been
-	 * activated or it will fail, i.e after creating a new custom template
-	 * or after calling `switchToTemplateMode()`.
-	 *
-	 * @param {string} newTitle the new title to set.
-	 * @return {Promise<void>}
-	 */
-	async editTemplateTitle( newTitle ) {
-		await this.page.click( 'button[aria-label="Template Options"]' );
-
-		const editDialog = this.page.locator(
-			'div.edit-site-template-details__group'
-		);
-
-		await editDialog.waitFor();
-		await editDialog.getByLabel( 'Title' ).fill( newTitle );
-
-		const editorContent = await this.page.getByLabel( 'Editor Content' );
-		await editorContent.click();
 	}
 }


### PR DESCRIPTION
## What?

Adds a (regression) E2E test for editing the title of a new custom template part. Regress-test the bug that was found and fixed here: https://github.com/WordPress/gutenberg/pull/49984 by @jsnajdr.

## Why?

A bug was introduced in 15.6 and was not found until after the plugin was released. This specific scenario wasn't being tested.

## How?

By creating a new custom template part of a post then editing its name, and making sure the name changes in the title button, after the edit dialog closes.

## Testing Instructions

All E2E tests should pass.

