### PR TITLE
[Font API] Do not print in admin using 'admin_print_styles' for themes with theme.json

### DIFF
--- a/lib/experimental/fonts-api/fonts-api.php
+++ b/lib/experimental/fonts-api/fonts-api.php
@@ -26,7 +26,14 @@ if ( ! function_exists( 'wp_fonts' ) ) {
 			// Initialize.
 			$wp_fonts->register_provider( 'local', 'WP_Fonts_Provider_Local' );
 			add_action( 'wp_head', 'wp_print_fonts', 50 );
-			add_action( 'admin_print_styles', 'wp_print_fonts', 50 );
+
+			/*
+			 * For themes without a theme.json, admin printing is initiated by the 'admin_print_styles' hook.
+			 * For themes with theme.json, admin printing is initiated by _wp_get_iframed_editor_assets().
+			 */
+			if ( ! wp_theme_has_theme_json() ) {
+				add_action( 'admin_print_styles', 'wp_print_fonts', 50 );
+			}
 		}
 
 		return $wp_fonts;

--- a/lib/experimental/fonts-api/fonts-api.php
+++ b/lib/experimental/fonts-api/fonts-api.php
@@ -22,7 +22,11 @@ if ( ! function_exists( 'wp_fonts' ) ) {
 
 		if ( ! ( $wp_fonts instanceof WP_Fonts ) ) {
 			$wp_fonts = new WP_Fonts();
+
+			// Initialize.
 			$wp_fonts->register_provider( 'local', 'WP_Fonts_Provider_Local' );
+			add_action( 'wp_head', 'wp_print_fonts', 50 );
+			add_action( 'admin_print_styles', 'wp_print_fonts', 50 );
 		}
 
 		return $wp_fonts;
@@ -200,9 +204,6 @@ if ( ! function_exists( 'wp_print_fonts' ) ) {
 		return wp_fonts()->do_items( $handles );
 	}
 }
-
-add_action( 'admin_print_styles', 'wp_print_fonts', 50 );
-add_action( 'wp_head', 'wp_print_fonts', 50 );
 
 /**
  * Add webfonts mime types.


### PR DESCRIPTION
Fixes #50064 

## What?

Adds decision making around hooking into `'admin_print_styles'`: If a theme does not have a `theme.json` file, then hook into the action; else, do not.

## Why?

Prior to this PR, hooking into this action caused the fonts to be printed twice for theme's with a `theme.json` file.

Why?

Fonts are printed  via the iframed editor assets functionality which directly invokes `wp_print_fonts()`. So instead of being in the main web page's `<head>`, the fonts are printed into the `iframe`.

For theme's without a `theme.json` file, there is no iframed editor. Thus, the hook registration is needed to print the fonts into the admin.

## How?

1. Moves both hook registrations into the `wp_fonts()` initialization code. No need to hook if `wp_fonts()` is never called.
2. Checks if a theme without a `theme.json` is being used. If yes, then hooks into 'admin_print_styles'.

## Testing Instructions

Set up on your test site:
1. Activate the Gutenberg plugin.
2. Activate TT3 theme.

Test in the admin:
1. Go to Appearance > Themes (or any admin screen that does not have a block editor in it).
2. Using your browser's dev tools, search the HMTL for `wp-fonts-local` `<style>` element.
     Expected: The element should _not_ exist.
3. Go to the Site Editor.
4. Using your browser's dev tools, search the HMTL for `wp-fonts-local` `<style>` element.
     Expected: The element should not be in the main document's `<head>`. Rather, it should only be in the `iframe`.
3. Go to Posts > open an existing post.
4. Using your browser's dev tools, search the HMTL for `wp-fonts-local` `<style>` element.
     Expected: The element should not be in the main document's `<head>`. Rather, it should only be in the `iframe`.

Test in the front-end:
1. Go to the front-end.
2. Using your browser's dev tools, search the HMTL for `wp-fonts-local` `<style>` element.
     Expected: The element should be in the main document's `<head>`.

## Screenshots or screencast <!-- if applicable -->

Non-block editor admin area 
![pr50259-1](https://user-images.githubusercontent.com/7284611/235743498-d3a806b5-61cc-4675-b5cd-6cdfd618cd9b.gif)

Site Editor:
![pr50259-2](https://user-images.githubusercontent.com/7284611/235744124-531750f9-cc1f-4e7f-b94b-59fddb662ce5.gif)

In a Post:
![pr50259-3](https://user-images.githubusercontent.com/7284611/235743886-6cdc72da-7034-4b2a-8abb-474b9bed258c.gif)

In the front-end:
![pr50259-4](https://user-images.githubusercontent.com/7284611/235744307-74d161df-5ae2-4c7e-b433-b232f132f8bb.gif)
