### PR TITLE
BlockControls, InspectorControls: remove useSlot, unify behavior on bad group

### DIFF
--- a/packages/block-editor/src/components/block-controls/slot.js
+++ b/packages/block-editor/src/components/block-controls/slot.js
@@ -7,6 +7,7 @@ import {
 	ToolbarGroup,
 	__experimentalUseSlotFills as useSlotFills,
 } from '@wordpress/components';
+import warning from '@wordpress/warning';
 
 /**
  * Internal dependencies
@@ -15,11 +16,14 @@ import groups from './groups';
 
 export default function BlockControlsSlot( { group = 'default', ...props } ) {
 	const accessibleToolbarState = useContext( ToolbarContext );
-	const Slot = groups[ group ].Slot;
-	const fills = useSlotFills( Slot.__unstableName );
-	const hasFills = Boolean( fills && fills.length );
+	const Slot = groups[ group ]?.Slot;
+	const fills = useSlotFills( Slot?.__unstableName );
+	if ( ! Slot ) {
+		warning( `Unknown BlockControls group "${ group }" provided.` );
+		return null;
+	}
 
-	if ( ! hasFills ) {
+	if ( ! fills?.length ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/block-controls/slot.native.js
+++ b/packages/block-editor/src/components/block-controls/slot.native.js
@@ -6,6 +6,7 @@ import {
 	__experimentalToolbarContext as ToolbarContext,
 	ToolbarGroup,
 } from '@wordpress/components';
+import warning from '@wordpress/warning';
 
 /**
  * Internal dependencies
@@ -14,7 +15,11 @@ import groups from './groups';
 
 export default function BlockControlsSlot( { group = 'default', ...props } ) {
 	const accessibleToolbarState = useContext( ToolbarContext );
-	const Slot = groups[ group ].Slot;
+	const Slot = groups[ group ]?.Slot;
+	if ( ! Slot ) {
+		warning( `Unknown BlockControls group "${ group }" provided.` );
+		return null;
+	}
 
 	if ( group === 'default' ) {
 		return <Slot { ...props } fillProps={ accessibleToolbarState } />;

--- a/packages/block-editor/src/components/inspector-controls/fill.js
+++ b/packages/block-editor/src/components/inspector-controls/fill.js
@@ -41,7 +41,7 @@ export default function InspectorControlsFill( {
 	const isDisplayed = useDisplayBlockControls();
 	const Fill = groups[ group ]?.Fill;
 	if ( ! Fill ) {
-		warning( `Unknown InspectorControl group "${ group }" provided.` );
+		warning( `Unknown InspectorControls group "${ group }" provided.` );
 		return null;
 	}
 	if ( ! isDisplayed ) {

--- a/packages/block-editor/src/components/inspector-controls/fill.native.js
+++ b/packages/block-editor/src/components/inspector-controls/fill.native.js
@@ -39,7 +39,7 @@ export default function InspectorControlsFill( {
 
 	const Fill = groups[ group ]?.Fill;
 	if ( ! Fill ) {
-		warning( `Unknown InspectorControl group "${ group }" provided.` );
+		warning( `Unknown InspectorControls group "${ group }" provided.` );
 		return null;
 	}
 	if ( ! isDisplayed ) {

--- a/packages/block-editor/src/components/inspector-controls/slot.js
+++ b/packages/block-editor/src/components/inspector-controls/slot.js
@@ -1,10 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalUseSlot as useSlot,
-	__experimentalUseSlotFills as useSlotFills,
-} from '@wordpress/components';
+import { __experimentalUseSlotFills as useSlotFills } from '@wordpress/components';
 import warning from '@wordpress/warning';
 import deprecated from '@wordpress/deprecated';
 
@@ -33,15 +30,13 @@ export default function InspectorControlsSlot( {
 		group = __experimentalGroup;
 	}
 	const Slot = groups[ group ]?.Slot;
-	const slot = useSlot( Slot?.__unstableName );
 	const fills = useSlotFills( Slot?.__unstableName );
-	if ( ! Slot || ! slot ) {
-		warning( `Unknown InspectorControl group "${ group }" provided.` );
+	if ( ! Slot ) {
+		warning( `Unknown InspectorControls group "${ group }" provided.` );
 		return null;
 	}
 
-	const hasFills = Boolean( fills && fills.length );
-	if ( ! hasFills ) {
+	if ( ! fills?.length ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/inspector-controls/slot.native.js
+++ b/packages/block-editor/src/components/inspector-controls/slot.native.js
@@ -27,7 +27,7 @@ export default function InspectorControlsSlot( {
 	}
 	const Slot = groups[ group ]?.Slot;
 	if ( ! Slot ) {
-		warning( `Unknown InspectorControl group "${ group }" provided.` );
+		warning( `Unknown InspectorControls group "${ group }" provided.` );
 		return null;
 	}
 


### PR DESCRIPTION
First, removes call of `useSlot` from `InspectorControlsSlot`. It performs no function, and should have been removed in #44642, after the introduction of the `useSlotFill` hook. There was a check if the return value of `useSlot` is falsy, but it is always truthy, even if the requested slot is not found. Because it returns a combination of the slot data and the update/unregister API.

Second, I'm unifying code that handles the situation where the passed `group` prop is invalid: the group is not known and has no slot associated. We don't want to crash, therefore careful use of `?.`. And we want to report a warning to console. I'm also updating the names of affected components to `BlockControls` and `InspectorControls`, using plural, because that's what the name of all the components is.