### PR TITLE
Try reusable block as a wrapper for patterns

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -42,7 +42,7 @@ Create and save content to reuse across your site. Update the block, and the cha
 -	**Name:** core/block
 -	**Category:** reusable
 -	**Supports:** ~~customClassName~~, ~~html~~, ~~inserter~~
--	**Attributes:** ref
+-	**Attributes:** ref, slug, type
 
 ## Button
 

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -98,7 +98,9 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-theme-previews', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableThemePreviews = true', 'before' );
 	}
-
+	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-pattern-enhancements', $gutenberg_experiments ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnablePatternEnhancements = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -113,6 +113,18 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
+	add_settings_field(
+		'gutenberg-pattern-enhancements',
+		__( 'Pattern enhancements', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Test Pattern enhancements', 'gutenberg' ),
+			'id'    => 'gutenberg-pattern-enhancements',
+		)
+	);
+
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -7,8 +7,16 @@
 	"description": "Create and save content to reuse across your site. Update the block, and the changes apply everywhere it’s used.",
 	"textdomain": "default",
 	"attributes": {
+		"type": {
+			"type": "string",
+			"enum": [ "reusable", "pattern" ],
+			"default": "reusable"
+		},
 		"ref": {
 			"type": "number"
+		},
+		"slug": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -1,143 +1,19 @@
 /**
- * WordPress dependencies
+ * Internal dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
-import {
-	useEntityBlockEditor,
-	useEntityProp,
-	useEntityRecord,
-} from '@wordpress/core-data';
-import {
-	Placeholder,
-	Spinner,
-	ToolbarGroup,
-	ToolbarButton,
-	TextControl,
-	PanelBody,
-} from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import {
-	useInnerBlocksProps,
-	__experimentalRecursionProvider as RecursionProvider,
-	__experimentalUseHasRecursion as useHasRecursion,
-	InnerBlocks,
-	BlockControls,
-	InspectorControls,
-	useBlockProps,
-	Warning,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
-import { store as reusableBlocksStore } from '@wordpress/reusable-blocks';
-import { ungroup } from '@wordpress/icons';
+import ReusableEdit from './reusable-edit';
+import PatternEdit from './pattern-edit';
 
-export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
-	const hasAlreadyRendered = useHasRecursion( ref );
-	const { record, hasResolved } = useEntityRecord(
-		'postType',
-		'wp_block',
-		ref
-	);
-	const isMissing = hasResolved && ! record;
+export default function SyncedBlockEdit( props ) {
+	const {
+		attributes: { type },
+	} = props;
 
-	const { canRemove, innerBlockCount } = useSelect(
-		( select ) => {
-			const { canRemoveBlock, getBlockCount } =
-				select( blockEditorStore );
-			return {
-				canRemove: canRemoveBlock( clientId ),
-				innerBlockCount: getBlockCount( clientId ),
-			};
-		},
-		[ clientId ]
-	);
-
-	const { __experimentalConvertBlockToStatic: convertBlockToStatic } =
-		useDispatch( reusableBlocksStore );
-
-	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
-		'postType',
-		'wp_block',
-		{ id: ref }
-	);
-	const [ title, setTitle ] = useEntityProp(
-		'postType',
-		'wp_block',
-		'title',
-		ref
-	);
-
-	const blockProps = useBlockProps( {
-		className: 'block-library-block__reusable-block-container',
-	} );
-
-	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		value: blocks,
-		onInput,
-		onChange,
-		renderAppender: blocks?.length
-			? undefined
-			: InnerBlocks.ButtonBlockAppender,
-	} );
-
-	if ( hasAlreadyRendered ) {
-		return (
-			<div { ...blockProps }>
-				<Warning>
-					{ __( 'Block cannot be rendered inside itself.' ) }
-				</Warning>
-			</div>
-		);
+	if ( type === 'reusable' ) {
+		return <ReusableEdit { ...props } />;
 	}
 
-	if ( isMissing ) {
-		return (
-			<div { ...blockProps }>
-				<Warning>
-					{ __( 'Block has been deleted or is unavailable.' ) }
-				</Warning>
-			</div>
-		);
+	if ( type === 'pattern' ) {
+		return <PatternEdit { ...props } />;
 	}
-
-	if ( ! hasResolved ) {
-		return (
-			<div { ...blockProps }>
-				<Placeholder>
-					<Spinner />
-				</Placeholder>
-			</div>
-		);
-	}
-
-	return (
-		<RecursionProvider uniqueId={ ref }>
-			{ canRemove && (
-				<BlockControls>
-					<ToolbarGroup>
-						<ToolbarButton
-							onClick={ () => convertBlockToStatic( clientId ) }
-							label={
-								innerBlockCount > 1
-									? __( 'Convert to regular blocks' )
-									: __( 'Convert to regular block' )
-							}
-							icon={ ungroup }
-							showTooltip
-						/>
-					</ToolbarGroup>
-				</BlockControls>
-			) }
-			<InspectorControls>
-				<PanelBody>
-					<TextControl
-						__nextHasNoMarginBottom
-						label={ __( 'Name' ) }
-						value={ title }
-						onChange={ setTitle }
-					/>
-				</PanelBody>
-			</InspectorControls>
-			<div { ...innerBlocksProps } />
-		</RecursionProvider>
-	);
 }

--- a/packages/block-library/src/block/index.js
+++ b/packages/block-library/src/block/index.js
@@ -10,6 +10,7 @@ import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
 import save from './save';
+import variations from './variations';
 
 const { name } = metadata;
 
@@ -19,6 +20,7 @@ export const settings = {
 	edit,
 	save,
 	icon,
+	variations,
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/block/index.js
+++ b/packages/block-library/src/block/index.js
@@ -9,6 +9,7 @@ import { symbol as icon } from '@wordpress/icons';
 import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
+import save from './save';
 
 const { name } = metadata;
 
@@ -16,6 +17,7 @@ export { metadata, name };
 
 export const settings = {
 	edit,
+	save,
 	icon,
 };
 

--- a/packages/block-library/src/block/index.js
+++ b/packages/block-library/src/block/index.js
@@ -1,7 +1,10 @@
 /**
  * WordPress dependencies
  */
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { select } from '@wordpress/data';
 import { symbol as icon } from '@wordpress/icons';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -21,6 +24,21 @@ export const settings = {
 	save,
 	icon,
 	variations,
+	__experimentalLabel: ( { type, slug } ) => {
+		// Attempt to find entity title if block is a template part.
+		// Require slug to request, otherwise entity is uncreated and will throw 404.
+		if ( type !== 'pattern' || ! slug ) {
+			return;
+		}
+
+		const entity =
+			select( blockEditorStore ).__experimentalGetParsedPattern( slug );
+		if ( ! entity ) {
+			return;
+		}
+
+		return entity.title ? decodeEntities( entity.title ) : undefined;
+	},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -13,42 +13,63 @@
  * @return string Rendered HTML of the referenced block.
  */
 function render_block_core_block( $attributes ) {
-	static $seen_refs = array();
+	if ( 'reusable' === $attributes['type'] ) {
+		static $seen_refs = array();
 
-	if ( empty( $attributes['ref'] ) ) {
-		return '';
+		if ( empty( $attributes['ref'] ) ) {
+			return '';
+		}
+
+		$reusable_block = get_post( $attributes['ref'] );
+		if ( ! $reusable_block || 'wp_block' !== $reusable_block->post_type ) {
+			return '';
+		}
+
+		if ( isset( $seen_refs[ $attributes['ref'] ] ) ) {
+			// WP_DEBUG_DISPLAY must only be honored when WP_DEBUG. This precedent
+			// is set in `wp_debug_mode()`.
+			$is_debug = WP_DEBUG && WP_DEBUG_DISPLAY;
+
+			return $is_debug ?
+				// translators: Visible only in the front end, this warning takes the place of a faulty block.
+				__( '[block rendering halted]' ) :
+				'';
+		}
+
+		if ( 'publish' !== $reusable_block->post_status || ! empty( $reusable_block->post_password ) ) {
+			return '';
+		}
+
+		$seen_refs[ $attributes['ref'] ] = true;
+
+		// Handle embeds for reusable blocks.
+		global $wp_embed;
+		$content = $wp_embed->run_shortcode( $reusable_block->post_content );
+		$content = $wp_embed->autoembed( $content );
+
+		$content = do_blocks( $content );
+		unset( $seen_refs[ $attributes['ref'] ] );
+		return $content;
 	}
 
-	$reusable_block = get_post( $attributes['ref'] );
-	if ( ! $reusable_block || 'wp_block' !== $reusable_block->post_type ) {
-		return '';
+	if ( 'pattern' === $attributes['type'] ) {
+		if ( empty( $attributes['slug'] ) ) {
+			return '';
+		}
+
+		if ( isset( $attributes['syncStatus'] ) && 'unsynced' === $attributes['syncStatus'] ) {
+			return sprintf( $wrapper, $content );
+		}
+
+		$slug     = $attributes['slug'];
+		$registry = WP_Block_Patterns_Registry::get_instance();
+		if ( ! $registry->is_registered( $slug ) ) {
+			return '';
+		}
+
+		$pattern = $registry->get_registered( $slug );
+		return do_blocks( $pattern['content'] );
 	}
-
-	if ( isset( $seen_refs[ $attributes['ref'] ] ) ) {
-		// WP_DEBUG_DISPLAY must only be honored when WP_DEBUG. This precedent
-		// is set in `wp_debug_mode()`.
-		$is_debug = WP_DEBUG && WP_DEBUG_DISPLAY;
-
-		return $is_debug ?
-			// translators: Visible only in the front end, this warning takes the place of a faulty block.
-			__( '[block rendering halted]' ) :
-			'';
-	}
-
-	if ( 'publish' !== $reusable_block->post_status || ! empty( $reusable_block->post_password ) ) {
-		return '';
-	}
-
-	$seen_refs[ $attributes['ref'] ] = true;
-
-	// Handle embeds for reusable blocks.
-	global $wp_embed;
-	$content = $wp_embed->run_shortcode( $reusable_block->post_content );
-	$content = $wp_embed->autoembed( $content );
-
-	$content = do_blocks( $content );
-	unset( $seen_refs[ $attributes['ref'] ] );
-	return $content;
 }
 
 /**

--- a/packages/block-library/src/block/pattern-edit.js
+++ b/packages/block-library/src/block/pattern-edit.js
@@ -1,0 +1,1 @@
+export default function PatternEdit() {}

--- a/packages/block-library/src/block/pattern-edit.js
+++ b/packages/block-library/src/block/pattern-edit.js
@@ -8,13 +8,10 @@ import {
 	store as blockEditorStore,
 	useBlockProps,
 	useInnerBlocksProps,
-	BlockControls,
 } from '@wordpress/block-editor';
-import { ToolbarButton } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 
 const PatternEdit = ( { attributes, clientId } ) => {
-	const { slug, templateLock } = attributes;
+	const { slug } = attributes;
 	const { selectedPattern, innerBlocks } = useSelect(
 		( select ) => {
 			return {
@@ -64,18 +61,7 @@ const PatternEdit = ( { attributes, clientId } ) => {
 		templateLock: 'contentOnly',
 	} );
 
-	return (
-		<>
-			<div { ...innerBlocksProps } />
-			<BlockControls group="other">
-				<ToolbarButton>
-					{ templateLock === false
-						? __( 'Edit content only' )
-						: __( 'Edit all' ) }
-				</ToolbarButton>
-			</BlockControls>
-		</>
-	);
+	return <div { ...innerBlocksProps } />;
 };
 
 export default PatternEdit;

--- a/packages/block-library/src/block/pattern-edit.js
+++ b/packages/block-library/src/block/pattern-edit.js
@@ -1,1 +1,118 @@
-export default function PatternEdit() {}
+/**
+ * WordPress dependencies
+ */
+import { cloneBlock } from '@wordpress/blocks';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import {
+	store as blockEditorStore,
+	useBlockProps,
+	useInnerBlocksProps,
+	BlockControls,
+} from '@wordpress/block-editor';
+import { ToolbarButton } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const PatternEdit = ( { attributes, clientId, setAttributes } ) => {
+	const { inheritedAlignment, slug, templateLock } = attributes;
+	const { selectedPattern, innerBlocks } = useSelect(
+		( select ) => {
+			return {
+				selectedPattern:
+					select( blockEditorStore ).__experimentalGetParsedPattern(
+						slug
+					),
+				innerBlocks:
+					select( blockEditorStore ).getBlock( clientId )
+						?.innerBlocks,
+			};
+		},
+		[ slug, clientId ]
+	);
+	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
+		useDispatch( blockEditorStore );
+
+	// Run this effect when the component loads.
+	// This adds the Pattern's contents to the post.
+	useEffect( () => {
+		if ( selectedPattern?.blocks && ! innerBlocks?.length ) {
+			// We batch updates to block list settings to avoid triggering cascading renders
+			// for each container block included in a tree and optimize initial render.
+			// Since the above uses microtasks, we need to use a microtask here as well,
+			// because nested pattern blocks cannot be inserted if the parent block supports
+			// inner blocks but doesn't have blockSettings in the state.
+			window.queueMicrotask( () => {
+				__unstableMarkNextChangeAsNotPersistent();
+				replaceInnerBlocks(
+					clientId,
+					selectedPattern.blocks.map( ( block ) =>
+						cloneBlock( block )
+					)
+				);
+			} );
+		}
+	}, [
+		clientId,
+		selectedPattern?.blocks,
+		replaceInnerBlocks,
+		__unstableMarkNextChangeAsNotPersistent,
+		innerBlocks,
+	] );
+
+	useEffect( () => {
+		const alignments = [ 'wide', 'full' ];
+		const blocks = innerBlocks;
+		if ( ! blocks || blocks.length === 0 ) {
+			return;
+		}
+		// Determine the widest setting of all the contained blocks.
+		const widestAlignment = blocks.reduce( ( accumulator, block ) => {
+			const { align } = block.attributes;
+			return alignments.indexOf( align ) >
+				alignments.indexOf( accumulator )
+				? align
+				: accumulator;
+		}, undefined );
+
+		// Set the attribute of the Pattern block to match the widest
+		// alignment.
+		setAttributes( {
+			inheritedAlignment: widestAlignment ?? '',
+		} );
+	}, [
+		innerBlocks,
+		selectedPattern?.blocks,
+		setAttributes,
+		inheritedAlignment,
+	] );
+
+	const blockProps = useBlockProps( {
+		className: inheritedAlignment && `align${ inheritedAlignment }`,
+	} );
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		templateLock: templateLock === 'contentOnly' ? 'contentOnly' : false,
+	} );
+
+	const handleSync = () => {
+		if ( templateLock === false ) {
+			setAttributes( { templateLock: 'contentOnly' } );
+		} else {
+			setAttributes( { templateLock: false } );
+		}
+	};
+
+	return (
+		<>
+			<div { ...innerBlocksProps } />
+			<BlockControls group="other">
+				<ToolbarButton onClick={ handleSync }>
+					{ templateLock === false
+						? __( 'Edit content only' )
+						: __( 'Edit all' ) }
+				</ToolbarButton>
+			</BlockControls>
+		</>
+	);
+};
+
+export default PatternEdit;

--- a/packages/block-library/src/block/pattern-edit.js
+++ b/packages/block-library/src/block/pattern-edit.js
@@ -13,8 +13,8 @@ import {
 import { ToolbarButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-const PatternEdit = ( { attributes, clientId, setAttributes } ) => {
-	const { inheritedAlignment, slug, templateLock } = attributes;
+const PatternEdit = ( { attributes, clientId } ) => {
+	const { slug, templateLock } = attributes;
 	const { selectedPattern, innerBlocks } = useSelect(
 		( select ) => {
 			return {
@@ -59,53 +59,16 @@ const PatternEdit = ( { attributes, clientId, setAttributes } ) => {
 		innerBlocks,
 	] );
 
-	useEffect( () => {
-		const alignments = [ 'wide', 'full' ];
-		const blocks = innerBlocks;
-		if ( ! blocks || blocks.length === 0 ) {
-			return;
-		}
-		// Determine the widest setting of all the contained blocks.
-		const widestAlignment = blocks.reduce( ( accumulator, block ) => {
-			const { align } = block.attributes;
-			return alignments.indexOf( align ) >
-				alignments.indexOf( accumulator )
-				? align
-				: accumulator;
-		}, undefined );
-
-		// Set the attribute of the Pattern block to match the widest
-		// alignment.
-		setAttributes( {
-			inheritedAlignment: widestAlignment ?? '',
-		} );
-	}, [
-		innerBlocks,
-		selectedPattern?.blocks,
-		setAttributes,
-		inheritedAlignment,
-	] );
-
-	const blockProps = useBlockProps( {
-		className: inheritedAlignment && `align${ inheritedAlignment }`,
-	} );
+	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		templateLock: templateLock === 'contentOnly' ? 'contentOnly' : false,
+		templateLock: 'contentOnly',
 	} );
-
-	const handleSync = () => {
-		if ( templateLock === false ) {
-			setAttributes( { templateLock: 'contentOnly' } );
-		} else {
-			setAttributes( { templateLock: false } );
-		}
-	};
 
 	return (
 		<>
 			<div { ...innerBlocksProps } />
 			<BlockControls group="other">
-				<ToolbarButton onClick={ handleSync }>
+				<ToolbarButton>
 					{ templateLock === false
 						? __( 'Edit content only' )
 						: __( 'Edit all' ) }

--- a/packages/block-library/src/block/reusable-edit.js
+++ b/packages/block-library/src/block/reusable-edit.js
@@ -1,0 +1,143 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+import {
+	useEntityBlockEditor,
+	useEntityProp,
+	useEntityRecord,
+} from '@wordpress/core-data';
+import {
+	Placeholder,
+	Spinner,
+	ToolbarGroup,
+	ToolbarButton,
+	TextControl,
+	PanelBody,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import {
+	useInnerBlocksProps,
+	__experimentalRecursionProvider as RecursionProvider,
+	__experimentalUseHasRecursion as useHasRecursion,
+	InnerBlocks,
+	BlockControls,
+	InspectorControls,
+	useBlockProps,
+	Warning,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import { store as reusableBlocksStore } from '@wordpress/reusable-blocks';
+import { ungroup } from '@wordpress/icons';
+
+export default function ReusableEdit( { attributes: { ref }, clientId } ) {
+	const hasAlreadyRendered = useHasRecursion( ref );
+	const { record, hasResolved } = useEntityRecord(
+		'postType',
+		'wp_block',
+		ref
+	);
+	const isMissing = hasResolved && ! record;
+
+	const { canRemove, innerBlockCount } = useSelect(
+		( select ) => {
+			const { canRemoveBlock, getBlockCount } =
+				select( blockEditorStore );
+			return {
+				canRemove: canRemoveBlock( clientId ),
+				innerBlockCount: getBlockCount( clientId ),
+			};
+		},
+		[ clientId ]
+	);
+
+	const { __experimentalConvertBlockToStatic: convertBlockToStatic } =
+		useDispatch( reusableBlocksStore );
+
+	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
+		'postType',
+		'wp_block',
+		{ id: ref }
+	);
+	const [ title, setTitle ] = useEntityProp(
+		'postType',
+		'wp_block',
+		'title',
+		ref
+	);
+
+	const blockProps = useBlockProps( {
+		className: 'block-library-block__reusable-block-container',
+	} );
+
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		value: blocks,
+		onInput,
+		onChange,
+		renderAppender: blocks?.length
+			? undefined
+			: InnerBlocks.ButtonBlockAppender,
+	} );
+
+	if ( hasAlreadyRendered ) {
+		return (
+			<div { ...blockProps }>
+				<Warning>
+					{ __( 'Block cannot be rendered inside itself.' ) }
+				</Warning>
+			</div>
+		);
+	}
+
+	if ( isMissing ) {
+		return (
+			<div { ...blockProps }>
+				<Warning>
+					{ __( 'Block has been deleted or is unavailable.' ) }
+				</Warning>
+			</div>
+		);
+	}
+
+	if ( ! hasResolved ) {
+		return (
+			<div { ...blockProps }>
+				<Placeholder>
+					<Spinner />
+				</Placeholder>
+			</div>
+		);
+	}
+
+	return (
+		<RecursionProvider uniqueId={ ref }>
+			{ canRemove && (
+				<BlockControls>
+					<ToolbarGroup>
+						<ToolbarButton
+							onClick={ () => convertBlockToStatic( clientId ) }
+							label={
+								innerBlockCount > 1
+									? __( 'Convert to regular blocks' )
+									: __( 'Convert to regular block' )
+							}
+							icon={ ungroup }
+							showTooltip
+						/>
+					</ToolbarGroup>
+				</BlockControls>
+			) }
+			<InspectorControls>
+				<PanelBody>
+					<TextControl
+						__nextHasNoMarginBottom
+						label={ __( 'Name' ) }
+						value={ title }
+						onChange={ setTitle }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...innerBlocksProps } />
+		</RecursionProvider>
+	);
+}

--- a/packages/block-library/src/block/save.js
+++ b/packages/block-library/src/block/save.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+
+export default function save( { attributes: { type }, innerBlocks } ) {
+	if ( type === 'reusable' ) {
+		return;
+	}
+
+	if ( type === 'pattern' ) {
+		if ( innerBlocks?.length === 0 ) {
+			return;
+		}
+
+		const blockProps = useBlockProps.save();
+		const innerBlocksProps = useInnerBlocksProps.save( blockProps );
+		return <div { ...innerBlocksProps }>{ innerBlocksProps.children }</div>;
+	}
+}

--- a/packages/block-library/src/block/variations.js
+++ b/packages/block-library/src/block/variations.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	symbol as reusableIcon,
+	receipt as patternIcon,
+} from '@wordpress/icons';
+
+const isActive = ( blockAttributes, variationAttributes ) =>
+	blockAttributes.type === variationAttributes.type;
+
+const variations = [
+	{
+		name: 'reusable',
+		title: __( 'Reusable block' ),
+		description: __(
+			'Create and save content to reuse across your site. Update the block, and the changes apply everywhere it’s used.'
+		),
+		attributes: { type: 'reusable' },
+		isDefault: true,
+		icon: reusableIcon,
+		isActive,
+	},
+	{
+		name: 'pattern',
+		title: __( 'Pattern' ),
+		description: __( 'Show a block pattern.' ),
+		attributes: { type: 'pattern' },
+		// @todo - add a pattern icon.
+		icon: patternIcon,
+		isActive,
+	},
+];
+
+export default variations;

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { createBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import {
@@ -9,23 +10,22 @@ import {
 } from '@wordpress/block-editor';
 
 const PatternEdit = ( { attributes, clientId } ) => {
-	const selectedPattern = useSelect(
+	const { slug } = attributes;
+	const { blocks: patternBlocks } = useSelect(
 		( select ) =>
-			select( blockEditorStore ).__experimentalGetParsedPattern(
-				attributes.slug
-			),
-		[ attributes.slug ]
+			select( blockEditorStore ).__experimentalGetParsedPattern( slug ),
+		[ slug ]
 	);
 
 	const { replaceBlocks, __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
 
 	// Run this effect when the component loads.
-	// This adds the Pattern's contents to the post.
+	// This converts a pattern in content to wp:block type.
 	// This change won't be saved.
 	// It will continue to pull from the pattern file unless changes are made to its respective template part.
 	useEffect( () => {
-		if ( selectedPattern?.blocks ) {
+		if ( patternBlocks ) {
 			// We batch updates to block list settings to avoid triggering cascading renders
 			// for each container block included in a tree and optimize initial render.
 			// Since the above uses microtasks, we need to use a microtask here as well,
@@ -33,10 +33,18 @@ const PatternEdit = ( { attributes, clientId } ) => {
 			// inner blocks but doesn't have blockSettings in the state.
 			window.queueMicrotask( () => {
 				__unstableMarkNextChangeAsNotPersistent();
-				replaceBlocks( clientId, selectedPattern.blocks );
+				const block = createBlock(
+					'core/block',
+					{
+						type: 'pattern',
+						slug,
+					},
+					patternBlocks
+				);
+				replaceBlocks( clientId, block );
 			} );
 		}
-	}, [ clientId, selectedPattern?.blocks ] );
+	}, [ clientId, patternBlocks, slug ] );
 
 	const props = useBlockProps();
 

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -11,7 +11,7 @@ import {
 
 const PatternEdit = ( { attributes, clientId } ) => {
 	const { slug } = attributes;
-	const { blocks: patternBlocks } = useSelect(
+	const pattern = useSelect(
 		( select ) =>
 			select( blockEditorStore ).__experimentalGetParsedPattern( slug ),
 		[ slug ]
@@ -25,26 +25,26 @@ const PatternEdit = ( { attributes, clientId } ) => {
 	// This change won't be saved.
 	// It will continue to pull from the pattern file unless changes are made to its respective template part.
 	useEffect( () => {
-		if ( patternBlocks ) {
-			// We batch updates to block list settings to avoid triggering cascading renders
-			// for each container block included in a tree and optimize initial render.
-			// Since the above uses microtasks, we need to use a microtask here as well,
-			// because nested pattern blocks cannot be inserted if the parent block supports
-			// inner blocks but doesn't have blockSettings in the state.
-			window.queueMicrotask( () => {
-				__unstableMarkNextChangeAsNotPersistent();
-				const block = createBlock(
-					'core/block',
-					{
-						type: 'pattern',
-						slug,
-					},
-					patternBlocks
-				);
-				replaceBlocks( clientId, block );
-			} );
-		}
-	}, [ clientId, patternBlocks, slug ] );
+		if ( ! pattern?.blocks ) return;
+
+		// We batch updates to block list settings to avoid triggering cascading renders
+		// for each container block included in a tree and optimize initial render.
+		// Since the above uses microtasks, we need to use a microtask here as well,
+		// because nested pattern blocks cannot be inserted if the parent block supports
+		// inner blocks but doesn't have blockSettings in the state.
+		window.queueMicrotask( () => {
+			__unstableMarkNextChangeAsNotPersistent();
+			const block = createBlock(
+				'core/block',
+				{
+					type: 'pattern',
+					slug,
+				},
+				pattern.blocks
+			);
+			replaceBlocks( clientId, block );
+		} );
+	}, [ clientId, pattern?.blocks, slug ] );
 
 	const props = useBlockProps();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is an alternative to #50272.

It's possibly one way to approach #48458, rather than embracing the wp:pattern block, we instead use the wp:block (reusable block) and leverage variations to keep a consistent experience.

At the moment all patterns in templates are now wrapped in this block type (they're converted when first rendered in the editor), and given a `contentOnly` lock.

## Why?
The idea is that this may make the potential unification of reusable blocks and patterns easier in the future.

## How?
This was put together very quickly in a hack session, so I expect there may be bugs and implementation issues. I borrowed a lot from #50272.

At the moment this PR takes quite a basic approach of adding a new `type` attribute that represents the underlying resource ('reusable' for a wp_block, or 'pattern' for patterns) with a default value of reusable.

Block variations are also added for these types.

In the block edit.js, save.js and index.php files, I've used simple if statements to either render a reusable block interface or a pattern interface. I expect it will be possible for a lot of the code to converge in the future, and this provides quite a good basis to refactor from.

## Testing Instructions
1. From the gutenberg experiments screen, enable the pattern experiment
2. Using Twenty Twenty Three, add a `<!-- wp:pattern {"slug":"twentytwentythree/cta"} -->` block via the code editor.
3. Switch to visual testing, and note that this block is now wrapped in a 'pattern' block and has `contentOnly` mode enabled.

## Screenshots or screencast
![Screen Shot 2023-05-04 at 4 29 37 pm](https://user-images.githubusercontent.com/677833/236151446-4f1163cd-2254-476f-8961-46e706b7c073.png)
