### PR TITLE
Fix site logo preview image size with long filenames

### DIFF
--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -139,6 +139,7 @@
 
 	img {
 		width: $grid-unit-50 * 0.5;
+		min-width: $grid-unit-50 * 0.5;
 		aspect-ratio: 1;
 		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
 		border-radius: 50% !important;

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -138,8 +138,8 @@
 	}
 
 	img {
-		width: $grid-unit-50 * 0.5;
-		min-width: $grid-unit-50 * 0.5;
+		width: 20px;
+		min-width: 20px;
 		aspect-ratio: 1;
 		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
 		border-radius: 50% !important;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/49992#issuecomment-1529014951

As noted by @ndiego , when a logo has a big filename(results to truncated text) the image icon preview doesn't preserve the `20px` wanted width. This was due to some `HStack` css conflict and this PR fixes that.