### PR TITLE
Cover: Use overflow: clip, falling back to overflow: hidden to allow sticky children (technically)

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -8,8 +8,10 @@
 	align-items: center;
 	padding: 1em;
 	// Prevent the `wp-block-cover__background` span from overflowing the container when border-radius is applied.
-	// TODO: Find an alternative to `overflow: hidden` so that sticky elements can be used inside the cover block.
+	// `overflow: hidden` is provided as a fallback for browsers that don't support `overflow: clip`.
 	overflow: hidden;
+	// Use clip instead of overflow: hidden so that sticky position works on child elements.
+	overflow: clip;
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 	// Keep the flex layout direction to the physical direction (LTR) in RTL languages.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up to https://github.com/WordPress/gutenberg/pull/50209.

Add `overflow: clip` rule to the Cover block's styling, falling back to `overflow: hidden`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In #50209, the `overflow: hidden` rule was re-instated for the Cover block, so that rounded borders would correctly clip the inner background element. However, `overflow: hidden` causes sticky positioned child elements to no longer be sticky to the overall document as it creates a new formatting context.

`overflow: clip` on the other hand clips the overflow content without creating a new formatting context, so that sticky children can still scroll along with the document (while sticking to the parent container).

Browser support appears to be pretty good amongst evergreen browsers (https://caniuse.com/?search=overflow%3Aclip), but to be on the safe side, I've preserved the fallback `overflow: hidden` for older browsers.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add an additional `overflow: clip` rule to the Cover block, that overrides `overflow: hidden`.
* `overflow: hidden` is preserved so that the border radius still works correctly on older browsers

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

* Test that the Cover block still displays correctly in the post editor, site editor, and on the site frontend
* Test with a variety of borders and border radii

Testing that this works correctly with sticky blocks is a little tricky — it involves creating a sticky group block outside of a Cover block, and then dragging it to be within the cover block. Then, add enough content to the cover block so that the sticky block is sticky when the window is scrolled. To make it easier, I've added some test markup below:

<details>

<summary>Test markup of a Cover block with a sticky group block within it</summary>

```html
<!-- wp:cover {"customOverlayColor":"#d7d7d7","isDark":false,"style":{"border":{"width":"5px","color":"#000000","radius":"59px"},"spacing":{"padding":{"top":"2em","right":"2em","bottom":"2em","left":"2em"}}},"layout":{"type":"constrained"}} -->
<div class="wp-block-cover is-light has-border-color" style="border-color:#000000;border-width:5px;border-radius:59px;padding-top:2em;padding-right:2em;padding-bottom:2em;padding-left:2em"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#d7d7d7"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"style":{"position":{"type":"sticky","top":"0px"},"color":{"background":"#944747"}},"textColor":"base","layout":{"type":"constrained"}} -->
<div class="wp-block-group has-base-color has-text-color has-background" style="background-color:#944747"><!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->
<p style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">A sticky group block</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">A title</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin auctor, magna at efficitur tristique, diam nibh malesuada risus, ac consectetur ex nibh blandit justo. Pellentesque egestas libero et erat bibendum vehicula. Nulla dignissim odio odio, ac ornare arcu lobortis non. Cras luctus suscipit accumsan. Fusce tortor eros, convallis sit amet suscipit eget, viverra sed ex. Sed dictum tempor velit, id fringilla turpis mattis at. Nullam in tincidunt ipsum. Morbi et lectus eget magna tempus suscipit at a quam. Vivamus sit amet turpis fermentum, facilisis quam eu, fringilla felis. Etiam et dolor sit amet nulla efficitur venenatis. Proin consectetur erat orci, a faucibus nulla gravida in.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Vivamus in libero et lacus dignissim volutpat non a massa. Etiam rhoncus posuere dui, in condimentum quam vehicula ut. Sed vel sollicitudin nulla. Phasellus sed egestas ipsum, quis posuere enim. Mauris dictum nisl erat, id dictum massa vehicula sit amet. Nulla ut dapibus tellus. Sed sed sem sit amet ante bibendum pharetra a eu massa. Donec in rhoncus mi, eu ultricies nisi. Curabitur sagittis aliquet iaculis. Sed accumsan nunc ac tellus auctor interdum. Sed nunc mi, semper sagittis efficitur eget, consequat quis diam. Nam ut odio id enim rutrum luctus eu nec ligula. Nunc dignissim at nisi a porttitor. Etiam dapibus diam nec ornare fringilla.</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->
```
</details>

## Screenshots or screencast <!-- if applicable -->

The below screengrab demonstrates that `overflow: clip` allows both the cover block's background to be clipped and for sticky children to work correctly. Note that the UI for allowing non-root sticky position has not been enabled yet, as that is being worked on over in https://github.com/WordPress/gutenberg/pull/49321

https://user-images.githubusercontent.com/14988353/235587574-c1777600-a19b-473c-828a-a3e6ec3a27a6.mp4