### PR TITLE
wp-env: Fix redirect loop for instances on port 80 (and 443)

### DIFF
--- a/packages/env/lib/config/add-or-replace-port.js
+++ b/packages/env/lib/config/add-or-replace-port.js
@@ -28,6 +28,14 @@ module.exports = function addOrReplacePort( input, port, replace = true ) {
 		return input;
 	}
 
+	// If the port is '80' or '443' we will not add it to the output.
+	// This is because these are the default ports for HTTP and HTTPS and
+	// browsers will not display them in the address bar. Adding them would
+	// result in a redirect loop.
+	if ( port === '80' || port === '443' ) {
+		return input;
+	}
+
 	// Place the port in the correct location in the input.
 	return matches[ 1 ] + ':' + port + matches[ 3 ];
 };

--- a/packages/env/lib/config/test/add-or-replace-port.js
+++ b/packages/env/lib/config/test/add-or-replace-port.js
@@ -51,4 +51,13 @@ describe( 'addOrReplacePort', () => {
 			expect( result ).toEqual( test.expect );
 		}
 	} );
+
+	it( 'should do nothing if port is 80 or 443', () => {
+		const testMap = [ { in: 'test', expect: 'test' } ];
+
+		for ( const test of testMap ) {
+			const result = addOrReplacePort( test.in, '80' );
+			expect( result ).toEqual( test.expect );
+		}
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This Pull Request introduces an exception within the `addOrReplacePort` function, ensuring that if the specified port is either 80 or 443, the input remains unaltered.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The modifications introduced in #49883 mandate the inclusion of port numbers in the constants `WP_TESTS_DOMAIN`, `WP_SITEURL`, and `WP_HOME`. Unfortunately, there doesn't appear to be a configuration option to bypass the addition of these ports.

As a result, this negatively impacts all `wp-env` instances operating on ports 80 or 443. Modern browsers automatically remove these default ports, which leads to a redirection loop in the frontend, rendering the site inaccessible to users
