### PR TITLE
Pattern block: Update block to retain wrapper

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -465,7 +465,7 @@ Show a block pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trun
 -	**Name:** core/pattern
 -	**Category:** theme
 -	**Supports:** 
--	**Attributes:** forcedAlignment, layout, slug, syncStatus
+-	**Attributes:** forcedAlignment, layout, slug, templateLock
 
 ## Post Author
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -465,7 +465,7 @@ Show a block pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trun
 -	**Name:** core/pattern
 -	**Category:** theme
 -	**Supports:** ~~html~~, ~~inserter~~
--	**Attributes:** slug
+-	**Attributes:** slug, unsynced
 
 ## Post Author
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -464,8 +464,8 @@ Show a block pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trun
 
 -	**Name:** core/pattern
 -	**Category:** theme
--	**Supports:** align (full, wide)
--	**Attributes:** align, layout, slug, syncStatus
+-	**Supports:** 
+-	**Attributes:** forcedAlignment, layout, slug, syncStatus
 
 ## Post Author
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -464,8 +464,8 @@ Show a block pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trun
 
 -	**Name:** core/pattern
 -	**Category:** theme
--	**Supports:** ~~html~~, ~~inserter~~
--	**Attributes:** slug, unsynced
+-	**Supports:** align (full, wide)
+-	**Attributes:** align, layout, slug, syncStatus
 
 ## Post Author
 

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -101,6 +101,9 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-theme-previews', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableThemePreviews = true', 'before' );
 	}
+	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-pattern-enhancements', $gutenberg_experiments ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnablePatternEnhancements = true', 'before' );
+	}
 
 }
 

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -125,6 +125,18 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
+	add_settings_field(
+		'gutenberg-pattern-enhancements',
+		__( 'Pattern enhancements', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Test the Pattern block enhancements', 'gutenberg' ),
+			'id'    => 'gutenberg-pattern-enhancements',
+		)
+	);
+
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useCallback } from '@wordpress/element';
-import { cloneBlock } from '@wordpress/blocks';
+import { createBlock, cloneBlock } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
@@ -35,10 +35,25 @@ const usePatternsState = ( onInsert, rootClientId ) => {
 	);
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const onClickPattern = useCallback( ( pattern, blocks ) => {
-		onInsert(
-			( blocks ?? [] ).map( ( block ) => cloneBlock( block ) ),
-			pattern.name
-		);
+		if ( window?.__experimentalEnablePatternEnhancements ) {
+			onInsert(
+				blocks
+					? [
+							createBlock(
+								'core/pattern',
+								{ slug: pattern.name },
+								blocks.map( ( block ) => cloneBlock( block ) )
+							),
+					  ]
+					: [],
+				pattern.name
+			);
+		} else {
+			onInsert(
+				( blocks ?? [] ).map( ( block ) => cloneBlock( block ) ),
+				pattern.name
+			);
+		}
 		createSuccessNotice(
 			sprintf(
 				/* translators: %s: block pattern title. */

--- a/packages/block-library/src/pattern/block.json
+++ b/packages/block-library/src/pattern/block.json
@@ -6,17 +6,28 @@
 	"category": "theme",
 	"description": "Show a block pattern.",
 	"supports": {
-		"html": false,
-		"inserter": false
+		"align": [ "wide", "full" ],
+		"__experimentalLayout": true
 	},
 	"textdomain": "default",
 	"attributes": {
 		"slug": {
 			"type": "string"
 		},
-		"unsynced": {
-			"type": "boolean",
-			"default": false
+		"align": {
+			"type": "string",
+			"default": "full"
+		},
+		"layout": {
+			"type": "object",
+			"default": {
+				"type": "constrained"
+			}
+		},
+		"syncStatus": {
+			"type": [ "string", "boolean" ],
+			"enum": [ "synced", "unsynced" ],
+			"default": "synced"
 		}
 	}
 }

--- a/packages/block-library/src/pattern/block.json
+++ b/packages/block-library/src/pattern/block.json
@@ -13,6 +13,10 @@
 	"attributes": {
 		"slug": {
 			"type": "string"
+		},
+		"unsynced": {
+			"type": "boolean",
+			"default": false
 		}
 	}
 }

--- a/packages/block-library/src/pattern/block.json
+++ b/packages/block-library/src/pattern/block.json
@@ -6,7 +6,6 @@
 	"category": "theme",
 	"description": "Show a block pattern.",
 	"supports": {
-		"align": [ "wide", "full" ],
 		"__experimentalLayout": {
 			"allowEditing": false
 		}
@@ -16,7 +15,7 @@
 		"slug": {
 			"type": "string"
 		},
-		"align": {
+		"forcedAlignment": {
 			"type": "string",
 			"default": "full"
 		},

--- a/packages/block-library/src/pattern/block.json
+++ b/packages/block-library/src/pattern/block.json
@@ -25,10 +25,10 @@
 				"type": "constrained"
 			}
 		},
-		"templateLock": {
+		"syncStatus": {
 			"type": [ "string", "boolean" ],
-			"enum": [ "contentOnly", false ],
-			"default": "contentOnly"
+			"enum": [ "full", "partial", "none" ],
+			"default": "none"
 		}
 	}
 }

--- a/packages/block-library/src/pattern/block.json
+++ b/packages/block-library/src/pattern/block.json
@@ -7,7 +7,9 @@
 	"description": "Show a block pattern.",
 	"supports": {
 		"align": [ "wide", "full" ],
-		"__experimentalLayout": true
+		"__experimentalLayout": {
+			"allowEditing": false
+		}
 	},
 	"textdomain": "default",
 	"attributes": {

--- a/packages/block-library/src/pattern/block.json
+++ b/packages/block-library/src/pattern/block.json
@@ -28,7 +28,7 @@
 		"syncStatus": {
 			"type": [ "string", "boolean" ],
 			"enum": [ "synced", "unsynced" ],
-			"default": "synced"
+			"default": "unsynced"
 		}
 	}
 }

--- a/packages/block-library/src/pattern/block.json
+++ b/packages/block-library/src/pattern/block.json
@@ -25,10 +25,10 @@
 				"type": "constrained"
 			}
 		},
