### PR TITLE
Do not show dynamic add new post, add new page commands

### DIFF
--- a/packages/commands/src/hooks/use-command.js
+++ b/packages/commands/src/hooks/use-command.js
@@ -26,6 +26,7 @@ export default function useCommand( command ) {
 			name: command.name,
 			group: command.group,
 			label: command.label,
+			icon: command.icon,
 			callback: currentCallback.current,
 		} );
 		return () => {
@@ -35,6 +36,7 @@ export default function useCommand( command ) {
 		command.name,
 		command.label,
 		command.group,
+		command.icon,
 		registerCommand,
 		unregisterCommand,
 	] );

--- a/packages/core-commands/src/add-post-type-commands.js
+++ b/packages/core-commands/src/add-post-type-commands.js
@@ -14,7 +14,7 @@ const { useCommand } = unlock( privateApis );
 
 export function useAddPostTypeCommands() {
 	useCommand( {
-		name: 'core/wp-admin/add-post',
+		name: 'add new post',
 		label: __( 'Add new post' ),
 		icon: plus,
 		callback: () => {
@@ -22,7 +22,7 @@ export function useAddPostTypeCommands() {
 		},
 	} );
 	useCommand( {
-		name: 'core/wp-admin/add-page',
+		name: 'add new page',
 		label: __( 'Add new page' ),
 		icon: plus,
 		callback: () => {

--- a/packages/core-commands/src/add-post-type-commands.js
+++ b/packages/core-commands/src/add-post-type-commands.js
@@ -2,9 +2,7 @@
  * WordPress dependencies
  */
 import { privateApis } from '@wordpress/commands';
-import { __, sprintf } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
-import { useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 
 /**
@@ -12,61 +10,23 @@ import { plus } from '@wordpress/icons';
  */
 import { unlock } from './lock-unlock';
 
-const { useCommandLoader } = unlock( privateApis );
-
-const getAddPostTypeCommandLoader = ( postType ) =>
-	function useAddCommandLoader( { search } ) {
-		let label;
-		if ( postType === 'post' ) {
-			label = __( 'Add a new post' );
-		} else if ( postType === 'page' ) {
-			label = __( 'Add a new page' );
-		} else {
-			throw 'unsupported post type ' + postType;
-		}
-		const hasRecordTitle =
-			!! search && ! label.toLowerCase().includes( search.toLowerCase() );
-		if ( postType === 'post' && hasRecordTitle ) {
-			/* translators: %s: Post title placeholder */
-			label = sprintf( __( 'Add a new post "%s"' ), search );
-		} else if ( postType === 'page' && hasRecordTitle ) {
-			/* translators: %s: Page title placeholder */
-			label = sprintf( __( 'Add a new page "%s"' ), search );
-		}
-
-		const commands = useMemo(
-			() => [
-				{
-					name: 'core/wp-admin/add-' + postType + '-' + search,
-					label,
-					icon: plus,
-					callback: () => {
-						document.location.href = addQueryArgs( 'post-new.php', {
-							post_type: postType,
-							post_title: hasRecordTitle ? search : undefined,
-						} );
-					},
-				},
-			],
-			[ hasRecordTitle, search, label ]
-		);
-
-		return {
-			isLoading: false,
-			commands,
-		};
-	};
-
-const useAddPostLoader = getAddPostTypeCommandLoader( 'post' );
-const useAddPageLoader = getAddPostTypeCommandLoader( 'page' );
+const { useCommand } = unlock( privateApis );
 
 export function useAddPostTypeCommands() {
-	useCommandLoader( {
-		name: 'core/wp-admin/add-post-loader',
-		hook: useAddPostLoader,
+	useCommand( {
+		name: 'core/wp-admin/add-post',
+		label: __( 'Add new post' ),
+		icon: plus,
+		callback: () => {
+			document.location.href = 'post-new.php';
+		},
 	} );
-	useCommandLoader( {
-		name: 'core/wp-admin/add-page-loader',
-		hook: useAddPageLoader,
+	useCommand( {
+		name: 'core/wp-admin/add-page',
+		label: __( 'Add new page' ),
+		icon: plus,
+		callback: () => {
+			document.location.href = 'post-new.php?post_type=page';
+		},
 	} );
 }


### PR DESCRIPTION
Related #48457

## What?

In trunk we have a behavior where if you type a random string in the command center, we show commands to create posts and pages with that random string as a title. That behavior has proven a bit confusing at times, this PR removes and only adds regular "add new post", "add new page" commands instead.

## Testing Instructions

1- Enable the command center experiment
2- Open the site editor
3- Open the command center: cmd + k
4- Type "add new" to filter and still show the "add new commands"
5- Type anything else to search and hide these two commands.
