### PR TITLE
Search Block: Center align button text in editor

### DIFF
--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -12,6 +12,7 @@
 		border-radius: initial;
 		display: flex;
 		align-items: center;
+		justify-content: center;
 	}
 
 	&__components-button-group {


### PR DESCRIPTION
## What?

Centre justifies the Search block's button text in the Editor.

## Why?

Without this tweak, the text appears right-aligned when the block's width is reduced. This differs from the frontend where the text remains centred.

Fixes: #50220

## How?

Adds `justify-content: center;` to the search block's button div in the editor.

## Testing Instructions

- Add a search block and reduce block width to 25%
- Make sure the `Search` text is centred

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="965" alt="Screenshot 2023-05-02 at 10 29 05 AM" src="https://user-images.githubusercontent.com/3629020/235542642-5742f7c0-f084-48ce-895d-8419cdf3d6a5.png">

After:

<img width="975" alt="Screenshot 2023-05-02 at 10 23 18 AM" src="https://user-images.githubusercontent.com/3629020/235542506-52d8e2f5-88bc-4445-906f-7e27a34074c1.png">