-		"syncStatus": {
+		"templateLock": {
 			"type": [ "string", "boolean" ],
-			"enum": [ "full", "partial", "none" ],
-			"default": "none"
+			"enum": [ "contentOnly", false ],
+			"default": "contentOnly"
 		}
 	}
 }

--- a/packages/block-library/src/pattern/block.json
+++ b/packages/block-library/src/pattern/block.json
@@ -25,10 +25,10 @@
 				"type": "constrained"
 			}
 		},
-		"syncStatus": {
+		"templateLock": {
 			"type": [ "string", "boolean" ],
-			"enum": [ "synced", "unsynced" ],
-			"default": "unsynced"
+			"enum": [ "contentOnly", false ],
+			"default": "contentOnly"
 		}
 	}
 }

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -12,18 +12,20 @@ import {
 import { ToolbarButton } from '@wordpress/components';
 
 const PatternEdit = ( { attributes, clientId, setAttributes } ) => {
+	const { forcedAlignment, slug } = attributes;
 	const { selectedPattern, innerBlocks } = useSelect(
 		( select ) => {
 			return {
-				selectedPattern: select(
-					blockEditorStore
-				).__experimentalGetParsedPattern( attributes.slug ),
+				selectedPattern:
+					select( blockEditorStore ).__experimentalGetParsedPattern(
+						slug
+					),
 				innerBlocks:
 					select( blockEditorStore ).getBlock( clientId )
 						?.innerBlocks,
 			};
 		},
-		[ attributes.slug, clientId ]
+		[ slug, clientId ]
 	);
 	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
@@ -52,7 +54,9 @@ const PatternEdit = ( { attributes, clientId, setAttributes } ) => {
 		innerBlocks,
 	] );
 
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( {
+		className: forcedAlignment && `align${ forcedAlignment }`,
+	} );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {} );
 	return (
 		<>

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -59,7 +59,9 @@ const PatternEdit = ( { attributes, clientId, setAttributes } ) => {
 			<div { ...innerBlocksProps } />
 			<BlockControls group="other">
 				<ToolbarButton
-					onClick={ () => setAttributes( { unsynced: true } ) }
+					onClick={ () =>
+						setAttributes( { syncStatus: 'unsynced' } )
+					}
 				>
 					Unsync
 				</ToolbarButton>

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -14,7 +14,7 @@ import { ToolbarButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 const PatternEdit = ( { attributes, clientId, setAttributes } ) => {
-	const { inheritedAlignment, slug, templateLock } = attributes;
+	const { inheritedAlignment, slug, syncStatus } = attributes;
 	const { selectedPattern, innerBlocks } = useSelect(
 		( select ) => {
 			return {
@@ -29,8 +29,11 @@ const PatternEdit = ( { attributes, clientId, setAttributes } ) => {
 		},
 		[ slug, clientId ]
 	);
-	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
-		useDispatch( blockEditorStore );
+	const {
+		replaceBlocks,
+		replaceInnerBlocks,
+		__unstableMarkNextChangeAsNotPersistent,
+	} = useDispatch( blockEditorStore );
 
 	// Run this effect when the component loads.
 	// This adds the Pattern's contents to the post.
@@ -43,23 +46,32 @@ const PatternEdit = ( { attributes, clientId, setAttributes } ) => {
 			// inner blocks but doesn't have blockSettings in the state.
 			window.queueMicrotask( () => {
 				__unstableMarkNextChangeAsNotPersistent();
-				replaceInnerBlocks(
-					clientId,
-					selectedPattern.blocks.map( ( block ) =>
-						cloneBlock( block )
-					)
-				);
+				if ( syncStatus === 'partial' ) {
+					replaceInnerBlocks(
+						clientId,
+						selectedPattern.blocks.map( ( block ) =>
+							cloneBlock( block )
+						)
+					);
+					return;
+				}
+				replaceBlocks( clientId, selectedPattern.blocks );
 			} );
 		}
 	}, [
 		clientId,
-		selectedPattern?.blocks,
+		selectedPattern.blocks,
 		replaceInnerBlocks,
 		__unstableMarkNextChangeAsNotPersistent,
 		innerBlocks,
+		syncStatus,
+		replaceBlocks,
 	] );
 
 	useEffect( () => {
+		if ( syncStatus !== 'partial' ) {
+			return;
+		}
 		const alignments = [ 'wide', 'full' ];
 		const blocks = innerBlocks;
 		if ( ! blocks || blocks.length === 0 ) {
@@ -81,36 +93,30 @@ const PatternEdit = ( { attributes, clientId, setAttributes } ) => {
 		} );
 	}, [
 		innerBlocks,
-		selectedPattern?.blocks,
+		selectedPattern.blocks,
 		setAttributes,
 		inheritedAlignment,
+		syncStatus,
 	] );
 
 	const blockProps = useBlockProps( {
-		className: inheritedAlignment && `align${ inheritedAlignment }`,
-	} );
-	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		templateLock: templateLock === 'contentOnly' ? 'contentOnly' : false,
+		className:
+			syncStatus === 'partial' &&
+			inheritedAlignment &&
+			`align${ inheritedAlignment }`,
 	} );
 
-	const handleSync = () => {
-		if ( templateLock === false ) {
-			setAttributes( { templateLock: 'contentOnly' } );
-		} else {
-			setAttributes( { templateLock: false } );
-		}
-	};
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		templateLock: syncStatus === 'partial' ? 'contentOnly' : false,
+	} );
+
+	if ( syncStatus !== 'partial' ) {
+		return <div { ...blockProps } />;
+	}
 
 	return (
 		<>
 			<div { ...innerBlocksProps } />
-			<BlockControls group="other">
-				<ToolbarButton onClick={ handleSync }>
-					{ templateLock === false
-						? __( 'Edit content only' )
-						: __( 'Edit all' ) }
-				</ToolbarButton>
-			</BlockControls>
 		</>
 	);
 };

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -65,23 +65,27 @@ const PatternEdit = ( { attributes, clientId, setAttributes } ) => {
 		className: forcedAlignment && `align${ forcedAlignment }`,
 	} );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {} );
