### PR TITLE
Post Terms: Use publicly_queryable to query taxonomies used to register variations

### DIFF
--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -64,8 +64,8 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 function register_block_core_post_terms() {
 	$taxonomies = get_taxonomies(
 		array(
-			'public'       => true,
-			'show_in_rest' => true,
+			'publicly_queryable' => true,
+			'show_in_rest'       => true,
 		),
 		'objects'
 	);


### PR DESCRIPTION
## What?
The Post Terms block makes variations for taxonomies available which are not fully usable due to incorrect visibility checks.

## Why?
The [server-side render function uses `is_taxonomy_viewable()`](https://github.com/WordPress/gutenberg/blob/bdb22cd7ab953c0830fe33ac69e5f0ecda529062/packages/block-library/src/post-terms/index.php#L21-L23) and also the [block edit checks for `publicly_queryable`](https://github.com/WordPress/gutenberg/blob/bdb22cd7ab953c0830fe33ac69e5f0ecda529062/packages/block-library/src/post-terms/edit.js#L55). When you you register a taxonomy with `public => true` but `publicly_queryable => false` you'll get the variation but it won't display any selected terms.

Related: https://github.com/WordPress/gutenberg/commit/727b89a4c83146fc8ee25293e674224b34bca707

## How?
This replaces the argument `public` with `publicly_queryable` passed to `get_taxonomies()`.

## Testing Instructions
* Register a taxonomy which has `public => true` and `publicly_queryable => false`
* Now insert the block variation into the post content
* Add some terms and notice how the preview doesn't update
* Try the same again with the patch: The block variation is no longer visible in the inserter