### PR TITLE
Update the WP version in which some JS APIs will be removed

### DIFF
--- a/packages/editor/src/components/deprecated.js
+++ b/packages/editor/src/components/deprecated.js
@@ -66,7 +66,7 @@ function deprecateComponent( name, Wrapped, staticsToHoist = [] ) {
 		deprecated( 'wp.editor.' + name, {
 			since: '5.3',
 			alternative: 'wp.blockEditor.' + name,
-			version: '6.2',
+			version: '6.4',
 		} );
 
 		return <Wrapped ref={ ref } { ...props } />;
@@ -87,7 +87,7 @@ function deprecateFunction( name, func ) {
 		deprecated( 'wp.editor.' + name, {
 			since: '5.3',
 			alternative: 'wp.blockEditor.' + name,
-			version: '6.2',
+			version: '6.4',
 		} );
 
 		return func( ...args );

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -528,7 +528,7 @@ const getBlockEditorAction =
 			since: '5.3',
 			alternative:
 				"`wp.data.dispatch( 'core/block-editor' )." + name + '`',
-			version: '6.2',
+			version: '6.4',
 		} );
 		registry.dispatch( blockEditorStore )[ name ]( ...args );
 	};

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1215,7 +1215,7 @@ function getBlockEditorSelector( name ) {
 		deprecated( "`wp.data.select( 'core/editor' )." + name + '`', {
 			since: '5.3',
 			alternative: "`wp.data.select( 'core/block-editor' )." + name + '`',
-			version: '6.2',
+			version: '6.4',
 		} );
 
 		return select( blockEditorStore )[ name ]( ...args );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/37854#issuecomment-1530629879

This PR updates the version of some APIs to be removed in WP 6.4 for now. The plan was to be removed in [6.2](https://make.wordpress.org/core/2022/05/03/block-editor-miscellaneous-dev-notes-for-wordpress-6-0/) but there was still a lot of usage. @annezazu any thoughts how we can ensure the removal for `6.4` by raising some more awareness? 