### PR TITLE
Save Button: Fix the label in the disabled state

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/site-editor.ts
@@ -17,6 +17,6 @@ export async function saveSiteEditorEntities( this: Editor ) {
 		'role=region[name="Save panel"i] >> role=button[name="Save"i]'
 	);
 	await this.page.waitForSelector(
-		'role=region[name="Editor top bar"i] >> role=button[name="Save"i][disabled]'
+		'role=region[name="Editor top bar"i] >> role=button[name="Saved"i][disabled]'
 	);
 }

--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -37,14 +37,20 @@ export default function SaveButton( {
 	const activateSaveEnabled = isPreviewingTheme() || isDirty;
 	const disabled = isSaving || ! activateSaveEnabled;
 
-	let label;
-	if ( isPreviewingTheme() && isDirty ) {
-		label = __( 'Activate & Save' );
-	} else if ( isPreviewingTheme() ) {
-		label = __( 'Activate' );
-	} else {
-		label = __( 'Save' );
-	}
+	const getLabel = () => {
+		if ( disabled ) {
+			return __( 'Saved' );
+		}
+
+		if ( isPreviewingTheme() && isDirty ) {
+			return __( 'Activate & Save' );
+		} else if ( isPreviewingTheme() ) {
+			return __( 'Activate' );
+		}
+
+		return __( 'Save' );
+	};
+	const label = getLabel();
 
 	return (
 		<Button


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
In https://github.com/WordPress/gutenberg/commit/843bbec25921b8c1d3584f7eca5f972f2433aa71#diff-07753d8ea6fd653136f72fa07b1dfa6e9c5a8bf59e79e1ccfeb9b90e27d9aeeeL38 we introduced a bug whereby the label of the save button always said "save" even if it wasn't enabled. This reinstates the behaviour that changes that text to "Saved" when the button is disabled.

## Why?
So that users know there are no changes to save.

## How?
Introduce a new function that gets the Label and add a disabled condition to it. I think this is slightly easier to read and less error prone that using the `let`.

## Testing Instructions
1. Open the Site Editor with no changes and confirm that the button says "Saved".
2. Make some changes and confirm that the button says "Save"

### Testing Instructions for Keyboard
As above

## Screenshots or screencast <!-- if applicable -->
<img width="359" alt="Screenshot 2023-05-03 at 11 24 50" src="https://user-images.githubusercontent.com/275961/235891583-ca5b9cf1-1459-4ed8-8b96-b736b7e6696c.png">
