### PR TITLE
Don't remount the block when the 'templateLock' is set to 'contentOnly'

### DIFF
--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -13,10 +13,6 @@ import { useEffect, useRef, useCallback } from '@wordpress/element';
  */
 import { store as blockEditorStore } from '../store';
 import { BlockControls, BlockSettingsMenuControls } from '../components';
-/**
- * External dependencies
- */
-import classnames from 'classnames';
 
 function StopEditingAsBlocksOnOutsideSelect( {
 	clientId,
@@ -156,15 +152,7 @@ export const withBlockControls = createHigherOrderComponent(
 						) }
 					</BlockSettingsMenuControls>
 				) }
-				<BlockEdit
-					key="edit"
-					{ ...props }
-					className={ classnames(
-						props.className,
-						isEditingAsBlocks &&
-							'is-content-locked-editing-as-blocks'
-					) }
-				/>
+				<BlockEdit key="edit" { ...props } />
 			</>
 		);
 	},

--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -101,7 +101,7 @@ export const withBlockControls = createHigherOrderComponent(
 		] );
 
 		if ( ! isContentLocked && ! isEditingAsBlocks ) {
-			return <BlockEdit { ...props } />;
+			return <BlockEdit key="edit" { ...props } />;
 		}
 
 		const showStopEditingAsBlocks = isEditingAsBlocks && ! isContentLocked;
@@ -157,6 +157,7 @@ export const withBlockControls = createHigherOrderComponent(
 					</BlockSettingsMenuControls>
 				) }
 				<BlockEdit
+					key="edit"
 					{ ...props }
 					className={ classnames(
 						props.className,

--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -33,7 +33,7 @@ function StopEditingAsBlocksOnOutsideSelect( {
 		if ( ! isBlockOrDescendantSelected ) {
 			stopEditingAsBlock();
 		}
-	}, [ isBlockOrDescendantSelected ] );
+	}, [ isBlockOrDescendantSelected, stopEditingAsBlock ] );
 	return null;
 }
 

--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -87,7 +87,6 @@ export const withBlockControls = createHigherOrderComponent(
 			__unstableSetTemporarilyEditingAsBlocks();
 		}, [
 			props.clientId,
-			focusModeToRevert,
 			updateSettings,
 			updateBlockListSettings,
 			getBlockListSettings,


### PR DESCRIPTION
## What?
Fixes #50163.

PR prevents remounting container `BlockEdit` components when the `templateLock` value is `contentOnly`.

## Why?
This is similar to #48209.

The `templateLock` and its derived value, `isContentLocked`, is initially `false`; after synchronizing the block list settings (`updateBlockListSettings`), it becomes `contentOnly`. Like the issue above, this causes `<BlockEdit />` to be recreated from scratch.

## How?
Set `key="edit"` on returned `BlockEdit` component from the filter.

## Testing Instructions
Use the reproduction code from https://gist.github.com/louwie17/20328e1d2c723e34e9cb979dd156fe47, or

1. Open a Post or Page.
2. Insert a Group block and set the `templaceLock` attribute to `contentOnly`.
3. Add the debugging code to the Group's edit component (see below).
4. Reload the editor.
5. Debugging code should only log mounting message - `edit mounting`.

```js
useEffect( () => {
  console.log( 'edit mounting' );
  return () => console.log( 'edit unmounting' );
}, [] );
```
