### PR TITLE
Edit Post: Don't export Slot/Fill constants separately

### DIFF
--- a/packages/edit-post/src/components/sidebar/plugin-document-setting-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-document-setting-panel/index.js
@@ -17,7 +17,7 @@ import warning from '@wordpress/warning';
 import { EnablePluginDocumentSettingPanelOption } from '../../preferences-modal/options';
 import { store as editPostStore } from '../../../store';
 
-export const { Fill, Slot } = createSlotFill( 'PluginDocumentSettingPanel' );
+const { Fill, Slot } = createSlotFill( 'PluginDocumentSettingPanel' );
 
 const PluginDocumentSettingFill = ( {
 	isEnabled,

--- a/packages/edit-post/src/components/sidebar/plugin-post-status-info/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-post-status-info/index.js
@@ -7,7 +7,7 @@
  */
 import { createSlotFill, PanelRow } from '@wordpress/components';
 
-export const { Fill, Slot } = createSlotFill( 'PluginPostStatusInfo' );
+const { Fill, Slot } = createSlotFill( 'PluginPostStatusInfo' );
 
 /**
  * Renders a row in the Summary panel of the Document sidebar.


### PR DESCRIPTION
## What?
PR removes `PluginDocumentSettingPanel` and `PluginPostStatusInfo` separate Slot/Fill exports. They aren't used anywhere, and files use default exports.

## Testing Instructions
CI tests should be green.