+
+	const handleSync = () => {
+		if ( syncStatus === 'synced' ) {
+			setAttributes( { syncStatus: 'unsynced' } );
+		} else {
+			setAttributes( { syncStatus: 'synced' } );
+			replaceInnerBlocks(
+				clientId,
+				selectedPattern.blocks.map( ( block ) => cloneBlock( block ) )
+			);
+		}
+	};
+
 	return (
 		<>
 			<div { ...innerBlocksProps } data-pattern-slug={ slug } />
 			<BlockControls group="other">
-				<ToolbarButton
-					onClick={ () =>
-						setAttributes( {
-							syncStatus:
-								syncStatus === 'unsynced'
-									? 'synced'
-									: 'unsynced',
-						} )
-					}
-				>
+				<ToolbarButton onClick={ handleSync }>
 					{ syncStatus === 'unsynced'
 						? __( 'Sync' )
-						: __( 'Unsync' ) }
+						: __( 'Desync' ) }
 				</ToolbarButton>
 			</BlockControls>
 		</>

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -103,7 +103,7 @@ const PatternEdit = ( { attributes, clientId, setAttributes } ) => {
 
 	return (
 		<>
-			<div { ...innerBlocksProps } data-pattern-slug={ slug } />
+			<div { ...innerBlocksProps } />
 			<BlockControls group="other">
 				<ToolbarButton onClick={ handleSync }>
 					{ templateLock === false

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -23,7 +23,6 @@ const PatternEdit = ( { attributes, clientId } ) => {
 		},
 		[ attributes.slug, clientId ]
 	);
-
 	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
 
@@ -53,7 +52,7 @@ const PatternEdit = ( { attributes, clientId } ) => {
 
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {} );
-	return <> { innerBlocksProps.children } </>;
+	return <div { ...innerBlocksProps }> { innerBlocksProps.children } </div>;
 };
 
 export default PatternEdit;

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -66,7 +66,7 @@ const PatternEdit = ( { attributes, clientId, setAttributes } ) => {
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {} );
 	return (
 		<>
-			<div { ...innerBlocksProps } />
+			<div { ...innerBlocksProps } data-pattern-slug={ slug } />
 			<BlockControls group="other">
 				<ToolbarButton
 					onClick={ () =>

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -11,9 +11,10 @@ import {
 	BlockControls,
 } from '@wordpress/block-editor';
 import { ToolbarButton } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 const PatternEdit = ( { attributes, clientId, setAttributes } ) => {
-	const { forcedAlignment, slug } = attributes;
+	const { forcedAlignment, slug, syncStatus } = attributes;
 	const { selectedPattern, innerBlocks } = useSelect(
 		( select ) => {
 			return {
@@ -70,10 +71,17 @@ const PatternEdit = ( { attributes, clientId, setAttributes } ) => {
 			<BlockControls group="other">
 				<ToolbarButton
 					onClick={ () =>
-						setAttributes( { syncStatus: 'unsynced' } )
+						setAttributes( {
+							syncStatus:
+								syncStatus === 'unsynced'
+									? 'synced'
+									: 'unsynced',
+						} )
 					}
 				>
-					Unsync
+					{ syncStatus === 'unsynced'
+						? __( 'Sync' )
+						: __( 'Unsync' ) }
 				</ToolbarButton>
 			</BlockControls>
 		</>

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { cloneBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import {
@@ -43,7 +44,12 @@ const PatternEdit = ( { attributes, clientId, setAttributes } ) => {
 			// inner blocks but doesn't have blockSettings in the state.
 			window.queueMicrotask( () => {
 				__unstableMarkNextChangeAsNotPersistent();
-				replaceInnerBlocks( clientId, selectedPattern.blocks );
+				replaceInnerBlocks(
+					clientId,
+					selectedPattern.blocks.map( ( block ) =>
+						cloneBlock( block )
+					)
+				);
 			} );
 		}
 	}, [

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -61,6 +61,35 @@ const PatternEdit = ( { attributes, clientId, setAttributes } ) => {
 		innerBlocks,
 	] );
 
+	useEffect( () => {
+		const alignments = [ 'wide', 'full' ];
+		const blocks =
+			syncStatus === 'synced' ? selectedPattern?.blocks : innerBlocks;
+		if ( ! blocks || blocks.length === 0 ) {
+			return;
+		}
+		// Determine the widest setting of all the contained blocks.
+		const widestAlignment = blocks.reduce( ( accumulator, block ) => {
+			const { align } = block.attributes;
+			return alignments.indexOf( align ) >
+				alignments.indexOf( accumulator )
+				? align
+				: accumulator;
+		}, undefined );
+
+		// Set the attribute of the Pattern block to match the widest
+		// alignment.
+		setAttributes( {
+			forcedAlignment: widestAlignment ?? '',
+		} );
+	}, [
+		innerBlocks,
+		selectedPattern?.blocks,
+		setAttributes,
+		syncStatus,
+		forcedAlignment,
+	] );
+
 	const blockProps = useBlockProps( {
 		className: forcedAlignment && `align${ forcedAlignment }`,
 	} );

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -7,9 +7,11 @@ import {
 	store as blockEditorStore,
 	useBlockProps,
 	useInnerBlocksProps,
+	BlockControls,
 } from '@wordpress/block-editor';
+import { ToolbarButton } from '@wordpress/components';
 
-const PatternEdit = ( { attributes, clientId } ) => {
+const PatternEdit = ( { attributes, clientId, setAttributes } ) => {
 	const { selectedPattern, innerBlocks } = useSelect(
 		( select ) => {
 			return {
@@ -52,7 +54,18 @@ const PatternEdit = ( { attributes, clientId } ) => {
 
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {} );
-	return <div { ...innerBlocksProps }> { innerBlocksProps.children } </div>;
+	return (
+		<>
+			<div { ...innerBlocksProps } />
+			<BlockControls group="other">
+				<ToolbarButton
+					onClick={ () => setAttributes( { unsynced: true } ) }
+				>
+					Unsync
+				</ToolbarButton>
+			</BlockControls>
+		</>
+	);
 };
 
 export default PatternEdit;

--- a/packages/block-library/src/pattern/index.js
+++ b/packages/block-library/src/pattern/index.js
@@ -4,12 +4,14 @@
 import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import PatternEdit from './edit';
+import PatternSave from './save';
 
 const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
 	edit: PatternEdit,
+	save: PatternSave,
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/pattern/index.js
+++ b/packages/block-library/src/pattern/index.js
@@ -3,15 +3,15 @@
  */
 import initBlock from '../utils/init-block';
 import metadata from './block.json';
-import PatternEdit from './edit';
+import PatternEditV1 from './v1/edit';
+import PatternEditV2 from './edit';
 import PatternSave from './save';
 
 const { name } = metadata;
 export { metadata, name };
 
-export const settings = {
-	edit: PatternEdit,
-	save: PatternSave,
-};
+export const settings = window?.__experimentalEnablePatternEnhancements
+	? { edit: PatternEditV2, save: PatternSave }
+	: { edit: PatternEditV1 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/pattern/index.php
+++ b/packages/block-library/src/pattern/index.php
@@ -32,8 +32,10 @@ function render_block_core_pattern( $attributes, $content ) {
 		return '';
 	}
 
+	$wrapper = '<div class="align' . $attributes['forcedAlignment'] . '" data-pattern-slug="' . $attributes['slug'] . '">%s</div>';
+
 	if ( isset( $attributes['syncStatus'] ) && 'unsynced' === $attributes['syncStatus'] ) {
-		return $content;
+		return sprintf( $wrapper, $content );
 	}
 
 	$slug     = $attributes['slug'];
@@ -43,7 +45,7 @@ function render_block_core_pattern( $attributes, $content ) {
 	}
 
 	$pattern = $registry->get_registered( $slug );
-	return do_blocks( $pattern['content'] );
+	return sprintf( $wrapper, do_blocks( $pattern['content'] ) );
 }
 
 add_action( 'init', 'register_block_core_pattern' );

--- a/packages/block-library/src/pattern/index.php
+++ b/packages/block-library/src/pattern/index.php
@@ -22,13 +22,18 @@ function register_block_core_pattern() {
 /**
  * Renders the `core/pattern` block on the server.
  *
- * @param array $attributes Block attributes.
+ * @param array  $attributes Block attributes.
+ * @param string $content    The block rendered content.
  *
  * @return string Returns the output of the pattern.
  */
-function render_block_core_pattern( $attributes ) {
+function render_block_core_pattern( $attributes, $content ) {
 	if ( empty( $attributes['slug'] ) ) {
 		return '';
+	}
+
+	if ( isset( $attributes['syncStatus'] ) && 'unsynced' === $attributes['syncStatus'] ) {
+		return $content;
 	}
 
 	$slug     = $attributes['slug'];

--- a/packages/block-library/src/pattern/save.js
+++ b/packages/block-library/src/pattern/save.js
@@ -4,7 +4,7 @@
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	if ( ! attributes.unsynced ) {
+	if ( attributes.syncStatus === 'synced' ) {
 		return null;
 	}
 	const blockProps = useBlockProps.save();

--- a/packages/block-library/src/pattern/save.js
+++ b/packages/block-library/src/pattern/save.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+export default function save() {
+	return (
+		<>
+			<InnerBlocks.Content />
+		</>
+	);
+}

--- a/packages/block-library/src/pattern/save.js
+++ b/packages/block-library/src/pattern/save.js
@@ -1,12 +1,15 @@
 /**
  * WordPress dependencies
  */
-import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 
-export default function save() {
+export default function save( { attributes } ) {
+	if ( ! attributes.unsynced ) {
+		return null;
+	}
+	const blockProps = useBlockProps.save();
+	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
 	return (
-		<div { ...useBlockProps.save() }>
-			<InnerBlocks.Content />
-		</div>
+		<div { ...{ ...innerBlocksProps } }>{ innerBlocksProps.children }</div>
 	);
 }

--- a/packages/block-library/src/pattern/save.js
+++ b/packages/block-library/src/pattern/save.js
@@ -3,7 +3,13 @@
  */
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 
-export default function save( { attributes: { inheritedAlignment } } ) {
+export default function save( {
+	attributes: { inheritedAlignment },
+	innerBlocks,
+} ) {
+	if ( innerBlocks?.length === 0 ) {
+		return;
+	}
 	const blockProps = useBlockProps.save( {
 		className: inheritedAlignment && `align${ inheritedAlignment }`,
 	} );

--- a/packages/block-library/src/pattern/save.js
+++ b/packages/block-library/src/pattern/save.js
@@ -3,11 +3,7 @@
  */
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 
-export default function save( { attributes } ) {
-	if ( attributes.syncStatus === 'synced' ) {
-		return null;
-	}
-
+export default function save() {
 	const blockProps = useBlockProps.save();
 	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
 	return <>{ innerBlocksProps.children }</>;

--- a/packages/block-library/src/pattern/save.js
+++ b/packages/block-library/src/pattern/save.js
@@ -1,12 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 export default function save() {
 	return (
-		<>
+		<div { ...useBlockProps.save() }>
 			<InnerBlocks.Content />
-		</>
+		</div>
 	);
 }

--- a/packages/block-library/src/pattern/save.js
+++ b/packages/block-library/src/pattern/save.js
@@ -4,10 +4,10 @@
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 
 export default function save( {
-	attributes: { inheritedAlignment },
+	attributes: { inheritedAlignment, syncStatus },
 	innerBlocks,
 } ) {
-	if ( innerBlocks?.length === 0 ) {
+	if ( innerBlocks?.length === 0 || syncStatus !== 'partial' ) {
 		return;
 	}
 	const blockProps = useBlockProps.save( {

--- a/packages/block-library/src/pattern/save.js
+++ b/packages/block-library/src/pattern/save.js
@@ -7,6 +7,7 @@ export default function save( { attributes } ) {
 	if ( attributes.syncStatus === 'synced' ) {
 		return null;
 	}
+
 	const blockProps = useBlockProps.save();
 	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
 	return <>{ innerBlocksProps.children }</>;

--- a/packages/block-library/src/pattern/save.js
+++ b/packages/block-library/src/pattern/save.js
@@ -9,7 +9,5 @@ export default function save( { attributes } ) {
 	}
 	const blockProps = useBlockProps.save();
 	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
-	return (
-		<div { ...{ ...innerBlocksProps } }>{ innerBlocksProps.children }</div>
-	);
+	return <>{ innerBlocksProps.children }</>;
 }

--- a/packages/block-library/src/pattern/save.js
+++ b/packages/block-library/src/pattern/save.js
@@ -4,10 +4,10 @@
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 
 export default function save( {
-	attributes: { inheritedAlignment, syncStatus },
+	attributes: { inheritedAlignment },
 	innerBlocks,
 } ) {
-	if ( innerBlocks?.length === 0 || syncStatus !== 'partial' ) {
+	if ( innerBlocks?.length === 0 ) {
 		return;
 	}
 	const blockProps = useBlockProps.save( {

--- a/packages/block-library/src/pattern/save.js
+++ b/packages/block-library/src/pattern/save.js
@@ -3,8 +3,10 @@
  */
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 
-export default function save() {
-	const blockProps = useBlockProps.save();
+export default function save( { attributes: { inheritedAlignment } } ) {
+	const blockProps = useBlockProps.save( {
+		className: inheritedAlignment && `align${ inheritedAlignment }`,
+	} );
 	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
-	return <>{ innerBlocksProps.children }</>;
+	return <div { ...innerBlocksProps }>{ innerBlocksProps.children }</div>;
 }

--- a/packages/block-library/src/pattern/v1/edit.js
+++ b/packages/block-library/src/pattern/v1/edit.js
@@ -1,0 +1,51 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import {
+	store as blockEditorStore,
+	useBlockProps,
+} from '@wordpress/block-editor';
+
+const PatternEdit = ( { attributes, clientId } ) => {
+	const selectedPattern = useSelect(
+		( select ) =>
+			select( blockEditorStore ).__experimentalGetParsedPattern(
+				attributes.slug
+			),
+		[ attributes.slug ]
+	);
+
+	const { replaceBlocks, __unstableMarkNextChangeAsNotPersistent } =
+		useDispatch( blockEditorStore );
+
+	// Run this effect when the component loads.
+	// This adds the Pattern's contents to the post.
+	// This change won't be saved.
+	// It will continue to pull from the pattern file unless changes are made to its respective template part.
+	useEffect( () => {
+		if ( selectedPattern?.blocks ) {
+			// We batch updates to block list settings to avoid triggering cascading renders
+			// for each container block included in a tree and optimize initial render.
+			// Since the above uses microtasks, we need to use a microtask here as well,
+			// because nested pattern blocks cannot be inserted if the parent block supports
+			// inner blocks but doesn't have blockSettings in the state.
+			window.queueMicrotask( () => {
+				__unstableMarkNextChangeAsNotPersistent();
+				replaceBlocks( clientId, selectedPattern.blocks );
+			} );
+		}
+	}, [
+		clientId,
+		selectedPattern?.blocks,
+		__unstableMarkNextChangeAsNotPersistent,
+		replaceBlocks,
+	] );
+
+	const props = useBlockProps();
+
+	return <div { ...props } />;
+};
+
+export default PatternEdit;

--- a/test/integration/fixtures/blocks/core__pattern.json
+++ b/test/integration/fixtures/blocks/core__pattern.json
@@ -3,7 +3,7 @@
 		"name": "core/pattern",
 		"isValid": true,
 		"attributes": {
-			"align": "full",
+			"forcedAlignment": "full",
 			"layout": {
 				"type": "constrained"
 			},

--- a/test/integration/fixtures/blocks/core__pattern.json
+++ b/test/integration/fixtures/blocks/core__pattern.json
@@ -3,7 +3,12 @@
 		"name": "core/pattern",
 		"isValid": true,
 		"attributes": {
-			"slug": "core/text-two-columns"
+			"align": "full",
+			"layout": {
+				"type": "constrained"
+			},
+			"slug": "core/text-two-columns",
+			"syncStatus": "synced"
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
## What?
If the syncStatus attribute of a pattern is set to `partial` a pattern block wrapper is added and and templateLock is set to `contentOnlye

## Why?

- Lays the groundwork for allowing the original pattern structure to be update and applied to the content of the pattern instance
- Allows for the option to shuffle pattern content with similar patterns

## How?

If pattern has `syncStatus===partial` adds a parent div that wraps the content of the pattern. Also currently defaults the innerBlocks templateLock to `contentOnly`.

## Testing Instructions

- With TT3 theme in editor code view add `<!-- wp:pattern {"slug":"twentytwentythree/cta"} -->`
- Switch to editor view and make sure the pattern is added as currently in trunk, ie. pattern block is removed and inner blocks of pattern added with no wrapper
- Switch to code view and add `<!-- wp:pattern {"slug":"twentytwentythree/cta", "syncStatus":"partial"} -->` 
- Switch back to editor view and check the CTA pattern still displays correctly (should display `wide` width) and has `Pattern` block wrapper around it, and editing is set to contentOnly
- Also check display is correct in frontend (should display `wide` width)

## Screenshots or screencast 


https://github.com/WordPress/gutenberg/assets/3629020/1f2d0e1e-d741-423f-8188-43e1504ec2cc




