### PR TITLE
[Fonts API] Automatically enqueue user-selected fonts

### DIFF
--- a/lib/experimental/fonts-api/class-wp-fonts-resolver.php
+++ b/lib/experimental/fonts-api/class-wp-fonts-resolver.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * WP_Fonts_Resolver class.
+ *
+ * @package    WordPress
+ * @subpackage Fonts API
+ * @since      X.X.X
+ */
+
+if ( class_exists( 'WP_Fonts_Resolver' ) ) {
+	return;
+}
+
+/**
+ * The Fonts API Resolver abstracts the processing of different data sources
+ * (such as theme.json and global styles) for font interactions with the API.
+ *
+ * This class is for internal core usage and is not supposed to be used by
+ * extenders (plugins and/or themes).
+ *
+ * @access private
+ */
+class WP_Fonts_Resolver {
+	/**
+	 * Defines the key structure in global styles to the fontFamily
+	 * user-selected font.
+	 *
+	 * @since X.X.X
+	 *
+	 * @var string[][]
+	 */
+	protected static $global_styles_font_family_structure = array(
+		array( 'elements', 'link', 'typography', 'fontFamily' ),
+		array( 'elements', 'heading', 'typography', 'fontFamily' ),
+		array( 'elements', 'caption', 'typography', 'fontFamily' ),
+		array( 'elements', 'button', 'typography', 'fontFamily' ),
+		array( 'typography', 'fontFamily' ),
+	);
+
+	/**
+	 * Enqueues user-selected fonts via global styles.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return array User selected font-families when exists, else empty array.
+	 */
+	public static function enqueue_user_selected_fonts() {
+		$global_styles       = wp_get_global_styles();
+		$user_selected_fonts = static::get_user_selected_fonts( $global_styles );
+		if ( empty( $user_selected_fonts ) ) {
+			return array();
+		}
+
+		wp_enqueue_fonts( $user_selected_fonts );
+		return $user_selected_fonts;
+	}
+
+	/**
+	 * Gets the user-selected font-family handles.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param  array $global_styles Global styles potentially containing user-selected fonts.
+	 * @return array User-selected font-families.
+	 */
+	private static function get_user_selected_fonts( array $global_styles ) {
+		$font_families = array();
+
+		foreach ( static::$global_styles_font_family_structure as $path ) {
+			$style_value = _wp_array_get( $global_styles, $path, '' );
+
+			$font_family = static::get_value_from_style( $style_value );
+			if ( '' !== $font_family ) {
+				$font_families[] = $font_family;
+			}
+		}
+
+		return array_unique( $font_families );
+	}
+
+	/**
+	 * Get the value (i.e. preset slug) from the given style value.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param string $style       The style to parse.
+	 * @param string $preset_type Optional. The type to parse. Default 'font-family'.
+	 * @return string Preset slug.
+	 */
+	private static function get_value_from_style( $style, $preset_type = 'font-family' ) {
+		if ( '' === $style ) {
+			return '';
+		}
+
+		$starting_pattern = "var:preset|{$preset_type}|";
+		if ( ! str_starts_with( $style, $starting_pattern ) ) {
+			return '';
+		}
+
+		return substr( $style, strlen( $starting_pattern ) );
+	}
+}

--- a/lib/experimental/fonts-api/fonts-api.php
+++ b/lib/experimental/fonts-api/fonts-api.php
@@ -198,8 +198,10 @@ if ( ! function_exists( 'wp_print_fonts' ) ) {
 			return array();
 		}
 
