### PR TITLE
test: Add BlockList coverage

### DIFF
--- a/packages/block-editor/src/components/block-list/block-list-item.native.js
+++ b/packages/block-editor/src/components/block-list/block-list-item.native.js
@@ -102,6 +102,7 @@ export class BlockListItem extends Component {
 		const {
 			blockAlignment,
 			clientId,
+			index,
 			isReadOnly,
 			shouldShowInsertionPointBefore,
 			shouldShowInsertionPointAfter,
@@ -134,7 +135,11 @@ export class BlockListItem extends Component {
 					pointerEvents={ isReadOnly ? 'box-only' : 'auto' }
 				>
 					{ shouldShowInsertionPointBefore && (
-						<BlockInsertionPoint />
+						<BlockInsertionPoint
+							testID={ `block-insertion-point-before-row-${
+								index + 1
+							}` }
+						/>
 					) }
 					<BlockListBlock
 						key={ clientId }
@@ -147,7 +152,11 @@ export class BlockListItem extends Component {
 					/>
 					{ ! shouldShowInnerBlockAppender() &&
 						shouldShowInsertionPointAfter && (
-							<BlockInsertionPoint />
+							<BlockInsertionPoint
+								testID={ `block-insertion-point-after-row-${
+									index + 1
+								}` }
+							/>
 						) }
 				</View>
 			</ReadableContentView>

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -305,7 +305,7 @@ export class BlockList extends Component {
 		);
 	}
 
-	renderItem( { item: clientId } ) {
+	renderItem( { item: clientId, index } ) {
 		const {
 			contentResizeMode,
 			contentStyle,
@@ -331,6 +331,7 @@ export class BlockList extends Component {
 		};
 		return (
 			<BlockListItem
+				index={ index }
 				isStackedHorizontally={ isStackedHorizontally }
 				rootClientId={ rootClientId }
 				clientId={ clientId }

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -204,6 +204,7 @@ export class BlockList extends Component {
 		const {
 			clearSelectedBlock,
 			blockClientIds,
+			rootClientId,
 			title,
 			header,
 			isReadOnly,
@@ -275,6 +276,9 @@ export class BlockList extends Component {
 					) }
 					data={ blockClientIds }
 					keyExtractor={ identity }
+					listKey={
+						rootClientId ? `list-${ rootClientId }` : 'list-root'
+					}
 					renderItem={ this.renderItem }
 					CellRendererComponent={ this.getCellRendererComponent }
 					shouldPreventAutomaticScroll={
@@ -422,6 +426,7 @@ export default compose( [
 					Platform.OS === 'ios' && isBlockInsertionPointVisible(),
 				isReadOnly,
 				isRootList: rootClientId === undefined,
+				rootClientId,
 				isFloatingToolbarVisible,
 				isStackedHorizontally,
 				maxWidth,

--- a/packages/block-editor/src/components/block-list/insertion-point.native.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.native.js
@@ -14,7 +14,7 @@ import { withPreferredColorScheme } from '@wordpress/compose';
  */
 import styles from './style.scss';
 
-const BlockInsertionPoint = ( { getStylesFromColorScheme } ) => {
+const BlockInsertionPoint = ( { getStylesFromColorScheme, testID } ) => {
 	const lineStyle = getStylesFromColorScheme(
 		styles.lineStyleAddHere,
 		styles.lineStyleAddHereDark
@@ -25,7 +25,7 @@ const BlockInsertionPoint = ( { getStylesFromColorScheme } ) => {
 	);
 
 	return (
-		<View style={ styles.containerStyleAddHere }>
+		<View style={ styles.containerStyleAddHere } testID={ testID }>
 			<View style={ lineStyle }></View>
 			<Text style={ labelStyle }>{ __( 'ADD BLOCK HERE' ) }</Text>
 			<View style={ lineStyle }></View>

--- a/packages/block-editor/src/components/block-list/test/index.native.js
+++ b/packages/block-editor/src/components/block-list/test/index.native.js
@@ -8,15 +8,52 @@ import {
 	initializeEditor,
 	screen,
 	setupCoreBlocks,
+	triggerBlockListLayout,
 	within,
 } from 'test/helpers';
 
 setupCoreBlocks( [ 'core/paragraph', 'core/group' ] );
 
 describe( 'BlockList', () => {
-	// Note: The Group block leverage BlockListCompact via `useCompact` when
-	// rendering its inner blocks, thus it is an appropriate test subject.
-	describe( 'when compact list enabled', () => {
+	describe( 'when empty', () => {
+		beforeEach( async () => {
+			// Arrange
+			await initializeEditor();
+		} );
+
+		it( 'renders a post title', async () => {
+			// Assert
+			expect( screen.getByPlaceholderText( 'Add title' ) ).toBeTruthy();
+		} );
+
+		it( 'renders a block appender as a content placeholder', async () => {
+			// Assert
+			expect(
+				screen.getByPlaceholderText( /Start writing/ )
+			).toBeTruthy();
+		} );
+
+		it( 'renders an end-of-list paragraph appender', async () => {
+			// Assert
+			expect(
+				screen.getByLabelText( 'Add paragraph block' )
+			).toBeTruthy();
+		} );
+	} );
+
+	describe( 'for inner blocks', () => {
+		it( 'renders an inner block appender', async () => {
+			await initializeEditor();
+			await addBlock( screen, 'Group' );
+			const groupBlock = await getBlock( screen, 'Group' );
+			triggerBlockListLayout( groupBlock );
+
+			// Assert
+			expect(
+				within( groupBlock ).getByTestId( 'appender-button' )
+			).toBeTruthy();
+		} );
+
 		describe( 'when a non-last block is selected', () => {
 			beforeEach( async () => {
 				// Arrange
@@ -68,6 +105,36 @@ describe( 'BlockList', () => {
 		} );
 
 		describe( 'when the last block is selected', () => {
+			it( 'renders an insertion point before the block', async () => {
+				// Arrange
+				await initializeEditor();
+				await addBlock( screen, 'Group' );
+				const groupBlock = await getBlock( screen, 'Group' );
+				fireEvent.press(
+					within( groupBlock ).getByTestId( 'appender-button' )
+				);
+				await addBlock( screen, 'Paragraph', { isPickerOpened: true } );
+				fireEvent.press( screen.getByLabelText( 'Navigate Up' ) );
+				fireEvent.press(
+					within( groupBlock ).getByTestId( 'appender-button' )
+				);
+				await addBlock( screen, 'Paragraph', { isPickerOpened: true } );
+
+				// Act
+				const paragraphBlock = await getBlock( screen, 'Paragraph', {
+					rowIndex: 2,
+				} );
+				fireEvent.press( paragraphBlock );
+				fireEvent( screen.getByLabelText( 'Add block' ), 'longPress' );
+				fireEvent.press( screen.getByText( 'Add Block Before ' ) );
+
+				// Assert
+				expect( screen.getByText( 'ADD BLOCK HERE' ) ).toBeTruthy();
+				expect(
+					screen.getByTestId( 'block-insertion-point-before-row-2' )
+				).toBeTruthy();
+			} );
+
 			it( 'renders an insertion point after the block', async () => {
 				// Arrange
 				await initializeEditor();

--- a/packages/block-editor/src/components/block-list/test/index.native.js
+++ b/packages/block-editor/src/components/block-list/test/index.native.js
@@ -13,88 +13,90 @@ import {
 
 setupCoreBlocks( [ 'core/paragraph', 'core/group' ] );
 
-// Note: The Group block leverage BlockListCompact via `useCompact` when
-// rendering its inner blocks, thus it is an appropriate test subject.
-describe( 'BlockListCompact', () => {
-	describe( 'when a non-last block is selected', () => {
-		beforeEach( async () => {
-			// Arrange
-			await initializeEditor();
-			await addBlock( screen, 'Group' );
-			const groupBlock = await getBlock( screen, 'Group' );
-			fireEvent.press(
-				within( groupBlock ).getByTestId( 'appender-button' )
-			);
-			await addBlock( screen, 'Paragraph', { isPickerOpened: true } );
-			fireEvent.press( screen.getByLabelText( 'Navigate Up' ) );
-			fireEvent.press(
-				within( groupBlock ).getByTestId( 'appender-button' )
-			);
-			await addBlock( screen, 'Paragraph', { isPickerOpened: true } );
+describe( 'BlockList', () => {
+	// Note: The Group block leverage BlockListCompact via `useCompact` when
+	// rendering its inner blocks, thus it is an appropriate test subject.
+	describe( 'when compact list enabled', () => {
+		describe( 'when a non-last block is selected', () => {
+			beforeEach( async () => {
+				// Arrange
+				await initializeEditor();
+				await addBlock( screen, 'Group' );
+				const groupBlock = await getBlock( screen, 'Group' );
+				fireEvent.press(
+					within( groupBlock ).getByTestId( 'appender-button' )
+				);
+				await addBlock( screen, 'Paragraph', { isPickerOpened: true } );
+				fireEvent.press( screen.getByLabelText( 'Navigate Up' ) );
+				fireEvent.press(
+					within( groupBlock ).getByTestId( 'appender-button' )
+				);
+				await addBlock( screen, 'Paragraph', { isPickerOpened: true } );
+			} );
+
+			it( 'renders an insertion point before the block', async () => {
+				// Act
+				const paragraphBlock = await getBlock( screen, 'Paragraph', {
+					rowIndex: 1,
+				} );
+				fireEvent.press( paragraphBlock );
+				fireEvent( screen.getByLabelText( 'Add block' ), 'longPress' );
+				fireEvent.press( screen.getByText( 'Add Block Before ' ) );
+
+				// Assert
+				expect( screen.getByText( 'ADD BLOCK HERE' ) ).toBeTruthy();
+				expect(
+					screen.getByTestId( 'block-insertion-point-before-row-1' )
+				).toBeTruthy();
+			} );
+
+			it( 'renders an insertion point after the block', async () => {
+				// Act
+				const paragraphBlock = await getBlock( screen, 'Paragraph', {
+					rowIndex: 1,
+				} );
+				fireEvent.press( paragraphBlock );
+				fireEvent( screen.getByLabelText( 'Add block' ), 'longPress' );
+				fireEvent.press( screen.getByText( 'Add Block After ' ) );
+
+				// Assert
+				expect( screen.getByText( 'ADD BLOCK HERE' ) ).toBeTruthy();
+				expect(
+					screen.getByTestId( 'block-insertion-point-before-row-2' )
+				).toBeTruthy();
+			} );
 		} );
 
-		it( 'renders an insertion point before the block', async () => {
-			// Act
-			const paragraphBlock = await getBlock( screen, 'Paragraph', {
-				rowIndex: 1,
+		describe( 'when the last block is selected', () => {
+			it( 'renders an insertion point after the block', async () => {
+				// Arrange
+				await initializeEditor();
+				await addBlock( screen, 'Group' );
+				const groupBlock = await getBlock( screen, 'Group' );
+				fireEvent.press(
+					within( groupBlock ).getByTestId( 'appender-button' )
+				);
+				await addBlock( screen, 'Paragraph', { isPickerOpened: true } );
+				fireEvent.press( screen.getByLabelText( 'Navigate Up' ) );
+				fireEvent.press(
+					within( groupBlock ).getByTestId( 'appender-button' )
+				);
+				await addBlock( screen, 'Paragraph', { isPickerOpened: true } );
+
+				// Act
+				const paragraphBlock = await getBlock( screen, 'Paragraph', {
+					rowIndex: 2,
+				} );
+				fireEvent.press( paragraphBlock );
+				fireEvent( screen.getByLabelText( 'Add block' ), 'longPress' );
+				fireEvent.press( screen.getByText( 'Add Block After ' ) );
+
+				// Assert
+				expect( screen.getByText( 'ADD BLOCK HERE' ) ).toBeTruthy();
+				expect(
+					screen.getByTestId( 'block-insertion-point-after-row-2' )
+				).toBeTruthy();
 			} );
-			fireEvent.press( paragraphBlock );
-			fireEvent( screen.getByLabelText( 'Add block' ), 'longPress' );
-			fireEvent.press( screen.getByText( 'Add Block Before ' ) );
-
-			// Assert
-			expect( screen.getByText( 'ADD BLOCK HERE' ) ).toBeTruthy();
-			expect(
-				screen.getByTestId( 'block-insertion-point-before-row-1' )
-			).toBeTruthy();
-		} );
-
-		it( 'renders an insertion point after the block', async () => {
-			// Act
-			const paragraphBlock = await getBlock( screen, 'Paragraph', {
-				rowIndex: 1,
-			} );
-			fireEvent.press( paragraphBlock );
-			fireEvent( screen.getByLabelText( 'Add block' ), 'longPress' );
-			fireEvent.press( screen.getByText( 'Add Block After ' ) );
-
-			// Assert
-			expect( screen.getByText( 'ADD BLOCK HERE' ) ).toBeTruthy();
-			expect(
-				screen.getByTestId( 'block-insertion-point-before-row-2' )
-			).toBeTruthy();
-		} );
-	} );
-
-	describe( 'when the last block is selected', () => {
-		it( 'renders an insertion point after the block', async () => {
-			// Arrange
-			await initializeEditor();
-			await addBlock( screen, 'Group' );
-			const groupBlock = await getBlock( screen, 'Group' );
-			fireEvent.press(
-				within( groupBlock ).getByTestId( 'appender-button' )
-			);
-			await addBlock( screen, 'Paragraph', { isPickerOpened: true } );
-			fireEvent.press( screen.getByLabelText( 'Navigate Up' ) );
-			fireEvent.press(
-				within( groupBlock ).getByTestId( 'appender-button' )
-			);
-			await addBlock( screen, 'Paragraph', { isPickerOpened: true } );
-
-			// Act
-			const paragraphBlock = await getBlock( screen, 'Paragraph', {
-				rowIndex: 2,
-			} );
-			fireEvent.press( paragraphBlock );
-			fireEvent( screen.getByLabelText( 'Add block' ), 'longPress' );
-			fireEvent.press( screen.getByText( 'Add Block After ' ) );
-
-			// Assert
-			expect( screen.getByText( 'ADD BLOCK HERE' ) ).toBeTruthy();
-			expect(
-				screen.getByTestId( 'block-insertion-point-after-row-2' )
-			).toBeTruthy();
 		} );
 	} );
 } );

--- a/packages/block-editor/src/components/block-list/test/index.native.js
+++ b/packages/block-editor/src/components/block-list/test/index.native.js
@@ -78,7 +78,7 @@ describe( 'BlockList', () => {
 				} );
 				fireEvent.press( paragraphBlock );
 				fireEvent( screen.getByLabelText( 'Add block' ), 'longPress' );
-				fireEvent.press( screen.getByText( 'Add Block Before ' ) );
+				fireEvent.press( screen.getByText( 'Add Block Before' ) );
 
 				// Assert
 				expect( screen.getByText( 'ADD BLOCK HERE' ) ).toBeTruthy();
@@ -94,7 +94,7 @@ describe( 'BlockList', () => {
 				} );
 				fireEvent.press( paragraphBlock );
 				fireEvent( screen.getByLabelText( 'Add block' ), 'longPress' );
-				fireEvent.press( screen.getByText( 'Add Block After ' ) );
+				fireEvent.press( screen.getByText( 'Add Block After' ) );
 
 				// Assert
 				expect( screen.getByText( 'ADD BLOCK HERE' ) ).toBeTruthy();
@@ -126,7 +126,7 @@ describe( 'BlockList', () => {
 				} );
 				fireEvent.press( paragraphBlock );
 				fireEvent( screen.getByLabelText( 'Add block' ), 'longPress' );
-				fireEvent.press( screen.getByText( 'Add Block Before ' ) );
+				fireEvent.press( screen.getByText( 'Add Block Before' ) );
 
 				// Assert
 				expect( screen.getByText( 'ADD BLOCK HERE' ) ).toBeTruthy();
@@ -156,7 +156,7 @@ describe( 'BlockList', () => {
 				} );
 				fireEvent.press( paragraphBlock );
 				fireEvent( screen.getByLabelText( 'Add block' ), 'longPress' );
-				fireEvent.press( screen.getByText( 'Add Block After ' ) );
+				fireEvent.press( screen.getByText( 'Add Block After' ) );
 
 				// Assert
 				expect( screen.getByText( 'ADD BLOCK HERE' ) ).toBeTruthy();

--- a/packages/block-editor/src/components/block-list/test/index.native.js
+++ b/packages/block-editor/src/components/block-list/test/index.native.js
@@ -1,0 +1,100 @@
+/**
+ * External dependencies
+ */
+import {
+	addBlock,
+	getBlock,
+	fireEvent,
+	initializeEditor,
+	screen,
+	setupCoreBlocks,
+	within,
+} from 'test/helpers';
+
+setupCoreBlocks( [ 'core/paragraph', 'core/group' ] );
+
+// Note: The Group block leverage BlockListCompact via `useCompact` when
+// rendering its inner blocks, thus it is an appropriate test subject.
+describe( 'BlockListCompact', () => {
+	describe( 'when a non-last block is selected', () => {
+		beforeEach( async () => {
+			// Arrange
+			await initializeEditor();
+			await addBlock( screen, 'Group' );
+			const groupBlock = await getBlock( screen, 'Group' );
+			fireEvent.press(
+				within( groupBlock ).getByTestId( 'appender-button' )
+			);
+			await addBlock( screen, 'Paragraph', { isPickerOpened: true } );
+			fireEvent.press( screen.getByLabelText( 'Navigate Up' ) );
+			fireEvent.press(
+				within( groupBlock ).getByTestId( 'appender-button' )
+			);
+			await addBlock( screen, 'Paragraph', { isPickerOpened: true } );
+		} );
+
+		it( 'renders an insertion point before the block', async () => {
+			// Act
+			const paragraphBlock = await getBlock( screen, 'Paragraph', {
+				rowIndex: 1,
+			} );
+			fireEvent.press( paragraphBlock );
+			fireEvent( screen.getByLabelText( 'Add block' ), 'longPress' );
+			fireEvent.press( screen.getByText( 'Add Block Before ' ) );
+
+			// Assert
+			expect( screen.getByText( 'ADD BLOCK HERE' ) ).toBeTruthy();
+			expect(
+				screen.getByTestId( 'block-insertion-point-before-row-1' )
+			).toBeTruthy();
+		} );
+
+		it( 'renders an insertion point after the block', async () => {
+			// Act
+			const paragraphBlock = await getBlock( screen, 'Paragraph', {
+				rowIndex: 1,
+			} );
+			fireEvent.press( paragraphBlock );
+			fireEvent( screen.getByLabelText( 'Add block' ), 'longPress' );
+			fireEvent.press( screen.getByText( 'Add Block After ' ) );
+
+			// Assert
+			expect( screen.getByText( 'ADD BLOCK HERE' ) ).toBeTruthy();
+			expect(
+				screen.getByTestId( 'block-insertion-point-before-row-2' )
+			).toBeTruthy();
+		} );
+	} );
+
+	describe( 'when the last block is selected', () => {
+		it( 'renders an insertion point after the block', async () => {
+			// Arrange
+			await initializeEditor();
+			await addBlock( screen, 'Group' );
+			const groupBlock = await getBlock( screen, 'Group' );
+			fireEvent.press(
+				within( groupBlock ).getByTestId( 'appender-button' )
+			);
+			await addBlock( screen, 'Paragraph', { isPickerOpened: true } );
+			fireEvent.press( screen.getByLabelText( 'Navigate Up' ) );
+			fireEvent.press(
+				within( groupBlock ).getByTestId( 'appender-button' )
+			);
+			await addBlock( screen, 'Paragraph', { isPickerOpened: true } );
+
+			// Act
+			const paragraphBlock = await getBlock( screen, 'Paragraph', {
+				rowIndex: 2,
+			} );
+			fireEvent.press( paragraphBlock );
+			fireEvent( screen.getByLabelText( 'Add block' ), 'longPress' );
+			fireEvent.press( screen.getByText( 'Add Block After ' ) );
+
+			// Assert
+			expect( screen.getByText( 'ADD BLOCK HERE' ) ).toBeTruthy();
+			expect(
+				screen.getByTestId( 'block-insertion-point-after-row-2' )
+			).toBeTruthy();
+		} );
+	} );
+} );

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -88,6 +88,7 @@ export const coreBlocks = [
 	column,
 	cover,
 	embed,
+	group,
 	file,
 	html,
 	mediaText,

--- a/test/native/__mocks__/styleMock.js
+++ b/test/native/__mocks__/styleMock.js
@@ -178,4 +178,7 @@ module.exports = {
 	mediaAreaPadding: {
 		width: 12,
 	},
+	defaultAppender: {
+		marginLeft: 16,
+	},
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add `BlockList` test coverage.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Relates to https://github.com/wordpress-mobile/gutenberg-mobile/issues/5617. Enable future, stable refactors and avoid regressions.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
**refactor: Add missing Group block type to core blocks list**
This exclusion appears to be erroneous and prevents the `setupCoreBlock`
test helper from succeeding when attempting to register the Group block
type.

**test: Add BlockList tests**
In order to assert the insertion point is in the correct index location,
the index must be passed to the test ID for each insertion point.

**refactor: Increase uniqueness of virtualized list keys**
A `listKey` was required to address the following error when running
tests against the `BlockList`:

```
VirtualizedList trace:
  Child (vertical):
    listKey: 8d343539-3801-4ff1-ac5b-858db2cdf662
    cellKey: 8d343539-3801-4ff1-ac5b-858db2cdf662
  Parent (vertical):
    listKey: rootList
    cellKey: rootList
```

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Due to the changes to the virtualized list key, we should likely test 
inserting, editing, moving, and removing various blocks.

1. Insert a few different blocks into the editor.
1. Edit, relocate (arrows and drag-and-drop), and remove blocks.
1. Undo/redo actions taken via the editor history buttons.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
