### PR TITLE
Post Template Block: Set block context via filter

### DIFF
--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -78,24 +78,22 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 	while ( $query->have_posts() ) {
 		$query->the_post();
 
-		// Get an instance of the current Post Template block.
-		$block_instance = $block->parsed_block;
-
 		// Set the block name to one that does not correspond to an existing registered block.
 		// This ensures that for the inner instances of the Post Template block, we do not render any block supports.
-		$block_instance['blockName'] = 'core/null';
+		$block->name = 'core/null';
 
+		$post_id              = get_the_ID();
+		$post_type            = get_post_type();
+		$filter_block_context = static function( $context ) use ( $post_id, $post_type ) {
+			$context['postType'] = $post_type;
+			$context['postId']   = $post_id;
+			return $context;
+		};
+		add_filter( 'render_block_context', $filter_block_context );
 		// Render the inner blocks of the Post Template block with `dynamic` set to `false` to prevent calling
 		// `render_callback` and ensure that no wrapper markup is included.
-		$block_content = (
-			new WP_Block(
-				$block_instance,
-				array(
-					'postType' => get_post_type(),
-					'postId'   => get_the_ID(),
-				)
-			)
-		)->render( array( 'dynamic' => false ) );
+		$block_content = $block->render( array( 'dynamic' => false ) );
+		remove_filter( 'render_block_context', $filter_block_context );
 
 		// Wrap the render inner blocks in a `li` element with the appropriate post classes.
 		$post_classes = implode( ' ', get_post_class( 'wp-block-post' ) );

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -78,9 +78,12 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 	while ( $query->have_posts() ) {
 		$query->the_post();
 
+		// Get an instance of the current Post Template block.
+		$block_instance = $block->parsed_block;
+
 		// Set the block name to one that does not correspond to an existing registered block.
 		// This ensures that for the inner instances of the Post Template block, we do not render any block supports.
-		$block->name = 'core/null';
+		$block_instance['blockName'] = 'core/null';
 
 		$post_id              = get_the_ID();
 		$post_type            = get_post_type();
@@ -92,7 +95,7 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 		add_filter( 'render_block_context', $filter_block_context );
 		// Render the inner blocks of the Post Template block with `dynamic` set to `false` to prevent calling
 		// `render_callback` and ensure that no wrapper markup is included.
-		$block_content = $block->render( array( 'dynamic' => false ) );
+		$block_content = ( new WP_Block( $block_instance ) )->render( array( 'dynamic' => false ) );
 		remove_filter( 'render_block_context', $filter_block_context );
 
 		// Wrap the render inner blocks in a `li` element with the appropriate post classes.

--- a/phpunit/blocks/render-post-template-test.php
+++ b/phpunit/blocks/render-post-template-test.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Tests for the Post Template block rendering.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ * @since 6.0.0
+ *
+ * @group blocks
+ */
+class Tests_Blocks_RenderPostTemplateBlock extends WP_UnitTestCase {
+
+	private static $post;
+	private static $other_post;
+
+	public function set_up() {
+		parent::set_up();
+
+		self::$post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_name'    => 'metaldog',
+				'post_title'   => 'Metal Dog',
+				'post_content' => 'Metal Dog content',
+				'post_excerpt' => 'Metal Dog',
+			)
+		);
+
+		self::$other_post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_name'    => 'ceilingcat',
+				'post_title'   => 'Ceiling Cat',
+				'post_content' => 'Ceiling Cat content',
+				'post_excerpt' => 'Ceiling Cat',
+			)
+		);
+	}
+
+	public function test_rendering_post_template() {
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:post-template --><!-- wp:post-title /--><!-- wp:post-excerpt /--><!-- /wp:post-template -->'
+		);
+		$block         = new WP_Block( $parsed_blocks[0] );
+		$markup        = $block->render();
+
+		$post_id       = self::$post->ID;
+		$other_post_id = self::$other_post->ID;
+
+		$expected = <<<END
+<ul class="wp-block-post-template is-layout-flow wp-block-post-template-is-layout-flow">
+	<li class="wp-block-post post-$other_post_id post type-post status-publish format-standard hentry category-uncategorized">
+		<h2 class="wp-block-post-title">Ceiling Cat</h2>
+		<div class="wp-block-post-excerpt">
+			<p class="wp-block-post-excerpt__excerpt">Ceiling Cat </p>
+		</div>
+	</li>
+	<li class="wp-block-post post-$post_id post type-post status-publish format-standard hentry category-uncategorized">
+		<h2 class="wp-block-post-title">Metal Dog</h2>
+		<div class="wp-block-post-excerpt">
+			<p class="wp-block-post-excerpt__excerpt">Metal Dog </p>
+		</div>
+	</li>
+</ul>
+END;
+		$this->assertSame(
+			str_replace( array( "\n", "\t" ), '', $expected ),
+			str_replace( array( "\n", "\t" ), '', $markup )
+		);
+	}
+}


### PR DESCRIPTION
## What?
In the Post Template block's render callback, instead of creating a new `WP_Block` instance with `postId` and `postType` context set, use the `render_block_context` filter to set that context and render the existing `WP_Block` instance.

## Why?
This approach arguably follows our established patterns with regard to handling block context better. Notably, with the previous approach, we were only setting block context for the Post Template block itself. In this PR, we extend it to apply to all child blocks, including ones that are dynamically inserted, e.g. via the `render_block` filter. This is relevant for Auto-inserting blocks (see #50103).

This follows the precedent of the Comment Template block, see #50279.

## How?
See "What".

## Testing Instructions
Verify that the Post Template block (and children) are still working as expected on the frontend:

1. Use a block theme that uses them (e.g. Twenty Twenty-Three).
2. On `trunk`, create a number of posts. View on the frontend, and take note (and a screenshot) of what the posts look like.
3. Switch to this branch, and rebuild GB.
4. Reload the page, and verify that it looks the same as before.

### Testing Instructions for Keyboard
N/A.

## Screenshots or screencast
N/A.