### PR TITLE
Global Styles: Fix positioning of gradient palette popovers on mobile

### DIFF
--- a/packages/edit-site/src/components/global-styles/gradients-palette-panel.js
+++ b/packages/edit-site/src/components/global-styles/gradients-palette-panel.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { useViewportMatch } from '@wordpress/compose';
 import {
 	__experimentalVStack as VStack,
 	__experimentalPaletteEdit as PaletteEdit,
@@ -17,6 +18,7 @@ import Subtitle from './subtitle';
 import { unlock } from '../../private-apis';
 
 const { useGlobalSetting } = unlock( blockEditorPrivateApis );
+const mobilePopoverProps = { placement: 'bottom-start', offset: 8 };
 
 const noop = () => {};
 
@@ -63,6 +65,9 @@ export default function GradientPalettePanel( { name } ) {
 		...( defaultDuotone && defaultDuotoneEnabled ? defaultDuotone : [] ),
 	];
 
+	const isMobileViewport = useViewportMatch( 'small', '<' );
+	const popoverProps = isMobileViewport ? mobilePopoverProps : undefined;
+
 	return (
 		<VStack
 			className="edit-site-global-styles-gradient-palette-panel"
@@ -76,6 +81,7 @@ export default function GradientPalettePanel( { name } ) {
 					onChange={ setThemeGradients }
 					paletteLabel={ __( 'Theme' ) }
 					paletteLabelHeadingLevel={ 3 }
+					popoverProps={ popoverProps }
 				/>
 			) }
 			{ !! defaultGradients &&
@@ -88,6 +94,7 @@ export default function GradientPalettePanel( { name } ) {
 						onChange={ setDefaultGradients }
 						paletteLabel={ __( 'Default' ) }
 						paletteLabelLevel={ 3 }
+						popoverProps={ popoverProps }
 					/>
 				) }
 			<PaletteEdit
@@ -99,6 +106,7 @@ export default function GradientPalettePanel( { name } ) {
 					'Custom gradients are empty! Add some gradients to create your own palette.'
 				) }
 				slugPrefix="custom-"
+				popoverProps={ popoverProps }
 			/>
 			{ !! duotonePalette && !! duotonePalette.length && (
 				<div>


### PR DESCRIPTION
## What?

Fixes positioning of gradient palette popovers while on small viewports.

## Why?

Without these tweaks the gradient palette popover is rendered outside the viewport and is hidden.

## How?

- Leverages the ability to pass custom popover props introduced in https://github.com/WordPress/gutenberg/pull/49975
- If the viewport is small, tweaked popover positioning props are passed through

## Testing Instructions
- In the Site Editor, navigate to Global Styles > Colors > Palette
- Switch to the Gradients tab
- Confirm the placement of popovers for theme, default, and custom palettes
- Resize to a small viewport and confirm the palette popovers all appear within the viewport

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="456" alt="Screenshot 2023-05-02 at 1 27 15 pm" src="https://user-images.githubusercontent.com/60436221/235573369-dc768c85-d1d6-4fb5-a685-d49363847b2d.png"> | <img width="455" alt="Screenshot 2023-05-02 at 1 24 04 pm" src="https://user-images.githubusercontent.com/60436221/235573386-232c7743-6a57-404f-8e62-a7f60e3b9662.png"> |
| <img width="453" alt="Screenshot 2023-05-02 at 1 27 22 pm" src="https://user-images.githubusercontent.com/60436221/235573377-dae421d4-8e4a-4d23-a067-76d1cf918682.png"> | <img width="456" alt="Screenshot 2023-05-02 at 1 24 13 pm" src="https://user-images.githubusercontent.com/60436221/235573397-3627a868-4633-421f-92c7-d5389b328cdd.png"> |
