### PR TITLE
Remove custom padding for tertiary buttons

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 -   `CheckboxControl`, `CustomGradientPicker`, `FormToggle`, : Refactor and correct the focus style for consistency ([#50127](https://github.com/WordPress/gutenberg/pull/50127)).
+-   `Button`, remove custom padding applied to `tertiary` variant. ([#50276](https://github.com/WordPress/gutenberg/pull/50276)).
 
 ### Internal
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -160,7 +160,6 @@
 		white-space: nowrap;
 		color: $components-color-accent;
 		background: transparent;
-		padding: $grid-unit-15 * 0.5; // This reduces the horizontal padding on tertiary/text buttons, so as to space them optically.
 
 		&:hover:not(:disabled) {
 			background: rgba(var(--wp-admin-theme-color--rgb), 0.04);


### PR DESCRIPTION
## What?
Removes the custom padding applied to tertiary buttons.

## Why?
They're now consistent with other button variants, and the horizontal spacing feels more balanced.

## How?
CSS.

## Testing Instructions
Observe that the tertiary button variant has the same padding as other button variants. 

## Before
![before](https://user-images.githubusercontent.com/846565/235863882-d3e7d036-b6ff-478d-af0e-d4764307fb41.gif)


## After
![after](https://user-images.githubusercontent.com/846565/235863904-340bd589-489a-4485-ab85-3f651fdc0c28.gif)
