### PR TITLE
Adds example to change the permalink structure

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -395,6 +395,23 @@ Success: Installed 1 of 1 plugins.
 ✔ Ran `plugin install custom-post-type-ui` in 'cli'. (in 6s 483ms)
 ```
 
+#### Changing the permalink structure
+You might want to do this to enable access to the REST API (`wp-env/wp/v2/`) endpoint in your wp-env environment. The endpoint is not available with plain permalinks.
+
+**Examples**
+
+To set the permalink to just the post name:
+
+```
+wp-env run cli "wp rewrite structure /%postname%/"
+```
+
+To set the permalink to the year, month, and post name:
+
+```
+wp-env run cli "wp rewrite structure /%year%/%monthnum%/%postname%/"
+```
+
 ### `wp-env destroy`
 
 ```sh


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds a new example to the wp-env page in the handbook showing how to change the permalink structure.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
With a default spin up of wp-env the REST API is not available, this is because it defaults to plain permalinks. Problem described in #49373. 

This PR provides documentation in the wp-env handbook page explaining how to easily enable the REST API when using wp-env, without having to do so via the permalinks admin page. Also it is not obvious that plain permalinks are the problem unless you already know that the REST API requires pretty permalinks to be enabled. 

More generally it allows people to customise the permalink structure in a wp-env environment.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
