### PR TITLE
Mark related selector as resolved when sideloading Navigation fallback

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -545,5 +545,12 @@ export const getNavigationFallbackId =
 				'wp_navigation',
 				record
 			);
+
+			// Resolve to avoid further network requests.
+			dispatch.finishResolution( 'getEntityRecord', [
+				'postType',
+				'wp_navigation',
+				fallback?.id,
+			] );
 		}
 	};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Mark resolvers relating to queries for retrieved Navigation fallback as "resolved" to avoid further network requests.

Closes https://github.com/WordPress/gutenberg/issues/50322

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Following work done in https://github.com/WordPress/gutenberg/pull/50032/ it was still sometimes possible (race condition?) to see network requests dispatched from calls to `getEntityRecord` after the navigation fallback had already been added to Core Data state.

Speaking with @youknowriad it is my understanding that whilst we are sideloading the record into state, we are not marking the related resolver as being "resolved". This means calls which trigger that resolver may still dispatch network requests to `wp/v2/navigation/{{FALLBACK_ID}}` when this record has already been sideloaded into state as the result of the original `getNavigationFallbackId` call. 


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We manually resolve the selector using:

```
dispatch.finishResolution( 'getEntityRecord', [
	'postType',
	'wp_navigation',
	fallback?.id,
] );
```



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Open Post Editor
- Open dev tools network 
- Open global block inserter
- Open Patterns tab
- Click `Headers`
- See lots of header patterns load which contain Nav blocks.
- Each Nav block will request the fallback
- Filter devtools network tab by `fallback` - see a single request only
- Filter by `navigation` 
    - see a _single_ `OPTIONS` request to `/wp-json/wp/v2/navigation/{{FALLBACK_ID}}`
    - see _no_ `GET` requests to `/wp-json/wp/v2/navigation/{{FALLBACK_ID}}`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
