### PR TITLE
Site Editor: Improve loading experience (v3)

### DIFF
--- a/packages/data/src/redux-store/metadata/selectors.js
+++ b/packages/data/src/redux-store/metadata/selectors.js
@@ -142,7 +142,7 @@ export function getCachedResolvers( state ) {
 export function hasResolvingSelectors( state ) {
 	return [ ...Object.values( state ) ].some( ( selectorState ) =>
 		[ ...selectorState._map.values() ].some(
-			( resolution ) => resolution[ 1 ].status === 'resolving'
+			( resolution ) => resolution[ 1 ]?.status === 'resolving'
 		)
 	);
 }

--- a/packages/data/src/redux-store/metadata/selectors.js
+++ b/packages/data/src/redux-store/metadata/selectors.js
@@ -131,3 +131,18 @@ export function isResolving( state, selectorName, args ) {
 export function getCachedResolvers( state ) {
 	return state;
 }
+
+/**
+ * Whether the store has any currently resolving selectors.
+ *
+ * @param {State} state Data state.
+ *
+ * @return {boolean} True if one or more selectors are resolving, false otherwise.
+ */
+export function hasResolvingSelectors( state ) {
+	return [ ...Object.values( state ) ].some( ( selectorState ) =>
+		[ ...selectorState._map.values() ].some(
+			( resolution ) => resolution[ 1 ].status === 'resolving'
+		)
+	);
+}

--- a/packages/data/src/redux-store/metadata/test/selectors.js
+++ b/packages/data/src/redux-store/metadata/test/selectors.js
@@ -324,3 +324,35 @@ describe( 'getResolutionError', () => {
 		).toBeFalsy();
 	} );
 } );
+
+describe( 'hasResolvingSelectors', () => {
+	let registry;
+	beforeEach( () => {
+		registry = createRegistry();
+		registry.registerStore( 'testStore', testStore );
+	} );
+
+	it( 'returns false if no requests have started', () => {
+		const { hasResolvingSelectors } = registry.select( 'testStore' );
+		const result = hasResolvingSelectors();
+
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns false if all requests have finished', () => {
+		registry.dispatch( 'testStore' ).startResolution( 'getFoo', [] );
+		registry.dispatch( 'testStore' ).finishResolution( 'getFoo', [] );
+		const { hasResolvingSelectors } = registry.select( 'testStore' );
+		const result = hasResolvingSelectors();
+
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns true if has started but not finished', () => {
+		registry.dispatch( 'testStore' ).startResolution( 'getFoo', [] );
+		const { hasResolvingSelectors } = registry.select( 'testStore' );
+		const result = hasResolvingSelectors();
+
+		expect( result ).toBe( true );
+	} );
+} );

