### PR TITLE
Global styles revisions: remove human time diff and custom author fields from the API response

### DIFF
--- a/lib/experimental/class-gutenberg-rest-global-styles-revisions-controller.php
+++ b/lib/experimental/class-gutenberg-rest-global-styles-revisions-controller.php
@@ -130,19 +130,6 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller extends WP_REST_Controll
 			$data['author'] = (int) $item->post_author;
 		}
 
-		if ( rest_is_field_included( 'author_avatar_url', $fields ) ) {
-			$data['author_avatar_url'] = get_avatar_url(
-				$item->post_author,
-				array(
-					'size' => 24,
-				)
-			);
-		}
-
-		if ( rest_is_field_included( 'author_display_name', $fields ) ) {
-			$data['author_display_name'] = get_the_author_meta( 'display_name', $item->post_author );
-		}
-
 		if ( rest_is_field_included( 'date', $fields ) ) {
 			$data['date'] = $item->post_date;
 		}
@@ -243,19 +230,6 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller extends WP_REST_Controll
 					'description' => __( 'The ID for the parent of the revision.', 'gutenberg' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit', 'embed' ),
-				),
-
-				// Adds custom global styles revisions schema.
-				'author_display_name' => array(
-					'description' => __( 'The display name of the author.', 'gutenberg' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
-				),
-
-				'author_avatar_url'   => array(
-					'description' => __( 'A URL to the avatar image of the author', 'gutenberg' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
 				),
 
 				// Adds settings and styles from the WP_REST_Global_Styles_Controller parent schema.

--- a/lib/experimental/class-gutenberg-rest-global-styles-revisions-controller.php
+++ b/lib/experimental/class-gutenberg-rest-global-styles-revisions-controller.php
@@ -192,53 +192,53 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller extends WP_REST_Controll
 				 * Adds settings and styles from the WP_REST_Revisions_Controller item fields.
 				 * Leaves out GUID as global styles shouldn't be accessible via URL.
 				 */
-				'author'              => array(
+				'author'       => array(
 					'description' => __( 'The ID for the author of the revision.', 'gutenberg' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),
-				'date'                => array(
+				'date'         => array(
 					'description' => __( "The date the revision was published, in the site's timezone.", 'gutenberg' ),
 					'type'        => 'string',
 					'format'      => 'date-time',
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),
-				'date_gmt'            => array(
+				'date_gmt'     => array(
 					'description' => __( 'The date the revision was published, as GMT.', 'gutenberg' ),
 					'type'        => 'string',
 					'format'      => 'date-time',
 					'context'     => array( 'view', 'edit' ),
 				),
-				'id'                  => array(
+				'id'           => array(
 					'description' => __( 'Unique identifier for the revision.', 'gutenberg' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),
-				'modified'            => array(
+				'modified'     => array(
 					'description' => __( "The date the revision was last modified, in the site's timezone.", 'gutenberg' ),
 					'type'        => 'string',
 					'format'      => 'date-time',
 					'context'     => array( 'view', 'edit' ),
 				),
-				'modified_gmt'        => array(
+				'modified_gmt' => array(
 					'description' => __( 'The date the revision was last modified, as GMT.', 'gutenberg' ),
 					'type'        => 'string',
 					'format'      => 'date-time',
 					'context'     => array( 'view', 'edit' ),
 				),
-				'parent'              => array(
+				'parent'       => array(
 					'description' => __( 'The ID for the parent of the revision.', 'gutenberg' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),
 
 				// Adds settings and styles from the WP_REST_Global_Styles_Controller parent schema.
-				'styles'              => array(
+				'styles'       => array(
 					'description' => __( 'Global styles.', 'gutenberg' ),
 					'type'        => array( 'object' ),
 					'context'     => array( 'view', 'edit' ),
 				),
-				'settings'            => array(
+				'settings'     => array(
 					'description' => __( 'Global settings.', 'gutenberg' ),
 					'type'        => array( 'object' ),
 					'context'     => array( 'view', 'edit' ),

--- a/lib/experimental/class-gutenberg-rest-global-styles-revisions-controller.php
+++ b/lib/experimental/class-gutenberg-rest-global-styles-revisions-controller.php
@@ -122,14 +122,6 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller extends WP_REST_Controll
 		$raw_revision_config = json_decode( $item->post_content, true );
 		$config              = ( new WP_Theme_JSON_Gutenberg( $raw_revision_config, 'custom' ) )->get_raw_data();
 
-		// Builds human-friendly date.
-		$now_gmt      = time();
-		$modified     = strtotime( $item->post_modified );
-		$modified_gmt = strtotime( $item->post_modified_gmt . ' +0000' );
-		/* translators: %s: Human-readable time difference. */
-		$time_ago   = sprintf( __( '%s ago', 'gutenberg' ), human_time_diff( $modified_gmt, $now_gmt ) );
-		$date_short = date_i18n( _x( 'j M @ H:i', 'revision date short format', 'gutenberg' ), $modified );
-
 		// Prepares item data.
 		$data   = array();
 		$fields = $this->get_fields_for_response( $request );
@@ -153,11 +145,6 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller extends WP_REST_Controll
 
 		if ( rest_is_field_included( 'date', $fields ) ) {
 			$data['date'] = $item->post_date;
-		}
-
-		if ( rest_is_field_included( 'date_display', $fields ) ) {
-			/* translators: 1: Human-readable time difference, 2: short date combined to show rendered revision date. */
-			$data['date_display'] = sprintf( __( '%1$s (%2$s)', 'gutenberg' ), $time_ago, $date_short );
 		}
 
 		if ( rest_is_field_included( 'date_gmt', $fields ) ) {
@@ -271,11 +258,6 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller extends WP_REST_Controll
 					'context'     => array( 'view', 'edit' ),
 				),
 
-				'date_display'        => array(
-					'description' => __( 'A human-friendly rendering of the date', 'gutenberg' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
-				),
 				// Adds settings and styles from the WP_REST_Global_Styles_Controller parent schema.
 				'styles'              => array(
 					'description' => __( 'Global styles.', 'gutenberg' ),

--- a/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
+++ b/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
@@ -104,11 +104,6 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 
 		// Author information.
 		$this->assertEquals( self::$admin_id, $data[0]['author'], 'Check that author id returns expected value' );
-		$this->assertEquals( get_the_author_meta( 'display_name', self::$admin_id ), $data[0]['author_display_name'], 'Check that author display_name returns expected value' );
-		$this->assertIsString(
-			$data[0]['author_avatar_url'],
-			'Check that author avatar_url returns expected value type'
-		);
 
 		// Global styles.
 		$this->assertEquals(
@@ -153,14 +148,12 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertCount( 11, $properties, 'Schema properties array does not have exactly 11 elements' );
+		$this->assertCount( 9, $properties, 'Schema properties array does not have exactly 9 elements' );
 		$this->assertArrayHasKey( 'id', $properties, 'Schema properties array does not have "id" key' );
 		$this->assertArrayHasKey( 'styles', $properties, 'Schema properties array does not have "styles" key' );
 		$this->assertArrayHasKey( 'settings', $properties, 'Schema properties array does not have "settings" key' );
 		$this->assertArrayHasKey( 'parent', $properties, 'Schema properties array does not have "parent" key' );
 		$this->assertArrayHasKey( 'author', $properties, 'Schema properties array does not have "author" key' );
-		$this->assertArrayHasKey( 'author_display_name', $properties, 'Schema properties array does not have "author_display_name" key' );
-		$this->assertArrayHasKey( 'author_avatar_url', $properties, 'Schema properties array does not have "author_avatar_url" key' );
 		$this->assertArrayHasKey( 'date', $properties, 'Schema properties array does not have "date" key' );
 		$this->assertArrayHasKey( 'date_gmt', $properties, 'Schema properties array does not have "date_gmt" key' );
 		$this->assertArrayHasKey( 'modified', $properties, 'Schema properties array does not have "modified" key' );

--- a/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
+++ b/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
@@ -98,7 +98,6 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 		// Dates.
 		$this->assertArrayHasKey( 'date', $data[0], 'Check that an date key exists' );
 		$this->assertArrayHasKey( 'date_gmt', $data[0], 'Check that an date_gmt key exists' );
-		$this->assertArrayHasKey( 'date_display', $data[0], 'Check that an date_display key exists' );
 		$this->assertArrayHasKey( 'modified', $data[0], 'Check that an modified key exists' );
 		$this->assertArrayHasKey( 'modified_gmt', $data[0], 'Check that an modified_gmt key exists' );
 		$this->assertArrayHasKey( 'modified_gmt', $data[0], 'Check that an modified_gmt key exists' );
@@ -143,6 +142,7 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 
 		$this->assertCount( 2, $data, 'Check that two revisions exists' );
 		$this->assertEquals( self::$second_admin_id, $data[0]['author'], 'Check that second author id returns expected value' );
+		$this->assertEquals( self::$admin_id, $data[1]['author'], 'Check that second author id returns expected value' );
 	}
 
 	/**
@@ -153,7 +153,7 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertCount( 12, $properties, 'Schema properties array does not have exactly 4 elements' );
+		$this->assertCount( 11, $properties, 'Schema properties array does not have exactly 11 elements' );
 		$this->assertArrayHasKey( 'id', $properties, 'Schema properties array does not have "id" key' );
 		$this->assertArrayHasKey( 'styles', $properties, 'Schema properties array does not have "styles" key' );
 		$this->assertArrayHasKey( 'settings', $properties, 'Schema properties array does not have "settings" key' );
@@ -163,7 +163,6 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 		$this->assertArrayHasKey( 'author_avatar_url', $properties, 'Schema properties array does not have "author_avatar_url" key' );
 		$this->assertArrayHasKey( 'date', $properties, 'Schema properties array does not have "date" key' );
 		$this->assertArrayHasKey( 'date_gmt', $properties, 'Schema properties array does not have "date_gmt" key' );
-		$this->assertArrayHasKey( 'date_display', $properties, 'Schema properties array does not have "date_display" key' );
 		$this->assertArrayHasKey( 'modified', $properties, 'Schema properties array does not have "modified" key' );
 		$this->assertArrayHasKey( 'modified_gmt', $properties, 'Schema properties array does not have "modified_gmt" key' );
 	}


### PR DESCRIPTION
## What?

Like it says in the title, this PR removes the human friendly time diff (`'date_display'`) and custom author fields (`'author_display_name'` and `'author_avatar_url'`)

## Why, for the love of all that is pure and innocent?!

To make the response appear a little closer to the regular post revisions object.

The assumption is that the consumer can format the raw dates and grab user information as they wish. 

Pursuant to the last point, there's a `humanTimeDiff` [JS function in the works that will take care of this.](https://github.com/WordPress/gutenberg/pull/50089/files#diff-14cba7c4c49fe9c301d3334f1c081c945ffd5539afe48c5d2707745bddffc38fR118) and, furthermore, we can match revision authors on the frontend using the response from [getUsers](https://developer.wordpress.org/block-editor/reference-guides/data/data-core/#getauthors).

See https://github.com/WordPress/gutenberg/pull/50089 for context

## How?

Liberal use of my keyboard's delete key, which now has dried pasta sauce on it because I didn't wipe my fingers properly after lunch. I am not a monster!

## Testing Instructions


Run the tests!

`npm run test:unit:php -- --filter Gutenberg_REST_Global_Styles_Revisions_Controller_Test`


You can also check the response in the console. Make sure you're in the site editor and your global styles have a few revisions already.

```
await wp.apiFetch( { url: `/index.php?rest_route=%2Fwp%2Fv2%2Fglobal-styles%2F${ wp.data.select('core').__experimentalGetCurrentGlobalStylesId() }%2Frevisions&_locale=user` } );
```

`date_display`, `author_display_name` and `author_avatar_url` should no longer appear in the response objects

<img width="1216" alt="Screenshot 2023-05-02 at 3 09 06 pm" src="https://user-images.githubusercontent.com/6458278/235583788-cfb56f8f-f5e0-4147-be32-1bca6b2b9e76.png">
