### PR TITLE
Cleaned up Port Validation and Removed Unnecessary Default Ports

### DIFF
--- a/packages/env/lib/config/add-or-replace-port.js
+++ b/packages/env/lib/config/add-or-replace-port.js
@@ -7,9 +7,10 @@ const { ValidationError } = require( './validate-config' );
 /**
  * Adds or replaces the port to the given domain or URI.
  *
- * @param {string}  input     The domain or URI to operate on.
- * @param {string}  port      The port to append.
- * @param {boolean} [replace] Indicates whether or not the port should be replaced if one is already present. Defaults to true.
+ * @param {string}        input     The domain or URI to operate on.
+ * @param {number|string} port      The port to append.
+ * @param {boolean}       [replace] Indicates whether or not the port should be replaced if one is already present. Defaults to true.
+ *
  * @return {string} The string with the port added or replaced.
  */
 module.exports = function addOrReplacePort( input, port, replace = true ) {
@@ -25,6 +26,13 @@ module.exports = function addOrReplacePort( input, port, replace = true ) {
 
 	// When a port is already present we will do nothing if the caller doesn't want it to be replaced.
 	if ( matches[ 2 ] !== undefined && ! replace ) {
+		return input;
+	}
+
+	// There's never a reason to add the default ports.
+	// We use == to catch both string and number ports.
+	// eslint-disable-next-line eqeqeq
+	if ( port == 80 || port == 443 ) {
 		return input;
 	}
 

--- a/packages/env/lib/config/test/add-or-replace-port.js
+++ b/packages/env/lib/config/test/add-or-replace-port.js
@@ -40,6 +40,33 @@ describe( 'addOrReplacePort', () => {
 		}
 	} );
 
+	it( 'should support number ports', () => {
+		const testMap = [ { in: 'test', expect: 'test:104' } ];
+
+		for ( const test of testMap ) {
+			const result = addOrReplacePort( test.in, 104, false );
+			expect( result ).toEqual( test.expect );
+		}
+	} );
+
+	it( 'should not add default HTTP port', () => {
+		const testMap = [ { in: 'test', expect: 'test' } ];
+
+		for ( const test of testMap ) {
+			const result = addOrReplacePort( test.in, 80, false );
+			expect( result ).toEqual( test.expect );
+		}
+	} );
+
+	it( 'should not add default HTTPS port', () => {
+		const testMap = [ { in: 'test', expect: 'test' } ];
+
+		for ( const test of testMap ) {
+			const result = addOrReplacePort( test.in, 443, false );
+			expect( result ).toEqual( test.expect );
+		}
+	} );
+
 	it( 'should do nothing if port is present but replacement is not requested', () => {
 		const testMap = [
 			{ in: 'test', expect: 'test:103' },

--- a/packages/env/lib/config/validate-config.js
+++ b/packages/env/lib/config/validate-config.js
@@ -39,8 +39,6 @@ function checkPort( configFile, configKey, port ) {
 		);
 	}
 
-	port = parseInt( port );
-
 	if ( port < 0 || port > 65535 ) {
 		throw new ValidationError(
 			`Invalid ${ configFile }: "${ configKey }" must be a valid port.`


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This pull request changes the addition of ports to certain `wp-config.php` values to avoid adding default ports. I also made a small change to remove unnecessary parsing from `checkPort`.

## Why?
https://github.com/WordPress/gutenberg/pull/49883 introduced a bug when using HTTP and HTTPS default ports. It adds them to the hostname even though they are not used and will cause issues.

## How?
When we are attempting to add or replace the default HTTP port (`80`) or the default HTTPS port (`443`), the port addition/replacement will not be performed.

## Testing Instructions

1. Create an override config and set the port for the web server to `80`.
2. Start/Update your environment.
3. Visit it and ensure the links work and do not have the port on them.