### PR TITLE
Typography: remove duplicate comment

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -265,12 +265,11 @@ function gutenberg_get_typography_value_and_unit( $raw_value, $options = array()
 		return null;
 	}
 
-	// Converts numeric values to pixel values by default.
 	if ( empty( $raw_value ) ) {
 		return null;
 	}
 
-	// Converts numbers to pixel values by default.
+	// Converts numeric values to pixel values by default.
 	if ( is_numeric( $raw_value ) ) {
 		$raw_value = $raw_value . 'px';
 	}


### PR DESCRIPTION
## What?
A comment in the typography block supports file was effectively doubled up. Let's get rid of it to avoid confusion.

## Why?

Duplicate comments, oh what a bore,
Such clutter makes one's eyes quite sore.
Fear not though, for there's a way,
To sweep them clean and save the day.

With a click or two,
They vanish, to them: adieu.
The typography file now is neat,
And contributors' eyes can freely fleet.

So let us thank the tools we wield,
For keeping our pages un-congealed.
And let us strive to always be,
Duplication's arch enemy.


