### PR TITLE
Fix issue with margin collapsing when selecting blocks

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -39,7 +39,6 @@
 	// so explicit radii set by tools are preserved.
 	&:where(.block-editor-block-list__block.is-multi-selected:not(.is-partially-selected)) {
 		border-radius: $radius-block-ui;
-		overflow: hidden;
 	}
 
 	.block-editor-block-list__block.is-multi-selected:not(.is-partially-selected) {


### PR DESCRIPTION
## What?

Followup to #44708. That PR added a border radius to the selection style, as well as an `overflow: hidden;`, the net result being that if you multi-select an image, a rounded radius is applied to every block inside, unless that block has its own radius. 

Unfortunately, that overflow property caused an issue with selecting a blockquote (and very probably other blocks that feature intrinsic margins, and paragraphs inside). Shown in this GIF, the quote appears to gain top and bottom padding, when multi selected:

![before](https://user-images.githubusercontent.com/1204802/235441343-e57d1f4c-bd86-4d92-afcd-d348d5f0daae.gif)

Turns out that this is due to margin collapsing. The quote itself has one margin, the paragraph inside has another. When overflow is applied onselect, the margins stop collapsing, and the quote appears to grow due to the paragraph margins:

![debugging](https://user-images.githubusercontent.com/1204802/235441446-9f437f2c-fb2f-476a-8adf-84c4b13e44c2.gif)

This PR removes the overflow property, fixing the issue:

![after](https://user-images.githubusercontent.com/1204802/235441440-02c510c4-089f-4767-aed3-c1c48ce6b771.gif)

It does have the side-effect, that when you select an image block, its corners no longer get "cropped off".

## Testing Instructions

Test a quote with a couple of paragraphs inside. Select several blocks, including the quote. The quote should not change size when selected.