### PR TITLE
Global styles revisions: ensure the revisions endpoint permissions match the global styles controller

### DIFF
--- a/lib/experimental/class-gutenberg-rest-global-styles-revisions-controller.php
+++ b/lib/experimental/class-gutenberg-rest-global-styles-revisions-controller.php
@@ -265,11 +265,16 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller extends WP_REST_Controll
 			return $post;
 		}
 
-		if ( ! current_user_can( 'read_post', $post->ID ) ) {
+		/*
+		 * The same check as WP_REST_Global_Styles_Controller->get_theme_items_permissions_check.
+		 */
+		if ( ! current_user_can( 'edit_theme_options' ) ) {
 			return new WP_Error(
-				'rest_cannot_view',
-				__( 'Sorry, you are not allowed to view revisions for this global style.', 'gutenberg' ),
-				array( 'status' => rest_authorization_required_code() )
+				'rest_cannot_manage_global_styles',
+				__( 'Sorry, you are not allowed to access the global styles on this site.', 'gutenberg' ),
+				array(
+					'status' => rest_authorization_required_code(),
+				)
 			);
 		}
 

--- a/lib/experimental/class-gutenberg-rest-global-styles-revisions-controller.php
+++ b/lib/experimental/class-gutenberg-rest-global-styles-revisions-controller.php
@@ -266,15 +266,13 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller extends WP_REST_Controll
 		}
 
 		/*
-		 * The same check as WP_REST_Global_Styles_Controller->get_theme_items_permissions_check.
+		 * The same check as WP_REST_Global_Styles_Controller->get_item_permissions_check.
 		 */
-		if ( ! current_user_can( 'edit_theme_options' ) ) {
+		if ( ! current_user_can( 'read_post', $post->ID ) ) {
 			return new WP_Error(
-				'rest_cannot_manage_global_styles',
-				__( 'Sorry, you are not allowed to access the global styles on this site.', 'gutenberg' ),
-				array(
-					'status' => rest_authorization_required_code(),
-				)
+				'rest_cannot_view',
+				__( 'Sorry, you are not allowed to view this global style.' ),
+				array( 'status' => rest_authorization_required_code() )
 			);
 		}
 

--- a/lib/experimental/class-gutenberg-rest-global-styles-revisions-controller.php
+++ b/lib/experimental/class-gutenberg-rest-global-styles-revisions-controller.php
@@ -271,7 +271,7 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller extends WP_REST_Controll
 		if ( ! current_user_can( 'read_post', $post->ID ) ) {
 			return new WP_Error(
 				'rest_cannot_view',
-				__( 'Sorry, you are not allowed to view this global style.' ),
+				__( 'Sorry, you are not allowed to view this global style.', 'gutenberg' ),
 				array( 'status' => rest_authorization_required_code() )
 			);
 		}

--- a/lib/experimental/class-gutenberg-rest-global-styles-revisions-controller.php
+++ b/lib/experimental/class-gutenberg-rest-global-styles-revisions-controller.php
@@ -271,7 +271,7 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller extends WP_REST_Controll
 		if ( ! current_user_can( 'read_post', $post->ID ) ) {
 			return new WP_Error(
 				'rest_cannot_view',
-				__( 'Sorry, you are not allowed to view this global style.', 'gutenberg' ),
+				__( 'Sorry, you are not allowed to view revisions for this global style.', 'gutenberg' ),
 				array( 'status' => rest_authorization_required_code() )
 			);
 		}

--- a/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
+++ b/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
@@ -14,6 +14,11 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 	/**
 	 * @var int
 	 */
+	protected static $author_id;
+
+	/**
+	 * @var int
+	 */
 	protected static $global_styles_id;
 
 	public function set_up() {
@@ -35,6 +40,11 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 		self::$second_admin_id = $factory->user->create(
 			array(
 				'role' => 'administrator',
+			)
+		);
+		self::$author_id       = $factory->user->create(
+			array(
+				'role' => 'author',
 			)
 		);
 		// This creates the global styles for the current theme.
@@ -158,6 +168,17 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 		$this->assertArrayHasKey( 'date_gmt', $properties, 'Schema properties array does not have "date_gmt" key' );
 		$this->assertArrayHasKey( 'modified', $properties, 'Schema properties array does not have "modified" key' );
 		$this->assertArrayHasKey( 'modified_gmt', $properties, 'Schema properties array does not have "modified_gmt" key' );
+	}
+
+	/**
+	 * @covers Gutenberg_REST_Global_Styles_Revisions_Controller::get_item_permissions_check
+	 */
+	public function test_get_item_permissions_check() {
+		wp_set_current_user( self::$author_id );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_cannot_manage_global_styles', $response, 403 );
 	}
 
 	/**

--- a/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
+++ b/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
@@ -178,7 +178,7 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertErrorResponse( 'rest_cannot_manage_global_styles', $response, 403 );
+		$this->assertErrorResponse( 'rest_cannot_view', $response, 403 );
 	}
 
 	/**


### PR DESCRIPTION

## What


Let's ensure that the endpoint for global styles revisions matches the [permissions for the global styles custom post type controller](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php#L178). Huzza!


## Why
So that
> the endpoint for global styles revisions matches the permissions for the global styles custom post type controller

I'm talking: `WP_REST_Global_Styles_Controller->get_item_permissions_check`

See https://github.com/WordPress/gutenberg/pull/50089 for context

## How?

Looking at how we manage [permissions for the stored global styles custom post rest controller](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php#L178), and copying it.

## Testing Instructions

Run the tests!

`npm run test:unit:php -- --filter Gutenberg_REST_Global_Styles_Revisions_Controller_Test`

