### PR TITLE
Template editing: improve revert notices

### DIFF
--- a/packages/edit-site/src/components/list/actions/index.js
+++ b/packages/edit-site/src/components/list/actions/index.js
@@ -19,9 +19,8 @@ import RenameMenuItem from './rename-menu-item';
 export default function Actions( { template } ) {
 	const { removeTemplate, revertTemplate } = useDispatch( editSiteStore );
 	const { saveEditedEntityRecord } = useDispatch( coreStore );
-	const { createSuccessNotice, createErrorNotice } =
+	const { createSuccessNotice, createErrorNotice, removeNotice } =
 		useDispatch( noticesStore );
-
 	const isRemovable = isTemplateRemovable( template );
 	const isRevertable = isTemplateRevertable( template );
 
@@ -30,6 +29,8 @@ export default function Actions( { template } ) {
 	}
 
 	async function revertAndSaveTemplate() {
+		const noticeId = 'edit-site-template-reverted';
+		removeNotice( noticeId );
 		try {
 			await revertTemplate( template, { allowUndo: false } );
 			await saveEditedEntityRecord(
@@ -37,9 +38,14 @@ export default function Actions( { template } ) {
 				template.type,
 				template.id
 			);
+			const notice =
+				template.type === 'wp_template'
+					? __( 'Template reverted.' )
+					: __( 'Template part reverted.' );
 
-			createSuccessNotice( __( 'Entity reverted.' ), {
+			createSuccessNotice( notice, {
 				type: 'snackbar',
+				id: noticeId,
 			} );
 		} catch ( error ) {
 			const errorMessage =

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -365,6 +365,8 @@ export function setIsSaveViewOpened( isOpen ) {
 export const revertTemplate =
 	( template, { allowUndo = true } = {} ) =>
 	async ( { registry } ) => {
+		const noticeId = 'edit-site-template-reverted';
+		registry.dispatch( noticesStore ).removeNotice( noticeId );
 		if ( ! isTemplateRevertable( template ) ) {
 			registry
 				.dispatch( noticesStore )
@@ -466,6 +468,7 @@ export const revertTemplate =
 					.dispatch( noticesStore )
 					.createSuccessNotice( __( 'Template reverted.' ), {
 						type: 'snackbar',
+						id: noticeId,
 						actions: [
 							{
 								label: __( 'Undo' ),
@@ -473,10 +476,6 @@ export const revertTemplate =
 							},
 						],
 					} );
-			} else {
-				registry
-					.dispatch( noticesStore )
-					.createSuccessNotice( __( 'Template reverted.' ) );
 			}
 		} catch ( error ) {
 			const errorMessage =

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -95,7 +95,7 @@ export default function EntitiesSavedStates( { close, onSave = identity } ) {
 	const { __unstableMarkLastChangeAsPersistent } =
 		useDispatch( blockEditorStore );
 
-	const { createSuccessNotice, createErrorNotice } =
+	const { createSuccessNotice, createErrorNotice, removeNotice } =
 		useDispatch( noticesStore );
 
 	// To group entities by type.
@@ -148,6 +148,8 @@ export default function EntitiesSavedStates( { close, onSave = identity } ) {
 	};
 
 	const saveCheckedEntitiesAndActivate = () => {
+		const saveNoticeId = 'site-editor-save-success';
+		removeNotice( saveNoticeId );
 		const entitiesToSave = dirtyEntityRecords.filter(
 			( { kind, name, key, property } ) => {
 				return ! unselectedEntities.some(
@@ -208,6 +210,7 @@ export default function EntitiesSavedStates( { close, onSave = identity } ) {
 				} else {
 					createSuccessNotice( __( 'Site updated.' ), {
 						type: 'snackbar',
+						id: saveNoticeId,
 					} );
 				}
 			} )


### PR DESCRIPTION
## What?
Improves wording on template revert notices, and prevents these notices from stacking.

## Why?
Current use of word 'Entity' is confusing, and the stacking of the notices is annoying.

Fixes: #44841

## How?
Specifies in notice if it is a template or template part that is being reverted and adds a notice id so only one snackbar appears at a time.

## Testing Instructions

- Edit a couple of templates and template parts
- In the Manage All screen from each choose the `Clear customizations` option from the Actions menu
- Make sure the snack bar says either `Template part reverted` or `Template reverted` and that only one snackbar with this message appears at a time
- Go into the main site edit and make sure a Green notice bar about the template revert does not appear at top of the screen

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/3629020/236079947-7200b872-5f34-4f2e-bc18-7f91ae68b039.mp4



