### PR TITLE
Cover: Re-instate overflow:hidden rule to fix issue with border radius

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -7,6 +7,9 @@
 	justify-content: center;
 	align-items: center;
 	padding: 1em;
+	// Prevent the `wp-block-cover__background` span from overflowing the container when border-radius is applied.
+	// TODO: Find an alternative to `overflow: hidden` so that sticky elements can be used inside the cover block.
+	overflow: hidden;
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 	// Keep the flex layout direction to the physical direction (LTR) in RTL languages.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes a regression introduced by #49913 by partially reverting it.

Re-instate `overflow: hidden` in the Cover block, to fix the issue where border radius doesn't get applied to the child background element of the Cover block, as reported in https://github.com/WordPress/gutenberg/pull/49913#issuecomment-1529011503.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The `overflow: hidden` rule was removed in order to support sticky position blocks at non-root positions, however the removal caused a regression for border radius. Sticky position at non-root positions has not yet been enabled (it's a work in progress over in https://github.com/WordPress/gutenberg/pull/49321), so for now, let's fix the regression, which should give a bit more time to come up with another solution that might allow for both cases (Cover blocks with rounded borders and sticky children).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add `overflow: hidden` rule to the Cover block's CSS

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

* Test that the cover block is rendering correctly both with and without borders and border-radius in the post and site editors
* Double-check that the block's placeholder state is still rendering correctly
* Double-check that the block is rendering correctly on the site frontend

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="743" alt="image" src="https://user-images.githubusercontent.com/14988353/235382092-7971e0a0-bfc0-41f5-beac-0a51b2dc4417.png"> | <img width="774" alt="image" src="https://user-images.githubusercontent.com/14988353/235382080-63b2ebd3-0401-44dd-861c-b4fe66a454bf.png"> |