### PR TITLE
Add some @types packages as proper dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
 			"hasInstallScript": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/gradient-parser": "0.1.2",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/annotations": "file:packages/annotations",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
@@ -114,7 +113,6 @@
 				"@testing-library/user-event": "14.4.3",
 				"@types/eslint": "7.28.0",
 				"@types/estree": "0.0.50",
-				"@types/highlight-words-core": "1.2.1",
 				"@types/istanbul-lib-report": "3.0.0",
 				"@types/mime": "2.0.3",
 				"@types/npm-package-arg": "6.1.1",
@@ -14375,11 +14373,6 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@types/gradient-parser": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.2.tgz",
-			"integrity": "sha512-e2s1svCYJY8JDr2t/OoB/H4aWZy4sXUOAZ0NdSSHjKACw1jeU54gf4xj38di0AgVIObgzN1JSikJ5oSo3vxwgA=="
-		},
 		"node_modules/@types/hammerjs": {
 			"version": "2.0.41",
 			"resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.41.tgz",
@@ -14388,8 +14381,7 @@
 		"node_modules/@types/highlight-words-core": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@types/highlight-words-core/-/highlight-words-core-1.2.1.tgz",
-			"integrity": "sha512-9VZUA5omXBfn+hDxFjUDu1FOJTBM3LmvqfDey+Z6Aa8B8/JmF5SMj6FBrjfgJ/Q3YXOZd3qyTDfJyMZSs/wCUA==",
-			"dev": true
+			"integrity": "sha512-9VZUA5omXBfn+hDxFjUDu1FOJTBM3LmvqfDey+Z6Aa8B8/JmF5SMj6FBrjfgJ/Q3YXOZd3qyTDfJyMZSs/wCUA=="
 		},
 		"node_modules/@types/html-minifier-terser": {
 			"version": "6.1.0",
@@ -56222,6 +56214,8 @@
 				"@emotion/utils": "^1.0.0",
 				"@floating-ui/react-dom": "^2.0.1",
 				"@radix-ui/react-dropdown-menu": "2.0.4",
+				"@types/gradient-parser": "0.1.3",
+				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.2.24",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/compose": "file:../compose",
@@ -56316,6 +56310,11 @@
 				"react": ">=16.8.0",
 				"react-dom": ">=16.8.0"
 			}
+		},
+		"packages/components/node_modules/@types/gradient-parser": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.3.tgz",
+			"integrity": "sha512-XDbrTSBlQV9nxE1GiDL3FaOPy4G/KaJkhDutBX48Kg8CYZMBARyyDFGCWfWJn4pobmInmwud1xxH7VJMAr0CKQ=="
 		},
 		"packages/components/node_modules/framer-motion": {
 			"version": "10.13.0",
@@ -68262,11 +68261,6 @@
 				"@types/node": "*"
 			}
 		},
