### PR TITLE
Do not include first time contributors section in changelog if there are not any

### DIFF
--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -919,6 +919,10 @@ function getContributorProps( pullRequests ) {
 		getContributorPropsMarkdownList,
 	] )( pullRequests );
 
+	if ( ! contributorsList ) {
+		return '';
+	}
+
 	return (
 		'## First time contributors' +
 		'\n\n' +

--- a/bin/plugin/commands/test/changelog.js
+++ b/bin/plugin/commands/test/changelog.js
@@ -485,6 +485,11 @@ describe( 'getContributorProps', () => {
 		// npm run other:changelog -- --milestone="Gutenberg 11.3"
 		expect( getContributorProps( pullRequests ) ).toMatchSnapshot();
 	} );
+	test( 'do not include first time contributors section if there are not any', () => {
+		expect(
+			getContributorProps( pullRequests.slice( 0, 4 ) )
+		).toMatchInlineSnapshot( `""` );
+	} );
 } );
 
 describe( 'getContributorList', () => {


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Do not include first time contributors section in changelog if there are not any. I noticed [here](https://github.com/WordPress/gutenberg/releases/tag/v15.7.0-rc.2) that we output the headers even with no new contributors.