### PR TITLE
Add class names to block settings dropdown menu items

### DIFF
--- a/packages/block-editor/src/components/block-lock/menu-item.js
+++ b/packages/block-editor/src/components/block-lock/menu-item.js
@@ -30,7 +30,7 @@ export default function BlockLockMenuItem( { clientId } ) {
 		<>
 			<MenuItem
 				icon={ isLocked ? unlock : lockOutline }
-				className='block-action-lock'
+				className="block-action-lock"
 				onClick={ toggleModal }
 			>
 				{ label }

--- a/packages/block-editor/src/components/block-lock/menu-item.js
+++ b/packages/block-editor/src/components/block-lock/menu-item.js
@@ -30,7 +30,7 @@ export default function BlockLockMenuItem( { clientId } ) {
 		<>
 			<MenuItem
 				icon={ isLocked ? unlock : lockOutline }
-				className={ 'block-action-lock' }
+				className='block-action-lock'
 				onClick={ toggleModal }
 			>
 				{ label }

--- a/packages/block-editor/src/components/block-lock/menu-item.js
+++ b/packages/block-editor/src/components/block-lock/menu-item.js
@@ -30,6 +30,7 @@ export default function BlockLockMenuItem( { clientId } ) {
 		<>
 			<MenuItem
 				icon={ isLocked ? unlock : lockOutline }
+				className={ 'block-action-lock' }
 				onClick={ toggleModal }
 			>
 				{ label }

--- a/packages/block-editor/src/components/block-settings-menu/block-convert-button.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-convert-button.js
@@ -12,6 +12,6 @@ export default function BlockConvertButton( { shouldRender, onClick, small } ) {
 	const label = __( 'Convert to Blocks' );
 	return <MenuItem 
 		onClick={ onClick }
-		className={ 'block-action-convert' }
+		className='block-action-convert'
 	>{ ! small && label }</MenuItem>;
 }

--- a/packages/block-editor/src/components/block-settings-menu/block-convert-button.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-convert-button.js
@@ -12,6 +12,6 @@ export default function BlockConvertButton( { shouldRender, onClick, small } ) {
 	const label = __( 'Convert to Blocks' );
 	return <MenuItem 
 		onClick={ onClick }
-		className='block-action-convert'
+		className="block-action-convert"
 	>{ ! small && label }</MenuItem>;
 }

--- a/packages/block-editor/src/components/block-settings-menu/block-convert-button.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-convert-button.js
@@ -10,5 +10,8 @@ export default function BlockConvertButton( { shouldRender, onClick, small } ) {
 	}
 
 	const label = __( 'Convert to Blocks' );
-	return <MenuItem onClick={ onClick }>{ ! small && label }</MenuItem>;
+	return <MenuItem 
+		onClick={ onClick }
+		className={ 'block-action-convert' }
+	>{ ! small && label }</MenuItem>;
 }

--- a/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
@@ -34,7 +34,7 @@ export function BlockModeToggle( {
 
 	return <MenuItem 
 		onClick={ onToggleMode }
-		className={ 'block-action-edit-mode' }
+		className='block-action-edit-mode'
 	>{ ! small && label }</MenuItem>;
 }
 

--- a/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
@@ -34,7 +34,7 @@ export function BlockModeToggle( {
 
 	return <MenuItem 
 		onClick={ onToggleMode }
-		className='block-action-edit-mode'
+		className="block-action-edit-mode"
 	>{ ! small && label }</MenuItem>;
 }
 

--- a/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
@@ -32,7 +32,10 @@ export function BlockModeToggle( {
 	const label =
 		mode === 'visual' ? __( 'Edit as HTML' ) : __( 'Edit visually' );
 
-	return <MenuItem onClick={ onToggleMode }>{ ! small && label }</MenuItem>;
+	return <MenuItem 
+		onClick={ onToggleMode }
+		className={ 'block-action-edit-mode' }
+	>{ ! small && label }</MenuItem>;
 }
 
 export default compose( [

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -45,7 +45,7 @@ function CopyMenuItem( { blocks, onCopy, label } ) {
 	const copyMenuItemLabel = label ? label : copyMenuItemBlocksLabel;
 	return <MenuItem 
 		ref={ ref }
-		className='block-action-copy'
+		className="block-action-copy"
 	>{ copyMenuItemLabel }</MenuItem>;
 }
 
@@ -236,7 +236,7 @@ export function BlockSettingsDropdown( {
 													}
 												/>
 											}
-											className='block-action-select-parent'
+											className="block-action-select-parent"
 											onClick={ () =>
 												selectBlock(
 													firstParentClientId
@@ -263,7 +263,7 @@ export function BlockSettingsDropdown( {
 								/>
 								{ canDuplicate && (
 									<MenuItem
-										className='block-action-duplicate'
+										className="block-action-duplicate"
 										onClick={ pipe(
 											onClose,
 											onDuplicate,
@@ -277,7 +277,7 @@ export function BlockSettingsDropdown( {
 								{ canInsertDefaultBlock && (
 									<>
 										<MenuItem
-											className='block-action-insert-before'
+											className="block-action-insert-before"
 											onClick={ pipe(
 												onClose,
 												onInsertBefore
@@ -287,7 +287,7 @@ export function BlockSettingsDropdown( {
 											{ __( 'Insert before' ) }
 										</MenuItem>
 										<MenuItem
-											className='block-action-insert-after'
+											className="block-action-insert-after"
 											onClick={ pipe(
 												onClose,
 												onInsertAfter
@@ -300,7 +300,7 @@ export function BlockSettingsDropdown( {
 								) }
 								{ canMove && ! onlyBlock && (
 									<MenuItem
-										className='block-action-move-to'
+										className="block-action-move-to"
 										onClick={ pipe( onClose, onMoveTo ) }
 									>
 										{ __( 'Move to' ) }
@@ -320,7 +320,7 @@ export function BlockSettingsDropdown( {
 									label={ __( 'Copy styles' ) }
 								/>
 								<MenuItem 
-									className='block-action-paste-styles'
+									className="block-action-paste-styles"
 									onClick={ onPasteStyles }
 								>
 									{ __( 'Paste styles' ) }
@@ -341,7 +341,7 @@ export function BlockSettingsDropdown( {
 							{ canRemove && (
 								<MenuGroup>
 									<MenuItem
-										className='block-action-delete'
+										className="block-action-delete"
 										onClick={ pipe(
 											onClose,
 											onRemove,

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -43,7 +43,10 @@ function CopyMenuItem( { blocks, onCopy, label } ) {
 	const copyMenuItemBlocksLabel =
 		blocks.length > 1 ? __( 'Copy blocks' ) : __( 'Copy block' );
 	const copyMenuItemLabel = label ? label : copyMenuItemBlocksLabel;
-	return <MenuItem ref={ ref }>{ copyMenuItemLabel }</MenuItem>;
+	return <MenuItem 
+		ref={ ref }
+		className={ 'block-action-copy' }
+	>{ copyMenuItemLabel }</MenuItem>;
 }
 
 export function BlockSettingsDropdown( {
@@ -233,6 +236,7 @@ export function BlockSettingsDropdown( {
 													}
 												/>
 											}
+											className={ 'block-action-select-parent' }
 											onClick={ () =>
 												selectBlock(
 													firstParentClientId
@@ -259,6 +263,7 @@ export function BlockSettingsDropdown( {
 								/>
 								{ canDuplicate && (
 									<MenuItem
+										className={ 'block-action-duplicate' }
 										onClick={ pipe(
 											onClose,
 											onDuplicate,
@@ -272,6 +277,7 @@ export function BlockSettingsDropdown( {
 								{ canInsertDefaultBlock && (
 									<>
 										<MenuItem
+											className={ 'block-action-insert-before' }
 											onClick={ pipe(
 												onClose,
 												onInsertBefore
@@ -281,6 +287,7 @@ export function BlockSettingsDropdown( {
 											{ __( 'Insert before' ) }
 										</MenuItem>
 										<MenuItem
+											className={ 'block-action-insert-after' }
 											onClick={ pipe(
 												onClose,
 												onInsertAfter
@@ -293,6 +300,7 @@ export function BlockSettingsDropdown( {
 								) }
 								{ canMove && ! onlyBlock && (
 									<MenuItem
+										className={ 'block-action-move-to' }
 										onClick={ pipe( onClose, onMoveTo ) }
 									>
 										{ __( 'Move to' ) }
@@ -311,7 +319,10 @@ export function BlockSettingsDropdown( {
 									onCopy={ onCopy }
 									label={ __( 'Copy styles' ) }
 								/>
-								<MenuItem onClick={ onPasteStyles }>
+								<MenuItem 
+									className={ 'block-action-paste-styles' }
+									onClick={ onPasteStyles }
+								>
 									{ __( 'Paste styles' ) }
 								</MenuItem>
 							</MenuGroup>
@@ -330,6 +341,7 @@ export function BlockSettingsDropdown( {
 							{ canRemove && (
 								<MenuGroup>
 									<MenuItem
+										className={ 'block-action-delete' }
 										onClick={ pipe(
 											onClose,
 											onRemove,

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -44,7 +44,7 @@ function CopyMenuItem( { blocks, onCopy, label } ) {
 		blocks.length > 1 ? __( 'Copy blocks' ) : __( 'Copy block' );
 	const copyMenuItemLabel = label ? label : copyMenuItemBlocksLabel;
 	return <MenuItem 
-		ref={ ref }
+		ref={ ref } 
 		className="block-action-copy"
 	>{ copyMenuItemLabel }</MenuItem>;
 }

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -260,7 +260,7 @@ export function BlockSettingsDropdown( {
 								<CopyMenuItem
 									blocks={ blocks }
 									onCopy={ onCopy }
-									className = "block-action-copy"
+									className="block-action-copy"
 								/>
 								{ canDuplicate && (
 									<MenuItem
@@ -319,7 +319,7 @@ export function BlockSettingsDropdown( {
 									blocks={ blocks }
 									onCopy={ onCopy }
 									label={ __( 'Copy styles' ) }
-									className = "block-action-copy-styles"
+									className="block-action-copy-styles"
 								/>
 								<MenuItem 
 									className="block-action-paste-styles"

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -38,15 +38,15 @@ const POPOVER_PROPS = {
 	variant: 'toolbar',
 };
 
-function CopyMenuItem( { blocks, onCopy, label } ) {
+function CopyMenuItem( { blocks, onCopy, label, className } ) {
 	const ref = useCopyToClipboard( () => serialize( blocks ), onCopy );
 	const copyMenuItemBlocksLabel =
 		blocks.length > 1 ? __( 'Copy blocks' ) : __( 'Copy block' );
 	const copyMenuItemLabel = label ? label : copyMenuItemBlocksLabel;
-	return <MenuItem 
+	return ( <MenuItem 
 		ref={ ref } 
-		className="block-action-copy"
-	>{ copyMenuItemLabel }</MenuItem>;
+		className={ className }
+	>{ copyMenuItemLabel }</MenuItem> );
 }
 
 export function BlockSettingsDropdown( {
@@ -260,6 +260,7 @@ export function BlockSettingsDropdown( {
 								<CopyMenuItem
 									blocks={ blocks }
 									onCopy={ onCopy }
+									className = "block-action-copy"
 								/>
 								{ canDuplicate && (
 									<MenuItem
@@ -318,6 +319,7 @@ export function BlockSettingsDropdown( {
 									blocks={ blocks }
 									onCopy={ onCopy }
 									label={ __( 'Copy styles' ) }
+									className = "block-action-copy-styles"
 								/>
 								<MenuItem 
 									className="block-action-paste-styles"

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -45,7 +45,7 @@ function CopyMenuItem( { blocks, onCopy, label } ) {
 	const copyMenuItemLabel = label ? label : copyMenuItemBlocksLabel;
 	return <MenuItem 
 		ref={ ref }
-		className={ 'block-action-copy' }
+		className='block-action-copy'
 	>{ copyMenuItemLabel }</MenuItem>;
 }
 
@@ -236,7 +236,7 @@ export function BlockSettingsDropdown( {
 													}
 												/>
 											}
-											className={ 'block-action-select-parent' }
+											className='block-action-select-parent'
 											onClick={ () =>
 												selectBlock(
 													firstParentClientId
@@ -263,7 +263,7 @@ export function BlockSettingsDropdown( {
 								/>
 								{ canDuplicate && (
 									<MenuItem
-										className={ 'block-action-duplicate' }
+										className='block-action-duplicate'
 										onClick={ pipe(
 											onClose,
 											onDuplicate,
@@ -277,7 +277,7 @@ export function BlockSettingsDropdown( {
 								{ canInsertDefaultBlock && (
 									<>
 										<MenuItem
-											className={ 'block-action-insert-before' }
+											className='block-action-insert-before'
 											onClick={ pipe(
 												onClose,
 												onInsertBefore
@@ -287,7 +287,7 @@ export function BlockSettingsDropdown( {
 											{ __( 'Insert before' ) }
 										</MenuItem>
 										<MenuItem
-											className={ 'block-action-insert-after' }
+											className='block-action-insert-after'
 											onClick={ pipe(
 												onClose,
 												onInsertAfter
@@ -300,7 +300,7 @@ export function BlockSettingsDropdown( {
 								) }
 								{ canMove && ! onlyBlock && (
 									<MenuItem
-										className={ 'block-action-move-to' }
+										className='block-action-move-to'
 										onClick={ pipe( onClose, onMoveTo ) }
 									>
 										{ __( 'Move to' ) }
@@ -320,7 +320,7 @@ export function BlockSettingsDropdown( {
 									label={ __( 'Copy styles' ) }
 								/>
 								<MenuItem 
-									className={ 'block-action-paste-styles' }
+									className='block-action-paste-styles'
 									onClick={ onPasteStyles }
 								>
 									{ __( 'Paste styles' ) }
@@ -341,7 +341,7 @@ export function BlockSettingsDropdown( {
 							{ canRemove && (
 								<MenuGroup>
 									<MenuItem
-										className={ 'block-action-delete' }
+										className='block-action-delete'
 										onClick={ pipe(
 											onClose,
 											onRemove,

--- a/packages/block-editor/src/components/convert-to-group-buttons/index.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/index.js
@@ -49,6 +49,7 @@ function ConvertToGroupButton( {
 		<>
 			{ isGroupable && (
 				<MenuItem
+					className={ 'block-action-group' }
 					onClick={ () => {
 						onConvertToGroup();
 						onClose();
@@ -59,6 +60,7 @@ function ConvertToGroupButton( {
 			) }
 			{ isUngroupable && (
 				<MenuItem
+					className={ 'block-action-ungroup' }
 					onClick={ () => {
 						onConvertFromGroup();
 						onClose();

--- a/packages/block-editor/src/components/convert-to-group-buttons/index.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/index.js
@@ -49,7 +49,7 @@ function ConvertToGroupButton( {
 		<>
 			{ isGroupable && (
 				<MenuItem
-					className='block-action-group'
+					className="block-action-group"
 					onClick={ () => {
 						onConvertToGroup();
 						onClose();
@@ -60,7 +60,7 @@ function ConvertToGroupButton( {
 			) }
 			{ isUngroupable && (
 				<MenuItem
-					className='block-action-ungroup'
+					className="block-action-ungroup"
 					onClick={ () => {
 						onConvertFromGroup();
 						onClose();

--- a/packages/block-editor/src/components/convert-to-group-buttons/index.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/index.js
@@ -49,7 +49,7 @@ function ConvertToGroupButton( {
 		<>
 			{ isGroupable && (
 				<MenuItem
-					className={ 'block-action-group' }
+					className='block-action-group'
 					onClick={ () => {
 						onConvertToGroup();
 						onClose();
@@ -60,7 +60,7 @@ function ConvertToGroupButton( {
 			) }
 			{ isUngroupable && (
 				<MenuItem
-					className={ 'block-action-ungroup' }
+					className='block-action-ungroup'
 					onClick={ () => {
 						onConvertFromGroup();
 						onClose();


### PR DESCRIPTION
## What?
Add class names to block settings dropdown menu items.

## Why?
It is not possible to differentiate between these buttons without assigning class names to the menu items.

## How?
`className` added to each menu item

## Testing Instructions
1. Switch to block editor
2. Add a block
3. Open the block settings menu dropdown (block toolbar)
4. Examine the source code and look at the unique class names given to the menu items.