### PR TITLE
[RNMobile] Extend non-cached endpoints on Android

### DIFF
--- a/packages/react-native-editor/src/api-fetch-setup.js
+++ b/packages/react-native-editor/src/api-fetch-setup.js
@@ -84,8 +84,14 @@ export const isPathSupported = ( path, method ) => {
 	);
 };
 
-export const shouldEnableCaching = ( path ) =>
-	! DISABLED_CACHING_ENDPOINTS.some( ( pattern ) => pattern.test( path ) );
+export const shouldEnableCaching = ( path ) => {
+	const disabledEndpoints = applyFilters(
+		'native.disabled_caching_endpoints',
+		DISABLED_CACHING_ENDPOINTS
+	);
+
+	return ! disabledEndpoints.some( ( pattern ) => pattern.test( path ) );
+};
 
 export default () => {
 	apiFetch.setFetchHandler( ( options ) => fetchHandler( options ) );

--- a/packages/react-native-editor/src/test/api-fetch-setup.test.js
+++ b/packages/react-native-editor/src/test/api-fetch-setup.test.js
@@ -93,4 +93,17 @@ describe( 'shouldEnableCaching', () => {
 			expect( shouldEnableCaching( path ) ).toBe( false );
 		} );
 	} );
+
+	it( 'does not enable caching for endpoints provided to filter', () => {
+		addFilter(
+			'native.disabled_caching_endpoints',
+			'gutenberg-mobile',
+			( endpoints ) => {
+				return [ ...endpoints, /wp\/v2\/categories/i ];
+			}
+		);
+
+		// Filter was used to stop caching an endpoint from `enabledCachingPaths` array.
+		expect( shouldEnableCaching( 'wp/v2/categories' ) ).toBe( false );
+	} );
 } );


### PR DESCRIPTION
* `gutenberg-mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5710

## What?

This PR introduces a refactoring of how non-cached endpoints are managed in [React Native's `api-fetch-setup` file](https://github.com/WordPress/gutenberg/blob/d80ecc277efd2a8e76c17fc059362a92b7437e37/packages/react-native-editor/src/api-fetch-setup.js), specifically for Android. A new filter, `native.disabled_caching_endpoints`, has been introduced that can dynamically extend the list of endpoints that shouldn't be cached.

## Why?

Previously, the list of non-cached endpoints was hardcoded and not flexible for extension. Given the growing complexity of the apps and the need to disable caching for specific endpoints dynamically, it is valuable to allow the possibility of adding more non-cached endpoints from different parts of the codebase.

## How?

https://github.com/WordPress/gutenberg/pull/50216/commits/801b7ba34720d2556a36b38c76acecf5d35d980a: A new filter, `native.disabled_caching_endpoints`, has been created. This filter is called within the `shouldEnableCaching` function every time a request is made, ensuring that the updated list of non-cachable endpoints is used for deciding whether to enable caching.

## Testing Instructions

Please refer to https://github.com/wordpress-mobile/gutenberg-mobile/pull/5710 for an example of the new filter being utilised in a different part of the codebase, along with testing steps for that scenario.