### PR TITLE
Group block: Allow adding of slug attrib to Group to make it act as a pattern wrapper

### DIFF
--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -18,6 +18,9 @@
 		},
 		"allowedBlocks": {
 			"type": "array"
+		},
+		"slug": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/group/save.js
+++ b/packages/block-library/src/group/save.js
@@ -3,6 +3,12 @@
  */
 import { useInnerBlocksProps, useBlockProps } from '@wordpress/block-editor';
 
-export default function save( { attributes: { tagName: Tag } } ) {
+export default function save( {
+	attributes: { tagName: Tag, slug },
+	innerBlocks,
+} ) {
+	if ( slug && innerBlocks?.length === 0 ) {
+		return;
+	}
 	return <Tag { ...useInnerBlocksProps.save( useBlockProps.save() ) } />;
 }


### PR DESCRIPTION
## What?
An experiment to see how well a Group might act as a permanent pattern block wrapper

## Why?
Part of work to enhance the pattern block https://github.com/WordPress/gutenberg/issues/48458

## How?
Adds a slug attribute, and retrieves the blocks from the associated theme template.

## Testing Instructions

- In the editor code view in TT3 theme add `<!-- wp:group {"slug":"twentytwentythree/cta"} /-->`
- Switch to editor view and the CTA blocks should appear

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/3629020/236114725-6fdb7c7d-2fbe-4c06-9e40-db9f4d7f560c.mp4


