### PR TITLE
Introduce `prepend_to_selector()` to avoid additional if checks and follow single responsibility principle

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -834,7 +834,7 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * Given the compounded $selector "h1, h2, h3"
 	 * and the $to_prepend selector ".some-class " the result will be
-	 * ".some-class h1, .some-class h2, .some-class h3".
+	 * ".some-class h1, .some-class  h2, .some-class  h3".
 	 *
 	 * @since 6.3.0
 	 *

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -811,14 +811,13 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * @since 5.8.0
 	 * @since 6.1.0 Added append position.
-	 * @since 6.3.0 Deprecated append position parameter.
+	 * @since 6.3.0 Removed append position parameter.
 	 *
-	 * @param string $selector   Original selector.
-	 * @param string $to_append  Selector to append.
-	 * @param string $deprecated Deprecated parameter.
+	 * @param string $selector  Original selector.
+	 * @param string $to_append Selector to append.
 	 * @return string The new selector.
 	 */
-	protected static function append_to_selector( $selector, $to_append, $deprecated = 'right' ) {
+	protected static function append_to_selector( $selector, $to_append ) {
 		if ( ! str_contains( $selector, ',' ) ) {
 			return $selector . $to_append;
 		}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -811,20 +811,46 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * @since 5.8.0
 	 * @since 6.1.0 Added append position.
+	 * @since 6.3.0 Deprecated append position parameter.
 	 *
-	 * @param string $selector  Original selector.
-	 * @param string $to_append Selector to append.
-	 * @param string $position  A position sub-selector should be appended. Default 'right'.
+	 * @param string $selector   Original selector.
+	 * @param string $to_append  Selector to append.
+	 * @param string $deprecated Deprecated parameter.
 	 * @return string The new selector.
 	 */
-	protected static function append_to_selector( $selector, $to_append, $position = 'right' ) {
+	protected static function append_to_selector( $selector, $to_append, $deprecated = 'right' ) {
 		if ( ! str_contains( $selector, ',' ) ) {
-			return 'right' === $position ? $selector . $to_append : $to_append . $selector;
+			return $selector . $to_append;
 		}
 		$new_selectors = array();
 		$selectors     = explode( ',', $selector );
 		foreach ( $selectors as $sel ) {
-			$new_selectors[] = 'right' === $position ? $sel . $to_append : $to_append . $sel;
+			$new_selectors[] = $sel . $to_append;
+		}
+		return implode( ',', $new_selectors );
+	}
+
+	/**
+	 * Prepends a sub-selector to an existing one.
+	 *
+	 * Given the compounded $selector "h1, h2, h3"
+	 * and the $to_prepend selector ".some-class " the result will be
+	 * ".some-class h1, .some-class h2, .some-class h3".
+	 *
+	 * @since 6.3.0
+	 *
+	 * @param string $selector   Original selector.
+	 * @param string $to_prepend Selector to prepend.
+	 * @return string The new selector.
+	 */
+	protected static function prepend_to_selector( $selector, $to_prepend ) {
+		if ( ! str_contains( $selector, ',' ) ) {
+			return $to_prepend . $selector;
+		}
+		$new_selectors = array();
+		$selectors     = explode( ',', $selector );
+		foreach ( $selectors as $sel ) {
+			$new_selectors[] = $to_prepend . $sel;
 		}
 		return implode( ',', $new_selectors );
 	}
@@ -3476,7 +3502,7 @@ class WP_Theme_JSON_Gutenberg {
 					$element_selector = array( $el_selector );
 					break;
 				}
-				$element_selector[] = static::append_to_selector( $el_selector, $selector . ' ', 'left' );
+				$element_selector[] = static::prepend_to_selector( $el_selector, $selector . ' ' );
 			}
 			$element_selectors[ $el_name ] = implode( ',', $element_selector );
 		}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1556,10 +1556,13 @@ class WP_Theme_JSON_Gutenberg {
 			$slugs = static::get_settings_slugs( $settings, $preset_metadata, $origins );
 			foreach ( $preset_metadata['classes'] as $class => $property ) {
 				foreach ( $slugs as $slug ) {
-					$css_var     = static::replace_slug_in_string( $preset_metadata['css_vars'], $slug );
-					$class_name  = static::replace_slug_in_string( $class, $slug );
-					$stylesheet .= static::to_ruleset(
-						static::append_to_selector( $selector, $class_name ),
+					$css_var    = static::replace_slug_in_string( $preset_metadata['css_vars'], $slug );
+					$class_name = static::replace_slug_in_string( $class, $slug );
+
+					// $selector is often empty, so we can save ourselves the `append_to_selector()` call then.
+					$new_selector = '' === $selector ? $class_name : static::append_to_selector( $selector, $class_name );
+					$stylesheet  .= static::to_ruleset(
+						$new_selector,
 						array(
 							array(
 								'name'  => $property,


### PR DESCRIPTION
## What?
This implements the WP core PR https://github.com/WordPress/wordpress-develop/pull/4380 in Gutenberg first, as requested on that PR, which makes sense given the current Gutenberg implementation differs slightly from current WP core's.

## Why?
Having to check on every `append_to_selector()` call what the append position is inefficient and violates the single responsibility principle. The code that calls this method already knows whether it needs to append or prepend, so having a separate `prepend_to_selector()` method with only that responsibility is more efficient.

Related: #47833
