### PR TITLE
Lodash: Refactor away from `_.mapValues()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -105,6 +105,7 @@ const restrictedImports = [
 			'lowerCase',
 			'map',
 			'mapKeys',
+			'mapValues',
 			'maxBy',
 			'memoize',
 			'merge',

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -3,7 +3,6 @@
  */
 const fs = require( 'fs' );
 const path = require( 'path' );
-const { mapValues } = require( 'lodash' );
 const SimpleGit = require( 'simple-git' );
 
 /**
@@ -475,10 +474,26 @@ async function runPerformanceTests( branches, options ) {
 					( r ) => r[ branch ][ dataPoint ]
 				);
 			} );
-			const medians = mapValues( resultsByDataPoint, median );
+			// @ts-ignore
+			const medians = Object.fromEntries(
+				Object.entries( resultsByDataPoint ).map(
+					( [ dataPoint, dataPointResults ] ) => [
+						dataPoint,
+						median( dataPointResults ),
+					]
+				)
+			);
 
 			// Format results as times.
-			results[ testSuite ][ branch ] = mapValues( medians, formatTime );
+			// @ts-ignore
+			results[ testSuite ][ branch ] = Object.fromEntries(
+				Object.entries( medians ).map(
+					( [ dataPoint, dataPointMedian ] ) => [
+						dataPoint,
+						formatTime( dataPointMedian ),
+					]
+				)
+			);
 		}
 	}
 

--- a/packages/blocks/src/api/parser/get-block-attributes.js
+++ b/packages/blocks/src/api/parser/get-block-attributes.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { parse as hpqParse } from 'hpq';
-import { mapValues } from 'lodash';
 import memoize from 'memize';
 
 /**
@@ -217,9 +216,13 @@ export const matcherFromSource = memoize( ( sourceConfig ) => {
 		case 'node':
 			return node( sourceConfig.selector );
 		case 'query':
-			const subMatchers = mapValues(
-				sourceConfig.query,
-				matcherFromSource
+			const subMatchers = Object.fromEntries(
+				Object.entries( sourceConfig.query ).map(
+					( [ key, subSourceConfig ] ) => [
+						key,
+						matcherFromSource( subSourceConfig ),
+					]
+				)
 			);
 			return query( sourceConfig.selector, subMatchers );
 		case 'tag':
@@ -275,8 +278,13 @@ export function getBlockAttributes(
 	const doc = parseHtml( innerHTML );
 	const blockType = normalizeBlockType( blockTypeOrName );
 
-	const blockAttributes = mapValues( blockType.attributes, ( schema, key ) =>
-		getBlockAttribute( key, schema, doc, attributes, innerHTML )
+	const blockAttributes = Object.fromEntries(
+		Object.entries( blockType.attributes ?? {} ).map(
+			( [ key, schema ] ) => [
+				key,
+				getBlockAttribute( key, schema, doc, attributes, innerHTML ),
+			]
+		)
 	);
 
 	return applyFilters(


### PR DESCRIPTION
## What?
This PR removes the last usage of Lodash's `_.mapValues()` and deprecates the function. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `Object.fromEntries( Object.entries().map() )` as a replacement. 

## Testing Instructions

Verify all checks are green. The changes are covered by existing tests and checks.