### PR TITLE
[Fonts API] Remove global from wp_print_fonts()

### DIFF
--- a/lib/experimental/fonts-api/fonts-api.php
+++ b/lib/experimental/fonts-api/fonts-api.php
@@ -183,7 +183,13 @@ if ( ! function_exists( 'wp_print_fonts' ) ) {
 	 *                        An empty array if none were processed.
 	 */
 	function wp_print_fonts( $handles = false ) {
-		global $wp_fonts;
+		$wp_fonts   = wp_fonts();
+		$registered = $wp_fonts->get_registered_font_families();
+
+		// Nothing to print, as no fonts are registered.
+		if ( empty( $registered ) ) {
+			return array();
+		}
 
 		if ( empty( $handles ) ) {
 			$handles = false;
@@ -191,13 +197,7 @@ if ( ! function_exists( 'wp_print_fonts' ) ) {
 
 		_wp_scripts_maybe_doing_it_wrong( __FUNCTION__ );
 
-		if ( ! ( $wp_fonts instanceof WP_Fonts ) ) {
-			if ( ! $handles ) {
-				return array(); // No need to instantiate if nothing is there.
-			}
-		}
-
-		return wp_fonts()->do_items( $handles );
+		return $wp_fonts->do_items( $handles );
 	}
 }
 

--- a/phpunit/fonts-api/wpPrintFonts-test.php
+++ b/phpunit/fonts-api/wpPrintFonts-test.php
@@ -15,31 +15,29 @@ require_once __DIR__ . '/../fixtures/mock-provider.php';
  */
 class Tests_Fonts_WpPrintFonts extends WP_Fonts_TestCase {
 
-	public function test_should_return_empty_array_when_global_not_instance() {
-		global $wp_fonts;
-		wp_fonts();
-		$wp_fonts = null;
-
+	public function test_should_return_empty_array_when_no_fonts_registered() {
 		$this->assertSame( array(), wp_print_fonts() );
-		$this->assertNotInstanceOf( WP_Webfonts::class, $wp_fonts );
 	}
 
 	/**
-	 * Unit test to mock WP_Webfonts::do_items().
+	 * Unit test which mocks WP_Fonts methods.
 	 *
 	 * @dataProvider data_mocked_handles
 	 *
-	 * @param string|string[]|false $handles  Handles to test.
-	 * @param array|string[]        $expected Expected array of processed handles.
+	 * @param string|string[] $handles Handles to test.
 	 */
-	public function test_should_return_mocked_handles( $handles, $expected ) {
-		$mock = $this->set_up_mock( 'do_items' );
+	public function test_should_return_mocked_handles( $handles ) {
+		$mock = $this->set_up_mock( array( 'get_registered_font_families', 'do_items' ) );
+		$mock->expects( $this->once() )
+			->method( 'get_registered_font_families' )
+			->will( $this->returnValue( $handles ) );
+
 		$mock->expects( $this->once() )
 			->method( 'do_items' )
 			->with(
 				$this->identicalTo( $handles )
 			)
-			->will( $this->returnValue( $expected ) );
+			->will( $this->returnValue( $handles ) );
 
 		wp_print_fonts( $handles );
 	}
@@ -51,13 +49,14 @@ class Tests_Fonts_WpPrintFonts extends WP_Fonts_TestCase {
 	 */
 	public function data_mocked_handles() {
 		return array(
-			'no handles'          => array(
-				'handles'  => false,
-				'expected' => array(),
+			'font family'            => array(
+				array( 'my-custom-font' ),
 			),
-			'font family handles' => array(
-				'handles'  => array( 'my-custom-font' ),
-				'expected' => array( 'my-custom-font' ),
+			'multiple font families' => array(
+				array(
+					'font1',
+					'font2',
+				),
 			),
 		);
 	}


### PR DESCRIPTION
Partially fixes #50075.
Sets up decision making for which fonts to print for PR #50151.

## What?

Removes the global check. Instead checks if any fonts are registered; if no, bails out.

## Why?

The original design (being replaced by this PR) comes from `wp_print_styles()`. 

The global check exists to avoid instantiating `WP_Fonts` when invoking `wp_print_fonts()`. In other words, if `wp_print_fonts()` is called _before_ the API is used, it would bail out. This technique saves the overhead within `wp_fonts()`, i.e. instantiating `WP_Fonts` and registering the local provider. However, this overhead is tiny and, in itself, not worthy of having a global variable for this purpose.

The function lacks a proper bail out check: if there are no fonts registered, then there's nothing to print. The global check assumed fonts are registered; however, this is a false assumption.

## How?

Removes the global check.

Replaces it with `wp_fonts()->get_registered_font_families()`. If it returns empty, then there are no fonts registered to print. Even if handles are passed into the `wp_print_fonts()`, those handles must be registered. 

Checking if no fonts are registered:
* is a simple, effective first-tier approach. More checks exist with `WP_Fonts::do_items()` stack.
* sets up the function for printing all registered fonts when in the Site Editor (see #50140).

## Testing Instructions

### Visually Test:

Set up on your test site:
1. Activate the Gutenberg plugin.
2. Activate TT3 theme.

Before applying this PR:
1. Go to the Site Editor > Styles > Typography.
2. Using your browser's dev tools, search the HMTL for `wp-fonts-local` `<style>` element.
3. Copying the internals of that element. You'll use this to compare after applying this PR.

After applying this PR:
1. Go to the Site Editor > Styles > Typography.
2. Using your browser's dev tools, search the HMTL for `wp-fonts-local` `<style>` element.
3. Compare the styles to the before styles from above. They should match.

To test the early bail out if no fonts are registered:
1. Add the following code to `wp-content/mu-plugins/test.php`:
```php
<?php

var_dump( wp_print_fonts() );
exit;
```

An empty array should be displayed in your browser.

### Running the automated tests

All tests should pass when running the PHPUnit tests:
```
npm run test:unit:php -- --filter Tests_Fonts_WpPrintFonts
```
