### PR TITLE
Layout: Fix issue where saving user global styles included layout definitions in layout settings

### DIFF
--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -62,10 +62,14 @@ export default function DimensionsPanel( { name, variation = '' } ) {
 		setStyle( updatedStyle );
 
 		if ( newStyle.layout !== settings.layout ) {
-			setSettings( {
-				...rawSettings,
-				layout: newStyle.layout,
-			} );
+			const updatedSettings = { ...rawSettings, layout: newStyle.layout };
+
+			// Ensure any changes to layout definitions are not persisted.
+			if ( updatedSettings.layout?.definitions ) {
+				delete updatedSettings.layout.definitions;
+			}
+
+			setSettings( updatedSettings );
 		}
 	};
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/50238 (potentially)

Update the global styles logic when settings are updated to exclude layout definitions. This will cause the `definitions` object to no longer be saved within the user data of global styles. For any sites that already have the definition saved in their user data, they can either clear their customizations, or make a change to `contentSize` or `wideSize` and re-save, to flush the `definitions` object from their user data.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In https://github.com/WordPress/gutenberg/pull/48070/ the `DimensionsPanel` was refactored to be used across both the block editor and in the site editor / global styles. In that refactor, we missed that before the refactor `contentSize` and `wideSize` were updated individually within the `layout` object, rather than getting and saving the whole layout object when settings were updated. The switch away from this resulted in the `definitions` object accidentally being included in the user data.

As a result, if a user goes to export their theme, the `definitions` object was included in the export, since it was included in the user saved styles.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Before updating the global styles settings, strip the updated layout object of the `definitions` object.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

* Open up global styles, and make a change to `contentSize` or `wideSize`, then save the global styles.
* In the ellipsis menu of the site editor, select `Export` under `Tools` to download a `.zip` file of your theme.
* In the exported `.zip` file, within the `theme.json` file, there should be no `settings.layout.definitions` key.
* Double-check that on your site, all layout styles are still working as expected (e.g. test that Stack and Row blocks still work, and their block spacing still works)
