### PR TITLE
Add changelog for eslint-plugin validating dependencies in `useSelect` and `useSuspenseSelect` hooks

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   Validate dependencies in `useSelect` and `useSuspenseSelect` hooks. ([#49900](https://github.com/WordPress/gutenberg/pull/49900)).
+
 ## 14.5.0 (2023-04-26)
 
 ## 14.4.0 (2023-04-12)


### PR DESCRIPTION
## What?

This is a follow-up to https://github.com/WordPress/gutenberg/pull/49900#issuecomment-1527870389.

In this PR, we add changelog that is missing from PR https://github.com/WordPress/gutenberg/pull/49900. The changelog is done by following https://github.com/WordPress/gutenberg/tree/f795ebee6977df1fc0b3578297c39e9bba1ebb91/packages#maintaining-changelogs

## Testing Instructions

Just adding a line of changelog. No testing required.
