### PR TITLE
Ensure there is always a Navigation available in the browse mode sidebar via fallback algorithm

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -588,7 +588,9 @@ export const getNavigationFallbackId =
 			dispatch.receiveEntityRecords(
 				'postType',
 				'wp_navigation',
-				record
+				record,
+				undefined,
+				true
 			);
 
 			// Resolve to avoid further network requests.

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -585,12 +585,14 @@ export const getNavigationFallbackId =
 		dispatch.receiveNavigationFallbackId( fallback?.id );
 
 		if ( record ) {
+			const invalidateNavigationQueries = true;
+
 			dispatch.receiveEntityRecords(
 				'postType',
 				'wp_navigation',
 				record,
 				undefined,
-				true
+				invalidateNavigationQueries
 			);
 
 			// Resolve to avoid further network requests.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Updates the `Navigation` section of the browse mode sidebar to ensure that a menu will be created and provided to the user when there are no _existing_ Navigations found.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently on `trunk`, the Navigation section of the sidebar will query for menus and if none are found will show an "empty" status. 

We know that we _always_ want users to have a menu available because:

- users want menus
- this is the standard behaviour of the Navigation _block_ and will happen anyway but just in a delayed form as the fallback operation wouldn't be triggered until the Navigation block was rendered in the editor content 

Therefore it makes sense that if there are no menus we dispatch a call to create one as early as possible in order to avoid situations where the Navigation panel initially appears empty and then updates itself in response to changes triggered by Navigation blocks in the editor canvas.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Uses the fallback algorithm by calling the `getNavigationFallbackId` selector to create and retrieve a Navigation post.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

It's easier to have a reduced test case. This can be achieved by:

- Removing all Navigation blocks from your site editor template contents. Likely just the `Header` but check elsewhere just in case.
- Deleting _all_ Navigations. I used WPCLI
```
// Remove
npm run wp-env run cli wp post list -- --post_type=wp_navigation --post_status=any
npm run wp-env run cli wp post delete {YOUR_ID} -- --force       

// Double check
npm run wp-env run cli wp post list -- --post_type=wp_navigation --post_status=any
```

With this in place you can test as follows:
- Open Network tab and filter by `navigation`.
- Load Site Editor
- Go to `Navigation` in Browse Mode sidebar.
- See fallback request dispatched
- See sidebar update to display the created menu.
- Use WPCLI to confirm the Navigation was created.
- Reload Site Editor 
- Do _not_ see fallback request triggered
- See menu displayed.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/444434/0ee395c7-535f-4fe4-bffe-3269fbfd2de6

