### PR TITLE
Comment Template Block: Set `commentId` context via filter

### DIFF
--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -25,13 +25,14 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 
 	$content = '';
 	foreach ( $comments as $comment ) {
-
-		$block_content = ( new WP_Block(
-			$block->parsed_block,
-			array(
-				'commentId' => $comment->comment_ID,
-			)
-		) )->render( array( 'dynamic' => false ) );
+		$comment_id           = $comment->comment_ID;
+		$filter_block_context = static function( $context ) use ( $comment_id ) {
+			$context['commentId'] = $comment_id;
+			return $context;
+		};
+		add_filter( 'render_block_context', $filter_block_context );
+		$block_content = $block->render( array( 'dynamic' => false ) );
+		remove_filter( 'render_block_context', $filter_block_context );
 
 		$children = $comment->get_children();
 


### PR DESCRIPTION
## What?
In the Comment Template block's render callback, instead of creating a new `WP_Block` instance with `commentId` context set, use the `render_block_context` filter to set that context and render the existing `WP_Block` instance.

## Why?
This approach arguably follows our established patterns with regard to handling block context better. Notably, with the previous approach, we were only setting block context for the Comment Template block itself. In this PR, we extend it to apply to all child blocks, including ones that are dynamically inserted, e.g. via the `render_block` filter. This is relevant for Auto-inserting blocks (see #50103).

## How?
See "What".

## Testing Instructions
Verify that the Comments block (and children) are still working as expected on the frontend:

1. Use a block theme that uses them (e.g. Twenty Twenty-Three).
2. On `trunk`, create a number of comments below a given post, nested at different levels. View that page on the frontend, and take note (and a screenshot) of what the comments look like.
3. Switch to this branch, and rebuild GB.
4. Reload the page, and verify that it looks the same as before.

Additionally, you can copy the relevant unit tests file from `wordpress-develop`, and run it against this branch in GB:

```
cp ../src/wordpress-develop/tests/phpunit/tests/blocks/renderCommentTemplate.php phpunit/blocks/render-comment-template-test.php
npm run test:unit:php -- --group=blocks
```

### Testing Instructions for Keyboard
N/A.

## Screenshots or screencast
N/A.