### PR TITLE
Use alert callout in the block deprecation docs

### DIFF
--- a/docs/reference-guides/block-api/block-deprecation.md
+++ b/docs/reference-guides/block-api/block-deprecation.md
@@ -55,7 +55,9 @@ Deprecations are defined on a block type as its `deprecated` property, an array 
 	- _Return_
 		- `boolean`: Whether or not this otherwise valid block is eligible to be migrated by this deprecation.
 
-It's important to note that `attributes`, `supports`, and `save` are not automatically inherited from the current version, since they can impact parsing and serialization of a block, so they must be defined on the deprecated object in order to be processed during a migration.
+<div class="callout callout-alert">
+It's important to note that <code>attributes</code>, <code>supports</code>, and <code>save</code> are not automatically inherited from the current version, since they can impact parsing and serialization of a block, so they must be defined on the deprecated object in order to be processed during a migration.
+</div>
 
 ### Example:
 


### PR DESCRIPTION
## What?
PR updates block documentation docs to use [alert callout](https://developer.wordpress.org/block-editor/contributors/documentation/#callout-notices) in block deprecation docs to highlight an important caveat.

## Why?
The fact that `attributes|supports` block settings aren't inherited by deprecation objects can be easily missed and result in broken deprecation. See #50281.

## Testing Instructions
CI is green.

The callouts are rendered only on the docs page, so testing locally is hard.
