### PR TITLE
Polish confirm dialog padding.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 -   `CheckboxControl`, `CustomGradientPicker`, `FormToggle`, : Refactor and correct the focus style for consistency ([#50127](https://github.com/WordPress/gutenberg/pull/50127)).
 -   `Button`, update spacing values in `has-text has-icon` buttons. ([#50277](https://github.com/WordPress/gutenberg/pull/50277)).
 -   `Button`, remove custom padding applied to `tertiary` variant. ([#50276](https://github.com/WordPress/gutenberg/pull/50276)).
+-   `Modal`: Correct padding for title less confirm variant. ([#50283](https://github.com/WordPress/gutenberg/pull/50283)).
 
 ### Breaking Changes
 

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -135,7 +135,7 @@
 
 	&.hide-header {
 		margin-top: 0;
-		padding-top: $grid-unit-30;
+		padding-top: $grid-unit-50;
 	}
 
 	&.is-scrollable:focus-visible {

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -135,7 +135,7 @@
 
 	&.hide-header {
 		margin-top: 0;
-		padding-top: $grid-unit-50;
+		padding-top: $grid-unit-40;
 	}
 
 	&.is-scrollable:focus-visible {


### PR DESCRIPTION
## What?

Updates the confirm/no-header modal to have correct padding.

Before:

<img width="520" alt="Screenshot 2023-05-03 at 11 32 35" src="https://user-images.githubusercontent.com/1204802/235882610-19549ffa-664d-470e-874c-1a3e06a6a86c.png">

After:

<img width="479" alt="Screenshot 2023-05-03 at 11 36 06" src="https://user-images.githubusercontent.com/1204802/235882630-c1e9aa05-9022-4b9c-8c41-1f1bb5af968a.png">

## Testing Instructions

Publish a post, then in the inspector choose "switch to draft" and observe a padding that is optically balanced around all elements.
