### PR TITLE
Site Editor Keyboard Navigation Flow

### DIFF
--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -47,44 +47,37 @@ function EditorCanvas( { enableResizing, settings, children, ...props } ) {
 		}
 	}, [ canvasMode ] );
 
-	const getIframeProps = () => {
-		const iframeProps = {
-			expand: isZoomOutMode,
-			scale: ( isZoomOutMode && 0.45 ) || undefined,
-			frameSize: isZoomOutMode ? 100 : undefined,
-			style: enableResizing ? {} : deviceStyles,
-			ref: mouseMoveTypingRef,
-			name: 'editor-canvas',
-			className: classnames( 'edit-site-visual-editor__editor-canvas', {
-				'is-focused': isFocused && canvasMode === 'view',
-			} ),
-			...props,
-		};
-
-		if ( canvasMode === 'view' ) {
-			iframeProps[ 'aria-label' ] = __( 'Editor Canvas' );
-			return Object.assign( {}, iframeProps, {
-				role: 'button',
-				tabIndex: 0,
-				onFocus: () => setIsFocused( true ),
-				onBlur: () => setIsFocused( false ),
-				onKeyDown: ( event ) => {
-					const { keyCode } = event;
-					if ( keyCode === ENTER || keyCode === SPACE ) {
-						event.preventDefault();
-						setCanvasMode( 'edit' );
-					}
-				},
-				onClick: () => setCanvasMode( 'edit' ),
-				readonly: true,
-			} );
-		}
-
-		return iframeProps;
+	const viewModeProps = {
+		'aria-label': __( 'Editor Canvas' ),
+		role: 'button',
+		tabIndex: 0,
+		onFocus: () => setIsFocused( true ),
+		onBlur: () => setIsFocused( false ),
+		onKeyDown: ( event ) => {
+			const { keyCode } = event;
+			if ( keyCode === ENTER || keyCode === SPACE ) {
+				event.preventDefault();
+				setCanvasMode( 'edit' );
+			}
+		},
+		onClick: () => setCanvasMode( 'edit' ),
+		readonly: true,
 	};
 
 	return (
-		<Iframe { ...getIframeProps() }>
+		<Iframe
+			expand={ isZoomOutMode }
+			scale={ ( isZoomOutMode && 0.45 ) || undefined }
+			frameSize={ isZoomOutMode ? 100 : undefined }
+			style={ enableResizing ? {} : deviceStyles }
+			ref={ mouseMoveTypingRef }
+			name="editor-canvas"
+			className={ classnames( 'edit-site-visual-editor__editor-canvas', {
+				'is-focused': isFocused && canvasMode === 'view',
+			} ) }
+			{ ...props }
+			{ ...( canvasMode === 'view' ? viewModeProps : {} ) }
+		>
 			<EditorStyles styles={ settings.styles } />
 			<style>{
 				// Forming a "block formatting context" to prevent margin collapsing.

--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -9,6 +14,8 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { ENTER, SPACE } from '@wordpress/keycodes';
+import { useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -31,6 +38,13 @@ function EditorCanvas( { enableResizing, settings, children, ...props } ) {
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 	const deviceStyles = useResizeCanvas( deviceType );
 	const mouseMoveTypingRef = useMouseMoveTypingReset();
+	const [ isFocused, setIsFocused ] = useState( false );
+
+	useEffect( () => {
+		if ( canvasMode === 'edit' ) {
+			setIsFocused( false );
+		}
+	}, [ canvasMode ] );
 
 	return (
 		<Iframe
@@ -40,9 +54,30 @@ function EditorCanvas( { enableResizing, settings, children, ...props } ) {
 			style={ enableResizing ? {} : deviceStyles }
 			ref={ mouseMoveTypingRef }
 			name="editor-canvas"
-			className="edit-site-visual-editor__editor-canvas"
+			className={ classnames( 'edit-site-visual-editor__editor-canvas', {
+				'is-focused': isFocused && canvasMode === 'view',
+			} ) }
 			{ ...props }
 			role={ canvasMode === 'view' ? 'button' : undefined }
+			tabIndex={ canvasMode === 'view' ? 0 : undefined }
+			aria-label={ canvasMode === 'view' ? 'Editor Canvas' : undefined }
+			onFocus={
+				canvasMode === 'view' ? () => setIsFocused( true ) : undefined
+			}
+			onBlur={
+				canvasMode === 'view' ? () => setIsFocused( false ) : undefined
+			}
+			onKeyDown={
+				canvasMode === 'view'
+					? ( event ) => {
+							const { keyCode } = event;
+							if ( keyCode === ENTER || keyCode === SPACE ) {
+								event.preventDefault();
+								setCanvasMode( 'edit' );
+							}
+					  }
+					: undefined
+			}
 			onClick={
 				canvasMode === 'view'
 					? () => setCanvasMode( 'edit' )

--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -16,6 +16,7 @@ import {
 import { useSelect, useDispatch } from '@wordpress/data';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 import { useState, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -46,45 +47,44 @@ function EditorCanvas( { enableResizing, settings, children, ...props } ) {
 		}
 	}, [ canvasMode ] );
 
-	return (
-		<Iframe
-			expand={ isZoomOutMode }
-			scale={ ( isZoomOutMode && 0.45 ) || undefined }
-			frameSize={ isZoomOutMode ? 100 : undefined }
-			style={ enableResizing ? {} : deviceStyles }
-			ref={ mouseMoveTypingRef }
-			name="editor-canvas"
-			className={ classnames( 'edit-site-visual-editor__editor-canvas', {
+	const getIframeProps = () => {
+		const iframeProps = {
+			expand: isZoomOutMode,
+			scale: ( isZoomOutMode && 0.45 ) || undefined,
+			frameSize: isZoomOutMode ? 100 : undefined,
+			style: enableResizing ? {} : deviceStyles,
+			ref: mouseMoveTypingRef,
+			name: 'editor-canvas',
+			className: classnames( 'edit-site-visual-editor__editor-canvas', {
 				'is-focused': isFocused && canvasMode === 'view',
-			} ) }
-			{ ...props }
-			role={ canvasMode === 'view' ? 'button' : undefined }
-			tabIndex={ canvasMode === 'view' ? 0 : undefined }
-			aria-label={ canvasMode === 'view' ? 'Editor Canvas' : undefined }
-			onFocus={
-				canvasMode === 'view' ? () => setIsFocused( true ) : undefined
-			}
-			onBlur={
-				canvasMode === 'view' ? () => setIsFocused( false ) : undefined
-			}
-			onKeyDown={
-				canvasMode === 'view'
-					? ( event ) => {
-							const { keyCode } = event;
-							if ( keyCode === ENTER || keyCode === SPACE ) {
-								event.preventDefault();
-								setCanvasMode( 'edit' );
-							}
-					  }
-					: undefined
-			}
-			onClick={
-				canvasMode === 'view'
-					? () => setCanvasMode( 'edit' )
-					: undefined
-			}
-			readonly={ canvasMode === 'view' }
-		>
+			} ),
+			...props,
+		};
+
+		if ( canvasMode === 'view' ) {
+			iframeProps[ 'aria-label' ] = __( 'Editor Canvas' );
+			return Object.assign( {}, iframeProps, {
+				role: 'button',
+				tabIndex: 0,
+				onFocus: () => setIsFocused( true ),
+				onBlur: () => setIsFocused( false ),
+				onKeyDown: ( event ) => {
+					const { keyCode } = event;
+					if ( keyCode === ENTER || keyCode === SPACE ) {
+						event.preventDefault();
+						setCanvasMode( 'edit' );
+					}
+				},
+				onClick: () => setCanvasMode( 'edit' ),
+				readonly: true,
+			} );
+		}
+
+		return iframeProps;
+	};
+
+	return (
+		<Iframe { ...getIframeProps() }>
 			<EditorStyles styles={ settings.styles } />
 			<style>{
 				// Forming a "block formatting context" to prevent margin collapsing.

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -32,7 +32,7 @@
 
 		&.is-focused {
 			outline: calc(2 * var(--wp-admin-border-width-focus)) solid var(--wp-admin-theme-color);
-			outline-offset: calc(2 * var(--wp-admin-border-width-focus));
+			outline-offset: calc(-2 * var(--wp-admin-border-width-focus));
 		}
 	}
 

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -31,10 +31,11 @@
 		height: 100%;
 
 		&.is-focused {
-			outline: ( $border-width-focus * 2 ) solid var(--wp-admin-theme-color);
-			outline-offset: -2 * $border-width-focus;
+			outline: calc(2 * var(--wp-admin-border-width-focus)) solid var(--wp-admin-theme-color);
+			outline-offset: calc(2 * var(--wp-admin-border-width-focus));
 		}
 	}
+
 
 	&.is-focus-mode {
 		.edit-site-layout.is-full-canvas & {

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -29,6 +29,11 @@
 
 	.edit-site-visual-editor__editor-canvas {
 		height: 100%;
+
+		&.is-focused {
+			outline: ( $border-width-focus * 2 ) solid var(--wp-admin-theme-color);
+			outline-offset: -2 * $border-width-focus;
+		}
 	}
 
 	&.is-focus-mode {

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -30,27 +30,41 @@ import { unlock } from '../../private-apis';
 const HUB_ANIMATION_DURATION = 0.3;
 
 const SiteHub = forwardRef( ( props, ref ) => {
-	const { canvasMode } = useSelect( ( select ) => {
+	const { canvasMode, dashboardLink } = useSelect( ( select ) => {
 		const { getCanvasMode, getSettings } = unlock(
 			select( editSiteStore )
 		);
+
 		return {
 			canvasMode: getCanvasMode(),
-			dashboardLink: getSettings().__experimentalDashboardLink,
+			dashboardLink:
+				getSettings().__experimentalDashboardLink || 'index.php',
 		};
 	}, [] );
+
 	const disableMotion = useReducedMotion();
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
-	const siteIconButtonProps = {
-		label: __( 'Open Navigation' ),
-		onClick: () => {
-			if ( canvasMode === 'edit' ) {
-				clearSelectedBlock();
-				setCanvasMode( 'view' );
-			}
-		},
-	};
+	
+	const isBackToDashboardButton = canvasMode === 'view';
+	const siteIconButtonProps = isBackToDashboardButton
+		? {
+				href: dashboardLink,
+				label: __( 'Go back to the Dashboard' ),
+		  }
+		: {
+				href: dashboardLink, // We need to keep the `href` here so the component doesn't remount as a `<button>` and break the animation.
+				role: 'button',
+				label: __( 'Open Navigation' ),
+				onClick: ( event ) => {
+					event.preventDefault();
+					if ( canvasMode === 'edit' ) {
+						clearSelectedBlock();
+						setCanvasMode( 'view' );
+					}
+				},
+		  };
+		  
 	const siteTitle = useSelect(
 		( select ) =>
 			select( coreStore ).getEntityRecord( 'root', 'site' )?.title,

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -45,7 +45,6 @@ const SiteHub = forwardRef( ( props, ref ) => {
 	const disableMotion = useReducedMotion();
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
-	
 	const isBackToDashboardButton = canvasMode === 'view';
 	const siteIconButtonProps = isBackToDashboardButton
 		? {
@@ -64,7 +63,7 @@ const SiteHub = forwardRef( ( props, ref ) => {
 					}
 				},
 		  };
-		  
+
 	const siteTitle = useSelect(
 		( select ) =>
 			select( coreStore ).getEntityRecord( 'root', 'site' )?.title,


### PR DESCRIPTION
Conversations from https://github.com/WordPress/gutenberg/pull/50067 influenced the direction of this PR.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes keyboard navigation in the Site Editor navigation.

## Why?
It's not possible to use a keyboard to navigate into the Site Editor Canvas. 

## How?
1. Uses the `<Iframe/>` component's `onFocus` and `onBlur` events to set an `isFocused` state and apply classes to display a focus ring. I initially tried adding a `tabindex` to the iframe and styling it directly, but the default iframe behavior when receiving focus seems to be to send focus to the first focusable element within it. [Here's a stripped down test of this behavior](https://codesandbox.io/s/gallant-northcutt-6kj20i?file=/index.html).

2. Adds an `onKeyDown` listener to the `<Iframe/>` to catch `ENTER` and `SPACE` keypresses. It's unclear to me why the `onClick` didn't handle this by default. 

3. Reverts the behavior of the WordPress W logo button in the top left back into a "Back to Dashboard" link when the sidebar navigation is open. To avoid the component from rerendering, the `href` is present even when the W functions as a button. I know this is not ideal, but it does work well to preserve the animation and semantic behavior we're looking for. Ideal? No. Functional? Yes. I think it's a decent balance, and tested fine in both keyboard and Safari + VoiceOver. [Thanks to @draganescu for this idea!](https://github.com/WordPress/gutenberg/pull/50067#issuecomment-1527387327).

### Testing Instructions for Keyboard

#### Opening the Editor Canvas
1. On a block theme, go to /wp-admin/site-editor.php
2. Use the keyboard to focus the editor canvas
3. There should be a blue focus ring on the editor canvas when the iframe has focus
4. Press Enter or Spacebar (test both)

#### Leaving the Editor Canvas
1. Use the keyboard to move focus to the W logo
2. Press Enter
3. Navigation sidebar should open
4. Press Enter again
5. You should be on the WP Admin Dashboard page

