### PR TITLE
Button: Update gap between icon and text.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 -   `CheckboxControl`, `CustomGradientPicker`, `FormToggle`, : Refactor and correct the focus style for consistency ([#50127](https://github.com/WordPress/gutenberg/pull/50127)).
+-   `Button`: Reduce the gap between icon and label in icon+text buttons, to make them seem contextual ([#50241](https://github.com/WordPress/gutenberg/pull/50241)).
 
 ### Internal
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -297,11 +297,11 @@
 		}
 
 		&.has-text svg {
-			margin-right: $grid-unit-10;
+			margin-right: $grid-unit-05;
 		}
 
 		&.has-text .dashicon {
-			margin-right: $grid-unit-10 + 2px;
+			margin-right: $grid-unit-05 + 2px;
 		}
 	}
 


### PR DESCRIPTION
## What?

Followup to https://github.com/WordPress/gutenberg/pull/50218#event-9143352790. Reduces the spacing between icon and text label in icon+text buttons. 

Before:

<img width="178" alt="Screenshot 2023-05-02 at 11 02 13" src="https://user-images.githubusercontent.com/1204802/235625054-9a42ab81-477c-49be-8843-cb8a0e9322ea.png">

<img width="171" alt="Screenshot 2023-05-02 at 11 02 20" src="https://user-images.githubusercontent.com/1204802/235625073-5962d7e3-4413-4fe2-96c9-2ca78bd6cd6a.png">

<img width="172" alt="Screenshot 2023-05-02 at 11 02 27" src="https://user-images.githubusercontent.com/1204802/235625082-58646a3d-0d57-43ce-883c-415f8837e9ec.png">

<img width="157" alt="Screenshot 2023-05-02 at 11 02 31" src="https://user-images.githubusercontent.com/1204802/235625098-376bc902-9b36-4d8e-aea9-ba7a64c31fee.png">


After:

<img width="177" alt="Screenshot 2023-05-02 at 10 58 11" src="https://user-images.githubusercontent.com/1204802/235624740-82e80964-3ad3-4474-b25f-f71a4035dca8.png">

<img width="175" alt="Screenshot 2023-05-02 at 10 58 17" src="https://user-images.githubusercontent.com/1204802/235624750-901ea4ca-c520-4f31-baf8-e8c86c00d33d.png">

<img width="162" alt="Screenshot 2023-05-02 at 10 58 27" src="https://user-images.githubusercontent.com/1204802/235624763-fa92f898-d269-4648-9f02-f27acd8e98b7.png">

<img width="177" alt="Screenshot 2023-05-02 at 10 58 49" src="https://user-images.githubusercontent.com/1204802/235624773-24f974d5-0c50-4986-9905-fe5d373f08a5.png">

<img width="169" alt="Screenshot 2023-05-02 at 10 58 32" src="https://user-images.githubusercontent.com/1204802/235624778-a21df9f3-26fc-4a9f-9f9f-76d01992672b.png">

<img width="169" alt="Screenshot 2023-05-02 at 10 58 40" src="https://user-images.githubusercontent.com/1204802/235624788-1221222c-d1b9-4477-9a96-f97bf982674c.png">

## Why?

The previous gap was large enough that it could look like two buttons, especially in the tertiary variant. The new spacing adds more context. 

## Testing Instructions

Test primary, secondary, tertiary buttons, with icons, in storybook: npm run storybook:dev, and observe the smaller gap.

