### PR TITLE
Navigation: Move the ALLOWED_BLOCKS const to a shared location

### DIFF
--- a/packages/block-library/src/navigation/edit/allowed-blocks.js
+++ b/packages/block-library/src/navigation/edit/allowed-blocks.js
@@ -1,0 +1,11 @@
+export const ALLOWED_BLOCKS = [
+	'core/navigation-link',
+	'core/search',
+	'core/social-links',
+	'core/page-list',
+	'core/spacer',
+	'core/home-link',
+	'core/site-title',
+	'core/site-logo',
+	'core/navigation-submenu',
+];

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -14,18 +14,7 @@ import { useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import PlaceholderPreview from './placeholder/placeholder-preview';
-
-const ALLOWED_BLOCKS = [
-	'core/navigation-link',
-	'core/search',
-	'core/social-links',
-	'core/page-list',
-	'core/spacer',
-	'core/home-link',
-	'core/site-title',
-	'core/site-logo',
-	'core/navigation-submenu',
-];
+import { ALLOWED_BLOCKS } from './allowed-blocks';
 
 const DEFAULT_BLOCK = {
 	name: 'core/navigation-link',

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -12,6 +12,7 @@ import { useContext, useEffect, useRef, useMemo } from '@wordpress/element';
  */
 import useNavigationMenu from '../use-navigation-menu';
 import { areBlocksDirty } from './are-blocks-dirty';
+import { ALLOWED_BLOCKS } from './allowed-blocks';
 
 const EMPTY_OBJECT = {};
 const DRAFT_MENU_PARAMS = [
@@ -23,18 +24,6 @@ const DRAFT_MENU_PARAMS = [
 const DEFAULT_BLOCK = {
 	name: 'core/navigation-link',
 };
-
-const ALLOWED_BLOCKS = [
-	'core/navigation-link',
-	'core/search',
-	'core/social-links',
-	'core/page-list',
-	'core/spacer',
-	'core/home-link',
-	'core/site-title',
-	'core/site-logo',
-	'core/navigation-submenu',
-];
 
 export default function UnsavedInnerBlocks( {
 	blocks,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Creates a new shared file to store the list of ALLOWED_BLOCKS inside the Navigation block

## Why?
So that they can't get out of sync.

## Testing Instructions
Check that the navigation block is still limited to the blocks inside ALLOWED_BLOCKS.