### PR TITLE
Fix command menu not re-opening after closing it

### DIFF
--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -147,6 +147,7 @@ export function CommandMenu() {
 		};
 	}, [] );
 	const [ loaders, setLoaders ] = useState( {} );
+	const commandMenuInput = useRef();
 
 	useEffect( () => {
 		registerShortcut( {
@@ -184,6 +185,13 @@ export function CommandMenu() {
 		setOpen( false );
 	};
 
+	useEffect( () => {
+		// Focus the command menu input when mounting the modal.
+		if ( open ) {
+			commandMenuInput.current.focus();
+		}
+	}, [ open ] );
+
 	if ( ! open ) {
 		return false;
 	}
@@ -200,9 +208,7 @@ export function CommandMenu() {
 				<Command label={ __( 'Global Command Menu' ) }>
 					<div className="commands-command-menu__header">
 						<Command.Input
-							// The input should be focused when the modal is opened.
-							// eslint-disable-next-line jsx-a11y/no-autofocus
-							autoFocus
+							ref={ commandMenuInput }
 							value={ search }
 							onValueChange={ setSearch }
 							placeholder={ __( 'Type a command or search' ) }


### PR DESCRIPTION
Related #48457 

## What?

In trunk when you close the command menu, the focus is lost which means we're unable to open the menu again if we hit `cmd + k`. The current PR solves that.

## How?

`autoFocus` prop shouldn't be used to auto focus inputs because it's performed too early in the React lifecycle causing `useFocusReturn` to break.

## Testing Instructions

1- Enable the "command center" experiment
2- Open the site editor
3- Focus anything in the page
4- Hit cmd + k
5- The command center is open and focus
6- Hit escape
7- Hit cmd + k again
8- The command center should open again.