-		"@types/gradient-parser": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.2.tgz",
-			"integrity": "sha512-e2s1svCYJY8JDr2t/OoB/H4aWZy4sXUOAZ0NdSSHjKACw1jeU54gf4xj38di0AgVIObgzN1JSikJ5oSo3vxwgA=="
-		},
 		"@types/hammerjs": {
 			"version": "2.0.41",
 			"resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.41.tgz",
@@ -68275,8 +68269,7 @@
 		"@types/highlight-words-core": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@types/highlight-words-core/-/highlight-words-core-1.2.1.tgz",
-			"integrity": "sha512-9VZUA5omXBfn+hDxFjUDu1FOJTBM3LmvqfDey+Z6Aa8B8/JmF5SMj6FBrjfgJ/Q3YXOZd3qyTDfJyMZSs/wCUA==",
-			"dev": true
+			"integrity": "sha512-9VZUA5omXBfn+hDxFjUDu1FOJTBM3LmvqfDey+Z6Aa8B8/JmF5SMj6FBrjfgJ/Q3YXOZd3qyTDfJyMZSs/wCUA=="
 		},
 		"@types/html-minifier-terser": {
 			"version": "6.1.0",
@@ -69576,6 +69569,8 @@
 				"@emotion/utils": "^1.0.0",
 				"@floating-ui/react-dom": "^2.0.1",
 				"@radix-ui/react-dropdown-menu": "2.0.4",
+				"@types/gradient-parser": "0.1.3",
+				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.2.24",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/compose": "file:../compose",
@@ -69647,6 +69642,11 @@
 					"requires": {
 						"@floating-ui/dom": "^1.3.0"
 					}
+				},
+				"@types/gradient-parser": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.3.tgz",
+					"integrity": "sha512-XDbrTSBlQV9nxE1GiDL3FaOPy4G/KaJkhDutBX48Kg8CYZMBARyyDFGCWfWJn4pobmInmwud1xxH7VJMAr0CKQ=="
 				},
 				"framer-motion": {
 					"version": "10.13.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
 		"IS_GUTENBERG_PLUGIN": true
 	},
 	"dependencies": {
-		"@types/gradient-parser": "0.1.2",
 		"@wordpress/a11y": "file:packages/a11y",
 		"@wordpress/annotations": "file:packages/annotations",
 		"@wordpress/api-fetch": "file:packages/api-fetch",
@@ -126,7 +125,6 @@
 		"@testing-library/user-event": "14.4.3",
 		"@types/eslint": "7.28.0",
 		"@types/estree": "0.0.50",
-		"@types/highlight-words-core": "1.2.1",
 		"@types/istanbul-lib-report": "3.0.0",
 		"@types/mime": "2.0.3",
 		"@types/npm-package-arg": "6.1.1",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -31,6 +31,7 @@
 -   `ContextSystemProvider`: Move out of `ui/` ([#54847](https://github.com/WordPress/gutenberg/pull/54847)).
 -   `SlotFill`: Migrate to TypeScript and Convert to Functional Component `<Slot bubblesVirtually />`. ([#51350](https://github.com/WordPress/gutenberg/pull/51350)).
 -   `Components`: move `ui/utils` to `utils` and remove `ui/` folder ([#54922](https://github.com/WordPress/gutenberg/pull/54922)).
+-   Ensure `@types/` dependencies used by final type files are included in the main dependency field ([#50231](https://github.com/WordPress/gutenberg/pull/50231)).
 
 ## 25.8.0 (2023-09-20)
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -40,6 +40,8 @@
 		"@emotion/utils": "^1.0.0",
 		"@floating-ui/react-dom": "^2.0.1",
 		"@radix-ui/react-dropdown-menu": "2.0.4",
+		"@types/gradient-parser": "0.1.3",
+		"@types/highlight-words-core": "1.2.1",
 		"@use-gesture/react": "^10.2.24",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/compose": "file:../compose",

--- a/packages/components/src/text/types.ts
+++ b/packages/components/src/text/types.ts
@@ -7,6 +7,7 @@ import type { TruncateProps } from '../truncate/types';
  * External dependencies
  */
 import type { CSSProperties } from 'react';
+import type { FindAllArgs } from 'highlight-words-core';
 
 export type TextSize =
 	| 'body'
@@ -59,7 +60,7 @@ export interface Props extends TruncateProps {
 	/**
 	 * Array of search words. String search terms are automatically cast to RegExps unless `highlightEscape` is true.
 	 */
-	highlightSanitize?: import('highlight-words-core').FindAllArgs[ 'sanitize' ];
+	highlightSanitize?: FindAllArgs[ 'sanitize' ];
 	/**
 	 * Sets `Text` to have `display: block`.
 	 */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This partially addresses #50157. It moves some `@types` dependencies to the main dep field of `@wordpress/components`.

## Why?
When publishing a package, dev dependencies are never installed by 3rd party consumers. However, when we import a type from an external dep in our own published types, that external dep must be installable by our 3rd party consumers, or they'll get errors in `tsc` about missing packages. As a result, those `@types/` packages we reference in our published build types must be normal dependencies in the specific package, rather than dev dependencies in the root package.json.

(The approach of adding all `@types` packages to the root package.json only works when we _only_ use our type info internally -- we'll need to adjust this approach now that we're publishing our own type information more frequently.)

## How?
See above

## Testing Instructions
CI

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
