### PR TITLE
List View: Allow right-click to open block settings dropdown, add editor setting

### DIFF
--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -38,6 +38,7 @@ function ListViewBlockSelectButton(
 		className,
 		block: { clientId },
 		onClick,
+		onContextMenu,
 		onToggleExpanded,
 		tabIndex,
 		onFocus,
@@ -237,6 +238,7 @@ function ListViewBlockSelectButton(
 					className
 				) }
 				onClick={ onClick }
+				onContextMenu={ onContextMenu }
 				onKeyDown={ onKeyDownHandler }
 				ref={ ref }
 				tabIndex={ tabIndex }

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -39,6 +39,7 @@ function ListViewBlockSelectButton(
 		block: { clientId },
 		onClick,
 		onContextMenu,
+		onMouseDown,
 		onToggleExpanded,
 		tabIndex,
 		onFocus,
@@ -240,6 +241,7 @@ function ListViewBlockSelectButton(
 				onClick={ onClick }
 				onContextMenu={ onContextMenu }
 				onKeyDown={ onKeyDownHandler }
+				onMouseDown={ onMouseDown }
 				ref={ ref }
 				tabIndex={ tabIndex }
 				onFocus={ onFocus }

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -13,7 +13,13 @@ import {
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { moreVertical } from '@wordpress/icons';
-import { useState, useRef, useCallback, memo } from '@wordpress/element';
+import {
+	useCallback,
+	useMemo,
+	useState,
+	useRef,
+	memo,
+} from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { sprintf, __ } from '@wordpress/i18n';
 import { ESCAPE } from '@wordpress/keycodes';
@@ -211,8 +217,37 @@ function ListViewBlock( {
 				event.preventDefault();
 			}
 		},
-		[ settingsRef, showBlockActions ]
+		[ allowRightClickOverrides, settingsRef, showBlockActions ]
 	);
+
+	const onMouseDown = useCallback(
+		( event ) => {
+			// Prevent right-click from focusing the block,
+			// because focus will be handled when opening the block settings dropdown.
+			if ( allowRightClickOverrides && event.button === 2 ) {
+				event.preventDefault();
+			}
+		},
+		[ allowRightClickOverrides ]
+	);
+
+	const settingsPopoverAnchor = useMemo( () => {
+		const { ownerDocument } = rowRef?.current || {};
+
+		// If no custom position is set, the settings dropdown will be anchored to the
+		// DropdownMenu toggle button.
+		if ( ! settingsAnchorRect || ! ownerDocument ) {
+			return undefined;
+		}
+
+		// Position the settings dropdown at the cursor when right-clicking a block.
+		return {
+			ownerDocument,
+			getBoundingClientRect() {
+				return settingsAnchorRect;
+			},
+		};
+	}, [ settingsAnchorRect ] );
 
 	const clearSettingsAnchorRect = useCallback( () => {
 		// Clear the custom position for the settings dropdown so that it is restored back
@@ -288,6 +323,7 @@ function ListViewBlock( {
 							block={ block }
 							onClick={ selectEditorBlock }
 							onContextMenu={ onContextMenu }
+							onMouseDown={ onMouseDown }
 							onToggleExpanded={ toggleExpanded }
 							isSelected={ isSelected }
 							position={ position }
@@ -355,7 +391,7 @@ function ListViewBlock( {
 							icon={ moreVertical }
 							label={ settingsAriaLabel }
 							popoverProps={ {
-								anchorRect: settingsAnchorRect, // Used to position the settings at the cursor on right-click.
+								anchor: settingsPopoverAnchor, // Used to position the settings at the cursor on right-click.
 							} }
 							toggleProps={ {
 								ref,

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -90,13 +90,11 @@ function ListViewBlock( {
 		},
 		[ clientId ]
 	);
-
-	const { allowRightClickOverrides } = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		return {
-			allowRightClickOverrides: getSettings().allowRightClickOverrides,
-		};
-	} );
+	const allowRightClickOverrides = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getSettings().allowRightClickOverrides,
+		[]
+	);
 
 	const showBlockActions =
 		// When a block hides its toolbar it also hides the block settings menu,

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -116,6 +116,15 @@ export default function EditPostPreferencesModal() {
 									label={ __( 'Show block breadcrumbs' ) }
 								/>
 							) }
+							<EnableFeature
+								featureName="allowRightClickOverrides"
+								help={ __(
+									'Allows contextual menus via right-click, overriding browser defaults.'
+								) }
+								label={ __(
+									'Allow right-click contextual menus'
+								) }
+							/>
 						</PreferencesModalSection>
 						<PreferencesModalSection
 							title={ __( 'Document settings' ) }

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -119,7 +119,7 @@ export default function EditPostPreferencesModal() {
 							<EnableFeature
 								featureName="allowRightClickOverrides"
 								help={ __(
-									'Allows contextual menus via right-click, overriding browser defaults.'
+									'Allows contextual list view menus via right-click, overriding browser defaults.'
 								) }
 								label={ __(
 									'Allow right-click contextual menus'

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -30,6 +30,7 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
 
 	const {
+		allowRightClickOverrides,
 		hasFixedToolbar,
 		focusMode,
 		isDistractionFree,
@@ -70,6 +71,9 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 			const isViewable = getPostType( postType )?.viewable ?? false;
 			const canEditTemplate = canUser( 'create', 'templates' );
 			return {
+				allowRightClickOverrides: isFeatureActive(
+					'allowRightClickOverrides'
+				),
 				hasFixedToolbar:
 					isFeatureActive( 'fixedToolbar' ) || ! isLargeViewport,
 				focusMode: isFeatureActive( 'focusMode' ),
@@ -106,6 +110,7 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 			focusMode,
 			isDistractionFree,
 			hasInlineToolbar,
+			allowRightClickOverrides,
 
 			// This is marked as experimental to give time for the quick inserter to mature.
 			__experimentalSetIsInserterOpened: setIsInserterOpened,
@@ -133,6 +138,7 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 		return result;
 	}, [
 		settings,
+		allowRightClickOverrides,
 		hasFixedToolbar,
 		hasInlineToolbar,
 		focusMode,

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -47,6 +47,7 @@ export function initializeEditor(
 	const root = createRoot( target );
 
 	dispatch( preferencesStore ).setDefaults( 'core/edit-post', {
+		allowRightClickOverrides: true,
 		editorMode: 'visual',
 		fixedToolbar: false,
 		fullscreenMode: true,

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -94,6 +94,7 @@ export function useSpecificEditorSettings() {
 	const {
 		templateSlug,
 		focusMode,
+		allowRightClickOverrides,
 		isDistractionFree,
 		hasFixedToolbar,
 		keepCaretInsideBlock,
@@ -126,6 +127,10 @@ export function useSpecificEditorSettings() {
 					'core/edit-site',
 					'distractionFree'
 				),
+				allowRightClickOverrides: !! getPreference(
+					'core/edit-site',
+					'allowRightClickOverrides'
+				),
 				hasFixedToolbar:
 					!! getPreference( 'core/edit-site', 'fixedToolbar' ) ||
 					! isLargeViewport,
@@ -149,6 +154,7 @@ export function useSpecificEditorSettings() {
 			supportsTemplateMode: true,
 			__experimentalSetIsInserterOpened: setIsInserterOpened,
 			focusMode: canvasMode === 'view' && focusMode ? false : focusMode,
+			allowRightClickOverrides,
 			isDistractionFree,
 			hasFixedToolbar,
 			keepCaretInsideBlock,
@@ -162,6 +168,7 @@ export function useSpecificEditorSettings() {
 		settings,
 		setIsInserterOpened,
 		focusMode,
+		allowRightClickOverrides,
 		isDistractionFree,
 		hasFixedToolbar,
 		keepCaretInsideBlock,

--- a/packages/edit-site/src/components/preferences-modal/index.js
+++ b/packages/edit-site/src/components/preferences-modal/index.js
@@ -65,6 +65,13 @@ export default function EditSitePreferencesModal() {
 						) }
 						label={ __( 'Display block breadcrumbs' ) }
 					/>
+					<EnableFeature
+						featureName="allowRightClickOverrides"
+						help={ __(
+							'Allows contextual menus via right-click, overriding browser defaults.'
+						) }
+						label={ __( 'Allow right-click contextual menus' ) }
+					/>
 				</PreferencesModalSection>
 			),
 		},

--- a/packages/edit-site/src/components/preferences-modal/index.js
+++ b/packages/edit-site/src/components/preferences-modal/index.js
@@ -68,7 +68,7 @@ export default function EditSitePreferencesModal() {
 					<EnableFeature
 						featureName="allowRightClickOverrides"
 						help={ __(
-							'Allows contextual menus via right-click, overriding browser defaults.'
+							'Allows contextual list view menus via right-click, overriding browser defaults.'
 						) }
 						label={ __( 'Allow right-click contextual menus' ) }
 					/>

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -52,6 +52,7 @@ export function initializeEditor( id, settings ) {
 	// We dispatch actions and update the store synchronously before rendering
 	// so that we won't trigger unnecessary re-renders with useEffect.
 	dispatch( preferencesStore ).setDefaults( 'core/edit-site', {
+		allowRightClickOverrides: true,
 		editorMode: 'visual',
 		fixedToolbar: false,
 		focusMode: false,

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -29,6 +29,7 @@ const BLOCK_EDITOR_SETTINGS = [
 	'__unstableGalleryWithImageBlocks',
 	'alignWide',
 	'allowedBlockTypes',
+	'allowRightClickOverrides',
 	'blockInspectorTabs',
 	'allowedMimeTypes',
 	'bodyPlaceholder',

--- a/test/e2e/specs/editor/various/a11y.spec.js
+++ b/test/e2e/specs/editor/various/a11y.spec.js
@@ -124,6 +124,13 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 		page,
 		pageUtils,
 	} ) => {
+		// Note: this test depends on a particular viewport height to determine whether or not
+		// the modal content is scrollable. If this tests fails and needs to be debugged locally,
+		// double-check the viewport height when running locally versus in CI. Additionally,
+		// when adding or removing items from the preference menu, this test may need to be updated
+		// if the height of panels has changed. It would be good to find a more robust way to test
+		// this behavior.
+
 		// Open the top bar Options menu.
 		await page.click(
 			'role=region[name="Editor top bar"i] >> role=button[name="Options"i]'
@@ -145,6 +152,9 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 		const generalTab = preferencesModal.locator(
 			'role=tab[name="General"i]'
 		);
+		const accessibilityTab = preferencesModal.locator(
+			'role=tab[name="Accessibility"i]'
+		);
 		const blocksTab = preferencesModal.locator(
 			'role=tab[name="Blocks"i]'
 		);
@@ -165,9 +175,20 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 			await tab.focus();
 		}
 
-		// The General tab panel content is short and not scrollable.
-		// Check it's not focusable.
+		// The Accessibility tab is currently short and not scrollable.
+		// Check that it cannot be focused by tabbing. Note: this test depends
+		// on a particular viewport height to determine whether or not the
+		// modal content is scrollable. If additional Accessibility options are
+		// added, then eventually this test will fail.
+		// TODO: find a more robust way to test this behavior.
 		await clickAndFocusTab( generalTab );
+		// Navigate down to the Accessibility tab.
+		await pageUtils.pressKeys( 'ArrowDown', { times: 2 } );
+		// Check the Accessibility tab panel is visible.
+		await expect(
+			preferencesModal.locator( 'role=tabpanel[name="Accessibility"i]' )
+		).toBeVisible();
+		await expect( accessibilityTab ).toBeFocused();
 		await pageUtils.pressKeys( 'Shift+Tab' );
 		await expect( closeButton ).toBeFocused();
 		await pageUtils.pressKeys( 'Shift+Tab' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #40287, based on a previous attempt in #41041

This PR adds right-click behaviour to the list view, so that right-clicking on a list view item will open the block settings menu, with the menu positioned over the mouse cursor.

It also adds an editor setting to the post and site editors so that users can disable the setting if they wish.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

<!--
This PR builds on the earlier experiment in https://github.com/WordPress/gutenberg/pull/41041 (it's currently nearly identical) — there has been some feedback recently that folks would like to explore this idea again, so I've dusted off that old PR. -->

The general idea, as raised in https://github.com/WordPress/gutenberg/issues/40287, is that in other web apps that people are used to, right-clicking an item opens up a contextual menu that is part of the app. The more that using Gutenberg feels like using an app, the more it might be appropriate that right-click feels like more of an in-app kind of behaviour. That's the idea, at least!

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add an `allowRightClickOverrides` setting in the post and site editors.
* At the button level in the List View, add an `onContextMenu` handler, and if the settings allow it, simulate a click on the settings dropdown when the button is right-clicked.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In the post editor, add some blocks.
2. Open up the list view, and right click on an item in the list. The block settings menu should open up.
3. Multi-select multiple blocks and right click on an item — you should still be able to remove multiple blocks via this dropdown.
4. Open up the Preferences in the editor, and toggle the right click overrides setting off.
5. Reload the editor for the change in preferences to take effect.
6. Check that the browser default context menu opens up when right clicking list view items.
7. Repeat the above in the site editor.

## Screenshots or screencast <!-- if applicable -->

Right-click items in the list view:

https://github.com/WordPress/gutenberg/assets/14988353/f0a62f23-36d9-48df-982e-b477a5390212

The setting:

| Post editor setting | Site editor setting |
| --- | --- |
| <img width="768" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/1ec5a31c-aef2-4ccc-9631-f021c2fbd081"> | <img width="766" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/87a1367b-3193-4547-b676-6d0c12ddcc6b"> |

<!--

https://github.com/WordPress/gutenberg/assets/14988353/f305b5d7-c2b1-4f49-b646-2f123409178c

<!--

## Current bugs

Sometimes, when right-clicking, the other menus don't disappear:

<img width="907" alt="image" src="https://user-images.githubusercontent.com/14988353/235834243-a38680ac-1da1-46a5-98f2-11fc3042c699.png">

-->