### PR TITLE
Components: relax link pattern matching in CHANGELOG CI check

### DIFF
--- a/.github/workflows/check-components-changelog.yml
+++ b/.github/workflows/check-components-changelog.yml
@@ -42,8 +42,8 @@ jobs:
                     exit 1
                   fi
 
-                  pr_link_pattern="\(\[#${PR_NUMBER}\]\(https://github\.com/WordPress/gutenberg/pull/${PR_NUMBER}\)\)"
-                  pr_link_grep_pattern="(\[#${PR_NUMBER}\](https://github\.com/WordPress/gutenberg/pull/${PR_NUMBER}))"
+                  pr_link_pattern="\[#${PR_NUMBER}\]\(https://github\.com/WordPress/gutenberg/pull/${PR_NUMBER}\)"
+                  pr_link_grep_pattern="\[#${PR_NUMBER}\](https://github\.com/WordPress/gutenberg/pull/${PR_NUMBER})"
 
                   unreleased_section=$(sed -n '/^## Unreleased$/,/^## /p' "${changelog_path}")
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Relaxes the pattern matching for Components CHANGELOG entries

## Why?
Entries referencing multiple PRs, or other similar cases where the link is present but the entry is formatted slightly differently from the norm currently trigger false failures.

#50133 is a recent example of this, where the check failed because the entry referenced two relevant PRs for a single change.

## How?
The problem stems from the pattern looking for the following pattern:
`([#${PR_NUMBER}\](https://github\.com/WordPress/gutenberg/pull/${PR_NUMBER})`
which includes the parentheses around the link to the PR.

This becomes a problem if those parenthesis aren't positioned as expected. In #50133, for example, the relevant PR link was second in the entry, so it matched the closing parenthesis, but the opening parenthesis wasn't where the check expected it to be.

This PR removes those parentheses from the check, making it more flexible. It will now effectively confirm the link is there, and that it's formatted as a proper markdown link, but not enforce any other formatting of the entry.

## Testing Instructions
1. Create a new branch off of this PR
2. Make a change to a component (not in a test, storybook, or mobile file)
3. Do not update the CHANGELOG
4. Push your branch and create a test PR
5. Confirm the check fails because you have no PR entry
6. Update the changelog with an entry referencing your test PR and any other PR. (See [this example](https://github.com/WordPress/gutenberg/pull/50133/files#diff-b5aa808176801bfde2277ac886bbbdf0863de109950303cdb89e2d33ebe16a28))
7. Confirm the check still runs, and this time passes when it detects your entry
8. Remove the second PR link from your entry, making it a single-PR change
9. Confirm the check still passes