-		// Skip this reassignment decision-making when using the default of `false`.
-		if ( false !== $handles ) {
+		if ( false === $handles ) {
+			// Automatically enqueue all user-selected fonts.
+			WP_Fonts_Resolver::enqueue_user_selected_fonts();
+		} else {
 			// When `true`, print all registered fonts for the iframed editor.
 			if ( $in_iframed_editor ) {
 				$queue           = $wp_fonts->queue;

--- a/lib/experimental/fonts-api/fonts-api.php
+++ b/lib/experimental/fonts-api/fonts-api.php
@@ -198,21 +198,17 @@ if ( ! function_exists( 'wp_print_fonts' ) ) {
 			return array();
 		}
 
-		if ( false === $handles ) {
+		if ( empty( $handles ) ) {
 			// Automatically enqueue all user-selected fonts.
 			WP_Fonts_Resolver::enqueue_user_selected_fonts();
-		} else {
-			// When `true`, print all registered fonts for the iframed editor.
-			if ( $in_iframed_editor ) {
-				$queue           = $wp_fonts->queue;
-				$done            = $wp_fonts->done;
-				$wp_fonts->done  = array();
-				$wp_fonts->queue = $registered;
-				$handles         = false;
-			} elseif ( empty( $handles ) ) {
-				// When falsey, assign `false` to print enqueued fonts.
-				$handles = false;
-			}
+			$handles = false;
+		} elseif ( $in_iframed_editor ) {
+			// Print all registered fonts for the iframed editor.
+			$queue           = $wp_fonts->queue;
+			$done            = $wp_fonts->done;
+			$wp_fonts->done  = array();
+			$wp_fonts->queue = $registered;
+			$handles         = false;
 		}
 
 		_wp_scripts_maybe_doing_it_wrong( __FUNCTION__ );

--- a/lib/load.php
+++ b/lib/load.php
@@ -112,7 +112,9 @@ if ( ! class_exists( 'WP_Fonts' ) ) {
 	require __DIR__ . '/experimental/fonts-api/register-fonts-from-theme-json.php';
 	require __DIR__ . '/experimental/fonts-api/class-wp-fonts.php';
 	require __DIR__ . '/experimental/fonts-api/class-wp-fonts-provider-local.php';
+	require __DIR__ . '/experimental/fonts-api/class-wp-fonts-resolver.php';
 	require __DIR__ . '/experimental/fonts-api/fonts-api.php';
+
 	// BC Layer files, which will not be backported to WP Core.
 	require __DIR__ . '/experimental/fonts-api/bc-layer/class-gutenberg-fonts-api-bc-layer.php';
 	require __DIR__ . '/experimental/fonts-api/bc-layer/webfonts-deprecations.php';

--- a/phpunit/fonts-api/wpFontsResolver/enqueueUserSelectedFonts-test.php
+++ b/phpunit/fonts-api/wpFontsResolver/enqueueUserSelectedFonts-test.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * WP_Fonts_Resolver::enqueue_user_selected_fonts() tests.
+ *
+ * @package    WordPress
+ * @subpackage Fonts API
+ */
+
+require_once __DIR__ . '/../wp-fonts-testcase.php';
+
+/**
+ * @group  fontsapi
+ * @covers WP_Fonts_Resolver::enqueue_user_selected_fonts
+ */
+class Tests_Fonts_WpFontsResolver_EnqueueUserSelectedFonts extends WP_Fonts_TestCase {
+	const FONTS_THEME = 'fonts-block-theme';
+	/**
+	 * Administrator ID.
+	 *
+	 * @var int
+	 */
+	private static $administrator_id = 0;
+
+	public static function set_up_before_class() {
+		self::$requires_switch_theme_fixtures = true;
+
+		parent::set_up_before_class();
+
+		self::$administrator_id = self::factory()->user->create(
+			array(
+				'role'       => 'administrator',
+				'user_email' => 'administrator@example.com',
+			)
+		);
+	}
+
+	/**
+	 * @dataProvider data_should_not_enqueue_when_no_user_selected_fonts
+	 *
+	 * @param array $styles Optional. Test styles. Default empty array.
+	 */
+	public function test_should_not_enqueue_when_no_user_selected_fonts( $styles = array() ) {
+		$this->set_up_global_styles( $styles );
+
+		$mock = $this->set_up_mock( 'enqueue' );
+		$mock->expects( $this->never() )
+			->method( 'enqueue' );
+
+		$expected = array();
+		$this->assertSame( $expected, WP_Fonts_Resolver::enqueue_user_selected_fonts() );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_should_not_enqueue_when_no_user_selected_fonts() {
+		return array(
+			'no user-selected styles' => array(),
+			'invalid element'         => array(
+				array(
+					'elements' => array(
+						'invalid' => array(
+							'typography' => array(
+								'fontFamily' => 'var:preset|font-family|font1',
+								'fontStyle'  => 'normal',
+								'fontWeight' => '400',
+							),
+						),
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider data_should_enqueue_when_user_selected_fonts
+	 *
+	 * @param array $styles   Test styles.
+	 * @param array $expected Expected results.
+	 */
+	public function test_should_enqueue_when_user_selected_fonts( $styles, $expected ) {
+		$mock = $this->set_up_mock( 'enqueue' );
+		$mock->expects( $this->once() )
+			->method( 'enqueue' )
+			->with(
+				$this->identicalTo( $expected )
+			);
+
+		$this->set_up_global_styles( $styles );
+
+		$this->assertSameSets( $expected, WP_Fonts_Resolver::enqueue_user_selected_fonts() );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_should_enqueue_when_user_selected_fonts() {
+		$fonts = array(
+			'font1-400-normal' => array(
+				'fontFamily' => 'var:preset|font-family|font1',
+				'fontStyle'  => 'normal',
+				'fontWeight' => '400',
+			),
+			'font1-400-italic' => array(
+				'fontFamily' => 'var:preset|font-family|font1',
+				'fontStyle'  => 'italic',
+				'fontWeight' => '400',
+			),
+			'font2-600-normal' => array(
+				'fontFamily' => 'var:preset|font-family|font2',
+				'fontStyle'  => 'normal',
+				'fontWeight' => '600',
+			),
+			'font2-600-italic' => array(
+				'fontFamily' => 'var:preset|font-family|font2',
+				'fontStyle'  => 'italic',
+				'fontWeight' => '600',
+			),
+			'font3-900-normal' => array(
+				'fontFamily' => 'var:preset|font-family|font3',
+				'fontStyle'  => 'normal',
+				'fontWeight' => '900',
+			),
+		);
+
+		return array(
+			'link'                  => array(
+				'styles'   => array(
+					'elements' => array(
+						'link' => array(
+							'typography' => $fonts['font1-400-italic'],
+						),
+					),
+				),
+				'expected' => array( 'font1' ),
+			),
+			'heading'               => array(
+				'styles'   => array(
+					'elements' => array(
+						'heading' => array(
+							'typography' => $fonts['font2-600-italic'],
+						),
+					),
+				),
+				'expected' => array( 'font2' ),
+			),
+			'caption'               => array(
+				'styles'   => array(
+					'elements' => array(
+						'caption' => array(
+							'typography' => $fonts['font2-600-normal'],
+						),
+					),
+				),
+				'expected' => array( 'font2' ),
+			),
+			'button'                => array(
+				'styles'   => array(
+					'elements' => array(
+						'button' => array(
+							'typography' => $fonts['font1-400-normal'],
+						),
+					),
+				),
+				'expected' => array( 'font1' ),
+			),
+			'text'                  => array(
+				'styles'   => array(
+					'typography' => $fonts['font1-400-normal'],
+				),
+				'expected' => array( 'font1' ),
+			),
+			'all elements'          => array(
+				'styles'   => array(
+					'elements' => array(
+						'link'    => array(
+							'typography' => $fonts['font1-400-italic'],
+						),
+						'heading' => array(
+							'typography' => $fonts['font2-600-italic'],
+						),
+						'caption' => array(
+							'typography' => $fonts['font2-600-normal'],
+						),
+						'button'  => array(
+							'typography' => $fonts['font1-400-normal'],
+						),
+					),
+				),
+				'expected' => array( 'font1', 'font2' ),
+			),
+			'all elements and text' => array(
+				'styles'   => array(
+					'elements'   => array(
+						'link'    => array(
+							'typography' => $fonts['font1-400-italic'],
+						),
+						'heading' => array(
+							'typography' => $fonts['font2-600-italic'],
+						),
+						'caption' => array(
+							'typography' => $fonts['font3-900-normal'],
+						),
+						'button'  => array(
+							'typography' => $fonts['font1-400-normal'],
+						),
+					),
+					'typography' => $fonts['font1-400-normal'],
+				),
+				'expected' => array( 'font1', 'font2', 'font3' ),
+			),
+			'with invalid element'  => array(
+				'styles'   => array(
+					'elements' => array(
+						'button'  => array(
+							'typography' => $fonts['font1-400-normal'],
+						),
+						'invalid' => array(
+							'typography' => $fonts['font3-900-normal'],
+						),
+					),
+				),
+				'expected' => array( 'font1' ),
+			),
+		);
+	}
+
+	/**
+	 * Sets up the global styles.
+	 *
+	 * @param array $styles User-selected styles structure.
+	 */
+	private function set_up_global_styles( array $styles ) {
+		switch_theme( static::FONTS_THEME );
+
+		if ( empty( $styles ) ) {
+			return;
+		}
+
+		// Make sure there is data from the user origin.
+		wp_set_current_user( self::$administrator_id );
+		$user_cpt = WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles( wp_get_theme(), true );
+		$config   = json_decode( $user_cpt['post_content'], true );
+
+		// Add the test styles.
+		$config['styles'] = $styles;
+
+		// Update the global styles and settings post.
+		$user_cpt['post_content'] = wp_json_encode( $config );
+		wp_update_post( $user_cpt, true, false );
+	}
+}


### PR DESCRIPTION
Fixes #40363

## What?

Adds a new feature to the Fonts API: automatic enqueue all user-selected fonts.

## Why?

Prior to this PR, the API automatically registers and enqueues all fonts defined in a theme's `theme.json` file, but not fonts from plugins. Instead, plugins were required to handle the enqueuing.

With this PR, the API now handles enqueuing those fonts that users select in the Site Editor > Styles > Typography.

Why the change?
1. To ensure all user-selected fonts are enqueued before printing.
2. To make it easier for plugin developers to interact with the API, i.e. by removing the need for their plugins to carry (and maintain) enqueuing.

## How?

tl;dr
A Resolver parses the global styles to collect the font-families. Then enqueues those found before printing happens.

Longer explanation:

User selections are made in the Site Editor > Styles > Typography UI. That data is available within the global styles custom post type (CPT), which is fetchable using `wp_get_global_styles()`. 

![Screen Shot 2023-05-03 at 11 09 44 AM](https://user-images.githubusercontent.com/7284611/235976226-8620d0b8-fc44-4176-a8ce-9229f55cc7cb.png)

If user selected, each of the following "Elements" are in the `wp_get_global_styles()` returned array:
* Text: `$global_styles['typography']['fontFamily']`
* Links: `$global_styles['elements']['link']['typography']['fontFamily']`
* Headings: `$global_styles['elements']['heading']['typography']['fontFamily']`
* Captions: `$global_styles['elements']['caption']['typography']['fontFamily']`
* Buttons: `$global_styles['elements']['button']['typography']['fontFamily']`

Since the global styles have a specific and known structure, the Resolver knowns how to iterate through the styles to find any that are defined.

This PR adds a resolver called `WP_Fonts_Resolver` for processing different data sources and interactions. Currently, it's processing the user-selected fonts that are available within the global styles (i.e. data returned from `wp_get_global_styles()`). Later, other functionality can be added to it, such as (a) reconciling any missing fonts in the theme.json and registering and (b) enqueuing the theme's theme.json defined fonts.

A  property (`WP_Fonts_Resolver::$global_styles_font_family_structure`) exists to define the nested key structure within the global styles data array. Iterating through that structure, `_wp_array_get()` searches to find each font-family if it exists.

If the parser finds a user-selected font, then the font-family is parsed from the style, which has a format of `var:preset|font-family|<font-family-handle>`. `WP_Fonts_Resolver::get_value_from_style()` handles this process.

Code Design notes:
- Why is `WP_Fonts_Resolver::$global_styles_font_family_structure` a protected static property instead of a `const`?

A `const` is public. Once introduced into Core, it must be maintained for BC. By making it as a property, the BC concern is removed providing more flexibility for future changes.

By having it as `$protected` rather than `$private`, it gives the Gutenberg plugin the means to modify that structure if needed for future changes (i.e. once the API is in Core).

- Why is `WP_Fonts_Resolver::get_value_from_style()` generic for any preset type?

Currently only the `font-family` preset type is needed. But in the future, other preset types might be needed, such as extracting the variation details, e.g. `font-weight`, `font-style`. So I designed this method to be generic for parsing any preset type from the given style.

- Why invoke in `wp_print_fonts()`? Why so late?

My thinking is: 
1. enqueue as late as possible to ensure all customizations have processed (i.e. in plugins). Why? To avoid having to dequeue a font if something changes before printing. 
2. Avoid potential race conditions where a plugin may be processing later for registration.

## Testing Instructions

### Automated Tests

```
npm run test:unit:php -- --filter Tests_Fonts_WpFontsResolver_EnqueueUserSelectedFonts
```

### Manually Testing

The key to testing is to select and save one or more fonts and then check that only those fonts are in the `<style id="wp-fonts-jetpack-google-fonts">` element on the front-end.

Set up:
On your test site:
1. Install and activate the Fonts API Tester using [Jetpack's Google Fonts composer package](https://github.com/ironprogrammer/webfonts-jetpack-test) - installation instructions are found in the [plugins' README.md page](https://github.com/ironprogrammer/webfonts-jetpack-test/blob/master/README.md).
2. Disable enqueuing in the Fonts API Tester's plugin: Open its root PHP file in your fav code editor. Comment out these lines of code:
```php
add_filter( 'pre_render_block', '\Automattic\Jetpack\Fonts\Introspectors\Blocks::enqueue_block_fonts', 10, 2 );
add_action( 'init', '\Automattic\Jetpack\Fonts\Introspectors\Global_Styles::enqueue_global_styles_fonts', 22 );
```
3. Activate the Gutenberg plugin from this branch.
4. Activate the TT3 theme.

Testing Instructions:
1. Go to the Site Editor > Styles > Typography.
2. For headings, select `Playfair Display` font and set Appearance to `Bold Italic`. 
3. For text, select `Poppins` font and set the Appearance to `Regular`. 
4. Save the styles.
5. Go to the front-end.
6. Open your browser's dev tools to inspect the HTML.
7. Search for `wp-fonts-jetpack-google-fonts`. Expected: It should exist in the `<head>`.
8. Open the `<style>` element and inspect the styles. Expected: It should only contain Poppins and Playfair Display, i.e. no other font-families should be in that element. (Note: there will be a lot of variations for each of these font families.)
     Tip: Copy the element's styles and then search for `font-family`. Check each one.

## Screenshots or screencast <!-- if applicable -->
