### PR TITLE
Add ndiego as codeowner for docs.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Documentation
-/docs                                           @ajitbohra @ryanwelcher @juanmaguitar @fabiankaegy
+/docs                                           @ajitbohra @ryanwelcher @juanmaguitar @fabiankaegy @ndiego
 
 # Schemas
 /schemas/json                                   @ajlende
@@ -57,7 +57,7 @@
 # Tooling
 /bin                                            @ntwb @nerrad @ajitbohra
 /bin/api-docs                                   @ntwb @nerrad @ajitbohra
-/docs/tool                                      @ajitbohra
+/docs/tool                                      @ajitbohra @ndiego
 /packages/babel-plugin-import-jsx-pragma        @ntwb @nerrad @ajitbohra
 /packages/babel-plugin-makepot                  @ntwb @nerrad @ajitbohra
 /packages/babel-preset-default                  @gziolo @ntwb @nerrad @ajitbohra


### PR DESCRIPTION
## What?
Added myself (ndiego) as a codeowner for `docs` and `docs/tool`. 

## Why?
Moving forward, I will be taking an active role in improving and maintaining Gutenberg/Block Editor documentation. 
