### PR TITLE
Rich text: rename index.js > index.ts for type-only exports  

### DIFF
--- a/packages/rich-text/src/index.ts
+++ b/packages/rich-text/src/index.ts
@@ -38,4 +38,4 @@ export { default as __unstableFormatEdit } from './component/format-edit';
  * An object which represents a formatted string. See main `@wordpress/rich-text`
  * documentation for more information.
  */
-export { type RichTextValue } from './types';
+export type { RichTextValue } from './types';

--- a/packages/rich-text/src/index.ts
+++ b/packages/rich-text/src/index.ts
@@ -38,4 +38,4 @@ export { default as __unstableFormatEdit } from './component/format-edit';
  * An object which represents a formatted string. See main `@wordpress/rich-text`
  * documentation for more information.
  */
-export { RichTextValue } from './types';
+export { type RichTextValue } from './types';


### PR DESCRIPTION

## What, why and how?

When compiling the project, Webpack was whining at me:

```
WARNING in ./packages/rich-text/build-module/index.js 36:0-40
[0]   export 'RichTextValue' (reexported as 'RichTextValue') was not found in './types' (module has no exports)
```

"Enough!" I said, and I muted it by renaming index.js > index.ts and exporting `RichTextValue` as a type. 

Related reading:
- https://javascript.plainenglish.io/leveraging-type-only-imports-and-exports-with-typescript-3-8-5c1be8bd17fb
- https://github.com/webpack/webpack/issues/7378

I don't know if this is the best way to go about it. 🤷  Checking with @noahtallen from https://github.com/WordPress/gutenberg/pull/49651

## Testing Instructions

Run `npm run dev`

You shouldn't see the following error in your console output.

<img width="714" alt="Screenshot 2023-05-01 at 3 10 09 pm" src="https://user-images.githubusercontent.com/6458278/235411250-686bbcc2-69f0-4d40-88c0-c2e15f6649a4.png">
