### PR TITLE
Changelog automation: apply proper top-level categorization precedence to meta PRs

### DIFF
--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -153,7 +153,6 @@ const GROUP_TITLE_ORDER = [
 	'Enhancements',
 	'New APIs',
 	'Bug Fixes',
-	'Accessibility',
 	'Performance',
 	'Experiments',
 	'Documentation',

--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -61,7 +61,6 @@ const UNKNOWN_FEATURE_FALLBACK_NAME = 'Uncategorized';
  * @type {Record<string,string>}
  */
 const LABEL_TYPE_MAPPING = {
-	'[Type] Code Quality': 'Code Quality',
 	'[Type] Developer Documentation': 'Documentation',
 	'[Package] Jest Puppeteer aXe': 'Tools',
 	'[Package] E2E Tests': 'Tools',
@@ -75,6 +74,7 @@ const LABEL_TYPE_MAPPING = {
 	'[Type] Build Tooling': 'Tools',
 	'Automated Testing': 'Tools',
 	'[Package] Dependency Extraction Webpack Plugin': 'Tools',
+	'[Type] Code Quality': 'Code Quality',
 	'[Type] Performance': 'Performance',
 	'[Type] Security': 'Security',
 	'[Feature] Navigation Screen': 'Experiments',

--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -61,8 +61,8 @@ const UNKNOWN_FEATURE_FALLBACK_NAME = 'Uncategorized';
  * @type {Record<string,string>}
  */
 const LABEL_TYPE_MAPPING = {
-	'[Feature] Navigation Screen': 'Experiments',
-	'[Package] Dependency Extraction Webpack Plugin': 'Tools',
+	'[Type] Code Quality': 'Code Quality',
+	'[Type] Developer Documentation': 'Documentation',
 	'[Package] Jest Puppeteer aXe': 'Tools',
 	'[Package] E2E Tests': 'Tools',
 	'[Package] E2E Test Utils': 'Tools',
@@ -74,16 +74,16 @@ const LABEL_TYPE_MAPPING = {
 	'[Package] Scripts': 'Tools',
 	'[Type] Build Tooling': 'Tools',
 	'Automated Testing': 'Tools',
+	'[Package] Dependency Extraction Webpack Plugin': 'Tools',
+	'[Type] Performance': 'Performance',
+	'[Type] Security': 'Security',
+	'[Feature] Navigation Screen': 'Experiments',
 	'[Type] Experimental': 'Experiments',
 	'[Type] Bug': 'Bug Fixes',
 	'[Type] Regression': 'Bug Fixes',
-	'[Type] Feature': 'Features',
 	'[Type] Enhancement': 'Enhancements',
 	'[Type] New API': 'New APIs',
-	'[Type] Performance': 'Performance',
-	'[Type] Developer Documentation': 'Documentation',
-	'[Type] Code Quality': 'Code Quality',
-	'[Type] Security': 'Security',
+	'[Type] Feature': 'Features',
 };
 
 /**
@@ -153,6 +153,7 @@ const GROUP_TITLE_ORDER = [
 	'Enhancements',
 	'New APIs',
 	'Bug Fixes',
+	'Accessibility',
 	'Performance',
 	'Experiments',
 	'Documentation',
@@ -303,12 +304,6 @@ function getIssueType( issue ) {
 		...getTypesByTitle( issue.title ),
 	];
 
-	// Force all tasks identified as Documentation tasks
-	// to appear under the main "Documentation" section.
-	if ( candidates.includes( 'Documentation' ) ) {
-		return 'Documentation';
-	}
-
 	return candidates.length ? candidates.sort( sortType )[ 0 ] : 'Various';
 }
 
@@ -377,7 +372,7 @@ function getIssueFeature( issue ) {
  */
 function sortType( a, b ) {
 	const [ aIndex, bIndex ] = [ a, b ].map( ( title ) => {
-		return Object.keys( LABEL_TYPE_MAPPING ).indexOf( title );
+		return Object.values( LABEL_TYPE_MAPPING ).indexOf( title );
 	} );
 
 	return aIndex - bIndex;

--- a/bin/plugin/commands/test/__snapshots__/changelog.js.snap
+++ b/bin/plugin/commands/test/__snapshots__/changelog.js.snap
@@ -5,12 +5,8 @@ exports[`getChangelog verify that the changelog is properly formatted 1`] = `
 
 ### Enhancements
 
-- Scripts: Use cssnano to minimize CSS files with build. ([33750](https://github.com/WordPress/gutenberg/pull/33750))
-- Scripts: Webpack configuration update to minimize CSS. ([33676](https://github.com/WordPress/gutenberg/pull/33676))
-
 #### Components
 - Add new ColorPicker. ([33714](https://github.com/WordPress/gutenberg/pull/33714))
-- Promote \`ItemGroup\`. ([33701](https://github.com/WordPress/gutenberg/pull/33701))
 - Update snackbar to use framer motion instead of react spring. ([33717](https://github.com/WordPress/gutenberg/pull/33717))
 - Use updated range styles. ([33824](https://github.com/WordPress/gutenberg/pull/33824))
 
@@ -39,7 +35,6 @@ exports[`getChangelog verify that the changelog is properly formatted 1`] = `
 ### Bug Fixes
 
 - Correct \`function_exists()\` check typo introduced in #33331. ([33513](https://github.com/WordPress/gutenberg/pull/33513))
-- ESLint Plugin: Include .jsx extenstion when linting import statements. ([33746](https://github.com/WordPress/gutenberg/pull/33746))
 - Fix block appender position in classic themes. ([33895](https://github.com/WordPress/gutenberg/pull/33895))
 - Fix misspelling of "queries" in filter documentation. ([33799](https://github.com/WordPress/gutenberg/pull/33799))
 - Fix positioning discrepancy with draggable chip. ([33893](https://github.com/WordPress/gutenberg/pull/33893))
@@ -81,12 +76,6 @@ exports[`getChangelog verify that the changelog is properly formatted 1`] = `
 #### Meta Boxes
 - Fix Safari 13 metaboxes from overlapping the content. ([33817](https://github.com/WordPress/gutenberg/pull/33817))
 
-#### Build Tooling
-- Readable JS assets Plugin: Fix webpack 5 support. ([33785](https://github.com/WordPress/gutenberg/pull/33785))
-
-#### Navigation Screen
-- Fix regressed menu selection dropdown placeholder value for Nav Editor menu locations UI. ([33748](https://github.com/WordPress/gutenberg/pull/33748))
-
 #### Accessibility
 - Fix some JAWS bugs. ([33627](https://github.com/WordPress/gutenberg/pull/33627))
 
@@ -114,6 +103,15 @@ exports[`getChangelog verify that the changelog is properly formatted 1`] = `
 
 #### Post Editor
 - Refactor the HierarchicalTermSelector so that it does not cause unnecessary loading of terms. ([33418](https://github.com/WordPress/gutenberg/pull/33418))
+
+
+### Experiments
+
+#### Navigation Screen
+- Fix regressed menu selection dropdown placeholder value for Nav Editor menu locations UI. ([33748](https://github.com/WordPress/gutenberg/pull/33748))
+
+#### Components
+- Promote \`ItemGroup\`. ([33701](https://github.com/WordPress/gutenberg/pull/33701))
 
 
 ### Documentation
@@ -157,16 +155,20 @@ exports[`getChangelog verify that the changelog is properly formatted 1`] = `
 
 ### Tools
 
+- ESLint Plugin: Include .jsx extenstion when linting import statements. ([33746](https://github.com/WordPress/gutenberg/pull/33746))
 - GitHub Templates: Fix spacing in bug report template. ([33761](https://github.com/WordPress/gutenberg/pull/33761))
 - GitHub Templates: Format bug report template. ([33786](https://github.com/WordPress/gutenberg/pull/33786))
+- Scripts: Use cssnano to minimize CSS files with build. ([33750](https://github.com/WordPress/gutenberg/pull/33750))
+- Scripts: Webpack configuration update to minimize CSS. ([33676](https://github.com/WordPress/gutenberg/pull/33676))
 - Update bug issue template to use forms. ([33713](https://github.com/WordPress/gutenberg/pull/33713))
+
+#### Build Tooling
+- Readable JS assets Plugin: Fix webpack 5 support. ([33785](https://github.com/WordPress/gutenberg/pull/33785))
+- Scripts: Update webpack to v5 (try 2). ([33818](https://github.com/WordPress/gutenberg/pull/33818))
 
 #### Testing
 - Add search performance measure and make other measures more stable. ([33848](https://github.com/WordPress/gutenberg/pull/33848))
 - E2E: Block Hierarchy Navigation wait for the column to be highlighted. ([33721](https://github.com/WordPress/gutenberg/pull/33721))
-
-#### Build Tooling
-- Scripts: Update webpack to v5 (try 2). ([33818](https://github.com/WordPress/gutenberg/pull/33818))
 
 
 ### Various

--- a/bin/plugin/commands/test/__snapshots__/changelog.js.snap
+++ b/bin/plugin/commands/test/__snapshots__/changelog.js.snap
@@ -131,8 +131,6 @@ exports[`getChangelog verify that the changelog is properly formatted 1`] = `
 
 ### Code Quality
 
-- Scripts: Fix typo in format change message. ([33945](https://github.com/WordPress/gutenberg/pull/33945))
-
 #### Components
 - Components utils: \`rtl()\` return type, \`rtl.watch()\` utility. ([33882](https://github.com/WordPress/gutenberg/pull/33882))
 - InputControl to TypeScript. ([33696](https://github.com/WordPress/gutenberg/pull/33696))
@@ -158,6 +156,7 @@ exports[`getChangelog verify that the changelog is properly formatted 1`] = `
 - ESLint Plugin: Include .jsx extenstion when linting import statements. ([33746](https://github.com/WordPress/gutenberg/pull/33746))
 - GitHub Templates: Fix spacing in bug report template. ([33761](https://github.com/WordPress/gutenberg/pull/33761))
 - GitHub Templates: Format bug report template. ([33786](https://github.com/WordPress/gutenberg/pull/33786))
+- Scripts: Fix typo in format change message. ([33945](https://github.com/WordPress/gutenberg/pull/33945))
 - Scripts: Use cssnano to minimize CSS files with build. ([33750](https://github.com/WordPress/gutenberg/pull/33750))
 - Scripts: Webpack configuration update to minimize CSS. ([33676](https://github.com/WordPress/gutenberg/pull/33676))
 - Update bug issue template to use forms. ([33713](https://github.com/WordPress/gutenberg/pull/33713))

--- a/bin/plugin/commands/test/changelog.js
+++ b/bin/plugin/commands/test/changelog.js
@@ -188,6 +188,17 @@ describe( 'getIssueType', () => {
 
 		expect( result ).toBe( 'Enhancements' );
 	} );
+
+	it( 'prioritizes meta categories', () => {
+		const result = getIssueType( {
+			labels: [
+				{ name: '[Type] Bug' },
+				{ name: '[Type] Build Tooling' },
+			],
+		} );
+
+		expect( result ).toBe( 'Tools' );
+	} );
 } );
 
 describe( 'getIssueFeature', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes the changelog automation generation to classify the meta/non-product PRs into the right top-level categories considering category precedence.

Please note that this will not solve uncategorized PRs.

## Why?
The changelog generation doesn't apply the right category precedence when there is more than one top-level label, like a `[Type] Build Tooling` label and `[Type] Bug`. Currently, a PR with both labels would be classified as a bugfix, but non-product and meta labels should always have precedence: fixing a tooling bug is not a bugfix in the product.

## How?
- Reordering the type mappings to have the right category precedence.
- Fixing a bug that uses the labels instead of the changelog categories to determine the category precedence. 

## Testing Instructions
Run `npm run other:changelog -- --milestone="Gutenberg 15.6"`