### PR TITLE
Try improving ListView drag and drop performance by computing `blocksData` ahead of time

### DIFF
--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useState, useCallback } from '@wordpress/element';
+import { useState, useCallback, useRef } from '@wordpress/element';
 import {
 	useThrottle,
 	__experimentalUseDropZone as useDropZone,
@@ -186,6 +186,7 @@ export function getListViewDropTarget( blocksData, position ) {
  * @return {WPListViewDropZoneTarget} The drop target.
  */
 export default function useListViewDropZone() {
+	const blocksData = useRef( null );
 	const {
 		getBlockRootClientId,
 		getBlockIndex,
@@ -199,51 +200,69 @@ export default function useListViewDropZone() {
 
 	const onBlockDrop = useOnBlockDrop( targetRootClientId, targetBlockIndex );
 
-	const draggedBlockClientIds = getDraggedBlockClientIds();
 	const throttled = useThrottle(
 		useCallback(
 			( event, currentTarget ) => {
 				const position = { x: event.clientX, y: event.clientY };
+				const draggedBlockClientIds = getDraggedBlockClientIds();
 				const isBlockDrag = !! draggedBlockClientIds?.length;
 
 				const blockElements = Array.from(
 					currentTarget.querySelectorAll( '[data-block]' )
 				);
 
-				const blocksData = blockElements.map( ( blockElement ) => {
-					const clientId = blockElement.dataset.block;
-					const isExpanded = blockElement.dataset.expanded === 'true';
-					const rootClientId = getBlockRootClientId( clientId );
+				if ( ! blocksData.current ) {
+					blocksData.current = blockElements.map(
+						( blockElement ) => {
+							const clientId = blockElement.dataset.block;
+							const isExpanded =
+								blockElement.dataset.expanded === 'true';
+							const rootClientId =
+								getBlockRootClientId( clientId );
 
-					return {
-						clientId,
-						isExpanded,
-						rootClientId,
-						blockIndex: getBlockIndex( clientId ),
-						element: blockElement,
-						isDraggedBlock: isBlockDrag
-							? draggedBlockClientIds.includes( clientId )
-							: false,
-						innerBlockCount: getBlockCount( clientId ),
-						canInsertDraggedBlocksAsSibling: isBlockDrag
-							? canInsertBlocks(
-									draggedBlockClientIds,
-									rootClientId
-							  )
-							: true,
-						canInsertDraggedBlocksAsChild: isBlockDrag
-							? canInsertBlocks( draggedBlockClientIds, clientId )
-							: true,
-					};
-				} );
+							return {
+								clientId,
+								isExpanded,
+								rootClientId,
+								blockIndex: getBlockIndex( clientId ),
+								element: blockElement,
+								isDraggedBlock: isBlockDrag
+									? draggedBlockClientIds.includes( clientId )
+									: false,
+								innerBlockCount: getBlockCount( clientId ),
+								canInsertDraggedBlocksAsSibling: isBlockDrag
+									? canInsertBlocks(
+											draggedBlockClientIds,
+											rootClientId
+									  )
+									: true,
+								canInsertDraggedBlocksAsChild: isBlockDrag
+									? canInsertBlocks(
+											draggedBlockClientIds,
+											clientId
+									  )
+									: true,
+							};
+						}
+					);
+				}
 
-				const newTarget = getListViewDropTarget( blocksData, position );
+				const newTarget = getListViewDropTarget(
+					blocksData.current,
+					position
+				);
 
 				if ( newTarget ) {
 					setTarget( newTarget );
 				}
 			},
-			[ draggedBlockClientIds ]
+			[
+				canInsertBlocks,
+				getBlockCount,
+				getBlockIndex,
+				getBlockRootClientId,
+				getDraggedBlockClientIds,
+			]
 		),
 		200
 	);
@@ -259,6 +278,7 @@ export default function useListViewDropZone() {
 		onDragEnd() {
 			throttled.cancel();
 			setTarget( null );
+			blocksData.current = null;
 		},
 	} );
 


### PR DESCRIPTION
## What?
Originally, when ListView drag and drop was introduced, there was a performance optimization in that the expensive `blocksData` was computed only once when the user started dragging.

At some point this has regressed and the data is now computed on every trigger of the dragover event.

This PR ensures `blocksData` is only be computed on drag start.

## Why?
The block list doesn't change when a user is dragging, so this isn't needed. 

This could be revised when collaborative editing is introduced, as then the block list may change while the user is dragging 😬. Hopefully there will be other ways to recompute the data (i.e. whenever the `blockOrder` changes?)

## How?
Store blocksData in a `ref` when the user starts dragging and clear it when the user stops.

## Testing Instructions
The easiest way to test is to set a logpoint in the `getBlocksData` function. Then start dragging and you should see only one line of console output.
