### PR TITLE
create-block script includes link to documentation in render.php file

### DIFF
--- a/packages/create-block-tutorial-template/block-templates/render.php.mustache
+++ b/packages/create-block-tutorial-template/block-templates/render.php.mustache
@@ -1,4 +1,9 @@
 {{#isDynamicVariant}}
+<?php
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render
+ */
+?>
 <p <?php echo get_block_wrapper_attributes(); ?>>
 	<?php echo esc_html( $attributes['message'] ); ?>
 </p>

--- a/packages/create-block/lib/templates/block/render.php.mustache
+++ b/packages/create-block/lib/templates/block/render.php.mustache
@@ -1,4 +1,9 @@
 {{#isDynamicVariant}}
+<?php
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render
+ */
+?>
 <p <?php echo get_block_wrapper_attributes(); ?>>
 	<?php esc_html_e( '{{title}} – hello from a dynamic block!', '{{textdomain}}' ); ?>
 </p>

--- a/packages/create-block/lib/templates/es5/render.php.mustache
+++ b/packages/create-block/lib/templates/es5/render.php.mustache
@@ -1,4 +1,9 @@
 {{#isDynamicVariant}}
+<?php
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render
+ */
+?>
 <p <?php echo get_block_wrapper_attributes(); ?>>
 	<?php esc_html_e( '{{title}} – hello from a dynamic block!', '{{textdomain}}' ); ?>
 </p>


### PR DESCRIPTION
When creating dynamic block php render files includes link to documentation

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Creating dynamic block `render.php` gets link to [documentation](https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render).

## Why?
Makes lives of developers little bit easier.
Original idea came from #47826 

## How?
Adds php comment block to beginning to file.

## Testing Instructions
1. From your terminal run following command `npx wp-create-block example-dynamic --variant dynamic`
2. Check `render.php` from just created `example-dynamic` directory 
#
### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
