### PR TITLE
Try always showing the dimensions controls

### DIFF
--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -184,12 +184,12 @@ function DimensionsToolsPanel( {
 }
 
 const DEFAULT_CONTROLS = {
-	contentSize: false,
-	wideSize: false,
-	padding: false,
-	margin: false,
-	blockGap: false,
-	minHeight: false,
+	contentSize: true,
+	wideSize: true,
+	padding: true,
+	margin: true,
+	blockGap: true,
+	minHeight: true,
 	childLayout: true,
 };
 

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -43,7 +43,11 @@
 		},
 		"spacing": {
 			"margin": true,
-			"padding": true
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
 		},
 		"typography": {
 			"fontSize": true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Sets the default display values for the controls in the Dimensions tool panel to true.

It's still possible to hide controls for individual blocks from their block.json settings.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Follow-up to [this discussion](https://github.com/WordPress/gutenberg/pull/49389/files#r1154149528). This has become more pressing to address because of the new global styles UI from #49428, where it's awkward to have the dimensions controls all hidden by default.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In a post or template, add blocks that have dimensions support enabled and check their dimensions panel in the sidebar. All supported controls should be visible by default.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

The biggest panel I found was for the Group block when nested inside a Row or Stack:

<img width="278" alt="Screenshot 2023-05-04 at 1 52 48 pm" src="https://user-images.githubusercontent.com/8096000/236109897-f5bc2b34-2ef6-49f1-ae07-63386e6aa2e3.png">

Otherwise everything looks pretty civilised 😄 

