### PR TITLE
Remove gutenberg plugin mention in schema

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -708,11 +708,11 @@
 							"type": "object",
 							"properties": {
 								"border": {
-									"description": "Settings related to borders.\nGutenberg plugin required.",
+									"description": "Settings related to borders.",
 									"type": "object",
 									"properties": {
 										"radius": {
-											"description": "Allow users to set custom border radius.\nGutenberg plugin required.",
+											"description": "Allow users to set custom border radius.",
 											"type": "boolean",
 											"default": false
 										}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Remove "Gutenberg plugin required." from schema.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- The schema is the Gutenberg version of the schema, so it is redundant.
- The schemas are not processed for release, so inclusion of this comment will be incorrect after a release.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove "Gutenberg plugin required." from schema.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
