### PR TITLE
Try: Light scrim and softer shadows.

### DIFF
--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -64,8 +64,10 @@ $canvas-padding: $grid-unit-30;
  * Shadows.
  */
 
-$shadow-popover: 0 0.7px 1px rgba($black, 0.1), 0 1.2px 1.7px -0.2px rgba($black, 0.1), 0 2.3px 3.3px -0.5px rgba($black, 0.1);
-$shadow-modal: 0 0.7px 1px rgba($black, 0.15), 0 2.7px 3.8px -0.2px rgba($black, 0.15), 0 5.5px 7.8px -0.3px rgba($black, 0.15), 0.1px 11.5px 16.4px -0.5px rgba($black, 0.15);
+// Depths 1-3
+$shadow-popover: 0 0.1px 0.4px rgba($black, 0.036), 0 0.4px 1.3px rgba($black, 0.054), 0 2px 6px rgba($black, 0.09);
+$shadow-confirm: 0 0.4px 0.8px rgba($black, 0.036), 0 1.3px 2.7px rgba($black, 0.054), 0 6px 12px rgba($black, 0.09);
+$shadow-modal: 0 0.8px 2.5px rgba($black, 0.036), 0 2.7px 8.5px rgba($black, 0.054), 0 12px 38px rgba($black, 0.09);
 
 /**
  * Editor widths.

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -5,7 +5,7 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
-	background-color: rgba($black, 0.35);
+	background-color: rgba($white, 0.75);
 	z-index: z-index(".components-modal__screen-overlay");
 	display: flex;
 	// backdrop-filter: blur($grid-unit);
@@ -54,6 +54,11 @@
 
 	@include break-large() {
 		max-height: 70%;
+	}
+
+	// Lower depth for "confirm" dialogs.
+	&.components-confirm-dialog {
+		box-shadow: $shadow-confirm;
 	}
 }
 

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -5,7 +5,7 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
-	background-color: rgba($white, 0.75);
+	background-color: rgba($black, 0.1);
 	z-index: z-index(".components-modal__screen-overlay");
 	display: flex;
 	// backdrop-filter: blur($grid-unit);


### PR DESCRIPTION
## What?

Work in progress!

Our shadows are not super consistent, and they can in places fel a bit heavy, especially the modal. Popover:

<img width="1392" alt="before, popover" src="https://user-images.githubusercontent.com/1204802/236162110-e7ab8e1b-dc86-47d7-97cd-8016f48b40f7.png">

Modal:

<img width="1392" alt="before, modal" src="https://user-images.githubusercontent.com/1204802/236162160-d7ff5b2a-9641-42a4-a2ad-663e1fddd946.png">

This PR aims to bring a little consistency and system to them, and make them lighter, literally, with a white scrim, and softer:

<img width="1392" alt="after, popover" src="https://user-images.githubusercontent.com/1204802/236162421-64d5d621-e309-4fa6-8f65-3e94657dbe13.png">

<img width="1392" alt="after, modal" src="https://user-images.githubusercontent.com/1204802/236162434-8fd1ee66-7c4b-4fff-9089-10359cfcc7e5.png">

It also adds a depth in between popover and modal, tentatively called "confirm", for the alert/confirm variant of the modal dialog component:

<img width="1392" alt="after, confirm" src="https://user-images.githubusercontent.com/1204802/236162671-29212e00-db4c-4776-b0be-b7e9a5cd6b2f.png">

This is a draft PR in part to validate these shadows, but also because the component needs a little work in order to work with the new light scrim. Notably that light scrim does not look good in the dark site view:

<img width="1392" alt="site view" src="https://user-images.githubusercontent.com/1204802/236162896-7a9a0325-b2cb-423b-a32e-9a67ae958e42.png">

## Testing Instructions

* Test popover in the top toolbar ellipsis menu.
* Test modal in the preferences dialog
* Test confirm by publishing a post, then clicking "switch to draft" in the document inspector.