--- a/packages/data/src/redux-store/test/index.js
+++ b/packages/data/src/redux-store/test/index.js
@@ -281,6 +281,7 @@ describe( 'resolveSelect', () => {
 
 	it( 'returns only store native selectors and excludes all meta ones', () => {
 		expect( Object.keys( registry.resolveSelect( 'store' ) ) ).toEqual( [
+			'hasResolvingSelectors',
 			'getItems',
 			'getItemsNoResolver',
 		] );

--- a/packages/e2e-test-utils/src/site-editor.js
+++ b/packages/e2e-test-utils/src/site-editor.js
@@ -10,6 +10,7 @@ import { addQueryArgs } from '@wordpress/url';
 
 const SELECTORS = {
 	visualEditor: '.edit-site-visual-editor iframe',
+	loadingSpinner: '.edit-site-canvas-spinner',
 };
 
 /**
@@ -128,6 +129,7 @@ export async function visitSiteEditor( query, skipWelcomeGuide = true ) {
 
 	await visitAdminPage( 'site-editor.php', query );
 	await page.waitForSelector( SELECTORS.visualEditor );
+	await page.waitForSelector( SELECTORS.loadingSpinner, { hidden: true } );
 
 	if ( skipWelcomeGuide ) {
 		await disableSiteEditorWelcomeGuide();

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -50,6 +50,16 @@ const interfaceLabels = {
 	footer: __( 'Editor footer' ),
 };
 
+function useIsEditorLoading() {
+	const { hasResolvingSelectors } = useSelect( ( select ) => {
+		return {
+			hasResolvingSelectors: select( coreStore ).hasResolvingSelectors(),
+		};
+	} );
+
+	return hasResolvingSelectors;
+}
+
 export default function Editor() {
 	const {
 		record: editedPost,
@@ -58,12 +68,6 @@ export default function Editor() {
 	} = useEditedEntityRecord();
 
 	const { id: editedPostId, type: editedPostType } = editedPost;
-
-	const { hasResolvingSelectors } = useSelect( ( select ) => {
-		return {
-			hasResolvingSelectors: select( coreStore ).hasResolvingSelectors(),
-		};
-	} );
 
 	const {
 		context,
@@ -159,7 +163,7 @@ export default function Editor() {
 	// action in <URlQueryController> from double-announcing.
 	useTitle( hasLoadedPost && title );
 
-	if ( ! hasLoadedPost || hasResolvingSelectors ) {
+	if ( useIsEditorLoading() || ! hasLoadedPost ) {
 		return <CanvasSpinner />;
 	}
 

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -164,6 +164,15 @@ export default function Editor() {
 	useEffect( () => {
 		if ( ! hasResolvingSelectors && ! loaded ) {
 			clearTimeout( timeoutRef.current );
+
+			/*
+			 * We're using an arbitrary 1s timeout here to catch brief moments
+			 * without any resolving selectors that would result in displaying
+			 * brief flickers of loading state and loaded state.
+			 *
+			 * It's worth experimenting with different values, since this also
+			 * adds 1s of artificial delay after loading has finished.
+			 */
 			timeoutRef.current = setTimeout( () => {
 				setLoaded( true );
 			}, 1000 );

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -4,7 +4,7 @@
 import { useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Notice } from '@wordpress/components';
-import { EntityProvider } from '@wordpress/core-data';
+import { EntityProvider, store as coreStore } from '@wordpress/core-data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import {
 	BlockContextProvider,
@@ -58,6 +58,12 @@ export default function Editor() {
 	} = useEditedEntityRecord();
 
 	const { id: editedPostId, type: editedPostType } = editedPost;
+
+	const { hasResolvingSelectors } = useSelect( ( select ) => {
+		return {
+			hasResolvingSelectors: select( coreStore ).hasResolvingSelectors(),
+		};
+	} );
 
 	const {
 		context,
@@ -153,7 +159,7 @@ export default function Editor() {
 	// action in <URlQueryController> from double-announcing.
 	useTitle( hasLoadedPost && title );
 
-	if ( ! hasLoadedPost ) {
+	if ( ! hasLoadedPost || hasResolvingSelectors ) {
 		return <CanvasSpinner />;
 	}
 

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -167,15 +167,11 @@ export default function Editor() {
 			timeoutRef.current = setTimeout( () => {
 				setLoaded( true );
 			}, 1000 );
-		}
 
-		if ( hasResolvingSelectors && timeoutRef.current ) {
-			clearTimeout( timeoutRef.current );
+			return () => {
+				clearTimeout( timeoutRef.current );
+			};
 		}
-
-		return () => {
-			clearTimeout( timeoutRef.current );
-		};
 	}, [ loaded, hasResolvingSelectors ] );
 
 	const isLoading = ! loaded || ! hasLoadedPost;

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -105,6 +105,7 @@
 	left: 0;
 	bottom: 0;
 	width: 100%;
+	overflow: hidden;
 
 	& > div {
 		color: $gray-900;


### PR DESCRIPTION
## What?

This experiments with loading the site editor behind the scenes and displaying it once it's finished loading. This time, we're doing it by checking whether we have any resolving selectors belonging to the core data store.

This PR is an alternative to #42525 and #47612, but this time, we don't utilize [Suspense](https://react.dev/reference/react/Suspense).

## Why?

We're aiming to find a way to improve the editor loading experience.

As @mtias [says](https://github.com/WordPress/gutenberg/issues/35503#issuecomment-973182125):

> The end goal should be that things load like a "screenshot"; all fully loaded when you start interacting.

See #35503 for more details and motivation.

## How?

We're building on what we've learned from #42525 and #47612. We're reusing the existing loading screen. 

### Demo - zoomed-out mode loading

https://user-images.githubusercontent.com/8436925/235678505-acbfb500-aea3-4d23-b0a7-796ce65d6d86.mov

### Demo - editor canvas loading

https://user-images.githubusercontent.com/8436925/235678660-36a0d5f3-5a4a-43b5-a5c9-f4019dffebb7.mov

## Testing Instructions
* Load the site editor and observe the loading experience. 
* Observe that at the time the fallback placeholder has been hidden, the editor has fully loaded.
* Test various use cases, like loading the zoomed-out site editor mode and the editor canvas mode.


