### PR TITLE
Ensure imported Classic Menu dirty state to include in Editor entity changes list

### DIFF
--- a/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
+++ b/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
@@ -97,7 +97,7 @@ function useConvertClassicToBlockMenu( clientId ) {
 					'wp_navigation',
 					navigationMenu.id,
 					{
-						status: postStatus,
+						status: 'publish',
 					},
 					{ throwOnError: true }
 				);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes a bug whereby importing a Classic Menu would not trigger a dirty state on the resulting `wp_navigation` entity and thus the new Navigation could not be saved.

Change causes newly imported Navigation Menu to show in the sidebar when you click "Save" in the editor.

Fixes https://github.com/WordPress/gutenberg/issues/49718 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It looks like https://github.com/WordPress/gutenberg/pull/43580 introduce a regression.

The bug is that when the classic menu is converted into a (block based) Navigation Menu the call to `editEntityRecord` does not set the status to `publish`. Rather it simply sets it to whatever the initial `status` argument was that was passed to the "convert" function:

https://github.com/WordPress/gutenberg/blob/44308e7e0e657fa527efa7dd3a90514ce0b40f87/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js#L100

This means that the entity never becomes "dirty" and thus never gets included in the "saved" changes when you click "Save" in the editor.

The clue is in the comment where it references `publish` as the expected state change:

https://github.com/WordPress/gutenberg/blob/44308e7e0e657fa527efa7dd3a90514ce0b40f87/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js#L88-L103


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The fix is to change the status argument back to a hard coded string `publish` in the `editEntityRecord` call.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Follow instructions in https://github.com/WordPress/gutenberg/issues/49718. 

On this branch once you you complete this step...

> Re-assign one of the two classic menus. Confirm that it is the classic menu that shows in the editor and the new "block" menu that shows on the front.

...the newly imported Classic Menu should be included in the sidebar when you click "Save" in the editor. Clicking and confirming the "Save" should cause the Navigation to update on the front of the site.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/444434/236181053-35da1668-be74-4f9a-8b25-cda9c233cbff.mp4

